### PR TITLE
QVAC-13086 feat: Scope CLI as @qvac/qvac-cli

### DIFF
--- a/packages/qvac-cli/CHANGELOG.md
+++ b/packages/qvac-cli/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ### 0.1.0
 
-- Initial release with `qvac bundle sdk`.
+- Initial release with `qvac bundle sdk`
+- Published as `@qvac/qvac-cli` (binary: `qvac`)
 

--- a/packages/qvac-cli/README.md
+++ b/packages/qvac-cli/README.md
@@ -16,13 +16,19 @@ A command-line interface for the QVAC ecosystem. QVAC CLI provides tooling for b
 Install globally:
 
 ```bash
-npm i -g qvac
+npm i -g @qvac/qvac-cli
 ```
 
-Or use directly via npx:
+Once installed, use the `qvac` command:
 
 ```bash
-npx qvac <command>
+qvac <command>
+```
+
+Or run directly via npx:
+
+```bash
+npx @qvac/qvac-cli <command>
 ```
 
 ## Command Reference

--- a/packages/qvac-cli/package.json
+++ b/packages/qvac-cli/package.json
@@ -5,6 +5,8 @@
   "author": "Tether",
   "license": "Apache-2.0",
   "type": "module",
+  "main": "./src/index.js",
+  "exports": "./src/index.js",
   "bin": {
     "qvac": "./src/index.js"
   },

--- a/packages/qvac-cli/package.json
+++ b/packages/qvac-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "qvac",
+  "name": "@qvac/qvac-cli",
   "version": "0.1.0",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The CLI package was named `qvac` (unscoped), which caused issues:

- **GPR publishing failed** — unscoped names can't be rewritten to `@tetherto/` scope
- **Name collision** — reserves the `qvac` name, blocking future shim package for `npx qvac`
- **Inconsistent** — other monorepo packages use `@qvac/` scope

---

## 📝 How does it solve it?

Renames the package from `qvac` to `@qvac/qvac-cli`:

- **Scoped name** — enables GPR publishing for dev usage
- **Binary preserved** — `qvac` command still works after global install
- **Prepares for shim** — frees up `qvac` name for future `npx qvac` forwarder

---

## Usage

### Install globally
npm i -g @qvac/qvac-cli

### Use the CLI
qvac bundle sdk

### Or via npx
npx @qvac/qvac-cli bundle sdk
