### PR TITLE
Added env variable forwarding for url generation scripts.

### DIFF
--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -305,6 +305,7 @@ jobs:
         env:
           BERGAMOT_LANG_PAIR: ${{ inputs.bergamot_language_pair || 'enit' }}
           AWS_REGION: eu-central-1
+          MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         run: |
           echo "🔑 Generating Bergamot model URLs for mobile tests..."
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -327,6 +328,7 @@ jobs:
         working-directory: ./monorepo/${{ inputs.workdir || env.PKG_DIR }}
         env:
           AWS_REGION: eu-central-1
+          MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         run: |
           echo "🔑 Generating IndicTrans model URLs for mobile tests..."
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
### What problem does this PR solve?

- Mobile integration test URL-generation steps rely on MODEL_S3_BUCKET, but that secret was not forwarded into the relevant workflow run environments.
- This can cause presigned URL generation scripts to miss required bucket configuration and fail or behave inconsistently in CI.


### How does it solve it?

- Adds MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }} to the env block of the Bergamot presigned URL generation step in integration-mobile-test-qvac-lib-infer-nmtcpp.yml.
- Adds the same env forwarding to the IndicTrans presigned URL generation step, ensuring both code paths receive the required secret.