### PR TITLE
QVAC-13378 Model Metadata

### DIFF
--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -177,14 +177,46 @@ jobs:
         shell: bash
         working-directory: ${{ env.WORKDIR }}
         run: |
-          echo "Creating models directory..."
           mkdir -p models/unit-test
-          echo "Downloading Llama-3.2-1B-Instruct-Q4_0.gguf from Hugging Face..."
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_0.gguf" -o models/unit-test/Llama-3.2-1B-Instruct-Q4_0.gguf
-          echo "Downloading SmolVLM-500M-Instruct-Q8_0.gguf from Hugging Face..."
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/SmolVLM2-500M-Video-Instruct-Q8_0.gguf" -o models/unit-test/SmolVLM-500M-Instruct-Q8_0.gguf
-          echo "Downloading mmproj-SmolVLM-500M-Instruct-Q8_0.gguf from Hugging Face..."
-          curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf" -o models/unit-test/mmproj-SmolVLM-500M-Instruct-Q8_0.gguf
+
+          HF="https://huggingface.co"
+          ODIR="models/unit-test"
+
+          hf_download() {
+            local repo="$1"               # owner/repo
+            local file="$2"               # filename on HF main branch
+            local dest_dir="${3:-$ODIR}"  # destination directory
+            local out_file="${4:-$file}"  # optional output filename (defaults to file)
+            echo "Downloading ${file} from ${HF}/${repo}..."
+            curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "${HF}/${repo}/resolve/main/${file}" -o "${dest_dir}/${out_file}"
+          }
+
+          hf_download_shards() {
+            local repo="$1"               # owner/repo
+            local pattern="$2"            # printf pattern, e.g. "MyModel-%05d-of-%05d.gguf"
+            local total="$3"              # total number of shards
+            local dest_dir="${4:-$ODIR}"  # destination directory
+            echo "Downloading $(printf "$pattern" 1 "$total") shards (${total} of ${total}) from ${HF}/${repo}..."
+            for i in $(seq 1 "$total"); do
+              local shard
+              shard=$(printf "$pattern" "$i" "$total")
+              curl -L --fail --retry 3 --retry-all-errors --retry-delay 2 "${HF}/${repo}/resolve/main/${shard}" -o "${dest_dir}/${shard}"
+            done
+          }
+
+          hf_download "bartowski/Llama-3.2-1B-Instruct-GGUF" "Llama-3.2-1B-Instruct-Q4_0.gguf"
+          hf_download "ggml-org/SmolVLM2-500M-Video-Instruct-GGUF" "SmolVLM2-500M-Video-Instruct-Q8_0.gguf" "$ODIR" "SmolVLM-500M-Instruct-Q8_0.gguf"
+          hf_download "ggml-org/SmolVLM2-500M-Video-Instruct-GGUF" "mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf" "$ODIR" "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf"
+          hf_download "Qwen/Qwen3-0.6B-GGUF" "Qwen3-0.6B-Q8_0.gguf"
+
+          hf_download_shards "jmb95/Qwen3-0.6B-UD-IQ1_S-sharded" "Qwen3-0.6B-UD-IQ1_S-%05d-of-%05d.gguf" 3
+          hf_download "jmb95/Qwen3-0.6B-UD-IQ1_S-sharded" "Qwen3-0.6B-UD-IQ1_S.tensors.txt"
+
+          hf_download "gianni-cor/bitnet_b1_58-large-TQ2_0" "bitnet_b1_58-large-TQ2_0.gguf"
+
+          hf_download_shards "jmb95/bitnet_b1_58-large-TQ2_0-sharded" "bitnet_b1_58-large-TQ2_0-%05d-of-%05d.gguf" 8
+          hf_download "jmb95/bitnet_b1_58-large-TQ2_0-sharded" "bitnet_b1_58-large-TQ2_0.tensors.txt"
+
           echo "Verify downloaded models..."
           ls -lh models/unit-test/
           du -sh models/unit-test/*

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "7248.1.2"
+      "version>=": "7248.1.3"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",

--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,4 +1,23 @@
 # Changelog
+## [0.10.0] - 2026-03-02
+
+### Added
+
+#### Model metadata querying via LlamaModel
+
+`LlamaModel` now exposes `ModelMetaData`, which parses GGUF key-values at init time (before weights are fully loaded) and makes them available for early decisions such as quantization detection and backend selection. Queries are available through `tryGetU32()`, `isU32OneOf()`, and `hasOneBitQuantization()`.
+
+#### ModelMetaData streaming synchronization
+
+For streaming model loads, `ModelMetaData` coordinates with `AsyncWeightsLoader` to borrow the first shard buffer. The synchronization state is encapsulated in a public nested class `ModelMetaData::FirstFileFromGgufStreamState` with `waitForRelease()` and `provide()` methods, protected by a mutex and condition variable. Both the consumer and producer waits are bounded by configurable timeouts.
+
+### Fixed
+
+#### GGUF streambuf reader fails to align data section (Fabric 1.1.3 upgrade)
+
+Fixed a bug in the GGUF buffer reader (`gguf_bytes_buffer_reader::align`) where `pubseekoff` was called without specifying a direction (`std::ios_base::in`). The default `which` parameter is `ios_base::in | ios_base::out`, and per the C++ spec, `std::stringbuf::seekoff` with `way=cur` and both directions set always returns `-1` — regardless of the streambuf's open mode. This caused `"gguf_init_from_reader_impl: failed to align data section"` when loading model metadata from an in-memory stream (e.g. during streaming model loads), while the disk-backed `FILE*` path was unaffected because `fseek` has no direction concept.
+
+The fix passes `std::ios_base::in` explicitly to `pubseekoff` in the llamacpp tether layer. This low-level alignment fix stems from the upgrade to Fabric 1.1.3.
 
 ## [0.9.2] - 2026-03-03
 

--- a/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
@@ -62,11 +62,13 @@ endif()
   )
 
   list(APPEND ADDON_SOURCES
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/AsyncWeightsLoader.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/CacheManager.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MtmdLlmContext.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/TextLlmContext.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/LoggingMacros.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/BackendSelection.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/ChatTemplateUtils.cpp
@@ -104,11 +106,13 @@ if(BUILD_CLI)
   # Cache management integration test with automatic model download
   add_executable(cli_tool
     ${PROJECT_SOURCE_DIR}/addon/src/cli/cli_tool.cc
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/AsyncWeightsLoader.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/CacheManager.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MtmdLlmContext.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/TextLlmContext.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/LoggingMacros.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/BackendSelection.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/utils/ChatTemplateUtils.cpp

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/LlmErrors.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/LlmErrors.hpp
@@ -28,6 +28,7 @@ enum LlmErrorCode : uint32_t {
   UserMessageNotProvided = 20,
   MediaRequestNotProvided = 21,
   UnableToDeleteThreadPool = 22,
+  UnableToLoadMetadata = 23,
   // mode llm spesific errors here
 };
 
@@ -75,6 +76,8 @@ inline std::string toString(LlmErrorCode code) {
     return "UserMessageNotProvided";
   case MediaRequestNotProvided:
     return "MediaRequestNotProvided";
+  case UnableToLoadMetadata:
+    return "UnableToLoadMetadata";
   default:
     return "UnknownLLMError";
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/AsyncWeightsLoader.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/AsyncWeightsLoader.cpp
@@ -1,0 +1,141 @@
+#include "model-interface/AsyncWeightsLoader.hpp"
+
+#include <chrono>
+
+#include "model-interface/ModelMetadata.hpp"
+
+using namespace qvac_lib_inference_addon_llama::errors;
+
+AsyncWeightsLoader::AsyncWeightsLoader(
+    const GGUFShards& shards, InitLoader& initLoader,
+    const std::string& loadingContext, ModelMetaData* modelMetadata)
+    : shards_(shards), initLoader_(initLoader), loadingContext_(loadingContext),
+      modelMetadata_(modelMetadata) {}
+
+void AsyncWeightsLoader::setWeightsForFile(
+    const std::string& filename, std::unique_ptr<Buf>&& shard) {
+  const std::filesystem::path filenamePath(filename);
+  isStreaming_ = true;
+
+  // Surface first-shard worker errors immediately.
+  if (firstShardWorker_.valid() &&
+      firstShardWorker_.wait_for(std::chrono::seconds(0)) ==
+          std::future_status::ready) {
+    firstShardWorker_.get();
+  }
+
+  if (shards_.gguf_files.empty()) {
+    auto [streamedFilesIt, inserted] =
+        streamedFiles_.emplace(filename, SharedBuffer(std::move(shard)));
+    if (!inserted) {
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          toString(UnableToLoadModel),
+          "Duplicate streamed shard filename: " + filename);
+    }
+    if (shouldLendFirstShard(filenamePath)) {
+      modelMetadata_->firstFileFromGgufStreamState.provide(
+          streamedFilesIt->second);
+    }
+    return;
+  }
+
+  if (modelMetadata_ == nullptr || isFirstShard(filenamePath)) {
+    // This will trigger the init method of LlamaModel
+    //
+    // When using metadata, it should only start whent the first
+    // shard is available. Because we do not want to time-out at init
+    // waiting for the first shard.
+    initLoader_.ensureLoadInBackground();
+  }
+
+  if (shouldLendFirstShard(filenamePath)) {
+    // Launch asynchronously so the calling (download) thread is not blocked
+    // while waiting for metadata to release the shard.
+    if (firstShardWorker_.valid()) {
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          toString(UnableToLoadModel),
+          "First-shard worker already started.");
+    }
+    firstShardWorker_ = std::async(
+        std::launch::async,
+        [this, filename, lambdaShard = std::move(shard)]() mutable {
+          auto shard = lendFirstShardAndWaitForRelease(std::move(lambdaShard));
+          fulfillSplitFuture(filename, std::move(shard));
+        });
+  } else {
+    fulfillSplitFuture(filename, std::move(shard));
+  }
+
+  // Make sure that last-shard checks if first-shard did complete successfully.
+  //
+  // A model is treated as sharded only when it has at least 2 shard files.
+  // `gguf_files` may still contain a single-GGUF path for non-sharded loads.
+  // In that case `isLastShard()` should evaluate false and this is a no-op.
+  if (isLastShard(filenamePath)) {
+    joinFirstShardWorker();
+  }
+}
+
+void AsyncWeightsLoader::joinFirstShardWorker() {
+  if (!firstShardWorker_.valid()) {
+    return;
+  }
+  firstShardWorker_.get();
+}
+
+std::map<std::string, std::unique_ptr<AsyncWeightsLoader::Buf>>
+AsyncWeightsLoader::extractIndividualStreamedFiles() {
+  joinFirstShardWorker();
+  std::map<std::string, std::unique_ptr<Buf>> extracted;
+  for (auto& [filename, shard] : streamedFiles_) {
+    extracted[filename] = shard.reclaimUnique();
+  }
+  return extracted;
+}
+
+bool AsyncWeightsLoader::hasIndividualStreamedFile(
+    const std::string& filename) const {
+  const std::string normalizedFilename =
+      std::filesystem::path(filename).filename().string();
+  return streamedFiles_.contains(normalizedFilename);
+}
+
+bool AsyncWeightsLoader::isFirstShard(
+    const std::filesystem::path& filenamePath) const {
+  const std::string normalizedFilename = filenamePath.filename().string();
+  const std::string firstShard =
+      shards_.gguf_files.empty()
+          ? normalizedFilename
+          : std::filesystem::path(shards_.gguf_files.front())
+                .filename()
+                .string();
+  return normalizedFilename == firstShard;
+}
+
+bool AsyncWeightsLoader::shouldLendFirstShard(
+    const std::filesystem::path& filenamePath) const {
+  return modelMetadata_ != nullptr && isFirstShard(filenamePath);
+}
+
+bool AsyncWeightsLoader::isLastShard(
+    const std::filesystem::path& filenamePath) const {
+  if (shards_.gguf_files.empty()) {
+    return false;
+  }
+  const std::string normalizedFilename = filenamePath.filename().string();
+  const std::string lastShard =
+      std::filesystem::path(shards_.gguf_files.back()).filename().string();
+  return normalizedFilename == lastShard;
+}
+
+std::unique_ptr<AsyncWeightsLoader::Buf>
+AsyncWeightsLoader::lendFirstShardAndWaitForRelease(
+    std::unique_ptr<Buf>&& shard) {
+  SharedBuffer lentShard(std::move(shard));
+  modelMetadata_->firstFileFromGgufStreamState.provide(lentShard);
+  modelMetadata_->firstFileFromGgufStreamState
+      .waitForRelease<METADATA_RELEASE_TIMEOUT_SEC>();
+  return lentShard.reclaimUnique();
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/AsyncWeightsLoader.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/AsyncWeightsLoader.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <filesystem>
+#include <future>
+#include <map>
+#include <memory>
+#include <streambuf>
+#include <string>
+
+#include <common/common.h>
+#include <llama-cpp.h>
+
+#include "ModelMetadata.hpp"
+#include "addon/LlmErrors.hpp"
+#include "qvac-lib-inference-addon-cpp/Errors.hpp"
+#include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
+#include "qvac-lib-inference-addon-cpp/InitLoader.hpp"
+#include "utils/BorrowablePtr.hpp"
+
+/// @brief Encapsulates async/streaming weights loading for sharded and
+/// single-GGUF models. Owns the streaming state and the buffered file map,
+/// and delegates shard fulfillment to llama.cpp.
+class AsyncWeightsLoader {
+public:
+  using Buf = std::basic_streambuf<char>;
+  using SharedBuffer = BorrowablePtr<Buf>;
+
+  /// @param modelMetadata Optional. When provided, the first shard received
+  /// via setWeightsForFile is lent to modelMetadata so that metadata parsing
+  /// can proceed before the shard is handed to the weights engine.
+  AsyncWeightsLoader(
+      const GGUFShards& shards, InitLoader& initLoader,
+      const std::string& loadingContext,
+      ModelMetaData* modelMetadata = nullptr);
+
+  virtual ~AsyncWeightsLoader() = default;
+  AsyncWeightsLoader(const AsyncWeightsLoader&) = delete;
+  AsyncWeightsLoader& operator=(const AsyncWeightsLoader&) = delete;
+  AsyncWeightsLoader(AsyncWeightsLoader&&) = delete;
+  AsyncWeightsLoader& operator=(AsyncWeightsLoader&&) = delete;
+
+  /// @brief Accept a streamed shard. For single-GGUF models the buffer is
+  /// stored until init() consumes it; for sharded models the shard is
+  /// fulfilled asynchronously via llama_model_load_fulfill_split_future.
+  /// If a ModelMetaData was supplied at construction, the shard matching the
+  /// first shard filename is lent to it and ownership is recovered before
+  /// proceeding.
+  /// @note C++ side expectation: calls are externally serialized and come from
+  /// the same thread (typically the JS event-loop / download thread). If this
+  /// method is invoked concurrently from multiple native threads, additional
+  /// synchronization is required by the caller.
+  /// @note For sharded models, the caller is responsible for eventually
+  /// calling this with the last shard filename. If the last-shard call never
+  /// happens, downstream llama.cpp model initialization may block waiting for
+  /// shard completion.
+  void
+  setWeightsForFile(const std::string& filename, std::unique_ptr<Buf>&& shard);
+
+  [[nodiscard]] bool isStreaming() const { return isStreaming_; }
+
+  /// @brief Moves the unsharded files out of the AsyncWeightsLoader
+  std::map<std::string, std::unique_ptr<Buf>> extractIndividualStreamedFiles();
+
+  [[nodiscard]] bool
+  hasIndividualStreamedFile(const std::string& filename) const;
+
+protected:
+  /// @brief Hands the shard to llama.cpp's split-future registry.
+  /// Override in tests to avoid touching the global promise registry.
+  virtual void fulfillSplitFuture(
+      const std::string& filename, std::unique_ptr<Buf>&& shard) {
+    using namespace qvac_lib_inference_addon_llama::errors;
+    if (!llama_model_load_fulfill_split_future(
+            filename.c_str(), loadingContext_.c_str(), std::move(shard))) {
+      std::string errorMsg = string_format(
+          "%s: failed to load model from %s\n", __func__, filename.c_str());
+      throw qvac_errors::StatusError(
+          ADDON_ID, toString(UnableToLoadModel), errorMsg);
+    }
+  }
+
+private:
+  /// @brief Waits for the first-shard async worker (if started) and rethrows
+  /// any exception raised in that worker.
+  void joinFirstShardWorker();
+
+  [[nodiscard]] bool
+  isFirstShard(const std::filesystem::path& filenamePath) const;
+  [[nodiscard]] bool
+  shouldLendFirstShard(const std::filesystem::path& filenamePath) const;
+  [[nodiscard]] bool
+  isLastShard(const std::filesystem::path& filenamePath) const;
+
+  /// Lends @p shard to modelMetadata_ (sharded path only), blocks until
+  /// metadata releases its reference, then returns the unique_ptr to the
+  /// caller.
+  std::unique_ptr<Buf>
+  lendFirstShardAndWaitForRelease(std::unique_ptr<Buf>&& shard);
+
+  // Timeout for waitForRelease (seconds) — fires if the metadata parser
+  // gets stuck and never finishes consuming/releasing the streamed buffer.
+  static constexpr int64_t METADATA_RELEASE_TIMEOUT_SEC = 60;
+
+  // These references are safe because LlamaModel owns both the referenced
+  // objects and this AsyncWeightsLoader in the same struct; C++ guarantees
+  // members are destroyed in reverse declaration order, so the loader is
+  // destroyed before the objects it references.
+  const GGUFShards& shards_;
+  InitLoader& initLoader_;
+  const std::string& loadingContext_;
+  ModelMetaData* modelMetadata_ = nullptr;
+
+  bool isStreaming_ = false;
+  std::map<std::string, SharedBuffer> streamedFiles_;
+  std::future<void> firstShardWorker_;
+};

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -63,11 +63,24 @@ static std::vector<std::string> split(const std::string& str, char delimiter) {
   return tokens;
 }
 
+void LlamaModel::resolveShardPaths(
+    GGUFShards& shards, const std::string& modelPath) {
+  if (shards.gguf_files.empty())
+    return;
+  auto baseDir = std::filesystem::path(modelPath).parent_path();
+  if (baseDir.empty())
+    return;
+  for (auto& f : shards.gguf_files)
+    f = (baseDir / f).string();
+  shards.tensors_file = (baseDir / shards.tensors_file).string();
+}
+
 LlamaModel::LlamaModel(
     std::string&& modelPath, std::string&& projectionPath,
     std::unordered_map<std::string, std::string>&& configFilemap)
     : loadingContext_(InitLoader::getLoadingContext("LlamaModel")),
-      shards_(GGUFShards::expandGGUFIntoShards(modelPath)) {
+      shards_(GGUFShards::expandGGUFIntoShards(modelPath)),
+      asyncWeightsLoader_(shards_, initLoader_, loadingContext_, &metadata_) {
   auto thisModelInit = [this](auto&&... args) {
     this->init(std::forward<decltype(args)>(args)...);
   };
@@ -89,6 +102,22 @@ void LlamaModel::init(
   // Set verbosity level
   setVerbosityLevel(configFilemap);
 
+  if (!asyncWeightsLoader_.isStreaming()) {
+    resolveShardPaths(shards_, modelPath);
+  }
+
+  metadata_.parse(
+      modelPath, shards_, asyncWeightsLoader_.isStreaming(), ADDON_ID);
+  {
+    auto fileType = metadata_.tryGetU32("general.file_type");
+    QLOG_IF(
+        Priority::DEBUG,
+        string_format(
+            "[LlamaModel] general.file_type = %s\n",
+            fileType.has_value() ? std::to_string(*fileType).c_str()
+                                 : "unknown"));
+  }
+
   {
     std::string backendsDir;
     if (auto backendsDirIt = configFilemap.find("backendsDir");
@@ -103,13 +132,14 @@ void LlamaModel::init(
   commonParamsParse(modelPath, configFilemap, params);
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
+  auto streamedFiles = asyncWeightsLoader_.extractIndividualStreamedFiles();
   common_init_result llamaInit = initFromConfig(
       params,
       modelPath,
-      singleGgufStreamedFiles_,
+      streamedFiles,
       shards_,
       loadingContext_,
-      isStreaming_,
+      asyncWeightsLoader_.isStreaming(),
       ADDON_ID,
       errorWhenFailed);
 
@@ -137,22 +167,7 @@ void LlamaModel::initializeBackend(const std::string& backendsDir) {
 void LlamaModel::setWeightsForFile(
     const std::string& filename,
     std::unique_ptr<std::basic_streambuf<char>>&& shard) {
-  isStreaming_ = true;
-  if (shards_.gguf_files.empty()) {
-    // Store it and make it available when `init` is called
-    singleGgufStreamedFiles_[filename] = std::move(shard);
-    return;
-  }
-  // Asynchronous shard loading
-  initLoader_.ensureLoadInBackground();
-  if (!llama_model_load_fulfill_split_future(
-          filename.c_str(), loadingContext_.c_str(), std::move(shard))) {
-    std::string errorMsg = string_format(
-        "%s: failed to load model from %s\n", __func__, filename.c_str());
-
-    throw qvac_errors::StatusError(
-        ADDON_ID, toString(UnableToLoadModel), errorMsg);
-  }
+  asyncWeightsLoader_.setWeightsForFile(filename, std::move(shard));
 }
 
 bool LlamaModel::isLoaded() { return static_cast<bool>(llmContext_); }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -9,9 +9,11 @@
 #include <llama.h>
 #include <picojson/picojson.h>
 
+#include "AsyncWeightsLoader.hpp"
 #include "CacheManager.hpp"
 #include "LlamaLazyInitializeBackend.hpp"
 #include "LlmContext.hpp"
+#include "ModelMetadata.hpp"
 #include "common/chat.h"
 #include "qvac-lib-inference-addon-cpp/BlobsStream.hpp"
 #include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
@@ -28,6 +30,11 @@ public:
   LlamaModel& operator=(const LlamaModel&) = delete;
   LlamaModel(LlamaModel&&) = delete;
   LlamaModel& operator=(LlamaModel&&) = delete;
+
+  /// @brief Resolves shard basenames in-place to absolute paths relative to
+  /// the parent directory of @p modelPath.
+  static void
+  resolveShardPaths(GGUFShards& shards, const std::string& modelPath);
 
   /**
    * The Constructor for llama model.
@@ -175,14 +182,13 @@ private:
       std::unordered_map<std::string, std::string>&& configFilemap);
 
   const std::string loadingContext_;
-  const GGUFShards shards_;
+  GGUFShards shards_;
   friend class InitLoader;
   InitLoader initLoader_;
+  ModelMetaData metadata_;
+  AsyncWeightsLoader asyncWeightsLoader_;
 
   bool isTextLlm_ = false;
-  bool isStreaming_ = false;
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>
-      singleGgufStreamedFiles_;
 
   // Backend handle must be declared before llmContext_ to ensure
   // llmContext_ is destroyed first (members destroyed in reverse order)

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
@@ -1,0 +1,133 @@
+#include "model-interface/ModelMetadata.hpp"
+
+#include <algorithm>
+
+#include <common/common.h>
+#include <common/log.h>
+#include <llama-cpp.h>
+#include <qvac-lib-inference-addon-cpp/Errors.hpp>
+
+#include "addon/LlmErrors.hpp"
+
+void ModelMetaData::FirstFileFromGgufStreamState::provide(
+    ModelMetaData::SharedBuffer& firstFileFromGgufStreamIn) {
+  std::lock_guard<std::mutex> lock(firstFileFromGgufStreamMutex_);
+  auto borrowed = firstFileFromGgufStreamIn.borrow();
+  if (!borrowed) {
+    throw qvac_errors::StatusError(
+        qvac_lib_inference_addon_llama::errors::ADDON_ID,
+        toString(qvac_lib_inference_addon_llama::errors::UnableToLoadModel),
+        "ModelMetaData::FirstFileFromGgufStreamState::provide: received empty "
+        "borrowed stream");
+  }
+  firstFileFromGgufStream_.emplace(std::move(borrowed));
+  hasProvidedFirstFileFromGgufStream_ = true;
+  firstFileFromGgufStreamCv_.notify_all();
+}
+
+void ModelMetaData::parse(
+    const std::string& modelPath, const GGUFShards& shards, bool isStreaming,
+    const char* addonId) {
+
+  auto loadFromStreambuf = [&modelPath,
+                            outMetadata = &this->metadata_,
+                            addonId](std::basic_streambuf<char>& streambuf) {
+    MetaResultStatus status =
+        llama_model_meta_from_streambuf(streambuf, outMetadata);
+    if (status != MetaResultStatus::SUCCESS) {
+      std::string statusStr = std::to_string(static_cast<int>(status));
+      std::string errorMsg = string_format(
+          "ModelMetadata::loadFromStreambuf: failed to load model metadata "
+          "while parsing GGUF, path=%s MetaResultStatus=%s\n",
+          modelPath.c_str(),
+          statusStr.c_str());
+      throw qvac_errors::StatusError(
+          addonId,
+          toString(
+              qvac_lib_inference_addon_llama::errors::UnableToLoadMetadata),
+          errorMsg);
+    }
+  };
+
+  auto loadFromDisk = [&modelPath, outMetadata = &this->metadata_, addonId](
+                          const std::string& diskPath) {
+    MetaResultStatus status =
+        llama_model_meta_from_file(diskPath.c_str(), outMetadata);
+    if (status != MetaResultStatus::SUCCESS) {
+      std::string statusStr = std::to_string(static_cast<int>(status));
+      std::string errorMsg = string_format(
+          "ModelMetadata::loadFromDisk: failed to load model metadata "
+          "while parsing GGUF, path=%s MetaResultStatus=%s\n",
+          diskPath.c_str(),
+          statusStr.c_str());
+      throw qvac_errors::StatusError(
+          addonId,
+          toString(
+              qvac_lib_inference_addon_llama::errors::UnableToLoadMetadata),
+          errorMsg);
+    }
+  };
+
+  if (isStreaming) {
+    LOG_INF("%s: load the model metadata from memory.\n", __func__);
+    static constexpr int64_t waitFirstFileTimeoutSec = 15;
+    firstFileFromGgufStreamState.waitConsumeAndClear<waitFirstFileTimeoutSec>(
+        [&](ModelMetaData::Buf& firstFileFromGgufStream) {
+          loadFromStreambuf(firstFileFromGgufStream);
+        });
+  } else {
+    if (shards.gguf_files.empty()) {
+      LOG_INF("%s: load the model metadata from disk file.\n", __func__);
+      loadFromDisk(modelPath);
+    } else {
+      LOG_INF("%s: load the model metadata from disk shards.\n", __func__);
+      loadFromDisk(shards.gguf_files.front());
+    }
+  }
+}
+
+void ModelMetaData::checkInitialized() const {
+  if (metadata_ == nullptr) {
+    throw qvac_errors::StatusError(
+        qvac_lib_inference_addon_llama::errors::ADDON_ID,
+        toString(qvac_lib_inference_addon_llama::errors::InvalidInputFormat),
+        "ModelMetaData: not initialized; call parse() before querying "
+        "metadata");
+  }
+}
+
+std::optional<uint32_t> ModelMetaData::tryGetU32(const char* key) const {
+  if (metadata_ == nullptr) {
+    return std::nullopt;
+  }
+  uint32_t value = 0;
+  MetaResultStatus status = llama_model_meta_get_u32(metadata_, key, &value);
+  if (status != MetaResultStatus::SUCCESS) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+bool ModelMetaData::isU32OneOf(
+    const char* key, std::initializer_list<uint32_t> values) const {
+  checkInitialized();
+  uint32_t value = 0;
+  MetaResultStatus status = llama_model_meta_get_u32(metadata_, key, &value);
+  if (status != MetaResultStatus::SUCCESS) {
+    LOG_WRN(
+        "ModelMetaData::isU32OneOf: failed to read key '%s', "
+        "llama_model_meta_get_u32 returned %s\n",
+        key,
+        std::to_string(static_cast<int>(status)).c_str());
+    return false;
+  }
+  return std::ranges::any_of(
+      values, [value](uint32_t queryValue) { return value == queryValue; });
+}
+
+bool ModelMetaData::hasOneBitQuantization() const {
+  return isU32OneOf(
+      "general.file_type",
+      {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0),
+       static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0)});
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+// Needed for GGUFShards
+#include <iomanip>
+#include <sstream>
+
+#include <llama-cpp.h>
+
+#include "addon/LlmErrors.hpp"
+#include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
+#include "utils/BorrowablePtr.hpp"
+
+/// @brief Access model metadata without loading weights into memory.
+/// @details After parse(), all GGUF key-values are held in-memory and can be
+/// queried without further disk or streambuf access.
+class ModelMetaData {
+  void checkInitialized() const;
+  metadata_handle_ptr metadata_;
+  using Buf = std::basic_streambuf<char>;
+  using SharedBuffer = BorrowablePtr<Buf>;
+
+public:
+  ModelMetaData() = default;
+
+  /// @param modelPath Model to load (single .gguf)
+  /// @param shards Containing sharded files, if any
+  /// @param isStreaming Whether metadata is loaded from streamed buffers
+  /// @param AddonID Identifier for error reporting
+  void parse(
+      const std::string& modelPath, const GGUFShards& shards, bool isStreaming,
+      const char* addonId);
+
+  /// @brief Returns the u32 value at @p key, or nullopt if
+  /// absent/uninitialized.
+  [[nodiscard]] std::optional<uint32_t> tryGetU32(const char* key) const;
+
+  /// @brief Returns true if the u32 value at @p key matches any of @p values.
+  [[nodiscard]] bool
+  isU32OneOf(const char* key, std::initializer_list<uint32_t> values) const;
+
+  [[nodiscard]] bool hasOneBitQuantization() const;
+
+  // Code below for streaming support
+
+  class FirstFileFromGgufStreamState {
+  public:
+    /// @brief Blocks until the metadata consumer finishes and releases the
+    /// streamed buffer, or throws on timeout.
+    template <int64_t TimeoutSeconds> void waitForRelease() {
+      std::unique_lock<std::mutex> lock(firstFileFromGgufStreamMutex_);
+      if (!firstFileFromGgufStreamCv_.wait_for(
+              lock, std::chrono::seconds(TimeoutSeconds), [this]() {
+                return hasProvidedFirstFileFromGgufStream_ &&
+                       !firstFileFromGgufStream_.has_value();
+              })) {
+        throw qvac_errors::StatusError(
+            qvac_lib_inference_addon_llama::errors::ADDON_ID,
+            toString(qvac_lib_inference_addon_llama::errors::UnableToLoadModel),
+            "ModelMetaData::waitForRelease: timed out waiting for metadata "
+            "consumer to release the streamed GGUF file");
+      }
+    }
+
+    /// @brief Provides the first streamed GGUF file.
+    /// @note To avoid deadlock, if ModelMetaData::parse() is already waiting
+    /// for the first streamed file, call this from another thread.
+    /// @note Underlying LLM engine should leave the streambuf pointing to the
+    /// beginning of the file.
+    void provide(SharedBuffer& firstFileFromGgufStream);
+
+  private:
+    friend class ModelMetaData;
+
+    template <int64_t TimeoutSeconds, typename Fn>
+    void waitConsumeAndClear(const Fn& processingFunction) {
+      auto clear = [this]() {
+        firstFileFromGgufStream_.reset();
+        firstFileFromGgufStreamCv_.notify_all();
+      };
+      std::unique_lock<std::mutex> lock(firstFileFromGgufStreamMutex_);
+      if (!firstFileFromGgufStreamCv_.wait_for(
+              lock, std::chrono::seconds(TimeoutSeconds), [this]() {
+                return firstFileFromGgufStream_.has_value();
+              })) {
+        throw qvac_errors::StatusError(
+            qvac_lib_inference_addon_llama::errors::ADDON_ID,
+            toString(qvac_lib_inference_addon_llama::errors::UnableToLoadModel),
+            "ModelMetaData::waitConsumeAndClear: timed out waiting for "
+            "first streamed GGUF file to be provided");
+      }
+      try {
+        processingFunction(firstFileFromGgufStream_->ref());
+      } catch (...) {
+        clear();
+        throw;
+      }
+      clear();
+    }
+
+    std::optional<SharedBuffer::Borrowed> firstFileFromGgufStream_;
+    std::mutex firstFileFromGgufStreamMutex_;
+    std::condition_variable firstFileFromGgufStreamCv_;
+    bool hasProvidedFirstFileFromGgufStream_ = false;
+  };
+  FirstFileFromGgufStreamState
+      firstFileFromGgufStreamState; // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+};

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BorrowablePtr.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BorrowablePtr.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+
+/// @brief Borrow/reclaim wrapper around unique ptr. Allows owner thread
+//         to share pointer with other threads but eventually reclaim ownership.
+/// @details Borrow leases are thread-safe and can be released from any thread.
+/// Owner operations (`borrow()` and `reclaimUnique()`) are synchronized
+/// internally and safe to invoke from different threads.
+template <typename T> class BorrowablePtr {
+  struct State {
+    std::mutex mu;
+    std::size_t activeBorrows = 0;
+  };
+
+  struct Deleter {
+    std::unique_ptr<T> inner;
+    void operator()(T*) noexcept { /* inner self-deletes if not released */ }
+    std::unique_ptr<T> release() { return std::move(inner); }
+  };
+
+public:
+  class Borrowed {
+  public:
+    Borrowed() = default;
+    ~Borrowed() = default;
+
+    Borrowed(const Borrowed&) = delete;
+    Borrowed& operator=(const Borrowed&) = delete;
+    Borrowed(Borrowed&& other) noexcept = default;
+    Borrowed& operator=(Borrowed&& other) noexcept = default;
+
+    explicit operator bool() const { return static_cast<bool>(ptr_); }
+    T& ref() const { return *ptr_; }
+
+  private:
+    friend class BorrowablePtr<T>;
+    Borrowed(std::shared_ptr<T> ptr, std::shared_ptr<void> lease)
+        : ptr_(std::move(ptr)), lease_(std::move(lease)) {}
+
+    std::shared_ptr<T> ptr_;
+    std::shared_ptr<void> lease_;
+  };
+
+  explicit BorrowablePtr(std::unique_ptr<T>&& value)
+      : state_(std::make_shared<State>()) {
+    if (!value) {
+      throw std::invalid_argument("BorrowablePtr requires non-null value");
+    }
+    T* raw = value.get();
+    ptr_ = std::shared_ptr<T>(raw, Deleter{std::move(value)});
+  }
+
+  BorrowablePtr(const BorrowablePtr&) = delete;
+  BorrowablePtr& operator=(const BorrowablePtr&) = delete;
+  BorrowablePtr(BorrowablePtr&& other) {
+    std::lock_guard<std::mutex> otherLock(other.mainOwnerMu_);
+    ptr_ = std::move(other.ptr_);
+    state_ = std::move(other.state_);
+  }
+  BorrowablePtr& operator=(BorrowablePtr&& other) {
+    if (this == &other) {
+      return *this;
+    }
+    std::scoped_lock lock(mainOwnerMu_, other.mainOwnerMu_);
+    ptr_ = std::move(other.ptr_);
+    state_ = std::move(other.state_);
+    return *this;
+  }
+
+  Borrowed borrow() const {
+    std::lock_guard<std::mutex> ownerLock(mainOwnerMu_);
+    if (!ptr_ || !state_) {
+      return {};
+    }
+    std::shared_ptr<void> lease;
+    {
+      std::lock_guard<std::mutex> lock(state_->mu);
+      ++state_->activeBorrows;
+      lease = std::shared_ptr<void>(nullptr, [state = state_](void*) {
+        std::lock_guard<std::mutex> releaseLock(state->mu);
+        if (state->activeBorrows > 0) {
+          --state->activeBorrows;
+        }
+      });
+    }
+    return Borrowed(ptr_, std::move(lease));
+  }
+
+  std::unique_ptr<T> reclaimUnique() {
+    std::lock_guard<std::mutex> ownerLock(mainOwnerMu_);
+    if (!state_) {
+      return {};
+    }
+    {
+      std::lock_guard<std::mutex> lock(state_->mu);
+      if (state_->activeBorrows > 0) {
+        throw std::runtime_error(
+            "Cannot reclaim unique ownership while borrows are active");
+      }
+      std::unique_ptr<T> unique = std::get_deleter<Deleter>(ptr_)->release();
+      ptr_.reset();
+      state_.reset();
+      return unique;
+    }
+  }
+
+private:
+  mutable std::mutex mainOwnerMu_;
+  std::shared_ptr<T> ptr_;
+  std::shared_ptr<State> state_;
+};

