### PR TITLE
QVAC-13619: Switch llamacpp-embed Linux builds from libstdc++ to clang's libc++

### DIFF
--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
@@ -68,13 +68,6 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Linux glibcxx
-        if: ${{ startsWith(matrix.os, 'ubuntu-22') }}
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y g++-13
-
       - name: Windows - enable git long paths
         if: ${{ matrix.platform == 'win32' }}
         shell: powershell

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -137,13 +137,6 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19 all
 
-      - if: ${{ startsWith(matrix.os, 'ubuntu-22') }}
-        name: Install g++-13 on Ubuntu 22.04
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y g++-13
-
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure windows runner
         run: |

--- a/packages/qvac-lib-infer-llamacpp-embed/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-embed/CMakeLists.txt
@@ -15,7 +15,14 @@ endif()
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
 find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
+set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/triplets;${VCPKG_OVERLAY_TRIPLETS}")
+
 project(qvac-lib-infer-llamacpp-embed C CXX)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_compile_options(-stdlib=libc++)
+  add_link_options(-stdlib=libc++ -static-libstdc++ -Wl,--exclude-libs,ALL)
+endif()
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)
 configure_file(${VCPKG_INSTALLED_PATH}/share/qvac-lint-cpp/.clang-format

--- a/packages/qvac-lib-infer-llamacpp-embed/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-embed/CMakeLists.txt
@@ -21,7 +21,7 @@ project(qvac-lib-infer-llamacpp-embed C CXX)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_compile_options(-stdlib=libc++)
-  add_link_options(-stdlib=libc++ -static-libstdc++ -Wl,--exclude-libs,ALL)
+  add_link_options(-stdlib=libc++ -static-libstdc++)
 endif()
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)
@@ -55,6 +55,10 @@ if((ANDROID OR UNIX) AND NOT APPLE)
 endif()  
 
 add_bare_module(qvac-lib-infer-llamacpp-embed EXPORTS ${BACKEND_DL_LIBS})
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_options(${qvac-lib-infer-llamacpp-embed} PRIVATE -Wl,--exclude-libs,ALL)
+endif()
 
 target_sources(
   ${qvac-lib-infer-llamacpp-embed}

--- a/packages/qvac-lib-infer-llamacpp-embed/README.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/README.md
@@ -38,7 +38,7 @@ This native C++ addon, built using the `Bare` Runtime, simplifies running text e
 - qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework
 - qvac-fabric-llm.cpp (≥7248.1.2): Inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
-- Ubuntu-22 requires g++-13 installed
+- Linux requires Clang/LLVM 19 with libc++
 
 
 ## Installation

--- a/packages/qvac-lib-infer-llamacpp-embed/build.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/build.md
@@ -59,14 +59,7 @@ If you want to build the addon from source instead of using pre-built packages, 
      - Xcode Command Line Tools
      - Apple clang version >= 15.0.0 (LLVM compiler is not supported at the moment)
      - For Android cross-compilation: Android NDK and Vulkan tools (`brew install shaderc vulkan-tools molten-vk vulkan-headers`)
-   - **Linux**: GCC/G++ compiler, CMake
-     - Ubuntu-22 requires g++-13 installed:
-        
-        ```bash
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y g++-13
-        ```
+   - **Linux**: Clang/LLVM (with libc++), CMake
    - **Windows**:  
       - Install Visual Studio 2022 with C++ tools, Clang and llvm tools
       - Install Vulkan

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg/toolchains/linux-clang.cmake
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg/toolchains/linux-clang.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_C_COMPILER "clang-19")
+set(CMAKE_CXX_COMPILER "clang++-19")
+
+include("$ENV{VCPKG_ROOT}/scripts/toolchains/linux.cmake")

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg/triplets/arm64-linux.cmake
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg/triplets/arm64-linux.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/linux-clang.cmake")
+set(VCPKG_C_FLAGS "-fPIC")
+set(VCPKG_CXX_FLAGS "-fPIC -stdlib=libc++")
+set(VCPKG_LINKER_FLAGS "-stdlib=libc++")

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg/triplets/x64-linux.cmake
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg/triplets/x64-linux.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/linux-clang.cmake")
+set(VCPKG_C_FLAGS "-fPIC")
+set(VCPKG_CXX_FLAGS "-fPIC -stdlib=libc++")
+set(VCPKG_LINKER_FLAGS "-stdlib=libc++")


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The llamacpp-embed addon on Linux depends on GCC's libstdc++, requiring `g++-13` to be installed on Ubuntu 22.04 for both builds and integration tests
- Aligns with the llamacpp-llm addon's migration to libc++ (already merged)

## 📝 How does it solve it?

- Add vcpkg overlay triplets (`x64-linux`, `arm64-linux`) with `-stdlib=libc++`, `-fPIC`, and a chainload toolchain selecting clang-19
- Update `CMakeLists.txt` to prepend overlay triplets and set `-stdlib=libc++ -static-libstdc++ -Wl,--exclude-libs,ALL` link options — libc++ is statically linked and internal symbols are hidden to avoid `__cxa_*` conflicts with the bare runtime's libstdc++
- Remove `g++-13` install steps from prebuild and integration test workflows
- Update `README.md` and `build.md` Linux prerequisites

## 🧪 How was it tested?

- CI prebuild and integration test workflows: https://github.com/tetherto/qvac/actions/runs/22488326308
- Run with fix for cpp-tests: https://github.com/tetherto/qvac/actions/runs/22507595289