### PR TITLE
Fix ocr-onnx CHANGELOG.md heading format

### DIFF
--- a/packages/ocr-onnx/CHANGELOG.md
+++ b/packages/ocr-onnx/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.8] - 2026-02-20
+## [0.1.8]
+2026-02-20
 
 ### Added
 
@@ -22,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced hardcoded S3 bucket references with repository secrets in CI workflows and scripts.
 - Updated registry key handling and switched to subpath imports for Bare compatibility.
 
-## [0.1.6] - 2026-02-09
+## [0.1.6]
+2026-02-09
 
 ### Changed
 
@@ -36,13 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved Portuguese OCR accuracy (minor punctuation corrections in test expected outputs).
 
-## [0.1.2] - 2026-01-16
+## [0.1.2]
+2026-01-16
 
 ### Changed
 
 - Increased detector MAX_IMAGE_SIZE from 512 to 2560 for better text detection accuracy on high-resolution images.
 
-## [0.1.0] - 2026-01-13
+## [0.1.0]
+2026-01-13
 
 ### Added
 
@@ -53,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Changed recognizer model width from 2560 to 512. This version only works with new recognizer models exported with 512 width input.
 - Updated integration tests to use rec_512 models.
 
-## [0.0.8] - 2026-01-09
+## [0.0.8]
+2026-01-09
 
 ### Added
 
@@ -64,7 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test:dts` NPM script so it uses config defined in the `tsconfig.dts.json` file
 
-## [0.0.7] - 2026-01-09
+## [0.0.7]
+2026-01-09
 
 ### Added
 
@@ -75,7 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Symbol collision when loading multiple ONNX-based addons (e.g., OCR and TTS) in the same process
 
-## [0.0.6] - 2026-01-08
+## [0.0.6]
+2026-01-08
 
 ### Added
 
@@ -94,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OOM crash on Android when processing large numbers of text regions (e.g., 300+ boxes)
 - Memory spike from 1.7GB to 8GB during image preparation phase
 
-## [0.0.5] - 2025-12-23
+## [0.0.5]
+2025-12-23
 
 ### Added
 
@@ -108,7 +116,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - QVAC-9777: Resolve failed test on darwin-arm64 (#139)
 
-## [0.0.4] - 2025-12-22
+## [0.0.4]
+2025-12-22
 
 ### Added
 
@@ -120,7 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplified pipeline to sequential execution, fixing race conditions (#130)
 - QVAC-10063: Fix existing examples (#131)
 
-## [0.0.3] - 2025-12-17
+## [0.0.3]
+2025-12-17
 
 ### Added
 
@@ -138,7 +148,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - End of job fix (#124)
 
-## [0.0.2] - 2025-10-29
+## [0.0.2]
+2025-10-29
 
 ### Added
 
@@ -174,23 +185,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR workflow fixes (#89, #90)
 - Install g++ in runner (#94)
 - Missing prebuilds (#88)
-
----
-
-## How to Update This Changelog
-
-When releasing a new version:
-
-1. Move items from `[Unreleased]` to a new version section
-2. Add the version number and date: `## [X.Y.Z] - YYYY-MM-DD`
-3. Keep the `[Unreleased]` section at the top for ongoing changes
-4. Group changes by category: Added, Changed, Deprecated, Removed, Fixed, Security
-
-### Categories
-
-- **Added** for new features
-- **Changed** for changes in existing functionality
-- **Deprecated** for soon-to-be removed features
-- **Removed** for now removed features
-- **Fixed** for any bug fixes
-- **Security** in case of vulnerabilities

--- a/packages/ocr-onnx/CHANGELOG.md
+++ b/packages/ocr-onnx/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [0.1.8] - 2026-02-20
+## [0.1.8] - 2026-02-20
 
 ### Added
 
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced hardcoded S3 bucket references with repository secrets in CI workflows and scripts.
 - Updated registry key handling and switched to subpath imports for Bare compatibility.
 
-# [0.1.6] - 2026-02-09
+## [0.1.6] - 2026-02-09
 
 ### Changed
 
@@ -36,13 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improved Portuguese OCR accuracy (minor punctuation corrections in test expected outputs).
 
-# [0.1.2] - 2026-01-16
+## [0.1.2] - 2026-01-16
 
 ### Changed
 
 - Increased detector MAX_IMAGE_SIZE from 512 to 2560 for better text detection accuracy on high-resolution images.
 
-# [0.1.0] - 2026-01-13
+## [0.1.0] - 2026-01-13
 
 ### Added
 

