### PR TITLE
QVAC-13263 chore[skiplog]: Release @qvac/registry-client v0.1.4

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [0.1.4]
+
+Release Date: 2026-02-13
+
+### ✨ Features
+
+- Read-only QVAC Registry client for model discovery via Hyperswarm
+- `findBy()` method for unified model queries with filters (`name`, `engine`, `quantization`, `includeDeprecated`)
+- Model metadata retrieval from the distributed registry
+- Automatic peer discovery and replication via Hyperswarm
+- Compatible with Bare and Node.js runtimes

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Release @qvac/registry-client v0.1.4

### Changelog

See packages/qvac-lib-registry-server/client/CHANGELOG.md