### PR TITLE
fix[mod]: undeprecate DocTR OCR models auto-deprecated by concurrent sync

### DIFF
--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -4013,7 +4013,8 @@
       "db_resnet50"
     ],
     "notes": "",
-    "link": "https://github.com/felixdittrich92/OnnxTR"
+    "link": "https://github.com/felixdittrich92/OnnxTR",
+    "deprecated": false
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/doctr/2026-03-04/db_mobilenet_v3_large.onnx",
@@ -4029,7 +4030,8 @@
       "db_mobilenet_v3_large"
     ],
     "notes": "",
-    "link": "https://github.com/felixdittrich92/OnnxTR"
+    "link": "https://github.com/felixdittrich92/OnnxTR",
+    "deprecated": false
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/doctr/2026-03-04/parseq.onnx",
@@ -4045,7 +4047,8 @@
       "parseq"
     ],
     "notes": "",
-    "link": "https://github.com/felixdittrich92/OnnxTR"
+    "link": "https://github.com/felixdittrich92/OnnxTR",
+    "deprecated": false
   },
   {
     "source": "s3:///qvac_models_compiled/ocr/doctr/2026-03-04/crnn_mobilenet_v3_small.onnx",
@@ -4061,7 +4064,8 @@
       "crnn_mobilenet_v3_small"
     ],
     "notes": "",
-    "link": "https://github.com/felixdittrich92/OnnxTR"
+    "link": "https://github.com/felixdittrich92/OnnxTR",
+    "deprecated": false
   },
   {
     "source": "https://huggingface.co/ResembleAI/chatterbox-turbo-ONNX/resolve/d21799bd0354adb85e348b8a0442a8405110a2cf/tokenizer.json",


### PR DESCRIPTION
## What problem does this PR solve?

The 4 DocTR models from #685 were auto-deprecated when the sync-staging job ran on #702 — the concurrent-PR issue now documented in #709.

Models affected:
- `db_resnet50.onnx`
- `db_mobilenet_v3_large.onnx`
- `parseq.onnx`
- `crnn_mobilenet_v3_small.onnx`

## How does it solve it?

Sets `"deprecated": false` on all 4 entries so the next sync clears the deprecation flags in the database.

Made with [Cursor](https://cursor.com)