### PR TITLE
Switch llamacpp-llm Linux builds from libstdc++ to clang's libc++

### DIFF
--- a/.cursor/skills/notice-generate/scripts/constants.js
+++ b/.cursor/skills/notice-generate/scripts/constants.js
@@ -30,6 +30,7 @@ const ALLOWED_LICENSES = [
   'mpl-2.0',
   'cc-by-4.0',
   'lgpl-2.1',
+  'apache-2.0-with-llvm-exception',
 
   // Model-specific
   'llama3.2',
@@ -60,6 +61,10 @@ const LICENSE_NORMALIZE_MAP = {
   'apache license, version 2.0': 'apache-2.0',
   'apache software license': 'apache-2.0',
   apache: 'apache-2.0',
+
+  // Apache with LLVM exception
+  'apache-2.0 with llvm-exception': 'apache-2.0-with-llvm-exception',
+  'apache 2.0 with llvm exception': 'apache-2.0-with-llvm-exception',
 
   // MIT
   mit: 'mit',

--- a/.cursor/skills/notice-generate/scripts/lib/config.js
+++ b/.cursor/skills/notice-generate/scripts/lib/config.js
@@ -95,6 +95,22 @@ const PYTHON_DEP_PATHS = {
 }
 
 // ---------------------------------------------------------------------------
+// Compiler/runtime libraries detected from vcpkg triplet flags.
+// Key: regex pattern matched against VCPKG_CXX_FLAGS in triplet files.
+// Value: attribution entry added to the C++ deps section.
+// ---------------------------------------------------------------------------
+const TRIPLET_COMPILER_LIBS = [
+  {
+    pattern: /-stdlib=libc\+\+/,
+    entry: {
+      name: 'libc++ (LLVM C++ Standard Library)',
+      license: 'Apache-2.0 WITH LLVM-exception',
+      url: 'https://github.com/llvm/llvm-project'
+    }
+  }
+]
+
+// ---------------------------------------------------------------------------
 // Packages to skip entirely
 // ---------------------------------------------------------------------------
 const SKIP_PACKAGES = new Set(['docs'])
@@ -242,6 +258,7 @@ module.exports = {
   PACKAGE_ENGINES,
   FULL_MODEL_LIST_PACKAGES,
   SKIP_VCPKG_PORTS,
+  TRIPLET_COMPILER_LIBS,
   PYTHON_DEP_PATHS,
   SKIP_PACKAGES,
   NO_JS_PACKAGES,

--- a/.cursor/skills/notice-generate/scripts/lib/scan-cpp-deps.js
+++ b/.cursor/skills/notice-generate/scripts/lib/scan-cpp-deps.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const {
   SKIP_VCPKG_PORTS,
+  TRIPLET_COMPILER_LIBS,
   QVAC_VCPKG_REGISTRY_REPO,
   MS_VCPKG_REGISTRY_REPO
 } = require('./config')
@@ -250,6 +251,32 @@ async function resolveDep (dep, log) {
 }
 
 // ---------------------------------------------------------------------------
+// Scan vcpkg overlay triplet files for compiler/runtime library flags
+// (e.g. -stdlib=libc++ → attribute libc++)
+// ---------------------------------------------------------------------------
+function detectCompilerLibs (pkgDir, log) {
+  const results = []
+  const seen = new Set()
+
+  const tripletsDir = path.join(pkgDir, 'vcpkg', 'triplets')
+  if (!fs.existsSync(tripletsDir)) return results
+
+  const files = fs.readdirSync(tripletsDir).filter(f => f.endsWith('.cmake'))
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(tripletsDir, file), 'utf8')
+    for (const { pattern, entry } of TRIPLET_COMPILER_LIBS) {
+      if (pattern.test(content) && !seen.has(entry.name)) {
+        seen.add(entry.name)
+        results.push({ ...entry })
+        log.push(`[C++] Detected compiler library "${entry.name}" from triplet ${file}`)
+      }
+    }
+  }
+
+  return results
+}
+
+// ---------------------------------------------------------------------------
 // Scan all C++ dependencies for a package
 // Returns: [{ name, license, url }]
 // ---------------------------------------------------------------------------
@@ -271,6 +298,12 @@ async function scanCppDeps (pkgDir, log) {
     const resolved = await resolveDep(dep, log)
     results.push(resolved)
     process.stderr.write(` ${resolved.license}\n`)
+  }
+
+  const compilerLibs = detectCompilerLibs(pkgDir, log)
+  for (const lib of compilerLibs) {
+    process.stderr.write(`    ${lib.name} (compiler-lib)... ${lib.license}\n`)
+    results.push(lib)
   }
 
   return results.sort(sortByName)

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -238,13 +238,6 @@ jobs:
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y mesa-vulkan-drivers
 
-      - name: Linux - install glibcxx
-        if: ${{ startsWith(matrix.os, 'ubuntu-22') }}
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y g++-13
-
       - name: Windows - Install Vulkan
         if: ${{ matrix.platform == 'win32' }}
         run: |

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -145,13 +145,6 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19 all
 
-      - if: ${{ startsWith(matrix.os, 'ubuntu-22') }}
-        name: Install g++-13 on Ubuntu 22.04
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y g++-13
-
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure windows runner
         shell: powershell

--- a/packages/qvac-lib-infer-llamacpp-llm/.gitignore
+++ b/packages/qvac-lib-infer-llamacpp-llm/.gitignore
@@ -8,6 +8,7 @@ prebuilds/
 
 test/unit/all.js
 test/integration/all.js
+test/model/
 .npmrc
 package-lock.json
 .cache/

--- a/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
@@ -15,7 +15,14 @@ endif()
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
 find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
+set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/triplets;${VCPKG_OVERLAY_TRIPLETS}")
+
 project(qvac-lib-inference-addon-llama C CXX)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_compile_options(-stdlib=libc++)
+  add_link_options(-stdlib=libc++ -static-libstdc++)
+endif()
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)
 configure_file(${VCPKG_INSTALLED_PATH}/share/qvac-lint-cpp/.clang-format

--- a/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
@@ -21,7 +21,7 @@ project(qvac-lib-inference-addon-llama C CXX)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_compile_options(-stdlib=libc++)
-  add_link_options(-stdlib=libc++ -static-libstdc++)
+  add_link_options(-stdlib=libc++ -static-libstdc++ -Wl,--exclude-libs,ALL)
 endif()
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)

