### PR TITLE
QVAC-10950: Addon cancel based on futures (addon-cpp)

### DIFF
--- a/packages/qvac-lib-inference-addon-cpp/CMakeLists.txt
+++ b/packages/qvac-lib-inference-addon-cpp/CMakeLists.txt
@@ -6,7 +6,7 @@ if(BUILD_TESTING)
 endif()
 
 project(qvac-lib-inference-addon-cpp
-  VERSION 1.0.0
+  VERSION 1.1.1
   LANGUAGES CXX)
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)
@@ -75,6 +75,8 @@ if(BUILD_TESTING)
         tests/cpp_output_handler_test.cpp
         tests/simple_addon_test.cpp
         tests/batched_addon_test.cpp
+        tests/job_runner_test.cpp
+        tests/addon_js_test.cpp
     )
     target_include_directories(unit_tests PRIVATE src tests/helpers_header)
     target_link_libraries(unit_tests PRIVATE GTest::gmock_main)

--- a/packages/qvac-lib-inference-addon-cpp/README.md
+++ b/packages/qvac-lib-inference-addon-cpp/README.md
@@ -168,8 +168,8 @@ addon.activate(handle)
 // Run a job
 addon.runJob(handle, { type: 'text', input: 'Hello world' })
 
-// Cancel current job
-addon.cancelJob(handle)
+// Cancel current job (returns a Promise)
+await addon.cancelJob(handle)
 
 // Cleanup
 addon.destroyInstance(handle)
@@ -261,8 +261,8 @@ Apps may suspend during processing:
 - **Workaround:** Cancel pending jobs on `suspend` event
 
 ```javascript
-process.on('suspend', () => {
-  addon.cancelJob(handle)
+process.on('suspend', async () => {
+  await addon.cancelJob(handle)
 })
 ```
 

--- a/packages/qvac-lib-inference-addon-cpp/docs/architecture.md
+++ b/packages/qvac-lib-inference-addon-cpp/docs/architecture.md
@@ -215,23 +215,22 @@ classDiagram
     class AddonCpp {
         +AddonCpp(outputCallback, model)
         +activate() void
-        +runJob(std::any input) void
+        +runJob(std::any input) bool
         +cancelJob() void
         +model IModel&
     }
     
     class AddonJs {
-        +AddonJs(env, jsHandle, outputCb, addonCpp)
-        +loadWeights(env, chunk) void
-        +activate(env) void
-        +runJob(env, input) void
-        +cancelJob(env) void
+        +AddonJs(env, outputCallback, model)
+        +loadWeights(env, weightsData) void
+        +runJob(input) js_value_t*
+        +cancelJob() js_value_t*
     }
     
     class JobRunner {
         +JobRunner(outputQueue, model, modelCancel)
         +start() void
-        +runJob(std::any input) void
+        +runJob(std::any input) bool
         +cancel() void
     }
     

