### PR TITLE
QVAC-13378 Model Metadata

### DIFF
--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -175,6 +175,27 @@ jobs:
           curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/SmolVLM2-500M-Video-Instruct-Q8_0.gguf" -o models/unit-test/SmolVLM-500M-Instruct-Q8_0.gguf
           echo "Downloading mmproj-SmolVLM-500M-Instruct-Q8_0.gguf from Hugging Face..."
           curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf" -o models/unit-test/mmproj-SmolVLM-500M-Instruct-Q8_0.gguf
+          
+          echo "Downloading Qwen3-0.6B-Q8_0.gguf from Hugging Face..."
+          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf" -o models/unit-test/Qwen3-0.6B-Q8_0.gguf
+          
+          echo "Downloading Qwen3-0.6B-UD-IQ1_S shards (3 of 3) + tensors file from Hugging Face..."
+          for i in 1 2 3; do
+            shard=$(printf "Qwen3-0.6B-UD-IQ1_S-%05d-of-00003.gguf" $i)
+            curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded/resolve/main/${shard}" -o "models/unit-test/${shard}"
+          done 
+          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded/resolve/main/Qwen3-0.6B-UD-IQ1_S.tensors.txt" -o models/unit-test/Qwen3-0.6B-UD-IQ1_S.tensors.txt
+
+          echo "Downloading bitnet_b1_58-large-TQ2_0.gguf (unsharded) from Hugging Face..."
+          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0/resolve/main/bitnet_b1_58-large-TQ2_0.gguf" -o models/unit-test/bitnet_b1_58-large-TQ2_0.gguf
+
+          echo "Downloading bitnet_b1_58-large-TQ2_0 shards (8 of 8) + tensors file from Hugging Face..."
+          for i in 1 2 3 4 5 6 7 8; do
+            shard=$(printf "bitnet_b1_58-large-TQ2_0-%05d-of-00008.gguf" $i)
+            curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded/resolve/main/${shard}" -o "models/unit-test/${shard}"
+          done
+          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded/resolve/main/bitnet_b1_58-large-TQ2_0.tensors.txt" -o models/unit-test/bitnet_b1_58-large-TQ2_0.tensors.txt
+
           echo "Verify downloaded models..."
           ls -lh models/unit-test/
           du -sh models/unit-test/*

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -167,34 +167,45 @@ jobs:
         shell: bash
         working-directory: ${{ env.WORKDIR }}
         run: |
-          echo "Creating models directory..."
           mkdir -p models/unit-test
-          echo "Downloading Llama-3.2-1B-Instruct-Q4_0.gguf from Hugging Face..."
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_0.gguf" -o models/unit-test/Llama-3.2-1B-Instruct-Q4_0.gguf
-          echo "Downloading SmolVLM-500M-Instruct-Q8_0.gguf from Hugging Face..."
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/SmolVLM2-500M-Video-Instruct-Q8_0.gguf" -o models/unit-test/SmolVLM-500M-Instruct-Q8_0.gguf
-          echo "Downloading mmproj-SmolVLM-500M-Instruct-Q8_0.gguf from Hugging Face..."
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf" -o models/unit-test/mmproj-SmolVLM-500M-Instruct-Q8_0.gguf
-          
-          echo "Downloading Qwen3-0.6B-Q8_0.gguf from Hugging Face..."
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf" -o models/unit-test/Qwen3-0.6B-Q8_0.gguf
-          
-          echo "Downloading Qwen3-0.6B-UD-IQ1_S shards (3 of 3) + tensors file from Hugging Face..."
-          for i in 1 2 3; do
-            shard=$(printf "Qwen3-0.6B-UD-IQ1_S-%05d-of-00003.gguf" $i)
-            curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded/resolve/main/${shard}" -o "models/unit-test/${shard}"
-          done 
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded/resolve/main/Qwen3-0.6B-UD-IQ1_S.tensors.txt" -o models/unit-test/Qwen3-0.6B-UD-IQ1_S.tensors.txt
 
-          echo "Downloading bitnet_b1_58-large-TQ2_0.gguf (unsharded) from Hugging Face..."
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0/resolve/main/bitnet_b1_58-large-TQ2_0.gguf" -o models/unit-test/bitnet_b1_58-large-TQ2_0.gguf
+          HF="https://huggingface.co"
+          ODIR="models/unit-test"
 
-          echo "Downloading bitnet_b1_58-large-TQ2_0 shards (8 of 8) + tensors file from Hugging Face..."
-          for i in 1 2 3 4 5 6 7 8; do
-            shard=$(printf "bitnet_b1_58-large-TQ2_0-%05d-of-00008.gguf" $i)
-            curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded/resolve/main/${shard}" -o "models/unit-test/${shard}"
-          done
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded/resolve/main/bitnet_b1_58-large-TQ2_0.tensors.txt" -o models/unit-test/bitnet_b1_58-large-TQ2_0.tensors.txt
+          hf_download() {
+            local repo="$1"               # owner/repo
+            local file="$2"               # filename on HF main branch
+            local dest_dir="${3:-$ODIR}"  # destination directory
+            local out_file="${4:-$file}"  # optional output filename (defaults to file)
+            echo "Downloading ${file} from ${HF}/${repo}..."
+            curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "${HF}/${repo}/resolve/main/${file}" -o "${dest_dir}/${out_file}"
+          }
+
+          hf_download_shards() {
+            local repo="$1"               # owner/repo
+            local pattern="$2"            # printf pattern, e.g. "MyModel-%05d-of-%05d.gguf"
+            local total="$3"              # total number of shards
+            local dest_dir="${4:-$ODIR}"  # destination directory
+            echo "Downloading $(printf "$pattern" 1 "$total") shards (${total} of ${total}) from ${HF}/${repo}..."
+            for i in $(seq 1 "$total"); do
+              local shard
+              shard=$(printf "$pattern" "$i" "$total")
+              curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "${HF}/${repo}/resolve/main/${shard}" -o "${dest_dir}/${shard}"
+            done
+          }
+
+          hf_download "bartowski/Llama-3.2-1B-Instruct-GGUF" "Llama-3.2-1B-Instruct-Q4_0.gguf"
+          hf_download "ggml-org/SmolVLM2-500M-Video-Instruct-GGUF" "SmolVLM2-500M-Video-Instruct-Q8_0.gguf" "$ODIR" "SmolVLM-500M-Instruct-Q8_0.gguf"
+          hf_download "ggml-org/SmolVLM2-500M-Video-Instruct-GGUF" "mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf" "$ODIR" "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf"
+          hf_download "Qwen/Qwen3-0.6B-GGUF" "Qwen3-0.6B-Q8_0.gguf"
+
+          hf_download_shards "jmb95/Qwen3-0.6B-UD-IQ1_S-sharded" "Qwen3-0.6B-UD-IQ1_S-%05d-of-%05d.gguf" 3
+          hf_download "jmb95/Qwen3-0.6B-UD-IQ1_S-sharded" "Qwen3-0.6B-UD-IQ1_S.tensors.txt"
+
+          hf_download "gianni-cor/bitnet_b1_58-large-TQ2_0" "bitnet_b1_58-large-TQ2_0.gguf"
+
+          hf_download_shards "jmb95/bitnet_b1_58-large-TQ2_0-sharded" "bitnet_b1_58-large-TQ2_0-%05d-of-%05d.gguf" 8
+          hf_download "jmb95/bitnet_b1_58-large-TQ2_0-sharded" "bitnet_b1_58-large-TQ2_0.tensors.txt"
 
           echo "Verify downloaded models..."
           ls -lh models/unit-test/

--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+## [Unreleased]
+
+### Fixed
+
+#### GGUF streambuf reader fails to align data section
+
+Fixed a bug in the GGUF buffer reader (`gguf_bytes_buffer_reader::align`) where `pubseekoff` was called without specifying a direction (`std::ios_base::in`). The default `which` parameter is `ios_base::in | ios_base::out`, and per the C++ spec, `std::stringbuf::seekoff` with `way=cur` and both directions set always returns `-1` — regardless of the streambuf's open mode. This caused `"gguf_init_from_reader_impl: failed to align data section"` when loading model metadata from an in-memory stream (e.g. during streaming model loads), while the disk-backed `FILE*` path was unaffected because `fseek` has no direction concept.
+
+The fix passes `std::ios_base::in` explicitly to `pubseekoff` in the llamacpp tether layer.
+
+### Changed
+
+#### ModelMetaData streaming synchronization refactored
+
+Replaced the `std::future`/`std::promise` handoff for the first streamed GGUF file with a `std::shared_ptr<std::basic_streambuf<char>>` protected by a mutex and condition variable. The synchronization state is encapsulated in a public nested class `ModelMetaData::FirstFileFromGgufStreamState` with `wait()`, `get()`, and `provide()` methods. This eliminates a race condition where `parse()` could call `future::get()` before the future had been moved in from the lender thread, and simplifies the API surface.
 
 ## [0.9.1] - 2026-02-23
 - Use patched version of addon-cpp to reduce logging noise.

--- a/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
@@ -55,6 +55,7 @@ add_bare_module(qvac-lib-inference-addon-llama EXPORTS ${BACKEND_DL_LIBS})
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MtmdLlmContext.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/TextLlmContext.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/LoggingMacros.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/BackendSelection.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/ChatTemplateUtils.cpp
@@ -97,6 +98,7 @@ if(BUILD_CLI)
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MtmdLlmContext.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/TextLlmContext.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/LoggingMacros.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/BackendSelection.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/ChatTemplateUtils.cpp

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/LlmErrors.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/LlmErrors.hpp
@@ -28,6 +28,7 @@ enum LlmErrorCode : uint32_t {
   UserMessageNotProvided = 20,
   MediaRequestNotProvided = 21,
   UnableToDeleteThreadPool = 22,
+  UnableToLoadMetadata = 23,
   // mode llm spesific errors here
 };
 
@@ -75,6 +76,8 @@ inline std::string toString(LlmErrorCode code) {
     return "UserMessageNotProvided";
   case MediaRequestNotProvided:
     return "MediaRequestNotProvided";
+  case UnableToLoadMetadata:
+    return "UnableToLoadMetadata";
   default:
     return "UnknownLLMError";
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/AsyncWeightsLoader.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/AsyncWeightsLoader.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <streambuf>
 #include <string>
+#include <thread>
 
 #include <common/common.h>
 #include <llama-cpp.h>
 
+#include "ModelMetadata.hpp"
 #include "addon/LlmErrors.hpp"
 #include "qvac-lib-inference-addon-cpp/Errors.hpp"
 #include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
@@ -27,9 +30,10 @@ public:
   /// can proceed before the shard is handed to the weights engine.
   AsyncWeightsLoader(
       const GGUFShards& shards, InitLoader& initLoader,
-      const std::string& loadingContext)
+      const std::string& loadingContext,
+      ModelMetaData* modelMetadata = nullptr)
       : shards_(shards), initLoader_(initLoader),
-        loadingContext_(loadingContext) {}
+        loadingContext_(loadingContext), modelMetadata_(modelMetadata) {}
 
   virtual ~AsyncWeightsLoader() = default;
   AsyncWeightsLoader(const AsyncWeightsLoader&) = delete;
@@ -40,25 +44,29 @@ public:
   /// @brief Accept a streamed shard. For single-GGUF models the buffer is
   /// stored until init() consumes it; for sharded models the shard is
   /// fulfilled asynchronously via llama_model_load_fulfill_split_future.
+  /// If a ModelMetaData was supplied at construction, the shard matching the
+  /// first shard filename is lent to it and ownership is recovered before
+  /// proceeding.
   void setWeightsForFile(
       const std::string& filename,
-      std::unique_ptr<std::basic_streambuf<char>>&& shard) {
+      std::unique_ptr<Buf>&& shard) {
     isStreaming_ = true;
 
     if (shards_.gguf_files.empty()) {
+      SharedBuffer lentShard(std::move(shard));
       if (shouldLendFirstShard(filename)) {
-        shard = lendFirstShard(std::move(shard));
+        modelMetadata_->firstFileFromGgufStreamState.provide(lentShard.shared());
       }
-      streamedFiles_[filename] = std::move(shard);
+      streamedFiles_.emplace(filename, std::move(lentShard));
       return;
     }
 
     initLoader_.ensureLoadInBackground();
-    if(shouldLendFirstShard(filename)) {
-      // Do operation in a separate thread to avoid blocking calling thread
-      // thread that could be handling download operations.
-      std::thread([this, filename, shardT= std::move(shard)]() mutable {
-        auto shard = lendFirstShard(std::move(shardT));
+    if (shouldLendFirstShard(filename)) {
+      // Spawn a separate thread so the calling (download) thread is not
+      // blocked while waiting for metadata to release the shard.
+      std::thread([this, filename, shard_ = std::move(shard)]() mutable {
+        auto shard = lendFirstShardAndWaitForRelease(std::move(shard_));
         fulfillSplitFuture(filename, std::move(shard));
       }).detach();
     } else {
@@ -68,8 +76,19 @@ public:
 
   [[nodiscard]] bool isStreaming() const { return isStreaming_; }
 
-  /// Mutable access so that initFromConfig can consume/erase entries.
-  auto& streamedFiles() { return streamedFiles_; }
+  /// @brief Moves the unsharded files out of the AsyncWeightsLoader
+  std::map<std::string, std::unique_ptr<Buf>> extractIndividualStreamedFiles() {
+    std::map<std::string, std::unique_ptr<Buf>> extracted;
+    for(auto& [filename, shard] : streamedFiles_) {
+      extracted[filename] = shard.toUnique();
+    }
+    return extracted;
+  }
+
+  [[nodiscard]] bool
+  hasIndividualStreamedFile(const std::string& filename) const {
+    return streamedFiles_.contains(filename);
+  }
 
 protected:
   /// @brief Hands the shard to llama.cpp's split-future registry.
@@ -99,39 +118,53 @@ private:
     return filename == firstShard;
   }
 
-  /// Lends @p shard to modelMetadata_, blocks until metadata releases its
-  /// reference, then returns the unique_ptr to the caller.
-  std::unique_ptr<Buf> lendFirstShard(std::unique_ptr<Buf>&& shard, bool waitForRelease = true) {
-    /// Holds a unique_ptr inside a shared_ptr's deleter so ownership can be
-    /// recovered via get_deleter<ShardDeleter>()->release() when use_count == 1.
-    struct ShardDeleter {
+  /// @brief Wraps a unique_ptr as a shared_ptr (for lending to metadata) while
+  /// keeping a clear path back to unique ownership via toUnique().
+  class SharedBuffer {
+  public:
+    explicit SharedBuffer(std::unique_ptr<Buf>&& shard)
+        : ptr_(shard.get(), Deleter{std::move(shard)}) {}
+
+    SharedBuffer(SharedBuffer&& other) noexcept
+        : ptr_(std::move(other.ptr_)) {}
+
+    /// The shared_ptr to pass to firstFileFromGgufStreamState.provide().
+    std::shared_ptr<Buf> shared() const { return ptr_; }
+
+    /// Assert sole ownership then move the unique_ptr out.
+    std::unique_ptr<Buf> toUnique() {
+      if (ptr_.use_count() > 1) {
+        throw qvac_errors::StatusError(
+            ADDON_ID, toString(UnableToLoadModel),
+            "First shard is still in use by metadata but should have been released.");
+      }
+      return std::get_deleter<Deleter>(ptr_)->release();
+    }
+
+  private:
+    struct Deleter {
       std::unique_ptr<Buf> inner;
       void operator()(Buf*) noexcept { /* inner self-deletes if not released */ }
       std::unique_ptr<Buf> release() { return std::move(inner); }
     };
-    auto lentShard = std::shared_ptr<Buf>(
-        shard.get(), ShardDeleter{std::move(shard)});
-    modelMetadata_->firstFileFromGgufStreamState.provide(lentShard);
+    std::shared_ptr<Buf> ptr_;
+  };
+
+  /// Lends @p shard to modelMetadata_ (sharded path only), blocks until
+  /// metadata releases its reference, then returns the unique_ptr to the caller.
+  std::unique_ptr<Buf> lendFirstShardAndWaitForRelease(
+      std::unique_ptr<Buf>&& shard) {
+    SharedBuffer lentShard(std::move(shard));
+    modelMetadata_->firstFileFromGgufStreamState.provide(lentShard.shared());
     modelMetadata_->firstFileFromGgufStreamState.waitForRelease();
-    if (lentShard.use_count() > 1) {
-      throw qvac_errors::StatusError(
-          ADDON_ID, toString(UnableToLoadModel),
-          "First shard is still in use by metadata but should have been released.");
-    }
-    return std::get_deleter<ShardDeleter>(lentShard)->release();
+    return lentShard.toUnique();
   }
 
-  [[nodiscard]] bool isStreaming() const { return isStreaming_; }
-
-  /// Mutable access so that initFromConfig can consume/erase entries.
-  auto& streamedFiles() { return streamedFiles_; }
-
-private:
   const GGUFShards& shards_;
   InitLoader& initLoader_;
   const std::string& loadingContext_;
+  ModelMetaData* modelMetadata_ = nullptr;
 
   bool isStreaming_ = false;
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>
-      streamedFiles_;
+  std::map<std::string, SharedBuffer> streamedFiles_;
 };

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/AsyncWeightsLoader.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/AsyncWeightsLoader.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <streambuf>
+#include <string>
+
+#include <common/common.h>
+#include <llama-cpp.h>
+
+#include "addon/LlmErrors.hpp"
+#include "qvac-lib-inference-addon-cpp/Errors.hpp"
+#include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
+#include "qvac-lib-inference-addon-cpp/InitLoader.hpp"
+
+using namespace qvac_lib_inference_addon_llama::errors;
+
+/// @brief Encapsulates async/streaming weights loading for sharded and
+/// single-GGUF models. Owns the streaming state and the buffered file map,
+/// and delegates shard fulfillment to llama.cpp.
+class AsyncWeightsLoader {
+public:
+  using Buf = std::basic_streambuf<char>;
+
+  /// @param modelMetadata Optional. When provided, the first shard received
+  /// via setWeightsForFile is lent to modelMetadata so that metadata parsing
+  /// can proceed before the shard is handed to the weights engine.
+  AsyncWeightsLoader(
+      const GGUFShards& shards, InitLoader& initLoader,
+      const std::string& loadingContext)
+      : shards_(shards), initLoader_(initLoader),
+        loadingContext_(loadingContext) {}
+
+  virtual ~AsyncWeightsLoader() = default;
+  AsyncWeightsLoader(const AsyncWeightsLoader&) = delete;
+  AsyncWeightsLoader& operator=(const AsyncWeightsLoader&) = delete;
+  AsyncWeightsLoader(AsyncWeightsLoader&&) = delete;
+  AsyncWeightsLoader& operator=(AsyncWeightsLoader&&) = delete;
+
+  /// @brief Accept a streamed shard. For single-GGUF models the buffer is
+  /// stored until init() consumes it; for sharded models the shard is
+  /// fulfilled asynchronously via llama_model_load_fulfill_split_future.
+  void setWeightsForFile(
+      const std::string& filename,
+      std::unique_ptr<std::basic_streambuf<char>>&& shard) {
+    isStreaming_ = true;
+
+    if (shards_.gguf_files.empty()) {
+      if (shouldLendFirstShard(filename)) {
+        shard = lendFirstShard(std::move(shard));
+      }
+      streamedFiles_[filename] = std::move(shard);
+      return;
+    }
+
+    initLoader_.ensureLoadInBackground();
+    if(shouldLendFirstShard(filename)) {
+      // Do operation in a separate thread to avoid blocking calling thread
+      // thread that could be handling download operations.
+      std::thread([this, filename, shardT= std::move(shard)]() mutable {
+        auto shard = lendFirstShard(std::move(shardT));
+        fulfillSplitFuture(filename, std::move(shard));
+      }).detach();
+    } else {
+      fulfillSplitFuture(filename, std::move(shard));
+    }
+  }
+
+  [[nodiscard]] bool isStreaming() const { return isStreaming_; }
+
+  /// Mutable access so that initFromConfig can consume/erase entries.
+  auto& streamedFiles() { return streamedFiles_; }
+
+protected:
+  /// @brief Hands the shard to llama.cpp's split-future registry.
+  /// Override in tests to avoid touching the global promise registry.
+  virtual void fulfillSplitFuture(
+      const std::string& filename, std::unique_ptr<Buf>&& shard) {
+    if (!llama_model_load_fulfill_split_future(
+            filename.c_str(), loadingContext_.c_str(), std::move(shard))) {
+      std::string errorMsg = string_format(
+          "%s: failed to load model from %s\n", __func__, filename.c_str());
+      throw qvac_errors::StatusError(
+          ADDON_ID, toString(UnableToLoadModel), errorMsg);
+    }
+  }
+
+private:
+  bool shouldLendFirstShard(const std::string& filename) const {
+    if (modelMetadata_ == nullptr) {
+      return false;
+    }
+    const std::string firstShard =
+        shards_.gguf_files.empty()
+            ? filename
+            : std::filesystem::path(shards_.gguf_files.front())
+                  .filename()
+                  .string();
+    return filename == firstShard;
+  }
+
+  /// Lends @p shard to modelMetadata_, blocks until metadata releases its
+  /// reference, then returns the unique_ptr to the caller.
+  std::unique_ptr<Buf> lendFirstShard(std::unique_ptr<Buf>&& shard, bool waitForRelease = true) {
+    /// Holds a unique_ptr inside a shared_ptr's deleter so ownership can be
+    /// recovered via get_deleter<ShardDeleter>()->release() when use_count == 1.
+    struct ShardDeleter {
+      std::unique_ptr<Buf> inner;
+      void operator()(Buf*) noexcept { /* inner self-deletes if not released */ }
+      std::unique_ptr<Buf> release() { return std::move(inner); }
+    };
+    auto lentShard = std::shared_ptr<Buf>(
+        shard.get(), ShardDeleter{std::move(shard)});
+    modelMetadata_->firstFileFromGgufStreamState.provide(lentShard);
+    modelMetadata_->firstFileFromGgufStreamState.waitForRelease();
+    if (lentShard.use_count() > 1) {
+      throw qvac_errors::StatusError(
+          ADDON_ID, toString(UnableToLoadModel),
+          "First shard is still in use by metadata but should have been released.");
+    }
+    return std::get_deleter<ShardDeleter>(lentShard)->release();
+  }
+
+  [[nodiscard]] bool isStreaming() const { return isStreaming_; }
+
+  /// Mutable access so that initFromConfig can consume/erase entries.
+  auto& streamedFiles() { return streamedFiles_; }
+
+private:
+  const GGUFShards& shards_;
+  InitLoader& initLoader_;
+  const std::string& loadingContext_;
+
+  bool isStreaming_ = false;
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>
+      streamedFiles_;
+};

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -63,22 +63,21 @@ static std::vector<std::string> split(const std::string& str, char delimiter) {
   return tokens;
 }
 