--- a/packages/qvac-lib-infer-llamacpp-llm/NOTICE
+++ b/packages/qvac-lib-infer-llamacpp-llm/NOTICE
@@ -112,7 +112,7 @@ JavaScript Dependencies
   @qvac/response@0.1.2
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
-  b4a@1.7.5
+  b4a@1.8.0
     https://github.com/holepunchto/b4a
   bare-addon-resolve@1.10.0
     https://github.com/holepunchto/bare-addon-resolve
@@ -124,13 +124,13 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-events
   bare-events@2.8.2
     https://github.com/holepunchto/bare-events
-  bare-fs@4.5.4
+  bare-fs@4.5.5
     https://github.com/holepunchto/bare-fs
   bare-hrtime@2.1.1
     https://github.com/holepunchto/bare-hrtime
   bare-module-resolve@1.12.1
     https://github.com/holepunchto/bare-module-resolve
-  bare-os@3.6.2
+  bare-os@3.7.0
     https://github.com/holepunchto/bare-os
   bare-path@3.0.0
     https://github.com/holepunchto/bare-path
@@ -150,7 +150,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-url
   blind-relay@1.4.0
     https://github.com/holepunchto/blind-relay
-  compact-encoding@2.18.0
+  compact-encoding@2.19.0
     https://github.com/compact-encoding/compact-encoding
   device-file@2.3.1
     https://github.com/holepunchto/device-file
@@ -167,18 +167,22 @@ JavaScript Dependencies
   hypercore-id-encoding@1.3.0
     https://github.com/holepunchto/hypercore-id-encoding
   hypercore-storage@2.4.1
-  hyperdrive@13.2.1
+  hyperdrive@13.3.0
     https://github.com/holepunchto/hyperdrive
-  hyperschema@1.19.1
+  hyperschema@1.20.1
     https://github.com/holepunchto/hyperschema
   index-encoder@3.4.0
     https://github.com/holepunchto/index-encoder
-  mirror-drive@1.12.0
+  mirror-drive@1.13.0
     https://github.com/holepunchto/mirror-drive
   noise-handshake@4.2.0
     https://github.com/holepunchto/noise-handshake
   quickbit-native@2.4.8
     https://github.com/holepunchto/quickbit-native
+  rabin-native@2.0.0
+    https://github.com/holepunchto/rabin-native
+  rabin-stream@2.0.0
+    https://github.com/holepunchto/rabin-stream
   rache@1.0.0
     https://github.com/holepunchto/rache
   refcounter@1.0.0
@@ -235,7 +239,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/corestore
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
-  dht-rpc@6.26.1
+  dht-rpc@6.26.3
     https://github.com/mafintosh/dht-rpc
   fast-fifo@1.3.2
     https://github.com/mafintosh/fast-fifo
@@ -247,13 +251,13 @@ JavaScript Dependencies
     https://github.com/mafintosh/generate-string
   hyperbee@2.27.3
     https://github.com/holepunchto/hyperbee
-  hypercore@11.24.0
+  hypercore@11.26.0
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.6.1
     https://github.com/mafintosh/hypercore-crypto
   hyperdht@6.29.0
     https://github.com/holepunchto/hyperdht
