### PR TITLE
chore(ocr): bump version to 0.1.8

### DIFF
--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/CHANGELOG.md
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.1.8] - 2026-02-20
+
+### Added
+
+- Performance statistics reporting: detection time, recognition time, total time, and text regions count are now exposed via the stats API.
+- Architecture documentation for the OCR pipeline.
+- NOTICE file with complete third-party dependency attributions (models, JS, Python, C++).
+- Auto-download models via registry-client in examples.
+
+### Changed
+
+- Migrated to new C++ addon architecture for improved stability and maintainability.
+- Applied clang-tidy naming conventions across C++ codebase.
+- Standardized Apache 2.0 license and copyright headers across all files.
+- Replaced hardcoded S3 bucket references with repository secrets in CI workflows and scripts.
+- Updated registry key handling and switched to subpath imports for Bare compatibility.
+
 # [0.1.6] - 2026-02-09
 
 ### Changed

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/package.json
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-onnx",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "description": "OCR addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/release-notes/v0.1.8.md
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/release-notes/v0.1.8.md
@@ -1,0 +1,26 @@
+# QVAC OCR Addon v0.1.8 Release Notes
+
+This release migrates the OCR addon to the new C++ addon architecture, adds performance statistics reporting, and includes several infrastructure improvements for open-source readiness.
+
+## New C++ Addon Architecture
+
+The OCR addon has been migrated to the new standardized C++ addon architecture. This provides a more robust foundation with improved stability, better error handling, and consistent patterns shared across all QVAC inference addons.
+
+## Performance Statistics
+
+The addon now exposes detailed performance metrics through the stats API. After running OCR, you can access `response.stats` to get:
+
+- **totalTime**: End-to-end processing time
+- **detectionTime**: Time spent in the text detection phase
+- **recognitionTime**: Time spent in the text recognition phase
+- **textRegionsCount**: Number of text regions detected
+
+This enables benchmarking and performance monitoring in production.
+
+## Infrastructure and Licensing
+
+- Added complete NOTICE file with third-party dependency attributions covering models, JavaScript, Python, and C++ dependencies.
+- Standardized Apache 2.0 license headers across all source files.
+- CI workflows now use repository secrets instead of hardcoded S3 bucket references, preparing the package for open-source distribution.
+- Examples now auto-download models via the registry client on first run, removing the need for manual model setup.
+- Added architecture documentation describing the OCR pipeline internals.


### PR DESCRIPTION
## Summary
- Bump OCR addon version from 0.1.6 to 0.1.8
- Add changelog entry and release notes for all changes since 0.1.6

### Key changes in 0.1.8
- Migrated to new C++ addon architecture
- Added performance statistics reporting (detection time, recognition time, total time, text regions count)
- Added NOTICE file with third-party dependency attributions
- Standardized Apache 2.0 license headers
- Replaced hardcoded S3 bucket with repository secrets in CI
- Added architecture documentation
- Examples now auto-download models via registry client

## Test plan
- [ ] Verify release notes check passes in CI
- [ ] Verify version bump is detected correctly