### PR TITLE
QVAC-13289 Cpp test workflow doesn't return as failed when tests are skipped fix

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/test/unit/test_bert_model.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/unit/test_bert_model.cpp
@@ -156,7 +156,7 @@ protected:
 
 TEST_F(BertModelTest, IsLoadedBeforeInit) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -166,7 +166,7 @@ TEST_F(BertModelTest, IsLoadedBeforeInit) {
 
 TEST_F(BertModelTest, InitializeBackend) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -176,7 +176,7 @@ TEST_F(BertModelTest, InitializeBackend) {
 
 TEST_F(BertModelTest, InitializeBackendWithEmptyDir) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -186,7 +186,7 @@ TEST_F(BertModelTest, InitializeBackendWithEmptyDir) {
 
 TEST_F(BertModelTest, ResetMethod) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -196,7 +196,7 @@ TEST_F(BertModelTest, ResetMethod) {
 
 TEST_F(BertModelTest, RuntimeStatsBeforeProcessing) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -205,7 +205,7 @@ TEST_F(BertModelTest, RuntimeStatsBeforeProcessing) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   auto stats = model.runtimeStats();
@@ -232,7 +232,7 @@ TEST_F(BertModelTest, RuntimeStatsBeforeProcessing) {
 
 TEST_F(BertModelTest, RuntimeStatsAfterProcessing) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -241,7 +241,7 @@ TEST_F(BertModelTest, RuntimeStatsAfterProcessing) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   // Process some input to generate stats
@@ -288,7 +288,7 @@ TEST_F(BertModelTest, ConstructorWithEmptyConfig) {
 
 TEST_F(BertModelTest, ConstructorWithBackendsDir) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -300,7 +300,7 @@ TEST_F(BertModelTest, ConstructorWithBackendsDir) {
 
 TEST_F(BertModelTest, ModelLoadsSuccessfully) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -330,7 +330,7 @@ TEST_F(BertModelTest, ModelFailsToLoadWithInvalidPath) {
 
 TEST_F(BertModelTest, EncodeHostF32SingleString) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -339,7 +339,7 @@ TEST_F(BertModelTest, EncodeHostF32SingleString) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string prompt = "Hello world";
@@ -362,7 +362,7 @@ TEST_F(BertModelTest, EncodeHostF32SingleString) {
 
 TEST_F(BertModelTest, EncodeHostF32MultipleStrings) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -371,7 +371,7 @@ TEST_F(BertModelTest, EncodeHostF32MultipleStrings) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<std::string> prompts = {
@@ -401,7 +401,7 @@ TEST_F(BertModelTest, EncodeHostF32MultipleStrings) {
 
 TEST_F(BertModelTest, EncodeHostF32EmptyString) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -410,7 +410,7 @@ TEST_F(BertModelTest, EncodeHostF32EmptyString) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string prompt = "";
@@ -422,7 +422,7 @@ TEST_F(BertModelTest, EncodeHostF32EmptyString) {
 
 TEST_F(BertModelTest, EncodeHostF32Sequences) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -431,7 +431,7 @@ TEST_F(BertModelTest, EncodeHostF32Sequences) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<std::string> sequences = {"First sequence", "Second sequence"};
@@ -447,7 +447,7 @@ TEST_F(BertModelTest, EncodeHostF32Sequences) {
 
 TEST_F(BertModelTest, EncodeHostF32SequencesEmpty) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -456,7 +456,7 @@ TEST_F(BertModelTest, EncodeHostF32SequencesEmpty) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<std::string> sequences;
@@ -468,7 +468,7 @@ TEST_F(BertModelTest, EncodeHostF32SequencesEmpty) {
 
 TEST_F(BertModelTest, ProcessWithStringInput) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -477,7 +477,7 @@ TEST_F(BertModelTest, ProcessWithStringInput) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = "Process this text";
@@ -491,7 +491,7 @@ TEST_F(BertModelTest, ProcessWithStringInput) {
 
 TEST_F(BertModelTest, ProcessWithVectorInput) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -500,7 +500,7 @@ TEST_F(BertModelTest, ProcessWithVectorInput) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<std::string> input = {"First", "Second", "Third"};
@@ -517,7 +517,7 @@ TEST_F(BertModelTest, ProcessWithVectorInput) {
 
 TEST_F(BertModelTest, ProcessWithCallback) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -526,7 +526,7 @@ TEST_F(BertModelTest, ProcessWithCallback) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = "Test callback";
@@ -546,7 +546,7 @@ TEST_F(BertModelTest, ProcessWithCallback) {
 
 TEST_F(BertModelTest, ContextOverflowSingleString) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -555,7 +555,7 @@ TEST_F(BertModelTest, ContextOverflowSingleString) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   // Get model's context size
@@ -576,7 +576,7 @@ TEST_F(BertModelTest, ContextOverflowSingleString) {
 
 TEST_F(BertModelTest, ContextOverflowMultipleStrings) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -585,7 +585,7 @@ TEST_F(BertModelTest, ContextOverflowMultipleStrings) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   const llama_model* llamaModel = model.getModel();
@@ -607,7 +607,7 @@ TEST_F(BertModelTest, ContextOverflowMultipleStrings) {
 
 TEST_F(BertModelTest, ContextOverflowSequences) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -616,7 +616,7 @@ TEST_F(BertModelTest, ContextOverflowSequences) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   const llama_model* llamaModel = model.getModel();
@@ -638,7 +638,7 @@ TEST_F(BertModelTest, ContextOverflowSequences) {
 
 TEST_F(BertModelTest, ProcessWithContextOverflow) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -647,7 +647,7 @@ TEST_F(BertModelTest, ProcessWithContextOverflow) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   const llama_model* llamaModel = model.getModel();
@@ -667,7 +667,7 @@ TEST_F(BertModelTest, ProcessWithContextOverflow) {
 
 TEST_F(BertModelTest, ModelLoadsAndProcessesMultipleTimes) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -676,7 +676,7 @@ TEST_F(BertModelTest, ModelLoadsAndProcessesMultipleTimes) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   // Process multiple times to verify model state is maintained
@@ -691,7 +691,7 @@ TEST_F(BertModelTest, ModelLoadsAndProcessesMultipleTimes) {
 
 TEST_F(BertModelTest, PreprocessPrompt) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::string config = "-dev\tcpu\n";
@@ -700,7 +700,7 @@ TEST_F(BertModelTest, PreprocessPrompt) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string prompt = "Line 1\nLine 2\nLine 3";

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_cache_management.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_cache_management.cpp
@@ -1015,8 +1015,8 @@ TEST_F(CacheManagementTest, CacheTokensExceedContextSize) {
   int smallContextSize = 128;
   if (cacheTokensBeforeSave <= smallContextSize) {
     FAIL() << "Cache tokens (" << cacheTokensBeforeSave
-                 << ") not enough to exceed context size (" << smallContextSize
-                 << ")";
+           << ") not enough to exceed context size (" << smallContextSize
+           << ")";
   }
 
   auto model_small =

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_cache_management.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_cache_management.cpp
@@ -149,12 +149,12 @@ protected:
 
 TEST_F(CacheManagementTest, InitialStateNoCache) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input =
@@ -171,12 +171,12 @@ TEST_F(CacheManagementTest, InitialStateNoCache) {
 
 TEST_F(CacheManagementTest, EnableCacheWithFilename) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input =
@@ -202,12 +202,12 @@ TEST_F(CacheManagementTest, EnableCacheWithFilename) {
 
 TEST_F(CacheManagementTest, SessionPersistence) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -242,12 +242,12 @@ TEST_F(CacheManagementTest, SessionPersistence) {
 
 TEST_F(CacheManagementTest, MultipleSessionCommands) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input =
@@ -264,12 +264,12 @@ TEST_F(CacheManagementTest, MultipleSessionCommands) {
 
 TEST_F(CacheManagementTest, ResetCommand) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -304,12 +304,12 @@ TEST_F(CacheManagementTest, ResetCommand) {
 
 TEST_F(CacheManagementTest, SwitchToSession2) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -348,12 +348,12 @@ TEST_F(CacheManagementTest, SwitchToSession2) {
 
 TEST_F(CacheManagementTest, DisableCache) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -377,12 +377,12 @@ TEST_F(CacheManagementTest, DisableCache) {
 
 TEST_F(CacheManagementTest, VerifyStatelessBehavior) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -406,12 +406,12 @@ TEST_F(CacheManagementTest, VerifyStatelessBehavior) {
 
 TEST_F(CacheManagementTest, ReEnableCacheAfterDisable) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -446,12 +446,12 @@ TEST_F(CacheManagementTest, ReEnableCacheAfterDisable) {
 
 TEST_F(CacheManagementTest, SessionCommandOnly) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "session", "content": "reset"}])";
@@ -462,12 +462,12 @@ TEST_F(CacheManagementTest, SessionCommandOnly) {
 
 TEST_F(CacheManagementTest, SaveWhenCacheDisabled) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "session", "content": "save"}])";
@@ -480,12 +480,12 @@ TEST_F(CacheManagementTest, SaveWhenCacheDisabled) {
 
 TEST_F(CacheManagementTest, ComplexSessionCommandChain) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -521,12 +521,12 @@ TEST_F(CacheManagementTest, ComplexSessionCommandChain) {
 
 TEST_F(CacheManagementTest, CacheClearedWhenNoSessionMessage) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -581,12 +581,12 @@ TEST_F(CacheManagementTest, CacheClearedWhenNoSessionMessage) {
 
 TEST_F(CacheManagementTest, CacheClearedWhenSwitchingToDifferentCache) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -639,12 +639,12 @@ TEST_F(CacheManagementTest, CacheClearedWhenSwitchingToDifferentCache) {
 
 TEST_F(CacheManagementTest, SingleShotInferenceAfterCacheCleared) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -676,12 +676,12 @@ TEST_F(CacheManagementTest, SingleShotInferenceAfterCacheCleared) {
 
 TEST_F(CacheManagementTest, CacheToNoCacheToCache) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -739,12 +739,12 @@ TEST_F(CacheManagementTest, CacheToNoCacheToCache) {
 
 TEST_F(CacheManagementTest, GetTokensCommand) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -789,12 +789,12 @@ TEST_F(CacheManagementTest, GetTokensCommand) {
 
 TEST_F(CacheManagementTest, SaveCommandReturnsZeroMetrics) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -843,12 +843,12 @@ TEST_F(CacheManagementTest, SaveCommandReturnsZeroMetrics) {
 
 TEST_F(CacheManagementTest, GetTokensCommandWithNoCache) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string getTokensInput =
@@ -860,12 +860,12 @@ TEST_F(CacheManagementTest, GetTokensCommandWithNoCache) {
 
 TEST_F(CacheManagementTest, GetTokensCommandAfterDisable) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -893,12 +893,12 @@ TEST_F(CacheManagementTest, GetTokensCommandAfterDisable) {
 
 TEST_F(CacheManagementTest, GetTokensCommandAfterReset) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -940,12 +940,12 @@ TEST_F(CacheManagementTest, GetTokensCommandAfterReset) {
 
 TEST_F(CacheManagementTest, CacheTokensExceedContextSize) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model_large = createModelWithContextSizeAndNPredict("4096", "100");
   if (!model_large) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string large_cache_path = "test_large_cache.bin";
@@ -1014,7 +1014,7 @@ TEST_F(CacheManagementTest, CacheTokensExceedContextSize) {
 
   int smallContextSize = 128;
   if (cacheTokensBeforeSave <= smallContextSize) {
-    GTEST_SKIP() << "Cache tokens (" << cacheTokensBeforeSave
+    FAIL() << "Cache tokens (" << cacheTokensBeforeSave
                  << ") not enough to exceed context size (" << smallContextSize
                  << ")";
   }
@@ -1022,7 +1022,7 @@ TEST_F(CacheManagementTest, CacheTokensExceedContextSize) {
   auto model_small =
       createModelWithContextSize(std::to_string(smallContextSize));
   if (!model_small) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string loadInput =

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
@@ -86,7 +86,7 @@ protected:
 
 TEST_F(LlamaModelTest, ConstructorValidParams) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   EXPECT_NO_THROW({
@@ -96,7 +96,7 @@ TEST_F(LlamaModelTest, ConstructorValidParams) {
 
 TEST_F(LlamaModelTest, IsLoadedMethodBeforeInit) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
@@ -105,7 +105,7 @@ TEST_F(LlamaModelTest, IsLoadedMethodBeforeInit) {
 
 TEST_F(LlamaModelTest, InitializeBackend) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
@@ -125,7 +125,7 @@ TEST_F(LlamaModelTest, InvalidModelPath) {
 
 TEST_F(LlamaModelTest, InvalidConfig) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::unordered_map<std::string, std::string> invalid_config;
@@ -139,14 +139,14 @@ TEST_F(LlamaModelTest, InvalidConfig) {
 
 TEST_F(LlamaModelTest, RuntimeStatsBeforeProcessing) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   auto stats = model.runtimeStats();
@@ -155,7 +155,7 @@ TEST_F(LlamaModelTest, RuntimeStatsBeforeProcessing) {
 
 TEST_F(LlamaModelTest, ResetMethod) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
@@ -164,14 +164,14 @@ TEST_F(LlamaModelTest, ResetMethod) {
 
 TEST_F(LlamaModelTest, ProcessStringInput) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello, how are you?"}])";
@@ -185,14 +185,14 @@ TEST_F(LlamaModelTest, ProcessStringInput) {
 
 TEST_F(LlamaModelTest, ProcessWithCallback) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<std::string> received_tokens;
@@ -212,14 +212,14 @@ TEST_F(LlamaModelTest, ProcessWithCallback) {
 
 TEST_F(LlamaModelTest, ProcessBinaryInput) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<uint8_t> binary_input = {0x48, 0x65, 0x6c, 0x6c, 0x6f};
@@ -237,14 +237,14 @@ TEST_F(LlamaModelTest, ProcessBinaryInput) {
 
 TEST_F(LlamaModelTest, ProcessEmptyInput) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string empty_input = "";
@@ -253,7 +253,7 @@ TEST_F(LlamaModelTest, ProcessEmptyInput) {
 
 TEST_F(LlamaModelTest, ProcessAfterInitialization) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   {
@@ -268,7 +268,7 @@ TEST_F(LlamaModelTest, ProcessAfterInitialization) {
     }
 
     if (!model.isLoaded()) {
-      GTEST_SKIP() << "Model failed to load";
+      FAIL() << "Model failed to load";
     }
 
     {
@@ -289,14 +289,14 @@ TEST_F(LlamaModelTest, ProcessAfterInitialization) {
 
 TEST_F(LlamaModelTest, IsLoadedAfterProcessing) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -310,14 +310,14 @@ TEST_F(LlamaModelTest, IsLoadedAfterProcessing) {
 
 TEST_F(LlamaModelTest, RuntimeStatsAfterProcessing) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello, world!"}])";
@@ -332,14 +332,14 @@ TEST_F(LlamaModelTest, RuntimeStatsAfterProcessing) {
 
 TEST_F(LlamaModelTest, RuntimeStatsAfterReset) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -358,14 +358,14 @@ TEST_F(LlamaModelTest, RuntimeStatsAfterReset) {
 
 TEST_F(LlamaModelTest, StopMethod) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   EXPECT_NO_THROW(model.stop());
@@ -373,14 +373,14 @@ TEST_F(LlamaModelTest, StopMethod) {
 
 TEST_F(LlamaModelTest, MultipleProcessCalls) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -397,7 +397,7 @@ TEST_F(LlamaModelTest, MultipleProcessCalls) {
 
 TEST_F(LlamaModelTest, DestructorCleanup) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   {
@@ -418,7 +418,7 @@ TEST_F(LlamaModelTest, DestructorCleanup) {
 
 TEST_F(LlamaModelTest, SetWeightsForFile) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
@@ -457,14 +457,14 @@ TEST_F(LlamaModelTest, LlamaLogCallback) {
 
 TEST_F(LlamaModelTest, InvalidJSONInput) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string invalid_json = "[{invalid json}";
@@ -473,14 +473,14 @@ TEST_F(LlamaModelTest, InvalidJSONInput) {
 
 TEST_F(LlamaModelTest, MalformedChatMessageFormat) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string invalid_message = R"([{"content": "Hello"}])";
@@ -492,14 +492,14 @@ TEST_F(LlamaModelTest, MalformedChatMessageFormat) {
 
 TEST_F(LlamaModelTest, EmptyMessagesArray) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string empty_messages = "[]";
@@ -513,14 +513,14 @@ TEST_F(LlamaModelTest, EmptyMessagesArray) {
 
 TEST_F(LlamaModelTest, VeryLongInput) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string long_content(10000, 'a');
@@ -537,14 +537,14 @@ TEST_F(LlamaModelTest, VeryLongInput) {
 
 TEST_F(LlamaModelTest, SpecialCharactersAndUnicode) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string unicode_input =
@@ -559,7 +559,7 @@ TEST_F(LlamaModelTest, SpecialCharactersAndUnicode) {
 
 TEST_F(LlamaModelTest, CommonParamsParseMissingDevice) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::unordered_map<std::string, std::string> config_no_device;
@@ -586,7 +586,7 @@ TEST_F(LlamaModelTest, CommonParamsParseMissingDevice) {
 
 TEST_F(LlamaModelTest, CommonParamsParseInvalidNDiscarded) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::unordered_map<std::string, std::string> config;
@@ -614,7 +614,7 @@ TEST_F(LlamaModelTest, CommonParamsParseInvalidNDiscarded) {
 
 TEST_F(LlamaModelTest, CommonParamsParseInvalidArgument) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::unordered_map<std::string, std::string> config;
@@ -642,14 +642,14 @@ TEST_F(LlamaModelTest, CommonParamsParseInvalidArgument) {
 
 TEST_F(LlamaModelTest, FormatPromptMediaInTextOnlyModel) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input =
@@ -659,7 +659,7 @@ TEST_F(LlamaModelTest, FormatPromptMediaInTextOnlyModel) {
 
 TEST_F(LlamaModelTest, FormatPromptMediaWithoutUserMessage) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   fs::path basePath;
@@ -680,7 +680,7 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutUserMessage) {
   }
 
   if (!fs::exists(multimodalModelPath) || !fs::exists(projectionPath)) {
-    GTEST_SKIP() << "Multimodal model and projection required for this test";
+    FAIL() << "Multimodal model and projection required for this test";
   }
 
   LlamaModel model(
@@ -688,7 +688,7 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutUserMessage) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([
@@ -700,7 +700,7 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutUserMessage) {
 
 TEST_F(LlamaModelTest, FormatPromptMediaWithoutRequest) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   fs::path basePath;
@@ -721,7 +721,7 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutRequest) {
   }
 
   if (!fs::exists(multimodalModelPath) || !fs::exists(projectionPath)) {
-    GTEST_SKIP() << "Multimodal model and projection required for this test";
+    FAIL() << "Multimodal model and projection required for this test";
   }
 
   LlamaModel model(
@@ -729,7 +729,7 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutRequest) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input =
@@ -739,7 +739,7 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutRequest) {
 
 TEST_F(LlamaModelTest, ProcessContextOverflow) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::unordered_map<std::string, std::string> small_ctx_config;
@@ -760,7 +760,7 @@ TEST_F(LlamaModelTest, ProcessContextOverflow) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string long_content(50000, 'a');
@@ -772,7 +772,7 @@ TEST_F(LlamaModelTest, ProcessContextOverflow) {
 
 TEST_F(LlamaModelTest, ProcessContextOverflowAfterDiscardFails) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::unordered_map<std::string, std::string> small_ctx_config;
@@ -794,7 +794,7 @@ TEST_F(LlamaModelTest, ProcessContextOverflowAfterDiscardFails) {
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string first_input = R"([{"role": "user", "content": "Hello"}])";
@@ -814,14 +814,14 @@ TEST_F(LlamaModelTest, ProcessContextOverflowAfterDiscardFails) {
 
 TEST_F(LlamaModelTest, ProcessEmptyMessagesAfterSessionCommands) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   LlamaModel model(getValidModelPath(), test_projection_path, config_files);
   model.waitForLoadInitialization();
 
   if (!model.isLoaded()) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string session_only_input =
@@ -836,7 +836,7 @@ TEST_F(LlamaModelTest, ProcessEmptyMessagesAfterSessionCommands) {
 
 TEST_F(LlamaModelTest, CommonParamsParseInvalidChatTemplate) {
   if (!fs::exists(getValidModelPath())) {
-    GTEST_SKIP() << "Test model not found at: " << getValidModelPath();
+    FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
   std::unordered_map<std::string, std::string> config;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llm_context_base.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llm_context_base.cpp
@@ -155,12 +155,12 @@ protected:
 
 TEST_F(LlmContextBaseTest, TextLlmContextProcessAndReset) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   auto stats = model->runtimeStats();
@@ -187,12 +187,12 @@ TEST_F(LlmContextBaseTest, TextLlmContextProcessAndReset) {
 
 TEST_F(LlmContextBaseTest, MtmdLlmContextProcessAndReset) {
   if (!hasValidMultimodalModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createMultimodalModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   auto stats = model->runtimeStats();
@@ -219,12 +219,12 @@ TEST_F(LlmContextBaseTest, MtmdLlmContextProcessAndReset) {
 
 TEST_F(LlmContextBaseTest, ProcessAndGetRuntimeStats) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -238,12 +238,12 @@ TEST_F(LlmContextBaseTest, ProcessAndGetRuntimeStats) {
 
 TEST_F(LlmContextBaseTest, ProcessWithCallback) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<std::string> tokens;
@@ -263,12 +263,12 @@ TEST_F(LlmContextBaseTest, ProcessWithCallback) {
 
 TEST_F(LlmContextBaseTest, ResetStateClearsCache) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -290,12 +290,12 @@ TEST_F(LlmContextBaseTest, ResetStateClearsCache) {
 
 TEST_F(LlmContextBaseTest, TextContextRejectsBinaryInput) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<uint8_t> media = {0x48, 0x65, 0x6c, 0x6c, 0x6f};
@@ -307,12 +307,12 @@ TEST_F(LlmContextBaseTest, TextContextRejectsBinaryInput) {
 
 TEST_F(LlmContextBaseTest, MultipleProcessCalls) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -334,13 +334,13 @@ TEST_F(LlmContextBaseTest, MultipleProcessCalls) {
 
 TEST_F(LlmContextBaseTest, VirtualDestructor) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   {
     auto model = createModel();
     if (!model) {
-      GTEST_SKIP() << "Model failed to load";
+      FAIL() << "Model failed to load";
     }
 
     std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -366,12 +366,12 @@ TEST_F(LlmContextBaseTest, VirtualDestructor) {
 
 TEST_F(LlmContextBaseTest, RuntimeStatsAccuracy) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -390,12 +390,12 @@ TEST_F(LlmContextBaseTest, RuntimeStatsAccuracy) {
 
 TEST_F(LlmContextBaseTest, RuntimeStatsConsistency) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_mtmd_llm_context.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_mtmd_llm_context.cpp
@@ -114,12 +114,12 @@ protected:
 
 TEST_F(MtmdLlmContextTest, Constructor) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   EXPECT_TRUE(model->isLoaded());
@@ -127,12 +127,12 @@ TEST_F(MtmdLlmContextTest, Constructor) {
 
 TEST_F(MtmdLlmContextTest, ProcessWithStringInput) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello, how are you?"}])";
@@ -146,12 +146,12 @@ TEST_F(MtmdLlmContextTest, ProcessWithStringInput) {
 
 TEST_F(MtmdLlmContextTest, ProcessWithCallback) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<std::string> generated_tokens;
@@ -171,12 +171,12 @@ TEST_F(MtmdLlmContextTest, ProcessWithCallback) {
 
 TEST_F(MtmdLlmContextTest, ProcessAndGetRuntimeStats) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -190,12 +190,12 @@ TEST_F(MtmdLlmContextTest, ProcessAndGetRuntimeStats) {
 
 TEST_F(MtmdLlmContextTest, LoadMediaBinary) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<uint8_t> image_data = {0xFF, 0xD8, 0xFF, 0xE0};
@@ -204,12 +204,12 @@ TEST_F(MtmdLlmContextTest, LoadMediaBinary) {
 
 TEST_F(MtmdLlmContextTest, LoadMediaFile) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input =
@@ -219,12 +219,12 @@ TEST_F(MtmdLlmContextTest, LoadMediaFile) {
 
 TEST_F(MtmdLlmContextTest, ResetState) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -248,12 +248,12 @@ TEST_F(MtmdLlmContextTest, ResetState) {
 
 TEST_F(MtmdLlmContextTest, ResetMedia) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<uint8_t> image_data = {0xFF, 0xD8, 0xFF, 0xE0};
@@ -270,12 +270,12 @@ TEST_F(MtmdLlmContextTest, ResetMedia) {
 
 TEST_F(MtmdLlmContextTest, MultimodalMessages) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input =
@@ -290,12 +290,12 @@ TEST_F(MtmdLlmContextTest, MultimodalMessages) {
 
 TEST_F(MtmdLlmContextTest, ProcessWithSessionCache) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input1 =
@@ -319,12 +319,12 @@ TEST_F(MtmdLlmContextTest, ProcessWithSessionCache) {
 
 TEST_F(MtmdLlmContextTest, InvalidMedia) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<uint8_t> invalid_data = {0x00, 0x01, 0x02};
@@ -333,12 +333,12 @@ TEST_F(MtmdLlmContextTest, InvalidMedia) {
 
 TEST_F(MtmdLlmContextTest, NonexistentFile) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input =
@@ -348,12 +348,12 @@ TEST_F(MtmdLlmContextTest, NonexistentFile) {
 
 TEST_F(MtmdLlmContextTest, ProcessWithTools) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([
@@ -383,12 +383,12 @@ TEST_F(MtmdLlmContextTest, ProcessWithTools) {
 
 TEST_F(MtmdLlmContextTest, ProcessWithMultipleTools) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Multimodal model or projection file not found";
+    FAIL() << "Multimodal model or projection file not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_text_llm_context.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_text_llm_context.cpp
@@ -101,12 +101,12 @@ protected:
 
 TEST_F(TextLlmContextTest, Constructor) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   EXPECT_TRUE(model->isLoaded());
@@ -114,12 +114,12 @@ TEST_F(TextLlmContextTest, Constructor) {
 
 TEST_F(TextLlmContextTest, ProcessWithStringInput) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello, how are you?"}])";
@@ -133,12 +133,12 @@ TEST_F(TextLlmContextTest, ProcessWithStringInput) {
 
 TEST_F(TextLlmContextTest, ProcessWithCallback) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<std::string> generated_tokens;
@@ -158,12 +158,12 @@ TEST_F(TextLlmContextTest, ProcessWithCallback) {
 
 TEST_F(TextLlmContextTest, ProcessAndGetRuntimeStats) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -177,12 +177,12 @@ TEST_F(TextLlmContextTest, ProcessAndGetRuntimeStats) {
 
 TEST_F(TextLlmContextTest, ResetState) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -201,12 +201,12 @@ TEST_F(TextLlmContextTest, ResetState) {
 
 TEST_F(TextLlmContextTest, LoadMediaDoesNothing) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::vector<uint8_t> binary_input = {0x48, 0x65, 0x6c, 0x6c, 0x6f};
@@ -217,12 +217,12 @@ TEST_F(TextLlmContextTest, LoadMediaDoesNothing) {
 
 TEST_F(TextLlmContextTest, MultipleMessages) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input =
@@ -237,12 +237,12 @@ TEST_F(TextLlmContextTest, MultipleMessages) {
 
 TEST_F(TextLlmContextTest, MultipleProcessCalls) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([{"role": "user", "content": "Hello"}])";
@@ -264,12 +264,12 @@ TEST_F(TextLlmContextTest, MultipleProcessCalls) {
 
 TEST_F(TextLlmContextTest, StopMethod) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   EXPECT_NO_THROW(model->stop());
@@ -277,12 +277,12 @@ TEST_F(TextLlmContextTest, StopMethod) {
 
 TEST_F(TextLlmContextTest, ProcessWithTools) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([
@@ -312,12 +312,12 @@ TEST_F(TextLlmContextTest, ProcessWithTools) {
 
 TEST_F(TextLlmContextTest, ProcessWithToolsInvalidFormat) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([
@@ -332,12 +332,12 @@ TEST_F(TextLlmContextTest, ProcessWithToolsInvalidFormat) {
 
 TEST_F(TextLlmContextTest, ProcessWithMultipleTools) {
   if (!hasValidModel()) {
-    GTEST_SKIP() << "Test model not found";
+    FAIL() << "Test model not found";
   }
 
   auto model = createModel();
   if (!model) {
-    GTEST_SKIP() << "Model failed to load";
+    FAIL() << "Model failed to load";
   }
 
   std::string input = R"([


### PR DESCRIPTION
## 🎯 What problem does this PR solve?
Currently when model is not found on the path the tests are skipped, without failing the tests. This make it confusing sometimes to see whether the tests were actually successful or just skipped.


## 📝 How does it solve it?
Replaced all skip conditions(GTEST_SKIP()) with FAIL(), so now it will raise and error.

## 🧪 How was it tested?
Ran npm run test:cpp without the models in path before and after applying the change and confirmed that it throws an error instead of skipping now.


Task link
https://app.asana.com/1/45238840754660/project/1212638335655939/task/1213265422364679?focus=true