--- a/packages/qvac-lib-infer-llamacpp-llm/docs/architecture.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/docs/architecture.md
@@ -237,6 +237,8 @@ graph TB
     
     subgraph "Layer 4: Model"
         LLAMAMODEL["LlamaModel<br/>(model-interface/LlamaModel.cpp)"]
+        METADATA["ModelMetaData<br/>(model-interface/ModelMetadata.cpp)"]
+        ASYNCWL["AsyncWeightsLoader<br/>(model-interface/AsyncWeightsLoader.cpp)"]
         TEXTCTX["TextLlmContext<br/>(model-interface/TextLlmContext.cpp)"]
         MTMDCTX["MtmdLlmContext<br/>(model-interface/MtmdLlmContext.cpp)"]
     end
@@ -260,7 +262,11 @@ graph TB
     JSINTERFACE --> ADDONCPP
     ADDONCPP --> WEIGHTSLOAD
     ADDONCPP --> LLAMAMODEL
+    ADDONCPP --> WEIGHTSLOAD
     
+    LLAMAMODEL --> METADATA
+    LLAMAMODEL --> ASYNCWL
+    ASYNCWL --> METADATA
     LLAMAMODEL --> TEXTCTX
     LLAMAMODEL --> MTMDCTX
     TEXTCTX --> LLAMACPP
