### PR TITLE
release(qvac-registry-client): v0.2.0

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.2.0]
+
+Release Date: 2026-02-26
+
+### ✨ Features
+
+- Add `downloadBlob(blobBinding, options)` method for direct blob download without metadata core sync — bypasses ~4s swarm discovery when blob coordinates are already known (#556)
+- Split `_open()` into fast network init and background metadata connection for improved startup latency (#556)
+
+### 🔧 Changed
+
+- `_getBlobsCore` now accepts z-base-32 encoded keys via `IdEnc.decode` in addition to hex and Buffer inputs (#556)
+
 ## [0.1.8]
 
 Release Date: 2026-02-25

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## What problem does this PR solve?

Releases @qvac/registry-client v0.2.0 with the new `downloadBlob` API that allows direct blob download without metadata core sync, cutting `client.ready()` from ~4s to ~52ms when blob coordinates are already known.

## How does it solve it?

- Bumps `package.json` version to `0.2.0`
- Updates `CHANGELOG.md` with features from #556: `downloadBlob` method, split `_open()` phases, z-base-32 key support in `_getBlobsCore`

## Breaking changes

None.
