### PR TITLE
chore(embed,llm): bump patch versions for busy-detection fix

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.11.2] - 2026-03-03
+
+### Fixed
+
+- **Deterministic busy detection:** Replaced the timing-based `_lastJobResult` + 30ms timeout with a synchronous `_hasActiveResponse` boolean flag. On fast hardware (iPhone Metal GPU), short embedding jobs could complete in under 30ms, causing the timeout-based race to be won by the resolved promise instead of the busy guard — allowing a second `run()` through. The flag is now checked synchronously inside `_withExclusiveRun` before any `await`, and cleared via a chained `response.await()` promise so ordering is structurally explicit.
+- **Concurrency test made deterministic:** The `run | run` concurrency test now uses `Promise.race` to handle the case where the first job finishes before the second `run()` is rejected, preventing flaky failures on fast hardware.
+
 ## [0.11.1] - 2026-02-23
 - Use patched version of addon-cpp to reduce logging noise.
 

--- a/packages/qvac-lib-infer-llamacpp-embed/package.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.9.2] - 2026-03-03
+
+### Fixed
+
+- **Deterministic busy detection:** Replaced the timing-based `_lastJobResult` + 30ms timeout with a synchronous `_hasActiveResponse` boolean flag. On fast hardware (iPhone Metal GPU), short jobs could complete in under 30ms, causing the timeout-based race to be won by the resolved promise instead of the busy guard — allowing a second `run()` through. The flag is now checked synchronously inside `_withExclusiveRun` before any `await`, and cleared via a chained `response.await()` promise so ordering is structurally explicit.
+- **Concurrency test made deterministic:** The `run | run` concurrency test now uses `Promise.race` to handle the case where the first job finishes before the second `run()` is rejected, preventing flaky failures on fast hardware.
+
 ## [0.9.1] - 2026-02-23
 - Use patched version of addon-cpp to reduce logging noise.
 

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump `@qvac/embed-llamacpp` from `0.11.1` to `0.11.2`
- Bump `@qvac/llm-llamacpp` from `0.9.1` to `0.9.2`
- Add release notes for #615 (replace timing-based busy detection with synchronous flag, deterministic concurrency tests)

## Test plan

- [x] Verify version fields in both `package.json` files
- [x] Verify CHANGELOG entries match PR #586 