### PR TITLE
release(qvac-lib-registry-client): v0.2.0

### DIFF
--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/qvac-lib-registry-client",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

- Bumps `@tetherto/qvac-lib-registry-client` from `0.1.3` to `0.2.0`
- Uses `feature-*` branch to trigger GPR publish (package not yet on npm)

## Changes since v0.1.3

- Add `findBy(params)` method to `QVACRegistryClient` for efficient indexed queries (#184)
- Bump `@tetherto/qvac-registry-schema-mono` dependency to `^0.2.1`
- Add `FindByParams` interface and `findBy` type definition
- Add `findBy` to client API surface and async function tests


Made with [Cursor](https://cursor.com)