### PR TITLE
chore[notask]: backmerge release-qvac-registry-schema-0.1.1 into main

### DIFF
--- a/packages/qvac-lib-registry-server/shared/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/shared/CHANGELOG.md
@@ -1,19 +1,12 @@
 # Changelog
 
-## 0.2.0
+## [0.1.1]
 
-### Features
+Release Date: 2026-02-13
 
-- Add `findBy()` method to `RegistryDatabase` for unified model querying with optional filters (`name`, `engine`, `quantization`, `includeDeprecated`)
-- Add `findModelsByEngineQuantization()` method for compound index queries
-- Add `models-by-engine-quantization` compound HyperDB index for efficient multi-field lookups
+### ✨ Features
 
-### Notes
-
-- The `findBy()` method intelligently routes to the most efficient HyperDB index based on the provided parameters
-- Compound index follows B-tree leftmost prefix matching: queries by `engine` alone or `engine + quantization` use the index natively; other combinations use in-memory filtering
-- Existing `findModels*` methods remain unchanged
-
-## 0.1.0
-
-- Initial release
+- HyperDB schema and database wrapper for QVAC Registry
+- `findBy()` method for unified model querying with optional filters (`name`, `engine`, `quantization`, `includeDeprecated`)
+- `findModelsByEngineQuantization()` method for compound index queries
+- `models-by-engine-quantization` compound HyperDB index for efficient multi-field lookups

--- a/packages/qvac-lib-registry-server/shared/package.json
+++ b/packages/qvac-lib-registry-server/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-schema",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "HyperDB schema and database wrapper for QVAC Registry",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## What problem does this PR solve?

The `release-qvac-registry-schema-0.1.1` branch has the v0.1.1 release commit (version bump + changelog) that needs to be merged back into `main` to keep the mainline up to date.

## How does it solve it?

Standard backmerge of `release-qvac-registry-schema-0.1.1` into `main`. Clean merge, no conflicts.

### Changed files

- `packages/qvac-lib-registry-server/CHANGELOG.md` — new changelog entry for v0.1.1
- `packages/qvac-lib-registry-server/shared/package.json` — version bump to 0.1.1

## How was it tested?

No functional changes — version bump and changelog only. Clean merge with no conflicts.
