### PR TITLE
fix[notask]: support multiple pipe-separated tags and updated models section in validator

### DIFF
--- a/packages/sdk/test/mocks/pr-body-mod-valid-all.md
+++ b/packages/sdk/test/mocks/pr-body-mod-valid-all.md
@@ -1,0 +1,30 @@
+## 🎯 What problem does this PR solve?
+
+- Updates model registry with new, updated, and removed models
+
+## 📝 How does it solve it?
+
+- Re-synced model definitions from registry
+
+## 📦 Models
+
+### Added models
+
+```
+OCR_RECOGNIZER_PARSEQ
+OCR_DETECTOR_DB_RESNET50
+```
+
+### Updated models
+
+```
+WHISPER_BASE_Q8_0
+PARAKEET_DECODER_FP32
+```
+
+### Removed models
+
+```
+WHISPER_TINY_EN_Q5_K
+```
+

--- a/packages/sdk/test/mocks/pr-body-mod-valid-updated.md
+++ b/packages/sdk/test/mocks/pr-body-mod-valid-updated.md
@@ -1,0 +1,18 @@
+## 🎯 What problem does this PR solve?
+
+- Refreshes model metadata from registry
+
+## 📝 How does it solve it?
+
+- Re-synced model definitions
+
+## 📦 Models
+
+### Updated models
+
+```
+WHISPER_BASE_Q8_0
+WHISPER_TINY_Q8_0
+PARAKEET_DECODER_FP32
+```
+

--- a/packages/sdk/test/unit/validator-cli.test.ts
+++ b/packages/sdk/test/unit/validator-cli.test.ts
@@ -49,6 +49,14 @@ const validMessages = [
   { msg: "fix[bc]: change return type", desc: "fix with bc tag" },
   { msg: "feat[mod]: add new models", desc: "feat with mod tag" },
   { msg: "chore[skiplog]: internal cleanup", desc: "chore with skiplog tag" },
+  {
+    msg: "feat[mod|notask]: update models",
+    desc: "feat with multiple pipe-separated tags",
+  },
+  {
+    msg: "fix[api|skiplog]: internal api change",
+    desc: "fix with two tags",
+  },
 ];
 
 for (const { msg, desc } of validMessages) {
@@ -151,6 +159,16 @@ const validTitles = [
     title: "QVAC-123 chore[skiplog]: internal change",
     desc: "skiplog tag",
     body: "pr-body-simple.md",
+  },
+  {
+    title: "feat[mod|notask]: update SDK constant models",
+    desc: "multiple tags with pipe separator (notask + mod)",
+    body: "pr-body-mod-valid-added.md",
+  },
+  {
+    title: "QVAC-123 feat[api|skiplog]: internal api change",
+    desc: "multiple tags with ticket",
+    body: "pr-body-api-valid.md",
   },
 ];
 
@@ -273,6 +291,33 @@ test("PR [mod]: accepts both Added and Removed sections", (t) => {
   t.ok(result.output.includes("✅ Valid PR"));
 });
 