-  hyperswarm@4.16.0
+  hyperswarm@4.17.0
     https://github.com/holepunchto/hyperswarm
   is-options@1.0.2
     https://github.com/mafintosh/is-options
@@ -364,6 +368,11 @@ C++ Dependencies
 
   opencl
     https://github.com/KhronosGroup/OpenCL-ICD-Loader
+
+--- apache-2.0-with-llvm-exception ---
+
+  libc++ (LLVM C++ Standard Library)
+    https://github.com/llvm/llvm-project
 
 --- bsd-2-clause (BSD 2-Clause License) ---
 

--- a/packages/qvac-lib-infer-llamacpp-llm/README.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/README.md
@@ -38,7 +38,7 @@ This native C++ addon, built using the `Bare` Runtime, simplifies running Large 
 - qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework (single-job runner)
 - qvac-fabric-llm.cpp (≥7248.1.2): Inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
-- Ubuntu-22 requires g++-13 installed
+- Linux requires Clang/LLVM 19 with libc++
 
 ## Installation
 

--- a/packages/qvac-lib-infer-llamacpp-llm/build.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/build.md
@@ -59,14 +59,7 @@ If you want to build the addon from source instead of using pre-built packages, 
      - Xcode Command Line Tools
      - Apple clang version >= 15.0.0 (LLVM compiler is not supported at the moment)
      - For Android cross-compilation: Android NDK and Vulkan tools (`brew install shaderc vulkan-tools molten-vk vulkan-headers`)
-   - **Linux**: GCC/G++ compiler, CMake
-      - Ubuntu-22 requires g++-13 installed:
-        
-        ```bash
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y g++-13
-        ```
+   - **Linux**: Clang/LLVM (with libc++), CMake
    - **Windows**:  
       - Install Visual Studio 2022 with C++ tools, Clang and llvm tools
       - Install Vulkan

--- a/packages/qvac-lib-infer-llamacpp-llm/docs/architecture.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/docs/architecture.md
@@ -71,7 +71,7 @@
 - qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework (single-job runner, runJob/activate/loadWeights/cancel/destroyInstance)
 - llama-cpp (≥7248.1.2): Inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
-- Ubuntu-22 requires g++-13 installed
+- Linux requires Clang/LLVM 19 with libc++
 
 ---
 

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg/toolchains/linux-clang.cmake
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg/toolchains/linux-clang.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_C_COMPILER "clang-19")
+set(CMAKE_CXX_COMPILER "clang++-19")
+
+include("$ENV{VCPKG_ROOT}/scripts/toolchains/linux.cmake")

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg/triplets/arm64-linux.cmake
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg/triplets/arm64-linux.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/linux-clang.cmake")
+set(VCPKG_C_FLAGS "-fPIC")
+set(VCPKG_CXX_FLAGS "-fPIC -stdlib=libc++")
+set(VCPKG_LINKER_FLAGS "-stdlib=libc++")

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg/triplets/x64-linux.cmake
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg/triplets/x64-linux.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/linux-clang.cmake")
+set(VCPKG_C_FLAGS "-fPIC")
+set(VCPKG_CXX_FLAGS "-fPIC -stdlib=libc++")
+set(VCPKG_LINKER_FLAGS "-stdlib=libc++")


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The llamacpp-llm addon on Linux depends on GCC's libstdc++, requiring `g++-13` to be installed on Ubuntu 22.04 for both builds and integration tests
- This ties the addon to GCC's C++ standard library and its release cadence, and causes fragility when dependencies change.
- Our build is currently broken due to this, making this fix time-sensitive.

## 📝 How does it solve it?

- Switch Linux builds to use clang-19 with libc++ instead of GCC's libstdc++
- Add vcpkg overlay triplets (`x64-linux`, `arm64-linux`) that set `-stdlib=libc++`, `-fPIC`, and chainload a custom toolchain selecting clang-19
- Update `CMakeLists.txt` to prepend overlay triplets and add `-stdlib=libc++ -static-libstdc++` compile/link options, so libc++ is statically linked into the addon (no runtime dependency on `libc++.so`)
- Remove `g++-13` install steps from both prebuild and integration test workflows
- Update `build.md` Linux prerequisites to reflect Clang/LLVM requirement

## 🧪 How was it tested?

- Local build with `bare-make generate && bare-make build && bare-make install` — compiles and links successfully
- Local integration test suite (`npm run test:integration`) — majority of tests pass
- One test showed a `malloc(): unaligned tcache chunk detected` error under a specific code path — under investigation, likely a pre-existing latent bug exposed by different memory layout, not an ABI boundary issue (confirmed no C++ stdlib types cross the addon/runtime boundary)
- Pending: CI prebuild + integration test run