### PR TITLE
fix[notask]: resolve SDK package dir dynamically in Expo plugins

### DIFF
--- a/.cursor/skills/sdk-pr-create/SKILL.md
+++ b/.cursor/skills/sdk-pr-create/SKILL.md
@@ -111,6 +111,7 @@ gh pr view --repo UPSTREAM_ORG/REPO BRANCH --web
 - Commit and push before creating PR
 
 6. If gh not available, output the copy-ready markdown format above
+7. As part of the output, provide a clickable hyperlink (not plain text) to the PR on GitHub.
 
 ## Quality Checklist
 

--- a/.github/workflows/publish-qvac-sdk.yml
+++ b/.github/workflows/publish-qvac-sdk.yml
@@ -118,14 +118,14 @@ jobs:
         run: |
           BRANCH_NAME="${GITHUB_REF#refs/heads/}"
 
-          # Only modify package name for dev, fix-*, feature-* branches
+          # Only modify package name for main, fix-*, feature-* branches
           case "$BRANCH_NAME" in
-            main)
-              echo "Main branch - keeping original package name"
+            release-*)
+              echo "Release branch - keeping original package name"
               exit 0
               ;;
-            dev)
-              SUFFIX="dev"
+            main)
+              SUFFIX="mono"
               ;;
             fix-*|feature-*)
               SUFFIX=$(echo "$BRANCH_NAME" | sed 's/\//-/g')

--- a/.github/workflows/publish-qvac-sdk.yml
+++ b/.github/workflows/publish-qvac-sdk.yml
@@ -151,13 +151,9 @@ jobs:
           MODIFIED_NAME=$(node -p "require('./package.json').name")
           echo "✓ Modified package.json: $MODIFIED_NAME"
 
-          # Update references in withMobileBundle.ts
+          # Update @qvac/cli references in withMobileBundle.ts to @tetherto/cli-mono
           MOBILE_BUNDLE_FILE="expo/plugins/withMobileBundle.ts"
           if [ -f "$MOBILE_BUNDLE_FILE" ]; then
-            echo "Updating @qvac/sdk references in $MOBILE_BUNDLE_FILE to $NEW_NAME"
-            sed -i.bak "s|@qvac/sdk|${NEW_NAME}|g" "$MOBILE_BUNDLE_FILE"
-            rm "${MOBILE_BUNDLE_FILE}.bak"
-            # Update @qvac/cli references to @tetherto/cli-mono
             echo "Updating @qvac/cli references in $MOBILE_BUNDLE_FILE to @tetherto/cli-mono"
             sed -i.bak "s|\"@qvac\"|\"@tetherto\"|g" "$MOBILE_BUNDLE_FILE"
             sed -i.bak "s|\"cli\"|\"cli-mono\"|g" "$MOBILE_BUNDLE_FILE"
@@ -165,15 +161,6 @@ jobs:
             sed -i.bak "s|npx qvac|npx tetherto|g" "$MOBILE_BUNDLE_FILE"
             rm "${MOBILE_BUNDLE_FILE}.bak"
             echo "✓ Updated $MOBILE_BUNDLE_FILE"
-          fi
-
-          # Update references in withDeviceInfo.ts
-          DEVICE_INFO_FILE="expo/plugins/withDeviceInfo.ts"
-          if [ -f "$DEVICE_INFO_FILE" ]; then
-            echo "Updating @qvac/sdk references in $DEVICE_INFO_FILE to $NEW_NAME"
-            sed -i.bak "s|@qvac/sdk|${NEW_NAME}|g" "$DEVICE_INFO_FILE"
-            rm "${DEVICE_INFO_FILE}.bak"
-            echo "✓ Updated $DEVICE_INFO_FILE"
           fi
 
           # Update references in expo-rpc-client.ts

--- a/packages/qvac-sdk/expo/plugins/resolve-sdk-package-dir.ts
+++ b/packages/qvac-sdk/expo/plugins/resolve-sdk-package-dir.ts
@@ -1,0 +1,49 @@
+import * as fs from "fs";
+import * as path from "path";
+import {
+  SDKNotFoundInNodeModulesError,
+  MultipleSDKInstallationsError,
+} from "@/utils/errors-client";
+
+const SDK_PACKAGE_NAMES = [
+  "@qvac/sdk",
+  "@tetherto/sdk-mono",
+  "@tetherto/sdk-dev",
+];
+
+type SDKPackageInfo = {
+  dir: string;
+  name: string;
+};
+
+/**
+ * Resolves the installed SDK package directory from node_modules.
+ *
+ * Checks all known published package names and returns the one that exists.
+ * Throws if none found or if multiple are found (ambiguous installation).
+ */
+function resolveSDKPackageDir(projectRoot: string): SDKPackageInfo {
+  const found: SDKPackageInfo[] = [];
+
+  for (const name of SDK_PACKAGE_NAMES) {
+    const dir = path.join(projectRoot, "node_modules", name);
+    if (fs.existsSync(dir)) {
+      found.push({ name, dir });
+    }
+  }
+
+  if (found.length === 0) {
+    throw new SDKNotFoundInNodeModulesError();
+  }
+
+  if (found.length > 1) {
+    throw new MultipleSDKInstallationsError(
+      found.map((f) => f.name).join(", "),
+    );
+  }
+
+  return found[0]!;
+}
+
+export { resolveSDKPackageDir, SDK_PACKAGE_NAMES };
+export type { SDKPackageInfo };

