### PR TITLE
chore[skiplog]: Release @qvac/registry-client v0.1.5

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.5]
+
+Release Date: 2026-02-14
+
+### 🔧 Changed
+
+- Upgraded Bare ecosystem dependencies:
+  - `bare-fs`: ^2.1.5 → ^4.5.2
+  - `bare-os`: ^2.2.0 → ^3.6.2
+  - `bare-process`: ^1.3.0 → ^4.2.2
+  - `corestore`: ^6.18.4 → ^7.4.5
+
 ## [0.1.4]
 
 Release Date: 2026-02-13

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Release @qvac/registry-client v0.1.5

### Changelog

See packages/qvac-lib-registry-server/client/CHANGELOG.md