### PR TITLE
LLM Benchmark: Bring back missing python dependency

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/benchmarks/client/requirements.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/benchmarks/client/requirements.txt
@@ -1,5 +1,6 @@
 torch>=2.0.0
 transformers>=4.30.0
+accelerate>=0.20.0
 datasets>=2.12.0
 numpy>=1.24.0
 huggingface_hub>=0.16.0


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A Python dependency (`accelerate`) was accidentally removed in some previous PR, which resulted in the LLM benchmark failing.

## 📝 How does it solve it?

- Adds back the removed dependency.

## 🧪 How was it tested?

- Ran the benchmark from a temp branch and made sure it completes successfully. Link to the run: https://github.com/tetherto/qvac/actions/runs/22740922523