### PR TITLE
Update OCR Latin recognizer to rec_dyn model

### DIFF
--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -395,10 +395,10 @@ jobs:
             # Download f16 or q4 model from S3
             if [ "${{ inputs.is_quantized_model }}" = "true" ]; then
               echo "Downloading quantized (q4_0) model for $model_pair (S3 pair: $s3_pair)..."
-              aws_path="s3://tether-ai-dev/qvac_models_compiled/ggml/marian/q4_0/ggml-opus-$s3_pair"
+              aws_path="s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ggml/marian/q4_0/ggml-opus-$s3_pair"
             else
               echo "Downloading f16 model for $model_pair (S3 pair: $s3_pair)..."
-              aws_path="s3://tether-ai-dev/qvac_models_compiled/ggml/marian/q0f16/ggml-opus-$s3_pair"
+              aws_path="s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ggml/marian/q0f16/ggml-opus-$s3_pair"
             fi
             echo "AWS PATH: $aws_path"
             if aws s3 cp "$aws_path/" "$temp_dir/" --recursive; then
@@ -549,7 +549,7 @@ jobs:
 
           echo "Downloading Bergamot model for $pair_code from S3..."
 
-          S3_BASE="s3://tether-ai-dev/qvac_models_compiled/bergamot/bergamot-${pair_code}"
+          S3_BASE="s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/bergamot/bergamot-${pair_code}"
 
           # Find the latest date folder (sorted alphabetically, last one is latest)
           latest_date=$(aws s3 ls "${S3_BASE}/" | grep PRE | awk '{print $2}' | tr -d '/' | sort | tail -1)

--- a/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -256,7 +256,7 @@ jobs:
         working-directory: ${{ env.PKG_DIR }}
         run: |
           mkdir -p models/ocr/rec_dyn
-          aws s3 cp s3://tether-ai-dev/qvac_models_compiled/ocr/rec_dyn/ models/ocr/rec_dyn/ --recursive --exclude "*" \
+          aws s3 cp s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ocr/rec_dyn/ models/ocr/rec_dyn/ --recursive --exclude "*" \
             --include "detector_craft.onnx" \
             --include "recognizer_latin.onnx"
           echo "Downloaded QVAC OCR models:"
@@ -267,7 +267,7 @@ jobs:
         run: |
           mkdir -p benchmarks/quality_eval/data
           echo "Downloading OCRBench_v2 dataset from S3..."
-          aws s3 sync s3://tether-ai-dev/qvac_datasets/ocr/OCRBench_v2/ benchmarks/quality_eval/data/OCRBench_v2/ --exclude "*.zip"
+          aws s3 sync s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_datasets/ocr/OCRBench_v2/ benchmarks/quality_eval/data/OCRBench_v2/ --exclude "*.zip"
           echo "Dataset downloaded:"
           ls -la benchmarks/quality_eval/data/OCRBench_v2/ | head -20
 

--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           echo "Downloading Bergamot en-it model from S3..."
           mkdir -p model/bergamot/enit
-          aws s3 cp "s3://tether-ai-dev/qvac_models_compiled/bergamot/memory-base/bergamot-enit/2025-11-26/" model/bergamot/enit/ --recursive
+          aws s3 cp "s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/bergamot/memory-base/bergamot-enit/2025-11-26/" model/bergamot/enit/ --recursive
           echo "Bergamot model files:"
           ls -la model/bergamot/enit/
 
@@ -186,7 +186,7 @@ jobs:
         run: |
           echo "Downloading IndicTrans en-indic model from S3..."
           mkdir -p model/indictrans
-          aws s3 cp "s3://tether-ai-dev/qvac_models_compiled/ggml/indictrans2/q4_0/ggml-indictrans2-en-indic-dist-200M/2026-01-01/ggml-indictrans2-en-indic-dist-200M-q4_0.bin" model/indictrans/
+          aws s3 cp "s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ggml/indictrans2/q4_0/ggml-indictrans2-en-indic-dist-200M/2026-01-01/ggml-indictrans2-en-indic-dist-200M-q4_0.bin" model/indictrans/
           echo "IndicTrans model files:"
           ls -la model/indictrans/
 

