### PR TITLE
QVAC-11777: add multi-instance tests

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/test/integration/multi-instance.test.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/integration/multi-instance.test.js
@@ -1,0 +1,177 @@
+'use strict'
+
+const test = require('brittle')
+const os = require('bare-os')
+const FilesystemDL = require('@qvac/dl-filesystem')
+const GGMLBert = require('../../index.js')
+const { ensureModel, getModelConfigs, TestLogger, waitForCompletion } = require('./utils')
+
+const platform = os.platform()
+const arch = os.arch()
+const isDarwinX64 = platform === 'darwin' && arch === 'x64'
+const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
+
+const DEFAULT_BATCH_SIZE = '1024'
+
+const TEST_MODEL = getModelConfigs()[0]
+
+async function createInstance (modelName, dirPath, device = 'gpu') {
+  const loader = new FilesystemDL({ dirPath })
+  const logger = new TestLogger()
+
+  if (isDarwinX64 || isLinuxArm64) {
+    device = 'cpu'
+  }
+
+  const ngl = device === 'cpu' ? '0' : '999'
+  const configParts = [`-ngl\t${ngl}`, `--batch_size\t${DEFAULT_BATCH_SIZE}`, `-dev\t${device}`]
+
+  if (platform === 'android') {
+    configParts.push('-fa\toff')
+  }
+
+  const config = configParts.join('\n')
+  const inference = new GGMLBert({ modelName, loader, logger, diskPath: dirPath }, config)
+
+  return { inference, loader }
+}
+
+test('Two embed instances can run inference simultaneously', {
+  timeout: 900_000
+}, async t => {
+  const modelName = TEST_MODEL.modelName
+  const [, dirPath] = await ensureModel(modelName)
+
+  const { inference: inference1, loader: loader1 } = await createInstance(modelName, dirPath)
+  const { inference: inference2, loader: loader2 } = await createInstance(modelName, dirPath)
+
+  t.teardown(async () => {
+    await inference1.destroy().catch(() => {})
+    await inference2.destroy().catch(() => {})
+    await loader1.close().catch(() => {})
+    await loader2.close().catch(() => {})
+  })
+
+  await inference1.load()
+  await inference2.load()
+
+  const sentences1 = ['Hello world', 'This is a test']
+  const sentences2 = ['Goodbye world', 'Another test sentence']
+  const response1 = await inference1.run(sentences1)
+  const response2 = await inference2.run(sentences2)
+
+  const [embeddings1, embeddings2] = await Promise.all([
+    waitForCompletion(response1),
+    waitForCompletion(response2)
+  ])
+
+  t.ok(embeddings1[0].length === sentences1.length, 'first instance produced correct number of embeddings')
+  t.ok(embeddings2[0].length === sentences2.length, 'second instance produced correct number of embeddings')
+  t.ok(embeddings1[0][0].length > 0, 'first instance embeddings have correct dimension')
+  t.ok(embeddings2[0][0].length > 0, 'second instance embeddings have correct dimension')
+})
+
+test('Repeated embed load/unload cycles should remain stable', {
+  timeout: 900_000
+}, async t => {
+  const modelName = TEST_MODEL.modelName
+  const [, dirPath] = await ensureModel(modelName)
+
+  const NUM_CYCLES = 6
+  const testSentence = 'This is a stability test sentence.'
+
+  for (let i = 0; i < NUM_CYCLES; i++) {
+    const { inference, loader } = await createInstance(modelName, dirPath)
+
+    await inference.load()
+    const response = await inference.run(testSentence)
+    const embeddings = await waitForCompletion(response)
+
+    t.ok(embeddings[0][0].length > 0, `cycle ${i + 1}: produced embeddings`)
+
+    await inference.destroy()
+    await loader.close()
+
+    t.pass(`cycle ${i + 1}: load/unload completed`)
+  }
+
+  t.pass(`all ${NUM_CYCLES} load/unload cycles completed successfully`)
+})
+
+test('Unloading one embed instance does not affect another running instance', {
+  timeout: 900_000
+}, async t => {
+  const modelName = TEST_MODEL.modelName
+  const [, dirPath] = await ensureModel(modelName)
+
+  const { inference: inference1, loader: loader1 } = await createInstance(modelName, dirPath)
+  const { inference: inference2, loader: loader2 } = await createInstance(modelName, dirPath)
+
+  t.teardown(async () => {
+    await inference1.destroy().catch(() => {})
+    await inference2.destroy().catch(() => {})
+    await loader1.close().catch(() => {})
+    await loader2.close().catch(() => {})
+  })
+
+  await inference1.load()
+  await inference2.load()
+
+  const largeBatch = Array(50).fill(null).map((_, i) => `Test sentence number ${i} for batch processing`)
+  const response1Promise = inference1.run(largeBatch)
+
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  await inference2.destroy()
+  await loader2.close()
+  t.pass('unloaded instance 2 while instance 1 is processing')
+
+  const response1 = await response1Promise
+  const embeddings1 = await waitForCompletion(response1)
+
+  t.ok(embeddings1[0].length === largeBatch.length, 'instance 1 completed processing after instance 2 was unloaded')
+})
+
+test('Multiple embed load/unload cycles on one instance while another processes', {
+  timeout: 900_000
+}, async t => {
+  const modelName = TEST_MODEL.modelName
+  const [, dirPath] = await ensureModel(modelName)
+
+  const { inference: inference1, loader: loader1 } = await createInstance(modelName, dirPath)
+
+  t.teardown(async () => {
+    await inference1.destroy().catch(() => {})
+    await loader1.close().catch(() => {})
+  })
+
+  await inference1.load()
+
+  const NUM_CYCLES = 3
+  const NUM_BATCHES = 5
+  let cyclesCompleted = 0
+
+  for (let batch = 0; batch < NUM_BATCHES; batch++) {
+    const sentences = Array(10).fill(null).map((_, i) => `Batch ${batch} sentence ${i}`)
+    const response1Promise = inference1.run(sentences)
+
+    if (cyclesCompleted < NUM_CYCLES) {
+      const { inference: inference2, loader: loader2 } = await createInstance(modelName, dirPath)
+      await inference2.load()
+      await inference2.destroy()
+      await loader2.close()
+      cyclesCompleted++
+      t.pass(`load/unload cycle ${cyclesCompleted} completed while instance 1 processes batch ${batch + 1}`)
+    }
+
+    const response1 = await response1Promise
+    const embeddings1 = await waitForCompletion(response1)
+    t.ok(embeddings1[0].length === sentences.length, `batch ${batch + 1} completed with correct count`)
+  }
+
+  t.ok(cyclesCompleted === NUM_CYCLES, `completed ${cyclesCompleted} load/unload cycles during processing`)
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/qvac-lib-infer-llamacpp-embed/test/integration/multi-instance.test.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/integration/multi-instance.test.js
@@ -2,58 +2,43 @@
 
 const test = require('brittle')
 const os = require('bare-os')
-const FilesystemDL = require('@qvac/dl-filesystem')
-const GGMLBert = require('../../index.js')
-const { ensureModel, getModelConfigs, TestLogger, waitForCompletion } = require('./utils')
+const { createEmbeddingsTestInstance, getModelConfigs, waitForCompletion } = require('./utils')
 
 const platform = os.platform()
 const arch = os.arch()
 const isDarwinX64 = platform === 'darwin' && arch === 'x64'
 const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
+const DEFAULT_DEVICE = (isDarwinX64 || isLinuxArm64) ? 'cpu' : 'gpu'
 
 const DEFAULT_BATCH_SIZE = '1024'
 
 const TEST_MODEL = getModelConfigs()[0]
 
-async function createInstance (modelName, dirPath, device = 'gpu') {
-  const loader = new FilesystemDL({ dirPath })
-  const logger = new TestLogger()
-
-  if (isDarwinX64 || isLinuxArm64) {
-    device = 'cpu'
-  }
-
-  const ngl = device === 'cpu' ? '0' : '999'
-  const configParts = [`-ngl\t${ngl}`, `--batch_size\t${DEFAULT_BATCH_SIZE}`, `-dev\t${device}`]
-
-  if (platform === 'android') {
-    configParts.push('-fa\toff')
-  }
-
-  const config = configParts.join('\n')
-  const inference = new GGMLBert({ modelName, loader, logger, diskPath: dirPath }, config)
-
-  return { inference, loader }
-}
-
 test('Two embed instances can run inference simultaneously', {
   timeout: 900_000
 }, async t => {
   const modelName = TEST_MODEL.modelName
-  const [, dirPath] = await ensureModel(modelName)
-
-  const { inference: inference1, loader: loader1 } = await createInstance(modelName, dirPath)
-  const { inference: inference2, loader: loader2 } = await createInstance(modelName, dirPath)
+  const { inference: inference1, loader: loader1 } = await createEmbeddingsTestInstance(
+    t,
+    modelName,
+    DEFAULT_DEVICE,
+    null,
+    DEFAULT_BATCH_SIZE
+  )
+  const { inference: inference2, loader: loader2 } = await createEmbeddingsTestInstance(
+    t,
+    modelName,
+    DEFAULT_DEVICE,
+    null,
+    DEFAULT_BATCH_SIZE
+  )
 
   t.teardown(async () => {
-    await inference1.destroy().catch(() => {})
-    await inference2.destroy().catch(() => {})
+    await inference1.unload().catch(() => {})
+    await inference2.unload().catch(() => {})
     await loader1.close().catch(() => {})
     await loader2.close().catch(() => {})
   })
-
-  await inference1.load()
-  await inference2.load()
 
   const sentences1 = ['Hello world', 'This is a test']
   const sentences2 = ['Goodbye world', 'Another test sentence']
@@ -75,21 +60,25 @@ test('Repeated embed load/unload cycles should remain stable', {
   timeout: 900_000
 }, async t => {
   const modelName = TEST_MODEL.modelName
-  const [, dirPath] = await ensureModel(modelName)
 
   const NUM_CYCLES = 6
   const testSentence = 'This is a stability test sentence.'
 
   for (let i = 0; i < NUM_CYCLES; i++) {
-    const { inference, loader } = await createInstance(modelName, dirPath)
+    const { inference, loader } = await createEmbeddingsTestInstance(
+      t,
+      modelName,
+      DEFAULT_DEVICE,
+      null,
+      DEFAULT_BATCH_SIZE
+    )
 
-    await inference.load()
     const response = await inference.run(testSentence)
     const embeddings = await waitForCompletion(response)
 
     t.ok(embeddings[0][0].length > 0, `cycle ${i + 1}: produced embeddings`)
 
-    await inference.destroy()
+    await inference.unload()
     await loader.close()
 
     t.pass(`cycle ${i + 1}: load/unload completed`)
@@ -102,27 +91,34 @@ test('Unloading one embed instance does not affect another running instance', {
   timeout: 900_000
 }, async t => {
   const modelName = TEST_MODEL.modelName
-  const [, dirPath] = await ensureModel(modelName)
-
-  const { inference: inference1, loader: loader1 } = await createInstance(modelName, dirPath)
-  const { inference: inference2, loader: loader2 } = await createInstance(modelName, dirPath)
+  const { inference: inference1, loader: loader1 } = await createEmbeddingsTestInstance(
+    t,
+    modelName,
+    DEFAULT_DEVICE,
+    null,
+    DEFAULT_BATCH_SIZE
+  )
+  const { inference: inference2, loader: loader2 } = await createEmbeddingsTestInstance(
+    t,
+    modelName,
+    DEFAULT_DEVICE,
+    null,
+    DEFAULT_BATCH_SIZE
+  )
 
   t.teardown(async () => {
-    await inference1.destroy().catch(() => {})
-    await inference2.destroy().catch(() => {})
+    await inference1.unload().catch(() => {})
+    await inference2.unload().catch(() => {})
     await loader1.close().catch(() => {})
     await loader2.close().catch(() => {})
   })
-
-  await inference1.load()
-  await inference2.load()
 
   const largeBatch = Array(50).fill(null).map((_, i) => `Test sentence number ${i} for batch processing`)
   const response1Promise = inference1.run(largeBatch)
 
   await new Promise(resolve => setTimeout(resolve, 100))
 
-  await inference2.destroy()
+  await inference2.unload()
   await loader2.close()
   t.pass('unloaded instance 2 while instance 1 is processing')
 
@@ -136,16 +132,18 @@ test('Multiple embed load/unload cycles on one instance while another processes'
   timeout: 900_000
 }, async t => {
   const modelName = TEST_MODEL.modelName
-  const [, dirPath] = await ensureModel(modelName)
-
-  const { inference: inference1, loader: loader1 } = await createInstance(modelName, dirPath)
+  const { inference: inference1, loader: loader1 } = await createEmbeddingsTestInstance(
+    t,
+    modelName,
+    DEFAULT_DEVICE,
+    null,
+    DEFAULT_BATCH_SIZE
+  )
 
   t.teardown(async () => {
-    await inference1.destroy().catch(() => {})
+    await inference1.unload().catch(() => {})
     await loader1.close().catch(() => {})
   })
-
-  await inference1.load()
 
   const NUM_CYCLES = 3
   const NUM_BATCHES = 5
@@ -156,9 +154,14 @@ test('Multiple embed load/unload cycles on one instance while another processes'
     const response1Promise = inference1.run(sentences)
 
     if (cyclesCompleted < NUM_CYCLES) {
-      const { inference: inference2, loader: loader2 } = await createInstance(modelName, dirPath)
-      await inference2.load()
-      await inference2.destroy()
+      const { inference: inference2, loader: loader2 } = await createEmbeddingsTestInstance(
+        t,
+        modelName,
+        DEFAULT_DEVICE,
+        null,
+        DEFAULT_BATCH_SIZE
+      )
+      await inference2.unload()
       await loader2.close()
       cyclesCompleted++
       t.pass(`load/unload cycle ${cyclesCompleted} completed while instance 1 processes batch ${batch + 1}`)

--- a/packages/qvac-lib-infer-llamacpp-embed/test/integration/utils.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/integration/utils.js
@@ -246,7 +246,7 @@ function removeErrorHandlers (response) {
  */
 async function cleanupResources (loader, inference) {
   await loader.close()
-  await inference.destroy()
+  await inference.unload()
 }
 
 /**

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
@@ -152,22 +152,17 @@ test('Unloading one instance does not affect another generating instance', {
   const chunks = []
   let unloadedInstance2 = false
 
-  await new Promise((resolve, reject) => {
-    response1
-      .onUpdate(async data => {
-        chunks.push(data)
-        if (!unloadedInstance2 && chunks.length >= 3) {
-          unloadedInstance2 = true
-          await addon2.unload()
-          await loader2.close()
-          t.pass('unloaded instance 2 while instance 1 is generating')
-        }
-      })
-      .onError(reject)
-      .await()
-      .then(resolve)
-      .catch(reject)
-  })
+  await response1
+    .onUpdate(data => {
+      chunks.push(data)
+      if (!unloadedInstance2 && chunks.length >= 3) {
+        unloadedInstance2 = true
+        addon2.unload()
+          .then(() => loader2.close())
+          .then(() => t.pass('unloaded instance 2 while instance 1 is generating'))
+      }
+    })
+    .await()
 
   const output1 = chunks.join('').trim()
   t.ok(output1.length > 0, 'instance 1 completed generation after instance 2 was unloaded')
@@ -198,24 +193,22 @@ test('Multiple load/unload cycles on one instance while another generates', {
   let cyclesCompleted = 0
   const NUM_CYCLES = 3
 
-  await new Promise((resolve, reject) => {
-    response1
-      .onUpdate(async data => {
-        chunks.push(data)
-        if (cyclesCompleted < NUM_CYCLES && chunks.length % 10 === 0) {
-          const { addon: addon2, loader: loader2 } = await createInstance(modelName, dirPath)
-          await addon2.load()
-          await addon2.unload()
-          await loader2.close()
-          cyclesCompleted++
-          t.pass(`load/unload cycle ${cyclesCompleted} completed while instance 1 generates`)
-        }
-      })
-      .onError(reject)
-      .await()
-      .then(resolve)
-      .catch(reject)
-  })
+  await response1
+    .onUpdate(data => {
+      chunks.push(data)
+      if (cyclesCompleted < NUM_CYCLES && chunks.length % 10 === 0) {
+        cyclesCompleted++
+        const cycleNum = cyclesCompleted
+        createInstance(modelName, dirPath)
+          .then(({ addon: addon2, loader: loader2 }) =>
+            addon2.load()
+              .then(() => addon2.unload())
+              .then(() => loader2.close())
+          )
+          .then(() => t.pass(`load/unload cycle ${cycleNum} completed while instance 1 generates`))
+      }
+    })
+    .await()
 
   const output1 = chunks.join('').trim()
   t.ok(output1.length > 0, 'instance 1 completed generation')

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
@@ -1,0 +1,227 @@
+'use strict'
+
+const test = require('brittle')
+const FilesystemDL = require('@qvac/dl-filesystem')
+const LlmLlamacpp = require('../../index.js')
+const { ensureModel } = require('./utils')
+const os = require('bare-os')
+
+const platform = os.platform()
+const arch = os.arch()
+const isDarwinX64 = platform === 'darwin' && arch === 'x64'
+const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
+const useCpu = isDarwinX64 || isLinuxArm64
+
+const DEFAULT_MODEL = {
+  name: 'Llama-3.2-1B-Instruct-Q4_0.gguf',
+  url: 'https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_0.gguf'
+}
+
+const BASE_PROMPT = [
+  { role: 'system', content: 'You are a helpful assistant.' },
+  { role: 'user', content: 'Say hello in one short sentence.' }
+]
+
+const LONG_PROMPT = [
+  { role: 'system', content: 'You are a storyteller. Write detailed stories.' },
+  { role: 'user', content: 'Tell a story about a knight.' }
+]
+
+function createLogger () {
+  return {
+    info: (...args) => console.info(...args),
+    warn: (...args) => console.warn(...args),
+    error: (...args) => console.error(...args),
+    debug: (...args) => console.debug(...args)
+  }
+}
+
+async function createInstance (modelName, dirPath, overrides = {}) {
+  const loader = new FilesystemDL({ dirPath })
+  const config = {
+    device: useCpu ? 'cpu' : 'gpu',
+    gpu_layers: '999',
+    ctx_size: '1024',
+    n_predict: '64',
+    verbosity: '2',
+    ...overrides
+  }
+
+  const addon = new LlmLlamacpp({
+    loader,
+    modelName,
+    diskPath: dirPath,
+    logger: createLogger(),
+    opts: { stats: true }
+  }, config)
+
+  return { addon, loader }
+}
+
+async function collectResponse (response) {
+  const chunks = []
+  await response.onUpdate(data => { chunks.push(data) }).await()
+  return chunks.join('').trim()
+}
+
+test('Two instances can run inference simultaneously', {
+  timeout: 900_000
+}, async t => {
+  const [modelName, dirPath] = await ensureModel({
+    modelName: DEFAULT_MODEL.name,
+    downloadUrl: DEFAULT_MODEL.url
+  })
+
+  const { addon: addon1, loader: loader1 } = await createInstance(modelName, dirPath)
+  const { addon: addon2, loader: loader2 } = await createInstance(modelName, dirPath)
+
+  t.teardown(async () => {
+    await addon1.unload().catch(() => {})
+    await addon2.unload().catch(() => {})
+    await loader1.close().catch(() => {})
+    await loader2.close().catch(() => {})
+  })
+
+  await addon1.load()
+  await addon2.load()
+
+  const response1 = await addon1.run(BASE_PROMPT)
+  const response2 = await addon2.run(BASE_PROMPT)
+
+  const [output1, output2] = await Promise.all([
+    collectResponse(response1),
+    collectResponse(response2)
+  ])
+
+  t.ok(output1.length > 0, 'first instance produced output')
+  t.ok(output2.length > 0, 'second instance produced output')
+})
+
+test('Repeated load/unload cycles should remain stable', {
+  timeout: 900_000
+}, async t => {
+  const [modelName, dirPath] = await ensureModel({
+    modelName: DEFAULT_MODEL.name,
+    downloadUrl: DEFAULT_MODEL.url
+  })
+
+  const NUM_CYCLES = 6
+
+  for (let i = 0; i < NUM_CYCLES; i++) {
+    const { addon, loader } = await createInstance(modelName, dirPath)
+
+    await addon.load()
+    const response = await addon.run(BASE_PROMPT)
+    const output = await collectResponse(response)
+
+    t.ok(output.length > 0, `cycle ${i + 1}: produced output`)
+
+    await addon.unload()
+    await loader.close()
+
+    t.pass(`cycle ${i + 1}: load/unload completed`)
+  }
+
+  t.pass(`all ${NUM_CYCLES} load/unload cycles completed successfully`)
+})
+
+test('Unloading one instance does not affect another generating instance', {
+  timeout: 900_000
+}, async t => {
+  const [modelName, dirPath] = await ensureModel({
+    modelName: DEFAULT_MODEL.name,
+    downloadUrl: DEFAULT_MODEL.url
+  })
+
+  const { addon: addon1, loader: loader1 } = await createInstance(modelName, dirPath, {
+    n_predict: '256'
+  })
+  const { addon: addon2, loader: loader2 } = await createInstance(modelName, dirPath)
+
+  t.teardown(async () => {
+    await addon1.unload().catch(() => {})
+    await addon2.unload().catch(() => {})
+    await loader1.close().catch(() => {})
+    await loader2.close().catch(() => {})
+  })
+
+  await addon1.load()
+  await addon2.load()
+
+  const response1 = await addon1.run(LONG_PROMPT)
+  const chunks = []
+  let unloadedInstance2 = false
+
+  await new Promise((resolve, reject) => {
+    response1
+      .onUpdate(async data => {
+        chunks.push(data)
+        if (!unloadedInstance2 && chunks.length >= 3) {
+          unloadedInstance2 = true
+          await addon2.unload()
+          await loader2.close()
+          t.pass('unloaded instance 2 while instance 1 is generating')
+        }
+      })
+      .onError(reject)
+      .await()
+      .then(resolve)
+      .catch(reject)
+  })
+
+  const output1 = chunks.join('').trim()
+  t.ok(output1.length > 0, 'instance 1 completed generation after instance 2 was unloaded')
+  t.ok(unloadedInstance2, 'instance 2 was unloaded during instance 1 generation')
+})
+
+test('Multiple load/unload cycles on one instance while another generates', {
+  timeout: 900_000
+}, async t => {
+  const [modelName, dirPath] = await ensureModel({
+    modelName: DEFAULT_MODEL.name,
+    downloadUrl: DEFAULT_MODEL.url
+  })
+
+  const { addon: addon1, loader: loader1 } = await createInstance(modelName, dirPath, {
+    n_predict: '512'
+  })
+
+  t.teardown(async () => {
+    await addon1.unload().catch(() => {})
+    await loader1.close().catch(() => {})
+  })
+
+  await addon1.load()
+
+  const response1 = await addon1.run(LONG_PROMPT)
+  const chunks = []
+  let cyclesCompleted = 0
+  const NUM_CYCLES = 3
+
+  await new Promise((resolve, reject) => {
+    response1
+      .onUpdate(async data => {
+        chunks.push(data)
+        if (cyclesCompleted < NUM_CYCLES && chunks.length % 10 === 0) {
+          const { addon: addon2, loader: loader2 } = await createInstance(modelName, dirPath)
+          await addon2.load()
+          await addon2.unload()
+          await loader2.close()
+          cyclesCompleted++
+          t.pass(`load/unload cycle ${cyclesCompleted} completed while instance 1 generates`)
+        }
+      })
+      .onError(reject)
+      .await()
+      .then(resolve)
+      .catch(reject)
+  })
+
+  const output1 = chunks.join('').trim()
+  t.ok(output1.length > 0, 'instance 1 completed generation')
+  t.ok(cyclesCompleted > 0, `completed ${cyclesCompleted} load/unload cycles during generation`)
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
@@ -152,12 +152,14 @@ test('Unloading one instance does not affect another generating instance', {
   const chunks = []
   let unloadedInstance2 = false
   let resolveAfterTokens
+  let thresholdReached = false
   const afterTokens = new Promise(resolve => { resolveAfterTokens = resolve })
 
   const responsePromise = response1
     .onUpdate(data => {
       chunks.push(data)
       if (resolveAfterTokens && chunks.length >= 3) {
+        thresholdReached = true
         resolveAfterTokens()
         resolveAfterTokens = null
       }
@@ -171,6 +173,7 @@ test('Unloading one instance does not affect another generating instance', {
     })
 
   await afterTokens
+  t.ok(thresholdReached, 'instance 1 produced enough tokens before unloading instance 2')
   if (!unloadedInstance2) {
     unloadedInstance2 = true
     await addon2.unload()

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
@@ -151,18 +151,34 @@ test('Unloading one instance does not affect another generating instance', {
   const response1 = await addon1.run(LONG_PROMPT)
   const chunks = []
   let unloadedInstance2 = false
+  let resolveAfterTokens
+  const afterTokens = new Promise(resolve => { resolveAfterTokens = resolve })
 
-  await response1
+  const responsePromise = response1
     .onUpdate(data => {
       chunks.push(data)
-      if (!unloadedInstance2 && chunks.length >= 3) {
-        unloadedInstance2 = true
-        addon2.unload()
-          .then(() => loader2.close())
-          .then(() => t.pass('unloaded instance 2 while instance 1 is generating'))
+      if (resolveAfterTokens && chunks.length >= 3) {
+        resolveAfterTokens()
+        resolveAfterTokens = null
       }
     })
     .await()
+    .finally(() => {
+      if (resolveAfterTokens) {
+        resolveAfterTokens()
+        resolveAfterTokens = null
+      }
+    })
+
+  await afterTokens
+  if (!unloadedInstance2) {
+    unloadedInstance2 = true
+    await addon2.unload()
+    await loader2.close()
+    t.pass('unloaded instance 2 while instance 1 is generating')
+  }
+
+  await responsePromise
 
   const output1 = chunks.join('').trim()
   t.ok(output1.length > 0, 'instance 1 completed generation after instance 2 was unloaded')
@@ -192,23 +208,52 @@ test('Multiple load/unload cycles on one instance while another generates', {
   const chunks = []
   let cyclesCompleted = 0
   const NUM_CYCLES = 3
+  const TOKENS_PER_CYCLE = 10
+  let resolveTokenTarget = null
+  let tokenTarget = 0
 
-  await response1
+  const waitForTokens = async (count) => {
+    if (chunks.length >= count) return
+    await new Promise(resolve => {
+      tokenTarget = count
+      resolveTokenTarget = resolve
+    })
+  }
+
+  const responsePromise = response1
     .onUpdate(data => {
       chunks.push(data)
-      if (cyclesCompleted < NUM_CYCLES && chunks.length % 10 === 0) {
-        cyclesCompleted++
-        const cycleNum = cyclesCompleted
-        createInstance(modelName, dirPath)
-          .then(({ addon: addon2, loader: loader2 }) =>
-            addon2.load()
-              .then(() => addon2.unload())
-              .then(() => loader2.close())
-          )
-          .then(() => t.pass(`load/unload cycle ${cycleNum} completed while instance 1 generates`))
+      if (resolveTokenTarget && chunks.length >= tokenTarget) {
+        const resolve = resolveTokenTarget
+        resolveTokenTarget = null
+        resolve()
       }
     })
     .await()
+    .finally(() => {
+      if (resolveTokenTarget) {
+        const resolve = resolveTokenTarget
+        resolveTokenTarget = null
+        resolve()
+      }
+    })
+
+  for (let i = 0; i < NUM_CYCLES; i++) {
+    const target = (i + 1) * TOKENS_PER_CYCLE
+    await waitForTokens(target)
+    if (chunks.length < target) {
+      break
+    }
+    cyclesCompleted++
+    const cycleNum = cyclesCompleted
+    const { addon: addon2, loader: loader2 } = await createInstance(modelName, dirPath)
+    await addon2.load()
+    await addon2.unload()
+    await loader2.close()
+    t.pass(`load/unload cycle ${cycleNum} completed while instance 1 generates`)
+  }
+
+  await responsePromise
 
   const output1 = chunks.join('').trim()
   t.ok(output1.length > 0, 'instance 1 completed generation')


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Adds test coverage for multi-instance isolation across both LLM and Embed inference packages
- Ensures that multiple model instances can operate independently without interfering with each other in both text generation and embedding workloads

## 📝 How does it solve it?

- **LLM Package** (`@qvac/llm-llamacpp`): Adds `test/integration/multi-instance.test.js` with 4 test cases:
  - Simultaneous inference across two independent LLM instances
  - Stability of repeated load/unload cycles (6 cycles)
  - Isolation when unloading one instance while another is actively generating
  - Concurrent load/unload operations on one instance while another generates

- **Embed Package** (`@qvac/llm-llamacpp-embed`): Adds `test/integration/multi-instance.test.js` with 4 test cases:
  - Simultaneous embedding inference across two independent instances
  - Stability of repeated load/unload cycles (6 cycles)
  - Isolation when unloading one instance while another is processing batch embeddings
  - Concurrent load/unload operations on one instance while another processes multiple batches

## 🧪 How was it tested?

- All 8 test cases (4 per package) pass, validating multi-instance isolation behavior
- LLM tests use Llama-3.2-1B-Instruct-Q4_0 with standard context size (1024)
- Embed tests use the default test model with batch processing
- Tests verify that instances remain isolated during concurrent operations and lifecycle management across both inference types