### PR TITLE
chore[skiplog]: Release @qvac/registry-client v0.1.6

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.1.6]
+
+Release Date: 2026-02-17
+
+### ✨ Features
+
+- Download resume support: interrupted model downloads can now be resumed instead of restarting from scratch (#387)
+
+### 🔧 Changed
+
+- Added NOTICE file and updated license metadata for sub-package compliance (#394)
+
+### 🐛 Fixed
+
+- Added missing `@qvac/error` devDependency to `@qvac/registry-server`, fixing CI integration test failures (#405)
+
 ## [0.1.5]
 
 Release Date: 2026-02-14

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

Bumps `@qvac/registry-client` from `0.1.5` → `0.1.6`.

## Changelog

### ✨ Features

- Download resume support: interrupted model downloads can now be resumed instead of restarting from scratch (#387)

### 🔧 Changed

- Added NOTICE file and updated license metadata for sub-package compliance (#394)

### 🐛 Fixed

- Added missing `@qvac/error` devDependency to `@qvac/registry-server`, fixing CI integration test failures (#405)
