### PR TITLE
QVAC-12185 chore: bump llamacpp deps and remove iphone 17 cpu override

### DIFF
--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -71,10 +71,10 @@
   "dependencies": {
     "@qvac/decoder-audio": "^0.3.3",
     "@qvac/dl-filesystem": "^0.2.0",
-    "@qvac/embed-llamacpp": "^0.10.3",
+    "@qvac/embed-llamacpp": "^0.10.7",
     "@qvac/error": "^0.1.1",
     "@qvac/langdetect-text": "^0.1.0",
-    "@qvac/llm-llamacpp": "^0.8.5",
+    "@qvac/llm-llamacpp": "^0.8.9",
     "@qvac/logging": "^0.1.0",
     "@qvac/ocr-onnx": "^0.1.5",
     "@qvac/rag": "^0.4.2",

--- a/packages/qvac-sdk/server/bare/registry/model-config-utils.ts
+++ b/packages/qvac-sdk/server/bare/registry/model-config-utils.ts
@@ -51,17 +51,6 @@ export const BUILTIN_DEVICE_PATTERNS: DevicePattern[] = [
       [ModelType.llamacppEmbedding]: { device: "cpu" },
     },
   },
-  {
-    name: "iPhone 17",
-    match: {
-      platform: "ios",
-      deviceModelPrefix: "iPhone 17",
-    },
-    defaults: {
-      [ModelType.llamacppCompletion]: { device: "cpu" },
-      [ModelType.llamacppEmbedding]: { device: "cpu" },
-    },
-  },
 ];
 
 export function matchesPattern(


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- `@qvac/sdk` was pinned to older `@qvac/embed-llamacpp` and `@qvac/llm-llamacpp` versions.
- SDK had a device-specific CPU override for the iPhone 17 family that is no longer needed, as the fixes upstream remove the need for it and GPU performs better on iphone

## 📝 How does it solve it?

- Bumps `@qvac/embed-llamacpp` from `^0.10.3` to `^0.10.7`
- Bumps `@qvac/llm-llamacpp` from `^0.8.5` to `^0.8.9` 
- Removes the built-in `iPhone 17` pattern from `BUILTIN_DEVICE_PATTERNS` so iPhone 17 uses default device behavior

## 🧪 How was it tested?

- I tried it on test expo app with iphone 17 (GPU and CPU loading + testing of LLM, Embed, and Vision models)