### PR TITLE
QVAC-12216 feat[api]: add parakeet transcription plugin

### DIFF
--- a/packages/qvac-sdk/bun.lock
+++ b/packages/qvac-sdk/bun.lock
@@ -13,6 +13,7 @@
         "@qvac/logging": "^0.1.0",
         "@qvac/ocr-onnx": "^0.1.5",
         "@qvac/rag": "^0.4.2",
+        "@qvac/transcription-parakeet": "^0.1.4",
         "@qvac/transcription-whispercpp": "^0.3.17",
         "@qvac/translation-nmtcpp": "^0.3.6",
         "@qvac/tts-onnx": "^0.2.13",
@@ -527,6 +528,8 @@
     "@qvac/rag": ["@qvac/rag@0.4.2", "", { "dependencies": { "@qvac/error": "^0.1.0", "bare-crypto": "^1.11.2", "hyperdht": "^6.23.0", "ready-resource": "^1.1.2", "uuid-random": "^1.3.2", "zod": "^4.1.13" }, "peerDependencies": { "bare-fetch": "^2.5.0", "hyperdb": "^4.19.0", "hyperschema": "^1.13.0", "llm-splitter": "^0.2.0" }, "optionalPeers": ["bare-fetch", "hyperdb", "hyperschema", "llm-splitter"] }, "sha512-vjDhgv5AG/n3d8dI0K9iS5xGhxHfnX+mzaefBnuaIDatf/z1PNm6c4d91j8jDNGprrBAz23pj4po0wUlFZe+ig=="],
 
     "@qvac/response": ["@qvac/response@0.1.2", "", { "dependencies": { "bare-events": "2.4.2" } }, "sha512-xWAsUyxOd7kqOayjFwUGOGiWlwQ8z6bzy5lOTUdI3uHGCAbdsqUMivpMymktd3ub+ZvF7F/iCM4dxdDCTISSdA=="],
