### PR TITLE
chore(infer-base): bump to 0.3.0 with finetune progress and ended() changes

### DIFF
--- a/packages/qvac-lib-infer-base/CHANGELOG
+++ b/packages/qvac-lib-infer-base/CHANGELOG
@@ -1,3 +1,13 @@
+# 0.3.0 - 2026-03-03
+
+### Added
+- FinetuneProgress event handling in _outputCallback to forward per-iteration stats via updateStats
+- ended() accepts optional terminal result argument for resolving await() with structured payloads
+
+### Changed
+- onFinish callback receives the end event result instead of always using this.output
+- JobEnded skips updateStats for finetune terminal payloads to avoid wrong shape on stats listeners
+
 # 0.0.1
 - feat: initial structure
 - feat: consolidate QvacResponse from @qvac/response into infer-base

--- a/packages/qvac-lib-infer-base/package.json
+++ b/packages/qvac-lib-infer-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/infer-base",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Base class for inference clients",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `QvacResponse` had no way to forward per-iteration finetune stats to listeners
- `ended()` always resolved `await()` with `this.output`, making it impossible to return structured terminal payloads
- `onFinish` callback always received `this.output` regardless of the actual end event result
- `JobEnded` emitted `updateStats` for finetune terminal payloads, causing wrong shape on stats listeners

## 📝 How does it solve it?

- Added `FinetuneProgress` event handling in `_outputCallback` to forward per-iteration stats via `updateStats`
- `ended()` accepts an optional terminal result argument for resolving `await()` with structured payloads
- `onFinish` callback now receives the end event result instead of always using `this.output`
- `JobEnded` skips `updateStats` for finetune terminal payloads to avoid wrong shape on stats listeners

## 🧪 How was it tested?

- Unit tests for finetune progress forwarding
- Unit tests for `ended()` with and without terminal result argument
- Verified `onFinish` receives correct payload
- Verified stats listeners are not called with finetune terminal payloads

## 💥 Breaking Changes

There are no breaking changes in this release.

## 🔌 API Changes

There are no API changes in this release.