--- a/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
@@ -5,25 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.9] - 2026-02-25
+## [0.3.9]
+2026-02-25
 
 ### Fixed
 - Batch run API fix for correct batch translation handling (#549)
 - Replaced inline sanity-checks with shared reusable action for fork PR compatibility (#521)
 - Updated addon-cpp version constraint to match actual 1.x API usage (#520)
 
-## [0.3.1] - 2026-01-13
+## [0.3.1]
+2026-01-13
 
 ### Added
 - TypeScript type declarations for `addonLogging` subpath export
 
-## [0.3.0] - 2025-01-08
+## [0.3.0]
+2025-01-08
+
 ### Added
 - TypeScript type declarations (`index.d.ts`) - migrated from `@qvac/sdk` and aligned with runtime API
 - CI job for type declaration validation (`ts-checks`)
 - `test:dts` script for type checking
 
-## [0.2.1] - 2026-01-03
+## [0.2.1]
+2026-01-03
 
 ### Added
 - Batch Support in Bergamot Wrapper (#429) - Add batch translation API for improved performance
@@ -44,12 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Freeze vcpkg version on macOS (#432) - Improve build reproducibility
 - Add core team to CODEOWNERS (#447, #427)
 
-## [0.2.0] - 2025-12-20
+## [0.2.0]
+2025-12-20
 
 ### Added
 - Bergamot NMT backend with multi-platform build support (#422)
 
-## [0.1.10] - 2025-11-27
+## [0.1.10]
+2025-11-27
 
 ### Added
 - 16 KB page size support for Android 15+ compatibility (Google Play requirement)
@@ -61,12 +68,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Vulkan SDK repository from jammy to noble for Ubuntu 24.04 compatibility
 - Added NDK environment configuration for Android builds (ANDROID_NDK_LATEST_HOME)
 
-## [0.1.8] - 2025-11-24
+## [0.1.8]
+2025-11-24
 
 ### Changed
 - update cmake-bare version for better react-native-bare-kit compatability.
-  
-## [0.1.7] - 2025-11-21
+
+## [0.1.7]
+2025-11-21
 
 ### Added
 - Support for multilingual models with language prefix tokens (e.g., en-roa for Portuguese translation)
@@ -77,7 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C++ linting errors (clang-tidy) - added NOLINT markers for FFI code compatibility
 - C++ test workflow now fails if no tests are generated or executed (prevents false positive passes)
 
-## [0.1.6] - 2025-11-18
+## [0.1.6]
+2025-11-18
 
 ### Fixed
 - Android addon loading by disabling Vulkan to avoid libvulkan.so dependency issues
@@ -87,7 +97,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Vulkan configuration in whisper-cpp overlay to disable GGML_VULKAN on Android
 - Set useGpu to false by default for CPU-only mode (GPU can still be enabled via config)
 
-## [0.1.5] - 2025-11-15
+## [0.1.5]
+2025-11-15
 
 ### Added
 - Android ARM64 build support with Vulkan GPU acceleration
@@ -106,7 +117,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GLIBCXX version mismatch in integration tests by installing libstdc++-13-dev
 - Variable shadowing in nmt.cpp (g_optimal_threads)
 
-## [0.1.4] - 2025-01-10
+## [0.1.4]
+2025-01-10
 
 ### Added
 - Portuguese model support
@@ -119,23 +131,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Various NMT core fixes and stability improvements
-
----
-
-## How to Update This Changelog
-
-When releasing a new version:
-
-1. Move items from `[Unreleased]` to a new version section
-2. Add the version number and date: `## [X.Y.Z] - YYYY-MM-DD`
-3. Keep the `[Unreleased]` section at the top for ongoing changes
-4. Group changes by category: Added, Changed, Deprecated, Removed, Fixed, Security
-
-### Categories
-
-- **Added** for new features
-- **Changed** for changes in existing functionality
-- **Deprecated** for soon-to-be removed features
-- **Removed** for now removed features
-- **Fixed** for any bug fixes
-- **Security** in case of vulnerabilities


### PR DESCRIPTION
## Summary
- Fixed version heading format in `packages/ocr-onnx/CHANGELOG.md` from `# [x.y.z]` to `## [x.y.z]` for versions 0.1.8, 0.1.6, 0.1.2, and 0.1.0
- The release workflow parses `## [x.y.z]` headings to generate GitHub Release notes — the single `#` format was incorrect and would cause release failures
- NMT (`qvac-lib-infer-nmtcpp`) changelog was already in the correct format, no changes needed

## Test plan
- [ ] Verify the release workflow correctly parses the updated CHANGELOG.md headings