### PR TITLE
ci(diffusion): improve SD workflow reliability and observability

### DIFF
--- a/.github/workflows/integration-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-test-lib-infer-diffusion.yml
@@ -252,3 +252,35 @@ jobs:
         shell: powershell
         env:
           QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
+
+      - name: List generated images
+        if: always()
+        shell: bash
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          echo "## Generated Images (${{ matrix.platform }}-${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if ls test/model/*.png 1>/dev/null 2>&1; then
+            echo "| File | Test Source | Size |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|------------|------|" >> $GITHUB_STEP_SUMMARY
+            for f in test/model/*.png; do
+              fname=$(basename "$f")
+              test_source=$(echo "$fname" | sed 's/--.*//')
+              size=$(du -h "$f" | cut -f1)
+              echo "| \`$fname\` | \`${test_source}.test.js\` | $size |" >> $GITHUB_STEP_SUMMARY
+            done
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "> Download the **sd-test-images-${{ matrix.platform }}-${{ matrix.arch }}** artifact to view images." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "*No images were generated.*" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload generated images
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: sd-test-images-${{ matrix.platform }}-${{ matrix.arch }}
+          path: ${{ env.WORKDIR }}/test/model/*.png
+          if-no-files-found: ignore
+          retention-days: 30
+

--- a/.github/workflows/prebuilds-lib-infer-diffusion.yml
+++ b/.github/workflows/prebuilds-lib-infer-diffusion.yml
@@ -361,6 +361,22 @@ jobs:
         run: |
           bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }}
 
+      - name: Dump vcpkg build logs on failure
+        if: failure()
+        shell: bash
+        run: |
+          LOG_DIR="${VCPKG_ROOT}/buildtrees/stable-diffusion-cpp"
+          if [ -d "$LOG_DIR" ]; then
+            for f in "$LOG_DIR"/{config,install,build}-*.log; do
+              [ -f "$f" ] || continue
+              echo "===== $(basename "$f") ====="
+              tail -200 "$f"
+              echo ""
+            done
+          else
+            echo "vcpkg buildtrees not found at $LOG_DIR"
+          fi
+
       - name: Run bare-make build
         working-directory: ${{ env.WORKDIR }}
         run: bare-make build


### PR DESCRIPTION
## What problem does this PR solve?

- Generated test images not visible in CI without downloading zip artifacts
- No diagnostic info when vcpkg builds fail in prebuilds workflow

## How does it solve it?

- Add step summary table listing generated images with test source traceability
- Add artifact upload for downloading images as zip
- Dump vcpkg build logs on prebuild failure

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213559015743995