-GGUFShards LlamaModel::expandAndResolveShards(const std::string& modelPath) {
-  auto shards = GGUFShards::expandGGUFIntoShards(modelPath);
-  if (shards.gguf_files.empty()) return shards;
+void LlamaModel::resolveShardPaths(
+    GGUFShards& shards, const std::string& modelPath) {
+  if (shards.gguf_files.empty()) return;
   auto baseDir = std::filesystem::path(modelPath).parent_path();
-  if (baseDir.empty()) return shards;
+  if (baseDir.empty()) return;
   for (auto& f : shards.gguf_files)
     f = (baseDir / f).string();
   shards.tensors_file = (baseDir / shards.tensors_file).string();
-  return shards;
 }
 
 LlamaModel::LlamaModel(
     std::string&& modelPath, std::string&& projectionPath,
     std::unordered_map<std::string, std::string>&& configFilemap)
     : loadingContext_(InitLoader::getLoadingContext("LlamaModel")),
-      shards_(expandAndResolveShards(modelPath)) {
+      shards_(GGUFShards::expandGGUFIntoShards(modelPath)) {
   auto thisModelInit = [this](auto&&... args) {
     this->init(std::forward<decltype(args)>(args)...);
   };
@@ -112,6 +111,10 @@ void LlamaModel::init(
 
   common_params params;
   commonParamsParse(modelPath, configFilemap, params);
+
+  if (!isStreaming_) {
+    resolveShardPaths(shards_, modelPath);
+  }
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
   common_init_result llamaInit = initFromConfig(

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -77,7 +77,8 @@ LlamaModel::LlamaModel(
     std::string&& modelPath, std::string&& projectionPath,
     std::unordered_map<std::string, std::string>&& configFilemap)
     : loadingContext_(InitLoader::getLoadingContext("LlamaModel")),
-      shards_(GGUFShards::expandGGUFIntoShards(modelPath)) {
+      shards_(GGUFShards::expandGGUFIntoShards(modelPath)),
+      asyncWeightsLoader_(shards_, initLoader_, loadingContext_) {
   auto thisModelInit = [this](auto&&... args) {
     this->init(std::forward<decltype(args)>(args)...);
   };
@@ -112,18 +113,19 @@ void LlamaModel::init(
   common_params params;
   commonParamsParse(modelPath, configFilemap, params);
 
-  if (!isStreaming_) {
+  if (!asyncWeightsLoader_.isStreaming()) {
     resolveShardPaths(shards_, modelPath);
   }
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
+  auto streamedFiles = asyncWeightsLoader_.extractIndividualStreamedFiles();
   common_init_result llamaInit = initFromConfig(
       params,
       modelPath,
-      singleGgufStreamedFiles_,
+      streamedFiles,
       shards_,
       loadingContext_,
-      isStreaming_,
+      asyncWeightsLoader_.isStreaming(),
       ADDON_ID,
       errorWhenFailed);
 
@@ -151,29 +153,7 @@ void LlamaModel::initializeBackend(const std::string& backendsDir) {
 void LlamaModel::setWeightsForFile(
     const std::string& filename,
     std::unique_ptr<std::basic_streambuf<char>>&& shard) {
-  isStreaming_ = true;
-  if (shards_.gguf_files.empty()) {
-    // Store it and make it available when `init` is called
-    singleGgufStreamedFiles_[filename] = std::move(shard);
-    return;
-  }
-
-  // TODO move to AsyncWeightsLoader class.
-  // TODO if first shard (check filename) notify metadata in a separate thread,
-  // in order not to halt download. Next time setWeightsWeights.
-  // Double-check fulfill_split futures can be loaded out of order.
-  // Add mutex for singleGgufStreamedFiles_
-
-  // Asynchronous shard loading
-  initLoader_.ensureLoadInBackground();
-  if (!llama_model_load_fulfill_split_future(
-          filename.c_str(), loadingContext_.c_str(), std::move(shard))) {
-    std::string errorMsg = string_format(
-        "%s: failed to load model from %s\n", __func__, filename.c_str());
-
-    throw qvac_errors::StatusError(
-        ADDON_ID, toString(UnableToLoadModel), errorMsg);
-  }
+  asyncWeightsLoader_.setWeightsForFile(filename, std::move(shard));
 }
 
 bool LlamaModel::isLoaded() { return static_cast<bool>(llmContext_); }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -63,11 +63,22 @@ static std::vector<std::string> split(const std::string& str, char delimiter) {
   return tokens;
 }
 
+GGUFShards LlamaModel::expandAndResolveShards(const std::string& modelPath) {
+  auto shards = GGUFShards::expandGGUFIntoShards(modelPath);
+  if (shards.gguf_files.empty()) return shards;
+  auto baseDir = std::filesystem::path(modelPath).parent_path();
+  if (baseDir.empty()) return shards;
+  for (auto& f : shards.gguf_files)
+    f = (baseDir / f).string();
+  shards.tensors_file = (baseDir / shards.tensors_file).string();
+  return shards;
+}
+
 LlamaModel::LlamaModel(
     std::string&& modelPath, std::string&& projectionPath,
     std::unordered_map<std::string, std::string>&& configFilemap)
     : loadingContext_(InitLoader::getLoadingContext("LlamaModel")),
-      shards_(GGUFShards::expandGGUFIntoShards(modelPath)) {
+      shards_(expandAndResolveShards(modelPath)) {
   auto thisModelInit = [this](auto&&... args) {
     this->init(std::forward<decltype(args)>(args)...);
   };

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -143,6 +143,13 @@ void LlamaModel::setWeightsForFile(
     singleGgufStreamedFiles_[filename] = std::move(shard);
     return;
   }
+
+  // TODO move to AsyncWeightsLoader class.
+  // TODO if first shard (check filename) notify metadata in a separate thread,
+  // in order not to halt download. Next time setWeightsWeights.
+  // Double-check fulfill_split futures can be loaded out of order.
+  // Add mutex for singleGgufStreamedFiles_
+
   // Asynchronous shard loading
   initLoader_.ensureLoadInBackground();
   if (!llama_model_load_fulfill_split_future(

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -78,7 +78,7 @@ LlamaModel::LlamaModel(
     std::unordered_map<std::string, std::string>&& configFilemap)
     : loadingContext_(InitLoader::getLoadingContext("LlamaModel")),
       shards_(GGUFShards::expandGGUFIntoShards(modelPath)),
-      asyncWeightsLoader_(shards_, initLoader_, loadingContext_) {
+      asyncWeightsLoader_(shards_, initLoader_, loadingContext_, &metadata_) {
   auto thisModelInit = [this](auto&&... args) {
     this->init(std::forward<decltype(args)>(args)...);
   };
@@ -100,6 +100,17 @@ void LlamaModel::init(
   // Set verbosity level
   setVerbosityLevel(configFilemap);
 
+  if (!asyncWeightsLoader_.isStreaming()) {
+    resolveShardPaths(shards_, modelPath);
+  }
+
+  metadata_.parse(modelPath, shards_, asyncWeightsLoader_.isStreaming(), ADDON_ID);
+  { 
+    auto fileType = metadata_.tryGetU32("general.file_type");
+    QLOG_IF(
+      Priority::DEBUG, string_format("[LlamaModel] general.file_type = %s\n", fileType.has_value() ? std::to_string(*fileType).c_str() : "unknown"));
+  }
+
   {
     std::string backendsDir;
     if (auto backendsDirIt = configFilemap.find("backendsDir");
@@ -112,10 +123,6 @@ void LlamaModel::init(
 
   common_params params;
   commonParamsParse(modelPath, configFilemap, params);
-
-  if (!asyncWeightsLoader_.isStreaming()) {
-    resolveShardPaths(shards_, modelPath);
-  }
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
   auto streamedFiles = asyncWeightsLoader_.extractIndividualStreamedFiles();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -29,9 +29,10 @@ public:
   LlamaModel(LlamaModel&&) = delete;
   LlamaModel& operator=(LlamaModel&&) = delete;
 
-  /// @brief Expands shard filenames and resolves them to absolute paths
-  /// relative to the parent directory of @p modelPath.
-  static GGUFShards expandAndResolveShards(const std::string& modelPath);
+  /// @brief Resolves shard basenames in-place to absolute paths relative to
+  /// the parent directory of @p modelPath.
+  static void resolveShardPaths(
+      GGUFShards& shards, const std::string& modelPath);
 
   /**
    * The Constructor for llama model.
@@ -179,7 +180,7 @@ private:
       std::unordered_map<std::string, std::string>&& configFilemap);
 
   const std::string loadingContext_;
-  const GGUFShards shards_;
+  GGUFShards shards_;
   friend class InitLoader;
   InitLoader initLoader_;
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -11,6 +11,7 @@
 
 #include "AsyncWeightsLoader.hpp"
 #include "CacheManager.hpp"
+#include "ModelMetadata.hpp"
 #include "LlamaLazyInitializeBackend.hpp"
 #include "LlmContext.hpp"
 #include "common/chat.h"
@@ -184,6 +185,7 @@ private:
   GGUFShards shards_;
   friend class InitLoader;
   InitLoader initLoader_;
+  ModelMetaData metadata_;
   AsyncWeightsLoader asyncWeightsLoader_;
 
   bool isTextLlm_ = false;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -29,6 +29,10 @@ public:
   LlamaModel(LlamaModel&&) = delete;
   LlamaModel& operator=(LlamaModel&&) = delete;
 
+  /// @brief Expands shard filenames and resolves them to absolute paths
+  /// relative to the parent directory of @p modelPath.
+  static GGUFShards expandAndResolveShards(const std::string& modelPath);
+
   /**
    * The Constructor for llama model.
    * @param modelPath - path to the model file.

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -9,6 +9,7 @@
 #include <llama.h>
 #include <picojson/picojson.h>
 
+#include "AsyncWeightsLoader.hpp"
 #include "CacheManager.hpp"
 #include "LlamaLazyInitializeBackend.hpp"
 #include "LlmContext.hpp"
@@ -183,11 +184,9 @@ private:
   GGUFShards shards_;
   friend class InitLoader;
   InitLoader initLoader_;
+  AsyncWeightsLoader asyncWeightsLoader_;
 
   bool isTextLlm_ = false;
-  bool isStreaming_ = false;
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>
-      singleGgufStreamedFiles_;
 
   // Backend handle must be declared before llmContext_ to ensure
   // llmContext_ is destroyed first (members destroyed in reverse order)

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
@@ -1,0 +1,183 @@
+#include "model-interface/ModelMetadata.hpp"
+
+#include <stdexcept>
+
+#include <common/common.h>
+#include <common/log.h>
+#include <llama-cpp.h>
+#include <qvac-lib-inference-addon-cpp/Errors.hpp>
+
+#include "addon/LlmErrors.hpp"
+
+namespace {
+void throwSinggleGgufStreamErrorNotFound(
+    std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>&
+        singleGgufStreamedFiles,
+    const std::string& modelPath, const char* AddonID) {
+  std::string availableFiles = " No files available.";
+  if (!singleGgufStreamedFiles.empty()) {
+    availableFiles = " Available files: ";
+    auto it = singleGgufStreamedFiles.begin();
+    availableFiles += it->first;
+    ++it;
+    for (; it != singleGgufStreamedFiles.end(); ++it) {
+      availableFiles += ", " + it->first;
+    }
+  }
+  std::string errorMsg = string_format(
+      "%s: failed to load model metadata. path=%s%s\n",
+      __func__,
+      modelPath.c_str(),
+      availableFiles.c_str());
+  throw qvac_errors::StatusError(
+      AddonID,
+      toString(qvac_lib_inference_addon_llama::errors::UnableToLoadMetadata),
+      errorMsg);
+}
+} // namespace
+
+void ModelMetaData::FirstFileFromGgufStreamState::wait() {
+  std::unique_lock<std::mutex> lock(firstFileFromGgufStreamMutex_);
+  firstFileFromGgufStreamCv_.wait(
+      lock, [this]() { return hasFirstFileFromGgufStream_; });
+}
+
+std::shared_ptr<std::basic_streambuf<char>>
+ModelMetaData::FirstFileFromGgufStreamState::get() {
+  std::lock_guard<std::mutex> lock(firstFileFromGgufStreamMutex_);
+  return firstFileFromGgufStream_;
+}
+
+void ModelMetaData::FirstFileFromGgufStreamState::provide(
+    std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStreamIn) {
+  if (!firstFileFromGgufStreamIn) {
+    throw qvac_errors::StatusError(
+        qvac_lib_inference_addon_llama::errors::ADDON_ID,
+        toString(qvac_lib_inference_addon_llama::errors::InvalidInputFormat),
+        "ModelMetaData::FirstFileFromGgufStreamState::provide: null streambuf");
+  }
+  std::lock_guard<std::mutex> lock(firstFileFromGgufStreamMutex_);
+  firstFileFromGgufStream_ = std::move(firstFileFromGgufStreamIn);
+  hasFirstFileFromGgufStream_ = true;
+  firstFileFromGgufStreamCv_.notify_all();
+}
+
+void ModelMetaData::FirstFileFromGgufStreamState::clear() {
+  std::lock_guard<std::mutex> lock(firstFileFromGgufStreamMutex_);
+  firstFileFromGgufStream_.reset();
+}
+
+void ModelMetaData::parse(
+    const std::string& modelPath,
+    std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>&
+        singleGgufStreamedFiles,
+    const GGUFShards& shards, bool isStreaming, const char* AddonID) {
+
+  auto loadFromStreambuf = [&modelPath,
+                            out_metadata = &this->metadata_,
+                            AddonID](std::basic_streambuf<char>& streambuf) {
+    MetaResultStatus status =
+        llama_model_meta_from_streambuf(streambuf, out_metadata);
+    if (status != MetaResultStatus::SUCCESS) {
+      std::string statusStr = std::to_string(status);
+      std::string errorMsg = string_format(
+          "ModelMetadata::loadFromStreambuf: failed to load model metadata "
+          "while parsing GGUF, path=%s MetaResultStatus=%s\n",
+          modelPath.c_str(),
+          statusStr.c_str());
+      throw qvac_errors::StatusError(
+          AddonID,
+          toString(
+              qvac_lib_inference_addon_llama::errors::UnableToLoadMetadata),
+          errorMsg);
+    }
+  };
+
+  auto loadFromDisk = [&modelPath, out_metadata = &this->metadata_, AddonID](
+                          const std::string& diskPath) {
+    MetaResultStatus status =
+        llama_model_meta_from_file(diskPath.c_str(), out_metadata);
+    if (status != MetaResultStatus::SUCCESS) {
+      std::string statusStr = std::to_string(status);
+      std::string errorMsg = string_format(
+          "ModelMetadata::loadFromDisk: failed to load model metadata "
+          "while parsing GGUF, path=%s MetaResultStatus=%s\n",
+          diskPath.c_str(),
+          statusStr.c_str());
+      throw qvac_errors::StatusError(
+          AddonID,
+          toString(
+              qvac_lib_inference_addon_llama::errors::UnableToLoadMetadata),
+          errorMsg);
+    }
+  };
+
+  if (isStreaming) {
+    // Wait for the first file from the gguf stream to be available.
+    firstFileFromGgufStreamState.wait();
+    if (shards.gguf_files.empty()) {
+      LOG_INF(
+          "%s: load the model metadata from memory (single file).\n", __func__);
+
+      // After waiting for the first file from the gguf stream to be available,
+      // It should have been inserted into singleGgufStreamedFiles but we will
+      // double check the inserted filename matches.
+      auto modelFilename = std::filesystem::path(modelPath).filename().string();
+      auto itGgufModelPath = singleGgufStreamedFiles.find(modelFilename);
+      if (itGgufModelPath == singleGgufStreamedFiles.end()) {
+        throwSinggleGgufStreamErrorNotFound(
+            singleGgufStreamedFiles, modelPath, AddonID);
+      }
+      loadFromStreambuf(*itGgufModelPath->second);
+    } else {
+      LOG_INF("%s: load the model metadata from memory shards.\n", __func__);
+      auto firstFileFromGgufStream = firstFileFromGgufStreamState.get();
+      loadFromStreambuf(*firstFileFromGgufStream);
+    }
+    firstFileFromGgufStreamState.clear();
+  } else {
+    if (shards.gguf_files.empty()) {
+      LOG_INF("%s: load the model metadata from disk file.\n", __func__);
+      loadFromDisk(modelPath);
+    } else {
+      LOG_INF("%s: load the model metadata from disk shards.\n", __func__);
+      loadFromDisk(shards.gguf_files.front());
+    }
+  }
+}
+
+void ModelMetaData::checkInitialized() const {
+  if (metadata_ == nullptr) {
+    throw qvac_errors::StatusError(
+        qvac_lib_inference_addon_llama::errors::ADDON_ID,
+        toString(qvac_lib_inference_addon_llama::errors::InvalidInputFormat),
+        "ModelMetaData: not initialized; call parse() before querying "
+        "metadata");
+  }
+}
+
+bool ModelMetaData::isU32OneOf(
+    const char* key, std::initializer_list<uint32_t> values) const {
+  checkInitialized();
+  uint32_t value = 0;
+  MetaResultStatus status =
+      llama_model_meta_get_u32(metadata_, key, &value);
+  if (status != MetaResultStatus::SUCCESS) {
+    LOG_WRN(
+        "ModelMetaData::isU32OneOf: failed to read key '%s', "
+        "llama_model_meta_get_u32 returned %s\n",
+        key, std::to_string(status).c_str());
+    return false;
+  }
+  for (uint32_t v : values) {
+    if (value == v) return true;
+  }
+  return false;
+}
+
+bool ModelMetaData::hasOneBitQuantization() const {
+  return isU32OneOf(
+      "general.file_type",
+      {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0),
+       static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0)});
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
@@ -1,7 +1,5 @@
 #include "model-interface/ModelMetadata.hpp"
 
-#include <stdexcept>
-
 #include <common/common.h>
 #include <common/log.h>
 #include <llama-cpp.h>
@@ -9,37 +7,16 @@
 
 #include "addon/LlmErrors.hpp"
 
-namespace {
-void throwSinggleGgufStreamErrorNotFound(
-    std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>&
-        singleGgufStreamedFiles,
-    const std::string& modelPath, const char* AddonID) {
-  std::string availableFiles = " No files available.";
-  if (!singleGgufStreamedFiles.empty()) {
-    availableFiles = " Available files: ";
-    auto it = singleGgufStreamedFiles.begin();
-    availableFiles += it->first;
-    ++it;
-    for (; it != singleGgufStreamedFiles.end(); ++it) {
-      availableFiles += ", " + it->first;
-    }
-  }
-  std::string errorMsg = string_format(
-      "%s: failed to load model metadata. path=%s%s\n",
-      __func__,
-      modelPath.c_str(),
-      availableFiles.c_str());
-  throw qvac_errors::StatusError(
-      AddonID,
-      toString(qvac_lib_inference_addon_llama::errors::UnableToLoadMetadata),
-      errorMsg);
-}
-} // namespace
-
 void ModelMetaData::FirstFileFromGgufStreamState::wait() {
   std::unique_lock<std::mutex> lock(firstFileFromGgufStreamMutex_);
   firstFileFromGgufStreamCv_.wait(
       lock, [this]() { return hasFirstFileFromGgufStream_; });
+}
+
+void ModelMetaData::FirstFileFromGgufStreamState::waitForRelease() {
+  std::unique_lock<std::mutex> lock(firstFileFromGgufStreamMutex_);
+  firstFileFromGgufStreamCv_.wait(
+      lock, [this]() { return hasFirstFileFromGgufStream_ && !firstFileFromGgufStream_; });
 }
 
 std::shared_ptr<std::basic_streambuf<char>>
@@ -65,12 +42,11 @@ void ModelMetaData::FirstFileFromGgufStreamState::provide(
 void ModelMetaData::FirstFileFromGgufStreamState::clear() {
   std::lock_guard<std::mutex> lock(firstFileFromGgufStreamMutex_);
   firstFileFromGgufStream_.reset();
+  firstFileFromGgufStreamCv_.notify_all();
 }
 
 void ModelMetaData::parse(
     const std::string& modelPath,
-    std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>&
-        singleGgufStreamedFiles,
     const GGUFShards& shards, bool isStreaming, const char* AddonID) {
 
   auto loadFromStreambuf = [&modelPath,
@@ -118,25 +94,9 @@ void ModelMetaData::parse(
   if (isStreaming) {
     // Wait for the first file from the gguf stream to be available.
     firstFileFromGgufStreamState.wait();
-    if (shards.gguf_files.empty()) {
-      LOG_INF(
-          "%s: load the model metadata from memory (single file).\n", __func__);
-
-      // After waiting for the first file from the gguf stream to be available,
-      // It should have been inserted into singleGgufStreamedFiles but we will
-      // double check the inserted filename matches.
-      auto modelFilename = std::filesystem::path(modelPath).filename().string();
-      auto itGgufModelPath = singleGgufStreamedFiles.find(modelFilename);
-      if (itGgufModelPath == singleGgufStreamedFiles.end()) {
-        throwSinggleGgufStreamErrorNotFound(
-            singleGgufStreamedFiles, modelPath, AddonID);
-      }
-      loadFromStreambuf(*itGgufModelPath->second);
-    } else {
-      LOG_INF("%s: load the model metadata from memory shards.\n", __func__);
-      auto firstFileFromGgufStream = firstFileFromGgufStreamState.get();
-      loadFromStreambuf(*firstFileFromGgufStream);
-    }
+    LOG_INF("%s: load the model metadata from memory.\n", __func__);
+    auto firstFileFromGgufStream = firstFileFromGgufStreamState.get();
+    loadFromStreambuf(*firstFileFromGgufStream);
     firstFileFromGgufStreamState.clear();
   } else {
     if (shards.gguf_files.empty()) {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
@@ -79,6 +79,8 @@ void ModelMetaData::parse(
     MetaResultStatus status =
         llama_model_meta_from_streambuf(streambuf, out_metadata);
     if (status != MetaResultStatus::SUCCESS) {
+      // leave object in a consistent uninitialized state, library can leave it in an invalid state
+      *out_metadata = nullptr;  
       std::string statusStr = std::to_string(status);
       std::string errorMsg = string_format(
           "ModelMetadata::loadFromStreambuf: failed to load model metadata "
@@ -98,6 +100,7 @@ void ModelMetaData::parse(
     MetaResultStatus status =
         llama_model_meta_from_file(diskPath.c_str(), out_metadata);
     if (status != MetaResultStatus::SUCCESS) {
+      *out_metadata = nullptr;
       std::string statusStr = std::to_string(status);
       std::string errorMsg = string_format(
           "ModelMetadata::loadFromDisk: failed to load model metadata "

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
@@ -119,6 +119,18 @@ void ModelMetaData::checkInitialized() const {
   }
 }
 
+std::optional<uint32_t> ModelMetaData::tryGetU32(const char* key) const {
+  if (metadata_ == nullptr) {
+    return std::nullopt;
+  }
+  uint32_t value = 0;
+  MetaResultStatus status = llama_model_meta_get_u32(metadata_, key, &value);
+  if (status != MetaResultStatus::SUCCESS) {
+    return std::nullopt;
+  }
+  return value;
+}
+
 bool ModelMetaData::isU32OneOf(
     const char* key, std::initializer_list<uint32_t> values) const {
   checkInitialized();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
@@ -2,7 +2,6 @@
 
 #include <condition_variable>
 #include <initializer_list>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -23,15 +22,11 @@ public:
   ModelMetaData() = default;
 
   /// @param modelPath Model to load (single .gguf)
-  /// @param singleGgufStreamedFiles Map containing .gguf files that finished
-  /// streaming
   /// @param shards Containing sharded files, if any
   /// @param isStreaming Whether metadata is loaded from streamed buffers
   /// @param AddonID Identifier for error reporting
   void parse(
       const std::string& modelPath,
-      std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>&
-          singleGgufStreamedFiles,
       const GGUFShards& shards, bool isStreaming, const char* AddonID);
 
   /// @brief Returns true if the u32 value at @p key matches any of @p values.
@@ -45,6 +40,7 @@ public:
   class FirstFileFromGgufStreamState {
   public:
     void wait();
+    void waitForRelease();
     std::shared_ptr<std::basic_streambuf<char>> get();
     /// @brief Provides the first streamed GGUF file.
     /// @note To avoid deadlock, if ModelMetaData::parse() is already waiting

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <condition_variable>
+#include <iomanip>
 #include <initializer_list>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <sstream>
 #include <string>
 
 #include <llama-cpp.h>

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
@@ -4,6 +4,7 @@
 #include <initializer_list>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 
 #include <llama-cpp.h>
@@ -28,6 +29,9 @@ public:
   void parse(
       const std::string& modelPath,
       const GGUFShards& shards, bool isStreaming, const char* AddonID);
+
+  /// @brief Returns the u32 value at @p key, or nullopt if absent/uninitialized.
+  [[nodiscard]] std::optional<uint32_t> tryGetU32(const char* key) const;
 
   /// @brief Returns true if the u32 value at @p key matches any of @p values.
   [[nodiscard]] bool

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <condition_variable>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <llama-cpp.h>
+
+#include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
+
+/// @brief Access model metadata without loading weights into memory.
+/// @details After parse(), all GGUF key-values are held in-memory and can be
+/// queried without further disk or streambuf access.
+class ModelMetaData {
+  void checkInitialized() const;
+
+  metadata_handle_ptr metadata_;
+
+public:
+  ModelMetaData() = default;
+
+  /// @param modelPath Model to load (single .gguf)
+  /// @param singleGgufStreamedFiles Map containing .gguf files that finished
+  /// streaming
+  /// @param shards Containing sharded files, if any
+  /// @param isStreaming Whether metadata is loaded from streamed buffers
+  /// @param AddonID Identifier for error reporting
+  void parse(
+      const std::string& modelPath,
+      std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>&
+          singleGgufStreamedFiles,
+      const GGUFShards& shards, bool isStreaming, const char* AddonID);
+
+  /// @brief Returns true if the u32 value at @p key matches any of @p values.
+  [[nodiscard]] bool
+  isU32OneOf(const char* key, std::initializer_list<uint32_t> values) const;
+
+  [[nodiscard]] bool hasOneBitQuantization() const;
+
+  // Code below for streaming support
+
+  class FirstFileFromGgufStreamState {
+  public:
+    void wait();
+    std::shared_ptr<std::basic_streambuf<char>> get();
+    /// @brief Provides the first streamed GGUF file.
+    /// @note To avoid deadlock, if ModelMetaData::parse() is already waiting
+    /// for the first streamed file, call this from another thread.
+    /// @note Underlying LLM engine should leave the streambuf pointing to the
+    /// beginning of the file.
+    void provide(
+        std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream);
+    /// @brief Releases the held streambuf reference. Call after metadata has
+    /// been parsed and the streambuf is no longer needed.
+    void clear();
+
+  private:
+    std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream_;
+    std::mutex firstFileFromGgufStreamMutex_;
+    std::condition_variable firstFileFromGgufStreamCv_;
+    bool hasFirstFileFromGgufStream_ = false;
+  };
+  FirstFileFromGgufStreamState firstFileFromGgufStreamState;
+};

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/http-loader.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/http-loader.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const https = require('bare-https')
+const BaseDL = require('@qvac/dl-base')
+
+/**
+ * A minimal HTTP/HTTPS loader that implements the BaseDL interface.
+ * Fetches model files from a remote base URL, following redirects.
+ */
+class HttpDL extends BaseDL {
+  constructor (opts) {
+    super(opts)
+
+    if (!opts || !opts.baseUrl) {
+      throw new Error('HttpDL requires a baseUrl option')
+    }
+
+    this.baseUrl = opts.baseUrl.endsWith('/') ? opts.baseUrl : opts.baseUrl + '/'
+    this._activeStreams = new Set()
+  }
+
+  /**
+   * Return the Content-Length of a remote file via an HTTP HEAD request.
+   * @param {string} filename
+   * @returns {Promise<number>} byte size
+   */
+  async getFileSize (filename) {
+    return this._request('HEAD', this.baseUrl + filename)
+  }
+
+  /**
+   * Fetch a file by name and return it as a readable stream.
+   * The stream is tracked so that close() can destroy it if needed.
+   * @param {string} filename
+   * @returns {Promise<NodeJS.ReadableStream>}
+   */
+  async getStream (filename) {
+    const response = await this._request('GET', this.baseUrl + filename)
+    this._activeStreams.add(response)
+    const cleanup = () => this._activeStreams.delete(response)
+    response.on('end', cleanup)
+    response.on('close', cleanup)
+    response.on('error', cleanup)
+    return response
+  }
+
+  async _close () {
+    for (const stream of this._activeStreams) {
+      stream.destroy()
+    }
+    this._activeStreams.clear()
+  }
+
+  _request (method, url, maxRedirects = 10) {
+    return new Promise((resolve, reject) => {
+      if (maxRedirects === 0) return reject(new Error(`Too many redirects for ${url}`))
+
+      const req = https.request(url, { method, agent: false }, (response) => {
+        if ([301, 302, 307, 308].includes(response.statusCode)) {
+          let loc = response.headers.location
+          if (loc && loc.startsWith('/')) {
+            const parsed = new URL(url)
+            loc = `${parsed.protocol}//${parsed.host}${loc}`
+          }
+          resolve(this._request(method, loc, maxRedirects - 1))
+          return
+        }
+
+        if (response.statusCode !== 200) {
+          reject(new Error(`HTTP ${response.statusCode} ${method} ${url}`))
+          return
+        }
+
+        if (method === 'HEAD') {
+          resolve(parseInt(response.headers['content-length'] || '0', 10))
+        } else {
+          resolve(response)
+        }
+      })
+
+      req.on('error', reject)
+      req.end()
+    })
+  }
+
+  async list () {
+    throw new Error('HttpDL does not support list()')
+  }
+}
+
+module.exports = HttpDL

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
@@ -5,12 +5,15 @@ const FilesystemDL = require('@qvac/dl-filesystem')
 
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
+const HttpDL = require('./http-loader')
 const os = require('bare-os')
+const path = require('bare-path')
 
 const platform = os.platform()
 const arch = os.arch()
 const isDarwinX64 = platform === 'darwin' && arch === 'x64'
 const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
+const isLinuxX64 = platform === 'linux' && arch === 'x64'
 const useCpu = isDarwinX64 || isLinuxArm64
 
 const DEFAULT_MODEL = {
@@ -121,6 +124,58 @@ test('model unload is clean and idempotent', { timeout: 600_000 }, async t => {
   } finally {
     await loader.close().catch(() => {})
   }
+})
+
+const SHARDED_MODEL = {
+  name: 'Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf',
+  baseUrl: 'https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded/resolve/main/'
+}
+
+// This test can take longer to download and execute. To avoid blowing up testing time on all
+// platforms, just use Linux for now. C++ tests already have faster coverage for each type
+// of load.
+test('network loader can run inference end-to-end with sharded model', { timeout: 4 * 60 * 1000, skip: !isLinuxX64 }, async t => {
+  const modelDir = path.resolve(__dirname, '../model')
+
+  const loader = new HttpDL({ baseUrl: SHARDED_MODEL.baseUrl })
+  const config = {
+    gpu_layers: '999',
+    ctx_size: '1024',
+    device: useCpu ? 'cpu' : 'gpu',
+    n_predict: '32',
+    verbosity: '2'
+  }
+
+  const addon = new LlmLlamacpp({
+    loader,
+    modelName: SHARDED_MODEL.name,
+    diskPath: modelDir,
+    logger: console,
+    opts: { stats: true }
+  }, config)
+
+  let progressMade = 0
+  let lastLogTime = 0
+  const LOG_INTERVAL_MS = 3000
+  const onProgress = (data) => {
+    if (typeof data !== 'object' || data === null) return
+    const now = Date.now()
+    const shard = data.currentFile.replace(/^.*\//, '')
+    progressMade = Math.max(progressMade, data.overallProgress)
+    if (data.action === 'loadingFile' && now - lastLogTime >= LOG_INTERVAL_MS) {
+      console.log(`\r  Loading ${shard}: ${data.currentFileProgress}%  (overall ${data.overallProgress}%)   `)
+      lastLogTime = now
+    } else if (data.action === 'completeFile') {
+      console.log(`\r  Loaded  ${shard}: 100.00% (overall ${data.overallProgress}%) [${data.filesProcessed}/${data.totalFiles}]\n`)
+      lastLogTime = now
+    }
+  }
+
+  await addon.load(true, onProgress)
+  const response = await addon.run(BASE_PROMPT)
+  const output = await collectResponse(response)
+  t.ok(output.length > 0, 'network-loaded sharded model should generate output')
+  t.ok(progressMade > 0, 'network-loaded sharded model should make progress')
 })
 
 // Keep event loop alive briefly to let pending async operations complete

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   # Placeholder tests (to be implemented)
   test_mtmd_llm_context.cpp
   test_llm_context_base.cpp
+  test_model_metadata.cpp
   # Utility tests
   test_utf8_token_buffer.cpp
   test_chat_template_utils.cpp
@@ -28,6 +29,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/CacheManager.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+  ${CMAKE_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/MtmdLlmContext.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/TextLlmContext.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/utils/LoggingMacros.cpp

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   test_mtmd_llm_context.cpp
   test_llm_context_base.cpp
   test_model_metadata.cpp
+  test_model_full_loading.cpp
   # Utility tests
   test_utf8_token_buffer.cpp
   test_chat_template_utils.cpp

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_addon_cpp.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_addon_cpp.cpp
@@ -24,24 +24,7 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "20";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
     fs::path backendDir;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_cache_management.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_cache_management.cpp
@@ -53,24 +53,7 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
     fs::path backendDir;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_chat_template_utils.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_chat_template_utils.cpp
@@ -20,24 +20,7 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
     fs::path backendDir;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
+#include <cstdlib>
 #include <filesystem>
 #include <string>
+
+#include <gtest/gtest.h>
+#include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
 
 namespace test_common {
 
@@ -66,18 +70,6 @@ struct BaseTestModelPath {
   }
 
   /**
-   * Default first shard path for split models.
-   * Uses Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf under the base dir.
-   * https://huggingface.co/jmb95/Llama-3.2-1B-Instruct-Q4_0-sharded
-   */
-  static std::string getSharded() {
-    fs::path p = path() / "Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf";
-    if (fs::exists(p))
-      return p.string();
-    return "Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf";
-  }
-
-  /**
    * Path for a specific filename under the base. If the file exists, returns
    * its full path; otherwise returns the filename only (for clearer errors).
    */
@@ -102,4 +94,101 @@ struct BaseTestModelPath {
   }
 };
 
+/**
+ * Encapsulates discovery and guard logic for a single optional test model,
+ * covering both single-file and sharded GGUF layouts.
+ *
+ * Construction resolves the path once: it checks @p envVar first, then
+ * looks for @p filename under BaseTestModelPath. When @p isSharded is true
+ * the shard list is also expanded via GGUFShards::expandGGUFIntoShards().
+ * Callers that need absolute shard paths should call
+ * LlamaModel::resolveShardPaths(model.shards, model.path) after construction.
+ *
+ * Use REQUIRE_MODEL() in the test body to skip or fail automatically when
+ * the model is absent.
+ *
+ * Single-file example:
+ *   TestModelPath m("my-model-Q4_0.gguf", "MY_MODEL_PATH",
+ *                   TestModelPath::OnMissing::Skip,
+ *                   "https://huggingface.co/...");
+ *
+ * Sharded example:
+ *   TestModelPath m("my-model-00001-of-00008.gguf", "MY_SHARD_PATH",
+ *                   TestModelPath::OnMissing::Skip, "https://...", true);
+ *   LlamaModel::resolveShardPaths(m.shards, m.path);  // resolve absolute paths
+ */
+struct TestModelPath {
+  enum class OnMissing { Fail, Skip };
+
+  std::string path;      ///< Resolved absolute path to the first (or only) file.
+  std::string filename;  ///< Bare .gguf filename used in diagnostic messages.
+  std::string envVar;    ///< Env-var name shown in the diagnostic (may be "").
+  std::string hfUrl;     ///< HuggingFace URL shown in the diagnostic (may be "").
+  OnMissing onMissing;   ///< Whether to FAIL or GTEST_SKIP when absent.
+  bool isSharded;        ///< True when the model is split across multiple files.
+  GGUFShards shards;     ///< Populated (without absolute paths) when isSharded.
+
+  TestModelPath() : onMissing(OnMissing::Skip), isSharded(false) {}
+
+  TestModelPath(
+      const char* filename,
+      const char* envVar,
+      OnMissing onMissing,
+      const char* hfUrl = "",
+      bool isSharded = false)
+      : filename(filename),
+        envVar(envVar ? envVar : ""),
+        hfUrl(hfUrl),
+        onMissing(onMissing),
+        isSharded(isSharded) {
+    const char* env = envVar ? std::getenv(envVar) : nullptr;
+    if (env && fs::exists(env)) {
+      path = env;
+    } else {
+      std::string p = BaseTestModelPath::get(filename);
+      if (fs::exists(p))
+        path = p;
+    }
+    if (isSharded && !path.empty())
+      shards = GGUFShards::expandGGUFIntoShards(path);
+  }
+
+  /**
+   * Returns true when the model is ready to use.
+   * For sharded models this requires at least one shard to have been
+   * resolved; for single-file models a non-empty path suffices.
+   */
+  [[nodiscard]] bool found() const {
+    return isSharded ? !shards.gguf_files.empty() : !path.empty();
+  }
+
+  [[nodiscard]] std::string missingMessage() const {
+    std::string msg = filename + " not found";
+    if (!envVar.empty())
+      msg += " (" + envVar + " or models/unit-test)";
+    else
+      msg += " in models/unit-test";
+    if (!hfUrl.empty())
+      msg += "; see " + hfUrl;
+    return msg;
+  }
+};
+
 } // namespace test_common
+
+/**
+ * Guard a test against a missing model: emits GTEST_SKIP() or FAIL()
+ * (as configured on the model) when the file was not found.
+ *
+ * Must be called directly from the test function body, not from a helper,
+ * so that GTEST_SKIP / FAIL return from the correct stack frame.
+ */
+#define REQUIRE_MODEL(m)                                                       \
+  do {                                                                         \
+    if (!(m).found()) {                                                        \
+      if ((m).onMissing == ::test_common::TestModelPath::OnMissing::Skip)      \
+        GTEST_SKIP() << (m).missingMessage();                                  \
+      else                                                                     \
+        FAIL() << (m).missingMessage();                                        \
+    }                                                                          \
+  } while (false)

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 namespace test_common {
@@ -32,5 +33,67 @@ inline const char* getTestGpuLayers() {
   return "99";
 #endif
 }
+
+namespace fs = std::filesystem;
+
+/**
+ * Reusable base path for unit-test models (e.g. models/unit-test).
+ * Use get() for the default model path, or get("filename.gguf") for a
+ * specific file under the base.
+ */
+struct BaseTestModelPath {
+  /** Base directory for unit-test models. */
+  static fs::path path() {
+    if (fs::exists(fs::path{"../../../models/unit-test"})) {
+      return fs::path{"../../../models/unit-test"};
+    }
+    return fs::path{"models/unit-test"};
+  }
+
+  /**
+   * Default model path: Llama-3.2-1B-Instruct-Q4_0.gguf if present,
+   * else test_model.gguf, else "Llama-3.2-1B-Instruct-Q4_0.gguf".
+   */
+  static std::string get() {
+    fs::path base = path();
+    fs::path p = base / "Llama-3.2-1B-Instruct-Q4_0.gguf";
+    if (fs::exists(p)) return p.string();
+    p = base / "test_model.gguf";
+    if (fs::exists(p)) return p.string();
+    return "Llama-3.2-1B-Instruct-Q4_0.gguf";
+  }
+
+  /**
+   * Default first shard path for split models.
+   * Uses Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf under the base dir.
+   * https://huggingface.co/jmb95/Llama-3.2-1B-Instruct-Q4_0-sharded
+   */
+  static std::string getSharded() {
+    fs::path p = path() / "Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf";
+    if (fs::exists(p)) return p.string();
+    return "Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf";
+  }
+
+  /**
+   * Path for a specific filename under the base. If the file exists, returns
+   * its full path; otherwise returns the filename only (for clearer errors).
+   */
+  static std::string get(const char* filename) {
+    fs::path p = path() / filename;
+    if (fs::exists(p)) return p.string();
+    return filename;
+  }
+
+  /**
+   * Path for a preferred filename with fallback. Tries preferred then fallback
+   * under the base; returns full path if either exists, else preferred.
+   */
+  static std::string get(const char* preferred, const char* fallback) {
+    fs::path base = path();
+    if (fs::exists(base / preferred)) return (base / preferred).string();
+    if (fs::exists(base / fallback)) return (base / fallback).string();
+    return preferred;
+  }
+};
 
 } // namespace test_common

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
@@ -57,9 +57,11 @@ struct BaseTestModelPath {
   static std::string get() {
     fs::path base = path();
     fs::path p = base / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(p)) return p.string();
+    if (fs::exists(p))
+      return p.string();
     p = base / "test_model.gguf";
-    if (fs::exists(p)) return p.string();
+    if (fs::exists(p))
+      return p.string();
     return "Llama-3.2-1B-Instruct-Q4_0.gguf";
   }
 
@@ -70,7 +72,8 @@ struct BaseTestModelPath {
    */
   static std::string getSharded() {
     fs::path p = path() / "Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf";
-    if (fs::exists(p)) return p.string();
+    if (fs::exists(p))
+      return p.string();
     return "Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf";
   }
 
@@ -80,7 +83,8 @@ struct BaseTestModelPath {
    */
   static std::string get(const char* filename) {
     fs::path p = path() / filename;
-    if (fs::exists(p)) return p.string();
+    if (fs::exists(p))
+      return p.string();
     return filename;
   }
 
@@ -90,8 +94,10 @@ struct BaseTestModelPath {
    */
   static std::string get(const char* preferred, const char* fallback) {
     fs::path base = path();
-    if (fs::exists(base / preferred)) return (base / preferred).string();
-    if (fs::exists(base / fallback)) return (base / fallback).string();
+    if (fs::exists(base / preferred))
+      return (base / preferred).string();
+    if (fs::exists(base / fallback))
+      return (base / fallback).string();
     return preferred;
   }
 };

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include <gtest/gtest.h>
+
 #include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
 
 namespace test_common {
@@ -120,27 +121,21 @@ struct BaseTestModelPath {
 struct TestModelPath {
   enum class OnMissing { Fail, Skip };
 
-  std::string path;      ///< Resolved absolute path to the first (or only) file.
-  std::string filename;  ///< Bare .gguf filename used in diagnostic messages.
-  std::string envVar;    ///< Env-var name shown in the diagnostic (may be "").
-  std::string hfUrl;     ///< HuggingFace URL shown in the diagnostic (may be "").
-  OnMissing onMissing;   ///< Whether to FAIL or GTEST_SKIP when absent.
-  bool isSharded;        ///< True when the model is split across multiple files.
-  GGUFShards shards;     ///< Populated (without absolute paths) when isSharded.
+  std::string path;     ///< Resolved absolute path to the first (or only) file.
+  std::string filename; ///< Bare .gguf filename used in diagnostic messages.
+  std::string envVar;   ///< Env-var name shown in the diagnostic (may be "").
+  std::string hfUrl;   ///< HuggingFace URL shown in the diagnostic (may be "").
+  OnMissing onMissing; ///< Whether to FAIL or GTEST_SKIP when absent.
+  bool isSharded;      ///< True when the model is split across multiple files.
+  GGUFShards shards;   ///< Populated (without absolute paths) when isSharded.
 
   TestModelPath() : onMissing(OnMissing::Skip), isSharded(false) {}
 
   TestModelPath(
-      const char* filename,
-      const char* envVar,
-      OnMissing onMissing,
-      const char* hfUrl = "",
-      bool isSharded = false)
-      : filename(filename),
-        envVar(envVar ? envVar : ""),
-        hfUrl(hfUrl),
-        onMissing(onMissing),
-        isSharded(isSharded) {
+      const char* filename, const char* envVar, OnMissing onMissing,
+      const char* hfUrl = "", bool isSharded = false)
+      : filename(filename), envVar(envVar ? envVar : ""), hfUrl(hfUrl),
+        onMissing(onMissing), isSharded(isSharded) {
     const char* env = envVar ? std::getenv(envVar) : nullptr;
     if (env && fs::exists(env)) {
       path = env;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
@@ -44,25 +44,7 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
-
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
     fs::path backendDir;
@@ -714,30 +696,19 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutUserMessage) {
     FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
-  fs::path basePath;
-  if (fs::exists(fs::path{"../../../models/unit-test"})) {
-    basePath = fs::path{"../../../models/unit-test"};
-  } else {
-    basePath = fs::path{"models/unit-test"};
-  }
-
-  fs::path multimodalModelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-  if (!fs::exists(multimodalModelPath)) {
-    multimodalModelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-  }
-
-  fs::path projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-  if (!fs::exists(projectionPath)) {
-    projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-  }
+  std::string multimodalModelPath = test_common::BaseTestModelPath::get(
+      "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+  std::string projectionPath = test_common::BaseTestModelPath::get(
+      "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+      "mmproj-SmolVLM-500M-Instruct.gguf");
 
   if (!fs::exists(multimodalModelPath) || !fs::exists(projectionPath)) {
     FAIL() << "Multimodal model and projection required for this test";
   }
 
   LlamaModel model(
-      multimodalModelPath.string(),
-      projectionPath.string(),
+      std::move(multimodalModelPath),
+      std::move(projectionPath),
       std::unordered_map<std::string, std::string>(config_files));
   model.waitForLoadInitialization();
 
@@ -757,30 +728,19 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutRequest) {
     FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
-  fs::path basePath;
-  if (fs::exists(fs::path{"../../../models/unit-test"})) {
-    basePath = fs::path{"../../../models/unit-test"};
-  } else {
-    basePath = fs::path{"models/unit-test"};
-  }
-
-  fs::path multimodalModelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-  if (!fs::exists(multimodalModelPath)) {
-    multimodalModelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-  }
-
-  fs::path projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-  if (!fs::exists(projectionPath)) {
-    projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-  }
+  std::string multimodalModelPath = test_common::BaseTestModelPath::get(
+      "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+  std::string projectionPath = test_common::BaseTestModelPath::get(
+      "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+      "mmproj-SmolVLM-500M-Instruct.gguf");
 
   if (!fs::exists(multimodalModelPath) || !fs::exists(projectionPath)) {
     FAIL() << "Multimodal model and projection required for this test";
   }
 
   LlamaModel model(
-      multimodalModelPath.string(),
-      projectionPath.string(),
+      std::move(multimodalModelPath),
+      std::move(projectionPath),
       std::unordered_map<std::string, std::string>(config_files));
   model.waitForLoadInitialization();
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llm_context_base.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llm_context_base.cpp
@@ -56,24 +56,7 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
     fs::path backendDir;
@@ -89,24 +72,11 @@ protected:
   bool hasValidModel() { return fs::exists(test_model_path); }
 
   bool hasValidMultimodalModel() {
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (!fs::exists(modelPath)) {
-      modelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-    }
-
-    fs::path projectionPath =
-        basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (!fs::exists(projectionPath)) {
-      projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-    }
-
+    std::string modelPath = test_common::BaseTestModelPath::get(
+        "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+    std::string projectionPath = test_common::BaseTestModelPath::get(
+        "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+        "mmproj-SmolVLM-500M-Instruct.gguf");
     return fs::exists(modelPath) && fs::exists(projectionPath);
   }
 
@@ -133,26 +103,11 @@ protected:
       return nullptr;
     }
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (!fs::exists(modelPath)) {
-      modelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-    }
-
-    fs::path projectionPath =
-        basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (!fs::exists(projectionPath)) {
-      projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-    }
-
-    std::string modelPathStr = modelPath.string();
-    std::string projectionPathStr = projectionPath.string();
+    std::string modelPathStr = test_common::BaseTestModelPath::get(
+        "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+    std::string projectionPathStr = test_common::BaseTestModelPath::get(
+        "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+        "mmproj-SmolVLM-500M-Instruct.gguf");
     auto configCopy = config_files;
     auto model = std::make_unique<LlamaModel>(
         std::move(modelPathStr),

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_full_loading.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_full_loading.cpp
@@ -38,20 +38,27 @@ protected:
 #endif
     config_["backendsDir"] = backendDir.string();
 
-    singleModel_ = MP(
-        "Llama-3.2-1B-Instruct-Q4_0.gguf",
-        nullptr,
-        MP::OnMissing::Fail,
-        "");
+    singleModel_ =
+        MP("Llama-3.2-1B-Instruct-Q4_0.gguf", nullptr, MP::OnMissing::Fail, "");
 
-    shardedModel_ = MP(
-        "Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf",
-        "SHARDED_MODEL_FIRST_SHARD_PATH",
-        MP::OnMissing::Skip,
-        "https://huggingface.co/jmb95/Llama-3.2-1B-Instruct-Q4_0-sharded",
-        true /* isSharded */);
+    shardedModel_ =
+        MP("Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf",
+           "SHARDED_MODEL_FIRST_SHARD_PATH",
+           MP::OnMissing::Fail,
+           "https://huggingface.co/jmb95/Qwen3-0.6-UD-IQ1_S-sharded",
+           true /* isSharded */);
     if (shardedModel_.found())
       LlamaModel::resolveShardPaths(shardedModel_.shards, shardedModel_.path);
+
+    largeShardedModel_ =
+        MP("Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf",
+           "LARGE_SHARDED_MODEL_FIRST_SHARD_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/jmb95/Llama-3.2-1B-Instruct-Q4_0-sharded",
+           true /* isSharded */);
+    if (largeShardedModel_.found())
+      LlamaModel::resolveShardPaths(
+          largeShardedModel_.shards, largeShardedModel_.path);
   }
 
   LlamaModel loadModel(const std::string& modelPath) {
@@ -61,9 +68,27 @@ protected:
     return LlamaModel(std::move(path), std::move(projection), std::move(cfg));
   }
 
+  void streamShardsIntoModel(
+      LlamaModel& model, const test_common::TestModelPath& mp) {
+    std::string tensorsBasename =
+        fs::path(mp.shards.tensors_file).filename().string();
+    auto tensorsBuf = readFileToStreambufBinary(mp.shards.tensors_file);
+    ASSERT_NE(tensorsBuf, nullptr)
+        << "Failed to open: " << mp.shards.tensors_file;
+    model.setWeightsForFile(tensorsBasename, std::move(tensorsBuf));
+
+    for (const auto& shardPath : mp.shards.gguf_files) {
+      auto streambuf = readFileToStreambufBinary(shardPath);
+      ASSERT_NE(streambuf, nullptr) << "Failed to open shard: " << shardPath;
+      model.setWeightsForFile(
+          fs::path(shardPath).filename().string(), std::move(streambuf));
+    }
+  }
+
   std::unordered_map<std::string, std::string> config_;
   test_common::TestModelPath singleModel_;
   test_common::TestModelPath shardedModel_;
+  test_common::TestModelPath largeShardedModel_;
 };
 
 TEST_F(ModelFullLoadingTest, SingleFile_LoadsSuccessfully) {
@@ -94,21 +119,22 @@ TEST_F(ModelFullLoadingTest, Sharded_LoadsSuccessfully) {
 TEST_F(ModelFullLoadingTest, StreamingShards_LoadsSuccessfully) {
   REQUIRE_MODEL(shardedModel_);
   LlamaModel model = loadModel(shardedModel_.path);
+  streamShardsIntoModel(model, shardedModel_);
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
 
-  std::string tensorsBasename =
-      fs::path(shardedModel_.shards.tensors_file).filename().string();
-  auto tensorsBuf =
-      readFileToStreambufBinary(shardedModel_.shards.tensors_file);
-  ASSERT_NE(tensorsBuf, nullptr)
-      << "Failed to open: " << shardedModel_.shards.tensors_file;
-  model.setWeightsForFile(tensorsBasename, std::move(tensorsBuf));
+TEST_F(ModelFullLoadingTest, LargeSharded_LoadsSuccessfully) {
+  REQUIRE_MODEL(largeShardedModel_);
+  LlamaModel model = loadModel(largeShardedModel_.path);
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
 
-  for (const auto& shardPath : shardedModel_.shards.gguf_files) {
-    auto streambuf = readFileToStreambufBinary(shardPath);
-    ASSERT_NE(streambuf, nullptr) << "Failed to open shard: " << shardPath;
-    model.setWeightsForFile(
-        fs::path(shardPath).filename().string(), std::move(streambuf));
-  }
+TEST_F(ModelFullLoadingTest, StreamingLargeShards_LoadsSuccessfully) {
+  REQUIRE_MODEL(largeShardedModel_);
+  LlamaModel model = loadModel(largeShardedModel_.path);
+  streamShardsIntoModel(model, largeShardedModel_);
   model.waitForLoadInitialization();
   EXPECT_TRUE(model.isLoaded());
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_full_loading.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_full_loading.cpp
@@ -1,0 +1,117 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/LlamaModel.hpp"
+#include "test_common.hpp"
+
+namespace fs = std::filesystem;
+
+static std::unique_ptr<std::basic_streambuf<char>>
+readFileToStreambufBinary(const std::string& path) {
+  auto buf = std::make_unique<std::filebuf>();
+  if (!buf->open(path, std::ios::binary | std::ios::in)) {
+    return nullptr;
+  }
+  return buf;
+}
+
+class ModelFullLoadingTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    config_["device"] = test_common::getTestDevice();
+    config_["ctx_size"] = "2048";
+    config_["gpu_layers"] = test_common::getTestGpuLayers();
+    config_["n_predict"] = "10";
+
+    fs::path backendDir;
+#ifdef TEST_BINARY_DIR
+    backendDir = fs::path(TEST_BINARY_DIR);
+#else
+    backendDir = fs::current_path() / "build" / "test" / "unit";
+#endif
+    config_["backendsDir"] = backendDir.string();
+
+    single_model_path_ = test_common::BaseTestModelPath::get();
+
+    shardedModel_ = MP(
+        "Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf",
+        "SHARDED_MODEL_FIRST_SHARD_PATH",
+        MP::OnMissing::Skip,
+        "https://huggingface.co/jmb95/Qwen3-0.6-UD-IQ1_S-sharded",
+        true /* isSharded */);
+    if (shardedModel_.found())
+      LlamaModel::resolveShardPaths(shardedModel_.shards, shardedModel_.path);
+  }
+
+  LlamaModel loadModel(const std::string& modelPath) {
+    std::string path = modelPath;
+    std::string projection;
+    auto cfg = config_;
+    return LlamaModel(std::move(path), std::move(projection), std::move(cfg));
+  }
+
+  std::unordered_map<std::string, std::string> config_;
+  std::string single_model_path_;
+  std::string sharded_model_path_;
+  GGUFShards shards_;
+};
+
+TEST_F(ModelFullLoadingTest, SingleFile_LoadsSuccessfully) {
+  if (!fs::exists(single_model_path_)) {
+    FAIL() << "Test model not found at: " << single_model_path_;
+  }
+  LlamaModel model = loadModel(single_model_path_);
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
+
+TEST_F(ModelFullLoadingTest, StreamingSingleFile_LoadsSuccessfully) {
+  if (!fs::exists(single_model_path_)) {
+    FAIL() << "Test model not found at: " << single_model_path_;
+  }
+  LlamaModel model = loadModel(single_model_path_);
+  std::string filename = fs::path(single_model_path_).filename().string();
+  auto streambuf = readFileToStreambufBinary(single_model_path_);
+  ASSERT_NE(streambuf, nullptr) << "Failed to open: " << single_model_path_;
+  model.setWeightsForFile(filename, std::move(streambuf));
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
+
+TEST_F(ModelFullLoadingTest, Sharded_LoadsSuccessfully) {
+  if (!fs::exists(sharded_model_path_)) {
+    GTEST_SKIP() << "Sharded model not found at: " << sharded_model_path_;
+  }
+  LlamaModel model = loadModel(sharded_model_path_);
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
+
+TEST_F(ModelFullLoadingTest, StreamingShards_LoadsSuccessfully) {
+  if (shards_.gguf_files.empty()) {
+    GTEST_SKIP() << "Sharded model not found at: " << sharded_model_path_;
+  }
+  LlamaModel model = loadModel(sharded_model_path_);
+  // Tensors list file first
+  std::string tensorsBasename =
+      fs::path(shards_.tensors_file).filename().string();
+  auto tensorsBuf = readFileToStreambufBinary(shards_.tensors_file);
+  ASSERT_NE(tensorsBuf, nullptr) << "Failed to open: " << shards_.tensors_file;
+  model.setWeightsForFile(tensorsBasename, std::move(tensorsBuf));
+
+  // Then each shard
+  for (const auto& shardPath : shards_.gguf_files) {
+    auto streambuf = readFileToStreambufBinary(shardPath);
+    ASSERT_NE(streambuf, nullptr) << "Failed to open shard: " << shardPath;
+    std::string filename = fs::path(shardPath).filename().string();
+    model.setWeightsForFile(filename, std::move(streambuf));
+  }
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_full_loading.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_full_loading.cpp
@@ -1,4 +1,3 @@
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -24,6 +23,8 @@ readFileToStreambufBinary(const std::string& path) {
 class ModelFullLoadingTest : public ::testing::Test {
 protected:
   void SetUp() override {
+    using MP = test_common::TestModelPath;
+
     config_["device"] = test_common::getTestDevice();
     config_["ctx_size"] = "2048";
     config_["gpu_layers"] = test_common::getTestGpuLayers();
@@ -37,13 +38,17 @@ protected:
 #endif
     config_["backendsDir"] = backendDir.string();
 
-    single_model_path_ = test_common::BaseTestModelPath::get();
+    singleModel_ = MP(
+        "Llama-3.2-1B-Instruct-Q4_0.gguf",
+        nullptr,
+        MP::OnMissing::Fail,
+        "");
 
     shardedModel_ = MP(
-        "Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf",
+        "Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf",
         "SHARDED_MODEL_FIRST_SHARD_PATH",
         MP::OnMissing::Skip,
-        "https://huggingface.co/jmb95/Qwen3-0.6-UD-IQ1_S-sharded",
+        "https://huggingface.co/jmb95/Llama-3.2-1B-Instruct-Q4_0-sharded",
         true /* isSharded */);
     if (shardedModel_.found())
       LlamaModel::resolveShardPaths(shardedModel_.shards, shardedModel_.path);
@@ -57,60 +62,52 @@ protected:
   }
 
   std::unordered_map<std::string, std::string> config_;
-  std::string single_model_path_;
-  std::string sharded_model_path_;
-  GGUFShards shards_;
+  test_common::TestModelPath singleModel_;
+  test_common::TestModelPath shardedModel_;
 };
 
 TEST_F(ModelFullLoadingTest, SingleFile_LoadsSuccessfully) {
-  if (!fs::exists(single_model_path_)) {
-    FAIL() << "Test model not found at: " << single_model_path_;
-  }
-  LlamaModel model = loadModel(single_model_path_);
+  REQUIRE_MODEL(singleModel_);
+  LlamaModel model = loadModel(singleModel_.path);
   model.waitForLoadInitialization();
   EXPECT_TRUE(model.isLoaded());
 }
 
 TEST_F(ModelFullLoadingTest, StreamingSingleFile_LoadsSuccessfully) {
-  if (!fs::exists(single_model_path_)) {
-    FAIL() << "Test model not found at: " << single_model_path_;
-  }
-  LlamaModel model = loadModel(single_model_path_);
-  std::string filename = fs::path(single_model_path_).filename().string();
-  auto streambuf = readFileToStreambufBinary(single_model_path_);
-  ASSERT_NE(streambuf, nullptr) << "Failed to open: " << single_model_path_;
+  REQUIRE_MODEL(singleModel_);
+  LlamaModel model = loadModel(singleModel_.path);
+  std::string filename = fs::path(singleModel_.path).filename().string();
+  auto streambuf = readFileToStreambufBinary(singleModel_.path);
+  ASSERT_NE(streambuf, nullptr) << "Failed to open: " << singleModel_.path;
   model.setWeightsForFile(filename, std::move(streambuf));
   model.waitForLoadInitialization();
   EXPECT_TRUE(model.isLoaded());
 }
 
 TEST_F(ModelFullLoadingTest, Sharded_LoadsSuccessfully) {
-  if (!fs::exists(sharded_model_path_)) {
-    GTEST_SKIP() << "Sharded model not found at: " << sharded_model_path_;
-  }
-  LlamaModel model = loadModel(sharded_model_path_);
+  REQUIRE_MODEL(shardedModel_);
+  LlamaModel model = loadModel(shardedModel_.path);
   model.waitForLoadInitialization();
   EXPECT_TRUE(model.isLoaded());
 }
 
 TEST_F(ModelFullLoadingTest, StreamingShards_LoadsSuccessfully) {
-  if (shards_.gguf_files.empty()) {
-    GTEST_SKIP() << "Sharded model not found at: " << sharded_model_path_;
-  }
-  LlamaModel model = loadModel(sharded_model_path_);
-  // Tensors list file first
+  REQUIRE_MODEL(shardedModel_);
+  LlamaModel model = loadModel(shardedModel_.path);
+
   std::string tensorsBasename =
-      fs::path(shards_.tensors_file).filename().string();
-  auto tensorsBuf = readFileToStreambufBinary(shards_.tensors_file);
-  ASSERT_NE(tensorsBuf, nullptr) << "Failed to open: " << shards_.tensors_file;
+      fs::path(shardedModel_.shards.tensors_file).filename().string();
+  auto tensorsBuf =
+      readFileToStreambufBinary(shardedModel_.shards.tensors_file);
+  ASSERT_NE(tensorsBuf, nullptr)
+      << "Failed to open: " << shardedModel_.shards.tensors_file;
   model.setWeightsForFile(tensorsBasename, std::move(tensorsBuf));
 
-  // Then each shard
-  for (const auto& shardPath : shards_.gguf_files) {
+  for (const auto& shardPath : shardedModel_.shards.gguf_files) {
     auto streambuf = readFileToStreambufBinary(shardPath);
     ASSERT_NE(streambuf, nullptr) << "Failed to open shard: " << shardPath;
-    std::string filename = fs::path(shardPath).filename().string();
-    model.setWeightsForFile(filename, std::move(streambuf));
+    model.setWeightsForFile(
+        fs::path(shardPath).filename().string(), std::move(streambuf));
   }
   model.waitForLoadInitialization();
   EXPECT_TRUE(model.isLoaded());

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -9,6 +10,7 @@
 #include <thread>
 
 #include <gtest/gtest.h>
+#include <llama-cpp.h>
 
 #include "model-interface/AsyncWeightsLoader.hpp"
 #include "model-interface/LlamaModel.hpp"
@@ -17,129 +19,8 @@
 
 namespace fs = std::filesystem;
 
-class ModelMetadataTest : public ::testing::Test {
-protected:
-  void SetUp() override {
-    normal_model_path_ = test_common::BaseTestModelPath::get();
+// ---- Shared utilities ----
 
-    // Optional bitnet one-bit model: bitnet_b1_58-large-TQ2_0.gguf
-    // https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0
-    const char* bitnetEnv = std::getenv("BITNET_MODEL_PATH");
-    if (bitnetEnv && fs::exists(bitnetEnv)) {
-      bitnet_model_path_ = bitnetEnv;
-    } else {
-      std::string p =
-          test_common::BaseTestModelPath::get("bitnet_b1_58-large-TQ2_0.gguf");
-      if (fs::exists(p))
-        bitnet_model_path_ = p;
-    }
-
-    // Optional sharded model (first shard path for disk shards test).
-    const char* shardEnv = std::getenv("SHARDED_MODEL_FIRST_SHARD_PATH");
-    std::string defaultShardedPath =
-        test_common::BaseTestModelPath::getSharded();
-    if (shardEnv && fs::exists(shardEnv)) {
-      sharded_first_shard_path_ = shardEnv;
-    } else if (fs::exists(defaultShardedPath)) {
-      sharded_first_shard_path_ = defaultShardedPath;
-    }
-
-    if (!sharded_first_shard_path_.empty()) {
-      shards_with_paths_ =
-          GGUFShards::expandGGUFIntoShards(sharded_first_shard_path_);
-      LlamaModel::resolveShardPaths(
-          shards_with_paths_, sharded_first_shard_path_);
-    }
-
-    // Auto-discover sharded bitnet model
-    // https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded
-    std::string p = test_common::BaseTestModelPath::get(
-        "bitnet_b1_58-large-TQ2_0-00001-of-00008.gguf");
-    if (fs::exists(p)) {
-      bitnet_sharded_first_shard_path_ = p;
-      bitnet_shards_with_paths_ =
-          GGUFShards::expandGGUFIntoShards(bitnet_sharded_first_shard_path_);
-      LlamaModel::resolveShardPaths(
-          bitnet_shards_with_paths_, bitnet_sharded_first_shard_path_);
-    }
-  }
-
-  std::string normal_model_path_;
-  std::string bitnet_model_path_;
-  std::string sharded_first_shard_path_;
-  GGUFShards shards_with_paths_;
-  std::string bitnet_sharded_first_shard_path_;
-  GGUFShards bitnet_shards_with_paths_;
-
-  [[nodiscard]] bool hasNormalModel() const {
-    return !normal_model_path_.empty() && fs::exists(normal_model_path_);
-  }
-  [[nodiscard]] bool hasBitnetModel() const {
-    return !bitnet_model_path_.empty() && fs::exists(bitnet_model_path_);
-  }
-  [[nodiscard]] bool hasShardedModel() const {
-    return !shards_with_paths_.gguf_files.empty();
-  }
-  [[nodiscard]] bool hasShardedBitnetModel() const {
-    return !bitnet_shards_with_paths_.gguf_files.empty();
-  }
-};
-
-// ---- Disk single file ----
-
-TEST_F(
-    ModelMetadataTest, DiskSingleFile_NormalModel_HasOneBitQuantizationFalse) {
-  if (!hasNormalModel()) {
-    FAIL() << "Test model not found at: " << normal_model_path_;
-  }
-  GGUFShards emptyShards;
-  ModelMetaData meta;
-  meta.parse(normal_model_path_, emptyShards, false /* isStreaming */, "Test");
-  EXPECT_FALSE(meta.hasOneBitQuantization());
-}
-
-TEST_F(
-    ModelMetadataTest, DiskSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
-  if (!hasBitnetModel()) {
-    GTEST_SKIP()
-        << "bitnet_b1_58-large-TQ2_0.gguf not found (BITNET_MODEL_PATH or "
-           "models/unit-test); see "
-           "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0";
-  }
-  GGUFShards emptyShards;
-  ModelMetaData meta;
-  meta.parse(bitnet_model_path_, emptyShards, false /* isStreaming */, "Test");
-  EXPECT_TRUE(meta.hasOneBitQuantization());
-}
-
-// ---- Disk shards ----
-
-TEST_F(ModelMetadataTest, DiskShards_NormalModel_HasOneBitQuantizationFalse) {
-  if (!hasShardedModel()) {
-    GTEST_SKIP() << "No sharded model in setup (set "
-                    "SHARDED_MODEL_FIRST_SHARD_PATH)";
-  }
-  ModelMetaData meta;
-  meta.parse(sharded_first_shard_path_, shards_with_paths_, false /* isStreaming */, "Test");
-  EXPECT_FALSE(meta.hasOneBitQuantization());
-}
-
-TEST_F(ModelMetadataTest, DiskShards_BitnetModel_HasOneBitQuantizationTrue) {
-  if (!hasShardedBitnetModel()) {
-    GTEST_SKIP() << "Sharded bitnet model not found; split with "
-                    "llama-gguf-split (see test_common.hpp)";
-  }
-  ModelMetaData meta;
-  meta.parse(bitnet_sharded_first_shard_path_, bitnet_shards_with_paths_, false /* isStreaming */, "Test");
-  EXPECT_TRUE(meta.hasOneBitQuantization());
-}
-
-// ---- Streaming single file ----
-
-// Use a file-backed streambuf so metadata parsing reads on demand and avoids
-// copying the entire GGUF file into memory during test setup.
-// Note that in real scenarios, the GGUF file is streamed from the network and
-// not read from disk. Still, this allows to test the streaming functionality.
 static std::unique_ptr<std::basic_streambuf<char>>
 readFileToStreambufBinary(const std::string& path) {
   auto buf = std::make_unique<std::filebuf>();
@@ -149,96 +30,12 @@ readFileToStreambufBinary(const std::string& path) {
   return buf;
 }
 
-TEST_F(
-    ModelMetadataTest,
-    StreamingSingleFile_NormalModel_HasOneBitQuantizationFalse) {
-  if (!hasNormalModel()) {
-    FAIL() << "Test model not found at: " << normal_model_path_;
-  }
-  auto streambuf = readFileToStreambufBinary(normal_model_path_);
-  ASSERT_NE(streambuf, nullptr);
-  GGUFShards emptyShards;
-  std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream(
-      streambuf.get(), [](std::basic_streambuf<char>*) {});
-  ModelMetaData meta;
-  std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
-    meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
-  });
-  meta.parse(normal_model_path_, emptyShards, true /* isStreaming */, "Test");
-  lenderThread.join();
-  EXPECT_FALSE(meta.hasOneBitQuantization());
-}
-
-TEST_F(
-    ModelMetadataTest,
-    StreamingSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
-  if (!hasBitnetModel()) {
-    GTEST_SKIP()
-        << "bitnet_b1_58-large-TQ2_0.gguf not found; see "
-           "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0";
-  }
-  auto streambuf = readFileToStreambufBinary(bitnet_model_path_);
-  ASSERT_NE(streambuf, nullptr);
-  GGUFShards emptyShards;
-  std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream(
-      streambuf.get(), [](std::basic_streambuf<char>*) {});
-  ModelMetaData meta;
-  std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
-    meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
-  });
-  meta.parse(bitnet_model_path_, emptyShards, true /* isStreaming */, "Test");
-  lenderThread.join();
-  EXPECT_TRUE(meta.hasOneBitQuantization());
-}
-
-// ---- Streaming shards ----
-
-TEST_F(
-    ModelMetadataTest, StreamingShards_NormalModel_HasOneBitQuantizationFalse) {
-  if (!hasShardedModel()) {
-    GTEST_SKIP() << "No sharded model in setup";
-  }
-  std::string firstPath = shards_with_paths_.gguf_files.front();
-  auto streambuf = readFileToStreambufBinary(firstPath);
-  ASSERT_NE(streambuf, nullptr);
-  std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream =
-      std::move(streambuf);
-  ModelMetaData meta;
-  std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
-    meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
-  });
-  meta.parse(sharded_first_shard_path_, shards_with_paths_, true /* isStreaming */, "Test");
-  lenderThread.join();
-  EXPECT_FALSE(meta.hasOneBitQuantization());
-}
-
-TEST_F(
-    ModelMetadataTest, StreamingShards_BitnetModel_HasOneBitQuantizationTrue) {
-  if (!hasShardedBitnetModel()) {
-    GTEST_SKIP() << "Sharded bitnet model not found; split with "
-                    "llama-gguf-split (see test_common.hpp)";
-  }
-  std::string firstPath = bitnet_shards_with_paths_.gguf_files.front();
-  auto streambuf = readFileToStreambufBinary(firstPath);
-  ASSERT_NE(streambuf, nullptr);
-  std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream =
-      std::move(streambuf);
-  ModelMetaData meta;
-  std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
-    meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
-  });
-  meta.parse(bitnet_sharded_first_shard_path_, bitnet_shards_with_paths_, true /* isStreaming */, "Test");
-  lenderThread.join();
-  EXPECT_TRUE(meta.hasOneBitQuantization());
-}
-
-// ---- AsyncWeightsLoader: mock and streaming tests ----
+// ---- MockAsyncWeightsLoader ----
 //
-// MockAsyncWeightsLoader overrides fulfillSplitFuture so tests never touch
-// the global promise registry (which would leak a permanent entry because no
-// llama_model_load_from_split_futures consumer is set up to erase it).
-// fulfilledFilenames records every call for assertion; waitForFulfillCount()
-// synchronises with the detached thread used by the sharded path.
+// Overrides fulfillSplitFuture so tests never touch the global promise
+// registry. fulfilledFilenames records every call for assertion;
+// waitForFulfillCount() synchronises with the detached thread used by the
+// sharded path.
 
 class MockAsyncWeightsLoader : public AsyncWeightsLoader {
 public:
@@ -246,7 +43,6 @@ public:
 
   std::multiset<std::string> fulfilledFilenames;
 
-  /// Block until at least @p n calls to fulfillSplitFuture have been recorded.
   void waitForFulfillCount(std::size_t n) {
     std::unique_lock<std::mutex> lock(mu_);
     cv_.wait(lock, [&] { return fulfilledFilenames.size() >= n; });
@@ -255,7 +51,6 @@ public:
 protected:
   void fulfillSplitFuture(
       const std::string& filename, std::unique_ptr<Buf>&&) override {
-    // shard destructs here; global promise registry is not touched
     {
       std::lock_guard<std::mutex> lock(mu_);
       fulfilledFilenames.insert(filename);
@@ -268,78 +63,315 @@ private:
   std::condition_variable cv_;
 };
 
+// ---- Common types ----
+
+using MetaChecker = std::function<void(const ModelMetaData&)>;
+
+// ---- Test fixture ----
+
+class ModelMetadataTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    using MP = test_common::TestModelPath;
+
+    normalModel_ = MP(
+        "Llama-3.2-1B-Instruct-Q4_0.gguf",
+        nullptr,
+        MP::OnMissing::Fail,
+        "");
+
+    bitnetModel_ = MP(
+        "bitnet_b1_58-large-TQ2_0.gguf",
+        "BITNET_MODEL_PATH",
+        MP::OnMissing::Skip,
+        "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0");
+
+    qwen3Model_ = MP(
+        "Qwen3-0.6B-Q8_0.gguf",
+        "QWEN3_MODEL_PATH",
+        MP::OnMissing::Skip,
+        "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF");
+
+    // MedGemma is a Gemma-3-based model used in integration tests.
+    // https://huggingface.co/unsloth/medgemma-4b-it-GGUF
+    gemma3Model_ = MP(
+        "medgemma-4b-it-Q4_1.gguf",
+        "GEMMA3_MODEL_PATH",
+        MP::OnMissing::Skip,
+        "https://huggingface.co/unsloth/medgemma-4b-it-GGUF");
+
+    // Sharded models: constructor expands the shard list; resolveShardPaths
+    // then fills in absolute paths (requires LlamaModel, kept out of
+    // test_common.hpp to avoid pulling in the heavy llama headers there).
+    // https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded
+    normalModelSharded_ = MP(
+        "Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf",
+        "SHARDED_MODEL_FIRST_SHARD_PATH",
+        MP::OnMissing::Skip,
+        "https://huggingface.co/jmb95/Qwen3-0.6-UD-IQ1_S-sharded",
+        true /* isSharded */);
+    if (normalModelSharded_.found())
+      LlamaModel::resolveShardPaths(
+          normalModelSharded_.shards, normalModelSharded_.path);
+
+    // https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded
+    bitnetModelSharded_ = MP(
+        "bitnet_b1_58-large-TQ2_0-00001-of-00008.gguf",
+        nullptr,
+        MP::OnMissing::Skip,
+        "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded",
+        true /* isSharded */);
+    if (bitnetModelSharded_.found())
+      LlamaModel::resolveShardPaths(
+          bitnetModelSharded_.shards, bitnetModelSharded_.path);
+  }
+
+  test_common::TestModelPath normalModel_;
+  test_common::TestModelPath bitnetModel_;
+  test_common::TestModelPath qwen3Model_;
+  test_common::TestModelPath gemma3Model_;
+  test_common::TestModelPath normalModelSharded_;
+  test_common::TestModelPath bitnetModelSharded_;
+
+  // ---- Parse-and-check helpers ----
+  //
+  // Each helper drives one parse strategy and calls check(meta) at the end.
+  // Use ASSERT_NO_FATAL_FAILURE() at the call site if early exit on fatal
+  // assertion failure is needed.
+
+  void parseDiskSingleFile(const std::string& path, MetaChecker check) {
+    GGUFShards emptyShards;
+    ModelMetaData meta;
+    meta.parse(path, emptyShards, false /* isStreaming */, "Test");
+    check(meta);
+  }
+
+  void parseDiskShards(
+      const std::string& firstShardPath,
+      const GGUFShards& shardsWithPaths,
+      MetaChecker check) {
+    ModelMetaData meta;
+    meta.parse(
+        firstShardPath, shardsWithPaths, false /* isStreaming */, "Test");
+    check(meta);
+  }
+
+  // Note: in real scenarios the GGUF is streamed from the network; a
+  // file-backed streambuf is used here so metadata parsing reads on demand
+  // without copying the entire file into memory.
+  void parseStreamingSingleFile(const std::string& path, MetaChecker check) {
+    auto streambuf = readFileToStreambufBinary(path);
+    ASSERT_NE(streambuf, nullptr);
+    GGUFShards emptyShards;
+    std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream(
+        streambuf.get(), [](std::basic_streambuf<char>*) {});
+    ModelMetaData meta;
+    std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
+      meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
+    });
+    meta.parse(path, emptyShards, true /* isStreaming */, "Test");
+    lenderThread.join();
+    check(meta);
+  }
+
+  void parseStreamingShards(
+      const std::string& firstShardPath,
+      const GGUFShards& shardsWithPaths,
+      MetaChecker check) {
+    auto streambuf =
+        readFileToStreambufBinary(shardsWithPaths.gguf_files.front());
+    ASSERT_NE(streambuf, nullptr);
+    std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream =
+        std::move(streambuf);
+    ModelMetaData meta;
+    std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
+      meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
+    });
+    meta.parse(firstShardPath, shardsWithPaths, true /* isStreaming */, "Test");
+    lenderThread.join();
+    check(meta);
+  }
+
+  // setWeightsForFile is called before parse() (mirrors real delayed-load
+  // usage). Invariants — shard is in extracted map, fulfillSplitFuture is
+  // never called for single-GGUF — are asserted by the helper itself.
+  void parseAsyncLoaderSingleFile(const std::string& path, MetaChecker check) {
+    auto singleFileStreambuf = readFileToStreambufBinary(path);
+    ASSERT_NE(singleFileStreambuf, nullptr);
+
+    const std::string filename = fs::path(path).filename().string();
+    GGUFShards emptyShards;
+    InitLoader initLoader;
+    ModelMetaData meta;
+    MockAsyncWeightsLoader loader(emptyShards, initLoader, "test", &meta);
+
+    loader.setWeightsForFile(filename, std::move(singleFileStreambuf));
+    meta.parse(path, emptyShards, true /* isStreaming */, "Test");
+    auto extracted = loader.extractIndividualStreamedFiles();
+    check(meta);
+    EXPECT_NE(extracted.find(filename), extracted.end());
+    EXPECT_TRUE(loader.fulfilledFilenames.empty());
+  }
+
+  // parse() is run on a separate thread because it blocks at wait() until
+  // setWeightsForFile() provides the first shard via lendFirstShard().
+  // waitForFulfillCount(1) makes assertions on fulfilledFilenames race-free.
+  void parseAsyncLoaderShards(
+      const std::string& firstShardPath,
+      const GGUFShards& shardsWithPaths,
+      MetaChecker check) {
+    GGUFShards shards = GGUFShards::expandGGUFIntoShards(firstShardPath);
+    const std::string firstShardFilename = shards.gguf_files.front();
+
+    auto firstShardBuf =
+        readFileToStreambufBinary(shardsWithPaths.gguf_files.front());
+    ASSERT_NE(firstShardBuf, nullptr);
+
+    InitLoader initLoader;
+    const std::string loadingContext =
+        InitLoader::getLoadingContext("TestShards");
+    ModelMetaData meta;
+    MockAsyncWeightsLoader loader(shards, initLoader, loadingContext, &meta);
+
+    std::thread parseThread([&]() {
+      meta.parse(
+          firstShardPath, shardsWithPaths, true /* isStreaming */, "Test");
+    });
+
+    loader.setWeightsForFile(firstShardFilename, std::move(firstShardBuf));
+    parseThread.join();
+    loader.waitForFulfillCount(1);
+
+    check(meta);
+    EXPECT_EQ(loader.fulfilledFilenames.count(firstShardFilename), 1u);
+  }
+};
+
+// ---- Disk single file ----
+
+TEST_F(
+    ModelMetadataTest, DiskSingleFile_NormalModel_HasOneBitQuantizationFalse) {
+  REQUIRE_MODEL(normalModel_);
+  parseDiskSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_FALSE(meta.hasOneBitQuantization());
+  });
+}
+
+TEST_F(
+    ModelMetadataTest, DiskSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseDiskSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.hasOneBitQuantization());
+  });
+}
+
+// ---- Disk shards ----
+
+TEST_F(ModelMetadataTest, DiskShards_NormalModel_HasOneBitQuantizationFalse) {
+  REQUIRE_MODEL(normalModelSharded_);
+  parseDiskShards(
+      normalModelSharded_.path,
+      normalModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
+}
+
+TEST_F(ModelMetadataTest, DiskShards_BitnetModel_HasOneBitQuantizationTrue) {
+  REQUIRE_MODEL(bitnetModelSharded_);
+  parseDiskShards(
+      bitnetModelSharded_.path,
+      bitnetModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
+}
+
+// ---- Streaming single file ----
+
+TEST_F(
+    ModelMetadataTest,
+    StreamingSingleFile_NormalModel_HasOneBitQuantizationFalse) {
+  REQUIRE_MODEL(normalModel_);
+  parseStreamingSingleFile(
+      normalModel_.path, [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
+}
+
+TEST_F(
+    ModelMetadataTest,
+    StreamingSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseStreamingSingleFile(
+      bitnetModel_.path, [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
+}
+
+// ---- Streaming shards ----
+
+TEST_F(
+    ModelMetadataTest, StreamingShards_NormalModel_HasOneBitQuantizationFalse) {
+  REQUIRE_MODEL(normalModelSharded_);
+  parseStreamingShards(
+      normalModelSharded_.path,
+      normalModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
+}
+
+TEST_F(
+    ModelMetadataTest, StreamingShards_BitnetModel_HasOneBitQuantizationTrue) {
+  REQUIRE_MODEL(bitnetModelSharded_);
+  parseStreamingShards(
+      bitnetModelSharded_.path,
+      bitnetModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
+}
+
 // ---- AsyncWeightsLoader: streaming single file ----
 //
-// Mirrors real delayed-load usage: setWeightsForFile is called during the
-// download phase (before activate()), so by the time parse() runs it finds
-// the single file already in streamedFiles_ and the wait() flag already set.
-// fulfillSplitFuture is never called for single-GGUF; the multiset stays empty.
+// setWeightsForFile is called during the download phase (before activate()),
+// so by the time parse() runs it finds the single file already in
+// streamedFiles_ and the wait() flag already set.
 
 TEST_F(
     ModelMetadataTest,
     AsyncLoader_SingleFile_NormalModel_MetadataParsedAndShardAvailable) {
-  if (!hasNormalModel()) {
-    FAIL() << "Test model not found at: " << normal_model_path_;
-  }
-  auto singleFileStreambuf = readFileToStreambufBinary(normal_model_path_);
-  ASSERT_NE(singleFileStreambuf, nullptr);
-
-  const std::string filename = fs::path(normal_model_path_).filename().string();
-  GGUFShards emptyShards;
-  InitLoader initLoader;
-  const std::string loadingContext = "test-normal";
-  ModelMetaData meta;
-  MockAsyncWeightsLoader loader(emptyShards, initLoader, loadingContext, &meta);
-
-  loader.setWeightsForFile(filename, std::move(singleFileStreambuf));
-  meta.parse(normal_model_path_, emptyShards, true /* isStreaming */, "Test");
-  auto extracted = loader.extractIndividualStreamedFiles();
-  EXPECT_FALSE(meta.hasOneBitQuantization());
-  EXPECT_NE(extracted.find(filename), extracted.end());
-  EXPECT_TRUE(loader.fulfilledFilenames.empty());
+  REQUIRE_MODEL(normalModel_);
+  parseAsyncLoaderSingleFile(
+      normalModel_.path, [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
 }
 
 TEST_F(
     ModelMetadataTest,
     AsyncLoader_SingleFile_BitnetModel_MetadataParsedAndShardAvailable) {
-  if (!hasBitnetModel()) {
-    GTEST_SKIP()
-        << "bitnet_b1_58-large-TQ2_0.gguf not found; see "
-           "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0";
-  }
-  auto singleFileStreambuf = readFileToStreambufBinary(bitnet_model_path_);
-  ASSERT_NE(singleFileStreambuf, nullptr);
-
-  const std::string filename = fs::path(bitnet_model_path_).filename().string();
-  GGUFShards emptyShards;
-  InitLoader initLoader;
-  const std::string loadingContext = "test-bitnet";
-  ModelMetaData meta;
-  MockAsyncWeightsLoader loader(emptyShards, initLoader, loadingContext, &meta);
-
-  loader.setWeightsForFile(filename, std::move(singleFileStreambuf));
-  meta.parse(bitnet_model_path_, emptyShards, true /* isStreaming */, "Test");
-  auto extracted = loader.extractIndividualStreamedFiles();
-  EXPECT_TRUE(meta.hasOneBitQuantization());
-  EXPECT_NE(extracted.find(filename), extracted.end());
-  EXPECT_TRUE(loader.fulfilledFilenames.empty());
+  REQUIRE_MODEL(bitnetModel_);
+  parseAsyncLoaderSingleFile(
+      bitnetModel_.path, [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
 }
 
 TEST_F(
     ModelMetadataTest,
     AsyncLoader_SingleFile_NoMetadata_ShardStoredWithoutLending) {
-  if (!hasNormalModel()) {
-    FAIL() << "Test model not found at: " << normal_model_path_;
-  }
-  auto singleFileStreambuf = readFileToStreambufBinary(normal_model_path_);
+  REQUIRE_MODEL(normalModel_);
+  auto singleFileStreambuf = readFileToStreambufBinary(normalModel_.path);
   ASSERT_NE(singleFileStreambuf, nullptr);
 
-  const std::string filename = fs::path(normal_model_path_).filename().string();
+  const std::string filename =
+      fs::path(normalModel_.path).filename().string();
   GGUFShards emptyShards;
   InitLoader initLoader;
-  const std::string loadingContext = "test-no-meta";
   // No ModelMetaData — lending is skipped entirely.
-  MockAsyncWeightsLoader loader(emptyShards, initLoader, loadingContext);
+  MockAsyncWeightsLoader loader(emptyShards, initLoader, "test-no-meta");
 
   loader.setWeightsForFile(filename, std::move(singleFileStreambuf));
 
@@ -350,76 +382,23 @@ TEST_F(
 }
 
 // ---- AsyncWeightsLoader: streaming shards ----
-//
-// For sharded models, parse() blocks at wait() and is unblocked by the
-// detached thread that lendFirstShard() spawns inside setWeightsForFile().
-// waitForFulfillCount(1) synchronises with that detached thread so assertions
-// on fulfilledFilenames are race-free.
 
 TEST_F(ModelMetadataTest, AsyncLoader_Shards_NormalModel_MetadataParsed) {
-  if (!hasShardedModel()) {
-    GTEST_SKIP()
-        << "No sharded model in setup (set SHARDED_MODEL_FIRST_SHARD_PATH)";
-  }
-
-  // Unresolved basenames: what AsyncWeightsLoader sees during streaming.
-  GGUFShards shards =
-      GGUFShards::expandGGUFIntoShards(sharded_first_shard_path_);
-  const std::string firstShardFilename = shards.gguf_files.front();
-
-  // Read the first shard from disk via its resolved absolute path.
-  auto firstShardBuf =
-      readFileToStreambufBinary(shards_with_paths_.gguf_files.front());
-  ASSERT_NE(firstShardBuf, nullptr);
-
-  InitLoader initLoader;
-  const std::string loadingContext =
-      InitLoader::getLoadingContext("TestShardsNormal");
-  ModelMetaData meta;
-  MockAsyncWeightsLoader loader(shards, initLoader, loadingContext, &meta);
-
-  // parse() blocks at wait() until the detached thread inside setWeightsForFile
-  // provides the first shard via lendFirstShard().
-  std::thread parseThread([&]() {
-    meta.parse(sharded_first_shard_path_, shards_with_paths_, true /* isStreaming */, "Test");
-  });
-
-  loader.setWeightsForFile(firstShardFilename, std::move(firstShardBuf));
-  parseThread.join();
-  loader.waitForFulfillCount(1);
-
-  EXPECT_FALSE(meta.hasOneBitQuantization());
-  EXPECT_EQ(loader.fulfilledFilenames.count(firstShardFilename), 1u);
+  REQUIRE_MODEL(normalModelSharded_);
+  parseAsyncLoaderShards(
+      normalModelSharded_.path,
+      normalModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
 }
 
 TEST_F(ModelMetadataTest, AsyncLoader_Shards_BitnetModel_MetadataParsed) {
-  if (!hasShardedBitnetModel()) {
-    GTEST_SKIP() << "Sharded bitnet model not found; split with "
-                    "llama-gguf-split (see test_common.hpp)";
-  }
-
-  GGUFShards shards =
-      GGUFShards::expandGGUFIntoShards(bitnet_sharded_first_shard_path_);
-  const std::string firstShardFilename = shards.gguf_files.front();
-
-  auto firstShardBuf =
-      readFileToStreambufBinary(bitnet_shards_with_paths_.gguf_files.front());
-  ASSERT_NE(firstShardBuf, nullptr);
-
-  InitLoader initLoader;
-  const std::string loadingContext =
-      InitLoader::getLoadingContext("TestShardsBitnet");
-  ModelMetaData meta;
-  MockAsyncWeightsLoader loader(shards, initLoader, loadingContext, &meta);
-
-  std::thread parseThread([&]() {
-    meta.parse(bitnet_sharded_first_shard_path_, bitnet_shards_with_paths_, true /* isStreaming */, "Test");
-  });
-
-  loader.setWeightsForFile(firstShardFilename, std::move(firstShardBuf));
-  parseThread.join();
-  loader.waitForFulfillCount(1);
-
-  EXPECT_TRUE(meta.hasOneBitQuantization());
-  EXPECT_EQ(loader.fulfilledFilenames.count(firstShardFilename), 1u);
+  REQUIRE_MODEL(bitnetModelSharded_);
+  parseAsyncLoaderShards(
+      bitnetModelSharded_.path,
+      bitnetModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
@@ -73,50 +73,53 @@ protected:
   void SetUp() override {
     using MP = test_common::TestModelPath;
 
-    normalModel_ =
-        MP("Llama-3.2-1B-Instruct-Q4_0.gguf", nullptr, MP::OnMissing::Fail, "");
+    normalModel_ = MP(
+        "Llama-3.2-1B-Instruct-Q4_0.gguf",
+        nullptr,
+        MP::OnMissing::Fail,
+        "");
 
-    bitnetModel_ =
-        MP("bitnet_b1_58-large-TQ2_0.gguf",
-           "BITNET_MODEL_PATH",
-           MP::OnMissing::Skip,
-           "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0");
+    bitnetModel_ = MP(
+        "bitnet_b1_58-large-TQ2_0.gguf",
+        "BITNET_MODEL_PATH",
+        MP::OnMissing::Skip,
+        "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0");
 
-    qwen3Model_ =
-        MP("Qwen3-0.6B-Q8_0.gguf",
-           "QWEN3_MODEL_PATH",
-           MP::OnMissing::Skip,
-           "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF");
+    qwen3Model_ = MP(
+        "Qwen3-0.6B-Q8_0.gguf",
+        "QWEN3_MODEL_PATH",
+        MP::OnMissing::Skip,
+        "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF");
 
     // MedGemma is a Gemma-3-based model used in integration tests.
     // https://huggingface.co/unsloth/medgemma-4b-it-GGUF
-    gemma3Model_ =
-        MP("medgemma-4b-it-Q4_1.gguf",
-           "GEMMA3_MODEL_PATH",
-           MP::OnMissing::Skip,
-           "https://huggingface.co/unsloth/medgemma-4b-it-GGUF");
+    gemma3Model_ = MP(
+        "medgemma-4b-it-Q4_1.gguf",
+        "GEMMA3_MODEL_PATH",
+        MP::OnMissing::Skip,
+        "https://huggingface.co/unsloth/medgemma-4b-it-GGUF");
 
     // Sharded models: constructor expands the shard list; resolveShardPaths
     // then fills in absolute paths (requires LlamaModel, kept out of
     // test_common.hpp to avoid pulling in the heavy llama headers there).
     // https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded
-    normalModelSharded_ = MP(
-        "Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf",
-        "SHARDED_MODEL_FIRST_SHARD_PATH",
-        MP::OnMissing::Skip,
-        "https://huggingface.co/jmb95/Qwen3-0.6-UD-IQ1_S-sharded",
-        true /* isSharded */);
+    normalModelSharded_ =
+        MP("Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf",
+           "SHARDED_MODEL_FIRST_SHARD_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/jmb95/Qwen3-0.6-UD-IQ1_S-sharded",
+           true /* isSharded */);
     if (normalModelSharded_.found())
       LlamaModel::resolveShardPaths(
           normalModelSharded_.shards, normalModelSharded_.path);
 
     // https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded
-    bitnetModelSharded_ =
-        MP("bitnet_b1_58-large-TQ2_0-00001-of-00008.gguf",
-           nullptr,
-           MP::OnMissing::Skip,
-           "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded",
-           true /* isSharded */);
+    bitnetModelSharded_ = MP(
+        "bitnet_b1_58-large-TQ2_0-00001-of-00008.gguf",
+        nullptr,
+        MP::OnMissing::Skip,
+        "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded",
+        true /* isSharded */);
     if (bitnetModelSharded_.found())
       LlamaModel::resolveShardPaths(
           bitnetModelSharded_.shards, bitnetModelSharded_.path);
@@ -143,7 +146,8 @@ protected:
   }
 
   void parseDiskShards(
-      const std::string& firstShardPath, const GGUFShards& shardsWithPaths,
+      const std::string& firstShardPath,
+      const GGUFShards& shardsWithPaths,
       MetaChecker check) {
     ModelMetaData meta;
     meta.parse(
@@ -170,7 +174,8 @@ protected:
   }
 
   void parseStreamingShards(
-      const std::string& firstShardPath, const GGUFShards& shardsWithPaths,
+      const std::string& firstShardPath,
+      const GGUFShards& shardsWithPaths,
       MetaChecker check) {
     auto streambuf =
         readFileToStreambufBinary(shardsWithPaths.gguf_files.front());
@@ -211,7 +216,8 @@ protected:
   // setWeightsForFile() provides the first shard via lendFirstShard().
   // waitForFulfillCount(1) makes assertions on fulfilledFilenames race-free.
   void parseAsyncLoaderShards(
-      const std::string& firstShardPath, const GGUFShards& shardsWithPaths,
+      const std::string& firstShardPath,
+      const GGUFShards& shardsWithPaths,
       MetaChecker check) {
     GGUFShards shards = GGUFShards::expandGGUFIntoShards(firstShardPath);
     const std::string firstShardFilename = shards.gguf_files.front();
@@ -286,18 +292,20 @@ TEST_F(
     ModelMetadataTest,
     StreamingSingleFile_NormalModel_HasOneBitQuantizationFalse) {
   REQUIRE_MODEL(normalModel_);
-  parseStreamingSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
-    EXPECT_FALSE(meta.hasOneBitQuantization());
-  });
+  parseStreamingSingleFile(
+      normalModel_.path, [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
 }
 
 TEST_F(
     ModelMetadataTest,
     StreamingSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
   REQUIRE_MODEL(bitnetModel_);
-  parseStreamingSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
-    EXPECT_TRUE(meta.hasOneBitQuantization());
-  });
+  parseStreamingSingleFile(
+      bitnetModel_.path, [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
 }
 
 // ---- Streaming shards ----
@@ -334,18 +342,20 @@ TEST_F(
     ModelMetadataTest,
     AsyncLoader_SingleFile_NormalModel_MetadataParsedAndShardAvailable) {
   REQUIRE_MODEL(normalModel_);
-  parseAsyncLoaderSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
-    EXPECT_FALSE(meta.hasOneBitQuantization());
-  });
+  parseAsyncLoaderSingleFile(
+      normalModel_.path, [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
 }
 
 TEST_F(
     ModelMetadataTest,
     AsyncLoader_SingleFile_BitnetModel_MetadataParsedAndShardAvailable) {
   REQUIRE_MODEL(bitnetModel_);
-  parseAsyncLoaderSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
-    EXPECT_TRUE(meta.hasOneBitQuantization());
-  });
+  parseAsyncLoaderSingleFile(
+      bitnetModel_.path, [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
 }
 
 TEST_F(
@@ -355,7 +365,8 @@ TEST_F(
   auto singleFileStreambuf = readFileToStreambufBinary(normalModel_.path);
   ASSERT_NE(singleFileStreambuf, nullptr);
 
-  const std::string filename = fs::path(normalModel_.path).filename().string();
+  const std::string filename =
+      fs::path(normalModel_.path).filename().string();
   GGUFShards emptyShards;
   InitLoader initLoader;
   // No ModelMetaData — lending is skipped entirely.
@@ -434,7 +445,8 @@ TEST_F(ModelMetadataTest, DiskSingleFile_LlamaArch_IsSpecificallyQ4_0) {
   REQUIRE_MODEL(normalModel_);
   parseDiskSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
     EXPECT_TRUE(meta.isU32OneOf(
-        "general.file_type", {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0)}));
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0)}));
     EXPECT_FALSE(meta.isU32OneOf(
         "general.file_type",
         {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0),
@@ -455,7 +467,8 @@ TEST_F(ModelMetadataTest, DiskSingleFile_Qwen3Arch_IsSpecificallyQ8_0) {
   REQUIRE_MODEL(qwen3Model_);
   parseDiskSingleFile(qwen3Model_.path, [](const ModelMetaData& meta) {
     EXPECT_TRUE(meta.isU32OneOf(
-        "general.file_type", {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0)}));
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0)}));
     EXPECT_FALSE(meta.isU32OneOf(
         "general.file_type",
         {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
@@ -478,7 +491,8 @@ TEST_F(ModelMetadataTest, DiskSingleFile_Gemma3Arch_IsSpecificallyQ4_1) {
   REQUIRE_MODEL(gemma3Model_);
   parseDiskSingleFile(gemma3Model_.path, [](const ModelMetaData& meta) {
     EXPECT_TRUE(meta.isU32OneOf(
-        "general.file_type", {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_1)}));
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_1)}));
     EXPECT_FALSE(meta.isU32OneOf(
         "general.file_type",
         {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
@@ -511,3 +525,4 @@ TEST_F(ModelMetadataTest, DiskSingleFile_BitnetArch_IsSpecificallyTQ2_0) {
          static_cast<uint32_t>(LLAMA_FTYPE_ALL_F32)}));
   });
 }
+

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
@@ -1,4 +1,3 @@
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -74,31 +73,28 @@ protected:
   void SetUp() override {
     using MP = test_common::TestModelPath;
 
-    normalModel_ = MP(
-        "Llama-3.2-1B-Instruct-Q4_0.gguf",
-        nullptr,
-        MP::OnMissing::Fail,
-        "");
+    normalModel_ =
+        MP("Llama-3.2-1B-Instruct-Q4_0.gguf", nullptr, MP::OnMissing::Fail, "");
 
-    bitnetModel_ = MP(
-        "bitnet_b1_58-large-TQ2_0.gguf",
-        "BITNET_MODEL_PATH",
-        MP::OnMissing::Skip,
-        "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0");
+    bitnetModel_ =
+        MP("bitnet_b1_58-large-TQ2_0.gguf",
+           "BITNET_MODEL_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0");
 
-    qwen3Model_ = MP(
-        "Qwen3-0.6B-Q8_0.gguf",
-        "QWEN3_MODEL_PATH",
-        MP::OnMissing::Skip,
-        "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF");
+    qwen3Model_ =
+        MP("Qwen3-0.6B-Q8_0.gguf",
+           "QWEN3_MODEL_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF");
 
     // MedGemma is a Gemma-3-based model used in integration tests.
     // https://huggingface.co/unsloth/medgemma-4b-it-GGUF
-    gemma3Model_ = MP(
-        "medgemma-4b-it-Q4_1.gguf",
-        "GEMMA3_MODEL_PATH",
-        MP::OnMissing::Skip,
-        "https://huggingface.co/unsloth/medgemma-4b-it-GGUF");
+    gemma3Model_ =
+        MP("medgemma-4b-it-Q4_1.gguf",
+           "GEMMA3_MODEL_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/unsloth/medgemma-4b-it-GGUF");
 
     // Sharded models: constructor expands the shard list; resolveShardPaths
     // then fills in absolute paths (requires LlamaModel, kept out of
@@ -115,12 +111,12 @@ protected:
           normalModelSharded_.shards, normalModelSharded_.path);
 
     // https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded
-    bitnetModelSharded_ = MP(
-        "bitnet_b1_58-large-TQ2_0-00001-of-00008.gguf",
-        nullptr,
-        MP::OnMissing::Skip,
-        "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded",
-        true /* isSharded */);
+    bitnetModelSharded_ =
+        MP("bitnet_b1_58-large-TQ2_0-00001-of-00008.gguf",
+           nullptr,
+           MP::OnMissing::Skip,
+           "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded",
+           true /* isSharded */);
     if (bitnetModelSharded_.found())
       LlamaModel::resolveShardPaths(
           bitnetModelSharded_.shards, bitnetModelSharded_.path);
@@ -147,8 +143,7 @@ protected:
   }
 
   void parseDiskShards(
-      const std::string& firstShardPath,
-      const GGUFShards& shardsWithPaths,
+      const std::string& firstShardPath, const GGUFShards& shardsWithPaths,
       MetaChecker check) {
     ModelMetaData meta;
     meta.parse(
@@ -175,8 +170,7 @@ protected:
   }
 
   void parseStreamingShards(
-      const std::string& firstShardPath,
-      const GGUFShards& shardsWithPaths,
+      const std::string& firstShardPath, const GGUFShards& shardsWithPaths,
       MetaChecker check) {
     auto streambuf =
         readFileToStreambufBinary(shardsWithPaths.gguf_files.front());
@@ -217,8 +211,7 @@ protected:
   // setWeightsForFile() provides the first shard via lendFirstShard().
   // waitForFulfillCount(1) makes assertions on fulfilledFilenames race-free.
   void parseAsyncLoaderShards(
-      const std::string& firstShardPath,
-      const GGUFShards& shardsWithPaths,
+      const std::string& firstShardPath, const GGUFShards& shardsWithPaths,
       MetaChecker check) {
     GGUFShards shards = GGUFShards::expandGGUFIntoShards(firstShardPath);
     const std::string firstShardFilename = shards.gguf_files.front();
@@ -293,20 +286,18 @@ TEST_F(
     ModelMetadataTest,
     StreamingSingleFile_NormalModel_HasOneBitQuantizationFalse) {
   REQUIRE_MODEL(normalModel_);
-  parseStreamingSingleFile(
-      normalModel_.path, [](const ModelMetaData& meta) {
-        EXPECT_FALSE(meta.hasOneBitQuantization());
-      });
+  parseStreamingSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_FALSE(meta.hasOneBitQuantization());
+  });
 }
 
 TEST_F(
     ModelMetadataTest,
     StreamingSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
   REQUIRE_MODEL(bitnetModel_);
-  parseStreamingSingleFile(
-      bitnetModel_.path, [](const ModelMetaData& meta) {
-        EXPECT_TRUE(meta.hasOneBitQuantization());
-      });
+  parseStreamingSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.hasOneBitQuantization());
+  });
 }
 
 // ---- Streaming shards ----
@@ -343,20 +334,18 @@ TEST_F(
     ModelMetadataTest,
     AsyncLoader_SingleFile_NormalModel_MetadataParsedAndShardAvailable) {
   REQUIRE_MODEL(normalModel_);
-  parseAsyncLoaderSingleFile(
-      normalModel_.path, [](const ModelMetaData& meta) {
-        EXPECT_FALSE(meta.hasOneBitQuantization());
-      });
+  parseAsyncLoaderSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_FALSE(meta.hasOneBitQuantization());
+  });
 }
 
 TEST_F(
     ModelMetadataTest,
     AsyncLoader_SingleFile_BitnetModel_MetadataParsedAndShardAvailable) {
   REQUIRE_MODEL(bitnetModel_);
-  parseAsyncLoaderSingleFile(
-      bitnetModel_.path, [](const ModelMetaData& meta) {
-        EXPECT_TRUE(meta.hasOneBitQuantization());
-      });
+  parseAsyncLoaderSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.hasOneBitQuantization());
+  });
 }
 
 TEST_F(
@@ -366,8 +355,7 @@ TEST_F(
   auto singleFileStreambuf = readFileToStreambufBinary(normalModel_.path);
   ASSERT_NE(singleFileStreambuf, nullptr);
 
-  const std::string filename =
-      fs::path(normalModel_.path).filename().string();
+  const std::string filename = fs::path(normalModel_.path).filename().string();
   GGUFShards emptyShards;
   InitLoader initLoader;
   // No ModelMetaData — lending is skipped entirely.
@@ -401,4 +389,125 @@ TEST_F(ModelMetadataTest, AsyncLoader_Shards_BitnetModel_MetadataParsed) {
       [](const ModelMetaData& meta) {
         EXPECT_TRUE(meta.hasOneBitQuantization());
       });
+}
+
+// ---- Disk single file – isU32OneOf: quantization per architecture ----
+//
+// Quantization is stored as a u32 under "general.file_type" (llama_ftype).
+// Model architecture ("general.architecture") is a string field and therefore
+// cannot be queried with isU32OneOf; it is exercised here implicitly by running
+// the same checker against models from different architecture families.
+//
+// Known models exercised:
+//   Llama-3.2-1B-Instruct-Q4_0  (llama  arch, LLAMA_FTYPE_MOSTLY_Q4_0)
+//   Qwen3-0.6B-Q8_0             (qwen3  arch, LLAMA_FTYPE_MOSTLY_Q8_0)
+//   medgemma-4b-it-Q4_1         (gemma3 arch, LLAMA_FTYPE_MOSTLY_Q4_1)
+//   bitnet_b1_58-large-TQ2_0    (bitnet arch, LLAMA_FTYPE_MOSTLY_TQ2_0)
+
+// Adreno 800+ requires Vulkan to be available when fine-tuning with any of
+// the quantization types listed here. The checker is shared across all
+// architecture-specific tests below so that every new model variant
+// automatically exercises the same gate.
+static const MetaChecker kVulkanNeededForFinetuneAdreno800Plus =
+    [](const ModelMetaData& meta) {
+      EXPECT_TRUE(meta.isU32OneOf(
+          "general.file_type",
+          {static_cast<uint32_t>(LLAMA_FTYPE_ALL_F32),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_F16),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_1),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0)}));
+    };
+
+// llama architecture – Llama-3.2-1B-Instruct-Q4_0
+
+TEST_F(
+    ModelMetadataTest,
+    DiskSingleFile_LlamaArch_Q4_0_VulkanNeededForFinetuneAdreno800Plus) {
+  REQUIRE_MODEL(normalModel_);
+  parseDiskSingleFile(normalModel_.path, kVulkanNeededForFinetuneAdreno800Plus);
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_LlamaArch_IsSpecificallyQ4_0) {
+  REQUIRE_MODEL(normalModel_);
+  parseDiskSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.isU32OneOf(
+        "general.file_type", {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0)}));
+    EXPECT_FALSE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0)}));
+  });
+}
+
+// qwen3 architecture – Qwen3-0.6B-Q8_0
+
+TEST_F(
+    ModelMetadataTest,
+    DiskSingleFile_Qwen3Arch_Q8_0_VulkanNeededForFinetuneAdreno800Plus) {
+  REQUIRE_MODEL(qwen3Model_);
+  parseDiskSingleFile(qwen3Model_.path, kVulkanNeededForFinetuneAdreno800Plus);
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_Qwen3Arch_IsSpecificallyQ8_0) {
+  REQUIRE_MODEL(qwen3Model_);
+  parseDiskSingleFile(qwen3Model_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.isU32OneOf(
+        "general.file_type", {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0)}));
+    EXPECT_FALSE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0)}));
+  });
+}
+
+// gemma3 architecture – medgemma-4b-it-Q4_1
+// Set GEMMA3_MODEL_PATH or place medgemma-4b-it-Q4_1.gguf in models/unit-test.
+
+TEST_F(
+    ModelMetadataTest,
+    DiskSingleFile_Gemma3Arch_Q4_1_VulkanNeededForFinetuneAdreno800Plus) {
+  REQUIRE_MODEL(gemma3Model_);
+  parseDiskSingleFile(gemma3Model_.path, kVulkanNeededForFinetuneAdreno800Plus);
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_Gemma3Arch_IsSpecificallyQ4_1) {
+  REQUIRE_MODEL(gemma3Model_);
+  parseDiskSingleFile(gemma3Model_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.isU32OneOf(
+        "general.file_type", {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_1)}));
+    EXPECT_FALSE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0)}));
+  });
+}
+
+// bitnet architecture – bitnet_b1_58-large-TQ2_0
+
+TEST_F(
+    ModelMetadataTest,
+    DiskSingleFile_BitnetArch_TQ2_0_VulkanNeededForFinetuneAdreno800Plus) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseDiskSingleFile(bitnetModel_.path, kVulkanNeededForFinetuneAdreno800Plus);
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_BitnetArch_IsSpecificallyTQ2_0) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseDiskSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0)}));
+    EXPECT_FALSE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_F16),
+         static_cast<uint32_t>(LLAMA_FTYPE_ALL_F32)}));
+  });
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
@@ -3,11 +3,14 @@
 #include <fstream>
 #include <map>
 #include <memory>
