### PR TITLE
QVAC-13348 feat: Use subpath imports for cross-runtime compatibility

### DIFF
--- a/packages/qvac-lib-registry-server/client/bin/cli.js
+++ b/packages/qvac-lib-registry-server/client/bin/cli.js
@@ -4,7 +4,7 @@
 const { command, flag, arg, summary, header, footer, description } = require('paparam')
 const { QVACRegistryClient } = require('../index')
 const IdEnc = require('hypercore-id-encoding')
-const path = require('path')
+const path = require('#path')
 
 const VERSION = require('../package.json').version
 

--- a/packages/qvac-lib-registry-server/client/examples/download-all-models.js
+++ b/packages/qvac-lib-registry-server/client/examples/download-all-models.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const path = require('path')
-const fs = require('fs')
+const path = require('#path')
+const fs = require('#fs')
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 
 const { QVACRegistryClient } = require('../index')

--- a/packages/qvac-lib-registry-server/client/examples/download-model.js
+++ b/packages/qvac-lib-registry-server/client/examples/download-model.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const path = require('path')
+const path = require('#path')
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 
 const { QVACRegistryClient } = require('../index')
-const os = require('os')
+const os = require('#os')
 
 async function downloadModelExample () {
   const tmpStorage = path.join(os.tmpdir(), `qvac-registry-download-${Date.now()}`)

--- a/packages/qvac-lib-registry-server/client/examples/example.js
+++ b/packages/qvac-lib-registry-server/client/examples/example.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const path = require('path')
+const path = require('#path')
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 
 const { QVACRegistryClient } = require('../index')
 const IdEnc = require('hypercore-id-encoding')
-const os = require('os')
+const os = require('#os')
 
 async function example () {
   const tmpStorage = path.join(os.tmpdir(), `qvac-registry-example-${Date.now()}`)

--- a/packages/qvac-lib-registry-server/client/examples/verify-checksums.js
+++ b/packages/qvac-lib-registry-server/client/examples/verify-checksums.js
@@ -13,8 +13,8 @@
  *   1 - One or more checksum mismatches found
  */
 
-const path = require('path')
-const fs = require('fs')
+const path = require('#path')
+const fs = require('#fs')
 const crypto = require('crypto')
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -9,8 +9,8 @@ const Corestore = require('corestore')
 const Hyperswarm = require('hyperswarm')
 const Hyperblobs = require('hyperblobs')
 const IdEnc = require('hypercore-id-encoding')
-const path = require('path')
-const fs = require('fs')
+const path = require('#path')
+const fs = require('#fs')
 
 class QVACRegistryClient extends ReadyResource {
   constructor (opts = {}) {

--- a/packages/qvac-lib-registry-server/client/lib/config.js
+++ b/packages/qvac-lib-registry-server/client/lib/config.js
@@ -3,8 +3,8 @@
 const { getEnv } = require('../utils/env')
 const { ENV_KEYS } = require('@qvac/registry-schema')
 const Logger = require('./logger')
-const os = require('os')
-const path = require('path')
+const os = require('#os')
+const path = require('#path')
 
 const DEFAULT_REGISTRY_CORE_KEY = 'u6pq8h3kof7ck9g6kjusykfxaxqaqtnoydq15hhyuzrf55nt384y'
 

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -12,6 +12,20 @@
     ".": "./index.js",
     "./types": "./index.d.ts"
   },
+  "imports": {
+    "#os": {
+      "bare": "bare-os",
+      "default": "os"
+    },
+    "#path": {
+      "bare": "bare-path",
+      "default": "path"
+    },
+    "#fs": {
+      "bare": "bare-fs",
+      "default": "fs"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",
@@ -36,17 +50,14 @@
     "b4a": "^1.6.7",
     "bare-fs": "^4.5.2",
     "bare-os": "^3.6.2",
+    "bare-path": "^3.0.0",
     "bare-process": "^4.2.2",
     "corestore": "^7.4.5",
-    "fs": "npm:bare-node-fs",
     "hyperblobs": "^2.8.0",
     "hypercore-id-encoding": "^1.3.0",
     "hyperdb": "^4.16.1",
     "hyperswarm": "^4.14.0",
-    "os": "npm:bare-node-os",
     "paparam": "^1.10.0",
-    "path": "npm:bare-node-path",
-    "process": "npm:bare-node-process",
     "ready-resource": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Problem

Staged Pear apps fail at runtime with `MODULE_NOT_FOUND: Cannot find module 'os'`.

**Root cause:** The `@qvac/registry-client` package used npm aliases (`"os": "npm:bare-node-os"`) to provide Bare-compatible shims. However, `pear stage --compact` uses `bare-module-traverse` for static analysis, which does not follow npm aliases. The aliased packages are not included in the staged bundle.

### Solution

Replace npm aliases with `#` prefixed subpath imports using the `imports` field with conditional resolution which:
- Works in Node: `#os` resolves to native `os` builtin
- Works in Bare: `#os` resolves to `bare-os` package
- Staging works: `bare-module-traverse` follows `imports` field during analysis
- Expo-safe: Won't conflict with React Native's module resolution

### How it was tested

**Setup:**
- [x] Built `@qvac/registry-client` with changes
- [x] Installed in Pear POC app via tarball

**Test 1: Local Pear run**
- [x] `pear run .` works without errors
- [x] Registry client initializes correctly

**Test 2: Staged app on remote machine**
- [x] `pear stage --compact <channel> .` completes
- [x] Stage analysis shows `bare-os`, `bare-path`, `bare-fs` included in bundle
- [x] Remote `pear run pear://<key>` works without `MODULE_NOT_FOUND` errors

**Test 3: Node.js CLI usage**
- [x] `npx qvac-registry <command>` works (uses native Node.js builtins)