### PR TITLE
docs(nmtcpp): add v0.3.9 release notes

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.9] - 2026-02-25
+
+### Fixed
+- Batch run API fix for correct batch translation handling (#549)
+- Replaced inline sanity-checks with shared reusable action for fork PR compatibility (#521)
+- Updated addon-cpp version constraint to match actual 1.x API usage (#520)
+
 ## [0.3.1] - 2026-01-13
 
 ### Added

--- a/packages/qvac-lib-infer-nmtcpp/release-notes/v0.3.9.md
+++ b/packages/qvac-lib-infer-nmtcpp/release-notes/v0.3.9.md
@@ -1,0 +1,23 @@
+# QVAC NMT Addon v0.3.9 Release Notes
+
+This release fixes the batch translation API, improves CI reliability for fork PRs, and corrects the addon-cpp version constraint.
+
+## Bug Fixes
+
+### Batch Run API Fix
+
+Fixed the batch run API to correctly handle batch translation requests. The batch example has been updated to reflect the corrected usage, and translation logic in `index.js` has been consolidated from `marian.js` for better maintainability.
+
+### CI Sanity-Checks for Fork PRs
+
+Replaced the inline sanity-checks job with the shared reusable action used by all other addons. The previous implementation failed on fork PRs due to missing fork fallback in the checkout step.
+
+### addon-cpp Version Constraint
+
+Updated the vcpkg.json addon-cpp version constraint from `>= 0.12.2` to match the actual 1.x API usage (AddonJs, JsInterface, OutputCallBackJs). Also deduplicated the qvac-lint-cpp entry and bumped it to `>= 1.4.4`.
+
+## Pull Requests
+
+- [#520](https://github.com/tetherto/qvac/pull/520) - fix(nmtcpp): update addon-cpp version constraint to match actual 1.x API usage
+- [#521](https://github.com/tetherto/qvac/pull/521) - fix(nmtcpp): replace inline sanity-checks with reusable action
+- [#549](https://github.com/tetherto/qvac/pull/549) - QVAC-13481: fix batch run API


### PR DESCRIPTION
## Summary
- Add release notes file (`release-notes/v0.3.9.md`) for NMT addon v0.3.9
- Add v0.3.9 changelog entry covering:
  - Batch run API fix (#549)
  - CI sanity-checks reusable action migration (#521)
  - addon-cpp version constraint correction (#520)

## Test plan
- [ ] Verify release notes file format matches existing conventions
- [ ] Verify changelog entry is correctly formatted