### PR TITLE
feat(diffusion): add JS layer with tests and error handling

### DIFF
--- a/packages/lib-infer-diffusion/examples/generate-image.js
+++ b/packages/lib-infer-diffusion/examples/generate-image.js
@@ -13,7 +13,7 @@ const MODELS_DIR = path.resolve(__dirname, '../models')
 const OUTPUT_DIR = path.resolve(__dirname, '../output')
 
 const MODEL_NAME = 'flux-2-klein-4b-Q8_0.gguf'
-const LLM_MODEL  = 'Qwen3-4B-Q4_K_M.gguf'
+const LLM_MODEL  = 'Qwen3-4B-Q6_K.gguf'
 const VAE_MODEL  = 'flux2-vae.safetensors'
 
 // ---------------------------------------------------------------------------

--- a/packages/lib-infer-diffusion/examples/load-model.js
+++ b/packages/lib-infer-diffusion/examples/load-model.js
@@ -12,7 +12,7 @@ const ImgStableDiffusion = require('../index')
 const MODELS_DIR = path.resolve(__dirname, '../models')
 
 const MODEL_NAME = 'flux-2-klein-4b-Q8_0.gguf'
-const LLM_MODEL  = 'Qwen3-4B-Q4_K_M.gguf' // Qwen3 4B text encoder — switch to Q6_K for better quality
+const LLM_MODEL  = 'Qwen3-4B-Q6_K.gguf'
 const VAE_MODEL  = 'flux2-vae.safetensors'
 
 async function main () {

--- a/packages/lib-infer-diffusion/lib/error.js
+++ b/packages/lib-infer-diffusion/lib/error.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const { QvacErrorBase, addCodes } = require('@qvac/error')
+
+class QvacErrorAddonDiffusion extends QvacErrorBase { }
+
+const { name, version } = require('../package.json')
+
+const ERR_CODES = Object.freeze({
+  FAILED_TO_LOAD: 8001,
+  FAILED_TO_ACTIVATE: 8002,
+  FAILED_TO_RUN: 8003,
+  FAILED_TO_CANCEL: 8004,
+  FAILED_TO_UNLOAD: 8005,
+  FAILED_TO_DESTROY: 8006,
+  INVALID_PARAMS: 8007
+})
+
+addCodes({
+  [ERR_CODES.FAILED_TO_LOAD]: {
+    name: 'FAILED_TO_LOAD',
+    message: (message) => `Failed to load model, error: ${message}`
+  },
+  [ERR_CODES.FAILED_TO_ACTIVATE]: {
+    name: 'FAILED_TO_ACTIVATE',
+    message: (message) => `Failed to activate model, error: ${message}`
+  },
+  [ERR_CODES.FAILED_TO_RUN]: {
+    name: 'FAILED_TO_RUN',
+    message: (message) => `Failed to run generation, error: ${message}`
+  },
+  [ERR_CODES.FAILED_TO_CANCEL]: {
+    name: 'FAILED_TO_CANCEL',
+    message: (message) => `Failed to cancel generation, error: ${message}`
+  },
+  [ERR_CODES.FAILED_TO_UNLOAD]: {
+    name: 'FAILED_TO_UNLOAD',
+    message: (message) => `Failed to unload model, error: ${message}`
+  },
+  [ERR_CODES.FAILED_TO_DESTROY]: {
+    name: 'FAILED_TO_DESTROY',
+    message: (message) => `Failed to destroy instance, error: ${message}`
+  },
+  [ERR_CODES.INVALID_PARAMS]: {
+    name: 'INVALID_PARAMS',
+    message: (message) => `Invalid generation parameters: ${message}`
+  }
+}, {
+  name,
+  version
+})
+
+module.exports = {
+  ERR_CODES,
+  QvacErrorAddonDiffusion
+}

--- a/packages/lib-infer-diffusion/package.json
+++ b/packages/lib-infer-diffusion/package.json
@@ -15,7 +15,8 @@
     "lint": "standard --ignore \"addon/**\"",
     "lint:fix": "standard --ignore \"addon/**\" --fix",
     "lint-cpp": "clang-tidy -p build $(find addon -name '*.cpp')",
-    "test": "npm run test:integration",
+    "test": "npm run test:unit && npm run test:integration",
+    "test:unit": "brittle-bare test/unit/**/*.test.js",
     "test:integration": "bare test/integration/all.js --exit",
     "test:dts": "tsc -p tsconfig.dts.json"
   },