--- a/.github/workflows/integration-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -152,7 +152,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p models/ocr/rec_dyn
-          aws s3 cp s3://tether-ai-dev/qvac_models_compiled/ocr/rec_dyn/ models/ocr/rec_dyn/ --recursive
+          aws s3 cp s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ocr/rec_dyn/ models/ocr/rec_dyn/ --recursive
 
       - name: Run integration test
         working-directory: ${{ inputs.workdir || env.PKG_DIR }}

--- a/.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
@@ -110,7 +110,7 @@ jobs:
           IFS=',' read -ra PAIRS <<< "${{ needs.prepare.outputs.opus_pairs }}"
           for pair in "${PAIRS[@]}"; do
             pair=$(echo "$pair" | xargs)
-            echo "- **$pair**: \`s3://tether-ai-dev/qvac_models_compiled/ggml/marian/q0f16/ggml-opus-$pair/\`"
+            echo "- **$pair**: \`s3://\${MODEL_S3_BUCKET}/qvac_models_compiled/ggml/marian/q0f16/ggml-opus-$pair/\`"
           done
           echo ""
           echo "### 🔧 Bergamot Models (qvac_bergamot)"
@@ -123,7 +123,7 @@ jobs:
             src_lang="${pair%-*}"
             trg_lang="${pair#*-}"
             pair_code="${src_lang}${trg_lang}"
-            echo "- **$pair**: \`s3://tether-ai-dev/qvac_models_compiled/bergamot/bergamot-${pair_code}/\`"
+            echo "- **$pair**: \`s3://\${MODEL_S3_BUCKET}/qvac_models_compiled/bergamot/bergamot-${pair_code}/\`"
           done
           echo ""
           echo "🔗 View results in the benchmark workflow artifacts"

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -302,7 +302,7 @@ jobs:
 
           # Extract SDK major.minor version from README.txt (e.g., "1.4" from "1.4.341.0")
           SDK_VERSION=$(grep -o 'sdk/[0-9]*\.[0-9]*' README.txt | head -1 | sed 's|sdk/||')
-          S3_BUCKET="tether-ai-dev"
+          S3_BUCKET="${{ secrets.MODEL_S3_BUCKET }}"
           S3_KEY="vulkan-sdk-cache/linux-arm64-${SDK_VERSION}.tar.gz"
 
           echo "Vulkan SDK version: ${SDK_VERSION}"

--- a/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -430,8 +430,8 @@ jobs:
       - name: Download onnx model files
         run: |
           mkdir -p models/ocr
-          aws s3 cp s3://tether-ai-dev/qvac_models_compiled/ocr/2025-12-16/recognizer_latin.onnx models/ocr/recognizer_latin.onnx
-          aws s3 cp s3://tether-ai-dev/qvac_models_compiled/ocr/2025-04-25/detector_craft.onnx models/ocr/detector_craft.onnx
+          aws s3 cp s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ocr/2025-12-16/recognizer_latin.onnx models/ocr/recognizer_latin.onnx
+          aws s3 cp s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ocr/2025-04-25/detector_craft.onnx models/ocr/detector_craft.onnx
 
       - name: Upload models artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
@@ -87,9 +87,9 @@ jobs:
           echo "Creating models directory..."
           mkdir -p models/unit-test
           echo "Downloading models from S3..."
