### PR TITLE
fix[notask]: use dynamic module resolution for bare-pack and tsx dependencies

### DIFF
--- a/packages/qvac-cli/src/bundle-sdk/bare-pack.js
+++ b/packages/qvac-cli/src/bundle-sdk/bare-pack.js
@@ -1,14 +1,19 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { createRequire } from 'node:module'
 import { spawn } from 'node:child_process'
 import { BarePackNotInstalledError, BarePackError } from '../errors.js'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
 
 function resolveBarePackBin () {
-  const binName = process.platform === 'win32' ? 'bare-pack.cmd' : 'bare-pack'
-  return path.resolve(__dirname, '..', '..', 'node_modules', '.bin', binName)
+  try {
+    const barePackPkgPath = require.resolve('bare-pack/package')
+    const barePackDir = path.dirname(barePackPkgPath)
+    return path.join(barePackDir, 'bin.js')
+  } catch {
+    return null
+  }
 }
 
 export async function runBarePack (options) {
@@ -23,7 +28,7 @@ export async function runBarePack (options) {
   } = options
 
   const barePackBin = resolveBarePackBin()
-  if (!fs.existsSync(barePackBin)) {
+  if (!barePackBin || !fs.existsSync(barePackBin)) {
     throw new BarePackNotInstalledError()
   }
 

--- a/packages/qvac-cli/src/config.js
+++ b/packages/qvac-cli/src/config.js
@@ -1,6 +1,9 @@
 import fs, { promises as fsp } from 'node:fs'
 import path from 'node:path'
+import { createRequire } from 'node:module'
 import { ConfigNotFoundError, ConfigLoadError } from './errors.js'
+
+const require = createRequire(import.meta.url)
 
 export const CONFIG_CANDIDATES = [
   'qvac.config.json',
@@ -44,7 +47,8 @@ export async function loadConfig (configPath) {
     }
 
     if (ext === '.ts') {
-      const { tsImport } = await import('tsx/esm/api')
+      const tsxApiPath = require.resolve('tsx/esm/api')
+      const { tsImport } = await import(tsxApiPath)
       const module = await tsImport(configPath, import.meta.url)
       return module.default ?? module
     }


### PR DESCRIPTION
## Problem
When the CLI is installed as a dependency, npm hoists bare-pack and tsx to the project root node_modules/ rather than nesting them under @qvac/cli/node_modules/. The previous implementation used relative path resolution (path.resolve(__dirname, ...)) which failed to locate these hoisted dependencies.

## Solution
Replace static relative path resolution with Node's require.resolve()

## How it was tested

**Setup:**
- [x] Packed CLI as tarball (`npm pack`)
- [x] Packed GPR-rewritten CLI variant (`@tetherto/cli-mono`)
- [x] Installed both in consumer desktop project alongside packed sdk

**Test 1: `@qvac/cli` (npm variant)**
- [x] `npx qvac bundle sdk` runs without errors
- [x] `bare-pack` binary resolved from hoisted `node_modules/bare-pack/`
- [x] Worker entries generated with `@qvac/sdk` references

**Test 2: `@tetherto/cli-mono` (GPR variant)**
- [x] `npx tetherto bundle sdk` runs without errors
- [x] SDK detected as `@tetherto/sdk-mono`
- [x] Worker entries generated with `@tetherto/sdk-mono` references
