### PR TITLE
Embedding add-on: Fix TS model config typing

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.11.3] - 2026-03-06
+
+### Fixed
+
+- The `GGMLConfig` type now exposes `embd_normalize` instead of `embed_normalize` in `index.d.ts`. This fixes a mismatch where TypeScript users could be guided toward an incorrect property name, reducing configuration mistakes and autocomplete friction.
+
 ## [0.11.2] - 2026-03-03
 
 ### Fixed

--- a/packages/qvac-lib-infer-llamacpp-embed/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-embed/index.d.ts
@@ -54,7 +54,7 @@ export interface GGMLConfig {
   batch_size?: NumericLike
   pooling?: 'none' | 'mean' | 'cls' | 'last' | 'rank'
   attention?: 'causal' | 'non-causal'
-  embed_normalize?: NumericLike
+  embd_normalize?: NumericLike
   flash_attn?: 'on' | 'off' | 'auto'
   'main-gpu'?: NumericLike | 'integrated' | 'dedicated'
   verbosity?: NumericLike

--- a/packages/qvac-lib-infer-llamacpp-embed/package.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `GGMLConfig` exposed `embed_normalize` in TypeScript types, but the actual expected option name is `embd_normalize`. This mismatch could mislead TypeScript users and cause add-on failure.

## 📝 How does it solve it?

- Updates `GGMLConfig` in `index.d.ts` to use `embd_normalize` instead of `embed_normalize`.

## 🧪 How was it tested?

- Ran quickstart examples with an additional `embd_normalize` param.

## 🔌 API Changes

No real API changes, just the typing change.