### PR TITLE
release(ocr): v0.1.7

### DIFF
--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/CHANGELOG.md
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.1.7] - 2026-02-12
+
+### Changed
+
+- Replaced fixed-width recognizer preprocessing with EasyOCR-style dynamic-width resizing for improved OCR accuracy. Images are now resized proportionally to model height with LANCZOS4 interpolation instead of aspect-preserving resize to a fixed 512px width.
+- Switched to dynamic-width recognizer models (`rec_dyn`). Batch inference now uses per-batch proportional width instead of fixed `RECOGNIZER_MODEL_WIDTH`.
+- Updated default model path from `rec_512` to `rec_dyn` across tests, benchmarks, and scripts.
+- Replaced English recognizer with Latin recognizer in unit tests (`recognizer_english.onnx` → `recognizer_latin.onnx`).
+- Added `--model-dir` CLI option to batch OCR CLI, evaluate script, and QVAC OCR backend for configurable model directory.
+
+### Fixed
+
+- Improved Portuguese OCR accuracy (minor punctuation corrections in test expected outputs).
+
 # [0.1.6] - 2026-02-09
 
 ### Changed

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/package.json
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-onnx",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "OCR addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/release-notes/v0.1.7.md
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/release-notes/v0.1.7.md
@@ -1,0 +1,19 @@
+# QVAC OCR Addon v0.1.7 Release Notes
+
+This release introduces EasyOCR-style dynamic-width recognizer preprocessing, improving OCR accuracy by preserving aspect ratios during text recognition.
+
+## Accuracy Improvements
+
+### Dynamic-Width Recognizer Preprocessing
+
+The text recognizer pipeline now uses EasyOCR-style dynamic-width resizing instead of the previous fixed-width (512px) approach. Images are resized proportionally to the model height (64px) using LANCZOS4 interpolation, and each batch uses the maximum proportional width across all images in the batch. This preserves the original aspect ratio of text regions, leading to better recognition accuracy.
+
+### Dynamic-Width Models
+
+Switched from fixed-width recognizer models (`rec_512`) to dynamic-width models (`rec_dyn`) that accept variable input widths. The English recognizer has been replaced by the Latin recognizer, which covers all Latin-script languages including English.
+
+## Benchmark Tooling
+
+### Configurable Model Directory
+
+Added `--model-dir` CLI option to the batch OCR CLI (`ocr_batch_cli.js`), evaluation script (`evaluate.py`), and QVAC OCR backend (`qvac_ocr_backend.py`), allowing easy switching between model directories for benchmarking.


### PR DESCRIPTION
## Summary
- Bump version to 0.1.7
- Add changelog entry for v0.1.7

## Changes (same as v0.1.6)
- Dynamic-width recognizer preprocessing (EasyOCR-style)
- Switched to `rec_dyn` models
- Updated default model path from `rec_512` to `rec_dyn`
- Added `--model-dir` CLI option
- Portuguese OCR accuracy fix