### PR TITLE
QVAC-10950: Fixup noisy logs

### DIFF
--- a/packages/qvac-lib-inference-addon-cpp/CHANGELOG.md
+++ b/packages/qvac-lib-inference-addon-cpp/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.1.2] - 2026-02-20
+Reduce noise from logs, macro for compile-time enabling of debug logs.
+
+## [1.1.1] - 2026-02-17
+- await addon.cancel() does not guarantee job is finished even though await is specified.
+- Other improvement/fixes related to run and cancel:
+
+Some tests were hanging when using cancel.
+- Detect reliably of job already running.
+
+Other improvements:
+- transitionCb unused
+
 ## [1.0.0] - 2025-12-15
 
 Refactored from complex templated Addon and JsInterface classes to a simpler architecture using `std::any` and output handlers. The use of `std::any` is better aligned with the already dynamic handling of JavaScript types. Refer to [docs/usage.md](docs/usage.md) for updated usage and examples.

--- a/packages/qvac-lib-inference-addon-cpp/CMakeLists.txt
+++ b/packages/qvac-lib-inference-addon-cpp/CMakeLists.txt
@@ -6,7 +6,7 @@ if(BUILD_TESTING)
 endif()
 
 project(qvac-lib-inference-addon-cpp
-  VERSION 1.1.1
+  VERSION 1.1.2
   LANGUAGES CXX)
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
@@ -122,7 +122,7 @@ public:
 
   ~JobRunner() {
     if (running_) {
-      QLOG(logger::Priority::DEBUG, "Stopping job");
+      QLOG_DEBUG("Stopping job");
       {
         std::lock_guard lock(mtx_);
         running_ = false;

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsBlobsStream.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsBlobsStream.hpp
@@ -81,7 +81,7 @@ public:
       if (it != shards_in_progress.end()) {
         auto data = std::move(it->second);
         shards_in_progress.erase(it);
-        QLOG(logger::Priority::DEBUG, "Finalizing shard " + filename);
+        QLOG_DEBUG("Finalizing shard " + filename);
         return std::make_unique<FinalizedStream<T>>(
             env, filename, std::move(data));
       }

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/Logger.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/Logger.hpp
@@ -43,3 +43,10 @@ do { \
 std::cout << "[" << qvac_lib_inference_addon_cpp::logger::to_string(prio)<<"]: "<< msg <<std::endl; \
 } while (0)
 #endif
+
+// Enable QLOG_DEBUG in debug builds (NDEBUG not set), not compiled in release.
+#ifndef NDEBUG
+#define QLOG_DEBUG(msg) QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, msg)
+#else
+#define QLOG_DEBUG(msg) ((void)0)
+#endif

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/handlers/OutputHandler.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/handlers/OutputHandler.hpp
@@ -32,8 +32,7 @@ auto callTypeChecked(F&& function, const std::any& arg, Obj* obj) {
 
 template <typename T> bool canHandle(const any& input) {
   bool result = input.type() == typeid(T);
-  QLOG(
-      Priority::DEBUG,
+  QLOG_DEBUG(
       "canHandle<" + string(typeid(T).name()) + "> for input type " +
           string(input.type().name()) + " = " + (result ? "TRUE" : "FALSE"));
   return result;

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputQueue.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputQueue.hpp
@@ -56,10 +56,9 @@ public:
   void queueJobEnded() { return queueOutput(model_.runtimeStats()); }
 
   void queueResult(std::any&& output) {
-    QLOG(
-        logger::Priority::DEBUG,
+    QLOG_DEBUG(
         std::string("[OutputQueue] queueResult called with type: ") +
-            output.type().name());
+        output.type().name());
     queueOutput(std::move(output));
   }
 

--- a/packages/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qvac-lib-inference-addon-cpp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "dependencies": [
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
`QLOG` does not filter by level, instead on different ad-dons we are relying on `QLOG_IF`. To fix it I added a compile-time check for debug logs. They will not be included on release builds.