--- a/packages/qvac-lib-inference-addon-cpp/docs/usage.md
+++ b/packages/qvac-lib-inference-addon-cpp/docs/usage.md
@@ -111,8 +111,7 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) {
   std::string text = inputObj.getPropertyAs<js::String, std::string>(env, "input");
   
   // Run the job with input wrapped in std::any
-  instance.addonCpp->runJob(std::any(std::move(text)));
-  return nullptr;
+  return instance.runJob(std::any(std::move(text)));
 }
 ```
 ### Exporting JavaScript Bindings

--- a/packages/qvac-lib-inference-addon-cpp/docs/usage.md
+++ b/packages/qvac-lib-inference-addon-cpp/docs/usage.md
@@ -67,7 +67,6 @@ namespace my_addon {
         env,
         args.get(0, "jsHandle"),
         args.getFunction(2, "outputCallback"),
-        args.get(3, "transitionCb"),
         std::move(outHandlers)
     );
     

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/InitLoader.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/InitLoader.hpp
@@ -23,14 +23,14 @@
 /// obtain `this.addon = this._createAddon(configurationParams)` prior to
 /// triggering any download or streaming. The actual model init method can be
 /// triggered by calling `waitForLoadInitialization` at `addon.activate()` or
-/// `ensureLoadInBackground` at `addon.loadWeights(...)` /
-/// `set_weights_for_file(...)` for models that support incremental file loading
+/// `ensureLoadInBackground` at `addon.loadWeights(...)` or
+/// `setWeightsForFile(...)` for models that support incremental file loading
 /// (sharded).
 class InitLoader {
 public:
   enum LOADER_TYPE : short { DELAYED, BACKGROUND, IMMEDIATE };
 
-  // @brief wait for init() to complete when delayed load has been used.
+  /// @brief wait for init() to complete when delayed load has been used.
   void waitForLoadInitialization() {
     if (loadType_ == LOADER_TYPE::DELAYED) {
       triggerInit();
@@ -111,7 +111,7 @@ public:
   void ensureLoadInBackground() {
     checkForErrors();
     if (loadType_ == LOADER_TYPE::IMMEDIATE) {
-      // Already loaded at init call. Nothing to left to do.
+      // Already loaded at init call. Nothing left to do.
       return;
     }
     if (loadType_ == LOADER_TYPE::DELAYED) {

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
@@ -114,7 +114,8 @@ public:
     processingThread_ = std::thread([this]() { this->process(); });
 
     // Make sure to wait until the thread is ready for a new job.
-    // Otherwise, the thread might ignore setJobInput notifications.
+    // Otherwise, the thread might ignore and lose new jobs quickly scheduled
+    // after construction, when its not ready for processing yet.
     std::unique_lock lock(mtx_);
     processCv_.wait(lock, [this]() { return ready_.load(); });
   }

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
@@ -44,8 +44,8 @@ private:
 
 class JobRunner {
   std::shared_ptr<OutputQueue> outputQueue_;
-  model::IModel *const model_;
-  model::IModelCancel *const modelCancel_;
+  model::IModel* const model_;
+  model::IModelCancel* const modelCancel_;
   mutable std::timed_mutex mtx_;
   mutable std::condition_variable_any processCv_;
   std::optional<std::any> job_;
@@ -54,7 +54,7 @@ class JobRunner {
   mutable std::atomic_bool ready_ = false;
   mutable ProcessingSync processingSync_;
 
-  void finalizeJob(std::unique_lock<std::timed_mutex> &lock) {
+  void finalizeJob(std::unique_lock<std::timed_mutex>& lock) {
     processingSync_.setActive(false);
     if (!lock.owns_lock()) {
       lock.lock();
@@ -91,7 +91,7 @@ class JobRunner {
 
         outputQueue_->queueResult(std::move(output));
         outputQueue_->queueJobEnded();
-      } catch (const std::exception &e) {
+      } catch (const std::exception& e) {
         finalizeJob(lock);
         outputQueue_->queueException(e);
       } catch (...) {
@@ -103,9 +103,9 @@ class JobRunner {
   }
 
 public:
-  explicit JobRunner(std::shared_ptr<OutputQueue> outputQueue,
-                     model::IModel *model,
-                     model::IModelCancel *modelCancel = nullptr)
+  explicit JobRunner(
+      std::shared_ptr<OutputQueue> outputQueue, model::IModel* model,
+      model::IModelCancel* modelCancel = nullptr)
       : outputQueue_(std::move(outputQueue)), model_(model),
         modelCancel_(modelCancel) {}
 
@@ -133,17 +133,20 @@ public:
     }
   }
 
-  void runJob(std::any input) {
+  bool runJob(std::any input) {
     std::unique_lock lock(mtx_, std::defer_lock);
     if (!lock.try_lock_for(std::chrono::milliseconds{100}) ||
         job_.has_value()) {
-      outputQueue_->queueException(std::runtime_error(
-          "Cannot set new job: a job is already set or being processed"));
-      return;
+      // Do not queue exception, there could be another job already
+      // running and we want to keep the messages on queue matching
+      // the valid jobs.
+      // Return a boolean instead.
+      return false;
     }
     job_ = std::move(input);
     lock.unlock();
     processCv_.notify_one();
+    return true;
   }
 
   void cancel() {

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
@@ -15,66 +15,97 @@
 
 namespace qvac_lib_inference_addon_cpp {
 
+/**
+ * @brief Tracks active processing state for synchronization.
+ *
+ * Used to synchronize cancel() with process() - cancel waits for processing
+ * to complete before returning, ensuring job_ is not reset while in use.
+ */
+class ProcessingSync {
+public:
+  void waitInactive() const {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, [this] { return !active_; });
+  }
+
+  void setActive(bool active) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      active_ = active;
+    }
+    cv_.notify_all();
+  }
+
+private:
+  bool active_{false};
+  mutable std::mutex mutex_;
+  mutable std::condition_variable cv_;
+};
+
 class JobRunner {
   std::shared_ptr<OutputQueue> outputQueue_;
-  model::IModel* const model_;
-  model::IModelCancel* const modelCancel_;
+  model::IModel *const model_;
+  model::IModelCancel *const modelCancel_;
   mutable std::timed_mutex mtx_;
   mutable std::condition_variable_any processCv_;
   std::optional<std::any> job_;
   mutable std::thread processingThread_;
   mutable std::atomic_bool running_ = false;
   mutable std::atomic_bool ready_ = false;
+  mutable ProcessingSync processingSync_;
+
+  void finalizeJob(std::unique_lock<std::timed_mutex> &lock) {
+    processingSync_.setActive(false);
+    if (!lock.owns_lock()) {
+      lock.lock();
+    }
+    job_.reset();
+  }
 
   void process() {
     while (running_) {
+      std::unique_lock lock(mtx_);
+
       try {
-        std::any* job = nullptr;
-        {
-          std::unique_lock lock(mtx_);
+        // Signal that thread is ready for a new job
+        ready_ = true;
+        processCv_.notify_all();
+        processCv_.wait(lock, [this] { return !running_ || job_.has_value(); });
 
-          // Signal that thread is ready for a new job
-          ready_ = true;
-          processCv_.notify_all();
-          processCv_.wait(lock);
-
-          if (!job_.has_value()) {
-            continue;
-          }
-
-          // Not ready for a new job. Has a job in progress now.
-          ready_ = false;
-          job = &job_.value();
+        if (!running_ || !job_.has_value()) {
+          continue;
         }
 
-        std::any output = model_->process(*job);
+        // Acquire processing while holding the main `lock` for atomicity.
+        ready_ = false;
+        processingSync_.setActive(true);
 
-        {
-          std::scoped_lock lock(mtx_);
-          // Make sure to reset job before queue result. Client might
-          // be waiting to queue a new job as soon as current is ended.
-          job_.reset();
-          outputQueue_->queueResult(std::move(output));
-          outputQueue_->queueJobEnded();
-        }
-      } catch (const std::exception& e) {
-        std::scoped_lock lock(mtx_);
-        job_.reset();
+        // Unlock main lock to ensure cancel() can acquire without blocking
+        lock.unlock();
+
+        std::any output = model_->process(job_.value());
+
+        // Make sure to reset job before queue result. Client might
+        // be waiting to queue a new job as soon as current is ended.
+        finalizeJob(lock);
+
+        outputQueue_->queueResult(std::move(output));
+        outputQueue_->queueJobEnded();
+      } catch (const std::exception &e) {
+        finalizeJob(lock);
         outputQueue_->queueException(e);
       } catch (...) {
-        std::scoped_lock lock(mtx_);
-        QLOG(
-            logger::Priority::DEBUG,
-            "process: Unknown exception in processing loop");
-        job_.reset();
+        finalizeJob(lock);
+        outputQueue_->queueException(
+            std::runtime_error("Unknown exception in processing loop"));
       }
     }
   }
 
 public:
-  explicit JobRunner(
-      std::shared_ptr<OutputQueue> outputQueue, model::IModel* model,
-      model::IModelCancel* modelCancel = nullptr)
+  explicit JobRunner(std::shared_ptr<OutputQueue> outputQueue,
+                     model::IModel *model,
+                     model::IModelCancel *modelCancel = nullptr)
       : outputQueue_(std::move(outputQueue)), model_(model),
         modelCancel_(modelCancel) {}
 
@@ -91,7 +122,10 @@ public:
   ~JobRunner() {
     if (running_) {
       QLOG(logger::Priority::DEBUG, "Stopping job");
-      running_ = false;
+      {
+        std::lock_guard lock(mtx_);
+        running_ = false;
+      }
       processCv_.notify_one();
       if (processingThread_.joinable()) {
         processingThread_.join();
@@ -103,9 +137,8 @@ public:
     std::unique_lock lock(mtx_, std::defer_lock);
     if (!lock.try_lock_for(std::chrono::milliseconds{100}) ||
         job_.has_value()) {
-      outputQueue_->queueException(
-          std::runtime_error(
-              "Cannot set new job: a job is already set or being processed"));
+      outputQueue_->queueException(std::runtime_error(
+          "Cannot set new job: a job is already set or being processed"));
       return;
     }
     job_ = std::move(input);
@@ -117,9 +150,11 @@ public:
     std::scoped_lock lock{mtx_};
     if (modelCancel_ == nullptr) {
       QLOG(logger::Priority::WARNING, "Model does not support cancellation");
+      return;
     }
-    if (job_.has_value() && modelCancel_ != nullptr) {
+    if (job_.has_value()) {
       modelCancel_->cancel();
+      processingSync_.waitInactive();
       job_.reset();
     }
   }

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
@@ -156,6 +156,11 @@ public:
       modelCancel_->cancel();
       processingSync_.waitInactive();
       job_.reset();
+      if (ready_.load()) {
+        // If the worker has not taken the job yet (ready_ == true, still in
+        // wait), it will never run queueJobEnded. Signal finished now.
+        outputQueue_->queueException(std::runtime_error("Job cancelled"));
+      }
     }
   }
 };

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsInterface.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsInterface.hpp
@@ -217,8 +217,8 @@ public:
   ///   throw StatusError(general_error::InvalidArgument, "Invalid type");
   /// }
   /// instance.runJob(std::move(anyInput));
-  static auto getInput(JsArgsParser &argsParser)
-      -> std::pair<std::string, js_value_t *> {
+  static auto getInput(JsArgsParser& argsParser)
+      -> std::pair<std::string, js_value_t*> {
     auto inputObj = argsParser.getJsObject(1, "inputObj");
     auto type = argsParser.getMapEntry(1, "type");
     auto input = inputObj.getProperty(argsParser.env_, "input");

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsInterface.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsInterface.hpp
@@ -277,8 +277,7 @@ public:
       -> js_value_t* try {
     JsArgsParser argsParser(env, info);
     auto& instance = getInstance(env, argsParser.get(0, "instance"));
-    instance.addonCpp->cancelJob();
-    return nullptr;
+    return instance.cancelJob();
   }
   JSCATCH
 };

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsInterface.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsInterface.hpp
@@ -121,8 +121,8 @@ public:
 
   /// @brief Try to obtain optional number argument
   /// @param argIndex The index of the argument to get
-  /// @return std::optional<int> containing the number if the argument exists
-  /// and is a number, nullopt otherwise
+  /// @return std::optional<CppNumberType> containing the number if the argument
+  /// exists and is a number, nullopt otherwise
   template <typename CppNumberType>
   std::optional<CppNumberType> getIntegralOptional(int argIndex) {
     static_assert(
@@ -204,7 +204,8 @@ public:
 
   /// @brief Can be used to get the input and type
   /// @example
-  /// auto [type, jsInput] = getInput<js::String>(argsParser);
+  /// auto& instance = getInstance(env, argsParser.get(0, "instance"));
+  /// auto [type, jsInput] = getInput(argsParser);
   ////
   /// std::any anyInput;
   /// if(type == "text") {
@@ -215,9 +216,9 @@ public:
   /// if(!anyInput.has_value()) {
   ///   throw StatusError(general_error::InvalidArgument, "Invalid type");
   /// }
-  /// instance.addonCpp->setJobInput(std::move(anyInput));
-  static auto getInput(JsArgsParser& argsParser)
-      -> std::pair<std::string, js_value_t*> {
+  /// instance.runJob(std::move(anyInput));
+  static auto getInput(JsArgsParser &argsParser)
+      -> std::pair<std::string, js_value_t *> {
     auto inputObj = argsParser.getJsObject(1, "inputObj");
     auto type = argsParser.getMapEntry(1, "type");
     auto input = inputObj.getProperty(argsParser.env_, "input");
@@ -228,10 +229,11 @@ public:
   /// @example
   /// auto inputs = getInputsArray(argsParser);
   ///
-  /// for (auto& [type, jsInput] : inputs) {
+  /// for (auto& [type, inputObj] : inputs) {
   ///   std::any anyInput;
   ///   if(type == "text") {
-  ///     anyInput = js::String(env, jsInput).as<std::string>(env);
+  ///     anyInput = inputObj.getProperty<js::String>(env,
+  ///     "input").as<std::string>(env);
   ///   }
   ///   // ... other types
   /// }

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsUtils.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsUtils.hpp
@@ -826,8 +826,8 @@ class JsAsyncTask {
       } catch (const std::exception& e) {
         rejectWithError(data->env, data->deferred, e.what());
       } catch (...) {
-        const char* unkownMsg = "Unknown error at JsAsyncTask";
-        rejectWithError(data->env, data->deferred, unkownMsg);
+        const char* unknownMsg = "Unknown error at JsAsyncTask";
+        rejectWithError(data->env, data->deferred, unknownMsg);
       }
     } else {
       // Resolve promise with undefined

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsUtils.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsUtils.hpp
@@ -2,10 +2,15 @@
 
 #include <cstdint>
 #include <cstring>
+#include <exception>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <span>
 #include <stdexcept>
+#include <string>
+#include <thread>
 #include <type_traits>
 #include <vector>
 
@@ -13,7 +18,6 @@
 
 #ifndef NDEBUG
 #include <cassert>
-#include <thread>
 #endif
 
 #include "Errors.hpp"
@@ -778,5 +782,103 @@ std::vector<CppType> toVector(js_env_t* env, Array array) {
   }
   return result;
 }
+
+/// @brief Utility for executing blocking C++ operations asynchronously and
+/// returning a JavaScript Promise/Future
+/// @details Handles thread spawning, promise creation, and result delivery
+/// back to the JavaScript event loop via uv_async.
+///
+/// @example
+/// return js::JsAsyncTask::run(env, []() {
+///   // Blocking operation here
+///   heavyComputation();
+/// });
+class JsAsyncTask {
+  struct CallbackData {
+    js_env_t* env;
+    js_deferred_t* deferred;
+    uv_async_t* async_handle;
+    std::exception_ptr error;
+
+    CallbackData(js_env_t* e, js_deferred_t* d, uv_async_t* h)
+        : env(e), deferred(d), async_handle(h), error(nullptr) {}
+  };
+
+  static void
+  rejectWithError(js_env_t* env, js_deferred_t* deferred, const char* msg) {
+    js_value_t* error_msg;
+    JS(js_create_string_utf8(env, (const utf8_t*)msg, strlen(msg), &error_msg));
+    js_value_t* error;
+    JS(js_create_error(env, nullptr, error_msg, &error));
+    JS(js_reject_deferred(env, deferred, error));
+  }
+
+  static void onComplete(uv_async_t* handle) {
+    std::unique_ptr<CallbackData> data(
+        static_cast<CallbackData*>(handle->data));
+
+    js_handle_scope_t* scope;
+    JS(js_open_handle_scope(data->env, &scope));
+
+    if (data->error) {
+      try {
+        std::rethrow_exception(data->error);
+      } catch (const std::exception& e) {
+        rejectWithError(data->env, data->deferred, e.what());
+      } catch (...) {
+        const char* unkownMsg = "Unknown error at JsAsyncTask";
+        rejectWithError(data->env, data->deferred, unkownMsg);
+      }
+    } else {
+      // Resolve promise with undefined
+      js_value_t* undefined;
+      JS(js_get_undefined(data->env, &undefined));
+      JS(js_resolve_deferred(data->env, data->deferred, undefined));
+    }
+
+    js_close_handle_scope(data->env, scope);
+
+    uv_close(reinterpret_cast<uv_handle_t*>(handle), [](uv_handle_t* h) {
+      delete reinterpret_cast<uv_async_t*>(h);
+    });
+  }
+
+public:
+  /// @brief Execute blocking work asynchronously and return a promise
+  /// @param env JavaScript environment
+  /// @param work Blocking operation to execute on a background thread
+  /// @return JavaScript Promise that resolves when work completes
+  static js_value_t* run(js_env_t* env, std::function<void()> work) {
+    // Create promise
+    js_deferred_t* deferred;
+    js_value_t* promise;
+    JS(js_create_promise(env, &deferred, &promise));
+
+    // Set up async handle
+    uv_loop_t* loop;
+    JS(js_get_env_loop(env, &loop));
+    auto* async_handle = new uv_async_t{};
+    if (uv_async_init(loop, async_handle, &JsAsyncTask::onComplete) != 0) {
+      delete async_handle;
+      throw qvac_errors::StatusError(
+          qvac_errors::general_error::InternalError,
+          "Failed to initialize async handle for JsAsyncTask");
+    }
+
+    auto* data = new CallbackData(env, deferred, async_handle);
+    async_handle->data = data;
+
+    std::thread([data, work = std::move(work)]() {
+      try {
+        work();
+      } catch (...) {
+        data->error = std::current_exception();
+      }
+      uv_async_send(data->async_handle);
+    }).detach();
+
+    return promise;
+  }
+};
 
 } // namespace qvac_lib_inference_addon_cpp::js

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/LlamacppUtils.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/LlamacppUtils.hpp
@@ -50,7 +50,7 @@ initFromShards(const GGUFShards& shards, common_params& params) {
 }
 
 /// @brief Initializes a model from a single gguf stream stored in memory
-/// @note For performance reasons `initFromShards` should be preferabily used
+/// @note For performance reasons `initFromShards` should be preferably used
 /// with streams. However, this function is still offered to unify the Js
 /// interface of the addon and separate concerns.
 inline common_init_result initFromMemory(
@@ -68,7 +68,7 @@ inline common_init_result initFromMemory(
   // sharded models should be used instead.
   std::vector<uint8_t> contiguousData;
   {
-    // Scope streambuf so that its destructed after reading, and JS garbage
+    // Scope streambuf so that it is destroyed after reading, and JS garbage
     // collection triggered.
     std::unique_ptr<std::basic_streambuf<char>> scopedStreambuf =
         std::move(streambuf);
@@ -94,7 +94,7 @@ inline common_init_result initFromMemory(
 /// @param shards Containing sharded files, if any
 /// @param loading_context What context to use when asynchronously loading
 /// shards
-/// @param isStreaming Should be set to true when `set_weights_for_file` is
+/// @param isStreaming Should be set to true when `setWeightsForFile` is
 /// being used to populate `singleGgufStreamedFiles` or call
 /// `llama_model_load_fulfill_split_future`
 inline common_init_result initFromConfig(
@@ -106,10 +106,10 @@ inline common_init_result initFromConfig(
   common_init_result llamaInit;
   // Stream should have been awaited by the time activate is called from JS
   // and init is triggered. isStreaming should be (thread) safe to use at this
-  // point because `set_weights_for_file` has already finished.
+  // point because `setWeightsForFile` has already finished.
   if (isStreaming) {
     if (shards.gguf_files.empty()) {
-      // Not optimal. Shards prefered when streaming.
+      // Not optimal. Shards preferred when streaming.
       LOG_INF(
           "%s: load the model gguf from stream and apply lora adapter, if "
           "any.\n",

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/addon/AddonCpp.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/addon/AddonCpp.hpp
@@ -56,7 +56,9 @@ public:
   }
 
   ~AddonCpp() { outputCallback_->stop(); }
-  void runJob(std::any input) { jobRunner_.runJob(std::move(input)); }
+
+  /// @returns False if the job cannot be run (e.g. because a job is already set or being processed)
+  bool runJob(std::any input) { return jobRunner_.runJob(std::move(input)); }
   void cancelJob() { jobRunner_.cancel(); }
 
   const std::reference_wrapper<model::IModel> model;

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/addon/AddonJs.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/addon/AddonJs.hpp
@@ -39,7 +39,6 @@ public:
 
   /**
    * @brief Cancels the currently running job asynchronously
-   * @param env JavaScript environment handle
    * @return JavaScript Promise that resolves when cancellation completes
    * @note This is a non-blocking operation that returns a future/promise
    */

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/addon/AddonJs.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/addon/AddonJs.hpp
@@ -19,16 +19,27 @@ class AddonJs {
   js::ThreadQueuedRefDeleter weights_deleter_ = {};
 
 public:
-  const std::unique_ptr<AddonCpp> addonCpp;
+  const std::shared_ptr<AddonCpp> addonCpp;
 
   AddonJs(
       js_env_t* env, std::unique_ptr<OutputCallBackInterface>&& outputCallback,
       std::unique_ptr<model::IModel>&& model)
       : env_(env), addonCpp(
-                       std::make_unique<AddonCpp>(
+                       std::make_shared<AddonCpp>(
                            std::move(outputCallback), std::move(model))) {}
 
   ~AddonJs() = default;
+
+  /**
+   * @brief Cancels the currently running job asynchronously
+   * @param env JavaScript environment handle
+   * @return JavaScript Promise that resolves when cancellation completes
+   * @note This is a non-blocking operation that returns a future/promise
+   */
+  js_value_t* cancelJob() {
+    return js::JsAsyncTask::run(
+        env_, [addonCppRef = addonCpp]() { addonCppRef->cancelJob(); });
+  }
 
   /**
    * @brief Loads model weights from JavaScript blob data

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/addon/AddonJs.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/addon/AddonJs.hpp
@@ -30,6 +30,13 @@ public:
 
   ~AddonJs() = default;
 
+  /// @returns JavaScript Boolean that indicates if the job was run
+  /// successfully. Can be false because a job is already set or being
+  /// processed.
+  js_value_t* runJob(std::any input) {
+    return js::Boolean::create(env_, addonCpp->runJob(std::move(input)));
+  }
+
   /**
    * @brief Cancels the currently running job asynchronously
    * @param env JavaScript environment handle

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputCallbackInterface.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputCallbackInterface.hpp
@@ -19,8 +19,8 @@ struct OutputCallBackInterface {
   /// @brief Notify the callback that a new output is available.
   virtual void notify() = 0;
 
-  /// @brief Stop the processing thread and wait for it to finish.
-  /// This should be called before destruction to ensure clean shutdown.
+  /// @brief Stop the callback; no further outputs will be processed.
+  /// Call before destruction for clean shutdown.
   virtual void stop() = 0;
 };
 } // namespace qvac_lib_inference_addon_cpp

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp
@@ -14,26 +14,23 @@ namespace qvac_lib_inference_addon_cpp {
 class OutputCallBackJs : public OutputCallBackInterface {
 
   std::mutex mtx_;
-  js_env_t* env_;
-  js_ref_t* jsHandle_;
-  js_ref_t* outputCb_;
-  js_value_t* transitionCb_;
-  js_threadsafe_function_t* threadsafeOutputCb_;
+  js_env_t *env_;
+  js_ref_t *jsHandle_;
+  js_ref_t *outputCb_;
+  js_threadsafe_function_t *threadsafeOutputCb_;
   std::shared_ptr<OutputQueue> outputQueue_ = nullptr;
   out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface>
       outputHandlers_;
   bool stopped_{false};
 
 public:
-  uv_async_t* jsOutputCallbackAsyncHandle_;
+  uv_async_t *jsOutputCallbackAsyncHandle_;
 
   OutputCallBackJs(
-      js_env_t* env, js_value_t* jsHandle, js_value_t* outputCb,
-      js_value_t* transitionCb,
-      out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface>&&
-          outputHandlers)
-      : env_(env), transitionCb_(transitionCb),
-        outputHandlers_(std::move(outputHandlers)) {
+      js_env_t *env, js_value_t *jsHandle, js_value_t *outputCb,
+      out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface>
+          &&outputHandlers)
+      : env_(env), outputHandlers_(std::move(outputHandlers)) {
     JS(js_create_reference(env_, jsHandle, 1, &jsHandle_));
     auto e1 = utils::onError([this, env = env_, jsHandle = jsHandle_]() {
       js_delete_reference(env, jsHandle);
@@ -51,9 +48,8 @@ public:
   ~OutputCallBackJs() {
     stop();
     // Important: uv_close might not be called outside the loop thread
-    uv_close(
-        reinterpret_cast<uv_handle_t*>(jsOutputCallbackAsyncHandle_),
-        [](uv_handle_t* handle) { delete handle; });
+    uv_close(reinterpret_cast<uv_handle_t *>(jsOutputCallbackAsyncHandle_),
+             [](uv_handle_t *handle) { delete handle; });
     if (js_delete_reference(env_, jsHandle_) != 0)
       QLOG(logger::Priority::WARNING, "Could not delete jsHandle reference");
     if (js_delete_reference(env_, outputCb_) != 0)
@@ -63,25 +59,23 @@ public:
   void
   initializeProcessingThread(std::shared_ptr<OutputQueue> outputQueue) final {
     this->outputQueue_ = outputQueue;
-    uv_loop_t* jsLoop;
+    uv_loop_t *jsLoop;
     JS(js_get_env_loop(env_, &jsLoop));
     jsOutputCallbackAsyncHandle_ = new uv_async_t{};
     if (uv_async_init(jsLoop, jsOutputCallbackAsyncHandle_, jsOutputCallback) !=
         0) {
       delete jsOutputCallbackAsyncHandle_;
-      throw qvac_errors::StatusError(
-          qvac_errors::general_error::InternalError,
-          "Could not initialize uv async handle");
+      throw qvac_errors::StatusError(qvac_errors::general_error::InternalError,
+                                     "Could not initialize uv async handle");
     }
     // jsOutputCallbackAsyncHandle_ has been correctly initialized, so if thread
     // fails it needs to be closed
     auto e3 = utils::onError([this]() {
-      uv_close(
-          reinterpret_cast<uv_handle_t*>(jsOutputCallbackAsyncHandle_),
-          [](uv_handle_t* handle) { delete handle; });
+      uv_close(reinterpret_cast<uv_handle_t *>(jsOutputCallbackAsyncHandle_),
+               [](uv_handle_t *handle) { delete handle; });
     });
     uv_handle_set_data(
-        reinterpret_cast<uv_handle_t*>(jsOutputCallbackAsyncHandle_), this);
+        reinterpret_cast<uv_handle_t *>(jsOutputCallbackAsyncHandle_), this);
   }
 
   void notify() final { uv_async_send(jsOutputCallbackAsyncHandle_); }
@@ -93,16 +87,16 @@ private:
    * @brief Creates JavaScript parameters for output events using handlers
    * @returns Pair of JavaScript values for output data and error
    */
-  std::pair<js_value_t*, js_value_t*>
-  createEventParams(const std::any& output) {
+  std::pair<js_value_t *, js_value_t *>
+  createEventParams(const std::any &output) {
     if (!output.has_value()) {
       // e.g. JobStarted events don't have data
       return {js::Undefined::create(env_), js::Undefined::create(env_)};
     }
 
-    out_handl::JsOutputHandlerInterface& handler = outputHandlers_.get(output);
+    out_handl::JsOutputHandlerInterface &handler = outputHandlers_.get(output);
     handler.setEnv(env_);
-    js_value_t* handlerResult = handler.handleOutput(output);
+    js_value_t *handlerResult = handler.handleOutput(output);
 
     // For Error events, put handler result in error parameter (second)
     // For other events, put handler result in output parameter (first)
@@ -120,9 +114,8 @@ private:
    *   outputCbParameters[2] = Output data
    *   outputCbParameters[3] = Error data
    */
-  void createOutputCbParams(
-      js_value_t* jsHandle, const std::any& output,
-      js_value_t** outputCbParameters) {
+  void createOutputCbParams(js_value_t *jsHandle, const std::any &output,
+                            js_value_t **outputCbParameters) {
     outputCbParameters[0] = jsHandle;
     outputCbParameters[1] = js::String::create(env_, output.type().name());
 
@@ -135,20 +128,20 @@ private:
    * process output queue
    * @param handle UV async handle containing addon instance data
    */
-  static void jsOutputCallback(uv_async_t* handle) try {
-    auto& outputCallBackJs = *reinterpret_cast<OutputCallBackJs*>(
-        uv_handle_get_data(reinterpret_cast<uv_handle_t*>(handle)));
-    js_handle_scope_t* scope;
+  static void jsOutputCallback(uv_async_t *handle) try {
+    auto &outputCallBackJs = *reinterpret_cast<OutputCallBackJs *>(
+        uv_handle_get_data(reinterpret_cast<uv_handle_t *>(handle)));
+    js_handle_scope_t *scope;
     JS(js_open_handle_scope(outputCallBackJs.env_, &scope));
     auto scopeCleanup = utils::onExit([env = outputCallBackJs.env_, scope]() {
       js_close_handle_scope(env, scope);
     });
-    js_value_t* outputCb;
-    JS(js_get_reference_value(
-        outputCallBackJs.env_, outputCallBackJs.outputCb_, &outputCb));
-    js_value_t* jsHandle;
-    JS(js_get_reference_value(
-        outputCallBackJs.env_, outputCallBackJs.jsHandle_, &jsHandle));
+    js_value_t *outputCb;
+    JS(js_get_reference_value(outputCallBackJs.env_, outputCallBackJs.outputCb_,
+                              &outputCb));
+    js_value_t *jsHandle;
+    JS(js_get_reference_value(outputCallBackJs.env_, outputCallBackJs.jsHandle_,
+                              &jsHandle));
     std::vector<std::any> outputQueue;
     {
       std::scoped_lock lk{outputCallBackJs.mtx_};
@@ -156,30 +149,26 @@ private:
     }
     for (size_t i = 0; !outputCallBackJs.stopped_ && i < outputQueue.size();
          i++) {
-      js_handle_scope_t* innerScope;
+      js_handle_scope_t *innerScope;
       JS(js_open_handle_scope(outputCallBackJs.env_, &innerScope));
       auto scopeCleanup =
           utils::onExit([env = outputCallBackJs.env_, innerScope]() {
             js_close_handle_scope(env, innerScope);
           });
       static constexpr auto outputCbParametersCount = 4;
-      js_value_t* outputCbParameters[outputCbParametersCount];
-      outputCallBackJs.createOutputCbParams(
-          jsHandle, outputQueue[i], outputCbParameters);
-      js_value_t* receiver;
+      js_value_t *outputCbParameters[outputCbParametersCount];
+      outputCallBackJs.createOutputCbParams(jsHandle, outputQueue[i],
+                                            outputCbParameters);
+      js_value_t *receiver;
       JS(js_get_global(outputCallBackJs.env_, &receiver));
-      JS(js_call_function(
-          outputCallBackJs.env_,
-          receiver,
-          outputCb,
-          utils::arrayCount(outputCbParameters),
-          outputCbParameters,
-          nullptr));
+      JS(js_call_function(outputCallBackJs.env_, receiver, outputCb,
+                          utils::arrayCount(outputCbParameters),
+                          outputCbParameters, nullptr));
     }
   } catch (...) {
-    auto& outputCallBackJs = *reinterpret_cast<OutputCallBackJs*>(
-        uv_handle_get_data(reinterpret_cast<uv_handle_t*>(handle)));
-    js_handle_scope_t* scope;
+    auto &outputCallBackJs = *reinterpret_cast<OutputCallBackJs *>(
+        uv_handle_get_data(reinterpret_cast<uv_handle_t *>(handle)));
+    js_handle_scope_t *scope;
     if (js_open_handle_scope(outputCallBackJs.env_, &scope) != 0)
       return;
     auto scopeCleanup = utils::onExit([env = outputCallBackJs.env_, scope]() {
@@ -190,7 +179,7 @@ private:
         0)
       return;
     if (isExceptionPending) {
-      js_value_t* error;
+      js_value_t *error;
       js_get_and_clear_last_exception(outputCallBackJs.env_, &error);
     }
     QLOG(logger::Priority::ERROR, "jsOutputCallback: failed");

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp
@@ -14,22 +14,22 @@ namespace qvac_lib_inference_addon_cpp {
 class OutputCallBackJs : public OutputCallBackInterface {
 
   std::mutex mtx_;
-  js_env_t *env_;
-  js_ref_t *jsHandle_;
-  js_ref_t *outputCb_;
-  js_threadsafe_function_t *threadsafeOutputCb_;
+  js_env_t* env_;
+  js_ref_t* jsHandle_;
+  js_ref_t* outputCb_;
+  js_threadsafe_function_t* threadsafeOutputCb_;
   std::shared_ptr<OutputQueue> outputQueue_ = nullptr;
   out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface>
       outputHandlers_;
   bool stopped_{false};
 
 public:
-  uv_async_t *jsOutputCallbackAsyncHandle_;
+  uv_async_t* jsOutputCallbackAsyncHandle_;
 
   OutputCallBackJs(
-      js_env_t *env, js_value_t *jsHandle, js_value_t *outputCb,
-      out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface>
-          &&outputHandlers)
+      js_env_t* env, js_value_t* jsHandle, js_value_t* outputCb,
+      out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface>&&
+          outputHandlers)
       : env_(env), outputHandlers_(std::move(outputHandlers)) {
     JS(js_create_reference(env_, jsHandle, 1, &jsHandle_));
     auto e1 = utils::onError([this, env = env_, jsHandle = jsHandle_]() {
@@ -48,8 +48,9 @@ public:
   ~OutputCallBackJs() {
     stop();
     // Important: uv_close might not be called outside the loop thread
-    uv_close(reinterpret_cast<uv_handle_t *>(jsOutputCallbackAsyncHandle_),
-             [](uv_handle_t *handle) { delete handle; });
+    uv_close(
+        reinterpret_cast<uv_handle_t*>(jsOutputCallbackAsyncHandle_),
+        [](uv_handle_t* handle) { delete handle; });
     if (js_delete_reference(env_, jsHandle_) != 0)
       QLOG(logger::Priority::WARNING, "Could not delete jsHandle reference");
     if (js_delete_reference(env_, outputCb_) != 0)
@@ -59,23 +60,25 @@ public:
   void
   initializeProcessingThread(std::shared_ptr<OutputQueue> outputQueue) final {
     this->outputQueue_ = outputQueue;
-    uv_loop_t *jsLoop;
+    uv_loop_t* jsLoop;
     JS(js_get_env_loop(env_, &jsLoop));
     jsOutputCallbackAsyncHandle_ = new uv_async_t{};
     if (uv_async_init(jsLoop, jsOutputCallbackAsyncHandle_, jsOutputCallback) !=
         0) {
       delete jsOutputCallbackAsyncHandle_;
-      throw qvac_errors::StatusError(qvac_errors::general_error::InternalError,
-                                     "Could not initialize uv async handle");
+      throw qvac_errors::StatusError(
+          qvac_errors::general_error::InternalError,
+          "Could not initialize uv async handle");
     }
     // jsOutputCallbackAsyncHandle_ has been correctly initialized, so if thread
     // fails it needs to be closed
     auto e3 = utils::onError([this]() {
-      uv_close(reinterpret_cast<uv_handle_t *>(jsOutputCallbackAsyncHandle_),
-               [](uv_handle_t *handle) { delete handle; });
+      uv_close(
+          reinterpret_cast<uv_handle_t*>(jsOutputCallbackAsyncHandle_),
+          [](uv_handle_t* handle) { delete handle; });
     });
     uv_handle_set_data(
-        reinterpret_cast<uv_handle_t *>(jsOutputCallbackAsyncHandle_), this);
+        reinterpret_cast<uv_handle_t*>(jsOutputCallbackAsyncHandle_), this);
   }
 
   void notify() final { uv_async_send(jsOutputCallbackAsyncHandle_); }
@@ -87,16 +90,16 @@ private:
    * @brief Creates JavaScript parameters for output events using handlers
    * @returns Pair of JavaScript values for output data and error
    */
-  std::pair<js_value_t *, js_value_t *>
-  createEventParams(const std::any &output) {
+  std::pair<js_value_t*, js_value_t*>
+  createEventParams(const std::any& output) {
     if (!output.has_value()) {
       // e.g. JobStarted events don't have data
       return {js::Undefined::create(env_), js::Undefined::create(env_)};
     }
 
-    out_handl::JsOutputHandlerInterface &handler = outputHandlers_.get(output);
+    out_handl::JsOutputHandlerInterface& handler = outputHandlers_.get(output);
     handler.setEnv(env_);
-    js_value_t *handlerResult = handler.handleOutput(output);
+    js_value_t* handlerResult = handler.handleOutput(output);
 
     // For Error events, put handler result in error parameter (second)
     // For other events, put handler result in output parameter (first)
@@ -114,8 +117,9 @@ private:
    *   outputCbParameters[2] = Output data
    *   outputCbParameters[3] = Error data
    */
-  void createOutputCbParams(js_value_t *jsHandle, const std::any &output,
-                            js_value_t **outputCbParameters) {
+  void createOutputCbParams(
+      js_value_t* jsHandle, const std::any& output,
+      js_value_t** outputCbParameters) {
     outputCbParameters[0] = jsHandle;
     outputCbParameters[1] = js::String::create(env_, output.type().name());
 
@@ -128,20 +132,20 @@ private:
    * process output queue
    * @param handle UV async handle containing addon instance data
    */
-  static void jsOutputCallback(uv_async_t *handle) try {
-    auto &outputCallBackJs = *reinterpret_cast<OutputCallBackJs *>(
-        uv_handle_get_data(reinterpret_cast<uv_handle_t *>(handle)));
-    js_handle_scope_t *scope;
+  static void jsOutputCallback(uv_async_t* handle) try {
+    auto& outputCallBackJs = *reinterpret_cast<OutputCallBackJs*>(
+        uv_handle_get_data(reinterpret_cast<uv_handle_t*>(handle)));
+    js_handle_scope_t* scope;
     JS(js_open_handle_scope(outputCallBackJs.env_, &scope));
     auto scopeCleanup = utils::onExit([env = outputCallBackJs.env_, scope]() {
       js_close_handle_scope(env, scope);
     });
-    js_value_t *outputCb;
-    JS(js_get_reference_value(outputCallBackJs.env_, outputCallBackJs.outputCb_,
-                              &outputCb));
-    js_value_t *jsHandle;
-    JS(js_get_reference_value(outputCallBackJs.env_, outputCallBackJs.jsHandle_,
-                              &jsHandle));
+    js_value_t* outputCb;
+    JS(js_get_reference_value(
+        outputCallBackJs.env_, outputCallBackJs.outputCb_, &outputCb));
+    js_value_t* jsHandle;
+    JS(js_get_reference_value(
+        outputCallBackJs.env_, outputCallBackJs.jsHandle_, &jsHandle));
     std::vector<std::any> outputQueue;
     {
       std::scoped_lock lk{outputCallBackJs.mtx_};
@@ -149,26 +153,30 @@ private:
     }
     for (size_t i = 0; !outputCallBackJs.stopped_ && i < outputQueue.size();
          i++) {
-      js_handle_scope_t *innerScope;
+      js_handle_scope_t* innerScope;
       JS(js_open_handle_scope(outputCallBackJs.env_, &innerScope));
       auto scopeCleanup =
           utils::onExit([env = outputCallBackJs.env_, innerScope]() {
             js_close_handle_scope(env, innerScope);
           });
       static constexpr auto outputCbParametersCount = 4;
-      js_value_t *outputCbParameters[outputCbParametersCount];
-      outputCallBackJs.createOutputCbParams(jsHandle, outputQueue[i],
-                                            outputCbParameters);
-      js_value_t *receiver;
+      js_value_t* outputCbParameters[outputCbParametersCount];
+      outputCallBackJs.createOutputCbParams(
+          jsHandle, outputQueue[i], outputCbParameters);
+      js_value_t* receiver;
       JS(js_get_global(outputCallBackJs.env_, &receiver));
-      JS(js_call_function(outputCallBackJs.env_, receiver, outputCb,
-                          utils::arrayCount(outputCbParameters),
-                          outputCbParameters, nullptr));
+      JS(js_call_function(
+          outputCallBackJs.env_,
+          receiver,
+          outputCb,
+          utils::arrayCount(outputCbParameters),
+          outputCbParameters,
+          nullptr));
     }
   } catch (...) {
-    auto &outputCallBackJs = *reinterpret_cast<OutputCallBackJs *>(
-        uv_handle_get_data(reinterpret_cast<uv_handle_t *>(handle)));
-    js_handle_scope_t *scope;
+    auto& outputCallBackJs = *reinterpret_cast<OutputCallBackJs*>(
+        uv_handle_get_data(reinterpret_cast<uv_handle_t*>(handle)));
+    js_handle_scope_t* scope;
     if (js_open_handle_scope(outputCallBackJs.env_, &scope) != 0)
       return;
     auto scopeCleanup = utils::onExit([env = outputCallBackJs.env_, scope]() {
@@ -179,7 +187,7 @@ private:
         0)
       return;
     if (isExceptionPending) {
-      js_value_t *error;
+      js_value_t* error;
       js_get_and_clear_last_exception(outputCallBackJs.env_, &error);
     }
     QLOG(logger::Priority::ERROR, "jsOutputCallback: failed");

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputQueue.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputQueue.hpp
@@ -45,7 +45,7 @@ public:
 
   ~OutputQueue() = default;
 
-  /// @brief Return current output queue and clears internal queue
+  /// @brief Returns the current output queue and clears the internal queue.
   std::vector<std::any> clear() {
     std::scoped_lock lk{mtx_};
     auto result = std::move(outputQueue_);

--- a/packages/qvac-lib-inference-addon-cpp/tests/addon_js_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/addon_js_test.cpp
@@ -30,23 +30,22 @@ public:
   void stop() override { stopped_ = true; }
 };
 
-TEST(AddonJsTest, CanInstantiateAddonJs) {
+AddonJs createTestAddonJs() {
   js_env_t env;
   auto outputCallback = std::make_unique<MockOutputCallback>();
   auto model = std::make_unique<MockModel>();
+  return AddonJs(&env, std::move(outputCallback), std::move(model));
+}
 
-  AddonJs addon(&env, std::move(outputCallback), std::move(model));
+TEST(AddonJsTest, CanInstantiateAddonJs) {
+  auto addon = createTestAddonJs();
 
   EXPECT_NE(addon.addonCpp, nullptr);
   EXPECT_EQ(addon.addonCpp->model.get().getName(), "MockModel");
 }
 
 TEST(AddonJsTest, AddonCppIsAccessibleViaAddonJs) {
-  js_env_t env;
-  auto outputCallback = std::make_unique<MockOutputCallback>();
-  auto model = std::make_unique<MockModel>();
-
-  AddonJs addon(&env, std::move(outputCallback), std::move(model));
+  auto addon = createTestAddonJs();
 
   // Verify the shared_ptr to AddonCpp is valid and accessible
   ASSERT_NE(addon.addonCpp, nullptr);
@@ -54,6 +53,29 @@ TEST(AddonJsTest, AddonCppIsAccessibleViaAddonJs) {
   // The model reference should be accessible through AddonCpp
   const model::IModel& modelRef = addon.addonCpp->model.get();
   EXPECT_EQ(modelRef.getName(), "MockModel");
+}
+
+TEST(AddonJsTest, RunJobRValue) {
+  auto addon = createTestAddonJs();
+  std::string testInput = "test-data";
+  EXPECT_NO_THROW(addon.runJob(std::any(std::move(testInput))));
+}
+
+TEST(AddonJsTest, RunJobUsesMoveSemantics) {
+  auto addon = createTestAddonJs();
+
+  // Prepare the test input and wrap it in a std::any
+  std::string testInput = "test-data";
+  std::any inputAny = testInput;
+
+  // Call runJob with std::move - intentionally moving inputAny
+  EXPECT_NO_THROW(addon.runJob(std::move(inputAny)));
+}
+
+TEST(AddonJsTest, CancelJobInvokesAddonCppCancelJob) {
+  auto addon = createTestAddonJs();
+  // No exception should be thrown
+  EXPECT_NO_THROW(addon.cancelJob());
 }
 
 } // namespace qvac_lib_inference_addon_cpp

--- a/packages/qvac-lib-inference-addon-cpp/tests/addon_js_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/addon_js_test.cpp
@@ -1,0 +1,59 @@
+#include <any>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "helpers_header/js.h"
+#include "qvac-lib-inference-addon-cpp/ModelInterfaces.hpp"
+#include "qvac-lib-inference-addon-cpp/addon/AddonJs.hpp"
+#include "qvac-lib-inference-addon-cpp/queue/OutputCallbackInterface.hpp"
+
+namespace qvac_lib_inference_addon_cpp {
+
+// Simple mock model for testing AddonJs instantiation
+class MockModel : public model::IModel {
+public:
+  std::string getName() const override { return "MockModel"; }
+  RuntimeStats runtimeStats() const override { return {}; }
+  std::any process(const std::any& input) override { return input; }
+};
+
+// Mock output callback for testing
+class MockOutputCallback : public OutputCallBackInterface {
+  bool stopped_{false};
+
+public:
+  void initializeProcessingThread(
+      std::shared_ptr<OutputQueue> /*outputQueue*/) override {}
+  void notify() override {}
+  void stop() override { stopped_ = true; }
+};
+
+TEST(AddonJsTest, CanInstantiateAddonJs) {
+  js_env_t env;
+  auto outputCallback = std::make_unique<MockOutputCallback>();
+  auto model = std::make_unique<MockModel>();
+
+  AddonJs addon(&env, std::move(outputCallback), std::move(model));
+
+  EXPECT_NE(addon.addonCpp, nullptr);
+  EXPECT_EQ(addon.addonCpp->model.get().getName(), "MockModel");
+}
+
+TEST(AddonJsTest, AddonCppIsAccessibleViaAddonJs) {
+  js_env_t env;
+  auto outputCallback = std::make_unique<MockOutputCallback>();
+  auto model = std::make_unique<MockModel>();
+
+  AddonJs addon(&env, std::move(outputCallback), std::move(model));
+
+  // Verify the shared_ptr to AddonCpp is valid and accessible
+  ASSERT_NE(addon.addonCpp, nullptr);
+
+  // The model reference should be accessible through AddonCpp
+  const model::IModel& modelRef = addon.addonCpp->model.get();
+  EXPECT_EQ(modelRef.getName(), "MockModel");
+}
+
+} // namespace qvac_lib_inference_addon_cpp

--- a/packages/qvac-lib-inference-addon-cpp/tests/helpers_header/js.h
+++ b/packages/qvac-lib-inference-addon-cpp/tests/helpers_header/js.h
@@ -165,7 +165,10 @@ typedef enum {
 } js_typedarray_type_t;
 
 // Value creation functions
-inline int js_get_undefined(js_env_t* env, js_value_t** result) { return -1; }
+inline int js_get_undefined(js_env_t* env, js_value_t** result) {
+  *result = new js_value_t{};
+  return 0;
+}
 
 inline int js_create_string_utf8(
     js_env_t* env, const utf8_t* data, size_t length, js_value_t** result) {
@@ -375,11 +378,13 @@ js_get_reference_value(js_env_t* env, js_ref_t* ref, js_value_t** result) {
 
 // Handle scope functions
 inline int js_open_handle_scope(js_env_t* env, js_handle_scope_t** result) {
-  return -1;
+  *result = new js_handle_scope_t{};
+  return 0;
 }
 
 inline int js_close_handle_scope(js_env_t* env, js_handle_scope_t* scope) {
-  return -1;
+  delete scope;
+  return 0;
 }
 
 // Global and function call functions
@@ -392,12 +397,16 @@ inline int js_call_function(
 }
 
 // Loop functions
-inline int js_get_env_loop(js_env_t* env, js_loop_t** result) { return -1; }
+inline int js_get_env_loop(js_env_t* env, js_loop_t** result) {
+  *result = new uv_loop_t{};
+  return 0;
+}
 
 inline int js_get_null(js_env_t* env, js_value_t** result) { return -1; }
 
 inline int js_get_boolean(js_env_t* env, bool value, js_value_t** result) {
-  return -1;
+  *result = new js_value_t{};
+  return 0;
 }
 
 // Additional functions needed for OutputCallbackJs

--- a/packages/qvac-lib-inference-addon-cpp/tests/helpers_header/js.h
+++ b/packages/qvac-lib-inference-addon-cpp/tests/helpers_header/js.h
@@ -13,7 +13,10 @@ struct js_value_t {};
 struct js_ref_t {};
 struct js_callback_info_t {};
 struct js_handle_scope_t {};
-struct uv_async_t {};
+struct js_deferred_t {};
+struct uv_async_t {
+  void* data;
+};
 struct uv_handle_t {};
 struct uv_loop_t {};
 
@@ -402,6 +405,30 @@ inline int js_is_exception_pending(js_env_t* env, bool* result) { return -1; }
 
 inline int js_get_and_clear_last_exception(js_env_t* env, js_value_t** result) {
   return -1;
+}
+
+// Promise/Future API (for async operations)
+inline int js_create_promise(
+    js_env_t* env, js_deferred_t** deferred, js_value_t** promise) {
+  *deferred = new js_deferred_t{};
+  *promise = new js_value_t{};
+  return 0;
+}
+
+inline int js_resolve_deferred(
+    js_env_t* env, js_deferred_t* deferred, js_value_t* resolution) {
+  return 0;
+}
+
+inline int js_reject_deferred(
+    js_env_t* env, js_deferred_t* deferred, js_value_t* rejection) {
+  return 0;
+}
+
+inline int js_create_error(
+    js_env_t* env, js_value_t* code, js_value_t* message, js_value_t** result) {
+  *result = new js_value_t{};
+  return 0;
 }
 
 // UV/libuv functions (minimal stubs for compilation)

--- a/packages/qvac-lib-inference-addon-cpp/tests/job_runner_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/job_runner_test.cpp
@@ -240,27 +240,10 @@ TEST_F(JobRunnerTest, CannotRunJobWhileProcessing) {
   jobRunner_->start();
 
   // Start first job
-  jobRunner_->runJob(std::string("test input 1"));
+  EXPECT_TRUE(jobRunner_->runJob(std::string("test input 1")));
 
   // Immediately try to start another
-  std::this_thread::sleep_for(std::chrono::milliseconds{10});
-  jobRunner_->runJob(std::string("test input 2"));
-
-  // Wait for processing
-  std::this_thread::sleep_for(std::chrono::milliseconds{300});
-
-  auto outputs = outputQueue_->clear();
-
-  // Should have error from second job attempt
-  bool found_error = false;
-  for (const auto& output : outputs) {
-    if (output.type() == typeid(Output::Error)) {
-      found_error = true;
-      auto error = std::any_cast<Output::Error>(output);
-      EXPECT_NE(error.find("Cannot set new job"), std::string::npos);
-    }
-  }
-  EXPECT_TRUE(found_error);
+  EXPECT_FALSE(jobRunner_->runJob(std::string("test input 2")));
 }
 
 // Stress test: multiple rapid cancel calls

--- a/packages/qvac-lib-inference-addon-cpp/tests/job_runner_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/job_runner_test.cpp
@@ -1,0 +1,482 @@
+#include <any>
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <stdexcept>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "qvac-lib-inference-addon-cpp/JobRunner.hpp"
+#include "qvac-lib-inference-addon-cpp/ModelInterfaces.hpp"
+#include "qvac-lib-inference-addon-cpp/RuntimeStats.hpp"
+#include "qvac-lib-inference-addon-cpp/queue/OutputCallbackInterface.hpp"
+#include "qvac-lib-inference-addon-cpp/queue/OutputQueue.hpp"
+
+namespace qvac_lib_inference_addon_cpp {
+
+// Mock output callback
+class MockOutputCallback : public OutputCallBackInterface {
+  std::atomic_bool stopped_{false};
+
+public:
+  void initializeProcessingThread(
+      std::shared_ptr<OutputQueue> /*outputQueue*/) override {}
+  void notify() override {}
+  void stop() override { stopped_ = true; }
+};
+
+// Mock model for JobRunner tests with controllable processing time
+// Renamed to avoid ODR violation with MockModel in other test files
+class JobRunnerTestModel : public model::IModel, public model::IModelCancel {
+  mutable std::atomic_bool cancel_requested_{false};
+  mutable std::atomic_int access_count_{0};
+  mutable std::atomic_bool is_processing_{false};
+  std::chrono::milliseconds process_time_;
+  bool access_input_multiple_times_;
+
+public:
+  explicit JobRunnerTestModel(
+      std::chrono::milliseconds process_time = std::chrono::milliseconds{100},
+      bool access_input_multiple_times = false)
+      : process_time_(process_time),
+        access_input_multiple_times_(access_input_multiple_times) {}
+
+  std::string getName() const override { return "JobRunnerTestModel"; }
+
+  std::any process(const std::any& input) override {
+    is_processing_ = true;
+
+    // Option 1: Access input multiple times (for testing race conditions)
+    if (access_input_multiple_times_) {
+      // Access the input data multiple times during processing
+      // Without proper synchronization, cancel() could reset job_
+      // while we're accessing input, causing a crash
+      for (int i = 0; i < 20 && !cancel_requested_.load(); ++i) {
+        try {
+          // Try to access the input - this could crash if job_ is reset
+          auto str = std::any_cast<std::string>(input);
+          access_count_++;
+          std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        } catch (...) {
+          // If we catch an exception, it means the input became invalid
+          is_processing_ = false;
+          throw std::runtime_error("Input was invalidated during processing");
+        }
+      }
+    } else {
+      // Option 2: Standard processing with controllable delay
+      auto start = std::chrono::steady_clock::now();
+
+      // Simulate processing with ability to be cancelled
+      while (!cancel_requested_.load()) {
+        auto elapsed = std::chrono::steady_clock::now() - start;
+        if (elapsed >= process_time_) {
+          break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+      }
+    }
+
+    cancel_requested_ = false;
+    is_processing_ = false;
+    return std::string("result");
+  }
+
+  RuntimeStats runtimeStats() const override { return RuntimeStats{}; }
+
+  void cancel() const override { cancel_requested_ = true; }
+
+  int getAccessCount() const { return access_count_.load(); }
+
+  bool isProcessing() const { return is_processing_.load(); }
+
+  // Wait for processing to complete (or timeout)
+  bool waitForProcessingToComplete(std::chrono::milliseconds timeout) const {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (is_processing_.load() &&
+           std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds{1});
+    }
+    return !is_processing_.load();
+  }
+};
+
+// Test fixture
+class JobRunnerTest : public ::testing::Test {
+protected:
+  std::unique_ptr<MockOutputCallback> callback_;
+  std::unique_ptr<JobRunnerTestModel> model_;
+  std::shared_ptr<OutputQueue> outputQueue_;
+  std::unique_ptr<JobRunner> jobRunner_;
+
+  void SetUp() override {
+    callback_ = std::make_unique<MockOutputCallback>();
+    model_ = std::make_unique<JobRunnerTestModel>();
+    outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+    jobRunner_ =
+        std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+    jobRunner_->start();
+  }
+
+  void TearDown() override {
+    jobRunner_.reset();
+    outputQueue_.reset();
+    model_.reset();
+    callback_.reset();
+  }
+};
+
+// Test basic job execution
+TEST_F(JobRunnerTest, BasicJobExecution) {
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{50});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  jobRunner_->runJob(std::string("test input"));
+
+  // Wait for job to complete
+  std::this_thread::sleep_for(std::chrono::milliseconds{200});
+
+  auto outputs = outputQueue_->clear();
+  EXPECT_GT(outputs.size(), 0);
+}
+
+// Test cancel without deadlock - this is the critical test
+TEST_F(JobRunnerTest, CancelDuringProcessingNoDeadlock) {
+  // Create a model with longer processing time
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{500});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  // Start a job
+  jobRunner_->runJob(std::string("test input"));
+
+  // Give it a moment to start processing
+  std::this_thread::sleep_for(std::chrono::milliseconds{50});
+
+  // Try to cancel from another thread with a timeout
+  auto cancel_future =
+      std::async(std::launch::async, [this]() { jobRunner_->cancel(); });
+
+  // Wait for cancel to complete with timeout
+  auto status = cancel_future.wait_for(std::chrono::seconds{2});
+
+  // If we hit the timeout, we have a deadlock
+  ASSERT_NE(status, std::future_status::timeout)
+      << "Deadlock detected: cancel() did not complete within timeout";
+
+  // Verify cancel completed successfully
+  EXPECT_EQ(status, std::future_status::ready);
+}
+
+// Test cancel on a job that hasn't started yet
+TEST_F(JobRunnerTest, CancelBeforeProcessing) {
+  // Don't start a job, just call cancel
+  jobRunner_->cancel();
+
+  // Should complete without issue and quickly (not hang)
+  SUCCEED();
+}
+
+// Test that cancel before any job has no effect on subsequent job execution
+TEST_F(JobRunnerTest, CancelBeforeJobThenRunNormally) {
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{50});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  // Call cancel when no job is running
+  jobRunner_->cancel();
+
+  // Should be able to run a job normally after cancel with no job
+  jobRunner_->runJob(std::string("test input"));
+
+  // Wait for job to complete
+  std::this_thread::sleep_for(std::chrono::milliseconds{150});
+
+  auto outputs = outputQueue_->clear();
+  EXPECT_GT(outputs.size(), 0);
+
+  // Verify we got a result (not an error)
+  bool found_result = false;
+  for (const auto& output : outputs) {
+    if (output.type() == typeid(std::string)) {
+      found_result = true;
+    }
+  }
+  EXPECT_TRUE(found_result);
+}
+
+// Test multiple jobs in sequence
+TEST_F(JobRunnerTest, MultipleJobsSequential) {
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{50});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  for (int i = 0; i < 3; ++i) {
+    jobRunner_->runJob(std::string("test input ") + std::to_string(i));
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+  }
+
+  auto outputs = outputQueue_->clear();
+  EXPECT_GT(outputs.size(), 0);
+}
+
+// Test that trying to run a job while one is in progress fails
+TEST_F(JobRunnerTest, CannotRunJobWhileProcessing) {
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{200});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  // Start first job
+  jobRunner_->runJob(std::string("test input 1"));
+
+  // Immediately try to start another
+  std::this_thread::sleep_for(std::chrono::milliseconds{10});
+  jobRunner_->runJob(std::string("test input 2"));
+
+  // Wait for processing
+  std::this_thread::sleep_for(std::chrono::milliseconds{300});
+
+  auto outputs = outputQueue_->clear();
+
+  // Should have error from second job attempt
+  bool found_error = false;
+  for (const auto& output : outputs) {
+    if (output.type() == typeid(Output::Error)) {
+      found_error = true;
+      auto error = std::any_cast<Output::Error>(output);
+      EXPECT_NE(error.find("Cannot set new job"), std::string::npos);
+    }
+  }
+  EXPECT_TRUE(found_error);
+}
+
+// Stress test: multiple rapid cancel calls
+TEST_F(JobRunnerTest, MultipleRapidCancels) {
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{100});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  // Start a job
+  jobRunner_->runJob(std::string("test input"));
+
+  // Call cancel multiple times from different threads
+  std::vector<std::future<void>> futures;
+  for (int i = 0; i < 5; ++i) {
+    futures.push_back(
+        std::async(std::launch::async, [this]() { jobRunner_->cancel(); }));
+  }
+
+  // Wait for all cancels with timeout
+  for (auto& future : futures) {
+    auto status = future.wait_for(std::chrono::seconds{2});
+    ASSERT_NE(status, std::future_status::timeout)
+        << "Deadlock detected in multiple cancel scenario";
+  }
+}
+
+// Test cancel during the critical window right after process() returns
+// This is the exact scenario that causes the deadlock
+TEST_F(JobRunnerTest, CancelInCriticalWindowNoDeadlock) {
+  // Create a model with very short processing time
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{50});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  // Run multiple iterations to increase chance of hitting the critical window
+  for (int iteration = 0; iteration < 10; ++iteration) {
+    // Start a job
+    jobRunner_->runJob(std::string("test input"));
+
+    // Cancel almost immediately - trying to hit the window between
+    // model_->process() returning and the lock being reacquired
+    std::this_thread::sleep_for(std::chrono::milliseconds{40});
+
+    auto cancel_future =
+        std::async(std::launch::async, [this]() { jobRunner_->cancel(); });
+
+    auto status = cancel_future.wait_for(std::chrono::seconds{1});
+    ASSERT_NE(status, std::future_status::timeout)
+        << "Deadlock detected in iteration " << iteration;
+
+    // Small delay before next iteration
+    std::this_thread::sleep_for(std::chrono::milliseconds{50});
+  }
+}
+
+// Test that cancel() properly waits for processing to complete before returning
+// This verifies that ProcessingSync prevents cancel() from resetting job_
+// while process() is still executing
+TEST_F(JobRunnerTest, CancelWaitsForProcessingToComplete) {
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{200});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  // Start a job
+  jobRunner_->runJob(std::string("test input"));
+
+  // Wait until processing has started
+  std::this_thread::sleep_for(std::chrono::milliseconds{50});
+  ASSERT_TRUE(model_->isProcessing()) << "Model should be processing";
+
+  // Call cancel while processing - it should block until processing completes
+  jobRunner_->cancel();
+
+  // After cancel() returns, processing must be complete
+  EXPECT_FALSE(model_->isProcessing())
+      << "Model should not be processing after cancel() returns";
+}
+
+// Test that cancel() while accessing input multiple times doesn't cause crashes
+// This tests the race condition where job_ could be reset while being accessed
+TEST_F(JobRunnerTest, CancelWhileAccessingInputNoCrash) {
+  // Use a model that accesses input data multiple times
+  auto model_with_access = std::make_unique<JobRunnerTestModel>(
+      std::chrono::milliseconds{100}, true /* access_input_multiple_times */);
+  auto* model_ptr = model_with_access.get();
+
+  auto local_output_queue =
+      std::make_shared<OutputQueue>(*callback_, *model_with_access);
+  auto local_job_runner = std::make_unique<JobRunner>(
+      local_output_queue, model_with_access.get(), model_with_access.get());
+  local_job_runner->start();
+
+  // Run multiple iterations to increase chance of hitting the race condition
+  for (int iteration = 0; iteration < 5; ++iteration) {
+    // Start a job with input data
+    local_job_runner->runJob(std::string("test input with data"));
+
+    // Cancel quickly while model is accessing input
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    local_job_runner->cancel();
+
+    // After cancel returns, processing must be complete
+    EXPECT_FALSE(model_ptr->isProcessing())
+        << "Model should not be processing after cancel() in iteration "
+        << iteration;
+
+    // Small delay before next iteration
+    std::this_thread::sleep_for(std::chrono::milliseconds{50});
+  }
+
+  // Verify that the model was able to access input at least once
+  EXPECT_GT(model_ptr->getAccessCount(), 0)
+      << "Model should have accessed input at least once";
+}
+
+// High-contention test to detect race between unlock() and setActive(true)
+// Uses many threads and iterations to increase probability of hitting the race
+// window
+TEST_F(
+    JobRunnerTest,
+    DetectRaceConditionBetweenUnlockAndSetActive_HighContention) {
+  // Use minimal processing time to maximize throughput
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{0});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  std::atomic_bool stop{false};
+  std::atomic_int iterations{0};
+
+  // Spawn multiple cancel threads that continuously try to cancel
+  std::vector<std::future<void>> cancel_threads;
+  for (int t = 0; t < 4; ++t) {
+    cancel_threads.push_back(std::async(std::launch::async, [this, &stop]() {
+      while (!stop.load()) {
+        jobRunner_->cancel();
+        std::this_thread::yield(); // Give other threads a chance
+      }
+    }));
+  }
+
+  // Main thread submits jobs rapidly
+  for (int i = 0; i < 200; ++i) {
+    jobRunner_->runJob(std::string("test"));
+    iterations++;
+
+    // Occasionally yield to give cancel threads a chance to run
+    if (i % 10 == 0) {
+      std::this_thread::yield();
+    }
+  }
+
+  stop = true;
+
+  // Wait for all cancel threads to finish
+  for (auto& f : cancel_threads) {
+    auto status = f.wait_for(std::chrono::seconds{2});
+    if (status == std::future_status::timeout) {
+      FAIL()
+          << "Cancel thread timed out - possible deadlock from race condition";
+    }
+  }
+
+  // Wait a bit for any pending operations
+  std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+  // Check output queue for bad_optional_access errors
+  auto outputs = outputQueue_->clear();
+  for (const auto& output : outputs) {
+    if (output.type() == typeid(Output::Error)) {
+      auto error = std::any_cast<Output::Error>(output);
+      if (error.find("bad_optional_access") != std::string::npos ||
+          error.find("optional") != std::string::npos) {
+        FAIL() << "BUG DETECTED: bad_optional_access in output after "
+               << iterations.load() << " iterations.\nError: " << error
+               << "\n\nThis indicates lock.unlock() happened before "
+                  "processingSync_.setActive(true)."
+               << "\nThe race: cancel() ran after unlock() but before "
+                  "setActive(true),"
+               << "\nso it saw active_=false, reset job_, then process() tried "
+                  "to access job_.value().";
+      }
+    }
+  }
+}
+
+// Test multiple cancel calls in sequence (not concurrent)
+TEST_F(JobRunnerTest, MultipleCancelsInSequence) {
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{100});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  // Start a job
+  jobRunner_->runJob(std::string("test input"));
+  std::this_thread::sleep_for(std::chrono::milliseconds{20});
+
+  // Cancel it
+  jobRunner_->cancel();
+
+  // Call cancel again - should be safe even though no job is running
+  jobRunner_->cancel();
+
+  // And again
+  jobRunner_->cancel();
+
+  // Should complete without hanging or crashing
+  SUCCEED();
+}
+
+} // namespace qvac_lib_inference_addon_cpp

--- a/packages/qvac-lib-inference-addon-cpp/tests/js_utils_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/js_utils_test.cpp
@@ -30,34 +30,36 @@ TEST(JsUtilsTest, ArrayCreate) {
 }
 
 TEST(JsUtilsTest, BooleanCreate) {
-    js_env_t env;
-    auto jsBoolean = js::Boolean::create(&env, true);
-    // Test passes if no exception is thrown
+  js_env_t env;
+  auto jsBoolean = js::Boolean::create(&env, true);
+  // Test passes if no exception is thrown
 }
 
 TEST(JsUtilsTest, JsAsyncTaskRun) {
-    js_env_t env;
-    // Test that JsAsyncTask::run creates a promise and executes work asynchronously
-    std::mutex mtx;
-    std::condition_variable cv;
-    bool workCompleted = false;
-    
-    js_value_t* promise = js::JsAsyncTask::run(&env, [&mtx, &cv, &workCompleted]() {
+  js_env_t env;
+  // Test that JsAsyncTask::run creates a promise and executes work
+  // asynchronously
+  std::mutex mtx;
+  std::condition_variable cv;
+  bool workCompleted = false;
+
+  js_value_t* promise =
+      js::JsAsyncTask::run(&env, [&mtx, &cv, &workCompleted]() {
         // Simple work function that signals completion
         {
-            std::lock_guard<std::mutex> lock(mtx);
-            workCompleted = true;
+          std::lock_guard<std::mutex> lock(mtx);
+          workCompleted = true;
         }
         cv.notify_one();
-    });
-    
-    // Test passes if no exception is thrown and promise is returned
-    EXPECT_NE(promise, nullptr);
-    
-    // Wait for the async task to complete
-    std::unique_lock<std::mutex> lock(mtx);
-    cv.wait(lock, [&workCompleted]() { return workCompleted; });
-    EXPECT_TRUE(workCompleted);
+      });
+
+  // Test passes if no exception is thrown and promise is returned
+  EXPECT_NE(promise, nullptr);
+
+  // Wait for the async task to complete
+  std::unique_lock<std::mutex> lock(mtx);
+  cv.wait(lock, [&workCompleted]() { return workCompleted; });
+  EXPECT_TRUE(workCompleted);
 }
 
 TEST(JsUtilsTest, UniqueJsRefConstructorWithDeleter) {

--- a/packages/qvac-lib-inference-addon-cpp/tests/js_utils_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/js_utils_test.cpp
@@ -2,6 +2,10 @@
 #include "helpers_header/js.h"
 #include <gtest/gtest.h>
 #include <utility>
+#include <thread>
+#include <chrono>
+#include <mutex>
+#include <condition_variable>
 
 namespace qvac_lib_inference_addon_cpp::js_utils {
 
@@ -23,6 +27,37 @@ TEST(JsUtilsTest, ArrayCreate) {
     js_env_t env;
     auto jsArray = js::Array::create(&env);
     // Test passes if no exception is thrown
+}
+
+TEST(JsUtilsTest, BooleanCreate) {
+    js_env_t env;
+    auto jsBoolean = js::Boolean::create(&env, true);
+    // Test passes if no exception is thrown
+}
+
+TEST(JsUtilsTest, JsAsyncTaskRun) {
+    js_env_t env;
+    // Test that JsAsyncTask::run creates a promise and executes work asynchronously
+    std::mutex mtx;
+    std::condition_variable cv;
+    bool workCompleted = false;
+    
+    js_value_t* promise = js::JsAsyncTask::run(&env, [&mtx, &cv, &workCompleted]() {
+        // Simple work function that signals completion
+        {
+            std::lock_guard<std::mutex> lock(mtx);
+            workCompleted = true;
+        }
+        cv.notify_one();
+    });
+    
+    // Test passes if no exception is thrown and promise is returned
+    EXPECT_NE(promise, nullptr);
+    
+    // Wait for the async task to complete
+    std::unique_lock<std::mutex> lock(mtx);
+    cv.wait(lock, [&workCompleted]() { return workCompleted; });
+    EXPECT_TRUE(workCompleted);
 }
 
 TEST(JsUtilsTest, UniqueJsRefConstructorWithDeleter) {

--- a/packages/qvac-lib-inference-addon-cpp/tests/simple_addon_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/simple_addon_test.cpp
@@ -14,11 +14,62 @@
 #include <gtest/gtest.h>
 
 #include "qvac-lib-inference-addon-cpp/ModelInterfaces.hpp"
+#include "qvac-lib-inference-addon-cpp/RuntimeStats.hpp"
 #include "qvac-lib-inference-addon-cpp/addon/AddonCpp.hpp"
 #include "qvac-lib-inference-addon-cpp/handlers/CppOutputHandlerImplementations.hpp"
+#include "qvac-lib-inference-addon-cpp/handlers/OutputHandler.hpp"
 #include "qvac-lib-inference-addon-cpp/queue/OutputCallbackCpp.hpp"
+#include "qvac-lib-inference-addon-cpp/queue/OutputQueue.hpp"
 
 namespace qvac_lib_inference_addon_cpp {
+
+/// Shared state for completion: either job-ended (RuntimeStats) or error
+/// (Output::Error) means the job is no longer pending (JS _finishPromise).
+struct JobCompletionState {
+  mutable std::mutex mutex_;
+  mutable std::condition_variable cv_;
+  mutable std::atomic<bool> completed_{false};
+
+  void signal() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    completed_ = true;
+    cv_.notify_all();
+  }
+
+  bool waitForCompletion(std::chrono::milliseconds timeout) const {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(
+        lock, timeout, [this] { return completed_.load(); });
+  }
+
+  void reset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    completed_ = false;
+  }
+};
+
+/// Handler that signals completion when job-ended (RuntimeStats) is received.
+struct JobEndedNotifier
+    : public out_handl::BaseOutputHandler<void, RuntimeStats> {
+  std::shared_ptr<JobCompletionState> state_;
+
+  explicit JobEndedNotifier(std::shared_ptr<JobCompletionState> state)
+      : BaseOutputHandler<void, RuntimeStats>(
+            [state](const RuntimeStats& /*stats*/) { state->signal(); }),
+        state_(std::move(state)) {}
+};
+
+/// Handler that signals completion when an error is received (e.g. "Job
+/// cancelled" when cancel() runs before the worker takes the job).
+struct JobErrorNotifier
+    : public out_handl::BaseOutputHandler<void, Output::Error> {
+  std::shared_ptr<JobCompletionState> state_;
+
+  explicit JobErrorNotifier(std::shared_ptr<JobCompletionState> state)
+      : BaseOutputHandler<void, Output::Error>(
+            [state](const Output::Error& /*err*/) { state->signal(); }),
+        state_(std::move(state)) {}
+};
 
 // Test model that blocks in process() until unblocked
 class BlockingTestModel : public model::IModel, public model::IModelCancel {
@@ -158,6 +209,34 @@ createTestAddon() {
   return {handler, std::move(addon)};
 }
 
+/// Creates addon with completion notifiers so tests can wait for job completion
+/// (job-ended or error). Simulates JS waitForCompletion / _finishPromise.
+std::tuple<
+    std::shared_ptr<JobCompletionState>,
+    std::shared_ptr<
+        out_handl::CppContainerOutputHandler<std::set<std::string>>>,
+    std::unique_ptr<AddonCpp>>
+createTestAddonWithCompletionNotifier() {
+  auto completionState = std::make_shared<JobCompletionState>();
+  auto jobEndedNotifier = std::make_shared<JobEndedNotifier>(completionState);
+  auto jobErrorNotifier = std::make_shared<JobErrorNotifier>(completionState);
+  auto stringHandler = std::make_shared<
+      out_handl::CppContainerOutputHandler<std::set<std::string>>>();
+
+  out_handl::OutputHandlers<out_handl::OutputHandlerInterface<void>>
+      outputHandlers;
+  outputHandlers.add(jobEndedNotifier);
+  outputHandlers.add(jobErrorNotifier);
+  outputHandlers.add(stringHandler);
+  auto outputCallback =
+      std::make_unique<OutputCallBackCpp>(std::move(outputHandlers));
+
+  auto addon = std::make_unique<AddonCpp>(
+      std::move(outputCallback), std::make_unique<BlockingTestModel>());
+
+  return {completionState, stringHandler, std::move(addon)};
+}
+
 // Helper function to wait for output to arrive in handler
 template <typename HandlerT>
 inline void
@@ -237,6 +316,41 @@ TEST(SimpleAddonTest, JobCancellationWorks) {
   {
     auto access = handler->access();
     EXPECT_EQ(access->size(), 0);
+  }
+}
+
+// Reproduces the bug where cancel() runs before the worker thread takes the
+// job: without JobRunner signalling completion in that case, nothing ever
+// queues job-ended or error, so "wait for completion" would hang (JS
+// _finishPromise never resolves). We run many iterations of runJob()+cancel()
+// and wait for completion (job-ended or error); without the fix, some
+// iterations time out when cancel() runs before the worker takes the job.
+TEST(SimpleAddonTest, CancelBeforeWorkerTakesJob_CompletionStillSignalled) {
+  auto [completionState, stringHandler, addon] =
+      createTestAddonWithCompletionNotifier();
+  addon->activate();
+
+  constexpr auto waitTimeout = std::chrono::milliseconds(500);
+  constexpr int iterations = 40;
+
+  for (int i = 0; i < iterations; ++i) {
+    completionState->reset();
+
+    // Submit a job then cancel as soon as possible (no yield), so we often
+    // cancel before the worker takes the job.
+    addon->runJob(std::any(std::string("quick")));
+    addon->cancelJob();
+
+    // Wait for completion (job-ended or error). JobRunner signals either
+    // queueJobEnded() or queueException("Job cancelled") when cancel() runs
+    // before the worker takes the job.
+    bool received = completionState->waitForCompletion(waitTimeout);
+
+    ASSERT_TRUE(received)
+        << "Iteration " << i << ": completion was not received within "
+        << waitTimeout.count()
+        << " ms. Simulates the stuck wait when cancel() runs before the "
+           "worker takes the job and JobRunner does not signal completion.";
   }
 }
 

--- a/packages/qvac-lib-inference-addon-cpp/tests/simple_addon_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/simple_addon_test.cpp
@@ -38,8 +38,7 @@ struct JobCompletionState {
 
   bool waitForCompletion(std::chrono::milliseconds timeout) const {
     std::unique_lock<std::mutex> lock(mutex_);
-    return cv_.wait_for(
-        lock, timeout, [this] { return completed_.load(); });
+    return cv_.wait_for(lock, timeout, [this] { return completed_.load(); });
   }
 
   void reset() {

--- a/packages/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qvac-lib-inference-addon-cpp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": [
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `await addon.cancel()` does not guarantee job is finished even though `await` is specified.

Other improvement/fixes related to run and cancel:
- Some tests were hanging when using cancel.
- Detect reliably of job already running.

Other improvements:
- `transitionCb` unused

## 📝 How does it solve it?

- Use asynchronous cancel based on futures.
- Additional unit tests directly detect hanging situation. Fixed by queuing exception on cancel if there is still a job running.
- Boolean returned to Js when running a job, to reliable tell the caller if it failed to run due to existing job already present. More reliable than exceptions. A boolean you know instantly (no await) if it was queued or not. A throw is not reliable because it has to be queued on the output queue, which can mess-up awaiting for the result of an already correct job that is running.
- Removed `transitionCb`

## 🧪 How was it tested?
CI from LLM https://github.com/tetherto/qvac/pull/172 or Embed https://github.com/tetherto/qvac/pull/182

## 💥 Breaking Changes

**BEFORE:**

```cpp
// Old: runJob did not return a boolean
void AddonCpp::runJob(std::any input);  // returned void, queued exception if job already running

