### PR TITLE
QVAC-13244 chore: consolidate registry core key constant and scope corestore cache by key

### DIFF
--- a/packages/qvac-sdk/constants/index.ts
+++ b/packages/qvac-sdk/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./audio";
+export * from "./registry";

--- a/packages/qvac-sdk/constants/registry.ts
+++ b/packages/qvac-sdk/constants/registry.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_REGISTRY_CORE_KEY =
+  "uf1fm44uzockp6azhcdiqt1esjgm65fwtimsh946e8kwysdes9ko";

--- a/packages/qvac-sdk/models/update-models/registry.ts
+++ b/packages/qvac-sdk/models/update-models/registry.ts
@@ -2,6 +2,7 @@ import { QVACRegistryClient } from "@qvac/registry-client";
 import { groupShardedModels } from "./shards";
 import { processRegistryModel } from "./processing";
 import type { CollectOptions, ProcessedModel } from "./types";
+import { DEFAULT_REGISTRY_CORE_KEY } from "@/constants";
 
 // Re-export for backward compat
 export {
@@ -9,9 +10,6 @@ export {
   extractModelName,
   toHexString,
 } from "./processing";
-
-const DEFAULT_REGISTRY_CORE_KEY =
-  "u6pq8h3kof7ck9g6kjusykfxaxqaqtnoydq15hhyuzrf55nt384y";
 
 export async function collectModels(
   options: CollectOptions = {},

--- a/packages/qvac-sdk/server/bare/registry/registry-client.ts
+++ b/packages/qvac-sdk/server/bare/registry/registry-client.ts
@@ -17,7 +17,7 @@ export async function getRegistryClient(): Promise<QVACRegistryClient> {
 
   registryClient = new QVACRegistryClient({
     registryCoreKey: DEFAULT_REGISTRY_CORE_KEY,
-    storage: getCacheDir("registry-corestore"),
+    storage: getCacheDir(`registry-corestore/${DEFAULT_REGISTRY_CORE_KEY}`),
   });
 
   await registryClient.ready();

--- a/packages/qvac-sdk/server/bare/registry/registry-client.ts
+++ b/packages/qvac-sdk/server/bare/registry/registry-client.ts
@@ -1,12 +1,9 @@
 import { QVACRegistryClient } from "@qvac/registry-client";
 import { getCacheDir } from "@/server/utils/cache";
 import { getServerLogger } from "@/logging";
+import { DEFAULT_REGISTRY_CORE_KEY } from "@/constants";
 
 const logger = getServerLogger();
-
-// Public QVAC Registry containing all available models
-const DEFAULT_REGISTRY_CORE_KEY =
-  "u6pq8h3kof7ck9g6kjusykfxaxqaqtnoydq15hhyuzrf55nt384y";
 
 let registryClient: QVACRegistryClient | null = null;
 


### PR DESCRIPTION
## Summary

- Moves `DEFAULT_REGISTRY_CORE_KEY` to a single shared constant in `constants/registry.ts`, removing duplicate definitions from `server/bare/registry/registry-client.ts` and `models/update-models/registry.ts`.
- Scopes the registry corestore cache directory by the registry key (`~/.qvac/registry-corestore/<key>/`), so switching to a new registry key automatically uses a fresh corestore instead of inheriting stale/incompatible cached data from the previous key.
