### PR TITLE
doc[notask]: add model license notices to package READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .githuman
+.env
 /.sync-repos
 sync-monorepo.sh
 reset_history.sh

--- a/README.md
+++ b/README.md
@@ -150,6 +150,20 @@ Legend:
 - For the standard development workflow used in this monorepo, see [`gitflow.md`](gitflow.md).
 - For development specifics of each QVAC component, refer to the documentation in the respective subdirectory under `/packages`.
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/packages/qvac-lib-infer-llamacpp-embed/README.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/README.md
@@ -277,6 +277,20 @@ These tests validate the native implementation and help catch issues early in de
 * **Hyperdrive** - A peer-to-peer filesystem built on Hypercore, supporting real-time file sharing, versioning, and sparse downloading. Ideal for decentralized apps and data syncing. [Learn more](https://docs.pears.com/building-blocks/hyperdrive).
 * **CoreStore** - A manager for multiple Hypercores, handling storage, replication, and key derivation. Simplifies working with many Hypercores in peer-to-peer applications. [Learn more](https://docs.pears.com/helpers/corestore).
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## License
 
 This project is licensed under the Apache-2.0 [License](./LICENSE) – see the LICENSE file for details.

--- a/packages/qvac-lib-infer-llamacpp-llm/README.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/README.md
@@ -336,6 +336,20 @@ These tests validate the native implementation and help catch issues early in de
 • **Hyperdrive** – Hyperdrive is a secure, real-time distributed file system designed for easy P2P file sharing. [Learn more](https://docs.pears.com/building-blocks/hyperdrive).  
 • **Corestore** – Corestore is a Hypercore factory that makes it easier to manage large collections of named Hypercores. [Learn more](https://docs.pears.com/helpers/corestore).
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## License
 
 This project is licensed under the Apache-2.0 [License](./LICENSE) – see the LICENSE file for details.

--- a/packages/qvac-lib-infer-nmtcpp/README.md
+++ b/packages/qvac-lib-infer-nmtcpp/README.md
@@ -1084,6 +1084,20 @@ npm run test:unit   # Unit tests only
 npm run test:cpp    # C++ tests only (requires build first)
 ```
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## License
 
 This project is licensed under the Apache-2.0 License - see the [LICENSE](LICENSE) file for details.<br>

--- a/packages/qvac-lib-infer-onnx-tts/README.md
+++ b/packages/qvac-lib-infer-onnx-tts/README.md
@@ -411,6 +411,20 @@ npm run coverage:cpp
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## License
 
 This project is licensed under the Apache-2.0 License - see the [LICENSE](./LICENSE) file for details.

--- a/packages/qvac-lib-infer-onnx-vad/README.md
+++ b/packages/qvac-lib-infer-onnx-vad/README.md
@@ -259,6 +259,20 @@ Benchmark results are kept up to date to reflect improvements in model architect
 * GitHub Repo: [tetherto/qvac-lib-infer-onnx-vad](https://github.com/tetherto/qvac-lib-infer-onnx-vad)
 * Silero VAD Paper & Model: [snakers4/silero-vad](https://github.com/snakers4/silero-vad)
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## License
 
 This project is licensed under the Apache-2.0 License – see the [LICENSE](LICENSE) file for details.

--- a/packages/qvac-lib-infer-whispercpp/README.md
+++ b/packages/qvac-lib-infer-whispercpp/README.md
@@ -559,6 +559,20 @@ All the errors from this library are in the range of 6001-7000
 *   PoC Repo: [tetherto/qvac-transcription-poc](https://github.com/tetherto/qvac-transcription-poc)
 *   Pear app (Desktop): TBD
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## License
 
 This project is licensed under the Apache-2.0 License – see the LICENSE file for details.

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/README.md
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/README.md
@@ -360,6 +360,20 @@ See `supportedLanguages.js` for the complete language definitions.
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## License
 
 This project is licensed under the Apache-2.0 License - see the [LICENSE](LICENSE) file for details.

--- a/packages/qvac-lib-registry-server/client/README.md
+++ b/packages/qvac-lib-registry-server/client/README.md
@@ -286,6 +286,20 @@ async function handleErrors () {
 }
 ```
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## License
 
 Apache-2.0

--- a/packages/qvac-sdk/README.md
+++ b/packages/qvac-sdk/README.md
@@ -483,6 +483,20 @@ This outputs a tarball under `dist/qvac-sdk-{version}.tgz` that you can install 
 npm i path/to/qvac-sdk-0.3.0.tgz
 ```
 
+## Model License Notices
+
+### Built with Llama
+
+Llama 3.2 is licensed under the Llama 3.2 Community License, Copyright (c) Meta Platforms, Inc. All Rights Reserved.
+
+### Built with Gemma
+
+Gemma is provided under and subject to the Gemma Terms of Use found at [ai.google.dev/gemma/terms](https://ai.google.dev/gemma/terms).
+
+### Built with Health AI Developer Foundations (MedGemma)
+
+HAI-DEF is provided under and subject to the Health AI Developer Foundations Terms of Use found at [https://developers.google.com/health-ai-developer-foundations/terms](https://developers.google.com/health-ai-developer-foundations/terms).
+
 ## More Resources
 
 - [Comprehensive documentation of this SDK](https://qvac.tether.dev/docs/sdk)


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Third-party model licenses (Llama 3.2, Gemma, MedGemma) require prominent attribution notices in documentation
- No such notices existed in any package README or the root README

## 📝 How does it solve it?

- Adds a "Model License Notices" section near the end of 11 README files (root + 10 packages)
- Each notice uses the required "Built with X" heading followed by the one-line copyright/license statement
- Also adds `.env` to `.gitignore`

**Packages updated:**
- Root `README.md`
- `qvac-sdk`
- `qvac-lib-infer-llamacpp-embed`
- `qvac-lib-infer-llamacpp-llm`
- `qvac-lib-infer-nmtcpp`
- `qvac-lib-infer-onnx-tts`
- `qvac-lib-infer-onnx-vad`
- `qvac-lib-infer-whispercpp`
- `qvac-lib-inference-addon-onnx-ocr-fasttext`
- `qvac-lib-registry-server/client`
