### PR TITLE
QVAC-13348 fix: Switch imports to bare-* for crossruntime compatibility

### DIFF
--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -325,15 +325,10 @@ jobs:
         shell: bash
         run: npm run lint
 
-      - name: Unit tests (node)
+      - name: Unit tests
         working-directory: ${{ env.PKG_DIR }}/client
         shell: bash
         run: npm run test:unit
-
-      - name: Unit tests (bare)
-        working-directory: ${{ env.PKG_DIR }}/client
-        shell: bash
-        run: npm run test:unit:bare
 
       - name: Validate typings
         working-directory: ${{ env.PKG_DIR }}/client

--- a/packages/qvac-lib-registry-server/client/bin/cli.js
+++ b/packages/qvac-lib-registry-server/client/bin/cli.js
@@ -1,10 +1,10 @@
-#!/usr/bin/env node
+#!/usr/bin/env bare
 'use strict'
 
 const { command, flag, arg, summary, header, footer, description } = require('paparam')
 const { QVACRegistryClient } = require('../index')
 const IdEnc = require('hypercore-id-encoding')
-const path = require('path')
+const path = require('bare-path')
 
 const VERSION = require('../package.json').version
 

--- a/packages/qvac-lib-registry-server/client/examples/download-all-models.js
+++ b/packages/qvac-lib-registry-server/client/examples/download-all-models.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const path = require('path')
-const fs = require('fs')
+const path = require('bare-path')
+const fs = require('bare-fs')
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 
 const { QVACRegistryClient } = require('../index')
 
-async function downloadAllModelsExample () {
+async function downloadAllModelsExample() {
   const tmpStorage = path.join(process.cwd(), '.cache', `registry-${Date.now()}`)
   const client = new QVACRegistryClient({
     registryCoreKey: process.env.QVAC_REGISTRY_CORE_KEY,

--- a/packages/qvac-lib-registry-server/client/examples/download-all-models.js
+++ b/packages/qvac-lib-registry-server/client/examples/download-all-models.js
@@ -6,7 +6,7 @@ require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 
 const { QVACRegistryClient } = require('../index')
 
-async function downloadAllModelsExample() {
+async function downloadAllModelsExample () {
   const tmpStorage = path.join(process.cwd(), '.cache', `registry-${Date.now()}`)
   const client = new QVACRegistryClient({
     registryCoreKey: process.env.QVAC_REGISTRY_CORE_KEY,

--- a/packages/qvac-lib-registry-server/client/examples/download-model.js
+++ b/packages/qvac-lib-registry-server/client/examples/download-model.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const path = require('path')
+const path = require('bare-path')
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 
 const { QVACRegistryClient } = require('../index')
-const os = require('os')
+const os = require('bare-os')
 
 async function downloadModelExample () {
   const tmpStorage = path.join(os.tmpdir(), `qvac-registry-download-${Date.now()}`)

--- a/packages/qvac-lib-registry-server/client/examples/example.js
+++ b/packages/qvac-lib-registry-server/client/examples/example.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const path = require('path')
+const path = require('bare-path')
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 
 const { QVACRegistryClient } = require('../index')
 const IdEnc = require('hypercore-id-encoding')
-const os = require('os')
+const os = require('bare-os')
 
 async function example () {
   const tmpStorage = path.join(os.tmpdir(), `qvac-registry-example-${Date.now()}`)

--- a/packages/qvac-lib-registry-server/client/examples/verify-checksums.js
+++ b/packages/qvac-lib-registry-server/client/examples/verify-checksums.js
@@ -13,8 +13,8 @@
  *   1 - One or more checksum mismatches found
  */
 
-const path = require('path')
-const fs = require('fs')
+const path = require('bare-path')
+const fs = require('bare-fs')
 const crypto = require('crypto')
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
 

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -9,8 +9,8 @@ const Corestore = require('corestore')
 const Hyperswarm = require('hyperswarm')
 const Hyperblobs = require('hyperblobs')
 const IdEnc = require('hypercore-id-encoding')
-const path = require('path')
-const fs = require('fs')
+const path = require('bare-path')
+const fs = require('bare-fs')
 
 class QVACRegistryClient extends ReadyResource {
   constructor (opts = {}) {

--- a/packages/qvac-lib-registry-server/client/lib/config.js
+++ b/packages/qvac-lib-registry-server/client/lib/config.js
@@ -3,8 +3,8 @@
 const { getEnv } = require('../utils/env')
 const { ENV_KEYS } = require('@qvac/registry-schema')
 const Logger = require('./logger')
-const os = require('os')
-const path = require('path')
+const os = require('bare-os')
+const path = require('bare-path')
 
 const DEFAULT_REGISTRY_CORE_KEY = 'u6pq8h3kof7ck9g6kjusykfxaxqaqtnoydq15hhyuzrf55nt384y'
 

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -23,8 +23,7 @@
     "NOTICE"
   ],
   "scripts": {
-    "test:unit": "brittle tests/unit/*.test.js",
-    "test:unit:bare": "brittle-bare tests/unit/*.test.js",
+    "test:unit": "brittle-bare tests/unit/*.test.js",
     "test": "npm run test:unit && npm run test:integration",
     "lint": "standard",
     "lint:fix": "standard --fix",
@@ -36,17 +35,14 @@
     "b4a": "^1.6.7",
     "bare-fs": "^4.5.2",
     "bare-os": "^3.6.2",
+    "bare-path": "^3.0.0",
     "bare-process": "^4.2.2",
     "corestore": "^7.4.5",
-    "fs": "npm:bare-node-fs",
     "hyperblobs": "^2.8.0",
     "hypercore-id-encoding": "^1.3.0",
     "hyperdb": "^4.16.1",
     "hyperswarm": "^4.14.0",
-    "os": "npm:bare-node-os",
     "paparam": "^1.10.0",
-    "path": "npm:bare-node-path",
-    "process": "npm:bare-node-process",
     "ready-resource": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Problem

Staged Pear apps fail at runtime with `MODULE_NOT_FOUND: Cannot find module 'os'`.

**Root cause:** The `@qvac/registry-client` package used npm aliases (`"os": "npm:bare-node-os"`) to provide Bare-compatible shims. However, `pear stage --compact` uses `bare-module-traverse` for static analysis, which does not follow npm aliases. The aliased packages are not included in the staged bundle.

### Solution

Since all consumers of `@qvac/registry-client` run in Bare context (`@qvac/sdk`, addon examples), simplify by making the package Bare-only:
- Use `bare-os`, `bare-path`, `bare-fs` directly instead of npm aliases
- Change CLI shebang from `#!/usr/bin/env node` to `#!/usr/bin/env bare`
- Update `test:unit` to use `brittle-bare`
- Remove redundant `test:unit:bare` script
- Update CI to single Bare test step

### How it was tested

**Setup:**
- [x] Built `@qvac/registry-client` with changes
- [x] Installed in Pear POC app via tarball

**Test 1: Local Pear run**
- [x] `pear run .` works without errors
- [x] Registry client initializes correctly

**Test 2: Staged app on remote machine**
- [x] `pear stage --compact <channel> .` completes
- [x] Stage analysis shows `bare-os`, `bare-path`, `bare-fs` included in bundle
- [x] Remote `pear run pear://<key>` works without `MODULE_NOT_FOUND` errors

**Test 3: Node.js CLI usage**
- [x] `npx qvac-registry <command>` works (uses native Node.js builtins)