### PR TITLE
infra[notask]: rewrite CLI references to @tetherto/cli-mono for GPR publishing

### DIFF
--- a/.github/actions/cli-rewrite-sdk-scope-for-gpr/action.yaml
+++ b/.github/actions/cli-rewrite-sdk-scope-for-gpr/action.yaml
@@ -10,6 +10,7 @@ runs:
       run: |
         # GPR SDK package name
         NEW_SDK_NAME="@tetherto/sdk-mono"
+        NEW_CLI_NAME="@tetherto/cli-mono"
 
         echo "Rewriting @qvac/sdk → $NEW_SDK_NAME in source files..."
 
@@ -29,4 +30,36 @@ runs:
           sed -i.bak "s|@qvac/sdk|${NEW_SDK_NAME}|g" "$INDEX_FILE"
           rm "${INDEX_FILE}.bak"
           echo "✓ Updated $INDEX_FILE"
+        fi
+
+        # Update package.json bin name: "qvac" → "tetherto"
+        PACKAGE_FILE="package.json"
+        if [ -f "$PACKAGE_FILE" ]; then
+          sed -i.bak 's|"qvac": "./src/index.js"|"tetherto": "./src/index.js"|g' "$PACKAGE_FILE"
+          rm "${PACKAGE_FILE}.bak"
+          echo "✓ Updated $PACKAGE_FILE (bin name)"
+        fi
+
+        # Update src/index.js Commander.js program name
+        MAIN_INDEX_FILE="src/index.js"
+        if [ -f "$MAIN_INDEX_FILE" ]; then
+          sed -i.bak "s|.name('qvac')|.name('tetherto')|g" "$MAIN_INDEX_FILE"
+          rm "${MAIN_INDEX_FILE}.bak"
+          echo "✓ Updated $MAIN_INDEX_FILE (program name)"
+        fi
+
+        # Update errors.js @qvac/cli references
+        ERRORS_FILE="src/errors.js"
+        if [ -f "$ERRORS_FILE" ]; then
+          sed -i.bak "s|@qvac/cli|${NEW_CLI_NAME}|g" "$ERRORS_FILE"
+          rm "${ERRORS_FILE}.bak"
+          echo "✓ Updated $ERRORS_FILE"
+        fi
+
+        # Update entry-gen.js npx qvac references
+        ENTRY_GEN_FILE="src/bundle-sdk/entry-gen.js"
+        if [ -f "$ENTRY_GEN_FILE" ]; then
+          sed -i.bak "s|npx qvac|npx tetherto|g" "$ENTRY_GEN_FILE"
+          rm "${ENTRY_GEN_FILE}.bak"
+          echo "✓ Updated $ENTRY_GEN_FILE"
         fi

--- a/.github/workflows/publish-qvac-sdk.yml
+++ b/.github/workflows/publish-qvac-sdk.yml
@@ -157,6 +157,13 @@ jobs:
             echo "Updating @qvac/sdk references in $MOBILE_BUNDLE_FILE to $NEW_NAME"
             sed -i.bak "s|@qvac/sdk|${NEW_NAME}|g" "$MOBILE_BUNDLE_FILE"
             rm "${MOBILE_BUNDLE_FILE}.bak"
+            # Update @qvac/cli references to @tetherto/cli-mono
+            echo "Updating @qvac/cli references in $MOBILE_BUNDLE_FILE to @tetherto/cli-mono"
+            sed -i.bak "s|\"@qvac\"|\"@tetherto\"|g" "$MOBILE_BUNDLE_FILE"
+            sed -i.bak "s|\"cli\"|\"cli-mono\"|g" "$MOBILE_BUNDLE_FILE"
+            sed -i.bak "s|@qvac/cli|@tetherto/cli-mono|g" "$MOBILE_BUNDLE_FILE"
+            sed -i.bak "s|npx qvac|npx tetherto|g" "$MOBILE_BUNDLE_FILE"
+            rm "${MOBILE_BUNDLE_FILE}.bak"
             echo "✓ Updated $MOBILE_BUNDLE_FILE"
           fi
 


### PR DESCRIPTION
## What problem does this PR solve?

- When publishing to GPR, the CLI package becomes `@tetherto/cli-mono` but the binary name remains `"qvac"` — causing conflicts when both `@qvac/cli` (npm) and `@tetherto/cli-mono` (GPR) are installed in the same project
- SDK's `withMobileBundle.ts` looks for `@qvac/cli` instead of `@tetherto/cli-mono` when running in GPR-published SDK
- Error messages and generated comments reference `@qvac/cli` and `npx qvac` which don't exist in GPR context

## How does it solve it?

- **CLI rewrite action**: Extend `cli-rewrite-sdk-scope-for-gpr` to also rewrite:
  - `package.json` bin name: `"qvac"` → `"tetherto"`
  - Commander.js program name: `.name('qvac')` → `.name('tetherto')`
  - `@qvac/cli` references in error messages
  - `npx qvac` → `npx tetherto` in generated entry file comments
- **SDK publish workflow**: Add rewrites in `withMobileBundle.ts` for:
  - CLI path segments: `"@qvac"` → `"@tetherto"`, `"cli"` → `"cli-mono"`
  - CLI references in comments and fallback command