### PR TITLE
QVAC-11735 chore[skiplog]: qvac-sdk v0.7.0 release changelog and NOTICE

### DIFF
--- a/packages/qvac-sdk/NOTICE
+++ b/packages/qvac-sdk/NOTICE
@@ -45,6 +45,10 @@ Third-Party Model Licenses
 
   de-tiny-ggml-model-f16
     https://huggingface.co/primeline/whisper-tiny-german-1224
+  detector_craft
+    https://www.jaided.ai/easyocr/modelhub/
+  dolphin-mixtral-2x7b-dop-Q2_K-00001-of-00005
+    https://huggingface.co/jmb95/laser-dolphin-mixtral-2x7b-dpo-GGUF
   en-base-ggml-model-f16
     https://huggingface.co/openai/whisper-base
   fr-base-ggml-model-f16
@@ -65,6 +69,8 @@ Third-Party Model Licenses
     https://huggingface.co/Helsinki-NLP/opus-mt-en-fr
   ggml-opus-en-it
     https://huggingface.co/Helsinki-NLP/opus-mt-en-it
+  ggml-opus-en-roa
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-roa
   ggml-opus-en-ru
     https://huggingface.co/Helsinki-NLP/opus-mt-en-ru
   ggml-opus-en-zh
@@ -86,6 +92,8 @@ Third-Party Model Licenses
   ggml-opus-mt-en-roa-f16
     https://huggingface.co/Helsinki-NLP/opus-mt-en-roa
   ggml-opus-mt-roa-en-f16
+    https://huggingface.co/Helsinki-NLP/opus-mt-roa-en
+  ggml-opus-roa-en
     https://huggingface.co/Helsinki-NLP/opus-mt-roa-en
   gpt-oss-20b-GGUF
     https://huggingface.co/unsloth/gpt-oss-20b-GGUF
@@ -109,6 +117,8 @@ Third-Party Model Licenses
     https://huggingface.co/unsloth/Qwen3-0.6B-GGUF
   Qwen3-1.7B-GGUF
     https://huggingface.co/unsloth/Qwen3-1.7B-GGUF
+  Qwen3-1.7B-Q4_0-00001-of-00005
+    https://huggingface.co/unsloth/Qwen3-1.7B-GGUF
   Qwen3-4B-Q4_0-00001-of-00005
     https://huggingface.co/unsloth/Qwen3-4B-GGUF
   Qwen3-4B-Q4_K_M
@@ -117,12 +127,40 @@ Third-Party Model Licenses
     https://huggingface.co/Qwen/Qwen3-8B-GGUF
   Qwen3-VL-2B-Instruct-GGUF
     https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF
+  recognizer_arabic
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_bengali
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_cyrillic
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_devanagari
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_japanese
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_kannada
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_korean
+    https://www.jaided.ai/easyocr/modelhub/
   recognizer_latin
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_tamil
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_telugu
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_thai
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_zh_sim
+    https://www.jaided.ai/easyocr/modelhub/
+  recognizer_zh_tra
     https://www.jaided.ai/easyocr/modelhub/
   ru-base-ggml-model-f16
     https://huggingface.co/CheeLi03/whisper-base-rus-8
   ru-tiny-ggml-model-f16
     https://huggingface.co/yaroslav0530/whisper-tiny-ru
+  salamandrata_2b_inst_q4-00001-of-00003
+    https://huggingface.co/BSC-LT/salamandraTA-2B-instruct-GGUF
+  salamandrata_2b_inst_q8-00001-of-00004
+    https://huggingface.co/BSC-LT/salamandraTA-2B-instruct-GGUF
   salamandraTA-2B-instruct-GGUF
     https://huggingface.co/BSC-LT/salamandraTA-2B-instruct-GGUF
   SmolVLM2-500M-Video-Instruct-GGUF
@@ -130,6 +168,10 @@ Third-Party Model Licenses
 
 --- cc-by-4.0 (Creative Commons Attribution 4.0 International) ---
 
+  decoder_joint-model
+    https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
+  encoder-model
+    https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
   ggml-opus-en-de
     https://huggingface.co/Helsinki-NLP/opus-mt-en-de
   ggml-opus-en-pt
@@ -138,6 +180,10 @@ Third-Party Model Licenses
     https://huggingface.co/Helsinki-NLP/opus-mt-ru-en
   ggml-opus-zh-en
     https://huggingface.co/Helsinki-NLP/opus-mt-zh-en
+  parakeet-tdt-0.6b-v3-onnx
+    https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
+  preprocessor
+    https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
 
 --- gemma (Gemma Terms of Use) ---
 
@@ -147,6 +193,10 @@ Third-Party Model Licenses
 --- health-ai-developer-foundations (HAI-DEF Terms of Use) ---
 
   medgemma-4b-it-GGUF
+    https://huggingface.co/unsloth/medgemma-4b-it-GGUF
+  medgemma-4b-it-Q4_1-00001-of-00005
+    https://huggingface.co/unsloth/medgemma-4b-it-GGUF
+  medgemma-4b-it-Q8_0-00001-of-00005
     https://huggingface.co/unsloth/medgemma-4b-it-GGUF
 
 --- llama3.2 (Llama 3.2 Community License) ---
