### PR TITLE
chore[notask]: Bump tts 0.5.4

### DIFF
--- a/packages/qvac-sdk/bun.lock
+++ b/packages/qvac-sdk/bun.lock
@@ -16,7 +16,7 @@
         "@qvac/registry-client": "^0.2.0",
         "@qvac/transcription-whispercpp": "^0.3.17",
         "@qvac/translation-nmtcpp": "^0.3.6",
-        "@qvac/tts-onnx": "^0.5.0",
+        "@qvac/tts-onnx": "^0.5.4",
         "fast-safe-stringify": "2.1.1",
         "which-runtime": "^1.3.2",
         "zod": "^4.0.17",
@@ -541,7 +541,7 @@
 
     "@qvac/translation-nmtcpp": ["@qvac/translation-nmtcpp@0.3.7", "", { "dependencies": { "@qvac/dl-hyperdrive": "^0.1.0", "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.2.0", "bare-path": "^3.0.0" } }, "sha512-tPR5aO5bfiWRGWFGkYaiO0wadyb8r6Bh/m9FhY78UBO5DOJgFpqazI83PYC6rthSSGx07CMLCiBp2rlEcjYmeQ=="],
 
-    "@qvac/tts-onnx": ["@qvac/tts-onnx@0.5.1", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.1.0", "bare-fs": "^4.5.1", "bare-path": "^3.0.0" } }, "sha512-n4w+mf8BiWmQW7vKPkk4Cj4MVXx6eyhe7Et62l7GLbYUWx5oJqNwgxwAWzFcXDVVKyq/f6TWiRlUrSGNENHaJw=="],
+    "@qvac/tts-onnx": ["@qvac/tts-onnx@0.5.4", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.1.0", "bare-fs": "^4.5.1", "bare-path": "^3.0.0" } }, "sha512-8S4beKOxBVkxM5MaQEYf0a9iL5YtrXdigu5VTX+F00XVGErZ06rOrHuFw+66CwvWCUfNcM1z0/r0KRVv8C1PHw=="],
 
     "@qvac/util-transcription": ["@qvac/util-transcription@0.1.5", "", { "dependencies": { "@qvac/decoder-audio": "^0.3.3", "@qvac/error": "^0.1.0", "@qvac/response": "^0.1.0" } }, "sha512-1dI6JDA4RfCjBKm05NayXua5Cjm3qYnJy/cZChJJwJW/DvxMipJXFNKpvl9O0o8J0Vuz03Fsouvqvwj5vT4YWw=="],
 

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -122,7 +122,7 @@
     "@qvac/rag": "^0.4.2",
     "@qvac/transcription-whispercpp": "^0.3.17",
     "@qvac/translation-nmtcpp": "^0.3.6",
-    "@qvac/tts-onnx": "^0.5.0",
+    "@qvac/tts-onnx": "^0.5.4",
     "@qvac/registry-client": "^0.2.0",
     "fast-safe-stringify": "2.1.1",
     "which-runtime": "^1.3.2",


### PR DESCRIPTION
## What problem does this PR solve
- Current tts addon version crashes on iOS

## How does this PR solve it
- Bump to tts v0.5.4 containing iOS crash fixes. 