@@ -285,8 +291,8 @@ graph TB
 | 1. JavaScript API | LlmLlamacpp, BaseInference | High-level API, error handling | JS | Ergonomic API for npm consumers |
 | 2. Bridge | LlamaInterface, binding.js | JS↔C++ communication | JS wrapper | Lifecycle management, handle safety |
 | 3. C++ Addon | JsInterface, AddonCpp/AddonJs | Single-job runner, threading, callbacks | C++ | Performance, native integration |
-| 4. Model | LlamaModel, Contexts | Inference logic, chat formatting | C++ | Direct llama.cpp integration |
-| 5. Backend | llama.cpp, GGML | Tensor ops, GPU kernels | C++ | Optimized inference |
+| 4. Model | LlamaModel, ModelMetaData, AsyncWeightsLoader, Contexts | Inference logic, metadata extraction, streaming weight coordination, chat formatting | C++ | Direct llama.cpp integration |
+|de4795ae-3b83-4c60-914c-290f0cbe27c3 5. Backend | llama.cpp, GGML | Tensor ops, GPU kernels | C++ | Optimized inference |
 
 **Data Flow Through Layers:**
 
@@ -362,6 +368,26 @@ graph TB
 - Progress tracking and reporting
 - Handles sharded GGUF expansion
 - Streaming chunk delivery
