### PR TITLE
CI: Run cpp-lint step before prebuilds on OCR addon

### DIFF
--- a/.github/workflows/on-pr-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/on-pr-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -150,8 +150,18 @@ jobs:
             exit 1
           fi
 
-  prebuild:
+  cpp-lint:
     needs: changes
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
+    secrets: inherit
+    with:
+      sha: ${{ github.event.pull_request.base.sha || github.sha }}
+      pr_head_sha: ${{ github.event.pull_request.head.sha }}
+      workdir: packages/qvac-lib-inference-addon-onnx-ocr-fasttext
+
+  prebuild:
+    needs: [sanity-checks, cpp-lint]
     if: |
       (needs.changes.outputs.pkg == 'true') &&
       (


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- **CI:** Prebuilds could run and fail late; no early gate for C++ lint on the OCR addon.

## 📝 How does it solve it?

- **Workflows:** Run a **cpp-lint** step before prebuilds in `on-pr-qvac-lib-inference-addon-onnx-ocr-fasttext.yml` so lint failures fail the job early.

## 🧪 How was it tested?

- CI: Run on temp branch. PR workflow runs the new cpp-lint step before prebuilds: https://github.com/tetherto/qvac/actions/runs/21950788050/job/63400741955