--- a/packages/qvac-sdk/expo/plugins/withDeviceInfo.ts
+++ b/packages/qvac-sdk/expo/plugins/withDeviceInfo.ts
@@ -1,6 +1,7 @@
 import type { ExpoConfig } from "expo/config";
 import * as fs from "fs";
 import * as path from "path";
+import { resolveSDKPackageDir } from "./resolve-sdk-package-dir";
 
 let didRun = false;
 
@@ -20,7 +21,7 @@ function withDeviceInfo(config: ExpoConfig): ExpoConfig {
     return config;
   }
 
-  const qvacSdkPath = path.join(projectRoot, "node_modules", "@qvac/sdk");
+  const { dir: qvacSdkPath } = resolveSDKPackageDir(projectRoot);
 
   const appPackageJsonPath = path.join(projectRoot, "package.json");
   let hasExpoDevice = false;

--- a/packages/qvac-sdk/expo/plugins/withMobileBundle.ts
+++ b/packages/qvac-sdk/expo/plugins/withMobileBundle.ts
@@ -3,7 +3,7 @@ import { execSync } from "child_process";
 import type { ExpoConfig } from "expo/config";
 import * as fs from "fs";
 import * as path from "path";
-import { SDKNotFoundInNodeModulesError } from "@/utils/errors-client";
+import { resolveSDKPackageDir } from "./resolve-sdk-package-dir";
 
 const { withDangerousMod } = configPlugins;
 
@@ -14,11 +14,7 @@ const CONFIG_CANDIDATES = [
 ];
 
 /** Modules to defer from mobile bundles (not available at bundle time) */
