### PR TITLE
infra[notask]: add server GPR and NPM publish jobs to registry workflow

### DIFF
--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -8,8 +8,7 @@ on:
       - reopened
       - labeled
     paths:
-      - "packages/qvac-lib-registry-server/shared/**"
-      - "packages/qvac-lib-registry-server/client/**"
+      - "packages/qvac-lib-registry-server/**"
   push:
     branches:
       - main
@@ -17,8 +16,7 @@ on:
       - feature-*
       - tmp-*
     paths:
-      - "packages/qvac-lib-registry-server/shared/**"
-      - "packages/qvac-lib-registry-server/client/**"
+      - "packages/qvac-lib-registry-server/**"
   workflow_dispatch:
 
 env:
@@ -79,6 +77,7 @@ jobs:
     outputs:
       schema_changed: ${{ steps.filter.outputs.schema }}
       client_changed: ${{ steps.filter.outputs.client }}
+      server_changed: ${{ steps.filter.outputs.server }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -120,6 +119,7 @@ jobs:
             if [[ -z "${BEFORE_SHA}" ]]; then
               echo "schema=true" >> "$GITHUB_OUTPUT"
               echo "client=true" >> "$GITHUB_OUTPUT"
+              echo "server=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
           fi
@@ -132,8 +132,15 @@ jobs:
 
           if git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- "${PKG_DIR}/client/" | grep -q .; then
             echo "client=true" >> "$GITHUB_OUTPUT"
-          else
+              echo "server=true" >> "$GITHUB_OUTPUT"          else
             echo "client=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Server changes = changes in PKG_DIR that are NOT in shared/ or client/
+          if git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- "${PKG_DIR}/" | grep -v -E "^${PKG_DIR}/(shared|client)/" | grep -q .; then
+            echo "server=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "server=false" >> "$GITHUB_OUTPUT"
           fi
 
   publish-logic:
@@ -420,3 +427,80 @@ jobs:
           repo_name: "registry-server"
           git-token: ${{ secrets.GITHUB_TOKEN }}
 
+  publish-server-gpr:
+    needs: [detect-changes, publish-logic, publish-schema]
+    if: |
+      needs.detect-changes.outputs.server_changed == 'true' &&
+      always() &&
+      (needs.publish-schema.result == 'success' || needs.publish-schema.result == 'skipped') &&
+      (needs.publish-logic.outputs.publish_feature == 'true' ||
+       needs.publish-logic.outputs.publish_main == 'true' ||
+       needs.publish-logic.outputs.publish_tmp == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: ${{  github.event.pull_request.base.repo.full_name || github.repository }}
+          ref: ${{  github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Configure npm for package registries
+        shell: bash
+        working-directory: ${{ env.PKG_DIR }}
+        run: |
+          echo "@tetherto:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
+          echo "@qvac:registry=https://registry.npmjs.org" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+
+      - name: Publish to GitHub Package Registry
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          workdir: ${{ env.PKG_DIR }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          name-suffix: ${{ env.NAME_SUFFIX }}
+
+  publish-server-npm:
+    needs: [detect-changes, publish-logic, publish-schema]
+    if: |
+      needs.detect-changes.outputs.server_changed == 'true' &&
+      always() &&
+      (needs.publish-schema.result == 'success' || needs.publish-schema.result == 'skipped') &&
+      needs.publish-logic.outputs.publish_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: ${{  github.event.pull_request.base.repo.full_name || github.repository }}
+          ref: ${{  github.event.pull_request.base.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Configure npm for package registries
+        shell: bash
+        working-directory: ${{ env.PKG_DIR }}
+        run: |
+          echo "@tetherto:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
+          echo "@qvac:registry=https://registry.npmjs.org" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: ${{ env.PKG_DIR }}
+          repo_name: "registry-server"
+          git-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Problem

Previously, the `publish-qvac-lib-registry-server.yml` workflow only published:
- Schema package (`shared/`)
- Client package (`client/`)

The server package at the root (`packages/qvac-lib-registry-server/`) was not being published.

### Changes

1. **Simplified path triggers** - Changed from specific subdirectory paths to `packages/qvac-lib-registry-server/**`

2. **Added `server_changed` detection** - New logic to detect server-specific changes (excludes `shared/` and `client/` subdirectories)

3. **Added server publish jobs**:
   - `publish-server-gpr` - Publishes to GPR on `main`/`feature-*`/`tmp-*` branches
   - `publish-server-npm` - Publishes to NPM on `release-*` branches

4. **Added `publish-schema` dependency** - Server jobs wait for schema to publish first (since server depends on `@qvac/registry-schema`)

5. **Fixed workflow_dispatch fallback** - Added `server=true` to the fallback case

### Flow After Changes

| Trigger | Schema | Client | Server |
|---------|--------|--------|--------|
| Push to `main` | GPR | GPR | GPR |
| Push to `feature-*` | GPR | GPR | GPR |
| Push to `release-*` | NPM | NPM | NPM |