+
+#### **ModelMetaData (model-interface/ModelMetadata.cpp)**
+
+**Responsibility:** Extract and query GGUF metadata without loading model weights into backend memory
+
+- Parses GGUF key-value metadata from disk files or streamed buffers
+- Enables early decisions (quantization detection, backend selection) before the full model is loaded
+- For streaming loads, coordinates with `AsyncWeightsLoader` to borrow the first shard buffer: `AsyncWeightsLoader` calls `provide()` to lend the buffer, `ModelMetaData::parse()` reads metadata via `waitConsumeAndClear()`, then releases it so the shard can proceed to llama.cpp
+- Exposes typed queries: `tryGetU32()`, `isU32OneOf()`, `hasOneBitQuantization()`
+- After `parse()`, all metadata is held in memory and no further disk/stream access is needed
+
+#### **AsyncWeightsLoader (model-interface/AsyncWeightsLoader.cpp)**
+
+**Responsibility:** Coordinate async/streaming weight loading for sharded and single-GGUF models
+
+- Receives streamed shards via `setWeightsForFile()` from the JavaScript download thread
+- For sharded models, the first shard is lent to `ModelMetaData` for metadata extraction before being forwarded to llama.cpp via `fulfillSplitFuture()`
+- The first-shard lending runs on an async worker thread to avoid blocking the download thread while metadata is parsed
+- `waitForRelease()` has a configurable timeout (template parameter, default 60s) to detect stalled metadata parsing 
+- For single-GGUF models, buffers are stored until `init()` consumes them
 
 #### **CacheManager (model-interface/CacheManager.cpp)**
 
@@ -905,4 +931,4 @@ Provide hand-written TypeScript definitions in `index.d.ts` alongside JavaScript
 **Related Document:**
 - [data-flows-detailed.md](data-flows-detailed.md) - Detailed data flow diagrams and sequences
 
-**Last Updated:** 2026-02-17
+**Last Updated:** 2026-03-02

--- a/packages/qvac-lib-infer-llamacpp-llm/docs/architecture.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/docs/architecture.md
@@ -292,7 +292,7 @@ graph TB
 | 2. Bridge | LlamaInterface, binding.js | JS↔C++ communication | JS wrapper | Lifecycle management, handle safety |
 | 3. C++ Addon | JsInterface, AddonCpp/AddonJs | Single-job runner, threading, callbacks | C++ | Performance, native integration |
 | 4. Model | LlamaModel, ModelMetaData, AsyncWeightsLoader, Contexts | Inference logic, metadata extraction, streaming weight coordination, chat formatting | C++ | Direct llama.cpp integration |
-|de4795ae-3b83-4c60-914c-290f0cbe27c3 5. Backend | llama.cpp, GGML | Tensor ops, GPU kernels | C++ | Optimized inference |
+| 5. Backend | llama.cpp, GGML | Tensor ops, GPU kernels | C++ | Optimized inference |
 
 **Data Flow Through Layers:**
 

