### PR TITLE
feat[api][notask]: add OpenAI-compatible REST API server (qvac serve)

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+dist
 .DS_Store
 package-lock.json

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,13 +5,13 @@
   "author": "Tether",
   "license": "Apache-2.0",
   "type": "module",
-  "main": "./src/index.js",
-  "exports": "./src/index.js",
+  "main": "./dist/index.js",
+  "exports": "./dist/index.js",
   "bin": {
-    "qvac": "./src/index.js"
+    "qvac": "./dist/index.js"
   },
   "files": [
-    "src/**/*",
+    "dist/**/*",
     "README.md",
     "LICENSE",
     "NOTICE"
@@ -33,6 +33,9 @@
     "directory": "packages/cli"
   },
   "scripts": {
+    "build": "rm -rf dist && tsc",
+    "build:watch": "tsc --watch",
+    "typecheck": "tsc --noEmit",
     "lint": "standard",
     "lint:fix": "standard --fix"
   },
@@ -42,6 +45,8 @@
     "tsx": "^4.21.0"
   },
   "devDependencies": {
-    "standard": "^17.1.2"
+    "@types/node": "^25.3.3",
+    "standard": "^17.1.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/packages/cli/src/bundle-sdk/bare-pack.ts
+++ b/packages/cli/src/bundle-sdk/bare-pack.ts
@@ -3,10 +3,21 @@ import path from 'node:path'
 import { createRequire } from 'node:module'
 import { spawn } from 'node:child_process'
 import { BarePackNotInstalledError, BarePackError } from '../errors.js'
+import type { Logger } from '../logger.js'
 
 const require = createRequire(import.meta.url)
 
-function resolveBarePackBin () {
+interface RunBarePackOptions {
+  entryPath: string
+  outputPath: string
+  hosts: string[]
+  importsMapPath: string
+  deferModules: string[]
+  logLevel: string
+  logger: Logger
+}
+
+function resolveBarePackBin (): string | null {
   try {
     const barePackPkgPath = require.resolve('bare-pack/package')
     const barePackDir = path.dirname(barePackPkgPath)
@@ -16,7 +27,7 @@ function resolveBarePackBin () {
   }
 }
 
-export async function runBarePack (options) {
+export async function runBarePack (options: RunBarePackOptions): Promise<void> {
   const {
     entryPath,
     outputPath,

--- a/packages/cli/src/bundle-sdk/constants.ts
+++ b/packages/cli/src/bundle-sdk/constants.ts
@@ -1,11 +1,8 @@
-/**
- * Built-in plugin registry mapping suffix to export name.
- * Specifier format: `${sdkName}/${suffix}/plugin`
- */
-export const BUILTIN_PLUGINS = {
+export const BUILTIN_PLUGINS: Record<string, { exportName: string }> = {
   'llamacpp-completion': { exportName: 'llmPlugin' },
   'llamacpp-embedding': { exportName: 'embeddingsPlugin' },
   'whispercpp-transcription': { exportName: 'whisperPlugin' },
+  'parakeet-transcription': { exportName: 'parakeetPlugin' },
   'nmtcpp-translation': { exportName: 'nmtPlugin' },
   'onnx-tts': { exportName: 'ttsPlugin' },
   'onnx-ocr': { exportName: 'ocrPlugin' }
@@ -13,7 +10,6 @@ export const BUILTIN_PLUGINS = {
 
 export const BUILTIN_SUFFIXES = Object.keys(BUILTIN_PLUGINS)
 
-/** Supported bare-pack host targets */
 export const DEFAULT_HOSTS = [
   'darwin-arm64',
   'darwin-x64',

--- a/packages/cli/src/bundle-sdk/entry-gen.ts
+++ b/packages/cli/src/bundle-sdk/entry-gen.ts
@@ -1,14 +1,8 @@
 import { parseBuiltinSpecifier } from './plugins.js'
 
-/**
- * Generates the worker entry file with selected plugins.
- * Uses only static imports for tree-shaking.
- * @param {string[]} pluginSpecifiers
- * @param {string} sdkName
- */
-export function generateWorkerEntry (pluginSpecifiers, sdkName) {
-  const imports = []
-  const registrations = []
+export function generateWorkerEntry (pluginSpecifiers: string[], sdkName: string): string {
+  const imports: string[] = []
+  const registrations: string[] = []
   let varIndex = 0
 
   for (const specifier of pluginSpecifiers) {

--- a/packages/cli/src/bundle-sdk/index.ts
+++ b/packages/cli/src/bundle-sdk/index.ts
@@ -9,12 +9,25 @@ import { generateWorkerEntry } from './entry-gen.js'
 import { runBarePack } from './bare-pack.js'
 import { generateAddonsManifest } from './manifest.js'
 
-/**
- * Resolves the SDK path.
- * If explicitSdkPath is provided, uses that directly.
- * Otherwise, auto-detects from node_modules/@qvac/sdk.
- */
-function resolveSdkPath (projectRoot, explicitSdkPath) {
+export interface BundleSdkOptions {
+  projectRoot?: string | undefined
+  configPath?: string | undefined
+  sdkPath?: string | undefined
+  hosts?: string[] | undefined
+  defer?: string[] | undefined
+  quiet?: boolean | undefined
+  verbose?: boolean | undefined
+}
+
+interface BundleSdkResult {
+  bundlePath: string
+  plugins: string[]
+  addons: string[]
+  entryPaths: { worker: string }
+  manifestPath: string
+}
+
+function resolveSdkPath (projectRoot: string, explicitSdkPath?: string): string {
   if (explicitSdkPath) {
     return path.isAbsolute(explicitSdkPath)
       ? explicitSdkPath
@@ -23,17 +36,14 @@ function resolveSdkPath (projectRoot, explicitSdkPath) {
   return path.join(projectRoot, 'node_modules', '@qvac', 'sdk')
 }
 
-/**
- * Reads the SDK package name from its package.json.
- */
-async function resolveSdkName (sdkPath) {
+async function resolveSdkName (sdkPath: string): Promise<string> {
   const sdkPackageJsonPath = path.join(sdkPath, 'package.json')
 
   try {
     if (fs.existsSync(sdkPackageJsonPath)) {
       const content = await fsp.readFile(sdkPackageJsonPath, 'utf8')
-      const pkg = JSON.parse(content)
-      return pkg.name
+      const pkg = JSON.parse(content) as { name?: string }
+      if (pkg.name) return pkg.name
     }
   } catch {
     // Fall through to default
@@ -42,7 +52,7 @@ async function resolveSdkName (sdkPath) {
   return DEFAULT_SDK_NAME
 }
 
-function resolveImportsMapPath (sdkPath, sdkName) {
+function resolveImportsMapPath (sdkPath: string, sdkName: string): string {
   const importsMapPath = path.join(sdkPath, 'bare-imports.json')
 
   if (fs.existsSync(importsMapPath)) {
@@ -52,7 +62,7 @@ function resolveImportsMapPath (sdkPath, sdkName) {
   throw new BareImportsMapNotFoundError(sdkName, importsMapPath)
 }
 
-export async function bundleSdk (options = {}) {
+export async function bundleSdk (options: BundleSdkOptions = {}): Promise<BundleSdkResult> {
   const startTime = Date.now()
 
   const projectRoot = options.projectRoot ?? process.cwd()
@@ -70,10 +80,10 @@ export async function bundleSdk (options = {}) {
 
   const configPath = findConfigFile(projectRoot, options.configPath)
 
-  let config = {}
+  let config: { plugins?: string[] } = {}
   if (configPath) {
     logger.info(`📄 Config: ${path.relative(projectRoot, configPath)}`)
-    config = await loadConfig(configPath)
+    config = await loadConfig(configPath) as { plugins?: string[] }
   } else {
     logger.info('📄 Config: (none)')
     logger.warn('No config file found — continuing with defaults.')
@@ -120,7 +130,6 @@ export async function bundleSdk (options = {}) {
   }
 
   await runBarePack({
-    projectRoot,
     entryPath,
     outputPath: bundlePath,
     hosts,

--- a/packages/cli/src/bundle-sdk/manifest.ts
+++ b/packages/cli/src/bundle-sdk/manifest.ts
@@ -1,12 +1,25 @@
 import fs, { promises as fsp } from 'node:fs'
 import path from 'node:path'
+import type { Logger } from '../logger.js'
 
-/**
- * Extracts the packed string from a bare-pack bundle without executing it.
- * Bundle format: `module.exports = "<packed string>";`
- * @param {string} bundleJsText
- */
-export function extractPackedString (bundleJsText) {
+interface BarePackHeader {
+  id?: string
+  resolutions?: Record<string, unknown>
+}
+
+interface GenerateAddonsManifestOptions {
+  bundlePath: string
+  outputDir: string
+  projectRoot: string
+  logger: Logger
+}
+
+interface GenerateAddonsManifestResult {
+  manifestPath: string
+  addons: string[]
+}
+
+export function extractPackedString (bundleJsText: string): string {
   const idx = bundleJsText.indexOf('module.exports')
   if (idx === -1) {
     throw new Error("bundle does not contain 'module.exports'")
@@ -18,51 +31,32 @@ export function extractPackedString (bundleJsText) {
   }
 
   let i = eq + 1
-  while (i < bundleJsText.length && /\s/.test(bundleJsText[i])) i++
+  while (i < bundleJsText.length && /\s/.test(bundleJsText[i] ?? '')) i++
 
   const quote = bundleJsText[i]
   if (quote !== '"' && quote !== "'") {
     throw new Error('export value is not a string literal')
   }
-  i++ // past opening quote
+  i++
 
   let out = ''
   let esc = false
 
   for (; i < bundleJsText.length; i++) {
-    const ch = bundleJsText[i]
+    const ch = bundleJsText[i]!
 
     if (esc) {
       switch (ch) {
-        case 'n':
-          out += '\n'
-          break
-        case 'r':
-          out += '\r'
-          break
-        case 't':
-          out += '\t'
-          break
-        case 'b':
-          out += '\b'
-          break
-        case 'f':
-          out += '\f'
-          break
-        case 'v':
-          out += '\v'
-          break
-        case '\\':
-          out += '\\'
-          break
-        case '"':
-          out += '"'
-          break
-        case "'":
-          out += "'"
-          break
+        case 'n': out += '\n'; break
+        case 'r': out += '\r'; break
+        case 't': out += '\t'; break
+        case 'b': out += '\b'; break
+        case 'f': out += '\f'; break
+        case 'v': out += '\v'; break
+        case '\\': out += '\\'; break
+        case '"': out += '"'; break
+        case "'": out += "'"; break
         case 'x': {
-          // \xHH
           const hex = bundleJsText.slice(i + 1, i + 3)
           if (!/^[0-9a-fA-F]{2}$/.test(hex)) throw new Error('bad \\x escape')
           out += String.fromCharCode(parseInt(hex, 16))
@@ -70,7 +64,6 @@ export function extractPackedString (bundleJsText) {
           break
         }
         case 'u': {
-          // \uHHHH
           const hex = bundleJsText.slice(i + 1, i + 5)
           if (!/^[0-9a-fA-F]{4}$/.test(hex)) throw new Error('bad \\u escape')
           out += String.fromCharCode(parseInt(hex, 16))
@@ -78,7 +71,6 @@ export function extractPackedString (bundleJsText) {
           break
         }
         default:
-          // Keep unknown escapes as-is
           out += ch
       }
       esc = false
@@ -89,7 +81,7 @@ export function extractPackedString (bundleJsText) {
       esc = true
       continue
     }
-    if (ch === quote) break // end of string literal
+    if (ch === quote) break
 
     out += ch
   }
@@ -101,7 +93,7 @@ export function extractPackedString (bundleJsText) {
   return out
 }
 
-export function extractBarePackHeader (packed) {
+export function extractBarePackHeader (packed: string): BarePackHeader {
   const firstNL = packed.indexOf('\n')
   if (firstNL === -1) {
     throw new Error('packed string missing first newline separator')
@@ -132,7 +124,7 @@ export function extractBarePackHeader (packed) {
     else if (ch === '}') {
       depth--
       if (depth === 0) {
-        i++ // include closing brace
+        i++
         break
       }
     }
@@ -142,10 +134,10 @@ export function extractBarePackHeader (packed) {
     throw new Error('unbalanced braces while extracting header JSON')
   }
 
-  return JSON.parse(packed.slice(jsonStart, i))
+  return JSON.parse(packed.slice(jsonStart, i)) as BarePackHeader
 }
 
-export async function generateAddonsManifest (options) {
+export async function generateAddonsManifest (options: GenerateAddonsManifestOptions): Promise<GenerateAddonsManifestResult> {
   const { bundlePath, outputDir, projectRoot, logger } = options
 
   logger.info('\n📦 Generating addons manifest...')
@@ -155,19 +147,17 @@ export async function generateAddonsManifest (options) {
   const header = extractBarePackHeader(packed)
   const resolutions = header.resolutions ?? {}
 
-  // Extract package names from resolution keys
-  const packageNames = new Set()
+  const packageNames = new Set<string>()
   const nodeModulesRegex = /\/node_modules\/(@[^/]+\/[^/]+|[^/]+)\//
 
   for (const key of Object.keys(resolutions)) {
     const match = key.match(nodeModulesRegex)
-    if (match) {
+    if (match?.[1]) {
       packageNames.add(match[1])
     }
   }
 
-  // Check which packages have "addon": true
-  const addons = []
+  const addons: string[] = []
   for (const pkgName of packageNames) {
     const pkgJsonPath = path.join(
       projectRoot,
@@ -177,17 +167,16 @@ export async function generateAddonsManifest (options) {
     )
     try {
       if (fs.existsSync(pkgJsonPath)) {
-        const pkgJson = JSON.parse(await fsp.readFile(pkgJsonPath, 'utf8'))
+        const pkgJson = JSON.parse(await fsp.readFile(pkgJsonPath, 'utf8')) as { addon?: boolean }
         if (pkgJson.addon === true) {
           addons.push(pkgName)
         }
       }
     } catch (err) {
-      logger.warn(`   Could not read ${pkgName}/package.json: ${err.message}`)
+      logger.warn(`   Could not read ${pkgName}/package.json: ${(err as Error).message}`)
     }
   }
 
-  // Sort for deterministic output
   addons.sort()
 
   const bundleId =

--- a/packages/cli/src/bundle-sdk/plugins.ts
+++ b/packages/cli/src/bundle-sdk/plugins.ts
@@ -1,11 +1,12 @@
 import { BUILTIN_PLUGINS, BUILTIN_SUFFIXES } from './constants.js'
 import { InvalidPluginSpecifierError } from '../errors.js'
+import type { Logger } from '../logger.js'
 
-export function buildBuiltinSpecifier (sdkName, suffix) {
+export function buildBuiltinSpecifier (sdkName: string, suffix: string): string {
   return `${sdkName}/${suffix}/plugin`
 }
 
-export function parseBuiltinSpecifier (specifier, sdkName) {
+export function parseBuiltinSpecifier (specifier: string, sdkName: string): { suffix: string; exportName: string } | null {
   const prefix = `${sdkName}/`
   const pluginSuffix = '/plugin'
 
@@ -20,11 +21,10 @@ export function parseBuiltinSpecifier (specifier, sdkName) {
   return null
 }
 
-export function resolvePluginSpecifiers (config, sdkName, logger) {
-  let { plugins = [] } = config
+export function resolvePluginSpecifiers (config: { plugins?: string[] }, sdkName: string, logger: Logger): string[] {
+  let plugins = config.plugins ?? []
 
-  // Default to all built-in plugins if none specified
-  if (!plugins || plugins.length === 0) {
+  if (plugins.length === 0) {
     const allBuiltins = BUILTIN_SUFFIXES.map((suffix) =>
       buildBuiltinSpecifier(sdkName, suffix)
     )
@@ -35,9 +35,9 @@ export function resolvePluginSpecifiers (config, sdkName, logger) {
 
   const uniquePlugins = [...new Set(plugins)]
 
-  const resolved = []
-  const customPlugins = []
-  const errors = []
+  const resolved: string[] = []
+  const customPlugins: string[] = []
+  const errors: string[] = []
 
   for (const specifier of uniquePlugins) {
     const builtin = parseBuiltinSpecifier(specifier, sdkName)

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -12,7 +12,7 @@ export const CONFIG_CANDIDATES = [
   'qvac.config.ts'
 ]
 
-export function findConfigFile (projectRoot, explicitPath) {
+export function findConfigFile (projectRoot: string, explicitPath?: string): string | null {
   if (explicitPath) {
     const absPath = path.resolve(projectRoot, explicitPath)
     if (fs.existsSync(absPath)) return absPath
@@ -27,7 +27,7 @@ export function findConfigFile (projectRoot, explicitPath) {
   return null
 }
 
-export async function loadConfig (configPath) {
+export async function loadConfig (configPath: string): Promise<unknown> {
   if (!configPath) {
     throw new ConfigNotFoundError(null, CONFIG_CANDIDATES)
   }
@@ -37,20 +37,20 @@ export async function loadConfig (configPath) {
   try {
     if (ext === '.json') {
       const content = await fsp.readFile(configPath, 'utf8')
-      return JSON.parse(content)
+      return JSON.parse(content) as unknown
     }
 
     if (ext === '.js' || ext === '.mjs') {
       const fileUrl = `file://${configPath}`
-      const module = await import(fileUrl)
-      return module.default ?? module
+      const mod = await import(fileUrl) as { default?: unknown }
+      return mod.default ?? mod
     }
 
     if (ext === '.ts') {
       const tsxApiPath = require.resolve('tsx/esm/api')
-      const { tsImport } = await import(tsxApiPath)
-      const module = await tsImport(configPath, import.meta.url)
-      return module.default ?? module
+      const { tsImport } = await import(tsxApiPath) as { tsImport: (path: string, base: string) => Promise<{ default?: unknown }> }
+      const mod = await tsImport(configPath, import.meta.url)
+      return mod.default ?? mod
     }
 
     throw new Error(

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,9 +1,5 @@
-// ─────────────────────────────────────────────────────────────────────────────
-// Config Errors
-// ─────────────────────────────────────────────────────────────────────────────
-
 export class ConfigNotFoundError extends Error {
-  constructor (explicitPath, candidates = []) {
+  constructor (explicitPath: string | null, candidates: string[] = []) {
     const message = explicitPath
       ? `Config file not found: ${explicitPath}`
       : `No config file found. Create one of:\n${candidates.map((c) => `  - ${c}`).join('\n')}`
@@ -13,7 +9,8 @@ export class ConfigNotFoundError extends Error {
 }
 
 export class ConfigLoadError extends Error {
-  constructor (configPath, cause) {
+  override cause: unknown
+  constructor (configPath: string, cause: unknown) {
     const causeMessage =
       cause instanceof Error ? cause.message : String(cause)
     super(`Failed to load config from ${configPath}: ${causeMessage}`)
@@ -22,21 +19,13 @@ export class ConfigLoadError extends Error {
   }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Plugin Errors
-// ─────────────────────────────────────────────────────────────────────────────
-
 export class InvalidPluginSpecifierError extends Error {
-  constructor (specifiers) {
+  constructor (specifiers: string[]) {
     const list = specifiers.map((s) => `  - ${s}`).join('\n')
     super(`Invalid plugin specifiers (must end with /plugin):\n${list}`)
     this.name = 'InvalidPluginSpecifierError'
   }
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Bundler Errors
-// ─────────────────────────────────────────────────────────────────────────────
 
 export class BarePackNotInstalledError extends Error {
   constructor () {
@@ -50,7 +39,9 @@ export class BarePackNotInstalledError extends Error {
 }
 
 export class BarePackError extends Error {
-  constructor (exitCode, entryPath, outputPath) {
+  entryPath: string
+  outputPath: string
+  constructor (exitCode: number, entryPath: string, outputPath: string) {
     super(
       `bare-pack exited with code ${exitCode}\n\n` +
       `  Entry file: ${entryPath}\n` +
@@ -64,7 +55,9 @@ export class BarePackError extends Error {
 }
 
 export class BareImportsMapNotFoundError extends Error {
-  constructor (sdkName, expectedPath) {
+  sdkName: string
+  expectedPath: string
+  constructor (sdkName: string, expectedPath: string) {
     super(
       'bare-imports.json not found.\n\n' +
       `  Expected at: ${expectedPath}\n\n` +
@@ -76,11 +69,7 @@ export class BareImportsMapNotFoundError extends Error {
   }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Error Handler (for CLI output)
-// ─────────────────────────────────────────────────────────────────────────────
-
-const ERROR_LABELS = {
+const ERROR_LABELS: Record<string, string> = {
   ConfigNotFoundError: 'Configuration Error',
   ConfigLoadError: 'Config Load Error',
   InvalidPluginSpecifierError: 'Plugin Error',
@@ -89,7 +78,7 @@ const ERROR_LABELS = {
   BareImportsMapNotFoundError: 'SDK Error'
 }
 
-export function handleError (error) {
+export function handleError (error: unknown): void {
   if (error instanceof Error) {
     const label = ERROR_LABELS[error.name]
     if (label) {
@@ -97,7 +86,7 @@ export function handleError (error) {
       console.error(`   ${error.message}\n`)
     } else {
       console.error('\n❌ Error:', error.message)
-      if (process.env.DEBUG) {
+      if (process.env['DEBUG']) {
         console.error(error.stack)
       }
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -57,6 +57,43 @@ function setupCli (): void {
       }
     })
 
+  program
+    .command('serve')
+    .description('Start an OpenAI-compatible REST API server backed by QVAC')
+    .option('-c, --config <path>', 'Config file path (default: auto-detect qvac.config.*)')
+    .option('-p, --port <number>', 'Port to listen on', '11434')
+    .option('-H, --host <address>', 'Host to bind to', '127.0.0.1')
+    .option('--model <alias>', 'Model alias to preload (repeatable, must be in config)', collect, [])
+    .option('--api-key <key>', 'Require Bearer token authentication')
+    .option('--cors', 'Enable CORS headers')
+    .option('-v, --verbose', 'Detailed output')
+    .action(async (options: {
+      config?: string
+      port: string
+      host: string
+      model: string[]
+      apiKey?: string
+      cors?: boolean
+      verbose?: boolean
+    }) => {
+      try {
+        const { startServer } = await import('./serve/index.js')
+        await startServer({
+          projectRoot: process.cwd(),
+          config: options.config,
+          port: parseInt(options.port, 10),
+          host: options.host,
+          model: options.model.length > 0 ? options.model : undefined,
+          apiKey: options.apiKey,
+          cors: options.cors,
+          verbose: options.verbose
+        })
+      } catch (error: unknown) {
+        handleError(error)
+        process.exit(1)
+      }
+    })
+
   program.parse()
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,17 +6,13 @@ import { bundleSdk } from './bundle-sdk/index.js'
 import { handleError } from './errors.js'
 
 const require = createRequire(import.meta.url)
-const pkg = require('../package.json')
+const pkg = require('../package.json') as { version: string }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// CLI Entry Point
-// ─────────────────────────────────────────────────────────────────────────────
-
-function collect (value, previous) {
+function collect (value: string, previous: string[]): string[] {
   return previous.concat([value])
 }
 
-function setupCli () {
+function setupCli (): void {
   const program = new Command()
 
   program
@@ -37,7 +33,14 @@ function setupCli () {
     .option('--defer <module>', 'Defer a module (repeatable)', collect, [])
     .option('-q, --quiet', 'Minimal output')
     .option('-v, --verbose', 'Detailed output')
-    .action(async (options) => {
+    .action(async (options: {
+      config?: string
+      sdkPath?: string
+      host: string[]
+      defer: string[]
+      quiet?: boolean
+      verbose?: boolean
+    }) => {
       try {
         await bundleSdk({
           projectRoot: process.cwd(),
@@ -48,7 +51,7 @@ function setupCli () {
           quiet: options.quiet,
           verbose: options.verbose
         })
-      } catch (error) {
+      } catch (error: unknown) {
         handleError(error)
         process.exit(1)
       }

--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -4,33 +4,42 @@ const LOG_LEVELS = {
   warn: 2,
   info: 3,
   debug: 4
+} as const
+
+type LogLevel = keyof typeof LOG_LEVELS
+
+export interface Logger {
+  error: (message: string) => void
+  warn: (message: string) => void
+  info: (message: string) => void
+  debug: (message: string) => void
 }
 
-export function createLogger (level = 'info') {
+export function createLogger (level: string = 'info'): Logger {
   if (!(level in LOG_LEVELS)) {
     const validLevels = Object.keys(LOG_LEVELS).join(', ')
     console.warn(`Invalid log level "${level}", falling back to "info". Valid levels: ${validLevels}`)
   }
 
-  const currentLevel = LOG_LEVELS[level] ?? LOG_LEVELS.info
+  const currentLevel = LOG_LEVELS[level as LogLevel] ?? LOG_LEVELS.info
 
   return {
-    error (message) {
+    error (message: string) {
       if (currentLevel >= LOG_LEVELS.error) {
         console.error(message)
       }
     },
-    warn (message) {
+    warn (message: string) {
       if (currentLevel >= LOG_LEVELS.warn) {
         console.warn(message)
       }
     },
-    info (message) {
+    info (message: string) {
       if (currentLevel >= LOG_LEVELS.info) {
         console.log(message)
       }
     },
-    debug (message) {
+    debug (message: string) {
       if (currentLevel >= LOG_LEVELS.debug) {
         console.debug(message)
       }

--- a/packages/cli/src/serve/adapters/openai/index.ts
+++ b/packages/cli/src/serve/adapters/openai/index.ts
@@ -1,0 +1,51 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { sendError } from '../../http.js'
+import type { APIAdapter, RouteContext } from '../types.js'
+
+export function createOpenAIAdapter (): APIAdapter {
+  return {
+    name: 'openai',
+    prefix: '/v1',
+
+    async route (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<boolean> {
+      const url = req.url ?? ''
+      const method = req.method ?? ''
+      const path = url.split('?')[0] ?? ''
+
+      if (!path.startsWith('/v1')) return false
+
+      if (method === 'GET' && path === '/v1/models') {
+        const { handleListModels } = await import('./routes/models.js')
+        handleListModels(req, res, ctx)
+        return true
+      }
+
+      if (method === 'GET' && path.startsWith('/v1/models/')) {
+        const { handleGetModel } = await import('./routes/models.js')
+        handleGetModel(req, res, ctx)
+        return true
+      }
+
+      if (method === 'DELETE' && path.startsWith('/v1/models/')) {
+        const { handleDeleteModel } = await import('./routes/models.js')
+        await handleDeleteModel(req, res, ctx)
+        return true
+      }
+
+      if (method === 'POST' && path === '/v1/chat/completions') {
+        const { handleChatCompletions } = await import('./routes/chat.js')
+        await handleChatCompletions(req, res, ctx)
+        return true
+      }
+
+      if (method === 'POST' && path === '/v1/embeddings') {
+        const { handleEmbeddings } = await import('./routes/embeddings.js')
+        await handleEmbeddings(req, res, ctx)
+        return true
+      }
+
+      sendError(res, 404, 'not_found', `Unknown endpoint: ${method} ${path}`)
+      return true
+    }
+  }
+}

--- a/packages/cli/src/serve/adapters/openai/routes/chat.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/chat.ts
@@ -1,0 +1,194 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readBody, sendJson, sendError, initSSE, sendSSE, endSSE } from '../../../http.js'
+import { resolveModelAlias } from '../../../config.js'
+import { sdkCompletion } from '../../../core/sdk.js'
+import type { SDKTool } from '../../../core/sdk.js'
+import {
+  openaiMessagesToHistory,
+  openaiToolsToSdk,
+  sdkToolCallsToOpenai,
+  logUnsupportedParams
+} from '../translate.js'
+import type { RouteContext } from '../../types.js'
+
+export async function handleChatCompletions (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<void> {
+  const body = await readBody(req)
+
+  if (!body['model']) {
+    sendError(res, 400, 'missing_model', '"model" is required.')
+    return
+  }
+
+  if (!body['messages'] || !Array.isArray(body['messages'])) {
+    sendError(res, 400, 'missing_messages', '"messages" must be an array.')
+    return
+  }
+
+  const modelName = body['model'] as string
+  const modelEntry = resolveModelAlias(ctx.serveConfig, modelName) ?? ctx.registry.getEntry(modelName)
+
+  if (!modelEntry) {
+    sendError(res, 404, 'model_not_found', `Model "${modelName}" is not available. Check serve.models config.`)
+    return
+  }
+
+  const endpointCategory = 'endpointCategory' in modelEntry ? modelEntry.endpointCategory : undefined
+  if (endpointCategory !== 'chat') {
+    sendError(res, 400, 'invalid_model_type', `Model "${modelName}" does not support chat completions.`)
+    return
+  }
+
+  const alias = 'alias' in modelEntry ? (modelEntry.alias as string) : modelEntry.id
+  const registryEntry = ctx.registry.getEntry(alias)
+  if (!registryEntry || registryEntry.state !== ctx.registry.STATES.READY) {
+    sendError(res, 503, 'model_not_ready', `Model "${modelName}" is not loaded yet.`)
+    return
+  }
+
+  logUnsupportedParams(body, ctx.logger)
+
+  const sdkModelId = registryEntry.sdkModelId ?? registryEntry.id
+  const history = openaiMessagesToHistory(body['messages'] as Array<{ role: string; content: string }>)
+  const tools = openaiToolsToSdk(body['tools'] as Array<{ type: string; function?: { name: string; description?: string; parameters?: Record<string, unknown> } }> | undefined)
+  const modelAlias = alias
+
+  try {
+    if (body['stream']) {
+      await handleStreamingCompletion(res, { sdkModelId, history, tools, modelAlias })
+    } else {
+      await handleBlockingCompletion(res, { sdkModelId, history, tools, modelAlias })
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.error(`Completion error for "${modelAlias}": ${message}`)
+    sendError(res, 500, 'completion_error', message)
+  }
+}
+
+interface CompletionParams {
+  sdkModelId: string
+  history: Array<{ role: string; content: string }>
+  tools?: SDKTool[] | undefined
+  modelAlias: string
+}
+
+async function handleBlockingCompletion (res: ServerResponse, params: CompletionParams): Promise<void> {
+  const result = await sdkCompletion({
+    modelId: params.sdkModelId,
+    history: params.history,
+    stream: false,
+    tools: params.tools
+  })
+
+  const text = await result.text
+  const toolCalls = await result.toolCalls
+
+  const hasToolCalls = toolCalls !== null && toolCalls !== undefined && toolCalls.length > 0
+  const finishReason = hasToolCalls ? 'tool_calls' : 'stop'
+
+  const message: Record<string, unknown> = { role: 'assistant', content: text || null }
+  if (hasToolCalls) {
+    message['tool_calls'] = sdkToolCallsToOpenai(toolCalls)
+  }
+
+  const completionTokens = text ? text.split(/\s+/).length : 0
+
+  sendJson(res, 200, {
+    id: `chatcmpl-${randomId()}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: params.modelAlias,
+    choices: [{
+      index: 0,
+      message,
+      finish_reason: finishReason
+    }],
+    usage: {
+      prompt_tokens: 0,
+      completion_tokens: completionTokens,
+      total_tokens: completionTokens
+    }
+  })
+}
+
+async function handleStreamingCompletion (res: ServerResponse, params: CompletionParams): Promise<void> {
+  const result = await sdkCompletion({
+    modelId: params.sdkModelId,
+    history: params.history,
+    stream: true,
+    tools: params.tools
+  })
+
+  initSSE(res)
+
+  const id = `chatcmpl-${randomId()}`
+  const created = Math.floor(Date.now() / 1000)
+
+  sendSSE(res, {
+    id,
+    object: 'chat.completion.chunk',
+    created,
+    model: params.modelAlias,
+    choices: [{
+      index: 0,
+      delta: { role: 'assistant', content: '' },
+      finish_reason: null
+    }]
+  })
+
+  let tokenCount = 0
+
+  for await (const token of result.tokenStream) {
+    tokenCount++
+    sendSSE(res, {
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: params.modelAlias,
+      choices: [{
+        index: 0,
+        delta: { content: token },
+        finish_reason: null
+      }]
+    })
+  }
+
+  const toolCalls = await result.toolCalls
+  if (toolCalls && toolCalls.length > 0) {
+    const openaiToolCalls = sdkToolCallsToOpenai(toolCalls)
+    sendSSE(res, {
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: params.modelAlias,
+      choices: [{
+        index: 0,
+        delta: { tool_calls: openaiToolCalls },
+        finish_reason: 'tool_calls'
+      }]
+    })
+  } else {
+    sendSSE(res, {
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: params.modelAlias,
+      choices: [{
+        index: 0,
+        delta: {},
+        finish_reason: 'stop'
+      }],
+      usage: {
+        prompt_tokens: 0,
+        completion_tokens: tokenCount,
+        total_tokens: tokenCount
+      }
+    })
+  }
+
+  endSSE(res)
+}
+
+function randomId (): string {
+  return Math.random().toString(36).slice(2, 12)
+}

--- a/packages/cli/src/serve/adapters/openai/routes/embeddings.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/embeddings.ts
@@ -1,0 +1,83 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readBody, sendJson, sendError } from '../../../http.js'
+import { resolveModelAlias } from '../../../config.js'
+import { sdkEmbed } from '../../../core/sdk.js'
+import type { RouteContext } from '../../types.js'
+
+export async function handleEmbeddings (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<void> {
+  const body = await readBody(req)
+
+  if (!body['model']) {
+    sendError(res, 400, 'missing_model', '"model" is required.')
+    return
+  }
+
+  if (!body['input']) {
+    sendError(res, 400, 'missing_input', '"input" is required.')
+    return
+  }
+
+  if (body['encoding_format'] && body['encoding_format'] !== 'float') {
+    ctx.logger.warn(`Ignoring unsupported encoding_format: ${body['encoding_format'] as string}`)
+  }
+
+  if (body['dimensions']) {
+    ctx.logger.warn(`Ignoring unsupported param: dimensions=${body['dimensions'] as string}`)
+  }
+
+  const modelName = body['model'] as string
+  const modelEntry = resolveModelAlias(ctx.serveConfig, modelName) ?? ctx.registry.getEntry(modelName)
+
+  if (!modelEntry) {
+    sendError(res, 404, 'model_not_found', `Model "${modelName}" is not available. Check serve.models config.`)
+    return
+  }
+
+  const endpointCategory = 'endpointCategory' in modelEntry ? modelEntry.endpointCategory : undefined
+  if (endpointCategory !== 'embedding') {
+    sendError(res, 400, 'invalid_model_type', `Model "${modelName}" does not support embeddings.`)
+    return
+  }
+
+  const alias = 'alias' in modelEntry ? (modelEntry.alias as string) : modelEntry.id
+  const registryEntry = ctx.registry.getEntry(alias)
+  if (!registryEntry || registryEntry.state !== ctx.registry.STATES.READY) {
+    sendError(res, 503, 'model_not_ready', `Model "${modelName}" is not loaded yet.`)
+    return
+  }
+
+  const sdkModelId = registryEntry.sdkModelId ?? registryEntry.id
+  const modelAlias = alias
+  const input = body['input']
+  const inputs = Array.isArray(input) ? input as string[] : [input as string]
+
+  try {
+    const embeddings = await sdkEmbed({
+      modelId: sdkModelId,
+      text: inputs.length === 1 ? inputs[0]! : inputs
+    })
+
+    const isBatch = Array.isArray(embeddings[0])
+    const vectors = isBatch ? embeddings as number[][] : [embeddings as number[]]
+
+    const data = vectors.map((vec, index) => ({
+      object: 'embedding',
+      index,
+      embedding: vec
+    }))
+
+    sendJson(res, 200, {
+      object: 'list',
+      data,
+      model: modelAlias,
+      usage: {
+        prompt_tokens: 0,
+        total_tokens: 0
+      }
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.error(`Embed error for "${modelAlias}": ${message}`)
+    sendError(res, 500, 'embed_error', message)
+  }
+}

--- a/packages/cli/src/serve/adapters/openai/routes/models.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/models.ts
@@ -1,0 +1,63 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { sendJson, sendError } from '../../../http.js'
+import type { ModelEntry } from '../../../core/model-registry.js'
+import type { RouteContext } from '../../types.js'
+
+export function handleListModels (_req: IncomingMessage, res: ServerResponse, ctx: RouteContext): void {
+  const entries = ctx.registry.getReady()
+
+  sendJson(res, 200, {
+    object: 'list',
+    data: entries.map(toModelObject)
+  })
+}
+
+export function handleGetModel (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): void {
+  const modelId = extractModelId(req.url ?? '')
+  const entry = ctx.registry.getEntry(modelId)
+
+  if (!entry || entry.state !== ctx.registry.STATES.READY) {
+    sendError(res, 404, 'model_not_found', `Model "${modelId}" not found or not loaded.`)
+    return
+  }
+
+  sendJson(res, 200, toModelObject(entry))
+}
+
+export async function handleDeleteModel (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<void> {
+  const modelId = extractModelId(req.url ?? '')
+  const entry = ctx.registry.getEntry(modelId)
+
+  if (!entry) {
+    sendError(res, 404, 'model_not_found', `Model "${modelId}" not found.`)
+    return
+  }
+
+  const { unloadModel } = await import('../../../core/lifecycle.js')
+  await unloadModel(modelId, ctx.registry, ctx.logger)
+
+  sendJson(res, 200, {
+    id: modelId,
+    object: 'model',
+    deleted: true
+  })
+}
+
+function extractModelId (url: string): string {
+  const path = url.split('?')[0] ?? ''
+  return decodeURIComponent(path.replace('/v1/models/', ''))
+}
+
+function toModelObject (entry: ModelEntry): {
+  id: string
+  object: string
+  created: number
+  owned_by: string
+} {
+  return {
+    id: entry.id,
+    object: 'model',
+    created: Math.floor(entry.createdAt / 1000),
+    owned_by: 'qvac'
+  }
+}

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -1,0 +1,80 @@
+import type { Logger } from '../../../logger.js'
+import type { SDKTool, SDKToolCall } from '../../core/sdk.js'
+
+interface OpenAIMessage {
+  role: string
+  content: string | null | undefined
+}
+
+interface OpenAITool {
+  type: string
+  function?: {
+    name: string
+    description?: string
+    parameters?: Record<string, unknown>
+  }
+}
+
+interface OpenAIToolCall {
+  id: string
+  type: string
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
+export function openaiMessagesToHistory (messages: OpenAIMessage[]): Array<{ role: string; content: string }> {
+  return messages.map((msg) => ({
+    role: msg.role,
+    content: typeof msg.content === 'string'
+      ? msg.content
+      : (msg.content ?? '').toString()
+  }))
+}
+
+export function openaiToolsToSdk (tools: OpenAITool[] | undefined): SDKTool[] | undefined {
+  if (!tools || tools.length === 0) return undefined
+
+  return tools
+    .map((t): SDKTool | null => {
+      if (t.type !== 'function' || !t.function) return null
+      const fn = t.function
+      return {
+        type: 'function',
+        name: fn.name,
+        description: fn.description ?? '',
+        parameters: fn.parameters ?? { type: 'object', properties: {} }
+      }
+    })
+    .filter((t): t is SDKTool => t !== null)
+}
+
+export function sdkToolCallsToOpenai (toolCalls: SDKToolCall[] | null | undefined): OpenAIToolCall[] | undefined {
+  if (!toolCalls || toolCalls.length === 0) return undefined
+
+  return toolCalls.map((tc) => ({
+    id: tc.id,
+    type: 'function',
+    function: {
+      name: tc.name,
+      arguments: typeof tc.arguments === 'string'
+        ? tc.arguments
+        : JSON.stringify(tc.arguments)
+    }
+  }))
+}
+
+const IGNORED_PARAMS = [
+  'temperature', 'max_tokens', 'top_p', 'n', 'logprobs',
+  'response_format', 'seed', 'frequency_penalty', 'presence_penalty',
+  'stop', 'max_completion_tokens'
+] as const
+
+export function logUnsupportedParams (body: Record<string, unknown>, logger: Logger): void {
+  for (const param of IGNORED_PARAMS) {
+    if (body[param] !== undefined) {
+      logger.warn(`Ignoring unsupported OpenAI param: ${param}=${JSON.stringify(body[param])}`)
+    }
+  }
+}

--- a/packages/cli/src/serve/adapters/types.ts
+++ b/packages/cli/src/serve/adapters/types.ts
@@ -1,0 +1,17 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { ModelRegistry, ServeConfig } from '../core/model-registry.js'
+import type { Logger } from '../../logger.js'
+
+export interface RouteContext {
+  registry: ModelRegistry
+  serveConfig: ServeConfig
+  logger: Logger
+}
+
+export type RouteHandler = (req: IncomingMessage, res: ServerResponse, ctx: RouteContext) => Promise<void> | void
+
+export interface APIAdapter {
+  name: string
+  prefix: string
+  route: (req: IncomingMessage, res: ServerResponse, ctx: RouteContext) => Promise<boolean>
+}

--- a/packages/cli/src/serve/config.ts
+++ b/packages/cli/src/serve/config.ts
@@ -1,0 +1,171 @@
+import { getSDK } from './core/sdk.js'
+import type { ServeConfig, ResolvedModelEntry } from './core/model-registry.js'
+
+const ENDPOINT_CATEGORY: Record<string, string> = {
+  llm: 'chat',
+  'llamacpp-completion': 'chat',
+  embeddings: 'embedding',
+  embedding: 'embedding',
+  'llamacpp-embedding': 'embedding',
+  whisper: 'transcription',
+  'whispercpp-transcription': 'transcription',
+  parakeet: 'transcription',
+  'parakeet-transcription': 'transcription',
+  nmt: 'translation',
+  'nmtcpp-translation': 'translation',
+  tts: 'speech',
+  'onnx-tts': 'speech',
+  ocr: 'ocr',
+  'onnx-ocr': 'ocr'
+}
+
+interface RawServeConfig {
+  serve?: {
+    models?: Record<string, string | ExplicitModelEntry>
+  }
+}
+
+interface ExplicitModelEntry {
+  src: string
+  type: string
+  default?: boolean
+  preload?: boolean
+  config?: Record<string, unknown>
+}
+
+interface CLIServeOptions {
+  model?: string | string[] | undefined
+}
+
+interface SDKModelConstant {
+  src: string
+  addon: string
+  name: string
+}
+
+export async function parseServeConfig (rawConfig: RawServeConfig, cliOptions: CLIServeOptions): Promise<ServeConfig> {
+  const serve = rawConfig.serve ?? {}
+  const rawModels = serve.models ?? {}
+
+  const models = new Map<string, ResolvedModelEntry>()
+  const registry = await loadModelConstants()
+
+  for (const [alias, entry] of Object.entries(rawModels)) {
+    const resolved = typeof entry === 'string'
+      ? resolveModelConstant(alias, entry, registry)
+      : parseExplicitEntry(alias, entry)
+
+    models.set(alias, resolved)
+  }
+
+  if (cliOptions.model) {
+    const cliModels = Array.isArray(cliOptions.model) ? cliOptions.model : [cliOptions.model]
+    for (const alias of cliModels) {
+      const entry = models.get(alias)
+      if (entry) {
+        entry.preload = true
+      }
+    }
+  }
+
+  return {
+    models,
+    defaults: resolveDefaults(models)
+  }
+}
+
+export function normalizeEndpointCategory (sdkType: string): string {
+  return ENDPOINT_CATEGORY[sdkType] ?? sdkType
+}
+
+function resolveModelConstant (alias: string, constantName: string, registry: Map<string, SDKModelConstant>): ResolvedModelEntry {
+  const model = registry.get(constantName)
+  if (!model) {
+    throw new Error(
+      `serve.models.${alias}: unknown model constant "${constantName}". ` +
+      'Use a valid SDK model name (e.g. QWEN3_600M_INST_Q4).'
+    )
+  }
+
+  return {
+    alias,
+    src: model.src,
+    sdkType: model.addon,
+    endpointCategory: normalizeEndpointCategory(model.addon),
+    isDefault: false,
+    preload: true,
+    config: {}
+  }
+}
+
+function parseExplicitEntry (alias: string, entry: ExplicitModelEntry): ResolvedModelEntry {
+  if (!entry.src) {
+    throw new Error(`serve.models.${alias}: "src" is required`)
+  }
+  if (!entry.type) {
+    throw new Error(`serve.models.${alias}: "type" is required`)
+  }
+
+  return {
+    alias,
+    src: entry.src,
+    sdkType: entry.type,
+    endpointCategory: normalizeEndpointCategory(entry.type),
+    isDefault: entry.default === true,
+    preload: entry.preload === true,
+    config: entry.config ?? {}
+  }
+}
+
+function resolveDefaults (models: Map<string, ResolvedModelEntry>): Map<string, string> {
+  const defaults = new Map<string, string>()
+
+  for (const [alias, entry] of models) {
+    if (entry.isDefault) {
+      defaults.set(entry.sdkType, alias)
+    }
+  }
+
+  return defaults
+}
+
+export function resolveModelAlias (serveConfig: ServeConfig, modelName: string | null | undefined): ResolvedModelEntry | null {
+  if (!modelName) return null
+
+  const entry = serveConfig.models.get(modelName)
+  if (entry) return entry
+
+  for (const [, e] of serveConfig.models) {
+    if (e.src === modelName) return e
+  }
+
+  return null
+}
+
+async function loadModelConstants (): Promise<Map<string, SDKModelConstant>> {
+  const map = new Map<string, SDKModelConstant>()
+
+  try {
+    const sdk = await getSDK()
+    for (const [key, value] of Object.entries(sdk)) {
+      if (isSDKModelConstant(value)) {
+        map.set(key, value)
+        map.set(value.name, value)
+      }
+    }
+  } catch {
+    // SDK not available — only explicit entries will work
+  }
+
+  return map
+}
+
+function isSDKModelConstant (value: unknown): value is SDKModelConstant {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    'src' in value &&
+    'addon' in value &&
+    'name' in value
+  )
+}

--- a/packages/cli/src/serve/config.ts
+++ b/packages/cli/src/serve/config.ts
@@ -21,8 +21,15 @@ const ENDPOINT_CATEGORY: Record<string, string> = {
 
 interface RawServeConfig {
   serve?: {
-    models?: Record<string, string | ExplicitModelEntry>
+    models?: Record<string, string | ConstantModelEntry | ExplicitModelEntry>
   }
+}
+
+interface ConstantModelEntry {
+  model: string
+  default?: boolean
+  preload?: boolean
+  config?: Record<string, unknown>
 }
 
 interface ExplicitModelEntry {
@@ -51,9 +58,14 @@ export async function parseServeConfig (rawConfig: RawServeConfig, cliOptions: C
   const registry = await loadModelConstants()
 
   for (const [alias, entry] of Object.entries(rawModels)) {
-    const resolved = typeof entry === 'string'
-      ? resolveModelConstant(alias, entry, registry)
-      : parseExplicitEntry(alias, entry)
+    let resolved: ResolvedModelEntry
+    if (typeof entry === 'string') {
+      resolved = resolveModelConstant(alias, entry, registry)
+    } else if (isConstantModelEntry(entry)) {
+      resolved = resolveModelConstant(alias, entry.model, registry, entry)
+    } else {
+      resolved = parseExplicitEntry(alias, entry as ExplicitModelEntry)
+    }
 
     models.set(alias, resolved)
   }
@@ -78,7 +90,16 @@ export function normalizeEndpointCategory (sdkType: string): string {
   return ENDPOINT_CATEGORY[sdkType] ?? sdkType
 }
 
-function resolveModelConstant (alias: string, constantName: string, registry: Map<string, SDKModelConstant>): ResolvedModelEntry {
+function isConstantModelEntry (entry: unknown): entry is ConstantModelEntry {
+  return (
+    entry !== null &&
+    typeof entry === 'object' &&
+    'model' in entry &&
+    typeof (entry as Record<string, unknown>)['model'] === 'string'
+  )
+}
+
+function resolveModelConstant (alias: string, constantName: string, registry: Map<string, SDKModelConstant>, overrides?: ConstantModelEntry): ResolvedModelEntry {
   const model = registry.get(constantName)
   if (!model) {
     throw new Error(
@@ -92,9 +113,9 @@ function resolveModelConstant (alias: string, constantName: string, registry: Ma
     src: model.src,
     sdkType: model.addon,
     endpointCategory: normalizeEndpointCategory(model.addon),
-    isDefault: false,
-    preload: true,
-    config: {}
+    isDefault: overrides?.default === true,
+    preload: overrides?.preload !== false,
+    config: overrides?.config ?? {}
   }
 }
 

--- a/packages/cli/src/serve/core/lifecycle.ts
+++ b/packages/cli/src/serve/core/lifecycle.ts
@@ -1,0 +1,88 @@
+import { sdkLoadModel, sdkUnloadModel, sdkClose } from './sdk.js'
+import type { ModelRegistry, ServeConfig } from './model-registry.js'
+import type { Logger } from '../../logger.js'
+
+export async function preloadModels (serveConfig: ServeConfig, registry: ModelRegistry, logger: Logger): Promise<void> {
+  const toPreload: string[] = []
+
+  for (const [alias, entry] of serveConfig.models) {
+    registry.register(alias, entry)
+    if (entry.preload) {
+      toPreload.push(alias)
+    }
+  }
+
+  if (toPreload.length === 0) {
+    logger.info('No models configured for preload.')
+    return
+  }
+
+  logger.info(`Preloading ${toPreload.length} model(s): ${toPreload.join(', ')}`)
+
+  for (const alias of toPreload) {
+    try {
+      await loadModel(alias, registry, logger)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`Failed to preload "${alias}": ${message}`)
+    }
+  }
+}
+
+export async function loadModel (alias: string, registry: ModelRegistry, logger: Logger): Promise<void> {
+  const entry = registry.getEntry(alias)
+  if (!entry) throw new Error(`Model "${alias}" not registered`)
+
+  if (entry.state === registry.STATES.READY) {
+    logger.debug(`Model "${alias}" already loaded.`)
+    return
+  }
+
+  if (entry.state === registry.STATES.LOADING) {
+    logger.debug(`Model "${alias}" is already loading, skipping.`)
+    return
+  }
+
+  logger.info(`Loading model "${alias}" from ${entry.src}...`)
+  registry.setLoading(alias)
+
+  try {
+    const sdkModelId = await sdkLoadModel({
+      src: entry.src,
+      type: entry.sdkType,
+      config: entry.config
+    })
+    registry.setReady(alias, sdkModelId)
+    logger.info(`Model "${alias}" loaded (SDK modelId: ${sdkModelId}).`)
+  } catch (err) {
+    registry.setError(alias, err)
+    throw err
+  }
+}
+
+export async function unloadModel (alias: string, registry: ModelRegistry, logger: Logger): Promise<void> {
+  const entry = registry.getEntry(alias)
+  if (!entry) throw new Error(`Model "${alias}" not found`)
+
+  if (entry.sdkModelId) {
+    try {
+      await sdkUnloadModel(entry.sdkModelId)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.warn(`SDK unload for "${alias}" failed: ${message}`)
+    }
+  }
+
+  logger.info(`Unloaded model "${alias}".`)
+  registry.remove(alias)
+}
+
+export async function shutdownSDK (logger: Logger): Promise<void> {
+  try {
+    await sdkClose()
+    logger.info('SDK connection closed.')
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    logger.warn(`SDK close error: ${message}`)
+  }
+}

--- a/packages/cli/src/serve/core/model-registry.ts
+++ b/packages/cli/src/serve/core/model-registry.ts
@@ -1,0 +1,141 @@
+const STATES = {
+  IDLE: 'idle',
+  LOADING: 'loading',
+  READY: 'ready',
+  UNLOADING: 'unloading',
+  ERROR: 'error'
+} as const
+
+export type ModelState = typeof STATES[keyof typeof STATES]
+
+export interface ModelEntry {
+  id: string
+  src: string
+  sdkType: string
+  endpointCategory: string
+  config: Record<string, unknown>
+  state: ModelState
+  createdAt: number
+  error: string | null
+  sdkModelId: string | null
+}
+
+export interface ServeConfig {
+  models: Map<string, ResolvedModelEntry>
+  defaults: Map<string, string>
+}
+
+export interface ResolvedModelEntry {
+  alias: string
+  src: string
+  sdkType: string
+  endpointCategory: string
+  isDefault: boolean
+  preload: boolean
+  config: Record<string, unknown>
+}
+
+export interface ModelRegistry {
+  STATES: typeof STATES
+  getEntry: (modelId: string) => ModelEntry | null
+  getAll: () => ModelEntry[]
+  getReady: () => ModelEntry[]
+  register: (alias: string, opts: {
+    src: string
+    sdkType: string
+    endpointCategory: string
+    config: Record<string, unknown>
+  }) => ModelEntry
+  setLoading: (modelId: string) => void
+  setReady: (modelId: string, sdkModelId?: string) => void
+  setError: (modelId: string, error: unknown) => void
+  remove: (modelId: string) => boolean
+  isAllowed: (modelId: string, serveConfig: ServeConfig) => boolean
+}
+
+export function createModelRegistry (): ModelRegistry {
+  const models = new Map<string, ModelEntry>()
+
+  function getEntry (modelId: string): ModelEntry | null {
+    return models.get(modelId) ?? null
+  }
+
+  function getAll (): ModelEntry[] {
+    return Array.from(models.values())
+  }
+
+  function getReady (): ModelEntry[] {
+    return getAll().filter((m) => m.state === STATES.READY)
+  }
+
+  function register (alias: string, opts: {
+    src: string
+    sdkType: string
+    endpointCategory: string
+    config: Record<string, unknown>
+  }): ModelEntry {
+    const existing = models.get(alias)
+    if (existing) return existing
+
+    const entry: ModelEntry = {
+      id: alias,
+      src: opts.src,
+      sdkType: opts.sdkType,
+      endpointCategory: opts.endpointCategory,
+      config: opts.config,
+      state: STATES.IDLE,
+      createdAt: Date.now(),
+      error: null,
+      sdkModelId: null
+    }
+    models.set(alias, entry)
+    return entry
+  }
+
+  function setLoading (modelId: string): void {
+    const entry = models.get(modelId)
+    if (entry) {
+      entry.state = STATES.LOADING
+      entry.error = null
+    }
+  }
+
+  function setReady (modelId: string, sdkModelId?: string): void {
+    const entry = models.get(modelId)
+    if (entry) {
+      entry.state = STATES.READY
+      entry.error = null
+      if (sdkModelId) entry.sdkModelId = sdkModelId
+    }
+  }
+
+  function setError (modelId: string, error: unknown): void {
+    const entry = models.get(modelId)
+    if (entry) {
+      entry.state = STATES.ERROR
+      entry.error = error instanceof Error ? error.message : String(error)
+    }
+  }
+
+  function remove (modelId: string): boolean {
+    return models.delete(modelId)
+  }
+
+  function isAllowed (modelId: string, serveConfig: ServeConfig): boolean {
+    if (serveConfig.models.size === 0) return true
+    return serveConfig.models.has(modelId)
+  }
+
+  return {
+    STATES,
+    getEntry,
+    getAll,
+    getReady,
+    register,
+    setLoading,
+    setReady,
+    setError,
+    remove,
+    isAllowed
+  }
+}

--- a/packages/cli/src/serve/core/sdk.ts
+++ b/packages/cli/src/serve/core/sdk.ts
@@ -1,0 +1,99 @@
+interface SDKModule {
+  loadModel: (opts: { modelSrc: string; modelType: string; modelConfig: Record<string, unknown> }) => Promise<string>
+  unloadModel: (opts: { modelId: string }) => Promise<void>
+  completion: (opts: {
+    modelId: string
+    history: Array<{ role: string; content: string }>
+    stream: boolean
+    tools?: SDKTool[]
+  }) => Promise<CompletionResult>
+  embed: (opts: { modelId: string; text: string | string[] }) => Promise<number[] | number[][]>
+  close: () => Promise<void>
+  [key: string]: unknown
+}
+
+export interface SDKTool {
+  type: string
+  name: string
+  description: string
+  parameters: Record<string, unknown>
+}
+
+export interface CompletionResult {
+  text: Promise<string>
+  stats: Promise<Record<string, unknown>>
+  toolCalls: Promise<SDKToolCall[] | null>
+  tokenStream: AsyncIterable<string>
+}
+
+export interface SDKToolCall {
+  id: string
+  name: string
+  arguments: string | Record<string, unknown>
+}
+
+let sdk: SDKModule | null = null
+
+export async function getSDK (): Promise<SDKModule> {
+  if (sdk) return sdk
+
+  try {
+    sdk = await import('@qvac/sdk') as unknown as SDKModule
+  } catch {
+    throw new Error(
+      '@qvac/sdk is required for "qvac serve". Install it: npm install @qvac/sdk'
+    )
+  }
+
+  return sdk
+}
+
+export async function sdkLoadModel (opts: {
+  src: string
+  type: string
+  config: Record<string, unknown>
+}): Promise<string> {
+  const { loadModel } = await getSDK()
+  const modelId = await loadModel({
+    modelSrc: opts.src,
+    modelType: opts.type,
+    modelConfig: opts.config
+  })
+  return modelId
+}
+
+export async function sdkUnloadModel (modelId: string): Promise<void> {
+  const { unloadModel } = await getSDK()
+  await unloadModel({ modelId })
+}
+
+export async function sdkCompletion (opts: {
+  modelId: string
+  history: Array<{ role: string; content: string }>
+  stream: boolean
+  tools?: SDKTool[] | undefined
+}): Promise<CompletionResult> {
+  const { completion } = await getSDK()
+  const params: Record<string, unknown> = {
+    modelId: opts.modelId,
+    history: opts.history,
+    stream: opts.stream
+  }
+  if (opts.tools) {
+    params['tools'] = opts.tools
+  }
+  return completion(params as Parameters<SDKModule['completion']>[0])
+}
+
+export async function sdkEmbed (opts: {
+  modelId: string
+  text: string | string[]
+}): Promise<number[] | number[][]> {
+  const { embed } = await getSDK()
+  return embed({ modelId: opts.modelId, text: opts.text })
+}
+
+export async function sdkClose (): Promise<void> {
+  const { close } = await getSDK()
+  await close()
+}

--- a/packages/cli/src/serve/http.ts
+++ b/packages/cli/src/serve/http.ts
@@ -1,0 +1,65 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+export function handleCors (req: IncomingMessage, res: ServerResponse): void {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204)
+    res.end()
+  }
+}
+
+export function readBody (req: IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => {
+      try {
+        const raw = Buffer.concat(chunks).toString('utf8')
+        resolve(raw ? JSON.parse(raw) as Record<string, unknown> : {})
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        reject(new Error(`Invalid JSON body: ${message}`))
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+export function sendJson (res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(payload)
+  })
+  res.end(payload)
+}
+
+export function sendError (res: ServerResponse, status: number, code: string, message: string): void {
+  sendJson(res, status, {
+    error: {
+      message,
+      type: status >= 500 ? 'server_error' : 'invalid_request_error',
+      code
+    }
+  })
+}
+
+export function initSSE (res: ServerResponse): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive'
+  })
+}
+
+export function sendSSE (res: ServerResponse, data: unknown): void {
+  res.write(`data: ${JSON.stringify(data)}\n\n`)
+}
+
+export function endSSE (res: ServerResponse): void {
+  res.write('data: [DONE]\n\n')
+  res.end()
+}

--- a/packages/cli/src/serve/http.ts
+++ b/packages/cli/src/serve/http.ts
@@ -29,6 +29,8 @@ export function readBody (req: IncomingMessage): Promise<Record<string, unknown>
 }
 
 export function sendJson (res: ServerResponse, status: number, body: unknown): void {
+  if (res.headersSent) return
+
   const payload = JSON.stringify(body)
   res.writeHead(status, {
     'Content-Type': 'application/json',
@@ -38,6 +40,12 @@ export function sendJson (res: ServerResponse, status: number, body: unknown): v
 }
 
 export function sendError (res: ServerResponse, status: number, code: string, message: string): void {
+  if (res.headersSent) {
+    sendSSE(res, { error: { message, type: 'server_error', code } })
+    endSSE(res)
+    return
+  }
+
   sendJson(res, status, {
     error: {
       message,

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -1,0 +1,94 @@
+import http from 'node:http'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { createLogger } from '../logger.js'
+import { findConfigFile, loadConfig } from '../config.js'
+import { parseServeConfig } from './config.js'
+import { createModelRegistry } from './core/model-registry.js'
+import { preloadModels, shutdownSDK } from './core/lifecycle.js'
+import { handleCors, sendError } from './http.js'
+import { createOpenAIAdapter } from './adapters/openai/index.js'
+import type { APIAdapter, RouteContext } from './adapters/types.js'
+
+export interface StartServerOptions {
+  projectRoot: string
+  config?: string | undefined
+  port: number
+  host: string
+  model?: string[] | undefined
+  apiKey?: string | undefined
+  cors?: boolean | undefined
+  verbose?: boolean | undefined
+}
+
+export async function startServer (options: StartServerOptions): Promise<http.Server> {
+  const logger = createLogger(options.verbose ? 'debug' : 'info')
+  const host = options.host ?? '127.0.0.1'
+  const port = options.port ?? 11434
+
+  const configPath = findConfigFile(options.projectRoot, options.config)
+  const rawConfig = configPath ? await loadConfig(configPath) as Record<string, unknown> : {}
+  const serveConfig = await parseServeConfig(rawConfig as Parameters<typeof parseServeConfig>[0], options)
+  const registry = createModelRegistry()
+
+  await preloadModels(serveConfig, registry, logger)
+
+  const adapters: APIAdapter[] = [
+    createOpenAIAdapter()
+  ]
+
+  const ctx: RouteContext = { registry, serveConfig, logger }
+
+  const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    if (options.cors) {
+      handleCors(req, res)
+      if (req.method === 'OPTIONS') return
+    }
+
+    if (options.apiKey) {
+      const auth = req.headers['authorization']
+      if (!auth || auth !== `Bearer ${options.apiKey}`) {
+        sendError(res, 401, 'invalid_api_key', 'Invalid or missing API key.')
+        return
+      }
+    }
+
+    try {
+      for (const adapter of adapters) {
+        const handled = await adapter.route(req, res, ctx)
+        if (handled) return
+      }
+
+      const method = req.method ?? ''
+      const path = (req.url ?? '').split('?')[0] ?? ''
+      sendError(res, 404, 'not_found', `Unknown endpoint: ${method} ${path}`)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`Unhandled error: ${message}`)
+      sendError(res, 500, 'internal_error', message)
+    }
+  })
+
+  const shutdown = (): void => {
+    logger.info('Shutting down...')
+    server.close(async () => {
+      await shutdownSDK(logger)
+      logger.info('Server stopped.')
+      process.exit(0)
+    })
+    setTimeout(() => process.exit(1), 10000)
+  }
+
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+
+  return new Promise((resolve, reject) => {
+    server.on('error', reject)
+    server.listen(port, host, () => {
+      const adapterNames = adapters.map((a) => a.name).join(', ')
+      logger.info(`QVAC API server listening on http://${host}:${port}`)
+      logger.info(`Adapters: ${adapterNames}`)
+      logger.info('Endpoints: POST /v1/chat/completions, POST /v1/embeddings, GET /v1/models')
+      resolve(server)
+    })
+  })
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+    "types": ["node"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a `qvac serve` command that exposes an OpenAI-compatible REST API backed by the QVAC SDK
- Builds on top of the CLI TypeScript migration (#722) with all serve modules written in TypeScript
- Uses an **adapter pattern** for future extensibility to other API formats (Anthropic, Gemini, etc.)

## Architecture

```
packages/cli/src/serve/
├── index.ts              # Server setup, adapter dispatch loop
├── config.ts             # Config parsing, model constants, endpoint normalization
├── http.ts               # Generic HTTP helpers (JSON, SSE, CORS, errors)
├── core/
│   ├── sdk.ts            # SDK wrapper (dynamic import, typed interface)
│   ├── model-registry.ts # In-memory model state registry
│   └── lifecycle.ts      # Model preloading, loading, unloading, shutdown
└── adapters/
    ├── types.ts           # APIAdapter interface (name, prefix, route)
    └── openai/
        ├── index.ts       # OpenAI adapter entry (routing)
        ├── translate.ts   # OpenAI <-> SDK format translation
        └── routes/
            ├── chat.ts        # POST /v1/chat/completions
            ├── embeddings.ts  # POST /v1/embeddings
            └── models.ts      # GET/DELETE /v1/models
```

Adding a new API adapter (e.g. Anthropic) requires:
1. Create `adapters/anthropic/` with routing + format translation
2. Register it in `serve/index.ts` alongside the OpenAI adapter

The core SDK operations (`core/`) are shared across all adapters.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/v1/models` | List loaded models |
| `GET` | `/v1/models/:id` | Get model details |
| `DELETE` | `/v1/models/:id` | Unload a model |
| `POST` | `/v1/chat/completions` | Chat completions (blocking + streaming) |
| `POST` | `/v1/embeddings` | Text embeddings (single + batch) |

## Features

- **Model configuration** via `qvac.config.json` using SDK model constants or explicit `src`/`type` entries
- **Endpoint category normalization** maps SDK addon types to API endpoint categories
- **OpenAI-to-SDK translation layer** for messages, tools, and tool calls
- **Optional CORS** and **Bearer token authentication**
- **Graceful shutdown** with SIGINT/SIGTERM handling

## Test plan

- [x] `bun run build` compiles without errors
- [x] `bun run typecheck` passes
- [x] `qvac serve --help` shows all options
- [x] Previously validated with live SDK: chat completions (blocking + streaming), embeddings, model listing, error handling
- [x] OpenAI API compliance verified with automated test script (44/44 passed)