### PR TITLE
QVAC-13491 feat[api]: add downloadBlob for direct blob download without metadata sync

### DIFF
--- a/packages/qvac-lib-registry-server/client/README.md
+++ b/packages/qvac-lib-registry-server/client/README.md
@@ -1,4 +1,4 @@
-# @tetherto/qvac-lib-registry-client
+# @qvac/registry-client
 
 Read-only client library for querying the QVAC Registry. It replicates the registry HyperDB via Hyperswarm and provides APIs for searching and retrieving model information.
 
@@ -13,7 +13,7 @@ Read-only client library for querying the QVAC Registry. It replicates the regis
 ## Installation
 
 ```bash
-npm install @tetherto/qvac-lib-registry-client
+npm install @qvac/registry-client
 ```
 
 Ensure the registry core key is available via environment variables or provided via options.
@@ -24,7 +24,7 @@ Ensure the registry core key is available via environment variables or provided 
 
 ```javascript
 'use strict'
-const { QVACRegistryClient } = require('@tetherto/qvac-lib-registry-client')
+const { QVACRegistryClient } = require('@qvac/registry-client')
 
 async function main () {
   const client = new QVACRegistryClient({
@@ -106,18 +106,45 @@ const fs = require('fs')
 result.artifact.stream.pipe(fs.createWriteStream('./model.ggml'))
 ```
 
+#### Direct Blob Download
+
+- `downloadBlob(blobBinding, options)`: Downloads a blob directly using known blob coordinates, bypassing the metadata core lookup. Useful when `coreKey`, `blockOffset`, `blockLength`, and `byteLength` are already known (e.g., from a previous query or generated model constants).
+  - `blobBinding`: `{ coreKey, blockOffset, blockLength, byteOffset, byteLength }` — `coreKey` accepts Buffer, hex, or z-base-32 strings
+  - `options`:
+    - `timeout`: Download timeout in ms (default: 30000)
+    - `outputFile`: Optional file path to save directly to disk
+    - `onProgress`: Callback `({ downloaded, total, cachedBlocks, totalBlocks }) => void`
+    - `signal`: `AbortSignal` for cancellation
+  - Returns: `{ artifact: { path, totalSize } | { stream, totalSize } }`
+
+This method only waits for the network layer (Corestore + Hyperswarm) — it does not wait for the metadata core to sync, making it faster for known blob coordinates.
+
+```javascript
+const result = await client.downloadBlob({
+  coreKey: 'ey46cahego89xox118uhyryakz47bcs8bbxu97tnnpmuwmgi5wmo',
+  blockOffset: 0,
+  blockLength: 665,
+  byteOffset: 0,
+  byteLength: 43537433
+}, {
+  outputFile: './downloaded/ggml-tiny-q8_0.bin',
+  timeout: 60000
+})
+console.log('Downloaded to:', result.artifact.path)
+```
+
 ## CLI
 
 The package includes a CLI for querying and downloading models from the registry.
 
 ### Install
 
-The package is hosted on GitHub Packages. Configure npm to use the GitHub registry for the `@tetherto` scope, then install globally:
+The package is hosted on npm. Configure npm to use the registry for the `@qvac` scope, then install globally:
 
 ```bash
-echo "@tetherto:registry=https://npm.pkg.github.com" >> ~/.npmrc
-echo "//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT" >> ~/.npmrc
-npm install -g @tetherto/registry-client-mono
+echo "@qvac:registry=https://registry.npmjs.org" >> ~/.npmrc
+echo "//registry.npmjs.org/:_authToken=YOUR_NPM_TOKEN" >> ~/.npmrc
+npm install -g @qvac/registry-client
 ```
 
 Verify installation:
@@ -220,7 +247,8 @@ $ qvac-registry list --engine @qvac/transcription-whispercpp --json | jq '.[0].p
 See the `examples/` folder for complete working examples:
 
 - `example.js`: List models, query by engine/name/quantization, find shards
-- `download-model.js`: Download a single model to disk
+- `download-model.js`: Download a single model to disk via metadata lookup
+- `download-blob.js`: Download a blob directly using known blob coordinates
 - `download-all-models.js`: Download all models in the registry
 
 Run examples:
@@ -229,6 +257,7 @@ Run examples:
 cd client
 node examples/example.js
 node examples/download-model.js
