### PR TITLE
QVAC-12216 feat: accept named file paths for Parakeet model artifacts

### DIFF
--- a/packages/qvac-lib-infer-parakeet/index.d.ts
+++ b/packages/qvac-lib-infer-parakeet/index.d.ts
@@ -4,21 +4,6 @@ import BaseInference from '@qvac/infer-base/WeightsProvider/BaseInference';
 import WeightsProvider from '@qvac/infer-base/WeightsProvider/WeightsProvider';
 import type { QvacResponse } from '@qvac/infer-base';
 import type Logger from '@qvac/logging';
-import type { Readable } from 'stream';
-
-/**
- * Loader interface provides the methods required by TranscriptionParakeet to fetch and manage streams.
- */
-export interface Loader {
-  /** Prepare the loader for operations */
-  ready(): Promise<void>;
-  /** Clean up or close any underlying resources */
-  close(): Promise<void>;
-  /** Obtain a readable stream for the specified path */
-  getStream(path: string): Promise<Readable>;
-  /** (Optional) Retrieve the size of a remote file in bytes */
-  getFileSize?(path: string): Promise<number>;
-}
 
 /**
  * Model type options for Parakeet
@@ -51,8 +36,8 @@ export interface ParakeetConfig {
  * Arguments required to construct an instance of TranscriptionParakeet
  */
 export interface TranscriptionParakeetArgs {
-  /** External loader instance */
-  loader: Loader;
+  /** External loader instance (e.g. FilesystemDL, HyperdriveDL) */
+  loader: unknown;
   /** Optional structured logger */
   logger?: Logger;
   /** Name of the model directory */
@@ -71,6 +56,16 @@ export interface TranscriptionParakeetArgs {
 export interface TranscriptionParakeetConfig {
   /** Direct path to model directory (alternative to diskPath + modelName) */
   path?: string;
+  /** Absolute path to encoder ONNX graph file (encoder-model.onnx) */
+  encoderPath?: string;
+  /** Absolute path to encoder ONNX weights file (encoder-model.onnx.data) */
+  encoderDataPath?: string;
+  /** Absolute path to decoder-joint ONNX file (decoder_joint-model.onnx) */
+  decoderPath?: string;
+  /** Absolute path to vocabulary file (vocab.txt) */
+  vocabPath?: string;
+  /** Absolute path to preprocessor ONNX file (preprocessor.onnx / nemo128.onnx) */
+  preprocessorPath?: string;
   /** Enable statistics collection */
   enableStats?: boolean;
   /** Parakeet-specific configuration */
@@ -222,7 +217,6 @@ declare namespace TranscriptionParakeet {
   export {
     TranscriptionParakeet as default,
     TranscriptionParakeet,
-    Loader,
     ModelType,
     ParakeetConfig,
     TranscriptionParakeetArgs,

--- a/packages/qvac-lib-infer-parakeet/index.js
+++ b/packages/qvac-lib-infer-parakeet/index.js
@@ -63,6 +63,11 @@ class TranscriptionParakeet extends BaseInference {
    * @param {boolean} [args.exclusiveRun=true] - Whether to run exclusively
    * @param {Object} config - environment-specific inference setup configuration
    * @param {string} [config.path] - Direct path to model (alternative to diskPath + modelName)
+   * @param {string} [config.encoderPath] - Absolute path to encoder ONNX graph file
+   * @param {string} [config.encoderDataPath] - Absolute path to encoder ONNX weights file
+   * @param {string} [config.decoderPath] - Absolute path to decoder-joint ONNX file
+   * @param {string} [config.vocabPath] - Absolute path to vocabulary file
+   * @param {string} [config.preprocessorPath] - Absolute path to preprocessor ONNX file
    * @param {Object} config.parakeetConfig - Parakeet-specific configuration
    * @param {string} [config.parakeetConfig.modelType='tdt'] - Model type: 'tdt', 'ctc', 'eou', or 'sortformer'
    * @param {number} [config.parakeetConfig.maxThreads=4] - Max CPU threads for inference
@@ -99,6 +104,20 @@ class TranscriptionParakeet extends BaseInference {
    */
   validateModelFiles () {
     const modelPath = this._config.path || this._getModelFilePath()
+
+    // When using named path overrides, skip directory-level validation
+    if (this._hasNamedPaths()) {
+      const modelType = this.params.modelType || 'tdt'
+      const requiredFiles = getRequiredModelFiles(modelType)
+      for (const file of requiredFiles) {
+        const filePath = this._resolveFilePath(modelPath, file)
+        if (!fs.existsSync(filePath)) {
+          this.logger.warn(`Model file not found: ${file} (${filePath})`)
+        }
+      }
+      return
+    }
+
     if (!modelPath) {
       return // Skip validation if no path specified yet
     }
@@ -132,6 +151,39 @@ class TranscriptionParakeet extends BaseInference {
       return ''
     }
     return path.join(this._diskPath, this._modelName)
+  }
+
+  /**
+   * Resolve the absolute path for a model file.
+   * Uses named config path if available, otherwise falls back to
+   * path.join(modelPath, filename).
+   * @param {string} modelPath - base model directory path
+   * @param {string} filename - model file name (e.g. 'encoder-model.onnx')
+   * @returns {string} - absolute path to the file
+   * @private
+   */
+  _resolveFilePath (modelPath, filename) {
+    const namedPaths = {
+      'encoder-model.onnx': this._config.encoderPath,
+      'encoder-model.onnx.data': this._config.encoderDataPath,
+      'decoder_joint-model.onnx': this._config.decoderPath,
+      'vocab.txt': this._config.vocabPath,
+      'preprocessor.onnx': this._config.preprocessorPath
+    }
+    if (namedPaths[filename]) {
+      return namedPaths[filename]
+    }
+    return path.join(modelPath, filename)
+  }
+
+  /**
+   * Whether individual file paths have been provided via named config params.
+   * @returns {boolean}
+   * @private
+   */
+  _hasNamedPaths () {
+    return !!(this._config.encoderPath || this._config.encoderDataPath ||
+      this._config.decoderPath || this._config.vocabPath || this._config.preprocessorPath)
   }
 
   /**
@@ -181,7 +233,7 @@ class TranscriptionParakeet extends BaseInference {
     const requiredFiles = getRequiredModelFiles(modelType)
 
     for (const file of requiredFiles) {
-      const filePath = path.join(modelPath, file)
+      const filePath = this._resolveFilePath(modelPath, file)
       if (fs.existsSync(filePath)) {
         this.logger.debug(`Loading ${file}...`)
 

--- a/packages/qvac-lib-infer-parakeet/package.json
+++ b/packages/qvac-lib-infer-parakeet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-parakeet",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "High-performance speech-to-text inference addon using NVIDIA Parakeet models for Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-parakeet/release-notes/v0.1.6.md
+++ b/packages/qvac-lib-infer-parakeet/release-notes/v0.1.6.md
@@ -1,0 +1,25 @@
+# QVAC Transcription Parakeet Addon v0.1.6 Release Notes
+
+This release replaces the generic `filePaths` map with explicit named path parameters for individual model artifacts, aligning with the pattern used by the TTS addon (`@qvac/tts-onnx`). It also cleans up unused type declarations.
+
+## New APIs
+
+The addon config now accepts individual named file paths, allowing the SDK to pass resolved cache locations directly without assembling a single model directory. Each parameter maps to a specific model artifact:
+
+```js
+const config = {
+  path: '/fallback/model/dir',
+  encoderPath: '/cache/abc/encoder-model.onnx',
+  encoderDataPath: '/cache/def/encoder-model.onnx.data',
+  decoderPath: '/cache/ghi/decoder_joint-model.onnx',
+  vocabPath: '/cache/jkl/vocab.txt',
+  preprocessorPath: '/cache/mno/preprocessor.onnx',
+  parakeetConfig: { modelType: 'tdt' },
+}
+```
+
+When named paths are not provided, files are resolved from `config.path` or `diskPath + modelName` as before — no migration required for existing callers.
+
+## Bug Fixes
+
+The `Loader` interface in the type declarations was declared but never enforced at runtime — the constructor passes the loader through to `BaseInference` and `WeightsProvider` without type constraints. This forced SDK consumers to double-cast through `unknown` when passing their own loader implementations (e.g. `FilesystemDL`). The `Loader` type and its `Readable` import have been removed, and the `loader` argument is now typed as `unknown`.


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The Parakeet addon only supports loading model files from a single directory, but the SDK resolves each file individually (via `registry://`, `http://`, `pear://`, or local paths) and files can land in different cache locations

## 📝 How does it solve it?

- Adds explicit named path parameters to `TranscriptionParakeetConfig` matching the TTS addon (`@qvac/tts-onnx`) pattern
- Removes unused `Loader` type from type declarations
- Bumps version to `0.1.6`
- Fully backward-compatible: without named paths, files resolve from `config.path` / `diskPath + modelName` as before

## Changes

### Named path parameters (new)

- `config.encoderPath` — encoder ONNX graph (`encoder-model.onnx`)
- `config.encoderDataPath` — encoder weights (`encoder-model.onnx.data`)
- `config.decoderPath` — decoder-joint ONNX (`decoder_joint-model.onnx`)
- `config.vocabPath` — vocabulary (`vocab.txt`)
- `config.preprocessorPath` — preprocessor ONNX (`preprocessor.onnx`)

### Type declaration cleanup

- Removed unused `Loader` interface and `Readable` import
- Changed `loader` arg type from `Loader` to `unknown` (passed through to BaseInference)
- Removed `Loader` from namespace exports

### Internal

- `_resolveFilePath()` maps standard filenames to their named config paths
- `_hasNamedPaths()` controls validation flow when named paths are provided
- `_loadModelWeights()` uses `_resolveFilePath()` instead of `path.join()`

## 🧪 How was it tested?

- [x] Tested via qvac-sdk parakeet example with locally cached files passed as named paths
- [x] Model loads and all 5 files finalize correctly

## Related

- Replaces standalone repo PR: tetherto/qvac-lib-infer-parakeet#49
- SDK counterpart: #366

Made with [Cursor](https://cursor.com)