### PR TITLE
Add descriptions to two Whisper tiny models in models.prod.json

### DIFF
--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -60,7 +60,7 @@
   {
     "source": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-tiny.bin",
     "engine": "@qvac/transcription-whispercpp",
-    "description": "",
+    "description": "Whisper tiny multilingual transcription model (f16).",
     "quantization": "",
     "params": "",
     "license": "MIT",
@@ -74,7 +74,7 @@
   {
     "source": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-tiny-q8_0.bin",
     "engine": "@qvac/transcription-whispercpp",
-    "description": "",
+    "description": "Whisper tiny multilingual transcription model (q8).",
     "quantization": "q8_0",
     "params": "",
     "license": "MIT",


### PR DESCRIPTION
**What problem does this PR solve?**
Two Whisper tiny model entries in `models.prod.json` had empty `description` fields, making it harder to identify model variants at a glance.

**How does it solve it?**
Populate `description` for the Whisper tiny multilingual f16 and q8 variants, following the same concise format established in #153.

**Breaking changes:** None.

Made with [Cursor](https://cursor.com)