// Old: cancelJob did not guarantee job was finished (JavaScript binding)
// In JavaScript: await addon.cancel() did NOT guarantee job had stopped

// Old: destroyInstance for teardown (via JsInterface)
JsInterface::destroyInstance(env, handle);
```

**AFTER:**

```cpp
// New: runJob returns bool to reliably detect if job is already running
bool AddonCpp::runJob(std::any input);  // returns true if accepted, false if job already running
// Exception is not queued to output queue when returning false, boolean return is more reliable

// New: cancelJob still returns void in C++ (unchanged signature)
// In C++: void AddonCpp::cancelJob();  // unchanged
// In JavaScript binding (AddonJs): js_value_t* cancelJob() returns Promise that resolves when cancellation completes
// The Promise is created via js::JsAsyncTask::run() which uses futures to wait for completion

// New: destroyInstance removed from JsInterface - use unload pattern instead
// (destroyInstance functionality moved to unload() in JavaScript layer)
```

## 🔌 API Changes

**C++ API (`AddonCpp`, `JobRunner`):**

```cpp
// JobRunner::runJob now returns bool instead of void
// - true: job was accepted and started
// - false: job was rejected because a job is already running
// Exception is still queued to output queue when returning false
bool JobRunner::runJob(std::any input);

// AddonCpp::runJob now returns bool (wraps JobRunner::runJob)
bool AddonCpp::runJob(std::any input);

