### PR TITLE
fix: allow workflow_dispatch to trigger publish-release-npm

### DIFF
--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -147,7 +147,7 @@ jobs:
 
   publish-release-npm:
     needs: [publish-logic, release-merge-guard]
-    if: needs.publish-logic.outputs.publish_release == 'true'
+    if: "!failure() && !cancelled() && needs.publish-logic.outputs.publish_release == 'true'"
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -147,7 +147,7 @@ jobs:
 
   publish-release-npm:
     needs: [publish-logic, release-merge-guard]
-    if: needs.publish-logic.outputs.publish_release == 'true'
+    if: "!failure() && !cancelled() && needs.publish-logic.outputs.publish_release == 'true'"
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Summary

- Fix `publish-release-npm` being skipped when triggered via `workflow_dispatch` on `release-*` branches
- The `release-merge-guard` job only runs on `push` events, causing the dependent `publish-release-npm` to be skipped on `workflow_dispatch`
- Use `!failure() && !cancelled()` condition so the publish job runs when the guard is skipped but still blocks when it fails

## Affected workflows

- `on-merge-qvac-lib-infer-parakeet.yml`
- `on-merge-qvac-lib-infer-whispercpp.yml`

## Context

This was introduced in PR #508 which added the `release-merge-guard` dependency. The previous whispercpp 0.4.0 release worked because it ran before #508 was merged.

Made with [Cursor](https://cursor.com)