### PR TITLE
QVAC-13067: Fix unit tests

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_logging_macros.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_logging_macros.cpp
@@ -19,7 +19,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevel0) {
   std::unordered_map<std::string, std::string> config;
   config["verbosity"] = "0";
 
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, Priority::ERROR);
   EXPECT_EQ(config.find("verbosity"), config.end());
@@ -29,7 +29,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevel1) {
   std::unordered_map<std::string, std::string> config;
   config["verbosity"] = "1";
 
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, Priority::WARNING);
   EXPECT_EQ(config.find("verbosity"), config.end());
@@ -39,7 +39,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevel2) {
   std::unordered_map<std::string, std::string> config;
   config["verbosity"] = "2";
 
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, Priority::INFO);
   EXPECT_EQ(config.find("verbosity"), config.end());
@@ -49,7 +49,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevel3) {
   std::unordered_map<std::string, std::string> config;
   config["verbosity"] = "3";
 
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, Priority::DEBUG);
   EXPECT_EQ(config.find("verbosity"), config.end());
@@ -60,7 +60,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevelMissingKey) {
   config["other_key"] = "value";
 
   Priority originalLevel = g_verbosityLevel;
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, originalLevel);
   EXPECT_NE(config.find("other_key"), config.end());
@@ -70,7 +70,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevelEmptyMap) {
   std::unordered_map<std::string, std::string> config;
 
   Priority originalLevel = g_verbosityLevel;
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, originalLevel);
   EXPECT_TRUE(config.empty());
@@ -80,7 +80,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevelInvalidNegative) {
   std::unordered_map<std::string, std::string> config;
   config["verbosity"] = "-1";
 
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, Priority::ERROR);
   EXPECT_NE(config.find("verbosity"), config.end());
@@ -90,7 +90,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevelInvalidTooHigh) {
   std::unordered_map<std::string, std::string> config;
   config["verbosity"] = "4";
 
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, Priority::ERROR);
   EXPECT_NE(config.find("verbosity"), config.end());
@@ -100,7 +100,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevelNonNumeric) {
   std::unordered_map<std::string, std::string> config;
   config["verbosity"] = "invalid";
 
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, Priority::ERROR);
   EXPECT_EQ(config.find("verbosity"), config.end());
@@ -110,7 +110,7 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevelEmptyString) {
   std::unordered_map<std::string, std::string> config;
   config["verbosity"] = "";
 
-  SetVerbosityLevel(config);
+  setVerbosityLevel(config);
 
   EXPECT_EQ(g_verbosityLevel, Priority::ERROR);
   EXPECT_EQ(config.find("verbosity"), config.end());
@@ -119,12 +119,12 @@ TEST_F(LoggingMacrosTest, SetVerbosityLevelEmptyString) {
 TEST_F(LoggingMacrosTest, VerbosityLevelPersistence) {
   std::unordered_map<std::string, std::string> config1;
   config1["verbosity"] = "2";
-  SetVerbosityLevel(config1);
+  setVerbosityLevel(config1);
   EXPECT_EQ(g_verbosityLevel, Priority::INFO);
 
   std::unordered_map<std::string, std::string> config2;
   config2["verbosity"] = "3";
-  SetVerbosityLevel(config2);
+  setVerbosityLevel(config2);
   EXPECT_EQ(g_verbosityLevel, Priority::DEBUG);
 }
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- cpp-tests step is failing because of naming changes that weren't applied to the test suite.

## 📝 How does it solve it?

- It applies the naming change to the test suite.

## 🧪 How was it tested?

- The tests were built with `npm run test:cpp:build` and then run with `cd build/test/unit && ./addon-test` which are the same commands the cpp-tests workflow uses. The tests passed.
