### PR TITLE
chore[notask]: Bump nmt to 0.3.9

### DIFF
--- a/packages/qvac-sdk/bun.lock
+++ b/packages/qvac-sdk/bun.lock
@@ -15,7 +15,7 @@
         "@qvac/rag": "^0.4.2",
         "@qvac/registry-client": "^0.2.0",
         "@qvac/transcription-whispercpp": "^0.3.17",
-        "@qvac/translation-nmtcpp": "^0.3.6",
+        "@qvac/translation-nmtcpp": "^0.3.9",
         "@qvac/tts-onnx": "^0.5.4",
         "fast-safe-stringify": "2.1.1",
         "which-runtime": "^1.3.2",
@@ -539,7 +539,7 @@
 
     "@qvac/transcription-whispercpp": ["@qvac/transcription-whispercpp@0.3.18", "", { "dependencies": { "@qvac/decoder-audio": "^0.3.3", "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.2.0", "@qvac/logging": "^0.1.0", "@qvac/util-transcription": "^0.1.4", "bare-channel": "^5.2.2", "bare-ffmpeg": "^1.0.0-32", "bare-node-worker-threads": "^1.0.0", "bare-path": "^3.0.0", "bare-stream": "^2.7.0", "bare-worker": "^4.1.0", "path": "npm:bare-path", "process": "npm:bare-process@^4.2.2", "stream": "npm:bare-node-stream", "worker_threads": "npm:bare-node-worker-threads@^1.0.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-RlvcV6NdnZqxuXOgpFC7gXhBAPR2NHMZcvLuPJQR7mF6p6kCKCXV0KauE6JjZxZORK2tSyn8bKFlNZC9Na+MIw=="],
 
-    "@qvac/translation-nmtcpp": ["@qvac/translation-nmtcpp@0.3.7", "", { "dependencies": { "@qvac/dl-hyperdrive": "^0.1.0", "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.2.0", "bare-path": "^3.0.0" } }, "sha512-tPR5aO5bfiWRGWFGkYaiO0wadyb8r6Bh/m9FhY78UBO5DOJgFpqazI83PYC6rthSSGx07CMLCiBp2rlEcjYmeQ=="],
+    "@qvac/translation-nmtcpp": ["@qvac/translation-nmtcpp@0.3.9", "", { "dependencies": { "@qvac/dl-hyperdrive": "^0.1.0", "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.2.0", "bare-path": "^3.0.0" } }, "sha512-hN3kaAdQ944OFI/UyupZFmTECdNfZKPMJDWy2joyx2UUi6i2Qv8G6hPPRj7JvCmrR5q9oJlOYN83+k4BQKFGpA=="],
 
     "@qvac/tts-onnx": ["@qvac/tts-onnx@0.5.4", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.1.0", "bare-fs": "^4.5.1", "bare-path": "^3.0.0" } }, "sha512-8S4beKOxBVkxM5MaQEYf0a9iL5YtrXdigu5VTX+F00XVGErZ06rOrHuFw+66CwvWCUfNcM1z0/r0KRVv8C1PHw=="],
 

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -121,7 +121,7 @@
     "@qvac/ocr-onnx": "^0.1.5",
     "@qvac/rag": "^0.4.2",
     "@qvac/transcription-whispercpp": "^0.3.17",
-    "@qvac/translation-nmtcpp": "^0.3.6",
+    "@qvac/translation-nmtcpp": "^0.3.9",
     "@qvac/tts-onnx": "^0.5.4",
     "@qvac/registry-client": "^0.2.0",
     "fast-safe-stringify": "2.1.1",


### PR DESCRIPTION
## Summary 

Includes batch translation fixes from  `@qvac/translation-nmtcpp`