### PR TITLE
release(qvac-registry-client): v0.1.7

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.1.7]
+
+Release Date: 2026-02-19
+
+### 🐛 Fixed
+
+- Fix Pear app crash (`MODULE_NOT_FOUND: Cannot find module 'os'`) by replacing npm aliases with `#`-prefixed subpath imports for cross-runtime Bare/Node.js compatibility (#446)
+- Update stale `DEFAULT_REGISTRY_CORE_KEY` to current production registry (#446)
+
 ## [0.1.6]
 
 Release Date: 2026-02-17

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## What problem does this PR solve?

Release `@qvac/registry-client@0.1.7` with the Pear runtime import fix and stale registry key update from #446.

## How does it solve it?

- Version bump to `0.1.7`
- Changelog update

All code changes already on `main` via #446.

## Breaking changes

None.