+#include <mutex>
+#include <set>
 #include <string>
 #include <thread>
 
 #include <gtest/gtest.h>
 
+#include "model-interface/AsyncWeightsLoader.hpp"
 #include "model-interface/LlamaModel.hpp"
 #include "model-interface/ModelMetadata.hpp"
 #include "test_common.hpp"
@@ -89,15 +92,9 @@ TEST_F(
   if (!hasNormalModel()) {
     FAIL() << "Test model not found at: " << normal_model_path_;
   }
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
   GGUFShards emptyShards;
   ModelMetaData meta;
-  meta.parse(
-      normal_model_path_,
-      emptyMap,
-      emptyShards,
-      false /* isStreaming */,
-      "Test");
+  meta.parse(normal_model_path_, emptyShards, false /* isStreaming */, "Test");
   EXPECT_FALSE(meta.hasOneBitQuantization());
 }
 
@@ -109,15 +106,9 @@ TEST_F(
            "models/unit-test); see "
            "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0";
   }
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
   GGUFShards emptyShards;
   ModelMetaData meta;
-  meta.parse(
-      bitnet_model_path_,
-      emptyMap,
-      emptyShards,
-      false /* isStreaming */,
-      "Test");
+  meta.parse(bitnet_model_path_, emptyShards, false /* isStreaming */, "Test");
   EXPECT_TRUE(meta.hasOneBitQuantization());
 }
 
