### PR TITLE
Add descriptions for gte-large and Qwen3-1.7B model entries

### DIFF
--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -290,7 +290,7 @@
   {
     "source": "https://huggingface.co/ChristianAzinn/gte-large-gguf/blob/f9fa5479908e72c2a8b9d6ba112911cd1e51be53/gte-large_fp16.gguf",
     "engine": "@qvac/embed-llamacpp",
-    "description": "",
+    "description": "General text embeddings model by Alibaba DAMO, 1024-dim, 512 token context",
     "quantization": "fp16",
     "params": "",
     "license": "MIT",
@@ -304,7 +304,7 @@
   {
     "source": "https://huggingface.co/unsloth/Qwen3-1.7B-GGUF/resolve/d7f544eead698dbd1f15126ef60b45a1e1933222/Qwen3-1.7B-Q4_0.gguf",
     "engine": "@qvac/llm-llamacpp",
-    "description": "",
+    "description": "Lightweight instruct model with hybrid thinking modes, 32K context",
     "quantization": "q4",
     "params": "1.7B",
     "license": "Apache-2.0",


### PR DESCRIPTION
## What problem does this PR solve?

Two model entries in `models.prod.json` (gte-large embedding and Qwen3-1.7B instruct) have empty description fields, making it harder to understand what each model does at a glance.

## How does it solve it?

Adds concise descriptions based on upstream model documentation:
- **gte-large**: "General text embeddings model by Alibaba DAMO, 1024-dim, 512 token context"
- **Qwen3-1.7B**: "Lightweight instruct model with hybrid thinking modes, 32K context"

## Breaking changes

None.

Made with [Cursor](https://cursor.com)