### PR TITLE
Remove leftover Hyperdrive mention

### DIFF
--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       gguf_model:
-        description: 'GGUF Model to benchmark (HuggingFace format: "owner/repo:quantization" or Hyperdrive: "hd://key/model.gguf")'
+        description: 'GGUF Model to benchmark (HuggingFace format: "owner/repo:quantization")'
         required: true
         default: "ChristianAzinn/gte-large-gguf:F16"
         type: string

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       gguf_model:
-        description: 'GGUF Model to benchmark (HuggingFace format: "owner/repo:quantization" or Hyperdrive: "hd://key/model.gguf")'
+        description: 'GGUF Model to benchmark (HuggingFace format: "owner/repo:quantization")'
         required: true
         default: "bartowski/Llama-3.2-1B-Instruct-GGUF:Q4_0"
         type: string


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Benchmark workflow input docs for both `llm` and `embed` still mention Hyperdrive GGUF URLs. That stale wording can mislead users about accepted model input formats.

## 📝 How does it solve it?

- Updates `.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml` to remove the Hyperdrive example from `gguf_model` input description.
- Updates `.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml` with the same wording fix so both workflows stay consistent.

## 🧪 How was it tested?

- No runtime/test execution needed; change is limited to workflow input description text.