### PR TITLE
chore: trigger release pipeline for parakeet 0.1.8

### DIFF
--- a/packages/qvac-lib-infer-parakeet/release-notes/v0.1.8.md
+++ b/packages/qvac-lib-infer-parakeet/release-notes/v0.1.8.md
@@ -17,4 +17,3 @@ ONNX Runtime resolves external data files relative to the model file's directory
 ## Backward Compatibility
 
 No API or behavioral changes. All existing callers continue to work without modification.
-


### PR DESCRIPTION
Trigger commit to kick off the parakeet 0.1.8 npm release pipeline.

Removes the extra trailing newline from release notes — no functional change.
