### PR TITLE
fix(nmtcpp): replace inline sanity-checks with reusable action

### DIFF
--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -47,84 +47,17 @@ jobs:
 
   sanity-checks:
     needs: changes
-    if: |
-      always() &&
-      ((needs.changes.outputs.pkg == 'true' &&
-        contains(github.event.pull_request.labels.*.name, 'verify')) ||
-       github.event_name == 'workflow_dispatch')
+    if: needs.changes.outputs.pkg == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - name: Run Sanity checks
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
-      - name: Fetch PR head and target branch
-        id: fetch_pr
-        if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
-        continue-on-error: true
-        run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-          git fetch origin ${{ github.event.pull_request.head.sha }}:refs/pr/head
-
-      - name: Check PR Status with Target Branch
-        continue-on-error: true
-        id: target_branch_checks
-        if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
-        run: |
-          TARGET_SHA=${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          if ! git merge-base --is-ancestor "$TARGET_SHA" "$PR_HEAD_SHA"; then
-            echo "::error title=PR is not up to date::This PR is not up to date with target branch"
-          fi
-
-      - name: Check for disallowed dependencies
-        id: check_dependencies
-        continue-on-error: true
-        working-directory: ${{ env.PKG_DIR }}
-        run: |
-          deps=$(jq -r '.dependencies, .devDependencies // {} | to_entries[] | .value' package.json)
-          if echo "$deps" | grep -Eq '^(git\+https:\/\/github.com|[0-9]+\.[0-9]+\.[0-9]+-(dev|tmp)[^"]*)$'; then
-            echo "::error title=Disallowed dependency detected::Do not use git URLs or dev/tmp versions in dependencies"
-          fi
-
-      - name: Run tests
-        id: run_tests
-        continue-on-error: true
-        uses: tetherto/qvac-devops/.github/actions/run-lint-and-unit-tests@monorepo_update
-        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
-          gpr-token: ${{ secrets.GITHUB_TOKEN }}
-          pat-token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
-          workdir: ${{ env.PKG_DIR }}
-
-      - name: Check for errors
-        run: |
-          count=0
-          if [ "${{ steps.run_tests.outcome }}" = "failure" ]; then
-            echo "::error::Step - Lint or unit tests failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.check_dependencies.outcome }}" = "failure" ]; then
-            echo "::error::Step - Check for disallowed dependencies failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.target_branch_checks.outcome }}" = "failure" ]; then
-            echo "::error::Step - Check PR Status with Target Branch failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.fetch_pr.outcome }}" = "failure" ]; then
-            echo "::error::Step - Fetch PR head and target branch failed"
-            count=$((count + 1))
-          fi
-          if [ $count -gt 0 ]; then
-            echo "::error::There were $count failed checks"
-            exit 1
-          fi
+          pat-token: ${{ secrets.PAT_TOKEN }}
+          run-integration: ${{ contains(github.event.pull_request.labels.*.name, 'verify') }}
+          workdir: packages/qvac-lib-infer-nmtcpp
 
   ts-checks:
     needs: [changes, sanity-checks]

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -47,7 +47,7 @@ jobs:
 
   sanity-checks:
     needs: changes
-    if: needs.changes.outputs.pkg == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
+    if: always() && ((needs.changes.outputs.pkg == 'true' && contains(github.event.pull_request.labels.*.name, 'verify')) || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks

--- a/packages/qvac-lib-infer-nmtcpp/index.js
+++ b/packages/qvac-lib-infer-nmtcpp/index.js
@@ -405,7 +405,7 @@ class TranslationNmtcpp extends BaseInference {
     }
     return this._outputCallback(addon, mappedEvent, JOB_ID, data, error)
   }
-  
+
   async _downloadWeights (reportProgressCallback) {
     const models = this._getFilesToDownload()
     if (!models.length) {

--- a/packages/qvac-lib-infer-nmtcpp/marian.js
+++ b/packages/qvac-lib-infer-nmtcpp/marian.js
@@ -33,7 +33,7 @@ class TranslationInterface {
       this._loggerInitialized = true
     }
   }
-  
+
   // For BaseInference.
   async destroyInstance () {
     await this.destroy()
@@ -110,7 +110,7 @@ class TranslationInterface {
   }
 
   /**
-   * Cancel a inference process 
+   * Cancel a inference process
    */
   async cancel () {
     try {

--- a/packages/qvac-lib-infer-nmtcpp/test/integration/indictrans.test.js
+++ b/packages/qvac-lib-infer-nmtcpp/test/integration/indictrans.test.js
@@ -125,7 +125,7 @@ for (const deviceConfig of DEVICE_CONFIGS) {
       if (model) {
         try {
           await model.unload()
-	  t.pass(`${label} After model.unload().`)
+          t.pass(`${label} After model.unload().`)
         } catch (e) {
           t.comment(`${label} unload() error: ` + e.message)
         }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The nmtcpp `sanity-checks` job used a direct `actions/checkout` of `github.event.pull_request.head.repo.full_name` without fork fallback, causing CI failures on PRs from forks
- It was the only addon with an inline sanity-checks implementation; all others use the shared reusable action

## 📝 How does it solve it?

- Replaced the inline checkout + custom sanity-check steps with the shared `tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update` action, consistent with llamacpp-llm, llamacpp-embed, whispercpp, parakeet, onnx-tts, and decoder-audio

## 🧪 How was it tested?

- Verified workflow YAML syntax
- Compared structure against working `on-pr-qvac-lib-infer-whispercpp.yml` and `on-pr-qvac-lib-infer-llamacpp-llm.yml` workflows
- Manually ran on temp branch to confirm it works: https://github.com/tetherto/qvac/actions/runs/22352835590