--- a/packages/qvac-lib-infer-llamacpp-llm/docs/data-flows-detailed.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/docs/data-flows-detailed.md
@@ -24,6 +24,7 @@ This document contains detailed diagrams showing how data moves through the `@qv
 **Weight Loading:**
 - JavaScript sends model weights in chunks (streaming, zero-copy)
 - C++ creates std::streambuf over JS ArrayBuffers
+- For streamed models, the first shard is lent to `ModelMetaData` for GGUF metadata extraction before proceeding to weight loading
 - llama.cpp reads weights via stream interface
 - Supports sharded models (GGUF multi-file)
 - JS references kept alive during load, cleaned up after
@@ -39,6 +40,7 @@ This document contains detailed diagrams showing how data moves through the `@qv
 
 - [Primary Inference Flow](#primary-inference-flow)
 - [Weight Loading Flow](#weight-loading-flow)
+- [Metadata Extraction Flow](#metadata-extraction-flow)
 - [Multimodal Inference Flow](#multimodal-inference-flow)
 - [Session Cache Flow](#session-cache-flow)
 
@@ -284,6 +286,97 @@ JavaScript sends each file separately. C++ concatenates into single logical stre
 
 ---
 
+## Metadata Extraction Flow
+
+`ModelMetaData` extracts GGUF key-value metadata (e.g., quantization type, architecture) from the model file *before* weights are loaded. This allows early decisions like backend selection and quantization detection without loading gigabytes of tensor data into memory.
+
+### Disk-Based Models
+
+For models loaded from disk, metadata is read directly from the file:
+
+```mermaid
+sequenceDiagram
+    participant Init as LlamaModel::init
+    participant Meta as ModelMetaData
+    participant GGUF as llama_model_meta_from_file
+
+    Init->>Meta: parse(modelPath, shards, isStreaming=false)
+    Meta->>GGUF: llama_model_meta_from_file(path)
+    GGUF-->>Meta: metadata handle
+    Meta-->>Init: ready for queries
+
+    Init->>Meta: tryGetU32("general.file_type")
+    Meta-->>Init: e.g. 7 (Q8_0)
+```
+
+### Streamed Models (Sharded)
+
+For streamed models, the first shard must be shared between metadata parsing and weight loading. `AsyncWeightsLoader` coordinates this handoff:
+
+```mermaid
+sequenceDiagram
+    participant DL as Download Thread
+    participant AWL as AsyncWeightsLoader
+    participant Worker as firstShardWorker (async)
+    participant State as FirstFileFromGgufStreamState
+    participant Meta as ModelMetaData::parse
+    participant LC as llama.cpp
+
+    Note over DL,Meta: setWeightsForFile() receives first shard
+
+    DL->>AWL: setWeightsForFile(filename, shard)
+    AWL->>AWL: ensureLoadInBackground()
+    AWL->>Worker: launch async (lendFirstShardAndWaitForRelease)
+
+    Worker->>State: provide(lentShard)
+    Note over State: Sets firstFileFromGgufStream_,<br/>notifies CV
+
+    Note over Meta: parse() was waiting on CV
+    State-->>Meta: CV wakes, borrows streambuf
+
+    Meta->>Meta: llama_model_meta_from_streambuf()
+    Meta->>State: clear() — resets optional,<br/>notifies CV
+
+    Note over Worker: waitForRelease() wakes
+    State-->>Worker: buffer released
+
+    Worker->>LC: fulfillSplitFuture(filename, shard)
+    Note over LC: Shard proceeds to weight loading
+
+    DL->>AWL: setWeightsForFile(shard 2..N)
+    AWL->>LC: fulfillSplitFuture() directly
+```
+
+<details>
+<summary>📊 LLM-Friendly: Metadata Extraction Details</summary>
+
+**Thread Coordination:**
+
+| Thread | Role | Blocks On |
+|--------|------|-----------|
+| Download (JS) | Delivers shards via `setWeightsForFile()` | Nothing (first shard launches async worker) |
+| firstShardWorker | Lends first shard to metadata, then forwards to llama.cpp | `waitForRelease()` — metadata consumer releasing the buffer |
+| Init (background) | Calls `metadata_.parse()` which waits for streamed buffer | `waitConsumeAndClear()` — provider delivering the buffer |
+
+**Synchronization:**
+
+| Primitive | Purpose | Timeout |
+|-----------|---------|---------|
+| `condition_variable` + `wait_for` | `waitConsumeAndClear` blocks until `provide()` delivers the buffer | 15s (configurable via template parameter) |
+| `condition_variable` + `wait_for` | `waitForRelease` blocks until metadata consumer releases the buffer | 60s (configurable via template parameter) |
+
+**Available Metadata Queries:**
+
+| Method | Returns | Use Case |
+|--------|---------|----------|
+| `tryGetU32(key)` | `optional<uint32_t>` | Read any GGUF u32 key |
+| `isU32OneOf(key, values)` | `bool` | Check if a key matches expected values |
+| `hasOneBitQuantization()` | `bool` | Detect TQ1_0/TQ2_0 quantization |
+
+</details>
+
+---
+
 ## Multimodal Inference Flow
 
 For vision + text models (e.g., LLaVA, Qwen2.5-Omni):
@@ -298,7 +391,7 @@ flowchart LR
     BuildMedia --> ModifyMsg[Modify message<br/>content: empty string]
     ModifyMsg --> BuildText[Build text item<br/>type: 'text', input: JSON]
     
-    BuildText --> RunJob[addon.runJob&#40;[media..., text]&#41;]
+    BuildText --> RunJob[addon.runJob&#40;&#91;media..., text&#93;&#41;]
     RunJob --> ProcessMedia{Has media?}
     ProcessMedia -->|Yes| LoadImage[LlamaModel.LoadMedia<br/>load image via llava]
     ProcessMedia -->|No| SkipMedia
@@ -372,5 +465,5 @@ flowchart TD
 **Related Documents:**
 - [architecture.md](architecture.md) - Complete architecture documentation
 
-**Last Updated:** 2026-02-17
+**Last Updated:** 2026-03-02
 

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/http-loader.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/http-loader.js
@@ -57,6 +57,7 @@ class HttpDL extends BaseDL {
 
       const req = https.request(url, { method, agent: false }, (response) => {
         if ([301, 302, 307, 308].includes(response.statusCode)) {
+          response.resume()
           let loc = response.headers.location
           if (loc && loc.startsWith('/')) {
             const parsed = new URL(url)
@@ -67,11 +68,13 @@ class HttpDL extends BaseDL {
         }
 
         if (response.statusCode !== 200) {
+          response.resume()
           reject(new Error(`HTTP ${response.statusCode} ${method} ${url}`))
           return
         }
 
         if (method === 'HEAD') {
+          response.resume()
           resolve(parseInt(response.headers['content-length'] || '0', 10))
         } else {
           resolve(response)

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/http-loader.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/http-loader.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const https = require('bare-https')
+const BaseDL = require('@qvac/dl-base')
+
+/**
+ * A minimal HTTP/HTTPS loader that implements the BaseDL interface.
+ * Fetches model files from a remote base URL, following redirects.
+ */
+class HttpDL extends BaseDL {
+  constructor (opts) {
+    super(opts)
+
+    if (!opts || !opts.baseUrl) {
+      throw new Error('HttpDL requires a baseUrl option')
+    }
+
+    this.baseUrl = opts.baseUrl.endsWith('/') ? opts.baseUrl : opts.baseUrl + '/'
+    this._activeStreams = new Set()
+  }
+
+  /**
+   * Return the Content-Length of a remote file via an HTTP HEAD request.
+   * @param {string} filename
+   * @returns {Promise<number>} byte size
+   */
+  async getFileSize (filename) {
+    return this._request('HEAD', this.baseUrl + filename)
+  }
+
+  /**
+   * Fetch a file by name and return it as a readable stream.
+   * The stream is tracked so that close() can destroy it if needed.
+   * @param {string} filename
+   * @returns {Promise<NodeJS.ReadableStream>}
+   */
+  async getStream (filename) {
+    const response = await this._request('GET', this.baseUrl + filename)
+    this._activeStreams.add(response)
+    const cleanup = () => this._activeStreams.delete(response)
+    response.on('end', cleanup)
+    response.on('close', cleanup)
+    response.on('error', cleanup)
+    return response
+  }
+
+  async _close () {
+    for (const stream of this._activeStreams) {
+      stream.destroy()
+    }
+    this._activeStreams.clear()
+  }
+
+  _request (method, url, maxRedirects = 10) {
+    return new Promise((resolve, reject) => {
+      if (maxRedirects === 0) return reject(new Error(`Too many redirects for ${url}`))
+
+      const req = https.request(url, { method, agent: false }, (response) => {
+        if ([301, 302, 307, 308].includes(response.statusCode)) {
+          let loc = response.headers.location
+          if (loc && loc.startsWith('/')) {
+            const parsed = new URL(url)
+            loc = `${parsed.protocol}//${parsed.host}${loc}`
+          }
+          resolve(this._request(method, loc, maxRedirects - 1))
+          return
+        }
+
+        if (response.statusCode !== 200) {
+          reject(new Error(`HTTP ${response.statusCode} ${method} ${url}`))
+          return
+        }
+
+        if (method === 'HEAD') {
+          resolve(parseInt(response.headers['content-length'] || '0', 10))
+        } else {
+          resolve(response)
+        }
+      })
+
+      req.on('error', reject)
+      req.end()
+    })
+  }
+
+  async list () {
+    throw new Error('HttpDL does not support list()')
+  }
+}
+
+module.exports = HttpDL

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
@@ -5,12 +5,15 @@ const FilesystemDL = require('@qvac/dl-filesystem')
 
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
+const HttpDL = require('./http-loader')
 const os = require('bare-os')
+const path = require('bare-path')
 
 const platform = os.platform()
 const arch = os.arch()
 const isDarwinX64 = platform === 'darwin' && arch === 'x64'
 const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
+const isLinuxX64 = platform === 'linux' && arch === 'x64'
 const useCpu = isDarwinX64 || isLinuxArm64
 
 const DEFAULT_MODEL = {
@@ -121,6 +124,58 @@ test('model unload is clean and idempotent', { timeout: 600_000 }, async t => {
   } finally {
     await loader.close().catch(() => {})
   }
+})
+
+const SHARDED_MODEL = {
+  name: 'Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf',
+  baseUrl: 'https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded/resolve/main/'
+}
+
+// This test can take longer to download and execute. To avoid blowing up testing time on all
+// platforms, just use Linux for now. C++ tests already have faster coverage for each type
+// of load.
+test('network loader can run inference end-to-end with sharded model', { timeout: 4 * 60 * 1000, skip: !isLinuxX64 }, async t => {
+  const modelDir = path.resolve(__dirname, '../model')
+
+  const loader = new HttpDL({ baseUrl: SHARDED_MODEL.baseUrl })
+  const config = {
+    gpu_layers: '999',
+    ctx_size: '1024',
+    device: useCpu ? 'cpu' : 'gpu',
+    n_predict: '32',
+    verbosity: '2'
+  }
+
+  const addon = new LlmLlamacpp({
+    loader,
+    modelName: SHARDED_MODEL.name,
+    diskPath: modelDir,
+    logger: console,
+    opts: { stats: true }
+  }, config)
+
+  let progressMade = 0
+  let lastLogTime = 0
+  const LOG_INTERVAL_MS = 3000
+  const onProgress = (data) => {
+    if (typeof data !== 'object' || data === null) return
+    const now = Date.now()
+    const shard = data.currentFile.replace(/^.*\//, '')
+    progressMade = Math.max(progressMade, data.overallProgress)
+    if (data.action === 'loadingFile' && now - lastLogTime >= LOG_INTERVAL_MS) {
+      console.log(`\r  Loading ${shard}: ${data.currentFileProgress}%  (overall ${data.overallProgress}%)   `)
+      lastLogTime = now
+    } else if (data.action === 'completeFile') {
+      console.log(`\r  Loaded  ${shard}: 100.00% (overall ${data.overallProgress}%) [${data.filesProcessed}/${data.totalFiles}]\n`)
+      lastLogTime = now
+    }
+  }
+
+  await addon.load(true, onProgress)
+  const response = await addon.run(BASE_PROMPT)
+  const output = await collectResponse(response)
+  t.ok(output.length > 0, 'network-loaded sharded model should generate output')
+  t.ok(progressMade > 0, 'network-loaded sharded model should make progress')
 })
 
 // Keep event loop alive briefly to let pending async operations complete

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
@@ -171,11 +171,16 @@ test('network loader can run inference end-to-end with sharded model', { timeout
     }
   }
 
-  await addon.load(true, onProgress)
-  const response = await addon.run(BASE_PROMPT)
-  const output = await collectResponse(response)
-  t.ok(output.length > 0, 'network-loaded sharded model should generate output')
-  t.ok(progressMade > 0, 'network-loaded sharded model should make progress')
+  try {
+    await addon.load(true, onProgress)
+    const response = await addon.run(BASE_PROMPT)
+    const output = await collectResponse(response)
+    t.ok(output.length > 0, 'network-loaded sharded model should generate output')
+    t.ok(progressMade > 0, 'network-loaded sharded model should make progress')
+  } finally {
+    await addon.unload().catch(() => {})
+    await loader.close().catch(() => {})
+  }
 })
 
 // Keep event loop alive briefly to let pending async operations complete

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
@@ -18,6 +18,8 @@ add_executable(
   # Placeholder tests (to be implemented)
   test_mtmd_llm_context.cpp
   test_llm_context_base.cpp
+  test_model_metadata.cpp
+  test_model_full_loading.cpp
   # Utility tests
   test_utf8_token_buffer.cpp
   test_chat_template_utils.cpp
@@ -25,9 +27,12 @@ add_executable(
   test_qwen_template.cpp
   test_logging_macros.cpp
   test_llama_lazy_init_backend.cpp
+  test_borrow_tracked_shared_buffer.cpp
+  ${CMAKE_SOURCE_DIR}/addon/src/model-interface/AsyncWeightsLoader.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/CacheManager.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+  ${CMAKE_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/MtmdLlmContext.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/TextLlmContext.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/utils/LoggingMacros.cpp

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_addon_cpp.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_addon_cpp.cpp
@@ -24,34 +24,10 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "20";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
-    fs::path backendDir;
-#ifdef TEST_BINARY_DIR
-    backendDir = fs::path(TEST_BINARY_DIR);
-#else
-    backendDir = fs::current_path() / "build" / "test" / "unit";
-#endif
-
-    config_files["backendsDir"] = backendDir.string();
+    config_files["backendsDir"] = test_common::getTestBackendsDir().string();
   }
 
   std::unordered_map<std::string, std::string> config_files;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_borrow_tracked_shared_buffer.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_borrow_tracked_shared_buffer.cpp
@@ -1,0 +1,62 @@
+#include <memory>
+#include <sstream>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "utils/BorrowablePtr.hpp"
+
+TEST(BorrowablePtrTest, ReclaimThrowsWhileBorrowIsActive) {
+  auto shard = std::make_unique<std::stringbuf>("abc");
+  BorrowablePtr<std::basic_streambuf<char>> buffer(std::move(shard));
+  auto lease = buffer.borrow();
+  ASSERT_TRUE(static_cast<bool>(lease));
+
+  EXPECT_THROW(buffer.reclaimUnique(), std::runtime_error);
+
+  lease = {};
+  auto unique = buffer.reclaimUnique();
+  EXPECT_NE(unique, nullptr);
+}
+
+TEST(BorrowablePtrTest, BorrowIsEmptyAfterOwnershipMovedOut) {
+  auto shard = std::make_unique<std::stringbuf>("abc");
+  BorrowablePtr<std::basic_streambuf<char>> buffer(std::move(shard));
+
+  auto unique = buffer.reclaimUnique();
+  EXPECT_NE(unique, nullptr);
+
+  auto lease = buffer.borrow();
+  EXPECT_FALSE(static_cast<bool>(lease));
+}
+
+TEST(BorrowablePtrTest, ReclaimTwiceReturnsNullSecondTime) {
+  auto shard = std::make_unique<std::stringbuf>("abc");
+  BorrowablePtr<std::basic_streambuf<char>> buffer(std::move(shard));
+
+  auto first = buffer.reclaimUnique();
+  EXPECT_NE(first, nullptr);
+
+  auto second = buffer.reclaimUnique();
+  EXPECT_EQ(second, nullptr);
+}
+
+TEST(BorrowablePtrTest, ConstructorRejectsNullUniquePtr) {
+  std::unique_ptr<std::basic_streambuf<char>> nullBuf;
+  EXPECT_THROW(
+      BorrowablePtr<std::basic_streambuf<char>>(std::move(nullBuf)),
+      std::invalid_argument);
+}
+
+TEST(BorrowablePtrTest, MoveTransfersOwnershipAndBorrowability) {
+  auto shard = std::make_unique<std::stringbuf>("abc");
+  BorrowablePtr<std::basic_streambuf<char>> src(std::move(shard));
+
+  BorrowablePtr<std::basic_streambuf<char>> dst(std::move(src));
+
+  auto movedFromLease = src.borrow();
+  EXPECT_FALSE(static_cast<bool>(movedFromLease));
+
+  auto movedToLease = dst.borrow();
+  EXPECT_TRUE(static_cast<bool>(movedToLease));
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_cache_management.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_cache_management.cpp
@@ -53,34 +53,10 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
-    fs::path backendDir;
-#ifdef TEST_BINARY_DIR
-    backendDir = fs::path(TEST_BINARY_DIR);
-#else
-    backendDir = fs::current_path() / "build" / "test" / "unit";
-#endif
-
-    config_files["backendsDir"] = backendDir.string();
+    config_files["backendsDir"] = test_common::getTestBackendsDir().string();
 
     session1_path = "test_session1.bin";
     session2_path = "test_session2.bin";

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_chat_template_utils.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_chat_template_utils.cpp
@@ -20,34 +20,10 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
-    fs::path backendDir;
-#ifdef TEST_BINARY_DIR
-    backendDir = fs::path(TEST_BINARY_DIR);
-#else
-    backendDir = fs::current_path() / "build" / "test" / "unit";
-#endif
-
-    config_files["backendsDir"] = backendDir.string();
+    config_files["backendsDir"] = test_common::getTestBackendsDir().string();
   }
 
   std::unordered_map<std::string, std::string> config_files;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
@@ -1,6 +1,14 @@
 #pragma once
 
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
 #include <string>
+
+#include <gtest/gtest.h>
+
+#include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
 
 namespace test_common {
 
@@ -33,4 +41,168 @@ inline const char* getTestGpuLayers() {
 #endif
 }
 
+namespace fs = std::filesystem;
+
+/**
+ * Reusable base path for unit-test models (e.g. models/unit-test).
+ * Use get() for the default model path, or get("filename.gguf") for a
+ * specific file under the base.
+ */
+struct BaseTestModelPath {
+  /** Base directory for unit-test models. */
+  static fs::path path() {
+    if (fs::exists(fs::path{"../../../models/unit-test"})) {
+      return fs::path{"../../../models/unit-test"};
+    }
+    return fs::path{"models/unit-test"};
+  }
+
+  /**
+   * Default model path: Llama-3.2-1B-Instruct-Q4_0.gguf if present,
+   * else test_model.gguf, else "Llama-3.2-1B-Instruct-Q4_0.gguf".
+   */
+  static std::string get() {
+    fs::path base = path();
+    fs::path p = base / "Llama-3.2-1B-Instruct-Q4_0.gguf";
+    if (fs::exists(p))
+      return p.string();
+    p = base / "test_model.gguf";
+    if (fs::exists(p))
+      return p.string();
+    return "Llama-3.2-1B-Instruct-Q4_0.gguf";
+  }
+
+  /**
+   * Path for a specific filename under the base. If the file exists, returns
+   * its full path; otherwise returns the filename only (for clearer errors).
+   */
+  static std::string get(const char* filename) {
+    fs::path p = path() / filename;
+    if (fs::exists(p))
+      return p.string();
+    return filename;
+  }
+
+  /**
+   * Path for a preferred filename with fallback. Tries preferred then fallback
+   * under the base; returns full path if either exists, else preferred.
+   */
+  static std::string get(const char* preferred, const char* fallback) {
+    fs::path base = path();
+    if (fs::exists(base / preferred))
+      return (base / preferred).string();
+    if (fs::exists(base / fallback))
+      return (base / fallback).string();
+    return preferred;
+  }
+};
+
+/**
+ * Encapsulates discovery and guard logic for a single optional test model,
+ * covering both single-file and sharded GGUF layouts.
+ *
+ * Construction resolves the path once: it checks @p envVar first, then
+ * looks for @p filename under BaseTestModelPath. When @p isSharded is true
+ * the shard list is also expanded via GGUFShards::expandGGUFIntoShards().
+ * Callers that need absolute shard paths should call
+ * LlamaModel::resolveShardPaths(model.shards, model.path) after construction.
+ *
+ * Use REQUIRE_MODEL() in the test body to skip or fail automatically when
+ * the model is absent.
+ *
+ * Single-file example:
+ *   TestModelPath m("my-model-Q4_0.gguf", "MY_MODEL_PATH",
+ *                   TestModelPath::OnMissing::Skip,
+ *                   "https://huggingface.co/...");
+ *
+ * Sharded example:
+ *   TestModelPath m("my-model-00001-of-00008.gguf", "MY_SHARD_PATH",
+ *                   TestModelPath::OnMissing::Skip, "https://...", true);
+ *   LlamaModel::resolveShardPaths(m.shards, m.path);  // resolve absolute paths
+ */
+struct TestModelPath {
+  enum class OnMissing { Fail, Skip };
+
+  std::string path;     ///< Resolved absolute path to the first (or only) file.
+  std::string filename; ///< Bare .gguf filename used in diagnostic messages.
+  std::string envVar;   ///< Env-var name shown in the diagnostic (may be "").
+  std::string hfUrl;   ///< HuggingFace URL shown in the diagnostic (may be "").
+  OnMissing onMissing; ///< Whether to FAIL or GTEST_SKIP when absent.
+  bool isSharded;      ///< True when the model is split across multiple files.
+  GGUFShards shards;   ///< Populated (without absolute paths) when isSharded.
+
+  TestModelPath() : onMissing(OnMissing::Skip), isSharded(false) {}
+
+  TestModelPath(
+      const char* filename, const char* envVar, OnMissing onMissing,
+      const char* hfUrl = "", bool isSharded = false)
+      : filename(filename), envVar(envVar ? envVar : ""), hfUrl(hfUrl),
+        onMissing(onMissing), isSharded(isSharded) {
+    const char* env = envVar ? std::getenv(envVar) : nullptr;
+    if (env && fs::exists(env)) {
+      path = env;
+    } else {
+      std::string p = BaseTestModelPath::get(filename);
+      if (fs::exists(p))
+        path = p;
+    }
+    if (isSharded && !path.empty())
+      shards = GGUFShards::expandGGUFIntoShards(path);
+  }
+
+  /**
+   * Returns true when the model is ready to use.
+   * For sharded models this requires at least one shard to have been
+   * resolved; for single-file models a non-empty path suffices.
+   */
+  [[nodiscard]] bool found() const {
+    return isSharded ? !shards.gguf_files.empty() : !path.empty();
+  }
+
+  [[nodiscard]] std::string missingMessage() const {
+    std::string msg = filename + " not found";
+    if (!envVar.empty())
+      msg += " (" + envVar + " or models/unit-test)";
+    else
+      msg += " in models/unit-test";
+    if (!hfUrl.empty())
+      msg += "; see " + hfUrl;
+    return msg;
+  }
+};
+
+inline fs::path getTestBackendsDir() {
+#ifdef TEST_BINARY_DIR
+  return fs::path(TEST_BINARY_DIR);
+#else
+  return fs::current_path() / "build" / "test" / "unit";
+#endif
+}
+
+inline std::unique_ptr<std::basic_streambuf<char>>
+readFileToStreambufBinary(const std::string& path) {
+  auto buf = std::make_unique<std::filebuf>();
+  if (!buf->open(path, std::ios::binary | std::ios::in)) {
+    return nullptr;
+  }
+  return buf;
+}
+
 } // namespace test_common
+
+/**
+ * Guard a test against a missing model: emits GTEST_SKIP() or FAIL()
+ * (as configured on the model) when the file was not found.
+ *
+ * Must be called directly from the test function body, not from a helper,
+ * so that GTEST_SKIP / FAIL return from the correct stack frame.
+ */
+#define REQUIRE_MODEL(m)                                                       \
+  do {                                                                         \
+    if (!(m).found()) {                                                        \
+      if ((m).onMissing == ::test_common::TestModelPath::OnMissing::Skip)      \
+        GTEST_SKIP() << (m).missingMessage();                                  \
+      else                                                                     \
+        FAIL() << (m).missingMessage();                                        \
+    }                                                                          \
+  } while (false)

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_lazy_init_backend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_lazy_init_backend.cpp
@@ -4,19 +4,14 @@
 #include <gtest/gtest.h>
 
 #include "model-interface/LlamaLazyInitializeBackend.hpp"
+#include "test_common.hpp"
 
 namespace fs = std::filesystem;
 
 class LlamaLazyInitializeBackendTest : public ::testing::Test {
 protected:
   std::string getTestBackendsDir() {
-    fs::path backendDir;
-#ifdef TEST_BINARY_DIR
-    backendDir = fs::path(TEST_BINARY_DIR);
-#else
-    backendDir = fs::current_path() / "build" / "test" / "unit";
-#endif
-    return backendDir.string();
+    return test_common::getTestBackendsDir().string();
   }
 };
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
@@ -44,25 +44,7 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
-
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
     fs::path backendDir;
@@ -714,30 +696,19 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutUserMessage) {
     FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
-  fs::path basePath;
-  if (fs::exists(fs::path{"../../../models/unit-test"})) {
-    basePath = fs::path{"../../../models/unit-test"};
-  } else {
-    basePath = fs::path{"models/unit-test"};
-  }
-
-  fs::path multimodalModelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-  if (!fs::exists(multimodalModelPath)) {
-    multimodalModelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-  }
-
-  fs::path projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-  if (!fs::exists(projectionPath)) {
-    projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-  }
+  std::string multimodalModelPath = test_common::BaseTestModelPath::get(
+      "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+  std::string projectionPath = test_common::BaseTestModelPath::get(
+      "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+      "mmproj-SmolVLM-500M-Instruct.gguf");
 
   if (!fs::exists(multimodalModelPath) || !fs::exists(projectionPath)) {
     FAIL() << "Multimodal model and projection required for this test";
   }
 
   LlamaModel model(
-      multimodalModelPath.string(),
-      projectionPath.string(),
+      std::move(multimodalModelPath),
+      std::move(projectionPath),
       std::unordered_map<std::string, std::string>(config_files));
   model.waitForLoadInitialization();
 
@@ -757,30 +728,19 @@ TEST_F(LlamaModelTest, FormatPromptMediaWithoutRequest) {
     FAIL() << "Test model not found at: " << getValidModelPath();
   }
 
-  fs::path basePath;
-  if (fs::exists(fs::path{"../../../models/unit-test"})) {
-    basePath = fs::path{"../../../models/unit-test"};
-  } else {
-    basePath = fs::path{"models/unit-test"};
-  }
-
-  fs::path multimodalModelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-  if (!fs::exists(multimodalModelPath)) {
-    multimodalModelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-  }
-
-  fs::path projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-  if (!fs::exists(projectionPath)) {
-    projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-  }
+  std::string multimodalModelPath = test_common::BaseTestModelPath::get(
+      "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+  std::string projectionPath = test_common::BaseTestModelPath::get(
+      "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+      "mmproj-SmolVLM-500M-Instruct.gguf");
 
   if (!fs::exists(multimodalModelPath) || !fs::exists(projectionPath)) {
     FAIL() << "Multimodal model and projection required for this test";
   }
 
   LlamaModel model(
-      multimodalModelPath.string(),
-      projectionPath.string(),
+      std::move(multimodalModelPath),
+      std::move(projectionPath),
       std::unordered_map<std::string, std::string>(config_files));
   model.waitForLoadInitialization();
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llm_context_base.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llm_context_base.cpp
@@ -56,57 +56,20 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
-    fs::path backendDir;
-#ifdef TEST_BINARY_DIR
-    backendDir = fs::path(TEST_BINARY_DIR);
-#else
-    backendDir = fs::current_path() / "build" / "test" / "unit";
-#endif
-
-    config_files["backendsDir"] = backendDir.string();
+    config_files["backendsDir"] = test_common::getTestBackendsDir().string();
   }
 
   bool hasValidModel() { return fs::exists(test_model_path); }
 
   bool hasValidMultimodalModel() {
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (!fs::exists(modelPath)) {
-      modelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-    }
-
-    fs::path projectionPath =
-        basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (!fs::exists(projectionPath)) {
-      projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-    }
-
+    std::string modelPath = test_common::BaseTestModelPath::get(
+        "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+    std::string projectionPath = test_common::BaseTestModelPath::get(
+        "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+        "mmproj-SmolVLM-500M-Instruct.gguf");
     return fs::exists(modelPath) && fs::exists(projectionPath);
   }
 
@@ -133,26 +96,11 @@ protected:
       return nullptr;
     }
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (!fs::exists(modelPath)) {
-      modelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-    }
-
-    fs::path projectionPath =
-        basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (!fs::exists(projectionPath)) {
-      projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-    }
-
-    std::string modelPathStr = modelPath.string();
-    std::string projectionPathStr = projectionPath.string();
+    std::string modelPathStr = test_common::BaseTestModelPath::get(
+        "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+    std::string projectionPathStr = test_common::BaseTestModelPath::get(
+        "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+        "mmproj-SmolVLM-500M-Instruct.gguf");
     auto configCopy = config_files;
     auto model = std::make_unique<LlamaModel>(
         std::move(modelPathStr),

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_full_loading.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_full_loading.cpp
@@ -1,0 +1,124 @@
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/LlamaModel.hpp"
+#include "test_common.hpp"
+
+namespace fs = std::filesystem;
+
+class ModelFullLoadingTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    using MP = test_common::TestModelPath;
+
+    config_["device"] = test_common::getTestDevice();
+    config_["ctx_size"] = "2048";
+    config_["gpu_layers"] = test_common::getTestGpuLayers();
+    config_["n_predict"] = "10";
+
+    config_["backendsDir"] = test_common::getTestBackendsDir().string();
+
+    singleModel_ =
+        MP("Llama-3.2-1B-Instruct-Q4_0.gguf", nullptr, MP::OnMissing::Fail, "");
+
+    shardedModel_ =
+        MP("Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf",
+           "SHARDED_MODEL_FIRST_SHARD_PATH",
+           MP::OnMissing::Fail,
+           "https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded",
+           true /* isSharded */);
+    if (shardedModel_.found())
+      LlamaModel::resolveShardPaths(shardedModel_.shards, shardedModel_.path);
+
+    largeShardedModel_ =
+        MP("Llama-3.2-1B-Instruct-Q4_0-00001-of-00008.gguf",
+           "LARGE_SHARDED_MODEL_FIRST_SHARD_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/jmb95/Llama-3.2-1B-Instruct-Q4_0-sharded",
+           true /* isSharded */);
+    if (largeShardedModel_.found())
+      LlamaModel::resolveShardPaths(
+          largeShardedModel_.shards, largeShardedModel_.path);
+  }
+
+  LlamaModel loadModel(const std::string& modelPath) {
+    std::string path = modelPath;
+    std::string projection;
+    auto cfg = config_;
+    return LlamaModel(std::move(path), std::move(projection), std::move(cfg));
+  }
+
+  void streamShardsIntoModel(
+      LlamaModel& model, const test_common::TestModelPath& mp) {
+    std::string tensorsBasename =
+        fs::path(mp.shards.tensors_file).filename().string();
+    auto tensorsBuf =
+        test_common::readFileToStreambufBinary(mp.shards.tensors_file);
+    ASSERT_NE(tensorsBuf, nullptr)
+        << "Failed to open: " << mp.shards.tensors_file;
+    model.setWeightsForFile(tensorsBasename, std::move(tensorsBuf));
+
+    for (const auto& shardPath : mp.shards.gguf_files) {
+      auto streambuf = test_common::readFileToStreambufBinary(shardPath);
+      ASSERT_NE(streambuf, nullptr) << "Failed to open shard: " << shardPath;
+      model.setWeightsForFile(
+          fs::path(shardPath).filename().string(), std::move(streambuf));
+    }
+  }
+
+  std::unordered_map<std::string, std::string> config_;
+  test_common::TestModelPath singleModel_;
+  test_common::TestModelPath shardedModel_;
+  test_common::TestModelPath largeShardedModel_;
+};
+
+TEST_F(ModelFullLoadingTest, SingleFile_LoadsSuccessfully) {
+  REQUIRE_MODEL(singleModel_);
+  LlamaModel model = loadModel(singleModel_.path);
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
+
+TEST_F(ModelFullLoadingTest, StreamingSingleFile_LoadsSuccessfully) {
+  REQUIRE_MODEL(singleModel_);
+  LlamaModel model = loadModel(singleModel_.path);
+  std::string filename = fs::path(singleModel_.path).filename().string();
+  auto streambuf = test_common::readFileToStreambufBinary(singleModel_.path);
+  ASSERT_NE(streambuf, nullptr) << "Failed to open: " << singleModel_.path;
+  model.setWeightsForFile(filename, std::move(streambuf));
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
+
+TEST_F(ModelFullLoadingTest, Sharded_LoadsSuccessfully) {
+  REQUIRE_MODEL(shardedModel_);
+  LlamaModel model = loadModel(shardedModel_.path);
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
+
+TEST_F(ModelFullLoadingTest, StreamingShards_LoadsSuccessfully) {
+  REQUIRE_MODEL(shardedModel_);
+  LlamaModel model = loadModel(shardedModel_.path);
+  streamShardsIntoModel(model, shardedModel_);
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
+
+TEST_F(ModelFullLoadingTest, LargeSharded_LoadsSuccessfully) {
+  REQUIRE_MODEL(largeShardedModel_);
+  LlamaModel model = loadModel(largeShardedModel_.path);
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}
+
+TEST_F(ModelFullLoadingTest, StreamingLargeShards_LoadsSuccessfully) {
+  REQUIRE_MODEL(largeShardedModel_);
+  LlamaModel model = loadModel(largeShardedModel_.path);
+  streamShardsIntoModel(model, largeShardedModel_);
+  model.waitForLoadInitialization();
+  EXPECT_TRUE(model.isLoaded());
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
@@ -1,0 +1,567 @@
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <future>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+#include <llama-cpp.h>
+
+#include "model-interface/AsyncWeightsLoader.hpp"
+#include "model-interface/LlamaModel.hpp"
+#include "model-interface/ModelMetadata.hpp"
+#include "test_common.hpp"
+
+namespace fs = std::filesystem;
+
+// ---- MockAsyncWeightsLoader ----
+//
+// Overrides fulfillSplitFuture so tests never touch the global promise
+// registry. fulfilledFilenames records every call for assertion;
+// waitForFulfillCount() synchronises with the detached thread used by the
+// sharded path.
+
+class MockAsyncWeightsLoader : public AsyncWeightsLoader {
+public:
+  using AsyncWeightsLoader::AsyncWeightsLoader;
+
+  std::multiset<std::string> fulfilledFilenames;
+
+  void waitForFulfillCount(std::size_t n) {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_.wait(lock, [&] { return fulfilledFilenames.size() >= n; });
+  }
+
+protected:
+  void fulfillSplitFuture(
+      const std::string& filename, std::unique_ptr<Buf>&&) override {
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      fulfilledFilenames.insert(filename);
+    }
+    cv_.notify_all();
+  }
+
+private:
+  std::mutex mu_;
+  std::condition_variable cv_;
+};
+
+// ---- Common types ----
+
+using MetaChecker = std::function<void(const ModelMetaData&)>;
+
+// ---- Test fixture ----
+
+class ModelMetadataTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    using MP = test_common::TestModelPath;
+
+    normalModel_ =
+        MP("Llama-3.2-1B-Instruct-Q4_0.gguf", nullptr, MP::OnMissing::Fail, "");
+
+    bitnetModel_ =
+        MP("bitnet_b1_58-large-TQ2_0.gguf",
+           "BITNET_MODEL_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0");
+
+    qwen3Model_ =
+        MP("Qwen3-0.6B-Q8_0.gguf",
+           "QWEN3_MODEL_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF");
+
+    // MedGemma is a Gemma-3-based model used in integration tests.
+    // https://huggingface.co/unsloth/medgemma-4b-it-GGUF
+    gemma3Model_ =
+        MP("medgemma-4b-it-Q4_1.gguf",
+           "GEMMA3_MODEL_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/unsloth/medgemma-4b-it-GGUF");
+
+    // Sharded models: constructor expands the shard list; resolveShardPaths
+    // then fills in absolute paths (requires LlamaModel, kept out of
+    // test_common.hpp to avoid pulling in the heavy llama headers there).
+    // https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded
+    normalModelSharded_ =
+        MP("Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf",
+           "SHARDED_MODEL_FIRST_SHARD_PATH",
+           MP::OnMissing::Skip,
+           "https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ-1_S-sharded",
+           true /* isSharded */);
+    if (normalModelSharded_.found())
+      LlamaModel::resolveShardPaths(
+          normalModelSharded_.shards, normalModelSharded_.path);
+
+    // https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded
+    bitnetModelSharded_ =
+        MP("bitnet_b1_58-large-TQ2_0-00001-of-00008.gguf",
+           nullptr,
+           MP::OnMissing::Skip,
+           "https://huggingface.co/jmb95/bitnet_b1_58-large-TQ2_0-sharded",
+           true /* isSharded */);
+    if (bitnetModelSharded_.found())
+      LlamaModel::resolveShardPaths(
+          bitnetModelSharded_.shards, bitnetModelSharded_.path);
+  }
+
+  test_common::TestModelPath normalModel_;
+  test_common::TestModelPath bitnetModel_;
+  test_common::TestModelPath qwen3Model_;
+  test_common::TestModelPath gemma3Model_;
+  test_common::TestModelPath normalModelSharded_;
+  test_common::TestModelPath bitnetModelSharded_;
+
+  // ---- Parse-and-check helpers ----
+  //
+  // Each helper drives one parse strategy and calls check(meta) at the end.
+  // Use ASSERT_NO_FATAL_FAILURE() at the call site if early exit on fatal
+  // assertion failure is needed.
+
+  void parseDiskSingleFile(const std::string& path, MetaChecker check) {
+    GGUFShards emptyShards;
+    ModelMetaData meta;
+    meta.parse(path, emptyShards, false /* isStreaming */, "Test");
+    check(meta);
+  }
+
+  void parseDiskShards(
+      const std::string& firstShardPath, const GGUFShards& shardsWithPaths,
+      MetaChecker check) {
+    ModelMetaData meta;
+    meta.parse(
+        firstShardPath, shardsWithPaths, false /* isStreaming */, "Test");
+    check(meta);
+  }
+
+  // Note: in real scenarios the GGUF is streamed from the network; a
+  // file-backed streambuf is used here so metadata parsing reads on demand
+  // without copying the entire file into memory.
+  void parseStreamingSingleFile(const std::string& path, MetaChecker check) {
+    std::unique_ptr<std::basic_streambuf<char>> streambuf =
+        test_common::readFileToStreambufBinary(path);
+    ASSERT_NE(streambuf, nullptr);
+    GGUFShards emptyShards;
+    BorrowablePtr<std::basic_streambuf<char>> firstFileFromGgufStream(
+        std::move(streambuf));
+    ModelMetaData meta;
+    std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
+      meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
+    });
+    meta.parse(path, emptyShards, true /* isStreaming */, "Test");
+    lenderThread.join();
+    check(meta);
+  }
+
+  void parseStreamingShards(
+      const std::string& firstShardPath, const GGUFShards& shardsWithPaths,
+      MetaChecker check) {
+    std::unique_ptr<std::basic_streambuf<char>> streambuf =
+        test_common::readFileToStreambufBinary(
+            shardsWithPaths.gguf_files.front());
+    ASSERT_NE(streambuf, nullptr);
+    BorrowablePtr<std::basic_streambuf<char>> firstFileFromGgufStream(
+        std::move(streambuf));
+    ModelMetaData meta;
+    std::thread lenderThread([&meta, &firstFileFromGgufStream]() {
+      meta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
+    });
+    meta.parse(firstShardPath, shardsWithPaths, true /* isStreaming */, "Test");
+    lenderThread.join();
+    check(meta);
+  }
+
+  // setWeightsForFile is called before parse() (mirrors real delayed-load
+  // usage). Invariants — shard is in extracted map, fulfillSplitFuture is
+  // never called for single-GGUF — are asserted by the helper itself.
+  void parseAsyncLoaderSingleFile(const std::string& path, MetaChecker check) {
+    std::unique_ptr<std::basic_streambuf<char>> singleFileStreambuf =
+        test_common::readFileToStreambufBinary(path);
+    ASSERT_NE(singleFileStreambuf, nullptr);
+
+    const std::string filename = fs::path(path).filename().string();
+    GGUFShards emptyShards;
+    InitLoader initLoader;
+    ModelMetaData meta;
+    MockAsyncWeightsLoader loader(emptyShards, initLoader, "test", &meta);
+
+    loader.setWeightsForFile(filename, std::move(singleFileStreambuf));
+    meta.parse(path, emptyShards, true /* isStreaming */, "Test");
+    std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>
+        extracted = loader.extractIndividualStreamedFiles();
+    check(meta);
+    EXPECT_NE(extracted.find(filename), extracted.end());
+    EXPECT_TRUE(loader.fulfilledFilenames.empty());
+  }
+
+  // parse() is run on a separate thread because it blocks at wait() until
+  // setWeightsForFile() provides the first shard via lendFirstShard().
+  // waitForFulfillCount(1) makes assertions on fulfilledFilenames race-free.
+  void parseAsyncLoaderShards(
+      const std::string& firstShardPath, const GGUFShards& shardsWithPaths,
+      MetaChecker check) {
+    GGUFShards shards = GGUFShards::expandGGUFIntoShards(firstShardPath);
+    const std::string firstShardFilename = shards.gguf_files.front();
+
+    std::unique_ptr<std::basic_streambuf<char>> firstShardBuf =
+        test_common::readFileToStreambufBinary(
+            shardsWithPaths.gguf_files.front());
+    ASSERT_NE(firstShardBuf, nullptr);
+
+    InitLoader initLoader;
+    const std::string loadingContext =
+        InitLoader::getLoadingContext("TestShards");
+    ModelMetaData meta;
+    MockAsyncWeightsLoader loader(shards, initLoader, loadingContext, &meta);
+
+    std::thread parseThread([&]() {
+      meta.parse(
+          firstShardPath, shardsWithPaths, true /* isStreaming */, "Test");
+    });
+
+    loader.setWeightsForFile(firstShardFilename, std::move(firstShardBuf));
+    parseThread.join();
+    loader.waitForFulfillCount(1);
+
+    check(meta);
+    EXPECT_EQ(loader.fulfilledFilenames.count(firstShardFilename), 1u);
+  }
+};
+
+// ---- Disk single file ----
+
+TEST_F(
+    ModelMetadataTest, DiskSingleFile_NormalModel_HasOneBitQuantizationFalse) {
+  REQUIRE_MODEL(normalModel_);
+  parseDiskSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_FALSE(meta.hasOneBitQuantization());
+  });
+}
+
+TEST_F(
+    ModelMetadataTest, DiskSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseDiskSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.hasOneBitQuantization());
+  });
+}
+
+// ---- Disk shards ----
+
+TEST_F(ModelMetadataTest, DiskShards_NormalModel_HasOneBitQuantizationFalse) {
+  REQUIRE_MODEL(normalModelSharded_);
+  parseDiskShards(
+      normalModelSharded_.path,
+      normalModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
+}
+
+TEST_F(ModelMetadataTest, DiskShards_BitnetModel_HasOneBitQuantizationTrue) {
+  REQUIRE_MODEL(bitnetModelSharded_);
+  parseDiskShards(
+      bitnetModelSharded_.path,
+      bitnetModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
+}
+
+// ---- Streaming single file ----
+
+TEST_F(
+    ModelMetadataTest,
+    StreamingSingleFile_NormalModel_HasOneBitQuantizationFalse) {
+  REQUIRE_MODEL(normalModel_);
+  parseStreamingSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_FALSE(meta.hasOneBitQuantization());
+  });
+}
+
+TEST_F(
+    ModelMetadataTest,
+    StreamingSingleFile_BitnetModel_HasOneBitQuantizationTrue) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseStreamingSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.hasOneBitQuantization());
+  });
+}
+
+// ---- Streaming shards ----
+
+TEST_F(
+    ModelMetadataTest, StreamingShards_NormalModel_HasOneBitQuantizationFalse) {
+  REQUIRE_MODEL(normalModelSharded_);
+  parseStreamingShards(
+      normalModelSharded_.path,
+      normalModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
+}
+
+TEST_F(
+    ModelMetadataTest, StreamingShards_BitnetModel_HasOneBitQuantizationTrue) {
+  REQUIRE_MODEL(bitnetModelSharded_);
+  parseStreamingShards(
+      bitnetModelSharded_.path,
+      bitnetModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
+}
+
+// ---- AsyncWeightsLoader: streaming single file ----
+//
+// setWeightsForFile is called during the download phase (before activate()),
+// so by the time parse() runs it finds the single file already in
+// streamedFiles_ and the wait() flag already set.
+
+TEST_F(
+    ModelMetadataTest,
+    AsyncLoader_SingleFile_NormalModel_MetadataParsedAndShardAvailable) {
+  REQUIRE_MODEL(normalModel_);
+  parseAsyncLoaderSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_FALSE(meta.hasOneBitQuantization());
+  });
+}
+
+TEST_F(
+    ModelMetadataTest,
+    AsyncLoader_SingleFile_BitnetModel_MetadataParsedAndShardAvailable) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseAsyncLoaderSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.hasOneBitQuantization());
+  });
+}
+
+TEST_F(
+    ModelMetadataTest,
+    AsyncLoader_SingleFile_NoMetadata_ShardStoredWithoutLending) {
+  REQUIRE_MODEL(normalModel_);
+  std::unique_ptr<std::basic_streambuf<char>> singleFileStreambuf =
+      test_common::readFileToStreambufBinary(normalModel_.path);
+  ASSERT_NE(singleFileStreambuf, nullptr);
+
+  const std::string filename = fs::path(normalModel_.path).filename().string();
+  GGUFShards emptyShards;
+  InitLoader initLoader;
+  // No ModelMetaData — lending is skipped entirely.
+  MockAsyncWeightsLoader loader(emptyShards, initLoader, "test-no-meta");
+
+  loader.setWeightsForFile(filename, std::move(singleFileStreambuf));
+
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>> extracted =
+      loader.extractIndividualStreamedFiles();
+  EXPECT_TRUE(loader.isStreaming());
+  EXPECT_NE(extracted.find(filename), extracted.end());
+  EXPECT_TRUE(loader.fulfilledFilenames.empty());
+}
+
+// ---- AsyncWeightsLoader: streaming shards ----
+
+TEST_F(ModelMetadataTest, AsyncLoader_Shards_NormalModel_MetadataParsed) {
+  REQUIRE_MODEL(normalModelSharded_);
+  parseAsyncLoaderShards(
+      normalModelSharded_.path,
+      normalModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_FALSE(meta.hasOneBitQuantization());
+      });
+}
+
+TEST_F(ModelMetadataTest, AsyncLoader_Shards_BitnetModel_MetadataParsed) {
+  REQUIRE_MODEL(bitnetModelSharded_);
+  parseAsyncLoaderShards(
+      bitnetModelSharded_.path,
+      bitnetModelSharded_.shards,
+      [](const ModelMetaData& meta) {
+        EXPECT_TRUE(meta.hasOneBitQuantization());
+      });
+}
+
+TEST_F(
+    ModelMetadataTest,
+    AsyncLoader_Shards_FirstShardWorkerBlocksUntilMetadataReleases) {
+  REQUIRE_MODEL(normalModelSharded_);
+
+  GGUFShards shards =
+      GGUFShards::expandGGUFIntoShards(normalModelSharded_.path);
+  const std::string firstShardFilename = shards.gguf_files.front();
+
+  std::unique_ptr<std::basic_streambuf<char>> firstShardBuf =
+      test_common::readFileToStreambufBinary(
+          normalModelSharded_.shards.gguf_files.front());
+  ASSERT_NE(firstShardBuf, nullptr);
+
+  InitLoader initLoader;
+  const std::string loadingContext =
+      InitLoader::getLoadingContext("TestFirstShardBlock");
+  ModelMetaData meta;
+  MockAsyncWeightsLoader loader(shards, initLoader, loadingContext, &meta);
+
+  loader.setWeightsForFile(firstShardFilename, std::move(firstShardBuf));
+
+  // Before metadata parse runs, the first-shard worker should still be waiting
+  // for release, so public extraction (which joins internally) must block.
+  auto extractFuture = std::async(std::launch::async, [&loader]() {
+    return loader.extractIndividualStreamedFiles();
+  });
+  EXPECT_EQ(
+      extractFuture.wait_for(std::chrono::milliseconds(150)),
+      std::future_status::timeout);
+
+  // Once metadata parsing consumes/releases the borrowed first shard, the
+  // worker should finish and extraction should complete.
+  auto parseFuture = std::async(std::launch::async, [&]() {
+    meta.parse(
+        normalModelSharded_.path,
+        normalModelSharded_.shards,
+        true /* isStreaming */,
+        "Test");
+  });
+  ASSERT_EQ(
+      parseFuture.wait_for(std::chrono::seconds(10)),
+      std::future_status::ready);
+  EXPECT_NO_THROW(parseFuture.get());
+
+  ASSERT_EQ(
+      extractFuture.wait_for(std::chrono::seconds(5)),
+      std::future_status::ready);
+  EXPECT_NO_THROW({
+    auto extracted = extractFuture.get();
+    EXPECT_TRUE(extracted.empty());
+  });
+
+  loader.waitForFulfillCount(1);
+  EXPECT_EQ(loader.fulfilledFilenames.count(firstShardFilename), 1u);
+}
+
+// ---- Disk single file – isU32OneOf: quantization per architecture ----
+//
+// Quantization is stored as a u32 under "general.file_type" (llama_ftype).
+// Model architecture ("general.architecture") is a string field and therefore
+// cannot be queried with isU32OneOf; it is exercised here implicitly by running
+// the same checker against models from different architecture families.
+//
+// Known models exercised:
+//   Llama-3.2-1B-Instruct-Q4_0  (llama  arch, LLAMA_FTYPE_MOSTLY_Q4_0)
+//   Qwen3-0.6B-Q8_0             (qwen3  arch, LLAMA_FTYPE_MOSTLY_Q8_0)
+//   medgemma-4b-it-Q4_1         (gemma3 arch, LLAMA_FTYPE_MOSTLY_Q4_1)
+//   bitnet_b1_58-large-TQ2_0    (bitnet arch, LLAMA_FTYPE_MOSTLY_TQ2_0)
+
+// Adreno 800+ requires Vulkan to be available when fine-tuning with any of
+// the quantization types listed here. The checker is shared across all
+// architecture-specific tests below so that every new model variant
+// automatically exercises the same gate.
+static const MetaChecker kVulkanNeededForFinetuneAdreno800Plus =
+    [](const ModelMetaData& meta) {
+      EXPECT_TRUE(meta.isU32OneOf(
+          "general.file_type",
+          {static_cast<uint32_t>(LLAMA_FTYPE_ALL_F32),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_F16),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_1),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0),
+           static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0)}));
+    };
+
+// llama architecture – Llama-3.2-1B-Instruct-Q4_0
+
+TEST_F(
+    ModelMetadataTest,
+    DiskSingleFile_LlamaArch_Q4_0_VulkanNeededForFinetuneAdreno800Plus) {
+  REQUIRE_MODEL(normalModel_);
+  parseDiskSingleFile(normalModel_.path, kVulkanNeededForFinetuneAdreno800Plus);
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_LlamaArch_IsSpecificallyQ4_0) {
+  REQUIRE_MODEL(normalModel_);
+  parseDiskSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.isU32OneOf(
+        "general.file_type", {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0)}));
+    EXPECT_FALSE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0)}));
+  });
+}
+
+// qwen3 architecture – Qwen3-0.6B-Q8_0
+
+TEST_F(
+    ModelMetadataTest,
+    DiskSingleFile_Qwen3Arch_Q8_0_VulkanNeededForFinetuneAdreno800Plus) {
+  REQUIRE_MODEL(qwen3Model_);
+  parseDiskSingleFile(qwen3Model_.path, kVulkanNeededForFinetuneAdreno800Plus);
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_Qwen3Arch_IsSpecificallyQ8_0) {
+  REQUIRE_MODEL(qwen3Model_);
+  parseDiskSingleFile(qwen3Model_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.isU32OneOf(
+        "general.file_type", {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0)}));
+    EXPECT_FALSE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0)}));
+  });
+}
+
+// gemma3 architecture – medgemma-4b-it-Q4_1
+// Set GEMMA3_MODEL_PATH or place medgemma-4b-it-Q4_1.gguf in models/unit-test.
+
+TEST_F(
+    ModelMetadataTest,
+    DiskSingleFile_Gemma3Arch_Q4_1_VulkanNeededForFinetuneAdreno800Plus) {
+  REQUIRE_MODEL(gemma3Model_);
+  parseDiskSingleFile(gemma3Model_.path, kVulkanNeededForFinetuneAdreno800Plus);
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_Gemma3Arch_IsSpecificallyQ4_1) {
+  REQUIRE_MODEL(gemma3Model_);
+  parseDiskSingleFile(gemma3Model_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.isU32OneOf(
+        "general.file_type", {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_1)}));
+    EXPECT_FALSE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ1_0)}));
+  });
+}
+
+// bitnet architecture – bitnet_b1_58-large-TQ2_0
+
+TEST_F(
+    ModelMetadataTest,
+    DiskSingleFile_BitnetArch_TQ2_0_VulkanNeededForFinetuneAdreno800Plus) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseDiskSingleFile(bitnetModel_.path, kVulkanNeededForFinetuneAdreno800Plus);
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_BitnetArch_IsSpecificallyTQ2_0) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseDiskSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    EXPECT_TRUE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_TQ2_0)}));
+    EXPECT_FALSE(meta.isU32OneOf(
+        "general.file_type",
+        {static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q4_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_Q8_0),
+         static_cast<uint32_t>(LLAMA_FTYPE_MOSTLY_F16),
+         static_cast<uint32_t>(LLAMA_FTYPE_ALL_F32)}));
+  });
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_mtmd_llm_context.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_mtmd_llm_context.cpp
@@ -48,37 +48,11 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "SmolVLM-500M-Instruct.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "SmolVLM-500M-Instruct-Q8_0.gguf";
-      }
-    }
-
-    fs::path projectionPath =
-        basePath / "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-    if (fs::exists(projectionPath)) {
-      test_projection_path = projectionPath.string();
-    } else {
-      projectionPath = basePath / "mmproj-SmolVLM-500M-Instruct.gguf";
-      if (fs::exists(projectionPath)) {
-        test_projection_path = projectionPath.string();
-      } else {
-        test_projection_path = "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get(
+        "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+    test_projection_path = test_common::BaseTestModelPath::get(
+        "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+        "mmproj-SmolVLM-500M-Instruct.gguf");
 
     fs::path backendDir;
 #ifdef TEST_BINARY_DIR

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_qwen3_reasoning_utils.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_qwen3_reasoning_utils.cpp
@@ -20,34 +20,10 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
-    fs::path backendDir;
-#ifdef TEST_BINARY_DIR
-    backendDir = fs::path(TEST_BINARY_DIR);
-#else
-    backendDir = fs::current_path() / "build" / "test" / "unit";
-#endif
-
-    config_files["backendsDir"] = backendDir.string();
+    config_files["backendsDir"] = test_common::getTestBackendsDir().string();
   }
 
   std::unordered_map<std::string, std::string> config_files;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_text_llm_context.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_text_llm_context.cpp
@@ -49,34 +49,10 @@ protected:
     config_files["gpu_layers"] = test_common::getTestGpuLayers();
     config_files["n_predict"] = "10";
 
-    fs::path basePath;
-    if (fs::exists(fs::path{"../../../models/unit-test"})) {
-      basePath = fs::path{"../../../models/unit-test"};
-    } else {
-      basePath = fs::path{"models/unit-test"};
-    }
-
-    fs::path modelPath = basePath / "Llama-3.2-1B-Instruct-Q4_0.gguf";
-    if (fs::exists(modelPath)) {
-      test_model_path = modelPath.string();
-    } else {
-      modelPath = basePath / "test_model.gguf";
-      if (fs::exists(modelPath)) {
-        test_model_path = modelPath.string();
-      } else {
-        test_model_path = "Llama-3.2-1B-Instruct-Q4_0.gguf";
-      }
-    }
+    test_model_path = test_common::BaseTestModelPath::get();
     test_projection_path = "";
 
-    fs::path backendDir;
-#ifdef TEST_BINARY_DIR
-    backendDir = fs::path(TEST_BINARY_DIR);
-#else
-    backendDir = fs::current_path() / "build" / "test" / "unit";
-#endif
-
-    config_files["backendsDir"] = backendDir.string();
+    config_files["backendsDir"] = test_common::getTestBackendsDir().string();
   }
 
   std::unordered_map<std::string, std::string> config_files;

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
@@ -7,7 +7,7 @@
     "picojson",
     {
       "name": "qvac-fabric",
-      "version>=": "7248.1.2"
+      "version>=": "7248.1.3"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
## What problem is this PR solving
Make possible to access model metadata from the LlamaModel class by extracting it from the `.gguf` binary.

## Dependencies
Requires https://github.com/tetherto/qvac-fabric-llm.cpp/pull/100/changes

## Tests Made:

### C++ tests
- Ran loading/metadata integration and C++ tests locally
- Ran loading/metadata integration and C++ tests on a temp branch
   - https://github.com/tetherto/qvac/actions/runs/22587719554 (C++ tests)  (Note that even from a temp branch, CI has to be manually triggered to take into account new workflow modifications, this PR CI is not enough). 
   - https://github.com/tetherto/qvac/actions/runs/22627516800 (latest run)

### PR CI for JS integration tests:
   - Old run https://github.com/tetherto/qvac/actions/runs/22582075512/job/65418469251?pr=576 (just failed C++ formatting and C++ test which need to be trigered manually)
   - Ongoing CI: latest run https://github.com/tetherto/qvac/actions/runs/22625941480/job/65563690164?pr=576
   
   