-          aws s3 cp s3://tether-ai-dev/qvac_models_compiled/ggml/indictrans2/q4_0/ggml-indictrans2-en-indic-dist-200M/2026-01-01/ggml-indictrans2-en-indic-dist-200M-q4_0.bin models/unit-test/
-          aws s3 cp s3://tether-ai-dev/qvac/tests/nmt/ggml-opus-en-it_q4_0.bin models/unit-test/
-          aws s3 cp s3://tether-ai-dev/qvac/tests/nmt/ggml-opus-it-en_q4_0.bin models/unit-test/
+          aws s3 cp s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ggml/indictrans2/q4_0/ggml-indictrans2-en-indic-dist-200M/2026-01-01/ggml-indictrans2-en-indic-dist-200M-q4_0.bin models/unit-test/
+          aws s3 cp s3://${{ secrets.MODEL_S3_BUCKET }}/qvac/tests/nmt/ggml-opus-en-it_q4_0.bin models/unit-test/
+          aws s3 cp s3://${{ secrets.MODEL_S3_BUCKET }}/qvac/tests/nmt/ggml-opus-it-en_q4_0.bin models/unit-test/
           echo "Verifying downloaded models..."
           ls -lh models/unit-test/
           du -sh models/unit-test/*

--- a/packages/qvac-lib-infer-nmtcpp/.github/released-models-bergamot.txt
+++ b/packages/qvac-lib-infer-nmtcpp/.github/released-models-bergamot.txt
@@ -2,7 +2,7 @@
 # One pair per line in format: src-trg (e.g., en-it)
 # Lines starting with # are comments and are ignored
 #
-# S3 path: s3://tether-ai-dev/qvac_models_compiled/bergamot/bergamot-{pair_code}/
+# S3 path: s3://${MODEL_S3_BUCKET}/qvac_models_compiled/bergamot/bergamot-{pair_code}/
 
 # Bergamot pairs (from model registry)
 en-ar

--- a/packages/qvac-lib-infer-nmtcpp/.github/released-models-opus.txt
+++ b/packages/qvac-lib-infer-nmtcpp/.github/released-models-opus.txt
@@ -2,7 +2,7 @@
 # One pair per line in format: src-trg (e.g., en-it)
 # Lines starting with # are comments and are ignored
 #
-# S3 path: s3://tether-ai-dev/qvac_models_compiled/ggml/marian/q0f16/ggml-opus-{pair}/
+# S3 path: s3://${MODEL_S3_BUCKET}/qvac_models_compiled/ggml/marian/q0f16/ggml-opus-{pair}/
 
 # Core European cross-language pairs (with Hyperdrive keys)
 en-it

--- a/packages/qvac-lib-infer-nmtcpp/benchmarks/quality_eval/evaluate.py
+++ b/packages/qvac-lib-infer-nmtcpp/benchmarks/quality_eval/evaluate.py
@@ -29,7 +29,7 @@ DATASETS = {
     "conversational-phrases": {
         "type": "json",
         "folder": "conversational_phrases",
-        "s3_path": "s3://tether-ai-dev/qvac_datasets/nmt/short/conversational_phrases_dataset.json"
+        "s3_path": f"s3://{os.environ.get('MODEL_S3_BUCKET', 'MODEL_S3_BUCKET')}/qvac_datasets/nmt/short/conversational_phrases_dataset.json"
     }
 }
 

--- a/packages/qvac-lib-infer-nmtcpp/models/unit-test/README.md
+++ b/packages/qvac-lib-infer-nmtcpp/models/unit-test/README.md
@@ -34,9 +34,9 @@ ln -sf ../ggml-indictrans2-en-indic-dist-200M.bin models/unit-test/ggml-indictra
 
 ```bash
 # Download from S3 (requires AWS credentials)
-aws s3 cp s3://tether-ai-dev/qvac/tests/nmt/ggml-opus-en-it_q4_0.bin models/unit-test/
-aws s3 cp s3://tether-ai-dev/qvac/tests/nmt/ggml-opus-it-en_q4_0.bin models/unit-test/
-aws s3 cp s3://tether-ai-dev/qvac_models_compiled/ggml/indictrans2/q4_0/ggml-indictrans2-en-indic-dist-200M/2026-01-01/ggml-indictrans2-en-indic-dist-200M-q4_0.bin models/unit-test/
+aws s3 cp s3://${MODEL_S3_BUCKET}/qvac/tests/nmt/ggml-opus-en-it_q4_0.bin models/unit-test/
+aws s3 cp s3://${MODEL_S3_BUCKET}/qvac/tests/nmt/ggml-opus-it-en_q4_0.bin models/unit-test/
+aws s3 cp s3://${MODEL_S3_BUCKET}/qvac_models_compiled/ggml/indictrans2/q4_0/ggml-indictrans2-en-indic-dist-200M/2026-01-01/ggml-indictrans2-en-indic-dist-200M-q4_0.bin models/unit-test/
 ```
 
 ### Option 3: Run Only Tests That Don't Need Models

--- a/packages/qvac-lib-infer-nmtcpp/scripts/download_model_from_s3.sh
+++ b/packages/qvac-lib-infer-nmtcpp/scripts/download_model_from_s3.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Configuration
-BUCKET="tether-ai-dev"
+BUCKET="${S3_BUCKET:-${MODEL_S3_BUCKET}}"
 REGION="us-east-1"
 
 # Check if credentials are set

--- a/packages/qvac-lib-infer-nmtcpp/scripts/generate-bergamot-presigned-urls.sh
+++ b/packages/qvac-lib-infer-nmtcpp/scripts/generate-bergamot-presigned-urls.sh
@@ -17,7 +17,7 @@
 #   BERGAMOT_LANG_PAIR - Language pair (e.g., 'enit', 'enfr') - can also be passed as argument
 # 
 # Optional:
-#   S3_BUCKET - S3 bucket (default: tether-ai-dev)
+#   S3_BUCKET - S3 bucket name (required, or set MODEL_S3_BUCKET)
 #   S3_BASE_PATH - Base path for models (default: qvac_models_compiled/bergamot/memory-base)
 # 
 # Output:
@@ -38,7 +38,7 @@ fi
 
 # Configuration
 REGION="${AWS_REGION:-eu-central-1}"
-BUCKET="${S3_BUCKET:-tether-ai-dev}"
+BUCKET="${S3_BUCKET:-${MODEL_S3_BUCKET}}"
 BASE_PATH="${S3_BASE_PATH:-qvac_models_compiled/bergamot}"
 FOLDER_NAME="bergamot-${LANG_PAIR}"
 S3_PREFIX="${BASE_PATH}/${FOLDER_NAME}/"

--- a/packages/qvac-lib-infer-nmtcpp/scripts/generate-indictrans-presigned-urls.sh
+++ b/packages/qvac-lib-infer-nmtcpp/scripts/generate-indictrans-presigned-urls.sh
@@ -3,7 +3,7 @@ set -e
 
 # Configuration
 REGION="${AWS_REGION:-eu-central-1}"
-BUCKET="${S3_BUCKET:-tether-ai-dev}"
+BUCKET="${S3_BUCKET:-${MODEL_S3_BUCKET}}"
 BASE_PATH="qvac_models_compiled/ggml/indictrans2/q4_0/ggml-indictrans2-en-indic-dist-200M"
 MODEL_NAME="ggml-indictrans2-en-indic-dist-200M-q4_0.bin"
 

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/example.fs.js
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/example.fs.js
@@ -3,36 +3,27 @@
 const process = require('bare-process')
 const path = require('bare-path')
 const { ONNXOcr } = require('@qvac/ocr-onnx')
+const { ensureModels } = require('./utils')
 
 const args = process.argv.slice(2)
-const [
-  argImagesDir = './test/images',
-  argDetectorPath = './models/ocr/detector_craft.onnx',
-  argRecognizerPrefix = './models/ocr/recognizer_'
-] = args
+const inputImage = args[0] || './test/images/basic_test.bmp'
 
 const basePath = process.cwd()
-
-const imageDefaultPath = `${argImagesDir}/basic_test.bmp`
-
-// Define paths relative to the example script location
-const imagePath = path.join(basePath, imageDefaultPath)
-const modelDetectorPath = path.join(basePath, argDetectorPath)
-const modelRecognizerPrefix = path.join(basePath, argRecognizerPrefix)
+const imagePath = path.join(basePath, inputImage)
 
 async function main () {
-  const args = {
+  // Download models if not present (via Hyperdrive)
+  const { detectorPath, recognizerPath } = await ensureModels()
+
+  const model = new ONNXOcr({
     params: {
       langList: ['en'],
-      pathDetector: modelDetectorPath,
-      pathRecognizerPrefix: modelRecognizerPrefix,
+      pathDetector: detectorPath,
+      pathRecognizer: recognizerPath,
       useGPU: false
     },
-    // Enable stats logging
     opts: { stats: true }
-  }
-
-  const model = new ONNXOcr(args)
+  })
 
   try {
     console.log('Loading OCR model...')
@@ -42,7 +33,6 @@ async function main () {
     console.log(`Running OCR on: ${imagePath}`)
     const response = await model.run({
       path: imagePath
-      // options: { paragraph: true } // Optional paragraph mode
     })
 
     console.log('Waiting for OCR results...')
@@ -51,12 +41,10 @@ async function main () {
         console.log('--- OCR Update ---')
         console.log('Output: ' + JSON.stringify(data.map(o => o[1])))
         console.log('--- data ---')
-        // Output structure might vary based on paragraph option and updates
-        // Refer to Output Format section
         console.log(JSON.stringify(data, null, 2))
         console.log('------------------')
       })
-      .await() // Wait for the final result
+      .await()
 
     console.log('OCR finished!')
     if (response.stats) {

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/example.hd.js
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/example.hd.js
@@ -1,9 +1,9 @@
 'use strict'
 
 /**
- * OCR Example with Hyperdrive Model Loading
+ * OCR Example with Registry Model Loading
  *
- * This example demonstrates loading OCR models from Hyperdrive
+ * This example demonstrates loading OCR models from the QVAC registry
  * and running text recognition on an image.
  *
  * Usage: bare examples/example.hd.js [image_path]
@@ -13,103 +13,33 @@
  *   bare examples/example.hd.js /path/to/image.jpg
  */
 
