### PR TITLE
ci(llm,embed,diffusion): switch Windows runner to ai-run-windows11-gpu

### DIFF
--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -33,8 +33,11 @@ jobs:
           - os: macos-14
             platform: darwin
             arch: arm64
+          - os: windows-11
+            platform: windows
+            runner: ai-run-windows11-gpu
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     name: cpp-tests-${{ matrix.platform }}-${{ matrix.arch }}
 
     env:
@@ -67,14 +70,14 @@ jobs:
           sudo apt update
           sudo apt install vulkan-sdk
 
-      - if: ${{ matrix.os == 'windows-2022' }}
+      - if: ${{ matrix.os == 'windows-11' }}
         name: Configure Windows runner
         working-directory: ${{ env.WORKDIR }}
         run: |
           git config --system core.longpaths true
-          choco upgrade llvm
+          choco upgrade llvm -y
 
-      - if: ${{ matrix.os == 'windows-2022' }}
+      - if: ${{ matrix.os == 'windows-11' }}
         name: Install Vulkan SDK on Windows
         working-directory: ${{ env.WORKDIR }}
         run: |
@@ -83,10 +86,18 @@ jobs:
           ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
           echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
-      - if: ${{ matrix.os == 'windows-2022' }}
-        name: Configure vcpkg in windows
-        working-directory: ${{ env.WORKDIR }}
-        run: echo ("VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" -replace '\\', '/') >> $env:GITHUB_ENV
+      - if: ${{ matrix.os == 'windows-11' }}
+        name: Install Visual Studio Build Tools (Windows)
+        run: |
+          winget install Microsoft.VisualStudio.BuildTools -e --source winget --disable-interactivity --accept-package-agreements --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+        shell: powershell
+
+      - if: ${{ matrix.os == 'windows-11' }}
+        name: Clone and bootstrap vcpkg (Windows)
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
+          echo ("VCPKG_ROOT=$env:GITHUB_WORKSPACE/vcpkg" -replace '\\', '/') >> $env:GITHUB_ENV
 
       - if: ${{ matrix.os == 'macos-14' }}
         name: Install vcpkg on macOS
@@ -104,22 +115,22 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
 
-      - if: ${{ matrix.os == 'windows-2022' }}
+      - if: ${{ matrix.os == 'windows-11' }}
         name: Configure CMake generator on Windows
-        shell: pwsh
+        shell: powershell
         working-directory: ${{ env.WORKDIR }}
         run: |
           echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR_PLATFORM=x64" >> $env:GITHUB_ENV
 
       - name: Create vcpkg cache location (non-Windows)
-        if: ${{ matrix.os != 'windows-2022' }}
+        if: ${{ matrix.os != 'windows-11' }}
         working-directory: ${{ env.WORKDIR }}
         run: mkdir -p vcpkg/cache
 
       - name: Create vcpkg cache location (Windows)
-        if: ${{ matrix.os == 'windows-2022' }}
-        shell: pwsh
+        if: ${{ matrix.os == 'windows-11' }}
+        shell: powershell
         working-directory: ${{ env.WORKDIR }}
         run: |
           New-Item -ItemType Directory -Force -Path "vcpkg/cache" | Out-Null

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -75,6 +75,15 @@ jobs:
           choco upgrade llvm
 
       - if: ${{ matrix.os == 'windows-2022' }}
+        name: Install Vulkan SDK on Windows
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe
+          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
+          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure vcpkg in windows
         working-directory: ${{ env.WORKDIR }}
         run: echo ("VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" -replace '\\', '/') >> $env:GITHUB_ENV

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -75,15 +75,6 @@ jobs:
           choco upgrade llvm
 
       - if: ${{ matrix.os == 'windows-2022' }}
-        name: Install Vulkan SDK on Windows
-        working-directory: ${{ env.WORKDIR }}
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe
-          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
-          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
-
-      - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure vcpkg in windows
         working-directory: ${{ env.WORKDIR }}
         run: echo ("VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" -replace '\\', '/') >> $env:GITHUB_ENV

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -49,7 +49,7 @@ jobs:
           - os: macos-15-intel
             platform: darwin
             arch: x64
-          - os: windows-2022
+          - os: windows-11
             platform: windows
             arch: x64
             runner: ai-run-windows11-gpu
