### PR TITLE
chore(embed): bump version to 0.11.2 and add changelog

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.11.2] - 2026-03-02
+- Fix intermittent `run | run` busy-detection failure on fast hardware (iPhone Metal GPU) by replacing the timing-based `_lastJobResult` + 30ms timeout with a `_hasActiveResponse` flag checked inside `_withExclusiveRun`.
+- Override `response.await()` to chain flag cleanup, ensuring the flag clears before the caller's `await` resolves.
+- Make `run | run` concurrency test deterministic with `Promise.race` — gracefully handles the case where the first job finishes before the second `run()` is called.
+
 ## [0.11.1] - 2026-02-23
 - Use patched version of addon-cpp to reduce logging noise.
 

--- a/packages/qvac-lib-infer-llamacpp-embed/package.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Adds changelog entry and version bump for the `run | run` busy-detection fix landed in #615

## 📝 How does it solve it?

- Bumps `@qvac/embed-llamacpp` from 0.11.1 → 0.11.2
- Adds CHANGELOG.md entry documenting the fix

