### PR TITLE
QVAC-13360: Replaced llama-cpp port with qvac-fabric

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-embed/CMakeLists.txt
@@ -7,7 +7,7 @@ if(BUILD_TESTING)
   list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
 
-option(VK_PROFILING "Force vk performance logging in llama-cpp" OFF)
+option(VK_PROFILING "Force vk performance logging in qvac-fabric" OFF)
 if(VK_PROFILING)
   list(APPEND VCPKG_MANIFEST_FEATURES "vk-profiling")
 endif()

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg-configuration.json
@@ -4,7 +4,7 @@
   ],
   "default-registry": {
     "kind": "git",
-    "baseline": "7cecf33d57bce5a9f8ab2fff4481fcbc01154a55",
+    "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",
     "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
@@ -1,12 +1,12 @@
 {
   "dependencies": [
     {
-      "name": "llama-cpp",
-      "version>=": "7248.1.2"
-    },
-    {
       "name": "opencl",
       "platform": "android"
+    },
+    {
+      "name": "qvac-fabric",
+      "version>=": "7248.1.2"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
@@ -25,15 +25,21 @@
       ]
     },
     "vk-profiling": {
-      "description": "Force vk performance logging in llama-cpp",
+      "description": "Force vk performance logging in qvac-fabric",
       "dependencies": [
         {
-          "name": "llama-cpp",
+          "name": "qvac-fabric",
           "features": [
             "force-profiler"
           ]
         }
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "name": "qvac-lib-inference-addon-cpp",
+      "version": "0.12.2"
+    }
+  ]
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
@@ -7,7 +7,7 @@ if(BUILD_TESTING)
   list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
 
-option(VK_PROFILING "Force vk performance logging in llama-cpp" OFF)
+option(VK_PROFILING "Force vk performance logging in qvac-fabric" OFF)
 if(VK_PROFILING)
   list(APPEND VCPKG_MANIFEST_FEATURES "vk-profiling")
 endif()

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
@@ -4,7 +4,7 @@
   ],
   "default-registry": {
     "kind": "git",
-    "baseline": "277ee854834679a7f71ef465be968ffb72e7957a",
+    "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",
     "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
@@ -1,14 +1,14 @@
 {
   "dependencies": [
     {
-      "name": "llama-cpp",
-      "version>=": "7248.1.2"
-    },
-    {
       "name": "opencl",
       "platform": "android"
     },
     "picojson",
+    {
+      "name": "qvac-fabric",
+      "version>=": "7248.1.2"
+    },
     {
       "name": "qvac-lib-inference-addon-cpp",
       "version>=": "0.12.2"
@@ -26,15 +26,21 @@
       ]
     },
     "vk-profiling": {
-      "description": "Force vk performance logging in llama-cpp",
+      "description": "Force vk performance logging in qvac-fabric",
       "dependencies": [
         {
-          "name": "llama-cpp",
+          "name": "qvac-fabric",
           "features": [
             "force-profiler"
           ]
         }
       ]
     }
-  }
+  },
+  "overrides": [
+    {
+      "name": "qvac-lib-inference-addon-cpp",
+      "version": "0.12.2"
+    }
+  ]
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The vcpkg port `llama-cpp` has been replaced by `qvac-fabric` in the registry; both LLM and embed packages still referenced the old port.

## 📝 How does it solve it?

- **qvac-lib-infer-llamacpp-llm** and **qvac-lib-infer-llamacpp-embed**: replace `llama-cpp` with `qvac-fabric` (version ≥ 7248.1.2) in `vcpkg.json`; update the `vk-profiling` feature to use `qvac-fabric`; bump `vcpkg-configuration.json` default-registry baseline to `803c0d119ea002694963e89237c207ff6ecf47f6`; update `CMakeLists.txt` VK_PROFILING option description to "qvac-fabric"; add `overrides` for `qvac-lib-inference-addon-cpp` at 0.12.2 in `vcpkg.json` (new baseline would raise it to 1.1.1 otherwise).

**Change set:** 6 files (embed: vcpkg.json, vcpkg-configuration.json, CMakeLists.txt; llm: same). No API or code changes; CMake still uses `find_package(llama CONFIG)` and `llama::llama` / `llama::common` (provided by the qvac-fabric port).

## 🧪 How was it tested?

- Build and test of both packages with the new registry baseline and `qvac-fabric` port.
