### PR TITLE
Implementation of IModel interface for PivotModelTranslation.

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-05
+
+This release adds pivot translation support so a single request can be translated through an intermediate language using two configured models. It also aligns the translation model with the shared `IModel` interface to improve consistency with other inference add-ons. Together, these updates make multi-hop translation flows easier to configure while preserving existing single-model usage.
+
+## Features
+
+Pivot translation is now available through a dedicated `PivotTranslationModel` that chains two `TranslationModel` instances and supports both single-text and batch processing flows. The JavaScript addon creation path now detects optional `pivotModel` configuration and automatically initializes either the pivot pipeline or the existing single-model pipeline based on user configuration. Build integration was updated to compile and link the new pivot model implementation as part of the addon.
+
+## Other
+
+The package API surface was cleaned up by promoting `processBatch` to the public `TranslationModel` interface to support pivot composition, and by removing unused includes in translation model headers and implementation files.
+
 ## [0.3.9]
 2026-02-25
 

--- a/packages/qvac-lib-infer-nmtcpp/CMakeLists.txt
+++ b/packages/qvac-lib-infer-nmtcpp/CMakeLists.txt
@@ -145,6 +145,7 @@ target_sources(
   PRIVATE
     ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/TranslationModel.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/PivotTranslationModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/nmt.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/nmt_tokenization.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/nmt_state_backend.cpp

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/addon/AddonJs.hpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/addon/AddonJs.hpp
@@ -13,6 +13,7 @@
 #include <qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp>
 
 #include "model-interface/TranslationModel.hpp"
+#include "model-interface/PivotTranslationModel.hpp"
 
 namespace {
 using namespace qvac_lib_inference_addon_cpp;
@@ -36,6 +37,7 @@ getConfigMap(
   js::Array configKeysArray(env, configKeys);
   uint32_t configKeysSz = configKeysArray.size(env);
 
+  bool hasPivotModel = false;
   while (configKeysSz > 0) {
     configKeysSz--;
     js_value_t* key;
@@ -43,11 +45,16 @@ getConfigMap(
     auto value = config.getProperty(env, key);
 
     std::string keyString = js::String::fromValue(key).as<std::string>(env);
+
     std::transform(
         keyString.begin(),
         keyString.end(),
         keyString.begin(),
         [](unsigned char c) { return std::tolower(c); });
+    if (keyString == "pivotmodel"){
+      hasPivotModel = true;
+      continue;
+    }
     if (js::is<js::Int32>(env, value) || js::is<js::Uint32>(env, value) ||
         js::is<js::BigInt>(env, value)) {
       auto jsNumber = js::Number{env, value};
@@ -78,18 +85,42 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   JsArgsParser args(env, info);
 
   auto configurationParamsJs = args.getJsObject(1, "config");
-  auto config = getConfigMap(env, configurationParamsJs, "config");
+  auto modelConfig = getConfigMap(env, configurationParamsJs, "config");
+
+  auto modelConfigJs = configurationParamsJs.getProperty<js::Object>(env, "config");
+  auto pivotModelConfigJs = modelConfigJs.getOptionalProperty<js::Object>(env, "pivotModel");
+  
+  std::unique_ptr<qvac_lib_inference_addon_cpp::model::IModel> model;
 
   auto modelPathJs =
       configurationParamsJs.getOptionalProperty<js::String>(env, "path");
+
   std::string modelPath =
       modelPathJs ? modelPathJs.value().as<std::string>(env) : "";
-  auto model =
-      std::make_unique<qvac_lib_inference_addon_marian::TranslationModel>(
-          modelPath);
+  // Checking for pivot translation
+  if (pivotModelConfigJs.has_value())
+  {
+    auto secondModelPathJs = pivotModelConfigJs->getOptionalProperty<js::String>(env, "path");
+    std::string secondModelPath = secondModelPathJs ? secondModelPathJs.value().as<std::string>(env) : "";
 
-  model->setConfig(config);
-  model->load();
+    auto pivotModelConfig = getConfigMap(env, pivotModelConfigJs.value(), "config");
+
+    auto pivotTranslationModel = std::make_unique<PivotTranslationModel>(modelPath, modelConfig, secondModelPath, pivotModelConfig);
+    model = std::move(pivotTranslationModel);
+  }
+  else
+  {
+    auto translationModel =
+        std::make_unique<qvac_lib_inference_addon_marian::TranslationModel>(
+            modelPath);
+
+    translationModel->setConfig(modelConfig);
+    translationModel->load();
+
+    model = std::move(translationModel);
+  }
+
+
   out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface> outHandlers;
 
   outHandlers.add(make_shared<out_handl::JsStringOutputHandler>());
@@ -115,6 +146,7 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
 
   AddonJs& instance = JsInterface::getInstance(env, args.get(0, "instance"));
   auto [type, jsInput] = JsInterface::getInput(args);
+
 
   std::any anyInput;
   if (type == "text") {

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/addon/AddonJs.hpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/addon/AddonJs.hpp
@@ -12,8 +12,8 @@
 #include <qvac-lib-inference-addon-cpp/handlers/OutputHandler.hpp>
 #include <qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp>
 
-#include "model-interface/TranslationModel.hpp"
 #include "model-interface/PivotTranslationModel.hpp"
+#include "model-interface/TranslationModel.hpp"
 
 namespace {
 using namespace qvac_lib_inference_addon_cpp;
@@ -51,7 +51,7 @@ getConfigMap(
         keyString.end(),
         keyString.begin(),
         [](unsigned char c) { return std::tolower(c); });
-    if (keyString == "pivotmodel"){
+    if (keyString == "pivotmodel") {
       hasPivotModel = true;
       continue;
     }
@@ -87,9 +87,11 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   auto configurationParamsJs = args.getJsObject(1, "config");
   auto modelConfig = getConfigMap(env, configurationParamsJs, "config");
 
-  auto modelConfigJs = configurationParamsJs.getProperty<js::Object>(env, "config");
-  auto pivotModelConfigJs = modelConfigJs.getOptionalProperty<js::Object>(env, "pivotModel");
-  
+  auto modelConfigJs =
+      configurationParamsJs.getProperty<js::Object>(env, "config");
+  auto pivotModelConfigJs =
+      modelConfigJs.getOptionalProperty<js::Object>(env, "pivotModel");
+
   std::unique_ptr<qvac_lib_inference_addon_cpp::model::IModel> model;
 
   auto modelPathJs =
@@ -98,18 +100,19 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   std::string modelPath =
       modelPathJs ? modelPathJs.value().as<std::string>(env) : "";
   // Checking for pivot translation
-  if (pivotModelConfigJs.has_value())
-  {
-    auto secondModelPathJs = pivotModelConfigJs->getOptionalProperty<js::String>(env, "path");
-    std::string secondModelPath = secondModelPathJs ? secondModelPathJs.value().as<std::string>(env) : "";
+  if (pivotModelConfigJs.has_value()) {
+    auto secondModelPathJs =
+        pivotModelConfigJs->getOptionalProperty<js::String>(env, "path");
+    std::string secondModelPath =
+        secondModelPathJs ? secondModelPathJs.value().as<std::string>(env) : "";
 
-    auto pivotModelConfig = getConfigMap(env, pivotModelConfigJs.value(), "config");
+    auto pivotModelConfig =
+        getConfigMap(env, pivotModelConfigJs.value(), "config");
 
-    auto pivotTranslationModel = std::make_unique<PivotTranslationModel>(modelPath, modelConfig, secondModelPath, pivotModelConfig);
+    auto pivotTranslationModel = std::make_unique<PivotTranslationModel>(
+        modelPath, modelConfig, secondModelPath, pivotModelConfig);
     model = std::move(pivotTranslationModel);
-  }
-  else
-  {
+  } else {
     auto translationModel =
         std::make_unique<qvac_lib_inference_addon_marian::TranslationModel>(
             modelPath);
@@ -119,7 +122,6 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
 
     model = std::move(translationModel);
   }
-
 
   out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface> outHandlers;
 
@@ -146,7 +148,6 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
 
   AddonJs& instance = JsInterface::getInstance(env, args.get(0, "instance"));
   auto [type, jsInput] = JsInterface::getInput(args);
-
 
   std::any anyInput;
   if (type == "text") {

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/PivotTranslationModel.cpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/PivotTranslationModel.cpp
@@ -1,0 +1,131 @@
+#include "PivotTranslationModel.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace qvac_lib_inference_addon_marian {
+
+PivotTranslationModel::PivotTranslationModel(
+    const std::string& firstModelPath,
+    std::unordered_map<std::string, std::variant<double, int64_t, std::string>> firstModelConfig,
+    const std::string& secondModelPath,
+    std::unordered_map<std::string, std::variant<double, int64_t, std::string>> secondModelConfig)
+    : firstModelPath_(firstModelPath),
+      secondModelPath_(secondModelPath),
+      firstModel_( std::make_unique<TranslationModel>(firstModelPath)),
+      secondModel_(std::make_unique<TranslationModel>(secondModelPath)) {
+
+        firstModel_->setConfig(std::move(firstModelConfig));
+        secondModel_->setConfig(std::move(secondModelConfig));
+        
+        firstModel_->load();
+        secondModel_->load();
+      }
+
+void PivotTranslationModel::load() {
+#ifndef HAVE_BERGAMOT
+  throw std::runtime_error(
+      "PivotTranslationModel requires Bergamot support at build time");
+#else
+  firstModel_->setUseGpu(useGpu_);
+  secondModel_->setUseGpu(useGpu_);
+
+  firstModel_->setConfig(config_);
+  secondModel_->setConfig(config_);
+
+  firstModel_->saveLoadParams(firstModelPath_);
+  secondModel_->saveLoadParams(secondModelPath_);
+
+  firstModel_->load();
+  secondModel_->load();
+#endif
+}
+
+void PivotTranslationModel::unload() {
+  firstModel_->unload();
+  secondModel_->unload();
+}
+
+void PivotTranslationModel::reload() {
+  unload();
+  load();
+}
+
+void PivotTranslationModel::reset() {
+  firstModel_->reset();
+  secondModel_->reset();
+}
+
+bool PivotTranslationModel::isLoaded() const {
+  return firstModel_->isLoaded() && secondModel_->isLoaded();
+}
+
+void PivotTranslationModel::saveLoadParams(
+    const std::string& firstModelPath,
+    const std::string& secondModelPath) {
+  firstModelPath_ = firstModelPath;
+  secondModelPath_ = secondModelPath;
+}
+
+void PivotTranslationModel::setConfig(
+    std::unordered_map<std::string, std::variant<double, int64_t, std::string>> config) {
+  config_ = std::move(config);
+  firstModel_->setConfig(config_);
+  secondModel_->setConfig(config_);
+}
+
+void PivotTranslationModel::setUseGpu(bool useGpu) {
+  useGpu_ = useGpu;
+  firstModel_->setUseGpu(useGpu_);
+  secondModel_->setUseGpu(useGpu_);
+}
+
+std::string PivotTranslationModel::getName() const {
+  return "PivotTranslationModel";
+}
+
+std::any PivotTranslationModel::process(const std::any& input) {
+  if (const auto* text = std::any_cast<std::string>(&input)) {
+    return translateString(*text);
+  }
+
+  if (const auto* batch = std::any_cast<std::vector<std::string>>(&input)) {
+    return translateBatch(*batch);
+  }
+
+  throw std::runtime_error(
+      "PivotTranslationModel expects std::string or std::vector<std::string> input");
+}
+
+qvac_lib_inference_addon_cpp::RuntimeStats PivotTranslationModel::runtimeStats() const {
+  auto firstStats = firstModel_->runtimeStats();
+  auto secondStats = secondModel_->runtimeStats();
+
+  qvac_lib_inference_addon_cpp::RuntimeStats merged;
+  for (const auto& [key, value] : firstStats) {
+    merged.push_back(std::make_pair(firstModel_->getName() + key, value));
+  }
+  for (const auto& [key, value] : secondStats) {
+    merged.push_back(std::make_pair(secondModel_->getName() + key, value));
+  }
+  return merged;
+}
+
+std::any PivotTranslationModel::translateString(const std::string& input) {
+  if (!isLoaded()) {
+    throw std::runtime_error("PivotTranslationModel models are not loaded");
+  }
+  const std::any firstOutput = firstModel_->process(input);
+  return secondModel_->process(firstOutput);
+}
+
+std::any PivotTranslationModel::translateBatch(
+    const std::vector<std::string>& inputs) {
+  if (!isLoaded()) {
+    throw std::runtime_error("PivotTranslationModel models are not loaded");
+  }
+  auto firstBatch = firstModel_->processBatch(inputs);
+  return secondModel_->processBatch(firstBatch);
+}
+
+} // namespace qvac_lib_inference_addon_cpp

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/PivotTranslationModel.cpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/PivotTranslationModel.cpp
@@ -7,20 +7,21 @@ namespace qvac_lib_inference_addon_marian {
 
 PivotTranslationModel::PivotTranslationModel(
     const std::string& firstModelPath,
-    std::unordered_map<std::string, std::variant<double, int64_t, std::string>> firstModelConfig,
+    std::unordered_map<std::string, std::variant<double, int64_t, std::string>>
+        firstModelConfig,
     const std::string& secondModelPath,
-    std::unordered_map<std::string, std::variant<double, int64_t, std::string>> secondModelConfig)
-    : firstModelPath_(firstModelPath),
-      secondModelPath_(secondModelPath),
-      firstModel_( std::make_unique<TranslationModel>(firstModelPath)),
+    std::unordered_map<std::string, std::variant<double, int64_t, std::string>>
+        secondModelConfig)
+    : firstModelPath_(firstModelPath), secondModelPath_(secondModelPath),
+      firstModel_(std::make_unique<TranslationModel>(firstModelPath)),
       secondModel_(std::make_unique<TranslationModel>(secondModelPath)) {
 
-        firstModel_->setConfig(std::move(firstModelConfig));
-        secondModel_->setConfig(std::move(secondModelConfig));
-        
-        firstModel_->load();
-        secondModel_->load();
-      }
+  firstModel_->setConfig(std::move(firstModelConfig));
+  secondModel_->setConfig(std::move(secondModelConfig));
+
+  firstModel_->load();
+  secondModel_->load();
+}
 
 void PivotTranslationModel::load() {
 #ifndef HAVE_BERGAMOT
@@ -61,14 +62,14 @@ bool PivotTranslationModel::isLoaded() const {
 }
 
 void PivotTranslationModel::saveLoadParams(
-    const std::string& firstModelPath,
-    const std::string& secondModelPath) {
+    const std::string& firstModelPath, const std::string& secondModelPath) {
   firstModelPath_ = firstModelPath;
   secondModelPath_ = secondModelPath;
 }
 
 void PivotTranslationModel::setConfig(
-    std::unordered_map<std::string, std::variant<double, int64_t, std::string>> config) {
+    std::unordered_map<std::string, std::variant<double, int64_t, std::string>>
+        config) {
   config_ = std::move(config);
   firstModel_->setConfig(config_);
   secondModel_->setConfig(config_);
@@ -93,11 +94,12 @@ std::any PivotTranslationModel::process(const std::any& input) {
     return translateBatch(*batch);
   }
 
-  throw std::runtime_error(
-      "PivotTranslationModel expects std::string or std::vector<std::string> input");
+  throw std::runtime_error("PivotTranslationModel expects std::string or "
+                           "std::vector<std::string> input");
 }
 
-qvac_lib_inference_addon_cpp::RuntimeStats PivotTranslationModel::runtimeStats() const {
+qvac_lib_inference_addon_cpp::RuntimeStats
+PivotTranslationModel::runtimeStats() const {
   auto firstStats = firstModel_->runtimeStats();
   auto secondStats = secondModel_->runtimeStats();
 
@@ -119,8 +121,8 @@ std::any PivotTranslationModel::translateString(const std::string& input) {
   return secondModel_->process(firstOutput);
 }
 
-std::any PivotTranslationModel::translateBatch(
-    const std::vector<std::string>& inputs) {
+std::any
+PivotTranslationModel::translateBatch(const std::vector<std::string>& inputs) {
   if (!isLoaded()) {
     throw std::runtime_error("PivotTranslationModel models are not loaded");
   }
@@ -128,4 +130,4 @@ std::any PivotTranslationModel::translateBatch(
   return secondModel_->processBatch(firstBatch);
 }
 
-} // namespace qvac_lib_inference_addon_cpp
+} // namespace qvac_lib_inference_addon_marian

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/PivotTranslationModel.hpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/PivotTranslationModel.hpp
@@ -12,14 +12,19 @@
 
 namespace qvac_lib_inference_addon_marian {
 
-class PivotTranslationModel : public qvac_lib_inference_addon_cpp::model::IModel {
+class PivotTranslationModel
+    : public qvac_lib_inference_addon_cpp::model::IModel {
 public:
   PivotTranslationModel() = default;
   PivotTranslationModel(
       const std::string& firstModelPath,
-      std::unordered_map<std::string, std::variant<double, int64_t, std::string>> firstModelconfig,
+      std::unordered_map<
+          std::string, std::variant<double, int64_t, std::string>>
+          firstModelconfig,
       const std::string& secondModelPath,
-      std::unordered_map<std::string, std::variant<double, int64_t, std::string>> secondModelConfig = {});
+      std::unordered_map<
+          std::string, std::variant<double, int64_t, std::string>>
+          secondModelConfig = {});
 
   ~PivotTranslationModel() override = default;
 
@@ -35,15 +40,16 @@ public:
   bool isLoaded() const;
 
   void saveLoadParams(
-      const std::string& firstModelPath,
-      const std::string& secondModelPath);
-  void setConfig(
-      std::unordered_map<std::string, std::variant<double, int64_t, std::string>> config);
+      const std::string& firstModelPath, const std::string& secondModelPath);
+  void setConfig(std::unordered_map<
+                 std::string, std::variant<double, int64_t, std::string>>
+                     config);
   void setUseGpu(bool useGpu);
 
   std::string getName() const override;
   std::any process(const std::any& input) override;
-  [[nodiscard]] qvac_lib_inference_addon_cpp::RuntimeStats runtimeStats() const override;
+  [[nodiscard]] qvac_lib_inference_addon_cpp::RuntimeStats
+  runtimeStats() const override;
 
 private:
   std::any translateString(const std::string& input);
@@ -57,7 +63,8 @@ private:
 
   bool useGpu_ = true;
 
-  std::unordered_map<std::string, std::variant<double, int64_t, std::string>> config_;
+  std::unordered_map<std::string, std::variant<double, int64_t, std::string>>
+      config_;
 };
 
-} // namespace qvac_lib_inference_addon_cpp
+} // namespace qvac_lib_inference_addon_marian

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/PivotTranslationModel.hpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/PivotTranslationModel.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <any>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include "TranslationModel.hpp"
+#include "qvac-lib-inference-addon-cpp/ModelInterfaces.hpp"
+
+namespace qvac_lib_inference_addon_marian {
+
+class PivotTranslationModel : public qvac_lib_inference_addon_cpp::model::IModel {
+public:
+  PivotTranslationModel() = default;
+  PivotTranslationModel(
+      const std::string& firstModelPath,
+      std::unordered_map<std::string, std::variant<double, int64_t, std::string>> firstModelconfig,
+      const std::string& secondModelPath,
+      std::unordered_map<std::string, std::variant<double, int64_t, std::string>> secondModelConfig = {});
+
+  ~PivotTranslationModel() override = default;
+
+  PivotTranslationModel(const PivotTranslationModel&) = delete;
+  PivotTranslationModel& operator=(const PivotTranslationModel&) = delete;
+  PivotTranslationModel(PivotTranslationModel&&) noexcept = default;
+  PivotTranslationModel& operator=(PivotTranslationModel&&) noexcept = default;
+
+  void load();
+  void unload();
+  void reload();
+  void reset();
+  bool isLoaded() const;
+
+  void saveLoadParams(
+      const std::string& firstModelPath,
+      const std::string& secondModelPath);
+  void setConfig(
+      std::unordered_map<std::string, std::variant<double, int64_t, std::string>> config);
+  void setUseGpu(bool useGpu);
+
+  std::string getName() const override;
+  std::any process(const std::any& input) override;
+  [[nodiscard]] qvac_lib_inference_addon_cpp::RuntimeStats runtimeStats() const override;
+
+private:
+  std::any translateString(const std::string& input);
+  std::any translateBatch(const std::vector<std::string>& inputs);
+
+  std::string firstModelPath_;
+  std::string secondModelPath_;
+
+  std::unique_ptr<TranslationModel> firstModel_;
+  std::unique_ptr<TranslationModel> secondModel_;
+
+  bool useGpu_ = true;
+
+  std::unordered_map<std::string, std::variant<double, int64_t, std::string>> config_;
+};
+
+} // namespace qvac_lib_inference_addon_cpp

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/TranslationModel.cpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/TranslationModel.cpp
@@ -1,7 +1,6 @@
 #include "TranslationModel.hpp"
 
 #include <filesystem>
-#include <iostream>
 #include <mutex>
 #include <sstream>
 #include <stdexcept>
@@ -295,7 +294,8 @@ std::string TranslationModel::indictransPreProcess(const std::string& text) {
 }
 
 std::any TranslationModel::process(const std::any& input) {
-  std::unique_lock<std::mutex> unique_lock(mtx_);
+  std::scoped_lock<std::mutex> scoped_lock(mtx_);
+
   if (auto* inputString = std::any_cast<std::string>(&input)) {
     return processString(*inputString);
   } else if (

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/TranslationModel.hpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/TranslationModel.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
-#include <mutex>
 #include <variant>
 
 #include "nmt.hpp"

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/TranslationModel.hpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/TranslationModel.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <mutex>
 #include <variant>
 
 #include "nmt.hpp"

--- a/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/TranslationModel.hpp
+++ b/packages/qvac-lib-infer-nmtcpp/addon/src/model-interface/TranslationModel.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <condition_variable>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -55,6 +54,8 @@ public:
 
   void saveLoadParams(const std::string& modelPath);
 
+  std::vector<std::string> processBatch(const std::vector<std::string>& texts);
+
 public: // overrides
   std::string getName() const override;
 
@@ -71,8 +72,6 @@ private:
   std::string indictransPreProcess(const std::string& text);
 
   void updateConfig();
-
-  std::vector<std::string> processBatch(const std::vector<std::string>& texts);
 
   std::string processString(const std::string& input);
 

--- a/packages/qvac-lib-infer-nmtcpp/package.json
+++ b/packages/qvac-lib-infer-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
### What problem does this PR solve?

- Adds support for pivot translation in @qvac/translation-nmtcpp by implementing the IModel flow for a two-model translation pipeline.
- Removes the limitation where addon instantiation only supported a single translation model path/config.

### How does it solve it?

- Introduces PivotTranslationModel and wires it into the build and addon initialization path.
- Updates AddonJs config parsing to detect optional pivotModel settings and instantiate either PivotTranslationModel or TranslationModel.
- Refines TranslationModel integration points used by pivot flow (including batch-processing accessibility and process locking update).
- Bumps packages/qvac-lib-infer-nmtcpp/package.json version from 0.3.9 to 0.4.0.