### PR TITLE
fix(ocr-onnx): populate NOTICE with native dependency attributions

### DIFF
--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/NOTICE
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/NOTICE
@@ -1,1 +1,19 @@
+This software includes ONNX Runtime
+(https://github.com/microsoft/onnxruntime) which is licensed
+under the MIT License.
+See https://github.com/microsoft/onnxruntime/blob/main/LICENSE for details.
 
+This software includes OpenCV
+(https://github.com/opencv/opencv) which is licensed
+under the Apache License 2.0.
+See https://github.com/opencv/opencv/blob/master/LICENSE for details.
+
+This software includes Protocol Buffers (protobuf)
+(https://github.com/protocolbuffers/protobuf) which is licensed
+under the BSD 3-Clause License.
+See https://github.com/protocolbuffers/protobuf/blob/main/LICENSE for details.
+
+This software includes FlatBuffers
+(https://github.com/google/flatbuffers) which is licensed
+under the Apache License 2.0.
+See https://github.com/google/flatbuffers/blob/master/LICENSE for details.


### PR DESCRIPTION
## Summary
- Populated the empty NOTICE file for `@qvac/ocr-onnx` with native C++ dependency attributions
- These libraries are statically linked into prebuild binaries and require attribution:
  - **ONNX Runtime** — MIT
  - **OpenCV** — Apache-2.0
  - **protobuf** — BSD-3-Clause
  - **FlatBuffers** — Apache-2.0

## Context
Identified during license audit (PR #353). The NOTICE file existed but was empty despite shipping prebuilds with statically linked dependencies.

## Test plan
- [ ] Verify all listed dependency URLs resolve correctly
- [ ] Confirm licenses match upstream repos