### PR TITLE
QVAC-13761 fix: Update changelog format for release automation

### DIFF
--- a/packages/qvac-sdk/CHANGELOG.md
+++ b/packages/qvac-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.7.0
+## [0.7.0]
 
 Release Date: 2026-02-27
 
@@ -44,7 +44,7 @@ Release Date: 2026-02-27
 - Update SDK pod changelog generation and shared tooling. (see PR [#155](https://github.com/tetherto/qvac/pull/155))
 - Configure test workflow with auth tokens. (see PR [#509](https://github.com/tetherto/qvac/pull/509))
 
-## v0.6.1
+## [0.6.1]
 
 Release Date: 2026-02-10
 
@@ -56,7 +56,7 @@ Release Date: 2026-02-10
 
 - Update SDK pod changelog generation and shared tooling. (see PR [#155](https://github.com/tetherto/qvac/pull/155))
 
-## v0.6.0
+## [0.6.0]
 
 Release Date: 2026-02-02
 
@@ -103,7 +103,7 @@ Release Date: 2026-02-02
 - RPC request logging summarization for large payloads. (see PR [#376](https://github.com/tetherto/qvac-sdk/pull/376))
 - Add github issue templates for bugs and features. (see PR [#388](https://github.com/tetherto/qvac-sdk/pull/388))
 
-## v0.5.0
+## [0.5.0]
 
 Release Date: 2025-12-19
 

--- a/scripts/sdk/generate-changelog-sdk-pod.cjs
+++ b/scripts/sdk/generate-changelog-sdk-pod.cjs
@@ -454,8 +454,13 @@ function rebuildRootChangelog(packageName) {
     }
 
     let content = fs.readFileSync(versionFile, "utf8").trim();
-    // Transform "# Changelog vX.Y.Z" to "## vX.Y.Z" for aggregated file
-    content = content.replace(/^# Changelog (v\d+\.\d+\.\d+)/, "## $1");
+    // Transform "# Changelog vX.Y.Z" to "## [X.Y.Z]" for aggregated file
+    content = content.replace(/^# Changelog v(\d+\.\d+\.\d+)/, "## [$1]");
+    // Rewrite relative links: ./file.md -> ./changelog/VERSION/file.md
+    content = content.replace(
+      /\(\.\/([^)]+\.md)\)/g,
+      `(./changelog/${version}/$1)`
+    );
     combined += content + "\n\n";
   }
 


### PR DESCRIPTION
- Change version headings from `## vX.Y.Z` to `## [X.Y.Z]` to comply
  with release automation requirements
- Rewrite relative links during aggregation to point to version subdir