### PR TITLE
fix(nmtcpp): update addon-cpp version constraint to match actual usage

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/vcpkg.json
+++ b/packages/qvac-lib-infer-nmtcpp/vcpkg.json
@@ -1,21 +1,17 @@
 {
   "dependencies": [
+    "bergamot-translator",
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "0.12.2"
+      "version>=": "1.1.2"
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.3.0"
+      "version>=": "1.4.4"
     },
     "sentencepiece",
-    "whisper-cpp",
     "ssplit",
-    {
-      "name": "qvac-lint-cpp",
-      "version>=": "1.4.1"
-    },
-    "bergamot-translator"
+    "whisper-cpp"
   ],
   "features": {
     "tests": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- vcpkg.json declares qvac-lib-inference-addon-cpp >= 0.12.2, but the code already uses the 1.x API (AddonJs, JsInterface, JsArgsParser, OutputCallBackJs, JsStringOutputHandler, JSCATCH). The stale constraint is misleading — it implies 0.12.x compatibility when the package would fail to build against it.
- qvac-lint-cpp had two duplicate entries (>= 1.3.0 and >= 1.4.1).

## 📝 How does it solve it?

- Bumped qvac-lib-inference-addon-cpp version constraint from >= 0.12.2 to >= 1.1.2 to accurately reflect the minimum version the code requires.
- Deduplicated qvac-lint-cpp entry and bumped to >= 1.4.4.
- Ran `vcpkg format-manifest` on vcpkg.json for consistency.

## 🧪 How was it tested?

- Built and ran integrations tests to confirm no errors were introduced with the changes.