### PR TITLE
chore [notask]: Publish @qvac/registry-schema

### DIFF
--- a/packages/qvac-lib-registry-server/shared/package.json
+++ b/packages/qvac-lib-registry-server/shared/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@tetherto/qvac-registry-schema",
-  "version": "0.2.1",
+  "name": "@qvac/registry-schema",
+  "version": "0.1.0",
   "description": "HyperDB schema and database wrapper for QVAC Registry",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

Migrates the registry schema package from GitHub Package Registry (`@tetherto` scope) to NPM (`@qvac` scope).

## Changes

- Renamed package: `@tetherto/qvac-registry-schema` → `@qvac/registry-schema`
- Reset version to `0.1.0` (fresh start for new NPM package)

## Migration Note

This package was previously published to GitHub Package Registry as `@tetherto/qvac-registry-schema-mono` (versions 0.1.0-0.2.1). The codebase is unchanged; only the package name and registry have changed.