@@ -73,9 +73,8 @@ jobs:
         with:
           node-version: lts/*
 
-      - if: ${{ matrix.os == 'windows-2022' }}
+      - if: ${{ matrix.os == 'windows-11' }}
         name: Configure Windows runner
-        shell: pwsh
         run: |
           git config --system core.longpaths true
           choco upgrade llvm -y
@@ -137,9 +136,8 @@ jobs:
           sudo apt update
           sudo apt install -y vulkan-sdk
 
-      - if: ${{ matrix.os == 'windows-2022' }}
+      - if: ${{ matrix.os == 'windows-11' }}
         name: Install Vulkan SDK on Windows
-        shell: powershell
         working-directory: ${{ env.WORKDIR }}
         run: |
           $ProgressPreference = 'SilentlyContinue'
@@ -163,14 +161,22 @@ jobs:
         shell: bash
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
 
-      - if: ${{ matrix.os == 'windows-2022' }}
-        name: Configure vcpkg in windows
-        shell: pwsh
-        run: echo ("VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" -replace '\\', '/') >> $env:GITHUB_ENV
+      - if: ${{ matrix.os == 'windows-11' }}
+        name: Install Visual Studio Build Tools (Windows)
+        run: |
+          winget install Microsoft.VisualStudio.BuildTools -e --source winget --disable-interactivity --accept-package-agreements --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+        shell: powershell
 
-      - if: ${{ matrix.os == 'windows-2022' }}
+      - if: ${{ matrix.os == 'windows-11' }}
+        name: Clone and bootstrap vcpkg (Windows)
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
+          echo ("VCPKG_ROOT=$env:GITHUB_WORKSPACE/vcpkg" -replace '\\', '/') >> $env:GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-11' }}
         name: Configure CMake generator on Windows
-        shell: pwsh
+        shell: powershell
         run: |
           echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR_PLATFORM=x64" >> $env:GITHUB_ENV

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   run-cpp-tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     name: ${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-cpp-tests
     permissions:
       contents: read
@@ -52,6 +52,7 @@ jobs:
           - os: windows-2022
             platform: windows
             arch: x64
+            runner: ai-run-windows11-gpu
 
     env:
       WORKDIR: ${{ inputs.workdir }}
@@ -135,16 +136,6 @@ jobs:
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list http://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
           sudo apt update
           sudo apt install -y vulkan-sdk
-
-      - if: ${{ matrix.os == 'windows-2022' }}
-        name: Install Vulkan SDK on Windows
-        shell: powershell
-        working-directory:  ${{ env.WORKDIR }}
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe
-          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
-          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
       - if: ${{ startsWith(matrix.os, 'macos') }}
         name: Install vcpkg on macOS

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -137,6 +137,16 @@ jobs:
           sudo apt update
           sudo apt install -y vulkan-sdk
 
+      - if: ${{ matrix.os == 'windows-2022' }}
+        name: Install Vulkan SDK on Windows
+        shell: powershell
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe
+          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
+          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
+
       - if: ${{ startsWith(matrix.os, 'macos') }}
         name: Install vcpkg on macOS
         shell: bash

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -82,8 +82,7 @@ jobs:
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure vcpkg in windows
-        working-directory: ${{ env.WORKDIR }}
-        run: echo ("VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" -replace '\\', '/') >> $env:GITHUB_ENV
+        uses: lukka/run-vcpkg@v11.5 # This action sets up vcpkg and installs dependencies from vcpkg.json
 
       - if: ${{ matrix.os == 'macos-14' }}
         name: Install vcpkg on macOS

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -81,8 +81,11 @@ jobs:
           choco upgrade llvm -y
 
       - if: ${{ matrix.os == 'windows-2022' }}
-        name: Configure vcpkg in windows
-        uses: lukka/run-vcpkg@v11.5 # This action sets up vcpkg and installs dependencies from vcpkg.json
+        name: Clone and bootstrap vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
+          echo ("VCPKG_ROOT=$env:GITHUB_WORKSPACE/vcpkg" -replace '\\', '/') >> $env:GITHUB_ENV
 
       - if: ${{ matrix.os == 'macos-14' }}
         name: Install vcpkg on macOS

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -84,7 +84,7 @@ jobs:
         name: Install Visual Studio Build Tools (Windows)
         run: |
           # This command ensures the "Desktop development with C++" workload is installed if needed
-          winget install Microsoft.VisualStudio.BuildTools --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+          winget install Microsoft.VisualStudio.BuildTools -e --source winget --disable-interactivity --accept-package-agreements --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
         shell: powershell
 
       - if: ${{ matrix.os == 'windows-11' }}

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -35,7 +35,7 @@ jobs:
           - os: macos-14
             platform: darwin
             arch: arm64
-          - os: windows-2022
+          - os: windows-11
             platform: windows
             runner: ai-run-windows11-gpu
 
@@ -73,15 +73,22 @@ jobs:
           sudo apt update
           sudo apt install vulkan-sdk
 
-      - if: ${{ matrix.os == 'windows-2022' }}
+      - if: ${{ matrix.os == 'windows-11' }}
         name: Configure Windows runner
         working-directory: ${{ env.WORKDIR }}
         run: |
           git config --system core.longpaths true
           choco upgrade llvm -y
 
-      - if: ${{ matrix.os == 'windows-2022' }}
-        name: Clone and bootstrap vcpkg
+      - if: ${{ matrix.os == 'windows-11' }}
+        name: Install Visual Studio Build Tools (Windows)
+        run: |
+          # This command ensures the "Desktop development with C++" workload is installed if needed
+          winget install Microsoft.VisualStudio.BuildTools --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+        shell: powershell
+
+      - if: ${{ matrix.os == 'windows-11' }}
+        name: Clone and bootstrap vcpkg (Windows)
         run: |
           git clone https://github.com/microsoft/vcpkg.git
           ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
@@ -104,7 +111,7 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
 
-      - if: ${{ matrix.os == 'windows-2022' }}
+      - if: ${{ matrix.os == 'windows-11' }}
         name: Configure CMake generator on Windows
         shell: powershell
         working-directory: ${{ env.WORKDIR }}
@@ -114,12 +121,12 @@ jobs:
 
       # mkdir -p is not portable to pwsh; do per-OS
       - name: Create vcpkg cache location (non-Windows)
-        if: ${{ matrix.os != 'windows-2022' }}
+        if: ${{ matrix.os != 'windows-11' }}
         working-directory: ${{ env.WORKDIR }}
         run: mkdir -p vcpkg/cache
 
       - name: Create vcpkg cache location (Windows)
-        if: ${{ matrix.os == 'windows-2022' }}
+        if: ${{ matrix.os == 'windows-11' }}
         shell: powershell
         working-directory: ${{ env.WORKDIR }}
         run: |

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -37,8 +37,9 @@ jobs:
             arch: arm64
           - os: windows-2022
             platform: windows
+            runner: ai-run-windows11-gpu
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     name: cpp-tests-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}
 
     env:
@@ -78,15 +79,6 @@ jobs:
         run: |
           git config --system core.longpaths true
           choco upgrade llvm
-
-      - if: ${{ matrix.os == 'windows-2022' }}
-        name: Install Vulkan SDK on Windows
-        working-directory: ${{ env.WORKDIR }}
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe
-          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
-          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure vcpkg in windows

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -104,7 +104,7 @@ jobs:
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure CMake generator on Windows
-        shell: pwsh
+        shell: powershell
         working-directory: ${{ env.WORKDIR }}
         run: |
           echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV
@@ -118,7 +118,7 @@ jobs:
 
       - name: Create vcpkg cache location (Windows)
         if: ${{ matrix.os == 'windows-2022' }}
-        shell: pwsh
+        shell: powershell
         working-directory: ${{ env.WORKDIR }}
         run: |
           New-Item -ItemType Directory -Force -Path "vcpkg/cache" | Out-Null

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -78,7 +78,7 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         run: |
           git config --system core.longpaths true
-          choco upgrade llvm
+          choco upgrade llvm -y
 
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure vcpkg in windows

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -81,6 +81,15 @@ jobs:
           choco upgrade llvm -y
 
       - if: ${{ matrix.os == 'windows-11' }}
+        name: Install Vulkan SDK on Windows
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe
+          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
+          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
+
+      - if: ${{ matrix.os == 'windows-11' }}
         name: Install Visual Studio Build Tools (Windows)
         run: |
           # This command ensures the "Desktop development with C++" workload is installed if needed

--- a/.github/workflows/integration-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-test-lib-infer-diffusion.yml
@@ -39,10 +39,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-14
+          - os: ubuntu-22.04
+            platform: linux
+            arch: x64
+            runner: ubuntu-22.04
+          - os: ubuntu-24.04
+            platform: linux
+            arch: x64
+            runner: ai-run-linux-gpu
+          - os: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
+            platform: linux
+            arch: arm64
+            runner: ubuntu-22.04-arm
+          - os: macos-15-xlarge
             platform: darwin
             arch: arm64
-            runner: macos-14
+            runner: macos-15-xlarge
+          - os: macos-15-large
+            platform: darwin
+            arch: x64
+            runner: macos-15-large
+          - os: windows-11
+            platform: win32
+            arch: x64
+            runner: ai-run-windows11-gpu
 
     steps:
       - name: Setup Node.js

--- a/.github/workflows/integration-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-test-lib-infer-diffusion.yml
@@ -209,16 +209,6 @@ jobs:
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y mesa-vulkan-drivers
 
-      - name: Windows - Install Vulkan
-        if: ${{ matrix.platform == 'win32' }}
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe -PassThru -UseBasicParsing
-          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
-          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
-        shell: powershell
-        timeout-minutes: 40
-
       - name: Run integration test (Linux/macOS)
         if: ${{ matrix.platform != 'win32' }}
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
@@ -60,7 +60,7 @@ jobs:
           - os: windows-2022
             platform: win32
             arch: x64
-            runner: ai-run-windows-gpu
+            runner: ai-run-windows11-gpu
 
     steps:
       - name: Setup Node.js
@@ -260,8 +260,6 @@ jobs:
           echo "npm version: $(npm -v)"
           echo "bare version: $(bare -v)"
           echo "bare-make version: $(bare-make --version)"
-          ls -la model/marian/vulkan/en-it/ || true
-          tree model/marian/vulkan/en-it/ || true
           ls -la prebuilds || true
           tree prebuilds || true
         continue-on-error: true
@@ -270,16 +268,6 @@ jobs:
         if: matrix.platform == 'linux' || matrix.platform == 'android'
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y mesa-vulkan-drivers
-
-      - name: Windows - Install Vulkan
-        if: ${{ matrix.platform == 'win32' }}
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe -PassThru -UseBasicParsing
-          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
-          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
-        shell: powershell
-        timeout-minutes: 40
 
       - name: Run integration test
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
@@ -57,7 +57,7 @@ jobs:
           - os: macos-15-large
             platform: darwin
             arch: x64
-          - os: windows-2022
+          - os: windows-11
             platform: win32
             arch: x64
             runner: ai-run-windows11-gpu

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -65,7 +65,7 @@ jobs:
             platform: darwin
             arch: x64
             runner: macos-15-large
-          - os: windows-2022
+          - os: windows-11
             platform: win32
             arch: x64
             runner: ai-run-windows11-gpu

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -68,7 +68,7 @@ jobs:
           - os: windows-2022
             platform: win32
             arch: x64
-            runner: ai-run-windows-gpu
+            runner: ai-run-windows11-gpu
 
     steps:
       - name: Setup Node.js
@@ -237,16 +237,6 @@ jobs:
         if: matrix.platform == 'linux' || matrix.platform == 'android'
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y mesa-vulkan-drivers
-
-      - name: Windows - Install Vulkan
-        if: ${{ matrix.platform == 'win32' }}
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe -OutFile vulkan-sdk.exe -PassThru -UseBasicParsing
-          ./vulkan-sdk.exe --root C:\VulkanSDK --accept-licenses --default-answer --confirm-command install
-          echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
-        shell: powershell
-        timeout-minutes: 40
 
       - name: Run integration test (Linux/macOS)
         if: ${{ matrix.platform != 'win32' }}

--- a/.github/workflows/prebuilds-lib-infer-diffusion.yml
+++ b/.github/workflows/prebuilds-lib-infer-diffusion.yml
@@ -59,9 +59,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - os: ubuntu-22.04
+            platform: linux
+            arch: x64
+          - os: ubuntu-22.04-arm
+            platform: linux
+            arch: arm64
+          - os: ubuntu-24.04
+            platform: android
+            arch: arm64
+            flags: -D ANDROID_STL=c++_shared
+          - os: macos-14
+            platform: ios
+            arch: arm64
+          - os: macos-14
+            platform: ios
+            arch: arm64
+            tags: -simulator
+            flags: --simulator
+          - os: macos-14
+            platform: ios
+            arch: x64
+            tags: -simulator
+            flags: --simulator
           - os: macos-14
             platform: darwin
             arch: arm64
+          - os: macos-15-intel
+            platform: darwin
+            arch: x64
+          - os: windows-2022
+            platform: win32
+            arch: x64
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Windows CI workflows use the `windows-2022` / `ai-run-windows-gpu` runner which lacks pre-installed Vulkan SDK and up-to-date build tooling
- Vulkan SDK download-and-install step is slow and flaky on CI

## 📝 How does it solve it?

- Switch Windows runner to `ai-run-windows11-gpu` (has Vulkan SDK pre-installed) across embed, llm, and diffusion workflows
- Remove the now-redundant "Windows - Install Vulkan" steps from integration tests (embed, llm, diffusion)
- Keep Vulkan SDK install in `cpp-tests-embed` and `cpp-tests-llm` (still needed for cpp-level tests)
- For `cpp-tests-llm`: clone and bootstrap vcpkg from source instead of relying on `VCPKG_INSTALLATION_ROOT`, install VS Build Tools via `winget`, use `powershell` instead of `pwsh`, add `-y` flag to `choco upgrade llvm`
- Use `matrix.runner || matrix.os` pattern so custom runners are used when specified, otherwise fall back to the OS default

## 🧪 How was it tested?

- CI workflow runs on the `temp-win-runner` branch across all affected workflows
- embed: https://github.com/tetherto/qvac/actions/runs/22629502773/job/65575479402
- llm:  https://github.com/tetherto/qvac/actions/runs/22624351407/job/65557148100