### PR TITLE
QVAC-10742: BitNet backend selection logic for Adreno (CI test, enabled BitNet)

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,4 +1,44 @@
 # Changelog
+## [0.11.0] - 2026-03-05
+
+### Added
+
+#### BitNet-aware backend selection for Adreno GPUs
+
+Backend selection now detects BitNet models (TQ1_0 / TQ2_0 quantization via `hasOneBitQuantization()` and `general.architecture == "bitnet"`) and adjusts GPU routing on Adreno devices:
+
+- **Adreno 800+** (e.g. Adreno 830): Vulkan is preferred over OpenCL, since BitNet TQ kernels are not supported on OpenCL.
+- **Adreno < 800** (e.g. Adreno 740): Falls back to CPU, as TQ kernels run faster on CPU than on older Adreno GPU backends.
+- **Non-Adreno GPUs**: No change — normal GPU selection applies.
+
+This logic only activates when no explicit `main-gpu` is configured.
+
+Adreno version detection works regardless of which backend exposes the GPU. The numeric generation (e.g. 830, 740) is parsed from the device description via `parseAdrenoVersion()` and tracked as `maxAdrenoVersion` during device enumeration for any Adreno device — whether it appears behind OpenCL, Vulkan, or another backend. This ensures the BitNet safety checks (CPU fallback on Adreno <800, Vulkan preference on Adreno 800+) are not bypassed when only Vulkan registers a device, as observed on Adreno 750.
+
+#### BitNet-aware config tuning (`tuneConfigMap`)
+
+For BitNet models, `tuneConfigMap` injects default overrides into the config map before argument parsing:
+
+- `flash-attn=off` — disables flash attention (unless the user explicitly set `flash-attn` or `flash_attn`).
+- `ubatch-size=128` — on Adreno 800+ only (unless the user explicitly set `ubatch-size` or `ubatch_size`).
+
+These entries are written to `configFilemap` (not to `common_params` directly), so they flow through the normal llama.cpp arg parser in `commonParamsParse`. The call sits after backend selection (where the Adreno version is known) but before the config map is converted to the arg vector.
+
+#### `ModelMetaData::tryGetString()` method
+
+`ModelMetaData` now exposes `tryGetString(key)` to retrieve string-typed GGUF metadata values. This is used by the BitNet backend selection logic to read `general.architecture`. Both `tryGetString()` and `hasOneBitQuantization()` are now virtual to support test mocking.
+
+#### Unit tests for BitNet backend selection
+
+Added comprehensive unit tests covering BitNet TQ backend selection across Adreno 830/740, non-Adreno GPUs, OpenCL-only scenarios, Vulkan-only scenarios, and mixed GPU/iGPU configurations. `MockModelMetaData` is defined in `test_common.hpp` and shared across test files.
+
+### Changed
+
+- Updated qvac-fabric-llm.cpp dependency from 7248.1.3 to 7248.1.4.
+- Refactored `ModelMetaData` internal getters using a template helper, reducing duplication between `tryGetU32` and `tryGetString`.
+- Added virtual destructor to `ModelMetaData` for correct polymorphic cleanup.
+- Simplified `REQUIRE_MODEL` test macro by removing the `do {} while(false)` wrapper to suppress compiler warnings.
+
 ## [0.10.0] - 2026-03-02
 
 ### Added

--- a/packages/qvac-lib-infer-llamacpp-llm/README.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/README.md
@@ -34,9 +34,16 @@ This native C++ addon, built using the `Bare` Runtime, simplifies running Large 
 | Android | arm64 | 12+ | ✅ Tier 1 | Vulkan, OpenCL (Adreno 700+) |
 | Windows | x64 | 10+ | ✅ Tier 1 | Vulkan |
 
+
+**Note — BitNet models (TQ1_0 / TQ2_0 quantization):**
+BitNet models require special backend handling on Adreno GPUs. When a BitNet model is detected and no explicit `main-gpu` is set:
+- **Adreno 800+** (e.g. Adreno 830): Vulkan is used instead of OpenCL.
+- **Adreno < 800** (e.g. Adreno 740): Falls back to CPU, as TQ kernels are not yet optimized for older Adreno OpenCL/Vulkan.
+- **Non-Adreno GPUs**: Normal GPU selection applies (no special behavior).
+
 **Dependencies:**
 - qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework (single-job runner)
-- qvac-fabric-llm.cpp (≥7248.1.2): Inference engine
+- qvac-fabric-llm.cpp (≥7248.1.4): Inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
 - Linux requires Clang/LLVM 19 with libc++
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -75,6 +75,34 @@ void LlamaModel::resolveShardPaths(
   shards.tensors_file = (baseDir / shards.tensors_file).string();
 }
 
+void LlamaModel::tuneConfigMap(
+    std::unordered_map<std::string, std::string>& configFilemap,
+    const ModelMetaData& metadata, const std::optional<int>& adrenoVersion) {
+
+  const bool isBitnet =
+      metadata.hasOneBitQuantization() &&
+      metadata.tryGetString("general.architecture") == "bitnet";
+
+  if (isBitnet && configFilemap.find("flash-attn") == configFilemap.end() &&
+      configFilemap.find("flash_attn") == configFilemap.end()) {
+    configFilemap["flash-attn"] = "off";
+    QLOG_IF(
+        Priority::INFO,
+        "[LlamaModel] BitNet model detected: disabling flash attention\n");
+  }
+
+  constexpr int kAdrenoUbatchThreshold = 800;
+  if (isBitnet && adrenoVersion.has_value() &&
+      adrenoVersion.value() >= kAdrenoUbatchThreshold &&
+      configFilemap.find("ubatch-size") == configFilemap.end() &&
+      configFilemap.find("ubatch_size") == configFilemap.end()) {
+    configFilemap["ubatch-size"] = "128";
+    QLOG_IF(
+        Priority::INFO,
+        "[LlamaModel] BitNet on Adreno 800+: defaulting ubatch-size=128\n");
+  }
+}
+
 LlamaModel::LlamaModel(
     std::string&& modelPath, std::string&& projectionPath,
     std::unordered_map<std::string, std::string>&& configFilemap)
@@ -129,7 +157,8 @@ void LlamaModel::init(
   }
 
   common_params params;
-  commonParamsParse(modelPath, configFilemap, params);
+  std::optional<int> adrenoVersion;
+  commonParamsParse(modelPath, configFilemap, params, adrenoVersion);
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
   auto streamedFiles = asyncWeightsLoader_.extractIndividualStreamedFiles();
