### PR TITLE
Move Vulkan SDK to S3 for llm/embed addons for linux-arm64

### DIFF
--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -277,11 +277,38 @@ jobs:
 
       - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
         name: Setup vulkan sdk path in linux arm64
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           VULKAN_SDK=~/vulkan/aarch64
           echo "VULKAN_SDK=$VULKAN_SDK" >> $GITHUB_ENV
+          
           cd ~/vulkan
-          ./vulkansdk --maxjobs
+          
+          # Extract SDK major.minor version from README.txt (e.g., "1.4" from "1.4.341.0")
+          SDK_VERSION=$(grep -o 'sdk/[0-9]*\.[0-9]*' README.txt | head -1 | sed 's|sdk/||')
+          S3_BUCKET="tether-ai-dev"
+          S3_KEY="vulkan-sdk-cache/linux-arm64-${SDK_VERSION}.tar.gz"
+          
+          echo "Vulkan SDK version: ${SDK_VERSION}"
+          
+          # Try to download cached build from S3
+          if aws s3 cp "s3://${S3_BUCKET}/${S3_KEY}" /tmp/vulkan-arm64-cache.tar.gz 2>/dev/null; then
+            echo "Found cached Vulkan SDK, extracting..."
+            tar xzf /tmp/vulkan-arm64-cache.tar.gz -C ~/vulkan
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          else
+            echo "No cache found, building Vulkan SDK for ARM64..."
+            ./vulkansdk --maxjobs
+            
+            # Upload the compiled SDK to S3 for future runs
+            echo "Uploading compiled SDK to S3..."
+            tar czf /tmp/vulkan-arm64-cache.tar.gz aarch64
+            aws s3 cp /tmp/vulkan-arm64-cache.tar.gz "s3://${S3_BUCKET}/${S3_KEY}"
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          fi
 
       - if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         name: Export rest of vulkan sdk variables in linux

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -291,11 +291,38 @@ jobs:
 
       - if: ${{ matrix.platform == 'linux' && matrix.arch == 'arm64' }}
         name: Setup vulkan sdk path in linux arm64
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           VULKAN_SDK=~/vulkan/aarch64
           echo "VULKAN_SDK=$VULKAN_SDK" >> $GITHUB_ENV
+          
           cd ~/vulkan
-          ./vulkansdk --maxjobs
+          
+          # Extract SDK major.minor version from README.txt (e.g., "1.4" from "1.4.341.0")
+          SDK_VERSION=$(grep -o 'sdk/[0-9]*\.[0-9]*' README.txt | head -1 | sed 's|sdk/||')
+          S3_BUCKET="tether-ai-dev"
+          S3_KEY="vulkan-sdk-cache/linux-arm64-${SDK_VERSION}.tar.gz"
+          
+          echo "Vulkan SDK version: ${SDK_VERSION}"
+          
+          # Try to download cached build from S3
+          if aws s3 cp "s3://${S3_BUCKET}/${S3_KEY}" /tmp/vulkan-arm64-cache.tar.gz 2>/dev/null; then
+            echo "Found cached Vulkan SDK, extracting..."
+            tar xzf /tmp/vulkan-arm64-cache.tar.gz -C ~/vulkan
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          else
+            echo "No cache found, building Vulkan SDK for ARM64..."
+            ./vulkansdk --maxjobs
+            
+            # Upload the compiled SDK to S3 for future runs
+            echo "Uploading compiled SDK to S3..."
+            tar czf /tmp/vulkan-arm64-cache.tar.gz aarch64
+            aws s3 cp /tmp/vulkan-arm64-cache.tar.gz "s3://${S3_BUCKET}/${S3_KEY}"
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          fi
 
       - if: ${{ startsWith(matrix.os, 'ubuntu-') }}
         name: Export rest of vulkan sdk variables in linux


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Vulkan SDK compilation for linux-arm64 is slow and runs on every prebuild workflow execution
- This adds unnecessary build time to CI/CD pipelines for llamacpp-llm and llamacpp-embed prebuilds

## 📝 How does it solve it?

- Adds S3 caching for the compiled Vulkan SDK on linux-arm64
- On workflow run, checks S3 (`tether-ai-dev` bucket) for a cached SDK matching the version from `README.txt`
- If cache hit: downloads and extracts the pre-compiled SDK (~instant)
- If cache miss: compiles the SDK as before, then uploads to S3 for future runs
- Uses AWS credentials from GitHub secrets for S3 access
- Applied to both `prebuilds-qvac-lib-infer-llamacpp-embed.yml` and `prebuilds-qvac-lib-infer-llamacpp-llm.yml`

## 🧪 How was it tested?

- Run prebuild workflows on linux-arm64 to verify:
  - First run compiles and uploads SDK to S3
  - Subsequent runs download from S3 cache

---

**Note**: This PR only changes GitHub Actions workflow files (`.github/workflows/`), so no package version bump is required.