### PR TITLE
QVAC-10950: Addon cancel based on futures (infer-base)

### DIFF
--- a/packages/qvac-lib-infer-base/CHANGELOG
+++ b/packages/qvac-lib-infer-base/CHANGELOG
@@ -1,3 +1,5 @@
+# 0.3.0
+- To be compatible with new addon-cpp architecture, use async keywords for `addon.cancel` and response cancel handler, as the updated addon-cpp now returns a JS future for cancelling.
 # 0.0.1
 - feat: initial structure
 - feat: consolidate QvacResponse from @qvac/response into infer-base

--- a/packages/qvac-lib-infer-base/WeightsProvider/BaseInference.js
+++ b/packages/qvac-lib-infer-base/WeightsProvider/BaseInference.js
@@ -275,8 +275,8 @@ class BaseInference {
       throw new QvacInferenceBaseError({ code: ERR_CODES.ADDON_NOT_INITIALIZED })
     }
     const response = new QvacResponse({
-      cancelHandler: () => {
-        return this.addon.cancel(jobId)
+      cancelHandler: async () => {
+        await this.addon.cancel()
       },
       pauseHandler: () => {
         return this.addon.pause()

--- a/packages/qvac-lib-infer-base/package.json
+++ b/packages/qvac-lib-infer-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/infer-base",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Base class for inference clients",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Cancel was only faking to be an async method because the binding cancel was not returning a future (`await` on the cancel method was waiting for operations to finish because we were directly returning the future, however adding `async` communicates the intent better and matches `README.md` see [discussion](https://github.com/tetherto/qvac/pull/165#discussion_r2811991356)).

## 📝 How does it solve it?

With addon-cpp changes https://github.com/tetherto/qvac/pull/168 now cancel implementations (e.g. LLM https://github.com/tetherto/qvac/pull/172 or Embed https://github.com/tetherto/qvac/pull/182) can await for the binding cancel, providing correct async semantics.

##  Note
Even if `binding.cancel` was returning a `nullptr` o `bool` instead of a future. The `await` keyword will work on it. When you await something that isn't a Promise (like null, undefined, a number, or a string), JavaScript automatically wraps that value in a resolved Promise.

## 🧪 How was it tested?
- CI from LLM https://github.com/tetherto/qvac/pull/172 or Embed https://github.com/tetherto/qvac/pull/182

