### PR TITLE
QVAC-13629: Switch whispercpp Linux builds from libstdc++ to clang's libc++

### DIFF
--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
@@ -63,9 +63,6 @@ jobs:
       - name: Install system dependencies (Linux)
         if: matrix.platform == 'linux'
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y g++-13
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 19 all

--- a/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
@@ -198,13 +198,6 @@ jobs:
           # Add whisper.cpp dependencies for integration tests
           sudo apt-get install -y libopenblas-dev liblapack-dev libfftw3-dev
 
-      - name: Linux - install glibcxx
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y g++-13
-
       - name: macOS - install whisper dependencies
         if: matrix.platform == 'darwin'
         shell: bash

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -261,13 +261,6 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19 all
 
-      - if: ${{ matrix.os == 'ubuntu-22.04' }}
-        name: Install g++-13 on Ubuntu 22.04
-        run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt update
-          sudo apt install -y g++-13
-
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}
         name: Install ccache on Linux
         run: sudo apt-get install -y ccache

--- a/packages/qvac-lib-infer-whispercpp/.gitignore
+++ b/packages/qvac-lib-infer-whispercpp/.gitignore
@@ -5,7 +5,10 @@ node_modules/
 .idea/
 prebuilds/
 addon/gst/.meson
-vcpkg/
+vcpkg/cache/
+vcpkg/ports/
+!vcpkg/triplets/
+!vcpkg/toolchains/
 benchmarks/data/
 
 test/unit/all.js

--- a/packages/qvac-lib-infer-whispercpp/CMakeLists.txt
+++ b/packages/qvac-lib-infer-whispercpp/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 add_bare_module(qvac-lib-infer-whispercpp EXPORTS)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_link_options(${qvac-lib-infer-whispercpp} PRIVATE -Wl,--exclude-libs,ALL)
+  target_link_options(${qvac-lib-infer-whispercpp}_module PRIVATE -Wl,--exclude-libs,ALL)
 endif()
 
 target_sources(

--- a/packages/qvac-lib-infer-whispercpp/CMakeLists.txt
+++ b/packages/qvac-lib-infer-whispercpp/CMakeLists.txt
@@ -20,7 +20,7 @@ project(qvac-lib-infer-whispercpp CXX C)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_compile_options(-stdlib=libc++)
-  add_link_options(-stdlib=libc++ -static-libstdc++ -Wl,--exclude-libs,ALL)
+  add_link_options(-stdlib=libc++ -static-libstdc++)
 endif()
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)
@@ -56,6 +56,10 @@ if(ANDROID)
 endif()
 
 add_bare_module(qvac-lib-infer-whispercpp EXPORTS)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_options(${qvac-lib-infer-whispercpp} PRIVATE -Wl,--exclude-libs,ALL)
+endif()
 
 target_sources(
   ${qvac-lib-infer-whispercpp}

--- a/packages/qvac-lib-infer-whispercpp/CMakeLists.txt
+++ b/packages/qvac-lib-infer-whispercpp/CMakeLists.txt
@@ -14,7 +14,14 @@ endif()
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
 find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
+set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/triplets;${VCPKG_OVERLAY_TRIPLETS}")
+
 project(qvac-lib-infer-whispercpp CXX C)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_compile_options(-stdlib=libc++)
+  add_link_options(-stdlib=libc++ -static-libstdc++ -Wl,--exclude-libs,ALL)
+endif()
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)
 configure_file(${VCPKG_INSTALLED_PATH}/share/qvac-lint-cpp/.clang-format

--- a/packages/qvac-lib-infer-whispercpp/README.md
+++ b/packages/qvac-lib-infer-whispercpp/README.md
@@ -37,7 +37,7 @@ This library simplifies running inference with the Whisper transcription model w
 - qvac-lib-inference-addon-cpp (=0.12.2): C++ addon framework
 - qvac-fabric-whisper.cpp (latest): Inference engine
 - Bare Runtime (≥1.24.2): JavaScript runtime
-- Ubuntu-22 requires g++-13 installed
+- Linux requires Clang/LLVM 19 with libc++
 
 ## Installation
 

--- a/packages/qvac-lib-infer-whispercpp/vcpkg/toolchains/linux-clang.cmake
+++ b/packages/qvac-lib-infer-whispercpp/vcpkg/toolchains/linux-clang.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_C_COMPILER "clang-19")
+set(CMAKE_CXX_COMPILER "clang++-19")
+
+include("$ENV{VCPKG_ROOT}/scripts/toolchains/linux.cmake")

--- a/packages/qvac-lib-infer-whispercpp/vcpkg/triplets/arm64-linux.cmake
+++ b/packages/qvac-lib-infer-whispercpp/vcpkg/triplets/arm64-linux.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/linux-clang.cmake")
+set(VCPKG_C_FLAGS "-fPIC")
+set(VCPKG_CXX_FLAGS "-fPIC -stdlib=libc++")
+set(VCPKG_LINKER_FLAGS "-stdlib=libc++")

--- a/packages/qvac-lib-infer-whispercpp/vcpkg/triplets/x64-linux.cmake
+++ b/packages/qvac-lib-infer-whispercpp/vcpkg/triplets/x64-linux.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/linux-clang.cmake")
+set(VCPKG_C_FLAGS "-fPIC")
+set(VCPKG_CXX_FLAGS "-fPIC -stdlib=libc++")
+set(VCPKG_LINKER_FLAGS "-stdlib=libc++")


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The whispercpp addon on Linux depends on GCC's libstdc++, requiring `g++-13` to be installed on Ubuntu 22.04 for builds and integration tests
- Aligns with the llamacpp-llm addon's migration to libc++ (already merged)

## 📝 How does it solve it?

- Add vcpkg overlay triplets (`x64-linux`, `arm64-linux`) with `-stdlib=libc++`, `-fPIC`, and a chainload toolchain selecting clang-19
- Update `CMakeLists.txt` to prepend overlay triplets and set `-stdlib=libc++ -static-libstdc++ -Wl,--exclude-libs,ALL` link options — libc++ is statically linked and internal symbols are hidden to avoid `__cxa_*` conflicts with the bare runtime's libstdc++
- Remove `g++-13` install steps from prebuild, integration test, and coverage workflows
- Update `.gitignore` to allow `vcpkg/triplets/` and `vcpkg/toolchains/` while keeping other vcpkg build artifacts ignored
- Update `README.md` Linux prerequisites

## 🧪 How was it tested?

- CI prebuild and integration test workflows: https://github.com/tetherto/qvac/actions/runs/22489918815
- Rebased and updated: https://github.com/tetherto/qvac/actions/runs/22572843754