### PR TITLE
QVAC-12174  Update to qvac-fabric-llm.cpp v7248.1.2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/addon.md
+++ b/.github/PULL_REQUEST_TEMPLATE/addon.md
@@ -1,0 +1,42 @@
+**Note**: be concise and prefer bullet points.
+
+## 🎯 What problem does this PR solve?
+
+-
+-
+
+## 📝 How does it solve it?
+
+-
+-
+
+## 🧪 How was it tested?
+
+**Delete this section if not applicable.**
+
+-
+-
+
+## 💥 Breaking Changes
+
+**Delete this section if not applicable.**
+
+**BEFORE:**
+
+```typescript
+// old code example
+```
+
+**AFTER:**
+
+```typescript
+// new code example
+```
+
+## 🔌 API Changes
+
+**Delete this section if not applicable.**
+
+```typescript
+// new API usage example
+```

--- a/packages/qvac-lib-infer-llamacpp-embed/package.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-llamacpp-embed/release-notes/v0.10.6.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/release-notes/v0.10.6.md
@@ -1,0 +1,17 @@
+# QVAC Embeddings Addon v0.10.6 Release Notes
+
+This release updates the underlying llama.cpp native library to v7248.1.2, bringing upstream improvements and fixes.
+
+## Breaking Changes
+
+There are no breaking changes in this release.
+
+## New APIs
+
+There are no new public APIs in this release.
+
+## Other
+
+### Native Library Update
+
+Updated the llama-cpp vcpkg dependency from v7248.1.1 to v7248.1.2. This brings the latest upstream llama.cpp improvements, optimizations, and bug fixes to the embeddings inference addon.

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "llama-cpp",
-      "version>=": "7248.1.1#0"
+      "version>=": "7248.1.2#0"
     },
     {
       "name": "opencl",

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/qvac-lib-infer-llamacpp-llm/release-notes/v0.8.8.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/release-notes/v0.8.8.md
@@ -1,0 +1,17 @@
+# QVAC LLM Addon v0.8.8 Release Notes
+
+This release updates the underlying llama.cpp native library to v7248.1.2, bringing upstream improvements and fixes.
+
+## Breaking Changes
+
+There are no breaking changes in this release.
+
+## New APIs
+
+There are no new public APIs in this release.
+
+## Other
+
+### Native Library Update
+
+Updated the llama-cpp vcpkg dependency from v7248.1.1 to v7248.1.2. This brings the latest upstream llama.cpp improvements, optimizations, and bug fixes to the LLM inference addon.

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "llama-cpp",
-      "version>=": "7248.1.1#0"
+      "version>=": "7248.1.2#0"
     },
     {
       "name": "opencl",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Updates the llama-cpp vcpkg dependency to v7248.1.2 across both LLM and embedding inference packages
- Keeps native inference libraries aligned with upstream qvac-fabric-llm.cpp improvements and fixes
- this fixes the crash when loading models into gpu on Apple A19 (iphone 17)

## 📝 How does it solve it?

- Bumps `llama-cpp` version constrain.1#0` to `7248.1.2#0` in:
  - `packages/qvac-lib-infer-llamacpp-llm/vcpkg.json`
  - `packages/qvac-lib-infer-llamacpp-embed/vcpkg.json`
- Increments package versions:
  - `@qvac/llm-llamacpp`: 0.8.7 → 0.8.8
  - `@qvac/embed-llamacpp`: 0.10.5 → 0.10.6

## 🧪 How was it tested?

- CI pipeline will verify builds succeed with the updated dependency
- Native unit tests and integration tests validate functionality for both packages


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213127419672528