### PR TITLE
fix(diffusion): add real cancel/abort support to native generation

### DIFF
--- a/packages/lib-infer-diffusion/addon/src/handlers/SdCtxHandlers.hpp
+++ b/packages/lib-infer-diffusion/addon/src/handlers/SdCtxHandlers.hpp
@@ -104,7 +104,7 @@ struct SdCtxConfig {
   bool forceSDXLVaeConvScale = false; // force SDXL VAE conv scale (compat fix)
 
   // ── Internal ──────────────────────────────────────────────────────────────
-  bool freeParamsImmediately = true;
+  bool freeParamsImmediately = false;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/lib-infer-diffusion/addon/src/handlers/SdCtxHandlers.hpp
+++ b/packages/lib-infer-diffusion/addon/src/handlers/SdCtxHandlers.hpp
@@ -104,6 +104,10 @@ struct SdCtxConfig {
   bool forceSDXLVaeConvScale = false; // force SDXL VAE conv scale (compat fix)
 
   // ── Internal ──────────────────────────────────────────────────────────────
+  // Upstream defaults to true, which frees model weight buffers after each
+  // generate_image_internal() call. The addon reuses a single sd_ctx across
+  // multiple generations, so freeing params after the first run causes a
+  // use-after-free SIGSEGV on the second run (including cancel-then-rerun).
   bool freeParamsImmediately = false;
 };
 

--- a/packages/lib-infer-diffusion/addon/src/model-interface/SdModel.cpp
+++ b/packages/lib-infer-diffusion/addon/src/model-interface/SdModel.cpp
@@ -29,6 +29,10 @@ struct ProgressCtx {
 };
 
 thread_local ProgressCtx tl_progressCtx;
+// Thread-local model pointer for abort callback routing — same pattern as
+// tl_progressCtx for progress.  Avoids relying on the process-global
+// sd_abort_cb_data when multiple SdModel instances could coexist.
+thread_local const SdModel* tl_abortModel = nullptr;
 
 void sdProgressCallback(int step, int steps, float /*time*/, void* /*data*/) {
   if (!tl_progressCtx.job || !tl_progressCtx.job->progressCallback)
@@ -44,6 +48,14 @@ void sdProgressCallback(int step, int steps, float /*time*/, void* /*data*/) {
       << elapsed << "}";
 
   tl_progressCtx.job->progressCallback(oss.str());
+}
+
+// Abort callback — wired into sd_set_abort_callback() so that
+// generate_image() can be interrupted mid-denoising.
+// Reads from thread-local tl_abortModel (not the global sd_abort_cb_data)
+// to avoid concurrency issues when multiple SdModel instances coexist.
+bool sdAbortCallback(void* /*data*/) {
+  return tl_abortModel && tl_abortModel->isCancelRequested();
 }
 
 } // namespace
@@ -206,6 +218,21 @@ std::any SdModel::process(const std::any& input) {
   tl_progressCtx.job = &job;
   tl_progressCtx.startTime = std::chrono::steady_clock::now();
   sd_set_progress_callback(sdProgressCallback, nullptr);
+  tl_abortModel = this;
+  sd_set_abort_callback(sdAbortCallback, nullptr);
+
+  // Scope guard: clear process-global callbacks on any exit path (including
+  // early exceptions from parsing/validation before generate_image runs).
+  auto clearCallbacks = [&]() {
+    tl_progressCtx.job = nullptr;
+    tl_abortModel = nullptr;
+    sd_set_progress_callback(nullptr, nullptr);
+    sd_set_abort_callback(nullptr, nullptr);
+  };
+  struct CallbackGuard {
+    std::function<void()> fn;
+    ~CallbackGuard() { fn(); }
+  } guard{clearCallbacks};
 
   // ── Parse JSON params ─────────────────────────────────────────────────────
   picojson::value v;
@@ -294,19 +321,30 @@ std::any SdModel::process(const std::any& input) {
   if (initImg.data)
     free(initImg.data);
 
+  const bool wasCancelled = cancelRequested_.load();
+
+  // Always free native image buffers, whether cancelled or not.
   int outputCount = 0;
   if (results) {
     for (int i = 0; i < gen.batchCount; ++i) {
-      if (results[i].data && !cancelRequested_.load()) {
-        auto png = encodeToPng(results[i]);
-        if (!png.empty() && job.outputCallback) {
-          job.outputCallback(png);
-          ++outputCount;
+      if (results[i].data) {
+        if (!wasCancelled) {
+          auto png = encodeToPng(results[i]);
+          if (!png.empty() && job.outputCallback) {
+            job.outputCallback(png);
+            ++outputCount;
+          }
         }
         free(results[i].data);
       }
     }
     free(results);
+  }
+
+  // If cancelled, propagate as an exception so JobRunner emits
+  // queueException (error path), not queueResult + queueJobEnded.
+  if (wasCancelled) {
+    throw std::runtime_error("Job cancelled");
   }
 
   const auto t1 = std::chrono::steady_clock::now();
@@ -334,7 +372,10 @@ std::any SdModel::process(const std::any& input) {
           ? (static_cast<double>(totalPixels_) / 1e6 / totalTimeSec)
           : 0.0;
 
-  // ── Build stats ────────────────────────────────────────────────────────────
+  // ── Build stats for runtimeStats() ─────────────────────────────────────────
+  // Stats are stored and emitted via queueJobEnded() → runtimeStats().
+  // process() returns std::any{} (empty) so images delivered via
+  // outputCallback are not duplicated as a queueResult event.
   lastStats_.clear();
 
   lastStats_.emplace_back("generation_time", genMs);
@@ -359,10 +400,9 @@ std::any SdModel::process(const std::any& input) {
   lastStats_.emplace_back("seed", gen.seed);
   lastStats_.emplace_back("output_count", static_cast<int64_t>(outputCount));
 
-  tl_progressCtx.job = nullptr;
-  sd_set_progress_callback(nullptr, nullptr);
-
-  return lastStats_;
+  // Return empty — images are already delivered via outputCallback,
+  // and stats are emitted by queueJobEnded() → runtimeStats().
+  return std::any{};
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lib-infer-diffusion/addon/src/model-interface/SdModel.cpp
+++ b/packages/lib-infer-diffusion/addon/src/model-interface/SdModel.cpp
@@ -343,6 +343,11 @@ std::any SdModel::process(const std::any& input) {
 
   // If cancelled, propagate as an exception so JobRunner emits
   // queueException (error path), not queueResult + queueJobEnded.
+  //
+  // This intentionally differs from the LLM addon, which returns normally
+  // on cancel (partial text output is still useful).  Diffusion produces no
+  // partial images, so a "successful" completion with output_count=0 would
+  // be misleading — throwing gives the JS caller an explicit cancel signal.
   if (wasCancelled) {
     throw std::runtime_error("Job cancelled");
   }

--- a/packages/lib-infer-diffusion/addon/src/model-interface/SdModel.hpp
+++ b/packages/lib-infer-diffusion/addon/src/model-interface/SdModel.hpp
@@ -99,6 +99,11 @@ public:
 
   void cancel() const final;
 
+  /** True if cancel() has been called since the last job started. */
+  [[nodiscard]] bool isCancelRequested() const noexcept {
+    return cancelRequested_.load();
+  }
+
   [[nodiscard]] qvac_lib_inference_addon_cpp::RuntimeStats
   runtimeStats() const final;
 

--- a/packages/lib-infer-diffusion/test/unit/CMakeLists.txt
+++ b/packages/lib-infer-diffusion/test/unit/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(
   test_model_loading.cpp
   test_single_step_inference.cpp
   test_full_generation.cpp
+  test_cancel_context.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/utils/BackendSelection.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/utils/LoggingMacros.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/SdModel.cpp

--- a/packages/lib-infer-diffusion/test/unit/test_cancel_context.cpp
+++ b/packages/lib-infer-diffusion/test/unit/test_cancel_context.cpp
@@ -74,8 +74,8 @@ protected:
   }
 
   // Helper: build a short GenerationJob (quick completion)
-  static SdModel::GenerationJob makeShortJob(
-      std::vector<std::vector<uint8_t>>& images) {
+  static SdModel::GenerationJob
+  makeShortJob(std::vector<std::vector<uint8_t>>& images) {
     SdModel::GenerationJob job;
     job.paramsJson = R"({
       "prompt": "solid white",
@@ -99,13 +99,8 @@ std::unique_ptr<SdModel> SdCancelContextTest::model = nullptr;
 // ---------------------------------------------------------------------------
 TEST_F(SdCancelContextTest, CancelWhenIdleIsNoop) {
   EXPECT_NO_THROW(model->cancel());
-  EXPECT_FALSE(model->isCancelRequested())
-      << "cancelRequested_ should be false — process() resets it on entry, "
-         "and cancel-when-idle should not leave the flag permanently set";
-
-  // Calling cancel when idle sets the flag, but the next process() resets it.
-  // Verify this by running a short job afterwards.
-  model->cancel();
+  // cancel() sets the flag even when idle — it is only cleared on process()
+  // entry.  This is safe: the flag is reset before the next generation begins.
   EXPECT_TRUE(model->isCancelRequested());
 
   std::vector<std::vector<uint8_t>> images;
@@ -142,8 +137,7 @@ TEST_F(SdCancelContextTest, CancelDuringGenerationThrowsJobCancelled) {
   cancelThread.join();
 
   // No output images should have been emitted (buffers freed, not encoded)
-  EXPECT_EQ(images.size(), 0u)
-      << "Cancelled generation should not emit images";
+  EXPECT_EQ(images.size(), 0u) << "Cancelled generation should not emit images";
 }
 
 // ---------------------------------------------------------------------------
@@ -179,8 +173,7 @@ TEST_F(SdCancelContextTest, RunAfterCancelProducesValidOutput) {
 
   EXPECT_NO_THROW(model->process(std::any(shortJob)));
   ASSERT_EQ(images.size(), 1u) << "Rerun after cancel should produce 1 image";
-  EXPECT_TRUE(sd_test_helpers::isPng(images[0]))
-      << "Output must be valid PNG";
+  EXPECT_TRUE(sd_test_helpers::isPng(images[0])) << "Output must be valid PNG";
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lib-infer-diffusion/test/unit/test_cancel_context.cpp
+++ b/packages/lib-infer-diffusion/test/unit/test_cancel_context.cpp
@@ -1,0 +1,259 @@
+#include <any>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/SdModel.hpp"
+#include "test_common.hpp"
+
+using namespace qvac_lib_inference_addon_sd;
+
+// ---------------------------------------------------------------------------
+// Test fixture — loads the model once per suite (expensive)
+// ---------------------------------------------------------------------------
+class SdCancelContextTest : public ::testing::Test {
+protected:
+  static std::unique_ptr<SdModel> model;
+
+  static void SetUpTestSuite() {
+    const auto path = sd_test_helpers::getModelPath();
+    if (path.empty())
+      return;
+
+    SdCtxConfig config{};
+    config.modelPath = path;
+    config.prediction = V_PRED;
+    config.nThreads = sd_test_helpers::getTestThreads();
+    config.device = sd_test_helpers::getTestDevice();
+    // freeParamsImmediately defaults to false in our config — this is what
+    // we're testing: the model must survive multiple generations and
+    // cancel-then-rerun without segfaulting.
+
+    model = std::make_unique<SdModel>(std::move(config));
+    model->load();
+  }
+
+  static void TearDownTestSuite() {
+    if (model) {
+      model->unload();
+      model.reset();
+    }
+  }
+
+  void SetUp() override {
+    if (!model)
+      GTEST_SKIP() << "SD2.1 model not available — set SD_TEST_MODEL_PATH or "
+                      "download to test/model/";
+  }
+
+  // Helper: build a GenerationJob with many steps (gives time to cancel)
+  static SdModel::GenerationJob makeLongJob(
+      std::atomic<int>& progressSteps,
+      std::vector<std::vector<uint8_t>>& images) {
+    SdModel::GenerationJob job;
+    job.paramsJson = R"({
+      "prompt": "a red fox in snow",
+      "steps": 50,
+      "width": 256,
+      "height": 256,
+      "cfg_scale": 7.5,
+      "seed": 42
+    })";
+    job.progressCallback = [&](const std::string&) {
+      progressSteps.fetch_add(1);
+    };
+    job.outputCallback = [&](const std::vector<uint8_t>& png) {
+      images.push_back(png);
+    };
+    return job;
+  }
+
+  // Helper: build a short GenerationJob (quick completion)
+  static SdModel::GenerationJob makeShortJob(
+      std::vector<std::vector<uint8_t>>& images) {
+    SdModel::GenerationJob job;
+    job.paramsJson = R"({
+      "prompt": "solid white",
+      "steps": 2,
+      "width": 256,
+      "height": 256,
+      "cfg_scale": 7.5,
+      "seed": 1
+    })";
+    job.outputCallback = [&](const std::vector<uint8_t>& png) {
+      images.push_back(png);
+    };
+    return job;
+  }
+};
+
+std::unique_ptr<SdModel> SdCancelContextTest::model = nullptr;
+
+// ---------------------------------------------------------------------------
+// 1. Cancel on idle model is safe (no crash, no state corruption)
+// ---------------------------------------------------------------------------
+TEST_F(SdCancelContextTest, CancelWhenIdleIsNoop) {
+  EXPECT_NO_THROW(model->cancel());
+  EXPECT_FALSE(model->isCancelRequested())
+      << "cancelRequested_ should be false — process() resets it on entry, "
+         "and cancel-when-idle should not leave the flag permanently set";
+
+  // Calling cancel when idle sets the flag, but the next process() resets it.
+  // Verify this by running a short job afterwards.
+  model->cancel();
+  EXPECT_TRUE(model->isCancelRequested());
+
+  std::vector<std::vector<uint8_t>> images;
+  auto job = makeShortJob(images);
+  EXPECT_NO_THROW(model->process(std::any(job)));
+  EXPECT_EQ(images.size(), 1u) << "Short job should produce 1 image";
+}
+
+// ---------------------------------------------------------------------------
+// 2. Cancel during generation throws "Job cancelled" (cancel-as-error)
+// ---------------------------------------------------------------------------
+TEST_F(SdCancelContextTest, CancelDuringGenerationThrowsJobCancelled) {
+  std::atomic<int> progressSteps{0};
+  std::vector<std::vector<uint8_t>> images;
+  auto job = makeLongJob(progressSteps, images);
+
+  // Fire cancel from another thread after the first progress tick
+  std::thread cancelThread([&] {
+    while (progressSteps.load() < 1)
+      std::this_thread::sleep_for(std::chrono::milliseconds{5});
+    model->cancel();
+  });
+
+  try {
+    model->process(std::any(job));
+    FAIL() << "process() should have thrown on cancel";
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "Job cancelled");
+  } catch (...) {
+    cancelThread.join();
+    FAIL() << "Unexpected exception type";
+  }
+
+  cancelThread.join();
+
+  // No output images should have been emitted (buffers freed, not encoded)
+  EXPECT_EQ(images.size(), 0u)
+      << "Cancelled generation should not emit images";
+}
+
+// ---------------------------------------------------------------------------
+// 3. Model is reusable after cancel (freeParamsImmediately = false)
+//    This is the exact scenario that caused the SIGSEGV before the fix.
+// ---------------------------------------------------------------------------
+TEST_F(SdCancelContextTest, RunAfterCancelProducesValidOutput) {
+  // First: start and cancel a long job
+  std::atomic<int> progressSteps{0};
+  std::vector<std::vector<uint8_t>> cancelledImages;
+  auto longJob = makeLongJob(progressSteps, cancelledImages);
+
+  std::thread cancelThread([&] {
+    while (progressSteps.load() < 1)
+      std::this_thread::sleep_for(std::chrono::milliseconds{5});
+    model->cancel();
+  });
+
+  try {
+    model->process(std::any(longJob));
+  } catch (const std::runtime_error&) {
+    // expected — "Job cancelled"
+  }
+  cancelThread.join();
+
+  // Second: run a short job on the same model instance.
+  // Before the fix, this would segfault because:
+  //   1. freeParamsImmediately=true freed weight buffers after first run
+  //   2. compute buffer was freed on wrong model (diffusion_model vs
+  //      work_diffusion_model), corrupting sd_ctx state
+  std::vector<std::vector<uint8_t>> images;
+  auto shortJob = makeShortJob(images);
+
+  EXPECT_NO_THROW(model->process(std::any(shortJob)));
+  ASSERT_EQ(images.size(), 1u) << "Rerun after cancel should produce 1 image";
+  EXPECT_TRUE(sd_test_helpers::isPng(images[0]))
+      << "Output must be valid PNG";
+}
+
+// ---------------------------------------------------------------------------
+// 4. Multiple sequential generations work (model reuse without cancel)
+//    Verifies freeParamsImmediately=false doesn't break normal reuse.
+// ---------------------------------------------------------------------------
+TEST_F(SdCancelContextTest, MultipleSequentialGenerationsSucceed) {
+  for (int i = 0; i < 3; ++i) {
+    std::vector<std::vector<uint8_t>> images;
+    auto job = makeShortJob(images);
+
+    EXPECT_NO_THROW(model->process(std::any(job)))
+        << "Generation " << i << " should not throw";
+    ASSERT_EQ(images.size(), 1u)
+        << "Generation " << i << " should produce 1 image";
+    EXPECT_TRUE(sd_test_helpers::isPng(images[0]))
+        << "Generation " << i << " output must be valid PNG";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Cancel flag is reset at the start of each process() call
+// ---------------------------------------------------------------------------
+TEST_F(SdCancelContextTest, CancelFlagResetOnProcessEntry) {
+  // Set cancel flag manually
+  model->cancel();
+  ASSERT_TRUE(model->isCancelRequested());
+
+  // process() should reset it at entry, then run normally
+  std::vector<std::vector<uint8_t>> images;
+  auto job = makeShortJob(images);
+
+  // With only 2 steps and the flag reset at entry, this should complete
+  // normally — the abort callback only fires during denoising, and
+  // cancelRequested_ is false by then.
+  EXPECT_NO_THROW(model->process(std::any(job)));
+  EXPECT_EQ(images.size(), 1u) << "Should produce 1 image";
+}
+
+// ---------------------------------------------------------------------------
+// 6. process() on unloaded model throws (not crash/segfault)
+// ---------------------------------------------------------------------------
+TEST_F(SdCancelContextTest, ProcessOnUnloadedModelThrows) {
+  SdCtxConfig config{};
+  SdModel unloadedModel(std::move(config));
+
+  std::vector<std::vector<uint8_t>> images;
+  auto job = makeShortJob(images);
+
+  EXPECT_THROW(unloadedModel.process(std::any(job)), std::exception);
+}
+
+// ---------------------------------------------------------------------------
+// 7. Runtime stats are populated after successful generation
+// ---------------------------------------------------------------------------
+TEST_F(SdCancelContextTest, RuntimeStatsPopulatedAfterGeneration) {
+  std::vector<std::vector<uint8_t>> images;
+  auto job = makeShortJob(images);
+
+  model->process(std::any(job));
+
+  auto stats = model->runtimeStats();
+  EXPECT_FALSE(stats.empty()) << "Stats should be populated after generation";
+
+  // Check expected stat keys exist
+  bool hasGenerationTime = false;
+  bool hasOutputCount = false;
+  for (const auto& [key, value] : stats) {
+    if (key == "generation_time")
+      hasGenerationTime = true;
+    if (key == "output_count")
+      hasOutputCount = true;
+  }
+  EXPECT_TRUE(hasGenerationTime) << "Stats must include generation_time";
+  EXPECT_TRUE(hasOutputCount) << "Stats must include output_count";
+}

--- a/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/abort-callback.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/abort-callback.patch
@@ -1,0 +1,73 @@
+diff --git a/include/stable-diffusion.h b/include/stable-diffusion.h
+index 51b2b32..8da9adf 100644
+--- a/include/stable-diffusion.h
++++ b/include/stable-diffusion.h
+@@ -331,10 +331,12 @@ typedef struct sd_ctx_t sd_ctx_t;
+ 
+ typedef void (*sd_log_cb_t)(enum sd_log_level_t level, const char* text, void* data);
+ typedef void (*sd_progress_cb_t)(int step, int steps, float time, void* data);
++typedef bool (*sd_abort_cb_t)(void* data);
+ typedef void (*sd_preview_cb_t)(int step, int frame_count, sd_image_t* frames, bool is_noisy, void* data);
+ 
+ SD_API void sd_set_log_callback(sd_log_cb_t sd_log_cb, void* data);
+ SD_API void sd_set_progress_callback(sd_progress_cb_t cb, void* data);
++SD_API void sd_set_abort_callback(sd_abort_cb_t cb, void* data);
+ SD_API void sd_set_preview_callback(sd_preview_cb_t cb, enum preview_t mode, int interval, bool denoised, bool noisy, void* data);
+ SD_API int32_t sd_get_num_physical_cores();
+ SD_API const char* sd_get_system_info();
+diff --git a/src/stable-diffusion.cpp b/src/stable-diffusion.cpp
+index d769d45..d51f039 100644
+--- a/src/stable-diffusion.cpp
++++ b/src/stable-diffusion.cpp
+@@ -2193,6 +2193,9 @@ public:
+                 int showstep = std::abs(step);
+                 pretty_progress(showstep, (int)steps, (t1 - t0) / 1000000.f / showstep);
+                 // LOG_INFO("step %d sampling completed taking %.2fs", step, (t1 - t0) * 1.0f / 1000000);
++                if (sd_abort_requested()) {
++                    return (ggml_tensor*)nullptr;
++                }
+             }
+             return denoised;
+         };
+diff --git a/src/util.cpp b/src/util.cpp
+index a94cfd9..343815d 100644
+--- a/src/util.cpp
++++ b/src/util.cpp
+@@ -270,6 +270,9 @@ int32_t sd_get_num_physical_cores() {
+ static sd_progress_cb_t sd_progress_cb = nullptr;
+ void* sd_progress_cb_data              = nullptr;
+ 
++static sd_abort_cb_t sd_abort_cb = nullptr;
++static void* sd_abort_cb_data   = nullptr;
++
+ static sd_preview_cb_t sd_preview_cb = nullptr;
+ static void* sd_preview_cb_data      = nullptr;
+ preview_t sd_preview_mode            = PREVIEW_NONE;
+@@ -423,6 +426,15 @@ void sd_set_progress_callback(sd_progress_cb_t cb, void* data) {
+     sd_progress_cb      = cb;
+     sd_progress_cb_data = data;
+ }
++
++void sd_set_abort_callback(sd_abort_cb_t cb, void* data) {
++    sd_abort_cb      = cb;
++    sd_abort_cb_data = data;
++}
++
++bool sd_abort_requested() {
++    return sd_abort_cb && sd_abort_cb(sd_abort_cb_data);
++}
+ void sd_set_preview_callback(sd_preview_cb_t cb, preview_t mode, int interval, bool denoised, bool noisy, void* data) {
+     sd_preview_cb       = cb;
+     sd_preview_cb_data  = data;
+diff --git a/src/util.h b/src/util.h
+index 7dee7bf..254041e 100644
+--- a/src/util.h
++++ b/src/util.h
+@@ -69,6 +69,7 @@ protected:
+ std::string path_join(const std::string& p1, const std::string& p2);
+ std::vector<std::string> split_string(const std::string& str, char delimiter);
+ void pretty_progress(int step, int steps, float time);
++bool sd_abort_requested();
+ 
+ void log_printf(sd_log_level_t level, const char* file, int line, const char* format, ...);
+ 

--- a/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/fix-abort-cleanup.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/fix-abort-cleanup.patch
@@ -1,0 +1,24 @@
+diff --git a/src/stable-diffusion.cpp b/src/stable-diffusion.cpp
+index d769d45..db3f242 100644
+--- a/src/stable-diffusion.cpp
++++ b/src/stable-diffusion.cpp
+@@ -2203,7 +2203,7 @@ public:
+                 control_net->free_control_ctx();
+                 control_net->free_compute_buffer();
+             }
+-            diffusion_model->free_compute_buffer();
++            work_diffusion_model->free_compute_buffer();
+             return NULL;
+         }
+ 
+@@ -3796,6 +3796,10 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
+ 
+     size_t t2 = ggml_time_ms();
+ 
++    if (result_images == nullptr) {
++        ggml_free(work_ctx);
++    }
++
+     LOG_INFO("generate_image completed in %.2fs", (t2 - t0) * 1.0f / 1000);
+ 
+     return result_images;

--- a/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/fix-failure-path-cleanup.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/fix-failure-path-cleanup.patch
@@ -2,30 +2,30 @@ diff --git a/src/stable-diffusion.cpp b/src/stable-diffusion.cpp
 index d769d45..db3f242 100644
 --- a/src/stable-diffusion.cpp
 +++ b/src/stable-diffusion.cpp
-@@ -2203,7 +2203,7 @@ public:
+@@ -2203,7 +2203,11 @@ public:
                  control_net->free_control_ctx();
                  control_net->free_compute_buffer();
              }
 -            diffusion_model->free_compute_buffer();
 +            // Upstream bug: abort/failure path freed the wrong model's compute
 +            // buffer (diffusion_model instead of work_diffusion_model).  The
-+            // success path at line ~2218 frees work_diffusion_model — this must
++            // success path at line ~2218 frees work_diffusion_model -- this must
 +            // match, otherwise sd_ctx state is corrupted and reuse segfaults.
 +            work_diffusion_model->free_compute_buffer();
              return NULL;
          }
- 
-@@ -3796,6 +3796,10 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
- 
+
+@@ -3796,6 +3800,13 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
+
      size_t t2 = ggml_time_ms();
- 
+
 +    // When generate_image_internal() returns NULL (abort or failure),
-+    // work_ctx is never freed inside that function — it only frees on
++    // work_ctx is never freed inside that function -- it only frees on
 +    // the success path.  Free it here to avoid leaking the ggml context.
 +    if (result_images == nullptr) {
 +        ggml_free(work_ctx);
 +    }
 +
      LOG_INFO("generate_image completed in %.2fs", (t2 - t0) * 1.0f / 1000);
- 
+
      return result_images;

--- a/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/fix-failure-path-cleanup.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/fix-failure-path-cleanup.patch
@@ -7,6 +7,10 @@ index d769d45..db3f242 100644
                  control_net->free_compute_buffer();
              }
 -            diffusion_model->free_compute_buffer();
++            // Upstream bug: abort/failure path freed the wrong model's compute
++            // buffer (diffusion_model instead of work_diffusion_model).  The
++            // success path at line ~2218 frees work_diffusion_model — this must
++            // match, otherwise sd_ctx state is corrupted and reuse segfaults.
 +            work_diffusion_model->free_compute_buffer();
              return NULL;
          }
@@ -15,6 +19,9 @@ index d769d45..db3f242 100644
  
      size_t t2 = ggml_time_ms();
  
++    // When generate_image_internal() returns NULL (abort or failure),
++    // work_ctx is never freed inside that function — it only frees on
++    // the success path.  Free it here to avoid leaking the ggml context.
 +    if (result_images == nullptr) {
 +        ggml_free(work_ctx);
 +    }

--- a/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/portfile.cmake
+++ b/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/portfile.cmake
@@ -22,7 +22,7 @@ vcpkg_from_github(
     PATCHES
         sd-cpu-only.patch
         abort-callback.patch
-        fix-abort-cleanup.patch
+        fix-failure-path-cleanup.patch
 )
 
 # --- GPU feature flags ---

--- a/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/portfile.cmake
+++ b/packages/lib-infer-diffusion/vcpkg/ports/stable-diffusion-cpp/portfile.cmake
@@ -21,6 +21,8 @@ vcpkg_from_github(
     HEAD_REF master
     PATCHES
         sd-cpu-only.patch
+        abort-callback.patch
+        fix-abort-cleanup.patch
 )
 
 # --- GPU feature flags ---


### PR DESCRIPTION
## What problem does this PR solve?

- `cancel()` only set an atomic flag checked **after** `generate_image()` returned - generation ran to full completion and output was silently discarded, burning full compute time
- Cancelled jobs appeared as successful completions with 0 images instead of errors
- `results[i].data` buffer leaked on cancel (free was inside the output-suppression branch)
- `process()` returned `lastStats_` AND `queueJobEnded()` emitted the same stats, causing duplicate `JobEnded` events in JS
- Upstream bug in `sample()`: abort path freed wrong compute buffer (`diffusion_model` instead of `work_diffusion_model`), corrupting `sd_ctx` and causing segfault on reuse after cancel
- Upstream bug in `generate_image()`: when `generate_image_internal()` returns NULL (abort), `work_ctx` (1GB ggml_context) is leaked — corrupts process-wide ggml state
- `freeParamsImmediately` defaulted to `true` — after any generation (success or abort), model weight buffers were permanently freed, making the second `generate_image()` call access freed memory and crash

## How does it solve it?

**Portfile patches (stable-diffusion.cpp):**

`abort-callback.patch`:
- Add `sd_abort_cb_t` typedef and `sd_set_abort_callback()` public API
- Add `sd_abort_requested()` helper checked in the denoise lambda - when abort fires, denoise returns `nullptr` which the sampler stack already treats as failure, so `generate_image()` returns `NULL`

`fix-abort-cleanup.patch`:
- Fix wrong compute buffer freed: abort path now frees `work_diffusion_model->free_compute_buffer()` (was `diffusion_model`), matching the success path
- Fix `work_ctx` leak: add `ggml_free(work_ctx)` in `generate_image()` when `result_images == nullptr`

**SdModel.cpp:**
- Wire `cancelRequested_` into abort callback via thread-local (matches existing progress callback pattern for concurrency safety)
- Scope guard ensures callbacks are cleared on all exit paths including early parse/validation exceptions
- Always free `results[i].data` whether cancelled or not (buffer leak fix)
- Cancelled jobs throw `"Job cancelled"` then `JobRunner` emits `queueException` instead of fake success with `queueResult + queueJobEnded`
- Return empty `std::any` from `process()` so `queueJobEnded()` is the sole terminal stats path (fixes duplicate `JobEnded` events)

**SdCtxHandlers.hpp:**
- Set `freeParamsImmediately = false` (was `true`) — the addon is designed for multiple generations on the same model instance. The upstream default frees model weights after first generation, making reuse crash.

**SdModel.hpp:**
- Add `isCancelRequested()` public accessor for the static abort callback

## How was it tested?

- Full integration test suite on combined branch `tmp-diffusion-cancel-fix`
- Cancel tests confirm generation aborts at the next denoising step (~5-9s) instead of running to completion
- Cancel-then-rerun test confirms `sd_ctx` is reusable after abort (previously segfaulted)

## CI Evidence

**Before (without C++ fix):** https://github.com/tetherto/qvac/actions/runs/22869760943

| Platform | "run then cancel" test | "cancel then run" test | Exit |
|----------|----------------------|----------------------|------|
| **linux-x64** | Timed out (10 min) - cancel didn't stop inference | Never reached | 134 |
| **linux-arm64** | Timed out (10 min) - cancel didn't stop inference | Never reached | 134 |
| **darwin-arm64** | Crashed - Metal encoder SIGABRT | Never reached | 134 |
| **darwin-x64** | "Passed" in 228s - full 50-step generation | **SIGSEGV (exit 139)** - reuse crash | 139 |
| **win32-x64** | Passed 8s (Vulkan) | **Crashed (exit 1)** - reuse crash | 1 |

**After (with C++ fix):** https://github.com/tetherto/qvac/actions/runs/22879138137

All 5 cancel/reuse API behavior tests pass on every platform that reaches them. Individual job failures are from pre-existing FLUX.2/SD3 generation timeouts on slow CPU runners (unrelated to this PR — the workflow uses `continue-on-error: true`).

| Platform | "run\|cancel" | "cancel\|run" | All 5 cancel tests | Job failure reason |
|----------|--------------|--------------|--------------------|--------------------|
| **darwin-arm64** | 5.7s | 14.4s | **All pass** | None — clean pass |
| **darwin-x64** | 9.4s | 35.6s | **All pass** | FLUX.2 timeout (30 min) |
| **linux-arm64** | ~15s | 64.2s | **All pass** | FLUX.2 timeout (30 min) |
| **linux-x64** | Pass | Pass | **All pass** | SD3 timeout (10 min) |
| **win32-x64** | Not reached | Not reached | Not reached | FLUX.2 model load 755s |

darwin-arm64 is the clean reference — all tests pass end-to-end including FLUX.2/SD3.

## Breaking Changes

None — cancel() now works as expected instead of being a no-op.

## API Changes

None — no public JS API changes.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213614313230763