### PR TITLE
fix(nmtcpp): add missing native dependency attributions to NOTICE

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/NOTICE
+++ b/packages/qvac-lib-infer-nmtcpp/NOTICE
@@ -6,8 +6,9 @@ This software includes components ported from indic_nlp_library
 (https://github.com/anoopkunchukuttan/indic_nlp_library) which is licensed
 under the MIT License. See ./third-party/indic-processor-deps/indicnlp/INDIC_NLP_LICENCE for details.
 
-This software includes bergamot-translator
-(https://github.com/browsermt/bergamot-translator) which is licensed
+This software includes a fork of bergamot-translator
+(https://github.com/tetherto/qvac-ext-bergamot-translator, forked from
+https://github.com/browsermt/bergamot-translator) which is licensed
 under the Mozilla Public License 2.0 (MPL-2.0).
 See https://github.com/browsermt/bergamot-translator/blob/main/LICENSE for details.
 

--- a/packages/qvac-lib-infer-nmtcpp/NOTICE
+++ b/packages/qvac-lib-infer-nmtcpp/NOTICE
@@ -26,6 +26,11 @@ This software includes ssplit-cpp
 under the Apache License 2.0 (C++ code) and LGPL 2.1 (nonbreaking_prefixes data).
 See https://github.com/browsermt/ssplit-cpp/blob/master/LICENSE.md for details.
 
+This software includes whisper.cpp
+(https://github.com/ggerganov/whisper.cpp) which is licensed
+under the MIT License.
+See https://github.com/ggerganov/whisper.cpp/blob/master/LICENSE for details.
+
 This software includes Protocol Buffers (protobuf)
 (https://github.com/protocolbuffers/protobuf) which is licensed
 under the BSD 3-Clause License.

--- a/packages/qvac-lib-infer-nmtcpp/NOTICE
+++ b/packages/qvac-lib-infer-nmtcpp/NOTICE
@@ -6,3 +6,27 @@ This software includes components ported from indic_nlp_library
 (https://github.com/anoopkunchukuttan/indic_nlp_library) which is licensed
 under the MIT License. See ./third-party/indic-processor-deps/indicnlp/INDIC_NLP_LICENCE for details.
 
+This software includes bergamot-translator
+(https://github.com/browsermt/bergamot-translator) which is licensed
+under the Mozilla Public License 2.0 (MPL-2.0).
+See https://github.com/browsermt/bergamot-translator/blob/main/LICENSE for details.
+
+This software includes sentencepiece
+(https://github.com/google/sentencepiece) which is licensed
+under the Apache License 2.0.
+See https://github.com/google/sentencepiece/blob/master/LICENSE for details.
+
+This software includes ggml
+(https://github.com/ggml-org/ggml) which is licensed
+under the MIT License.
+See https://github.com/ggml-org/ggml/blob/master/LICENSE for details.
+
+This software includes ssplit-cpp
+(https://github.com/browsermt/ssplit-cpp) which is licensed
+under the Apache License 2.0 (C++ code) and LGPL 2.1 (nonbreaking_prefixes data).
+See https://github.com/browsermt/ssplit-cpp/blob/master/LICENSE.md for details.
+
+This software includes Protocol Buffers (protobuf)
+(https://github.com/protocolbuffers/protobuf) which is licensed
+under the BSD 3-Clause License.
+See https://github.com/protocolbuffers/protobuf/blob/main/LICENSE for details.

--- a/packages/qvac-lib-infer-nmtcpp/NOTICE
+++ b/packages/qvac-lib-infer-nmtcpp/NOTICE
@@ -12,6 +12,12 @@ https://github.com/browsermt/bergamot-translator) which is licensed
 under the Mozilla Public License 2.0 (MPL-2.0).
 See https://github.com/browsermt/bergamot-translator/blob/main/LICENSE for details.
 
+This software includes a fork of Marian NMT
+(https://github.com/tetherto/qvac-ext-marian-dev, forked from
+https://github.com/marian-nmt/marian-dev) which is licensed
+under the MIT License.
+See https://github.com/marian-nmt/marian-dev/blob/master/LICENSE.md for details.
+
 This software includes sentencepiece
 (https://github.com/google/sentencepiece) which is licensed
 under the Apache License 2.0.
@@ -31,6 +37,27 @@ This software includes whisper.cpp
 (https://github.com/ggerganov/whisper.cpp) which is licensed
 under the MIT License.
 See https://github.com/ggerganov/whisper.cpp/blob/master/LICENSE for details.
+
+This software includes intgemm
+(https://github.com/kpu/intgemm) which is licensed
+under the MIT License.
+See https://github.com/kpu/intgemm/blob/master/LICENSE for details.
+
+This software includes ruy
+(https://github.com/google/ruy) which is licensed
+under the Apache License 2.0.
+See https://github.com/google/ruy/blob/master/LICENSE for details.
+
+This software includes simd_utils
+(https://github.com/browsermt/simd_utils, forked from
+https://github.com/JishinMaster/simd_utils) which is licensed
+under the BSD 2-Clause License.
+See https://github.com/JishinMaster/simd_utils/blob/master/LICENSE for details.
+
+This software includes Abseil C++ Library
+(https://github.com/abseil/abseil-cpp) which is licensed
+under the Apache License 2.0.
+See https://github.com/abseil/abseil-cpp/blob/master/LICENSE for details.
 
 This software includes Protocol Buffers (protobuf)
 (https://github.com/protocolbuffers/protobuf) which is licensed


### PR DESCRIPTION
## Summary
- Added missing native C++ dependency attributions to the `qvac-lib-infer-nmtcpp` NOTICE file
- These libraries are statically linked into prebuild binaries and require attribution under their respective licenses:
  - **bergamot-translator** — MPL-2.0
  - **sentencepiece** — Apache-2.0
  - **ggml** — MIT
  - **ssplit-cpp** — Apache-2.0 / LGPL-2.1
  - **protobuf** — BSD-3-Clause

## Context
Identified during license audit (PR #353). The existing NOTICE only covered JS third-party ports (sacremoses, indic_nlp_library) but was missing the native dependencies that ship in prebuilds.

## Test plan
- [ ] Verify all listed dependency URLs resolve correctly
- [ ] Confirm licenses match upstream repos