### PR TITLE
fix: pass MODEL_S3_BUCKET secret to mobile test workflow

### DIFF
--- a/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -326,6 +326,8 @@ jobs:
       - name: Generate presigned URLs for OCR models
         working-directory: ./addon/${{ inputs.workdir || env.PKG_DIR }}
         shell: bash
+        env:
+          MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         run: |
           echo "🔑 Generating presigned URLs for OCR models..."
           chmod +x scripts/generate-ocr-presigned-urls.sh


### PR DESCRIPTION
## Summary
- Pass `MODEL_S3_BUCKET` secret as an environment variable to the presigned URL generation step in the mobile integration test workflow
- The `generate-ocr-presigned-urls.sh` script reads the bucket name from `MODEL_S3_BUCKET` env var, but it was not being set, causing the bucket name to be empty and model verification to fail

## Test plan
- [x] Trigger mobile integration tests and verify presigned URL generation succeeds
- [x] Verify the S3 bucket name appears in the CI logs