### PR TITLE
 QVAC-11735 chore[skiplog]: qvac-sdk v0.7.0 release changelog and NOTICE

### DIFF
--- a/.cursor/rules/sdk/docs/holepunchto-bare-rpc-8a5edab282632443.txt
+++ b/.cursor/rules/sdk/docs/holepunchto-bare-rpc-8a5edab282632443.txt
@@ -2072,7 +2072,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.platform }}-${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*

--- a/.cursor/rules/sdk/docs/holepunchto-bare-rpc-8a5edab282632443.txt
+++ b/.cursor/rules/sdk/docs/holepunchto-bare-rpc-8a5edab282632443.txt
@@ -2073,7 +2073,7 @@ jobs:
     name: ${{ matrix.platform }}-${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - run: npm install -g bare-runtime

--- a/.cursor/rules/sdk/docs/holepunchto-hyperswarm-8a5edab282632443.txt
+++ b/.cursor/rules/sdk/docs/holepunchto-hyperswarm-8a5edab282632443.txt
@@ -3410,7 +3410,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6 # v6 https://github.com/actions/checkout
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2 https://github.com/actions/setup-node/releases/tag/v3.8.2
+        uses: actions/setup-node@v6 # v6 https://github.com/actions/setup-node
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.cursor/rules/sdk/docs/holepunchto-hyperswarm-8a5edab282632443.txt
+++ b/.cursor/rules/sdk/docs/holepunchto-hyperswarm-8a5edab282632443.txt
@@ -3408,7 +3408,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1 https://github.com/actions/checkout/releases/tag/v4.1.1
+      - uses: actions/checkout@v6 # v6 https://github.com/actions/checkout
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2 https://github.com/actions/setup-node/releases/tag/v3.8.2
         with:

--- a/.github/actions/cpp-lint/action.yaml
+++ b/.github/actions/cpp-lint/action.yaml
@@ -28,12 +28,12 @@ runs:
   using: composite
   steps:
     - name: Checkout PR head and target
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
-        fetch-depth: 0
-        token: ${{ inputs.pat-token }}
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
+        token: ${{ inputs.pat-token }}
+        fetch-depth: 0
 
     - name: Configure git
       shell: bash

--- a/.github/actions/cpp-lint/action.yaml
+++ b/.github/actions/cpp-lint/action.yaml
@@ -40,9 +40,9 @@ runs:
       run: git config --global --add url."https://${{ inputs.pat-token }}:x-oauth-basic@github.com/".insteadOf "git@github.com:"
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: "18.x"
+        node-version: 18
 
     - name: Restore npm cache
       id: cache-npm

--- a/.github/actions/cpp-lint/action.yaml
+++ b/.github/actions/cpp-lint/action.yaml
@@ -46,12 +46,11 @@ runs:
 
     - name: Restore npm cache
       id: cache-npm
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
-        path: ~/.npm
         key: npm-${{ runner.os }}-${{ hashFiles('**/package.json') }}
-        restore-keys: |
-          npm-${{ runner.os }}-
+        path: ~/.npm
+        restore-keys: npm-${{ runner.os }}-
 
     - run: |
         # @qvac/* from npmjs.org
@@ -82,10 +81,10 @@ runs:
       run: mkdir -p vcpkg/cache
  
     - name: Get vcpkg cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
-        path: vcpkg/cache
         key: linux-x64-${{ hashFiles( 'vcpkg.json', 'vcpkg-configuration.json', 'vcpkg/ports/**' ) }}
+        path: vcpkg/cache
         restore-keys: linux-x64-
 
     - name: Install bare-make

--- a/.github/actions/publish-library-to-gpr/action.yaml
+++ b/.github/actions/publish-library-to-gpr/action.yaml
@@ -44,10 +44,10 @@ runs:
         ls -l ${{ inputs.path }}
         tree ${{ inputs.path }}
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: lts/*
-        registry-url: "https://npm.pkg.github.com/"
+        registry-url: https://npm.pkg.github.com/
         scope: "@tetherto"
 
     - name: Resolve publish directory

--- a/.github/actions/publish-library-to-npm/action.yaml
+++ b/.github/actions/publish-library-to-npm/action.yaml
@@ -46,10 +46,10 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: "18.x"
-        registry-url: "https://registry.npmjs.org/"
+        node-version: 18
+        registry-url: https://registry.npmjs.org/
         scope: "@qvac"
 
     - name: Publish to NPM and optionally tag repo

--- a/.github/actions/run-lint-and-integration-tests/action.yaml
+++ b/.github/actions/run-lint-and-integration-tests/action.yaml
@@ -19,9 +19,9 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: "18.x"
+        node-version: 18
 
     - name: Restore npm cache
       id: cache-npm

--- a/.github/actions/run-lint-and-integration-tests/action.yaml
+++ b/.github/actions/run-lint-and-integration-tests/action.yaml
@@ -25,12 +25,11 @@ runs:
 
     - name: Restore npm cache
       id: cache-npm
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
-        path: ~/.npm
         key: npm-${{ runner.os }}-${{ hashFiles('**/package.json') }}
-        restore-keys: |
-          npm-${{ runner.os }}-
+        path: ~/.npm
+        restore-keys: npm-${{ runner.os }}-
 
     - name: Configure .npmrc for both npmjs and GitHub Packages
       shell: bash

--- a/.github/actions/run-lint-and-unit-tests/action.yaml
+++ b/.github/actions/run-lint-and-unit-tests/action.yaml
@@ -23,9 +23,9 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: "18.x"
+        node-version: 18
 
     - name: Restore npm cache
       id: cache-npm

--- a/.github/actions/run-lint-and-unit-tests/action.yaml
+++ b/.github/actions/run-lint-and-unit-tests/action.yaml
@@ -29,12 +29,11 @@ runs:
 
     - name: Restore npm cache
       id: cache-npm
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
-        path: ~/.npm
         key: npm-${{ runner.os }}-${{ hashFiles(format('{0}/package-lock.json', inputs.workdir), format('{0}/package.json', inputs.workdir)) }}
-        restore-keys: |
-          npm-${{ runner.os }}-
+        path: ~/.npm
+        restore-keys: npm-${{ runner.os }}-
 
     - name: Configure .npmrc for both npmjs and GitHub Packages
       run: |

--- a/.github/actions/sanity-checks/action.yaml
+++ b/.github/actions/sanity-checks/action.yaml
@@ -25,12 +25,12 @@ runs:
   using: composite
   steps:
     - name: Checkout PR head and target
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
-        fetch-depth: 0
-        token: ${{ inputs.pat-token }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
+        token: ${{ inputs.pat-token }}
+        fetch-depth: 0
 
     - name: Fetch PR head and target branch
       shell: bash

--- a/.github/actions/yamlfmt/action.yaml
+++ b/.github/actions/yamlfmt/action.yaml
@@ -14,7 +14,7 @@ runs:
         exit 1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '>=1.22'
 

--- a/.github/workflows/approval-worker.yml
+++ b/.github/workflows/approval-worker.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Get latest PR head SHA
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
@@ -359,7 +359,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: chatterbox-benchmark-results-v${{ steps.version.outputs.version }}
           path: packages/qvac-lib-infer-onnx-tts/benchmarks/results/

--- a/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
@@ -125,9 +125,9 @@ jobs:
           brew install ffmpeg cmake
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: 3.11
 
       - name: Install Bare runtime
         run: |

--- a/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
@@ -85,9 +85,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
           submodules: recursive
 
       - name: Configure scoped registry for @tetherto and @qvac packages

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
@@ -202,9 +202,7 @@ jobs:
           free -h
 
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
@@ -210,11 +210,11 @@ jobs:
           node-version: lts/*
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
-          cache: 'pip'
-          cache-dependency-path: 'benchmarks/client/requirements.txt'
+          python-version: 3.10
+          cache: pip
+          cache-dependency-path: benchmarks/client/requirements.txt
 
       - name: Configure scoped registry for @tetherto and @qvac packages
         env:

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
@@ -477,7 +477,7 @@ jobs:
           fi
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: benchmark-results-${{ github.run_number }}
@@ -487,7 +487,7 @@ jobs:
           retention-days: 90
 
       - name: Upload server logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: server-logs-${{ github.run_number }}

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
@@ -205,7 +205,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
@@ -254,12 +254,11 @@ jobs:
       - name: Get vcpkg cache (monorepo)
         if: inputs.addon_version == ''
         id: cache-vcpkg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ${{ env.WORKDIR }}/vcpkg/cache
           key: linux-x64-${{ hashFiles(format('{0}/vcpkg.json', env.WORKDIR), format('{0}/vcpkg-configuration.json', env.WORKDIR), format('{0}/vcpkg/ports/**', env.WORKDIR), 'vcpkg.json', 'vcpkg-configuration.json', 'vcpkg/ports/**') }}
-          restore-keys: |
-            linux-x64-
+          path: ${{ env.WORKDIR }}/vcpkg/cache
+          restore-keys: linux-x64-
 
       - name: Build addon from source (monorepo workdir)
         if: inputs.addon_version == ''

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
@@ -252,9 +252,7 @@ jobs:
           free -h
 
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
@@ -255,7 +255,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
@@ -519,7 +519,7 @@ jobs:
           fi
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: benchmark-results-${{ github.run_number }}
@@ -529,7 +529,7 @@ jobs:
           retention-days: 90
 
       - name: Upload server logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: server-logs-${{ github.run_number }}

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
@@ -260,11 +260,11 @@ jobs:
           node-version: lts/*
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
-          cache: 'pip'
-          cache-dependency-path: '${{ inputs.workdir }}/benchmarks/client/requirements.txt'
+          python-version: 3.10
+          cache: pip
+          cache-dependency-path: ${{ inputs.workdir }}/benchmarks/client/requirements.txt
 
       - name: Configure scoped registry for @tetherto and @qvac packages
         env:

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
@@ -298,10 +298,10 @@ jobs:
       - name: Get vcpkg cache
         if: inputs.addon_version == ''
         id: cache-vcpkg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ${{ inputs.workdir }}/vcpkg/cache
           key: linux-x64-${{ hashFiles( format('{0}/vcpkg.json', inputs.workdir), format('{0}/vcpkg-configuration.json', inputs.workdir), format('{0}/vcpkg/ports/**', inputs.workdir) ) }}
+          path: ${{ inputs.workdir }}/vcpkg/cache
           restore-keys: linux-x64-
 
       - name: Build addon from source

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -183,9 +183,8 @@ jobs:
           sudo ./llvm.sh 19 all
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
           submodules: recursive
 
       - name: Set up Node.js
@@ -320,9 +319,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
       - name: Set up Node.js

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -334,10 +334,10 @@ jobs:
         run: npm install -g bare-runtime
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
-          cache: 'pip'
+          python-version: 3.10
+          cache: pip
 
       - name: Download build artifact
         if: needs.setup.outputs.qvac_needed == 'true' && needs.build.result == 'success'

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -292,7 +292,7 @@ jobs:
           bare-make install
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: qvac-addon-build-${{ inputs.translators }}
           path: |
@@ -679,7 +679,7 @@ jobs:
           PYTHONUNBUFFERED: 1
 
       - name: Upload evaluation results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: results-${{ matrix.pair }}-${{ inputs.translators }}-${{ steps.metrics.outputs.metrics }}-${{ inputs.hyperparams }}${{ inputs.use_pivot && '-pivot' || '' }}
@@ -687,7 +687,7 @@ jobs:
           retention-days: 30
 
       - name: Upload evaluation logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: logs-${{ matrix.pair }}-${{ inputs.translators }}-${{ steps.metrics.outputs.metrics }}-${{ inputs.hyperparams }}
@@ -813,7 +813,7 @@ jobs:
           echo "- Metrics: chrF++=\`${{ inputs.metric_chrfpp }}\`, COMET=\`${{ inputs.metric_comet }}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload consolidated results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: consolidated-results-${{ inputs.translators }}
           path: all-results

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -188,7 +188,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -325,9 +325,9 @@ jobs:
 
       - name: Set up Node.js
         if: needs.setup.outputs.qvac_needed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 20
 
       - name: Install bare-runtime
         if: needs.setup.outputs.qvac_needed == 'true'

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -474,12 +474,11 @@ jobs:
         continue-on-error: true
 
       - name: Cache datasets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ${{ env.PKG_DIR }}/benchmarks/quality_eval/data
           key: datasets-${{ needs.setup.outputs.datasets_cache_key }}
-          restore-keys: |
-            datasets-
+          path: ${{ env.PKG_DIR }}/benchmarks/quality_eval/data
+          restore-keys: datasets-
 
       - name: Free up disk space
         run: |

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -341,7 +341,7 @@ jobs:
 
       - name: Download build artifact
         if: needs.setup.outputs.qvac_needed == 'true' && needs.build.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: qvac-addon-build-${{ inputs.translators }}
           path: ${{ env.PKG_DIR }}
@@ -703,7 +703,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: all-results
           pattern: results-*

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -358,7 +358,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: needs.setup.outputs.qvac_needed == 'true'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/benchmark-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-parakeet.yml
@@ -134,9 +134,8 @@ jobs:
           df -h
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
           submodules: recursive
 
       - name: Configure scoped registry for @tetherto and @qvac packages

--- a/.github/workflows/benchmark-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-parakeet.yml
@@ -175,9 +175,9 @@ jobs:
           sudo apt-get install -y ffmpeg build-essential cmake unzip curl
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: 3.12
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/benchmark-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-whispercpp.yml
@@ -285,9 +285,8 @@ jobs:
           df -h
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
           submodules: recursive
 
       - name: Configure scoped registry for @tetherto and @qvac packages

--- a/.github/workflows/benchmark-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-whispercpp.yml
@@ -325,9 +325,9 @@ jobs:
           sudo apt-get install -y ffmpeg build-essential cmake unzip curl
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: 3.12
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -75,7 +75,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -188,9 +188,9 @@ jobs:
 
       - name: Set up Node.js
         if: needs.setup.outputs.qvac_needed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 20
 
       - name: Install bare-runtime
         if: needs.setup.outputs.qvac_needed == 'true'

--- a/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -70,9 +70,8 @@ jobs:
           sudo apt install -y g++-13
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
           submodules: recursive
 
       - name: Set up Node.js
@@ -186,9 +185,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           submodules: recursive
 
       - name: Set up Node.js

--- a/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -197,10 +197,10 @@ jobs:
         run: npm install -g bare-runtime
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
-          cache: 'pip'
+          python-version: 3.10
+          cache: pip
 
       - name: Download build artifact
         if: needs.setup.outputs.qvac_needed == 'true' && needs.build.result == 'success'

--- a/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -165,7 +165,7 @@ jobs:
         run: ccache -s
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: qvac-addon-build
           path: |
@@ -349,7 +349,7 @@ jobs:
           PYTHONUNBUFFERED: 1
 
       - name: Upload evaluation results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: ocr-benchmark-results
@@ -358,7 +358,7 @@ jobs:
           retention-days: 30
 
       - name: Upload evaluation logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: ocr-benchmark-logs
@@ -488,7 +488,7 @@ jobs:
           PYTHON_SCRIPT
 
       - name: Upload consolidated results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ocr-benchmark-consolidated
           path: results

--- a/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -107,23 +107,21 @@ jobs:
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
 
       - name: Cache vcpkg packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
+          key: vcpkg-linux-x64-${{ hashFiles('packages/qvac-lib-inference-addon-onnx-ocr-fasttext/**/vcpkg.json', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/**/CMakeLists.txt') }}
           path: |
             ${{ env.VCPKG_ROOT }}/installed
             ${{ env.VCPKG_ROOT }}/packages
             ~/.cache/vcpkg
