### PR TITLE
feat[notask]: add --sdk-path option to CLI for explicit sdk location

### DIFF
--- a/packages/qvac-cli/src/bundle-sdk/index.js
+++ b/packages/qvac-cli/src/bundle-sdk/index.js
@@ -13,14 +13,25 @@ import {
 import { runBarePack } from './bare-pack.js'
 import { generateAddonsManifest } from './manifest.js'
 
-async function resolveSdkName (projectRoot) {
-  const sdkPackageJsonPath = path.join(
-    projectRoot,
-    'node_modules',
-    '@qvac',
-    'sdk',
-    'package.json'
-  )
+/**
+ * Resolves the SDK path.
+ * If explicitSdkPath is provided, uses that directly.
+ * Otherwise, auto-detects from node_modules/@qvac/sdk.
+ */
+function resolveSdkPath (projectRoot, explicitSdkPath) {
+  if (explicitSdkPath) {
+    return path.isAbsolute(explicitSdkPath)
+      ? explicitSdkPath
+      : path.join(projectRoot, explicitSdkPath)
+  }
+  return path.join(projectRoot, 'node_modules', '@qvac', 'sdk')
+}
+
+/**
+ * Reads the SDK package name from its package.json.
+ */
+async function resolveSdkName (sdkPath) {
+  const sdkPackageJsonPath = path.join(sdkPath, 'package.json')
 
   try {
     if (fs.existsSync(sdkPackageJsonPath)) {
@@ -35,19 +46,14 @@ async function resolveSdkName (projectRoot) {
   return DEFAULT_SDK_NAME
 }
 
-function resolveImportsMapPath (projectRoot, sdkName) {
-  const fromNodeModules = path.join(
-    projectRoot,
-    'node_modules',
-    sdkName,
-    'bare-imports.json'
-  )
+function resolveImportsMapPath (sdkPath, sdkName) {
+  const importsMapPath = path.join(sdkPath, 'bare-imports.json')
 
-  if (fs.existsSync(fromNodeModules)) {
-    return fromNodeModules
+  if (fs.existsSync(importsMapPath)) {
+    return importsMapPath
   }
 
-  throw new BareImportsMapNotFoundError(sdkName, fromNodeModules)
+  throw new BareImportsMapNotFoundError(sdkName, importsMapPath)
 }
 
 export async function bundleSdk (options = {}) {
@@ -83,10 +89,12 @@ export async function bundleSdk (options = {}) {
     )
   }
 
-  const sdkName = await resolveSdkName(projectRoot)
+  const sdkPath = resolveSdkPath(projectRoot, options.sdkPath)
+  const sdkName = await resolveSdkName(sdkPath)
   logger.info(`📦 SDK: ${sdkName}`)
+  logger.debug(`   Path: ${sdkPath}`)
 
-  const importsMapPath = resolveImportsMapPath(projectRoot, sdkName)
+  const importsMapPath = resolveImportsMapPath(sdkPath, sdkName)
 
   const pluginSpecifiers = resolvePluginSpecifiers(config, sdkName, logger)
   logger.info(`\n📦 Plugins to include (${pluginSpecifiers.length}):`)

--- a/packages/qvac-cli/src/index.js
+++ b/packages/qvac-cli/src/index.js
@@ -32,6 +32,7 @@ function setupCli () {
     .command('sdk')
     .description('Generate a tree-shaken Bare worker bundle with selected plugins')
     .option('-c, --config <path>', 'Config file path (default: auto-detect qvac.config.*)')
+    .option('--sdk-path <path>', 'Path to SDK package (default: auto-detect in node_modules)')
     .option('--host <target>', 'Target host (repeatable)', collect, [])
     .option('--defer <module>', 'Defer a module (repeatable)', collect, [])
     .option('-q, --quiet', 'Minimal output')
@@ -41,6 +42,7 @@ function setupCli () {
         await bundleSdk({
           projectRoot: process.cwd(),
           configPath: options.config,
+          sdkPath: options.sdkPath,
           hosts: options.host.length > 0 ? options.host : undefined,
           defer: options.defer.length > 0 ? options.defer : undefined,
           quiet: options.quiet,

--- a/packages/qvac-sdk/expo/plugins/withMobileBundle.ts
+++ b/packages/qvac-sdk/expo/plugins/withMobileBundle.ts
@@ -140,11 +140,12 @@ function runBundler(
   const hostFlags = MOBILE_HOSTS.map((h) => `--host ${h}`).join(" ");
   const deferFlags = DEFERRED_MODULES.map((m) => `--defer "${m}"`).join(" ");
   const configFlag = configPath ? `--config "${configPath}"` : "";
+  const sdkPathFlag = `--sdk-path "${qvacSdkPath}"`;
   const cliCommand = resolveCliCommand(projectRoot);
 
   try {
     execSync(
-      `${cliCommand} bundle sdk ${configFlag} ${hostFlags} ${deferFlags} --quiet`,
+      `${cliCommand} bundle sdk ${sdkPathFlag} ${configFlag} ${hostFlags} ${deferFlags} --quiet`,
       { stdio: "inherit", cwd: projectRoot },
     );
   } catch (error) {


### PR DESCRIPTION
## What problem does this PR solve?

- CLI hardcodes SDK path as `node_modules/@qvac/sdk`, requiring workflow rewrites for GPR publishing where SDK is `@tetherto/sdk-mono`
- SDK's `withMobileBundle.ts` already knows its own path but has no way to tell CLI where to find it
- Tight coupling between CLI and SDK package name creates maintenance burden and fragile sed-based workarounds

## How does it solve it?

- **New CLI option**: Add `--sdk-path <path>` to `bundle sdk` command that accepts explicit SDK location
- **SDK passes its path**: `withMobileBundle.ts` now passes `--sdk-path "${qvacSdkPath}"` when invoking CLI
- **Backward compatible**: Without `--sdk-path`, CLI falls back to auto-detecting `@qvac/sdk` in node_modules
- **Package-name agnostic**: CLI reads `package.json` from provided path to determine actual SDK name

## Usage Example

### Explicit SDK path (new)
npx qvac bundle sdk --sdk-path ./node_modules/@tetherto/sdk-mono

### Auto-detect (existing behavior, still works)
npx qvac bundle sdk