@@ -128,14 +119,8 @@ TEST_F(ModelMetadataTest, DiskShards_NormalModel_HasOneBitQuantizationFalse) {
     GTEST_SKIP() << "No sharded model in setup (set "
                     "SHARDED_MODEL_FIRST_SHARD_PATH)";
   }
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
   ModelMetaData meta;
-  meta.parse(
-      sharded_first_shard_path_,
-      emptyMap,
-      shards_with_paths_,
-      false /* isStreaming */,
-      "Test");
+  meta.parse(sharded_first_shard_path_, shards_with_paths_, false /* isStreaming */, "Test");
   EXPECT_FALSE(meta.hasOneBitQuantization());
 }
 
@@ -144,14 +129,8 @@ TEST_F(ModelMetadataTest, DiskShards_BitnetModel_HasOneBitQuantizationTrue) {
     GTEST_SKIP() << "Sharded bitnet model not found; split with "
                     "llama-gguf-split (see test_common.hpp)";
   }
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
   ModelMetaData meta;
-  meta.parse(
-      bitnet_sharded_first_shard_path_,
-      emptyMap,
-      bitnet_shards_with_paths_,
-      false /* isStreaming */,
-      "Test");
+  meta.parse(bitnet_sharded_first_shard_path_, bitnet_shards_with_paths_, false /* isStreaming */, "Test");
   EXPECT_TRUE(meta.hasOneBitQuantization());
 }
 
