### PR TITLE
QVAC-13377 feat: Add electron-forge plugin for native addon tree-shaking

### DIFF
--- a/packages/qvac-sdk/electron-forge/index.cjs
+++ b/packages/qvac-sdk/electron-forge/index.cjs
@@ -25,11 +25,15 @@
  *   1. Excludes unused @qvac addon packages based on qvac/addons.manifest.json
  *   2. Prunes non-target platform prebuilds after packaging
  *   3. Ensures asar: false (Forge default; required for Bare worker)
+ *
+ * Notes:
+ *   - macOS universal builds (arch: "universal") are not supported
  */
 
 "use strict";
 
 const { PluginBase } = require("@electron-forge/plugin-base");
+const { createRequire } = require("module");
 const path = require("path");
 const fs = require("fs");
 
@@ -38,6 +42,8 @@ const fs = require("fs");
 // ============================================
 
 const PREFIX = "[qvac:electron-forge]";
+
+const EXPECTED_FS_ERROR_CODES = new Set(["ENOENT", "EACCES", "EPERM", "ENOTDIR"]);
 
 const LOG_LEVELS = {
   off: 0,
@@ -79,8 +85,7 @@ const logger = {
     if (currentLevel >= LOG_LEVELS.debug) console.log(PREFIX, msg);
   },
   fsError(context, err) {
-    const EXPECTED_CODES = new Set(["ENOENT", "EACCES", "EPERM", "ENOTDIR"]);
-    if (err && EXPECTED_CODES.has(err.code)) return;
+    if (err && EXPECTED_FS_ERROR_CODES.has(err.code)) return;
     this.warn(`Unexpected error in ${context}: ${err?.message || err}`);
   },
 };
@@ -155,6 +160,28 @@ const MOBILE_PREBUILD_PATTERNS = [
   /[\\/]prebuilds[\\/]ios-/,
 ];
 