@@ -321,7 +350,7 @@ qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {
 void LlamaModel::commonParamsParse(
     const std::string& modelPath,
     std::unordered_map<std::string, std::string>& configFilemap,
-    common_params& params) {
+    common_params& params, std::optional<int>& outAdrenoVersion) {
 
   std::vector<std::string> configVector;
 
@@ -380,7 +409,11 @@ void LlamaModel::commonParamsParse(
     const std::optional<MainGpu> mainGpu = tryMainGpuFromMap(configFilemap);
 
     const std::pair<BackendType, std::string> chosenBackend = chooseBackend(
-        preferredBackend, LlamaModel::llamaLogCallback, mainGpu, &metadata_);
+        preferredBackend,
+        LlamaModel::llamaLogCallback,
+        mainGpu,
+        &metadata_,
+        &outAdrenoVersion);
 
     if (chosenBackend.first == BackendType::GPU) {
       params.mmproj_backend = chosenBackend.second;
@@ -402,6 +435,8 @@ void LlamaModel::commonParamsParse(
     configVector.emplace_back(chosenBackend.second);
     configFilemap.erase(deviceIt);
   }
+
+  tuneConfigMap(configFilemap, metadata_, outAdrenoVersion);
 
   // Handle both reverse-prompt variants
   for (const std::string& key : {"reverse-prompt", "reverse_prompt"}) {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -379,8 +379,8 @@ void LlamaModel::commonParamsParse(
 
     const std::optional<MainGpu> mainGpu = tryMainGpuFromMap(configFilemap);
 
-    const std::pair<BackendType, std::string> chosenBackend =
-        chooseBackend(preferredBackend, LlamaModel::llamaLogCallback, mainGpu);
+    const std::pair<BackendType, std::string> chosenBackend = chooseBackend(
+        preferredBackend, LlamaModel::llamaLogCallback, mainGpu, &metadata_);
 
     if (chosenBackend.first == BackendType::GPU) {
       params.mmproj_backend = chosenBackend.second;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -36,6 +36,17 @@ public:
   static void
   resolveShardPaths(GGUFShards& shards, const std::string& modelPath);
 
+  /// @brief Apply specific parameter defaults based on model metadata
+  /// and detected Adreno GPU version by inserting entries into configFilemap.
+  /// Must be called before commonParamsParse so inserted entries are processed.
+  ///
+  /// @param configFilemap The user-supplied config map (will be written to).
+  /// @param metadata Model metadata (architecture, quantization info).
+  /// @param adrenoVersion Detected Adreno GPU version, if any.
+  static void tuneConfigMap(
+      std::unordered_map<std::string, std::string>& configFilemap,
+      const ModelMetaData& metadata, const std::optional<int>& adrenoVersion);
+
   /**
    * The Constructor for llama model.
    * @param modelPath - path to the model file.
@@ -141,7 +152,7 @@ private:
   void commonParamsParse(
       const std::string& modelPath,
       std::unordered_map<std::string, std::string>& configFilemap,
-      common_params& params);
+      common_params& params, std::optional<int>& outAdrenoVersion);
 
   /**
    * The Format prompt method. It formats the prompt json to chat messages.

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.cpp
@@ -96,33 +96,39 @@ void ModelMetaData::checkInitialized() const {
   }
 }
 
-std::optional<uint32_t> ModelMetaData::tryGetU32(const char* key) const {
-  if (metadata_ == nullptr) {
+template <typename T, typename F>
+static std::optional<T>
+tryGet(const metadata_handle_ptr& metadata, const char* key, F&& getter) {
+  if (metadata == nullptr) {
     return std::nullopt;
   }
-  uint32_t value = 0;
-  MetaResultStatus status = llama_model_meta_get_u32(metadata_, key, &value);
+  T value{};
+  MetaResultStatus status = getter(metadata, key, &value);
   if (status != MetaResultStatus::SUCCESS) {
     return std::nullopt;
   }
   return value;
 }
 
+std::optional<uint32_t> ModelMetaData::tryGetU32(const char* key) const {
+  return tryGet<uint32_t>(metadata_, key, llama_model_meta_get_u32);
+}
+
+std::optional<std::string> ModelMetaData::tryGetString(const char* key) const {
+  return tryGet<std::string>(metadata_, key, llama_model_meta_get_str);
+}
+
 bool ModelMetaData::isU32OneOf(
     const char* key, std::initializer_list<uint32_t> values) const {
   checkInitialized();
-  uint32_t value = 0;
-  MetaResultStatus status = llama_model_meta_get_u32(metadata_, key, &value);
-  if (status != MetaResultStatus::SUCCESS) {
-    LOG_WRN(
-        "ModelMetaData::isU32OneOf: failed to read key '%s', "
-        "llama_model_meta_get_u32 returned %s\n",
-        key,
-        std::to_string(static_cast<int>(status)).c_str());
+  auto value = tryGetU32(key);
+  if (!value.has_value()) {
+    LOG_WRN("ModelMetaData::isU32OneOf: failed to read key '%s'\n", key);
     return false;
   }
-  return std::ranges::any_of(
-      values, [value](uint32_t queryValue) { return value == queryValue; });
+  return std::ranges::any_of(values, [v = value.value()](uint32_t queryValue) {
+    return v == queryValue;
+  });
 }
 
 bool ModelMetaData::hasOneBitQuantization() const {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
@@ -32,6 +32,7 @@ class ModelMetaData {
 
 public:
   ModelMetaData() = default;
+  virtual ~ModelMetaData() = default;
 
   /// @param modelPath Model to load (single .gguf)
   /// @param shards Containing sharded files, if any
@@ -51,9 +52,10 @@ public:
 
   /// @brief Returns the string value at @p key, or nullopt if
   /// absent/uninitialized or not a string type.
-  [[nodiscard]] std::optional<std::string> tryGetString(const char* key) const;
+  [[nodiscard]] virtual std::optional<std::string>
+  tryGetString(const char* key) const;
 
-  [[nodiscard]] bool hasOneBitQuantization() const;
+  [[nodiscard]] virtual bool hasOneBitQuantization() const;
 
   // Code below for streaming support
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/ModelMetadata.hpp
@@ -49,6 +49,10 @@ public:
   [[nodiscard]] bool
   isU32OneOf(const char* key, std::initializer_list<uint32_t> values) const;
 
+  /// @brief Returns the string value at @p key, or nullopt if
+  /// absent/uninitialized or not a string type.
+  [[nodiscard]] std::optional<std::string> tryGetString(const char* key) const;
+
   [[nodiscard]] bool hasOneBitQuantization() const;
 
   // Code below for streaming support

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.cpp
@@ -227,7 +227,8 @@ std::optional<MainGpu> backend_selection::tryMainGpuFromMap(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, const BackendInterface& bckI,
-    const ModelMetaData* metadata, const std::optional<MainGpu>& mainGpu) {
+    const ModelMetaData* metadata, const std::optional<MainGpu>& mainGpu,
+    std::optional<int>* outAdrenoVersion) {
 
   std::vector<std::string> gpuBackends;
   std::vector<std::string> igpuBackends;
@@ -303,6 +304,10 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     openClBackends.clear();
   }
 
+  if (outAdrenoVersion != nullptr) {
+    *outAdrenoVersion = maxAdrenoVersion;
+  }
+
   // Normally, check if Adreno GPU is present and force OpenCL backend,
   // otherwise let llama.cpp choose Vulkan GPU backend. There are some
   // exceptions such as BitNet models which do not currently support OpenCl,
@@ -329,7 +334,8 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata) {
+    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata,
+    std::optional<int>* outAdrenoVersion) {
   BackendInterface bckI{
       ggml_backend_dev_count,
       ggml_backend_dev_backend_reg,
@@ -340,5 +346,5 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
       ggml_backend_dev_type,
       llamaLogcallback};
   return backend_selection::chooseBackend(
-      preferredBackendType, bckI, metadata, mainGpu);
+      preferredBackendType, bckI, metadata, mainGpu, outAdrenoVersion);
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.cpp
@@ -3,16 +3,36 @@
 #include <algorithm>
 #include <cctype>
 #include <optional>
+#include <regex>
 #include <variant>
 #include <vector>
 
+#include <common/log.h>
 #include <ggml-backend.h>
 
 #include "common/common.h"
+#include "model-interface/ModelMetadata.hpp"
 
 using namespace backend_selection;
 
 namespace {
+std::optional<int> parseAdrenoVersion(const std::string& gpuDescription) {
+  static const std::regex adrenoRegex(R"(dreno.*?(\d+))");
+  std::smatch matches;
+  if (std::regex_search(gpuDescription, matches, adrenoRegex) &&
+      matches.size() > 1) {
+    try {
+      return std::stoi(matches[1].str());
+    } catch (const std::exception& e) {
+      LOG_WRN(
+          "parseAdrenoVersion: failed to parse version from '%s': %s\n",
+          gpuDescription.c_str(),
+          e.what());
+    }
+  }
+  return std::nullopt;
+}
+
 struct DeviceDescription {
   std::string gpuDescription;
   std::string gpuBackend;
@@ -62,7 +82,8 @@ struct DeviceDescription {
 void emplaceIfValidDevice(
     const BackendInterface& bckI, std::vector<std::string>& gpuBackends,
     std::vector<std::string>& igpuBackends,
-    std::vector<std::string>& openClBackends, const ggml_backend_reg_t reg,
+    std::vector<std::string>& openClBackends,
+    std::optional<int>& maxAdrenoVersion, const ggml_backend_reg_t reg,
     const DeviceDescription& devDescr,
     const enum ggml_backend_dev_type backendTypeEnum) {
   if (bckI.ggml_backend_reg_name(reg) != std::string("RPC")) {
@@ -77,7 +98,15 @@ void emplaceIfValidDevice(
     const bool isOpenCl =
         devDescr.gpuBackend.find("opencl") != std::string::npos;
     const bool isAdreno =
-        devDescr.gpuDescription.find("adreno") != std::string::npos;
+        devDescr.gpuDescription.find("dreno") != std::string::npos;
+    if (isAdreno) {
+      auto version = parseAdrenoVersion(devDescr.gpuDescription);
+      if (version.has_value() && (!maxAdrenoVersion.has_value() ||
+                                  version.value() > maxAdrenoVersion.value())) {
+        maxAdrenoVersion = version;
+      }
+    }
+
     if (isOpenCl && isAdreno) {
       logEmplaceGpuBackend(devDescr.gpuBackend);
       openClBackends.emplace_back(devDescr.gpuBackend);
@@ -114,7 +143,8 @@ void tryEmplaceDevice(
     std::optional<MainGpuType> mainGpuType,
     std::vector<std::string>& gpuBackends,
     std::vector<std::string>& igpuBackends,
-    std::vector<std::string>& openClBackends) {
+    std::vector<std::string>& openClBackends,
+    std::optional<int>& maxAdrenoVersion) {
   const ggml_backend_dev_t dev = bckI.ggml_backend_dev_get(deviceIndex);
   const ggml_backend_reg_t reg = bckI.ggml_backend_dev_backend_reg(dev);
   const enum ggml_backend_dev_type backendTypeEnum =
@@ -129,6 +159,7 @@ void tryEmplaceDevice(
         gpuBackends,
         igpuBackends,
         openClBackends,
+        maxAdrenoVersion,
         reg,
         devDescr,
         backendTypeEnum);
@@ -196,11 +227,12 @@ std::optional<MainGpu> backend_selection::tryMainGpuFromMap(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, const BackendInterface& bckI,
-    const std::optional<MainGpu>& mainGpu) {
+    const ModelMetaData* metadata, const std::optional<MainGpu>& mainGpu) {
 
   std::vector<std::string> gpuBackends;
   std::vector<std::string> igpuBackends;
   std::vector<std::string> openClBackends;
+  std::optional<int> maxAdrenoVersion;
 
   if (preferredBackendType == BackendType::GPU) {
     bool loopAllDevices = true;
@@ -208,7 +240,6 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     if (mainGpu.has_value()) {
       const MainGpu& mainGpuValue = mainGpu.value();
       if (std::holds_alternative<int>(mainGpuValue)) {
-        // Direct device index specified
         const int deviceIndex = std::get<int>(mainGpuValue);
         const size_t deviceCount = bckI.ggml_backend_dev_count();
         if (deviceIndex >= 0 &&
@@ -219,7 +250,8 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
               std::nullopt,
               gpuBackends,
               igpuBackends,
-              openClBackends);
+              openClBackends,
+              maxAdrenoVersion);
           loopAllDevices = false;
         } else {
           std::string errorMsg = string_format(
@@ -235,12 +267,46 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
     for (size_t i = 0; loopAllDevices && i < bckI.ggml_backend_dev_count();
          ++i) {
       ::tryEmplaceDevice(
-          bckI, i, gpuType, gpuBackends, igpuBackends, openClBackends);
+          bckI,
+          i,
+          gpuType,
+          gpuBackends,
+          igpuBackends,
+          openClBackends,
+          maxAdrenoVersion);
     }
   }
 
-  // check if Adreno GPU is present and force OpenCL backend, otherwise let
-  // llama.cpp choose Vulkan GPU backend
+  const bool isBitnetOneBitAdreno =
+      !mainGpu.has_value() && // No explicit selection
+      metadata != nullptr && metadata->hasOneBitQuantization() &&
+      metadata->tryGetString("general.architecture") == "bitnet" &&
+      maxAdrenoVersion.has_value();
+
+  constexpr int kAdrenoVulkanThreshold = 800;
+  if (isBitnetOneBitAdreno &&
+      maxAdrenoVersion.value() < kAdrenoVulkanThreshold) {
+    bckI.llamaLogCallback(
+        GGML_LOG_LEVEL_INFO,
+        "BitNet TQ on Adreno <800: only CPU supported",
+        nullptr);
+    openClBackends.clear();
+    gpuBackends.clear();
+    igpuBackends.clear();
+  } else if (
+      isBitnetOneBitAdreno &&
+      maxAdrenoVersion.value() >= kAdrenoVulkanThreshold) {
+    bckI.llamaLogCallback(
+        GGML_LOG_LEVEL_INFO,
+        "BitNet TQ on Adreno 800+: preferring Vulkan over OpenCL",
+        nullptr);
+    openClBackends.clear();
+  }
+
+  // Normally, check if Adreno GPU is present and force OpenCL backend,
+  // otherwise let llama.cpp choose Vulkan GPU backend. There are some
+  // exceptions such as BitNet models which do not currently support OpenCl,
+  // cl backends should have been cleared at this point for those cases.
   if (!openClBackends.empty()) {
     bckI.llamaLogCallback(GGML_LOG_LEVEL_INFO, "Chosen GPU OpenCL", nullptr);
     return {BackendType::GPU, openClBackends.front()};
@@ -263,7 +329,7 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
 
 std::pair<BackendType, std::string> backend_selection::chooseBackend(
     const BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu) {
+    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata) {
   BackendInterface bckI{
       ggml_backend_dev_count,
       ggml_backend_dev_backend_reg,
@@ -273,5 +339,6 @@ std::pair<BackendType, std::string> backend_selection::chooseBackend(
       ggml_backend_dev_name,
       ggml_backend_dev_type,
       llamaLogcallback};
-  return backend_selection::chooseBackend(preferredBackendType, bckI, mainGpu);
+  return backend_selection::chooseBackend(
+      preferredBackendType, bckI, metadata, mainGpu);
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.hpp
@@ -44,7 +44,8 @@ struct BackendInterface {
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, const BackendInterface& bckI,
     const ModelMetaData* metadata = nullptr,
-    const std::optional<MainGpu>& mainGpu = std::nullopt);
+    const std::optional<MainGpu>& mainGpu = std::nullopt,
+    std::optional<int>* outAdrenoVersion = nullptr);
 
 /// @brief Choose the backend to use for the model based on GPU device and
 /// available backends. Prefer OpenCL backend for Adreno GPUs, otherwise
@@ -54,5 +55,6 @@ std::pair<BackendType, std::string> chooseBackend(
 ///   - Adreno <800: prefer CPU (TQ kernels run faster on CPU)
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata);
+    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata,
+    std::optional<int>* outAdrenoVersion = nullptr);
 } // namespace backend_selection

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/BackendSelection.hpp
@@ -9,6 +9,8 @@
 #include <llama.h>
 #include <qvac-lib-inference-addon-cpp/Errors.hpp>
 
+class ModelMetaData;
+
 namespace backend_selection {
 
 enum BackendType : std::uint8_t { CPU, GPU };
@@ -41,12 +43,16 @@ struct BackendInterface {
 
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, const BackendInterface& bckI,
+    const ModelMetaData* metadata = nullptr,
     const std::optional<MainGpu>& mainGpu = std::nullopt);
 
 /// @brief Choose the backend to use for the model based on GPU device and
-/// available backends. Prefer OpenCL backend for Adreno GPUs, otherwise Vulkan
-/// backend. Uses CPU if no GPU backends are available.
+/// available backends. Prefer OpenCL backend for Adreno GPUs, otherwise
+/// Vulkan backend. Uses CPU if no GPU backends are available. For BitNet
+/// models with TQ1_0/TQ2_0 quantization on Adreno GPUs:
+///   - Adreno 800+: prefer Vulkan over OpenCL
+///   - Adreno <800: prefer CPU (TQ kernels run faster on CPU)
 std::pair<BackendType, std::string> chooseBackend(
     BackendType preferredBackendType, llamaLogCallbackF llamaLogcallback,
-    const std::optional<MainGpu>& mainGpu = std::nullopt);
+    const std::optional<MainGpu>& mainGpu, const ModelMetaData* metadata);
 } // namespace backend_selection

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/bitnet.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/bitnet.test.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const test = require('brittle')
+const FilesystemDL = require('@qvac/dl-filesystem')
+const LlmLlamacpp = require('../../index.js')
+const { ensureModel } = require('./utils')
+const { attachSpecLogger } = require('./spec-logger')
+const os = require('bare-os')
+
+const isAndroid = os.platform() === 'android'
+
+const BITNET_MODEL = {
+  name: 'bitnet_b1_58-large-TQ2_0.gguf',
+  url: 'https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0/resolve/main/bitnet_b1_58-large-TQ2_0.gguf'
+}
+
+const PROMPT = [
+  { role: 'user', content: 'What is 2 + 2?' }
+]
+
+async function collectResponse (response) {
+  const chunks = []
+  await response
+    .onUpdate(data => { chunks.push(data) })
+    .await()
+  return chunks.join('').trim()
+}
+
+test('bitnet model can run simple inference', { timeout: 600_000, skip: !isAndroid }, async t => {
+  const [modelName, dirPath] = await ensureModel({
+    modelName: BITNET_MODEL.name,
+    downloadUrl: BITNET_MODEL.url
+  })
+
+  const loader = new FilesystemDL({ dirPath })
+  const specLogger = attachSpecLogger({ forwardToConsole: true })
+
+  const config = {
+    gpu_layers: '999',
+    ctx_size: '1024',
+    device: 'gpu',
+    n_predict: '32',
+    verbosity: '2'
+  }
+
+  const addon = new LlmLlamacpp({
+    loader,
+    modelName,
+    diskPath: dirPath,
+    logger: console,
+    opts: { stats: true }
+  }, config)
+
+  try {
+    await addon.load()
+    const response = await addon.run(PROMPT)
+    const output = await collectResponse(response)
+
+    t.ok(output.length > 0, 'bitnet model should generate output')
+    t.comment(`BitNet output: "${output}"`)
+  } finally {
+    await addon.unload().catch(() => { })
+    await loader.close().catch(() => { })
+    specLogger.release()
+  }
+})

--- a/packages/qvac-lib-infer-llamacpp-llm/test/mobile/integration.auto.cjs
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/mobile/integration.auto.cjs
@@ -10,6 +10,10 @@ async function runApiBehaviorTest (options = {}) { // eslint-disable-line no-unu
   return runIntegrationModule('../integration/api-behavior.test.js', options)
 }
 
+async function runBitnetTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/bitnet.test.js', options)
+}
+
 async function runCacheStateMachineTest (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/cache-state-machine.test.js', options)
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
   test_text_llm_context.cpp
   test_addon_cpp.cpp
   test_backend_selection.cpp
+  test_tune_config_map.cpp
   # Placeholder tests (to be implemented)
   test_mtmd_llm_context.cpp
   test_llm_context_base.cpp

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_backend_selection.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_backend_selection.cpp
@@ -10,6 +10,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "model-interface/ModelMetadata.hpp"
 #include "utils/BackendSelection.hpp"
 
 using namespace backend_selection;
@@ -170,6 +171,7 @@ protected:
 
 // GPU Description
 constexpr const char* ADRENO_DESC = "Adreno (TM) 740";
+constexpr const char* ADRENO_830_DESC = "Adreno (TM) 830";
 constexpr const char* MALI_DESC = "Mali-G715";
 
 // GPU Backend
@@ -203,7 +205,36 @@ void expectChosen(
     const std::string& expectedBackendName,
     const std::optional<MainGpu>& mainGpu) {
   BackendInterface bckI = mockBackend.toBackendInterface();
-  auto result = chooseBackend(expectedBackend, bckI, mainGpu);
+  auto result = chooseBackend(expectedBackend, bckI, nullptr, mainGpu);
+  expectChosen(result, expectedBackend, expectedBackendName);
+}
+
+class MockModelMetaData : public ModelMetaData {
+public:
+  MockModelMetaData(bool oneBitQuant, std::string arch)
+      : oneBitQuant_(oneBitQuant), arch_(std::move(arch)) {}
+
+  [[nodiscard]] bool hasOneBitQuantization() const override {
+    return oneBitQuant_;
+  }
+  std::optional<std::string> tryGetString(const char* key) const override {
+    if (std::string(key) == "general.architecture")
+      return arch_;
+    return std::nullopt;
+  }
+
+private:
+  bool oneBitQuant_;
+  std::string arch_;
+};
+
+void expectChosenWithMetadata(
+    MockBackendInterface& mockBackend, BackendType preferredBackend,
+    BackendType expectedBackend, const std::string& expectedBackendName,
+    const ModelMetaData& metadata,
+    const std::optional<MainGpu>& mainGpu = std::nullopt) {
+  BackendInterface bckI = mockBackend.toBackendInterface();
+  auto result = chooseBackend(preferredBackend, bckI, &metadata, mainGpu);
   expectChosen(result, expectedBackend, expectedBackendName);
 }
 
@@ -451,4 +482,148 @@ TEST_F(BackendSelectionTest, ChooseBackendWithMainGpuIntegerIndexOne) {
 
   MainGpu mainGpu = 1;
   expectChosen(mockBackend, BackendType::GPU, "vulkan1", mainGpu);
+}
+
+// ---- BitNet TQ backend selection for Adreno GPUs ----
+
+// Adreno 830 (800+) with bitnet TQ: should prefer Vulkan over OpenCL
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno830_ChoosesVulkanOverOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", bitnetMeta);
+}
+
+// Adreno 740 (<800) with bitnet TQ: should fall back to CPU
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno740_ChoosesCPU) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::CPU, "none", bitnetMeta);
+}
+
+// Adreno 830 without bitnet: should still choose OpenCL (existing behavior)
+TEST_F(BackendSelectionTest, NoBitnet_Adreno830_ChoosesOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData nonBitnetMeta(false, "llama");
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      nonBitnetMeta);
+}
+
+// Adreno 740 without bitnet: should still choose OpenCL (existing behavior)
+TEST_F(BackendSelectionTest, NoBitnet_Adreno740_ChoosesOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_DESC, VULKAN0_BACK));
+  MockModelMetaData nonBitnetMeta(false, "llama");
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      nonBitnetMeta);
+}
+
+// Non-Adreno GPU with bitnet: normal GPU selection (no special behavior)
+TEST_F(BackendSelectionTest, BitnetTQ_Mali_ChoosesVulkanNormally) {
+  mockBackend.addDevice(createGPUDevice(MALI_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", bitnetMeta);
+}
+
+// Adreno 800+ with bitnet TQ, only OpenCL available (no Vulkan): falls to CPU
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno830_OnlyOpenCL_FallsToCPU) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::CPU, "none", bitnetMeta);
+}
+
+// Adreno 800+ with bitnet TQ, both Vulkan GPU and iGPU: prefers GPU Vulkan
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno830_VulkanGPUAndIGPU_ChoosesGPU) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN1_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", bitnetMeta);
+}
+
+// Adreno 740 (<800) with bitnet TQ, only Vulkan (no OpenCL device): should
+// fall back to CPU. maxAdrenoVersion must be populated from Vulkan device.
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno740_OnlyVulkan_ChoosesCPU) {
+  mockBackend.addDevice(createIGPUDevice(ADRENO_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::CPU, "none", bitnetMeta);
+}
+
+// Adreno 830 (800+) with bitnet TQ, only Vulkan (no OpenCL device): should
+// choose Vulkan. maxAdrenoVersion must be populated from Vulkan device.
+TEST_F(BackendSelectionTest, BitnetTQ_Adreno830_OnlyVulkan_ChoosesVulkan) {
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  expectChosenWithMetadata(
+      mockBackend, BackendType::GPU, BackendType::GPU, "vulkan0", bitnetMeta);
+}
+
+// ---- Explicit mainGpu bypasses bitnet Adreno logic ----
+
+// Adreno 830 + bitnet + explicit mainGpu index: should keep OpenCL (normal
+// Adreno path), NOT switch to Vulkan (bitnet special path).
+TEST_F(
+    BackendSelectionTest, BitnetTQ_Adreno830_ExplicitMainGpuIndex_KeepsOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  MainGpu mainGpu = 0;
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      bitnetMeta,
+      mainGpu);
+}
+
+// Adreno 740 (<800) + bitnet + explicit mainGpu index: should keep OpenCL,
+// NOT fall back to CPU (bitnet special path).
+TEST_F(
+    BackendSelectionTest, BitnetTQ_Adreno740_ExplicitMainGpuIndex_KeepsOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  MainGpu mainGpu = 0;
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      bitnetMeta,
+      mainGpu);
+}
+
+// Adreno 830 + bitnet + explicit mainGpu Integrated: should keep OpenCL,
+// NOT switch to Vulkan.
+TEST_F(
+    BackendSelectionTest,
+    BitnetTQ_Adreno830_ExplicitMainGpuIntegrated_KeepsOpenCL) {
+  mockBackend.addDevice(createGPUDevice(ADRENO_830_DESC, OPENCL_BACK));
+  mockBackend.addDevice(createIGPUDevice(ADRENO_830_DESC, VULKAN0_BACK));
+  MockModelMetaData bitnetMeta(true, "bitnet");
+  MainGpu mainGpu = MainGpuType::Integrated;
+  expectChosenWithMetadata(
+      mockBackend,
+      BackendType::GPU,
+      BackendType::GPU,
+      "gpuopencl",
+      bitnetMeta,
+      mainGpu);
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_backend_selection.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_backend_selection.cpp
@@ -10,10 +10,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "model-interface/ModelMetadata.hpp"
+#include "test_common.hpp"
 #include "utils/BackendSelection.hpp"
 
 using namespace backend_selection;
+using test_common::MockModelMetaData;
 
 // Mock types for ggml backend structures
 struct MockDevice {
@@ -208,25 +209,6 @@ void expectChosen(
   auto result = chooseBackend(expectedBackend, bckI, nullptr, mainGpu);
   expectChosen(result, expectedBackend, expectedBackendName);
 }
-
-class MockModelMetaData : public ModelMetaData {
-public:
-  MockModelMetaData(bool oneBitQuant, std::string arch)
-      : oneBitQuant_(oneBitQuant), arch_(std::move(arch)) {}
-
-  [[nodiscard]] bool hasOneBitQuantization() const override {
-    return oneBitQuant_;
-  }
-  std::optional<std::string> tryGetString(const char* key) const override {
-    if (std::string(key) == "general.architecture")
-      return arch_;
-    return std::nullopt;
-  }
-
-private:
-  bool oneBitQuant_;
-  std::string arch_;
-};
 
 void expectChosenWithMetadata(
     MockBackendInterface& mockBackend, BackendType preferredBackend,

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
@@ -4,10 +4,12 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include <gtest/gtest.h>
 
+#include "model-interface/ModelMetadata.hpp"
 #include "qvac-lib-inference-addon-cpp/GGUFShards.hpp"
 
 namespace test_common {
@@ -178,6 +180,25 @@ inline fs::path getTestBackendsDir() {
   return fs::current_path() / "build" / "test" / "unit";
 #endif
 }
+
+class MockModelMetaData : public ModelMetaData {
+public:
+  MockModelMetaData(bool oneBitQuant, std::string arch)
+      : oneBitQuant_(oneBitQuant), arch_(std::move(arch)) {}
+
+  [[nodiscard]] bool hasOneBitQuantization() const override {
+    return oneBitQuant_;
+  }
+  std::optional<std::string> tryGetString(const char* key) const override {
+    if (std::string(key) == "general.architecture")
+      return arch_;
+    return std::nullopt;
+  }
+
+private:
+  bool oneBitQuant_;
+  std::string arch_;
+};
 
 inline std::unique_ptr<std::basic_streambuf<char>>
 readFileToStreambufBinary(const std::string& path) {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_common.hpp
@@ -198,11 +198,9 @@ readFileToStreambufBinary(const std::string& path) {
  * so that GTEST_SKIP / FAIL return from the correct stack frame.
  */
 #define REQUIRE_MODEL(m)                                                       \
-  do {                                                                         \
-    if (!(m).found()) {                                                        \
-      if ((m).onMissing == ::test_common::TestModelPath::OnMissing::Skip)      \
-        GTEST_SKIP() << (m).missingMessage();                                  \
-      else                                                                     \
-        FAIL() << (m).missingMessage();                                        \
-    }                                                                          \
-  } while (false)
+  if (!(m).found()) {                                                          \
+    if ((m).onMissing == ::test_common::TestModelPath::OnMissing::Skip)        \
+      GTEST_SKIP() << (m).missingMessage();                                    \
+    FAIL() << (m).missingMessage();                                            \
+  }                                                                            \
+  static_assert(true, "")

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_model_metadata.cpp
@@ -319,6 +319,50 @@ TEST_F(
       });
 }
 
+// ---- tryGetString: architecture detection via "general.architecture" ----
+//
+// The "general.architecture" GGUF string key is "bitnet" for BitNet models
+// and a different value (e.g. "llama", "qwen3") for all others.
+
+TEST_F(ModelMetadataTest, DiskSingleFile_NormalModel_ArchitectureIsNotBitnet) {
+  REQUIRE_MODEL(normalModel_);
+  parseDiskSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    auto arch = meta.tryGetString("general.architecture");
+    ASSERT_TRUE(arch.has_value());
+    EXPECT_NE(arch.value(), "bitnet");
+  });
+}
+
+TEST_F(ModelMetadataTest, DiskSingleFile_BitnetModel_ArchitectureIsBitnet) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseDiskSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    auto arch = meta.tryGetString("general.architecture");
+    ASSERT_TRUE(arch.has_value());
+    EXPECT_EQ(arch.value(), "bitnet");
+  });
+}
+
+TEST_F(
+    ModelMetadataTest,
+    StreamingSingleFile_NormalModel_ArchitectureIsNotBitnet) {
+  REQUIRE_MODEL(normalModel_);
+  parseStreamingSingleFile(normalModel_.path, [](const ModelMetaData& meta) {
+    auto arch = meta.tryGetString("general.architecture");
+    ASSERT_TRUE(arch.has_value());
+    EXPECT_NE(arch.value(), "bitnet");
+  });
+}
+
+TEST_F(
+    ModelMetadataTest, StreamingSingleFile_BitnetModel_ArchitectureIsBitnet) {
+  REQUIRE_MODEL(bitnetModel_);
+  parseStreamingSingleFile(bitnetModel_.path, [](const ModelMetaData& meta) {
+    auto arch = meta.tryGetString("general.architecture");
+    ASSERT_TRUE(arch.has_value());
+    EXPECT_EQ(arch.value(), "bitnet");
+  });
+}
+
 // ---- AsyncWeightsLoader: streaming single file ----
 //
 // setWeightsForFile is called during the download phase (before activate()),

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_tune_config_map.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_tune_config_map.cpp
@@ -1,0 +1,161 @@
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/LlamaModel.hpp"
+#include "test_common.hpp"
+
+using test_common::MockModelMetaData;
+
+class TuneConfigMapTest : public ::testing::Test {
+protected:
+  std::unordered_map<std::string, std::string> configFilemap_;
+};
+
+// ---- Non-BitNet: no modifications ----
+
+TEST_F(TuneConfigMapTest, NonBitnet_NoChanges) {
+  MockModelMetaData meta(false, "llama");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, std::nullopt);
+
+  EXPECT_EQ(configFilemap_.count("flash-attn"), 0);
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+TEST_F(TuneConfigMapTest, OneBitButNotBitnetArch_NoChanges) {
+  MockModelMetaData meta(true, "llama");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_.count("flash-attn"), 0);
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+TEST_F(TuneConfigMapTest, BitnetArchButNotOneBit_NoChanges) {
+  MockModelMetaData meta(false, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_.count("flash-attn"), 0);
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+// ---- BitNet without Adreno: flash-attn disabled, ubatch unchanged ----
+
+TEST_F(TuneConfigMapTest, Bitnet_NoAdreno_FlashAttnDisabled) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, std::nullopt);
+
+  ASSERT_EQ(configFilemap_.count("flash-attn"), 1);
+  EXPECT_EQ(configFilemap_["flash-attn"], "off");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_NoAdreno_UbatchUnchanged) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, std::nullopt);
+
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+// ---- BitNet with Adreno <800: flash-attn disabled, ubatch unchanged ----
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno740_FlashAttnDisabled) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 740);
+
+  ASSERT_EQ(configFilemap_.count("flash-attn"), 1);
+  EXPECT_EQ(configFilemap_["flash-attn"], "off");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno740_UbatchUnchanged) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 740);
+
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}
+
+// ---- BitNet with Adreno 800+: flash-attn disabled AND ubatch=128 ----
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno830_FlashAttnDisabled) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  ASSERT_EQ(configFilemap_.count("flash-attn"), 1);
+  EXPECT_EQ(configFilemap_["flash-attn"], "off");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno830_UbatchSetTo128) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  ASSERT_EQ(configFilemap_.count("ubatch-size"), 1);
+  EXPECT_EQ(configFilemap_["ubatch-size"], "128");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno800_UbatchSetTo128) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 800);
+
+  ASSERT_EQ(configFilemap_.count("ubatch-size"), 1);
+  EXPECT_EQ(configFilemap_["ubatch-size"], "128");
+}
+
+// ---- User overrides are respected ----
+
+TEST_F(TuneConfigMapTest, Bitnet_UserSetFlashAttnHyphen_Respected) {
+  MockModelMetaData meta(true, "bitnet");
+  configFilemap_["flash-attn"] = "on";
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_["flash-attn"], "on");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_UserSetFlashAttnUnderscore_Respected) {
+  MockModelMetaData meta(true, "bitnet");
+  configFilemap_["flash_attn"] = "on";
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_.count("flash-attn"), 0);
+  EXPECT_EQ(configFilemap_["flash_attn"], "on");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno830_UserSetUbatchHyphen_Respected) {
+  MockModelMetaData meta(true, "bitnet");
+  configFilemap_["ubatch-size"] = "256";
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_["ubatch-size"], "256");
+}
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno830_UserSetUbatchUnderscore_Respected) {
+  MockModelMetaData meta(true, "bitnet");
+  configFilemap_["ubatch_size"] = "64";
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 830);
+
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+  EXPECT_EQ(configFilemap_["ubatch_size"], "64");
+}
+
+// ---- Edge: Adreno 799 (just below threshold) ----
+
+TEST_F(TuneConfigMapTest, Bitnet_Adreno799_UbatchUnchanged) {
+  MockModelMetaData meta(true, "bitnet");
+
+  LlamaModel::tuneConfigMap(configFilemap_, meta, 799);
+
+  EXPECT_EQ(configFilemap_.count("ubatch-size"), 0);
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
@@ -7,7 +7,7 @@
     "picojson",
     {
       "name": "qvac-fabric",
-      "version>=": "7248.1.3"
+      "version>=": "7248.1.4"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
@@ -1,0 +1,36 @@
+# Function to detect Vulkan version from NDK vulkan_core.h
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    # CMAKE_HOST_SYSTEM_PROCESSOR is unavailable here. Use a glob pattern to complete the folder instead. 
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT vulkan_core_h)
+        message(FATAL "vulkan_core.h not found, using default version")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL "Could not extract VK_HEADER_VERSION from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+
+     # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL "Could not extract major.minor version from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+endfunction()

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/portfile.cmake
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,108 @@
+vcpkg_from_git(
+  OUT_SOURCE_PATH SOURCE_PATH
+  URL https://github.com/jesusmb1995/llama.cpp
+  REF 17f296f44793a09eb058e4dbf2a5d5ef19df340a
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+)
+
+if (VCPKG_TARGET_IS_ANDROID)
+  # NDK only comes with C headers.
+  # Make sure C++ header exists, it will be used by ggml tensor library.
+  # Need to determine installed vulkan version and download correct headers
+  include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+  detect_ndk_vulkan_version()
+  message(STATUS "Using Vulkan C++ wrappers from version: ${vulkan_version}")
+  file(DOWNLOAD
+    "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+    "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    TLS_VERIFY ON
+  )
+
+  file(ARCHIVE_EXTRACT
+    INPUT "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    DESTINATION "${SOURCE_PATH}"
+    PATTERNS "*.hpp"
+  )
+
+  file(RENAME
+    "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}"
+    "${SOURCE_PATH}/ggml/src/ggml-vulkan/vulkan_cpp_wrapper"
+  )
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID)
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_VULKAN_DISABLE_COOPMAT=ON
+    -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    -DGGML_OPENCL=ON)
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_OPENMP=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_MTMD=ON
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME llama)
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME ggml)
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (NOT DL_BACKENDS AND VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "qvac-fabric",
+  "version": "7248.1.4",
+  "description": "LLM inference in C/C++",
+  "homepage": "https://github.com/tetherto/qvac-fabric-llm.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    }
+  }
+}