+node examples/download-blob.js
 node examples/download-all-models.js
 ```
 
@@ -271,8 +300,8 @@ The client uses custom error codes in the range 19001-20000. All errors extend `
 ### Error Handling Example
 
 ```javascript
-const { QVACRegistryClient } = require('@tetherto/qvac-lib-registry-client')
-const { QvacErrorRegistryClient } = require('@tetherto/qvac-lib-registry-client/utils/error')
+const { QVACRegistryClient } = require('@qvac/registry-client')
+const { QvacErrorRegistryClient } = require('@qvac/registry-client/utils/error')
 
 async function handleErrors () {
   const client = new QVACRegistryClient({

--- a/packages/qvac-lib-registry-server/client/examples/download-blob.js
+++ b/packages/qvac-lib-registry-server/client/examples/download-blob.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const path = require('path')
+require('dotenv').config({ path: path.resolve(__dirname, '../../.env') })
+
+const { QVACRegistryClient } = require('../index')
+const os = require('os')
+
+// ggml-tiny-q8_0.bin from output.json (~43MB, 665 blocks)
+const WHISPER_TINY_Q8 = {
+  coreKey: 'ey46cahego89xox118uhyryakz47bcs8bbxu97tnnpmuwmgi5wmo',
+  blockOffset: 0,
+  blockLength: 665,
+  byteOffset: 0,
+  byteLength: 43537433,
+  sha256: 'c2085835d3f50733e2ff6e4b41ae8a2b8d8110461e18821b09a15c40c42d1cca'
+}
+
+async function downloadBlobExample () {
+  const t0 = Date.now()
+
+  const tmpStorage = path.join(os.tmpdir(), `qvac-registry-blob-${Date.now()}`)
+  const client = new QVACRegistryClient({
+    registryCoreKey: process.env.QVAC_REGISTRY_CORE_KEY,
+    storage: tmpStorage
+  })
+
+  console.log('Using temporary storage:', tmpStorage)
+  console.log('Waiting for client.ready() (includes metadata core sync)...')
+
+  await client.ready()
+  const tReady = Date.now()
+  console.log(`[TIMING] client.ready() took ${tReady - t0}ms`)
+
+  const outputFile = path.join(process.cwd(), 'downloaded', 'ggml-tiny-q8_0.bin')
+
+  console.log(`\nDownloading blob directly (${(WHISPER_TINY_Q8.byteLength / 1024 / 1024).toFixed(1)} MB)...`)
+  const tDownloadStart = Date.now()
+
+  const result = await client.downloadBlob(WHISPER_TINY_Q8, {
+    timeout: 60000,
+    outputFile
+  })
+
+  const tDone = Date.now()
+
+  console.log('\nArtifact saved to:', result.artifact.path)
+  console.log(`Total size: ${(result.artifact.totalSize / 1024 / 1024).toFixed(1)} MB`)
+
+  console.log('\n--- Timing Summary ---')
+  console.log(`client.ready() (metadata core sync): ${tReady - t0}ms`)
+  console.log(`Blob download:                       ${tDone - tDownloadStart}ms`)
+  console.log(`Total wall time:                     ${tDone - t0}ms`)
+
+  await client.close()
+}
+
+downloadBlobExample().catch(console.error)

--- a/packages/qvac-lib-registry-server/client/examples/download-model.js
+++ b/packages/qvac-lib-registry-server/client/examples/download-model.js
@@ -7,6 +7,8 @@ const { QVACRegistryClient } = require('../index')
 const os = require('os')
 
 async function downloadModelExample () {
+  const t0 = Date.now()
+
   const tmpStorage = path.join(os.tmpdir(), `qvac-registry-download-${Date.now()}`)
   const client = new QVACRegistryClient({
     registryCoreKey: process.env.QVAC_REGISTRY_CORE_KEY,
@@ -14,10 +16,16 @@ async function downloadModelExample () {
   })
 
   console.log('Using temporary storage:', tmpStorage)
+  console.log('Waiting for client.ready() (includes metadata core sync)...')
 
-  console.log('Connected to registry...\n')
+  await client.ready()
+  const tReady = Date.now()
+  console.log(`[TIMING] client.ready() took ${tReady - t0}ms\n`)
 
   const models = await client.findModels({})
+  const tQuery = Date.now()
+  console.log(`[TIMING] findModels query took ${tQuery - tReady}ms`)
+
   if (models.length === 0) {
     console.log('No models available to download.')
     return
@@ -28,15 +36,22 @@ async function downloadModelExample () {
 
   const outputFile = path.join(process.cwd(), 'downloaded', path.basename(targetModel.path))
 
+  const tDownloadStart = Date.now()
   const result = await client.downloadModel(targetModel.path, targetModel.source, {
     timeout: 60000,
     peerTimeout: 15000,
     outputFile
   })
+  const tDone = Date.now()
 
-  console.log('\n✅ Model downloaded successfully!')
-  console.log('Model metadata:', result.model)
+  console.log('\nModel downloaded successfully!')
   console.log('Artifact saved to:', result.artifact.path)
+
+  console.log('\n--- Timing Summary ---')
+  console.log(`client.ready() (metadata core sync): ${tReady - t0}ms`)
+  console.log(`findModels query:                    ${tQuery - tReady}ms`)
+  console.log(`downloadModel (lookup + transfer):   ${tDone - tDownloadStart}ms`)
+  console.log(`Total wall time:                     ${tDone - t0}ms`)
 
   await client.close()
 }

--- a/packages/qvac-lib-registry-server/client/index.d.ts
+++ b/packages/qvac-lib-registry-server/client/index.d.ts
@@ -1,5 +1,5 @@
 export interface QVACBlobBinding {
-  coreKey: Buffer
+  coreKey: Buffer | string
   blockOffset: number
   blockLength: number
   byteOffset: number
@@ -43,6 +43,17 @@ export interface QVACDownloadOptions {
   outputFile?: string
 }
 
+export interface QVACBlobDownloadOptions {
+  timeout?: number
+  outputFile?: string
+  onProgress?: (progress: { downloaded: number, total: number, cachedBlocks: number, totalBlocks: number }) => void
+  signal?: AbortSignal
+}
+
+export interface QVACBlobDownloadResult {
+  artifact: QVACDownloadedArtifact & { totalSize: number }
+}
+
 export interface QVACRegistryClientOptions {
   storage?: string
   registryCoreKey?: string
@@ -75,6 +86,7 @@ export class QVACRegistryClient {
 
   getModel (path: string, source: string): Promise<QVACModelEntry | null>
   downloadModel (path: string, source: string, options?: QVACDownloadOptions): Promise<QVACDownloadResult>
+  downloadBlob (blobBinding: QVACBlobBinding, options?: QVACBlobDownloadOptions): Promise<QVACBlobDownloadResult>
 
   findBy (params?: FindByParams): Promise<QVACModelEntry[]>
   findModels (query?: QVACModelQuery): Promise<QVACModelEntry[]>

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -23,6 +23,7 @@ class QVACRegistryClient extends ReadyResource {
     this.corestore = null
     this.hyperswarm = null
     this._connectionHandler = null
+    this._metadataReady = null
 
     this.storage = this.registryConfig.getRegistryStorage(opts.storage)
     this.registryCoreKey = this.registryConfig.getRegistryCoreKey(opts.registryCoreKey)
@@ -38,11 +39,6 @@ class QVACRegistryClient extends ReadyResource {
   async _open () {
     this.logger.debug('_open called')
 
-    if (!this.registryCoreKey) {
-      this.logger.error('Missing registry core key for read mode')
-      throw new QvacErrorRegistryClient({ code: ERR_CODES.FAILED_TO_CONNECT, adds: 'Missing registry core key. Set QVAC_REGISTRY_CORE_KEY environment variable.' })
-    }
-
     this.logger.debug('Creating corestore for open')
     this.corestore = new Corestore(this.storage)
     await this.corestore.ready()
@@ -56,6 +52,15 @@ class QVACRegistryClient extends ReadyResource {
     }
     this.hyperswarm.on('connection', this._connectionHandler)
 
+    this._metadataReady = this._connectMetadataCore()
+  }
+
+  async _connectMetadataCore () {
+    if (!this.registryCoreKey) {
+      this.logger.error('Missing registry core key for read mode')
+      throw new QvacErrorRegistryClient({ code: ERR_CODES.FAILED_TO_CONNECT, adds: 'Missing registry core key. Set QVAC_REGISTRY_CORE_KEY environment variable.' })
+    }
+
     const viewKey = IdEnc.decode(this.registryCoreKey)
     const viewCore = this.corestore.get({ key: viewKey })
     await viewCore.ready()
@@ -65,19 +70,28 @@ class QVACRegistryClient extends ReadyResource {
       discoveryKey: IdEnc.normalize(viewCore.discoveryKey)
     })
 
+    const foundPeers = viewCore.findingPeers()
     this.hyperswarm.join(viewCore.discoveryKey, { client: true, server: false })
-    await this.hyperswarm.flush()
+    this.hyperswarm.flush().then(() => foundPeers())
 
     this.logger.debug('Waiting for view core sync')
-    await viewCore.update({ wait: true })
+    await viewCore.update()
 
     this.logger.debug('Creating RegistryDatabase from view core')
     this.db = new RegistryDatabase(viewCore, { extension: false })
     await this.db.ready()
 
-    this.logger.debug('QVACRegistryClient ready', {
+    this.logger.debug('QVACRegistryClient metadata ready', {
       length: viewCore.length
     })
+  }
+
+  async _ensureMetadata () {
+    await this.ready()
+    await this._metadataReady
+    if (!this.db) {
+      throw new QvacErrorRegistryClient({ code: ERR_CODES.FAILED_TO_CONNECT, adds: 'Registry database not available.' })
+    }
   }
 
   async getModel (path, source) {
@@ -86,7 +100,7 @@ class QVACRegistryClient extends ReadyResource {
 
     try {
       this.logger.info('Getting model', { path, source })
-      await this.ready()
+      await this._ensureMetadata()
 
       const result = await this.db.getModel(path, source)
       this.logger.debug('getModel result', { result })
@@ -98,7 +112,7 @@ class QVACRegistryClient extends ReadyResource {
   }
 
   async findModels (query = {}, opts = {}) {
-    await this.ready()
+    await this._ensureMetadata()
     const { includeDeprecated = false } = opts
     this.logger.debug('findModels called', { query, includeDeprecated })
 
@@ -112,19 +126,19 @@ class QVACRegistryClient extends ReadyResource {
   }
 
   async findModelsByEngine (query = {}) {
-    await this.ready()
+    await this._ensureMetadata()
     this.logger.debug('findModelsByEngine called', { query })
     return this.db.findModelsByEngine(query).toArray()
   }
 
   async findModelsByName (query = {}) {
-    await this.ready()
+    await this._ensureMetadata()
     this.logger.debug('findModelsByName called', { query })
     return this.db.findModelsByName(query).toArray()
   }
 
   async findModelsByQuantization (query = {}) {
-    await this.ready()
+    await this._ensureMetadata()
     this.logger.debug('findModelsByQuantization called', { query })
     return this.db.findModelsByQuantization(query).toArray()
   }
@@ -140,7 +154,7 @@ class QVACRegistryClient extends ReadyResource {
    * @returns {Promise<Array>} Array of matching models
    */
   async findBy (params = {}) {
-    await this.ready()
+    await this._ensureMetadata()
     this.logger.debug('findBy called', { params })
     return this.db.findBy(params)
   }
@@ -169,9 +183,14 @@ class QVACRegistryClient extends ReadyResource {
   }
 
   async _getBlobsCore (blobsCoreKey) {
-    const keyBuffer = Buffer.isBuffer(blobsCoreKey)
-      ? blobsCoreKey
-      : Buffer.from(blobsCoreKey.data || blobsCoreKey, 'hex')
+    let keyBuffer
+    if (Buffer.isBuffer(blobsCoreKey)) {
+      keyBuffer = blobsCoreKey
+    } else if (typeof blobsCoreKey === 'object' && blobsCoreKey.data) {
+      keyBuffer = Buffer.from(blobsCoreKey.data)
+    } else {
+      keyBuffer = IdEnc.decode(blobsCoreKey)
+    }
 
     this.logger.debug('Creating hyperblobs core', {
       blobCore: IdEnc.normalize(keyBuffer)
@@ -198,7 +217,7 @@ class QVACRegistryClient extends ReadyResource {
 
     try {
       this.logger.info('Downloading model', { path, source })
-      await this.ready()
+      await this._ensureMetadata()
 
       const model = await this.getModel(path, source)
       if (!model) {
@@ -219,10 +238,11 @@ class QVACRegistryClient extends ReadyResource {
         discoveryKey: IdEnc.normalize(core.discoveryKey)
       })
 
+      const foundBlobPeers = core.findingPeers()
       this.hyperswarm.join(core.discoveryKey, { client: true, server: false })
-      await this.hyperswarm.flush()
+      this.hyperswarm.flush().then(() => foundBlobPeers())
 
-      await core.update({ wait: true })
+      await core.update()
       this.logger.debug('Blobs core updated')
 
       const totalSize = model.blobBinding.byteLength
@@ -283,6 +303,107 @@ class QVACRegistryClient extends ReadyResource {
           await core.close()
         } catch (cleanupError) {
           this.logger.warn('Error closing blob core on error', { error: cleanupError.message })
+        }
+      }
+
+      throw error
+    }
+  }
+
+  async downloadBlob (blobBinding, options = {}) {
+    if (!blobBinding || !blobBinding.coreKey) {
+      throw new Error('Invalid blobBinding: coreKey is required')
+    }
+    if (typeof blobBinding.blockOffset !== 'number' ||
+        typeof blobBinding.blockLength !== 'number' ||
+        typeof blobBinding.byteLength !== 'number') {
+      throw new Error('Invalid blobBinding: blockOffset, blockLength, and byteLength are required numbers')
+    }
+
+    if (options && typeof options !== 'object') {
+      throw new Error(`Invalid options: ${typeof options}`)
+    }
+
+    let core, blobs
+
+    try {
+      this.logger.info('Downloading blob directly', {
+        coreKey: typeof blobBinding.coreKey === 'string' ? blobBinding.coreKey.slice(0, 12) + '...' : '(buffer)',
+        blockOffset: blobBinding.blockOffset,
+        blockLength: blobBinding.blockLength,
+        byteLength: blobBinding.byteLength
+      })
+
+      await this.ready()
+
+      const blobsCore = await this._getBlobsCore(blobBinding.coreKey)
+      core = blobsCore.core
+      blobs = blobsCore.blobs
+
+      this.logger.debug('Joining swarm for blobs core (direct)', {
+        discoveryKey: IdEnc.normalize(core.discoveryKey)
+      })
+
+      const foundBlobPeers = core.findingPeers()
+      this.hyperswarm.join(core.discoveryKey, { client: true, server: false })
+      this.hyperswarm.flush().then(() => foundBlobPeers())
+
+      await core.update()
+      this.logger.debug('Blobs core updated (direct)')
+
+      const pointer = {
+        blockOffset: blobBinding.blockOffset,
+        blockLength: blobBinding.blockLength,
+        byteOffset: blobBinding.byteOffset || 0,
+        byteLength: blobBinding.byteLength
+      }
+      const totalSize = blobBinding.byteLength
+
+      let artifact
+      if (options.outputFile) {
+        await this._streamBlobToFile(blobs, core, pointer, options.outputFile, options)
+        artifact = { path: options.outputFile, totalSize }
+
+        if (blobs) await blobs.close()
+        if (core) await core.close()
+      } else {
+        const stream = blobs.createReadStream(pointer, {
+          wait: true,
+          timeout: options.timeout || 30000
+        })
+        artifact = { stream, totalSize }
+
+        const cleanup = async () => {
+          if (blobs) {
+            try { await blobs.close() } catch (e) {
+              this.logger.warn('Error closing blob instance', { error: e.message })
+            }
+          }
+          if (core) {
+            try { await core.close() } catch (e) {
+              this.logger.warn('Error closing blob core', { error: e.message })
+            }
+          }
+          this.logger.debug('Blob resources closed after stream end')
+        }
+
+        stream.on('close', cleanup)
+      }
+
+      this.logger.info('Blob download complete (direct)')
+
+      return { artifact }
+    } catch (error) {
+      this.logger.error('Error downloading blob directly', error)
+
+      if (blobs) {
+        try { await blobs.close() } catch (e) {
+          this.logger.warn('Error closing blob instance on error', { error: e.message })
+        }
+      }
+      if (core) {
+        try { await core.close() } catch (e) {
+          this.logger.warn('Error closing blob core on error', { error: e.message })
         }
       }
 
@@ -367,6 +488,11 @@ class QVACRegistryClient extends ReadyResource {
 
   async _close () {
     this.logger.debug('_close called')
+
+    if (this._metadataReady) {
+      await this._metadataReady.catch(() => {})
+      this._metadataReady = null
+    }
 
     if (this.db) {
       this.logger.debug('Closing database')

--- a/packages/qvac-lib-registry-server/client/tests/unit/client.api.test.js
+++ b/packages/qvac-lib-registry-server/client/tests/unit/client.api.test.js
@@ -9,6 +9,7 @@ test('client api surface', async t => {
   t.ok(typeof QVACRegistryClient === 'function', 'QVACRegistryClient is a constructor')
   t.ok(QVACRegistryClient.prototype.getModel, 'has getModel method')
   t.ok(QVACRegistryClient.prototype.downloadModel, 'has downloadModel method')
+  t.ok(QVACRegistryClient.prototype.downloadBlob, 'has downloadBlob method')
   t.ok(QVACRegistryClient.prototype.findModels, 'has findModels method')
   t.ok(QVACRegistryClient.prototype.findModelsByEngine, 'has findModelsByEngine method')
   t.ok(QVACRegistryClient.prototype.findModelsByName, 'has findModelsByName method')

--- a/packages/qvac-lib-registry-server/client/tests/unit/client.errors.test.js
+++ b/packages/qvac-lib-registry-server/client/tests/unit/client.errors.test.js
@@ -66,6 +66,34 @@ test('client error - invalid source parameter', async t => {
   }
 })
 
+test('downloadBlob - rejects missing coreKey', async t => {
+  t.plan(3)
+
+  const QVACRegistryClient = require('../../lib/client')
+  const testClient = Object.create(QVACRegistryClient.prototype)
+
+  try {
+    await testClient.downloadBlob(null)
+    t.fail('Should have thrown')
+  } catch (error) {
+    t.ok(error.message.includes('coreKey is required'), 'Throws for null blobBinding')
+  }
+
+  try {
+    await testClient.downloadBlob({})
+    t.fail('Should have thrown')
+  } catch (error) {
+    t.ok(error.message.includes('coreKey is required'), 'Throws for missing coreKey')
+  }
+
+  try {
+    await testClient.downloadBlob({ coreKey: 'abc', blockOffset: 'not-a-number', blockLength: 0, byteLength: 0 })
+    t.fail('Should have thrown')
+  } catch (error) {
+    t.ok(error.message.includes('required numbers'), 'Throws for non-number offsets')
+  }
+})
+
 test('client error - invalid options parameter', async t => {
   t.plan(1)
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

When blob coordinates (coreKey, blockOffset, blockLength, byteLength) are already known — e.g. from generated model constants in the SDK — `downloadModel` still forces a full metadata core sync (~4s swarm discovery + view core update) before it can start the actual download.

## 🛠 How does it solve it?

- Split `_open()` into two phases: fast network init (Corestore + Hyperswarm) that resolves immediately, and `_connectMetadataCore()` that runs concurrently in the background
- Add `downloadBlob(blobBinding, options)` method that only waits for the network layer, bypassing metadata core sync entirely
- All metadata-dependent methods (`getModel`, `findModels`, `findBy`, `downloadModel`, etc.) use `_ensureMetadata()` which awaits the metadata connection — preserving existing behavior
- `_getBlobsCore` now handles z-base-32 keys via `IdEnc.decode` in addition to hex and Buffer inputs

## New API

```javascript
const result = await client.downloadBlob({
  coreKey: 'ey46cahego89xox118uhyryakz47bcs8bbxu97tnnpmuwmgi5wmo',
  blockOffset: 0,
  blockLength: 665,
  byteOffset: 0,
  byteLength: 43537433
}, {
  outputFile: './model.bin',
  timeout: 60000,
  onProgress: ({ downloaded, total }) => console.log(`${downloaded}/${total}`)
})
```

## Breaking changes

None. Existing `downloadModel` and all query methods behave identically.

## How was it tested

- Unit tests for `downloadBlob` input validation and API surface (brittle)
- Manual comparison via timing examples (`download-blob.js` vs `download-model.js`): `client.ready()` dropped from ~4s to ~52ms for blob-only path