### PR TITLE
QVAC-13166 Fix cpp-test pipeline doesn't checkout the PR branch but main

### DIFF
--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -37,6 +37,7 @@ jobs:
       changelog-path: packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
 
   sanity-checks:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
@@ -49,12 +50,18 @@ jobs:
           workdir: packages/qvac-lib-infer-llamacpp-llm
 
   cpp-tests:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: sanity-checks
     uses: ./.github/workflows/cpp-tests-llm.yml
     secrets: inherit
     with:
       workdir: packages/qvac-lib-infer-llamacpp-llm
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name }}
+      ref: ${{ github.event.pull_request.head.ref }}
 
   cpp-lint:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
     uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
     secrets: inherit
     with:


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- cpp-tests was missing ref to PR branch. So the tests ran against main branch by default.

## 📝 How does it solve it?

- Added ref to request branch in on -pr workflow of llm addon
- Aslo added verify label requirement to cpp-tests, cpp-lint and sanity-checks


Task link
https://app.asana.com/1/45238840754660/project/1212638335655939/task/1213228017508993?focus=true