### PR TITLE
QVAC-13160 infra: disable automatic qvac-sdk test workflow triggers

### DIFF
--- a/.github/workflows/test-qvac-sdk.yml
+++ b/.github/workflows/test-qvac-sdk.yml
@@ -5,20 +5,22 @@
 name: QVAC Tests (Qvac-sdk)
 
 on:
-  pull_request:
-    paths:
-      - "packages/qvac-sdk/**"
-    branches:
-      - main
-      - release-*
-  push:
-    branches:
-      - main
-      - release-*
-      - feature-*
-      - tmp-*
-    paths:
-      - "packages/qvac-sdk/**"
+  # Disabled until it's stabilised, to not waste compute resources
+  workflow_dispatch:
+  # pull_request:
+  #   paths:
+  #     - "packages/qvac-sdk/**"
+  #   branches:
+  #     - main
+  #     - release-*
+  # push:
+  #   branches:
+  #     - main
+  #     - release-*
+  #     - feature-*
+  #     - tmp-*
+  #   paths:
+  #     - "packages/qvac-sdk/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- SDK E2E tests are currently unstable and create noisy failures in routine branch activity.
- Automatic triggers consume CI resources while the suite is not reliable enough to gate changes.

## 📝 How does it solve it?

- Disables `pull_request` and `push` triggers for `QVAC Tests (Qvac-sdk)`.
- Keeps `workflow_dispatch` enabled so the workflow can still be run manually when needed.