+test("PR [mod]: accepts only Updated models section", (t) => {
+  const body = loadMock("pr-body-mod-valid-updated.md");
+  const result = runValidator(
+    `--type=pr --title="QVAC-123 feat[mod]: refresh model metadata" --body=${escapeShellArg(body)}`,
+  );
+  t.is(result.exitCode, 0);
+  t.ok(result.output.includes("✅ Valid PR"));
+});
+
+test("PR [mod]: accepts Added, Updated, and Removed sections together", (t) => {
+  const body = loadMock("pr-body-mod-valid-all.md");
+  const result = runValidator(
+    `--type=pr --title="QVAC-123 feat[mod]: full model update" --body=${escapeShellArg(body)}`,
+  );
+  t.is(result.exitCode, 0);
+  t.ok(result.output.includes("✅ Valid PR"));
+});
+
+test("PR [mod|notask]: accepts multiple tags with models body", (t) => {
+  const body = loadMock("pr-body-mod-valid-all.md");
+  const result = runValidator(
+    `--type=pr --title="feat[mod|notask]: update SDK constant models" --body=${escapeShellArg(body)}`,
+  );
+  t.is(result.exitCode, 0);
+  t.ok(result.output.includes("✅ Valid PR"));
+});
+
 test("PR [mod]: rejects without Models section", (t) => {
   const body = loadMock("pr-body-mod-invalid-no-section.md");
   const result = runValidator(
@@ -383,4 +428,13 @@ test("parsed: PR with [notask] returns null ticket", (t) => {
   );
   t.is(result.exitCode, 0);
   t.ok(result.output.includes('"ticket": null'));
+});
+
+test("parsed: commit with multiple tags returns all tags", (t) => {
+  const result = runValidator(
+    `--type=commit --msg="feat[mod|notask]: update models"`,
+  );
+  t.is(result.exitCode, 0);
+  t.ok(result.output.includes('"mod"'));
+  t.ok(result.output.includes('"notask"'));
 });

--- a/scripts/sdk/validator.cjs
+++ b/scripts/sdk/validator.cjs
@@ -18,10 +18,12 @@ const ALLOWED_PREFIXES = ["feat", "fix", "doc", "test", "chore", "infra"];
  * Single source of truth for allowed tags
  * To add a new tag, just add it to this array - regex patterns are built automatically
  *
+ * Multiple tags are separated by | inside brackets, e.g. [mod|notask]
+ *
  * Special tags:
  * - [notask]: Allows PR title to omit the ticket number (e.g., "feat[notask]: quick fix")
  * - [skiplog]: PR will be skipped by changelog generator
- * - [mod]: Model changes - requires Models section with Added/Removed subsections
+ * - [mod]: Model changes - requires Models section with Added/Updated/Removed subsections
  */
 const ALLOWED_TAGS = ["bc", "api", "notask", "skiplog", "mod"];
 
@@ -67,17 +69,19 @@ function shouldSkipValidation(message) {
 function buildPatterns() {
   const prefixPattern = ALLOWED_PREFIXES.join("|");
 
-  const tagPattern = ALLOWED_TAGS.join("|");
+  // Matches pipe-separated tags inside brackets: [mod], [mod|notask], etc.
+  // The inner content is captured separately for parsing.
+  const bracketGroup = `(\\[([a-z]+(?:\\|[a-z]+)*)\\])`;
 
   return {
-    commit: new RegExp(`^(${prefixPattern})(\\[(${tagPattern})\\])?:\\s+(.+)`),
-    // PR with ticket: "TICKET prefix[tag]: subject"
+    commit: new RegExp(`^(${prefixPattern})${bracketGroup}?:\\s+(.+)`),
+    // PR with ticket: "TICKET prefix[tag|tag]: subject"
     pr: new RegExp(
-      `^([A-Z]+-\\d+)\\s+(${prefixPattern})(\\[(${tagPattern})\\])?:\\s+(.+)$`,
+      `^([A-Z]+-\\d+)\\s+(${prefixPattern})${bracketGroup}?:\\s+(.+)$`,
     ),
-    // PR without ticket (for [notask]): "prefix[tag]: subject"
+    // PR without ticket (for [notask]): "prefix[tag|tag]: subject"
     prNoTicket: new RegExp(
-      `^(${prefixPattern})(\\[(${tagPattern})\\])?:\\s+(.+)$`,
+      `^(${prefixPattern})${bracketGroup}?:\\s+(.+)$`,
     ),
     ticket: /^[A-Z]+-\d+$/,
   };
@@ -91,14 +95,14 @@ const TICKET_PATTERN = PATTERNS.ticket;
 
 /**
  * Parse tags from tag string
- * @param {string} tagString - Tag string like "[breaking,api]" or "[api]"
+ * @param {string} tagString - Tag string like "[api]" or "[mod|notask]"
  * @returns {string[]} Array of tags
  */
 function parseTags(tagString) {
   if (!tagString) return [];
   const cleaned = tagString.replace(/[\[\]]/g, "");
   return cleaned
-    .split(",")
+    .split("|")
     .map((t) => t.trim())
     .filter(Boolean);
 }
@@ -130,7 +134,7 @@ function hasBeforeAfterExamples(body) {
 }
 
 /**
- * Check if body contains valid Models section with Added and/or Removed subsections
+ * Check if body contains valid Models section with Added, Updated, and/or Removed subsections
  * At least one subsection with content must be present
  * @param {string} body - The PR body
  * @returns {{ valid: boolean, error?: string }}
@@ -149,17 +153,22 @@ function hasModelsSection(body) {
   const addedPattern = /###\s*Added\s*(?:models)?\s*\n[\s\S]*?```[\s\S]*?```/i;
   const hasAdded = addedPattern.test(body);
 
+  // Check for Updated models subsection with code block
+  const updatedPattern =
+    /###\s*Updated\s*(?:models)?\s*\n[\s\S]*?```[\s\S]*?```/i;
+  const hasUpdated = updatedPattern.test(body);
+
   // Check for Removed models subsection with code block
   const removedPattern =
     /###\s*Removed\s*(?:models)?\s*\n[\s\S]*?```[\s\S]*?```/i;
   const hasRemoved = removedPattern.test(body);
 
   // At least one subsection must be present
-  if (!hasAdded && !hasRemoved) {
+  if (!hasAdded && !hasUpdated && !hasRemoved) {
     return {
       valid: false,
       error:
-        "Must include at least one subsection (### Added models or ### Removed models) with a fenced code block",
+        "Must include at least one subsection (### Added models, ### Updated models, or ### Removed models) with a fenced code block",
     };
   }
 
@@ -191,9 +200,9 @@ function validateCommit(message) {
     return {
       valid: false,
       error:
-        `Invalid commit message format. Expected: prefix[tags]?: subject\n` +
+        `Invalid commit message format. Expected: prefix[tag|tag]?: subject\n` +
         `Allowed prefixes: ${ALLOWED_PREFIXES.join(", ")}\n` +
-        `Allowed tags: ${ALLOWED_TAGS.map((t) => `[${t}]`).join(", ")}\n` +
+        `Allowed tags: ${ALLOWED_TAGS.join(", ")}\n` +
         `Example: feat[api]: add new loadModel signature`,
     };
   }
@@ -206,7 +215,7 @@ function validateCommit(message) {
     if (!ALLOWED_TAGS.includes(tag)) {
       return {
         valid: false,
-        error: `Invalid tag: [${tag}]. Allowed tags: ${ALLOWED_TAGS.map((t) => `[${t}]`).join(", ")}`,
+        error: `Invalid tag: ${tag}. Allowed tags: ${ALLOWED_TAGS.join(", ")}`,
       };
     }
   }
@@ -268,9 +277,9 @@ function validatePR(title, body) {
         return {
           valid: false,
           error:
-            `Invalid PR title format. Expected: TICKET prefix[tags]: subject\n` +
+            `Invalid PR title format. Expected: TICKET prefix[tag|tag]: subject\n` +
             `Allowed prefixes: ${ALLOWED_PREFIXES.join(", ")}\n` +
-            `Allowed tags: ${ALLOWED_TAGS.map((t) => `[${t}]`).join(", ")}\n` +
+            `Allowed tags: ${ALLOWED_TAGS.join(", ")}\n` +
             `Example: QVAC-123 feat[api]: add new loadModel signature\n` +
             `Note: Use [notask] tag to omit the ticket number`,
         };
@@ -279,9 +288,9 @@ function validatePR(title, body) {
       return {
         valid: false,
         error:
-          `Invalid PR title format. Expected: TICKET prefix[tags]: subject\n` +
+          `Invalid PR title format. Expected: TICKET prefix[tag|tag]: subject\n` +
           `Allowed prefixes: ${ALLOWED_PREFIXES.join(", ")}\n` +
-          `Allowed tags: ${ALLOWED_TAGS.map((t) => `[${t}]`).join(", ")}\n` +
+          `Allowed tags: ${ALLOWED_TAGS.join(", ")}\n` +
           `Example: QVAC-123 feat[api]: add new loadModel signature\n` +
           `Note: Use [notask] tag to omit the ticket number`,
       };
@@ -295,7 +304,7 @@ function validatePR(title, body) {
     if (!ALLOWED_TAGS.includes(tag)) {
       return {
         valid: false,
-        error: `Invalid tag: [${tag}]. Allowed tags: ${ALLOWED_TAGS.map((t) => `[${t}]`).join(", ")}`,
+        error: `Invalid tag: ${tag}. Allowed tags: ${ALLOWED_TAGS.join(", ")}`,
       };
     }
   }
@@ -342,7 +351,7 @@ function validatePR(title, body) {
             `PRs with [mod] tag must include a Models section.\n` +
             `Required structure (at least one subsection required):\n` +
             `  ## 📦 Models\n` +
-            `  ### Added models\n` +
+            `  ### Added models | ### Updated models | ### Removed models\n` +
             `  \`\`\`\n` +
             `  MODEL_CONSTANT_NAME\n` +
             `  \`\`\`\n\n` +


### PR DESCRIPTION
## Summary
- Fix validator regex to support multiple pipe-separated tags in a single bracket group (e.g. `feat[mod|notask]: ...`)
- Previously only a single `[tag]` was allowed; now `[tag1|tag2|...]` works for commits and PRs
- Add `### Updated models` as a valid subsection for `[mod]` tag validation, alongside `### Added models` and `### Removed models`
- Update `parseTags()` to split on `|` instead of `,`
- Add test cases and mock files covering the new functionality


Made with [Cursor](https://cursor.com)