### PR TITLE
ci: register stable-diffusion-cpp workflows

### DIFF
--- a/.github/workflows/cpp-tests-stable-diffusion-cpp.yml
+++ b/.github/workflows/cpp-tests-stable-diffusion-cpp.yml
@@ -1,0 +1,237 @@
+name: CPP Tests (Stable Diffusion)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workdir:
+        description: "Working directory"
+        type: string
+        required: false
+        default: "packages/qvac-lib-infer-stable-diffusion-cpp"
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref to checkout"
+        type: string
+        required: false
+      repository:
+        description: "Repository to checkout"
+        type: string
+        required: false
+      workdir:
+        description: "Working directory"
+        type: string
+        required: false
+        default: "packages/qvac-lib-infer-stable-diffusion-cpp"
+
+jobs:
+  test-cpp:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux
+
+    runs-on: ${{ matrix.os }}
+    name: cpp-tests-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}
+
+    env:
+      WORKDIR: ${{ inputs.workdir }}
+      # keep cache inside workdir so everything is self-contained
+      VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/${{ inputs.workdir }}/vcpkg/cache,readwrite"
+      GIT_TERMINAL_PROMPT: "0"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - if: ${{ matrix.os == 'ubuntu-24.04' }}
+        name: Install llvm-19 on Linux
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 19 all
+
+      - if: ${{ matrix.os == 'ubuntu-24.04' }}
+        name: Install Vulkan SDK on Linux
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list http://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
+          sudo apt update
+          sudo apt install vulkan-sdk
+
+      - if: ${{ matrix.os == 'windows-2022' }}
+        name: Configure Windows runner
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          git config --system core.longpaths true
+          choco upgrade llvm
+
+      - if: ${{ matrix.os == 'windows-2022' }}
+        name: Install Vulkan SDK on Windows
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe
+          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
+          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-2022' }}
+        name: Configure vcpkg in windows
+        working-directory: ${{ env.WORKDIR }}
+        run: echo ("VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" -replace '\\', '/') >> $env:GITHUB_ENV
+
+      - if: ${{ matrix.os == 'macos-14' }}
+        name: Install vcpkg on macOS
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git vcpkg_microsoft
+          cd vcpkg_microsoft && ./bootstrap-vcpkg.sh -disableMetrics
+          VCPKG_ROOT="$(pwd)"
+          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
+          echo "$VCPKG_ROOT" >> $GITHUB_PATH
+          # Set deployment target for C++20 std::format support
+          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+
+      - if: ${{ matrix.os == 'ubuntu-24.04' }}
+        name: Configure vcpkg in linux
+        working-directory: ${{ env.WORKDIR }}
+        run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-2022' }}
+        name: Configure CMake generator on Windows
+        shell: pwsh
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV
+          echo "CMAKE_GENERATOR_PLATFORM=x64" >> $env:GITHUB_ENV
+
+      # mkdir -p is not portable to pwsh; do per-OS
+      - name: Create vcpkg cache location (non-Windows)
+        if: ${{ matrix.os != 'windows-2022' }}
+        working-directory: ${{ env.WORKDIR }}
+        run: mkdir -p vcpkg/cache
+
+      - name: Create vcpkg cache location (Windows)
+        if: ${{ matrix.os == 'windows-2022' }}
+        shell: pwsh
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          New-Item -ItemType Directory -Force -Path "vcpkg/cache" | Out-Null
+
+      - name: Get vcpkg cache
+        uses: actions/cache@v5
+        with:
+          key: cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-${{ hashFiles(format('{0}/vcpkg.json', inputs.workdir), format('{0}/vcpkg-configuration.json', inputs.workdir)) }}
+          path: ${{ env.WORKDIR }}/vcpkg/cache
+          restore-keys: cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Configure scoped registry for @tetherto and @qvac packages
+        shell: bash
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          cat > .npmrc <<NPMRC
+          registry=https://registry.npmjs.org/
+          @qvac:registry=https://registry.npmjs.org/
+          @tetherto:registry=https://npm.pkg.github.com/
+          //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+          //npm.pkg.github.com/:_authToken=${{ secrets.PAT_TOKEN }}
+          NPMRC
+          git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "git@github.com:"
+
+      - name: Install NPM dependencies
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          npm install
+          npm install -g bare bare-make
+
+      - name: Build C++ tests with coverage
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        working-directory: ${{ env.WORKDIR }}
+        run: npm run coverage:cpp:build
+
+      - name: Build C++ tests
+        if: ${{ matrix.os != 'ubuntu-24.04' }}
+        working-directory: ${{ env.WORKDIR }}
+        run: npm run test:cpp:build
+
+      - name: Run C++ tests
+        id: cpp-tests
+        shell: bash
+        working-directory: ${{ env.WORKDIR }}
+        env:
+          # keep as repo-root absolute path to avoid assuming it's copied into workdir
+          LSAN_OPTIONS: suppressions=${{ github.workspace }}/.lsan-suppressions.txt
+        run: |
+          # Windows build will typically emit addon-test.exe; unix emits addon-test
+          EXE="build/test/unit/addon-test"
+          if [ -f "build/test/unit/addon-test.exe" ]; then
+            EXE="build/test/unit/addon-test.exe"
+          fi
+
+          if [ ! -f "$EXE" ]; then
+            echo "ERROR: Test executable not found at $EXE"
+            ls -lah build/test/unit || true
+            exit 1
+          fi
+
+          (cd build/test/unit/ && "./$(basename "$EXE")" --gtest_output=xml:cpp-test-results.xml)
+
+          if [ -f build/test/unit/cpp-test-results.xml ]; then
+            test_count=$(grep -c '<testcase' build/test/unit/cpp-test-results.xml || echo "0")
+            if [ "$test_count" -eq 0 ]; then
+              echo "ERROR: No tests were executed! Test count: $test_count"
+              exit 1
+            fi
+            echo "Successfully executed $test_count test(s)"
+          else
+            echo "ERROR: Test results file not generated"
+            exit 1
+          fi
+
+      - name: Generate Coverage Report
+        if: ${{ matrix.os == 'ubuntu-24.04' && always() }}
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          npm run coverage:cpp:report
+          COVERAGE=$(grep 'TOTAL' build/test/unit/coverage-summary.txt | awk '{print $10}' || echo "0.0")
+          echo "LINE_COVERAGE_PERCENTAGE=${COVERAGE}" >> $GITHUB_ENV
+
+      - name: Archive Coverage Results
+        if: ${{ matrix.os == 'ubuntu-24.04' && always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: cpp-coverage-report-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}
+          path: |
+            ${{ env.WORKDIR }}/build/test/unit/coverage-html/
+            ${{ env.WORKDIR }}/build/test/unit/lcov.info
+            ${{ env.WORKDIR }}/build/test/unit/coverage-summary.txt
+            ${{ env.WORKDIR }}/build/test/unit/cpp-test-results.xml
+          retention-days: 30
+
+      - name: Coverage Summary
+        if: ${{ matrix.os == 'ubuntu-24.04' && always() }}
+        shell: bash
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          echo "## C++ Test Coverage Summary" >> $GITHUB_STEP_SUMMARY
+          echo "**Coverage:** ${{ env.LINE_COVERAGE_PERCENTAGE }}%" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f build/test/unit/coverage-summary.txt ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat build/test/unit/coverage-summary.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/create-github-release-qvac-lib-infer-stable-diffusion-cpp.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-stable-diffusion-cpp.yml
@@ -1,0 +1,93 @@
+name: Create GitHub Release (Stable Diffusion)
+
+on:
+  workflow_call:
+    inputs:
+      published_version:
+        description: "Version published in prebuild workflow"
+        required: false
+        type: string
+      prev_sha:
+        description: "Previous commit SHA for version comparison"
+        required: false
+        type: string
+      release_name:
+        description: "Human-readable release name"
+        required: false
+        type: string
+        default: "QVAC Stable Diffusion Addon"
+      workdir:
+        description: "Working directory (optional)"
+        required: false
+        type: string
+        default: "packages/qvac-lib-infer-stable-diffusion-cpp"
+
+permissions:
+  contents: write
+
+jobs:
+  publish-release:
+    if: inputs.published_version != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect version bump
+        id: version
+        uses: ./.github/actions/detect-version-bump
+        with:
+          current_version: ${{ inputs.published_version }}
+          prev_sha: ${{ inputs.prev_sha }}
+          workdir: ${{ inputs.workdir }}
+
+      - name: Verify release notes exist in CHANGELOG
+        if: steps.version.outputs.bumped == 'true'
+        id: changelog
+        working-directory: ${{ inputs.workdir }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.current }}"
+          changelog_path="CHANGELOG.md"
+          release_notes_path="${RUNNER_TEMP}/release-notes-v${version}.md"
+
+          if [ ! -s "${changelog_path}" ]; then
+            echo "Missing or empty changelog: ${changelog_path}"
+            exit 1
+          fi
+
+          start_line=$(awk -v version="${version}" '$0 ~ "^## \\[" version "\\]" { print NR; exit }' "${changelog_path}")
+          if [ -z "${start_line}" ]; then
+            echo "Could not find changelog heading for version ${version} in ${changelog_path}"
+            exit 1
+          fi
+
+          end_line=$(awk -v start="${start_line}" 'NR > start && /^## \[/ { print NR - 1; found=1; exit } END { if (!found) print NR }' "${changelog_path}")
+          if [ -z "${end_line}" ] || [ "${end_line}" -lt "${start_line}" ]; then
+            echo "Invalid changelog section bounds for version ${version}"
+            exit 1
+          fi
+
+          sed -n "$((start_line + 1)),$((end_line))p" "${changelog_path}" > "${release_notes_path}"
+
+          if ! awk 'BEGIN { has_content=0 } /[^[:space:]]/ { has_content=1 } END { exit has_content ? 0 : 1 }' "${release_notes_path}"; then
+            echo "Changelog section for version ${version} is empty"
+            exit 1
+          fi
+
+          echo "release_notes_path=${release_notes_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.bumped == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: stable-diffusion-cpp-v${{ steps.version.outputs.current }}
+          name: ${{ inputs.release_name }} v${{ steps.version.outputs.current }}
+          body_path: ${{ steps.changelog.outputs.release_notes_path }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-test-qvac-lib-infer-stable-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-stable-diffusion-cpp.yml
@@ -1,0 +1,249 @@
+name: Integration Tests (Stable Diffusion)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "ref"
+        type: string
+      repository:
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/SHA) to test"
+        type: string
+        required: false
+        default: main
+      prebuild_package:
+        description: "NPM package containing prebuilds (e.g. @qvac/img-stable-diffusion-cpp@0.1.0)"
+        type: string
+        required: true
+
+jobs:
+  run-integration-tests:
+    timeout-minutes: 360
+    continue-on-error: true
+    runs-on: ${{ matrix.runner }}
+    name: test-${{ matrix.platform }}-${{ matrix.arch }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      WORKDIR: packages/qvac-lib-infer-stable-diffusion-cpp
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            platform: linux
+            arch: x64
+            runner: ubuntu-22.04
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Windows - enable git long paths
+        if: ${{ matrix.platform == 'win32' }}
+        run: |
+          git config --system core.longpaths true
+          git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "git@github.com:"
+        shell: powershell
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Configure scoped registry for @tetherto and @qvac packages (Linux/macOS)
+        if: ${{ matrix.platform != 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        env:
+          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_PAT: ${{ secrets.PAT_TOKEN }}
+        run: |
+          echo "=== Debug: Github event name is '${{ github.event_name }}' ==="
+          echo "Configuring scoped registry for @tetherto and @qvac packages..."
+          set -eu
+          echo "Writing .npmrc for dual registry install…"
+          cat > .npmrc <<NPMRC
+          registry=https://registry.npmjs.org/
+          @qvac:registry=https://registry.npmjs.org/
+          @tetherto:registry=https://npm.pkg.github.com/
+          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          //npm.pkg.github.com/:_authToken=${GPR_TOKEN}
+          NPMRC
+
+          # Optional: make private git deps work without prompting
+          if [ -n "${GIT_PAT:-}" ]; then
+            git config --global url."https://${GIT_PAT}:@github.com/".insteadOf "https://github.com/"
+          else
+            # Using the workflow's GITHUB_TOKEN for git clones when possible
+            git config --global url."https://${{ github.token }}:@github.com/".insteadOf "https://github.com/"
+          fi
+        shell: bash
+
+      - name: Configure scoped registry for @tetherto and @qvac packages (Windows)
+        if: ${{ matrix.platform == 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        env:
+          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_PAT: ${{ secrets.PAT_TOKEN }}
+        run: |
+          echo "=== Debug: Github event name is '${{ github.event_name }}' ==="
+          echo "=== Configuring scoped registry for @tetherto and @qvac packages ==="
+          echo "Writing .npmrc for dual registry install…"
+          @"
+          registry=https://registry.npmjs.org/
+          @qvac:registry=https://registry.npmjs.org/
+          @tetherto:registry=https://npm.pkg.github.com/
+          //registry.npmjs.org/:_authToken=$env:NPM_TOKEN
+          //npm.pkg.github.com/:_authToken=$env:GPR_TOKEN
+          "@ | Out-File -FilePath .npmrc -Encoding utf8
+
+          echo "=== Verifying .npmrc creation ==="
+          Get-Content .npmrc
+          echo "=================================="
+
+          # Configure git
+          if ($env:GIT_PAT) {
+            git config --global url."https://$env:GIT_PAT:@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://$env:GIT_PAT:@github.com/".insteadOf "git@github.com:"
+          } else {
+            git config --global url."https://${{ github.token }}:@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://${{ github.token }}:@github.com/".insteadOf "git@github.com:"
+          }
+        shell: powershell
+
+      - name: Install NPM dependencies
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          npm install
+          npm install -g bare bare-make bare-runtime bare-https brittle
+
+      - name: Download prebuilds (from artifacts)
+        if: ${{ !inputs.prebuild_package }}
+        uses: actions/download-artifact@v7
+        with:
+          path: ${{ env.WORKDIR }}/prebuilds
+          merge-multiple: true
+
+      - name: Download prebuilds from package (Linux/macOS)
+        if: ${{ inputs.prebuild_package && matrix.platform != 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        shell: bash
+        run: |
+          PACKAGE="${{ inputs.prebuild_package }}"
+          echo "Downloading $PACKAGE from npm..."
+
+          if ! npm pack $PACKAGE; then
+            echo "ERROR: Failed to download $PACKAGE from npm"
+            echo "Please check that the package exists"
+            exit 1
+          fi
+
+          tar -xzf *.tgz
+
+          if [ ! -d "package/prebuilds" ]; then
+            echo "ERROR: No prebuilds directory found in package"
+            echo "The downloaded package may not contain prebuilt binaries"
+            exit 1
+          fi
+
+          mv package/prebuilds ./prebuilds
+          rm -rf package *.tgz
+
+          echo "Prebuilds downloaded from npm successfully"
+          ls -la prebuilds/
+
+      - name: Download prebuilds from package (Windows)
+        if: ${{ inputs.prebuild_package && matrix.platform == 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        shell: powershell
+        run: |
+          $PACKAGE = "${{ inputs.prebuild_package }}"
+
+          echo "Downloading $PACKAGE from npm..."
+
+          npm pack $PACKAGE
+          if ($LASTEXITCODE -ne 0) {
+            echo "ERROR: Failed to download $PACKAGE from npm"
+            echo "Please check that the package exists"
+            exit 1
+          }
+
+          $TARBALL = Get-ChildItem -Filter "*.tgz" | Select-Object -First 1 -ExpandProperty Name
+          if (-not $TARBALL) {
+            echo "ERROR: Could not find downloaded tarball"
+            exit 1
+          }
+
+          echo "Extracting $TARBALL..."
+          tar -xzf $TARBALL
+
+          if (-not (Test-Path "package/prebuilds")) {
+            echo "ERROR: No prebuilds directory found in package"
+            echo "The downloaded package may not contain prebuilt binaries"
+            exit 1
+          }
+
+          Move-Item package/prebuilds ./prebuilds
+
+          Remove-Item -Recurse -Force package
+          Remove-Item $TARBALL
+
+          echo "Prebuilds downloaded from npm successfully"
+          Get-ChildItem prebuilds/
+
+      - name: Linux - install dependencies
+        if: matrix.platform == 'linux' || matrix.platform == 'android'
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y mesa-vulkan-drivers
+
+      - name: Linux - install glibcxx
+        if: ${{ startsWith(matrix.os, 'ubuntu-22') }}
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt update
+          sudo apt install -y g++-13
+
+      - name: Windows - Install Vulkan
+        if: ${{ matrix.platform == 'win32' }}
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe -PassThru -UseBasicParsing
+          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
+          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
+        shell: powershell
+        timeout-minutes: 40
+
+      - name: Run integration test (Linux/macOS)
+        if: ${{ matrix.platform != 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          npm run test:integration 2>&1 | tee test-output.log
+          exit ${PIPESTATUS[0]}
+        shell: bash
+        env:
+          QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
+
+      - name: Run integration test (Windows)
+        if: ${{ matrix.platform == 'win32' }}
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          bare test/integration/all.js --exit | Tee-Object test-output.log
+        shell: powershell
+        env:
+          QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}

--- a/.github/workflows/on-merge-qvac-lib-infer-stable-diffusion-cpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-stable-diffusion-cpp.yml
@@ -1,0 +1,175 @@
+name: On Merge Trigger (Stable Diffusion)
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+      - feature-*
+      - tmp-*
+    paths:
+      - "packages/qvac-lib-infer-stable-diffusion-cpp/**"
+      - ".github/workflows/*stable-diffusion-cpp*.yml"
+
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish with"
+        required: false
+        default: "dev"
+        type: choice
+        options:
+          - latest
+          - dev
+
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to publish with"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+
+jobs:
+  publish-logic:
+    runs-on: ubuntu-latest
+    outputs:
+      publish_main: ${{ steps.logic.outputs.publish_main }}
+      publish_release: ${{ steps.logic.outputs.publish_release }}
+      publish_feature: ${{ steps.logic.outputs.publish_feature }}
+      publish_tmp: ${{ steps.logic.outputs.publish_tmp }}
+      gpr_tag: ${{ steps.logic.outputs.gpr_tag }}
+    steps:
+      - id: logic
+        shell: bash
+        run: |
+          set -euo pipefail
+          ref_name="${GITHUB_REF_NAME}"
+          event_name="${GITHUB_EVENT_NAME}"
+
+          publish_main="false"
+          publish_release="false"
+          publish_feature="false"
+          publish_tmp="false"
+
+          if [ "$event_name" = "push" ] || [ "$event_name" = "workflow_dispatch" ]; then
+            if [ "$ref_name" = "main" ]; then
+              publish_main="true"
+            elif [[ "$ref_name" == release-* ]]; then
+              publish_release="true"
+            elif [[ "$ref_name" == feature-* ]]; then
+              publish_feature="true"
+            elif [[ "$ref_name" == tmp-* ]]; then
+              publish_tmp="true"
+            fi
+          fi
+
+          gpr_tag="dev"
+          if [ "$ref_name" = "main" ]; then
+            gpr_tag="dev"
+          elif [[ "$ref_name" == feature-* ]]; then
+            gpr_tag="feature"
+          elif [[ "$ref_name" == tmp-* ]]; then
+            gpr_tag="temp"
+          fi
+
+          echo "publish_main=$publish_main" >> "$GITHUB_OUTPUT"
+          echo "publish_release=$publish_release" >> "$GITHUB_OUTPUT"
+          echo "publish_feature=$publish_feature" >> "$GITHUB_OUTPUT"
+          echo "publish_tmp=$publish_tmp" >> "$GITHUB_OUTPUT"
+          echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
+
+  release-merge-guard:
+    name: Release Merge Guard
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.ref_name, 'release-') &&
+      github.event.before != '0000000000000000000000000000000000000000'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/release-merge-guard
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          base-ref: ${{ github.ref_name }}
+          base-sha: ${{ github.event.before }}
+          head-sha: ${{ github.sha }}
+          package-slug: qvac-lib-infer-stable-diffusion-cpp
+          package-json-path: packages/qvac-lib-infer-stable-diffusion-cpp/package.json
+          changelog-path: packages/qvac-lib-infer-stable-diffusion-cpp/CHANGELOG.md
+
+  publish-main-gpr:
+    needs: publish-logic
+    if: needs.publish-logic.outputs.publish_main == 'true'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    uses: ./.github/workflows/prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
+      publish_target: "gpr"
+      workdir: "packages/qvac-lib-infer-stable-diffusion-cpp"
+
+  publish-feature-gpr:
+    needs: publish-logic
+    if: needs.publish-logic.outputs.publish_feature == 'true'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    uses: ./.github/workflows/prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
+      publish_target: "gpr"
+      workdir: "packages/qvac-lib-infer-stable-diffusion-cpp"
+
+  publish-tmp-gpr:
+    needs: publish-logic
+    if: needs.publish-logic.outputs.publish_tmp == 'true'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    uses: ./.github/workflows/prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
+      publish_target: "gpr"
+      workdir: "packages/qvac-lib-infer-stable-diffusion-cpp"
+
+  publish-release-npm:
+    needs: [publish-logic, release-merge-guard]
+    if: needs.publish-logic.outputs.publish_release == 'true'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    uses: ./.github/workflows/prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      tag: "latest"
+      publish_target: "npm"
+      workdir: "packages/qvac-lib-infer-stable-diffusion-cpp"
+
+  # Create GitHub release only for actual releases (after NPM publish)
+  publish-release:
+    needs: [publish-release-npm]
+    if:  needs.publish-release-npm.result == 'success' && needs.publish-release-npm.outputs.published_version != ''
+    permissions:
+      contents: write
+    uses: ./.github/workflows/create-github-release-qvac-lib-infer-stable-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      release_name: "QVAC Stable Diffusion Addon"
+      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      prev_sha: ${{ github.event.before }}
+      workdir: "packages/qvac-lib-infer-stable-diffusion-cpp"

--- a/.github/workflows/on-pr-close-qvac-lib-infer-stable-diffusion-cpp.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-stable-diffusion-cpp.yml
@@ -1,0 +1,61 @@
+name: Delete NPM Versions (Stable Diffusion)
+
+on:
+  pull_request:
+    types:
+      - closed
+    paths:
+      - "packages/qvac-lib-infer-stable-diffusion-cpp/**"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Specific version to target for deletion"
+        required: false
+        type: string
+      pr-number:
+        description: "PR number to target for deletion"
+        required: false
+        type: string
+      pattern:
+        description: "Pattern to target for deletion"
+        required: false
+        type: string
+      packages:
+        description: "Packages to target for deletion, space separated"
+        required: false
+        type: string
+        default: "@qvac/img-stable-diffusion-cpp @tetherto/img-stable-diffusion-cpp"
+      dry-run:
+        description: "Is dry run? If true, lists versions without deleting."
+        type: boolean
+        default: true
+
+run-name: Delete NPM Versions (img-stable-diffusion-cpp) ${{ inputs.version }} ${{ inputs.pr-number }} ${{ inputs.dry-run }}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  print-context-trigger:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - run: |
+          echo "Inputs Context: $INPUTS_CONTEXT"
+        env:
+          INPUTS_CONTEXT: ${{ toJSON(inputs) }}
+      - run: |
+          echo "GitHub Context: $GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+
+  delete-npm-versions-trigger:
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@monorepo_update
+    with:
+      version: ${{ inputs.version }}
+      pr-number: ${{ inputs.pr-number }}
+      pattern: ${{ inputs.pattern }}
+      packages: ${{ inputs.packages }}
+      dry-run: ${{ inputs.dry-run || true }}
+    secrets: inherit

--- a/.github/workflows/on-pr-qvac-lib-infer-stable-diffusion-cpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-stable-diffusion-cpp.yml
@@ -1,0 +1,89 @@
+name: On PR Trigger (Stable Diffusion)
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+    branches:
+      - main
+      - release-*
+      - feature-*
+      - tmp-*
+    paths:
+      - "packages/qvac-lib-infer-stable-diffusion-cpp/**"
+      - ".github/workflows/*stable-diffusion-cpp*.yml"
+  workflow_dispatch:
+
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+
+env:
+  PKG_DIR: packages/qvac-lib-infer-stable-diffusion-cpp
+
+jobs:
+  sanity-checks:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Sanity checks
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          pat-token: ${{ secrets.PAT_TOKEN }}
+          run-integration: ${{ contains(github.event.pull_request.labels.*.name, 'verify') }}
+          workdir: packages/qvac-lib-infer-stable-diffusion-cpp
+
+  cpp-lint:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
+    secrets: inherit
+    with:
+      sha: ${{ github.event.pull_request.base.sha }}
+      pr_head_sha: ${{ github.event.pull_request.head.sha }}
+      workdir: packages/qvac-lib-infer-stable-diffusion-cpp
+
+  prebuild:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    uses: ./.github/workflows/prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name }}
+      ref: ${{ github.event.pull_request.head.ref }}
+      publish_target: "gpr"
+      tag: pr-${{ github.event.pull_request.number }}
+
+  run-integration-tests:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: prebuild
+    uses: ./.github/workflows/integration-test-qvac-lib-infer-stable-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      repository: ${{ github.event.pull_request.head.repo.full_name }}
+      ref: ${{ github.event.pull_request.head.ref }}
+
+  merge-guard:
+    needs:
+      [
+        run-integration-tests,
+        sanity-checks,
+        prebuild,
+        cpp-lint,
+      ]
+    if: always()
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
+    with:
+      sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
+      build-status: ${{ needs.prebuild.result == 'success'}}
+    secrets: inherit

--- a/.github/workflows/prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml
@@ -1,0 +1,520 @@
+name: Prebuilds (Stable Diffusion)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish with ('latest' by default)"
+        required: true
+        default: "latest"
+        type: choice
+        options:
+          - latest
+          - dev
+      workdir:
+        description: "Working directory (optional)"
+        required: false
+        type: string
+        default: "packages/qvac-lib-infer-stable-diffusion-cpp"
+
+  workflow_call:
+    inputs:
+      ref:
+        description: "ref"
+        type: string
+        required: false
+      repository:
+        type: string
+        required: false
+        default: "tetherto/qvac"
+      tag:
+        description: "Tag to publish"
+        type: string
+        required: false
+        default: "dev"
+      publish_target:
+        description: "Where to publish: 'npm', 'gpr' or 'both'"
+        type: string
+        required: false
+        default: ""
+      workdir:
+        description: "Working directory (optional)"
+        required: false
+        type: string
+        default: "packages/qvac-lib-infer-stable-diffusion-cpp"
+    outputs:
+      published_version:
+        description: "The version that was published"
+        value: ${{ jobs.publish-npm.outputs.published_version || jobs.publish-gpr.outputs.published_version }}
+
+env:
+  WORKDIR: ${{ inputs.workdir }}
+
+jobs:
+  prebuild:
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            platform: linux
+            arch: x64
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
+
+    env:
+      # Keep vcpkg cache inside the package folder (monorepo-friendly)
+      VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}/${{ inputs.workdir || 'packages/qvac-lib-infer-stable-diffusion-cpp' }}/vcpkg/cache,readwrite
+
+    steps:
+      - if: ${{ matrix.platform == 'android' }}
+        name: Select NDK
+        run: |
+          echo "ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+          echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+
+      - name: print env
+        run: printenv
+
+      - if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+        name: Maximize build space
+        run: |
+          sudo docker image prune --all --force
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/share/dotnet
+
+      - name: Echo workflow inputs
+        shell: bash
+        run: |
+          echo "Workflow inputs:"
+          echo "Tag: ${{ inputs.tag || github.event.inputs.tag }}"
+          echo "Ref: ${{ inputs.ref || github.ref }}"
+          echo "Repository: ${{ inputs.repository || github.repository }}"
+          echo "Workdir: ${{ env.WORKDIR }}"
+          echo "Matrix platform: ${{ matrix.platform }}"
+          echo "Matrix arch: ${{ matrix.arch }}"
+          echo "Matrix tags: ${{ matrix.tags }}"
+
+      - if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+        name: Install llvm-19
+        run: |
+          wget -q https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 19 all
+
+      - if: ${{ startsWith(matrix.os, 'ubuntu-22') }}
+        name: Install g++-13 on Ubuntu 22.04
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt update
+          sudo apt install -y g++-13
+
+      - if: ${{ matrix.os == 'windows-2022' }}
+        name: Configure windows runner
+        shell: powershell
+        run: |
+          git config --system core.longpaths true
+          choco upgrade llvm
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Configure scoped registry for @tetherto and @qvac packages
+        env:
+          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_PAT: ${{ secrets.PAT_TOKEN }}
+        shell: bash
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          echo "Configuring scoped registry for @tetherto and @qvac packages..."
+          set -eu
+          cat > .npmrc <<NPMRC
+          registry=https://registry.npmjs.org/
+          @qvac:registry=https://registry.npmjs.org/
+          @tetherto:registry=https://npm.pkg.github.com/
+          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          //npm.pkg.github.com/:_authToken=${GIT_PAT}
+          NPMRC
+
+          if [ -n "${GIT_PAT:-}" ]; then
+            git config --global url."https://${GIT_PAT}:@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://${GIT_PAT}:@github.com/".insteadOf "git@github.com:"
+          else
+            git config --global url."https://${{ github.token }}:@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://${{ github.token }}:@github.com/".insteadOf "git@github.com:"
+          fi
+
+      - name: Install global dependencies
+        run: npm install -g bare bare-make
+
+      - if: ${{ matrix.os == 'windows-2022' && matrix.arch == 'arm64' }}
+        name: Rename win sdk folder to disable it
+        shell: powershell
+        run: |
+          Rename-Item -Path "C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0" -NewName "C:\Program Files (x86)\Windows Kits\10\Include\old-10.0.26100.0"
+          Rename-Item -Path "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0" -NewName "C:\Program Files (x86)\Windows Kits\10\bin\old-10.0.26100.0"
+          Rename-Item -Path "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.26100.0" -NewName "C:\Program Files (x86)\Windows Kits\10\Lib\old-10.0.26100.0"
+
+      - if: ${{ matrix.os == 'macos-14' || matrix.os == 'macos-15-intel' }}
+        name: Install vcpkg in macos
+        shell: bash
+        run: |
+          cd ..
+          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git
+          cd vcpkg && ./bootstrap-vcpkg.sh -disableMetrics
+          VCPKG_ROOT=$(pwd)
+          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
+          echo "$VCPKG_ROOT" >> $GITHUB_PATH
+
+      - if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+        name: Configure vcpkg in linux
+        run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-2022' }}
+        name: Configure vcpkg in windows
+        shell: powershell
+        run: echo ("VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" -replace '\\', '/') >> $env:GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-2022' }}
+        name: Configure cmake generator in windows
+        shell: powershell
+        run: echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-2022' && matrix.arch == 'x64' }}
+        shell: powershell
+        run: echo "CMAKE_GENERATOR_PLATFORM=x64" >> $env:GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-2022' && matrix.arch == 'x86' }}
+        shell: powershell
+        run: echo "CMAKE_GENERATOR_PLATFORM=Win32" >> $env:GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-2022' && matrix.arch == 'arm64' }}
+        shell: powershell
+        run: echo "CMAKE_GENERATOR_PLATFORM=ARM64" >> $env:GITHUB_ENV
+
+      - if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+        name: Update apt sources
+        run: sudo apt-get update
+
+      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
+        name: Install ccache on Linux
+        run: sudo apt-get install -y ccache
+
+      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
+        name: Configure ccache
+        run: |
+          ccache --set-config=max_size=2G
+          ccache --set-config=compression=true
+          ccache -z
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
+
+      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
+        name: Get ccache cache
+        uses: actions/cache@v5
+        with:
+          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ~/.cache/ccache-arm
+
+      - if: ${{ matrix.platform == 'linux' }}
+        name: Install required packages linux
+        run: sudo apt-get install libxi-dev libxtst-dev libxrandr-dev
+
+      - if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+        name: Install vulkan in linux
+        run: |
+          sudo apt install -y xz-utils
+          wget -q -O /tmp/vulkansdk.tar.xz https://sdk.lunarg.com/sdk/download/latest/linux/vulkan_sdk.tar.xz
+          cd ~
+          mkdir -p vulkan
+          cd vulkan
+          tar xf /tmp/vulkansdk.tar.xz --strip-components=1
+
+      - if: ${{ (matrix.platform == 'linux' && matrix.arch == 'x64') || (matrix.platform == 'android') }}
+        name: Setup vulkan sdk path in linux x64
+        run: |
+          VULKAN_SDK=~/vulkan/x86_64
+          echo "VULKAN_SDK=$VULKAN_SDK" >> $GITHUB_ENV
+
+      - if: ${{ matrix.platform == 'linux' && matrix.arch == 'arm64' }}
+        name: Setup vulkan sdk path in linux arm64
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          VULKAN_SDK=~/vulkan/aarch64
+          echo "VULKAN_SDK=$VULKAN_SDK" >> $GITHUB_ENV
+
+          cd ~/vulkan
+
+          # Extract SDK major.minor version from README.txt (e.g., "1.4" from "1.4.341.0")
+          SDK_VERSION=$(grep -o 'sdk/[0-9]*\.[0-9]*' README.txt | head -1 | sed 's|sdk/||')
+          S3_BUCKET="${{ secrets.MODEL_S3_BUCKET }}"
+          S3_KEY="vulkan-sdk-cache/linux-arm64-${SDK_VERSION}.tar.gz"
+
+          echo "Vulkan SDK version: ${SDK_VERSION}"
+
+          # Try to download cached build from S3
+          if aws s3 cp "s3://${S3_BUCKET}/${S3_KEY}" /tmp/vulkan-arm64-cache.tar.gz 2>/dev/null; then
+            echo "Found cached Vulkan SDK, extracting..."
+            tar xzf /tmp/vulkan-arm64-cache.tar.gz -C ~/vulkan
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          else
+            echo "No cache found, building Vulkan SDK for ARM64..."
+            ./vulkansdk --maxjobs
+
+            # Upload the compiled SDK to S3 for future runs
+            echo "Uploading compiled SDK to S3..."
+            tar czf /tmp/vulkan-arm64-cache.tar.gz aarch64
+            aws s3 cp /tmp/vulkan-arm64-cache.tar.gz "s3://${S3_BUCKET}/${S3_KEY}"
+            rm /tmp/vulkan-arm64-cache.tar.gz
+          fi
+
+      - if: ${{ startsWith(matrix.os, 'ubuntu-') }}
+        name: Export rest of vulkan sdk variables in linux
+        run: |
+          echo "PATH=$VULKAN_SDK/bin:$PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$VULKAN_SDK/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> $GITHUB_ENV
+          echo "VK_ADD_LAYER_PATH=$VULKAN_SDK/share/vulkan/explicit_layer.d" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$VULKAN_SDK/share/pkgconfig:$VULKAN_SDK/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}" >> $GITHUB_ENV
+
+      - if: ${{ matrix.platform == 'win32' }}
+        name: Install Vulkan SDK (Windows)
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $ProgressPreference = "SilentlyContinue"
+
+          # Use a stable URL (latest) but download with BITS (more reliable than Invoke-WebRequest)
+          $url = "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe"
+          $out = "$env:RUNNER_TEMP\vulkan-sdk.exe"
+
+          # Some environments need TLS 1.2 explicitly
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+          Write-Host "Downloading Vulkan SDK from $url to $out"
+          Start-BitsTransfer -Source $url -Destination $out
+
+          Write-Host "Installing Vulkan SDK..."
+          & $out --root "C:\VulkanSDK" --accept-licenses --default-answer --confirm-command install
+
+          "VULKAN_SDK=C:\VulkanSDK" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          "PATH=C:\VulkanSDK\Bin;$Env:PATH" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+
+      - if: ${{ matrix.platform == 'android' }}
+        name: Configure runner for cross compilation - android
+        run: |
+          echo "ANDROID_TOOLCHAIN_ROOT=$(echo $ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/linux-x86_64" >> $GITHUB_ENV
+          echo "ANDROID_NATIVE_API_LEVEL=34" >> $GITHUB_ENV
+
+      - name: Install npm dependencies
+        working-directory: ${{ env.WORKDIR }}
+        run: npm install
+
+      - name: Create vcpkg cache location
+        working-directory: ${{ env.WORKDIR }}
+        run: mkdir -p vcpkg/cache
+
+      - name: Get vcpkg cache
+        id: cache-vcpkg
+        uses: actions/cache@v5
+        with:
+          key: ${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles(format('{0}/vcpkg.json', env.WORKDIR), format('{0}/vcpkg-configuration.json', env.WORKDIR), format('{0}/vcpkg/ports/**', env.WORKDIR)) }}
+          path: ${{ env.WORKDIR }}/vcpkg/cache
+          restore-keys: ${{ matrix.platform }}-${{ matrix.arch }}-
+
+      - name: Run bare-make generate
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }} $CFG_OPTS
+
+      - name: Run bare-make build
+        working-directory: ${{ env.WORKDIR }}
+        run: bare-make build
+
+      - name: Run bare-make install
+        working-directory: ${{ env.WORKDIR }}
+        run: bare-make install
+
+      - name: Smoke check (tmp-*) package name & prebuilds listing
+        if: ${{ startsWith(github.ref, 'refs/heads/tmp-')
+                || startsWith(github.ref_name, 'tmp-')
+                || (inputs.ref != '' && (startsWith(inputs.ref, 'refs/heads/tmp-') || startsWith(inputs.ref, 'tmp-'))) }}
+        shell: bash
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          echo "package.json name (post-build): $(node -e "console.log(JSON.parse(require('fs').readFileSync('package.json','utf8')).name)")"
+          echo "prebuilds directory:"
+          ls -la prebuilds || true
+          find prebuilds -maxdepth 1 -type d -print || true
+
+      - name: Strip debug symbols
+        if: ${{ matrix.platform != 'win32' }}
+        shell: bash
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          if [[ "${{ matrix.platform }}" == "android" ]]; then
+            find prebuilds -name "*.bare" -exec $ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip {} \;
+          elif [[ "${{ matrix.platform }}" == "darwin" || "${{ matrix.platform }}" == "ios" ]]; then
+            find prebuilds -name "*.bare" -exec strip -S {} \;
+          else
+            find prebuilds -name "*.bare" -exec strip --strip-debug {} \;
+          fi
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: sd-cpp-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
+          path: ${{ env.WORKDIR }}/prebuilds
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: prebuild
+    permissions:
+      contents: write
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: prebuilds
+          merge-multiple: true
+
+      - name: Upload merged artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: prebuilds
+          path: prebuilds
+
+  publish-gpr:
+    needs: [prebuild, merge]
+    if: ${{ inputs.publish_target == 'gpr'
+          || inputs.publish_target == 'both'
+          || (
+              (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
+              && (inputs.publish_target == '' || inputs.publish_target == null)
+              && (
+                github.ref_name == 'main'
+                || startsWith(github.ref_name, 'feature-')
+                || startsWith(github.ref_name, 'tmp-')
+                || (inputs.ref != '' && (
+                      inputs.ref == 'refs/heads/main'
+                      || startsWith(inputs.ref, 'refs/heads/feature-')
+                      || startsWith(inputs.ref, 'refs/heads/tmp-')
+                   ))
+              )
+            ) }}
+    continue-on-error: true
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: prebuilds
+          path: ${{ env.WORKDIR }}/prebuilds
+
+      - name: Scope package as @tetherto for GPR
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const fs=require('fs');const f='${{ env.WORKDIR }}/package.json';const p=JSON.parse(fs.readFileSync(f,'utf8'));const want='@tetherto/img-stable-diffusion-cpp';if(p.name!==want){p.name=want;fs.writeFileSync(f,JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);} "
+          node -e "console.log('Effective package name (publish-gpr):', JSON.parse(require('fs').readFileSync('${{ env.WORKDIR }}/package.json','utf8')).name)"
+
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
+          workdir:  ${{ env.WORKDIR }}
+          name-suffix: "-mono"
+
+  publish-npm:
+    needs: [prebuild, merge]
+    if: ${{ inputs.publish_target == 'npm'
+          || inputs.publish_target == 'both'
+          || (
+              (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
+              && (inputs.publish_target == '' || inputs.publish_target == null)
+              && (
+                startsWith(github.ref_name, 'release-')
+                || (inputs.ref != '' && startsWith(inputs.ref, 'refs/heads/release-'))
+              )
+            ) }}
+    continue-on-error: false
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: prebuilds
+          path: ${{ env.WORKDIR }}/prebuilds
+
+      # Re-assert scope for public npm (fresh checkout)
+      - name: Scope package as @qvac for npm
+        working-directory: ${{ env.WORKDIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));const want='@qvac/img-stable-diffusion-cpp';if(p.name!==want){p.name=want;fs.writeFileSync('package.json',JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);}"
+          node -e "console.log('Effective package name (publish-npm):', JSON.parse(require('fs').readFileSync('package.json','utf8')).name)"
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: 'latest'
+          workdir: ${{ env.WORKDIR }}
+          repo_name: "stable-diffusion-cpp"
+          git-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml
@@ -344,7 +344,7 @@ jobs:
       - name: Run bare-make generate
         working-directory: ${{ env.WORKDIR }}
         run: |
-          bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }} $CFG_OPTS
+          bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }}
 
       - name: Run bare-make build
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/release-notes-check-qvac-lib-infer-stable-diffusion-cpp.yml
+++ b/.github/workflows/release-notes-check-qvac-lib-infer-stable-diffusion-cpp.yml
@@ -1,0 +1,75 @@
+name: Release Notes Check (Stable Diffusion)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "packages/qvac-lib-infer-stable-diffusion-cpp/**"
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  release-notes-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate release notes on version bump (monorepo-aware)
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { decodeContent, validateReleaseNotesOnVersionBump, formatFailures } = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/release-notes-check.js`
+            );
+
+            const pullNumber = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const baseSha = context.payload.pull_request.base.sha;
+            const headSha = context.payload.pull_request.head.sha;
+
+            // List PR files with pagination
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: pullNumber, per_page: 100 }
+            );
+
+            async function readJsonAtRef(path, ref) {
+              try {
+                const resp = await github.rest.repos.getContent({ owner, repo, path, ref });
+                const raw = decodeContent(resp);
+                if (!raw) return null;
+                return JSON.parse(raw);
+              } catch (e) {
+                core.warning(`Could not read ${path} at ref ${ref}: ${e.message}`);
+                return null;
+              }
+            }
+
+            async function readTextAtRef(path, ref) {
+              try {
+                const resp = await github.rest.repos.getContent({ owner, repo, path, ref });
+                return decodeContent(resp);
+              } catch (e) {
+                core.warning(`Could not read ${path} at ref ${ref}: ${e.message}`);
+                return null;
+              }
+            }
+            const failures = await validateReleaseNotesOnVersionBump({
+              files,
+              baseSha,
+              headSha,
+              readJsonAtRef,
+              readTextAtRef,
+              log: (message) => core.info(message)
+            });
+
+            if (failures.length > 0) {
+              core.setFailed(formatFailures(failures));
+            } else {
+              core.info('All detected version bumps have matching changelog sections.');
+            }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The new `@qvac/img-stable-diffusion-cpp` addon (on `feature-media-generation`) has no CI workflows
- Workflow files must exist on `main` for GitHub Actions to register them for `workflow_dispatch` triggering

## 📝 How does it solve it?

- Adds 8 CI workflow files adapted from the LLM addon templates (`*llamacpp-llm*.yml`)
- Phase 1: Linux x64 only matrix, `workflow_dispatch` + `workflow_call` triggers

### Workflows added

| Workflow | Purpose |
|----------|---------|
| `prebuilds-qvac-lib-infer-stable-diffusion-cpp.yml` | Native prebuilds |
| `integration-test-qvac-lib-infer-stable-diffusion-cpp.yml` | Integration tests |
| `cpp-tests-stable-diffusion-cpp.yml` | C++ unit tests |
| `on-pr-qvac-lib-infer-stable-diffusion-cpp.yml` | PR orchestration |
| `on-merge-qvac-lib-infer-stable-diffusion-cpp.yml` | Post-merge publishing |
| `create-github-release-qvac-lib-infer-stable-diffusion-cpp.yml` | GitHub release creation |
| `on-pr-close-qvac-lib-infer-stable-diffusion-cpp.yml` | GPR version cleanup |
| `release-notes-check-qvac-lib-infer-stable-diffusion-cpp.yml` | Changelog validation |

## 🧪 How was it tested?

- All YAML files validated with Python `yaml.safe_load`
- Verified no stale `llamacpp`/`llama-cpp` references remain
- Verified artifact prefix, GPR/NPM scopes, matrix configuration