+function toArray(value) {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function createAddonIgnorePatterns(exclusions) {
+  const patterns = [];
+  for (const addon of exclusions) {
+    const parts = addon.split("/").map(escapeRegExp);
+    patterns.push(
+      new RegExp(
+        `[\\\\/]node_modules[\\\\/]${parts.join("[\\\\/]")}([\\\\/]|$)`,
+      ),
+    );
+  }
+  return patterns;
+}
+
 function isDir(dirPath) {
   try {
     return fs.statSync(dirPath).isDirectory();
@@ -181,7 +208,25 @@ function findQvacScopeDir(startDir) {
   }
 
   logger.debug(`Resolved SDK package: ${sdkPkg.name}`);
-  return path.dirname(path.dirname(sdkPkg.path));
+
+  // Use Node's resolution paths to handle monorepos, workspaces, and hoisted layouts.
+  const baseDir = path.resolve(startDir);
+  const req = createRequire(path.join(baseDir, "package.json"));
+  const nodeModulesDirs = req.resolve.paths(sdkPkg.name) || [];
+
+  for (const nodeModulesDir of nodeModulesDirs) {
+    const scopeDir = path.join(nodeModulesDir, "@qvac");
+    if (isDir(scopeDir)) return scopeDir;
+  }
+
+  // Fallback: derive from SDK path for flat node_modules layouts (npm/yarn/bun).
+  const derived = path.dirname(path.dirname(sdkPkg.path));
+  if (path.basename(derived) === "@qvac" && isDir(derived)) return derived;
+
+  throw new Error(
+    `Could not find @qvac packages. ` +
+      `Ensure dependencies are installed under node_modules (PnP is not supported).`,
+  );
 }
 
 /**
@@ -432,7 +477,10 @@ class QvacForgePlugin extends PluginBase {
       forgeConfig.packagerConfig = {};
     }
 
-    // 1. Set asar: false (Bare worker can't load from asar)
+    // 1. Block macOS universal builds early
+    this.checkForUniversalArch(forgeConfig);
+
+    // 2. Set asar: false (Bare worker can't load from asar)
     if (forgeConfig.packagerConfig.asar === true) {
       logger.warn(
         "asar is enabled — Bare worker may fail to load. Overriding to false.",
@@ -440,18 +488,15 @@ class QvacForgePlugin extends PluginBase {
     }
     forgeConfig.packagerConfig.asar = false;
 
-    // 2. Generate exclusion list for unused addons
+    // 3. Generate exclusion list for unused addons
     const exclusions = generateExclusionList(this.projectDir, this.strict);
 
-    // 3. Create ignore function
+    // 4. Merge ignore patterns to exclude unused addons + mobile prebuilds
     const existingIgnore = forgeConfig.packagerConfig.ignore;
-    forgeConfig.packagerConfig.ignore = this.createIgnoreFunction(
-      exclusions,
-      existingIgnore,
-    );
+    forgeConfig.packagerConfig.ignore = this.createIgnore(exclusions, existingIgnore);
 
-    // 4. Add afterPrune hook for prebuild pruning
-    const existingAfterPrune = forgeConfig.packagerConfig.afterPrune || [];
+    // 5. Add afterPrune hook for prebuild pruning
+    const existingAfterPrune = toArray(forgeConfig.packagerConfig.afterPrune);
     forgeConfig.packagerConfig.afterPrune = [
       ...existingAfterPrune,
       this.createPruneHook(),
@@ -461,46 +506,74 @@ class QvacForgePlugin extends PluginBase {
     return forgeConfig;
   }
 
-  createIgnoreFunction(exclusions, existingIgnore) {
-    return (filePath) => {
-      // Check existing ignore first
-      if (existingIgnore) {
-        if (typeof existingIgnore === "function" && existingIgnore(filePath)) {
-          return true;
-        }
-        if (existingIgnore instanceof RegExp && existingIgnore.test(filePath)) {
-          return true;
-        }
-        if (Array.isArray(existingIgnore)) {
-          for (const pattern of existingIgnore) {
-            if (pattern instanceof RegExp && pattern.test(filePath))
-              return true;
-            if (typeof pattern === "string" && filePath.includes(pattern))
-              return true;
-          }
-        }
+  /**
+   * Blocks macOS universal builds (darwin/universal)
+   * Forge expands universal targets before Packager hooks run, so we must detect
+   * it before pruning runs.
+   */
+  checkForUniversalArch(forgeConfig) {
+    if (forgeConfig?.packagerConfig?.arch === "universal") {
+      throw new Error(
+        `macOS universal packaging is not supported by @qvac/sdk/electron-forge. ` +
+          `Native addon prebuilds are architecture-specific and cannot be merged. ` +
+          `Build separate darwin-arm64 and darwin-x64 packages instead.`,
+      );
+    }
+
+    const args = process.argv.slice(2);
+    let arch = null;
+    for (let i = 0; i < args.length; i += 1) {
+      const arg = args[i];
+
+      if (arg === "--arch" || arg === "-a") {
+        arch = args[i + 1] || null;
+        continue;
       }
 
-      // Check @qvac addon exclusions
-      for (const addon of exclusions) {
-        // Match paths like /node_modules/@qvac/embed-llamacpp/
-        if (
-          filePath.includes(`/node_modules/${addon}/`) ||
-          filePath.includes(`\\node_modules\\${addon}\\`)
-        ) {
-          return true;
-        }
+      if (typeof arg === "string" && arg.startsWith("--arch=")) {
+        arch = arg.slice("--arch=".length) || null;
+        continue;
       }
+    }
 
-      // Always exclude mobile prebuilds in desktop builds
-      for (const pattern of MOBILE_PREBUILD_PATTERNS) {
-        if (pattern.test(filePath)) {
-          return true;
+    if (arch === "universal") {
+      throw new Error(
+        `macOS universal packaging is not supported by @qvac/sdk/electron-forge. ` +
+          `Native addon prebuilds are architecture-specific and cannot be merged. ` +
+          `Build separate darwin-arm64 and darwin-x64 packages instead.`,
+      );
+    }
+  }
+
+  createIgnore(exclusions, existingIgnore) {
+    const addonIgnorePatterns = createAddonIgnorePatterns(exclusions);
+
+    if (typeof existingIgnore === "function") {
+      return (filePath) => {
+        if (existingIgnore(filePath)) return true;
+
+        // Check @qvac addon exclusions
+        for (const pattern of addonIgnorePatterns) {
+          if (pattern.test(filePath)) return true;
         }
-      }
 
-      return false;
-    };
+        // Always exclude mobile prebuilds in desktop builds
+        for (const pattern of MOBILE_PREBUILD_PATTERNS) {
+          if (pattern.test(filePath)) return true;
+        }
+
+        return false;
+      };
+    }
+
+    const patterns = [
+      ...toArray(existingIgnore),
+      /^\/out\//,
+      ...MOBILE_PREBUILD_PATTERNS,
+      ...addonIgnorePatterns,
+    ];
+
+    return patterns;
   }
 
   createPruneHook() {

--- a/packages/qvac-sdk/electron-forge/index.cjs
+++ b/packages/qvac-sdk/electron-forge/index.cjs
@@ -1,0 +1,530 @@
+/**
+ * @qvac/sdk/electron-forge
+ *
+ * Electron Forge plugin for QVAC SDK.
+ * Provides automatic native addon tree-shaking and prebuild pruning.
+ *
+ * Usage:
+ *   // forge.config.cjs
+ *   const QvacForgePlugin = require("@qvac/sdk/electron-forge");
+ *
+ *   module.exports = {
+ *     plugins: [new QvacForgePlugin()],
+ *     makers: [...],
+ *   };
+ *
+ *   // With options:
+ *   new QvacForgePlugin({ logLevel: "debug" })
+ *
+ * Options:
+ *   - logLevel: "off" | "error" | "warn" | "info" | "debug"
+ *   - strict: boolean - throws on missing manifest instead of warning
+ *   - projectDir: string - override project root directory
+ *
+ * What it does automatically:
+ *   1. Excludes unused @qvac addon packages based on qvac/addons.manifest.json
+ *   2. Prunes non-target platform prebuilds after packaging
+ *   3. Ensures asar: false (Forge default; required for Bare worker)
+ */
+
+"use strict";
+
+const { PluginBase } = require("@electron-forge/plugin-base");
+const path = require("path");
+const fs = require("fs");
+
+// ============================================
+// Logger
+// ============================================
+
+const PREFIX = "[qvac:electron-forge]";
+
+const LOG_LEVELS = {
+  off: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+function getDefaultLevel() {
+  const level = process.env.QVAC_LOG_LEVEL?.toLowerCase();
+  return level && level in LOG_LEVELS ? level : "info";
+}
+
+let currentLevel = LOG_LEVELS[getDefaultLevel()];
+
+function setLogLevel(level) {
+  if (!(level in LOG_LEVELS)) {
+    console.warn(
+      `${PREFIX} Invalid log level "${level}", using "info". Valid: ${Object.keys(LOG_LEVELS).join(", ")}`,
+    );
+    currentLevel = LOG_LEVELS.info;
+    return;
+  }
+  currentLevel = LOG_LEVELS[level];
+}
+
+const logger = {
+  error(msg) {
+    if (currentLevel >= LOG_LEVELS.error) console.error(PREFIX, msg);
+  },
+  warn(msg) {
+    if (currentLevel >= LOG_LEVELS.warn) console.warn(PREFIX, msg);
+  },
+  info(msg) {
+    if (currentLevel >= LOG_LEVELS.info) console.log(PREFIX, msg);
+  },
+  debug(msg) {
+    if (currentLevel >= LOG_LEVELS.debug) console.log(PREFIX, msg);
+  },
+  fsError(context, err) {
+    const EXPECTED_CODES = new Set(["ENOENT", "EACCES", "EPERM", "ENOTDIR"]);
+    if (err && EXPECTED_CODES.has(err.code)) return;
+    this.warn(`Unexpected error in ${context}: ${err?.message || err}`);
+  },
+};
+
+// ============================================
+// Manifest Reader
+// ============================================
+
+/**
+ * Reads qvac/addons.manifest.json from the project directory.
+ *
+ * @param {string} projectDir - Project root directory
+ * @param {boolean} strict - If true, throws on missing/invalid manifest
+ * @returns {Set<string>|null} Set of required addon names, or null if not found
+ */
+function readManifest(projectDir, strict = false) {
+  const manifestPath = path.join(projectDir, "qvac", "addons.manifest.json");
+
+  if (!fs.existsSync(manifestPath)) {
+    const msg =
+      "No qvac/addons.manifest.json found. Run 'npx qvac bundle sdk' first.";
+    if (strict) throw new Error(msg);
+    logger.warn(msg);
+    return null;
+  }
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    return new Set(manifest.addons || []);
+  } catch (err) {
+    const msg = `Failed to parse addons.manifest.json: ${err.message}`;
+    if (strict) throw new Error(msg);
+    logger.error(msg);
+    return null;
+  }
+}
+
+// ============================================
+// SDK Package Resolution
+// ============================================
+
+const SDK_PACKAGE_NAMES = ["@qvac/sdk", "@tetherto/sdk-mono"];
+
+/**
+ * Resolves the SDK package entry point using Node's module resolution.
+ * Tries each known package name in order.
+ *
+ * @param {string} startDir - Directory to start resolution from
+ * @returns {{ name: string, path: string }|null} Package info or null if not found
+ */
+function resolveSDKPackage(startDir) {
+  for (const name of SDK_PACKAGE_NAMES) {
+    try {
+      const pkgPath = require.resolve(`${name}/package`, { paths: [startDir] });
+      return { name, path: pkgPath };
+    } catch {
+      // Try next package name
+    }
+  }
+  return null;
+}
+
+// ============================================
+// Addon Discovery
+// ============================================
+
+/**
+ * Mobile prebuild patterns to always exclude in desktop builds.
+ */
+const MOBILE_PREBUILD_PATTERNS = [
+  /[\\/]prebuilds[\\/]android-/,
+  /[\\/]prebuilds[\\/]ios-/,
+];
+
+function isDir(dirPath) {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch (err) {
+    logger.fsError("isDir", err);
+    return false;
+  }
+}
+
+/**
+ * Finds the @qvac scope directory using Node's module resolution.
+ *
+ * @param {string} startDir - Directory to start searching from
+ * @returns {string} Path to node_modules/@qvac
+ * @throws {Error} If @qvac scope directory cannot be found
+ */
+function findQvacScopeDir(startDir) {
+  const sdkPkg = resolveSDKPackage(startDir);
+  if (!sdkPkg) {
+    throw new Error(
+      `Could not find QVAC SDK. ` +
+        `Ensure one of [${SDK_PACKAGE_NAMES.join(", ")}] is installed.`,
+    );
+  }
+
+  logger.debug(`Resolved SDK package: ${sdkPkg.name}`);
+  return path.dirname(path.dirname(sdkPkg.path));
+}
+
+/**
+ * Discovers installed @qvac addon packages by scanning node_modules/@qvac
+ * for packages that have `addon: true` in package.json.
+ *
+ * @param {string} projectDir - Project root directory
+ * @returns {string[]} Array of package names like "@qvac/llm-llamacpp"
+ */
+function discoverQvacAddonPackages(projectDir) {
+  let scopeDir;
+  try {
+    scopeDir = findQvacScopeDir(projectDir);
+  } catch (err) {
+    logger.warn(err.message);
+    return [];
+  }
+
+  let entries;
+  try {
+    entries = fs.readdirSync(scopeDir);
+  } catch (err) {
+    logger.fsError("discoverQvacAddonPackages", err);
+    return [];
+  }
+
+  const discovered = [];
+
+  for (const name of entries) {
+    const pkgDir = path.join(scopeDir, name);
+    if (!isDir(pkgDir)) continue;
+
+    let isAddon = false;
+
+    const pkgJsonPath = path.join(pkgDir, "package.json");
+    if (fs.existsSync(pkgJsonPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+        isAddon = pkg.addon === true;
+      } catch (err) {
+        logger.warn(`Failed to parse ${pkgJsonPath}: ${err.message}`);
+      }
+    }
+
+    if (isAddon) {
+      discovered.push(`@qvac/${name}`);
+    }
+  }
+
+  discovered.sort();
+  return discovered;
+}
+
+/**
+ * Generates list of @qvac addon packages to exclude.
+ *
+ * @param {string} projectDir - Project root directory
+ * @param {boolean} strict - If true, throws on missing manifest
+ * @returns {string[]} Array of package names to exclude
+ */
+function generateExclusionList(projectDir, strict = false) {
+  const requiredAddons = readManifest(projectDir, strict);
+  const exclusions = [];
+
+  if (requiredAddons) {
+    const addonPackages = discoverQvacAddonPackages(projectDir);
+
+    if (addonPackages.length === 0) {
+      logger.warn(
+        "No @qvac addon packages discovered. Skipping addon exclusions.",
+      );
+    }
+
+    for (const pkg of addonPackages) {
+      if (!requiredAddons.has(pkg)) {
+        exclusions.push(pkg);
+        logger.info(`Excluding unused addon: ${pkg}`);
+      } else {
+        logger.info(`Including required addon: ${pkg}`);
+      }
+    }
+  }
+
+  return exclusions;
+}
+
+// ============================================
+// Prebuild Pruning
+// ============================================
+
+/**
+ * Recursively finds all prebuilds directories under a root path.
+ *
+ * @param {string} rootPath - Root directory to search
+ * @returns {string[]} Array of absolute paths to prebuilds directories
+ */
+function findPrebuildsDirs(rootPath) {
+  const results = [];
+
+  function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      logger.fsError("findPrebuildsDirs", err);
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.name === "prebuilds") {
+        results.push(fullPath);
+      } else if (entry.name !== "node_modules" || dir === rootPath) {
+        walk(fullPath);
+      }
+    }
+  }
+
+  walk(rootPath);
+  return results;
+}
+
+/**
+ * Estimates the size of a directory.
+ *
+ * @param {string} dirPath - Directory path
+ * @returns {number} Size in bytes
+ */
+function getDirSize(dirPath) {
+  let size = 0;
+
+  function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      logger.fsError("getDirSize", err);
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else {
+        try {
+          size += fs.statSync(fullPath).size;
+        } catch (err) {
+          logger.fsError("getDirSize.stat", err);
+        }
+      }
+    }
+  }
+
+  walk(dirPath);
+  return size;
+}
+
+/**
+ * Prunes prebuilds for a given path, keeping only target platform-arch.
+ *
+ * @param {string} buildPath - Path to the app directory containing node_modules
+ * @param {string} platform - Target platform (darwin, win32, linux)
+ * @param {string} arch - Target architecture (arm64, x64, etc.)
+ * @returns {{ deleted: number, bytes: number }}
+ */
+function prunePrebuildsForPath(buildPath, platform, arch) {
+  const nodeModulesPath = path.join(buildPath, "node_modules");
+
+  if (!fs.existsSync(nodeModulesPath)) {
+    logger.debug("No node_modules found, skipping prebuild pruning.");
+    return { deleted: 0, bytes: 0 };
+  }
+
+  const keepPrefix = `${platform}-${arch}`;
+  logger.debug(`Keeping prefix: ${keepPrefix}`);
+
+  const prebuildsDirs = findPrebuildsDirs(nodeModulesPath);
+  let totalDeleted = 0;
+  let totalBytes = 0;
+
+  for (const prebuildsDir of prebuildsDirs) {
+    let entries;
+    try {
+      entries = fs.readdirSync(prebuildsDir, { withFileTypes: true });
+    } catch (err) {
+      logger.fsError("prunePrebuildsForPath", err);
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      // Keep if entry matches target platform-arch (prefix match for musl variants)
+      const shouldKeep = entry.name.startsWith(keepPrefix);
+
+      if (!shouldKeep) {
+        const fullPath = path.join(prebuildsDir, entry.name);
+        try {
+          const size = getDirSize(fullPath);
+          totalBytes += size;
+          fs.rmSync(fullPath, { recursive: true, force: true });
+          totalDeleted++;
+          logger.debug(`Deleted: ${entry.name}`);
+        } catch (err) {
+          logger.warn(`Failed to delete ${fullPath}: ${err.message}`);
+        }
+      }
+    }
+  }
+
+  return { deleted: totalDeleted, bytes: totalBytes };
+}
+
+// ============================================
+// QVAC Forge Plugin
+// ============================================
+
+class QvacForgePlugin extends PluginBase {
+  name = "qvac";
+
+  constructor(config = {}) {
+    super(config);
+    this.projectDir = config.projectDir || process.cwd();
+    this.strict = config.strict || false;
+
+    if (config.logLevel) {
+      setLogLevel(config.logLevel);
+    }
+
+    logger.debug("QvacForgePlugin initialized");
+    logger.debug(`Project directory: ${this.projectDir}`);
+  }
+
+  getHooks() {
+    return {
+      resolveForgeConfig: this.configurePackager.bind(this),
+    };
+  }
+
+  async configurePackager(forgeConfig) {
+    logger.info("Configuring packager for QVAC...");
+
+    // Ensure packagerConfig exists
+    if (!forgeConfig.packagerConfig) {
+      forgeConfig.packagerConfig = {};
+    }
+
+    // 1. Set asar: false (Bare worker can't load from asar)
+    if (forgeConfig.packagerConfig.asar === true) {
+      logger.warn(
+        "asar is enabled — Bare worker may fail to load. Overriding to false.",
+      );
+    }
+    forgeConfig.packagerConfig.asar = false;
+
+    // 2. Generate exclusion list for unused addons
+    const exclusions = generateExclusionList(this.projectDir, this.strict);
+
+    // 3. Create ignore function
+    const existingIgnore = forgeConfig.packagerConfig.ignore;
+    forgeConfig.packagerConfig.ignore = this.createIgnoreFunction(
+      exclusions,
+      existingIgnore,
+    );
+
+    // 4. Add afterPrune hook for prebuild pruning
+    const existingAfterPrune = forgeConfig.packagerConfig.afterPrune || [];
+    forgeConfig.packagerConfig.afterPrune = [
+      ...existingAfterPrune,
+      this.createPruneHook(),
+    ];
+
+    logger.debug("Packager configuration complete");
+    return forgeConfig;
+  }
+
+  createIgnoreFunction(exclusions, existingIgnore) {
+    return (filePath) => {
+      // Check existing ignore first
+      if (existingIgnore) {
+        if (typeof existingIgnore === "function" && existingIgnore(filePath)) {
+          return true;
+        }
+        if (existingIgnore instanceof RegExp && existingIgnore.test(filePath)) {
+          return true;
+        }
+        if (Array.isArray(existingIgnore)) {
+          for (const pattern of existingIgnore) {
+            if (pattern instanceof RegExp && pattern.test(filePath))
+              return true;
+            if (typeof pattern === "string" && filePath.includes(pattern))
+              return true;
+          }
+        }
+      }
+
+      // Check @qvac addon exclusions
+      for (const addon of exclusions) {
+        // Match paths like /node_modules/@qvac/embed-llamacpp/
+        if (
+          filePath.includes(`/node_modules/${addon}/`) ||
+          filePath.includes(`\\node_modules\\${addon}\\`)
+        ) {
+          return true;
+        }
+      }
+
+      // Always exclude mobile prebuilds in desktop builds
+      for (const pattern of MOBILE_PREBUILD_PATTERNS) {
+        if (pattern.test(filePath)) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+  }
+
+  createPruneHook() {
+    return (buildPath, electronVersion, platform, arch, done) => {
+      logger.info(`Pruning prebuilds for ${platform}-${arch}...`);
+
+      try {
+        const result = prunePrebuildsForPath(buildPath, platform, arch);
+        const mbSaved = (result.bytes / 1024 / 1024).toFixed(1);
+        logger.info(
+          `Pruned ${result.deleted} prebuild dirs (~${mbSaved} MB reclaimed)`,
+        );
+        done();
+      } catch (err) {
+        logger.error(`Prebuild pruning failed: ${err.message}`);
+        done(err);
+      }
+    };
+  }
+}
+
+// ============================================
+// Exports
+// ============================================
+
+module.exports = QvacForgePlugin;
+module.exports.setLogLevel = setLogLevel;

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -55,7 +55,10 @@
     "./logging": {
       "import": "./dist/logging/index.js"
     },
-    "./pear-pre": "./dist/pear/pre.js"
+    "./pear-pre": "./dist/pear/pre.js",
+    "./electron-forge": {
+      "require": "./electron-forge/index.cjs"
+    }
   },
   "imports": {
     "#rpc": {
@@ -72,6 +75,7 @@
   "files": [
     "bare-imports.json",
     "dist/**/*",
+    "electron-forge/**/*",
     "expo/plugins/patches/**/*",
     "!dist/**/*.map",
     "!**/package-lock.json",
@@ -130,6 +134,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@electron-forge/plugin-base": "^7.11.1",
     "@expo/config-plugins": "^54.0.1",
     "@lancedb/lancedb": "^0.21.3",
     "@modelcontextprotocol/sdk": "^1.12.1",
@@ -166,6 +171,7 @@
     "typescript-eslint": "^8.39.0"
   },
   "peerDependencies": {
+    "@electron-forge/plugin-base": "^7.11.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@qvac/cli": "^0.1.2",
     "bare-abort-controller": "^1.0.0",
@@ -201,7 +207,7 @@
     "tar-stream": "^3.1.7"
   },
   "peerDependenciesMeta": {
-    "@qvac/cli": {
+    "@electron-forge/plugin-base": {
       "optional": true
     },
     "@modelcontextprotocol/sdk": {

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -207,6 +207,9 @@
     "tar-stream": "^3.1.7"
   },
   "peerDependenciesMeta": {
+    "@qvac/cli": {
+      "optional": true
+    },
     "@electron-forge/plugin-base": {
       "optional": true
     },


### PR DESCRIPTION
### Problem

Electron apps using the SDK include all native addon packages even when only using a subset of plugins. This significantly increases app size and distribution costs.

**Current state:**

- All `@qvac` addon packages bundled regardless of usage
- All platform prebuilds included (darwin, win32, linux, android, ios)
- No automated way to exclude unused addons in Electron Forge projects

### Solution

Add `@qvac/sdk/electron-forge` — a self-contained Forge plugin that provides automatic native addon tree-shaking and prebuild pruning:

**1. Manifest-based addon exclusion**

- Reads `qvac/addons.manifest.json` (generated by CLI)
- Excludes unused `@qvac` addon packages via packager `ignore` config
- Only includes addons required by configured plugins

**2. Prebuild pruning (afterPrune hook)**

- Removes non-target platform prebuilds after packaging
- Keeps only the target platform-arch (e.g., `darwin-arm64`)
- Automatically excludes mobile prebuilds (android-_, ios-_)

**3. ASAR compatibility**

- Ensures `asar: false` (Forge default, required for Bare worker)
- Warns and overrides if user has explicitly enabled asar

**4. Hook composition**

- Merges with user's existing `ignore` patterns (functions, RegExp, strings, arrays)
- Appends to existing `afterPrune` hooks

### User Experience

**Minimal setup:**

`forge.config.cjs`:

```javascript
const QvacForgePlugin = require("@qvac/sdk/electron-forge");

module.exports = {
  plugins: [new QvacForgePlugin()],
  makers: [
    { name: "@electron-forge/maker-dmg" },
    {
      name: "@electron-forge/maker-zip",
      platforms: ["darwin", "linux", "win32"],
    },
  ],
};
```

**With options:**

```javascript
new QvacForgePlugin({
  logLevel: "debug", // "off" | "error" | "warn" | "info" | "debug"
  projectDir: __dirname, // Project root (defaults to cwd)
  strict: false, // Throw on missing manifest
});
```

**Build output:**

```
[qvac:electron-forge] QvacForgePlugin initialized
[qvac:electron-forge] Configuring packager for QVAC...
[qvac:electron-forge] Excluding unused addon: @qvac/embed-llamacpp
[qvac:electron-forge] Excluding unused addon: @qvac/ocr-onnx
[qvac:electron-forge] Excluding unused addon: @qvac/transcription-whispercpp
[qvac:electron-forge] Excluding unused addon: @qvac/translation-nmtcpp
[qvac:electron-forge] Excluding unused addon: @qvac/tts-onnx
[qvac:electron-forge] Including required addon: @qvac/llm-llamacpp
[qvac:electron-forge] Packager configuration complete
[qvac:electron-forge] Pruning prebuilds for darwin-arm64...
[qvac:electron-forge] Pruned 134 prebuild dirs (~524.2 MB reclaimed)
```

### Architecture

Self-contained single-file module (~500 lines):

```
electron-forge/
└── index.cjs       # Plugin class + all helper functions
```

**Components:**

- `QvacForgePlugin` — Extends `@electron-forge/plugin-base`
- `logger` — Prefixed logging with level control
- `readManifest()` — Reads `qvac/addons.manifest.json`
- `discoverQvacAddonPackages()` — Scans `node_modules/@qvac` for addons
- `generateExclusionList()` — Determines which addons to exclude
- `prunePrebuildsForPath()` — Removes non-target platform prebuilds
- `createIgnoreFunction()` — Merges with existing ignore patterns
- `createPruneHook()` — Returns afterPrune callback

### API

| Export                      | Description                     |
| --------------------------- | ------------------------------- |
| `QvacForgePlugin` (default) | Forge plugin class              |
| `setLogLevel(level)`        | Sets log level programmatically |

### Constructor Options

| Option       | Type      | Default         | Description                               |
| ------------ | --------- | --------------- | ----------------------------------------- |
| `projectDir` | `string`  | `process.cwd()` | Project root directory                    |
| `strict`     | `boolean` | `false`         | Throw on missing manifest                 |
| `logLevel`   | `string`  | `"info"`        | Log level (off, error, warn, info, debug) |

### Environment Variables

| Variable         | Description                                    |
| ---------------- | ---------------------------------------------- |
| `QVAC_LOG_LEVEL` | Sets log level (off, error, warn, info, debug) |

### Forge Hooks Used

| Hook                 | Purpose                                         |
| -------------------- | ----------------------------------------------- |
| `resolveForgeConfig` | Injects `ignore` function and `afterPrune` hook |

### How it was tested

**Setup:**

- [x] Built SDK with electron-forge module
- [x] Installed in Electron POC app via tarball
- [x] Configured `forge.config.cjs` with `QvacForgePlugin`

**Test 1: Addon exclusion (1 plugin configured)**

- [x] 5 unused addon packages excluded
- [x] Only `@qvac/llm-llamacpp` included
- [x] Logs show correct exclusion decisions

**Test 2: Prebuild pruning**

- [x] `afterPrune` hook removes non-target prebuilds
- [x] darwin-arm64: ~524 MB reclaimed (134 dirs)
- [x] darwin-x64: ~515 MB reclaimed (134 dirs)
- [x] linux-x64: ~433 MB reclaimed (134 dirs)
- [x] win32-x64: ~463 MB reclaimed (134 dirs)

**Test 3: No config file (all plugins)**

- [x] Gracefully bundles all 6 plugins when no `qvac.config.json`
- [x] 25 native addons included (vs 19 with 1 plugin)
- [x] 153 prebuild dirs pruned (~994 MB reclaimed)

**Test 4: Packaged app runs correctly**

- [x] `npm run forge:package` produces working app
- [x] `npm run forge:make` produces DMG installer
- [x] App launches and functions correctly

**Test 5: Cross-platform packaging**

- [x] darwin-arm64 DMG — built and tested ✓
- [x] darwin-arm64 ZIP — built ✓
- [x] linux-x64 packaged from macOS — built ✓ (no installer)

**Test 6: Ignore composition**

- [x] User's existing ignore patterns preserved
- [x] Supports RegExp, function, string, and array patterns

### Known Limitations

1. **Cross-platform installers not supported**: Electron Forge can only create installers (DMG, EXE, DEB) for the current platform.


2. **macOS universal builds not supported**: The plugin blocks `arch: "universal"` since native addon prebuild layouts are incompatible with universal stitching. Build separate `arm64` and `x64` packages instead.

3. **Peer dependencies required**: Electron apps must install SDK peer dependencies (`bare-rpc`, `bare-runtime`, `tar-stream`, etc.) as direct dependencies for packaged builds.

4. **CommonJS only**: The module is CommonJS (`.cjs`) because Forge configs are typically CommonJS.

5. **Tested version**: @electron-forge/cli >=7.0.0 (tested with v7.11.1)

6. **Optional peer dependency**: Requires `@electron-forge/plugin-base` as optional peer dependency (users install with Forge CLI).