### PR TITLE
Fix --exclude-libs target to use _module shared library

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-embed/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 add_bare_module(qvac-lib-infer-llamacpp-embed EXPORTS ${BACKEND_DL_LIBS})
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_link_options(${qvac-lib-infer-llamacpp-embed} PRIVATE -Wl,--exclude-libs,ALL)
+  target_link_options(${qvac-lib-infer-llamacpp-embed}_module PRIVATE -Wl,--exclude-libs,ALL)
 endif()
 
 target_sources(


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The target-specific `-Wl,--exclude-libs,ALL` was was not being applied to the .bare module, causing false "free on address not malloc()-ed" errors on CI

## 📝 How does it solve it?

- Apply `-Wl,--exclude-libs,ALL` to the `_module` shared library target (the actual `.bare` binary) instead of the OBJECT library target, which silently ignored the flag
- The `.bare` shared library correctly hides internal symbols (libc++abi, llama.cpp)
- Test executables are unaffected, allowing ASan and dynamically loaded ggml backends to work correctly

## 🧪 How was it tested?

- Local C++ tests (`npm run test:cpp`) pass with ASan enabled
- Verified with `nm -D` that `__cxa_throw` is no longer exported from the `.bare` binary