// JobRunner::cancel still returns void (unchanged signature)
void JobRunner::cancel();

// AddonCpp::cancelJob still returns void (wraps JobRunner::cancel, unchanged signature)
void AddonCpp::cancelJob();
```

**JavaScript Binding (`AddonJs`):**

```cpp
// AddonJs::runJob returns JavaScript Boolean
// Wraps AddonCpp::runJob() bool return value
js_value_t* AddonJs::runJob(std::any input);

// AddonJs::cancelJob returns JavaScript Promise
// Uses js::JsAsyncTask::run() which uses futures to wrap the C++ cancelJob() call
// The Promise resolves when cancellation completes, ensuring await cancel() in JavaScript
// guarantees the job has stopped
js_value_t* AddonJs::cancelJob();
```

**Summary:**
- **C++ `runJob()`**: Returns `bool` instead of `void`; `false` indicates a job is already running (more reliable than checking for exceptions).
- **C++ `cancelJob()`**: Still returns `void` (unchanged signature).
- **JavaScript binding `cancelJob()`**: Returns a `Promise` (via `js::JsAsyncTask::run()`) that resolves when cancellation completes, ensuring `await cancel()` in JavaScript guarantees the job has stopped.
- **`JsInterface::destroyInstance()`**: Removed; teardown handled via `unload()` in JavaScript layer.

##  Notes
Previous, non-monorepo PR: https://github.com/tetherto/qvac-lib-inference-addon-cpp/pull/82