@@ -176,11 +226,15 @@ Third-Party Model Licenses
     https://huggingface.co/ai4bharat/indictrans2-indic-indic-1B
   ggml-indictrans2-indic-indic-dist-320M-f16
     https://huggingface.co/ai4bharat/indictrans2-indic-indic-dist-320M
+  gte-large_fp16-00001-of-00005
+    https://huggingface.co/ChristianAzinn/gte-large-gguf
   gte-large-gguf
     https://huggingface.co/ChristianAzinn/gte-large-gguf
   pt-tiny-ggml-model-f16
     https://huggingface.co/DavyCosta701/whisper-tiny-pt-bpra
   tiny_acft_q8_0
+    https://voiceinput.futo.org/VoiceInput/tiny_en_acft_q8_0.bin
+  tiny_en_acft_q8_0
     https://voiceinput.futo.org/VoiceInput/tiny_en_acft_q8_0.bin
   whisper-vad
     https://huggingface.co/ggml-org/whisper-vad
@@ -189,41 +243,41 @@ Third-Party Model Licenses
 
 --- mpl-2.0 (Mozilla Public License 2.0) ---
 
-  lex.50.50.aren.s2t
+  model.aren.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/aren
-  lex.50.50.csen.s2t
+  model.csen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/csen
-  lex.50.50.enar.s2t
+  model.enar.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enar
-  lex.50.50.encs.s2t
+  model.encs.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/encs
-  lex.50.50.enes.s2t
+  model.enes.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enes
-  lex.50.50.enfr.s2t
+  model.enfr.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enfr
-  lex.50.50.enit.s2t
+  model.enit.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/tiny/enit
-  lex.50.50.enja.s2t
+  model.enja.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enja
-  lex.50.50.enpt.s2t
+  model.enpt.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enpt
-  lex.50.50.enru.s2t
+  model.enru.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enru
-  lex.50.50.enzh.s2t
+  model.enzh.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enzh
-  lex.50.50.esen.s2t
+  model.esen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/tiny/esen
-  lex.50.50.fren.s2t
+  model.fren.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/fren
-  lex.50.50.iten.s2t
+  model.iten.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/iten
-  lex.50.50.jaen.s2t
+  model.jaen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/jaen
-  lex.50.50.pten.s2t
+  model.pten.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/pten
-  lex.50.50.ruen.s2t
+  model.ruen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/tiny/ruen
-  lex.50.50.zhen.s2t
+  model.zhen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/zhen
 
 --- openrail ---
@@ -268,14 +322,14 @@ JavaScript Dependencies
   @qvac/ocr-onnx@0.1.7
     https://github.com/tetherto/qvac-lib-inference-addon-onnx-ocr-fasttext
   @qvac/rag@0.4.2
-  @qvac/registry-client@0.1.5
+  @qvac/registry-client@0.1.6
   @qvac/registry-schema@0.1.1
   @qvac/response@0.1.2
   @qvac/transcription-whispercpp@0.3.18
     https://github.com/tetherto/qvac-lib-infer-whispercpp
   @qvac/translation-nmtcpp@0.3.7
     https://github.com/tetherto/qvac-lib-infer-nmtcpp
-  @qvac/tts-onnx@0.2.13
+  @qvac/tts-onnx@0.5.3
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
   b4a@1.7.4
@@ -386,7 +440,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-zlib
   blind-relay@1.4.0
     https://github.com/holepunchto/blind-relay
-  compact-encoding@2.18.0
+  compact-encoding@2.19.0
     https://github.com/compact-encoding/compact-encoding
   device-file@2.3.1
     https://github.com/holepunchto/device-file

