### PR TITLE
release(qvac-registry-schema): v0.2.0

### DIFF
--- a/packages/qvac-lib-registry-server/shared/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/shared/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.2.0
+
+### Features
+
+- Add `findBy()` method to `RegistryDatabase` for unified model querying with optional filters (`name`, `engine`, `quantization`, `includeDeprecated`)
+- Add `findModelsByEngineQuantization()` method for compound index queries
+- Add `models-by-engine-quantization` compound HyperDB index for efficient multi-field lookups
+
+### Notes
+
+- The `findBy()` method intelligently routes to the most efficient HyperDB index based on the provided parameters
+- Compound index follows B-tree leftmost prefix matching: queries by `engine` alone or `engine + quantization` use the index natively; other combinations use in-memory filtering
+- Existing `findModels*` methods remain unchanged
+
+## 0.1.0
+
+- Initial release

--- a/packages/qvac-lib-registry-server/shared/package.json
+++ b/packages/qvac-lib-registry-server/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/qvac-registry-schema",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "HyperDB schema and database wrapper for QVAC Registry",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

- Bump `@tetherto/qvac-registry-schema` version from `0.1.0` to `0.2.0`
- Add `CHANGELOG.md` for the schema package

## Changes included in v0.2.0

These features were already merged into `main` via PR #145:

- **`findBy()` method** on `RegistryDatabase` — unified model querying with optional filters (`name`, `engine`, `quantization`, `includeDeprecated`)
- **`findModelsByEngineQuantization()` method** — direct compound index access
- **`models-by-engine-quantization` compound HyperDB index** — efficient multi-field lookups using B-tree leftmost prefix matching
- **Unit tests** for `RegistryDatabase.findBy()` (10 tests, 28 assertions)

## Release checklist

- [x] Version bump in `packages/qvac-lib-registry-server/shared/package.json`
- [x] Changelog update in `packages/qvac-lib-registry-server/shared/CHANGELOG.md`


Made with [Cursor](https://cursor.com)