### PR TITLE
Message logic that can fix multiple images in smaller models

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -564,7 +564,6 @@ LlamaModel::formatPrompt(const std::string& input) {
   if (err.empty() && chatJson.is<picojson::array>()) {
     auto& obj = chatJson.get<picojson::array>();
 
-    int addMediaPlaceholder = 0;
     bool isNextUser = false;
     for (const auto& subObj : obj) {
       if (subObj.is<picojson::object>()) {
@@ -610,16 +609,18 @@ LlamaModel::formatPrompt(const std::string& input) {
           if (!content.empty()) {
             llmContext_->loadMedia(content);
           }
-          addMediaPlaceholder++;
+          // Push one user message per image so the tokenizer can match each
+          // marker to the corresponding bitmap in order (first marker -> first
+          // image, etc.).
+          common_chat_msg mediaMsg;
+          mediaMsg.role = "user";
+          mediaMsg.content = mtmd_default_marker();
+          chatMsgs.push_back(mediaMsg);
           isNextUser = true;
           continue;
         }
         if (newMsg.role == "user" && isNextUser) {
           isNextUser = false;
-          while (addMediaPlaceholder > 0) {
-            addMediaPlaceholder--;
-            content.insert(0, mtmd_default_marker());
-          }
         }
         if (newMsg.role != "user" && isNextUser) {
           llmContext_->resetMedia();
@@ -633,14 +634,6 @@ LlamaModel::formatPrompt(const std::string& input) {
         newMsg.content = content;
         chatMsgs.push_back(newMsg);
       }
-    }
-
-    if (addMediaPlaceholder > 0) {
-      llmContext_->resetMedia();
-      std::string errorMsg =
-          string_format("%s: No request for media was made\n", __func__);
-      throw qvac_errors::StatusError(
-          ADDON_ID, toString(MediaRequestNotProvided), errorMsg);
     }
   }
   if (!err.empty()) {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/image.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/image.test.js
@@ -1,13 +1,12 @@
 'use strict'
-
+// test/integration/image.test.js
 const test = require('brittle')
 const fs = require('bare-fs')
-const os = require('bare-os')
-const FilesystemDL = require('@qvac/dl-filesystem')
-
-const LlmLlamacpp = require('../../index.js')
+const path = require('bare-path')
 const { ensureModel, getMediaPath } = require('./utils')
-const { attachSpecLogger } = require('./spec-logger')
+const FilesystemDL = require('@qvac/dl-filesystem')
+const LlmLlamacpp = require('../../index.js')
+const os = require('bare-os')
 
 const platform = os.platform()
 const arch = os.arch()
@@ -26,11 +25,25 @@ const MULTIMODAL_MODEL_CONFIG = {
   projModel: {
     modelName: 'mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf',
     downloadUrl: 'https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf'
-  }
+  },
+  ctx_size: '2048'
+}
+
+const LARGE_MULTIMODAL_CONFIG = {
+  llmModel: {
+    modelName: 'Qwen3VL-2B-Instruct-Q4_K_M.gguf',
+    downloadUrl: 'https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF/resolve/main/Qwen3VL-2B-Instruct-Q4_K_M.gguf'
+  },
+  projModel: {
+    modelName: 'mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf',
+    downloadUrl: 'https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf'
+  },
+  ctx_size: '7046'
 }
 
 const TEST_CONSTANTS = {
   timeout: 900_000, // 15 minutes
+  maxWaitSeconds: 1000,
   defaultPrompt: 'Describe the image briefly in one sentence.'
 }
 
@@ -57,65 +70,56 @@ const DEVICE_CONFIGS = isMobile
  * @param {string} device - Device type ('cpu' or 'gpu')
  * @returns {Object} Model configuration object
  */
-function getConfig (device) {
+function getConfig (device, modelConfig) {
   return {
     gpu_layers: '98',
-    ctx_size: '2048',
     temp: '0.0',
     verbosity: '2',
-    device
+    device,
+    ctx_size: modelConfig.ctx_size
   }
 }
 
 /**
- * Sets up a multimodal addon with LLM and projection models
+ * Sets up a multimodal LlmLlamacpp instance with LLM and projection models
  * @param {Object} t - Test instance
  * @param {string} device - Device to use ('cpu' or 'gpu')
- * @returns {Promise<{addon: LlmLlamacpp, loader: FilesystemDL, llmModelPath: string, projModelPath: string}>}
+ * @returns {Promise<{inference: LlmLlamacpp, loader: FilesystemDL}>}
  */
-async function setupMultimodalAddon (t, device = 'gpu') {
-  const [llmModelName, llmDirPath] = await ensureModel(MULTIMODAL_MODEL_CONFIG.llmModel)
-  const llmModelPath = `${llmDirPath}/${llmModelName}`
-  t.ok(fs.existsSync(llmModelPath), 'LLM model file should exist')
+async function setupMultimodalInference (t, device = 'gpu', modelConfig = MULTIMODAL_MODEL_CONFIG) {
+  const [modelName, dirPath] = await ensureModel(modelConfig.llmModel)
+  t.ok(fs.existsSync(path.join(dirPath, modelName)), 'LLM model file should exist')
 
-  const [projModelName] = await ensureModel(MULTIMODAL_MODEL_CONFIG.projModel)
-  const projModelPath = `${llmDirPath}/${projModelName}`
-  t.ok(fs.existsSync(projModelPath), 'Projection model file should exist')
+  const [projModelName] = await ensureModel(modelConfig.projModel)
+  t.ok(fs.existsSync(path.join(dirPath, projModelName)), 'Projection model file should exist')
 
-  const specLogger = attachSpecLogger({ forwardToConsole: true })
-  const loader = new FilesystemDL({ dirPath: llmDirPath })
-
-  const addon = new LlmLlamacpp({
+  const loader = new FilesystemDL({ dirPath })
+  const inference = new LlmLlamacpp({
+    modelName,
     loader,
-    modelName: llmModelName,
-    diskPath: llmDirPath,
-    projectionModel: projModelName,
     logger: console,
-    opts: { stats: true }
-  }, getConfig(device))
-
-  await addon.load()
-
-  const status = await addon.status()
-  t.ok(['LOADING', 'IDLE', 'LISTENING'].includes(status), 'Addon should have valid initial status')
+    diskPath: dirPath,
+    projectionModel: projModelName
+  }, getConfig(device, modelConfig))
 
   t.teardown(async () => {
-    specLogger.release()
-    await addon.unload().catch(() => {})
-    await loader.close().catch(() => {})
+    await loader.close()
+    await inference.unload()
   })
 
-  return { addon, loader, llmModelPath, projModelPath }
+  await inference.load()
+
+  return { inference, loader }
 }
 
 /**
- * Describes an image using the addon and collects performance metrics
- * @param {LlmLlamacpp} addon - Addon instance
+ * Describes an image using the inference instance
+ * @param {LlmLlamacpp} inference - LlmLlamacpp instance
  * @param {string} imageFilePath - Path to the image file
  * @param {string} prompt - Custom prompt for image description
- * @returns {Promise<{generatedText: string, totalTime: number, stats: Object}>}
+ * @returns {Promise<{generatedText: string, startTime: number, endTime: number}>}
  */
-async function describeImage (addon, imageFilePath, prompt = TEST_CONSTANTS.defaultPrompt) {
+async function describeImage (inference, imageFilePath, prompt = TEST_CONSTANTS.defaultPrompt) {
   const imageBytes = new Uint8Array(fs.readFileSync(imageFilePath))
 
   const messages = [
@@ -125,21 +129,67 @@ async function describeImage (addon, imageFilePath, prompt = TEST_CONSTANTS.defa
   ]
 
   const startTime = Date.now()
-  const response = await addon.run(messages)
-  const chunks = []
+  const response = await inference.run(messages)
+  const generatedText = []
+  let error = null
 
-  await response
-    .onUpdate(data => {
-      chunks.push(data)
-    })
-    .await()
+  response.onUpdate(data => {
+    generatedText.push(data)
+  }).onError(err => {
+    error = err
+  })
 
-  const totalTime = Date.now() - startTime
+  await response.await()
+
+  if (error) {
+    throw new Error('Inference error: ' + error)
+  }
 
   return {
-    generatedText: chunks.join(''),
-    totalTime,
-    stats: response.stats || {}
+    generatedText: generatedText.join(''),
+    startTime,
+    endTime: Date.now()
+  }
+}
+
+/**
+ * Runs inference with multiple images and a single text prompt (e.g. "what is in these two images?").
+ * @param {LlmLlamacpp} inference - LlmLlamacpp instance
+ * @param {string[]} imageFilePaths - Paths to image files (order preserved)
+ * @param {string} prompt - Text prompt after the images
+ * @returns {Promise<{generatedText: string, startTime: number, endTime: number}>}
+ */
+async function describeMultipleImages (inference, imageFilePaths, prompt) {
+  const messages = [
+    { role: 'system', content: 'You are a helpful, respectful and honest assistant.' }
+  ]
+  for (const imageFilePath of imageFilePaths) {
+    const imageBytes = new Uint8Array(fs.readFileSync(imageFilePath))
+    messages.push({ role: 'user', type: 'media', content: imageBytes })
+  }
+  messages.push({ role: 'user', content: prompt })
+
+  const startTime = Date.now()
+  const response = await inference.run(messages)
+  const generatedText = []
+  let error = null
+
+  response.onUpdate(data => {
+    generatedText.push(data)
+  }).onError(err => {
+    error = err
+  })
+
+  await response.await()
+
+  if (error) {
+    throw new Error('Inference error: ' + error)
+  }
+
+  return {
+    generatedText: generatedText.join(''),
+    startTime,
+    endTime: Date.now()
   }
 }
 
@@ -167,87 +217,95 @@ function checkKeywordsInText (text, keywords) {
  * Formats performance metrics for test output
  * @param {string} label - Test label (e.g., '[GPU]')
  * @param {number} totalTime - Total execution time in milliseconds
- * @param {Object} stats - Statistics object from addon
  * @returns {string} Formatted performance metrics string
  */
-function formatPerformanceMetrics (label, totalTime, stats) {
-  const ttft = stats.TTFT || 0
-  const tps = stats.TPS || 0
-  const generatedTokens = stats.generatedTokens || 0
-  const promptTokens = stats.promptTokens || 0
+function formatPerformanceMetrics (label, totalTime) {
   const totalSeconds = (totalTime / 1000).toFixed(2)
 
   return `${label} Performance Metrics:
-    - Total time: ${totalTime}ms (${totalSeconds}s)
-    - Time to first token (TTFT): ${ttft}ms
-    - Generated tokens: ${generatedTokens} tokens
-    - Prompt tokens: ${promptTokens} tokens
-    - Tokens per second (TPS): ${tps.toFixed(2)} t/s`
+    - Total time: ${totalTime}ms (${totalSeconds}s)`
 }
 
-/**
- * Image test cases with expected recognition keywords
- * Each test case validates that the model can recognize key elements in the image
- * @typedef {Object} ImageTestCase
- * @property {string} name - Human-readable test case name
- * @property {string} imageFile - Image filename in media directory
- * @property {string[]} keywords - Keywords expected to appear in model output
- * @property {string} keywordType - Description of keyword category for error messages
- */
-const imageTestCases = [
-  {
-    name: 'elephant',
-    imageFile: 'elephant.jpg',
-    keywords: ['elephant', 'elephants'],
-    keywordType: 'elephant-related'
-  },
-  {
-    name: 'fruit plate',
-    imageFile: 'fruitPlate.png',
-    keywords: ['fruit', 'fruits', 'plate', 'apple', 'apples'],
-    keywordType: 'fruit-related'
-  },
-  {
-    name: 'high-res aurora',
-    imageFile: 'highRes3000x4000.jpg',
-    keywords: ['sky', 'light', 'lights', 'mountain', 'snow', 'aurora'],
-    keywordType: 'aurora-sky-related'
-  }
-]
+// TODO: Fix multi-image for smaller models? Seems like an image per separate message works
+// TODO: on smaller models, rather than all images on same message.
+// TODO: Discussion at: https://github.com/tetherto/qvac/pull/172#discussion_r2807275659
+test('llama addon can handle multiple images in one prompt', { timeout: TEST_CONSTANTS.timeout, skip: true }, async t => {
+  const imageFiles = ['elephant.jpg', 'fruitPlate.png']
+  const imagePaths = imageFiles.map(f => getMediaPath(f))
+  const prompt = 'What is in these two images?'
 
-for (const testCase of imageTestCases) {
-  test(`llama addon can recognize ${testCase.name} in an image`, { timeout: TEST_CONSTANTS.timeout }, async t => {
-    for (const deviceConfig of DEVICE_CONFIGS) {
-      const label = `[${deviceConfig.id.toUpperCase()}]`
+  for (const deviceConfig of DEVICE_CONFIGS) {
+    const label = `[${deviceConfig.id.toUpperCase()}]`
 
-      // Setup test infrastructure
-      const { addon } = await setupMultimodalAddon(t, deviceConfig.device)
+    const { inference } = await setupMultimodalInference(t, deviceConfig.device, LARGE_MULTIMODAL_CONFIG)
 
-      // Verify image file exists
-      const imageFilePath = getMediaPath(testCase.imageFile)
-      t.ok(fs.existsSync(imageFilePath), `${label} ${testCase.imageFile} image file should exist`)
-
-      // Run image description inference
-      const { generatedText, totalTime, stats } = await describeImage(addon, imageFilePath, TEST_CONSTANTS.defaultPrompt)
-
-      // Log output and statistics
-      t.comment(`${label} Generated text: ${generatedText}`)
-      t.comment(`${label} Stats from addon: ${JSON.stringify(stats, null, 2)}`)
-      t.comment(formatPerformanceMetrics(label, totalTime, stats))
-
-      // Assertions: Content recognition
-      const { foundKeywords, hasMatch } = checkKeywordsInText(generatedText, testCase.keywords)
-      t.ok(hasMatch,
-        `${label} Output should contain at least one ${testCase.keywordType} word as a whole word. ` +
-        `Found keywords: ${foundKeywords.join(', ') || 'none'}. ` +
-        `Full output: "${generatedText}"`)
+    for (const p of imagePaths) {
+      t.ok(fs.existsSync(p), `${label} image file should exist: ${p}`)
     }
-  })
-}
 
-// Keep event loop alive briefly to let pending async operations complete
-// This prevents C++ destructors from running while async cleanup is still happening
-// which can cause segfaults (exit code 139)
-setImmediate(() => {
-  setTimeout(() => {}, 500)
+    const { generatedText, startTime, endTime } = await describeMultipleImages(
+      inference,
+      imagePaths,
+      prompt
+    )
+    const totalTime = endTime - startTime
+
+    t.comment(`${label} Generated text: ${generatedText}`)
+    t.comment(formatPerformanceMetrics(label, totalTime))
+
+    t.ok(generatedText.length > 0, `${label} Should generate some text for multiple images`)
+
+    // Expect output to reference both images: at least one elephant-related and one fruit-related
+    const elephantKeywords = ['elephant', 'elephants']
+    const fruitKeywords = ['fruit', 'fruits', 'plate', 'apple', 'apples']
+    const { hasMatch: hasElephant } = checkKeywordsInText(generatedText, elephantKeywords)
+    const { hasMatch: hasFruit } = checkKeywordsInText(generatedText, fruitKeywords)
+
+    t.ok(
+      hasElephant && hasFruit,
+      `${label} Output should mention both images (elephant and fruit). ` +
+      `Full output: "${generatedText}"`
+    )
+  }
+})
+
+// TODO: Fix, currently fails with small model
+test('llama addon can handle multiple images in one prompt (small model)', { timeout: TEST_CONSTANTS.timeout, skip: false }, async t => {
+  const imageFiles = ['elephant.jpg', 'fruitPlate.png']
+  const imagePaths = imageFiles.map(f => getMediaPath(f))
+  const prompt = 'What is in these two images?'
+
+  for (const deviceConfig of DEVICE_CONFIGS) {
+    const label = `[${deviceConfig.id.toUpperCase()}]`
+
+    const { inference } = await setupMultimodalInference(t, deviceConfig.device, MULTIMODAL_MODEL_CONFIG)
+
+    for (const p of imagePaths) {
+      t.ok(fs.existsSync(p), `${label} image file should exist: ${p}`)
+    }
+
+    const { generatedText, startTime, endTime } = await describeMultipleImages(
+      inference,
+      imagePaths,
+      prompt
+    )
+    const totalTime = endTime - startTime
+
+    t.comment(`${label} Generated text: ${generatedText}`)
+    t.comment(formatPerformanceMetrics(label, totalTime))
+
+    t.ok(generatedText.length > 0, `${label} Should generate some text for multiple images`)
+
+    // Expect output to reference both images: at least one elephant-related and one fruit-related
+    const elephantKeywords = ['elephant', 'elephants']
+    const fruitKeywords = ['fruit', 'fruits', 'plate', 'apple', 'apples']
+    const { hasMatch: hasElephant } = checkKeywordsInText(generatedText, elephantKeywords)
+    const { hasMatch: hasFruit } = checkKeywordsInText(generatedText, fruitKeywords)
+
+    t.ok(
+      hasElephant && hasFruit,
+      `${label} Output should mention both images (elephant and fruit). ` +
+      `Full output: "${generatedText}"`
+    )
+  }
 })


### PR DESCRIPTION
This PR is just to be shared with the vision team, not to be merged.

# How to test?
Go to previous commit (not last). Compile the addon and perform `bare test/integration/image.test.js`. See how the test fails when using the smaller vision model. To compare, go to last commit which includes fix, re-compile and re-run the test and see it passing.

Example failing:
```
image decoded (batch 1/1) in 6 ms
Job 2 completed. Stats: {"TTFT":95.99000000000001,"TPS":301.26153266804744,"CacheTokens":0,"generatedTokens":24,"promptTokens":164}
    # [GPU] Generated text:  The images contain a white plate with a variety of fruits, including apples, blueberries, blackberries, and sliced apples.
    # [GPU] Performance Metrics:
    - Total time: 594ms (0.59s)
    ok 5 - [GPU] Should generate some text for multiple images
    not ok 6 - [GPU] Output should mention both images (elephant and fruit). Full output: " The images contain a white plate with a variety of fruits, including apples, blueberries, blackbe
rries, and sliced apples."
      ---
      operator: ok
      source: |
        
            t.ok(
        ------^
              hasElephant && hasFruit,
              `${label} Output should mention both images (elephant and fruit). ` +
      stack: |
        Object.explain (./node_modules/brittle/lib/errors.js:20:15)
        explain (./node_modules/brittle/index.js:840:34)
        Test._ok (./node_modules/brittle/index.js:424:25)
        ./test/integration/image.test.js:305:7
        async Test._run (./node_modules/brittle/index.js:597:7)
      ...
not ok 2 - llama addon can handle multiple images in one prompt (small model) # time = 911ms

1..2
# tests = 1/2 pass
# asserts = 5/6 pass
# time = 912ms

# not ok
```

Example passing, after patch:
```
image decoded (batch 1/1) in 3 ms
encoding image slice...
image slice encoded in 33 ms
decoding image batch 1/1, n_tokens_batch = 64
image decoded (batch 1/1) in 2 ms
Job 2 completed. Stats: {"TTFT":99.184,"TPS":301.3667870164097,"CacheTokens":0,"generatedTokens":51,"promptTokens":173}
    # [GPU] Generated text:  The images you've shared are of a fruit salad. The first image shows a whole, gray elephant standing on a white background, while the second image features a pl
ate of fruit salad with various fruits, including apples, blueberries, blackberries, and pears.
    # [GPU] Performance Metrics:
    - Total time: 762ms (0.76s)
    ok 5 - [GPU] Should generate some text for multiple images
    ok 6 - [GPU] Output should mention both images (elephant and fruit). Full output: " The images you've shared are of a fruit salad. The first image shows a whole, gray elephant standing 
on a white background, while the second image features a plate of fruit salad with various fruits, including apples, blueberries, blackberries, and pears."
ok 2 - llama addon can handle multiple images in one prompt (small model) # time = 1057ms

1..2
# tests = 2/2 pass
# asserts = 6/6 pass
# time = 1059ms

# ok
```

Models passing before and now (Large):
```
const LARGE_MULTIMODAL_CONFIG = {
  llmModel: {
    modelName: 'Qwen3VL-2B-Instruct-Q4_K_M.gguf',
    downloadUrl: 'https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF/resolve/main/Qwen3VL-2B-Instruct-Q4_K_M.gguf'
  },
  projModel: {
    modelName: 'mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf',
    downloadUrl: 'https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf'
  },
  ctx_size: '7046'
}
```

Model only passing now, after the patch. This is the same model already used in other image integration tests:
```
const MULTIMODAL_MODEL_CONFIG = {
  llmModel: {
    modelName: 'SmolVLM2-500M-Video-Instruct-Q8_0.gguf',
    downloadUrl: 'https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/SmolVLM2-500M-Video-Instruct-Q8_0.gguf'
  },
  projModel: {
    modelName: 'mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf',
    downloadUrl: 'https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf'
  },
  ctx_size: '2048'
}
```

# Why the patch is needed for smaller models (e.g. SmolVLM2-500-video) [AI-generated response]

**Commit `b3d24089` ("fix_multiple_images_context")** changes how multiple images are represented in the chat message list that gets passed to the template and tokenizer.

## Before the patch (old behavior)

- For each `type: 'media'` message the code called `loadMedia(content)` and incremented a counter `addMediaPlaceholder`.
- When the **next** user message (the text prompt) was seen, all placeholders were **prepended** into that single message's content:
  - `content` became something like `"<image><image>What is in these two images?"`.
- So the model saw **one** user turn whose content was: two placeholders immediately adjacent, then the question.

## After the patch (current behavior)

- For each `type: 'media'` message the code still calls `loadMedia(content)`, but instead of counting placeholders it **immediately** appends a **separate** user message whose content is only the placeholder: `mediaMsg.content = mtmd_default_marker()`, then `chatMsgs.push_back(mediaMsg)`.
- So the conversation becomes: `[user: <image>]`, `[user: <image>]`, `[user: What is in these two images?]`.

## Why better models (Qwen3VL) pass without the patch

- Larger VLMs have stronger multi-image reasoning and more robust handling of "multiple placeholders in one blob."
- They can still associate both image embeddings with the question when the prompt is a single user message with `<image><image>...` and often pass the test even with the old format.

## Why worse/smaller models (SmolVLM2-500-video) need the patch

1. **Placeholder–bitmap order**  
   The tokenizer matches placeholders in the **order they appear in the tokenized prompt** to the **order of bitmaps** in `bitmaps_.entries`. Emitting **one user message per image** makes that ordering explicit and stable (first message → first placeholder → first bitmap, etc.), which smaller models rely on more.

2. **Template structure**  
   With one message per image, the chat template can render each image in its own "turn" (with whatever turn markers, newlines, etc. the template uses). That often matches how smaller VLMs were trained (e.g. "user sends one image, then another, then text"). A single user message with `<image><image>...` is a different distribution and can confuse them.

3. **Attention and separation**  
   In the old format, both image embeddings sit back-to-back in the sequence with no template-generated tokens between them. Smaller models may under-attend to one of the two or blend them. With separate messages, template formatting typically inserts tokens between the two image regions, giving clearer separation and making it easier for the model to treat "first image" and "second image" distinctly.

## Summary

The patch doesn't change the fact that we have two images and two placeholders; it changes **how** they're represented in the message list (one placeholder per user message) so that:

- Placeholder order matches bitmap order in a simple, predictable way.
- The rendered prompt looks like "image, image, question" with the template's usual structure, which matches what smaller models were trained on and improves multi-image behavior.

That's why the test can pass with Qwen3VL without the patch but needs the patch for SmolVLM2-500-video. The release note ("Multimodal parser now emits one user message per image (each with a single placeholder) so the tokenizer maps each placeholder to the corresponding bitmap and all images are in context") is exactly this logic.

---

## Comparison: llama.cpp mtmd-cli (single-turn)

The [llama.cpp mtmd-cli](https://github.com/ggml-org/llama.cpp/blob/afa6bfe4f7530c0a6df527a6cd74fa551c36abdf/tools/mtmd/mtmd-cli.cpp) uses the **prepend-markers-to-one-message** approach (same as our old behavior):

```cpp
// Single-turn path (around line 339)
if (params.prompt.find(mtmd_default_marker()) == std::string::npos) {
    for (size_t i = 0; i < params.image.size(); i++) {
        // most models require the marker before each image
        // ref: https://github.com/ggml-org/llama.cpp/pull/17616
        params.prompt = mtmd_default_marker() + params.prompt;
    }
}
common_chat_msg msg;
msg.role = "user";
msg.content = params.prompt;   // one message: N×marker + prompt text
for (const auto & image : params.image) {
    if (!ctx.load_media(image)) { ... }
}
eval_message(ctx, msg);
```

- They build **one** user message whose content is **(N × marker) + prompt**.
- They load all images in order into `bitmaps`, then call `eval_message` once.
- The CLI is documented as *"NOT production-ready"* and *"a playground for trying multimodal support"*; it does not use a chat template with multiple user turns for multi-image.

So our **patched** behavior (one user message per image) deliberately differs from mtmd-cli to improve multi-image behavior for smaller models, at the cost of diverging from the reference CLI’s simpler “all markers in one message” style.
