### PR TITLE
fix: correct workflow file references in whispercpp PR workflow

### DIFF
--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -37,7 +37,7 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
     with:
       package-slug: qvac-lib-infer-whispercpp
-      package-json-path: packages/packages/qvac-lib-infer-whispercpp/package.json
+      package-json-path: packages/qvac-lib-infer-whispercpp/package.json
       changelog-path: packages/qvac-lib-infer-whispercpp/CHANGELOG.md
 
   sanity-checks:
@@ -69,7 +69,7 @@ jobs:
 
   cpp-tests-coverage:
     if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/cpp-tests-whisper.cpp.yml
+    uses: ./.github/workflows/cpp-tests-whispercpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## Summary

- Fix cpp-tests workflow reference: `cpp-tests-whisper.cpp.yml` → `cpp-tests-whispercpp.yml`
- Fix duplicate `packages` in `package-json-path` for release-pr-guard job: `packages/packages/qvac-lib-infer-whispercpp/package.json` → `packages/qvac-lib-infer-whispercpp/package.json`

## Context

The whispercpp PR workflow has been failing with "This run likely failed because of a workflow file issue" errors.

**Failed runs (before fix):**
- https://github.com/tetherto/qvac/actions/runs/21667899737
- https://github.com/tetherto/qvac/actions/runs/21541481705

**Working run (after fix):**
- https://github.com/tetherto/qvac/actions/runs/21701919183

## Test plan

- [x] Triggered workflow manually from feature branch - jobs are now running successfully
- [ ] Verify PR workflow triggers correctly after merge