### PR TITLE
QVAC-13512: Reload instance

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.12.0] - 2026-03-09
+
+### Added
+
+#### Hot-reload support (`LlamaModel::reload()`)
+
+`LlamaModel` now stores its construction arguments (`modelPath`, `projectionPath`, `configFilemap`) and exposes a `reload()` method that rebuilds the model in-place from the stored args with `IMMEDIATE` loading (synchronous, blocking). This avoids tearing down and reconstructing the entire `LlamaModel` instance when the same model needs to be reloaded — for example, to reclaim GPU memory or recover from a corrupted context state.
+
+All mutable model state (context, cache manager, backends handle, async weights loader, etc.) is grouped into an internal `ReloadableState` struct. On reload, the old state is replaced atomically with a freshly initialized one.
+
+#### Thread-safe reload with `shared_mutex`
+
+`LlamaModel` is now protected by a `std::shared_mutex` (`stateMtx_`):
+
+- **Shared lock** for all read/use operations: `processPrompt`, `process`, `cancel`, `reset`, `runtimeStats`, `isLoaded`, `waitForLoadInitialization`, and `setWeightsForFile`.
+- **Exclusive lock** only in `reload()` via `setInitLoader()`.
+
+This means `reload()` blocks until all in-flight operations complete, while concurrent reads (e.g. multiple inference queries) can proceed in parallel. `cancel()` uses `std::try_to_lock` to gracefully skip cancellation if a reload is already in progress, since there would be nothing to cancel after the reload completes.
+
+#### Streaming-loaded model reload guard
+
+`reload()` now throws `ReloadNotSupportedForStreamedModel` (`StatusError`, error code 24) when called on a model that was loaded via streamed shards (`setWeightsForFile`). The streamed weight buffers are consumed (moved out) by llama.cpp during the initial load and cannot be replayed on reload.
+
+### Changed
+
+- Refactored `LlamaModel` internals: extracted `processPromptImpl` and `cancelImpl` (lock-free implementations) to separate locking concerns from business logic.
+- `initializeBackend()` is now private — it is only called internally during `init()`.
+
 ## [0.11.1] - 2026-03-09
 
 ### Added
@@ -11,7 +39,6 @@
 - Prefill runs report `TTFT=0`, `TPS=0`, `generatedTokens=0`, `promptTokens=0`, while `CacheTokens` reflects actual KV cache occupancy.
 - JS `normalizeRunOptions` validates `prefill` as a boolean; a `TypeError` is thrown otherwise.
 - C++ `evalMessage`/`evalMessageWithTools` suppress logits on the last token when prefill is set; `processPrompt` returns immediately after evaluation.
-
 
 ## [0.11.0] - 2026-03-05
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/LlmErrors.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/LlmErrors.hpp
@@ -29,6 +29,7 @@ enum LlmErrorCode : uint32_t {
   MediaRequestNotProvided = 21,
   UnableToDeleteThreadPool = 22,
   UnableToLoadMetadata = 23,
+  ReloadNotSupportedForStreamedModel = 24,
   // mode llm spesific errors here
 };
 
@@ -78,6 +79,8 @@ inline std::string toString(LlmErrorCode code) {
     return "MediaRequestNotProvided";
   case UnableToLoadMetadata:
     return "UnableToLoadMetadata";
+  case ReloadNotSupportedForStreamedModel:
+    return "ReloadNotSupportedForStreamedModel";
   default:
     return "UnknownLLMError";
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -112,7 +112,7 @@ LlamaModel::LlamaModel(
           std::move(modelPath),
           std::move(projectionPath),
           std::move(configFilemap)} {
-  setInitLoader();
+  setInitLoader(InitLoader::LOADER_TYPE::DELAYED);
 }
 
 void LlamaModel::reload() {
@@ -127,14 +127,17 @@ void LlamaModel::reload() {
           "Cannot reload a model that was loaded via streamed shards; "
           "the streamed weights have already been consumed.");
     }
-    constructionArgs_.loaderType = InitLoader::LOADER_TYPE::IMMEDIATE;
   }
-  setInitLoader();
+  setInitLoader(InitLoader::LOADER_TYPE::IMMEDIATE);
 }
 
