### PR TITLE
Use S3 cache for Vulkan SDK on Linux arm64 in prebuilds

### DIFF
--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -292,15 +292,11 @@ jobs:
           sudo apt install -y vulkan-sdk
 
       - if: ${{ matrix.os == 'ubuntu-24.04-arm64-private' }}
-        name: Cache Vulkan SDK for linux arm64
-        id: cache-vulkan-arm64
-        uses: actions/cache@v4
-        with:
-          path: ~/vulkan
-          key: vulkan-sdk-linux-arm64-v1
-
-      - if: ${{ matrix.os == 'ubuntu-24.04-arm64-private' && steps.cache-vulkan-arm64.outputs.cache-hit != 'true' }}
-        name: Build Vulkan SDK for linux arm64
+        name: Build Vulkan SDK for linux arm64 (with S3 cache)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           sudo apt install -y xz-utils
           wget -q -O /tmp/vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/latest/linux/vulkan_sdk.tar.xz
@@ -308,7 +304,29 @@ jobs:
           mkdir -p vulkan
           cd vulkan
           tar xf /tmp/vulkansdk.tar.xz --strip-components=1
-          ./vulkansdk --maxjobs
+
+          # Extract SDK major.minor version from README.txt (e.g., "1.4" from "1.4.341.0")
+          SDK_VERSION=$(grep -o 'sdk/[0-9]*\.[0-9]*' README.txt | head -1 | sed 's|sdk/||')
+          S3_BUCKET="tether-ai-dev"
+          S3_KEY="vulkan-sdk-cache/linux-arm64-${SDK_VERSION}.tar.gz"
+
+          echo "Vulkan SDK version: ${SDK_VERSION}"
+
+          # Try to download cached build from S3
+          if aws s3 cp "s3://${S3_BUCKET}/${S3_KEY}" /tmp/vulkan-arm64-cache.tar.gz 2>/dev/null; then
+            echo "Found cached Vulkan SDK, extracting..."
+            tar xzf /tmp/vulkan-arm64-cache.tar.gz -C ~/vulkan
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          else
+            echo "No cache found, building Vulkan SDK for ARM64..."
+            ./vulkansdk --maxjobs
+
+            # Upload the compiled SDK to S3 for future runs
+            echo "Uploading compiled SDK to S3..."
+            tar czf /tmp/vulkan-arm64-cache.tar.gz aarch64
+            aws s3 cp /tmp/vulkan-arm64-cache.tar.gz "s3://${S3_BUCKET}/${S3_KEY}"
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          fi
 
       - if: ${{ matrix.os == 'ubuntu-24.04-arm64-private' }}
         name: Setup Vulkan SDK environment for linux arm64

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -323,11 +323,38 @@ jobs:
 
       - if: ${{ matrix.platform == 'linux' && matrix.arch == 'arm64' }}
         name: Setup vulkan sdk path in linux arm64
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           VULKAN_SDK=~/vulkan/aarch64
           echo "VULKAN_SDK=$VULKAN_SDK" >> $GITHUB_ENV
+
           cd ~/vulkan
-          ./vulkansdk --maxjobs
+
+          # Extract SDK major.minor version from README.txt (e.g., "1.4" from "1.4.341.0")
+          SDK_VERSION=$(grep -o 'sdk/[0-9]*\.[0-9]*' README.txt | head -1 | sed 's|sdk/||')
+          S3_BUCKET="tether-ai-dev"
+          S3_KEY="vulkan-sdk-cache/linux-arm64-${SDK_VERSION}.tar.gz"
+
+          echo "Vulkan SDK version: ${SDK_VERSION}"
+
+          # Try to download cached build from S3
+          if aws s3 cp "s3://${S3_BUCKET}/${S3_KEY}" /tmp/vulkan-arm64-cache.tar.gz 2>/dev/null; then
+            echo "Found cached Vulkan SDK, extracting..."
+            tar xzf /tmp/vulkan-arm64-cache.tar.gz -C ~/vulkan
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          else
+            echo "No cache found, building Vulkan SDK for ARM64..."
+            ./vulkansdk --maxjobs
+
+            # Upload the compiled SDK to S3 for future runs
+            echo "Uploading compiled SDK to S3..."
+            tar czf /tmp/vulkan-arm64-cache.tar.gz aarch64
+            aws s3 cp /tmp/vulkan-arm64-cache.tar.gz "s3://${S3_BUCKET}/${S3_KEY}"
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          fi
 
       - if: ${{ matrix.platform == 'linux' }}
         name: Export rest of vulkan sdk variables in linux


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Linux arm64 prebuilds for whispercpp and nmtcpp rebuild the Vulkan SDK every run (or rely on a small, volatile GitHub Actions cache), which is slow and unreliable.
- Inconsistent caching: LLM and embed prebuilds already use S3 for Vulkan; whispercpp and nmtcpp did not.

## 📝 How does it solve it?

- **prebuilds-qvac-lib-infer-whispercpp.yml**: In the “Setup vulkan sdk path in linux arm64” step, add S3-backed caching: try to download `linux-arm64-${SDK_VERSION}.tar.gz` from `tether-ai-dev`; on miss, run `./vulkansdk --maxjobs` and upload the resulting `aarch64` tarball to S3.
- **prebuilds-qvac-lib-infer-nmtcpp.yml**: Replace the Vulkan “Cache” + “Build” steps with a single “Build Vulkan SDK for linux arm64 (with S3 cache)” step that uses the same S3 download-or-build-and-upload logic (and remove the `actions/cache` step for `~/vulkan`).
- Both use the same pattern as the LLM/embed workflows: SDK version from `README.txt`, bucket `tether-ai-dev`, key `vulkan-sdk-cache/linux-arm64-${SDK_VERSION}.tar.gz`, with AWS credentials from secrets.

## 🧪 How was it tested?

- Ran the prebuilds on the temp branch.
  - whispercpp: https://github.com/tetherto/qvac/actions/runs/21863344527/job/63097974059
  - nmtcpp: https://github.com/tetherto/qvac/actions/runs/21863296503/job/63097807326 
