### PR TITLE
QVAC-12185 chore: prepare qvac-sdk 0.6.1 release

### DIFF
--- a/packages/qvac-sdk/changelog/0.6.1/CHANGELOG.md
+++ b/packages/qvac-sdk/changelog/0.6.1/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.6.1
+
+Release Date: 2026-02-10
+
+## 🧹 Chores
+
+- Bump llamacpp dependencies and remove iphone 17 cpu override. (see PR [#213](https://github.com/tetherto/qvac/pull/213))
+
+## ⚙️ Infrastructure
+
+- Update SDK pod changelog generation and shared tooling. (see PR [#155](https://github.com/tetherto/qvac/pull/155))
+

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

 - Release qvac-sdk v0.6.1 (fix apple a19 chip issues with llamacpp addons)

## 🧹 Chores

- Bump llamacpp dependencies and remove iphone 17 cpu override. (see PR [#213](https://github.com/tetherto/qvac/pull/213))

## ⚙️ Infrastructure

- Update SDK pod changelog generation and shared tooling. (see PR [#155](https://github.com/tetherto/qvac/pull/155))

