### PR TITLE
QVAC-13100: Add minimum compiler version to build.md

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/build.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/build.md
@@ -56,7 +56,8 @@ If you want to build the addon from source instead of using pre-built packages, 
 
 4. **Platform-specific requirements**:
    - **macOS**: 
-     - Xcode Command Line Tools (LLVM compiler is not supported)
+     - Xcode Command Line Tools
+     - Apple clang version >= 15.0.0 (LLVM compiler is not supported at the moment)
      - For Android cross-compilation: Android NDK and Vulkan tools (`brew install shaderc vulkan-tools molten-vk vulkan-headers`)
    - **Linux**: GCC/G++ compiler, CMake
      - Ubuntu-22 requires g++-13 installed:

--- a/packages/qvac-lib-infer-llamacpp-llm/build.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/build.md
@@ -56,7 +56,8 @@ If you want to build the addon from source instead of using pre-built packages, 
 
 4. **Platform-specific requirements**:
    - **macOS**: 
-     - Xcode Command Line Tools (LLVM compiler is not supported)
+     - Xcode Command Line Tools
+     - Apple clang version >= 15.0.0 (LLVM compiler is not supported at the moment)
      - For Android cross-compilation: Android NDK and Vulkan tools (`brew install shaderc vulkan-tools molten-vk vulkan-headers`)
    - **Linux**: GCC/G++ compiler, CMake
       - Ubuntu-22 requires g++-13 installed:


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Build prerequisites for macOS were incomplete in addon build docs.

## 📝 How does it solve it?

- Updates macOS requirements in `packages/qvac-lib-infer-llamacpp-llm/build.md` to explicitly require Apple clang `>= 15.0.0`.
- Applies the same clarification in `packages/qvac-lib-infer-llamacpp-embed/build.md` for consistency across related llama.cpp addons.

## 🧪 How was it tested?

- N/A (doc-only change)