### PR TITLE
fix(ci): use matrix.os for diffusion integration test artifact names

### DIFF
--- a/.github/workflows/integration-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-test-lib-infer-diffusion.yml
@@ -258,7 +258,7 @@ jobs:
         shell: bash
         working-directory: ${{ env.WORKDIR }}
         run: |
-          echo "## Generated Images (${{ matrix.platform }}-${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
+          echo "## Generated Images (${{ matrix.os }}-${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if ls test/model/*.png 1>/dev/null 2>&1; then
             echo "| File | Test Source | Size |" >> $GITHUB_STEP_SUMMARY
@@ -269,8 +269,6 @@ jobs:
               size=$(du -h "$f" | cut -f1)
               echo "| \`$fname\` | \`${test_source}.test.js\` | $size |" >> $GITHUB_STEP_SUMMARY
             done
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "> Download the **sd-test-images-${{ matrix.platform }}-${{ matrix.arch }}** artifact to view images." >> $GITHUB_STEP_SUMMARY
           else
             echo "*No images were generated.*" >> $GITHUB_STEP_SUMMARY
           fi
@@ -279,7 +277,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: sd-test-images-${{ matrix.platform }}-${{ matrix.arch }}
+          name: sd-test-images-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ env.WORKDIR }}/test/model/*.png
           if-no-files-found: ignore
           retention-days: 30


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Multiple matrix entries in the diffusion integration test workflow share the same `platform-arch` combination (e.g. `ubuntu-22.04` and `ubuntu-24.04` both map to `linux-x64`), causing **409 artifact upload collisions**
- Step summary shows a non-actionable "Download the artifact" hint that isn't clickable

## 📝 How does it solve it?

- Use `matrix.os` instead of `matrix.platform` in artifact names and step summary headings, producing unique names (e.g. `sd-test-images-ubuntu-22.04-x64` vs `sd-test-images-ubuntu-24.04-x64`)
- Remove the non-actionable download hint text from step summary

## 🧪 How was it tested?

- Verified fix in workflow run [22743958305](https://github.com/tetherto/qvac/actions/runs/22743958305) — no more 409 collisions
- All 7 integration test matrix entries upload artifacts successfully

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213657916824671