### PR TITLE
Scope --exclude-libs,ALL to bare module target only

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 add_bare_module(qvac-lib-inference-addon-llama EXPORTS ${BACKEND_DL_LIBS})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_link_options(${qvac-lib-inference-addon-llama} PRIVATE -Wl,--exclude-libs,ALL)
+  target_link_options(${qvac-lib-inference-addon-llama}_module PRIVATE -Wl,--exclude-libs,ALL)
 endif()
 
   set(ADDON_SOURCES

--- a/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
@@ -21,7 +21,7 @@ project(qvac-lib-inference-addon-llama C CXX)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   add_compile_options(-stdlib=libc++)
-  add_link_options(-stdlib=libc++ -static-libstdc++ -Wl,--exclude-libs,ALL)
+  add_link_options(-stdlib=libc++ -static-libstdc++)
 endif()
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)
@@ -52,6 +52,11 @@ if((ANDROID OR UNIX) AND NOT APPLE)
 endif()
 
 add_bare_module(qvac-lib-inference-addon-llama EXPORTS ${BACKEND_DL_LIBS})
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_options(${qvac-lib-inference-addon-llama} PRIVATE -Wl,--exclude-libs,ALL)
+endif()
+
   set(ADDON_SOURCES
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp
   )


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The directory-wide `-Wl,--exclude-libs,ALL` link option was applied to all targets including C++ test executables, hiding ASan's `malloc`/`free` interceptors and causing false "free on address not malloc()-ed" errors in the `addon-test` binary on CI

## 📝 How does it solve it?

- Move `-Wl,--exclude-libs,ALL` from directory-wide `add_link_options` to a target-specific `target_link_options` on the bare module only
- The `.bare` shared library still hides all internal symbols (libc++abi, llama.cpp, etc.)
- Test executables no longer have their symbol visibility restricted, allowing ASan and dynamically loaded ggml backends to work correctly

## 🧪 How was it tested?

- Local C++ test suite (`npm run test:cpp`) passes with no ASan errors
- CI cpp-tests workflow