### PR TITLE
chore: remove Visual Studio Build Tools install step from CI workflows

### DIFF
--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -87,12 +87,6 @@ jobs:
           echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
       - if: ${{ matrix.os == 'windows-11' }}
-        name: Install Visual Studio Build Tools (Windows)
-        run: |
-          winget install Microsoft.VisualStudio.BuildTools -e --source winget --disable-interactivity --accept-package-agreements --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
-        shell: powershell
-
-      - if: ${{ matrix.os == 'windows-11' }}
         name: Clone and bootstrap vcpkg (Windows)
         run: |
           git clone https://github.com/microsoft/vcpkg.git

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -162,12 +162,6 @@ jobs:
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
 
       - if: ${{ matrix.os == 'windows-11' }}
-        name: Install Visual Studio Build Tools (Windows)
-        run: |
-          winget install Microsoft.VisualStudio.BuildTools -e --source winget --disable-interactivity --accept-package-agreements --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
-        shell: powershell
-
-      - if: ${{ matrix.os == 'windows-11' }}
         name: Clone and bootstrap vcpkg (Windows)
         run: |
           git clone https://github.com/microsoft/vcpkg.git

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -90,13 +90,6 @@ jobs:
           echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
       - if: ${{ matrix.os == 'windows-11' }}
-        name: Install Visual Studio Build Tools (Windows)
-        run: |
-          # This command ensures the "Desktop development with C++" workload is installed if needed
-          winget install Microsoft.VisualStudio.BuildTools -e --source winget --disable-interactivity --accept-package-agreements --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
-        shell: powershell
-
-      - if: ${{ matrix.os == 'windows-11' }}
         name: Clone and bootstrap vcpkg (Windows)
         run: |
           git clone https://github.com/microsoft/vcpkg.git


### PR DESCRIPTION
## Summary
- Removed the "Install Visual Studio Build Tools (Windows)" step from `cpp-tests-llm.yml`, `cpp-tests-embed.yml`, and `cpp-tests-diffusion.yml`
- GitHub-hosted Windows runners already include Visual Studio Build Tools, making this explicit install step unnecessary and adding extra CI time

## Test plan
- [ ] Verify Windows CI jobs in cpp-tests-llm, cpp-tests-embed, and cpp-tests-diffusion pass without the install step