### PR TITLE
release(qvac-registry-schema): v0.2.1

### DIFF
--- a/packages/qvac-lib-registry-server/shared/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/shared/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.2.0
+
+### Features
+
+- Add `findBy()` method to `RegistryDatabase` for unified model querying with optional filters (`name`, `engine`, `quantization`, `includeDeprecated`)
+- Add `findModelsByEngineQuantization()` method for compound index queries
+- Add `models-by-engine-quantization` compound HyperDB index for efficient multi-field lookups
+
+### Notes
+
+- The `findBy()` method intelligently routes to the most efficient HyperDB index based on the provided parameters
+- Compound index follows B-tree leftmost prefix matching: queries by `engine` alone or `engine + quantization` use the index natively; other combinations use in-memory filtering
+- Existing `findModels*` methods remain unchanged
+
+## 0.1.0
+
+- Initial release

--- a/packages/qvac-lib-registry-server/shared/package.json
+++ b/packages/qvac-lib-registry-server/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/qvac-registry-schema",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "HyperDB schema and database wrapper for QVAC Registry",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/packages/qvac-lib-registry-server/shared/package.json
+++ b/packages/qvac-lib-registry-server/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/qvac-registry-schema",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "HyperDB schema and database wrapper for QVAC Registry",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

- Bumps `@tetherto/qvac-registry-schema` from `0.2.0` to `0.2.1`
- Patch release to fix issues from the previous v0.2.0 release

## Changes

- Version bump in `packages/qvac-lib-registry-server/shared/package.json`


Made with [Cursor](https://cursor.com)