### PR TITLE
release(qvac-registry-client): v0.1.7

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.1.7]
+
+Release Date: 2026-02-19
+
+### 🐛 Fixed
+
+- Fix Pear app crash (`MODULE_NOT_FOUND: Cannot find module 'os'`) by replacing npm aliases with `#`-prefixed subpath imports for cross-runtime Bare/Node.js compatibility (#446)
+- Update stale `DEFAULT_REGISTRY_CORE_KEY` to current production registry
+
 ## [0.1.6]
 
 Release Date: 2026-02-17

--- a/packages/qvac-lib-registry-server/client/bin/cli.js
+++ b/packages/qvac-lib-registry-server/client/bin/cli.js
@@ -4,7 +4,7 @@
 const { command, flag, arg, summary, header, footer, description } = require('paparam')
 const { QVACRegistryClient } = require('../index')
 const IdEnc = require('hypercore-id-encoding')
-const path = require('path')
+const path = require('#path')
 
 const VERSION = require('../package.json').version
 
@@ -23,7 +23,7 @@ function createClient (parentFlags) {
 }
 
 function getRootFlags (cmd) {
-  let current = cmd
+  let current = cmd.command || cmd
   while (current.parent) current = current.parent
   return current.flags || {}
 }

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -9,8 +9,8 @@ const Corestore = require('corestore')
 const Hyperswarm = require('hyperswarm')
 const Hyperblobs = require('hyperblobs')
 const IdEnc = require('hypercore-id-encoding')
-const path = require('path')
-const fs = require('fs')
+const path = require('#path')
+const fs = require('#fs')
 
 class QVACRegistryClient extends ReadyResource {
   constructor (opts = {}) {

--- a/packages/qvac-lib-registry-server/client/lib/compat/fs.js
+++ b/packages/qvac-lib-registry-server/client/lib/compat/fs.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('fs')

--- a/packages/qvac-lib-registry-server/client/lib/compat/os.js
+++ b/packages/qvac-lib-registry-server/client/lib/compat/os.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('os')

--- a/packages/qvac-lib-registry-server/client/lib/compat/path.js
+++ b/packages/qvac-lib-registry-server/client/lib/compat/path.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('path')

--- a/packages/qvac-lib-registry-server/client/lib/config.js
+++ b/packages/qvac-lib-registry-server/client/lib/config.js
@@ -3,10 +3,10 @@
 const { getEnv } = require('../utils/env')
 const { ENV_KEYS } = require('@qvac/registry-schema')
 const Logger = require('./logger')
-const os = require('os')
-const path = require('path')
+const os = require('#os')
+const path = require('#path')
 
-const DEFAULT_REGISTRY_CORE_KEY = 'u6pq8h3kof7ck9g6kjusykfxaxqaqtnoydq15hhyuzrf55nt384y'
+const DEFAULT_REGISTRY_CORE_KEY = 'uf1fm44uzockp6azhcdiqt1esjgm65fwtimsh946e8kwysdes9ko'
 
 class RegistryConfig {
   constructor (opts = {}) {

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -12,6 +12,20 @@
     ".": "./index.js",
     "./types": "./index.d.ts"
   },
+  "imports": {
+    "#os": {
+      "bare": "bare-os",
+      "default": "./lib/compat/os.js"
+    },
+    "#path": {
+      "bare": "bare-path",
+      "default": "./lib/compat/path.js"
+    },
+    "#fs": {
+      "bare": "bare-fs",
+      "default": "./lib/compat/fs.js"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",
@@ -36,17 +50,14 @@
     "b4a": "^1.6.7",
     "bare-fs": "^4.5.2",
     "bare-os": "^3.6.2",
+    "bare-path": "^3.0.0",
     "bare-process": "^4.2.2",
     "corestore": "^7.4.5",
-    "fs": "npm:bare-node-fs",
     "hyperblobs": "^2.8.0",
     "hypercore-id-encoding": "^1.3.0",
     "hyperdb": "^4.16.1",
     "hyperswarm": "^4.14.0",
-    "os": "npm:bare-node-os",
     "paparam": "^1.10.0",
-    "path": "npm:bare-node-path",
-    "process": "npm:bare-node-process",
     "ready-resource": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## What problem does this PR solve?

Pear app crashes with `MODULE_NOT_FOUND: Cannot find module 'os'` because `pear stage --compact` doesn't follow npm aliases. Also ships the stale registry core key fix from #446.

## How does it solve it?

- Replace npm aliases (`"os": "npm:bare-node-os"`, etc.) with `#`-prefixed subpath imports using conditional `bare`/`default` resolution in `imports` field
- Add `lib/compat/` wrappers for Node.js builtin re-exports
- Update `DEFAULT_REGISTRY_CORE_KEY` to current production registry
- Bump version to `0.1.7`, update CHANGELOG

## Breaking changes

None.

Made with [Cursor](https://cursor.com)