### PR TITLE
Release qvac lib infer llamacpp embed 0.11.3

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/README.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/README.md
@@ -289,3 +289,4 @@ These tests validate the native implementation and help catch issues early in de
 This project is licensed under the Apache-2.0 [License](./LICENSE) – see the LICENSE file for details.
 
 _For questions or issues, please open an issue on the GitHub repository._
+


### PR DESCRIPTION
This PR is to release a new version of the embeddings add-on.