@@ -178,22 +157,14 @@ TEST_F(
   }
   auto streambuf = readFileToStreambufBinary(normal_model_path_);
   ASSERT_NE(streambuf, nullptr);
-  std::string filename = fs::path(normal_model_path_).filename().string();
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> streamed;
-  streamed[filename] = std::move(streambuf);
   GGUFShards emptyShards;
   std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream(
-      streamed[filename].get(), [](std::basic_streambuf<char>*) {});
+      streambuf.get(), [](std::basic_streambuf<char>*) {});
   ModelMetaData meta;
   std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
     meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
   });
-  meta.parse(
-      normal_model_path_,
-      streamed,
-      emptyShards,
-      true /* isStreaming */,
-      "Test");
+  meta.parse(normal_model_path_, emptyShards, true /* isStreaming */, "Test");
   lenderThread.join();
   EXPECT_FALSE(meta.hasOneBitQuantization());
 }
@@ -208,22 +179,14 @@ TEST_F(
   }
   auto streambuf = readFileToStreambufBinary(bitnet_model_path_);
   ASSERT_NE(streambuf, nullptr);
-  std::string filename = fs::path(bitnet_model_path_).filename().string();
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> streamed;
-  streamed[filename] = std::move(streambuf);
   GGUFShards emptyShards;
   std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream(
-      streamed[filename].get(), [](std::basic_streambuf<char>*) {});
+      streambuf.get(), [](std::basic_streambuf<char>*) {});
   ModelMetaData meta;
   std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
     meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
   });
