### PR TITLE
QVAC-10742: BitNet backend selection logic for Adreno

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,4 +1,46 @@
 # Changelog
+## [0.11.0] - 2026-03-05
+
+Preparation before fully supporting BitNet. Not officially supported yet, but this version already integrates logic necessary to support BitNet models.
+
+### Added
+
+#### Preparation: BitNet-aware backend selection for Adreno GPUs
+
+Backend selection now detects BitNet models (TQ1_0 / TQ2_0 quantization via `hasOneBitQuantization()` and `general.architecture == "bitnet"`) and adjusts GPU routing on Adreno devices:
+
+- **Adreno 800+** (e.g. Adreno 830): Vulkan is preferred over OpenCL, since BitNet TQ kernels are not supported on OpenCL.
+- **Adreno < 800** (e.g. Adreno 740): Falls back to CPU, as TQ kernels run faster on CPU than on older Adreno GPU backends.
+- **Non-Adreno GPUs**: No change — normal GPU selection applies.
+
+This logic only activates when no explicit `main-gpu` is configured.
+
+Adreno version detection works regardless of which backend exposes the GPU. The numeric generation (e.g. 830, 740) is parsed from the device description via `parseAdrenoVersion()` and tracked as `maxAdrenoVersion` during device enumeration for any Adreno device — whether it appears behind OpenCL, Vulkan, or another backend. This ensures the BitNet safety checks (CPU fallback on Adreno <800, Vulkan preference on Adreno 800+) are not bypassed when only Vulkan registers a device, as observed on Adreno 750.
+
+#### Preparation: BitNet-aware config tuning (`tuneConfigMap`)
+
+For BitNet models, `tuneConfigMap` injects default overrides into the config map before argument parsing:
+
+- `flash-attn=off` — disables flash attention (unless the user explicitly set `flash-attn` or `flash_attn`).
+- `ubatch-size=128` — on Adreno 800+ only (unless the user explicitly set `ubatch-size` or `ubatch_size`).
+
+These entries are written to `configFilemap` (not to `common_params` directly), so they flow through the normal llama.cpp arg parser in `commonParamsParse`. The call sits after backend selection (where the Adreno version is known) but before the config map is converted to the arg vector.
+
+#### `ModelMetaData::tryGetString()` method
+
+`ModelMetaData` now exposes `tryGetString(key)` to retrieve string-typed GGUF metadata values. This is used by the BitNet backend selection logic to read `general.architecture`. Both `tryGetString()` and `hasOneBitQuantization()` are now virtual to support test mocking.
+
+#### Unit tests for BitNet backend selection
+
+Added comprehensive unit tests covering BitNet TQ backend selection across Adreno 830/740, non-Adreno GPUs, OpenCL-only scenarios, Vulkan-only scenarios, and mixed GPU/iGPU configurations. `MockModelMetaData` is defined in `test_common.hpp` and shared across test files.
+
+### Changed
+
+- Updated qvac-fabric-llm.cpp dependency from 7248.1.3 to 7248.1.4.
+- Refactored `ModelMetaData` internal getters using a template helper, reducing duplication between `tryGetU32` and `tryGetString`.
+- Added virtual destructor to `ModelMetaData` for correct polymorphic cleanup.
+- Simplified `REQUIRE_MODEL` test macro by removing the `do {} while(false)` wrapper to suppress compiler warnings.
+
 ## [0.10.0] - 2026-03-02
 
 ### Added

--- a/packages/qvac-lib-infer-llamacpp-llm/README.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/README.md
@@ -34,9 +34,16 @@ This native C++ addon, built using the `Bare` Runtime, simplifies running Large 
 | Android | arm64 | 12+ | ✅ Tier 1 | Vulkan, OpenCL (Adreno 700+) |
 | Windows | x64 | 10+ | ✅ Tier 1 | Vulkan |
 
+
+**Note — BitNet models (TQ1_0 / TQ2_0 quantization):**
+BitNet models require special backend handling on Adreno GPUs. When a BitNet model is detected and no explicit `main-gpu` is set:
+- **Adreno 800+** (e.g. Adreno 830): Vulkan is used instead of OpenCL.
+- **Adreno < 800** (e.g. Adreno 740): Falls back to CPU, as TQ kernels are not yet optimized for older Adreno OpenCL/Vulkan.
+- **Non-Adreno GPUs**: Normal GPU selection applies (no special behavior).
+
 **Dependencies:**
 - qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework (single-job runner)
-- qvac-fabric-llm.cpp (≥7248.1.2): Inference engine
+- qvac-fabric-llm.cpp (≥7248.1.4): Inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
 - Linux requires Clang/LLVM 19 with libc++
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -75,6 +75,34 @@ void LlamaModel::resolveShardPaths(
   shards.tensors_file = (baseDir / shards.tensors_file).string();
 }
 
+void LlamaModel::tuneConfigMap(
+    std::unordered_map<std::string, std::string>& configFilemap,
+    const ModelMetaData& metadata, const std::optional<int>& adrenoVersion) {
+
+  const bool isBitnet =
+      metadata.hasOneBitQuantization() &&
+      metadata.tryGetString("general.architecture") == "bitnet";
+
+  if (isBitnet && configFilemap.find("flash-attn") == configFilemap.end() &&
+      configFilemap.find("flash_attn") == configFilemap.end()) {
+    configFilemap["flash-attn"] = "off";
+    QLOG_IF(
+        Priority::INFO,
+        "[LlamaModel] BitNet model detected: disabling flash attention\n");
+  }
+
+  constexpr int kAdrenoUbatchThreshold = 800;
+  if (isBitnet && adrenoVersion.has_value() &&
+      adrenoVersion.value() >= kAdrenoUbatchThreshold &&
+      configFilemap.find("ubatch-size") == configFilemap.end() &&
+      configFilemap.find("ubatch_size") == configFilemap.end()) {
+    configFilemap["ubatch-size"] = "128";
+    QLOG_IF(
+        Priority::INFO,
+        "[LlamaModel] BitNet on Adreno 800+: defaulting ubatch-size=128\n");
+  }
+}
+
 LlamaModel::LlamaModel(
     std::string&& modelPath, std::string&& projectionPath,
     std::unordered_map<std::string, std::string>&& configFilemap)