-          key: vcpkg-linux-x64-${{ hashFiles('packages/qvac-lib-inference-addon-onnx-ocr-fasttext/**/vcpkg.json', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/**/CMakeLists.txt') }}
-          restore-keys: |
-            vcpkg-linux-x64-
+          restore-keys: vcpkg-linux-x64-
 
       - name: Cache ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.ccache
           key: ccache-linux-x64-${{ github.sha }}
-          restore-keys: |
-            ccache-linux-x64-
+          path: ~/.ccache
+          restore-keys: ccache-linux-x64-
 
       - name: Install system dependencies
         run: |
@@ -140,12 +138,11 @@ jobs:
           ccache -z
 
       - name: Cache npm dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.npm
           key: npm-${{ hashFiles('packages/qvac-lib-inference-addon-onnx-ocr-fasttext/package-lock.json') }}
-          restore-keys: |
-            npm-
+          path: ~/.npm
+          restore-keys: npm-
 
       - name: Install npm dependencies
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -240,7 +240,7 @@ jobs:
           sudo apt-get install -y mesa-vulkan-drivers g++-13
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/benchmark-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Download build artifact
         if: needs.setup.outputs.qvac_needed == 'true' && needs.build.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: qvac-addon-build
           path: ${{ env.PKG_DIR }}
@@ -374,11 +374,12 @@ jobs:
 
     steps:
       - name: Download results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: ocr-benchmark-results
           path: results
+
       - name: Skip summary if results are missing
         if: ${{ !hashFiles('results/**') }}
         run: |

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
@@ -83,7 +83,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
@@ -74,10 +74,10 @@ jobs:
           sudo rm -rf /usr/share/dotnet
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.event.inputs.ref || github.event.pull_request.head.sha || github.sha }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.event.inputs.ref || github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           lfs: true
           fetch-depth: 0

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Archive Coverage Results
         if: ${{ matrix.coverage }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report-${{ matrix.platform }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
@@ -199,7 +199,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Download all coverage reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: coverage-reports
 

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Archive Coverage Results
         if: matrix.coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report-${{ matrix.platform }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
           lfs: true
 

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
@@ -45,7 +45,7 @@ jobs:
           lfs: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
@@ -78,12 +78,11 @@ jobs:
 
       - name: Get ccache cache
         if: matrix.platform == 'linux'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.cache/ccache
           key: ccache-cpp-coverage-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles(format('{0}/vcpkg.json', env.PKG_DIR)) }}
-          restore-keys: |
-            ccache-cpp-coverage-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-
+          path: ~/.cache/ccache
+          restore-keys: ccache-cpp-coverage-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Configure scoped registry for @tetherto and @qvac packages
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
@@ -238,7 +238,7 @@ jobs:
     if: always()
     steps:
       - name: Download all coverage reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: coverage-reports
 

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
           lfs: true
 

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Archive Coverage Results
         if: matrix.coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report-${{ matrix.platform }}-${{ matrix.arch }}
           path: |

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
@@ -56,7 +56,7 @@ jobs:
           lfs: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
@@ -225,7 +225,7 @@ jobs:
     if: always()
     steps:
       - name: Download all coverage reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: coverage-reports
 

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -261,7 +261,7 @@ jobs:
 
       - name: Archive Coverage Results
         if: ${{ matrix.os == 'ubuntu-24.04' && always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cpp-coverage-report-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}
           path: |

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -80,10 +80,10 @@ jobs:
           choco upgrade llvm -y
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure scoped registry for @tetherto and @qvac packages

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -68,7 +68,7 @@ jobs:
           echo "workdir=${{ env.WORKDIR }}"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -179,10 +179,8 @@ jobs:
         run: mkdir -p "${{ env.WORKDIR }}/vcpkg/cache"
 
       - name: Get vcpkg cache (package-local)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: |
-            ${{ github.workspace }}/${{ env.WORKDIR }}/vcpkg/cache
           key: >-
             cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-${{
               hashFiles(
@@ -194,8 +192,8 @@ jobs:
                 'vcpkg/ports/**'
               )
             }}
-          restore-keys: |
-            cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-
+          path: ${{ github.workspace }}/${{ env.WORKDIR }}/vcpkg/cache
+          restore-keys: cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-
 
       - name: Download test models (into package dir)
         shell: bash

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -49,11 +49,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - if: ${{ matrix.os == 'ubuntu-24.04' }}
         name: Install llvm-19 on Linux

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -139,7 +139,7 @@ jobs:
           restore-keys: cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Archive Coverage Results
         if: ${{ matrix.os == 'ubuntu-24.04' && always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cpp-coverage-report-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}
           path: |

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -132,10 +132,10 @@ jobs:
           New-Item -ItemType Directory -Force -Path "vcpkg/cache" | Out-Null
 
       - name: Get vcpkg cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ${{ env.WORKDIR }}/vcpkg/cache
           key: cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-${{ hashFiles(format('{0}/vcpkg.json', inputs.workdir), format('{0}/vcpkg-configuration.json', inputs.workdir)) }}
+          path: ${{ env.WORKDIR }}/vcpkg/cache
           restore-keys: cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-
 
       - name: Setup Node.js

--- a/.github/workflows/create-github-release-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-llamacpp-embed.yml
@@ -27,7 +27,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-github-release-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-llamacpp-llm.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-github-release-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-nmtcpp.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-github-release-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-onnx-tts.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-github-release-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-parakeet.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-github-release-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-whispercpp.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-github-release-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/create-github-release-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -28,7 +28,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -35,7 +35,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
@@ -311,10 +311,10 @@ jobs:
       # Android-specific steps
       - name: Set up JDK 17
         if: matrix.platform == 'Android'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: "17"
-          distribution: "temurin"
+          java-version: 17
+          distribution: temurin
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'

--- a/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
@@ -84,21 +84,21 @@ jobs:
           df -h
 
       - name: Checkout monorepo (addon package lives under workdir)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          path: addon
-          ref: ${{ inputs.ref || github.event.inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.event.inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
+          path: addon
           fetch-depth: 0
 
       - name: Checkout mobile test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tetherto/qvac-test-addon-mobile
+          ref: ${{ env.TEST_FRAMEWORK_REF }}
           token: ${{ secrets.PAT_TOKEN }}
           path: test-framework
-          ref: ${{ env.TEST_FRAMEWORK_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
@@ -643,7 +643,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -78,12 +78,12 @@ jobs:
           df -h
 
       - name: Checkout monorepo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
+          fetch-depth: 0
 
       - name: Verify addon directory exists
         run: |
@@ -100,12 +100,12 @@ jobs:
           ls -la "${ADDON_DIR}" | head -50
 
       - name: Checkout mobile test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tetherto/qvac-test-addon-mobile
+          ref: ${{ env.TEST_FRAMEWORK_REF }}
           token: ${{ secrets.PAT_TOKEN }}
           path: test-framework
-          ref: ${{ env.TEST_FRAMEWORK_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -396,10 +396,10 @@ jobs:
       # Android-specific steps
       - name: Set up JDK 17
         if: matrix.platform == 'Android'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: 17
+          distribution: temurin
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -699,7 +699,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -153,19 +153,19 @@ jobs:
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           path: ${{ env.ADDON_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && !inputs.package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           path: ${{ env.ADDON_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
         continue-on-error: true
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -95,7 +95,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -399,10 +399,10 @@ jobs:
       # Android-specific steps
       - name: Set up JDK 17
         if: matrix.platform == 'Android'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: "17"
-          distribution: "temurin"
+          java-version: 17
+          distribution: temurin
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -77,21 +77,21 @@ jobs:
           df -h
 
       - name: Checkout addon repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          path: addon
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
+          path: addon
           fetch-depth: 0
 
       - name: Checkout mobile test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tetherto/qvac-test-addon-mobile
+          ref: ${{ env.TEST_FRAMEWORK_REF }}
           token: ${{ secrets.PAT_TOKEN }}
           path: test-framework
-          ref: ${{ env.TEST_FRAMEWORK_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -731,7 +731,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -139,19 +139,19 @@ jobs:
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           path: ${{ env.ADDON_WORKDIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && !inputs.package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           path: ${{ env.ADDON_WORKDIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
         continue-on-error: true
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -496,10 +496,10 @@ jobs:
       # Android-specific steps
       - name: Set up JDK 17
         if: matrix.platform == 'Android'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: "17"
-          distribution: "temurin"
+          java-version: 17
+          distribution: temurin
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -83,21 +83,21 @@ jobs:
           df -h
 
       - name: Checkout monorepo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          path: monorepo
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
+          path: monorepo
           fetch-depth: 0
 
       - name: Checkout mobile test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tetherto/qvac-test-addon-mobile
+          ref: ${{ env.TEST_FRAMEWORK_REF }}
           token: ${{ secrets.PAT_TOKEN }}
           path: test-framework
-          ref: ${{ env.TEST_FRAMEWORK_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -1396,7 +1396,7 @@ jobs:
 
       - name: Comment PR with results
         if: always() && github.event.pull_request.number
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -294,7 +294,7 @@ jobs:
         run: npm run test:mobile:validate
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -146,19 +146,19 @@ jobs:
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           path: monorepo/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && !inputs.package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           path: monorepo/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
         continue-on-error: true
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -89,21 +89,21 @@ jobs:
           df -h
 
       - name: Checkout addon repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          path: addon
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
+          path: addon
           fetch-depth: 0
 
       - name: Checkout mobile test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tetherto/qvac-test-addon-mobile
+          ref: ${{ env.TEST_FRAMEWORK_REF }}
           token: ${{ secrets.PAT_TOKEN }}
           path: test-framework
-          ref: ${{ env.TEST_FRAMEWORK_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -107,7 +107,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -424,10 +424,10 @@ jobs:
       # Android-specific steps
       - name: Set up JDK 17
         if: matrix.platform == 'Android'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: "17"
-          distribution: "temurin"
+          java-version: 17
+          distribution: temurin
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -151,19 +151,19 @@ jobs:
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && github.event_name != 'workflow_dispatch'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           path: ${{ env.ADDON_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && github.event_name != 'workflow_dispatch'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           path: ${{ env.ADDON_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
         continue-on-error: true
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -759,7 +759,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -409,10 +409,10 @@ jobs:
       # Android-specific steps
       - name: Set up JDK 17
         if: matrix.platform == 'Android'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: "17"
-          distribution: "temurin"
+          java-version: 17
+          distribution: temurin
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -86,21 +86,21 @@ jobs:
           df -h
 
       - name: Checkout addon repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          path: addon
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
+          path: addon
           fetch-depth: 0
 
       - name: Checkout mobile test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tetherto/qvac-test-addon-mobile
+          ref: ${{ env.TEST_FRAMEWORK_REF }}
           token: ${{ secrets.PAT_TOKEN }}
           path: test-framework
-          ref: ${{ env.TEST_FRAMEWORK_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -720,7 +720,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -145,19 +145,19 @@ jobs:
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && github.event_name != 'workflow_dispatch'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           path: ${{ env.ADDON_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && github.event_name != 'workflow_dispatch'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           path: ${{ env.ADDON_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
         continue-on-error: true
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -84,21 +84,21 @@ jobs:
           df -h
 
       - name: Checkout addon repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          path: addon
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
+          path: addon
           fetch-depth: 0
 
       - name: Checkout mobile test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tetherto/qvac-test-addon-mobile
+          ref: ${{ env.TEST_FRAMEWORK_REF }}
           token: ${{ secrets.PAT_TOKEN }}
           path: test-framework
-          ref: ${{ env.TEST_FRAMEWORK_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -402,10 +402,10 @@ jobs:
       # Android-specific steps
       - name: Set up JDK 17
         if: matrix.platform == 'Android'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: 17
+          distribution: temurin
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -734,7 +734,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -144,19 +144,19 @@ jobs:
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && github.event_name != 'workflow_dispatch'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           path: addon/${{ inputs.workdir }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && github.event_name != 'workflow_dispatch'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           path: addon/${{ inputs.workdir }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
         continue-on-error: true
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -80,21 +80,21 @@ jobs:
           df -h
 
       - name: Checkout addon repository (monorepo)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          path: addon
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
+          path: addon
           fetch-depth: 0
 
       - name: Checkout mobile test framework
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: tetherto/qvac-test-addon-mobile
+          ref: ${{ env.TEST_FRAMEWORK_REF }}
           token: ${{ secrets.PAT_TOKEN }}
           path: test-framework
-          ref: ${{ env.TEST_FRAMEWORK_REF }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -98,7 +98,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -438,10 +438,10 @@ jobs:
       # ---------- Android-specific ----------
       - name: Set up JDK 17
         if: matrix.platform == 'Android'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: 17
+          distribution: temurin
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'

--- a/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -1349,7 +1349,7 @@ jobs:
 
       - name: Comment PR with results
         if: always() && github.event.pull_request.number
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -317,7 +317,7 @@ jobs:
           echo "✅ Test framework dependencies installed"
 
       - name: Configure AWS credentials for model download
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -770,7 +770,7 @@ jobs:
       # Kept as-is from your workflow (only paths above needed monorepo porting)
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -143,19 +143,19 @@ jobs:
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           path: addon/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && !inputs.package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           path: addon/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
+          pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
         continue-on-error: true
 

--- a/.github/workflows/integration-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-test-qvac-lib-decoder-audio.yml
@@ -56,10 +56,10 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure scoped registry for @tetherto and @qvac packages

--- a/.github/workflows/integration-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-test-qvac-lib-decoder-audio.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
@@ -81,10 +81,10 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure scoped registry for @tetherto and @qvac packages (Linux/macOS)

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Download prebuilds (from artifacts)
         if: ${{ !inputs.prebuild_package }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ env.WORKDIR }}/prebuilds
           merge-multiple: true

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -85,10 +85,10 @@ jobs:
         shell: powershell
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure scoped registry for @tetherto and @qvac packages (Linux/macOS)

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -161,7 +161,7 @@ jobs:
 
       - name: Download prebuilds (from artifacts)
         if: ${{ !inputs.prebuild_package }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ env.WORKDIR }}/prebuilds
           merge-multiple: true

--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -70,10 +70,10 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure scoped registry for @tetherto and @qvac packages

--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ inputs.workdir || env.PKG_DIR }}/prebuilds
           merge-multiple: true

--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -164,7 +164,7 @@ jobs:
           sudo apt-get install -y mesa-vulkan-drivers gcc-13 g++-13 libstdc++-13-dev
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
@@ -85,10 +85,10 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure scoped registry for @tetherto and @qvac packages

--- a/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ inputs.workdir }}/prebuilds
           merge-multiple: true

--- a/.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
@@ -71,10 +71,10 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure scoped registry for @tetherto and @qvac packages

--- a/.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ inputs.workdir }}/prebuilds
           merge-multiple: true

--- a/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
@@ -74,10 +74,10 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure scoped registry for @tetherto and @qvac packages (Unix)

--- a/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ inputs.workdir }}/prebuilds
           merge-multiple: true

--- a/.github/workflows/integration-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/integration-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -78,10 +78,10 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure scoped registry for @tetherto and @qvac packages

--- a/.github/workflows/integration-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/integration-test-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ inputs.workdir || env.PKG_DIR }}/prebuilds
           merge-multiple: true

--- a/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
@@ -194,7 +194,7 @@ jobs:
           bare-make install
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: qvac-addon-build
           path: |
@@ -293,7 +293,7 @@ jobs:
           echo "Hello world" | bare nmt-cli --model "models/$TEST_QUANT/$out_prefix/$DATE/$out_prefix.bin" "$SRC" "$DST"
 
       - name: Upload models artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ inputs.upload_models || github.event.inputs.upload_models }}
         with:
           name: ggml-opus-${{ matrix.quant }}-${{ matrix.model }}
@@ -339,7 +339,7 @@ jobs:
           fi
 
       - name: Upload merged models artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ggml-opus-merged-models
           path: bundle/models

--- a/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
@@ -66,11 +66,9 @@ jobs:
       quants: ${{ steps.prepare_quants.outputs.quants }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           lfs: true
-          fetch-depth: 1
 
       - name: Set up Python (with pip cache)
         uses: actions/setup-python@v5
@@ -126,9 +124,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -216,10 +212,7 @@ jobs:
         quant: ${{ fromJson(needs.setup.outputs.quants) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 1
+        uses: actions/checkout@v6
 
       - name: Set up Python (with pip cache)
         uses: actions/setup-python@v5

--- a/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
@@ -127,9 +127,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: 20
 
       - name: Configure scoped registry for @tetherto and @qvac packages
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
@@ -71,10 +71,10 @@ jobs:
           lfs: true
 
       - name: Set up Python (with pip cache)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
-          cache: "pip"
+          python-version: 3
+          cache: pip
           cache-dependency-path: ${{ env.PKG_DIR }}/scripts/conversion_scripts/requirements.txt
 
       - name: Prepare models output
@@ -215,10 +215,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python (with pip cache)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
-          cache: "pip"
+          python-version: 3
+          cache: pip
           cache-dependency-path: ${{ env.PKG_DIR }}/scripts/conversion_scripts/requirements.txt
 
       - name: Install bare-runtime

--- a/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
@@ -225,7 +225,7 @@ jobs:
         run: npm install -g bare-runtime
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: qvac-addon-build
           path: ${{ env.PKG_DIR }}
@@ -307,10 +307,10 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: "ggml-opus-*"
           path: merged_raw
+          pattern: ggml-opus-*
           merge-multiple: true
 
       - name: Merge all model artifacts

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -125,9 +125,8 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0
 
       - name: Publish to GitHub Packages
@@ -149,9 +148,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
+        uses: actions/checkout@v6
 
       - name: Publish to NPM Package Registry
         id: publish

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -149,7 +149,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -67,12 +67,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Fetch PR head and target branch
         id: fetch_pr
@@ -146,7 +146,7 @@ jobs:
         working-directory: ${{ env.PKG_DIR }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/on-pr-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/on-pr-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -44,10 +44,10 @@ jobs:
       pkg: ${{ steps.filter.outputs.pkg }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -70,14 +70,14 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg/cache,readwrite"
       PKG_DIR: packages/qvac-lib-inference-addon-onnx-ocr-fasttext
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
           sparse-checkout: |
             packages/qvac-lib-inference-addon-onnx-ocr-fasttext
+          fetch-depth: 0
 
       - name: Fetch PR head and target branch
         id: fetch_pr

--- a/.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get addon version
         id: get-version

--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -139,7 +139,7 @@ jobs:
     steps:
       # Checkout base branch — config file is read from here (trusted)
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -188,7 +188,7 @@ jobs:
     steps:
       # Checkout PR head — this is the code we're actually testing
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -212,9 +212,9 @@ jobs:
 
       - name: Setup Node
         if: matrix.pkg_manager == 'npm'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: 22
 
       - name: Configure scoped registry
         env:

--- a/.github/workflows/pr-models-validation-qvac-lib-registry-server.yml
+++ b/.github/workflows/pr-models-validation-qvac-lib-registry-server.yml
@@ -30,7 +30,7 @@ jobs:
       models_only: ${{ steps.filter.outputs.models == 'true' && steps.filter.outputs.other == 'false' }}
       other_changed: ${{ steps.filter.outputs.other }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
@@ -105,7 +105,7 @@ jobs:
        github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -143,7 +143,7 @@ jobs:
        github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -206,7 +206,7 @@ jobs:
       QVAC_WRITER_PUBLIC_KEY: ${{ secrets.QVAC_WRITER_PUBLIC_KEY }}
       QVAC_WRITER_SECRET_KEY: ${{ secrets.QVAC_WRITER_SECRET_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -263,7 +263,7 @@ jobs:
     env:
       QVAC_REGISTRY_CORE_KEY: ${{ secrets.QVAC_REGISTRY_CORE_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/pr-models-validation-qvac-lib-registry-server.yml
+++ b/.github/workflows/pr-models-validation-qvac-lib-registry-server.yml
@@ -110,10 +110,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: 20
+          cache: npm
           cache-dependency-path: ${{ env.PKG_DIR }}/package-lock.json
 
       - name: Configure npm for private packages
@@ -148,10 +148,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: 20
+          cache: npm
           cache-dependency-path: |
             ${{ env.PKG_DIR }}/package-lock.json
             ${{ env.PKG_DIR }}/client/package-lock.json
@@ -226,10 +226,10 @@ jobs:
           echo "✓ All required secrets are set"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: 20
+          cache: npm
           cache-dependency-path: ${{ env.PKG_DIR }}/package-lock.json
 
       - name: Configure npm for private packages
@@ -278,10 +278,10 @@ jobs:
           echo "✓ All required secrets are set"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
-          cache: "npm"
+          node-version: 20
+          cache: npm
           cache-dependency-path: ${{ env.PKG_DIR }}/package-lock.json
 
       - name: Configure npm for private packages

--- a/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
@@ -49,11 +49,11 @@ jobs:
 
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: yamlfmt
         uses: tetherto/qvac-devops/.github/actions/yamlfmt@monorepo_update

--- a/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
@@ -153,10 +153,10 @@ jobs:
 
       - name: Get vcpkg cache
         id: cache-vcpkg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ${{ env.PKG_DIR }}/vcpkg/cache
           key: ${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles('packages/qvac-lib-inference-addon-cpp/vcpkg.json', 'packages/qvac-lib-inference-addon-cpp/vcpkg-configuration.json', 'packages/qvac-lib-inference-addon-cpp/vcpkg/ports/**') }}
+          path: ${{ env.PKG_DIR }}/vcpkg/cache
 
       - name: Generate buildsystem
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
@@ -61,7 +61,7 @@ jobs:
           workdir: ${{ env.PKG_DIR }}
         
       - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -151,11 +151,11 @@ jobs:
           choco upgrade llvm
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -458,11 +458,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v4
@@ -500,11 +500,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -407,7 +407,7 @@ jobs:
             find prebuilds -name "*.bare" -exec strip --strip-debug {} \;
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: llama-cpp-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
           path: ${{ inputs.workdir }}/prebuilds
@@ -426,7 +426,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload merged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prebuilds
           path: prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -158,7 +158,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -249,10 +249,10 @@ jobs:
 
       - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
         name: Get ccache cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.cache/ccache-arm
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ~/.cache/ccache-arm
 
       - if: ${{ matrix.platform == 'linux' }}
         name: Install required packages linux
@@ -356,10 +356,10 @@ jobs:
 
       - name: Get vcpkg cache
         id: cache-vcpkg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: vcpkg/cache
           key: ${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles(format('{0}/vcpkg.json', inputs.workdir), format('{0}/vcpkg-configuration.json', inputs.workdir), format('{0}/vcpkg/ports/**', inputs.workdir)) }}
+          path: vcpkg/cache
           restore-keys: ${{ matrix.platform }}-${{ matrix.arch }}-
 
       - if: ${{ inputs.vk-profiling }}

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -420,7 +420,7 @@ jobs:
 
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: prebuilds
           merge-multiple: true
@@ -465,7 +465,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds
@@ -507,7 +507,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -160,11 +160,11 @@ jobs:
           choco upgrade llvm
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -480,11 +480,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -534,11 +534,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -430,7 +430,7 @@ jobs:
             find prebuilds -name "*.bare" -exec strip --strip-debug {} \;
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: llama-cpp-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
           path: ${{ env.WORKDIR }}/prebuilds
@@ -448,7 +448,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload merged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prebuilds
           path: prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -167,7 +167,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -487,7 +487,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 
@@ -541,7 +541,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -264,10 +264,10 @@ jobs:
 
       - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
         name: Get ccache cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.cache/ccache-arm
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ~/.cache/ccache-arm
 
       - if: ${{ matrix.platform == 'linux' }}
         name: Install required packages linux
@@ -372,10 +372,10 @@ jobs:
 
       - name: Get vcpkg cache
         id: cache-vcpkg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ${{ env.WORKDIR }}/vcpkg/cache
           key: ${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles(format('{0}/vcpkg.json', env.WORKDIR), format('{0}/vcpkg-configuration.json', env.WORKDIR), format('{0}/vcpkg/ports/**', env.WORKDIR)) }}
+          path: ${{ env.WORKDIR }}/vcpkg/cache
           restore-keys: ${{ matrix.platform }}-${{ matrix.arch }}-
 
       - if: ${{ inputs.vk-profiling }}

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -442,7 +442,7 @@ jobs:
       contents: write
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: prebuilds
           merge-multiple: true
@@ -492,7 +492,7 @@ jobs:
           node-version: lts/*
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds
@@ -546,7 +546,7 @@ jobs:
           node-version: lts/*
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -115,12 +115,12 @@ jobs:
         run: |
           git config --system core.longpaths true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
           token: ${{ secrets.PAT_TOKEN }}
           submodules: recursive
-          ref: ${{ inputs.ref || github.ref }}
-          repository: ${{ inputs.repository || github.repository }}
 
       - if: ${{ matrix.platform == 'android' }}
         name: Setup Android NDK
@@ -777,11 +777,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          lfs: false
-          fetch-depth: 1
+        uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v4
@@ -809,11 +805,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          lfs: false
-          fetch-depth: 1
+        uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v4
@@ -841,7 +833,7 @@ jobs:
       new_version: ${{ steps.check.outputs.version }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
 

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -670,7 +670,7 @@ jobs:
           path: ${{ env.PKG_DIR }}/vcpkg/cache
           key: vcpkg-nmtcpp-v1-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles('packages/qvac-lib-infer-nmtcpp/vcpkg.json', 'packages/qvac-lib-infer-nmtcpp/vcpkg-configuration.json', 'packages/qvac-lib-infer-nmtcpp/vcpkg-overlays/**') }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
           path: ${{ env.PKG_DIR }}/prebuilds/*
@@ -689,7 +689,7 @@ jobs:
           cp -rv prebuilds/android-arm64/* prebuilds/android-arm/
           cp -rv prebuilds/android-arm64/* prebuilds/android-x64/
           cp -rv prebuilds/android-arm64/* prebuilds/android-ia32/
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: prebuilds
           path: prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -144,7 +144,7 @@ jobs:
           echo "  API Level: 24"
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -350,7 +350,7 @@ jobs:
 
       - name: Restore vcpkg cache
         id: cache-vcpkg
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.PKG_DIR }}/vcpkg/cache
           key: vcpkg-nmtcpp-v1-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles('packages/qvac-lib-infer-nmtcpp/vcpkg.json', 'packages/qvac-lib-infer-nmtcpp/vcpkg-configuration.json', 'packages/qvac-lib-infer-nmtcpp/vcpkg-overlays/**') }}
@@ -665,7 +665,7 @@ jobs:
 
       - if: ${{ steps.cache-vcpkg.outputs.cache-hit != 'true' }}
         name: Save vcpkg cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ env.PKG_DIR }}/vcpkg/cache
           key: vcpkg-nmtcpp-v1-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles('packages/qvac-lib-infer-nmtcpp/vcpkg.json', 'packages/qvac-lib-infer-nmtcpp/vcpkg-configuration.json', 'packages/qvac-lib-infer-nmtcpp/vcpkg-overlays/**') }}

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -679,10 +679,11 @@ jobs:
     runs-on: ubuntu-24.04
     needs: prebuild
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: prebuilds
           merge-multiple: true
+
       - run: |
           tree prebuilds/android-*
           mkdir -p prebuilds/android-arm prebuilds/android-ia32 prebuilds/android-x64
@@ -780,7 +781,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.PKG_DIR }}/prebuilds
@@ -808,7 +809,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.PKG_DIR }}/prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
@@ -465,7 +465,7 @@ jobs:
       - name: Show ccache stats
         run: ccache -s
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: onnx-tts-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
           path: ${{ env.WORKDIR }}/prebuilds
@@ -486,7 +486,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload merged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prebuilds
           path: prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
@@ -252,7 +252,7 @@ jobs:
           git submodule update --init --recursive
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
@@ -241,11 +241,11 @@ jobs:
             ccache-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Initialize and update submodules
         run: |
@@ -576,9 +576,7 @@ jobs:
       WORKDIR: ${{ inputs.workdir || github.event.inputs.workdir || 'packages/qvac-lib-infer-onnx-tts' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
+        uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v4
@@ -609,9 +607,7 @@ jobs:
       WORKDIR: ${{ inputs.workdir || github.event.inputs.workdir || 'packages/qvac-lib-infer-onnx-tts' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
+        uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
@@ -199,10 +199,10 @@ jobs:
 
       - if: ${{ matrix.os != 'windows-2022' }}
         name: Get ccache cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.cache/ccache
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles('packages/qvac-lib-infer-onnx-tts/vcpkg.json') }}
+          path: ~/.cache/ccache
           restore-keys: |
             ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-
             ccache-${{ matrix.platform }}-${{ matrix.arch }}-
@@ -233,10 +233,10 @@ jobs:
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Get ccache cache (Windows)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~\AppData\Local\ccache
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles('packages/qvac-lib-infer-onnx-tts/vcpkg.json') }}
+          path: ~\AppData\Local\ccache
           restore-keys: |
             ccache-${{ matrix.platform }}-${{ matrix.arch }}-
 

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
@@ -480,7 +480,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: prebuilds
           merge-multiple: true
@@ -579,7 +579,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds
@@ -610,7 +610,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
@@ -370,7 +370,7 @@ jobs:
       - name: Show ccache stats
         run: ccache -s
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: parakeet-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
           path: ${{ env.WORKDIR }}/prebuilds
@@ -388,7 +388,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload merged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prebuilds
           path: prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
@@ -144,11 +144,11 @@ jobs:
             ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref }}
           repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -422,9 +422,7 @@ jobs:
       WORKDIR: ${{ inputs.workdir || 'packages/qvac-lib-infer-parakeet' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
+        uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v4
@@ -493,9 +491,7 @@ jobs:
       WORKDIR: ${{ inputs.workdir || 'packages/qvac-lib-infer-parakeet' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
+        uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
@@ -151,7 +151,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
@@ -136,10 +136,10 @@ jobs:
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Get ccache cache (Windows)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~\AppData\Local\ccache
           key: ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles(format('{0}/vcpkg.json', env.WORKDIR)) }}
+          path: ~\AppData\Local\ccache
           restore-keys: |
             ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-
 
@@ -270,10 +270,10 @@ jobs:
 
       - if: ${{ matrix.os != 'windows-2022' }}
         name: Get ccache cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.cache/ccache
           key: ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles(format('{0}/vcpkg.json', env.WORKDIR)) }}
+          path: ~/.cache/ccache
           restore-keys: |
             ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-
             ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-

--- a/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
@@ -382,7 +382,7 @@ jobs:
       contents: write
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: prebuilds
           merge-multiple: true
@@ -425,7 +425,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds
@@ -494,7 +494,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -160,11 +160,11 @@ jobs:
             ccache-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0
 
       - name: Setup node
@@ -476,9 +476,8 @@ jobs:
       WORKDIR: ${{ inputs.workdir || 'packages/qvac-lib-infer-whispercpp' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0
 
       - name: Download prebuild artifacts
@@ -555,9 +554,8 @@ jobs:
       WORKDIR: ${{ inputs.workdir || 'packages/qvac-lib-infer-whispercpp' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0
 
       - name: Download prebuild artifacts

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -426,7 +426,7 @@ jobs:
       - name: Show ccache stats
         run: ccache -s
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: whisper-cpp-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
           path: ${{ inputs.workdir }}/prebuilds
@@ -442,7 +442,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload merged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prebuilds
           path: prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -168,7 +168,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -151,10 +151,10 @@ jobs:
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Get ccache cache (Windows)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~\AppData\Local\ccache
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.tags }}-${{ hashFiles(format('{0}/vcpkg.json', inputs.workdir)) }}
+          path: ~\AppData\Local\ccache
           restore-keys: |
             ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.tags }}-
             ccache-${{ matrix.platform }}-${{ matrix.arch }}-
@@ -287,10 +287,10 @@ jobs:
 
       - if: ${{ matrix.os != 'windows-2022' }}
         name: Get ccache cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ~/.cache/ccache
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles(format('{0}/vcpkg.json', inputs.workdir)) }}
+          path: ~/.cache/ccache
           restore-keys: |
             ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-
             ccache-${{ matrix.platform }}-${{ matrix.arch }}-
@@ -385,14 +385,14 @@ jobs:
 
       - name: Get vcpkg cache
         id: cache-vcpkg
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
-          path: ${{ inputs.workdir }}/vcpkg/cache
           key: vcpkg-v2-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles(
             format('{0}/vcpkg.json', inputs.workdir),
             format('{0}/vcpkg-configuration.json', inputs.workdir),
             format('{0}/vcpkg/ports/**', inputs.workdir)
            ) }}
+          path: ${{ inputs.workdir }}/vcpkg/cache
           restore-keys: |
             vcpkg-v2-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-
             vcpkg-v2-${{ matrix.platform }}-${{ matrix.arch }}-

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -436,7 +436,7 @@ jobs:
     needs: prebuild
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: prebuilds
           merge-multiple: true
@@ -481,7 +481,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds
@@ -559,7 +559,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download prebuild artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.WORKDIR }}/prebuilds

--- a/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -388,7 +388,7 @@ jobs:
           path: ${{ env.PKG_DIR }}/vcpkg/cache
           key: vcpkg-v3-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles('packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg.json', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg-configuration.json', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg/ports/**', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg-override-triplets/**') }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: onnx-ocr-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
           path: ${{ env.PKG_DIR }}/prebuilds
@@ -416,7 +416,7 @@ jobs:
           cp -rv prebuilds/android-arm64/* prebuilds/android-ia32/
 
       - name: Upload merged artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prebuilds
           path: prebuilds
@@ -434,7 +434,7 @@ jobs:
           aws s3 cp s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ocr/2025-04-25/detector_craft.onnx models/ocr/detector_craft.onnx
 
       - name: Upload models artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: models
           path: models

--- a/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -201,11 +201,11 @@ jobs:
             ccache-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
         uses: actions/setup-node@v4
@@ -523,11 +523,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download prebuild artifacts into package dir
         uses: actions/download-artifact@v4
@@ -556,11 +556,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ inputs.ref || github.ref }}
           repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Download prebuild artifacts into package dir
         uses: actions/download-artifact@v4

--- a/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -208,7 +208,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -153,7 +153,7 @@ jobs:
       - if: ${{ matrix.os != 'windows-2022' }}
         name: Restore ccache cache
         id: cache-ccache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ccache
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ github.sha }}
@@ -193,7 +193,7 @@ jobs:
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Restore ccache cache (Windows)
         id: cache-ccache-win
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~\AppData\Local\ccache
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.sha }}
@@ -333,7 +333,7 @@ jobs:
 
       - name: Restore vcpkg cache
         id: cache-vcpkg
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.PKG_DIR }}/vcpkg/cache
           key: vcpkg-v3-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles('packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg.json', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg-configuration.json', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg/ports/**', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg-override-triplets/**') }}
@@ -369,21 +369,21 @@ jobs:
 
       - if: ${{ matrix.os != 'windows-2022' && steps.cache-ccache.outputs.cache-hit != 'true' }}
         name: Save ccache cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/.cache/ccache
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ github.sha }}
 
       - if: ${{ matrix.os == 'windows-2022' && steps.cache-ccache-win.outputs.cache-hit != 'true' }}
         name: Save ccache cache (Windows)
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~\AppData\Local\ccache
           key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.sha }}
 
       - if: ${{ steps.cache-vcpkg.outputs.cache-hit != 'true' }}
         name: Save vcpkg cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ env.PKG_DIR }}/vcpkg/cache
           key: vcpkg-v3-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles('packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg.json', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg-configuration.json', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg/ports/**', 'packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg-override-triplets/**') }}

--- a/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/prebuilds-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -403,7 +403,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: prebuilds
           merge-multiple: true
@@ -530,7 +530,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download prebuild artifacts into package dir
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.PKG_DIR }}/prebuilds
@@ -563,7 +563,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Download prebuild artifacts into package dir
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: prebuilds
           path: ${{ env.PKG_DIR }}/prebuilds

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -82,11 +82,11 @@ jobs:
       client_changed: ${{ steps.filter.outputs.client }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          repository: ${{  github.event.pull_request.base.repo.full_name || github.repository }}
-          ref: ${{  github.event.pull_request.base.sha || github.sha }}
           fetch-depth: 0
 
       - name: Fetch PR head commits
@@ -200,11 +200,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          repository: ${{  github.event.pull_request.base.repo.full_name || github.repository }}
-          ref: ${{  github.event.pull_request.base.sha || github.sha }}
           fetch-depth: 0
 
       - name: Configure npm for GitHub Package Registry
@@ -234,11 +234,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          repository: ${{  github.event.pull_request.base.repo.full_name || github.repository }}
-          ref: ${{  github.event.pull_request.base.sha || github.sha }}
           fetch-depth: 0
 
       - name: Configure npm for GitHub Package Registry
@@ -289,11 +289,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Checkout PR head
@@ -363,11 +363,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          repository: ${{  github.event.pull_request.base.repo.full_name || github.repository }}
-          ref: ${{  github.event.pull_request.base.sha || github.sha }}
           fetch-depth: 0
 
       - name: Configure npm for package registries
@@ -401,11 +401,11 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          repository: ${{  github.event.pull_request.base.repo.full_name || github.repository }}
-          ref: ${{  github.event.pull_request.base.sha || github.sha }}
           fetch-depth: 0
 
       - name: Configure npm for package registries

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -305,9 +305,9 @@ jobs:
           git checkout --detach ${{ github.event.pull_request.head.sha }}
 
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: 20
 
       - name: Configure npm for package registries
         shell: bash

--- a/.github/workflows/publish-qvac-sdk.yml
+++ b/.github/workflows/publish-qvac-sdk.yml
@@ -53,9 +53,7 @@ jobs:
       READ_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          token: ${{ env.READ_REPO_TOKEN }}
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -271,7 +269,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -329,7 +327,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-qvac-sdk.yml
+++ b/.github/workflows/publish-qvac-sdk.yml
@@ -175,7 +175,7 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: ${{ env.WORKDIR }}/dist/

--- a/.github/workflows/publish-qvac-sdk.yml
+++ b/.github/workflows/publish-qvac-sdk.yml
@@ -272,7 +272,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: ${{ env.WORKDIR }}/dist/
@@ -330,7 +330,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dist
           path: ${{ env.WORKDIR }}/dist/

--- a/.github/workflows/release-notes-check-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-decoder-audio.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/release-notes-check-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-decoder-audio.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout PR head (into pr/)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0
           path: pr
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -61,13 +61,13 @@ jobs:
           echo "PR version: $version"
 
       - name: Checkout base (into base/)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0
           path: base
+          fetch-depth: 0
 
       - name: Read base package version (monorepo workdir)
         id: base-package-version

--- a/.github/workflows/release-notes-check-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-decoder-audio.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Validate Release Notes on version bump
         if: steps.version.outputs.bumped == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pullNumber = context.payload.pull_request.number;

--- a/.github/workflows/release-notes-check-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-llamacpp-embed.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate release notes on version bump (monorepo-aware)
         uses: actions/github-script@v7

--- a/.github/workflows/release-notes-check-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-llamacpp-embed.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Validate release notes on version bump (monorepo-aware)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { decodeContent, validateReleaseNotesOnVersionBump, formatFailures } = require(

--- a/.github/workflows/release-notes-check-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-llamacpp-llm.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate release notes on version bump (monorepo-aware)
         uses: actions/github-script@v7

--- a/.github/workflows/release-notes-check-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-llamacpp-llm.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Validate release notes on version bump (monorepo-aware)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { decodeContent, validateReleaseNotesOnVersionBump, formatFailures } = require(

--- a/.github/workflows/release-notes-check-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-onnx-tts.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/release-notes-check-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-onnx-tts.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout PR head (into pr/)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0
           path: pr
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -61,13 +61,13 @@ jobs:
           echo "PR version: $version"
 
       - name: Checkout base (into base/)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0
           path: base
+          fetch-depth: 0
 
       - name: Read base package version (monorepo workdir)
         id: base-package-version

--- a/.github/workflows/release-notes-check-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-onnx-tts.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Validate Release Notes on version bump
         if: steps.version.outputs.bumped == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pullNumber = context.payload.pull_request.number;

--- a/.github/workflows/release-notes-check-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-parakeet.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/release-notes-check-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-parakeet.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout PR head (into pr/)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0
           path: pr
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -61,13 +61,13 @@ jobs:
           echo "PR version: $version"
 
       - name: Checkout base (into base/)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0
           path: base
+          fetch-depth: 0
 
       - name: Read base package version (monorepo workdir)
         id: base-package-version

--- a/.github/workflows/release-notes-check-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-parakeet.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Validate Release Notes on version bump
         if: steps.version.outputs.bumped == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pullNumber = context.payload.pull_request.number;

--- a/.github/workflows/release-notes-check-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-whispercpp.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/release-notes-check-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-whispercpp.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout PR head (into pr/)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name }}
           ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0
           path: pr
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -61,13 +61,13 @@ jobs:
           echo "PR version: $version"
 
       - name: Checkout base (into base/)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          fetch-depth: 0
           path: base
+          fetch-depth: 0
 
       - name: Read base package version (monorepo workdir)
         id: base-package-version

--- a/.github/workflows/release-notes-check-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-whispercpp.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Validate Release Notes on version bump
         if: steps.version.outputs.bumped == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pullNumber = context.payload.pull_request.number;

--- a/.github/workflows/release-notes-check-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -41,7 +41,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout base repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0

--- a/.github/workflows/release-notes-check-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/release-notes-check-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-inference-addon-onnx-ocr-fasttext.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Validate Release Notes on version bump
         if: steps.version.outputs.bumped == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pullNumber = context.payload.pull_request.number;

--- a/.github/workflows/repository-dispatch-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/repository-dispatch-qvac-lib-infer-whispercpp.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           # Ensure we are on the exact merge commit being evaluated
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
 
       - name: Detect README change
         id: changed

--- a/.github/workflows/repository-dispatch-qvac-sdk.yml
+++ b/.github/workflows/repository-dispatch-qvac-sdk.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
 
       - name: Detect README change
         id: changed

--- a/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
@@ -27,10 +27,10 @@ jobs:
       packages: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.event.pull_request.head.ref }}
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name }}
+          ref: ${{ inputs.ref || github.event.pull_request.head.ref }}
           token: ${{ secrets.PAT_TOKEN }}
           submodules: recursive
 

--- a/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Archive Coverage Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: |

--- a/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
@@ -76,7 +76,7 @@ jobs:
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
@@ -149,7 +149,7 @@ jobs:
 
       - name: Comment Coverage on PR
         if: github.event_name == 'pull_request_target' && always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/test-desktop-qvac-sdk.yml
+++ b/.github/workflows/test-desktop-qvac-sdk.yml
@@ -59,9 +59,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: 22
 
       - name: Configure npm registries
         env:
@@ -203,9 +203,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: 22
 
       - name: Configure npm registries
         env:

--- a/.github/workflows/test-desktop-qvac-sdk.yml
+++ b/.github/workflows/test-desktop-qvac-sdk.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload consumer logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: consumer-log-${{ steps.runid.outputs.platform }}
           path: ${{ inputs.working-directory }}/consumer.log
@@ -174,7 +174,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: results-${{ steps.runid.outputs.platform }}-${{ github.run_number }}
           path: ${{ inputs.working-directory }}/reports/results-*.json
@@ -182,7 +182,7 @@ jobs:
 
       - name: Upload baseline (main/develop only)
         if: always() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: baseline-${{ steps.runid.outputs.platform }}
           path: ${{ inputs.working-directory }}/reports/results-*.json

--- a/.github/workflows/test-desktop-qvac-sdk.yml
+++ b/.github/workflows/test-desktop-qvac-sdk.yml
@@ -55,9 +55,8 @@ jobs:
       MQTT_USERNAME: ${{ secrets.MQTT_USERNAME }}
       MQTT_PASSWORD: ${{ secrets.MQTT_PASSWORD }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          repository: ${{ github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-node@v4
@@ -202,7 +201,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-desktop-qvac-sdk.yml
+++ b/.github/workflows/test-desktop-qvac-sdk.yml
@@ -225,10 +225,10 @@ jobs:
         run: npm install --ignore-scripts
 
       - name: Download current results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
-          pattern: results-*
           path: ${{ inputs.working-directory }}/current-results/
+          pattern: results-*
           merge-multiple: true
 
       - name: Download baseline results

--- a/.github/workflows/test-desktop-qvac-sdk.yml
+++ b/.github/workflows/test-desktop-qvac-sdk.yml
@@ -321,7 +321,7 @@ jobs:
           fi
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/trigger-docs-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/trigger-docs-qvac-lib-infer-nmtcpp.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/trigger-docs-qvac-sdk.yml
+++ b/.github/workflows/trigger-docs-qvac-sdk.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout merge commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/trigger-reusable-lib-qvac-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-cli.yml
@@ -102,7 +102,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -139,7 +139,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -164,7 +164,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
@@ -102,9 +102,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (dev)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -135,9 +136,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (feature)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -156,9 +158,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (tmp)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
@@ -102,9 +102,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (dev)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -135,9 +136,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (feature)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -156,9 +158,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (tmp)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
@@ -101,9 +101,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (dev)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -134,9 +135,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (feature)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -155,9 +157,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (tmp)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-error-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-error-base.yml
@@ -102,9 +102,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (dev)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -135,9 +136,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (feature)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -156,9 +158,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (tmp)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
@@ -102,9 +102,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (dev)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -135,9 +136,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (feature)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -156,9 +158,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (tmp)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
@@ -102,9 +102,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (dev)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -135,9 +136,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (feature)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -156,9 +158,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (tmp)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-logging.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-logging.yml
@@ -102,9 +102,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (dev)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -135,9 +136,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (feature)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -156,9 +158,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (tmp)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-rag.yml
@@ -102,9 +102,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (dev)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -135,9 +136,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (feature)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:
@@ -156,9 +158,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Publish to GitHub Packages (tmp)
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
         with:

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/CMakeLists.txt
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.25)
 
 option(BUILD_TESTING "Build tests" OFF)
+option(ENABLE_XNNPACK "Enable XNNPack execution provider" ON)
+
 # Force Apple Clang instead of Homebrew LLVM
 if(APPLE)
  message(STATUS "enter special apple")
@@ -62,6 +64,10 @@ endif()
 
 if(BUILD_TESTING)
   list(APPEND VCPKG_MANIFEST_FEATURES "tests")
+endif()
+
+if(ENABLE_XNNPACK)
+  list(APPEND VCPKG_MANIFEST_FEATURES "xnnpack")
 endif()
 
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
@@ -162,7 +168,7 @@ target_compile_definitions(
 function(strip_libraries LIB_DIR LIB_NAMES)
   foreach(LIB_NAME IN LISTS LIB_NAMES)
     set(LIB_PATH "${LIB_DIR}/${LIB_NAME}")
-    
+
     execute_process(
       COMMAND ${LLVM_STRIP} --strip-debug "${LIB_PATH}"
       ERROR_VARIABLE STRIP_ERROR

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/addon/AddonJs.hpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/addon/AddonJs.hpp
@@ -205,7 +205,7 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface> outHandlers;
   outHandlers.add(make_shared<PipelineOutputHandler>());
   unique_ptr<OutputCallBackInterface> callback = make_unique<OutputCallBackJs>(
-      env, args[0], args[2], args[3], std::move(outHandlers));
+      env, args[0], args[2], std::move(outHandlers));
 
   auto addon = make_unique<AddonJs>(env, std::move(callback), std::move(model));
 

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Steps.cpp
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/addon/pipeline/Steps.cpp
@@ -2,9 +2,14 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <string>
 #include <iostream>
 #include <sstream>
+#include <string>
+#include <thread>
+
+#include <onnxruntime/onnxruntime_session_options_config_keys.h>
+
+#include "AndroidLog.hpp"
 #include "qvac-lib-inference-addon-cpp/Logger.hpp"
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -27,21 +32,81 @@ std::string InferredText::toString() const {
 };
 
 Ort::SessionOptions getOrtSessionOptions(bool useGPU) {
-  QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
-       "[ORT] getOrtSessionOptions called with useGPU=" + std::to_string(useGPU));
+  const std::string initMsg =
+      "[ORT] getOrtSessionOptions called with useGPU=" + std::to_string(useGPU);
+  QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, initMsg);
+  ALOG_DEBUG(initMsg);
   Ort::SessionOptions sessionOptions;
   sessionOptions.SetGraphOptimizationLevel(
       GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
 
+  const auto providers = Ort::GetAvailableProviders();
+  // Log available execution providers for debugging
+  std::stringstream providersMsg;
+  providersMsg << "[ORT] Available execution providers: ";
+  for (size_t i = 0; i < providers.size(); ++i) {
+    providersMsg << providers[i];
+    if (i < providers.size() - 1) {
+      providersMsg << ", ";
+    }
+  }
+  QLOG(
+      qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
+      providersMsg.str());
+  ALOG_DEBUG(providersMsg.str());
+
   if (!useGPU) {
-    // Enable multi-threading for CPU-only execution on desktop
-    sessionOptions.SetIntraOpNumThreads(0);  // 0 = use all available cores
-    sessionOptions.SetInterOpNumThreads(0);
-    QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, "[ORT] CPU-only mode configured");
+    bool useDefaultThreadSettings = true;
+    std::string cpuMsg = "[ORT] CPU-only mode configured. ";
+
+    try {
+      const bool xnnpackAvailable =
+          std::find(
+              providers.begin(), providers.end(), "XnnpackExecutionProvider") !=
+          providers.end();
+      if (xnnpackAvailable) {
+        // Order must be: spinning -> intra -> inter -> AppendEP.
+        // Also see:
+        // https://onnxruntime.ai/docs/execution-providers/Xnnpack-ExecutionProvider.html
+        int availableThreads =
+            std::max(1, static_cast<int>(std::thread::hardware_concurrency()));
+
+        sessionOptions.SetExecutionMode(ExecutionMode::ORT_PARALLEL);
+        sessionOptions.AddConfigEntry(
+            kOrtSessionOptionsConfigAllowIntraOpSpinning, "1");
+        sessionOptions.AddConfigEntry(
+            kOrtSessionOptionsConfigAllowInterOpSpinning, "1");
+        sessionOptions.SetIntraOpNumThreads(availableThreads);
+        sessionOptions.SetInterOpNumThreads(availableThreads);
+
+#ifdef __ANDROID__
+        // Cap threads on Android: avoid thermal throttling and big.LITTLE
+        // contention.
+        availableThreads = std::min(availableThreads, 4);
+#endif
+        sessionOptions.AppendExecutionProvider(
+            "XNNPACK",
+            {{"intra_op_num_threads", std::to_string(availableThreads)}});
+
+        cpuMsg.append("XNNPack EP appended.");
+        useDefaultThreadSettings = false;
+      } else {
+        cpuMsg.append("XNNPack EP not available.");
+      }
+    } catch (const std::exception& e) {
+      cpuMsg.append("Failed to append XNNPack: " + std::string(e.what()));
+    }
+
+    if (useDefaultThreadSettings) {
+      sessionOptions.SetIntraOpNumThreads(0); // 0 = use all available cores
+      sessionOptions.SetInterOpNumThreads(0);
+    }
+
+    QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, cpuMsg);
+    ALOG_DEBUG(cpuMsg);
+
     return sessionOptions;
   }
-
-  const auto providers = Ort::GetAvailableProviders();
 
 #ifdef __ANDROID__
   try {
@@ -56,8 +121,10 @@ Ort::SessionOptions getOrtSessionOptions(bool useGPU) {
           sessionOptions, nnapiFlags));
     }
   } catch (const std::exception& e) {
-    QLOG(qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-         std::string("Error setting up NNAPI provider: ") + e.what());
+    const std::string errMsg =
+        std::string("Error setting up NNAPI provider: ") + e.what();
+    QLOG(qvac_lib_inference_addon_cpp::logger::Priority::ERROR, errMsg);
+    ALOG_ERROR(errMsg);
   }
 
 #elif defined(__APPLE__)

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg-configuration.json
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "cd26df3b3f4d3ba46efacdf8625f2a8fb5b4420b",
+    "baseline": "9503ea89fa282691596d0ab9cf74a6c5a178f5ae",
     "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
@@ -77,7 +77,8 @@
         "vcpkg-boost",
         "mimalloc",
         "wil",
-        "gtest"
+        "gtest",
+        "fxdiv"
       ]
     }
   ]

--- a/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg.json
+++ b/packages/qvac-lib-inference-addon-onnx-ocr-fasttext/vcpkg.json
@@ -53,6 +53,17 @@
       "dependencies": [
         "gtest"
       ]
+    },
+    "xnnpack": {
+      "description": "Enable XNNPack execution provider for optimized CPU inference",
+      "dependencies": [
+        {
+          "name": "onnxruntime",
+          "features": [
+            "xnnpack-ep"
+          ]
+        }
+      ]
     }
   },
   "overrides": [

--- a/packages/qvac-sdk/NOTICE
+++ b/packages/qvac-sdk/NOTICE
@@ -45,6 +45,10 @@ Third-Party Model Licenses
 
   de-tiny-ggml-model-f16
     https://huggingface.co/primeline/whisper-tiny-german-1224
+  detector_craft
+    https://www.jaided.ai/easyocr/modelhub/
+  dolphin-mixtral-2x7b-dop-Q2_K-00001-of-00005
+    https://huggingface.co/jmb95/laser-dolphin-mixtral-2x7b-dpo-GGUF
   en-base-ggml-model-f16
     https://huggingface.co/openai/whisper-base
   fr-base-ggml-model-f16
@@ -65,6 +69,8 @@ Third-Party Model Licenses
     https://huggingface.co/Helsinki-NLP/opus-mt-en-fr
   ggml-opus-en-it
     https://huggingface.co/Helsinki-NLP/opus-mt-en-it
+  ggml-opus-en-roa
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-roa
   ggml-opus-en-ru
     https://huggingface.co/Helsinki-NLP/opus-mt-en-ru
   ggml-opus-en-zh
@@ -86,6 +92,8 @@ Third-Party Model Licenses
   ggml-opus-mt-en-roa-f16
     https://huggingface.co/Helsinki-NLP/opus-mt-en-roa
   ggml-opus-mt-roa-en-f16
+    https://huggingface.co/Helsinki-NLP/opus-mt-roa-en
+  ggml-opus-roa-en
     https://huggingface.co/Helsinki-NLP/opus-mt-roa-en
   gpt-oss-20b-GGUF
     https://huggingface.co/unsloth/gpt-oss-20b-GGUF
@@ -109,6 +117,8 @@ Third-Party Model Licenses
     https://huggingface.co/unsloth/Qwen3-0.6B-GGUF
   Qwen3-1.7B-GGUF
     https://huggingface.co/unsloth/Qwen3-1.7B-GGUF
+  Qwen3-1.7B-Q4_0-00001-of-00005
+    https://huggingface.co/unsloth/Qwen3-1.7B-GGUF
   Qwen3-4B-Q4_0-00001-of-00005
     https://huggingface.co/unsloth/Qwen3-4B-GGUF
   Qwen3-4B-Q4_K_M
@@ -117,12 +127,40 @@ Third-Party Model Licenses
     https://huggingface.co/Qwen/Qwen3-8B-GGUF
   Qwen3-VL-2B-Instruct-GGUF
     https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF
+  recognizer_arabic
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_bengali
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_cyrillic
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_devanagari
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_japanese
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_kannada
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_korean
+    https://www.jaided.ai/easyocr/modelhub/
   recognizer_latin
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_tamil
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_telugu
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_thai
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_zh_sim
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_zh_tra
     https://www.jaided.ai/easyocr/modelhub/
   ru-base-ggml-model-f16
     https://huggingface.co/CheeLi03/whisper-base-rus-8
   ru-tiny-ggml-model-f16
     https://huggingface.co/yaroslav0530/whisper-tiny-ru
+  salamandrata_2b_inst_q4-00001-of-00003
+    https://huggingface.co/BSC-LT/salamandraTA-2B-instruct-GGUF
+  salamandrata_2b_inst_q8-00001-of-00004
+    https://huggingface.co/BSC-LT/salamandraTA-2B-instruct-GGUF
   salamandraTA-2B-instruct-GGUF
     https://huggingface.co/BSC-LT/salamandraTA-2B-instruct-GGUF
   SmolVLM2-500M-Video-Instruct-GGUF
@@ -130,6 +168,10 @@ Third-Party Model Licenses
 
 --- cc-by-4.0 (Creative Commons Attribution 4.0 International) ---
 
+  decoder_joint-model
+    https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
+  encoder-model
+    https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
   ggml-opus-en-de
     https://huggingface.co/Helsinki-NLP/opus-mt-en-de
   ggml-opus-en-pt
@@ -138,6 +180,10 @@ Third-Party Model Licenses
     https://huggingface.co/Helsinki-NLP/opus-mt-ru-en
   ggml-opus-zh-en
     https://huggingface.co/Helsinki-NLP/opus-mt-zh-en
+  parakeet-tdt-0.6b-v3-onnx
+    https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
+  preprocessor
+    https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
 
 --- gemma (Gemma Terms of Use) ---
 
@@ -147,6 +193,10 @@ Third-Party Model Licenses
 --- health-ai-developer-foundations (HAI-DEF Terms of Use) ---
 
   medgemma-4b-it-GGUF
+    https://huggingface.co/unsloth/medgemma-4b-it-GGUF
+  medgemma-4b-it-Q4_1-00001-of-00005
+    https://huggingface.co/unsloth/medgemma-4b-it-GGUF
+  medgemma-4b-it-Q8_0-00001-of-00005
     https://huggingface.co/unsloth/medgemma-4b-it-GGUF
 
 --- llama3.2 (Llama 3.2 Community License) ---
@@ -176,11 +226,15 @@ Third-Party Model Licenses
     https://huggingface.co/ai4bharat/indictrans2-indic-indic-1B
   ggml-indictrans2-indic-indic-dist-320M-f16
     https://huggingface.co/ai4bharat/indictrans2-indic-indic-dist-320M
+  gte-large_fp16-00001-of-00005
+    https://huggingface.co/ChristianAzinn/gte-large-gguf
   gte-large-gguf
     https://huggingface.co/ChristianAzinn/gte-large-gguf
   pt-tiny-ggml-model-f16
     https://huggingface.co/DavyCosta701/whisper-tiny-pt-bpra
   tiny_acft_q8_0
+    https://voiceinput.futo.org/VoiceInput/tiny_en_acft_q8_0.bin
+  tiny_en_acft_q8_0
     https://voiceinput.futo.org/VoiceInput/tiny_en_acft_q8_0.bin
   whisper-vad
     https://huggingface.co/ggml-org/whisper-vad
@@ -189,41 +243,41 @@ Third-Party Model Licenses
 
 --- mpl-2.0 (Mozilla Public License 2.0) ---
 
-  lex.50.50.aren.s2t
+  model.aren.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/aren
-  lex.50.50.csen.s2t
+  model.csen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/csen
-  lex.50.50.enar.s2t
+  model.enar.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enar
-  lex.50.50.encs.s2t
+  model.encs.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/encs
-  lex.50.50.enes.s2t
+  model.enes.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enes
-  lex.50.50.enfr.s2t
+  model.enfr.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enfr
-  lex.50.50.enit.s2t
+  model.enit.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/tiny/enit
-  lex.50.50.enja.s2t
+  model.enja.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enja
-  lex.50.50.enpt.s2t
+  model.enpt.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enpt
-  lex.50.50.enru.s2t
+  model.enru.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enru
-  lex.50.50.enzh.s2t
+  model.enzh.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enzh
-  lex.50.50.esen.s2t
+  model.esen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/tiny/esen
-  lex.50.50.fren.s2t
+  model.fren.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/fren
-  lex.50.50.iten.s2t
+  model.iten.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/iten
-  lex.50.50.jaen.s2t
+  model.jaen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/jaen
-  lex.50.50.pten.s2t
+  model.pten.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/pten
-  lex.50.50.ruen.s2t
+  model.ruen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/tiny/ruen
-  lex.50.50.zhen.s2t
+  model.zhen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/zhen
 
 --- openrail ---
@@ -268,14 +322,14 @@ JavaScript Dependencies
   @qvac/ocr-onnx@0.1.7
     https://github.com/tetherto/qvac-lib-inference-addon-onnx-ocr-fasttext
   @qvac/rag@0.4.2
-  @qvac/registry-client@0.1.5
+  @qvac/registry-client@0.1.6
   @qvac/registry-schema@0.1.1
   @qvac/response@0.1.2
   @qvac/transcription-whispercpp@0.3.18
     https://github.com/tetherto/qvac-lib-infer-whispercpp
   @qvac/translation-nmtcpp@0.3.7
     https://github.com/tetherto/qvac-lib-infer-nmtcpp
-  @qvac/tts-onnx@0.2.13
+  @qvac/tts-onnx@0.5.3
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
   b4a@1.7.4
@@ -386,7 +440,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-zlib
   blind-relay@1.4.0
     https://github.com/holepunchto/blind-relay
-  compact-encoding@2.18.0
+  compact-encoding@2.19.0
     https://github.com/compact-encoding/compact-encoding
   device-file@2.3.1
     https://github.com/holepunchto/device-file

--- a/packages/qvac-sdk/changelog/0.7.0/CHANGELOG.md
+++ b/packages/qvac-sdk/changelog/0.7.0/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog v0.7.0
+
+Release Date: 2026-02-21
+
+## ✨ Features
+
+- QVAC Model Registry integratoin. (see PR [#323](https://github.com/tetherto/qvac/pull/323)) - See [breaking changes](./breaking.md)
+- Add --sdk-path option to CLI for explicit sdk location. (see PR [#384](https://github.com/tetherto/qvac/pull/384))
+- Add Pear pear.pre hook for auto-generated worker entry. (see PR [#451](https://github.com/tetherto/qvac/pull/451))
+
+## 🔌 API
+
+- Harden node rpc socket lifecycle and async close handling. (see PR [#263](https://github.com/tetherto/qvac/pull/263)) - See [API changes](./api.md)
+- Add Plugins. (see PR [#327](https://github.com/tetherto/qvac/pull/327)) - See [API changes](./api.md)
+- Add Chatterbox and Supertonic TTS engines. (see PR [#375](https://github.com/tetherto/qvac/pull/375)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Corestore directory deletion order causing EBUSY on Windows. (see PR [#266](https://github.com/tetherto/qvac/pull/266))
+- Add path traversal protection. (see PR [#281](https://github.com/tetherto/qvac/pull/281))
+- Reject empty text input in TTS and wrap addon errors. (see PR [#300](https://github.com/tetherto/qvac/pull/300))
+- Extract expo-device to stubbable module and add Android build config plugins. (see PR [#351](https://github.com/tetherto/qvac/pull/351))
+- Remove persistent node-rpc-client truncation from expo plugin. (see PR [#386](https://github.com/tetherto/qvac/pull/386))
+- Resolve SDK package dir dynamically in Expo plugins. (see PR [#396](https://github.com/tetherto/qvac/pull/396))
+- Fix delegate RPC client connection bugs. (see PR [#402](https://github.com/tetherto/qvac/pull/402))
+- Use stable corestore storage path for registry download resume. (see PR [#422](https://github.com/tetherto/qvac/pull/422))
+- Await closeRegistryClient in findModelShards to fix Windows fd-lock race. (see PR [#454](https://github.com/tetherto/qvac/pull/454))
+
+## 🧹 Chores
+
+- Bump llamacpp deps and remove iphone 17 cpu override. (see PR [#213](https://github.com/tetherto/qvac/pull/213))
+- Backmerge release-qvac-sdk-0.6.1 into main. (see PR [#285](https://github.com/tetherto/qvac/pull/285))
+- Add plugin path constants and cleanup dead exports. (see PR [#376](https://github.com/tetherto/qvac/pull/376))
+- Consolidate registry core key constant and scope corestore cache by key. (see PR [#439](https://github.com/tetherto/qvac/pull/439))
+
+## ⚙️ Infrastructure
+
+- Update SDK pod changelog generation and shared tooling. (see PR [#155](https://github.com/tetherto/qvac/pull/155))

--- a/packages/qvac-sdk/changelog/0.7.0/CHANGELOG_LLM.md
+++ b/packages/qvac-sdk/changelog/0.7.0/CHANGELOG_LLM.md
@@ -1,0 +1,218 @@
+# QVAC SDK v0.7.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.7.0
+
+This release integrates the Model Registry directly into the SDK, enabling model discovery and search without external dependencies. It also introduces a Plugin system for extending the SDK with custom model types and handlers, adds two new TTS engines (Chatterbox and Supertonic), and includes numerous stability fixes across Windows, Expo, and RPC layers.
+
+---
+
+## 💥 Breaking Changes
+
+### Model Registry Integration
+
+The model registry is now built into the SDK. As part of this integration, model constant names have been normalized for consistency and the metadata type has been renamed.
+
+#### Constant Renames
+
+Many model constants have been renamed to follow cleaner naming conventions. The main patterns:
+
+- **Bergamot**: language code pairs are now separated with underscores (`BERGAMOT_AREN` → `BERGAMOT_AR_EN`)
+- **Whisper**: verbose author/repo prefixes removed (`WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16` → `WHISPER_EN_BASE_Q0F16`)
+- **LLM**: version prefixes normalized (`QWEN_3_8B_INST_Q4_K_M` → `QWEN3_8B_INST_Q4_K_M`)
+- **OCR**: language-specific `CRAFT_` prefix dropped where redundant (`OCR_CRAFT_JAPANESE_RECOGNIZER` → `OCR_JAPANESE_RECOGNIZER`)
+- **Marian**: `Q0F16` quantization label simplified to `F16`
+
+See the full rename table in `breaking.md` for all affected constants.
+
+#### `HyperdriveItem` → `RegistryItem`
+
+The model metadata type has been renamed. The shape also changed — `hyperdriveKey`/`hyperbeeKey` fields are replaced by `registryPath`, `registrySource`, `blobCoreKey`, and new metadata fields (`engine`, `quantization`, `params`).
+
+**Before:**
+
+```typescript
+import type { HyperdriveItem } from "@qvac/sdk";
+
+function getSize(model: HyperdriveItem): number {
+  return model.expectedSize;
+}
+```
+
+**After:**
+
+```typescript
+import type { RegistryItem } from "@qvac/sdk";
+
+function getSize(model: RegistryItem): number {
+  return model.expectedSize;
+}
+```
+
+#### Registry Operations via SDK
+
+New functions for model discovery and search are available directly through the SDK:
+
+```typescript
+import {
+  modelRegistryList,
+  modelRegistrySearch,
+  modelRegistryGetModel,
+} from "@qvac/sdk";
+
+const allModels = await modelRegistryList();
+const llmModels = await modelRegistrySearch({ engine: "@qvac/llm-llamacpp" });
+const whisperModels = await modelRegistrySearch({ filter: "whisper" });
+const q4Models = await modelRegistrySearch({ quantization: "q4" });
+const specific = await modelRegistryGetModel(registryPath, registrySource);
+```
+
+#### Engine-Addon Mapping Utilities
+
+```typescript
+import { resolveCanonicalEngine, getAddonFromEngine } from "@qvac/sdk";
+
+const engine = resolveCanonicalEngine("@qvac/llm-llamacpp"); // "llamacpp-completion"
+const addon = getAddonFromEngine("llamacpp-completion"); // "llm"
+```
+
+---
+
+## 🔌 New APIs
+
+### Plugin System
+
+The SDK now supports plugins, allowing you to extend it with custom model types and handlers. Plugins can handle both request/reply and streaming interactions.
+
+```typescript
+import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from "@qvac/sdk";
+
+// Invoke a plugin handler (request/reply)
+const result = await invokePlugin<MyResponse>({
+  modelId,
+  handler: "myHandler",
+  params: { key: "value" },
+});
+
+// Invoke a plugin handler (streaming)
+for await (const chunk of invokePluginStream<MyStreamResponse>({
+  modelId,
+  handler: "myStreamHandler",
+  params: { key: "value" },
+})) {
+  console.log(chunk.result);
+}
+
+// Define a custom plugin
+const myPlugin = definePlugin({
+  modelType: "custom-type",
+  displayName: "Custom Plugin",
+  addonPackage: "@my/addon",
+  createModel: (params) => ({ model, loader }),
+  handlers: {
+    myHandler: defineHandler({
+      requestSchema: myRequestSchema,
+      responseSchema: myResponseSchema,
+      streaming: false,
+      handler: async (request) => ({ type: "pluginInvoke", result: "..." }),
+    }),
+  },
+});
+```
+
+### Chatterbox and Supertonic TTS Engines
+
+Two new text-to-speech engines are now available, each suited for different use cases.
+
+**Chatterbox** excels at voice cloning, requiring a reference audio sample to replicate a target voice:
+
+```typescript
+const modelId = await loadModel({
+  modelSrc,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "chatterbox",
+    language: "en",
+    ttsTokenizerSrc,
+    ttsSpeechEncoderSrc,
+    ttsEmbedTokensSrc,
+    ttsConditionalDecoderSrc,
+    ttsLanguageModelSrc,
+    referenceAudioSrc,
+  },
+});
+```
+
+**Supertonic** is a general-purpose TTS engine with configurable speed and inference quality:
+
+```typescript
+const modelId = await loadModel({
+  modelSrc,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "supertonic",
+    language: "en",
+    ttsTokenizerSrc,
+    ttsTextEncoderSrc,
+    ttsLatentDenoiserSrc,
+    ttsVoiceDecoderSrc,
+    ttsVoiceSrc,
+    ttsSpeed: 1.0,
+    ttsNumInferenceSteps: 5,
+  },
+});
+```
+
+Both engines use the same inference API:
+
+```typescript
+const result = textToSpeech({
+  modelId,
+  text: "Your text here",
+  inputType: "text",
+  stream: false,
+});
+```
+
+### `close()` is Now Async
+
+The SDK `close()` function now returns a Promise, ensuring all RPC sockets and resources are fully cleaned up before your process exits.
+
+**Before:**
+
+```typescript
+import { close } from "@qvac/sdk";
+close();
+```
+
+**After:**
+
+```typescript
+import { close } from "@qvac/sdk";
+await close();
+```
+
+---
+
+## ✨ Features
+
+### CLI `--sdk-path` Option
+
+The CLI now accepts an explicit `--sdk-path` option for specifying the SDK location, useful in monorepo setups or non-standard project layouts where automatic resolution may not find the correct package.
+
+### Pear `pear.pre` Hook
+
+Added support for auto-generating a worker entry point via the `pear.pre` build hook, simplifying Pear application setup.
+
+---
+
+## 🐞 Bug Fixes
+
+- **Windows EBUSY on cleanup** — Fixed corestore directory deletion order that caused `EBUSY` errors on Windows when cleaning up after model operations.
+- **Path traversal protection** — Added validation to prevent path traversal attacks when resolving model file paths.
+- **TTS empty input handling** — The SDK now rejects empty text input in TTS calls with a clear error instead of silently failing, and addon errors are properly wrapped.
+- **Expo device module** — Extracted `expo-device` into a stubbable module, fixing build issues and adding Android build config plugin support.
+- **Expo plugin truncation** — Removed persistent `node-rpc-client` truncation from the Expo plugin that was corrupting RPC messages.
+- **Expo SDK path resolution** — SDK package directory is now resolved dynamically in Expo plugins, fixing failures when the SDK is installed in non-standard locations.
+- **Delegate RPC client** — Fixed connection bugs in the delegate RPC client that could cause dropped messages or failed reconnections.
+- **Registry download resume** — Switched to a stable corestore storage path so interrupted registry downloads can properly resume instead of restarting from scratch.
+- **Windows fd-lock race** — Added proper `await` on `closeRegistryClient` in `findModelShards` to prevent file descriptor lock races on Windows.

--- a/packages/qvac-sdk/changelog/0.7.0/api.md
+++ b/packages/qvac-sdk/changelog/0.7.0/api.md
@@ -1,0 +1,125 @@
+# 🔌 API Changes v0.7.0
+
+## Harden node rpc socket lifecycle and async close handling
+
+PR: [#263](https://github.com/tetherto/qvac/pull/263)
+
+```typescript
+import { close } from "@qvac/sdk";
+
+close();
+```
+
+```typescript
+import { close } from "@qvac/sdk";
+
+await close();
+```
+
+---
+
+## Add Plugins
+
+PR: [#327](https://github.com/tetherto/qvac/pull/327)
+
+```typescript
+import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from "@qvac/sdk";
+
+// Invoke a plugin handler (request/reply)
+const result = await invokePlugin<MyResponse>({
+  modelId,
+  handler: "myHandler",
+  params: { key: "value" },
+});
+
+// Invoke a plugin handler (streaming)
+for await (const chunk of invokePluginStream<MyStreamResponse>({
+  modelId,
+  handler: "myStreamHandler",
+  params: { key: "value" },
+})) {
+  console.log(chunk.result);
+}
+
+// Define a custom plugin
+const myPlugin = definePlugin({
+  modelType: "custom-type",
+  displayName: "Custom Plugin",
+  addonPackage: "@my/addon",
+  createModel: (params) => ({ model, loader }),
+  handlers: {
+    myHandler: defineHandler({
+      requestSchema: myRequestSchema,
+      responseSchema: myResponseSchema,
+      streaming: false,
+      handler: async (request) => ({ type: "pluginInvoke", result: ... }),
+    }),
+  },
+});
+```
+
+---
+
+## Add Chatterbox and Supertonic TTS engines
+
+PR: [#375](https://github.com/tetherto/qvac/pull/375)
+
+```typescript
+import { 
+  PLUGIN_TTS, 
+  SDK_DEFAULT_PLUGINS, 
+  type BuiltinPlugin 
+} from "qvac-sdk";
+```
+
+```typescript
+// Chatterbox TTS (voice cloning)
+const modelId = await loadModel({
+  modelSrc,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "chatterbox",
+    language: "en",
+    ttsTokenizerSrc,
+    ttsSpeechEncoderSrc,
+    ttsEmbedTokensSrc,
+    ttsConditionalDecoderSrc,
+    ttsLanguageModelSrc,
+    referenceAudioSrc,
+  },
+});
+
+// Supertonic TTS (general-purpose)
+const modelId = await loadModel({
+  modelSrc,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "supertonic",
+    language: "en",
+    ttsTokenizerSrc,
+    ttsTextEncoderSrc,
+    ttsLatentDenoiserSrc,
+    ttsVoiceDecoderSrc,
+    ttsVoiceSrc,
+    ttsSpeed: 1.0,           // optional
+    ttsNumInferenceSteps: 5, // optional
+  },
+});
+
+// Text-to-speech usage (same for both engines)
+const result = textToSpeech({
+  modelId,
+  text: "Your text here",
+  inputType: "text",
+  stream: false,
+});
+```
+
+```typescript
+export type TtsChatterboxConfig = z.infer<typeof ttsChatterboxConfigSchema>;
+export type TtsSupertonicConfig = z.infer<typeof ttsSupertonicConfigSchema>;
+export type TtsConfig = z.infer<typeof ttsConfigSchema>; // Now a union
+```
+
+---
+

--- a/packages/qvac-sdk/changelog/0.7.0/breaking.md
+++ b/packages/qvac-sdk/changelog/0.7.0/breaking.md
@@ -1,0 +1,210 @@
+# 💥 Breaking Changes v0.7.0
+
+## Model Registry merge to main
+
+PR: [#323](https://github.com/tetherto/qvac/pull/323)
+
+**BEFORE:**
+```typescript
+import { BERGAMOT_AREN, WHISPER_TINY_Q5_1, MARIAN_OPUS_DE_EN_Q0F32 } from "@qvac/sdk";
+
+await loadModel({ modelSrc: BERGAMOT_AREN.src, modelType: "translation" });
+```
+
+**AFTER:**
+```typescript
+import { BERGAMOT_AR_EN, WHISPER_TINY_Q5_1, MARIAN_OPUS_DE_EN_F32 } from "@qvac/sdk";
+
+await loadModel({ modelSrc: BERGAMOT_AR_EN.src, modelType: "translation" });
+```
+
+### Full List
+### Bergamot: language codes separated with underscore (`AREN` → `AR_EN`)
+
+| Before | After |
+|--------|-------|
+| `BERGAMOT_AREN` | `BERGAMOT_AR_EN` |
+| `BERGAMOT_AREN_VOCAB` | `BERGAMOT_AR_EN_VOCAB` |
+| `BERGAMOT_CSEN` | `BERGAMOT_CS_EN` |
+| `BERGAMOT_CSEN_VOCAB` | `BERGAMOT_CS_EN_VOCAB` |
+| `BERGAMOT_ENAR` | `BERGAMOT_EN_AR` |
+| `BERGAMOT_ENAR_VOCAB` | `BERGAMOT_EN_AR_VOCAB` |
+| `BERGAMOT_ENCS` | `BERGAMOT_EN_CS` |
+| `BERGAMOT_ENES` | `BERGAMOT_EN_ES` |
+| `BERGAMOT_ENES_VOCAB` | `BERGAMOT_EN_ES_VOCAB` |
+| `BERGAMOT_ENFR` | `BERGAMOT_EN_FR` |
+| `BERGAMOT_ENFR_VOCAB` | `BERGAMOT_EN_FR_VOCAB` |
+| `BERGAMOT_ENIT` | `BERGAMOT_EN_IT` |
+| `BERGAMOT_ENIT_VOCAB` | `BERGAMOT_EN_IT_VOCAB` |
+| `BERGAMOT_ENJA` | `BERGAMOT_EN_JA` |
+| `BERGAMOT_ENJA_SRCVOCAB` | `BERGAMOT_EN_JA_SRCVOCAB` |
+| `BERGAMOT_ENJA_TRGVOCAB` | `BERGAMOT_EN_JA_TRGVOCAB` |
+| `BERGAMOT_ENPT` | `BERGAMOT_EN_PT` |
+| `BERGAMOT_ENPT_VOCAB` | `BERGAMOT_EN_PT_VOCAB` |
+| `BERGAMOT_ENRU` | `BERGAMOT_EN_RU` |
+| `BERGAMOT_ENRU_VOCAB` | `BERGAMOT_EN_RU_VOCAB` |
+| `BERGAMOT_ENZH` | `BERGAMOT_EN_ZH` |
+| `BERGAMOT_ENZH_SRCVOCAB` | `BERGAMOT_EN_ZH_SRCVOCAB` |
+| `BERGAMOT_ENZH_TRGVOCAB` | `BERGAMOT_EN_ZH_TRGVOCAB` |
+| `BERGAMOT_ESEN` | `BERGAMOT_ES_EN` |
+| `BERGAMOT_ESEN_VOCAB` | `BERGAMOT_ES_EN_VOCAB` |
+| `BERGAMOT_FREN` | `BERGAMOT_FR_EN` |
+| `BERGAMOT_ITEN` | `BERGAMOT_IT_EN` |
+| `BERGAMOT_ITEN_VOCAB` | `BERGAMOT_IT_EN_VOCAB` |
+| `BERGAMOT_JAEN` | `BERGAMOT_JA_EN` |
+| `BERGAMOT_JAEN_VOCAB` | `BERGAMOT_JA_EN_VOCAB` |
+| `BERGAMOT_PTEN` | `BERGAMOT_PT_EN` |
+| `BERGAMOT_RUEN` | `BERGAMOT_RU_EN` |
+| `BERGAMOT_RUEN_VOCAB` | `BERGAMOT_RU_EN_VOCAB` |
+| `BERGAMOT_ZHEN` | `BERGAMOT_ZH_EN` |
+| `BERGAMOT_ZHEN_VOCAB` | `BERGAMOT_ZH_EN_VOCAB` |
+
+### Whisper: author/repo names removed from constant names
+
+| Before | After |
+|--------|-------|
+| `WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16` | `WHISPER_EN_BASE_Q0F16` |
+| `WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_Q8_0` | `WHISPER_EN_BASE_Q8_0` |
+| `WHISPER_FRENCH_BASE_PERSONALIZEDREFRIGERATOR_WHISPER_BASE_FR_F16` | `WHISPER_FRENCH_BASE_F16` |
+| `WHISPER_FRENCH_BASE_PERSONALIZEDREFRIGERATOR_WHISPER_BASE_FR_Q8_0` | `WHISPER_FRENCH_BASE_Q8_0` |
+| `WHISPER_GERMAN_BASE_AWARE_AI_WHISPER_BASE_GERMAN_F16` | `WHISPER_GERMAN_BASE_F16` |
+| `WHISPER_GERMAN_BASE_AWARE_AI_WHISPER_BASE_GERMAN_Q8_0` | `WHISPER_GERMAN_BASE_Q8_0` |
+| `WHISPER_ITALIAN_BASE_GUSTAVV_ANDRZEJEWSKI_DISTIL_WHISPER_BASE_IT_F16` | `WHISPER_ITALIAN_BASE_F16` |
+| `WHISPER_ITALIAN_BASE_GUSTAVV_ANDRZEJEWSKI_DISTIL_WHISPER_BASE_IT_Q8_0` | `WHISPER_ITALIAN_BASE_Q8_0` |
+| `WHISPER_JAPANESE_BASE_BYGREENCN_WHISPER_BASE_JA_F16` | `WHISPER_JAPANESE_BASE_F16` |
+| `WHISPER_JAPANESE_BASE_BYGREENCN_WHISPER_BASE_JA_Q8_0` | `WHISPER_JAPANESE_BASE_Q8_0` |
+| `WHISPER_JAPANESE_TINY_TINY_CHEELI03_WHISPER_TINY_JA_PUCT_4K_F16` | `WHISPER_JAPANESE_TINY_F16` |
+| `WHISPER_JAPANESE_TINY_TINY_CHEELI03_WHISPER_TINY_JA_PUCT_4K_Q8_0` | `WHISPER_JAPANESE_TINY_Q8_0` |
+| `WHISPER_LARGE_3` | `WHISPER_LARGE_V3_TURBO` |
+| `WHISPER_PORTUGUESE_BASE_MARIANA_COELHO_9_WHISPER_BASE_PT_F16` | `WHISPER_PORTUGUESE_BASE_F16` |
+| `WHISPER_PORTUGUESE_BASE_MARIANA_COELHO_9_WHISPER_BASE_PT_Q8_0` | `WHISPER_PORTUGUESE_BASE_Q8_0` |
+| `WHISPER_RUSSIAN_BASE_CHEELI03_WHISPER_BASE_RUS_8_F16` | `WHISPER_RUSSIAN_BASE_F16` |
+| `WHISPER_RUSSIAN_BASE_CHEELI03_WHISPER_BASE_RUS_8_Q8_0` | `WHISPER_RUSSIAN_BASE_Q8_0` |
+| `WHISPER_RUSSIAN_TINY_TINY_YAROSLAV0530_WHISPER_TINY_RU_F16` | `WHISPER_RUSSIAN_TINY_F16` |
+| `WHISPER_RUSSIAN_TINY_TINY_YAROSLAV0530_WHISPER_TINY_RU_Q8_0` | `WHISPER_RUSSIAN_TINY_Q8_0` |
+| `WHISPER_SMALL_Q8` | `WHISPER_SMALL_Q8_0` |
+
+### LLM: version prefix normalization (`QWEN_3_` → `QWEN3_`, etc.)
+
+| Before | After |
+|--------|-------|
+| `LASER_DOLPHIN_2_6_2X7B_INST_Q2_K` | `LASER_DOLPHIN_2X7B_INST_Q2_K` |
+| `LLAMA_TOOL_CALLING_3_2_1B_INST_Q4_K` | `LLAMA_TOOL_CALLING_1B_INST_Q4_K` |
+| `MMPROJ_QWEN3_VL_1_2B_MULTIMODAL_Q4_K` | `MMPROJ_QWEN3VL_2B_MULTIMODAL_Q4_K` |
+| `MMPROJ_SMOLVLM2_2_500M_MULTIMODAL_F16` | `MMPROJ_SMOLVLM2_500M_MULTIMODAL_F16` |
+| `MMPROJ_SMOLVLM2_2_500M_MULTIMODAL_Q8_0` | `MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0` |
+| `QWEN_3_1_7B_INST_Q4` | `QWEN3_1_7B_INST_Q4` |
+| `QWEN_3_1_7B_INST_Q4_SHARD` | `QWEN3_1_7B_INST_Q4_SHARD` |
+| `QWEN_3_4B_INST_Q4_SHARD` | `QWEN3_4B_INST_Q4_SHARD` |
+| `QWEN_3_8B_INST_Q4_K_M` | `QWEN3_8B_INST_Q4_K_M` |
+| `QWEN3_VL_1_2B_MULTIMODAL_Q4_K` | `QWEN3VL_2B_MULTIMODAL_Q4_K` |
+| `SMOLVLM2_2_500M_MULTIMODAL_F16` | `SMOLVLM2_500M_MULTIMODAL_F16` |
+| `SMOLVLM2_2_500M_MULTIMODAL_Q8_0` | `SMOLVLM2_500M_MULTIMODAL_Q8_0` |
+
+### OCR: dropped language-specific `CRAFT_` prefix
+
+| Before | After |
+|--------|-------|
+| `OCR_CRAFT_ENGLISH_DETECTOR` | `OCR_CRAFT_DETECTOR` |
+| `OCR_CRAFT_JAPANESE_RECOGNIZER` | `OCR_JAPANESE_RECOGNIZER` |
+| `OCR_CRAFT_KOREAN_RECOGNIZER` | `OCR_KOREAN_RECOGNIZER` |
+| `OCR_CRAFT_LATIN_RECOGNIZER` | `OCR_LATIN_RECOGNIZER` |
+| `OCR_CRAFT_LATIN_RECOGNIZER_1` | `OCR_LATIN_RECOGNIZER_1` |
+| `OCR_CRAFT_THAI_RECOGNIZER` | `OCR_THAI_RECOGNIZER` |
+| `OCR_CRAFT_ZH_SIM_RECOGNIZER` | `OCR_ZH_SIM_RECOGNIZER` |
+
+### Marian: `Q0F16` → `F16`
+
+| Before | After |
+|--------|-------|
+| `MARIAN_EN_HI_INDIC_1B_Q0F16` | `MARIAN_EN_HI_INDIC_1B_F16` |
+| `MARIAN_EN_HI_INDIC_200M_Q0F16` | `MARIAN_EN_HI_INDIC_200M_F16` |
+| `MARIAN_HI_EN_INDIC_1B_Q0F16` | `MARIAN_HI_EN_INDIC_1B_F16` |
+| `MARIAN_HI_EN_INDIC_200M_Q0F16` | `MARIAN_HI_EN_INDIC_200M_F16` |
+| `MARIAN_HI_HI_INDIC_1B_Q0F16` | `MARIAN_HI_HI_INDIC_1B_F16` |
+| `MARIAN_HI_HI_INDIC_320M_Q0F16` | `MARIAN_HI_HI_INDIC_320M_F16` |
+
+### `HyperdriveItem` type renamed to `RegistryItem`
+
+Apps that reference the model metadata type will need to update. The shape also changed — `hyperdriveKey`/`hyperbeeKey` fields are replaced by `registryPath`, `registrySource`, `blobCoreKey`, and new metadata fields (`engine`, `quantization`, `params`).
+
+BEFORE:
+```typescript
+import type { HyperdriveItem } from "@qvac/sdk";
+
+function getSize(model: HyperdriveItem): number {
+  return model.expectedSize;
+}
+```
+
+AFTER:
+```typescript
+import type { RegistryItem } from "@qvac/sdk";
+
+function getSize(model: RegistryItem): number {
+  return model.expectedSize;
+}
+```
+
+## API additions
+
+### Registry operations via SDK
+
+New functions for model discovery and search directly through the SDK, without needing to depend on the registry client package separately:
+
+```typescript
+import {
+  modelRegistryList,
+  modelRegistrySearch,
+  modelRegistryGetModel,
+  type ModelRegistryEntry,
+} from "@qvac/sdk";
+
+const models = await modelRegistryList();
+const llmModels = await modelRegistrySearch({ engine: "@qvac/llm-llamacpp" });
+const whisperModels = await modelRegistrySearch({ filter: "whisper" });
+const q4Models = await modelRegistrySearch({ quantization: "q4" });
+const specific = await modelRegistryGetModel(registryPath, registrySource);
+```
+
+### Engine-addon mapping utilities
+
+```typescript
+import { resolveCanonicalEngine, getAddonFromEngine, ENGINE_TO_ADDON } from "@qvac/sdk";
+
+const engine = resolveCanonicalEngine("@qvac/llm-llamacpp"); // "llamacpp-completion"
+const addon = getAddonFromEngine("llamacpp-completion"); // "llm"
+```
+
+## Key changes
+
+### New files
+- `client/api/registry.ts` — SDK client API for registry operations
+- `schemas/registry.ts` — Zod schemas for registry request/response types
+- `schemas/engine-addon-map.ts` — canonical engine-to-addon mapping with strict validation
+- `schemas/sdk-errors-registry.ts` — registry-specific error codes
+- `server/rpc/handlers/registry.ts` — RPC handlers for registry list/search/get
+- `server/rpc/handlers/load-model/registry.ts` — model download from registry with shard support
+- `server/bare/registry/registry-client.ts` — registry client lifecycle management
+- `models/update-models/` — modular update-models script (codegen, naming, processing, shards, registry, history)
+- `test/unit/update-models-naming.test.ts` — unit tests for model naming and shard grouping
+
+### Modified files
+- `package.json` — added `@tetherto/registry-client-mono` dependency, `tsx` dev dependency, new scripts
+- `index.ts`, `client/api/index.ts` — export new registry API functions
+- `schemas/common.ts`, `schemas/index.ts` — registry schemas integrated into request/response unions
+- `server/rpc/handle-request.ts`, `server/rpc/handlers/index.ts` — registry RPC routing
+- `server/rpc/handlers/load-model/handler.ts`, `resolve.ts`, `download-manager.ts` — registry source support in model loading
+- `models/hyperdrive/models.ts` — regenerated with improved naming and shard metadata
+- `utils/errors-client.ts`, `utils/errors-server.ts` — registry error classes
+- Examples updated to use current registry model paths
+
+## Test plan
+
+- [x] `bun run build` passes in `packages/qvac-sdk`
+- [x] `bun run test:unit` passes (including new update-models naming/shard tests)
+- [x] `npx tsx examples/registry-query.ts` lists and searches models from the registry
+- [x] Model loading from registry paths works end-to-end
+
+---
+

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- qvac-sdk needs a v0.7.0 release with version bump, changelog, and updated NOTICE
- Covers all changes since the monorepo migration (25 PRs, 20 included in changelog)

## 📝 How does it solve it?

- Bumps `packages/qvac-sdk/package.json` version from `0.6.1` to `0.7.0`
- Generates changelog files in `packages/qvac-sdk/changelog/0.7.0/`:
  - `CHANGELOG.md` — categorized PR list (features, API, fixes, chores, infra)
  - `breaking.md` — model constant renames, `HyperdriveItem` → `RegistryItem`, new registry APIs
  - `api.md` — async `close()`, Plugin system, Chatterbox/Supertonic TTS engines
  - `CHANGELOG_LLM.md` — human-readable release notes
- Regenerates `packages/qvac-sdk/NOTICE` (110 models, 167 JS dependencies)