### PR TITLE
release qvac-lib-infer-llamacpp-llm: v0.8.9 (#151)

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/qvac-lib-infer-llamacpp-llm/release-notes/v0.8.9.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/release-notes/v0.8.9.md
@@ -1,0 +1,3 @@
+# QVAC LLM Addon v0.8.9 Release Notes
+
+This release updates the qvac-fabric-llm.cpp vcpkg dependency from v7248.1.1 to v7248.1.2. This brings the fix for apple A19 devices when loading models using Metal backend.


### PR DESCRIPTION
* bump version to 0.8.9

* release notes

* update release notes