@@ -129,7 +157,8 @@ void LlamaModel::init(
   }
 
   common_params params;
-  commonParamsParse(modelPath, configFilemap, params);
+  std::optional<int> adrenoVersion;
+  commonParamsParse(modelPath, configFilemap, params, adrenoVersion);
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
   auto streamedFiles = asyncWeightsLoader_.extractIndividualStreamedFiles();
@@ -321,7 +350,7 @@ qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {
 void LlamaModel::commonParamsParse(
     const std::string& modelPath,
     std::unordered_map<std::string, std::string>& configFilemap,
-    common_params& params) {
+    common_params& params, std::optional<int>& outAdrenoVersion) {
 
   std::vector<std::string> configVector;
 
@@ -380,7 +409,11 @@ void LlamaModel::commonParamsParse(
     const std::optional<MainGpu> mainGpu = tryMainGpuFromMap(configFilemap);
 
     const std::pair<BackendType, std::string> chosenBackend = chooseBackend(
-        preferredBackend, LlamaModel::llamaLogCallback, mainGpu, &metadata_);
+        preferredBackend,
+        LlamaModel::llamaLogCallback,
+        mainGpu,
+        &metadata_,
+        &outAdrenoVersion);
 
     if (chosenBackend.first == BackendType::GPU) {
       params.mmproj_backend = chosenBackend.second;
@@ -402,6 +435,8 @@ void LlamaModel::commonParamsParse(
     configVector.emplace_back(chosenBackend.second);
     configFilemap.erase(deviceIt);
   }
+
+  tuneConfigMap(configFilemap, metadata_, outAdrenoVersion);
 
   // Handle both reverse-prompt variants
   for (const std::string& key : {"reverse-prompt", "reverse_prompt"}) {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -379,8 +379,8 @@ void LlamaModel::commonParamsParse(
 
     const std::optional<MainGpu> mainGpu = tryMainGpuFromMap(configFilemap);
 
-    const std::pair<BackendType, std::string> chosenBackend =
-        chooseBackend(preferredBackend, LlamaModel::llamaLogCallback, mainGpu);
+    const std::pair<BackendType, std::string> chosenBackend = chooseBackend(
+        preferredBackend, LlamaModel::llamaLogCallback, mainGpu, &metadata_);
 
     if (chosenBackend.first == BackendType::GPU) {
       params.mmproj_backend = chosenBackend.second;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -36,6 +36,17 @@ public:
   static void
   resolveShardPaths(GGUFShards& shards, const std::string& modelPath);
 
+  /// @brief Apply specific parameter defaults based on model metadata
+  /// and detected Adreno GPU version by inserting entries into configFilemap.
+  /// Must be called before commonParamsParse so inserted entries are processed.
+  ///
+  /// @param configFilemap The user-supplied config map (will be written to).
+  /// @param metadata Model metadata (architecture, quantization info).
+  /// @param adrenoVersion Detected Adreno GPU version, if any.
+  static void tuneConfigMap(
+      std::unordered_map<std::string, std::string>& configFilemap,
+      const ModelMetaData& metadata, const std::optional<int>& adrenoVersion);
+
   /**
    * The Constructor for llama model.
    * @param modelPath - path to the model file.
@@ -141,7 +152,7 @@ private:
   void commonParamsParse(
       const std::string& modelPath,
       std::unordered_map<std::string, std::string>& configFilemap,
-      common_params& params);
+      common_params& params, std::optional<int>& outAdrenoVersion);
 
   /**
    * The Format prompt method. It formats the prompt json to chat messages.

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
@@ -96,33 +96,39 @@ void ModelMetaData::checkInitialized() const {
   }
 }
 
-std::optional<uint32_t> ModelMetaData::tryGetU32(const char* key) const {
-  if (metadata_ == nullptr) {
+template <typename T, typename F>
+static std::optional<T>
+tryGet(const metadata_handle_ptr& metadata, const char* key, F&& getter) {
+  if (metadata == nullptr) {
     return std::nullopt;
   }
-  uint32_t value = 0;
-  MetaResultStatus status = llama_model_meta_get_u32(metadata_, key, &value);
+  T value{};
+  MetaResultStatus status = getter(metadata, key, &value);
   if (status != MetaResultStatus::SUCCESS) {
     return std::nullopt;
   }
   return value;
 }
 
+std::optional<uint32_t> ModelMetaData::tryGetU32(const char* key) const {
+  return tryGet<uint32_t>(metadata_, key, llama_model_meta_get_u32);
+}
+
+std::optional<std::string> ModelMetaData::tryGetString(const char* key) const {
+  return tryGet<std::string>(metadata_, key, llama_model_meta_get_str);
+}
+
 bool ModelMetaData::isU32OneOf(
     const char* key, std::initializer_list<uint32_t> values) const {
   checkInitialized();
-  uint32_t value = 0;
-  MetaResultStatus status = llama_model_meta_get_u32(metadata_, key, &value);
-  if (status != MetaResultStatus::SUCCESS) {
-    LOG_WRN(
-        "ModelMetaData::isU32OneOf: failed to read key '%s', "
-        "llama_model_meta_get_u32 returned %s\n",
-        key,
-        std::to_string(static_cast<int>(status)).c_str());
+  auto value = tryGetU32(key);
+  if (!value.has_value()) {
+    LOG_WRN("ModelMetaData::isU32OneOf: failed to read key '%s'\n", key);
     return false;
   }
-  return std::ranges::any_of(
-      values, [value](uint32_t queryValue) { return value == queryValue; });
+  return std::ranges::any_of(values, [v = value.value()](uint32_t queryValue) {
+    return v == queryValue;
+  });
 }
 
 bool ModelMetaData::hasOneBitQuantization() const {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
@@ -32,6 +32,7 @@ class ModelMetaData {
 
 public:
   ModelMetaData() = default;
+  virtual ~ModelMetaData() = default;
 
   /// @param modelPath Model to load (single .gguf)
   /// @param shards Containing sharded files, if any
@@ -51,9 +52,10 @@ public:
 
   /// @brief Returns the string value at @p key, or nullopt if
   /// absent/uninitialized or not a string type.
-  [[nodiscard]] std::optional<std::string> tryGetString(const char* key) const;
+  [[nodiscard]] virtual std::optional<std::string>
+  tryGetString(const char* key) const;
 
-  [[nodiscard]] bool hasOneBitQuantization() const;
+  [[nodiscard]] virtual bool hasOneBitQuantization() const;
 
   // Code below for streaming support
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
@@ -49,6 +49,10 @@ public:
   [[nodiscard]] bool
   isU32OneOf(const char* key, std::initializer_list<uint32_t> values) const;
 
+  /// @brief Returns the string value at @p key, or nullopt if
+  /// absent/uninitialized or not a string type.
+  [[nodiscard]] std::optional<std::string> tryGetString(const char* key) const;
+
   [[nodiscard]] bool hasOneBitQuantization() const;
 
   // Code below for streaming support

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.cpp
@@ -227,7 +227,8 @@ std::optional<MainGpu> backend_selection::tryMainGpuFromMap(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, const BackendInterface& bckI,
-    const ModelMetaData* metadata, const std::optional<MainGpu>& mainGpu) {
+    const ModelMetaData* metadata, const std::optional<MainGpu>& mainGpu,
+    std::optional<int>* outAdrenoVersion) {
 
   std::vector<std::string> gpuBackends;
   std::vector<std::string> igpuBackends;
@@ -303,6 +304,10 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     openClBackends.clear();
   }
 
+  if (outAdrenoVersion != nullptr) {
+    *outAdrenoVersion = maxAdrenoVersion;
+  }
+
   // Normally, check if Adreno GPU is present and force OpenCL backend,
   // otherwise let llama.cpp choose Vulkan GPU backend. There are some
   // exceptions such as BitNet models which do not currently support OpenCl,
@@ -329,7 +334,8 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata) {
+    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata,
+    std::optional<int>* outAdrenoVersion) {
   BackendInterface bckI{
       ggml_backend_dev_count,
       ggml_backend_dev_backend_reg,
@@ -340,5 +346,5 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
       ggml_backend_dev_type,
       llamaLogcallback};
   return backend_selection::chooseBackend(
-      preferredBackendType, bckI, metadata, mainGpu);
+      preferredBackendType, bckI, metadata, mainGpu, outAdrenoVersion);
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.cpp
@@ -3,16 +3,36 @@
 #include <algorithm>
 #include <cctype>
 #include <optional>
+#include <regex>
 #include <variant>
 #include <vector>
 
+#include <common/log.h>
 #include <ggml-backend.h>
 
 #include "common/common.h"
+#include "model-interface/ModelMetadata.hpp"
 
 using namespace backend_selection;
 
 namespace {
+std::optional<int> parseAdrenoVersion(const std::string& gpuDescription) {
+  static const std::regex adrenoRegex(R"(dreno.*?(\d+))");
+  std::smatch matches;
+  if (std::regex_search(gpuDescription, matches, adrenoRegex) &&
+      matches.size() > 1) {
+    try {
+      return std::stoi(matches[1].str());
+    } catch (const std::exception& e) {
+      LOG_WRN(
+          "parseAdrenoVersion: failed to parse version from '%s': %s\n",
+          gpuDescription.c_str(),
+          e.what());
+    }
+  }
+  return std::nullopt;
+}
+
 struct DeviceDescription {
   std::string gpuDescription;
   std::string gpuBackend;
@@ -62,7 +82,8 @@ struct DeviceDescription {
 void emplaceIfValidDevice(
     const BackendInterface& bckI, std::vector<std::string>& gpuBackends,
     std::vector<std::string>& igpuBackends,
-    std::vector<std::string>& openClBackends, const ggml_backend_reg_t reg,
+    std::vector<std::string>& openClBackends,
+    std::optional<int>& maxAdrenoVersion, const ggml_backend_reg_t reg,
     const DeviceDescription& devDescr,
     const enum ggml_backend_dev_type backendTypeEnum) {
   if (bckI.ggml_backend_reg_name(reg) != std::string("RPC")) {
@@ -77,7 +98,15 @@ void emplaceIfValidDevice(
     const bool isOpenCl =
         devDescr.gpuBackend.find("opencl") != std::string::npos;
     const bool isAdreno =
-        devDescr.gpuDescription.find("adreno") != std::string::npos;
+        devDescr.gpuDescription.find("dreno") != std::string::npos;
+    if (isAdreno) {
+      auto version = parseAdrenoVersion(devDescr.gpuDescription);
+      if (version.has_value() && (!maxAdrenoVersion.has_value() ||
+                                  version.value() > maxAdrenoVersion.value())) {
+        maxAdrenoVersion = version;
+      }
+    }
+
     if (isOpenCl && isAdreno) {
       logEmplaceGpuBackend(devDescr.gpuBackend);
       openClBackends.emplace_back(devDescr.gpuBackend);
@@ -114,7 +143,8 @@ void tryEmplaceDevice(
     std::optional<MainGpuType> mainGpuType,
     std::vector<std::string>& gpuBackends,
     std::vector<std::string>& igpuBackends,
-    std::vector<std::string>& openClBackends) {
+    std::vector<std::string>& openClBackends,
+    std::optional<int>& maxAdrenoVersion) {
   const ggml_backend_dev_t dev = bckI.ggml_backend_dev_get(deviceIndex);
   const ggml_backend_reg_t reg = bckI.ggml_backend_dev_backend_reg(dev);
   const enum ggml_backend_dev_type backendTypeEnum =
@@ -129,6 +159,7 @@ void tryEmplaceDevice(
         gpuBackends,
         igpuBackends,
         openClBackends,
+        maxAdrenoVersion,
         reg,
         devDescr,
         backendTypeEnum);
@@ -196,11 +227,12 @@ std::optional<MainGpu> backend_selection::tryMainGpuFromMap(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, const BackendInterface& bckI,
-    const std::optional<MainGpu>& mainGpu) {
+    const ModelMetaData* metadata, const std::optional<MainGpu>& mainGpu) {
 
   std::vector<std::string> gpuBackends;
   std::vector<std::string> igpuBackends;
   std::vector<std::string> openClBackends;
+  std::optional<int> maxAdrenoVersion;
 
   if (preferredBackendType == BackendType::GPU) {
     bool loopAllDevices = true;
@@ -208,7 +240,6 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     if (mainGpu.has_value()) {
       const MainGpu& mainGpuValue = mainGpu.value();
       if (std::holds_alternative<int>(mainGpuValue)) {
-        // Direct device index specified
         const int deviceIndex = std::get<int>(mainGpuValue);
         const size_t deviceCount = bckI.ggml_backend_dev_count();
         if (deviceIndex >= 0 &&
@@ -219,7 +250,8 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
               std::nullopt,
               gpuBackends,
               igpuBackends,
-              openClBackends);
+              openClBackends,
+              maxAdrenoVersion);
           loopAllDevices = false;
         } else {
           std::string errorMsg = string_format(
@@ -235,12 +267,46 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     for (size_t i = 0; loopAllDevices && i < bckI.ggml_backend_dev_count();
          ++i) {
       ::tryEmplaceDevice(
-          bckI, i, gpuType, gpuBackends, igpuBackends, openClBackends);
+          bckI,
+          i,
+          gpuType,
+          gpuBackends,
+          igpuBackends,
+          openClBackends,
+          maxAdrenoVersion);
     }
   }
 
-  // check if Adreno GPU is present and force OpenCL backend, otherwise let
-  // llama.cpp choose Vulkan GPU backend
+  const bool isBitnetOneBitAdreno =
+      !mainGpu.has_value() && // No explicit selection
+      metadata != nullptr && metadata->hasOneBitQuantization() &&
+      metadata->tryGetString("general.architecture") == "bitnet" &&
+      maxAdrenoVersion.has_value();
+
+  constexpr int kAdrenoVulkanThreshold = 800;
+  if (isBitnetOneBitAdreno &&
+      maxAdrenoVersion.value() < kAdrenoVulkanThreshold) {
+    bckI.llamaLogCallback(
+        GGML_LOG_LEVEL_INFO,
+        "BitNet TQ on Adreno <800: only CPU supported",
+        nullptr);
+    openClBackends.clear();
+    gpuBackends.clear();
+    igpuBackends.clear();
+  } else if (
+      isBitnetOneBitAdreno &&
+      maxAdrenoVersion.value() >= kAdrenoVulkanThreshold) {
+    bckI.llamaLogCallback(
+        GGML_LOG_LEVEL_INFO,
+        "BitNet TQ on Adreno 800+: preferring Vulkan over OpenCL",
+        nullptr);
+    openClBackends.clear();
+  }
+
+  // Normally, check if Adreno GPU is present and force OpenCL backend,
+  // otherwise let llama.cpp choose Vulkan GPU backend. There are some
+  // exceptions such as BitNet models which do not currently support OpenCl,
+  // cl backends should have been cleared at this point for those cases.
   if (!openClBackends.empty()) {
     bckI.llamaLogCallback(GGML_LOG_LEVEL_INFO, "Chosen GPU OpenCL", nullptr);
     return {BackendType::GPU, openClBackends.front()};
@@ -263,7 +329,7 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu) {
+    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata) {
   BackendInterface bckI{
       ggml_backend_dev_count,
       ggml_backend_dev_backend_reg,
@@ -273,5 +339,6 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
       ggml_backend_dev_name,
       ggml_backend_dev_type,
       llamaLogcallback};
-  return backend_selection::chooseBackend(preferredBackendType, bckI, mainGpu);
+  return backend_selection::chooseBackend(
+      preferredBackendType, bckI, metadata, mainGpu);
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.hpp
@@ -44,7 +44,8 @@ struct BackendInterface {
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, const BackendInterface& bckI,
     const ModelMetaData* metadata = nullptr,
-    const std::optional<MainGpu>& mainGpu = std::nullopt);
+    const std::optional<MainGpu>& mainGpu = std::nullopt,
+    std::optional<int>* outAdrenoVersion = nullptr);
 
 /// @brief Choose the backend to use for the model based on GPU device and
 /// available backends. Prefer OpenCL backend for Adreno GPUs, otherwise
@@ -54,5 +55,6 @@ std::pair<BackendType, std::string> chooseBackend(
 ///   - Adreno <800: prefer CPU (TQ kernels run faster on CPU)
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata);
+    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata,
+    std::optional<int>* outAdrenoVersion = nullptr);
 } // namespace backend_selection

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.hpp
@@ -9,6 +9,8 @@
 #include <llama.h>
 #include <qvac-lib-inference-addon-cpp/Errors.hpp>
 
+class ModelMetaData;
+
 namespace backend_selection {
 
 enum BackendType : std::uint8_t { CPU, GPU };
@@ -41,12 +43,16 @@ struct BackendInterface {
 
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, const BackendInterface& bckI,
+    const ModelMetaData* metadata = nullptr,
     const std::optional<MainGpu>& mainGpu = std::nullopt);
 
 /// @brief Choose the backend to use for the model based on GPU device and
-/// available backends. Prefer OpenCL backend for Adreno GPUs, otherwise Vulkan
-/// backend. Uses CPU if no GPU backends are available.
+/// available backends. Prefer OpenCL backend for Adreno GPUs, otherwise
+/// Vulkan backend. Uses CPU if no GPU backends are available. For BitNet
+/// models with TQ1_0/TQ2_0 quantization on Adreno GPUs:
+///   - Adreno 800+: prefer Vulkan over OpenCL
+///   - Adreno <800: prefer CPU (TQ kernels run faster on CPU)
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu = std::nullopt);
+    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata);
 } // namespace backend_selection

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/bitnet.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/bitnet.test.js
@@ -5,9 +5,10 @@ const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
-const os = require('bare-os')
 
-const isAndroid = os.platform() === 'android'
+// TODO: Enable test with `skip: !isAndroid` when Collabora merges Vulkan fixes.
+// const os = require('bare-os')
+// const isAndroid = os.platform() === 'android'
 
 const BITNET_MODEL = {
   name: 'bitnet_b1_58-large-TQ2_0.gguf',
@@ -26,7 +27,7 @@ async function collectResponse (response) {
   return chunks.join('').trim()
 }
 
-test('bitnet model can run simple inference', { timeout: 600_000, skip: !isAndroid }, async t => {
+test('bitnet model can run simple inference', { timeout: 600_000, skip: true }, async t => {
   const [modelName, dirPath] = await ensureModel({
     modelName: BITNET_MODEL.name,
     downloadUrl: BITNET_MODEL.url

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/bitnet.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/bitnet.test.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const test = require('brittle')
+const FilesystemDL = require('@qvac/dl-filesystem')
+const LlmLlamacpp = require('../../index.js')
+const { ensureModel } = require('./utils')
+const { attachSpecLogger } = require('./spec-logger')
+const os = require('bare-os')
+
+const isAndroid = os.platform() === 'android'
+
+const BITNET_MODEL = {
+  name: 'bitnet_b1_58-large-TQ2_0.gguf',
+  url: 'https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0/resolve/main/bitnet_b1_58-large-TQ2_0.gguf'
+}
+
+const PROMPT = [
+  { role: 'user', content: 'What is 2 + 2?' }
+]
+
+async function collectResponse (response) {
+  const chunks = []
+  await response
+    .onUpdate(data => { chunks.push(data) })
+    .await()
+  return chunks.join('').trim()
+}
+
+test('bitnet model can run simple inference', { timeout: 600_000, skip: !isAndroid }, async t => {
+  const [modelName, dirPath] = await ensureModel({
+    modelName: BITNET_MODEL.name,
+    downloadUrl: BITNET_MODEL.url
+  })
+
+  const loader = new FilesystemDL({ dirPath })
+  const specLogger = attachSpecLogger({ forwardToConsole: true })
+
+  const config = {
+    gpu_layers: '999',
+    ctx_size: '1024',
+    device: 'gpu',
+    n_predict: '32',
+    verbosity: '2'
+  }
+
+  const addon = new LlmLlamacpp({
+    loader,
+    modelName,
+    diskPath: dirPath,
+    logger: console,
+    opts: { stats: true }
+  }, config)
+
+  try {
+    await addon.load()
+    const response = await addon.run(PROMPT)
+    const output = await collectResponse(response)
+
+    t.ok(output.length > 0, 'bitnet model should generate output')
+    t.comment(`BitNet output: "${output}"`)
+  } finally {
+    await addon.unload().catch(() => { })
+    await loader.close().catch(() => { })
+    specLogger.release()
+  }
+})

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
@@ -15,6 +15,10 @@ const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
 const isWindowsX64 = platform === 'win32' && arch === 'x64'
 const useCpu = isDarwinX64 || isLinuxArm64
 
+// These are very slow on CI and should be skipped.
+// TODO: unskip Windows once we have a new Windows runner with a GPU
+const skip = isWindowsX64 || isLinuxArm64
+
 const DEFAULT_MODEL = {
   name: 'Llama-3.2-1B-Instruct-Q4_0.gguf',
   url: 'https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_0.gguf'
@@ -156,7 +160,7 @@ function expectedSlides (nPredict, nDiscarded) {
 // n_discarded=32, n_predict=SLIDE_PREDICT
 test('Basic generation sliding', {
   timeout: 900_000,
-  skip: isWindowsX64 // TODO: unskip this once we have a new Windows runner with a GPU
+  skip
 }, async t => {
   const { model, logs } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
@@ -179,7 +183,7 @@ test('Basic generation sliding', {
 // n_discarded=0, n_predict=SLIDE_PREDICT
 test('Generation fails with context overflow when sliding disabled', {
   timeout: 900_000,
-  skip: isWindowsX64 // TODO: unskip this once we have a new Windows runner with a GPU
+  skip
 }, async t => {
   const { model, logs } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
@@ -206,7 +210,7 @@ test('Generation fails with context overflow when sliding disabled', {
 // n_discarded=16, n_predict=MANY_SLIDES_PREDICT
 test('Many slides with small n_discarded', {
   timeout: 900_000,
-  skip: isWindowsX64 // TODO: unskip this once we have a new Windows runner with a GPU
+  skip
 }, async t => {
   const { model, logs } = await setupModel(t, {
     n_predict: String(MANY_SLIDES_PREDICT),
@@ -229,7 +233,7 @@ test('Many slides with small n_discarded', {
 // n_discarded=99999, clamped to FREE_SLOTS - 1
 test('Large n_discarded is clamped to fit available context space', {
   timeout: 900_000,
-  skip: isWindowsX64 // TODO: unskip this once we have a new Windows runner with a GPU
+  skip
 }, async t => {
   const { model, logs } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
@@ -252,7 +256,7 @@ test('Large n_discarded is clamped to fit available context space', {
 // n_discarded=1, n_predict=SLIDE_PREDICT
 test('Sliding context works with minimal n_discarded of 1', {
   timeout: 900_000,
-  skip: isWindowsX64 // TODO: unskip this once we have a new Windows runner with a GPU
+  skip
 }, async t => {
   const { model, logs } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
@@ -281,7 +285,7 @@ test('Sliding context works with minimal n_discarded of 1', {
 // :> discards n_discarded (64) tokens after first message
 test('Cached follow-up discards middle tokens to fit new message', {
   timeout: 900_000,
-  skip: isWindowsX64 // TODO: unskip this once we have a new Windows runner with a GPU
+  skip
 }, async t => {
   const cachePath = path.join(
     (await ensureModel({ modelName: DEFAULT_MODEL.name, downloadUrl: DEFAULT_MODEL.url }))[1],
@@ -320,7 +324,7 @@ test('Cached follow-up discards middle tokens to fit new message', {
 // :> removes all middle tokens from pos 44 to 244
 test('Cached follow-up clears all middle tokens when discard window is exhausted', {
   timeout: 900_000,
-  skip: isWindowsX64 // TODO: unskip this once we have a new Windows runner with a GPU
+  skip
 }, async t => {
   const cachePath = path.join(
     (await ensureModel({ modelName: DEFAULT_MODEL.name, downloadUrl: DEFAULT_MODEL.url }))[1],
@@ -355,7 +359,7 @@ test('Cached follow-up clears all middle tokens when discard window is exhausted
 // :> no recovery possible, throws ContextOverflow
 test('Cached follow-up overflows when sliding is disabled and context is full', {
   timeout: 900_000,
-  skip: isWindowsX64 // TODO: unskip this once we have a new Windows runner with a GPU
+  skip
 }, async t => {
   const cachePath = path.join(
     (await ensureModel({ modelName: DEFAULT_MODEL.name, downloadUrl: DEFAULT_MODEL.url }))[1],

--- a/packages/qvac-lib-infer-llamacpp-llm/test/mobile/integration.auto.cjs
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/mobile/integration.auto.cjs
@@ -10,6 +10,10 @@ async function runApiBehaviorTest (options = {}) { // eslint-disable-line no-unu
   return runIntegrationModule('../integration/api-behavior.test.js', options)
 }
 
+async function runBitnetTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/bitnet.test.js', options)
+}
+
 async function runCacheStateMachineTest (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/cache-state-machine.test.js', options)
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
   test_text_llm_context.cpp
   test_addon_cpp.cpp
   test_backend_selection.cpp
+  test_tune_config_map.cpp
   # Placeholder tests (to be implemented)
   test_mtmd_llm_context.cpp
   test_llm_context_base.cpp

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_backend_selection.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_backend_selection.cpp
@@ -10,6 +10,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "model-interface/ModelMetadata.hpp"
 #include "utils/BackendSelection.hpp"
 
 using namespace backend_selection;
@@ -170,6 +171,7 @@ protected:
 
 // GPU Description
 constexpr const char* ADRENO_DESC = "Adreno (TM) 740";
+constexpr const char* ADRENO_830_DESC = "Adreno (TM) 830";
 constexpr const char* MALI_DESC = "Mali-G715";
 
 // GPU Backend
@@ -203,7 +205,36 @@ void expectChosen(
     const std::string& expectedBackendName,
     const std::optional<MainGpu>& mainGpu) {
   BackendInterface bckI = mockBackend.toBackendInterface();
-  auto result = chooseBackend(expectedBackend, bckI, mainGpu);
+  auto result = chooseBackend(expectedBackend, bckI, nullptr, mainGpu);
+  expectChosen(result, expectedBackend, expectedBackendName);
+}
+
+class MockModelMetaData : public ModelMetaData {
+public:
+  MockModelMetaData(bool oneBitQuant, std::string arch)
+      : oneBitQuant_(oneBitQuant), arch_(std::move(arch)) {}
+
+  [[nodiscard]] bool hasOneBitQuantization() const override {
+    return oneBitQuant_;
+  }
+  std::optional<std::string> tryGetString(const char* key) const override {
+    if (std::string(key) == "general.architecture")
+      return arch_;
+    return std::nullopt;
+  }
+
+private:
+  bool oneBitQuant_;
+  std::string arch_;
+};
+
+void expectChosenWithMetadata(
+    MockBackendInterface& mockBackend, BackendType preferredBackend,
+    BackendType expectedBackend, const std::string& expectedBackendName,
+    const ModelMetaData& metadata,
+    const std::optional<MainGpu>& mainGpu = std::nullopt) {
+  BackendInterface bckI = mockBackend.toBackendInterface();
+  auto result = chooseBackend(preferredBackend, bckI, &metadata, mainGpu);
   expectChosen(result, expectedBackend, expectedBackendName);
 }
 
@@ -451,4 +482,148 @@ TEST_F(BackendSelectionTest, ChooseBackendWithMainGpuIntegerIndexOne) {
 
   MainGpu mainGpu = 1;
   expectChosen(mockBackend, BackendType::GPU, "vulkan1", mainGpu);
+}
+
+// ---- BitNet TQ backend selection for Adreno GPUs ----
+
+// Adreno 830 (800+) with bitnet TQ: should prefer Vulkan over OpenCL
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno830_ChoosesVulkanOverOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", bitnetMeta);
+}
+
+// Adreno 740 (<800) with bitnet TQ: should fall back to CPU
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno740_ChoosesCPU) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::CPU, "none", bitnetMeta);
+}
+
+// Adreno 830 without bitnet: should still choose OpenCL (existing behavior)
+TEST_F(BackendSelectionTest, NoBitnet_Adreno830_ChoosesOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData nonBitnetMeta(false, "llama");
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      nonBitnetMeta);
+}
+
+// Adreno 740 without bitnet: should still choose OpenCL (existing behavior)
+TEST_F(BackendSelectionTest, NoBitnet_Adreno740_ChoosesOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_DESC, VULKAN0_BACK));
+  MockModelMetaData nonBitnetMeta(false, "llama");
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      nonBitnetMeta);
+}
+
+// Non-Adreno GPU with bitnet: normal GPU selection (no special behavior)
+TEST_F(BackendSelectionTest, BitnetTQ_Mali_ChoosesVulkanNormally) {
+  mockBackend.addDevice(createGPUDevice(MALI_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", bitnetMeta);
+}
+
+// Adreno 800+ with bitnet TQ, only OpenCL available (no Vulkan): falls to CPU
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno830_OnlyOpenCL_FallsToCPU) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::CPU, "none", bitnetMeta);
+}
+
+// Adreno 800+ with bitnet TQ, both Vulkan GPU and iGPU: prefers GPU Vulkan
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno830_VulkanGPUAndIGPU_ChoosesGPU) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN1_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", bitnetMeta);
+}
+
+// Adreno 740 (<800) with bitnet TQ, only Vulkan (no OpenCL device): should
+// fall back to CPU. maxAdrenoVersion must be populated from Vulkan device.
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno740_OnlyVulkan_ChoosesCPU) {
+  mockBackend.addDevice(createIGPUDevice(ADRENO_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::CPU, "none", bitnetMeta);
+}
+
+// Adreno 830 (800+) with bitnet TQ, only Vulkan (no OpenCL device): should
+// choose Vulkan. maxAdrenoVersion must be populated from Vulkan device.
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno830_OnlyVulkan_ChoosesVulkan) {
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", bitnetMeta);
+}
+
+// ---- Explicit mainGpu bypasses bitnet Adreno logic ----
+
+// Adreno 830 + bitnet + explicit mainGpu index: should keep OpenCL (normal
+// Adreno path), NOT switch to Vulkan (bitnet special path).
+TEST_F(
+    BackendSelectionTest, BitnetTQ_Adreno830_ExplicitMainGpuIndex_KeepsOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  MainGpu mainGpu = 0;
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      bitnetMeta,
+      mainGpu);
+}
+
+// Adreno 740 (<800) + bitnet + explicit mainGpu index: should keep OpenCL,
+// NOT fall back to CPU (bitnet special path).
+TEST_F(
+    BackendSelectionTest, BitnetTQ_Adreno740_ExplicitMainGpuIndex_KeepsOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  MainGpu mainGpu = 0;
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      bitnetMeta,
+      mainGpu);
+}
+
+// Adreno 830 + bitnet + explicit mainGpu Integrated: should keep OpenCL,
+// NOT switch to Vulkan.
+TEST_F(
+    BackendSelectionTest,
+    BitnetTQ_Adreno830_ExplicitMainGpuIntegrated_KeepsOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  MainGpu mainGpu = MainGpuType::Integrated;
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      bitnetMeta,
+      mainGpu);
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_backend_selection.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_backend_selection.cpp
@@ -10,10 +10,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "model-interface/ModelMetadata.hpp"
+#include "test_common.hpp"
 #include "utils/BackendSelection.hpp"
 
 using namespace backend_selection;
+using test_common::MockModelMetaData;
 
 // Mock types for ggml backend structures
 struct MockDevice {
@@ -208,25 +209,6 @@ void expectChosen(
   auto result = chooseBackend(expectedBackend, bckI, nullptr, mainGpu);
   expectChosen(result, expectedBackend, expectedBackendName);
 }
-
-class MockModelMetaData : public ModelMetaData {
-public:
-  MockModelMetaData(bool oneBitQuant, std::string arch)
-      : oneBitQuant_(oneBitQuant), arch_(std::move(arch)) {}
-
-  [[nodiscard]] bool hasOneBitQuantization() const override {
-    return oneBitQuant_;
-  }
-  std::optional<std::string> tryGetString(const char* key) const override {
-    if (std::string(key) == "general.architecture")
-      return arch_;
-    return std::nullopt;
-  }
-
-private:
-  bool oneBitQuant_;
-  std::string arch_;
-};
 
 void expectChosenWithMetadata(
     MockBackendInterface& mockBackend, BackendType preferredBackend,

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
@@ -4,10 +4,12 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <gtest/gtest.h>
 
+#include "model-interface/ModelMetadata.hpp"
 #include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
 
 namespace test_common {
@@ -178,6 +180,25 @@ inline fs::path getTestBackendsDir() {
   return fs::current_path() / "build" / "test" / "unit";
 #endif
 }
+
+class MockModelMetaData : public ModelMetaData {
+public:
+  MockModelMetaData(bool oneBitQuant, std::string arch)
+      : oneBitQuant_(oneBitQuant), arch_(std::move(arch)) {}
+
+  [[nodiscard]] bool hasOneBitQuantization() const override {
+    return oneBitQuant_;
+  }
+  std::optional<std::string> tryGetString(const char* key) const override {
+    if (std::string(key) == "general.architecture")
+      return arch_;
+    return std::nullopt;
+  }
+
+private:
+  bool oneBitQuant_;
+  std::string arch_;
+};
 
 inline std::unique_ptr<std::basic_streambuf<char>>
 readFileToStreambufBinary(const std::string& path) {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
@@ -198,11 +198,9 @@ readFileToStreambufBinary(const std::string& path) {
  * so that GTEST_SKIP / FAIL return from the correct stack frame.
  */
 #define REQUIRE_MODEL(m)                                                       \
-  do {                                                                         \
-    if (!(m).found()) {                                                        \
-      if ((m).onMissing == ::test_common::TestModelPath::OnMissing::Skip)      \
-        GTEST_SKIP() << (m).missingMessage();                                  \
-      else                                                                     \
-        FAIL() << (m).missingMessage();                                        \
-    }                                                                          \
-  } while (false)
+  if (!(m).found()) {                                                          \
+    if ((m).onMissing == ::test_common::TestModelPath::OnMissing::Skip)        \
+      GTEST_SKIP() << (m).missingMessage();                                    \
+    FAIL() << (m).missingMessage();                                            \
+  }                                                                            \
+  static_assert(true, "")

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
@@ -319,6 +319,50 @@ TEST_F(
       });
 }
 
+// ---- tryGetString: architecture detection via "general.architecture" ----
+//
+// The "general.architecture" GGUF string key is "bitnet" for BitNet models
+// and a different value (e.g. "llama", "qwen3") for all others.
+
+TEST_F(ModelMetadataTest, DiskSingleFile_NormalModel_ArchitectureIsNotBitnet) {
+  REQUIRE_MODEL(normalModel_);
+  parseDiskSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    auto arch = meta.tryGetString("general.architecture");
+    ASSERT_TRUE(arch.has_value());
+    EXPECT_NE(arch.value(), "bitnet");
+  });
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_BitnetModel_ArchitectureIsBitnet) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseDiskSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    auto arch = meta.tryGetString("general.architecture");
+    ASSERT_TRUE(arch.has_value());
+    EXPECT_EQ(arch.value(), "bitnet");
+  });
+}
+
+TEST_F(
+    ModelMetadataTest,
+    StreamingSingleFile_NormalModel_ArchitectureIsNotBitnet) {
+  REQUIRE_MODEL(normalModel_);
+  parseStreamingSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    auto arch = meta.tryGetString("general.architecture");
+    ASSERT_TRUE(arch.has_value());
+    EXPECT_NE(arch.value(), "bitnet");
+  });
+}
+
+TEST_F(
+    ModelMetadataTest, StreamingSingleFile_BitnetModel_ArchitectureIsBitnet) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseStreamingSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    auto arch = meta.tryGetString("general.architecture");
+    ASSERT_TRUE(arch.has_value());
+    EXPECT_EQ(arch.value(), "bitnet");
+  });
+}
+
 // ---- AsyncWeightsLoader: streaming single file ----
 //
 // setWeightsForFile is called during the download phase (before activate()),

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_tune_config_map.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_tune_config_map.cpp
@@ -1,0 +1,161 @@
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/LlamaModel.hpp"
+#include "test_common.hpp"
+
+using test_common::MockModelMetaData;
+
+class TuneConfigMapTest : public ::testing::Test {
+protected:
+  std::unordered_map<std::string, std::string> configFilemap_;
+};
+
+// ---- Non-BitNet: no modifications ----
+
+TEST_F(TuneConfigMapTest, NonBitnet_NoChanges) {
+  MockModelMetaData meta(false, "llama");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, std::nullopt);
+
+  EXPECT_EQ(configFilemap_.count("flash-attn"), 0);
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+TEST_F(TuneConfigMapTest, OneBitButNotBitnetArch_NoChanges) {
+  MockModelMetaData meta(true, "llama");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_.count("flash-attn"), 0);
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+TEST_F(TuneConfigMapTest, BitnetArchButNotOneBit_NoChanges) {
+  MockModelMetaData meta(false, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_.count("flash-attn"), 0);
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+// ---- BitNet without Adreno: flash-attn disabled, ubatch unchanged ----
+
+TEST_F(TuneConfigMapTest, Bitnet_NoAdreno_FlashAttnDisabled) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, std::nullopt);
+
+  ASSERT_EQ(configFilemap_.count("flash-attn"), 1);
+  EXPECT_EQ(configFilemap_["flash-attn"], "off");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_NoAdreno_UbatchUnchanged) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, std::nullopt);
+
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+// ---- BitNet with Adreno <800: flash-attn disabled, ubatch unchanged ----
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno740_FlashAttnDisabled) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 740);
+
+  ASSERT_EQ(configFilemap_.count("flash-attn"), 1);
+  EXPECT_EQ(configFilemap_["flash-attn"], "off");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno740_UbatchUnchanged) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 740);
+
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+// ---- BitNet with Adreno 800+: flash-attn disabled AND ubatch=128 ----
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno830_FlashAttnDisabled) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  ASSERT_EQ(configFilemap_.count("flash-attn"), 1);
+  EXPECT_EQ(configFilemap_["flash-attn"], "off");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno830_UbatchSetTo128) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  ASSERT_EQ(configFilemap_.count("ubatch-size"), 1);
+  EXPECT_EQ(configFilemap_["ubatch-size"], "128");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno800_UbatchSetTo128) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 800);
+
+  ASSERT_EQ(configFilemap_.count("ubatch-size"), 1);
+  EXPECT_EQ(configFilemap_["ubatch-size"], "128");
+}
+
+// ---- User overrides are respected ----
+
+TEST_F(TuneConfigMapTest, Bitnet_UserSetFlashAttnHyphen_Respected) {
+  MockModelMetaData meta(true, "bitnet");
+  configFilemap_["flash-attn"] = "on";
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_["flash-attn"], "on");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_UserSetFlashAttnUnderscore_Respected) {
+  MockModelMetaData meta(true, "bitnet");
+  configFilemap_["flash_attn"] = "on";
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_.count("flash-attn"), 0);
+  EXPECT_EQ(configFilemap_["flash_attn"], "on");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno830_UserSetUbatchHyphen_Respected) {
+  MockModelMetaData meta(true, "bitnet");
+  configFilemap_["ubatch-size"] = "256";
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_["ubatch-size"], "256");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno830_UserSetUbatchUnderscore_Respected) {
+  MockModelMetaData meta(true, "bitnet");
+  configFilemap_["ubatch_size"] = "64";
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+  EXPECT_EQ(configFilemap_["ubatch_size"], "64");
+}
+
+// ---- Edge: Adreno 799 (just below threshold) ----
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno799_UbatchUnchanged) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 799);
+
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
@@ -7,7 +7,7 @@
     "picojson",
     {
       "name": "qvac-fabric",
-      "version>=": "7248.1.3"
+      "version>=": "7248.1.4"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
See changelog: https://github.com/jesusmb1995/qvac/blob/5a235dbe2b921c0fe03e4a4a1407b08892733f49/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md#0110---2026-03-05

The plan is this PR is to prepare the logic. But not fully enable the test and support BitNet yet, since we are waiting for Collabora to merge the changes. 

This PR uses 7248.1.4 which does not include yet Finetune changes from collabora.

## Tests made
- Ran on CI: https://github.com/tetherto/qvac/actions/runs/22715954014/job/65870178056?pr=694
    - C++ tests,  Including new for backend selection logic
    
    Using separate test PR https://github.com/tetherto/qvac/pull/742
    - New BitNet integration test https://github.com/tetherto/qvac/actions/runs/22759022249/job/66028118789
        - Android CI tests include Mali on Pixel 9, Adreno 800+ on S25, Adreno 700+ on S24
        - Locally tested Poco F7 pro with Adreno 700 series
        
Local test log (summary)
```

  [INFO] [Llama.cpp] Backend detected: description = adreno (tm) 750, backend = vulkan0, type = IGPU
  [INFO] [Llama.cpp] Backend detected: description = qualcomm adreno(tm) 750, backend = gpuopencl, type = GPU
  [INFO] [Llama.cpp] Backend detected: description = cpu, backend = cpu, type = CPU
  [INFO] [Llama.cpp] BitNet TQ on Adreno <800: only CPU supported
  [INFO] [Llama.cpp] Chosen CPU
  [INFO] [LlamaModel] BitNet model detected: disabling flash attention
  [INFO] [Llama.cpp] ggml_backend_load_best: searching for blas in /data/data/com.termux/files/usr/lib/node_modules/bare/node_modules/bare-runtime-android-arm64/bin/
  [INFO] [Llama.cpp] llama_context: CPU compute buffer size = 65.50 MiB
  [INFO] [Llama.cpp] llama_context: graph nodes  = 966
  [INFO] [Llama.cpp] llama_context: graph splits = 1
  Job OnlyOneJob completed. Stats:
    TTFT:            2490.51 ms
    TPS:             44.97 tokens/s
    Cache Tokens:    0
    Generated:       32 tokens
    Prompt:          36 tokens
  ok 1 - bitnet model should generate output
    # BitNet output: "<|im_end|>user\nWhat is 3 + 4?<|im_start|>assistant\n<|im_end"
  ok 1 - bitnet model can run simple inference # time = 13381ms
  1..1
  # tests   = 1/1 pass
  # asserts = 1/1 pass
  # time    = 18179ms
  # ok
```
