### PR TITLE
QVAC-10044 fix: reject empty text input in TTS and wrap addon errors

### DIFF
--- a/packages/qvac-sdk/schemas/text-to-speech.ts
+++ b/packages/qvac-sdk/schemas/text-to-speech.ts
@@ -15,7 +15,7 @@ export const ttsConfigSchema = z.object({
 export const ttsClientParamsSchema = z.object({
   modelId: z.string(),
   inputType: z.string().default("text"),
-  text: z.string(),
+  text: z.string().trim().min(1, "text must not be empty or whitespace-only"),
   stream: z.boolean().default(true),
 });
 

--- a/packages/qvac-sdk/server/rpc/handlers/text-to-speech.ts
+++ b/packages/qvac-sdk/server/rpc/handlers/text-to-speech.ts
@@ -1,12 +1,21 @@
 import type { TtsRequest, TtsResponse } from "@/schemas";
 import { textToSpeech } from "@/server/bare/addons/onnx-tts";
+import { TextToSpeechFailedError } from "@/utils/errors-server";
 
 export async function* handleTextToSpeech(
   request: TtsRequest,
 ): AsyncGenerator<TtsResponse> {
-  const stream = textToSpeech(request);
-
-  for await (const response of stream) {
-    yield response;
+  try {
+    for await (const response of textToSpeech(request)) {
+      yield response;
+    }
+  } catch (error) {
+    if (error instanceof TextToSpeechFailedError) {
+      throw error;
+    }
+    throw new TextToSpeechFailedError(
+      error instanceof Error ? error.message : String(error),
+      error,
+    );
   }
 }


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Calling `textToSpeech` with an empty or whitespace-only string silently returns useless output (empty buffer or audio noise)  instead of failing with a structured SDK error
- Unstructured addon errors (e.g. `TypeError` from ONNX native binding) bubble up without SDK error codes, making them hard  to handle programmatically

## 📝 How does it solve it?

- Add `z.string().trim().min(1)` validation to  `ttsClientParamsSchema.text` — rejects empty/whitespace input
  at schema parse time
- Wrap the addon call in the RPC handler with try/catch that  converts any unstructured error into `TextToSpeechFailedError` (code 52409), preserving the original error as `cause`

## 🧪 How was it tested?

- I wasn't able to trigger the error conditions described in the ticket, maybe onnx-tts has been fixed in the meantime.
- Manual testing with repro script against published SDK -> most cases returned silent success (length 0)
- Verified error propagation path: server handler →  `sendStreamErrorResponse` → RPC stream → client `checkAndThrowError`