-void LlamaModel::setInitLoader() {
-  cancelImpl();
+void LlamaModel::setInitLoader(
+    std::optional<InitLoader::LOADER_TYPE> loaderType) {
+  cancel();
   std::unique_lock lock(stateMtx_);
+  if (loaderType.has_value()) {
+    constructionArgs_.loaderType = loaderType.value();
+  }
   state_ = std::make_unique<ReloadableState>(
       constructionArgs_, loadingContext_, metadata_);
   state_->initLoader_.init(

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -27,6 +27,7 @@
 #include "qvac-lib-inference-addon-cpp/LlamacppUtils.hpp"
 #include "utils/BackendSelection.hpp"
 #include "utils/LoggingMacros.hpp"
+#include "utils/SharedSnapshot.hpp"
 
 using namespace qvac_lib_inference_addon_llama::errors;
 using namespace qvac_lib_inference_addon_cpp::logger;
@@ -138,26 +139,39 @@ void LlamaModel::setInitLoader(
   if (loaderType.has_value()) {
     constructionArgs_.loaderType = loaderType.value();
   }
-  state_ = std::make_unique<ReloadableState>(
+  state_ = std::make_shared<ReloadableState>(
       constructionArgs_, loadingContext_, metadata_);
+  bool callerHoldsLock =
+      constructionArgs_.loaderType == InitLoader::LOADER_TYPE::IMMEDIATE;
   state_->initLoader_.init(
-      constructionArgs_.loaderType, [this]() { this->init(); });
+      constructionArgs_.loaderType,
+      [this, acquireLock = !callerHoldsLock]() { this->init(acquireLock); });
 }
 
-void LlamaModel::init() {
+void LlamaModel::init(bool acquireLock) {
+  SharedSnapshot snap(state_, stateMtx_);
+  if (!acquireLock) {
+    snap.disable();
+  }
+  snap.lockRead();
+
   const auto& modelPath = constructionArgs_.modelPath;
   auto configFilemap = constructionArgs_.configFilemap;
 
   setVerbosityLevel(configFilemap);
 
-  if (!state_->asyncWeightsLoader_.isStreaming()) {
-    resolveShardPaths(state_->shards_, modelPath);
+  if (!snap->asyncWeightsLoader_.isStreaming()) {
+    if (!snap.promoteToWrite()) {
+      return;
+    }
+    resolveShardPaths(snap->shards_, modelPath);
+    snap.demoteToRead();
   }
 
   metadata_.parse(
       modelPath,
-      state_->shards_,
-      state_->asyncWeightsLoader_.isStreaming(),
+      snap->shards_,
+      snap->asyncWeightsLoader_.isStreaming(),
       ADDON_ID);
   {
     auto fileType = metadata_.tryGetU32("general.file_type");
@@ -169,6 +183,10 @@ void LlamaModel::init() {
                                  : "unknown"));
   }
 
+  if (!snap.promoteToWrite()) {
+    return;
+  }
+
   {
     std::string backendsDir;
     if (auto backendsDirIt = configFilemap.find("backendsDir");
@@ -176,7 +194,7 @@ void LlamaModel::init() {
       backendsDir = backendsDirIt->second;
       configFilemap.erase(backendsDirIt);
     }
-    initializeBackend(backendsDir);
+    snap->backendsHandle_ = LlamaBackendsHandle(backendsDir);
   }
 
   common_params params;
@@ -185,38 +203,40 @@ void LlamaModel::init() {
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
   auto streamedFiles =
-      state_->asyncWeightsLoader_.extractIndividualStreamedFiles();
+      snap->asyncWeightsLoader_.extractIndividualStreamedFiles();
+
+  snap.demoteToRead();
+
   common_init_result llamaInit = initFromConfig(
       params,
       modelPath,
       streamedFiles,
-      state_->shards_,
+      snap->shards_,
       loadingContext_,
-      state_->asyncWeightsLoader_.isStreaming(),
+      snap->asyncWeightsLoader_.isStreaming(),
       ADDON_ID,
       errorWhenFailed);
 
-  // Create the appropriate context based on projectionPath
-  state_->llmContext_ = createContext(
+  if (!snap.promoteToWrite()) {
+    return;
+  }
+
+  snap->isTextLlm_ = constructionArgs_.projectionPath.empty();
+  snap->llmContext_ = createContext(
       std::string(constructionArgs_.projectionPath),
       params,
       std::move(llamaInit));
 
-  // Apply configured nDiscarded if provided (> 0)
-  if (state_->configuredNDiscarded_ > 0 && state_->llmContext_) {
-    state_->llmContext_->setNDiscarded(state_->configuredNDiscarded_);
+  if (snap->configuredNDiscarded_ > 0 && snap->llmContext_) {
+    snap->llmContext_->setNDiscarded(snap->configuredNDiscarded_);
   }
 
-  if (state_->llmContext_) {
-    state_->cacheManager_.emplace(
-        state_->llmContext_.get(),
-        state_->configuredNDiscarded_,
+  if (snap->llmContext_) {
+    snap->cacheManager_.emplace(
+        snap->llmContext_.get(),
+        snap->configuredNDiscarded_,
         [this](bool resetStats) { this->resetState(resetStats); });
   }
-}
-
-void LlamaModel::initializeBackend(const std::string& backendsDir) {
-  state_->backendsHandle_ = LlamaBackendsHandle(backendsDir);
 }
 
 void LlamaModel::setWeightsForFile(
@@ -381,7 +401,8 @@ qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {
   auto perfData = llama_perf_context(state_->llmContext_->getCtx());
   constexpr double kMillisInSecond = 1000.0;
 
-  double timeToFirstToken = state_->lastRunWasPrefill_ ? 0.0 : perfData.t_p_eval_ms;
+  double timeToFirstToken =
+      state_->lastRunWasPrefill_ ? 0.0 : perfData.t_p_eval_ms;
   double tokensPerSecond =
       (!state_->lastRunWasPrefill_ && perfData.t_eval_ms > 0)
           ? kMillisInSecond / perfData.t_eval_ms * perfData.n_eval
@@ -783,10 +804,8 @@ std::unique_ptr<LlmContext> LlamaModel::createContext(
     common_init_result&& llamaInit) {
   if (!projectionPath.empty()) {
     params.mmproj.path = std::move(projectionPath);
-    state_->isTextLlm_ = false;
     return std::make_unique<MtmdLlmContext>(params, std::move(llamaInit));
   }
-  state_->isTextLlm_ = true;
   return std::make_unique<TextLlmContext>(params, std::move(llamaInit));
 }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -107,18 +107,38 @@ LlamaModel::LlamaModel(
     std::string&& modelPath, std::string&& projectionPath,
     std::unordered_map<std::string, std::string>&& configFilemap)
     : loadingContext_(InitLoader::getLoadingContext("LlamaModel")),
-      shards_(GGUFShards::expandGGUFIntoShards(modelPath)),
-      asyncWeightsLoader_(shards_, initLoader_, loadingContext_, &metadata_) {
-  auto thisModelInit = [this](auto&&... args) {
-    this->init(std::forward<decltype(args)>(args)...);
-  };
-  initLoader_.init(
-      InitLoader::LOADER_TYPE::DELAYED,
-      thisModelInit,
-      std::move(modelPath),
-      std::move(projectionPath),
-      std::move(configFilemap));
+      constructionArgs_{modelPath, projectionPath, configFilemap},
+      state_(
+          std::make_unique<ReloadableState>(
+              constructionArgs_, loadingContext_, metadata_)) {
+  auto constArgsCpy =
+      constructionArgs_; // TODO fix design, now that args are copied inside the
+                         // LlamaModel, we could just safely use them directly
+                         // on init, without passing anything
+  init(std::move(constArgsCpy), state_);
 }
+
+void LlamaModel::reload() {
+  ConstructionArgs argsCopy = constructionArgs_;
+  argsCopy.loaderType = InitLoader::LOADER_TYPE::IMMEDIATE;
+  state_ =
+      std::make_unique<ReloadableState>(argsCopy, loadingContext_, metadata_);
+  init(std::move(argsCopy), state_);
+}
+
+void LlamaModel::init(
+    ConstructionArgs&& args, std::unique_ptr<ReloadableState>& state) {
+  auto thisModelInit = [this](auto&&... initArgs) {
+    this->init(std::forward<decltype(initArgs)>(initArgs)...);
+  };
+  state->initLoader_.init(
+      args.loaderType,
+      thisModelInit,
+      std::move(args.modelPath),
+      std::move(args.projectionPath),
+      std::move(args.configFilemap));
+}
+
 void LlamaModel::init(
     // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     std::string&& modelPathRvalue, std::string&& projectionPath,
@@ -130,12 +150,15 @@ void LlamaModel::init(
   // Set verbosity level
   setVerbosityLevel(configFilemap);
 
-  if (!asyncWeightsLoader_.isStreaming()) {
-    resolveShardPaths(shards_, modelPath);
+  if (!state_->asyncWeightsLoader_.isStreaming()) {
+    resolveShardPaths(state_->shards_, modelPath);
   }
 
   metadata_.parse(
-      modelPath, shards_, asyncWeightsLoader_.isStreaming(), ADDON_ID);
+      modelPath,
+      state_->shards_,
+      state_->asyncWeightsLoader_.isStreaming(),
+      ADDON_ID);
   {
     auto fileType = metadata_.tryGetU32("general.file_type");
     QLOG_IF(
@@ -161,45 +184,46 @@ void LlamaModel::init(
   commonParamsParse(modelPath, configFilemap, params, adrenoVersion);
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
-  auto streamedFiles = asyncWeightsLoader_.extractIndividualStreamedFiles();
+  auto streamedFiles =
+      state_->asyncWeightsLoader_.extractIndividualStreamedFiles();
   common_init_result llamaInit = initFromConfig(
       params,
       modelPath,
       streamedFiles,
-      shards_,
+      state_->shards_,
       loadingContext_,
-      asyncWeightsLoader_.isStreaming(),
+      state_->asyncWeightsLoader_.isStreaming(),
       ADDON_ID,
       errorWhenFailed);
 
   // Create the appropriate context based on projectionPath
-  llmContext_ =
+  state_->llmContext_ =
       createContext(std::move(projectionPath), params, std::move(llamaInit));
 
   // Apply configured nDiscarded if provided (> 0)
-  if (configuredNDiscarded_ > 0 && llmContext_) {
-    llmContext_->setNDiscarded(configuredNDiscarded_);
+  if (state_->configuredNDiscarded_ > 0 && state_->llmContext_) {
+    state_->llmContext_->setNDiscarded(state_->configuredNDiscarded_);
   }
 
-  if (llmContext_) {
-    cacheManager_.emplace(
-        llmContext_.get(), configuredNDiscarded_, [this](bool resetStats) {
-          this->resetState(resetStats);
-        });
+  if (state_->llmContext_) {
+    state_->cacheManager_.emplace(
+        state_->llmContext_.get(),
+        state_->configuredNDiscarded_,
+        [this](bool resetStats) { this->resetState(resetStats); });
   }
 }
 
 void LlamaModel::initializeBackend(const std::string& backendsDir) {
-  backendsHandle_ = LlamaBackendsHandle(backendsDir);
+  state_->backendsHandle_ = LlamaBackendsHandle(backendsDir);
 }
 
 void LlamaModel::setWeightsForFile(
     const std::string& filename,
     std::unique_ptr<std::basic_streambuf<char>>&& shard) {
-  asyncWeightsLoader_.setWeightsForFile(filename, std::move(shard));
+  state_->asyncWeightsLoader_.setWeightsForFile(filename, std::move(shard));
 }
 
-bool LlamaModel::isLoaded() { return static_cast<bool>(llmContext_); }
+bool LlamaModel::isLoaded() { return static_cast<bool>(state_->llmContext_); }
 
 void LlamaModel::llamaLogCallback(
     ggml_log_level level, const char* text, void* userData) {
@@ -229,8 +253,8 @@ void LlamaModel::llamaLogCallback(
   QLOG_IF(priority, string_format("[Llama.cpp] %s", text));
 }
 void LlamaModel::cancel() const {
-  if (llmContext_) {
-    llmContext_->stop();
+  if (state_->llmContext_) {
+    state_->llmContext_->stop();
   }
 }
 
@@ -247,8 +271,8 @@ std::any LlamaModel::process(const std::any& input) {
 LlamaModel::ResolvedPrompt
 LlamaModel::resolveChatAndTools(const std::string& input) {
   ResolvedPrompt resolved;
-  if (cacheManager_.has_value()) {
-    resolved.isCacheLoaded = cacheManager_->handleCache(
+  if (state_->cacheManager_.has_value()) {
+    resolved.isCacheLoaded = state_->cacheManager_->handleCache(
         resolved.chatMsgs,
         resolved.tools,
         input,
@@ -256,8 +280,8 @@ LlamaModel::resolveChatAndTools(const std::string& input) {
           return this->formatPrompt(inputPrompt);
         });
     resolved.shouldResetAfterInference =
-        cacheManager_->isCacheDisabled() ||
-        !cacheManager_->wasCacheUsedInLastPrompt();
+        state_->cacheManager_->isCacheDisabled() ||
+        !state_->cacheManager_->wasCacheUsedInLastPrompt();
   } else {
     auto formatted = formatPrompt(input);
     resolved.chatMsgs = std::move(formatted.first);
@@ -268,7 +292,7 @@ LlamaModel::resolveChatAndTools(const std::string& input) {
 }
 
 std::string LlamaModel::processPrompt(const Prompt& prompt) {
-  lastRunWasPrefill_ = prompt.prefill;
+  state_->lastRunWasPrefill_ = prompt.prefill;
 
   for (const auto& media : prompt.media) {
     loadMedia(media);
@@ -286,9 +310,9 @@ std::string LlamaModel::processPrompt(const Prompt& prompt) {
 
   bool evalOk =
       resolved.tools.empty()
-          ? llmContext_->evalMessage(
+          ? state_->llmContext_->evalMessage(
                 resolved.chatMsgs, resolved.isCacheLoaded, prompt.prefill)
-          : llmContext_->evalMessageWithTools(
+          : state_->llmContext_->evalMessageWithTools(
                 resolved.chatMsgs,
                 resolved.tools,
                 resolved.isCacheLoaded,
@@ -311,7 +335,7 @@ std::string LlamaModel::processPrompt(const Prompt& prompt) {
     callback = [&](const std::string& token) { oss << token; };
   }
 
-  if (!llmContext_->generateResponse(callback)) {
+  if (!state_->llmContext_->generateResponse(callback)) {
     resetState();
     std::string errorMsg = string_format("%s: context overflow\n", __func__);
     throw qvac_errors::StatusError(
@@ -328,23 +352,23 @@ std::string LlamaModel::processPrompt(const Prompt& prompt) {
 }
 
 qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {
-  auto perfData = llama_perf_context(llmContext_->getCtx());
+  auto perfData = llama_perf_context(state_->llmContext_->getCtx());
   constexpr double kMillisInSecond = 1000.0;
 
-  double timeToFirstToken = lastRunWasPrefill_ ? 0.0 : perfData.t_p_eval_ms;
+  double timeToFirstToken = state_->lastRunWasPrefill_ ? 0.0 : perfData.t_p_eval_ms;
   double tokensPerSecond =
-      (!lastRunWasPrefill_ && perfData.t_eval_ms > 0)
+      (!state_->lastRunWasPrefill_ && perfData.t_eval_ms > 0)
           ? kMillisInSecond / perfData.t_eval_ms * perfData.n_eval
           : 0.0;
 
-  int32_t generatedTokens = lastRunWasPrefill_ ? 0 : perfData.n_eval;
-  int32_t promptTokens = lastRunWasPrefill_ ? 0 : perfData.n_p_eval;
-  llama_perf_context_reset(llmContext_->getCtx());
+  int32_t generatedTokens = state_->lastRunWasPrefill_ ? 0 : perfData.n_eval;
+  int32_t promptTokens = state_->lastRunWasPrefill_ ? 0 : perfData.n_p_eval;
+  llama_perf_context_reset(state_->llmContext_->getCtx());
 
   return {
       {"TTFT", timeToFirstToken},
       {"TPS", tokensPerSecond},
-      {"CacheTokens", llmContext_->getNPast()},
+      {"CacheTokens", state_->llmContext_->getNPast()},
       {"generatedTokens", generatedTokens},
       {"promptTokens", promptTokens}};
 }
@@ -380,7 +404,7 @@ void LlamaModel::commonParamsParse(
     try {
       long long parsed = std::stoll(iter->second);
       if (parsed > 0) {
-        configuredNDiscarded_ = static_cast<llama_pos>(parsed);
+        state_->configuredNDiscarded_ = static_cast<llama_pos>(parsed);
       }
     } catch (...) {
       std::string errorMsg = string_format(
@@ -620,7 +644,7 @@ void LlamaModel::commonParamsParse(
 std::pair<std::vector<common_chat_msg>, std::vector<common_chat_tool>>
 LlamaModel::formatPrompt(const std::string& input) {
   if (input.empty()) {
-    llmContext_->resetMedia();
+    state_->llmContext_->resetMedia();
     std::string errorMsg = string_format("%s: empty prompt\n", __func__);
     throw qvac_errors::StatusError(ADDON_ID, toString(EmptyPrompt), errorMsg);
   }
@@ -670,14 +694,14 @@ LlamaModel::formatPrompt(const std::string& input) {
 
         if (jsonObj.find("type") != jsonObj.end() &&
             jsonObj["type"].get<std::string>() == "media") {
-          if (isTextLlm_) {
+          if (state_->isTextLlm_) {
             const char* errorMsg = "Media not supported by text-only models";
             throw qvac_errors::StatusError(
                 ADDON_ID, toString(MediaNotSupported), errorMsg);
           }
 
           if (!content.empty()) {
-            llmContext_->loadMedia(content);
+            state_->llmContext_->loadMedia(content);
           }
           addMediaPlaceholder++;
           isNextUser = true;
@@ -691,7 +715,7 @@ LlamaModel::formatPrompt(const std::string& input) {
           }
         }
         if (newMsg.role != "user" && isNextUser) {
-          llmContext_->resetMedia();
+          state_->llmContext_->resetMedia();
           std::string errorMsg = string_format(
               "%s: Must append a user question after loading "
               "media\n",
@@ -705,7 +729,7 @@ LlamaModel::formatPrompt(const std::string& input) {
     }
 
     if (addMediaPlaceholder > 0) {
-      llmContext_->resetMedia();
+      state_->llmContext_->resetMedia();
       std::string errorMsg =
           string_format("%s: No request for media was made\n", __func__);
       throw qvac_errors::StatusError(
@@ -713,7 +737,7 @@ LlamaModel::formatPrompt(const std::string& input) {
     }
   }
   if (!err.empty()) {
-    llmContext_->resetMedia();
+    state_->llmContext_->resetMedia();
     std::string errorMsg =
         string_format("%s: Invalid input format: %s\n", __func__, err.c_str());
     throw qvac_errors::StatusError(
@@ -723,8 +747,8 @@ LlamaModel::formatPrompt(const std::string& input) {
 }
 
 void LlamaModel::resetState(bool resetStats) {
-  llmContext_->setNDiscarded(configuredNDiscarded_);
-  llmContext_->resetState(resetStats);
+  state_->llmContext_->setNDiscarded(state_->configuredNDiscarded_);
+  state_->llmContext_->resetState(resetStats);
 }
 
 std::unique_ptr<LlmContext> LlamaModel::createContext(
@@ -732,21 +756,21 @@ std::unique_ptr<LlmContext> LlamaModel::createContext(
     common_init_result&& llamaInit) {
   if (!projectionPath.empty()) {
     params.mmproj.path = std::move(projectionPath);
-    isTextLlm_ = false;
+    state_->isTextLlm_ = false;
     return std::make_unique<MtmdLlmContext>(params, std::move(llamaInit));
   }
-  isTextLlm_ = true;
+  state_->isTextLlm_ = true;
   return std::make_unique<TextLlmContext>(params, std::move(llamaInit));
 }
 
 bool LlamaModel::loadMedia(const std::vector<uint8_t>& input) {
-  if (isTextLlm_) {
+  if (state_->isTextLlm_) {
     QLOG_IF(Priority::ERROR, "Media not supported by text-only models");
     throw qvac_errors::StatusError(
         ADDON_ID,
         toString(MediaNotSupported),
         "Media not supported by text-only models");
   }
-  llmContext_->loadMedia(input);
+  state_->llmContext_->loadMedia(input);
   return true;
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <functional>
 #include <iostream>
+#include <shared_mutex>
 #include <sstream>
 #include <string>
 #include <system_error>
@@ -115,11 +116,20 @@ LlamaModel::LlamaModel(
 }
 
 void LlamaModel::reload() {
-  constructionArgs_.loaderType = InitLoader::LOADER_TYPE::IMMEDIATE;
+  { 
+    std::shared_lock lock(stateMtx_);
+    if (state_->asyncWeightsLoader_.isStreaming()) {
+      // TODO: Make Fabric support moving/streaming existing loaded tensors
+      // TODO: to a different backend.
+    }
+    constructionArgs_.loaderType = InitLoader::LOADER_TYPE::IMMEDIATE;
+  }
   setInitLoader();
 }
 
 void LlamaModel::setInitLoader() {
+  cancelImpl();
+  std::unique_lock lock(stateMtx_);
   state_ = std::make_unique<ReloadableState>(
       constructionArgs_, loadingContext_, metadata_);
   state_->initLoader_.init(
@@ -204,10 +214,14 @@ void LlamaModel::initializeBackend(const std::string& backendsDir) {
 void LlamaModel::setWeightsForFile(
     const std::string& filename,
     std::unique_ptr<std::basic_streambuf<char>>&& shard) {
+  std::shared_lock lock(stateMtx_);
   state_->asyncWeightsLoader_.setWeightsForFile(filename, std::move(shard));
 }
 
-bool LlamaModel::isLoaded() { return static_cast<bool>(state_->llmContext_); }
+bool LlamaModel::isLoaded() {
+  std::shared_lock lock(stateMtx_);
+  return static_cast<bool>(state_->llmContext_);
+}
 
 void LlamaModel::llamaLogCallback(
     ggml_log_level level, const char* text, void* userData) {
@@ -236,20 +250,34 @@ void LlamaModel::llamaLogCallback(
   // level
   QLOG_IF(priority, string_format("[Llama.cpp] %s", text));
 }
+
 void LlamaModel::cancel() const {
-  if (state_->llmContext_) {
+  std::shared_lock lock(stateMtx_, std::try_to_lock);
+  if (!lock.owns_lock()) {
+    // If lock could not be acquired, it means reload
+    // is in progress. It would be pointless to cancel
+    // after it finishes reloading since there would be
+    // nothing executing.
+    return;
+  }
+  cancelImpl();
+}
+
+void LlamaModel::cancelImpl() const {
+  if (state_ && state_->llmContext_) {
     state_->llmContext_->stop();
   }
 }
 
 std::any LlamaModel::process(const std::any& input) {
+  std::shared_lock lock(stateMtx_);
   if (input.type() != typeid(Prompt)) {
     throw qvac_errors::StatusError(
         ADDON_ID,
         toString(qvac_errors::general_error::InvalidArgument),
         "Invalid input type");
   }
-  return processPrompt(std::any_cast<const Prompt&>(input));
+  return processPromptImpl(std::any_cast<const Prompt&>(input));
 }
 
 LlamaModel::ResolvedPrompt
@@ -276,6 +304,11 @@ LlamaModel::resolveChatAndTools(const std::string& input) {
 }
 
 std::string LlamaModel::processPrompt(const Prompt& prompt) {
+  std::shared_lock lock(stateMtx_);
+  return processPromptImpl(prompt);
+}
+
+std::string LlamaModel::processPromptImpl(const Prompt& prompt) {
   state_->lastRunWasPrefill_ = prompt.prefill;
 
   for (const auto& media : prompt.media) {
@@ -336,6 +369,7 @@ std::string LlamaModel::processPrompt(const Prompt& prompt) {
 }
 
 qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {
+  std::shared_lock lock(stateMtx_);
   auto perfData = llama_perf_context(state_->llmContext_->getCtx());
   constexpr double kMillisInSecond = 1000.0;
 
@@ -356,6 +390,7 @@ qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {
       {"generatedTokens", generatedTokens},
       {"promptTokens", promptTokens}};
 }
+
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-function-cognitive-complexity)
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-function-cognitive-complexity)
 void LlamaModel::commonParamsParse(

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -155,6 +155,14 @@ void LlamaModel::init(bool acquireLock) {
   }
   snap.lockRead();
 
+  // Defensive guard: not reachable under normal usage because reload() is
+  // only called after waitForLoadInitialization() returns, at which point the
+  // delayed init callback has already completed. Protects against a misuse
+  // scenario where reload() races with the initial delayed load.
+  if (snap->llmContext_) {
+    return;
+  }
+
   const auto& modelPath = constructionArgs_.modelPath;
   auto configFilemap = constructionArgs_.configFilemap;
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -116,11 +116,16 @@ LlamaModel::LlamaModel(
 }
 
 void LlamaModel::reload() {
-  { 
+  {
     std::shared_lock lock(stateMtx_);
     if (state_->asyncWeightsLoader_.isStreaming()) {
       // TODO: Make Fabric support moving/streaming existing loaded tensors
       // TODO: to a different backend.
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          toString(ReloadNotSupportedForStreamedModel),
+          "Cannot reload a model that was loaded via streamed shards; "
+          "the streamed weights have already been consumed.");
     }
     constructionArgs_.loaderType = InitLoader::LOADER_TYPE::IMMEDIATE;
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -107,47 +107,29 @@ LlamaModel::LlamaModel(
     std::string&& modelPath, std::string&& projectionPath,
     std::unordered_map<std::string, std::string>&& configFilemap)
     : loadingContext_(InitLoader::getLoadingContext("LlamaModel")),
-      constructionArgs_{modelPath, projectionPath, configFilemap},
-      state_(
-          std::make_unique<ReloadableState>(
-              constructionArgs_, loadingContext_, metadata_)) {
-  auto constArgsCpy =
-      constructionArgs_; // TODO fix design, now that args are copied inside the
-                         // LlamaModel, we could just safely use them directly
-                         // on init, without passing anything
-  init(std::move(constArgsCpy), state_);
+      constructionArgs_{
+          std::move(modelPath),
+          std::move(projectionPath),
+          std::move(configFilemap)} {
+  setInitLoader();
 }
 
 void LlamaModel::reload() {
-  ConstructionArgs argsCopy = constructionArgs_;
-  argsCopy.loaderType = InitLoader::LOADER_TYPE::IMMEDIATE;
-  state_ =
-      std::make_unique<ReloadableState>(argsCopy, loadingContext_, metadata_);
-  init(std::move(argsCopy), state_);
+  constructionArgs_.loaderType = InitLoader::LOADER_TYPE::IMMEDIATE;
+  setInitLoader();
 }
 
-void LlamaModel::init(
-    ConstructionArgs&& args, std::unique_ptr<ReloadableState>& state) {
-  auto thisModelInit = [this](auto&&... initArgs) {
-    this->init(std::forward<decltype(initArgs)>(initArgs)...);
-  };
-  state->initLoader_.init(
-      args.loaderType,
-      thisModelInit,
-      std::move(args.modelPath),
-      std::move(args.projectionPath),
-      std::move(args.configFilemap));
+void LlamaModel::setInitLoader() {
+  state_ = std::make_unique<ReloadableState>(
+      constructionArgs_, loadingContext_, metadata_);
+  state_->initLoader_.init(
+      constructionArgs_.loaderType, [this]() { this->init(); });
 }
 
-void LlamaModel::init(
-    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-    std::string&& modelPathRvalue, std::string&& projectionPath,
-    std::unordered_map<std::string, std::string>&& configFilemapRvalue) {
-  std::string modelPath = std::move(modelPathRvalue);
-  std::unordered_map<std::string, std::string> configFilemap =
-      std::move(configFilemapRvalue);
+void LlamaModel::init() {
+  const auto& modelPath = constructionArgs_.modelPath;
+  auto configFilemap = constructionArgs_.configFilemap;
 
-  // Set verbosity level
   setVerbosityLevel(configFilemap);
 
   if (!state_->asyncWeightsLoader_.isStreaming()) {
@@ -197,8 +179,10 @@ void LlamaModel::init(
       errorWhenFailed);
 
   // Create the appropriate context based on projectionPath
-  state_->llmContext_ =
-      createContext(std::move(projectionPath), params, std::move(llamaInit));
+  state_->llmContext_ = createContext(
+      std::string(constructionArgs_.projectionPath),
+      params,
+      std::move(llamaInit));
 
   // Apply configured nDiscarded if provided (> 0)
   if (state_->configuredNDiscarded_ > 0 && state_->llmContext_) {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -108,20 +109,16 @@ public:
   /**
    * The Reset method.
    */
-  void reset() { resetState(); }
+  void reset() {
+    std::shared_lock lock(stateMtx_);
+    resetState();
+  }
 
   /// @brief Rebuilds reloadable model state using stored construction args.
-  /// TODO: Caller must ensure model is not in use before calling this method.
-  /// TODO: At JS-addon level thats possible by calling cancel() before
-  /// reloading.
-  /// TODO: on a custom operation
-  /// TODO: Add thread-safety guarantees.
+  /// Acquires exclusive lock on stateMtx_; tries to cancel and blocks until
+  /// any in-flight operation that access the state finishes, then safely swaps
+  /// the state.
   void reload();
-
-  /**
-   * Initialize backend (llama.cpp setup).
-   */
-  void initializeBackend(const std::string& backendsDir = "");
 
   /**
    * Check if model is loaded.
@@ -132,6 +129,7 @@ public:
    * Ensure model is initialized
    */
   void waitForLoadInitialization() final {
+    std::shared_lock lock(stateMtx_);
     state_->initLoader_.waitForLoadInitialization();
   }
 
@@ -149,6 +147,10 @@ public:
   llamaLogCallback(ggml_log_level level, const char* text, void* userData);
 
 private:
+  // Impl without mutexes
+  std::string processPromptImpl(const Prompt& prompt);
+  void cancelImpl() const;
+
   struct ReloadableState {
     ReloadableState(
         const ConstructionArgs& args, const std::string& loadingContext,
@@ -185,6 +187,11 @@ private:
     bool shouldResetAfterInference = false;
   };
   ResolvedPrompt resolveChatAndTools(const std::string& input);
+
+  /**
+   * Initialize backend (llama.cpp setup).
+   */
+  void initializeBackend(const std::string& backendsDir = "");
 
   /**
    * The Common params parse method. It parses the common params.
@@ -239,5 +246,9 @@ private:
   const std::string loadingContext_;
   ModelMetaData metadata_;
   ConstructionArgs constructionArgs_;
+
+  /// Shared lock for all methods that read/use state_ members; exclusive lock
+  /// only in reload()
+  mutable std::shared_mutex stateMtx_;
   std::unique_ptr<ReloadableState> state_;
 };

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -129,8 +130,12 @@ public:
    * Ensure model is initialized
    */
   void waitForLoadInitialization() final {
-    std::shared_lock lock(stateMtx_);
-    state_->initLoader_.waitForLoadInitialization();
+    std::shared_ptr<ReloadableState> localState;
+    {
+      std::shared_lock lock(stateMtx_);
+      localState = state_;
+    }
+    localState->initLoader_.waitForLoadInitialization();
   }
 
   /**
@@ -189,11 +194,6 @@ private:
   ResolvedPrompt resolveChatAndTools(const std::string& input);
 
   /**
-   * Initialize backend (llama.cpp setup).
-   */
-  void initializeBackend(const std::string& backendsDir = "");
-
-  /**
    * The Common params parse method. It parses the common params.
    *
    * @param model_path - model path.
@@ -242,7 +242,7 @@ private:
   void setInitLoader(
       std::optional<InitLoader::LOADER_TYPE> loaderType = std::nullopt);
 
-  void init();
+  void init(bool acquireLock);
 
   const std::string loadingContext_;
   ModelMetaData metadata_;
@@ -251,5 +251,5 @@ private:
   /// Shared lock for all methods that read/use state_ members; exclusive lock
   /// only in reload()
   mutable std::shared_mutex stateMtx_;
-  std::unique_ptr<ReloadableState> state_;
+  std::shared_ptr<ReloadableState> state_;
 };

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -58,6 +58,13 @@ public:
       std::string&& modelPath, std::string&& projectionPath,
       std::unordered_map<std::string, std::string>&& configFilemap);
 
+  struct ConstructionArgs {
+    std::string modelPath;
+    std::string projectionPath;
+    std::unordered_map<std::string, std::string> configFilemap;
+    InitLoader::LOADER_TYPE loaderType = InitLoader::LOADER_TYPE::DELAYED;
+  };
+
   /**
    * The Destructor for llama model.
    * Members are destroyed in reverse order of declaration, ensuring
@@ -103,6 +110,14 @@ public:
    */
   void reset() { resetState(); }
 
+  /// @brief Rebuilds reloadable model state using stored construction args.
+  /// TODO: Caller must ensure model is not in use before calling this method.
+  /// TODO: At JS-addon level thats possible by calling cancel() before
+  /// reloading.
+  /// TODO: on a custom operation
+  /// TODO: Add thread-safety guarantees.
+  void reload();
+
   /**
    * Initialize backend (llama.cpp setup).
    */
@@ -117,7 +132,7 @@ public:
    * Ensure model is initialized
    */
   void waitForLoadInitialization() final {
-    initLoader_.waitForLoadInitialization();
+    state_->initLoader_.waitForLoadInitialization();
   }
 
   /**
@@ -134,6 +149,35 @@ public:
   llamaLogCallback(ggml_log_level level, const char* text, void* userData);
 
 private:
+  struct ReloadableState {
+    ReloadableState(
+        const ConstructionArgs& args, const std::string& loadingContext,
+        ModelMetaData& metadata)
+        : shards_(GGUFShards::expandGGUFIntoShards(args.modelPath)),
+          asyncWeightsLoader_(shards_, initLoader_, loadingContext, &metadata) {
+    }
+
+    GGUFShards shards_;
+    friend class InitLoader;
+    InitLoader initLoader_;
+    AsyncWeightsLoader asyncWeightsLoader_;
+
+    bool isTextLlm_ = false;
+
+    // Backend handle must be declared before llmContext_ to ensure
+    // llmContext_ is destroyed first (members destroyed in reverse order)
+    std::optional<LlamaBackendsHandle> backendsHandle_;
+
+    // Store the appropriate context (TextLlmContext or MtmdLlmContext)
+    // Destroyed before backendsHandle_ to avoid use-after-free
+    std::unique_ptr<LlmContext> llmContext_;
+
+    // configuration values parsed from configFilemap
+    llama_pos configuredNDiscarded_ = 0;
+    std::optional<CacheManager> cacheManager_;
+    bool lastRunWasPrefill_ = false;
+  };
+
   struct ResolvedPrompt {
     std::vector<common_chat_msg> chatMsgs;
     std::vector<common_chat_tool> tools;
@@ -192,25 +236,10 @@ private:
       std::string&& modelPath, std::string&& projectionPath,
       std::unordered_map<std::string, std::string>&& configFilemap);
 
+  void init(ConstructionArgs&& args, std::unique_ptr<ReloadableState>& state);
+
   const std::string loadingContext_;
-  GGUFShards shards_;
-  friend class InitLoader;
-  InitLoader initLoader_;
   ModelMetaData metadata_;
-  AsyncWeightsLoader asyncWeightsLoader_;
-
-  bool isTextLlm_ = false;
-
-  // Backend handle must be declared before llmContext_ to ensure
-  // llmContext_ is destroyed first (members destroyed in reverse order)
-  std::optional<LlamaBackendsHandle> backendsHandle_;
-
-  // Store the appropriate context (TextLlmContext or MtmdLlmContext)
-  // Destroyed before backendsHandle_ to avoid use-after-free
-  std::unique_ptr<LlmContext> llmContext_;
-
-  // configuration values parsed from configFilemap
-  llama_pos configuredNDiscarded_ = 0;
-  std::optional<CacheManager> cacheManager_;
-  bool lastRunWasPrefill_ = false;
+  ConstructionArgs constructionArgs_;
+  std::unique_ptr<ReloadableState> state_;
 };

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -232,11 +232,9 @@ private:
    */
   bool loadMedia(const std::vector<uint8_t>& input);
 
-  void init(
-      std::string&& modelPath, std::string&& projectionPath,
-      std::unordered_map<std::string, std::string>&& configFilemap);
+  void setInitLoader();
 
-  void init(ConstructionArgs&& args, std::unique_ptr<ReloadableState>& state);
+  void init();
 
   const std::string loadingContext_;
   ModelMetaData metadata_;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -239,7 +239,8 @@ private:
    */
   bool loadMedia(const std::vector<uint8_t>& input);
 
-  void setInitLoader();
+  void setInitLoader(
+      std::optional<InitLoader::LOADER_TYPE> loaderType = std::nullopt);
 
   void init();
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
@@ -29,6 +29,10 @@ void ModelMetaData::parse(
     const std::string& modelPath, const GGUFShards& shards, bool isStreaming,
     const char* addonId) {
 
+  if (metadata_ != nullptr) {
+    return;
+  }
+
   auto loadFromStreambuf = [&modelPath,
                             outMetadata = &this->metadata_,
                             addonId](std::basic_streambuf<char>& streambuf) {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/SharedSnapshot.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/SharedSnapshot.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <cassert>
+#include <memory>
+#include <shared_mutex>
+
+/// @brief Captures a snapshot of a shared_ptr and manages read/write lock
+///        promotion on the associated shared_mutex.
+///
+/// Standard C++ has no atomic read→write lock promotion. This class wraps
+/// the unlock-read / lock-write dance and checks whether the source pointer
+/// was swapped during the gap (returning false from promoteToWrite).
+///
+/// When disabled (via disable()), all lock operations become no-ops and
+/// promoteToWrite always returns true. Use this when the caller already
+/// holds an external lock on the mutex.
+///
+/// @code
+///   SharedSnapshot snap(state_, stateMtx_);
+///   if (!callerHoldsLock) snap.disable();
+///   snap.lockRead();               // no-op if disabled; always snapshots
+///   // ... work via snap-> ...
+///   if (!snap.promoteToWrite()) {  // no-op (returns true) if disabled
+///     return;                      // source was swapped, work is stale
+///   }
+///   // ... commit results ...
+///   snap.demoteToRead();           // no-op if disabled
+/// @endcode
+template <typename T> class SharedSnapshot {
+public:
+  SharedSnapshot(const std::shared_ptr<T>& source, std::shared_mutex& mtx)
+      : source_(&source),
+        readLock_(mtx, std::defer_lock),
+        writeLock_(mtx, std::defer_lock) {
+    assert(source_ != nullptr && "source must not be null");
+  }
+
+  void enable() { enabled_ = true; }
+  void disable() { enabled_ = false; }
+
+  /// Snapshot the source pointer. Acquires the read lock when enabled.
+  void lockRead() {
+    if (enabled_) {
+      readLock_.lock();
+    }
+    snapshot_ = *source_;
+    assert(snapshot_ != nullptr && "source shared_ptr holds null after lock");
+  }
+
+  /// Release read lock, acquire write lock.
+  /// Returns false if the source pointer was swapped since the snapshot.
+  /// Always returns true when disabled.
+  bool promoteToWrite() {
+    if (!enabled_) {
+      return true;
+    }
+    readLock_.unlock();
+    writeLock_.lock();
+    return isValid();
+  }
+
+  /// Release write lock, re-acquire read lock.
+  /// No-op when disabled.
+  void demoteToRead() {
+    if (!enabled_) {
+      return;
+    }
+    writeLock_.unlock();
+    readLock_.lock();
+  }
+
+  [[nodiscard]] bool isValid() const { return *source_ == snapshot_; }
+
+  T* operator->() const {
+    assert(snapshot_ != nullptr && "snapshot not captured; call lockRead first");
+    return snapshot_.get();
+  }
+  T& operator*() const {
+    assert(snapshot_ != nullptr && "snapshot not captured; call lockRead first");
+    return *snapshot_;
+  }
+  const std::shared_ptr<T>& get() const { return snapshot_; }
+
+private:
+  const std::shared_ptr<T>* source_;
+  std::shared_ptr<T> snapshot_;
+  std::shared_lock<std::shared_mutex> readLock_;
+  std::unique_lock<std::shared_mutex> writeLock_;
+  bool enabled_ = true;
+};

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
@@ -110,6 +110,74 @@ TEST_F(LlamaModelTest, InitializeBackend) {
   EXPECT_NO_THROW(model.initializeBackend());
 }
 
+TEST_F(LlamaModelTest, ReloadLoadsImmediatelyAndInferenceStillWorks) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  LlamaModel model = createModel();
+  model.waitForLoadInitialization();
+  if (!model.isLoaded()) {
+    FAIL() << "Model failed to load before reload";
+  }
+
+  LlamaModel::Prompt prompt;
+  prompt.input = R"([{"role": "user", "content": "Hello before reload"}])";
+  EXPECT_NO_THROW({
+    std::string output = model.processPrompt(prompt);
+    EXPECT_GE(output.length(), 0);
+  });
+
+  EXPECT_NO_THROW(model.reload());
+  EXPECT_TRUE(model.isLoaded());
+
+  prompt.input = R"([{"role": "user", "content": "Hello after reload"}])";
+  EXPECT_NO_THROW({
+    std::string output = model.processPrompt(prompt);
+    EXPECT_GE(output.length(), 0);
+  });
+}
+
+TEST_F(LlamaModelTest, ReloadWithoutArgsUsesStoredConstructionArgs) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  LlamaModel model = createModel();
+  model.waitForLoadInitialization();
+  if (!model.isLoaded()) {
+    FAIL() << "Model failed to load before reload";
+  }
+
+  LlamaModel::Prompt prompt;
+  prompt.input = R"([{"role": "user", "content": "First pass"}])";
+  EXPECT_NO_THROW({
+    std::string output = model.processPrompt(prompt);
+    EXPECT_GE(output.length(), 0);
+  });
+
+  EXPECT_NO_THROW(model.reload());
+  EXPECT_TRUE(model.isLoaded());
+
+  prompt.input = R"([{"role": "user", "content": "Second pass"}])";
+  EXPECT_NO_THROW({
+    std::string output = model.processPrompt(prompt);
+    EXPECT_GE(output.length(), 0);
+  });
+}
+
+TEST_F(LlamaModelTest, ReloadThrowsForModelBuiltWithInvalidPath) {
+  std::string invalidPath = getInvalidModelPath();
+  std::string projectionPath = test_projection_path;
+  std::unordered_map<std::string, std::string> config = config_files;
+  LlamaModel model(
+      std::move(invalidPath), std::move(projectionPath), std::move(config));
+
+  // Constructor uses delayed init and does not throw immediately.
+  EXPECT_FALSE(model.isLoaded());
+  EXPECT_THROW(model.reload(), qvac_errors::StatusError);
+}
+
 TEST_F(LlamaModelTest, InvalidModelPath) {
   std::string invalid_path = getInvalidModelPath();
   std::unordered_map<std::string, std::string> empty_config;

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
@@ -101,15 +101,6 @@ TEST_F(LlamaModelTest, IsLoadedMethodBeforeInit) {
   EXPECT_FALSE(model.isLoaded());
 }
 
-TEST_F(LlamaModelTest, InitializeBackend) {
-  if (!fs::exists(getValidModelPath())) {
-    FAIL() << "Test model not found at: " << getValidModelPath();
-  }
-
-  LlamaModel model = createModel();
-  EXPECT_NO_THROW(model.initializeBackend());
-}
-
 TEST_F(LlamaModelTest, ReloadLoadsImmediatelyAndInferenceStillWorks) {
   if (!fs::exists(getValidModelPath())) {
     FAIL() << "Test model not found at: " << getValidModelPath();

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_model.cpp
@@ -1,6 +1,10 @@
+#include <atomic>
+#include <chrono>
+#include <exception>
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <thread>
 #include <unordered_map>
 
 #include <gtest/gtest.h>
@@ -952,4 +956,99 @@ TEST_F(LlamaModelTest, CommonParamsParseInvalidChatTemplate) {
         model.waitForLoadInitialization();
       },
       qvac_errors::StatusError);
+}
+
+TEST_F(LlamaModelTest, ReloadThrowsForStreamedShardedModel) {
+  using MP = test_common::TestModelPath;
+  MP shardedModel(
+      "Qwen3-0.6B-UD-IQ1_S-00001-of-00003.gguf",
+      "SHARDED_MODEL_FIRST_SHARD_PATH",
+      MP::OnMissing::Fail,
+      "https://huggingface.co/jmb95/Qwen3-0.6B-UD-IQ1_S-sharded",
+      true /* isSharded */);
+  REQUIRE_MODEL(shardedModel);
+  LlamaModel::resolveShardPaths(shardedModel.shards, shardedModel.path);
+
+  std::string path = shardedModel.path;
+  std::string projection;
+  auto cfg = config_files;
+  LlamaModel model(std::move(path), std::move(projection), std::move(cfg));
+
+  {
+    std::string tensorsBasename =
+        fs::path(shardedModel.shards.tensors_file).filename().string();
+    auto tensorsBuf = test_common::readFileToStreambufBinary(
+        shardedModel.shards.tensors_file);
+    ASSERT_NE(tensorsBuf, nullptr);
+    model.setWeightsForFile(tensorsBasename, std::move(tensorsBuf));
+
+    for (const auto& shardPath : shardedModel.shards.gguf_files) {
+      auto streambuf = test_common::readFileToStreambufBinary(shardPath);
+      ASSERT_NE(streambuf, nullptr);
+      model.setWeightsForFile(
+          fs::path(shardPath).filename().string(), std::move(streambuf));
+    }
+  }
+
+  model.waitForLoadInitialization();
+  ASSERT_TRUE(model.isLoaded());
+
+  EXPECT_THROW(model.reload(), qvac_errors::StatusError);
+}
+
+TEST_F(LlamaModelTest, ReloadDuringProcessingWaitsAndDoesNotCrash) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  config_files["n_predict"] = "64";
+  LlamaModel model = createModel();
+  model.waitForLoadInitialization();
+
+  if (!model.isLoaded()) {
+    FAIL() << "Model failed to load";
+  }
+
+  std::atomic<bool> generationStarted{false};
+  std::string inferenceOutput;
+  std::exception_ptr inferenceException;
+
+  std::thread inferenceThread([&]() {
+    try {
+      LlamaModel::Prompt prompt;
+      prompt.input = R"([{"role": "user", "content": "Tell me a long story"}])";
+      prompt.outputCallback = [&](const std::string& token) {
+        generationStarted.store(true, std::memory_order_release);
+        inferenceOutput += token;
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+      };
+      model.processPrompt(prompt);
+    } catch (...) {
+      inferenceException = std::current_exception();
+    }
+  });
+
+  while (!generationStarted.load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+  EXPECT_NO_THROW(model.reload());
+  EXPECT_TRUE(model.isLoaded());
+
+  // Inference must have completed before reload() returned, because
+  // processPrompt holds a shared lock and reload needs an exclusive one.
+  EXPECT_FALSE(inferenceOutput.empty());
+
+  inferenceThread.join();
+
+  if (inferenceException) {
+    FAIL() << "Inference thread threw unexpectedly";
+  }
+
+  LlamaModel::Prompt postReload;
+  postReload.input = R"([{"role": "user", "content": "Hello after reload"}])";
+  EXPECT_NO_THROW({
+    std::string output = model.processPrompt(postReload);
+    EXPECT_GE(output.length(), 0);
+  });
 }


### PR DESCRIPTION

## 🎯 What problem does this PR solve?
Finetuning only works on Vulkan but inference is very slow. We need to maintain OpenCL on some devices, and only switch to Finetuning when finetune is attempted to be used. We need to move model from OpenCL to Vulkan in that case. Is it feasible to do from C++? Try to find best solution and implement it.

Needed for https://github.com/dev-nid/qvac/pull/1

## 📝 How does it solve it?
- Can reload directly from same instance, and modify original arguments (e.g. backend)

### `reload()` over `reinitialize()`

The Finetune draft branch added a `reinitialize()` method that tears down and
recreates the model context with config overrides. This approach:

- Has no thread safety (no mutex protection).
- Duplicates the initialization logic from `init()`.
- Bypasses the `InitLoader` and `AsyncWeightsLoader` pipelines.

This PR instead introduces a **`reload()`** method backed by a
**`ReloadableState`** struct that encapsulates all mutable model state
(`GGUFShards`, `InitLoader`, `AsyncWeightsLoader`, `LlmContext`,
`CacheManager`, `LlamaBackendsHandle`). Reload works by:

1. Acquiring an exclusive `std::shared_mutex` lock (`stateMtx_`).
2. Cancelling any in-flight inference.
3. Constructing a fresh `ReloadableState` from stored `ConstructionArgs`.
4. Re-running the same `init()` path used at construction time.

All read-side methods (`processPrompt`, `cancel`, `runtimeStats`, etc.)
acquire a shared lock, so reload is safe even when inference is running
concurrently.

The `reload()` approach also include C++ tests to independently test this feature and does not rely on testing finetune.

## 🧪 How was it tested?
C++ tests ran at CI
C++ and integration tests did pass https://github.com/tetherto/qvac/actions/runs/22867663670/job/66340146398?pr=579
```
Running main() from /opt/vcpkg/buildtrees/gtest/src/v1.17.0-0c449efaff.clean/googletest/src/gtest_main.cc
Note: Google Test filter = LlamaModelTest.ReloadWithoutArgsUsesStoredConstructionArgs
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from LlamaModelTest
[ RUN      ] LlamaModelTest.ReloadWithoutArgsUsesStoredConstructionArgs
parse: load the model metadata from disk file.
initFromConfig: load the model from disk file and apply lora adapter, if any.
common_init_from_model_and_params: added <|end_of_text|> logit bias = -inf
common_init_from_model_and_params: added <|eom_id|> logit bias = -inf
common_init_from_model_and_params: added <|eot_id|> logit bias = -inf
common_init_from_model_and_params: setting dry_penalty_last_n to ctx_size = 2048
parse: load the model metadata from disk file.
initFromConfig: load the model from disk file and apply lora adapter, if any.
common_init_from_model_and_params: added <|end_of_text|> logit bias = -inf
common_init_from_model_and_params: added <|eom_id|> logit bias = -inf
common_init_from_model_and_params: added <|eot_id|> logit bias = -inf
common_init_from_model_and_params: setting dry_penalty_last_n to ctx_size = 2048
[       OK ] LlamaModelTest.ReloadWithoutArgsUsesStoredConstructionArgs (4599 ms)
[----------] 1 test from LlamaModelTest (4599 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (4599 ms total)
[  PASSED  ] 1 test.
```