+
+    "@qvac/transcription-parakeet": ["@qvac/transcription-parakeet@0.1.4", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.2.0", "@qvac/logging": "^0.1.0", "bare-fs": "^4.5.1", "bare-path": "^3.0.0", "path": "npm:bare-path", "process": "npm:bare-process@^4.2.2" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-hHLIuUG4VRvdThQ3yTun5T4cvbEKDyNycIyrAHs31f07MG322i6emqgyq44snodF6b/1JEz3gXGLFmOEb0GLPA=="],
 
     "@qvac/transcription-whispercpp": ["@qvac/transcription-whispercpp@0.3.17", "", { "dependencies": { "@qvac/decoder-audio": "^0.3.3", "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.2.0", "@qvac/logging": "^0.1.0", "@qvac/util-transcription": "^0.1.4", "bare-channel": "^5.2.2", "bare-ffmpeg": "^1.0.0-32", "bare-node-worker-threads": "^1.0.0", "bare-path": "^3.0.0", "bare-stream": "^2.7.0", "bare-worker": "^4.1.0", "path": "npm:bare-path", "process": "npm:bare-process@^4.2.2", "stream": "npm:bare-node-stream", "worker_threads": "npm:bare-node-worker-threads@^1.0.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-SJKHGwbKbnfIh4nrupYOr/8B2IDejSIAGUs8vf2h8ZHI+ydMmDmOeq41qwvgDSDmlCQ2mWBWO9WClsjJfCSMrg=="],
 
@@ -2560,6 +2563,8 @@
 
     "@qvac/response/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
 
+    "@qvac/transcription-parakeet/@qvac/infer-base": ["@qvac/infer-base@0.2.2", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/logging": "^0.1.0", "bare-events": "2.4.2", "bare-os": "^3.2.0", "bare-path": "^3.0.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-8D/5PRIy/A+Uhg1ZSoJMu5FSPDHdrMKZoPnAzTZMceikTj+BWwTV//j8pXbRABsjrFbqBegvr/LujirC9I2cRQ=="],
+
     "@qvac/transcription-whispercpp/@qvac/infer-base": ["@qvac/infer-base@0.2.0", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/logging": "^0.1.0", "bare-events": "2.4.2", "bare-os": "^3.2.0", "bare-path": "^3.0.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-Sk5FcbNSbOx6fHzb4FwFdwj6aSdO6K2iYiEJWQfnap/C8EaEzgLvw6l5IiBT/w51SaEGXgHg95hwo9PZoCTJ+g=="],
 
     "@qvac/translation-nmtcpp/@qvac/infer-base": ["@qvac/infer-base@0.2.0", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/logging": "^0.1.0", "bare-events": "2.4.2", "bare-os": "^3.2.0", "bare-path": "^3.0.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-Sk5FcbNSbOx6fHzb4FwFdwj6aSdO6K2iYiEJWQfnap/C8EaEzgLvw6l5IiBT/w51SaEGXgHg95hwo9PZoCTJ+g=="],
@@ -2817,6 +2822,8 @@
     "@qvac/embed-llamacpp/@qvac/infer-base/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
 
     "@qvac/llm-llamacpp/@qvac/infer-base/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
+
+    "@qvac/transcription-parakeet/@qvac/infer-base/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
 
     "@qvac/transcription-whispercpp/@qvac/infer-base/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
 

--- a/packages/qvac-sdk/examples/parakeet-filesystem.ts
+++ b/packages/qvac-sdk/examples/parakeet-filesystem.ts
@@ -1,0 +1,51 @@
+import { loadModel, unloadModel, transcribe } from "@qvac/sdk";
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+
+if (!args[0]) {
+  console.error(
+    "Usage: bun run examples/parakeet-filesystem.ts <wav-file-path> [model-path-or-url]",
+  );
+  process.exit(1);
+}
+
+const audioFilePath = args[0];
+
+// Default to a HuggingFace HTTP URL if no model path provided
+const modelSrc =
+  args[1] ||
+  "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.onnx";
+
+try {
+  console.log("🦜 Starting Parakeet transcription example...");
+
+  // Load the Parakeet model
+  console.log("📥 Loading Parakeet model...");
+  const modelId = await loadModel({
+    modelSrc,
+    modelType: "parakeet",
+    onProgress: (progress) => {
+      console.log(
+        `📊 Download progress: ${progress.percentage.toFixed(1)}%`,
+      );
+    },
+  });
+
+  console.log(`✅ Parakeet model loaded with ID: ${modelId}`);
+
+  // Perform transcription
+  console.log("🎧 Transcribing audio...");
+  const text = await transcribe({ modelId, audioChunk: audioFilePath });
+
+  console.log("📝 Transcription result:");
+  console.log(text);
+
+  // Unload the model when done
+  console.log("🧹 Unloading Parakeet model...");
+  await unloadModel({ modelId });
+  console.log("✅ Parakeet model unloaded successfully");
+} catch (error) {
+  console.error("❌ Error:", error);
+  process.exit(1);
+}

--- a/packages/qvac-sdk/logging/namespaces.ts
+++ b/packages/qvac-sdk/logging/namespaces.ts
@@ -2,6 +2,7 @@ export const ADDON_NAMESPACES = {
   LLAMACPP_LLM: "llamacpp:llm",
   LLAMACPP_EMBED: "llamacpp:embed",
   WHISPERCPP: "whispercpp",
+  PARAKEET: "parakeet",
   TTS: "tts",
   NMTCPP: "nmtcpp",
   RAG_HYPERDB: "rag:hyperdb",

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/server/bare/plugins/whispercpp-transcription/plugin.d.ts",
       "import": "./dist/server/bare/plugins/whispercpp-transcription/plugin.js"
     },
+    "./parakeet-transcription/plugin": {
+      "types": "./dist/server/bare/plugins/parakeet-transcription/plugin.d.ts",
+      "import": "./dist/server/bare/plugins/parakeet-transcription/plugin.js"
+    },
     "./nmtcpp-translation/plugin": {
       "types": "./dist/server/bare/plugins/nmtcpp-translation/plugin.d.ts",
       "import": "./dist/server/bare/plugins/nmtcpp-translation/plugin.js"
@@ -111,6 +115,7 @@
     "@qvac/logging": "^0.1.0",
     "@qvac/ocr-onnx": "^0.1.5",
     "@qvac/rag": "^0.4.2",
+    "@qvac/transcription-parakeet": "^0.1.4",
     "@qvac/transcription-whispercpp": "^0.3.17",
     "@qvac/translation-nmtcpp": "^0.3.6",
     "@qvac/tts-onnx": "^0.2.13",

--- a/packages/qvac-sdk/schemas/get-model-info.ts
+++ b/packages/qvac-sdk/schemas/get-model-info.ts
@@ -34,6 +34,7 @@ export const modelInfoSchema = z.object({
   addon: z.enum([
     "llamacpp-completion",
     "whispercpp-transcription",
+    "parakeet-transcription",
     "llamacpp-embedding",
     "nmtcpp-translation",
     "vad",

--- a/packages/qvac-sdk/schemas/index.ts
+++ b/packages/qvac-sdk/schemas/index.ts
@@ -20,6 +20,7 @@ export * from "./translate";
 export * from "./translation-config";
 export * from "./llamacpp-config";
 export * from "./whispercpp-config";
+export * from "./parakeet-config";
 export * from "./text-to-speech";
 export * from "./error";
 export * from "./rag";
@@ -55,6 +56,7 @@ export {
   // Per-model-type schemas for discriminated unions
   llmModelTypeSchema,
   whisperModelTypeSchema,
+  parakeetModelTypeSchema,
   embeddingsModelTypeSchema,
   nmtModelTypeSchema,
   ttsModelTypeSchema,
@@ -64,6 +66,7 @@ export {
   type ModelTypeInput,
   type LlmModelTypeInput,
   type WhisperModelTypeInput,
+  type ParakeetModelTypeInput,
   type EmbeddingsModelTypeInput,
   type NmtModelTypeInput,
   type TtsModelTypeInput,

--- a/packages/qvac-sdk/schemas/load-model.ts
+++ b/packages/qvac-sdk/schemas/load-model.ts
@@ -6,6 +6,7 @@ import {
   type EmbedConfig,
 } from "./llamacpp-config";
 import { whisperConfigSchema } from "./whispercpp-config";
+import { parakeetConfigSchema } from "./parakeet-config";
 import { delegateSchema } from "./delegate";
 import { nmtConfigSchema } from "./translation-config";
 import { ttsConfigSchema } from "./text-to-speech";
@@ -18,6 +19,7 @@ import {
 import {
   llmModelTypeSchema,
   whisperModelTypeSchema,
+  parakeetModelTypeSchema,
   embeddingsModelTypeSchema,
   nmtModelTypeSchema,
   ttsModelTypeSchema,
@@ -43,6 +45,13 @@ const loadModelOptionsBaseSchema = z.union([
     modelConfig: whisperConfigSchema.partial().strict().optional(),
     seed: z.boolean().optional(),
     vadModelSrc: modelSrcInputSchema.optional(),
+    delegate: delegateSchema,
+  }),
+  z.object({
+    modelSrc: modelSrcInputSchema,
+    modelType: parakeetModelTypeSchema,
+    modelConfig: parakeetConfigSchema.partial().strict().optional(),
+    seed: z.boolean().optional(),
     delegate: delegateSchema,
   }),
   z.object({
@@ -146,6 +155,28 @@ export const loadModelOptionsToRequestSchema = z.union([
       vadModelSrc: data.vadModelSrc
         ? modelInputToSrcSchema.parse(data.vadModelSrc)
         : undefined,
+    })),
+  z
+    .object({
+      modelSrc: modelSrcInputSchema,
+      modelType: parakeetModelTypeSchema,
+      modelConfig: parakeetConfigSchema.partial().strict().optional(),
+      seed: z.boolean().optional(),
+      delegate: delegateSchema,
+      onProgress: z.unknown().optional(),
+      withProgress: z.boolean().optional(),
+    })
+    .transform((data) => ({
+      type: "loadModel" as const,
+      modelType: ModelType.parakeetTranscription,
+      modelSrc: modelInputToSrcSchema.parse(data.modelSrc),
+      modelName: modelInputToNameSchema.parse(data.modelSrc),
+      modelConfig: (data.modelConfig ?? {}) as z.infer<
+        typeof parakeetConfigSchema
+      >,
+      seed: data.seed ?? false,
+      withProgress: data.withProgress ?? !!data.onProgress,
+      delegate: data.delegate,
     })),
   z
     .object({
@@ -292,6 +323,11 @@ export const loadWhisperModelRequestSchema = commonModelConfigSchema.extend({
   modelConfig: whisperConfigSchema, // whisper has no defaults
 });
 
+export const loadParakeetModelRequestSchema = commonModelConfigSchema.extend({
+  modelType: z.literal(ModelType.parakeetTranscription),
+  modelConfig: parakeetConfigSchema, // modelType defaults to "tdt"
+});
+
 export const loadEmbeddingsModelRequestSchema = commonModelConfigSchema.extend({
   modelType: z.literal(ModelType.llamacppEmbedding),
   modelConfig: embedConfigBaseSchema,
@@ -328,6 +364,7 @@ export const loadModelSrcRequestSchema = z
   .union([
     loadLlmModelRequestSchema,
     loadWhisperModelRequestSchema,
+    loadParakeetModelRequestSchema,
     loadEmbeddingsModelRequestSchema,
     loadNmtModelRequestSchema,
     loadTtsModelRequestSchema,

--- a/packages/qvac-sdk/schemas/model-types.ts
+++ b/packages/qvac-sdk/schemas/model-types.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 export const ModelType = {
   llamacppCompletion: "llamacpp-completion",
   whispercppTranscription: "whispercpp-transcription",
+  parakeetTranscription: "parakeet-transcription",
   llamacppEmbedding: "llamacpp-embedding",
   nmtcppTranslation: "nmtcpp-translation",
   onnxTts: "onnx-tts",
@@ -19,6 +20,7 @@ export const ModelType = {
 const AliasKeys = {
   llm: "llm",
   whisper: "whisper",
+  parakeet: "parakeet",
   embeddings: "embeddings",
   nmt: "nmt",
   tts: "tts",
@@ -33,6 +35,7 @@ const AliasKeys = {
 export const ModelTypeAliases = {
   [AliasKeys.llm]: ModelType.llamacppCompletion,
   [AliasKeys.whisper]: ModelType.whispercppTranscription,
+  [AliasKeys.parakeet]: ModelType.parakeetTranscription,
   [AliasKeys.embeddings]: ModelType.llamacppEmbedding,
   [AliasKeys.nmt]: ModelType.nmtcppTranslation,
   [AliasKeys.tts]: ModelType.onnxTts,
@@ -152,6 +155,18 @@ export const whisperModelTypeSchema = modelTypeInputSchema
     'Whisper model type: "whisper" (alias) or "whispercpp-transcription" (canonical)',
   );
 export type WhisperModelTypeInput = z.infer<typeof whisperModelTypeSchema>;
+
+/**
+ * Parakeet/Transcription model type schema.
+ * - Alias: `"parakeet"` → resolves to `"parakeet-transcription"`
+ * - Canonical: `"parakeet-transcription"`
+ */
+export const parakeetModelTypeSchema = modelTypeInputSchema
+  .extract([AliasKeys.parakeet, ModelType.parakeetTranscription])
+  .describe(
+    'Parakeet model type: "parakeet" (alias) or "parakeet-transcription" (canonical)',
+  );
+export type ParakeetModelTypeInput = z.infer<typeof parakeetModelTypeSchema>;
 
 /**
  * Embeddings model type schema.

--- a/packages/qvac-sdk/schemas/parakeet-config.ts
+++ b/packages/qvac-sdk/schemas/parakeet-config.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 // Only TDT is currently supported
-// Other variants (ctc, eou, sortformer) can be added once tested upstream
+// Other variants (ctc, eou, sortformer) can be added once available upstream
 // and their download logic is implemented in http.ts.
 export const parakeetModelTypeEnumSchema = z.enum(["tdt"]);
 export type ParakeetModelVariant = z.infer<typeof parakeetModelTypeEnumSchema>;

--- a/packages/qvac-sdk/schemas/parakeet-config.ts
+++ b/packages/qvac-sdk/schemas/parakeet-config.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+// Only TDT is currently supported
+// Other variants (ctc, eou, sortformer) can be added once tested upstream
+// and their download logic is implemented in http.ts.
+export const parakeetModelTypeEnumSchema = z.enum(["tdt"]);
+export type ParakeetModelVariant = z.infer<typeof parakeetModelTypeEnumSchema>;
+
+export const parakeetConfigSchema = z.object({
+  modelType: parakeetModelTypeEnumSchema.default("tdt"),
+  maxThreads: z.number().int().optional(),
+  useGPU: z.boolean().optional(),
+  sampleRate: z.number().int().optional(),
+  channels: z.number().int().optional(),
+  captionEnabled: z.boolean().optional(),
+  timestampsEnabled: z.boolean().optional(),
+  seed: z.number().int().optional(),
+});
+
+export type ParakeetConfig = z.infer<typeof parakeetConfigSchema>;

--- a/packages/qvac-sdk/schemas/sdk-config.ts
+++ b/packages/qvac-sdk/schemas/sdk-config.ts
@@ -3,6 +3,7 @@ import { logLevelSchema } from "./logging-stream";
 import { ModelType } from "./model-types";
 import { llmConfigBaseSchema, embedConfigBaseSchema } from "./llamacpp-config";
 import { whisperConfigSchema } from "./whispercpp-config";
+import { parakeetConfigSchema } from "./parakeet-config";
 import { ocrConfigSchema } from "./ocr";
 import { runtimeContextSchema } from "./runtime-context";
 
@@ -10,6 +11,7 @@ import { runtimeContextSchema } from "./runtime-context";
 const AliasKeys = {
   llm: "llm",
   whisper: "whisper",
+  parakeet: "parakeet",
   embeddings: "embeddings",
   nmt: "nmt",
   tts: "tts",
@@ -46,6 +48,9 @@ export const deviceConfigDefaultsSchema = z
     [ModelType.whispercppTranscription]: whisperConfigSchema
       .partial()
       .optional(),
+    [ModelType.parakeetTranscription]: parakeetConfigSchema
+      .partial()
+      .optional(),
     [ModelType.nmtcppTranslation]: z.record(z.string(), z.unknown()).optional(),
     [ModelType.onnxTts]: z.record(z.string(), z.unknown()).optional(),
     [ModelType.onnxOcr]: ocrConfigSchema.partial().optional(),
@@ -53,6 +58,7 @@ export const deviceConfigDefaultsSchema = z
     [AliasKeys.llm]: llmConfigBaseSchema.optional(),
     [AliasKeys.embeddings]: embedConfigBaseSchema.optional(),
     [AliasKeys.whisper]: whisperConfigSchema.partial().optional(),
+    [AliasKeys.parakeet]: parakeetConfigSchema.partial().optional(),
     [AliasKeys.nmt]: z.record(z.string(), z.unknown()).optional(),
     [AliasKeys.tts]: z.record(z.string(), z.unknown()).optional(),
     [AliasKeys.ocr]: ocrConfigSchema.partial().optional(),

--- a/packages/qvac-sdk/server/bare/plugins/index.ts
+++ b/packages/qvac-sdk/server/bare/plugins/index.ts
@@ -1,6 +1,7 @@
 export { llmPlugin } from "./llamacpp-completion/plugin";
 export { embeddingsPlugin } from "./llamacpp-embedding/plugin";
 export { whisperPlugin } from "./whispercpp-transcription/plugin";
+export { parakeetPlugin } from "./parakeet-transcription/plugin";
 export { nmtPlugin } from "./nmtcpp-translation/plugin";
 export { ttsPlugin } from "./onnx-tts/plugin";
 export { ocrPlugin } from "./onnx-ocr/plugin";

--- a/packages/qvac-sdk/server/bare/plugins/parakeet-transcription/ops/transcribe-stream.ts
+++ b/packages/qvac-sdk/server/bare/plugins/parakeet-transcription/ops/transcribe-stream.ts
@@ -1,0 +1,29 @@
+import { getModel } from "@/server/bare/registry/model-registry";
+import type { TranscribeParams, AudioFormat } from "@/schemas";
+import { createAudioStream } from "@/server/bare/utils/audio-input";
+import { getServerLogger } from "@/logging";
+
+const logger = getServerLogger();
+
+export async function* transcribe(
+  params: TranscribeParams,
+): AsyncGenerator<string, void, void> {
+  const model = getModel(params.modelId);
+  const audioFormat: AudioFormat = "s16le";
+
+  const audioStream = await createAudioStream(params.audioChunk, audioFormat);
+
+  const response = await model.run(audioStream);
+
+  for await (const output of response.iterate()) {
+    logger.debug("Parakeet Streaming Transcription Update:", output);
+
+    const text = (output as { text: string }[])
+      .map((chunk) => chunk.text)
+      .join("");
+
+    if (text.trim()) {
+      yield text;
+    }
+  }
+}

--- a/packages/qvac-sdk/server/bare/plugins/parakeet-transcription/plugin.ts
+++ b/packages/qvac-sdk/server/bare/plugins/parakeet-transcription/plugin.ts
@@ -1,0 +1,74 @@
+import parakeetAddonLogging from "@qvac/transcription-parakeet/addonLogging";
+import TranscriptionParakeet, {
+  type ParakeetConfig as TranscriptionParakeetConfig,
+  type TranscriptionParakeetArgs,
+  type TranscriptionParakeetConfig as UpstreamConfig,
+} from "@qvac/transcription-parakeet";
+import {
+  definePlugin,
+  ModelType,
+  type CreateModelParams,
+  type PluginModelResult,
+  type ParakeetConfig,
+} from "@/schemas";
+import { ADDON_NAMESPACES, createStreamLogger } from "@/logging";
+import { parseModelPath } from "@/server/utils";
+import FilesystemDL from "@qvac/dl-filesystem";
+import { transcribe } from "@/server/bare/plugins/parakeet-transcription/ops/transcribe-stream";
+import { createTranscribeStreamHandler } from "@/server/bare/utils/transcription-handler";
+
+function createParakeetModel(
+  modelId: string,
+  modelPath: string,
+  parakeetConfig: ParakeetConfig,
+) {
+  const { dirPath } = parseModelPath(modelPath);
+
+  const loader = new FilesystemDL({ dirPath });
+  const logger = createStreamLogger(modelId, "parakeet");
+
+  // modelName uses the directory name (not file name) because parakeet is a
+  // multi-file model — the addon resolves individual files relative to dirPath.
+  const args = {
+    loader,
+    logger,
+    modelName: parseModelPath(dirPath).basePath,
+    diskPath: dirPath,
+  } as unknown as TranscriptionParakeetArgs;
+
+  const config: UpstreamConfig = {
+    path: dirPath,
+    parakeetConfig: parakeetConfig as TranscriptionParakeetConfig,
+  };
+
+  const model = new TranscriptionParakeet(args, config);
+
+  return { model, loader };
+}
+
+export const parakeetPlugin = definePlugin({
+  modelType: ModelType.parakeetTranscription,
+  displayName: "Parakeet (NVIDIA NeMo ONNX)",
+  addonPackage: "@qvac/transcription-parakeet",
+
+  createModel(params: CreateModelParams): PluginModelResult {
+    const parakeetConfig = (params.modelConfig ?? {}) as ParakeetConfig;
+
+    const { model, loader } = createParakeetModel(
+      params.modelId,
+      params.modelPath,
+      parakeetConfig,
+    );
+
+    return { model, loader };
+  },
+
+  handlers: {
+    transcribeStream: createTranscribeStreamHandler(transcribe),
+  },
+
+  logging: {
+    module: parakeetAddonLogging,
+    namespace: ADDON_NAMESPACES.PARAKEET,
+  },
+});

--- a/packages/qvac-sdk/server/bare/plugins/whispercpp-transcription/ops/transcribe-stream.ts
+++ b/packages/qvac-sdk/server/bare/plugins/whispercpp-transcription/ops/transcribe-stream.ts
@@ -2,17 +2,8 @@ import {
   getModel,
   getModelConfig,
 } from "@/server/bare/registry/model-registry";
-import { Readable } from "bare-stream";
-import fs from "bare-fs";
-import {
-  needsDecoding,
-  decodeAudioToStream,
-} from "@/server/utils/audio/decoder";
 import type { TranscribeParams, WhisperConfig, AudioFormat } from "@/schemas";
-import {
-  AudioFileNotFoundError,
-  InvalidAudioChunkError,
-} from "@/utils/errors-server";
+import { createAudioStream } from "@/server/bare/utils/audio-input";
 import { getServerLogger } from "@/logging";
 
 const logger = getServerLogger();
@@ -42,41 +33,12 @@ export async function* transcribe(
   }
 
   try {
-    let audioStream: Readable;
+    const audioStream = await createAudioStream(params.audioChunk, audioFormat);
 
-    const audioChunk = params.audioChunk;
-
-    switch (audioChunk.type) {
-      case "base64": {
-        const audioBuffer = Buffer.from(audioChunk.value, "base64");
-        audioStream = Readable.from([audioBuffer]);
-        break;
-      }
-      case "filePath": {
-        const filePath = audioChunk.value;
-        try {
-          fs.accessSync(filePath);
-        } catch (error: unknown) {
-          throw new AudioFileNotFoundError(filePath, error);
-        }
-
-        if (needsDecoding(filePath)) {
-          audioStream = await decodeAudioToStream(filePath, audioFormat);
-        } else {
-          audioStream = fs.createReadStream(filePath) as unknown as Readable;
-        }
-        break;
-      }
-      default:
-        throw new InvalidAudioChunkError();
-    }
-
-    // Run transcription with streaming enabled
     const response = await model.run(audioStream);
 
     for await (const output of response.iterate()) {
       logger.debug("Streaming Transcription Update:", output);
-      // Filter out blank audio chunks and process the text
       const text = (output as { text: string }[])
         .filter((chunk) => !chunk.text.includes("[BLANK_AUDIO]"))
         .map((chunk) => chunk.text)

--- a/packages/qvac-sdk/server/bare/plugins/whispercpp-transcription/plugin.ts
+++ b/packages/qvac-sdk/server/bare/plugins/whispercpp-transcription/plugin.ts
@@ -4,9 +4,6 @@ import TranscriptionWhispercpp, {
 } from "@qvac/transcription-whispercpp";
 import {
   definePlugin,
-  defineHandler,
-  transcribeStreamRequestSchema,
-  transcribeStreamResponseSchema,
   ModelType,
   type CreateModelParams,
   type PluginModelResult,
@@ -16,6 +13,7 @@ import { ADDON_NAMESPACES, createStreamLogger } from "@/logging";
 import { parseModelPath } from "@/server/utils";
 import FilesystemDL from "@qvac/dl-filesystem";
 import { transcribe } from "@/server/bare/plugins/whispercpp-transcription/ops/transcribe-stream";
+import { createTranscribeStreamHandler } from "@/server/bare/utils/transcription-handler";
 
 function createWhisperModel(
   modelId: string,
@@ -79,30 +77,7 @@ export const whisperPlugin = definePlugin({
   },
 
   handlers: {
-    transcribeStream: defineHandler({
-      requestSchema: transcribeStreamRequestSchema,
-      responseSchema: transcribeStreamResponseSchema,
-      streaming: true,
-
-      handler: async function* (request) {
-        for await (const text of transcribe({
-          modelId: request.modelId,
-          audioChunk: request.audioChunk,
-          prompt: request.prompt,
-        })) {
-          yield {
-            type: "transcribeStream" as const,
-            text,
-          };
-        }
-
-        yield {
-          type: "transcribeStream" as const,
-          text: "",
-          done: true,
-        };
-      },
-    }),
+    transcribeStream: createTranscribeStreamHandler(transcribe),
   },
 
   logging: {

--- a/packages/qvac-sdk/server/bare/registry/model-config-utils.ts
+++ b/packages/qvac-sdk/server/bare/registry/model-config-utils.ts
@@ -14,6 +14,7 @@ export const CANONICAL_TO_ALIAS: Record<CanonicalModelType, string> = {
   [ModelType.llamacppCompletion]: "llm",
   [ModelType.llamacppEmbedding]: "embeddings",
   [ModelType.whispercppTranscription]: "whisper",
+  [ModelType.parakeetTranscription]: "parakeet",
   [ModelType.nmtcppTranslation]: "nmt",
   [ModelType.onnxTts]: "tts",
   [ModelType.onnxOcr]: "ocr",

--- a/packages/qvac-sdk/server/bare/utils/audio-input.ts
+++ b/packages/qvac-sdk/server/bare/utils/audio-input.ts
@@ -1,0 +1,44 @@
+import { Readable } from "bare-stream";
+import fs from "bare-fs";
+import {
+  needsDecoding,
+  decodeAudioToStream,
+} from "@/server/utils/audio/decoder";
+import type { AudioInput, AudioFormat } from "@/schemas";
+import {
+  AudioFileNotFoundError,
+  InvalidAudioChunkError,
+} from "@/utils/errors-server";
+
+/**
+ * Converts an AudioInput (base64 or filePath) into a Readable stream,
+ * decoding the audio when necessary.
+ *
+ * Shared by all transcription plugins (Whisper, Parakeet, etc.).
+ */
+export async function createAudioStream(
+  audioChunk: AudioInput,
+  audioFormat: AudioFormat,
+): Promise<Readable> {
+  switch (audioChunk.type) {
+    case "base64": {
+      const audioBuffer = Buffer.from(audioChunk.value, "base64");
+      return Readable.from([audioBuffer]);
+    }
+    case "filePath": {
+      const filePath = audioChunk.value;
+      try {
+        fs.accessSync(filePath);
+      } catch (error: unknown) {
+        throw new AudioFileNotFoundError(filePath, error);
+      }
+
+      if (needsDecoding(filePath)) {
+        return decodeAudioToStream(filePath, audioFormat);
+      }
+      return fs.createReadStream(filePath) as unknown as Readable;
+    }
+    default:
+      throw new InvalidAudioChunkError();
+  }
+}

--- a/packages/qvac-sdk/server/bare/utils/transcription-handler.ts
+++ b/packages/qvac-sdk/server/bare/utils/transcription-handler.ts
@@ -1,0 +1,43 @@
+import {
+  defineHandler,
+  transcribeStreamRequestSchema,
+  transcribeStreamResponseSchema,
+  type TranscribeParams,
+} from "@/schemas";
+
+type TranscribeFn = (
+  params: TranscribeParams,
+) => AsyncGenerator<string, void, void>;
+
+/**
+ * Creates a standard `transcribeStream` handler definition for a
+ * transcription plugin.  Every transcription addon (Whisper, Parakeet, …)
+ * follows the same yield-then-done protocol — this helper avoids
+ * duplicating that boilerplate across plugins.
+ */
+export function createTranscribeStreamHandler(transcribeFn: TranscribeFn) {
+  return defineHandler({
+    requestSchema: transcribeStreamRequestSchema,
+    responseSchema: transcribeStreamResponseSchema,
+    streaming: true,
+
+    handler: async function* (request) {
+      for await (const text of transcribeFn({
+        modelId: request.modelId,
+        audioChunk: request.audioChunk,
+        prompt: request.prompt,
+      })) {
+        yield {
+          type: "transcribeStream" as const,
+          text,
+        };
+      }
+
+      yield {
+        type: "transcribeStream" as const,
+        text: "",
+        done: true,
+      };
+    },
+  });
+}

--- a/packages/qvac-sdk/server/rpc/handlers/load-model/handler.ts
+++ b/packages/qvac-sdk/server/rpc/handlers/load-model/handler.ts
@@ -8,6 +8,7 @@ import { normalizeModelType, ModelType } from "@/schemas";
 import { hyperdriveUrlSchema } from "@/schemas/load-model";
 import { loadModel } from "@/server/bare/addons";
 import { resolveModelPath } from "@/server/rpc/handlers/load-model/resolve";
+import { downloadParakeetModelFromHttp } from "@/server/rpc/handlers/load-model/http";
 import {
   getModelEntry,
   updateModelConfig,
@@ -64,7 +65,20 @@ export async function handleLoadModel(
       : undefined;
 
   try {
-    const modelPath = await resolveModelPath(modelSrc, progressCallback, seed);
+    // Parakeet models are multi-file and need a dedicated downloader for HTTP
+    let modelPath: string;
+    if (
+      canonicalModelType === ModelType.parakeetTranscription &&
+      typeof modelSrc === "string" &&
+      (modelSrc.startsWith("http://") || modelSrc.startsWith("https://"))
+    ) {
+      modelPath = await downloadParakeetModelFromHttp(
+        modelSrc,
+        progressCallback,
+      );
+    } else {
+      modelPath = await resolveModelPath(modelSrc, progressCallback, seed);
+    }
 
     let projectionModelPath: string | undefined;
     if (projectionModelSrc) {

--- a/packages/qvac-sdk/server/rpc/handlers/load-model/http.ts
+++ b/packages/qvac-sdk/server/rpc/handlers/load-model/http.ts
@@ -960,3 +960,176 @@ async function downloadShardsWithConcurrency(
     });
   }
 }
+
+// ============================================================================
+// Parakeet multi-file download
+// ============================================================================
+
+/**
+ * Required model files for each parakeet model variant.
+ * The preprocessor URL may differ from the main repo.
+ */
+const PARAKEET_TDT_FILES = [
+  "encoder-model.onnx",
+  "encoder-model.onnx.data",
+  "decoder_joint-model.onnx",
+  "vocab.txt",
+];
+
+const PARAKEET_TDT_PREPROCESSOR_URL =
+  "https://huggingface.co/ysdede/parakeet-tdt-0.6b-v2-onnx/resolve/main/nemo128.onnx";
+
+/**
+ * Downloads all required parakeet model files to a dedicated cache directory.
+ * Accepts a base URL like:
+ *   https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.onnx
+ * Or a repo-level URL like:
+ *   https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
+ *
+ * Returns path to encoder-model.onnx within the cached model directory.
+ */
+export async function downloadParakeetModelFromHttp(
+  url: string,
+  progressCallback?: (progress: ModelProgressUpdate) => void,
+): Promise<string> {
+  // Derive the base URL (repo resolve/main/ prefix) from the input URL
+  let baseUrl: string;
+  const resolveMainIdx = url.indexOf("/resolve/main/");
+  if (resolveMainIdx !== -1) {
+    baseUrl = url.substring(0, resolveMainIdx + "/resolve/main/".length);
+  } else {
+    // Assume repo-level URL, append /resolve/main/
+    baseUrl = url.replace(/\/+$/, "") + "/resolve/main/";
+  }
+
+  const downloadKey = createHttpDownloadKey(baseUrl);
+
+  // Dedup: reuse existing download if one is already in progress for this URL
+  const existing = getActiveDownload(downloadKey);
+  if (existing) {
+    logger.info(`📥 Reusing existing parakeet download for: ${downloadKey}`);
+    return existing.promise;
+  }
+
+  // Create a dedicated cache directory for this parakeet model
+  const cacheDir = getModelsCacheDir();
+  const modelHash = generateShortHash(baseUrl);
+  const modelDir = path.join(cacheDir, `parakeet_${modelHash}`);
+  const encoderPath = path.join(modelDir, "encoder-model.onnx");
+
+  const abortController = new AbortController();
+
+  const downloadPromise = (async () => {
+    try {
+      await fsPromises.mkdir(modelDir, { recursive: true });
+    } catch {
+      // directory may already exist
+    }
+
+    try {
+      // Download each required file
+      for (const fileName of PARAKEET_TDT_FILES) {
+        if (abortController.signal.aborted) {
+          throw new DownloadCancelledError();
+        }
+
+        const filePath = path.join(modelDir, fileName);
+        const fileUrl = `${baseUrl}${fileName}`;
+
+        try {
+          await fsPromises.access(filePath);
+          const stats = await fsPromises.stat(filePath);
+          if (stats.size > 0) {
+            logger.info(`✅ Parakeet file cached: ${fileName}`);
+            continue;
+          }
+        } catch {
+          // file doesn't exist, download it
+        }
+
+        logger.info(`📥 Downloading parakeet file: ${fileName}`);
+        await performHttpDownload(
+          fileUrl,
+          filePath,
+          downloadKey,
+          progressCallback,
+          abortController.signal,
+        );
+        logger.info(`✅ Downloaded: ${fileName}`);
+      }
+
+      // Download preprocessor (from a different HuggingFace repo)
+      if (abortController.signal.aborted) {
+        throw new DownloadCancelledError();
+      }
+
+      const preprocessorPath = path.join(modelDir, "preprocessor.onnx");
+      try {
+        await fsPromises.access(preprocessorPath);
+        const stats = await fsPromises.stat(preprocessorPath);
+        if (stats.size > 0) {
+          logger.info(`✅ Parakeet preprocessor cached`);
+        } else {
+          throw new Error("empty file");
+        }
+      } catch {
+        logger.info(`📥 Downloading parakeet preprocessor`);
+        await performHttpDownload(
+          PARAKEET_TDT_PREPROCESSOR_URL,
+          preprocessorPath,
+          downloadKey,
+          progressCallback,
+          abortController.signal,
+        );
+        logger.info(`✅ Downloaded: preprocessor.onnx`);
+      }
+
+      return encoderPath;
+    } catch (error) {
+      logger.error(
+        "❌ Error downloading parakeet model:",
+        error instanceof Error ? error.message : String(error),
+      );
+
+      if (error instanceof Error && error.message === "Download cancelled") {
+        if (shouldClearCache(downloadKey)) {
+          logger.info(
+            "🗑️ Clearing cache - deleting parakeet model directory",
+          );
+          try {
+            await fsPromises.rm(modelDir, { recursive: true, force: true });
+            logger.info(`✅ Deleted parakeet model directory: ${modelDir}`);
+          } catch (cleanupError) {
+            logger.debug(
+              "Failed to delete parakeet model directory during cleanup",
+              { path: modelDir, error: cleanupError },
+            );
+          }
+        } else {
+          logger.info(
+            "📥 Download paused - partial parakeet files preserved for resume",
+          );
+        }
+        clearClearCacheFlag(downloadKey);
+      }
+
+      throw error instanceof Error ? error : new Error(String(error));
+    } finally {
+      unregisterDownload(downloadKey);
+    }
+  })();
+
+  // Register with download manager for dedup and cancellation
+  registerDownload(downloadKey, {
+    key: downloadKey,
+    promise: downloadPromise,
+    abortController,
+    startTime: Date.now(),
+    type: "http",
+    url: baseUrl,
+    modelPath: encoderPath,
+    ...(progressCallback && { onProgress: progressCallback }),
+  } as HttpDownloadEntry);
+
+  return downloadPromise;
+}

--- a/packages/qvac-sdk/server/worker.ts
+++ b/packages/qvac-sdk/server/worker.ts
@@ -9,6 +9,7 @@ import {
   llmPlugin,
   embeddingsPlugin,
   whisperPlugin,
+  parakeetPlugin,
   nmtPlugin,
   ttsPlugin,
   ocrPlugin,
@@ -24,6 +25,7 @@ logger.info("🐻 Hello from Bare");
 registerPlugin(llmPlugin);
 registerPlugin(embeddingsPlugin);
 registerPlugin(whisperPlugin);
+registerPlugin(parakeetPlugin);
 registerPlugin(nmtPlugin);
 registerPlugin(ttsPlugin);
 registerPlugin(ocrPlugin);

--- a/packages/qvac-sdk/test/unit/model-types.test.ts
+++ b/packages/qvac-sdk/test/unit/model-types.test.ts
@@ -13,6 +13,7 @@ import {
 test("ModelType contains all canonical values", (t) => {
   t.is(ModelType.llamacppCompletion, "llamacpp-completion");
   t.is(ModelType.whispercppTranscription, "whispercpp-transcription");
+  t.is(ModelType.parakeetTranscription, "parakeet-transcription");
   t.is(ModelType.llamacppEmbedding, "llamacpp-embedding");
   t.is(ModelType.nmtcppTranslation, "nmtcpp-translation");
   t.is(ModelType.onnxTts, "onnx-tts");
@@ -22,6 +23,7 @@ test("ModelType contains all canonical values", (t) => {
 test("ModelTypeAliases maps to correct canonical values", (t) => {
   t.is(ModelTypeAliases.llm, ModelType.llamacppCompletion);
   t.is(ModelTypeAliases.whisper, ModelType.whispercppTranscription);
+  t.is(ModelTypeAliases.parakeet, ModelType.parakeetTranscription);
   t.is(ModelTypeAliases.embeddings, ModelType.llamacppEmbedding);
   t.is(ModelTypeAliases.nmt, ModelType.nmtcppTranslation);
   t.is(ModelTypeAliases.tts, ModelType.onnxTts);
@@ -32,6 +34,7 @@ test("PUBLIC_MODEL_TYPES contains both canonical and alias keys", (t) => {
   // Canonical keys
   t.is(PUBLIC_MODEL_TYPES.llamacppCompletion, "llamacpp-completion");
   t.is(PUBLIC_MODEL_TYPES.whispercppTranscription, "whispercpp-transcription");
+  t.is(PUBLIC_MODEL_TYPES.parakeetTranscription, "parakeet-transcription");
   t.is(PUBLIC_MODEL_TYPES.llamacppEmbedding, "llamacpp-embedding");
   t.is(PUBLIC_MODEL_TYPES.nmtcppTranslation, "nmtcpp-translation");
   t.is(PUBLIC_MODEL_TYPES.onnxTts, "onnx-tts");
@@ -40,6 +43,7 @@ test("PUBLIC_MODEL_TYPES contains both canonical and alias keys", (t) => {
   // Alias keys
   t.is(PUBLIC_MODEL_TYPES.llm, "llamacpp-completion");
   t.is(PUBLIC_MODEL_TYPES.whisper, "whispercpp-transcription");
+  t.is(PUBLIC_MODEL_TYPES.parakeet, "parakeet-transcription");
   t.is(PUBLIC_MODEL_TYPES.embeddings, "llamacpp-embedding");
   t.is(PUBLIC_MODEL_TYPES.nmt, "nmtcpp-translation");
   t.is(PUBLIC_MODEL_TYPES.tts, "onnx-tts");
@@ -50,6 +54,7 @@ test("normalizeModelType converts aliases to canonical", (t) => {
   // Aliases should normalize to canonical
   t.is(normalizeModelType("llm"), "llamacpp-completion");
   t.is(normalizeModelType("whisper"), "whispercpp-transcription");
+  t.is(normalizeModelType("parakeet"), "parakeet-transcription");
   t.is(normalizeModelType("embeddings"), "llamacpp-embedding");
   t.is(normalizeModelType("nmt"), "nmtcpp-translation");
   t.is(normalizeModelType("tts"), "onnx-tts");
@@ -62,6 +67,10 @@ test("normalizeModelType passes through canonical values unchanged", (t) => {
     normalizeModelType("whispercpp-transcription"),
     "whispercpp-transcription",
   );
+  t.is(
+    normalizeModelType("parakeet-transcription"),
+    "parakeet-transcription",
+  );
   t.is(normalizeModelType("llamacpp-embedding"), "llamacpp-embedding");
   t.is(normalizeModelType("nmtcpp-translation"), "nmtcpp-translation");
   t.is(normalizeModelType("onnx-tts"), "onnx-tts");
@@ -72,6 +81,7 @@ test("isModelTypeAlias correctly identifies aliases", (t) => {
   // Aliases
   t.is(isModelTypeAlias("llm"), true);
   t.is(isModelTypeAlias("whisper"), true);
+  t.is(isModelTypeAlias("parakeet"), true);
   t.is(isModelTypeAlias("embeddings"), true);
   t.is(isModelTypeAlias("nmt"), true);
   t.is(isModelTypeAlias("tts"), true);
@@ -80,6 +90,7 @@ test("isModelTypeAlias correctly identifies aliases", (t) => {
   // Canonical values are not aliases
   t.is(isModelTypeAlias("llamacpp-completion"), false);
   t.is(isModelTypeAlias("whispercpp-transcription"), false);
+  t.is(isModelTypeAlias("parakeet-transcription"), false);
   t.is(isModelTypeAlias("llamacpp-embedding"), false);
   t.is(isModelTypeAlias("nmtcpp-translation"), false);
   t.is(isModelTypeAlias("onnx-tts"), false);
@@ -89,6 +100,7 @@ test("isModelTypeAlias correctly identifies aliases", (t) => {
 test("modelTypeInputSchema accepts aliases", (t) => {
   t.is(modelTypeInputSchema.parse("llm"), "llm");
   t.is(modelTypeInputSchema.parse("whisper"), "whisper");
+  t.is(modelTypeInputSchema.parse("parakeet"), "parakeet");
   t.is(modelTypeInputSchema.parse("embeddings"), "embeddings");
   t.is(modelTypeInputSchema.parse("nmt"), "nmt");
   t.is(modelTypeInputSchema.parse("tts"), "tts");
@@ -103,6 +115,10 @@ test("modelTypeInputSchema accepts canonical values", (t) => {
   t.is(
     modelTypeInputSchema.parse("whispercpp-transcription"),
     "whispercpp-transcription",
+  );
+  t.is(
+    modelTypeInputSchema.parse("parakeet-transcription"),
+    "parakeet-transcription",
   );
   t.is(modelTypeInputSchema.parse("llamacpp-embedding"), "llamacpp-embedding");
   t.is(modelTypeInputSchema.parse("nmtcpp-translation"), "nmtcpp-translation");
@@ -120,6 +136,7 @@ test("modelTypeInputSchema rejects invalid values", (t) => {
 test("modelTypeSchema transforms aliases to canonical", (t) => {
   t.is(modelTypeSchema.parse("llm"), "llamacpp-completion");
   t.is(modelTypeSchema.parse("whisper"), "whispercpp-transcription");
+  t.is(modelTypeSchema.parse("parakeet"), "parakeet-transcription");
   t.is(modelTypeSchema.parse("embeddings"), "llamacpp-embedding");
   t.is(modelTypeSchema.parse("nmt"), "nmtcpp-translation");
   t.is(modelTypeSchema.parse("tts"), "onnx-tts");
@@ -131,6 +148,10 @@ test("modelTypeSchema passes through canonical values", (t) => {
   t.is(
     modelTypeSchema.parse("whispercpp-transcription"),
     "whispercpp-transcription",
+  );
+  t.is(
+    modelTypeSchema.parse("parakeet-transcription"),
+    "parakeet-transcription",
   );
   t.is(modelTypeSchema.parse("llamacpp-embedding"), "llamacpp-embedding");
   t.is(modelTypeSchema.parse("nmtcpp-translation"), "nmtcpp-translation");


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The SDK lacks support for NVIDIA's Parakeet (NeMo ONNX) speech-to-text model, limiting users to Whisper for transcription
- Whisper and Parakeet plugins duplicated ~50 lines of identical audio-input handling and handler boilerplate

## 📝 How does it solve it?

- Adds a thin Parakeet transcription plugin following the existing plugin architecture (`definePlugin` / `defineHandler`)
- Multi-file HTTP downloader with per-file caching, deduplication, and abort/resume support for Parakeet's multi-artifact model (encoder, decoder, vocab, preprocessor)
- Extracts shared utilities into `server/bare/utils/`:
  - `audio-input.ts` — `createAudioStream()` handles base64/filePath resolution and decoding (used by both Whisper and Parakeet)
  - `transcription-handler.ts` — `createTranscribeStreamHandler()` eliminates the identical yield-then-done handler wrapper
- Registers `parakeet-transcription` model type, config schema, logging namespace, and plugin

## 🧪 How was it tested?

- Typecheck, lint, and full build pass (`bun run build`)
- Unit tests updated and passing for model type registration, alias resolution, and config defaults
- End-to-end: `whispercpp-filesystem.ts` and `parakeet-filesystem.ts` examples run successfully via `bare` with a 48kHz WAV file, producing correct transcription output
- Verified both absolute and relative audio file path resolution works for both plugins
- Tested before and after the shared-utility refactor — identical transcription output

## 🔌 API Changes

```typescript
import { loadModel, transcribe } from "@qvac/sdk";

const modelId = await loadModel({
  modelSrc: "https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main/encoder-model.onnx",
  modelType: "parakeet",
  onProgress: (p) => console.log(`${p.percentage.toFixed(1)}%`),
});

const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
```