### PR TITLE
release(qvac-lib-registry-client): v0.2.0

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to `@tetherto/qvac-lib-registry-client` will be documented in this file.
+
+## [0.2.0] - 2026-02-12
+
+### Added
+
+- `findBy(params)` method on `QVACRegistryClient` for efficient indexed queries by name, engine, and quantization (#184)
+- `FindByParams` interface for typed query parameters (name, engine, quantization, includeDeprecated)
+- `findBy` type definition in `index.d.ts`
+
+### Changed
+
+- Bumped `@tetherto/qvac-registry-schema-mono` dependency from `^0.1.x` to `^0.2.1`
+
+## [0.1.3] - Previous release
+
+- Initial stable release with `findModels`, `getModel`, `downloadModel`, and query-by-index methods

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/qvac-lib-registry-client",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

- Bumps `@tetherto/qvac-lib-registry-client` from `0.1.3` to `0.2.0`

## Changes since v0.1.3

- Add `findBy(params)` method to `QVACRegistryClient` for efficient indexed queries (#184)
- Bump `@tetherto/qvac-registry-schema-mono` dependency to `^0.2.1`
- Add `FindByParams` interface and `findBy` type definition
- Add `findBy` to client API surface and async function tests

