### PR TITLE
FInetune support added in infer-base

### DIFF
--- a/packages/qvac-lib-infer-base/WeightsProvider/BaseInference.d.ts
+++ b/packages/qvac-lib-infer-base/WeightsProvider/BaseInference.d.ts
@@ -106,14 +106,14 @@ declare class BaseInference {
   /**
    * Handles output callbacks from the inference process
    * @param addon The addon instance.
-   * @param event Event type ('Error' | 'Output' | 'JobEnded').
+   * @param event Event type ('Error' | 'Output' | 'FinetuneProgress' | 'JobEnded').
    * @param jobId Job identifier.
    * @param data Event data.
    * @param error Error if any.
    */
   protected _outputCallback(
     addon: any,
-    event: 'Error' | 'Output' | 'JobEnded',
+    event: 'Error' | 'Output' | 'FinetuneProgress' | 'JobEnded',
     jobId: string,
     data: any,
     error?: Error

--- a/packages/qvac-lib-infer-base/WeightsProvider/BaseInference.js
+++ b/packages/qvac-lib-infer-base/WeightsProvider/BaseInference.js
@@ -315,12 +315,21 @@ class BaseInference {
         }
       }
       response.updateOutput(data)
+    } else if (event === 'FinetuneProgress') {
+      if (this.opts?.stats) {
+        response.updateStats(data.stats)
+      }
     } else if (event === 'JobEnded') {
       this.logger.info(`Job ${jobId} completed. Stats: ${JSON.stringify(data)}`)
-      if (this.opts?.stats) {
+      const isFinetuneTerminal = data && typeof data === 'object' && data.op === 'finetune' && typeof data.status === 'string'
+      if (this.opts?.stats && !isFinetuneTerminal) {
         response.updateStats(data)
       }
-      response.ended()
+      if (isFinetuneTerminal) {
+        response.ended(data)
+      } else {
+        response.ended()
+      }
       this._deleteJobMapping(jobId)
     } else {
       this.logger.debug(`Received event for job ${jobId}: ${event}`)

--- a/packages/qvac-lib-infer-base/package.json
+++ b/packages/qvac-lib-infer-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/infer-base",
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "Base class for inference clients",
   "main": "index.js",
   "scripts": {

--- a/packages/qvac-lib-infer-base/package.json
+++ b/packages/qvac-lib-infer-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/infer-base",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Base class for inference clients",
   "main": "index.js",
   "scripts": {

--- a/packages/qvac-lib-infer-base/src/QvacResponse.d.ts
+++ b/packages/qvac-lib-infer-base/src/QvacResponse.d.ts
@@ -21,9 +21,9 @@ declare class QvacResponse<Output = any> extends EventEmitter {
 
   onUpdate(callback: (data: Output) => void): this
 
-  onFinish(callback?: (outputs: Output[]) => void): this
+  onFinish(callback?: (result: Output[] | any) => void): this
 
-  await(): Promise<Output[]>
+  await(): Promise<Output[] | any>
 
   onError(callback: (error: Error) => void): this
 
@@ -36,7 +36,7 @@ declare class QvacResponse<Output = any> extends EventEmitter {
   updateOutput(output: Output): void
   updateStats(stats: any): void
   failed(error: Error): void
-  ended(): void
+  ended(result?: Output[] | any): void
   getLatest(): Output
   iterate(): AsyncIterableIterator<Output>
 

--- a/packages/qvac-lib-infer-base/src/QvacResponse.js
+++ b/packages/qvac-lib-infer-base/src/QvacResponse.js
@@ -58,20 +58,20 @@ class QvacResponse extends EventEmitter {
 
   /**
    * Registers a callback for when the response finishes.
-   * If a callback is provided, it is invoked with the final output array.
-   * @param {Function} [callback] - Optional callback invoked with the final outputs.
+   * If a callback is provided, it is invoked with the terminal result.
+   * @param {Function} [callback] - Optional callback invoked with the terminal result.
    * @returns {QvacResponse} The current instance for chaining.
    */
   onFinish (callback) {
     if (callback) {
-      this.once('end', () => callback(this.output))
+      this.once('end', (result) => callback(result))
     }
     return this
   }
 
   /**
-   * Returns a promise that resolves with the final outputs when the response finishes.
-   * @returns {Promise<any[]>} A promise that resolves with the final outputs or rejects if an error occurs.
+   * Returns a promise that resolves with the terminal result when the response finishes.
+   * @returns {Promise<any>} A promise that resolves with the terminal result or rejects if an error occurs.
    */
   await () {
     return this._finishPromise
@@ -154,12 +154,12 @@ class QvacResponse extends EventEmitter {
   }
 
   /**
-   * Marks the response as ended, emits an 'end' event, and resolves the finish promise with the outputs.
+   * Marks the response as ended, emits an 'end' event, and resolves the finish promise.
    */
-  ended () {
+  ended (result = this.output) {
     this._status = statuses.ENDED
-    this.emit('end')
-    this._resolveFinish(this.output)
+    this.emit('end', result)
+    this._resolveFinish(result)
   }
 
   /**

--- a/packages/qvac-lib-infer-base/test/unit/QvacResponse.test.js
+++ b/packages/qvac-lib-infer-base/test/unit/QvacResponse.test.js
@@ -58,6 +58,36 @@ test('onFinish resolves with final outputs on ended via await()', async t => {
   )
 })
 
+test('onFinish and await resolve with custom terminal result', async t => {
+  const response = new QvacResponse({
+    cancelHandler: dummyCancelHandler,
+    pauseHandler: dummyPauseHandler,
+    continueHandler: dummyContinueHandler
+  })
+
+  const terminalResult = {
+    op: 'finetune',
+    status: 'DONE',
+    stats: { train_loss: 0.42 }
+  }
+  let finishCallbackResult = null
+
+  response.onFinish(result => {
+    finishCallbackResult = result
+  })
+
+  response.updateOutput('intermediate')
+  response.ended(terminalResult)
+
+  const result = await response.await()
+  t.is(result, terminalResult, 'await() resolves with custom terminal result')
+  t.is(
+    finishCallbackResult,
+    terminalResult,
+    'onFinish callback receives custom terminal result'
+  )
+})
+
 test('failed should trigger error and reject await()', async t => {
   const response = new QvacResponse({
     cancelHandler: dummyCancelHandler,

--- a/packages/qvac-lib-infer-base/test/unit/base.inference.test.js
+++ b/packages/qvac-lib-infer-base/test/unit/base.inference.test.js
@@ -2,6 +2,7 @@
 
 const test = require('brittle')
 const BaseInference = require('../..')
+const WeightsProviderBaseInference = require('../../WeightsProvider/BaseInference')
 const { ERR_CODES } = require('../../src/error')
 
 const platformDefinitions = {
@@ -690,6 +691,74 @@ test('BaseInference - outputCallback without stats option does not call updateSt
   inference._outputCallback(null, 'JobEnded', 'test1', { duration: 100 })
 
   t.not(statsCalled, 'updateStats should not be called when stats option is false')
+})
+
+test('WeightsProvider BaseInference - FinetuneProgress forwards stats when enabled', t => {
+  const inference = new WeightsProviderBaseInference({ opts: { stats: true } })
+  const progressStats = { loss: 1.23, current_batch: 2, total_batches: 10 }
+  let updateStatsPayload = null
+
+  const mockResponse = {
+    updateStats: (stats) => { updateStatsPayload = stats }
+  }
+
+  inference._saveJobToResponseMapping('p1', mockResponse)
+  inference._outputCallback(null, 'FinetuneProgress', 'p1', { stats: progressStats })
+
+  t.is(updateStatsPayload, progressStats, 'progress stats should be forwarded as-is')
+  t.ok(inference._jobToResponse.has('p1'), 'mapping should be retained for progress events')
+})
+
+test('WeightsProvider BaseInference - FinetuneProgress does not forward stats when disabled', t => {
+  const inference = new WeightsProviderBaseInference({ opts: {} })
+  let statsCalled = false
+
+  const mockResponse = {
+    updateStats: () => { statsCalled = true }
+  }
+
+  inference._saveJobToResponseMapping('p2', mockResponse)
+  inference._outputCallback(null, 'FinetuneProgress', 'p2', { stats: { loss: 0.5 } })
+
+  t.not(statsCalled, 'updateStats should not be called when stats option is false')
+})
+
+test('WeightsProvider BaseInference - JobEnded finetune terminal ends with payload and skips stats update', t => {
+  const inference = new WeightsProviderBaseInference({ opts: { stats: true } })
+  const terminalPayload = { op: 'finetune', status: 'PAUSED', stats: { train_loss: 0.4 } }
+  let statsCalled = false
+  let endedArg
+
+  const mockResponse = {
+    updateStats: () => { statsCalled = true },
+    ended: (result) => { endedArg = result }
+  }
+
+  inference._saveJobToResponseMapping('f1', mockResponse)
+  inference._outputCallback(null, 'JobEnded', 'f1', terminalPayload)
+
+  t.not(statsCalled, 'terminal finetune payload should not be sent via updateStats')
+  t.is(endedArg, terminalPayload, 'ended() should receive terminal finetune payload')
+  t.not(inference._jobToResponse.has('f1'), 'mapping removed on JobEnded')
+})
+
+test('WeightsProvider BaseInference - JobEnded non-finetune still updates stats and ends normally', t => {
+  const inference = new WeightsProviderBaseInference({ opts: { stats: true } })
+  const normalPayload = { duration: 120 }
+  let statsPayload
+  let endedArg = 'not-called'
+
+  const mockResponse = {
+    updateStats: (stats) => { statsPayload = stats },
+    ended: (result) => { endedArg = result }
+  }
+
+  inference._saveJobToResponseMapping('f2', mockResponse)
+  inference._outputCallback(null, 'JobEnded', 'f2', normalPayload)
+
+  t.is(statsPayload, normalPayload, 'non-finetune payload should still be forwarded to updateStats')
+  t.is(endedArg, undefined, 'ended() should be called without terminal result for non-finetune jobs')
+  t.not(inference._jobToResponse.has('f2'), 'mapping removed on JobEnded')
 })
 
 test('BaseInference - multiple loadWeights calls handle state correctly', async t => {


### PR DESCRIPTION
### Problem

QvacResponse was designed around inference (runJob): the addon streams text chunks via Output events, and when JobEnded fires, the response resolves with the accumulated output array. Stats are optional metadata attached at the end.
Finetuning doesn't fit this model:

- **During the job:** Training emits FinetuneProgress events with per-iteration metrics (loss, learning rate, etc.) — not text output. These events were unhandled and silently dropped, so consumers had no way to track training progress.
- **At job completion:** The JobEnded payload for a finetune carries the terminal result ({ op: 'finetune', status: 'completed' }), not inference stats. The existing code fed this into updateStats() — overwriting real training metrics with terminal metadata — and then resolved the promise with the (empty) output array, discarding the actual finetune result.

In short: inference produces text outputs and resolves with them; finetuning produces progress stats and resolves with a terminal status. The base layer had no way to distinguish between the two.

### Solution

#### BaseInference._outputCallback
- Added a FinetuneProgress event branch that routes data.stats to response.updateStats(), streaming per-iteration training metrics to consumers.
- In the JobEnded branch, added a isFinetuneTerminal check (data.op === 'finetune' && typeof data.status === 'string') to separate the two flows:

    - Finetune jobs: skips updateStats() (avoids overwriting training metrics with terminal metadata) and calls response.ended(data) to resolve with the terminal result.
    - Regular jobs: unchanged — stats are updated and response.ended() resolves with accumulated outputs.

#### QvacResponse.ended
- Changed signature from ended() to ended(result = this.output) so callers can pass a custom result while defaulting to the accumulated output array for backward compatibility.
#### QvacResponse.onFinish
- Changed from () => callback(this.output) to (result) => callback(result) so the finish callback receives whatever ended() resolved with instead of always reading the output array.