### PR TITLE
ci(llm): add NO_GPU flag and per-runner timeout to LLM integration tests

### DIFF
--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   run-integration-tests:
-    timeout-minutes: 360
+    timeout-minutes: ${{ matrix.timeout_minutes || 360 }}
     continue-on-error: true
     runs-on: ${{ matrix.runner }}
     name: test-${{ matrix.platform }}-${{ matrix.arch }}
@@ -34,6 +34,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       WORKDIR: packages/qvac-lib-infer-llamacpp-llm
+      NO_GPU: ${{ matrix.no_gpu || 'false' }}
     permissions:
       contents: read
       packages: read
@@ -45,18 +46,22 @@ jobs:
             platform: linux
             arch: x64
             runner: ubuntu-22.04
+            no_gpu: 'true'
           - os: ubuntu-24.04
             platform: linux
             arch: x64
             runner: ai-run-linux-gpu
+            timeout_minutes: 480
           - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64
             runner: ubuntu-24.04-arm
+            no_gpu: 'true'
           - os: ubuntu-22.04-arm
             platform: linux
             arch: arm64
             runner: ubuntu-22.04-arm
+            no_gpu: 'true'
           - os: macos-15-xlarge
             platform: darwin
             arch: arm64

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -56,7 +56,6 @@ jobs:
             platform: linux
             arch: arm64
             runner: ubuntu-24.04-arm
-            no_gpu: 'true'
           - os: ubuntu-22.04-arm
             platform: linux
             arch: arm64

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   run-integration-tests:
-    timeout-minutes: ${{ matrix.timeout_minutes || 360 }}
+    timeout-minutes: 480
     continue-on-error: true
     runs-on: ${{ matrix.runner }}
     name: test-${{ matrix.platform }}-${{ matrix.arch }}
@@ -51,7 +51,6 @@ jobs:
             platform: linux
             arch: x64
             runner: ai-run-linux-gpu
-            timeout_minutes: 480
           - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64
@@ -73,7 +72,6 @@ jobs:
             platform: win32
             arch: x64
             runner: ai-run-windows11-gpu
-            timeout_minutes: 480
 
     steps:
       - name: Setup Node.js

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -74,6 +74,7 @@ jobs:
             platform: win32
             arch: x64
             runner: ai-run-windows11-gpu
+            timeout_minutes: 480
 
     steps:
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
- Add `NO_GPU` env var driven by matrix `no_gpu` field, so non-GPU runners can skip GPU-dependent tests
- Make `timeout-minutes` configurable per matrix entry (defaults to 360, set to 480 for `ai-run-linux-gpu`)
- Mark `ubuntu-22.04`, `ubuntu-24.04-arm`, and `ubuntu-22.04-arm` runners as `no_gpu: true`

## Test plan
- [ ] Verify the workflow file is valid YAML and renders correctly in the Actions UI
- [ ] Trigger a manual workflow run and confirm the `NO_GPU` env var is set correctly per runner
- [ ] Confirm the GPU runner uses the 480-minute timeout
