### PR TITLE
chore[notask]: backmerge release-qvac-cli-0.1.2 into main

### DIFF
--- a/packages/qvac-cli/CHANGELOG.md
+++ b/packages/qvac-cli/CHANGELOG.md
@@ -1,15 +1,28 @@
 # Changelog 
 
+## [0.1.2]
+
+Release Date: 2026-02-14
+
+### 🔧 Changed
+
+- Make `bare-pack` resolution self-contained — CLI now resolves `bare-pack` from its own `node_modules` instead of relying on consumer project
+- Use explicit SDK exports in worker entry generation (`@qvac/sdk/worker-core`, `@qvac/sdk/plugins`, `@qvac/sdk/logging`) to align with SDK's tightened package boundaries
+
+### 📝 Documentation
+
+- Updated README to reflect that `bare-pack` is bundled with CLI (no longer a user dependency)
+
 ## [0.1.1]
 
 Release Date: 2026-02-11
 
-## 🧹 Chores
+### 🧹 Chores
 
 - Add qvac-cli to sdk pod & remove manual CHANGELOG. (see PR [#228](https://github.com/tetherto/qvac/pull/228))
 - Standardize logger & log levels. (see PR [#257](https://github.com/tetherto/qvac/pull/257))
 
-## ⚙️ Infrastructure
+### ⚙️ Infrastructure
 
 - Add GPR scope rewrite action and rename CLI to @qvac/cli. (see PR [#230](https://github.com/tetherto/qvac/pull/230))
 

--- a/packages/qvac-cli/package.json
+++ b/packages/qvac-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What problem does this PR solve?

The `release-qvac-cli-0.1.2` branch has the v0.1.2 release commit (version bump + changelog) that needs to be merged back into `main` to keep the mainline up to date.

## How does it solve it?

Standard backmerge of `release-qvac-cli-0.1.2` into `main`. Clean merge, no conflicts.

### Changed files

- `packages/qvac-cli/CHANGELOG.md` — new changelog entry for v0.1.2
- `packages/qvac-cli/package.json` — version bump to 0.1.2

## How was it tested?

No functional changes — version bump and changelog only. Clean merge with no conflicts.