### PR TITLE
QVAC-13265 feat: Release @qvac/registry-server v0.1.0 [GPR]

### DIFF
--- a/packages/qvac-lib-registry-server/lib/config.js
+++ b/packages/qvac-lib-registry-server/lib/config.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const process = require('process')
 const IdEnc = require('hypercore-id-encoding')
-const { ENV_KEYS } = require('@tetherto/qvac-registry-schema-mono')
+const { ENV_KEYS } = require('@qvac/registry-schema')
 const { getEnv, updateEnvFile } = require('../utils/env')
 
 const AUTOBASE_ENV_KEY = ENV_KEYS.QVAC_AUTOBASE_KEY || 'QVAC_AUTOBASE_KEY'

--- a/packages/qvac-lib-registry-server/lib/generate-schema.js
+++ b/packages/qvac-lib-registry-server/lib/generate-schema.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { QVAC_MAIN_REGISTRY } = require('@tetherto/qvac-registry-schema-mono')
+const { QVAC_MAIN_REGISTRY } = require('@qvac/registry-schema')
 
 module.exports = function generateQVACRegistrySchema (schema) {
   schema.register({

--- a/packages/qvac-lib-registry-server/lib/registry-service.js
+++ b/packages/qvac-lib-registry-server/lib/registry-service.js
@@ -27,7 +27,7 @@ function deriveRpcDiscoveryKey (autobaseKey) {
     .digest()
 }
 
-const schema = require('@tetherto/qvac-registry-schema-mono')
+const schema = require('@qvac/registry-schema')
 const { Router, encode: encodeDispatch } = schema.hyperdispatchSpec
 const RegistryDatabase = schema.RegistryDatabase
 const ReseedTracker = require('./reseed-tracker')

--- a/packages/qvac-lib-registry-server/migrations/001-fix-s3-bucket-in-path.js
+++ b/packages/qvac-lib-registry-server/migrations/001-fix-s3-bucket-in-path.js
@@ -33,7 +33,7 @@ const Corestore = require('corestore')
 const Autobase = require('autobase')
 const IdEnc = require('hypercore-id-encoding')
 
-const schema = require('@tetherto/qvac-registry-schema')
+const schema = require('@qvac/registry-schema')
 const { Router, encode: encodeDispatch } = schema.hyperdispatchSpec
 const RegistryDatabase = schema.RegistryDatabase
 const { QVAC_MAIN_REGISTRY } = schema
@@ -44,7 +44,7 @@ const DISPATCH_ADD_INDEXER = `@${QVAC_MAIN_REGISTRY}/add-indexer`
 const DISPATCH_REMOVE_INDEXER = `@${QVAC_MAIN_REGISTRY}/remove-indexer`
 const DISPATCH_DELETE_MODEL = `@${QVAC_MAIN_REGISTRY}/delete-model`
 
-function readEnvFile () {
+function readEnvFile() {
   const envPath = path.resolve('.env')
   const env = {}
   try {
@@ -65,7 +65,7 @@ function readEnvFile () {
   return env
 }
 
-function parseArgs () {
+function parseArgs() {
   const args = process.argv.slice(2)
   const env = readEnvFile()
 
@@ -98,7 +98,7 @@ function parseArgs () {
   return result
 }
 
-function printUsage () {
+function printUsage() {
   console.log('Usage: node migrations/001-fix-s3-bucket-in-path.js --bucket=<name> --storage=<path> [--bootstrap=<key>] [--dry-run]')
   console.log('')
   console.log('Options:')
@@ -111,7 +111,7 @@ function printUsage () {
   console.log('  node migrations/001-fix-s3-bucket-in-path.js --bucket=tether-ai-dev --storage=./storage --dry-run')
 }
 
-async function runMigration () {
+async function runMigration() {
   const opts = parseArgs()
 
   if (!opts.bucket || !opts.storage) {
@@ -170,16 +170,16 @@ async function runMigration () {
     await context.view.deleteModel(path, source)
   })
 
-  function openView (store) {
+  function openView(store) {
     const dbCore = store.get('db-view')
     return new RegistryDatabase(dbCore, { extension: false })
   }
 
-  async function closeView (view) {
+  async function closeView(view) {
     await view.close()
   }
 
-  async function apply (nodes, view, base) {
+  async function apply(nodes, view, base) {
     if (!view.opened) await view.ready()
     for (const node of nodes) {
       const op = node.value

--- a/packages/qvac-lib-registry-server/migrations/001-fix-s3-bucket-in-path.js
+++ b/packages/qvac-lib-registry-server/migrations/001-fix-s3-bucket-in-path.js
@@ -44,7 +44,7 @@ const DISPATCH_ADD_INDEXER = `@${QVAC_MAIN_REGISTRY}/add-indexer`
 const DISPATCH_REMOVE_INDEXER = `@${QVAC_MAIN_REGISTRY}/remove-indexer`
 const DISPATCH_DELETE_MODEL = `@${QVAC_MAIN_REGISTRY}/delete-model`
 
-function readEnvFile() {
+function readEnvFile () {
   const envPath = path.resolve('.env')
   const env = {}
   try {
@@ -65,7 +65,7 @@ function readEnvFile() {
   return env
 }
 
-function parseArgs() {
+function parseArgs () {
   const args = process.argv.slice(2)
   const env = readEnvFile()
 
@@ -98,7 +98,7 @@ function parseArgs() {
   return result
 }
 
-function printUsage() {
+function printUsage () {
   console.log('Usage: node migrations/001-fix-s3-bucket-in-path.js --bucket=<name> --storage=<path> [--bootstrap=<key>] [--dry-run]')
   console.log('')
   console.log('Options:')
@@ -111,7 +111,7 @@ function printUsage() {
   console.log('  node migrations/001-fix-s3-bucket-in-path.js --bucket=tether-ai-dev --storage=./storage --dry-run')
 }
 
-async function runMigration() {
+async function runMigration () {
   const opts = parseArgs()
 
   if (!opts.bucket || !opts.storage) {
@@ -170,16 +170,16 @@ async function runMigration() {
     await context.view.deleteModel(path, source)
   })
 
-  function openView(store) {
+  function openView (store) {
     const dbCore = store.get('db-view')
     return new RegistryDatabase(dbCore, { extension: false })
   }
 
-  async function closeView(view) {
+  async function closeView (view) {
     await view.close()
   }
 
-  async function apply(nodes, view, base) {
+  async function apply (nodes, view, base) {
     if (!view.opened) await view.ready()
     for (const node of nodes) {
       const op = node.value

--- a/packages/qvac-lib-registry-server/package-lock.json
+++ b/packages/qvac-lib-registry-server/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.864.0",
         "@huggingface/gguf": "^0.3.3",
         "@huggingface/hub": "^2.4.1",
-        "@tetherto/qvac-registry-schema-mono": "^0.2.1",
+        "@qvac/registry-schema": "^0.1.1",
         "autobase": "^7.18.1",
         "b4a": "^1.6.7",
         "blind-peer": "^2.9.4",
@@ -1048,6 +1048,18 @@
       "version": "0.4.0",
       "license": "MIT"
     },
+    "node_modules/@qvac/registry-schema": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@qvac/registry-schema/-/registry-schema-0.1.1.tgz",
+      "integrity": "sha512-Mm0zQqc/KTplE2wtdFseSd2995H4RK0hAW63ZDE/9TXfCxuW0medjcpVOXVGFoI+mkTM2cxubcO/eJvJlZih1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "hyperdb": "^4.16.0",
+        "hyperdispatch": "^1.4.0",
+        "hyperschema": "^1.13.0",
+        "ready-resource": "^1.2.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "dev": true,
@@ -1681,18 +1693,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@tetherto/qvac-registry-schema-mono": {
-      "version": "0.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@tetherto/qvac-registry-schema-mono/0.2.1/479fa2834c1206be35189b335fcc6a0f5dd3b08c",
-      "integrity": "sha512-0V8F2ymtHJUUOFf3kI8f6a83U1sjWuEIAN44Xlv6Eb6sl3M7T+WH3zSmY10/PE99rWTD6ZrNtmOvvNLcAaVYBQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "hyperdb": "^4.16.0",
-        "hyperdispatch": "^1.4.0",
-        "hyperschema": "^1.13.0",
-        "ready-resource": "^1.2.0"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {

--- a/packages/qvac-lib-registry-server/package.json
+++ b/packages/qvac-lib-registry-server/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@tetherto/qvac-lib-registry-server",
-  "version": "0.1.1",
+  "name": "@qvac/registry-server",
+  "version": "0.1.0",
   "description": "QVAC Registry server: exposes replication endpoints and lifecycle scripts for bare/pear",
   "license": "Apache-2.0",
   "type": "commonjs",
@@ -54,7 +54,7 @@
     "@aws-sdk/client-s3": "^3.864.0",
     "@huggingface/gguf": "^0.3.3",
     "@huggingface/hub": "^2.4.1",
-    "@tetherto/qvac-registry-schema-mono": "^0.2.1",
+    "@qvac/registry-schema": "^0.1.1",
     "autobase": "^7.18.1",
     "b4a": "^1.6.7",
     "blind-peer": "^2.9.4",

--- a/packages/qvac-lib-registry-server/scripts/bin.js
+++ b/packages/qvac-lib-registry-server/scripts/bin.js
@@ -14,7 +14,7 @@ const fs = require('fs')
 
 const RegistryService = require('../lib/registry-service')
 const RegistryConfig = require('../lib/config')
-const { AUTOBASE_NAMESPACE } = require('@tetherto/qvac-registry-schema-mono')
+const { AUTOBASE_NAMESPACE } = require('@qvac/registry-schema')
 
 const DEFAULT_STORAGE = './corestore'
 const DEFAULT_WRITER_STORAGE = './writer-storage'

--- a/packages/qvac-lib-registry-server/scripts/build-db-spec.js
+++ b/packages/qvac-lib-registry-server/scripts/build-db-spec.js
@@ -14,7 +14,7 @@ const HyperDBBuilder = require('hyperdb/builder')
 const Hyperdispatch = require('hyperdispatch')
 const Hyperschema = require('hyperschema')
 const generateQVACRegistrySchema = require('../lib/generate-schema')
-const { QVAC_MAIN_REGISTRY } = require('@tetherto/qvac-registry-schema-mono')
+const { QVAC_MAIN_REGISTRY } = require('@qvac/registry-schema')
 
 const SCHEMA_DIR = path.join(__dirname, '..', 'shared', 'spec', 'hyperschema')
 const DB_DIR = path.join(__dirname, '..', 'shared', 'spec', 'hyperdb')


### PR DESCRIPTION
## Migrate registry-server to @qvac scope

### Summary

Migrate `@tetherto/qvac-lib-registry-server` to `@qvac/registry-server`

- Package rename and version reset to 0.1.0
- Fix migration file import
- Update all lib/scripts imports