### PR TITLE
chore[notask]: backmerge release-qvac-sdk-0.6.1 into main

### DIFF
--- a/packages/qvac-sdk/changelog/0.6.1/CHANGELOG.md
+++ b/packages/qvac-sdk/changelog/0.6.1/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.6.1
+
+Release Date: 2026-02-10
+
+## 🧹 Chores
+
+- Bump llamacpp dependencies and remove iphone 17 cpu override. (see PR [#213](https://github.com/tetherto/qvac/pull/213))
+
+## ⚙️ Infrastructure
+
+- Update SDK pod changelog generation and shared tooling. (see PR [#155](https://github.com/tetherto/qvac/pull/155))
+

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## What problem does this PR solve?

The `release-qvac-sdk-0.6.1` branch has the v0.6.1 release commit (version bump + changelog) that needs to be merged back into `main` to keep the mainline up to date.

## How does it solve it?

Standard backmerge of `release-qvac-sdk-0.6.1` into `main`. Clean merge, no conflicts.

### Changed files

- `packages/qvac-sdk/changelog/0.6.1/CHANGELOG.md` — new changelog entry for v0.6.1
- `packages/qvac-sdk/package.json` — version bump to 0.6.1

## How was it tested?

No functional changes — version bump and changelog only. Clean merge with no conflicts.