--- a/packages/qvac-sdk/changelog/0.7.0/CHANGELOG.md
+++ b/packages/qvac-sdk/changelog/0.7.0/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog v0.7.0
+
+Release Date: 2026-02-21
+
+## ✨ Features
+
+- QVAC Model Registry integratoin. (see PR [#323](https://github.com/tetherto/qvac/pull/323)) - See [breaking changes](./breaking.md)
+- Add --sdk-path option to CLI for explicit sdk location. (see PR [#384](https://github.com/tetherto/qvac/pull/384))
+- Add Pear pear.pre hook for auto-generated worker entry. (see PR [#451](https://github.com/tetherto/qvac/pull/451))
+
+## 🔌 API
+
+- Harden node rpc socket lifecycle and async close handling. (see PR [#263](https://github.com/tetherto/qvac/pull/263)) - See [API changes](./api.md)
+- Add Plugins. (see PR [#327](https://github.com/tetherto/qvac/pull/327)) - See [API changes](./api.md)
+- Add Chatterbox and Supertonic TTS engines. (see PR [#375](https://github.com/tetherto/qvac/pull/375)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Corestore directory deletion order causing EBUSY on Windows. (see PR [#266](https://github.com/tetherto/qvac/pull/266))
+- Add path traversal protection. (see PR [#281](https://github.com/tetherto/qvac/pull/281))
+- Reject empty text input in TTS and wrap addon errors. (see PR [#300](https://github.com/tetherto/qvac/pull/300))
+- Extract expo-device to stubbable module and add Android build config plugins. (see PR [#351](https://github.com/tetherto/qvac/pull/351))
+- Remove persistent node-rpc-client truncation from expo plugin. (see PR [#386](https://github.com/tetherto/qvac/pull/386))
+- Resolve SDK package dir dynamically in Expo plugins. (see PR [#396](https://github.com/tetherto/qvac/pull/396))
+- Fix delegate RPC client connection bugs. (see PR [#402](https://github.com/tetherto/qvac/pull/402))
+- Use stable corestore storage path for registry download resume. (see PR [#422](https://github.com/tetherto/qvac/pull/422))
+- Await closeRegistryClient in findModelShards to fix Windows fd-lock race. (see PR [#454](https://github.com/tetherto/qvac/pull/454))
+
+## 🧹 Chores
+
+- Bump llamacpp deps and remove iphone 17 cpu override. (see PR [#213](https://github.com/tetherto/qvac/pull/213))
+- Backmerge release-qvac-sdk-0.6.1 into main. (see PR [#285](https://github.com/tetherto/qvac/pull/285))
+- Add plugin path constants and cleanup dead exports. (see PR [#376](https://github.com/tetherto/qvac/pull/376))
+- Consolidate registry core key constant and scope corestore cache by key. (see PR [#439](https://github.com/tetherto/qvac/pull/439))
+
+## ⚙️ Infrastructure
+
+- Update SDK pod changelog generation and shared tooling. (see PR [#155](https://github.com/tetherto/qvac/pull/155))

--- a/packages/qvac-sdk/changelog/0.7.0/CHANGELOG_LLM.md
+++ b/packages/qvac-sdk/changelog/0.7.0/CHANGELOG_LLM.md
@@ -1,0 +1,218 @@
+# QVAC SDK v0.7.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.7.0
+
+This release integrates the Model Registry directly into the SDK, enabling model discovery and search without external dependencies. It also introduces a Plugin system for extending the SDK with custom model types and handlers, adds two new TTS engines (Chatterbox and Supertonic), and includes numerous stability fixes across Windows, Expo, and RPC layers.
+
+---
+
+## 💥 Breaking Changes
+
+### Model Registry Integration
+
+The model registry is now built into the SDK. As part of this integration, model constant names have been normalized for consistency and the metadata type has been renamed.
+
+#### Constant Renames
+
+Many model constants have been renamed to follow cleaner naming conventions. The main patterns:
+
+- **Bergamot**: language code pairs are now separated with underscores (`BERGAMOT_AREN` → `BERGAMOT_AR_EN`)
+- **Whisper**: verbose author/repo prefixes removed (`WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16` → `WHISPER_EN_BASE_Q0F16`)
+- **LLM**: version prefixes normalized (`QWEN_3_8B_INST_Q4_K_M` → `QWEN3_8B_INST_Q4_K_M`)
+- **OCR**: language-specific `CRAFT_` prefix dropped where redundant (`OCR_CRAFT_JAPANESE_RECOGNIZER` → `OCR_JAPANESE_RECOGNIZER`)
+- **Marian**: `Q0F16` quantization label simplified to `F16`
+
+See the full rename table in `breaking.md` for all affected constants.
+
+#### `HyperdriveItem` → `RegistryItem`
+
+The model metadata type has been renamed. The shape also changed — `hyperdriveKey`/`hyperbeeKey` fields are replaced by `registryPath`, `registrySource`, `blobCoreKey`, and new metadata fields (`engine`, `quantization`, `params`).
+
+**Before:**
+
+```typescript
+import type { HyperdriveItem } from "@qvac/sdk";
+
+function getSize(model: HyperdriveItem): number {
+  return model.expectedSize;
+}
+```
+
+**After:**
+
+```typescript
+import type { RegistryItem } from "@qvac/sdk";
+
+function getSize(model: RegistryItem): number {
+  return model.expectedSize;
+}
+```
+
+#### Registry Operations via SDK
+
+New functions for model discovery and search are available directly through the SDK:
+
+```typescript
+import {
+  modelRegistryList,
+  modelRegistrySearch,
+  modelRegistryGetModel,
+} from "@qvac/sdk";
+
+const allModels = await modelRegistryList();
+const llmModels = await modelRegistrySearch({ engine: "@qvac/llm-llamacpp" });
+const whisperModels = await modelRegistrySearch({ filter: "whisper" });
+const q4Models = await modelRegistrySearch({ quantization: "q4" });
+const specific = await modelRegistryGetModel(registryPath, registrySource);
+```
+
+#### Engine-Addon Mapping Utilities
+
+```typescript
+import { resolveCanonicalEngine, getAddonFromEngine } from "@qvac/sdk";
+
+const engine = resolveCanonicalEngine("@qvac/llm-llamacpp"); // "llamacpp-completion"
+const addon = getAddonFromEngine("llamacpp-completion"); // "llm"
+```
+
+---
+
+## 🔌 New APIs
+
+### Plugin System
+
+The SDK now supports plugins, allowing you to extend it with custom model types and handlers. Plugins can handle both request/reply and streaming interactions.
+
+```typescript
+import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from "@qvac/sdk";
+
+// Invoke a plugin handler (request/reply)
+const result = await invokePlugin<MyResponse>({
+  modelId,
+  handler: "myHandler",
+  params: { key: "value" },
+});
+
+// Invoke a plugin handler (streaming)
+for await (const chunk of invokePluginStream<MyStreamResponse>({
+  modelId,
+  handler: "myStreamHandler",
+  params: { key: "value" },
+})) {
+  console.log(chunk.result);
+}
+
+// Define a custom plugin
+const myPlugin = definePlugin({
+  modelType: "custom-type",
+  displayName: "Custom Plugin",
+  addonPackage: "@my/addon",
+  createModel: (params) => ({ model, loader }),
+  handlers: {
+    myHandler: defineHandler({
+      requestSchema: myRequestSchema,
+      responseSchema: myResponseSchema,
+      streaming: false,
+      handler: async (request) => ({ type: "pluginInvoke", result: "..." }),
+    }),
+  },
+});
+```
+
+### Chatterbox and Supertonic TTS Engines
+
+Two new text-to-speech engines are now available, each suited for different use cases.
+
+**Chatterbox** excels at voice cloning, requiring a reference audio sample to replicate a target voice:
+
+```typescript
+const modelId = await loadModel({
+  modelSrc,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "chatterbox",
+    language: "en",
+    ttsTokenizerSrc,
+    ttsSpeechEncoderSrc,
+    ttsEmbedTokensSrc,
+    ttsConditionalDecoderSrc,
+    ttsLanguageModelSrc,
+    referenceAudioSrc,
+  },
+});
+```
+
+**Supertonic** is a general-purpose TTS engine with configurable speed and inference quality:
+
+```typescript
+const modelId = await loadModel({
+  modelSrc,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "supertonic",
+    language: "en",
+    ttsTokenizerSrc,
+    ttsTextEncoderSrc,
+    ttsLatentDenoiserSrc,
+    ttsVoiceDecoderSrc,
+    ttsVoiceSrc,
+    ttsSpeed: 1.0,
+    ttsNumInferenceSteps: 5,
+  },
+});
+```
+
+Both engines use the same inference API:
+
+```typescript
+const result = textToSpeech({
+  modelId,
+  text: "Your text here",
+  inputType: "text",
+  stream: false,
+});
+```
+
+### `close()` is Now Async
+
+The SDK `close()` function now returns a Promise, ensuring all RPC sockets and resources are fully cleaned up before your process exits.
+
+**Before:**
+
+```typescript
+import { close } from "@qvac/sdk";
+close();
+```
+
+**After:**
+
+```typescript
+import { close } from "@qvac/sdk";
+await close();
+```
+
+---
+
+## ✨ Features
+
+### CLI `--sdk-path` Option
+
+The CLI now accepts an explicit `--sdk-path` option for specifying the SDK location, useful in monorepo setups or non-standard project layouts where automatic resolution may not find the correct package.
+
+### Pear `pear.pre` Hook
+
+Added support for auto-generating a worker entry point via the `pear.pre` build hook, simplifying Pear application setup.
+
+---
+
+## 🐞 Bug Fixes
+
+- **Windows EBUSY on cleanup** — Fixed corestore directory deletion order that caused `EBUSY` errors on Windows when cleaning up after model operations.
+- **Path traversal protection** — Added validation to prevent path traversal attacks when resolving model file paths.
+- **TTS empty input handling** — The SDK now rejects empty text input in TTS calls with a clear error instead of silently failing, and addon errors are properly wrapped.
+- **Expo device module** — Extracted `expo-device` into a stubbable module, fixing build issues and adding Android build config plugin support.
+- **Expo plugin truncation** — Removed persistent `node-rpc-client` truncation from the Expo plugin that was corrupting RPC messages.
+- **Expo SDK path resolution** — SDK package directory is now resolved dynamically in Expo plugins, fixing failures when the SDK is installed in non-standard locations.
+- **Delegate RPC client** — Fixed connection bugs in the delegate RPC client that could cause dropped messages or failed reconnections.
+- **Registry download resume** — Switched to a stable corestore storage path so interrupted registry downloads can properly resume instead of restarting from scratch.
+- **Windows fd-lock race** — Added proper `await` on `closeRegistryClient` in `findModelShards` to prevent file descriptor lock races on Windows.

--- a/packages/qvac-sdk/changelog/0.7.0/api.md
+++ b/packages/qvac-sdk/changelog/0.7.0/api.md
@@ -1,0 +1,125 @@
+# 🔌 API Changes v0.7.0
+
+## Harden node rpc socket lifecycle and async close handling
+
+PR: [#263](https://github.com/tetherto/qvac/pull/263)
+
+```typescript
+import { close } from "@qvac/sdk";
+
+close();
+```
+
+```typescript
+import { close } from "@qvac/sdk";
+
+await close();
+```
+
+---
+
+## Add Plugins
+
+PR: [#327](https://github.com/tetherto/qvac/pull/327)
+
+```typescript
+import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from "@qvac/sdk";
+
+// Invoke a plugin handler (request/reply)
+const result = await invokePlugin<MyResponse>({
+  modelId,
+  handler: "myHandler",
+  params: { key: "value" },
+});
+
+// Invoke a plugin handler (streaming)
+for await (const chunk of invokePluginStream<MyStreamResponse>({
+  modelId,
+  handler: "myStreamHandler",
+  params: { key: "value" },
+})) {
+  console.log(chunk.result);
+}
+
+// Define a custom plugin
+const myPlugin = definePlugin({
+  modelType: "custom-type",
+  displayName: "Custom Plugin",
+  addonPackage: "@my/addon",
+  createModel: (params) => ({ model, loader }),
+  handlers: {
+    myHandler: defineHandler({
+      requestSchema: myRequestSchema,
+      responseSchema: myResponseSchema,
+      streaming: false,
+      handler: async (request) => ({ type: "pluginInvoke", result: ... }),
+    }),
+  },
+});
+```
+
+---
+
+## Add Chatterbox and Supertonic TTS engines
+
+PR: [#375](https://github.com/tetherto/qvac/pull/375)
+
+```typescript
+import { 
+  PLUGIN_TTS, 
+  SDK_DEFAULT_PLUGINS, 
+  type BuiltinPlugin 
+} from "qvac-sdk";
+```
+
+```typescript
+// Chatterbox TTS (voice cloning)
+const modelId = await loadModel({
+  modelSrc,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "chatterbox",
+    language: "en",
+    ttsTokenizerSrc,
+    ttsSpeechEncoderSrc,
+    ttsEmbedTokensSrc,
+    ttsConditionalDecoderSrc,
+    ttsLanguageModelSrc,
+    referenceAudioSrc,
+  },
+});
+
+// Supertonic TTS (general-purpose)
+const modelId = await loadModel({
+  modelSrc,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "supertonic",
+    language: "en",
+    ttsTokenizerSrc,
+    ttsTextEncoderSrc,
+    ttsLatentDenoiserSrc,
+    ttsVoiceDecoderSrc,
+    ttsVoiceSrc,
+    ttsSpeed: 1.0,           // optional
+    ttsNumInferenceSteps: 5, // optional
+  },
+});
+
+// Text-to-speech usage (same for both engines)
+const result = textToSpeech({
+  modelId,
+  text: "Your text here",
+  inputType: "text",
+  stream: false,
+});
+```
+
+```typescript
+export type TtsChatterboxConfig = z.infer<typeof ttsChatterboxConfigSchema>;
+export type TtsSupertonicConfig = z.infer<typeof ttsSupertonicConfigSchema>;
+export type TtsConfig = z.infer<typeof ttsConfigSchema>; // Now a union
+```
+
+---
+

--- a/packages/qvac-sdk/changelog/0.7.0/breaking.md
+++ b/packages/qvac-sdk/changelog/0.7.0/breaking.md
@@ -1,0 +1,210 @@
+# 💥 Breaking Changes v0.7.0
+
+## Model Registry merge to main
+
+PR: [#323](https://github.com/tetherto/qvac/pull/323)
+
+**BEFORE:**
+```typescript
+import { BERGAMOT_AREN, WHISPER_TINY_Q5_1, MARIAN_OPUS_DE_EN_Q0F32 } from "@qvac/sdk";
+
+await loadModel({ modelSrc: BERGAMOT_AREN.src, modelType: "translation" });
+```
+
+**AFTER:**
+```typescript
+import { BERGAMOT_AR_EN, WHISPER_TINY_Q5_1, MARIAN_OPUS_DE_EN_F32 } from "@qvac/sdk";
+
+await loadModel({ modelSrc: BERGAMOT_AR_EN.src, modelType: "translation" });
+```
+
+### Full List
+### Bergamot: language codes separated with underscore (`AREN` → `AR_EN`)
+
+| Before | After |
+|--------|-------|
+| `BERGAMOT_AREN` | `BERGAMOT_AR_EN` |
+| `BERGAMOT_AREN_VOCAB` | `BERGAMOT_AR_EN_VOCAB` |
+| `BERGAMOT_CSEN` | `BERGAMOT_CS_EN` |
+| `BERGAMOT_CSEN_VOCAB` | `BERGAMOT_CS_EN_VOCAB` |
+| `BERGAMOT_ENAR` | `BERGAMOT_EN_AR` |
+| `BERGAMOT_ENAR_VOCAB` | `BERGAMOT_EN_AR_VOCAB` |
+| `BERGAMOT_ENCS` | `BERGAMOT_EN_CS` |
+| `BERGAMOT_ENES` | `BERGAMOT_EN_ES` |
+| `BERGAMOT_ENES_VOCAB` | `BERGAMOT_EN_ES_VOCAB` |
+| `BERGAMOT_ENFR` | `BERGAMOT_EN_FR` |
+| `BERGAMOT_ENFR_VOCAB` | `BERGAMOT_EN_FR_VOCAB` |
+| `BERGAMOT_ENIT` | `BERGAMOT_EN_IT` |
+| `BERGAMOT_ENIT_VOCAB` | `BERGAMOT_EN_IT_VOCAB` |
+| `BERGAMOT_ENJA` | `BERGAMOT_EN_JA` |
+| `BERGAMOT_ENJA_SRCVOCAB` | `BERGAMOT_EN_JA_SRCVOCAB` |
+| `BERGAMOT_ENJA_TRGVOCAB` | `BERGAMOT_EN_JA_TRGVOCAB` |
+| `BERGAMOT_ENPT` | `BERGAMOT_EN_PT` |
+| `BERGAMOT_ENPT_VOCAB` | `BERGAMOT_EN_PT_VOCAB` |
+| `BERGAMOT_ENRU` | `BERGAMOT_EN_RU` |
+| `BERGAMOT_ENRU_VOCAB` | `BERGAMOT_EN_RU_VOCAB` |
+| `BERGAMOT_ENZH` | `BERGAMOT_EN_ZH` |
+| `BERGAMOT_ENZH_SRCVOCAB` | `BERGAMOT_EN_ZH_SRCVOCAB` |
+| `BERGAMOT_ENZH_TRGVOCAB` | `BERGAMOT_EN_ZH_TRGVOCAB` |
+| `BERGAMOT_ESEN` | `BERGAMOT_ES_EN` |
+| `BERGAMOT_ESEN_VOCAB` | `BERGAMOT_ES_EN_VOCAB` |
+| `BERGAMOT_FREN` | `BERGAMOT_FR_EN` |
+| `BERGAMOT_ITEN` | `BERGAMOT_IT_EN` |
+| `BERGAMOT_ITEN_VOCAB` | `BERGAMOT_IT_EN_VOCAB` |
+| `BERGAMOT_JAEN` | `BERGAMOT_JA_EN` |
+| `BERGAMOT_JAEN_VOCAB` | `BERGAMOT_JA_EN_VOCAB` |
+| `BERGAMOT_PTEN` | `BERGAMOT_PT_EN` |
+| `BERGAMOT_RUEN` | `BERGAMOT_RU_EN` |
+| `BERGAMOT_RUEN_VOCAB` | `BERGAMOT_RU_EN_VOCAB` |
+| `BERGAMOT_ZHEN` | `BERGAMOT_ZH_EN` |
+| `BERGAMOT_ZHEN_VOCAB` | `BERGAMOT_ZH_EN_VOCAB` |
+
+### Whisper: author/repo names removed from constant names
+
+| Before | After |
+|--------|-------|
+| `WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_F16` | `WHISPER_EN_BASE_Q0F16` |
+| `WHISPER_ENGLISH_BASE_OPENAI_WHISPER_BASE_Q8_0` | `WHISPER_EN_BASE_Q8_0` |
+| `WHISPER_FRENCH_BASE_PERSONALIZEDREFRIGERATOR_WHISPER_BASE_FR_F16` | `WHISPER_FRENCH_BASE_F16` |
+| `WHISPER_FRENCH_BASE_PERSONALIZEDREFRIGERATOR_WHISPER_BASE_FR_Q8_0` | `WHISPER_FRENCH_BASE_Q8_0` |
+| `WHISPER_GERMAN_BASE_AWARE_AI_WHISPER_BASE_GERMAN_F16` | `WHISPER_GERMAN_BASE_F16` |
+| `WHISPER_GERMAN_BASE_AWARE_AI_WHISPER_BASE_GERMAN_Q8_0` | `WHISPER_GERMAN_BASE_Q8_0` |
+| `WHISPER_ITALIAN_BASE_GUSTAVV_ANDRZEJEWSKI_DISTIL_WHISPER_BASE_IT_F16` | `WHISPER_ITALIAN_BASE_F16` |
+| `WHISPER_ITALIAN_BASE_GUSTAVV_ANDRZEJEWSKI_DISTIL_WHISPER_BASE_IT_Q8_0` | `WHISPER_ITALIAN_BASE_Q8_0` |
+| `WHISPER_JAPANESE_BASE_BYGREENCN_WHISPER_BASE_JA_F16` | `WHISPER_JAPANESE_BASE_F16` |
+| `WHISPER_JAPANESE_BASE_BYGREENCN_WHISPER_BASE_JA_Q8_0` | `WHISPER_JAPANESE_BASE_Q8_0` |
+| `WHISPER_JAPANESE_TINY_TINY_CHEELI03_WHISPER_TINY_JA_PUCT_4K_F16` | `WHISPER_JAPANESE_TINY_F16` |
+| `WHISPER_JAPANESE_TINY_TINY_CHEELI03_WHISPER_TINY_JA_PUCT_4K_Q8_0` | `WHISPER_JAPANESE_TINY_Q8_0` |
+| `WHISPER_LARGE_3` | `WHISPER_LARGE_V3_TURBO` |
+| `WHISPER_PORTUGUESE_BASE_MARIANA_COELHO_9_WHISPER_BASE_PT_F16` | `WHISPER_PORTUGUESE_BASE_F16` |
+| `WHISPER_PORTUGUESE_BASE_MARIANA_COELHO_9_WHISPER_BASE_PT_Q8_0` | `WHISPER_PORTUGUESE_BASE_Q8_0` |
+| `WHISPER_RUSSIAN_BASE_CHEELI03_WHISPER_BASE_RUS_8_F16` | `WHISPER_RUSSIAN_BASE_F16` |
+| `WHISPER_RUSSIAN_BASE_CHEELI03_WHISPER_BASE_RUS_8_Q8_0` | `WHISPER_RUSSIAN_BASE_Q8_0` |
+| `WHISPER_RUSSIAN_TINY_TINY_YAROSLAV0530_WHISPER_TINY_RU_F16` | `WHISPER_RUSSIAN_TINY_F16` |
+| `WHISPER_RUSSIAN_TINY_TINY_YAROSLAV0530_WHISPER_TINY_RU_Q8_0` | `WHISPER_RUSSIAN_TINY_Q8_0` |
+| `WHISPER_SMALL_Q8` | `WHISPER_SMALL_Q8_0` |
+
+### LLM: version prefix normalization (`QWEN_3_` → `QWEN3_`, etc.)
+
+| Before | After |
+|--------|-------|
+| `LASER_DOLPHIN_2_6_2X7B_INST_Q2_K` | `LASER_DOLPHIN_2X7B_INST_Q2_K` |
+| `LLAMA_TOOL_CALLING_3_2_1B_INST_Q4_K` | `LLAMA_TOOL_CALLING_1B_INST_Q4_K` |
+| `MMPROJ_QWEN3_VL_1_2B_MULTIMODAL_Q4_K` | `MMPROJ_QWEN3VL_2B_MULTIMODAL_Q4_K` |
+| `MMPROJ_SMOLVLM2_2_500M_MULTIMODAL_F16` | `MMPROJ_SMOLVLM2_500M_MULTIMODAL_F16` |
+| `MMPROJ_SMOLVLM2_2_500M_MULTIMODAL_Q8_0` | `MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0` |
+| `QWEN_3_1_7B_INST_Q4` | `QWEN3_1_7B_INST_Q4` |
+| `QWEN_3_1_7B_INST_Q4_SHARD` | `QWEN3_1_7B_INST_Q4_SHARD` |
+| `QWEN_3_4B_INST_Q4_SHARD` | `QWEN3_4B_INST_Q4_SHARD` |
+| `QWEN_3_8B_INST_Q4_K_M` | `QWEN3_8B_INST_Q4_K_M` |
+| `QWEN3_VL_1_2B_MULTIMODAL_Q4_K` | `QWEN3VL_2B_MULTIMODAL_Q4_K` |
+| `SMOLVLM2_2_500M_MULTIMODAL_F16` | `SMOLVLM2_500M_MULTIMODAL_F16` |
+| `SMOLVLM2_2_500M_MULTIMODAL_Q8_0` | `SMOLVLM2_500M_MULTIMODAL_Q8_0` |
+
+### OCR: dropped language-specific `CRAFT_` prefix
+
+| Before | After |
+|--------|-------|
+| `OCR_CRAFT_ENGLISH_DETECTOR` | `OCR_CRAFT_DETECTOR` |
+| `OCR_CRAFT_JAPANESE_RECOGNIZER` | `OCR_JAPANESE_RECOGNIZER` |
+| `OCR_CRAFT_KOREAN_RECOGNIZER` | `OCR_KOREAN_RECOGNIZER` |
+| `OCR_CRAFT_LATIN_RECOGNIZER` | `OCR_LATIN_RECOGNIZER` |
+| `OCR_CRAFT_LATIN_RECOGNIZER_1` | `OCR_LATIN_RECOGNIZER_1` |
+| `OCR_CRAFT_THAI_RECOGNIZER` | `OCR_THAI_RECOGNIZER` |
+| `OCR_CRAFT_ZH_SIM_RECOGNIZER` | `OCR_ZH_SIM_RECOGNIZER` |
+
+### Marian: `Q0F16` → `F16`
+
+| Before | After |
+|--------|-------|
+| `MARIAN_EN_HI_INDIC_1B_Q0F16` | `MARIAN_EN_HI_INDIC_1B_F16` |
+| `MARIAN_EN_HI_INDIC_200M_Q0F16` | `MARIAN_EN_HI_INDIC_200M_F16` |
+| `MARIAN_HI_EN_INDIC_1B_Q0F16` | `MARIAN_HI_EN_INDIC_1B_F16` |
+| `MARIAN_HI_EN_INDIC_200M_Q0F16` | `MARIAN_HI_EN_INDIC_200M_F16` |
+| `MARIAN_HI_HI_INDIC_1B_Q0F16` | `MARIAN_HI_HI_INDIC_1B_F16` |
+| `MARIAN_HI_HI_INDIC_320M_Q0F16` | `MARIAN_HI_HI_INDIC_320M_F16` |
+
+### `HyperdriveItem` type renamed to `RegistryItem`
+
+Apps that reference the model metadata type will need to update. The shape also changed — `hyperdriveKey`/`hyperbeeKey` fields are replaced by `registryPath`, `registrySource`, `blobCoreKey`, and new metadata fields (`engine`, `quantization`, `params`).
+
+BEFORE:
+```typescript
+import type { HyperdriveItem } from "@qvac/sdk";
+
+function getSize(model: HyperdriveItem): number {
+  return model.expectedSize;
+}
+```
+
+AFTER:
+```typescript
+import type { RegistryItem } from "@qvac/sdk";
+
+function getSize(model: RegistryItem): number {
+  return model.expectedSize;
+}
+```
+
+## API additions
+
+### Registry operations via SDK
+
+New functions for model discovery and search directly through the SDK, without needing to depend on the registry client package separately:
+
+```typescript
+import {
+  modelRegistryList,
+  modelRegistrySearch,
+  modelRegistryGetModel,
+  type ModelRegistryEntry,
+} from "@qvac/sdk";
+
+const models = await modelRegistryList();
+const llmModels = await modelRegistrySearch({ engine: "@qvac/llm-llamacpp" });
+const whisperModels = await modelRegistrySearch({ filter: "whisper" });
+const q4Models = await modelRegistrySearch({ quantization: "q4" });
+const specific = await modelRegistryGetModel(registryPath, registrySource);
+```
+
+### Engine-addon mapping utilities
+
+```typescript
+import { resolveCanonicalEngine, getAddonFromEngine, ENGINE_TO_ADDON } from "@qvac/sdk";
+
+const engine = resolveCanonicalEngine("@qvac/llm-llamacpp"); // "llamacpp-completion"
+const addon = getAddonFromEngine("llamacpp-completion"); // "llm"
+```
+
+## Key changes
+
+### New files
+- `client/api/registry.ts` — SDK client API for registry operations
+- `schemas/registry.ts` — Zod schemas for registry request/response types
+- `schemas/engine-addon-map.ts` — canonical engine-to-addon mapping with strict validation
+- `schemas/sdk-errors-registry.ts` — registry-specific error codes
+- `server/rpc/handlers/registry.ts` — RPC handlers for registry list/search/get
+- `server/rpc/handlers/load-model/registry.ts` — model download from registry with shard support
+- `server/bare/registry/registry-client.ts` — registry client lifecycle management
+- `models/update-models/` — modular update-models script (codegen, naming, processing, shards, registry, history)
+- `test/unit/update-models-naming.test.ts` — unit tests for model naming and shard grouping
+
+### Modified files
+- `package.json` — added `@tetherto/registry-client-mono` dependency, `tsx` dev dependency, new scripts
+- `index.ts`, `client/api/index.ts` — export new registry API functions
+- `schemas/common.ts`, `schemas/index.ts` — registry schemas integrated into request/response unions
+- `server/rpc/handle-request.ts`, `server/rpc/handlers/index.ts` — registry RPC routing
+- `server/rpc/handlers/load-model/handler.ts`, `resolve.ts`, `download-manager.ts` — registry source support in model loading
+- `models/hyperdrive/models.ts` — regenerated with improved naming and shard metadata
+- `utils/errors-client.ts`, `utils/errors-server.ts` — registry error classes
+- Examples updated to use current registry model paths
+
+## Test plan
+
+- [x] `bun run build` passes in `packages/qvac-sdk`
+- [x] `bun run test:unit` passes (including new update-models naming/shard tests)
+- [x] `npx tsx examples/registry-query.ts` lists and searches models from the registry
+- [x] Model loading from registry paths works end-to-end
+
+---
+

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- qvac-sdk needs a v0.7.0 release with version bump, changelog, and updated NOTICE
- Covers all changes since the monorepo migration (25 PRs, 20 included in changelog)

## 📝 How does it solve it?

- Bumps `packages/qvac-sdk/package.json` version from `0.6.1` to `0.7.0`
- Generates changelog files in `packages/qvac-sdk/changelog/0.7.0/`:
  - `CHANGELOG.md` — categorized PR list (features, API, fixes, chores, infra)
  - `breaking.md` — model constant renames, `HyperdriveItem` → `RegistryItem`, new registry APIs
  - `api.md` — async `close()`, Plugin system, Chatterbox/Supertonic TTS engines
  - `CHANGELOG_LLM.md` — human-readable release notes
- Regenerates `packages/qvac-sdk/NOTICE` (110 models, 167 JS dependencies)