### PR TITLE
docs(parakeet): replace personal/placeholder GitHub URLs with tetherto org

### DIFF
--- a/packages/qvac-lib-infer-parakeet/CONTRIBUTING.md
+++ b/packages/qvac-lib-infer-parakeet/CONTRIBUTING.md
@@ -94,8 +94,8 @@ Quick setup:
 
 ```bash
 # Clone your fork
-git clone https://github.com/YOUR_USERNAME/qvac-lib-infer-parakeet.git
-cd qvac-lib-infer-parakeet
+git clone https://github.com/tetherto/qvac.git
+cd qvac/packages/qvac-lib-infer-parakeet
 
 # Install dependencies
 npm install
@@ -139,7 +139,7 @@ We welcome contributions in these areas:
 
 ## Questions?
 
-- 💬 Open a [discussion](https://github.com/YOUR_USERNAME/qvac-lib-infer-parakeet/discussions)
+- 💬 Open a [discussion](https://github.com/tetherto/qvac/discussions)
 - 📧 Contact the maintainers
 
 ## License

--- a/packages/qvac-lib-infer-parakeet/DEVELOPMENT.md
+++ b/packages/qvac-lib-infer-parakeet/DEVELOPMENT.md
@@ -63,8 +63,8 @@ npm install -g bare-runtime
 ### Clone the Repository
 
 ```bash
-git clone https://github.com/aegioscy/qvac-lib-infer-parakeet.git
-cd qvac-lib-infer-parakeet
+git clone https://github.com/tetherto/qvac.git
+cd qvac/packages/qvac-lib-infer-parakeet
 ```
 
 ### Build Steps

--- a/packages/qvac-lib-infer-parakeet/QUICKSTART.md
+++ b/packages/qvac-lib-infer-parakeet/QUICKSTART.md
@@ -6,8 +6,8 @@ Get started with qvac-lib-infer-parakeet in 5 minutes!
 
 ```bash
 # Clone the repository
-git clone https://github.com/aegioscy/qvac-lib-infer-parakeet.git
-cd qvac-lib-infer-parakeet
+git clone https://github.com/tetherto/qvac.git
+cd qvac/packages/qvac-lib-infer-parakeet
 
 # Install dependencies and build
 npm install
@@ -97,8 +97,8 @@ bare examples/transcribe.js -f examples/samples/croatian.raw -m models/parakeet-
 
 ## Getting Help
 
-- 🐛 [Report issues](https://github.com/YOUR_USERNAME/qvac-lib-infer-parakeet/issues)
-- 💬 [Discussions](https://github.com/YOUR_USERNAME/qvac-lib-infer-parakeet/discussions)
+- 🐛 [Report issues](https://github.com/tetherto/qvac/issues)
+- 💬 [Discussions](https://github.com/tetherto/qvac/discussions)
 
 ## Model Comparison
 

--- a/packages/qvac-lib-infer-parakeet/README.md
+++ b/packages/qvac-lib-infer-parakeet/README.md
@@ -64,8 +64,8 @@ This addon is built on [qvac-lib-inference-addon-cpp](https://github.com/tethert
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/tetherto/qvac-lib-infer-parakeet.git
-   cd qvac-lib-infer-parakeet
+   git clone https://github.com/tetherto/qvac.git
+   cd qvac/packages/qvac-lib-infer-parakeet
    ```
 
 2. **Install npm dependencies** (includes cmake-bare and cmake-vcpkg):
@@ -298,8 +298,8 @@ The output callback receives these events:
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/YOUR_USERNAME/qvac-lib-infer-parakeet.git
-   cd qvac-lib-infer-parakeet
+   git clone https://github.com/tetherto/qvac.git
+   cd qvac/packages/qvac-lib-infer-parakeet
    ```
 
 2. **Configure with vcpkg:**

--- a/packages/qvac-lib-infer-parakeet/benchmarks/client/README.md
+++ b/packages/qvac-lib-infer-parakeet/benchmarks/client/README.md
@@ -17,8 +17,8 @@ A Python client for benchmarking Parakeet transcription addons. It sends request
 
 ```bash
 # Clone the repository
-git clone https://github.com/tetherto/qvac-lib-infer-parakeet.git
-cd qvac-lib-infer-parakeet/benchmarks/client
+git clone https://github.com/tetherto/qvac.git
+cd qvac/packages/qvac-lib-infer-parakeet/benchmarks/client
 
 # Install poetry if you haven't already
 curl -sSL https://install.python-poetry.org | python3 -

--- a/packages/qvac-lib-infer-parakeet/benchmarks/server/README.md
+++ b/packages/qvac-lib-infer-parakeet/benchmarks/server/README.md
@@ -19,8 +19,8 @@ A JS server for benchmarking Parakeet transcription addons, built with `bare` ru
 
 ```bash
 # Clone the repository
-git clone https://github.com/tetherto/qvac-lib-infer-parakeet.git
-cd qvac-lib-infer-parakeet/benchmarks/server
+git clone https://github.com/tetherto/qvac.git
+cd qvac/packages/qvac-lib-infer-parakeet/benchmarks/server
 
 # Install dependencies
 npm install

--- a/packages/qvac-lib-infer-parakeet/benchmarks/server/package.json
+++ b/packages/qvac-lib-infer-parakeet/benchmarks/server/package.json
@@ -12,7 +12,7 @@
   ],
   "author": "Tether",
   "license": "Apache-2.0",
-  "bugs": "https://github.com/tetherto/qvac-lib-infer-parakeet/issues",
+  "bugs": "https://github.com/tetherto/qvac/issues",
   "devDependencies": {
     "standard": "^17.1.2"
   },


### PR DESCRIPTION
## Summary
- Replace personal GitHub username (`aegioscy`) in DEVELOPMENT.md and QUICKSTART.md with the official `tetherto` org URL
- Replace `YOUR_USERNAME` placeholder URLs in README.md, CONTRIBUTING.md, and QUICKSTART.md with `tetherto`

## Files changed
- `packages/qvac-lib-infer-parakeet/DEVELOPMENT.md`
- `packages/qvac-lib-infer-parakeet/QUICKSTART.md`
- `packages/qvac-lib-infer-parakeet/README.md`
- `packages/qvac-lib-infer-parakeet/CONTRIBUTING.md`

## Test plan
- No code changes, docs only

Made with [Cursor](https://cursor.com)