### PR TITLE
Fix/whisper silence hallucination (#210)

### DIFF
--- a/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
@@ -46,7 +46,7 @@ jobs:
           - os: macos-14-xlarge
             platform: darwin
             arch: arm64
-          - os: windows-2022
+          - os: ai-run-windows-gpu
             platform: win32
             arch: x64
 
@@ -68,7 +68,8 @@ jobs:
           repository: ${{ inputs.repository || github.repository }}
           token: ${{ secrets.PAT_TOKEN }}
 
-      - name: Configure scoped registry for @tetherto and @qvac packages
+      - name: Configure scoped registry for @tetherto and @qvac packages (Unix)
+        if: ${{ matrix.platform != 'win32' }}
         working-directory: ${{ env.WORKDIR }}
         env:
           GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -80,6 +81,7 @@ jobs:
           set -eu
           echo "Writing .npmrc for dual registry install…"
           cat > .npmrc <<NPMRC
+          always-auth=true
           registry=https://registry.npmjs.org/
           @qvac:registry=https://registry.npmjs.org/
           @tetherto:registry=https://npm.pkg.github.com/
@@ -95,12 +97,36 @@ jobs:
             git config --global url."https://${{ github.token }}:@github.com/".insteadOf "https://github.com/"
           fi
 
+      - name: Configure scoped registry for @tetherto and @qvac packages (Windows)
+        if: ${{ matrix.platform == 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        env:
+          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_PAT: ${{ secrets.PAT_TOKEN }}
+        shell: powershell
+        run: |
+          Write-Host "Configuring scoped registry for @tetherto and @qvac packages..."
+          $npmrc = @"
+          always-auth=true
+          registry=https://registry.npmjs.org/
+          @qvac:registry=https://registry.npmjs.org/
+          @tetherto:registry=https://npm.pkg.github.com/
+          //registry.npmjs.org/:_authToken=$env:NPM_TOKEN
+          //npm.pkg.github.com/:_authToken=$env:GPR_TOKEN
+          "@
+          $npmrc | Out-File -FilePath .npmrc -Encoding utf8
+          if ($env:GIT_PAT) {
+            git config --global url."https://$($env:GIT_PAT):@github.com/".insteadOf "https://github.com/"
+          } else {
+            git config --global url."https://${{ github.token }}:@github.com/".insteadOf "https://github.com/"
+          }
+
       - name: Install NPM dependencies
         working-directory: ${{ env.WORKDIR }}
-        shell: bash
         run: |
           npm install
-          npm install -g bare bare-make
+          npm install -g bare@1.26.0 bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}
@@ -109,15 +135,33 @@ jobs:
           path: ${{ env.WORKDIR }}/prebuilds
           merge-multiple: true
 
-      - name: Download prebuilds from package
-        if: ${{ inputs.prebuild_package }}
+      - name: Download prebuilds from package (Unix)
+        if: ${{ inputs.prebuild_package && matrix.platform != 'win32' }}
         working-directory: ${{ env.WORKDIR }}
         shell: bash
         run: |
           mkdir -p prebuilds
-          npm pack "${{ inputs.prebuild_package }}" --pack-destination /tmp
+          npm pack ${{ inputs.prebuild_package }} --pack-destination /tmp
           tar -xzf /tmp/*.tgz -C /tmp
           cp -r /tmp/package/prebuilds/* prebuilds/
+          find prebuilds -type f -name 'tetherto__*' | while read f; do
+            mv "$f" "${f/tetherto__/qvac__}"
+          done
+
+      - name: Download prebuilds from package (Windows)
+        if: ${{ inputs.prebuild_package && matrix.platform == 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        shell: powershell
+        run: |
+          New-Item -ItemType Directory -Force -Path prebuilds | Out-Null
+          npm pack ${{ inputs.prebuild_package }} --pack-destination $env:TEMP
+          $tgz = Get-ChildItem "$env:TEMP\*.tgz" | Select-Object -First 1
+          tar -xzf $tgz.FullName -C $env:TEMP
+          Copy-Item -Path "$env:TEMP\package\prebuilds\*" -Destination prebuilds -Recurse -Force
+          Get-ChildItem -Path prebuilds -Recurse -File -Filter 'tetherto__*' | ForEach-Object {
+            $newName = $_.Name -replace 'tetherto__', 'qvac__'
+            Rename-Item -Path $_.FullName -NewName $newName
+          }
 
       - name: Install gh cli for ai-run-linux-gpu
         if: matrix.os == 'ai-run-linux-gpu'
@@ -155,18 +199,36 @@ jobs:
         run: |
           brew install --quiet openblas lapack fftw
 
-      - name: Run integration test
+      - name: Run integration test (Unix)
+        if: ${{ matrix.platform != 'win32' }}
         working-directory: ${{ env.WORKDIR }}
         shell: bash
-        run: |
-          npm run test:integration
+        run: npm run test:integration
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
 
-      - name: Print run state
+      - name: Run integration test (Windows)
+        if: ${{ matrix.platform == 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        shell: powershell
+        run: npm run test:integration
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+      - name: Print run state (Unix)
+        if: ${{ matrix.platform != 'win32' }}
         working-directory: ${{ env.WORKDIR }}
         shell: bash
         run: |
           ls -la prebuilds || true
           tree prebuilds || true
+        continue-on-error: true
+
+      - name: Print run state (Windows)
+        if: ${{ matrix.platform == 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        shell: powershell
+        run: |
+          Get-ChildItem prebuilds -ErrorAction SilentlyContinue
+          tree prebuilds /F 2>$null
         continue-on-error: true

--- a/packages/qvac-lib-infer-whispercpp/addon/src/model-interface/whisper.cpp/WhisperModel.cpp
+++ b/packages/qvac-lib-infer-whispercpp/addon/src/model-interface/whisper.cpp/WhisperModel.cpp
@@ -68,13 +68,6 @@ void WhisperModel::load() {
       throw std::runtime_error("Failed to initialize Whisper context");
     }
 
-    state_.reset(whisper_init_state(ctx_.get()));
-    if (state_ == nullptr) {
-      QLOG(
-          qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-          "Failed to initialize Whisper state");
-      throw std::runtime_error("Failed to initialize Whisper state");
-    }
     is_loaded_ = true;
     QLOG(
         qvac_lib_inference_addon_cpp::logger::Priority::INFO,
@@ -238,9 +231,8 @@ void WhisperModel::warmup() {
   params.new_segment_callback_user_data = nullptr;
 
   // Run warmup inference to "heat up" the model
-  whisper_full_with_state(
+  whisper_full(
       ctx_.get(),
-      state_.get(),
       params,
       silentAudio.data(),
       static_cast<int>(silentAudio.size()));
@@ -282,12 +274,8 @@ void WhisperModel::process(const Input& input) {
   params.new_segment_callback = onNewSegment;
   params.new_segment_callback_user_data = &ud;
 
-  int result = whisper_full_with_state(
-      ctx_.get(),
-      state_.get(),
-      params,
-      input.data(),
-      static_cast<int>(input.size()));
+  int result = whisper_full(
+      ctx_.get(), params, input.data(), static_cast<int>(input.size()));
 
   const auto t1 = std::chrono::steady_clock::now();
   totalWallMs_ += std::chrono::duration<double, std::milli>(t1 - t0).count();
@@ -371,10 +359,7 @@ bool WhisperModel::configContextIsChanged(
   return false;
 }
 
-void WhisperModel::resetContext() {
-  ctx_.reset();
-  state_.reset();
-}
+void WhisperModel::resetContext() { ctx_.reset(); }
 
 void WhisperModel::setConfig(const WhisperConfig& config) {
   bool contextChanged = configContextIsChanged(cfg_, config);

--- a/packages/qvac-lib-infer-whispercpp/addon/src/model-interface/whisper.cpp/WhisperModel.hpp
+++ b/packages/qvac-lib-infer-whispercpp/addon/src/model-interface/whisper.cpp/WhisperModel.hpp
@@ -121,16 +121,7 @@ private:
     }
   };
 
-  struct WhisperStateDeleter {
-    void operator()(whisper_state* state) const noexcept {
-      if (state != nullptr) {
-        whisper_free_state(state);
-      }
-    }
-  };
-
   std::unique_ptr<whisper_context, WhisperContextDeleter> ctx_{nullptr};
-  std::unique_ptr<whisper_state, WhisperStateDeleter> state_{nullptr};
   bool stream_ended_ = false;
   bool is_loaded_ = false;
   bool is_warmed_up_ = false;

--- a/packages/qvac-lib-infer-whispercpp/package.json
+++ b/packages/qvac-lib-infer-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-whispercpp/release-notes/v0.3.18.md
+++ b/packages/qvac-lib-infer-whispercpp/release-notes/v0.3.18.md
@@ -1,0 +1,25 @@
+# QVAC Transcription Whisper Addon v0.3.18 Release Notes
+
+This release updates the whisper.cpp integration to use the latest API and improves Windows platform support for CI/CD workflows.
+
+## Features
+
+### Enhanced Windows Platform Support
+
+The integration test workflow now includes comprehensive Windows support with PowerShell-specific configurations. This includes separate registry configuration steps for Unix and Windows platforms, ensuring proper package authentication across all environments. The workflow now uses the `ai-run-windows-gpu` runner for better GPU-accelerated testing on Windows.
+
+### Prebuild Package Renaming Support
+
+Added automatic renaming of prebuild packages from `tetherto__*` to `qvac__*` format during the package download process. This ensures consistency across all platforms and simplifies the build artifact management.
+
+## Bug Fixes
+
+### Whisper.cpp API Compatibility
+
+Updated the integration with whisper.cpp to use the new 4-parameter API for `whisper_full()`. The previous 5-parameter version that included an explicit state parameter has been deprecated. The state is now managed internally by the whisper.cpp context, simplifying the code and removing unnecessary state management overhead.
+
+Removed the obsolete `whisper_state` member variable and related initialization code, as the new whisper.cpp API handles state management automatically through the context object.
+
+## Other
+
+Updated the integration test workflow to use a specific version of `bare@1.26.0` for better build consistency. Added the `always-auth=true` configuration for npm registry authentication to improve reliability when downloading private packages.


### PR DESCRIPTION
* Fix/whisper silence hallucination (#160)

* Refactor `WhisperModel` to remove unnecessary `state_` handling and streamline `whisper_full` usage. Update workflows for cross-platform compatibility and bump package version to 0.3.18.

* Add v0.3.18 release notes detailing API updates, Windows CI/CD enhancements, prebuild package renaming, and bug fixes

* Update workflow for Whispercpp integration tests: rename workflow, tweak inputs/env variables, and remove redundant comments

* Refactor `WhisperModel` to streamline formatting of function calls and simplify method implementation.

* Simplify integration test workflow by unifying Unix/Windows steps, updating OS matrix, and removing redundant configurations.

* Enhance integration test workflow: add Windows-specific steps, configure scoped registries, improve prebuild handling, and update test execution logic.

* Update integration test workflow: adjust OS matrix, add `working-directory` to steps, and refine platform-specific configurations.

* Update integration test workflow: specify test file paths under `tests/` directory for Android and iOS configurations.

* Merge main into fix/whispercpp-vad (#201)

* update prebuild download location for addon workflows

* Use S3 cache for Vulkan SDK on Linux arm64 in prebuilds (#200)

Reuse the same S3 Vulkan SDK cache (bucket tether-ai-dev) in prebuilds-qvac-lib-infer-whispercpp and prebuilds-qvac-lib-infer-nmtcpp. Replaces the previous GitHub Actions cache in nmtcpp and adds S3 download-or-build-and-upload in whispercpp so arm64 builds match the LLM/embed workflows.

---------




* Fix integration tests name in whispercpp

* Revert wrong change in mobile tests for whispercpp

---------