### PR TITLE
fix: Pin the piper-tts version to 1.3.0

### DIFF
--- a/packages/qvac-lib-infer-onnx-tts/benchmarks/python-server/requirements.txt
+++ b/packages/qvac-lib-infer-onnx-tts/benchmarks/python-server/requirements.txt
@@ -1,6 +1,6 @@
 fastapi>=0.104.1
 uvicorn>=0.24.0
 pydantic>=2.5.0
-piper-tts>=1.2.0
+piper-tts==1.3.0
 numpy>=1.24.0
 


### PR DESCRIPTION
## What does this PR do?
- This PR solves the broken benchmarks suite by pinning the version of `piper-tts` module to 1.3.0 in `python-server`