@@ -25,6 +26,7 @@
     "addon.js",
     "addonLogging.js",
     "addonLogging.d.ts",
+    "lib",
     "prebuilds",
     "index.d.ts",
     "LICENSE",
@@ -43,12 +45,19 @@
     "@qvac/dl-hyperdrive": "^0.1.1",
     "bare-buffer": "^3.4.2",
     "bare-fs": "^4.5.1",
+    "brittle": "^3.17.0",
     "cmake-bare": "1.7.5",
     "cmake-vcpkg": "^1.1.0",
+    "os": "npm:bare-os@^3.6.2",
+    "process": "npm:bare-process",
+    "sinon": "^21.0.0",
+    "tty": "npm:bare-node-tty",
+    "util": "npm:bare-utils@^1.5.1",
     "standard": "^17.0.0",
     "typescript": "^5.9.2"
   },
   "dependencies": {
+    "@qvac/error": "^0.1.0",
     "@qvac/infer-base": "^0.2.2",
     "bare-path": "^3.0.0",
     "bare-process": "^4.2.2"

--- a/packages/lib-infer-diffusion/test/integration/all.js
+++ b/packages/lib-infer-diffusion/test/integration/all.js
@@ -1,0 +1,5 @@
+'use strict'
+
+require('./model-loading.test.js')
+require('./api-behavior.test.js')
+require('./config-parameters.test.js')

--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const test = require('brittle')
+const FilesystemDL = require('@qvac/dl-filesystem')
+const ImgStableDiffusion = require('../../index.js')
+const { ensureFlux2Models, collectImages } = require('./utils')
+
+const SAFE_PROMPT = 'a small red cube on a white table, studio lighting, simple'
+
+async function setupModel (t) {
+  const models = ensureFlux2Models()
+  const loader = new FilesystemDL({ dirPath: models.modelsDir })
+
+  const model = new ImgStableDiffusion(
+    {
+      loader,
+      logger: console,
+      diskPath: models.modelsDir,
+      modelName: models.modelName,
+      llmModel: models.llmModel,
+      vaeModel: models.vaeModel,
+      opts: { stats: true }
+    },
+    { threads: 4 }
+  )
+
+  await model.load()
+
+  t.teardown(async () => {
+    await model.unload().catch(() => {})
+    await loader.close().catch(() => {})
+  })
+
+  return { model }
+}
+
+test('idle | run: produces image with valid PNG', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    steps: 5,
+    width: 256,
+    height: 256,
+    seed: 42
+  })
+
+  t.ok(response, 'run() returns a response')
+  t.ok(typeof response.onUpdate === 'function', 'response has onUpdate')
+  t.ok(typeof response.await === 'function', 'response has await')
+
+  const { images } = await collectImages(response)
+
+  t.ok(images.length > 0, 'received at least one image')
+
+  const png = images[0]
+  t.ok(
+    png[0] === 0x89 && png[1] === 0x50 && png[2] === 0x4E && png[3] === 0x47,
+    'output starts with PNG magic bytes (\\x89PNG)'
+  )
+  t.ok(png.length > 100, `PNG has reasonable size (${png.length} bytes)`)
+})
+
+test('idle | cancel: no-op', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+  await model.cancel()
+  t.pass('cancel when idle does not throw')
+})
+
+test('run | cancel: stops generation', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    steps: 50,
+    width: 512,
+    height: 512,
+    seed: 1
+  })
+
+  await model.cancel()
+
+  try {
+    await response.await()
+  } catch (err) {
+    if (!/cancel|aborted|stopp?ed|unloaded/i.test(err?.message || '')) throw err
+  }
+
+  t.pass('cancel during run resolves and stops job')
+})
+
+test('progress ticks arrive during generation', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    steps: 10,
+    width: 256,
+    height: 256,
+    seed: 7
+  })
+
+  const { ticks, images } = await collectImages(response)
+
+  t.ok(ticks.length > 0, `received ${ticks.length} progress tick(s)`)
+  t.ok(ticks[0].step >= 0, 'first tick has step >= 0')
+  t.ok(ticks[0].total > 0, 'first tick has a total')
+  t.ok(images.length > 0, 'image arrives after ticks')
+})
+
+test('stats contain generation_time', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    steps: 5,
+    width: 256,
+    height: 256,
+    seed: 1
+  })
+
+  await collectImages(response)
+
+  t.ok(response.stats, 'response has stats')
+  t.ok('generation_time' in response.stats, 'stats contains generation_time')
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/lib-infer-diffusion/test/integration/config-parameters.test.js
+++ b/packages/lib-infer-diffusion/test/integration/config-parameters.test.js
@@ -1,0 +1,134 @@
+'use strict'
+
+const test = require('brittle')
+const FilesystemDL = require('@qvac/dl-filesystem')
+const ImgStableDiffusion = require('../../index.js')
+const { ensureFlux2Models, collectImages } = require('./utils')
+
+const SAFE_PROMPT = 'a small blue sphere, plain white background, minimal'
+
+async function setupModel (t, configOverrides = {}) {
+  const models = ensureFlux2Models()
+  const loader = new FilesystemDL({ dirPath: models.modelsDir })
+
+  const model = new ImgStableDiffusion(
+    {
+      loader,
+      logger: console,
+      diskPath: models.modelsDir,
+      modelName: models.modelName,
+      llmModel: models.llmModel,
+      vaeModel: models.vaeModel,
+      opts: { stats: true }
+    },
+    { threads: 4, ...configOverrides }
+  )
+
+  await model.load()
+
+  t.teardown(async () => {
+    await model.unload().catch(() => {})
+    await loader.close().catch(() => {})
+  })
+
+  return { model }
+}
+
+test('fixed seed accepted and produces an image', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    steps: 5,
+    width: 256,
+    height: 256,
+    seed: 999
+  })
+  const { images } = await collectImages(response)
+
+  t.ok(images.length >= 1, 'fixed seed run produced an image')
+  t.ok(images[0].length > 100, 'image has reasonable byte size')
+})
+
+test('256x256 dimensions accepted', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    steps: 5,
+    width: 256,
+    height: 256,
+    seed: 1
+  })
+
+  const { images } = await collectImages(response)
+  t.ok(images.length > 0, '256x256 generation produced an image')
+  t.ok(images[0].length > 100, 'image has reasonable byte size')
+})
+
+test('512x512 dimensions accepted', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    steps: 5,
+    width: 512,
+    height: 512,
+    seed: 1
+  })
+
+  const { images } = await collectImages(response)
+  t.ok(images.length > 0, '512x512 generation produced an image')
+  t.ok(images[0].length > 100, 'image has reasonable byte size')
+})
+
+test('low step count (3) still produces an image', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    steps: 3,
+    width: 256,
+    height: 256,
+    seed: 10
+  })
+
+  const { images } = await collectImages(response)
+  t.ok(images.length > 0, '3-step generation produced an image')
+})
+
+test('guidance parameter accepted', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    steps: 5,
+    width: 256,
+    height: 256,
+    guidance: 7.5,
+    seed: 42
+  })
+
+  const { images } = await collectImages(response)
+  t.ok(images.length > 0, 'generation with guidance=7.5 produced an image')
+})
+
+test('negative prompt accepted', { timeout: 600_000 }, async (t) => {
+  const { model } = await setupModel(t)
+
+  const response = await model.run({
+    prompt: SAFE_PROMPT,
+    negative_prompt: 'blurry, low quality',
+    steps: 5,
+    width: 256,
+    height: 256,
+    seed: 42
+  })
+
+  const { images } = await collectImages(response)
+  t.ok(images.length > 0, 'generation with negative prompt produced an image')
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/lib-infer-diffusion/test/integration/model-loading.test.js
+++ b/packages/lib-infer-diffusion/test/integration/model-loading.test.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const test = require('brittle')
+const FilesystemDL = require('@qvac/dl-filesystem')
+const ImgStableDiffusion = require('../../index.js')
+const { ensureFlux2Models, collectImages } = require('./utils')
+
+const SAFE_PROMPT = 'a small red cube on a white table, studio lighting, simple'
+
+function createModel (models, loader) {
+  return new ImgStableDiffusion(
+    {
+      loader,
+      logger: console,
+      diskPath: models.modelsDir,
+      modelName: models.modelName,
+      llmModel: models.llmModel,
+      vaeModel: models.vaeModel
+    },
+    { threads: 4 }
+  )
+}
+
+test('load and unload end-to-end', { timeout: 600_000 }, async (t) => {
+  const models = ensureFlux2Models()
+  const loader = new FilesystemDL({ dirPath: models.modelsDir })
+
+  const model = createModel(models, loader)
+
+  try {
+    await model.load()
+    t.pass('model loaded successfully')
+  } finally {
+    await model.unload()
+    await loader.close()
+    t.pass('model unloaded successfully')
+  }
+})
+
+test('unload is idempotent', { timeout: 600_000 }, async (t) => {
+  const models = ensureFlux2Models()
+  const loader = new FilesystemDL({ dirPath: models.modelsDir })
+
+  const model = createModel(models, loader)
+
+  try {
+    await model.load()
+
+    await model.unload()
+    t.pass('first unload succeeded')
+
+    await model.unload()
+    t.pass('second unload succeeded (idempotent)')
+  } finally {
+    await loader.close()
+  }
+})
+
+test('load, generate, unload cycle', { timeout: 600_000 }, async (t) => {
+  const models = ensureFlux2Models()
+  const loader = new FilesystemDL({ dirPath: models.modelsDir })
+
+  const model = createModel(models, loader)
+
+  try {
+    await model.load()
+    t.pass('loaded')
+
+    const response = await model.run({
+      prompt: SAFE_PROMPT,
+      steps: 5,
+      width: 256,
+      height: 256,
+      seed: 100
+    })
+
+    const { images } = await collectImages(response)
+    t.ok(images.length > 0, 'generation produced an image')
+
+    await model.unload()
+    t.pass('unloaded after generation')
+  } finally {
+    await loader.close().catch(() => {})
+  }
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/lib-infer-diffusion/test/integration/utils.js
+++ b/packages/lib-infer-diffusion/test/integration/utils.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const fs = require('bare-fs')
+const path = require('bare-path')
+
+const MODELS_DIR = path.resolve(__dirname, '../../models')
+
+const FLUX2_MODELS = {
+  model: 'flux-2-klein-4b-Q8_0.gguf',
+  llm: 'Qwen3-4B-Q6_K.gguf',
+  vae: 'flux2-vae.safetensors'
+}
+
+function ensureFlux2Models () {
+  const missing = []
+  for (const [key, filename] of Object.entries(FLUX2_MODELS)) {
+    const fullPath = path.join(MODELS_DIR, filename)
+    if (!fs.existsSync(fullPath)) {
+      missing.push(`${key}: ${filename}`)
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing model files in ${MODELS_DIR}:\n  ${missing.join('\n  ')}\n` +
+      'Run ./scripts/download-model.sh first.'
+    )
+  }
+
+  return {
+    modelsDir: MODELS_DIR,
+    modelName: FLUX2_MODELS.model,
+    llmModel: FLUX2_MODELS.llm,
+    vaeModel: FLUX2_MODELS.vae
+  }
+}
+
+async function collectImages (response) {
+  const images = []
+  const ticks = []
+  await response
+    .onUpdate(data => {
+      if (data instanceof Uint8Array) {
+        images.push(data)
+      } else if (typeof data === 'string') {
+        try { ticks.push(JSON.parse(data)) } catch (_) {}
+      }
+    })
+    .await()
+  return { images, ticks }
+}
+
+module.exports = {
+  MODELS_DIR,
+  FLUX2_MODELS,
+  ensureFlux2Models,
+  collectImages
+}

--- a/packages/lib-infer-diffusion/test/mock/MockedBinding.js
+++ b/packages/lib-infer-diffusion/test/mock/MockedBinding.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const MINIMAL_PNG = new Uint8Array([
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+  0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR length + type
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // 1x1 pixel
+  0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, // 8-bit RGB + CRC
+  0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, // IDAT length + type
+  0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00, // compressed data
+  0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC, // CRC
+  0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, // IEND length + type
+  0x44, 0xAE, 0x42, 0x60, 0x82                     // IEND CRC
+])
+
+class MockedBinding {
+  constructor () {
+    this._handle = null
+    this._jsHandle = null
+    this._outputCb = null
+    this._cancelled = false
+    this._running = false
+  }
+
+  createInstance (jsHandle, configurationParams, outputCb) {
+    this._jsHandle = jsHandle
+    this._outputCb = outputCb
+    this._handle = { id: Date.now() }
+    return this._handle
+  }
+
+  activate (handle) {
+    if (handle !== this._handle) throw new Error('Invalid handle')
+  }
+
+  runJob (handle, data) {
+    if (handle !== this._handle) throw new Error('Invalid handle')
+    if (this._running) return false
+
+    this._running = true
+    this._cancelled = false
+
+    let params = {}
+    if (data && data.type === 'text' && data.input) {
+      try { params = JSON.parse(data.input) } catch (_) {}
+    }
+
+    const steps = params.steps || 20
+    const batchCount = params.batch_count || 1
+    let currentStep = 0
+
+    const emitNextStep = () => {
+      if (this._cancelled || !this._running) return
+
+      currentStep++
+      if (currentStep <= steps) {
+        const tick = JSON.stringify({
+          step: currentStep,
+          total: steps,
+          elapsed_ms: currentStep * 50
+        })
+        this._outputCb(this._jsHandle, 'Output', tick, null)
+        setTimeout(emitNextStep, 1)
+      } else {
+        for (let i = 0; i < batchCount; i++) {
+          this._outputCb(this._jsHandle, 'Output', new Uint8Array(MINIMAL_PNG), null)
+        }
+        this._outputCb(this._jsHandle, 'JobEnded', {
+          generation_time: steps * 50,
+          seed: params.seed != null ? params.seed : 42
+        }, null)
+        this._running = false
+      }
+    }
+
+    setTimeout(emitNextStep, 5)
+    return true
+  }
+
+  cancel (handle) {
+    if (handle !== this._handle) throw new Error('Invalid handle')
+    this._cancelled = true
+    if (this._running) {
+      this._running = false
+      this._outputCb(this._jsHandle, 'JobEnded', {
+        generation_time: 0,
+        cancelled: true
+      }, null)
+    }
+  }
+
+  unloadModel (handle) {
+    if (handle !== this._handle) throw new Error('Invalid handle')
+  }
+
+  destroyInstance (handle) {
+    if (handle !== this._handle) throw new Error('Invalid handle')
+    this._handle = null
+    this._jsHandle = null
+    this._outputCb = null
+    this._running = false
+  }
+
+  setLogger () {}
+  releaseLogger () {}
+}
+
+module.exports = MockedBinding

--- a/packages/lib-infer-diffusion/test/mock/utils.js
+++ b/packages/lib-infer-diffusion/test/mock/utils.js
@@ -1,0 +1,14 @@
+'use strict'
+
+function wait (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function transitionCb (instance, state) {
+  console.log(`[mock] state → ${state}`)
+}
+
+module.exports = {
+  wait,
+  transitionCb
+}

--- a/packages/lib-infer-diffusion/test/unit/diffusion.inference.test.js
+++ b/packages/lib-infer-diffusion/test/unit/diffusion.inference.test.js
@@ -1,0 +1,282 @@
+'use strict'
+
+const process = require('process')
+global.process = process
+
+const test = require('brittle')
+const sinon = require('sinon')
+
+const ImgStableDiffusion = require('../../index.js')
+const { SdInterface } = require('../../addon.js')
+const MockedBinding = require('../mock/MockedBinding.js')
+const { wait } = require('../mock/utils.js')
+
+function createMockedModel ({ binding, onOutput, stats = false } = {}) {
+  const fakeLoader = {
+    ready: async () => {},
+    close: async () => {},
+    getStream: async () => (async function * () {})(),
+    download: async () => ({ await: async () => {} }),
+    getFileSize: async () => 0
+  }
+
+  const model = new ImgStableDiffusion(
+    {
+      loader: fakeLoader,
+      logger: console,
+      diskPath: '/tmp/fake-models',
+      modelName: 'fake-model.gguf',
+      opts: { stats }
+    },
+    { threads: 1 }
+  )
+
+  sinon.stub(model.weightsProvider, 'downloadFiles').resolves()
+
+  sinon.stub(model, '_createAddon').callsFake((configurationParams) => {
+    const _binding = binding || new MockedBinding()
+    const addon = new SdInterface(
+      _binding,
+      configurationParams,
+      model._addonOutputCallback.bind(model)
+    )
+    return addon
+  })
+
+  return model
+}
+
+async function collectImages (response) {
+  const images = []
+  const ticks = []
+  await response
+    .onUpdate(data => {
+      if (data instanceof Uint8Array) {
+        images.push(data)
+      } else if (typeof data === 'string') {
+        try { ticks.push(JSON.parse(data)) } catch (_) {}
+      }
+    })
+    .await()
+  return { images, ticks }
+}
+
+test('load/activate lifecycle completes without error', async (t) => {
+  const model = createMockedModel()
+
+  await model.load()
+  t.pass('model.load() succeeded')
+
+  await model.unload()
+  t.pass('model.unload() succeeded')
+})
+
+test('txt2img produces PNG image output', async (t) => {
+  const model = createMockedModel()
+  await model.load()
+
+  try {
+    const response = await model.run({
+      prompt: 'a test image',
+      steps: 5,
+      width: 512,
+      height: 512,
+      seed: 42
+    })
+
+    t.ok(response, 'run() returns a response')
+    t.ok(typeof response.onUpdate === 'function', 'response has onUpdate')
+    t.ok(typeof response.await === 'function', 'response has await')
+
+    const { images } = await collectImages(response)
+
+    t.ok(images.length > 0, 'received at least one image')
+    t.ok(images[0] instanceof Uint8Array, 'image is a Uint8Array')
+    t.ok(
+      images[0][0] === 0x89 && images[0][1] === 0x50 &&
+      images[0][2] === 0x4E && images[0][3] === 0x47,
+      'image starts with PNG magic bytes'
+    )
+  } finally {
+    await model.unload()
+  }
+})
+
+test('progress ticks are emitted before the image', async (t) => {
+  const model = createMockedModel()
+  await model.load()
+
+  try {
+    const response = await model.run({
+      prompt: 'a test image',
+      steps: 5,
+      width: 256,
+      height: 256,
+      seed: 1
+    })
+
+    const { ticks, images } = await collectImages(response)
+
+    t.ok(ticks.length > 0, 'received progress ticks')
+    t.ok(ticks[0].step === 1, 'first tick step is 1')
+    t.ok(ticks[0].total === 5, 'first tick total matches steps param')
+    t.ok(images.length > 0, 'received image after ticks')
+  } finally {
+    await model.unload()
+  }
+})
+
+test('JobEnded fires with stats containing generation_time', async (t) => {
+  const model = createMockedModel({ stats: true })
+  await model.load()
+
+  try {
+    const response = await model.run({
+      prompt: 'a test image',
+      steps: 3,
+      width: 256,
+      height: 256,
+      seed: 1
+    })
+
+    await collectImages(response)
+
+    t.ok(response.stats, 'response has stats')
+    t.ok('generation_time' in response.stats, 'stats contains generation_time')
+  } finally {
+    await model.unload()
+  }
+})
+
+test('concurrent run() throws busy error', async (t) => {
+  const hangingBinding = new MockedBinding()
+  const origRunJob = hangingBinding.runJob.bind(hangingBinding)
+  hangingBinding.runJob = function (handle, data) {
+    // Override to hang: start the job but never emit JobEnded
+    if (handle !== this._handle) throw new Error('Invalid handle')
+    this._running = true
+    this._cancelled = false
+    return true
+  }
+
+  const model = createMockedModel({ binding: hangingBinding })
+  await model.load()
+
+  try {
+    const firstResponse = await model.run({
+      prompt: 'first image',
+      steps: 5,
+      width: 256,
+      height: 256,
+      seed: 1
+    })
+
+    await t.exception(
+      async () => {
+        await model.run({
+          prompt: 'second image',
+          steps: 5,
+          width: 256,
+          height: 256,
+          seed: 2
+        })
+      },
+      /already set or being processed/,
+      'second run() throws busy error'
+    )
+
+    firstResponse.failed(new Error('test cleanup'))
+  } finally {
+    await model.unload().catch(() => {})
+  }
+})
+
+test('cancel during generation stops cleanly', async (t) => {
+  const model = createMockedModel()
+  await model.load()
+
+  try {
+    const response = await model.run({
+      prompt: 'a test image',
+      steps: 100,
+      width: 256,
+      height: 256,
+      seed: 1
+    })
+
+    await model.cancel()
+    t.pass('cancel() resolved without error')
+
+    try {
+      await response.await()
+    } catch (_) {}
+    t.pass('response settled after cancel')
+  } finally {
+    await model.unload()
+  }
+})
+
+test('unload is idempotent', async (t) => {
+  const model = createMockedModel()
+  await model.load()
+
+  await model.unload()
+  t.pass('first unload succeeded')
+
+  await model.unload()
+  t.pass('second unload succeeded (idempotent)')
+})
+
+test('img2img throws when init_image is missing', async (t) => {
+  const model = createMockedModel()
+  await model.load()
+
+  try {
+    await t.exception(
+      async () => {
+        await model.img2img({ prompt: 'test' })
+      },
+      /init_image/,
+      'img2img throws without init_image'
+    )
+  } finally {
+    await model.unload()
+  }
+})
+
+test('batch_count > 1 produces multiple images', async (t) => {
+  const model = createMockedModel()
+  await model.load()
+
+  try {
+    const response = await model.run({
+      prompt: 'a test image',
+      steps: 3,
+      width: 256,
+      height: 256,
+      seed: 1,
+      batch_count: 3
+    })
+
+    const { images } = await collectImages(response)
+    t.ok(images.length === 3, `received 3 images (got ${images.length})`)
+  } finally {
+    await model.unload()
+  }
+})
+
+test('cancel when idle is a no-op', async (t) => {
+  const model = createMockedModel()
+  await model.load()
+
+  try {
+    await model.cancel()
+    t.pass('cancel when idle does not throw')
+  } finally {
+    await model.unload()
+  }
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})


### PR DESCRIPTION
## Summary

- Add JavaScript layer for `lib-infer-diffusion` addon following the pattern of existing QVAC addons (LLM, Whisper, TTS)
- Add `lib/error.js` with `QvacErrorAddonDiffusion` and error codes (8001–8007)
- Add 10 unit tests (`brittle` + `sinon` + `MockedBinding`) covering load/unload lifecycle, txt2img, progress ticks, stats, concurrency, cancel, img2img validation, and batch generation
- Add 14 integration tests (FLUX.2 models) covering model loading, API behavior, and configuration parameters (seed, dimensions, steps, guidance, negative prompt)
- Fix LLM model name in examples to match downloaded `Qwen3-4B-Q6_K.gguf`
- Update `package.json` with test scripts, dev dependencies, and `@qvac/error` dependency

## Test plan

- [x] Unit tests pass: 10/10 tests, 22/22 assertions
- [x] Integration tests pass: 14/14 tests, 30/30 assertions
- [x] Examples (`generate-image.js`, `load-model.js`) verified manually with FLUX.2 models

Made with [Cursor](https://cursor.com)