### PR TITLE
QVAC-12185 chore: prepare qvac-sdk 0.6.1 release

### DIFF
--- a/packages/qvac-sdk/changelog/0.6.1/CHANGELOG.md
+++ b/packages/qvac-sdk/changelog/0.6.1/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.6.1
+
+Release Date: 2026-02-10
+
+## 🧹 Chores
+
+- Bump llamacpp deps and remove iphone 17 cpu override. (see PR [#213](https://github.com/tetherto/qvac/pull/213))
+
+## ⚙️ Infrastructure
+
+- Update SDK pod changelog generation and shared tooling. (see PR [#155](https://github.com/tetherto/qvac/pull/155))
+

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- `qvac-sdk` needs a dedicated `0.6.1` release update from the monorepo baseline with no package tag history.
- Release metadata must include a version bump and a generated changelog for release automation.

## 📝 How does it solve it?

- Bumps `packages/qvac-sdk/package.json` from `0.6.0` to `0.6.1`.
- Generates `packages/qvac-sdk/changelog/0.6.1/CHANGELOG.md` using migration flags:
  - `--base-commit=6283176`
  - `--base-version=0.6.0`

## 🧪 How was it tested?

- Ran changelog generation command successfully:
  - `node scripts/sdk/generate-changelog-sdk-pod.cjs --package=qvac-sdk --base-commit=6283176 --base-version=0.6.0`
- Verified output files and git diff contain only release version + changelog changes.