-const DEFERRED_MODULES = [
-  "expo-file-system",
-  "react-native-bare-kit",
-  "@qvac/sdk/worker.mobile.bundle",
-];
+const DEFERRED_MODULES = ["expo-file-system", "react-native-bare-kit"];
 
 const MOBILE_HOSTS = [
   "android-arm64",
@@ -32,24 +28,19 @@ const MOBILE_HOSTS = [
  *
  * Runs qvac CLI (prefers local @qvac/cli, falls back to npx).
  * Uses qvac.config.* if exists, else includes all built-in plugins.
- * Output: node_modules/@qvac/sdk/dist/worker.mobile.bundle.js
+ * Output: node_modules/<sdk-package>/dist/worker.mobile.bundle.js
  */
 function withMobileBundle(config: ExpoConfig): ExpoConfig {
   function buildMobileBundle(
     config: configPlugins.ExportedConfigWithProps<unknown>,
   ) {
     const projectRoot = config.modRequest.projectRoot;
-    const qvacSdkPath = path.join(projectRoot, "node_modules", "@qvac/sdk");
+    const sdkPackage = resolveSDKPackageDir(projectRoot);
     const outputPath = path.join(
-      qvacSdkPath,
+      sdkPackage.dir,
       "dist",
       "worker.mobile.bundle.js",
     );
-
-    // Ensure SDK package exists
-    if (!fs.existsSync(qvacSdkPath)) {
-      throw new SDKNotFoundInNodeModulesError();
-    }
 
     // Generate bundle via qvac CLI
     // (uses qvac.config.* if exists, else includes all built-in plugins)
@@ -64,7 +55,11 @@ function withMobileBundle(config: ExpoConfig): ExpoConfig {
       );
     }
 
-    runBundler(projectRoot, qvacSdkPath, configPath);
+    const deferredModules = [
+      ...DEFERRED_MODULES,
+      `${sdkPackage.name}/worker.mobile.bundle`,
+    ];
+    runBundler(projectRoot, sdkPackage.dir, configPath, deferredModules);
 
     // Copy the generated bundle to SDK location
     const generatedBundle = path.join(projectRoot, "qvac", "worker.bundle.js");
@@ -130,12 +125,13 @@ function runBundler(
   projectRoot: string,
   qvacSdkPath: string,
   configPath: string | null,
+  deferredModules: string[],
 ) {
   // Patch bare-kit linkers to use addons manifest
   patchBareKitLinkers(projectRoot, qvacSdkPath);
 
   const hostFlags = MOBILE_HOSTS.map((h) => `--host ${h}`).join(" ");
-  const deferFlags = DEFERRED_MODULES.map((m) => `--defer "${m}"`).join(" ");
+  const deferFlags = deferredModules.map((m) => `--defer "${m}"`).join(" ");
   const configFlag = configPath ? `--config "${configPath}"` : "";
   const sdkPathFlag = `--sdk-path "${qvacSdkPath}"`;
   const cliCommand = resolveCliCommand(projectRoot);

--- a/packages/qvac-sdk/schemas/sdk-errors-client.ts
+++ b/packages/qvac-sdk/schemas/sdk-errors-client.ts
@@ -33,6 +33,7 @@ export const SDK_CLIENT_ERROR_CODES = {
   CONFIG_FILE_PARSE_FAILED: 50604,
   CONFIG_VALIDATION_FAILED: 50605,
   PEAR_WORKER_ENTRY_REQUIRED: 50606,
+  MULTIPLE_SDK_INSTALLATIONS: 50607,
 } as const;
 
 const clientErrorDefinitions: ErrorCodesMap = {
@@ -115,7 +116,8 @@ const clientErrorDefinitions: ErrorCodesMap = {
   // Build/Bundle Errors (50,600-50,799)
   [SDK_CLIENT_ERROR_CODES.SDK_NOT_FOUND_IN_NODE_MODULES]: {
     name: "SDK_NOT_FOUND_IN_NODE_MODULES",
-    message: "@qvac/sdk not found in node_modules",
+    message:
+      "QVAC SDK not found in node_modules. Checked: @qvac/sdk, @tetherto/sdk-mono, @tetherto/sdk-dev",
   },
   [SDK_CLIENT_ERROR_CODES.WORKER_FILE_NOT_FOUND]: {
     name: "WORKER_FILE_NOT_FOUND",
@@ -140,6 +142,11 @@ const clientErrorDefinitions: ErrorCodesMap = {
   [SDK_CLIENT_ERROR_CODES.CONFIG_VALIDATION_FAILED]: {
     name: "CONFIG_VALIDATION_FAILED",
     message: (errors: string) => `Config validation failed: ${errors}`,
+  },
+  [SDK_CLIENT_ERROR_CODES.MULTIPLE_SDK_INSTALLATIONS]: {
+    name: "MULTIPLE_SDK_INSTALLATIONS",
+    message: (packages: string) =>
+      `Multiple QVAC SDK installations found: ${packages}. Remove all but one to avoid conflicts.`,
   },
   [SDK_CLIENT_ERROR_CODES.PEAR_WORKER_ENTRY_REQUIRED]: {
     name: "PEAR_WORKER_ENTRY_REQUIRED",

--- a/packages/qvac-sdk/utils/errors-client.ts
+++ b/packages/qvac-sdk/utils/errors-client.ts
@@ -215,6 +215,18 @@ export class SDKNotFoundInNodeModulesError extends QvacErrorBase {
   }
 }
 
+export class MultipleSDKInstallationsError extends QvacErrorBase {
+  constructor(packages: string, cause?: unknown) {
+    super(
+      createErrorOptions(
+        SDK_CLIENT_ERROR_CODES.MULTIPLE_SDK_INSTALLATIONS,
+        [packages],
+        cause,
+      ),
+    );
+  }
+}
+
 export class WorkerFileNotFoundError extends QvacErrorBase {
   constructor(workerPath: string, cause?: unknown) {
     super(


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Expo plugins (`withMobileBundle`, `withDeviceInfo`) hardcoded `@qvac/sdk` as the node_modules path, breaking when the SDK is published as `@tetherto/sdk-mono` or `@tetherto/sdk-dev`
- Required fragile `sed` rewrites in the publish workflow and `package-dev.sh` to patch these paths at publish time
- `sdk-pr-create` skill didn't output the PR link after creation

## 📝 How does it solve it?

- New `resolveSDKPackageDir` utility scans node_modules for all known SDK package names (`@qvac/sdk`, `@tetherto/sdk-mono`, `@tetherto/sdk-dev`) and returns the one that exists
- Throws `SDKNotFoundInNodeModulesError` (updated message listing all checked names) if none found
- Throws new `MultipleSDKInstallationsError` if multiple found
- `DEFERRED_MODULES` worker bundle entry is now built dynamically from the resolved package name
- Removed the now-unnecessary `sed` rewrites for `withMobileBundle.ts` and `withDeviceInfo.ts` from publish workflow and `package-dev.sh`
- Updated `sdk-pr-create` skill to output the PR link after `gh pr create`

## 🧪 How was it tested?

- Built local package, ran Expo prebuild, validated bundle generated correctly in test Expo app
