### PR TITLE
release(qvac-registry-client): v0.1.8

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.8]
+
+Release Date: 2026-02-20
+
+### 🔧 Changed
+
+- Fix package name references in README to `@qvac/registry-client`
+
 ## [0.1.7]
 
 Release Date: 2026-02-19

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## What problem does this PR solve?

Publish `@qvac/registry-client@0.1.8` with README package name fix.

## How does it solve it?

- Version bump to `0.1.8`
- Changelog update

## Breaking changes

None.