### PR TITLE
feat(qvac-lib-registry-client): add findBy() method using schema's findBy

### DIFF
--- a/packages/qvac-lib-registry-server/client/index.d.ts
+++ b/packages/qvac-lib-registry-server/client/index.d.ts
@@ -56,6 +56,17 @@ export interface QVACModelQuery {
   lt?: Record<string, any>
 }
 
+export interface FindByParams {
+  /** Filter by name (partial match, case-insensitive) */
+  name?: string
+  /** Filter by engine (exact match) */
+  engine?: string
+  /** Filter by quantization (partial match, case-insensitive) */
+  quantization?: string
+  /** Include deprecated models (default: false) */
+  includeDeprecated?: boolean
+}
+
 export class QVACRegistryClient {
   constructor (opts?: QVACRegistryClientOptions)
 
@@ -64,6 +75,8 @@ export class QVACRegistryClient {
 
   getModel (path: string, source: string): Promise<QVACModelEntry | null>
   downloadModel (path: string, source: string, options?: QVACDownloadOptions): Promise<QVACDownloadResult>
+
+  findBy (params?: FindByParams): Promise<QVACModelEntry[]>
   findModels (query?: QVACModelQuery): Promise<QVACModelEntry[]>
   findModelsByEngine (query?: QVACModelQuery): Promise<QVACModelEntry[]>
   findModelsByName (query?: QVACModelQuery): Promise<QVACModelEntry[]>

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -129,6 +129,22 @@ class QVACRegistryClient extends ReadyResource {
     return this.db.findModelsByQuantization(query).toArray()
   }
 
+  /**
+   * Find models with optional filters.
+   * Uses the database's findBy method for efficient indexed queries.
+   * @param {Object} params - Filter parameters
+   * @param {string} [params.name] - Filter by name (partial match)
+   * @param {string} [params.engine] - Filter by engine (exact match)
+   * @param {string} [params.quantization] - Filter by quantization (partial match)
+   * @param {boolean} [params.includeDeprecated=false] - Include deprecated models
+   * @returns {Promise<Array>} Array of matching models
+   */
+  async findBy (params = {}) {
+    await this.ready()
+    this.logger.debug('findBy called', { params })
+    return this.db.findBy(params)
+  }
+
   _validateString (value, name) {
     if (typeof value !== 'string' || value.length === 0) {
       throw new Error(`Invalid ${name}: ${value}`)

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@tetherto/qvac-registry-schema-mono": "^0.1.0",
+    "@tetherto/qvac-registry-schema-mono": "^0.2.1",
     "b4a": "^1.6.7",
     "bare-fs": "^2.1.5",
     "bare-os": "^2.2.0",

--- a/packages/qvac-lib-registry-server/client/tests/unit/client.api.test.js
+++ b/packages/qvac-lib-registry-server/client/tests/unit/client.api.test.js
@@ -13,6 +13,7 @@ test('client api surface', async t => {
   t.ok(QVACRegistryClient.prototype.findModelsByEngine, 'has findModelsByEngine method')
   t.ok(QVACRegistryClient.prototype.findModelsByName, 'has findModelsByName method')
   t.ok(QVACRegistryClient.prototype.findModelsByQuantization, 'has findModelsByQuantization method')
+  t.ok(QVACRegistryClient.prototype.findBy, 'has findBy method')
   t.ok(QVACRegistryClient.prototype.ready, 'has ready method')
   t.ok(QVACRegistryClient.prototype.close, 'has close method')
 })
@@ -24,4 +25,5 @@ test('client find methods are async functions', async t => {
   t.ok(QVACRegistryClient.prototype.findModelsByEngine.constructor.name === 'AsyncFunction', 'findModelsByEngine is async')
   t.ok(QVACRegistryClient.prototype.findModelsByName.constructor.name === 'AsyncFunction', 'findModelsByName is async')
   t.ok(QVACRegistryClient.prototype.findModelsByQuantization.constructor.name === 'AsyncFunction', 'findModelsByQuantization is async')
+  t.ok(QVACRegistryClient.prototype.findBy.constructor.name === 'AsyncFunction', 'findBy is async')
 })


### PR DESCRIPTION
## Summary

Add `findBy(params)` method to `QVACRegistryClient` that delegates to the schema's `RegistryDatabase.findBy()` for efficient indexed queries.

## Why

The registry client previously only exposed low-level index-specific methods (`findModelsByEngine`, `findModelsByName`, etc.), requiring callers to choose the right index manually. The new `findBy()` provides a single entry point that automatically selects the most efficient HyperDB index based on the provided params — including the new compound `engine + quantization` index added in #145.

The `addon`/`modelType` filter is intentionally excluded from this method. It is a derived concept (engine → addon mapping) that exists only in the SDK layer, not in the database schema. The SDK server handler applies this mapping after receiving results from the client.

## Changes

- `client/lib/client.js`: Add `findBy()` method delegating to `this.db.findBy()`
- `client/index.d.ts`: Add `FindByParams` interface and `findBy` type definition
- `client/package.json`: Bump `@tetherto/qvac-registry-schema-mono` to `^0.2.1`
- `client/tests/unit/client.api.test.js`: Add `findBy` to API surface and async function tests

## Dependencies

Depends on `@tetherto/qvac-registry-schema-mono` v0.2.1 (released in #174).
