### PR TITLE
QVAC-13067: Applied clang-tidy naming changes

### DIFF
--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/addon/AddonJs.hpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/addon/AddonJs.hpp
@@ -43,13 +43,13 @@ getJsArrayFromOutput(js_env_t* env, const Pipeline::Output& inferredTextList) {
   for (size_t i = 0; i < inferredTextListLength; i++) {
 
     // Create bounding box elements: [ [x1, y1], [x2, y2], [x3, y3], [x4, y4 ]
-    constexpr size_t BOX_COORDINATES_LENGTH = 4;
-    std::array<js_value_t*, BOX_COORDINATES_LENGTH> jsBoxCoordinatesElements{};
+    constexpr size_t boxCoordinatesLength = 4;
+    std::array<js_value_t*, boxCoordinatesLength> jsBoxCoordinatesElements{};
     for (size_t boxCoordinateIndex = 0;
-         boxCoordinateIndex < BOX_COORDINATES_LENGTH;
+         boxCoordinateIndex < boxCoordinatesLength;
          boxCoordinateIndex++) {
-      constexpr size_t COORDINATE_PAIR_LENGTH = 2;
-      std::array<js_value_t*, COORDINATE_PAIR_LENGTH> jsCoordinatePairElement{};
+      constexpr size_t coordinatePairLength = 2;
+      std::array<js_value_t*, coordinatePairLength> jsCoordinatePairElement{};
       jsCoordinatePairElement.at(0) =
           qvac_lib_inference_addon_cpp::js::Number::create(
               env, inferredTextList[i].boxCoordinates.at(boxCoordinateIndex).x);
@@ -60,8 +60,8 @@ getJsArrayFromOutput(js_env_t* env, const Pipeline::Output& inferredTextList) {
           createArrayFromElements(env, std::span{jsCoordinatePairElement});
     }
 
-    constexpr size_t INFERRED_TEXT_LENGTH = 3;
-    std::array<js_value_t*, INFERRED_TEXT_LENGTH> jsInferredTextElements{};
+    constexpr size_t inferredTextLength = 3;
+    std::array<js_value_t*, inferredTextLength> jsInferredTextElements{};
     jsInferredTextElements.at(0) =
         createArrayFromElements(env, std::span{jsBoxCoordinatesElements});
     jsInferredTextElements.at(1) =

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/js-interface/binding.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/js-interface/binding.cpp
@@ -3,8 +3,7 @@
 #include "../addon/AddonJs.hpp"
 
 js_value_t* qvacLibInferenceAddonOnnxOcrFasttextExports(
-    js_env_t* env,
-    js_value_t* exports) {
+    js_env_t* env, js_value_t* exports) {
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define V(name, fn)                                                            \

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/js-interface/binding.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/js-interface/binding.cpp
@@ -4,7 +4,7 @@
 
 js_value_t* qvacLibInferenceAddonOnnxOcrFasttextExports(
     js_env_t* env,
-    js_value_t* exports) { // NOLINT(readability-identifier-naming)
+    js_value_t* exports) {
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define V(name, fn)                                                            \

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Lang.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Lang.cpp
@@ -11,6 +11,8 @@ namespace qvac_lib_inference_addon_onnx_ocr_fasttext {
 
 namespace {
 
+// clang-format off
+// Disabled to maintain formatting of the lists.
 constexpr auto LATIN_LANG_LIST = std::to_array<std::string_view>(
     {"af", "az", "bs", "cs", "cy", "da", "de", "en", "es", "et", "fr",       "ga", "hr", "hu", "id", "is", "it", "ku", "la", "lt", "lv",
      "mi", "ms", "mt", "nl", "no", "oc", "pi", "pl", "pt", "ro", "rs_latin", "sk", "sl", "sq", "sv", "sw", "tl", "tr", "uz", "vi"});
@@ -910,6 +912,7 @@ const std::map<std::string_view, std::u32string_view> LANG_TO_CHARS_MAP = {
      U"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzĐđĂăÂâÊêÔôƠơƯưÀàẰằẦầÈèỀềÌìÒòỒồỜờÙùỪừỲỳẢảẲẳẨẩẺẻỂểỈỉỎỏỔổỞởỦủỬửỶỷÃãẴẵẪẫẼẽỄễĨĩÕõỖỗỠỡŨũỮữỸỹÁáẮắ"
      U"Ấ"
      "ấÉéẾếÍíÓóỐốỚớÚúỨứÝýẠạẶặẬậẸẹỆệỊịỌọỘộỢợỤụỰựỴỵ"}};
+// clang-format on
 
 bool contains(std::span<const std::string> vec, std::string_view str) {
   return std::find(vec.begin(), vec.end(), str) != vec.end();
@@ -934,27 +937,35 @@ std::set<std::string_view> setDifference(const std::set<std::string> &setA, cons
 }
 
 bool isLatinLang(std::string_view lang) {
-  return std::find(LATIN_LANG_LIST.begin(), LATIN_LANG_LIST.end(), lang) != LATIN_LANG_LIST.end();
+  return std::find(LATIN_LANG_LIST.begin(), LATIN_LANG_LIST.end(), lang) !=
+         LATIN_LANG_LIST.end();
 }
 
 bool isArabicLang(std::string_view lang) {
-  return std::find(ARABIC_LANG_LIST.begin(), ARABIC_LANG_LIST.end(), lang) != ARABIC_LANG_LIST.end();
+  return std::find(ARABIC_LANG_LIST.begin(), ARABIC_LANG_LIST.end(), lang) !=
+         ARABIC_LANG_LIST.end();
 }
 
 bool isBengaliLang(std::string_view lang) {
-  return std::find(BENGALI_LANG_LIST.begin(), BENGALI_LANG_LIST.end(), lang) != BENGALI_LANG_LIST.end();
+  return std::find(BENGALI_LANG_LIST.begin(), BENGALI_LANG_LIST.end(), lang) !=
+         BENGALI_LANG_LIST.end();
 }
 
 bool isCyrillicLang(std::string_view lang) {
-  return std::find(CYRILLIC_LANG_LIST.begin(), CYRILLIC_LANG_LIST.end(), lang) != CYRILLIC_LANG_LIST.end();
+  return std::find(
+             CYRILLIC_LANG_LIST.begin(), CYRILLIC_LANG_LIST.end(), lang) !=
+         CYRILLIC_LANG_LIST.end();
 }
 
 bool isDevanagariLang(std::string_view lang) {
-  return std::find(DEVANAGARI_LANG_LIST.begin(), DEVANAGARI_LANG_LIST.end(), lang) != DEVANAGARI_LANG_LIST.end();
+  return std::find(
+             DEVANAGARI_LANG_LIST.begin(), DEVANAGARI_LANG_LIST.end(), lang) !=
+         DEVANAGARI_LANG_LIST.end();
 }
 
 bool isOtherLang(std::string_view lang) {
-  return std::find(OTHER_LANG_LIST.begin(), OTHER_LANG_LIST.end(), lang) != OTHER_LANG_LIST.end();
+  return std::find(OTHER_LANG_LIST.begin(), OTHER_LANG_LIST.end(), lang) !=
+         OTHER_LANG_LIST.end();
 }
 
 bool isValidLang(std::string_view lang) {
@@ -1056,7 +1067,7 @@ std::vector<bool> populateIgnoreIndexVector(std::u32string_view fullCharList, st
   std::unordered_set<char32_t> langCharsSet(symbols.begin(), symbols.end());
 
   for (const auto &lang : langList) {
-    const std::u32string_view &langChars = LANG_TO_CHARS_MAP.at(lang);
+    const std::u32string_view& langChars = LANG_TO_CHARS_MAP.at(lang);
     langCharsSet.insert(langChars.begin(), langChars.end());
   }
 

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Lang.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Lang.cpp
@@ -10,18 +10,17 @@
 namespace qvac_lib_inference_addon_onnx_ocr_fasttext {
 
 namespace {
-// NOLINTBEGIN(readability-identifier-naming)
 
-constexpr auto latinLangList = std::to_array<std::string_view>(
+constexpr auto LATIN_LANG_LIST = std::to_array<std::string_view>(
     {"af", "az", "bs", "cs", "cy", "da", "de", "en", "es", "et", "fr",       "ga", "hr", "hu", "id", "is", "it", "ku", "la", "lt", "lv",
      "mi", "ms", "mt", "nl", "no", "oc", "pi", "pl", "pt", "ro", "rs_latin", "sk", "sl", "sq", "sv", "sw", "tl", "tr", "uz", "vi"});
-constexpr auto arabicLangList = std::to_array<std::string_view>({"ar", "fa", "ug", "ur"});
-constexpr auto bengaliLangList = std::to_array<std::string_view>({"bn", "as", "mni"});
-constexpr auto cyrillicLangList = std::to_array<std::string_view>(
+constexpr auto ARABIC_LANG_LIST = std::to_array<std::string_view>({"ar", "fa", "ug", "ur"});
+constexpr auto BENGALI_LANG_LIST = std::to_array<std::string_view>({"bn", "as", "mni"});
+constexpr auto CYRILLIC_LANG_LIST = std::to_array<std::string_view>(
     {"ru", "rs_cyrillic", "be", "bg", "uk", "mn", "abq", "ady", "kbd", "ava", "dar", "inh", "che", "lbe", "lez", "tab", "tjk"});
-constexpr auto devanagariLangList =
+constexpr auto DEVANAGARI_LANG_LIST =
     std::to_array<std::string_view>({"hi", "mr", "ne", "bh", "mai", "ang", "bho", "mah", "sck", "new", "gom", "sa", "bgc"});
-constexpr auto otherLangList = std::to_array<std::string_view>({"th", "ch_sim", "ch_tra", "ja", "ko", "ta", "te", "kn"});
+constexpr auto OTHER_LANG_LIST = std::to_array<std::string_view>({"th", "ch_sim", "ch_tra", "ja", "ko", "ta", "te", "kn"});
 
 /**
  * @brief represents information about a language group, such as latin, cyrillic, etc.
@@ -35,7 +34,7 @@ struct LangGroupInfo {
 using LangToLangGroupInfoMap = std::map<std::string_view, LangGroupInfo, std::less<>>;
 using GenToModelCharacteristicsMap = std::map<std::string_view, LangToLangGroupInfoMap, std::less<>>;
 
-const GenToModelCharacteristicsMap recognitionModels = {
+const GenToModelCharacteristicsMap RECOGNITION_MODELS = {
     {"gen1",
      {
          {"latin_g1",
@@ -522,7 +521,7 @@ const GenToModelCharacteristicsMap recognitionModels = {
            U"0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ €₽"}},
      }}};
 
-const std::map<std::string_view, std::u32string_view> langToCharsMap = {
+const std::map<std::string_view, std::u32string_view> LANG_TO_CHARS_MAP = {
     {"ab", U"АБВГӶҔДЕЖЗӠИКҚҞЛМНОПԤҦРСТҬУФХҲЦҴЧҶҼҾШЫҨЏЬӘабвгӷҕдежзӡикқҟлмнопԥҧрстҭуфхҳцҵчҷҽҿшыҩџьә"},
     {"abq", U"АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдеёжзийклмнопрстуфхцчшщъыьэюяI"},
     {"ady", U"АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдеёжзийклмнопрстуфхцчшщъыьэюяӀӏ"},
@@ -935,27 +934,27 @@ std::set<std::string_view> setDifference(const std::set<std::string> &setA, cons
 }
 
 bool isLatinLang(std::string_view lang) {
-  return std::find(latinLangList.begin(), latinLangList.end(), lang) != latinLangList.end();
+  return std::find(LATIN_LANG_LIST.begin(), LATIN_LANG_LIST.end(), lang) != LATIN_LANG_LIST.end();
 }
 
 bool isArabicLang(std::string_view lang) {
-  return std::find(arabicLangList.begin(), arabicLangList.end(), lang) != arabicLangList.end();
+  return std::find(ARABIC_LANG_LIST.begin(), ARABIC_LANG_LIST.end(), lang) != ARABIC_LANG_LIST.end();
 }
 
 bool isBengaliLang(std::string_view lang) {
-  return std::find(bengaliLangList.begin(), bengaliLangList.end(), lang) != bengaliLangList.end();
+  return std::find(BENGALI_LANG_LIST.begin(), BENGALI_LANG_LIST.end(), lang) != BENGALI_LANG_LIST.end();
 }
 
 bool isCyrillicLang(std::string_view lang) {
-  return std::find(cyrillicLangList.begin(), cyrillicLangList.end(), lang) != cyrillicLangList.end();
+  return std::find(CYRILLIC_LANG_LIST.begin(), CYRILLIC_LANG_LIST.end(), lang) != CYRILLIC_LANG_LIST.end();
 }
 
 bool isDevanagariLang(std::string_view lang) {
-  return std::find(devanagariLangList.begin(), devanagariLangList.end(), lang) != devanagariLangList.end();
+  return std::find(DEVANAGARI_LANG_LIST.begin(), DEVANAGARI_LANG_LIST.end(), lang) != DEVANAGARI_LANG_LIST.end();
 }
 
 bool isOtherLang(std::string_view lang) {
-  return std::find(otherLangList.begin(), otherLangList.end(), lang) != otherLangList.end();
+  return std::find(OTHER_LANG_LIST.begin(), OTHER_LANG_LIST.end(), lang) != OTHER_LANG_LIST.end();
 }
 
 bool isValidLang(std::string_view lang) {
@@ -984,65 +983,65 @@ void validateSimultaneousSupportedLanguages(std::string_view language,
 LangGroupInfo validateAndGetInfoFromLangList(std::span<const std::string> langList) {
   if (contains(langList, "th")) {
     validateSimultaneousSupportedLanguages("thai", langList, std::set<std::string_view>{"th", "en"}, R"(["th","en"])");
-    return recognitionModels.at("gen1").at("thai_g1");
+    return RECOGNITION_MODELS.at("gen1").at("thai_g1");
   }
   if (contains(langList, "ch_tra")) {
     validateSimultaneousSupportedLanguages("chinese_tra", langList, std::set<std::string_view>{"ch_tra", "en"}, R"(["ch_tra","en"])");
-    return recognitionModels.at("gen1").at("zh_tra_g1");
+    return RECOGNITION_MODELS.at("gen1").at("zh_tra_g1");
   }
   if (contains(langList, "ch_sim")) {
     validateSimultaneousSupportedLanguages("chinese_sim", langList, std::set<std::string_view>{"ch_sim", "en"}, R"(["ch_sim","en"])");
-    return recognitionModels.at("gen2").at("zh_sim_g2");
+    return RECOGNITION_MODELS.at("gen2").at("zh_sim_g2");
   }
   if (contains(langList, "ja")) {
     validateSimultaneousSupportedLanguages("japanese", langList, std::set<std::string_view>{"ja", "en"}, R"(["ja","en"])");
-    return recognitionModels.at("gen2").at("japanese_g2");
+    return RECOGNITION_MODELS.at("gen2").at("japanese_g2");
   }
   if (contains(langList, "ko")) {
     validateSimultaneousSupportedLanguages("korean", langList, std::set<std::string_view>{"ko", "en"}, R"(["ko","en"])");
-    return recognitionModels.at("gen2").at("korean_g2");
+    return RECOGNITION_MODELS.at("gen2").at("korean_g2");
   }
   if (contains(langList, "ta")) {
     validateSimultaneousSupportedLanguages("tamil", langList, std::set<std::string_view>{"ta", "en"}, R"(["ta","en"])");
-    return recognitionModels.at("gen1").at("tamil_g1");
+    return RECOGNITION_MODELS.at("gen1").at("tamil_g1");
   }
   if (contains(langList, "te")) {
     validateSimultaneousSupportedLanguages("telugu", langList, std::set<std::string_view>{"te", "en"}, R"(["te","en"])");
-    return recognitionModels.at("gen2").at("telugu_g2");
+    return RECOGNITION_MODELS.at("gen2").at("telugu_g2");
   }
   if (contains(langList, "kn")) {
     validateSimultaneousSupportedLanguages("kannada", langList, std::set<std::string_view>{"kn", "en"}, R"(["kn","en"])");
-    return recognitionModels.at("gen2").at("kannada_g2");
+    return RECOGNITION_MODELS.at("gen2").at("kannada_g2");
   }
 
   for (const auto &lang : langList) {
-    if (contains(bengaliLangList, lang)) {
-      std::set<std::string_view> allowed = toSet(bengaliLangList);
+    if (contains(BENGALI_LANG_LIST, lang)) {
+      std::set<std::string_view> allowed = toSet(BENGALI_LANG_LIST);
       allowed.insert("en");
       validateSimultaneousSupportedLanguages("bengali", langList, allowed, R"(["bn","as","en"])");
-      return recognitionModels.at("gen1").at("bengali_g1");
+      return RECOGNITION_MODELS.at("gen1").at("bengali_g1");
     }
-    if (contains(arabicLangList, lang)) {
-      std::set<std::string_view> allowed = toSet(arabicLangList);
+    if (contains(ARABIC_LANG_LIST, lang)) {
+      std::set<std::string_view> allowed = toSet(ARABIC_LANG_LIST);
       allowed.insert("en");
       validateSimultaneousSupportedLanguages("arabic", langList, allowed, R"(["ar","fa","ur","ug","en"])");
-      return recognitionModels.at("gen1").at("arabic_g1");
+      return RECOGNITION_MODELS.at("gen1").at("arabic_g1");
     }
-    if (contains(devanagariLangList, lang)) {
-      std::set<std::string_view> allowed = toSet(devanagariLangList);
+    if (contains(DEVANAGARI_LANG_LIST, lang)) {
+      std::set<std::string_view> allowed = toSet(DEVANAGARI_LANG_LIST);
       allowed.insert("en");
       validateSimultaneousSupportedLanguages("devanagari", langList, allowed, R"(["hi","mr","ne","en"])");
-      return recognitionModels.at("gen1").at("devanagari_g1");
+      return RECOGNITION_MODELS.at("gen1").at("devanagari_g1");
     }
-    if (contains(cyrillicLangList, lang)) {
-      std::set<std::string_view> allowed = toSet(cyrillicLangList);
+    if (contains(CYRILLIC_LANG_LIST, lang)) {
+      std::set<std::string_view> allowed = toSet(CYRILLIC_LANG_LIST);
       allowed.insert("en");
       validateSimultaneousSupportedLanguages("cyrillic", langList, allowed, R"(["ru","rs_cyrillic","be","bg","uk","mn","en"])");
-      return recognitionModels.at("gen2").at("cyrillic_g2");
+      return RECOGNITION_MODELS.at("gen2").at("cyrillic_g2");
     }
   }
 
-  return recognitionModels.at("gen2").at("latin_g2");
+  return RECOGNITION_MODELS.at("gen2").at("latin_g2");
 }
 
 /**
@@ -1057,7 +1056,7 @@ std::vector<bool> populateIgnoreIndexVector(std::u32string_view fullCharList, st
   std::unordered_set<char32_t> langCharsSet(symbols.begin(), symbols.end());
 
   for (const auto &lang : langList) {
-    const std::u32string_view &langChars = langToCharsMap.at(lang);
+    const std::u32string_view &langChars = LANG_TO_CHARS_MAP.at(lang);
     langCharsSet.insert(langChars.begin(), langChars.end());
   }
 
@@ -1094,5 +1093,4 @@ std::tuple<std::u32string_view, std::vector<bool>, bool> getCharsInfoFromLangLis
   return {langInfo.characters, ignoreChars, langInfo.lang != "arabic"};
 }
 
-// NOLINTEND(readability-identifier-naming)
 } // namespace qvac_lib_inference_addon_onnx_ocr_fasttext

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Pipeline.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Pipeline.cpp
@@ -116,7 +116,8 @@ Pipeline::Output Pipeline::process(Pipeline::Input input) {
     float initialResizeRatio = 1.0F;
     int maxDim = std::max(image.cols, image.rows);
     if (maxDim > maxInputSize) {
-      initialResizeRatio = static_cast<float>(maxInputSize) / static_cast<float>(maxDim);
+      initialResizeRatio =
+          static_cast<float>(maxInputSize) / static_cast<float>(maxDim);
       int newWidth = static_cast<int>(static_cast<float>(image.cols) * initialResizeRatio);
       int newHeight = static_cast<int>(static_cast<float>(image.rows) * initialResizeRatio);
       cv::Mat resized;
@@ -135,7 +136,9 @@ Pipeline::Output Pipeline::process(Pipeline::Input input) {
     StepDetectionInference::Input detectionInput{image, input.paragraph, input.rotationAngles, input.boxMarginMultiplier, initialResizeRatio};
     StepDetectionInference::Output detectionOutput = stepDetection_->process(std::move(detectionInput));
     auto detectionEnd = std::chrono::high_resolution_clock::now();
-    double detectionTimeSec = static_cast<double>((detectionEnd - detectionStart).count()) / nanosecondsToSeconds;
+    double detectionTimeSec =
+        static_cast<double>((detectionEnd - detectionStart).count()) /
+        nanosecondsToSeconds;
     QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, "[Pipeline] Step 1: Detection complete in " + std::to_string(detectionTimeSec) + "s");
     ALOG_INFO(std::string("[Pipeline] Step 1: Detection complete"));
 
@@ -154,14 +157,18 @@ Pipeline::Output Pipeline::process(Pipeline::Input input) {
     auto recognitionStart = std::chrono::high_resolution_clock::now();
     StepRecognizeText::Output recognitionOutput = stepRecognition_->process(std::move(boundingBoxOutput));
     auto recognitionEnd = std::chrono::high_resolution_clock::now();
-    double recognitionTimeSec = static_cast<double>((recognitionEnd - recognitionStart).count()) / nanosecondsToSeconds;
+    double recognitionTimeSec =
+        static_cast<double>((recognitionEnd - recognitionStart).count()) /
+        nanosecondsToSeconds;
     std::string step3Msg = "[Pipeline] Step 3: Recognition complete (" + std::to_string(recognitionOutput.size()) + " text regions) in " + std::to_string(recognitionTimeSec) + "s";
     QLOG(qvac_lib_inference_addon_cpp::logger::Priority::INFO, step3Msg);
     ALOG_INFO(step3Msg);
 
     // Record processing time and stats
     auto timeEnd = std::chrono::high_resolution_clock::now();
-    double processingTimeSec = static_cast<double>((timeEnd - timeStart).count()) / nanosecondsToSeconds;
+    double processingTimeSec =
+        static_cast<double>((timeEnd - timeStart).count()) /
+        nanosecondsToSeconds;
     {
       std::scoped_lock scopedLock(processingTimeMtx_);
       processingTime_.push(processingTimeSec);
@@ -183,7 +190,9 @@ Pipeline::Output Pipeline::process(Pipeline::Input input) {
     auto timeEnd = std::chrono::high_resolution_clock::now();
     {
       std::scoped_lock scopedLock(processingTimeMtx_);
-      processingTime_.push(static_cast<double>((timeEnd - timeStart).count()) / nanosecondsToSeconds);
+      processingTime_.push(
+          static_cast<double>((timeEnd - timeStart).count()) /
+          nanosecondsToSeconds);
     }
     throw;
   }

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Pipeline.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Pipeline.cpp
@@ -97,7 +97,7 @@ Pipeline::Output Pipeline::process(Pipeline::Input input) {
   QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, "[Pipeline] Sequential process() starting");
   ALOG_DEBUG(std::string("[Pipeline] Sequential process() starting"));
   auto timeStart = std::chrono::high_resolution_clock::now();
-  static constexpr double NANOSECONDS_TO_SECONDS = 1e9;
+  static constexpr double nanosecondsToSeconds = 1e9;
 
   try {
     validatePipelineInput(input);
@@ -112,11 +112,11 @@ Pipeline::Output Pipeline::process(Pipeline::Input input) {
     }
 
     // Resize image to max 1200px on longest side
-    constexpr int MAX_INPUT_SIZE = 1200;
+    constexpr int maxInputSize = 1200;
     float initialResizeRatio = 1.0F;
     int maxDim = std::max(image.cols, image.rows);
-    if (maxDim > MAX_INPUT_SIZE) {
-      initialResizeRatio = static_cast<float>(MAX_INPUT_SIZE) / static_cast<float>(maxDim);
+    if (maxDim > maxInputSize) {
+      initialResizeRatio = static_cast<float>(maxInputSize) / static_cast<float>(maxDim);
       int newWidth = static_cast<int>(static_cast<float>(image.cols) * initialResizeRatio);
       int newHeight = static_cast<int>(static_cast<float>(image.rows) * initialResizeRatio);
       cv::Mat resized;
@@ -135,7 +135,7 @@ Pipeline::Output Pipeline::process(Pipeline::Input input) {
     StepDetectionInference::Input detectionInput{image, input.paragraph, input.rotationAngles, input.boxMarginMultiplier, initialResizeRatio};
     StepDetectionInference::Output detectionOutput = stepDetection_->process(std::move(detectionInput));
     auto detectionEnd = std::chrono::high_resolution_clock::now();
-    double detectionTimeSec = static_cast<double>((detectionEnd - detectionStart).count()) / NANOSECONDS_TO_SECONDS;
+    double detectionTimeSec = static_cast<double>((detectionEnd - detectionStart).count()) / nanosecondsToSeconds;
     QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, "[Pipeline] Step 1: Detection complete in " + std::to_string(detectionTimeSec) + "s");
     ALOG_INFO(std::string("[Pipeline] Step 1: Detection complete"));
 
@@ -154,14 +154,14 @@ Pipeline::Output Pipeline::process(Pipeline::Input input) {
     auto recognitionStart = std::chrono::high_resolution_clock::now();
     StepRecognizeText::Output recognitionOutput = stepRecognition_->process(std::move(boundingBoxOutput));
     auto recognitionEnd = std::chrono::high_resolution_clock::now();
-    double recognitionTimeSec = static_cast<double>((recognitionEnd - recognitionStart).count()) / NANOSECONDS_TO_SECONDS;
+    double recognitionTimeSec = static_cast<double>((recognitionEnd - recognitionStart).count()) / nanosecondsToSeconds;
     std::string step3Msg = "[Pipeline] Step 3: Recognition complete (" + std::to_string(recognitionOutput.size()) + " text regions) in " + std::to_string(recognitionTimeSec) + "s";
     QLOG(qvac_lib_inference_addon_cpp::logger::Priority::INFO, step3Msg);
     ALOG_INFO(step3Msg);
 
     // Record processing time and stats
     auto timeEnd = std::chrono::high_resolution_clock::now();
-    double processingTimeSec = static_cast<double>((timeEnd - timeStart).count()) / NANOSECONDS_TO_SECONDS;
+    double processingTimeSec = static_cast<double>((timeEnd - timeStart).count()) / nanosecondsToSeconds;
     {
       std::scoped_lock scopedLock(processingTimeMtx_);
       processingTime_.push(processingTimeSec);
@@ -183,7 +183,7 @@ Pipeline::Output Pipeline::process(Pipeline::Input input) {
     auto timeEnd = std::chrono::high_resolution_clock::now();
     {
       std::scoped_lock scopedLock(processingTimeMtx_);
-      processingTime_.push(static_cast<double>((timeEnd - timeStart).count()) / NANOSECONDS_TO_SECONDS);
+      processingTime_.push(static_cast<double>((timeEnd - timeStart).count()) / nanosecondsToSeconds);
     }
     throw;
   }

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepBoundingBox.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepBoundingBox.cpp
@@ -1,4 +1,3 @@
-// NOLINTBEGIN(readability-identifier-naming)
 #include "StepBoundingBox.hpp"
 
 #include <opencv2/opencv.hpp>
@@ -505,4 +504,3 @@ std::vector<UnalignedBox> StepBoundingBox::getOutputUnalignedBoxes(const float i
 }
 
 } // namespace qvac_lib_inference_addon_onnx_ocr_fasttext
-// NOLINTEND(readability-identifier-naming)

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepDetectionInference.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepDetectionInference.cpp
@@ -167,7 +167,13 @@ std::vector<Ort::Value> StepDetectionInference::runInference(cv::Mat inputBlob) 
   constexpr std::array<const char*, 1> inputNames = {"input"};
   constexpr std::array<const char*, 2> outputNames = {"output", "feature"};
 
-  return ortSession_.Run(Ort::RunOptions{nullptr}, inputNames.data(), &inputTensor, 1, outputNames.data(), 2);
+  return ortSession_.Run(
+      Ort::RunOptions{nullptr},
+      inputNames.data(),
+      &inputTensor,
+      1,
+      outputNames.data(),
+      2);
 }
 
 StepDetectionInference::Output StepDetectionInference::process(const StepDetectionInference::Input &input) {

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepDetectionInference.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepDetectionInference.cpp
@@ -164,10 +164,10 @@ std::vector<Ort::Value> StepDetectionInference::runInference(cv::Mat inputBlob) 
   Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
   Ort::Value inputTensor = Ort::Value::CreateTensor<float>(memoryInfo, inputData, inputTensorSize, inputShape.data(), inputShape.size());
 
-  constexpr std::array<const char*, 1> INPUT_NAMES = {"input"};
-  constexpr std::array<const char*, 2> OUTPUT_NAMES = {"output", "feature"};
+  constexpr std::array<const char*, 1> inputNames = {"input"};
+  constexpr std::array<const char*, 2> outputNames = {"output", "feature"};
 
-  return ortSession_.Run(Ort::RunOptions{nullptr}, INPUT_NAMES.data(), &inputTensor, 1, OUTPUT_NAMES.data(), 2);
+  return ortSession_.Run(Ort::RunOptions{nullptr}, inputNames.data(), &inputTensor, 1, outputNames.data(), 2);
 }
 
 StepDetectionInference::Output StepDetectionInference::process(const StepDetectionInference::Input &input) {

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepRecognizeText.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepRecognizeText.cpp
@@ -671,17 +671,20 @@ void StepRecognizeText::expandImgListWithRotatedImgs(std::optional<std::vector<i
       cv::Mat &baseImg = imageList[0].image;
       cv::Mat rotatedImg;
       if (angle == angle90) {
-        if (canBypassRotations && imageList[0].isMultiCharacter && baseImg.cols > ratioDifferenceToIgnoreRotation * baseImg.rows) {
+        if (canBypassRotations && imageList[0].isMultiCharacter &&
+            baseImg.cols > ratioDifferenceToIgnoreRotation * baseImg.rows) {
           continue;
         }
         cv::rotate(baseImg, rotatedImg, cv::ROTATE_90_CLOCKWISE);
       } else if (angle == angle180) {
-        if (canBypassRotations && imageList[0].isMultiCharacter && baseImg.rows > ratioDifferenceToIgnoreRotation * baseImg.cols) {
+        if (canBypassRotations && imageList[0].isMultiCharacter &&
+            baseImg.rows > ratioDifferenceToIgnoreRotation * baseImg.cols) {
           continue;
         }
         cv::rotate(baseImg, rotatedImg, cv::ROTATE_180);
       } else if (angle == angle270) {
-        if (canBypassRotations && imageList[0].isMultiCharacter && baseImg.cols > ratioDifferenceToIgnoreRotation * baseImg.rows) {
+        if (canBypassRotations && imageList[0].isMultiCharacter &&
+            baseImg.cols > ratioDifferenceToIgnoreRotation * baseImg.rows) {
           continue;
         }
         cv::rotate(baseImg, rotatedImg, cv::ROTATE_90_COUNTERCLOCKWISE);
@@ -702,7 +705,8 @@ std::pair<std::string, float> StepRecognizeText::getTextAndConfidenceFromPreds(c
   const int charSpaceSize = preds.size[2];
   assert(batchIdx >= 0 && batchIdx < preds.size[0]);
 
-  std::vector<std::vector<float>> predsProb(imgSubcolumnsSize, std::vector<float>(charSpaceSize, 0.0F));
+  std::vector<std::vector<float>> predsProb(
+      imgSubcolumnsSize, std::vector<float>(charSpaceSize, 0.0F));
   for (int subcolumn = 0; subcolumn < imgSubcolumnsSize; subcolumn++) {
     float maxVal = -std::numeric_limits<float>::infinity();
     for (int charIndex = 0; charIndex < charSpaceSize; charIndex++) {
@@ -744,7 +748,8 @@ std::pair<std::string, float> StepRecognizeText::getTextAndConfidenceFromPreds(c
   for (int subcolumn = 0; subcolumn < imgSubcolumnsSize; subcolumn++) {
     size_t charIndexMax = 0;
     float maxProbVal = predsProb[subcolumn][0];
-    for (size_t charIndex = 1; charIndex < static_cast<size_t>(charSpaceSize); charIndex++) {
+    for (size_t charIndex = 1; charIndex < static_cast<size_t>(charSpaceSize);
+         charIndex++) {
       if (predsProb[subcolumn][charIndex] > maxProbVal) {
         maxProbVal = predsProb[subcolumn][charIndex];
         charIndexMax = charIndex;
@@ -792,7 +797,13 @@ cv::Mat StepRecognizeText::runInferenceOnImg(const cv::Mat &img) {
 
   std::array<Ort::Value, 1> inputTensors = {std::move(imageTensor)};
 
-  auto outputTensors = ortSession_.Run(Ort::RunOptions{nullptr}, inputNames.data(), inputTensors.data(), 1, outputNames.data(), 1);
+  auto outputTensors = ortSession_.Run(
+      Ort::RunOptions{nullptr},
+      inputNames.data(),
+      inputTensors.data(),
+      1,
+      outputNames.data(),
+      1);
 
   Ort::Value &predsTensor = outputTensors[0];
   auto *predsData = predsTensor.GetTensorMutableData<float>();
@@ -853,7 +864,12 @@ cv::Mat StepRecognizeText::runBatchInference(const std::vector<cv::Mat> &images,
   std::array<Ort::Value, 1> inputTensors = {std::move(inputTensor)};
 
   auto outputTensors = ortSession_.Run(
-      Ort::RunOptions{nullptr}, inputNames.data(), inputTensors.data(), 1, outputNames.data(), 1);
+      Ort::RunOptions{nullptr},
+      inputNames.data(),
+      inputTensors.data(),
+      1,
+      outputNames.data(),
+      1);
 
   Ort::Value &predsTensor = outputTensors[0];
   auto *predsData = predsTensor.GetTensorMutableData<float>();

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepRecognizeText.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/StepRecognizeText.cpp
@@ -1,4 +1,3 @@
-// NOLINTBEGIN(readability-identifier-naming)
 #include "StepRecognizeText.hpp"
 
 #include "Lang.hpp"
@@ -637,8 +636,8 @@ void StepRecognizeText::populateImageList(const Input &input) {
     sumHeight += height;
   }
   float meanHeight = imgListOfLists_.empty() ? 1.0F : sumHeight / static_cast<float>(imgListOfLists_.size());
-  constexpr float Y_CENTER_THRESHOLD = 0.5F; // Same as EasyOCR's ycenter_ths
-  float rowThreshold = Y_CENTER_THRESHOLD * meanHeight;
+  constexpr float yCenterThreshold = 0.5F; // Same as EasyOCR's ycenter_ths
+  float rowThreshold = yCenterThreshold * meanHeight;
 
   // Sort by y_center first, then by x for boxes on same row
   std::sort(imgListOfLists_.begin(), imgListOfLists_.end(), [rowThreshold](const std::vector<SubImage> &listA, const std::vector<SubImage> &listB) {
@@ -659,11 +658,11 @@ void StepRecognizeText::populateImageList(const Input &input) {
 }
 
 void StepRecognizeText::expandImgListWithRotatedImgs(std::optional<std::vector<int>> &rotationAngles) {
-  constexpr int RATIO_DIFFERENCE_TO_IGNORE_ROTATION = 5;
+  constexpr int ratioDifferenceToIgnoreRotation = 5;
   bool canBypassRotations = !rotationAngles.has_value();
-  constexpr int ANGLE_90 = 90;
-  constexpr int ANGLE_180 = 180;
-  constexpr int ANGLE_270 = 270;
+  constexpr int angle90 = 90;
+  constexpr int angle180 = 180;
+  constexpr int angle270 = 270;
   // Use per-image rotationAngles if provided, otherwise use config default
   const std::vector<int> &angles = rotationAngles ? *rotationAngles : config_.defaultRotationAngles;
 
@@ -671,18 +670,18 @@ void StepRecognizeText::expandImgListWithRotatedImgs(std::optional<std::vector<i
     for (auto &imageList : imgListOfLists_) {
       cv::Mat &baseImg = imageList[0].image;
       cv::Mat rotatedImg;
-      if (angle == ANGLE_90) {
-        if (canBypassRotations && imageList[0].isMultiCharacter && baseImg.cols > RATIO_DIFFERENCE_TO_IGNORE_ROTATION * baseImg.rows) {
+      if (angle == angle90) {
+        if (canBypassRotations && imageList[0].isMultiCharacter && baseImg.cols > ratioDifferenceToIgnoreRotation * baseImg.rows) {
           continue;
         }
         cv::rotate(baseImg, rotatedImg, cv::ROTATE_90_CLOCKWISE);
-      } else if (angle == ANGLE_180) {
-        if (canBypassRotations && imageList[0].isMultiCharacter && baseImg.rows > RATIO_DIFFERENCE_TO_IGNORE_ROTATION * baseImg.cols) {
+      } else if (angle == angle180) {
+        if (canBypassRotations && imageList[0].isMultiCharacter && baseImg.rows > ratioDifferenceToIgnoreRotation * baseImg.cols) {
           continue;
         }
         cv::rotate(baseImg, rotatedImg, cv::ROTATE_180);
-      } else if (angle == ANGLE_270) {
-        if (canBypassRotations && imageList[0].isMultiCharacter && baseImg.cols > RATIO_DIFFERENCE_TO_IGNORE_ROTATION * baseImg.rows) {
+      } else if (angle == angle270) {
+        if (canBypassRotations && imageList[0].isMultiCharacter && baseImg.cols > ratioDifferenceToIgnoreRotation * baseImg.rows) {
           continue;
         }
         cv::rotate(baseImg, rotatedImg, cv::ROTATE_90_COUNTERCLOCKWISE);
@@ -699,53 +698,53 @@ void StepRecognizeText::expandImgListWithRotatedImgs(std::optional<std::vector<i
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 std::pair<std::string, float> StepRecognizeText::getTextAndConfidenceFromPreds(const cv::Mat &preds, int batchIdx) {
   assert(preds.dims == 3);
-  const int IMG_SUBCOLUMNS_SIZE = preds.size[1];
-  const int CHAR_SPACE_SIZE = preds.size[2];
+  const int imgSubcolumnsSize = preds.size[1];
+  const int charSpaceSize = preds.size[2];
   assert(batchIdx >= 0 && batchIdx < preds.size[0]);
 
-  std::vector<std::vector<float>> predsProb(IMG_SUBCOLUMNS_SIZE, std::vector<float>(CHAR_SPACE_SIZE, 0.0F));
-  for (int subcolumn = 0; subcolumn < IMG_SUBCOLUMNS_SIZE; subcolumn++) {
+  std::vector<std::vector<float>> predsProb(imgSubcolumnsSize, std::vector<float>(charSpaceSize, 0.0F));
+  for (int subcolumn = 0; subcolumn < imgSubcolumnsSize; subcolumn++) {
     float maxVal = -std::numeric_limits<float>::infinity();
-    for (int charIndex = 0; charIndex < CHAR_SPACE_SIZE; charIndex++) {
+    for (int charIndex = 0; charIndex < charSpaceSize; charIndex++) {
       float val = preds.at<float>(batchIdx, subcolumn, charIndex);
       maxVal = std::max(val, maxVal);
     }
 
     float subcolumnSumExp = 0.0F;
-    for (int charIndex = 0; charIndex < CHAR_SPACE_SIZE; charIndex++) {
+    for (int charIndex = 0; charIndex < charSpaceSize; charIndex++) {
       float val = preds.at<float>(batchIdx, subcolumn, charIndex);
       float expVal = std::exp(val - maxVal);
       predsProb[subcolumn][charIndex] = expVal;
       subcolumnSumExp += expVal;
     }
-    for (int charIndex = 0; charIndex < CHAR_SPACE_SIZE; charIndex++) {
+    for (int charIndex = 0; charIndex < charSpaceSize; charIndex++) {
       predsProb[subcolumn][charIndex] /= subcolumnSumExp;
     }
   }
 
-  for (int subcolumn = 0; subcolumn < IMG_SUBCOLUMNS_SIZE; subcolumn++) {
-    for (int charIndex = 0; charIndex < CHAR_SPACE_SIZE; charIndex++) {
+  for (int subcolumn = 0; subcolumn < imgSubcolumnsSize; subcolumn++) {
+    for (int charIndex = 0; charIndex < charSpaceSize; charIndex++) {
       if (ignoreChars_[charIndex]) {
         predsProb[subcolumn][charIndex] = 0.0F;
       }
     }
     float subcolumnSum = 0.0F;
-    for (int charIndex = 0; charIndex < CHAR_SPACE_SIZE; charIndex++) {
+    for (int charIndex = 0; charIndex < charSpaceSize; charIndex++) {
       subcolumnSum += predsProb[subcolumn][charIndex];
     }
     if (subcolumnSum > 0.0F) {
-      for (int charIndex = 0; charIndex < CHAR_SPACE_SIZE; charIndex++) {
+      for (int charIndex = 0; charIndex < charSpaceSize; charIndex++) {
         predsProb[subcolumn][charIndex] /= subcolumnSum;
       }
     }
   }
 
-  std::vector<size_t> predsIndex(IMG_SUBCOLUMNS_SIZE, 0);
-  std::vector<float> predsMaxProb(IMG_SUBCOLUMNS_SIZE, 0.0F);
-  for (int subcolumn = 0; subcolumn < IMG_SUBCOLUMNS_SIZE; subcolumn++) {
+  std::vector<size_t> predsIndex(imgSubcolumnsSize, 0);
+  std::vector<float> predsMaxProb(imgSubcolumnsSize, 0.0F);
+  for (int subcolumn = 0; subcolumn < imgSubcolumnsSize; subcolumn++) {
     size_t charIndexMax = 0;
     float maxProbVal = predsProb[subcolumn][0];
-    for (size_t charIndex = 1; charIndex < static_cast<size_t>(CHAR_SPACE_SIZE); charIndex++) {
+    for (size_t charIndex = 1; charIndex < static_cast<size_t>(charSpaceSize); charIndex++) {
       if (predsProb[subcolumn][charIndex] > maxProbVal) {
         maxProbVal = predsProb[subcolumn][charIndex];
         charIndexMax = charIndex;
@@ -788,12 +787,12 @@ cv::Mat StepRecognizeText::runInferenceOnImg(const cv::Mat &img) {
   Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
   Ort::Value imageTensor = Ort::Value::CreateTensor<float>(memoryInfo, imageData, imageTensorSize, imageShape.data(), imageShape.size());
 
-  constexpr std::array<const char*, 1> INPUT_NAMES = {"image"};
-  constexpr std::array<const char*, 1> OUTPUT_NAMES = {"output"};
+  constexpr std::array<const char*, 1> inputNames = {"image"};
+  constexpr std::array<const char*, 1> outputNames = {"output"};
 
   std::array<Ort::Value, 1> inputTensors = {std::move(imageTensor)};
 
-  auto outputTensors = ortSession_.Run(Ort::RunOptions{nullptr}, INPUT_NAMES.data(), inputTensors.data(), 1, OUTPUT_NAMES.data(), 1);
+  auto outputTensors = ortSession_.Run(Ort::RunOptions{nullptr}, inputNames.data(), inputTensors.data(), 1, outputNames.data(), 1);
 
   Ort::Value &predsTensor = outputTensors[0];
   auto *predsData = predsTensor.GetTensorMutableData<float>();
@@ -848,13 +847,13 @@ cv::Mat StepRecognizeText::runBatchInference(const std::vector<cv::Mat> &images,
   Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
       memoryInfo, batchData.data(), inputTensorSize, inputShape.data(), inputShape.size());
 
-  constexpr std::array<const char*, 1> INPUT_NAMES = {"image"};
-  constexpr std::array<const char*, 1> OUTPUT_NAMES = {"output"};
+  constexpr std::array<const char*, 1> inputNames = {"image"};
+  constexpr std::array<const char*, 1> outputNames = {"output"};
 
   std::array<Ort::Value, 1> inputTensors = {std::move(inputTensor)};
 
   auto outputTensors = ortSession_.Run(
-      Ort::RunOptions{nullptr}, INPUT_NAMES.data(), inputTensors.data(), 1, OUTPUT_NAMES.data(), 1);
+      Ort::RunOptions{nullptr}, inputNames.data(), inputTensors.data(), 1, outputNames.data(), 1);
 
   Ort::Value &predsTensor = outputTensors[0];
   auto *predsData = predsTensor.GetTensorMutableData<float>();
@@ -1088,5 +1087,3 @@ std::string StepRecognizeText::decodeGreedy(const std::vector<size_t> &textIndex
 }
 
 } // namespace qvac_lib_inference_addon_onnx_ocr_fasttext
-
-// NOLINTEND(readability-identifier-naming)

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/package.json
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/package.json
@@ -12,6 +12,7 @@
     "mobile:copy-prebuilds": "cp -r prebuilds/android-arm64 prebuilds/android-ia32 || echo 'Warning: Failed to copy prebuilds to android-ia32'; cp -r prebuilds/android-arm64 prebuilds/android-arm || echo 'Warning: Failed to copy prebuilds to android-arm'; cp -r prebuilds/android-arm64 prebuilds/android-x64 || echo 'Warning: Failed to copy prebuilds to android-x64'; cp -r prebuilds/ios-arm64 prebuilds/ios-arm64-simulator 2>/dev/null || echo 'iOS prebuilds already present'; cp -r prebuilds/ios-arm64 prebuilds/ios-x64-simulator 2>/dev/null || echo 'iOS prebuilds already present'",
     "lint": "standard",
     "lint:fix": "standard --fix",
+    "lint-cpp": "clang-tidy -p build $(find addon -name '*.cpp')",
     "test:unit": "bare test/unit/ocr.test.js",
     "test:example": "bare examples/example.fs.js",
     "test:integration": "npm run test:integration:generate && bare test/integration/all.js --exit",

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/test/lang_test.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/test/lang_test.cpp
@@ -68,30 +68,30 @@ TEST(ValidateUnknownLanguages, ValidAndInvalidLanguages) {
 
 TEST(GetCharsInfoFromLangList, Empty) {
   std::u32string_view characters;
-  std::vector<bool> ignore_characters;
-  bool left_to_right;
+  std::vector<bool> ignoreCharacters;
+  bool leftToRight;
 
-  std::tie(characters, ignore_characters, left_to_right) =
+  std::tie(characters, ignoreCharacters, leftToRight) =
       getCharsInfoFromLangList({});
 
   EXPECT_FALSE(characters.empty());
-  EXPECT_EQ(characters.size(), ignore_characters.size());
+  EXPECT_EQ(characters.size(), ignoreCharacters.size());
 
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 }
 
 TEST(GetCharsInfoFromLangList, English) {
   std::u32string_view characters;
-  std::vector<bool> ignore_characters;
-  bool left_to_right;
+  std::vector<bool> ignoreCharacters;
+  bool leftToRight;
 
-  std::tie(characters, ignore_characters, left_to_right) =
+  std::tie(characters, ignoreCharacters, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"en"});
 
   EXPECT_FALSE(characters.empty());
-  EXPECT_EQ(characters.size(), ignore_characters.size());
+  EXPECT_EQ(characters.size(), ignoreCharacters.size());
 
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 }
 
 TEST(GetCharsInfoFromLangList, EnglishIsValidWithAnyLanguageGroup) {
@@ -155,60 +155,60 @@ TEST(GetCharsInfoFromLangList, MixingLanguageGroups) {
 }
 
 TEST(GetCharsInfoFromLangList, LeftToRight) {
-  bool left_to_right;
+  bool leftToRight;
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"en", "hu"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"th"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"ch_tra"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"ch_sim"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"ja"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"ko"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"ta"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"te"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"kn"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"bn", "as"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) =
+  std::tie(std::ignore, std::ignore, leftToRight) =
       getCharsInfoFromLangList(std::vector<std::string>{"hi", "ne"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
-  std::tie(std::ignore, std::ignore, left_to_right) = getCharsInfoFromLangList(
+  std::tie(std::ignore, std::ignore, leftToRight) = getCharsInfoFromLangList(
       std::vector<std::string>{"ru", "rs_cyrillic", "be"});
-  EXPECT_TRUE(left_to_right);
+  EXPECT_TRUE(leftToRight);
 
   // Arabic, Farsi, Uyghur and Urdu are written right to left.
-  std::tie(std::ignore, std::ignore, left_to_right) = getCharsInfoFromLangList(
+  std::tie(std::ignore, std::ignore, leftToRight) = getCharsInfoFromLangList(
       std::vector<std::string>{"ar", "fa", "ug", "ur"});
-  EXPECT_FALSE(left_to_right);
+  EXPECT_FALSE(leftToRight);
 }
 
 } // namespace qvac_lib_inference_addon_onnx_ocr_fasttext

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg.json
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg.json
@@ -3,42 +3,48 @@
   "version": "0.1.14",
   "dependencies": [
     {
-      "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.0.0"
+      "name": "onnxruntime",
+      "features": [
+        "nnapi-ep"
+      ],
+      "platform": "android"
     },
     {
-      "name": "opencv4",
-      "default-features": false,
-      "features": ["jpeg","png","tiff","webp","quirc" ]
+      "name": "onnxruntime",
+      "features": [
+        "dml-ep"
+      ],
+      "platform": "windows"
+    },
+    {
+      "name": "onnxruntime",
+      "features": [
+        "coreml-ep"
+      ],
+      "platform": "osx | ios"
     },
     {
       "name": "onnxruntime",
       "platform": "!(android | osx | ios | windows)"
     },
     {
-      "name": "onnxruntime",
-      "features": ["dml-ep"],
-      "platform": "windows"
+      "name": "opencv4",
+      "default-features": false,
+      "features": [
+        "jpeg",
+        "png",
+        "quirc",
+        "tiff",
+        "webp"
+      ]
     },
     {
-      "name": "onnxruntime",
-      "features": ["nnapi-ep"],
-      "platform": "android"
-    },
-    {
-      "name": "onnxruntime",
-      "features": ["coreml-ep"],
-      "platform": "osx | ios"
+      "name": "qvac-lib-inference-addon-cpp",
+      "version>=": "1.0.0"
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.4.1"
-    }
-  ],
-  "overrides": [
-    {
-      "name": "flatbuffers",
-      "version": "23.5.26"
+      "version>=": "1.4.4"
     }
   ],
   "features": {
@@ -48,5 +54,11 @@
         "gtest"
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "name": "flatbuffers",
+      "version": "23.5.26"
+    }
+  ]
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- clang-tidy `readability-identifier-naming` was disabled via NOLINT in addon and test code.
- Inconsistent identifier style (mix of snake_case and UPPER_SNAKE for locals/globals) vs project lint rules.

## 📝 How does it solve it?

- Removed all `NOLINT` / `NOLINTBEGIN` / `NOLINTEND` that suppressed `readability-identifier-naming`.
- Renamed identifiers to satisfy clang-tidy.
- Added `lint-cpp` script in `package.json` and ran `git-clang-format` for formatting.

## 🧪 How was it tested?

- `npm run lint-cpp` passes with no `readability-identifier-naming` warnings in addon or test.
- Existing tests (e.g. `test/lang_test.cpp`, `npm run test:integration`) still pass; changes are naming-only, no behavior change.