-  meta.parse(
-      bitnet_model_path_,
-      streamed,
-      emptyShards,
-      true /* isStreaming */,
-      "Test");
+  meta.parse(bitnet_model_path_, emptyShards, true /* isStreaming */, "Test");
   lenderThread.join();
   EXPECT_TRUE(meta.hasOneBitQuantization());
 }
@@ -240,17 +203,11 @@ TEST_F(
   ASSERT_NE(streambuf, nullptr);
   std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream =
       std::move(streambuf);
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
   ModelMetaData meta;
   std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
     meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
   });
-  meta.parse(
-      sharded_first_shard_path_,
-      emptyMap,
-      shards_with_paths_,
-      true /* isStreaming */,
-      "Test");
+  meta.parse(sharded_first_shard_path_, shards_with_paths_, true /* isStreaming */, "Test");
   lenderThread.join();
   EXPECT_FALSE(meta.hasOneBitQuantization());
 }
@@ -266,17 +223,203 @@ TEST_F(
   ASSERT_NE(streambuf, nullptr);
   std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream =
       std::move(streambuf);
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
   ModelMetaData meta;
   std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
     meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
   });
-  meta.parse(
-      bitnet_sharded_first_shard_path_,
-      emptyMap,
-      bitnet_shards_with_paths_,
-      true /* isStreaming */,
-      "Test");
+  meta.parse(bitnet_sharded_first_shard_path_, bitnet_shards_with_paths_, true /* isStreaming */, "Test");
   lenderThread.join();
   EXPECT_TRUE(meta.hasOneBitQuantization());
