### PR TITLE
chore: remove CHANGELOG from files

### DIFF
--- a/packages/qvac-cli/package.json
+++ b/packages/qvac-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/qvac-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -13,7 +13,6 @@
   "files": [
     "src/**/*",
     "README.md",
-    "CHANGELOG.md",
     "LICENSE"
   ],
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The `CHANGELOG.md` was included in the published package files, which is inconsistent with other packages in the qvac monorepo.

---

## 📝 How does it solve it?

- Removes `CHANGELOG.md` from the `files` array in `package.json`
- Bumps version to `0.1.1`