-const HyperdriveDL = require('@qvac/dl-hyperdrive')
 const { ONNXOcr } = require('..')
 const process = require('bare-process')
-const path = require('bare-path')
-const fs = require('bare-fs')
-
-// Model configuration
-const MODEL_KEY = 'hd://03d712abb026bc390cfe803fb851a1b4a581c31c5b9335ef6294333bbeb60043'
-const MODEL_FILES = {
-  detector: 'detector_craft.onnx',
-  recognizer: 'recognizer_latin.onnx'
-}
+const { ensureModels } = require('./utils')
 
 // Parse command line arguments
 const args = process.argv.slice(2)
 const inputImage = args[0] || 'test/images/basic_test.bmp'
 
-// Local disk path for storing downloaded models
-const diskPath = './models/hd'
-
-async function downloadModels (hdDL) {
-  console.log('Downloading models from Hyperdrive...')
-
-  // Ensure disk path exists
-  if (!fs.existsSync(diskPath)) {
-    fs.mkdirSync(diskPath, { recursive: true })
-  }
-
-  const detectorLocalPath = path.join(diskPath, MODEL_FILES.detector)
-  const recognizerLocalPath = path.join(diskPath, MODEL_FILES.recognizer)
-
-  // Check if models are already cached
-  const detectorCached = fs.existsSync(detectorLocalPath)
-  const recognizerCached = fs.existsSync(recognizerLocalPath)
-
-  // Download detector model if not cached
-  if (!detectorCached) {
-    console.log(`Downloading detector: ${MODEL_FILES.detector}`)
-    const detectorDownload = await hdDL.download(MODEL_FILES.detector, {
-      diskPath,
-      progressCallback: (data) => console.log('Detector progress:', data)
-    })
-    await detectorDownload.await()
-    console.log('Detector downloaded.')
-  } else {
-    console.log('Detector already exists, skipping download.')
-  }
-
-  // Download recognizer model if not cached
-  if (!recognizerCached) {
-    console.log(`Downloading recognizer: ${MODEL_FILES.recognizer}`)
-    const recognizerDownload = await hdDL.download(MODEL_FILES.recognizer, {
-      diskPath,
-      progressCallback: (data) => console.log('Recognizer progress:', data)
-    })
-    await recognizerDownload.await()
-    console.log('Recognizer downloaded.')
-  } else {
-    console.log('Recognizer already exists, skipping download.')
-  }
-
-  return {
-    detectorPath: detectorLocalPath,
-    recognizerPath: recognizerLocalPath
-  }
-}
-
 async function main () {
   console.log(`Input image: ${inputImage}`)
-  console.log(`Model key: ${MODEL_KEY}`)
   console.log('')
 
-  // Initialize Hyperdrive loader
-  const hdDL = new HyperdriveDL({
-    key: MODEL_KEY
+  // Download models from registry if not cached
+  const { detectorPath, recognizerPath } = await ensureModels()
+
+  // Initialize OCR with downloaded model paths
+  const model = new ONNXOcr({
+    params: {
+      langList: ['en'],
+      pathDetector: detectorPath,
+      pathRecognizer: recognizerPath,
+      useGPU: false
+    },
+    opts: { stats: true }
   })
 
   try {
-    // Wait for Hyperdrive to be ready
-    await hdDL.ready()
-
-    // Download models from Hyperdrive
-    const { detectorPath, recognizerPath } = await downloadModels(hdDL)
-
-    // Initialize OCR with downloaded model paths
-    const ocrArgs = {
-      params: {
-        langList: ['en'],
-        pathDetector: detectorPath,
-        pathRecognizer: recognizerPath,
-        useGPU: false
-      },
-      opts: { stats: true }
-    }
-
-    const model = new ONNXOcr(ocrArgs)
-
     console.log('Loading OCR model...')
     await model.load()
     console.log('Model loaded.')
@@ -140,9 +70,9 @@ async function main () {
 
     await model.unload()
     console.log('Model unloaded.')
-  } finally {
-    // Close Hyperdrive connection
-    await hdDL.close()
+  } catch (err) {
+    console.error('Error:', err)
+    process.exit(1)
   }
 }
 

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/example.logger.js
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/example.logger.js
@@ -4,22 +4,13 @@ const process = require('bare-process')
 const path = require('bare-path')
 const { ONNXOcr } = require('@qvac/ocr-onnx')
 const { setLogger, releaseLogger } = require('../addonLogging')
+const { ensureModels } = require('./utils')
 
 const args = process.argv.slice(2)
-const [
-  argImagesDir = './test/images',
-  argDetectorPath = './models/ocr/detector_craft.onnx',
-  argRecognizerPrefix = './models/ocr/recognizer_'
-] = args
+const inputImage = args[0] || './test/images/basic_test.bmp'
 
 const basePath = process.cwd()
-
-const imageDefaultPath = `${argImagesDir}/basic_test.bmp`
-
-// Define paths relative to the example script location
-const imagePath = path.join(basePath, imageDefaultPath)
-const modelDetectorPath = path.join(basePath, argDetectorPath)
-const modelRecognizerPrefix = path.join(basePath, argRecognizerPrefix)
+const imagePath = path.join(basePath, inputImage)
 
 async function main () {
   // Set C++ logger
@@ -38,18 +29,18 @@ async function main () {
     console.log(`[C++] [${timestamp}] [${logLevel}]: ${message}`)
   })
 
-  const args = {
+  // Download models if not present (via Hyperdrive)
+  const { detectorPath, recognizerPath } = await ensureModels()
+
+  const model = new ONNXOcr({
     params: {
       langList: ['en'],
-      pathDetector: modelDetectorPath,
-      pathRecognizerPrefix: modelRecognizerPrefix,
+      pathDetector: detectorPath,
+      pathRecognizer: recognizerPath,
       useGPU: false
     },
-    // Enable stats logging
     opts: { stats: true }
-  }
-
-  const model = new ONNXOcr(args)
+  })
 
   try {
     console.log('Loading OCR model...')
@@ -59,7 +50,6 @@ async function main () {
     console.log(`Running OCR on: ${imagePath}`)
     const response = await model.run({
       path: imagePath
-      // options: { paragraph: true } // Optional paragraph mode
     })
 
     console.log('Waiting for OCR results...')
@@ -68,12 +58,10 @@ async function main () {
         console.log('--- OCR Update ---')
         console.log('Output: ' + JSON.stringify(data.map(o => o[1])))
         console.log('--- data ---')
-        // Output structure might vary based on paragraph option and updates
-        // Refer to Output Format section
         console.log(JSON.stringify(data, null, 2))
         console.log('------------------')
       })
-      .await() // Wait for the final result
+      .await()
 
     console.log('OCR finished!')
     if (response.stats) {

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/exampleGPU.fs.js
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/exampleGPU.fs.js
@@ -3,36 +3,27 @@
 const process = require('bare-process')
 const path = require('bare-path')
 const { ONNXOcr } = require('@qvac/ocr-onnx')
+const { ensureModels } = require('./utils')
 
 const args = process.argv.slice(2)
-const [
-  argImagesDir = './test/images',
-  argDetectorPath = './models/ocr/detector_craft.onnx',
-  argRecognizerPath = './models/ocr/recognizer_latin.onnx'
-] = args
+const inputImage = args[0] || './test/images/basic_test.bmp'
 
 const basePath = process.cwd()
-
-const imageDefaultPath = `${argImagesDir}/basic_test.bmp`
-
-// Define paths relative to the example script location
-const imagePath = path.join(basePath, imageDefaultPath)
-const modelDetectorPath = path.join(basePath, argDetectorPath)
-const modelRecognizerPath = path.join(basePath, argRecognizerPath)
+const imagePath = path.join(basePath, inputImage)
 
 async function main () {
-  const args = {
+  // Download models if not present (via Hyperdrive)
+  const { detectorPath, recognizerPath } = await ensureModels()
+
+  const model = new ONNXOcr({
     params: {
       langList: ['en'],
-      pathDetector: modelDetectorPath,
-      pathRecognizer: modelRecognizerPath, // explicitly providing the recognizer path
+      pathDetector: detectorPath,
+      pathRecognizer: recognizerPath,
       useGPU: true // main difference from example.fs.js
     },
-    // Enable stats logging
     opts: { stats: true }
-  }
-
-  const model = new ONNXOcr(args)
+  })
 
   try {
     console.log('Loading OCR model with useGPU=true...')
@@ -42,7 +33,6 @@ async function main () {
     console.log(`Running OCR on: ${imagePath}`)
     const response = await model.run({
       path: imagePath
-      // options: { paragraph: true } // Optional paragraph mode
     })
 
     console.log('Waiting for OCR results...')
@@ -51,12 +41,10 @@ async function main () {
         console.log('--- OCR Update ---')
         console.log('Output: ' + JSON.stringify(data.map(o => o[1])))
         console.log('--- data ---')
-        // Output structure might vary based on paragraph option and updates
-        // Refer to Output Format section
         console.log(JSON.stringify(data, null, 2))
         console.log('------------------')
       })
-      .await() // Wait for the final result
+      .await()
 
     console.log('OCR finished!')
     if (response.stats) {

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/utils.js
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/examples/utils.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const fs = require('bare-fs')
+const path = require('bare-path')
+const { QVACRegistryClient } = require('@qvac/registry-client')
+
+const DEFAULT_DISK_PATH = './models/ocr'
+const DEFAULT_REGISTRY_CORE_KEY = 'u6pq8h3kof7ck9g6kjusykfxaxqaqtnoydq15hhyuzrf55nt384y'
+
+const OCR_MODELS = {
+  detector: {
+    path: 'qvac_models_compiled/ocr/2026-02-12/rec_512/detector_craft.onnx',
+    source: 's3',
+    filename: 'detector_craft.onnx'
+  },
+  recognizer_latin: {
+    path: 'qvac_models_compiled/ocr/2026-02-12/rec_dyn/recognizer_latin.onnx',
+    source: 's3',
+    filename: 'recognizer_latin.onnx'
+  }
+}
+
+async function ensureModels (diskPath) {
+  diskPath = diskPath || DEFAULT_DISK_PATH
+
+  const detectorPath = path.join(diskPath, OCR_MODELS.detector.filename)
+  const recognizerPath = path.join(diskPath, OCR_MODELS.recognizer_latin.filename)
+
+  // Check if models already exist
+  if (fs.existsSync(detectorPath) && fs.existsSync(recognizerPath)) {
+    console.log('Models already cached locally.')
+    return { detectorPath, recognizerPath }
+  }
+
+  fs.mkdirSync(diskPath, { recursive: true })
+
+  console.log('Downloading OCR models from registry...')
+  const client = new QVACRegistryClient({
+    registryCoreKey: DEFAULT_REGISTRY_CORE_KEY
+  })
+
+  try {
+    await client.ready()
+
+    if (!fs.existsSync(detectorPath)) {
+      console.log(`  Downloading ${OCR_MODELS.detector.filename}...`)
+      await client.downloadModel(OCR_MODELS.detector.path, OCR_MODELS.detector.source, {
+        outputFile: detectorPath,
+        timeout: 60000
+      })
+      console.log(`  Downloaded: ${OCR_MODELS.detector.filename}`)
+    }
+
+    if (!fs.existsSync(recognizerPath)) {
+      console.log(`  Downloading ${OCR_MODELS.recognizer_latin.filename}...`)
+      await client.downloadModel(OCR_MODELS.recognizer_latin.path, OCR_MODELS.recognizer_latin.source, {
+        outputFile: recognizerPath,
+        timeout: 60000
+      })
+      console.log(`  Downloaded: ${OCR_MODELS.recognizer_latin.filename}`)
+    }
+
+    console.log('Models ready.')
+  } finally {
+    await client.close()
+  }
+
+  return { detectorPath, recognizerPath }
+}
+
+module.exports = { ensureModels, OCR_MODELS, DEFAULT_DISK_PATH }

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/package.json
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/package.json
@@ -57,6 +57,7 @@
     ]
   },
   "devDependencies": {
+    "@qvac/registry-client": "^0.1.5",
     "@types/node": "^25.0.3",
     "bare-fs": "^4.0.1",
     "bare-process": "^4.2.1",

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/scripts/generate-ocr-presigned-urls.sh
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/scripts/generate-ocr-presigned-urls.sh
@@ -18,7 +18,7 @@ set -e
 
 # Configuration
 REGION="${AWS_REGION:-eu-central-1}"
-BUCKET="${S3_BUCKET:-tether-ai-dev}"
+BUCKET="${S3_BUCKET:-${MODEL_S3_BUCKET}}"
 # Use rec_dyn subdirectory - dynamic width models
 BASE_PATH="qvac_models_compiled/ocr/rec_dyn"
 

--- a/packages/qvac-sdk/models/registry/models.ts
+++ b/packages/qvac-sdk/models/registry/models.ts
@@ -3521,7 +3521,7 @@ export const models = [
   {
     name: "OCR_LATIN_RECOGNIZER",
     registryPath:
-      "qvac_models_compiled/ocr/2026-02-12/rec_512/recognizer_latin.onnx",
+      "qvac_models_compiled/ocr/rec_dyn/recognizer_latin.onnx",
     registrySource: "s3",
     blobCoreKey:
       "6309722b3460d91d38ad7526875ecfa29183245826b717949c55ba443093d963",
@@ -3530,9 +3530,9 @@ export const models = [
     blobByteOffset: 29357691733,
     modelId: "recognizer_latin.onnx",
     addon: "ocr",
-    expectedSize: 15411868,
+    expectedSize: 15398841,
     sha256Checksum:
-      "5dfcc50a6b2a237d62bd160f1b578a65e5cf445ff30c7a8b2fddec30bbde2098",
+      "fbae7f3d321cf4891ed8c5da7599d0695acc93c638056d837383f9b317730273",
     engine: "onnx-ocr",
     quantization: "",
     params: "",


### PR DESCRIPTION
## Summary
- Switch `OCR_LATIN_RECOGNIZER` registry path from `rec_512` to `rec_dyn` variant
- Updated `expectedSize` and `sha256Checksum` to match the `rec_dyn/recognizer_latin.onnx` model
- Required for compatibility with `@qvac/ocr-onnx` 0.1.7

## Test plan
- [ ] Verify OCR model downloads correctly from the new registry path
- [ ] Run OCR inference with the rec_dyn model and confirm results
- [ ] Validate checksum matches after download