### PR TITLE
chore[skiplog]: Release @qvac/registry-client v0.1.6

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.1.6]
+
+Release Date: 2026-02-16
+
+### ✨ Features
+
+- Download resume support via corestore block persistence: when using a persistent storage path, previously downloaded Hypercore blocks are cached locally — subsequent `downloadModel` calls only fetch missing blocks from the network (#387)
+- `onProgress` callback and `signal` (AbortController) options for `downloadModel` in `outputFile` mode, enabling cancellation and real-time progress tracking with accurate initial offset for resumed downloads (#387)
+- CLI tool (`qvac-registry`) with `list`, `get`, and `download` subcommands for querying and downloading models directly from the terminal (#315)
+
+### 🔧 Changed
+
+- Default registry core key fallback: client no longer requires `QVAC_REGISTRY_CORE_KEY` to be set — falls back to the production registry key when no explicit key is provided (#360)
+- Updated CLI install docs with GitHub Packages setup instructions (#360)
+
+### 🧪 Tests
+
+- Added integration tests for download resume: full download, cancel + resume, and progress reporting on resume (#387)
+
 ## [0.1.5]
 
 Release Date: 2026-02-14

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Release @qvac/registry-client v0.1.6

### Changelog

See packages/qvac-lib-registry-server/client/CHANGELOG.md