+}
+
+// ---- AsyncWeightsLoader: mock and streaming tests ----
+//
+// MockAsyncWeightsLoader overrides fulfillSplitFuture so tests never touch
+// the global promise registry (which would leak a permanent entry because no
+// llama_model_load_from_split_futures consumer is set up to erase it).
+// fulfilledFilenames records every call for assertion; waitForFulfillCount()
+// synchronises with the detached thread used by the sharded path.
+
+class MockAsyncWeightsLoader : public AsyncWeightsLoader {
+public:
+  using AsyncWeightsLoader::AsyncWeightsLoader;
+
+  std::multiset<std::string> fulfilledFilenames;
+
+  /// Block until at least @p n calls to fulfillSplitFuture have been recorded.
+  void waitForFulfillCount(std::size_t n) {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_.wait(lock, [&] { return fulfilledFilenames.size() >= n; });
+  }
+
+protected:
+  void fulfillSplitFuture(
+      const std::string& filename, std::unique_ptr<Buf>&&) override {
+    // shard destructs here; global promise registry is not touched
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      fulfilledFilenames.insert(filename);
+    }
+    cv_.notify_all();
+  }
+
+private:
+  std::mutex mu_;
+  std::condition_variable cv_;
+};
+
+// ---- AsyncWeightsLoader: streaming single file ----
+//
+// Mirrors real delayed-load usage: setWeightsForFile is called during the
+// download phase (before activate()), so by the time parse() runs it finds
+// the single file already in streamedFiles_ and the wait() flag already set.
+// fulfillSplitFuture is never called for single-GGUF; the multiset stays empty.
+
+TEST_F(
+    ModelMetadataTest,
+    AsyncLoader_SingleFile_NormalModel_MetadataParsedAndShardAvailable) {
+  if (!hasNormalModel()) {
+    FAIL() << "Test model not found at: " << normal_model_path_;
+  }
+  auto singleFileStreambuf = readFileToStreambufBinary(normal_model_path_);
+  ASSERT_NE(singleFileStreambuf, nullptr);
+
+  const std::string filename = fs::path(normal_model_path_).filename().string();
+  GGUFShards emptyShards;
+  InitLoader initLoader;
+  const std::string loadingContext = "test-normal";
+  ModelMetaData meta;
+  MockAsyncWeightsLoader loader(emptyShards, initLoader, loadingContext, &meta);
+
+  loader.setWeightsForFile(filename, std::move(singleFileStreambuf));
+  meta.parse(normal_model_path_, emptyShards, true /* isStreaming */, "Test");
+  auto extracted = loader.extractIndividualStreamedFiles();
+  EXPECT_FALSE(meta.hasOneBitQuantization());
+  EXPECT_NE(extracted.find(filename), extracted.end());
+  EXPECT_TRUE(loader.fulfilledFilenames.empty());
+}
+
+TEST_F(
+    ModelMetadataTest,
+    AsyncLoader_SingleFile_BitnetModel_MetadataParsedAndShardAvailable) {
+  if (!hasBitnetModel()) {
+    GTEST_SKIP()
+        << "bitnet_b1_58-large-TQ2_0.gguf not found; see "
+           "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0";
+  }
+  auto singleFileStreambuf = readFileToStreambufBinary(bitnet_model_path_);
+  ASSERT_NE(singleFileStreambuf, nullptr);
+
+  const std::string filename = fs::path(bitnet_model_path_).filename().string();
+  GGUFShards emptyShards;
+  InitLoader initLoader;
+  const std::string loadingContext = "test-bitnet";
+  ModelMetaData meta;
+  MockAsyncWeightsLoader loader(emptyShards, initLoader, loadingContext, &meta);
+
+  loader.setWeightsForFile(filename, std::move(singleFileStreambuf));
+  meta.parse(bitnet_model_path_, emptyShards, true /* isStreaming */, "Test");
+  auto extracted = loader.extractIndividualStreamedFiles();
+  EXPECT_TRUE(meta.hasOneBitQuantization());
+  EXPECT_NE(extracted.find(filename), extracted.end());
+  EXPECT_TRUE(loader.fulfilledFilenames.empty());
+}
+
+TEST_F(
+    ModelMetadataTest,
+    AsyncLoader_SingleFile_NoMetadata_ShardStoredWithoutLending) {
+  if (!hasNormalModel()) {
+    FAIL() << "Test model not found at: " << normal_model_path_;
+  }
+  auto singleFileStreambuf = readFileToStreambufBinary(normal_model_path_);
+  ASSERT_NE(singleFileStreambuf, nullptr);
+
+  const std::string filename = fs::path(normal_model_path_).filename().string();
+  GGUFShards emptyShards;
+  InitLoader initLoader;
+  const std::string loadingContext = "test-no-meta";
+  // No ModelMetaData — lending is skipped entirely.
+  MockAsyncWeightsLoader loader(emptyShards, initLoader, loadingContext);
+
+  loader.setWeightsForFile(filename, std::move(singleFileStreambuf));
+
+  auto extracted = loader.extractIndividualStreamedFiles();
+  EXPECT_TRUE(loader.isStreaming());
+  EXPECT_NE(extracted.find(filename), extracted.end());
+  EXPECT_TRUE(loader.fulfilledFilenames.empty());
+}
+
+// ---- AsyncWeightsLoader: streaming shards ----
+//
+// For sharded models, parse() blocks at wait() and is unblocked by the
+// detached thread that lendFirstShard() spawns inside setWeightsForFile().
+// waitForFulfillCount(1) synchronises with that detached thread so assertions
+// on fulfilledFilenames are race-free.
+
+TEST_F(ModelMetadataTest, AsyncLoader_Shards_NormalModel_MetadataParsed) {
+  if (!hasShardedModel()) {
+    GTEST_SKIP()
+        << "No sharded model in setup (set SHARDED_MODEL_FIRST_SHARD_PATH)";
+  }
+
+  // Unresolved basenames: what AsyncWeightsLoader sees during streaming.
+  GGUFShards shards =
+      GGUFShards::expandGGUFIntoShards(sharded_first_shard_path_);
+  const std::string firstShardFilename = shards.gguf_files.front();
+
+  // Read the first shard from disk via its resolved absolute path.
+  auto firstShardBuf =
+      readFileToStreambufBinary(shards_with_paths_.gguf_files.front());
+  ASSERT_NE(firstShardBuf, nullptr);
+
+  InitLoader initLoader;
+  const std::string loadingContext =
+      InitLoader::getLoadingContext("TestShardsNormal");
+  ModelMetaData meta;
+  MockAsyncWeightsLoader loader(shards, initLoader, loadingContext, &meta);
+
+  // parse() blocks at wait() until the detached thread inside setWeightsForFile
+  // provides the first shard via lendFirstShard().
+  std::thread parseThread([&]() {
+    meta.parse(sharded_first_shard_path_, shards_with_paths_, true /* isStreaming */, "Test");
+  });
+
+  loader.setWeightsForFile(firstShardFilename, std::move(firstShardBuf));
+  parseThread.join();
+  loader.waitForFulfillCount(1);
+
+  EXPECT_FALSE(meta.hasOneBitQuantization());
+  EXPECT_EQ(loader.fulfilledFilenames.count(firstShardFilename), 1u);
+}
+
+TEST_F(ModelMetadataTest, AsyncLoader_Shards_BitnetModel_MetadataParsed) {
+  if (!hasShardedBitnetModel()) {
+    GTEST_SKIP() << "Sharded bitnet model not found; split with "
+                    "llama-gguf-split (see test_common.hpp)";
+  }
+
+  GGUFShards shards =
+      GGUFShards::expandGGUFIntoShards(bitnet_sharded_first_shard_path_);
+  const std::string firstShardFilename = shards.gguf_files.front();
+
+  auto firstShardBuf =
+      readFileToStreambufBinary(bitnet_shards_with_paths_.gguf_files.front());
+  ASSERT_NE(firstShardBuf, nullptr);
+
+  InitLoader initLoader;
+  const std::string loadingContext =
+      InitLoader::getLoadingContext("TestShardsBitnet");
+  ModelMetaData meta;
+  MockAsyncWeightsLoader loader(shards, initLoader, loadingContext, &meta);
+
+  std::thread parseThread([&]() {
+    meta.parse(bitnet_sharded_first_shard_path_, bitnet_shards_with_paths_, true /* isStreaming */, "Test");
+  });
+
+  loader.setWeightsForFile(firstShardFilename, std::move(firstShardBuf));
+  parseThread.join();
+  loader.waitForFulfillCount(1);
+
+  EXPECT_TRUE(meta.hasOneBitQuantization());
+  EXPECT_EQ(loader.fulfilledFilenames.count(firstShardFilename), 1u);
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
@@ -41,9 +41,12 @@ protected:
       sharded_first_shard_path_ = defaultShardedPath;
     }
 