### PR DESCRIPTION
Same PR as https://github.com/tetherto/qvac/pull/694

But enables BitNet tests at `packages/qvac-lib-infer-llamacpp-llm/test/integration/bitnet.test.js`. For which we need to use a Fabric branch with Collabora changes merged (https://github.com/tetherto/qvac-fabric-llm.cpp/pull/99)

The exact Llama.cpp branch is [https://github.com/jesusmb1995/llama.cpp/pull/new/feature-qvac-lib-inference-finetune-and-meta� ](https://github.com/tetherto/qvac-fabric-llm.cpp/compare/temp-7248...jesusmb1995:llama.cpp:feature-qvac-lib-inference-finetune-and-meta) (Collabora LoRa Finetuning PR + metadata changes from 7248.1.4)

CI did pass https://github.com/tetherto/qvac/actions/runs/22759022249/job/66028118789

Example log for S25:
```
...
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [Llama.cpp] Backend detected: description = cpu, backend = cpu, type = CPU
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [Llama.cpp] BitNet TQ on Adreno 800+: preferring Vulkan over OpenCL
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [Llama.cpp] Chosen iGPU Backend
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [LlamaModel] BitNet model detected: disabling flash attention
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [LlamaModel] BitNet on Adreno 800+: defaulting ubatch-size=128
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [Llama.cpp] ggml_backend_load_best: searching for blas in /system
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [LlamaModel] BitNet model detected: disabling flash attention
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [LlamaModel] BitNet on Adreno 800+: defaulting ubatch-size=128
...
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [WARNING]: [Llama.cpp] llama_context: n_ctx_seq (1024) < n_ctx_train (2048) -- the full capacity of the model will not be utilized
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [Llama.cpp] llama_context: Vulkan_Host  output buffer size =     0.12 MiB
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [Llama.cpp] llama_kv_cache:    Vulkan0 KV buffer size =   144.00 MiB
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [Llama.cpp] llama_kv_cache: size =  144.00 MiB (  1024 cells,  24 layers,  1/1 seqs), K (f16):   72.00 MiB, V (f16):   72.00 MiB
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [Llama.cpp] llama_context:    Vulkan0 compute buffer size =    54.83 MiB
03-06 06:24:33.270   541   588 I bare    : [2026-03-06T14:24:33.270Z] [C++ TEST] [INFO]: [Llama.cpp] llama_context: Vulkan_Host compute buffer size =     2.75 MiB
03-06 06:24:33.271   541   588 I bare    : [2026-03-06T14:24:33.271Z] [C++ TEST] [INFO]: [Llama.cpp] llama_context: graph nodes  = 966
03-06 06:24:33.271   541   588 I bare    : [2026-03-06T14:24:33.271Z] [C++ TEST] [INFO]: [Llama.cpp] llama_context: graph splits = 3
03-06 06:24:35.450   541   588 I bare    : Job OnlyOneJob completed. Stats: {"TTFT":1651.582,"TPS":61.73077665033373,"CacheTokens":0,"generatedTokens":32,"promptTokens":36}
03-06 06:24:35.450   541   588 I bare    :     ok 1 - bitnet model should generate output
03-06 06:24:35.450   541   588 I bare    :     # BitNet output: "What is 2 + 1?<|im_end|>
03-06 06:24:35.450   541   588 I bare    :
03-06 06:24:35.450   541   588 I bare    : The output should look like:
03-06 06:24:35.450   541   588 I bare    : [['2','2'], ['2"
03-06 06:24:35.487   541   588 I bare    : ok 5 - bitnet model can run simple inference # time = 26931.555042ms
03-06 06:24:35.487   541   588 I bare    : [TestRunner][2026-03-06T14:24:35.487Z] runBitnetTest -> end :: duration=26932ms
03-06 06:24:35.488   541   588 I bare    : [TestRunner][2026-03-06T14:24:35.488Z] runCacheStateMachineTest -> start
03-06 06:24:35.489   541   588 I bare    :
03-06 06:24:35.489   541   588 I bare    : # CacheTokens remain zero without session message
0
...
```

Example log Pixel 9:
```
...
03-06 15:11:00.364 26843 26891 I bare    : [2026-03-06T14:11:00.364Z] [C++ TEST] [INFO]: [Llama.cpp] Chosen iGPU Backend
03-06 15:11:00.364 26843 26891 I bare    : [2026-03-06T14:11:00.364Z] [C++ TEST] [INFO]: [LlamaModel] BitNet model detected: disabling flash attention
...
03-06 15:11:00.364 26843 26891 I bare    : [2026-03-06T14:11:00.364Z] [C++ TEST] [INFO]: [Llama.cpp] llama_kv_cache:    Vulkan0 KV buffer size =   144.00 MiB
03-06 15:11:00.364 26843 26891 I bare    : [2026-03-06T14:11:00.364Z] [C++ TEST] [INFO]: [Llama.cpp] llama_kv_cache: size =  144.00 MiB (  1024 cells,  24 layers,  1/1 seqs), K (f16):   72.00 MiB, V (f16):   72.00 MiB
03-06 15:11:00.365 26843 26891 I bare    : [2026-03-06T14:11:00.364Z] [C++ TEST] [INFO]: [Llama.cpp] llama_context:    Vulkan0 compute buffer size =   103.96 MiB
03-06 15:11:00.365 26843 26891 I bare    : [2026-03-06T14:11:00.365Z] [C++ TEST] [INFO]: [Llama.cpp] llama_context: Vulkan_Host compute buffer size =    11.01 MiB
03-06 15:11:00.365 26843 26891 I bare    : [2026-03-06T14:11:00.365Z] [C++ TEST] [INFO]: [Llama.cpp] llama_context: graph nodes  = 966
03-06 15:11:00.365 26843 26891 I bare    : [2026-03-06T14:11:00.365Z] [C++ TEST] [INFO]: [Llama.cpp] llama_context: graph splits = 3
03-06 15:11:05.514 26843 26891 I bare    : Job OnlyOneJob completed. Stats: {"TTFT":3311.39,"TPS":17.58958872243519,"CacheTokens":0,"generatedTokens":32,"promptTokens":36}
03-06 15:11:05.515 26843 26891 I bare    :     ok 1 - bitnet model should generate output
03-06 15:11:05.515 26843 26891 I bare    :     # BitNet output: "What is 3 + 2?<|im_end|>
03-06 15:11:05.515 26843 26891 I bare    : <|im_start|>microphone
03-06 15:11:05.515 26843 26891 I bare    : What is 4 +"
03-06 15:11:05.555 26843 26891 I bare    : ok 5 - bitnet model can run simple inference # time = 27896.99802ms
03-06 15:11:05.590 26843 26891 I bare    : [TestRunner][2026-03-06T14:11:05.590Z] runBitnetTest -> end :: duration=27934ms
```