### PR TITLE
chore(llm): bump version to 0.9.2 and add changelog

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.2] - 2026-03-02
+- Fix intermittent `run | run` busy-detection failure on fast hardware by replacing the timing-based `_lastJobResult` + 30ms timeout with a `_hasActiveResponse` flag checked inside `_withExclusiveRun`.
+- Override `response.await()` to chain flag cleanup, ensuring the flag clears before the caller's `await` resolves.
+- Make `run | run` concurrency test deterministic with `Promise.race` — gracefully handles the case where the first job finishes before the second `run()` is called.
+
 ## [0.9.1] - 2026-02-23
 - Use patched version of addon-cpp to reduce logging noise.
 

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Adds changelog entry and version bump for the `run | run` busy-detection fix landed in #615

## 📝 How does it solve it?

- Bumps `@qvac/llm-llamacpp` from 0.9.1 → 0.9.2
- Adds CHANGELOG.md entry documenting the fix