-    if (!sharded_first_shard_path_.empty())
+    if (!sharded_first_shard_path_.empty()) {
       shards_with_paths_ =
-          LlamaModel::expandAndResolveShards(sharded_first_shard_path_);
+          GGUFShards::expandGGUFIntoShards(sharded_first_shard_path_);
+      LlamaModel::resolveShardPaths(
+          shards_with_paths_, sharded_first_shard_path_);
+    }
 
     // Auto-discover sharded bitnet model
     // https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded
@@ -52,7 +55,9 @@ protected:
     if (fs::exists(p)) {
       bitnet_sharded_first_shard_path_ = p;
       bitnet_shards_with_paths_ =
-          LlamaModel::expandAndResolveShards(bitnet_sharded_first_shard_path_);
+          GGUFShards::expandGGUFIntoShards(bitnet_sharded_first_shard_path_);
+      LlamaModel::resolveShardPaths(
+          bitnet_shards_with_paths_, bitnet_sharded_first_shard_path_);
     }
   }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
@@ -1,0 +1,277 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/LlamaModel.hpp"
+#include "model-interface/ModelMetadata.hpp"
+#include "test_common.hpp"
+
+namespace fs = std::filesystem;
+
+class ModelMetadataTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    normal_model_path_ = test_common::BaseTestModelPath::get();
+
+    // Optional bitnet one-bit model: bitnet_b1_58-large-TQ2_0.gguf
+    // https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0
+    const char* bitnetEnv = std::getenv("BITNET_MODEL_PATH");
+    if (bitnetEnv && fs::exists(bitnetEnv)) {
+      bitnet_model_path_ = bitnetEnv;
+    } else {
+      std::string p =
+          test_common::BaseTestModelPath::get("bitnet_b1_58-large-TQ2_0.gguf");
+      if (fs::exists(p))
+        bitnet_model_path_ = p;
+    }
+
+    // Optional sharded model (first shard path for disk shards test).
+    const char* shardEnv = std::getenv("SHARDED_MODEL_FIRST_SHARD_PATH");
+    std::string defaultShardedPath =
+        test_common::BaseTestModelPath::getSharded();
+    if (shardEnv && fs::exists(shardEnv)) {
+      sharded_first_shard_path_ = shardEnv;
+    } else if (fs::exists(defaultShardedPath)) {
+      sharded_first_shard_path_ = defaultShardedPath;
+    }
+
+    if (!sharded_first_shard_path_.empty())
+      shards_with_paths_ =
+          LlamaModel::expandAndResolveShards(sharded_first_shard_path_);
+
+    // Auto-discover sharded bitnet model
+    // https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded
+    std::string p = test_common::BaseTestModelPath::get(
+        "bitnet_b1_58-large-TQ2_0-00001-of-00008.gguf");
+    if (fs::exists(p)) {
+      bitnet_sharded_first_shard_path_ = p;
+      bitnet_shards_with_paths_ =
+          LlamaModel::expandAndResolveShards(bitnet_sharded_first_shard_path_);
+    }
+  }
+
+  std::string normal_model_path_;
+  std::string bitnet_model_path_;
+  std::string sharded_first_shard_path_;
+  GGUFShards shards_with_paths_;
+  std::string bitnet_sharded_first_shard_path_;
+  GGUFShards bitnet_shards_with_paths_;
+
+  [[nodiscard]] bool hasNormalModel() const {
+    return !normal_model_path_.empty() && fs::exists(normal_model_path_);
+  }
+  [[nodiscard]] bool hasBitnetModel() const {
+    return !bitnet_model_path_.empty() && fs::exists(bitnet_model_path_);
+  }
+  [[nodiscard]] bool hasShardedModel() const {
+    return !shards_with_paths_.gguf_files.empty();
+  }
+  [[nodiscard]] bool hasShardedBitnetModel() const {
+    return !bitnet_shards_with_paths_.gguf_files.empty();
+  }
+};
+
+// ---- Disk single file ----
+
+TEST_F(
+    ModelMetadataTest, DiskSingleFile_NormalModel_HasOneBitQuantizationFalse) {
+  if (!hasNormalModel()) {
+    FAIL() << "Test model not found at: " << normal_model_path_;
+  }
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
+  GGUFShards emptyShards;
+  ModelMetaData meta;
+  meta.parse(
+      normal_model_path_,
+      emptyMap,
+      emptyShards,
+      false /* isStreaming */,
+      "Test");
+  EXPECT_FALSE(meta.hasOneBitQuantization());
+}
+
+TEST_F(
+    ModelMetadataTest, DiskSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
+  if (!hasBitnetModel()) {
+    GTEST_SKIP()
+        << "bitnet_b1_58-large-TQ2_0.gguf not found (BITNET_MODEL_PATH or "
+           "models/unit-test); see "
+           "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0";
+  }
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
+  GGUFShards emptyShards;
+  ModelMetaData meta;
+  meta.parse(
+      bitnet_model_path_,
+      emptyMap,
+      emptyShards,
+      false /* isStreaming */,
+      "Test");
+  EXPECT_TRUE(meta.hasOneBitQuantization());
+}
+
+// ---- Disk shards ----
+
+TEST_F(ModelMetadataTest, DiskShards_NormalModel_HasOneBitQuantizationFalse) {
+  if (!hasShardedModel()) {
+    GTEST_SKIP() << "No sharded model in setup (set "
+                    "SHARDED_MODEL_FIRST_SHARD_PATH)";
+  }
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
+  ModelMetaData meta;
+  meta.parse(
+      sharded_first_shard_path_,
+      emptyMap,
+      shards_with_paths_,
+      false /* isStreaming */,
+      "Test");
+  EXPECT_FALSE(meta.hasOneBitQuantization());
+}
+
+TEST_F(ModelMetadataTest, DiskShards_BitnetModel_HasOneBitQuantizationTrue) {
+  if (!hasShardedBitnetModel()) {
+    GTEST_SKIP() << "Sharded bitnet model not found; split with "
+                    "llama-gguf-split (see test_common.hpp)";
+  }
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
+  ModelMetaData meta;
+  meta.parse(
+      bitnet_sharded_first_shard_path_,
+      emptyMap,
+      bitnet_shards_with_paths_,
+      false /* isStreaming */,
+      "Test");
+  EXPECT_TRUE(meta.hasOneBitQuantization());
+}
+
+// ---- Streaming single file ----
+
+// Use a file-backed streambuf so metadata parsing reads on demand and avoids
+// copying the entire GGUF file into memory during test setup.
+// Note that in real scenarios, the GGUF file is streamed from the network and
+// not read from disk. Still, this allows to test the streaming functionality.
+static std::unique_ptr<std::basic_streambuf<char>>
+readFileToStreambufBinary(const std::string& path) {
+  auto buf = std::make_unique<std::filebuf>();
+  if (!buf->open(path, std::ios::binary | std::ios::in)) {
+    return nullptr;
+  }
+  return buf;
+}
+
+TEST_F(
+    ModelMetadataTest,
+    StreamingSingleFile_NormalModel_HasOneBitQuantizationFalse) {
+  if (!hasNormalModel()) {
+    FAIL() << "Test model not found at: " << normal_model_path_;
+  }
+  auto streambuf = readFileToStreambufBinary(normal_model_path_);
+  ASSERT_NE(streambuf, nullptr);
+  std::string filename = fs::path(normal_model_path_).filename().string();
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> streamed;
+  streamed[filename] = std::move(streambuf);
+  GGUFShards emptyShards;
+  std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream(
+      streamed[filename].get(), [](std::basic_streambuf<char>*) {});
+  ModelMetaData meta;
+  std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
+    meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
+  });
+  meta.parse(
+      normal_model_path_,
+      streamed,
+      emptyShards,
+      true /* isStreaming */,
+      "Test");
+  lenderThread.join();
+  EXPECT_FALSE(meta.hasOneBitQuantization());
+}
+
+TEST_F(
+    ModelMetadataTest,
+    StreamingSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
+  if (!hasBitnetModel()) {
+    GTEST_SKIP()
+        << "bitnet_b1_58-large-TQ2_0.gguf not found; see "
+           "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0";
+  }
+  auto streambuf = readFileToStreambufBinary(bitnet_model_path_);
+  ASSERT_NE(streambuf, nullptr);
+  std::string filename = fs::path(bitnet_model_path_).filename().string();
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> streamed;
+  streamed[filename] = std::move(streambuf);
+  GGUFShards emptyShards;
+  std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream(
+      streamed[filename].get(), [](std::basic_streambuf<char>*) {});
+  ModelMetaData meta;
+  std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
+    meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
+  });
+  meta.parse(
+      bitnet_model_path_,
+      streamed,
+      emptyShards,
+      true /* isStreaming */,
+      "Test");
+  lenderThread.join();
+  EXPECT_TRUE(meta.hasOneBitQuantization());
+}
+
+// ---- Streaming shards ----
+
+TEST_F(
+    ModelMetadataTest, StreamingShards_NormalModel_HasOneBitQuantizationFalse) {
+  if (!hasShardedModel()) {
+    GTEST_SKIP() << "No sharded model in setup";
+  }
+  std::string firstPath = shards_with_paths_.gguf_files.front();
+  auto streambuf = readFileToStreambufBinary(firstPath);
+  ASSERT_NE(streambuf, nullptr);
+  std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream =
+      std::move(streambuf);
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
+  ModelMetaData meta;
+  std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
+    meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
+  });
+  meta.parse(
+      sharded_first_shard_path_,
+      emptyMap,
+      shards_with_paths_,
+      true /* isStreaming */,
+      "Test");
+  lenderThread.join();
+  EXPECT_FALSE(meta.hasOneBitQuantization());
+}
+
+TEST_F(
+    ModelMetadataTest, StreamingShards_BitnetModel_HasOneBitQuantizationTrue) {
+  if (!hasShardedBitnetModel()) {
+    GTEST_SKIP() << "Sharded bitnet model not found; split with "
+                    "llama-gguf-split (see test_common.hpp)";
+  }
+  std::string firstPath = bitnet_shards_with_paths_.gguf_files.front();
+  auto streambuf = readFileToStreambufBinary(firstPath);
+  ASSERT_NE(streambuf, nullptr);
+  std::shared_ptr<std::basic_streambuf<char>> firstFileFromGgufStream =
+      std::move(streambuf);
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> emptyMap;
+  ModelMetaData meta;
+  std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
+    meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
+  });
+  meta.parse(
+      bitnet_sharded_first_shard_path_,
+      emptyMap,
+      bitnet_shards_with_paths_,
+      true /* isStreaming */,
+      "Test");
+  lenderThread.join();
+  EXPECT_TRUE(meta.hasOneBitQuantization());
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_mtmd_llm_context.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_mtmd_llm_context.cpp
@@ -48,37 +48,11 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "SmolVLM-500M-Instruct-Q8_0.gguf";
-      }
-    }
-
-    fs::path projectionPath =
-        basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (fs::exists(projectionPath)) {
-      test_projection_path = projectionPath.string();
-    } else {
-      projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-      if (fs::exists(projectionPath)) {
-        test_projection_path = projectionPath.string();
-      } else {
-        test_projection_path = "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get(
+        "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+    test_projection_path = test_common::BaseTestModelPath::get(
+        "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+        "mmproj-SmolVLM-500M-Instruct.gguf");
 
     fs::path backendDir;
 #ifdef TEST_BINARY_DIR

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_qwen3_reasoning_utils.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_qwen3_reasoning_utils.cpp
@@ -20,24 +20,7 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
     fs::path backendDir;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_text_llm_context.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_text_llm_context.cpp
@@ -49,24 +49,7 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
     fs::path backendDir;

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
@@ -1,0 +1,36 @@
+# Function to detect Vulkan version from NDK vulkan_core.h
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    # CMAKE_HOST_SYSTEM_PROCESSOR is unavailable here. Use a glob pattern to complete the folder instead. 
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT vulkan_core_h)
+        message(FATAL "vulkan_core.h not found, using default version")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL "Could not extract VK_HEADER_VERSION from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+
+     # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL "Could not extract major.minor version from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+endfunction()

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/portfile.cmake
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,108 @@
+vcpkg_from_git(
+  OUT_SOURCE_PATH SOURCE_PATH
+  URL https://github.com/jesusmb1995/llama.cpp
+  REF 336e91604da610c810eb0ff1c103224a4343c10c
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+)
+
+if (VCPKG_TARGET_IS_ANDROID)
+  # NDK only comes with C headers.
+  # Make sure C++ header exists, it will be used by ggml tensor library.
+  # Need to determine installed vulkan version and download correct headers
+  include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+  detect_ndk_vulkan_version()
+  message(STATUS "Using Vulkan C++ wrappers from version: ${vulkan_version}")
+  file(DOWNLOAD
+    "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+    "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    TLS_VERIFY ON
+  )
+
+  file(ARCHIVE_EXTRACT
+    INPUT "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    DESTINATION "${SOURCE_PATH}"
+    PATTERNS "*.hpp"
+  )
+
+  file(RENAME
+    "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}"
+    "${SOURCE_PATH}/ggml/src/ggml-vulkan/vulkan_cpp_wrapper"
+  )
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID)
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_VULKAN_DISABLE_COOPMAT=ON
+    -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    -DGGML_OPENCL=ON)
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_OPENMP=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_MTMD=ON
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME llama)
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME ggml)
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (NOT DL_BACKENDS AND VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "qvac-fabric",
+  "version": "7248.1.2",
+  "description": "LLM inference in C/C++",
+  "homepage": "https://github.com/ggml-org/llama.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    }
+  }
+}


### PR DESCRIPTION
## What problem is this PR solving
Make possible to access model metadata from the LlamaModel class by extracting it from the `.gguf` binary.

## Dependencies
Requires https://github.com/tetherto/qvac-fabric-llm.cpp/pull/100/changes

## Tests Made:
- Ran loading/metadata integration and C++ tests locally
- Ran loading/metadata integration and C++ tests on a temp branch
   - https://github.com/tetherto/qvac/actions/runs/22453021631 (C++ tests)
   - https://github.com/tetherto/qvac/pull/576 (CI from temp branch)

