### PR TITLE
fix(diffusion): JS layer review fixes and cancel test coverage

### DIFF
--- a/packages/lib-infer-diffusion/README.md
+++ b/packages/lib-infer-diffusion/README.md
@@ -1,8 +1,6 @@
 # qvac-lib-infer-stable-diffusion-cpp
 
-Native C++ addon for text-to-image generation using [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp), built for the Bare Runtime. Supports **Stable Diffusion 1.x / 2.x** and **FLUX.2 [klein]**.
-
-> **Scope:** SD3, FLUX.1, and video generation (Wan2.x) are intentionally **not** supported.
+Native C++ addon for text-to-image and image-to-image generation using [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp), built for the Bare Runtime. Supports **Stable Diffusion 1.x / 2.x / XL / 3** and **FLUX.2 [klein]**.
 
 ## Table of Contents
 

--- a/packages/lib-infer-diffusion/README.md
+++ b/packages/lib-infer-diffusion/README.md
@@ -219,12 +219,13 @@ const args = {
 
 | Property | Required | Description |
 |----------|----------|-------------|
-| `loader` | ✅ | Data loader that provides model file access |
-| `diskPath` | ✅ | Local directory where model files are stored |
+| `loader` | — | Data loader instance (e.g. FilesystemDL). Not used internally — retained for type compatibility with BaseInference |
+| `diskPath` | ✅ | Local directory where model files are already stored |
 | `modelName` | ✅ | Diffusion model file name (all-in-one for SD1.x/2.x; diffusion-only GGUF for FLUX.2) |
 | `logger` | — | Logger instance (e.g. `console`) |
-| `clipLModel` | — | Separate CLIP-L text encoder (SD1.x / SDXL) |
-| `clipGModel` | — | Separate CLIP-G text encoder (SDXL) |
+| `clipLModel` | — | Separate CLIP-L text encoder (FLUX.1 / SD3) |
+| `clipGModel` | — | Separate CLIP-G text encoder (SDXL / SD3) |
+| `t5XxlModel` | — | Separate T5-XXL text encoder (FLUX.1 / SD3) |
 | `llmModel` | — | Qwen3 LLM text encoder (FLUX.2 [klein]) |
 | `vaeModel` | — | Separate VAE file |
 
@@ -261,15 +262,7 @@ The constructor stores configuration only — no memory is allocated yet.
 await model.load()
 ```
 
-This downloads any missing files via the loader, creates the native `sd_ctx_t`, and loads all weights into memory. It can take 10–30 seconds depending on disk speed and model size.
-
-Optionally track download progress:
-
-```js
-await model.load(true, progress => {
-  process.stdout.write(`\rLoading: ${progress.overallProgress}%`)
-})
-```
+This creates the native `sd_ctx_t` and loads all weights into memory. It can take 10–30 seconds depending on disk speed and model size. All model files must already be present on disk at `diskPath`.
 
 ### 7. Run Inference
 
@@ -325,12 +318,12 @@ require('bare-fs').writeFileSync('output.png', images[0])
 
 > **Sampler note:** Do not set `sampling_method: 'euler_a'` for FLUX.2 models — it will produce random noise. Leave the field unset to let the library auto-select `euler` for flow-matching models.
 
-#### Image-to-image (`model.img2img`)
+#### Image-to-image (via `model.run` with `init_image`)
 
 ```js
 const inputPng = require('bare-fs').readFileSync('input.png')
 
-const response = await model.img2img({
+const response = await model.run({
   prompt: 'a photo of a cat in a snowy landscape',
   init_image: inputPng,
   strength: 0.75,  // 0.0 = no change, 1.0 = full redraw

--- a/packages/lib-infer-diffusion/README.md
+++ b/packages/lib-infer-diffusion/README.md
@@ -2,6 +2,8 @@
 
 Native C++ addon for text-to-image and image-to-image generation using [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp), built for the Bare Runtime. Supports **Stable Diffusion 1.x / 2.x / XL / 3** and **FLUX.2 [klein]**.
 
+> **Scope:** Video generation (Wan2.x) is intentionally **not** supported.
+
 ## Table of Contents
 
 - [Supported platforms](#supported-platforms)

--- a/packages/lib-infer-diffusion/README.md
+++ b/packages/lib-infer-diffusion/README.md
@@ -13,13 +13,12 @@ Native C++ addon for text-to-image and image-to-image generation using [stable-d
 - [Running the Examples](#running-the-examples)
 - [Usage](#usage)
   - [1. Import the Model Class](#1-import-the-model-class)
-  - [2. Create a Data Loader](#2-create-a-data-loader)
-  - [3. Create the `args` object](#3-create-the-args-object)
-  - [4. Create the `config` object](#4-create-the-config-object)
-  - [5. Create a Model Instance](#5-create-a-model-instance)
-  - [6. Load the Model](#6-load-the-model)
-  - [7. Run Inference](#7-run-inference)
-  - [8. Release Resources](#8-release-resources)
+  - [2. Create the `args` object](#2-create-the-args-object)
+  - [3. Create the `config` object](#3-create-the-config-object)
+  - [4. Create a Model Instance](#4-create-a-model-instance)
+  - [5. Load the Model](#5-load-the-model)
+  - [6. Run Inference](#6-run-inference)
+  - [7. Release Resources](#7-release-resources)
 - [Model File Reference](#model-file-reference)
 - [FLUX.2 Implementation Notes](#flux2-implementation-notes)
 - [License](#license)
@@ -192,23 +191,13 @@ Source: [`examples/generate-image.js`](./examples/generate-image.js)
 const ImgStableDiffusion = require('@qvac/img-stable-diffusion-cpp')
 ```
 
-### 2. Create a Data Loader
-
-Use `@qvac/dl-filesystem` to serve pre-downloaded model files from disk:
+### 2. Create the `args` object
 
 ```js
-const FilesystemDL = require('@qvac/dl-filesystem')
 const path = require('bare-path')
 
 const MODELS_DIR = path.resolve(__dirname, './models')
-const loader = new FilesystemDL({ dirPath: MODELS_DIR })
-```
-
-### 3. Create the `args` object
-
-```js
 const args = {
-  loader,
   logger: console,
   diskPath: MODELS_DIR,
   modelName:  'flux-2-klein-4b-Q8_0.gguf',
@@ -219,7 +208,6 @@ const args = {
 
 | Property | Required | Description |
 |----------|----------|-------------|
-| `loader` | — | Data loader instance (e.g. FilesystemDL). Not used internally — retained for type compatibility with BaseInference |
 | `diskPath` | ✅ | Local directory where model files are already stored |
 | `modelName` | ✅ | Diffusion model file name (all-in-one for SD1.x/2.x; diffusion-only GGUF for FLUX.2) |
 | `logger` | — | Logger instance (e.g. `console`) |
@@ -229,7 +217,7 @@ const args = {
 | `llmModel` | — | Qwen3 LLM text encoder (FLUX.2 [klein]) |
 | `vaeModel` | — | Separate VAE file |
 
-### 4. Create the `config` object
+### 3. Create the `config` object
 
 ```js
 const config = {
@@ -248,7 +236,7 @@ All config values are coerced to strings internally before being passed to the n
 | `vae_on_cpu` | `true` \| `false` | `false` | Force VAE to run on CPU |
 | `flash_attn` | `true` \| `false` | `false` | Enable flash attention (reduces memory) |
 
-### 5. Create a Model Instance
+### 4. Create a Model Instance
 
 ```js
 const model = new ImgStableDiffusion(args, config)
@@ -256,7 +244,7 @@ const model = new ImgStableDiffusion(args, config)
 
 The constructor stores configuration only — no memory is allocated yet.
 
-### 6. Load the Model
+### 5. Load the Model
 
 ```js
 await model.load()
@@ -264,7 +252,7 @@ await model.load()
 
 This creates the native `sd_ctx_t` and loads all weights into memory. It can take 10–30 seconds depending on disk speed and model size. All model files must already be present on disk at `diskPath`.
 
-### 7. Run Inference
+### 6. Run Inference
 
 #### Text-to-image (`model.run`)
 
@@ -331,11 +319,10 @@ const response = await model.run({
 })
 ```
 
-### 8. Release Resources
+### 7. Release Resources
 
 ```js
 await model.unload()
-await loader.close()
 ```
 
 `unload()` calls `free_sd_ctx` which releases all GPU and CPU memory. The JS object can be safely garbage collected afterwards.

--- a/packages/lib-infer-diffusion/README.md
+++ b/packages/lib-infer-diffusion/README.md
@@ -2,7 +2,7 @@
 
 Native C++ addon for text-to-image and image-to-image generation using [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp), built for the Bare Runtime. Supports **Stable Diffusion 1.x / 2.x / XL / 3** and **FLUX.2 [klein]**.
 
-> **Scope:** Video generation (Wan2.x) is intentionally **not** supported.
+> **Scope:** Video generation (Wan2.x) is not yet supported.
 
 ## Table of Contents
 

--- a/packages/lib-infer-diffusion/addon.js
+++ b/packages/lib-infer-diffusion/addon.js
@@ -28,7 +28,9 @@ class SdInterface {
     // C++ getSubmap expects every config value to be a JS string.
     // Coerce numbers and booleans here so the native layer never sees non-string values.
     configurationParams.config = Object.fromEntries(
-      Object.entries(configurationParams.config).map(([k, v]) => [k, String(v)])
+      Object.entries(configurationParams.config)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => [k, String(v)])
     )
 
     this._handle = this._binding.createInstance(
@@ -61,15 +63,6 @@ class SdInterface {
   async runJob (params) {
     const paramsJson = JSON.stringify(params)
     return this._binding.runJob(this._handle, { type: 'text', input: paramsJson })
-  }
-
-  /**
-   * Release model weights from memory (free_sd_ctx) without destroying the
-   * instance. The instance can be reloaded by calling activate() again.
-   */
-  async unloadWeights () {
-    if (!this._handle) return
-    this._binding.unloadModel(this._handle)
   }
 
   /**

--- a/packages/lib-infer-diffusion/docs/architecture.md
+++ b/packages/lib-infer-diffusion/docs/architecture.md
@@ -549,7 +549,7 @@ See [qvac-lib-inference-addon-cpp Decision 4: Why Bare Runtime](https://github.c
 
 Diffusion models consist of multiple large files (diffusion model, text encoders, VAE). The addon needs these files to create the native `sd_ctx_t` context.
 
-Unlike the LLM addon which historically used WeightsProvider for streaming from Hyperdrive, diffusion loads files directly from disk paths — no loader abstraction is involved.
+Unlike the LLM addon which historically used WeightsProvider for streaming weights, diffusion loads files directly from disk paths — no loader abstraction is involved.
 
 ### Decision
 

--- a/packages/lib-infer-diffusion/docs/architecture.md
+++ b/packages/lib-infer-diffusion/docs/architecture.md
@@ -428,7 +428,7 @@ sequenceDiagram
 
 **Thread Safety Rules:**
 
-1. ✅ Call addon methods from any thread (runJob, cancel, activate, loadWeights, destroyInstance)
+1. ✅ Call addon methods from any thread (runJob, cancel, activate, destroyInstance)
 2. ✅ Processing thread calls model methods
 3. ❌ Don't call JS functions from C++ thread (use uv_async_send)
 4. ❌ Don't call model methods from JS thread

--- a/packages/lib-infer-diffusion/docs/architecture.md
+++ b/packages/lib-infer-diffusion/docs/architecture.md
@@ -540,7 +540,7 @@ See [qvac-lib-inference-addon-cpp Decision 4: Why Bare Runtime](https://github.c
 <summary>⚡ TL;DR</summary>
 
 **Chose:** Require model files to already exist on disk at `diskPath`
-**Why:** Simplicity — diffusion uses FilesystemDL which serves pre-downloaded files, no streaming/download layer needed
+**Why:** Simplicity — the addon loads files directly from disk, no streaming/download layer needed
 **Cost:** Caller must ensure files are present before calling `load()`
 
 </details>
@@ -549,7 +549,7 @@ See [qvac-lib-inference-addon-cpp Decision 4: Why Bare Runtime](https://github.c
 
 Diffusion models consist of multiple large files (diffusion model, text encoders, VAE). The addon needs these files to create the native `sd_ctx_t` context.
 
-Unlike the LLM addon which historically used WeightsProvider for streaming from Hyperdrive, diffusion uses `@qvac/dl-filesystem` (FilesystemDL) which only serves files already present on disk.
+Unlike the LLM addon which historically used WeightsProvider for streaming from Hyperdrive, diffusion loads files directly from disk paths — no loader abstraction is involved.
 
 ### Decision
 

--- a/packages/lib-infer-diffusion/docs/architecture.md
+++ b/packages/lib-infer-diffusion/docs/architecture.md
@@ -23,8 +23,8 @@
 ### Architecture Decisions
 - [Decision 1: stable-diffusion.cpp as Inference Backend](#decision-1-stable-diffusioncpp-as-inference-backend)
 - [Decision 2: Bare Runtime over Node.js](#decision-2-bare-runtime-over-nodejs)
-- [Decision 3: Pluggable Data Loader Architecture](#decision-3-pluggable-data-loader-architecture)
-- [Decision 4: Incremental Buffer-Based Weight Loading](#decision-4-incremental-buffer-based-weight-loading)
+- [Decision 3: Disk-Local Model Files](#decision-3-disk-local-model-files)
+- [Decision 4: Direct File Path Loading](#decision-4-direct-file-path-loading)
 - [Decision 5: Generation Parameters Format](#decision-5-generation-parameters-format-json-serialization)
 - [Decision 6: Exclusive Run Queue](#decision-6-exclusive-run-queue-indexjs)
 - [Decision 7: TypeScript Definitions](#decision-7-typescript-definitions)
@@ -42,21 +42,19 @@
 
 **Core value:**
 - High-level JavaScript API for diffusion model inference
-- Peer-to-peer model distribution via Hyperdrive
 - Progress callback during generation steps
-- Text-to-image, image-to-image, and video generation
-- Pluggable model weight loaders
+- Text-to-image and image-to-image generation via single `run()` API
+- Disk-local model files (no download/streaming layer)
 
 ## Key Features
 
 - **Cross-platform**: macOS, Linux, Windows, iOS, Android
-- **Multiple loaders**: Hyperdrive (P2P), filesystem, custom
+- **Disk-local models**: Files must be present on disk at `diskPath`
 - **Progress tracking**: Step-by-step generation progress callbacks
 - **GPU acceleration**: Metal, Vulkan, CUDA, OpenCL
 - **Quantized models**: GGUF, safetensors, checkpoint formats
-- **Diffusion models**: SD1.x, SD2.x, SDXL, SD3, FLUX, Wan (video), Qwen Image, Z-Image
-- **Advanced features**: LoRA, ControlNet, ESRGAN upscaling, TAESD decoding
-- **Generation modes**: txt2img, img2img, inpainting, video generation
+- **Diffusion models**: SD1.x, SD2.x, SDXL, SD3, FLUX.2 [klein]
+- **Generation modes**: txt2img, img2img (auto-detected via `init_image` parameter)
 
 ## Target Platforms
 
@@ -69,7 +67,7 @@
 | Windows | x64 | 10+ | ✅ Tier 1 | Vulkan, CUDA |
 
 **Dependencies:**
-- qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework (single-job runner, runJob/activate/loadWeights/cancel/destroyInstance)
+- qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework (single-job runner, runJob/activate/cancel/destroyInstance)
 - stable-diffusion.cpp: Diffusion inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
 - Ubuntu-22 requires g++-13 installed
@@ -97,7 +95,6 @@ graph TB
     
     subgraph "core libs"
         BASE["@qvac/infer-base"]
-        DL["@qvac/dl-hyperdrive"]
     end
     
     subgraph "Native Framework"
@@ -111,7 +108,6 @@ graph TB
     
     APP --> IMG
     IMG --> BASE
-    IMG --> DL
     IMG --> ADDON
     ADDON --> BARE
     ADDON --> SDCPP
@@ -126,8 +122,7 @@ graph TB
 
 | Package | Type | Version | Purpose |
 |---------|------|---------|---------|
-| @qvac/infer-base | Framework | ^0.2.0 | Base classes, WeightsProvider, QvacResponse |
-| @qvac/dl-hyperdrive | Peer | ^0.1.1 | P2P model loading |
+| @qvac/infer-base | Framework | ^0.2.0 | Base classes (BaseInference, QvacResponse) |
 | qvac-lib-inference-addon-cpp | Native | ≥1.1.1 | C++ addon framework (single-job runner) |
 | stable-diffusion.cpp | Native | latest | Diffusion inference engine |
 | Bare Runtime | Runtime | ≥1.24.0 | JavaScript execution |
@@ -140,7 +135,6 @@ graph TB
 | ImgStableDiffusion | BaseInference | Inheritance | Template method pattern |
 | ImgStableDiffusion | SdInterface | Composition | Method calls |
 | SdInterface | C++ Addon | require.addon() | Native binding |
-| WeightsProvider | Data Loader | Interface | Stream protocol |
 
 </details>
 
@@ -154,44 +148,29 @@ graph TB
 classDiagram
     class ImgStableDiffusion {
         +constructor(args, config)
-        +load(closeLoader, onProgress) Promise~void~
-        +txt2img(params) Promise~QvacImageResponse~
-        +img2img(params) Promise~QvacImageResponse~
-        +txt2vid(params) Promise~QvacVideoResponse~
+        +load() Promise~void~
+        +run(params: GenerationParams) Promise~QvacResponse~
+        +cancel() Promise~void~
         +unload() Promise~void~
-        +downloadWeights(onProgress, opts) Promise~string~
     }
-    
+
     class BaseInference {
         <<abstract>>
         +load() Promise~void~
         +run() Promise~QvacResponse~
         +unload() Promise~void~
+        #_runInternal() Promise~QvacResponse~
+        #_withExclusiveRun(fn) Promise~any~
     }
-    
-    class QvacImageResponse {
-        +onStep(callback) QvacImageResponse
-        +await() Promise~ImageResult~
+
+    class QvacResponse {
+        +onUpdate(callback) QvacResponse
+        +await() Promise~void~
         +cancel() Promise~void~
-        +stats object
     }
-    
-    class QvacVideoResponse {
-        +onFrame(callback) QvacVideoResponse
-        +await() Promise~VideoResult~
-        +cancel() Promise~void~
-        +stats object
-    }
-    
-    class WeightsProvider {
-        +downloadFiles(files, path, opts) Promise~void~
-        +streamFiles(shards, onChunk, onProgress) Promise~void~
-    }
-    
+
     ImgStableDiffusion --|> BaseInference
-    ImgStableDiffusion *-- WeightsProvider
-    ImgStableDiffusion ..> QvacImageResponse : creates
-    ImgStableDiffusion ..> QvacVideoResponse : creates
+    ImgStableDiffusion ..> QvacResponse : creates
 ```
 
 <details>
@@ -201,20 +180,16 @@ classDiagram
 
 | Class | Responsibility | Lifecycle | Dependencies |
 |-------|----------------|-----------|--------------|
-| ImgStableDiffusion | Orchestrate model lifecycle, manage loading/inference | Created by user, persistent | WeightsProvider, SdInterface |
-| BaseInference | Define standard inference API | Abstract base class | None |
-| QvacImageResponse | Handle image generation progress and result | Created per txt2img/img2img call | None |
-| QvacVideoResponse | Handle video generation progress and result | Created per txt2vid call | None |
-| WeightsProvider | Abstract model weight loading | Created by ImgStableDiffusion | DataLoader |
+| ImgStableDiffusion | Orchestrate model lifecycle, manage loading/inference | Created by user, persistent | SdInterface |
+| BaseInference | Define standard inference API (template method pattern) | Abstract base class | None |
+| QvacResponse | Handle generation progress and result | Created per `run()` call | None |
 
 **Key Relationships:**
 
 | From | To | Type | Purpose |
 |------|-----|------|---------|
 | ImgStableDiffusion | BaseInference | Inheritance | Standard QVAC inference API |
-| ImgStableDiffusion | WeightsProvider | Composition | Model weight acquisition |
-| ImgStableDiffusion | QvacImageResponse | Creates | Progress/result per image generation |
-| ImgStableDiffusion | QvacVideoResponse | Creates | Progress/result per video generation |
+| ImgStableDiffusion | QvacResponse | Creates | Progress/result per generation |
 
 </details>
 
@@ -232,8 +207,7 @@ graph TB
         APP["Application Code"]
         IMGCLASS["ImgStableDiffusion<br/>(index.js)"]
         BASEINF["BaseInference<br/>(@qvac/infer-base)"]
-        WEIGHTSPR["WeightsProvider<br/>(@qvac/infer-base)"]
-        RESPONSE["QvacImageResponse<br/>QvacVideoResponse"]
+        RESPONSE["QvacResponse"]
     end
     
     subgraph "Layer 2: Bridge"
@@ -244,7 +218,6 @@ graph TB
     subgraph "Layer 3: C++ Addon"
         JSINTERFACE["JsInterface<br/>(addon-cpp JsInterface)"]
         ADDONCPP["AddonCpp / AddonJs<br/>(addon-cpp + addon/AddonJs.hpp)"]
-        WEIGHTSLOAD["WeightsLoader<br/>(addon-cpp)"]
     end
     
     subgraph "Layer 4: Model"
@@ -262,16 +235,13 @@ graph TB
     
     APP --> IMGCLASS
     IMGCLASS --> BASEINF
-    IMGCLASS --> WEIGHTSPR
     IMGCLASS --> SDIF
     IMGCLASS -.-> RESPONSE
-    
+
     SDIF --> BINDING
     BINDING --> JSINTERFACE
-    WEIGHTSPR --> WEIGHTSLOAD
-    
+
     JSINTERFACE --> ADDONCPP
-    ADDONCPP --> WEIGHTSLOAD
     ADDONCPP --> SDMODEL
     
     SDMODEL --> TXT2IMG
@@ -297,7 +267,7 @@ graph TB
 
 | Layer | Components | Responsibility | Language | Why This Layer |
 |-------|------------|----------------|----------|----------------|
-| 1. JavaScript API | ImgStableDiffusion, BaseInference | High-level API, error handling | JS | Ergonomic API for npm consumers |
+| 1. JavaScript API | ImgStableDiffusion, BaseInference, QvacResponse | High-level API, error handling | JS | Ergonomic API for npm consumers |
 | 2. Bridge | SdInterface, binding.js | JS↔C++ communication | JS wrapper | Lifecycle management, handle safety |
 | 3. C++ Addon | JsInterface, AddonCpp/AddonJs | Single-job runner, threading, callbacks | C++ | Performance, native integration |
 | 4. Model | SdModel, Contexts | Diffusion logic, sampling | C++ | Direct stable-diffusion.cpp integration |
@@ -325,7 +295,7 @@ graph TB
 
 #### **ImgStableDiffusion (index.js)**
 
-**Responsibility:** Main API class, orchestrates model lifecycle, manages data loaders
+**Responsibility:** Main API class, orchestrates model lifecycle and inference
 
 **Why JavaScript:**
 - High-level API ergonomics for npm consumers
@@ -365,16 +335,6 @@ graph TB
 - Output dispatching via uv_async
 
 **IMG specialization:** createInstance builds SdModel with config; runJob parses generation params (prompt, negative_prompt, cfg_scale, steps, etc.)
-
-#### **WeightsProvider (@qvac/infer-base)**
-
-**Responsibility:** Abstracts model weight acquisition
-
-**Why JavaScript:**
-- Integrates with data loaders (Hyperdrive, filesystem)
-- Progress tracking and reporting
-- Handles multi-file models (UNet, VAE, CLIP, etc.)
-- Streaming chunk delivery
 
 #### **BackendSelection (utils/BackendSelection.cpp)**
 
@@ -417,13 +377,13 @@ sequenceDiagram
     participant Model as SdModel
     participant SD as stable-diffusion.cpp
     
-    JS->>IF: txt2img(params)
+    JS->>IF: run(params)
     IF->>Bind: runJob(handle, paramsJson)
     Bind->>Addon: runJob(params) [lock mutex]
     Addon->>Addon: Set job input
     Addon->>Addon: cv.notify_one()
     Bind-->>IF: accepted (boolean)
-    IF-->>JS: QvacImageResponse
+    IF-->>JS: QvacResponse
     
     Note over Addon: Processing Thread
     Addon->>Addon: Take job
@@ -574,94 +534,82 @@ See [qvac-lib-inference-addon-cpp Decision 4: Why Bare Runtime](https://github.c
 
 ---
 
-## Decision 3: Pluggable Data Loader Architecture
+## Decision 3: Disk-Local Model Files
 
 <details>
 <summary>⚡ TL;DR</summary>
 
-**Chose:** Abstract data loading via WeightsProvider interface  
-**Why:** Support multiple distribution methods (P2P, HTTP, local files, S3)  
-**Cost:** Additional abstraction layer, must implement loader interface
+**Chose:** Require model files to already exist on disk at `diskPath`
+**Why:** Simplicity — diffusion uses FilesystemDL which serves pre-downloaded files, no streaming/download layer needed
+**Cost:** Caller must ensure files are present before calling `load()`
 
 </details>
 
 ### Context
 
-Need to load multi-GB model files from various sources:
-- Local filesystem (for offline/development)
-- P2P networks (for privacy/decentralization)
-- HTTP/CDN (for enterprise deployments)
-- Cloud storage (S3, Azure Blob, etc.)
+Diffusion models consist of multiple large files (diffusion model, text encoders, VAE). The addon needs these files to create the native `sd_ctx_t` context.
 
-Diffusion models typically consist of multiple components (UNet, VAE, CLIP text encoders, safety checker) that may be distributed separately.
+Unlike the LLM addon which historically used WeightsProvider for streaming from Hyperdrive, diffusion uses `@qvac/dl-filesystem` (FilesystemDL) which only serves files already present on disk.
 
 ### Decision
 
-Create a pluggable data loader abstraction (WeightsProvider interface) that decouples model loading from the inference engine, allowing applications to choose their distribution strategy.
+Require all model files to be present on disk at `diskPath` before `load()` is called. The addon constructs file paths by joining `diskPath` with each model filename and passes them directly to stable-diffusion.cpp.
 
 ### Rationale
 
-**Flexibility:**
-- Different users have different distribution needs
-- Enterprise may require HTTP/CDN, privacy users may prefer P2P
-- Development/testing needs local filesystem access
+**Simplicity:**
+- No download/streaming abstraction layer needed
+- No WeightsProvider, no progress tracking for downloads
+- Direct file paths to stable-diffusion.cpp
 
-**Multi-Component Models:**
-- Diffusion models have multiple weight files (UNet, VAE, text encoder)
-- LoRA weights loaded separately
-- ControlNet models as add-ons
-- Loader abstraction handles all components uniformly
-
-**Extensibility:**
-- Applications can implement custom loaders
-- Future-proof: new distribution methods don't require engine changes
+**Split-model support:**
+- Diffusion models may have multiple components (diffusion GGUF, CLIP-L, CLIP-G, T5-XXL, LLM encoder, VAE)
+- All resolved as `path.join(diskPath, filename)` in `_load()`
+- Split vs all-in-one layout detected via heuristic (`isSplitLayout = !!llmModel || !!t5XxlModel`)
 
 ### Trade-offs
-- ✅ Can mock loaders for unit testing
-- ❌ Additional abstraction complexity
-- ❌ Applications must choose/implement their loader
+- ✅ Simple, no abstraction overhead
+- ✅ No streaming/buffering complexity
+- ❌ Caller responsible for ensuring files exist on disk
 
 ---
 
-## Decision 4: Incremental Buffer-Based Weight Loading
+## Decision 4: Direct File Path Loading
 
 <details>
 <summary>⚡ TL;DR</summary>
 
-**Chose:** Buffer-based weight loader using custom std::streambuf over JavaScript ArrayBuffers  
-**Why:** Avoid storage duplication, zero-copy, supports loading from P2P sources  
-**Cost:** Complex streambuf implementation, JavaScript reference lifecycle management
+**Chose:** Pass file paths directly to stable-diffusion.cpp via `sd_ctx_params_t`
+**Why:** stable-diffusion.cpp natively loads from file paths; no need for buffer intermediary
+**Cost:** Files must exist on disk (no streaming from P2P sources)
 
 </details>
 
 ### Context
 
-Diffusion models are large (2-10+ GB). stable-diffusion.cpp expects weight data as files or buffers. Loading directly from Hyperdrive (P2P) without duplicating to disk is essential for mobile devices with limited storage.
+stable-diffusion.cpp accepts model files via file paths in its context parameters (`model_path`, `diffusion_model_path`, `clip_l_path`, `vae_path`, etc.). The addon constructs these paths from `diskPath` + filenames.
 
 ### Decision
 
-Implement custom `std::streambuf` over JavaScript-owned ArrayBuffers with incremental chunk loading, as provided by `qvac-lib-inference-addon-cpp` framework.
+Pass absolute file paths directly to stable-diffusion.cpp rather than using buffer-based loading. The `_load()` method constructs a `configurationParams` object with resolved paths and passes it to the native addon.
 
 ### Rationale
 
-**Avoid Storage Duplication:**
-- Load directly from Hyperdrive streams without saving to disk
-- No temporary files consuming additional storage
-- Critical for mobile devices with limited storage
+**Simplicity:**
+- stable-diffusion.cpp handles file I/O internally
+- No custom streambuf or buffer management needed
+- No JavaScript reference lifecycle concerns
 
-**Zero-Copy:**
-- C++ reads directly from JavaScript ArrayBuffer memory
-- No memcpy of multi-GB model files
-
-**Component Loading:**
-- Load UNet, VAE, CLIP sequentially
-- Report progress per component
-- Handle optional components (LoRA, ControlNet) dynamically
+**Split-model routing:**
+- All-in-one checkpoints (SD1.x, SD2.x, SDXL) → `model_path`
+- Standalone diffusion GGUFs (FLUX.2, SD3 split) → `diffusion_model_path`
+- Separate encoders → `clipLPath`, `clipGPath`, `t5XxlPath`, `llmPath`
+- VAE → `vaePath`
 
 ### Trade-offs
-- ✅ Can report loading progress per component
-- ❌ Complex streambuf implementation
-- ❌ Must keep JS buffers alive during load
+- ✅ No buffer management complexity
+- ✅ stable-diffusion.cpp handles memory-mapped I/O efficiently
+- ❌ Cannot stream from P2P sources directly (files must be on disk first)
 
 ---
 
@@ -708,37 +656,26 @@ Serialize generation parameters to JSON string before passing to C++.
 ### Parameter Schema
 
 ```typescript
-interface Txt2ImgParams {
+interface GenerationParams {
   prompt: string;
   negative_prompt?: string;
-  width?: number;           // default: 512
-  height?: number;          // default: 512
-  steps?: number;           // default: 20
-  cfg_scale?: number;       // default: 7.0
-  sampler?: string;         // 'euler_a' | 'euler' | 'dpm++_2m' | etc.
-  seed?: number;            // -1 for random
-  batch_count?: number;     // default: 1
-  loras?: LoraConfig[];
-  controlnet?: ControlNetConfig;
-}
-
-interface Img2ImgParams extends Txt2ImgParams {
-  init_image: Uint8Array;   // PNG/JPEG bytes
-  strength?: number;        // 0.0-1.0, default: 0.75
-}
-
-interface Txt2VidParams {
-  prompt: string;
-  negative_prompt?: string;
-  width?: number;
-  height?: number;
-  frames?: number;
-  fps?: number;
-  steps?: number;
-  cfg_scale?: number;
-  seed?: number;
+  width?: number;             // default: 512
+  height?: number;            // default: 512
+  steps?: number;             // default: 20
+  cfg_scale?: number;         // CFG scale (SD1/SD2/SDXL/SD3)
+  guidance?: number;          // Distilled guidance (FLUX.2)
+  sampling_method?: string;   // 'euler' | 'euler_a' | 'dpm++_2m' | etc.
+  scheduler?: string;         // 'default' | 'karras' | 'exponential' | etc.
+  seed?: number;              // -1 for random
+  batch_count?: number;       // default: 1
+  vae_tiling?: boolean;       // Enable VAE tiling (for large images)
+  cache_preset?: string;      // 'slow' | 'medium' | 'fast' | 'ultra'
+  init_image?: Uint8Array;    // PNG/JPEG bytes — if provided, runs img2img
+  strength?: number;          // img2img: 0.0 = keep source, 1.0 = full redraw
 }
 ```
+
+Mode is determined automatically: if `init_image` is provided, runs img2img; otherwise txt2img.
 
 ---
 
@@ -828,4 +765,4 @@ Provide hand-written TypeScript definitions in `index.d.ts`.
 
 ---
 
-**Last Updated:** 2026-02-23
+**Last Updated:** 2026-03-11

--- a/packages/lib-infer-diffusion/docs/data-flows-detailed.md
+++ b/packages/lib-infer-diffusion/docs/data-flows-detailed.md
@@ -15,7 +15,7 @@ This document contains detailed diagrams showing how data moves through the `@qv
 - Cross-thread flow: JS → submit job via `runJob(params)` → wake C++ → process diffusion steps → output → uv_async_send → JS callback
 
 **Generation Path:**
-- JS calls `txt2img(params)` → returns QvacImageResponse immediately (non-blocking)
+- JS calls `model.run(params)` → returns QvacResponse immediately (non-blocking)
 - JS serializes params to JSON, calls `addon.runJob(paramsJson)` once; returns boolean (accepted or job already active)
 - C++ single-job runner takes the job, executes diffusion loop → generates image
 - Queues progress/output events → triggers JS callback asynchronously
@@ -35,11 +35,11 @@ This document contains detailed diagrams showing how data moves through the `@qv
 
 ```mermaid
 flowchart TD
-    Start([JS: model.txt2img]) --> ParseParams[Parse generation params]
+    Start([JS: model.run]) --> ParseParams[Parse generation params]
     ParseParams --> SerializeJSON[Serialize to JSON]
     
     SerializeJSON --> RunJob[addon.runJob(paramsJson)]
-    RunJob --> CreateResp[Create QvacImageResponse]
+    RunJob --> CreateResp[Create QvacResponse]
     CreateResp --> ReturnJS([Return to JavaScript])
     
     RunJob -.->|Enters native| LockMutex[Lock mutex]
@@ -91,7 +91,7 @@ flowchart TD
     UnlockCB --> ForEach[For each output event]
     
     ForEach --> InvokeJS[Call JavaScript outputCb]
-    InvokeJS --> UpdateResponse[QvacImageResponse emits]
+    InvokeJS --> UpdateResponse[QvacResponse emits]
     UpdateResponse --> ProgressYield([onStep callback / await])
 ```
 
@@ -164,4 +164,4 @@ flowchart TD
 **Related Documents:**
 - [architecture.md](architecture.md) - Complete architecture documentation
 
-**Last Updated:** 2026-02-23
+**Last Updated:** 2026-03-11

--- a/packages/lib-infer-diffusion/examples/generate-image-sd2.js
+++ b/packages/lib-infer-diffusion/examples/generate-image-sd2.js
@@ -3,7 +3,6 @@
 const path = require('bare-path')
 const process = require('bare-process')
 const fs = require('bare-fs')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const ImgStableDiffusion = require('../index')
 
 // ---------------------------------------------------------------------------
@@ -52,11 +51,8 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const loader = new FilesystemDL({ dirPath: MODELS_DIR })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: MODELS_DIR,
       modelName: MODEL_NAME
@@ -125,7 +121,6 @@ async function main () {
   } finally {
     console.log('\nUnloading model...')
     await model.unload()
-    await loader.close()
     console.log('Done.')
   }
 }

--- a/packages/lib-infer-diffusion/examples/generate-image-sd3.js
+++ b/packages/lib-infer-diffusion/examples/generate-image-sd3.js
@@ -3,7 +3,6 @@
 const path = require('bare-path')
 const process = require('bare-process')
 const fs = require('bare-fs')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const ImgStableDiffusion = require('../index')
 
 // ---------------------------------------------------------------------------
@@ -55,11 +54,8 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const loader = new FilesystemDL({ dirPath: MODELS_DIR })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: MODELS_DIR,
       modelName: MODEL_NAME
@@ -132,7 +128,6 @@ async function main () {
   } finally {
     console.log('\nUnloading model...')
     await model.unload()
-    await loader.close()
     console.log('Done.')
   }
 }

--- a/packages/lib-infer-diffusion/examples/generate-image-sdxl.js
+++ b/packages/lib-infer-diffusion/examples/generate-image-sdxl.js
@@ -3,7 +3,6 @@
 const path = require('bare-path')
 const process = require('bare-process')
 const fs = require('bare-fs')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const ImgStableDiffusion = require('../index')
 
 // ---------------------------------------------------------------------------
@@ -52,11 +51,8 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const loader = new FilesystemDL({ dirPath: MODELS_DIR })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: MODELS_DIR,
       modelName: MODEL_NAME
@@ -125,7 +121,6 @@ async function main () {
   } finally {
     console.log('\nUnloading model...')
     await model.unload()
-    await loader.close()
     console.log('Done.')
   }
 }

--- a/packages/lib-infer-diffusion/examples/generate-image.js
+++ b/packages/lib-infer-diffusion/examples/generate-image.js
@@ -3,7 +3,6 @@
 const path = require('bare-path')
 const process = require('bare-process')
 const fs = require('bare-fs')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const ImgStableDiffusion = require('../index')
 
 // ---------------------------------------------------------------------------
@@ -42,11 +41,8 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const loader = new FilesystemDL({ dirPath: MODELS_DIR })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: MODELS_DIR,
       modelName: MODEL_NAME,
@@ -112,7 +108,6 @@ async function main () {
   } finally {
     console.log('\nUnloading model...')
     await model.unload()
-    await loader.close()
     console.log('Done.')
   }
 }

--- a/packages/lib-infer-diffusion/examples/load-model.js
+++ b/packages/lib-infer-diffusion/examples/load-model.js
@@ -2,7 +2,6 @@
 
 const path = require('bare-path')
 const process = require('bare-process')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const ImgStableDiffusion = require('../index')
 
 // ---------------------------------------------------------------------------
@@ -24,13 +23,9 @@ async function main () {
   console.log('VAE        :', VAE_MODEL)
   console.log()
 
-  // ── 1. Filesystem loader (serves pre-downloaded weights from disk) ─────────
-  const loader = new FilesystemDL({ dirPath: MODELS_DIR })
-
-  // ── 2. Construct — stores config, allocates nothing ───────────────────────
+  // ── 1. Construct — stores config, allocates nothing ────────────────────────
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: MODELS_DIR,
       modelName: MODEL_NAME,
@@ -43,21 +38,20 @@ async function main () {
   )
 
   try {
-    // ── 3. Load — reads weights into memory via activate() → new_sd_ctx() ───
+    // ── 2. Load — reads weights into memory via activate() → new_sd_ctx() ───
     console.log('Loading model weights (this takes a moment)...')
     const t0 = Date.now()
     await model.load()
     console.log(`Model loaded in ${((Date.now() - t0) / 1000).toFixed(1)}s`)
     console.log()
 
-    // ── 4. Model is live — add inference calls here ───────────────────────
+    // ── 3. Model is live — add inference calls here ───────────────────────
     console.log('Model is ready. (No inference in this example.)')
     console.log()
   } finally {
-    // ── 5. Unload — calls free_sd_ctx, releases all GPU/CPU memory ─────────
+    // ── 4. Unload — calls free_sd_ctx, releases all GPU/CPU memory ─────────
     console.log('Unloading model...')
     await model.unload()
-    await loader.close()
     console.log('Done — all resources released.')
   }
 }

--- a/packages/lib-infer-diffusion/examples/quickstart.js
+++ b/packages/lib-infer-diffusion/examples/quickstart.js
@@ -13,7 +13,6 @@ const path = require('bare-path')
 const process = require('bare-process')
 const fs = require('bare-fs')
 const binding = require('../binding')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const ImgStableDiffusion = require('../index')
 
 const MODELS_DIR = path.resolve(__dirname, '../models')
@@ -47,11 +46,8 @@ async function main () {
   console.log(`Model : ${MODEL_NAME}`)
   console.log(`Prompt: ${PROMPT}\n`)
 
-  const loader = new FilesystemDL({ dirPath: MODELS_DIR })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: MODELS_DIR,
       modelName: MODEL_NAME,
@@ -131,7 +127,6 @@ async function main () {
     // 7. Cleanup
     console.log('\n5. Cleaning up...')
     await model.unload()
-    await loader.close()
     binding.releaseLogger()
     console.log('\nDone!')
   }

--- a/packages/lib-infer-diffusion/examples/runtime-stats-sd2.js
+++ b/packages/lib-infer-diffusion/examples/runtime-stats-sd2.js
@@ -3,7 +3,6 @@
 const path = require('bare-path')
 const process = require('bare-process')
 const fs = require('bare-fs')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const ImgStableDiffusion = require('../index')
 
 // ---------------------------------------------------------------------------
@@ -60,11 +59,8 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const loader = new FilesystemDL({ dirPath: MODELS_DIR })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: MODELS_DIR,
       modelName: MODEL_NAME,
@@ -177,7 +173,6 @@ async function main () {
   } finally {
     console.log('\nUnloading model...')
     await model.unload()
-    await loader.close()
     console.log('Done.')
   }
 }

--- a/packages/lib-infer-diffusion/index.d.ts
+++ b/packages/lib-infer-diffusion/index.d.ts
@@ -1,21 +1,8 @@
-import BaseInference, {
-  ReportProgressCallback
-} from '@qvac/infer-base/WeightsProvider/BaseInference'
+import BaseInference from '@qvac/infer-base/WeightsProvider/BaseInference'
 import type { QvacResponse } from '@qvac/infer-base'
 import type QvacLogger from '@qvac/logging'
 
 export type NumericLike = number | `${number}`
-
-export interface Loader {
-  ready(): Promise<void>
-  close(): Promise<void>
-  getStream(path: string): Promise<AsyncIterable<Uint8Array>>
-  download(
-    path: string,
-    opts: { diskPath: string; progressReporter?: unknown }
-  ): Promise<{ await(): Promise<void> }>
-  getFileSize?(path: string): Promise<number>
-}
 
 export interface Addon {
   activate(): Promise<void>
@@ -103,7 +90,6 @@ export interface GenerationParams {
 }
 
 export interface ImgStableDiffusionArgs {
-  loader: Loader
   logger?: QvacLogger | Console | null
   opts?: { stats?: boolean }
   diskPath?: string
@@ -135,4 +121,4 @@ export default class ImgStableDiffusion extends BaseInference {
   cancel(): Promise<void>
 }
 
-export { ReportProgressCallback, QvacResponse }
+export { QvacResponse }

--- a/packages/lib-infer-diffusion/index.d.ts
+++ b/packages/lib-infer-diffusion/index.d.ts
@@ -19,7 +19,7 @@ export interface Loader {
 
 export interface Addon {
   activate(): Promise<void>
-  runJob(params: GenerationParams): Promise<boolean>
+  runJob(params: GenerationParams & { mode: 'txt2img' | 'img2img' }): Promise<boolean>
   cancel(): Promise<void>
   unload(): Promise<void>
 }
@@ -76,7 +76,7 @@ export interface SdConfig {
   [key: string]: string | number | boolean | undefined
 }
 
-export interface Txt2ImgParams {
+export interface GenerationParams {
   prompt: string
   negative_prompt?: string
   width?: number
@@ -96,22 +96,10 @@ export interface Txt2ImgParams {
   vae_tiling?: boolean
   /** Cache preset: slow/medium/fast/ultra */
   cache_preset?: string
-}
-
-export interface Img2ImgParams extends Txt2ImgParams {
-  /** Input image as PNG/JPEG bytes */
-  init_image: Uint8Array
-  /** Denoising strength (0.0–1.0) */
-  strength?: number
-}
-
-/** Internal union sent to the native addon (includes mode). */
-export interface GenerationParams extends Txt2ImgParams {
-  mode: 'txt2img' | 'img2img' | 'txt2vid'
+  /** Input image as PNG/JPEG bytes — if provided, runs img2img instead of txt2img */
   init_image?: Uint8Array
+  /** img2img denoising strength (0.0–1.0). 0 = keep source, 1 = ignore source */
   strength?: number
-  frames?: number
-  fps?: number
 }
 
 export interface ImgStableDiffusionArgs {
@@ -131,39 +119,16 @@ export interface ImgStableDiffusionArgs {
   vaeModel?: string
 }
 
-export interface DownloadWeightsOptions {
-  closeLoader?: boolean
-}
-
-export interface DownloadResult {
-  filePath: string | null
-  error: boolean
-  completed: boolean
-}
-
 export default class ImgStableDiffusion extends BaseInference {
   protected addon: Addon
 
   constructor(args: ImgStableDiffusionArgs, config: SdConfig)
 
-  _load(
-    closeLoader?: boolean,
-    onDownloadProgress?: ReportProgressCallback | ((bytes: number) => void)
-  ): Promise<void>
+  _load(): Promise<void>
 
-  load(
-    closeLoader?: boolean,
-    onDownloadProgress?: ReportProgressCallback | ((bytes: number) => void)
-  ): Promise<void>
+  load(): Promise<void>
 
-  downloadWeights(
-    onDownloadProgress?: (progress: Record<string, any>) => any,
-    opts?: DownloadWeightsOptions
-  ): Promise<Record<string, DownloadResult>>
-
-  run(params: Txt2ImgParams): Promise<QvacResponse>
-
-  img2img(params: Img2ImgParams): Promise<QvacResponse>
+  run(params: GenerationParams): Promise<QvacResponse>
 
   unload(): Promise<void>
 

--- a/packages/lib-infer-diffusion/index.d.ts
+++ b/packages/lib-infer-diffusion/index.d.ts
@@ -55,7 +55,7 @@ export type ScheduleType = 'default' | 'discrete' | 'karras' | 'exponential' | '
 export interface SdConfig {
   /** Number of CPU threads (-1 = auto) */
   threads?: NumericLike
-  /** Preferred compute device: 'gpu' or 'cpu' */
+  /** Preferred compute device: 'gpu' (Metal/CUDA/Vulkan) or 'cpu' */
   device?: 'gpu' | 'cpu'
   /** Weight quantization type */
   wtype?: WeightType
@@ -63,8 +63,6 @@ export interface SdConfig {
   rng?: RngType
   /** Sampling schedule */
   schedule?: ScheduleType
-  /** Compute backend: 'gpu' (default) uses Metal/CUDA/Vulkan, 'cpu' forces CPU-only */
-  device?: 'cpu' | 'gpu'
   /** Run CLIP encoder on CPU even when GPU is available */
   clip_on_cpu?: boolean
   /** Run VAE decoder on CPU even when GPU is available */
@@ -78,55 +76,42 @@ export interface SdConfig {
   [key: string]: string | number | boolean | undefined
 }
 
-export interface GenerationParams {
-  mode: 'txt2img' | 'img2img' | 'txt2vid'
-  prompt: string
-  negative_prompt?: string
-  width?: number
-  height?: number
-  steps?: number
-  cfg_scale?: number
-  sampler?: SamplerMethod
-  seed?: number
-  batch_count?: number
-  /** img2img only: input image as PNG/JPEG bytes */
-  init_image?: Uint8Array
-  /** img2img only: denoising strength (0.0–1.0) */
-  strength?: number
-  /** txt2vid only: number of frames */
-  frames?: number
-  /** txt2vid only: frames per second */
-  fps?: number
-}
-
 export interface Txt2ImgParams {
   prompt: string
   negative_prompt?: string
   width?: number
   height?: number
   steps?: number
+  /** CFG scale (SD1/SD2/SDXL/SD3) */
   cfg_scale?: number
-  sampler?: SamplerMethod
+  /** Distilled guidance (FLUX.2) */
+  guidance?: number
+  /** Sampler name (e.g. 'euler', 'dpm++_2m') */
+  sampling_method?: SamplerMethod
+  /** Scheduler name */
+  scheduler?: ScheduleType
   seed?: number
   batch_count?: number
+  /** Enable VAE tiling (for large images) */
+  vae_tiling?: boolean
+  /** Cache preset: slow/medium/fast/ultra */
+  cache_preset?: string
 }
 
 export interface Img2ImgParams extends Txt2ImgParams {
+  /** Input image as PNG/JPEG bytes */
   init_image: Uint8Array
+  /** Denoising strength (0.0–1.0) */
   strength?: number
 }
 
-export interface Txt2VidParams {
-  prompt: string
-  negative_prompt?: string
-  width?: number
-  height?: number
+/** Internal union sent to the native addon (includes mode). */
+export interface GenerationParams extends Txt2ImgParams {
+  mode: 'txt2img' | 'img2img' | 'txt2vid'
+  init_image?: Uint8Array
+  strength?: number
   frames?: number
   fps?: number
-  steps?: number
-  cfg_scale?: number
-  sampler?: SamplerMethod
-  seed?: number
 }
 
 export interface ImgStableDiffusionArgs {
@@ -156,12 +141,6 @@ export interface DownloadResult {
   completed: boolean
 }
 
-export interface StepProgressEvent {
-  step: number
-  total: number
-  elapsed_ms?: number
-}
-
 export default class ImgStableDiffusion extends BaseInference {
   protected addon: Addon
 
@@ -178,15 +157,13 @@ export default class ImgStableDiffusion extends BaseInference {
   ): Promise<void>
 
   downloadWeights(
-    onDownloadProgress?: (progress: Record<string, any>, opts: DownloadWeightsOptions) => any,
+    onDownloadProgress?: (progress: Record<string, any>) => any,
     opts?: DownloadWeightsOptions
   ): Promise<Record<string, DownloadResult>>
 
-  txt2img(params: Txt2ImgParams): Promise<QvacResponse>
+  run(params: Txt2ImgParams): Promise<QvacResponse>
 
   img2img(params: Img2ImgParams): Promise<QvacResponse>
-
-  txt2vid(params: Txt2VidParams): Promise<QvacResponse>
 
   unload(): Promise<void>
 

--- a/packages/lib-infer-diffusion/index.js
+++ b/packages/lib-infer-diffusion/index.js
@@ -9,13 +9,11 @@ const { SdInterface } = require('./addon')
 const noop = () => {}
 const LOG_METHODS = ['error', 'warn', 'info', 'debug']
 
-/** Max ms to wait for the previous job to finish before throwing. */
-const PREVIOUS_JOB_WAIT_MS = 30
 const RUN_BUSY_ERROR_MESSAGE = 'Cannot set new job: a job is already set or being processed'
 
 /**
- * Image and video generation using stable-diffusion.cpp.
- * Supports SD1.x, SD2.x, SDXL, SD3, FLUX, Wan2.x video models.
+ * Text-to-image and image-to-image generation using stable-diffusion.cpp.
+ * Supports SD1.x, SD2.x, SDXL, SD3, and FLUX.2 [klein].
  */
 class ImgStableDiffusion extends BaseInference {
   /**
@@ -57,26 +55,24 @@ class ImgStableDiffusion extends BaseInference {
     this._llmModel = llmModel || null
     this._vaeModel = vaeModel || null
     this.weightsProvider = new WeightsProvider(loader, this.logger)
-    this._lastJobResult = Promise.resolve()
+    this._hasActiveResponse = false
   }
 
-  /**
-   * Load model weights, initialize the native addon, and activate.
-   * @param {boolean} [closeLoader=true]
-   * @param {Function} [onDownloadProgress]
-   */
+  _getWeightFiles () {
+    const files = [this._modelName]
+    if (this._clipLModel) files.push(this._clipLModel)
+    if (this._clipGModel) files.push(this._clipGModel)
+    if (this._t5XxlModel) files.push(this._t5XxlModel)
+    if (this._llmModel) files.push(this._llmModel)
+    if (this._vaeModel) files.push(this._vaeModel)
+    return files
+  }
+
   async _load (closeLoader = true, onDownloadProgress = noop) {
     this.logger.info('Starting stable-diffusion model load')
 
     try {
-      const filesToDownload = [this._modelName]
-      if (this._clipLModel) filesToDownload.push(this._clipLModel)
-      if (this._clipGModel) filesToDownload.push(this._clipGModel)
-      if (this._t5XxlModel) filesToDownload.push(this._t5XxlModel)
-      if (this._llmModel) filesToDownload.push(this._llmModel)
-      if (this._vaeModel) filesToDownload.push(this._vaeModel)
-
-      await this.weightsProvider.downloadFiles(filesToDownload, this._diskPath, {
+      await this.weightsProvider.downloadFiles(this._getWeightFiles(), this._diskPath, {
         closeLoader,
         onDownloadProgress
       })
@@ -125,14 +121,7 @@ class ImgStableDiffusion extends BaseInference {
    * @param {object} [opts]
    */
   async _downloadWeights (onDownloadProgress, opts) {
-    const filesToDownload = [this._modelName]
-    if (this._clipLModel) filesToDownload.push(this._clipLModel)
-    if (this._clipGModel) filesToDownload.push(this._clipGModel)
-    if (this._t5XxlModel) filesToDownload.push(this._t5XxlModel)
-    if (this._llmModel) filesToDownload.push(this._llmModel)
-    if (this._vaeModel) filesToDownload.push(this._vaeModel)
-
-    return this.weightsProvider.downloadFiles(filesToDownload, this._diskPath, {
+    return this.weightsProvider.downloadFiles(this._getWeightFiles(), this._diskPath, {
       closeLoader: opts.closeLoader,
       onDownloadProgress
     })
@@ -186,9 +175,6 @@ class ImgStableDiffusion extends BaseInference {
     } else if (data instanceof Uint8Array) {
       mappedEvent = 'Output'
     } else if (typeof data === 'string') {
-      try {
-        JSON.parse(data)
-      } catch (_) {}
       mappedEvent = 'Output'
     }
 
@@ -215,7 +201,7 @@ class ImgStableDiffusion extends BaseInference {
         currentJobResponse.failed(new Error('Model was unloaded'))
         this._deleteJobMapping('OnlyOneJob')
       }
-      // Guard: addon may never have been created if _load() threw before assignment.
+      this._hasActiveResponse = false
       if (this.addon) {
         await super.unload()
       }
@@ -246,7 +232,7 @@ class ImgStableDiffusion extends BaseInference {
    * @param {string}  [params.cache_preset]         - Cache preset: slow/medium/fast/ultra
    * @returns {Promise<QvacResponse>}
    */
-  async run (params) {
+  async _runInternal (params) {
     return this._runGeneration({ ...params, mode: 'txt2img' })
   }
 
@@ -268,14 +254,9 @@ class ImgStableDiffusion extends BaseInference {
     this.logger.info('Starting generation with mode:', params.mode)
 
     return this._withExclusiveRun(async () => {
-      await new Promise((resolve, reject) => {
-        const timer = setTimeout(() => {
-          reject(new Error(RUN_BUSY_ERROR_MESSAGE))
-        }, PREVIOUS_JOB_WAIT_MS)
-        this._lastJobResult
-          .then(() => { clearTimeout(timer); resolve() })
-          .catch(() => { clearTimeout(timer); resolve() })
-      })
+      if (this._hasActiveResponse) {
+        throw new Error(RUN_BUSY_ERROR_MESSAGE)
+      }
 
       const response = this._createResponse('OnlyOneJob')
 
@@ -295,7 +276,10 @@ class ImgStableDiffusion extends BaseInference {
         throw new Error(msg)
       }
 
-      this._lastJobResult = response.await()
+      this._hasActiveResponse = true
+      const finalized = response.await().finally(() => { this._hasActiveResponse = false })
+      finalized.catch(() => {})
+      response.await = () => finalized
 
       this.logger.info('Generation job started successfully')
 

--- a/packages/lib-infer-diffusion/index.js
+++ b/packages/lib-infer-diffusion/index.js
@@ -16,8 +16,6 @@ const RUN_BUSY_ERROR_MESSAGE = 'Cannot set new job: a job is already set or bein
 class ImgStableDiffusion extends BaseInference {
   /**
    * @param {object} args
-   * @param {object} [args.loader] - Data loader (FilesystemDL). Not used internally — weight
-   *                                  files must already be present on disk at diskPath.
    * @param {object} [args.logger] - Structured logger
    * @param {object} [args.opts] - Optional inference options
    * @param {string} [args.diskPath='.'] - Local directory containing model weight files
@@ -32,7 +30,6 @@ class ImgStableDiffusion extends BaseInference {
   constructor (
     {
       opts = {},
-      loader,
       logger = null,
       diskPath = '.',
       modelName,

--- a/packages/lib-infer-diffusion/index.js
+++ b/packages/lib-infer-diffusion/index.js
@@ -3,10 +3,8 @@
 const path = require('bare-path')
 
 const BaseInference = require('@qvac/infer-base/WeightsProvider/BaseInference')
-const WeightsProvider = require('@qvac/infer-base/WeightsProvider/WeightsProvider')
 const { SdInterface } = require('./addon')
 
-const noop = () => {}
 const LOG_METHODS = ['error', 'warn', 'info', 'debug']
 
 const RUN_BUSY_ERROR_MESSAGE = 'Cannot set new job: a job is already set or being processed'
@@ -18,10 +16,11 @@ const RUN_BUSY_ERROR_MESSAGE = 'Cannot set new job: a job is already set or bein
 class ImgStableDiffusion extends BaseInference {
   /**
    * @param {object} args
-   * @param {object} args.loader - Data loader (Hyperdrive, filesystem, etc.)
+   * @param {object} [args.loader] - Data loader (FilesystemDL). Not used internally — weight
+   *                                  files must already be present on disk at diskPath.
    * @param {object} [args.logger] - Structured logger
    * @param {object} [args.opts] - Optional inference options
-   * @param {string} [args.diskPath='.'] - Local directory for downloaded weights
+   * @param {string} [args.diskPath='.'] - Local directory containing model weight files
    * @param {string} args.modelName - Model file name (e.g. 'flux1-dev-q4_0.gguf')
    * @param {string} [args.clipLModel] - Optional CLIP-L model file name (FLUX.1 / SD3)
    * @param {string} [args.clipGModel] - Optional CLIP-G model file name (SDXL / SD3)
@@ -54,29 +53,13 @@ class ImgStableDiffusion extends BaseInference {
     this._t5XxlModel = t5XxlModel || null
     this._llmModel = llmModel || null
     this._vaeModel = vaeModel || null
-    this.weightsProvider = new WeightsProvider(loader, this.logger)
     this._hasActiveResponse = false
   }
 
-  _getWeightFiles () {
-    const files = [this._modelName]
-    if (this._clipLModel) files.push(this._clipLModel)
-    if (this._clipGModel) files.push(this._clipGModel)
-    if (this._t5XxlModel) files.push(this._t5XxlModel)
-    if (this._llmModel) files.push(this._llmModel)
-    if (this._vaeModel) files.push(this._vaeModel)
-    return files
-  }
-
-  async _load (closeLoader = true, onDownloadProgress = noop) {
+  async _load () {
     this.logger.info('Starting stable-diffusion model load')
 
     try {
-      await this.weightsProvider.downloadFiles(this._getWeightFiles(), this._diskPath, {
-        closeLoader,
-        onDownloadProgress
-      })
-
       // Route the primary model file to the correct stable-diffusion.cpp param:
       //
       //   model_path           — all-in-one checkpoints that embed their own text
@@ -114,17 +97,6 @@ class ImgStableDiffusion extends BaseInference {
       this.logger.error('Error during stable-diffusion model load:', error)
       throw error
     }
-  }
-
-  /**
-   * @param {Function} [onDownloadProgress]
-   * @param {object} [opts]
-   */
-  async _downloadWeights (onDownloadProgress, opts) {
-    return this.weightsProvider.downloadFiles(this._getWeightFiles(), this._diskPath, {
-      closeLoader: opts.closeLoader,
-      onDownloadProgress
-    })
   }
 
   /**
@@ -194,7 +166,7 @@ class ImgStableDiffusion extends BaseInference {
    * Unload the model and release all resources.
    */
   async unload () {
-    return this._withExclusiveRun(async () => {
+    return await this._withExclusiveRun(async () => {
       await this.cancel()
       const currentJobResponse = this._jobToResponse.get('OnlyOneJob')
       if (currentJobResponse) {
@@ -210,7 +182,11 @@ class ImgStableDiffusion extends BaseInference {
   }
 
   /**
-   * Generate an image from a text prompt (primary API).
+   * Generate an image from a text prompt, or from an input image + text prompt.
+   *
+   * Mode is determined automatically:
+   *   - If `params.init_image` is provided → img2img
+   *   - Otherwise → txt2img
    *
    * Returns a QvacResponse that streams two types of updates:
    *   - Uint8Array  — PNG-encoded output image (one per batch_count)
@@ -230,30 +206,15 @@ class ImgStableDiffusion extends BaseInference {
    * @param {number} [params.batch_count=1]         - Images per call
    * @param {boolean} [params.vae_tiling=false]     - Enable VAE tiling (for large images)
    * @param {string}  [params.cache_preset]         - Cache preset: slow/medium/fast/ultra
+   * @param {Uint8Array} [params.init_image]        - Source image bytes for img2img (PNG/JPEG)
+   * @param {number}    [params.strength=0.75]      - img2img: 0 = keep source, 1 = ignore source
    * @returns {Promise<QvacResponse>}
    */
   async _runInternal (params) {
-    return this._runGeneration({ ...params, mode: 'txt2img' })
-  }
+    const mode = params.init_image ? 'img2img' : 'txt2img'
+    this.logger.info('Starting generation with mode:', mode)
 
-  /**
-   * Generate an image from an input image and text prompt.
-   *
-   * @param {object} params
-   * @param {Uint8Array} params.init_image   - Source image bytes (PNG/JPEG)
-   * @param {string}     params.prompt
-   * @param {number}    [params.strength=0.75] - 0 = keep source, 1 = ignore source
-   * @returns {Promise<QvacResponse>}
-   */
-  async img2img (params) {
-    if (!params.init_image) throw new Error('img2img requires init_image')
-    return this._runGeneration({ ...params, mode: 'img2img' })
-  }
-
-  async _runGeneration (params) {
-    this.logger.info('Starting generation with mode:', params.mode)
-
-    return this._withExclusiveRun(async () => {
+    return await this._withExclusiveRun(async () => {
       if (this._hasActiveResponse) {
         throw new Error(RUN_BUSY_ERROR_MESSAGE)
       }
@@ -262,7 +223,7 @@ class ImgStableDiffusion extends BaseInference {
 
       let accepted
       try {
-        accepted = await this.addon.runJob(params)
+        accepted = await this.addon.runJob({ ...params, mode })
       } catch (error) {
         this._deleteJobMapping('OnlyOneJob')
         response.failed(error)

--- a/packages/lib-infer-diffusion/package.json
+++ b/packages/lib-infer-diffusion/package.json
@@ -59,8 +59,6 @@
   "bugs": "https://github.com/tetherto/qvac-lib-infer-stable-diffusion-cpp/issues",
   "homepage": "https://github.com/tetherto/qvac-lib-infer-stable-diffusion-cpp#readme",
   "devDependencies": {
-    "@qvac/dl-filesystem": "^0.1.2",
-    "@qvac/dl-hyperdrive": "^0.1.1",
     "@types/node": "^24.2.1",
     "bare-buffer": "^3.4.2",
     "bare-fs": "^4.5.1",
@@ -81,9 +79,7 @@
   "engines": {
     "bare": ">=1.24.0"
   },
-  "peerDependencies": {
-    "@qvac/dl-hyperdrive": "^0.1.1"
-  },
+  "peerDependencies": {},
   "exports": {
     "./package": "./package.json",
     ".": {

--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const os = require('bare-os')
 const binding = require('../../binding')
 const ImgStableDiffusion = require('../../index')
@@ -48,10 +47,8 @@ async function setupModel (t) {
     downloadUrl: MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: modelDir,
       modelName
@@ -67,7 +64,6 @@ async function setupModel (t) {
 
   t.teardown(async () => {
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     try { binding.releaseLogger() } catch (_) {}
   })
 

--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -98,13 +98,23 @@ test('idle | cancel: allowed, no-op', { timeout: 600000, skip: isMobile }, async
 test('run | cancel: cancels current job', { timeout: 600000, skip: isMobile }, async t => {
   const { model } = await setupModel(t)
   const response = await model.run(LONG_PARAMS)
-  const cancelPromise = model.cancel()
+
+  // Cancel inside onUpdate after first progress tick — ensures native generation
+  // is actually active (matches LLM addon's runAndCancelAfterFirstToken pattern)
+  let cancelFired = false
+  let chain = response.onUpdate(async data => {
+    if (cancelFired) return
+    if (typeof data === 'string') {
+      cancelFired = true
+      await model.cancel()
+    }
+  })
+
   try {
-    await response.await()
+    await chain.await()
   } catch (err) {
     if (!/cancel|aborted|stopp?ed/i.test(err?.message || '')) throw err
   }
-  await cancelPromise
   t.pass('cancel during run resolves and stops job')
 })
 
@@ -140,11 +150,20 @@ test('run | run: second run() throws busy error', { timeout: 600000, skip: isMob
 test('cancel | run: can run again after cancel', { timeout: 600000, skip: isMobile }, async t => {
   const { model } = await setupModel(t)
 
-  // Start and cancel a long job
+  // Start a long job and cancel after first progress tick
   const response1 = await model.run(LONG_PARAMS)
-  await model.cancel()
+  let cancelFired = false
+  const chain1 = response1.onUpdate(async data => {
+    if (cancelFired) return
+    if (typeof data === 'string') {
+      cancelFired = true
+      await model.cancel()
+    }
+  })
   // Wait for the cancelled job to fully settle (resolve or reject)
-  await response1.onUpdate(() => {}).await().catch(() => {})
+  await chain1.await().catch(err => {
+    if (!/cancel|aborted|stopp?ed/i.test(err?.message || '')) throw err
+  })
 
   // Should be able to run again
   const response2 = await model.run(SHORT_PARAMS)

--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -102,7 +102,7 @@ test('run | cancel: cancels current job', { timeout: 600000, skip: isMobile }, a
   // Cancel inside onUpdate after first progress tick — ensures native generation
   // is actually active (matches LLM addon's runAndCancelAfterFirstToken pattern)
   let cancelFired = false
-  let chain = response.onUpdate(async data => {
+  const chain = response.onUpdate(async data => {
     if (cancelFired) return
     if (typeof data === 'string') {
       cancelFired = true

--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -1,0 +1,163 @@
+'use strict'
+
+const test = require('brittle')
+const FilesystemDL = require('@qvac/dl-filesystem')
+const os = require('bare-os')
+const binding = require('../../binding')
+const ImgStableDiffusion = require('../../index')
+const {
+  ensureModel,
+  setupJsLogger
+} = require('./utils')
+
+const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
+const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
+const isMobile = os.platform() === 'ios' || os.platform() === 'android'
+const useCpu = isDarwinX64 || isLinuxArm64
+
+// Smallest model for fast behavior tests
+const MODEL = {
+  name: 'stable-diffusion-v2-1-Q8_0.gguf',
+  url: 'https://huggingface.co/gpustack/stable-diffusion-v2-1-GGUF/resolve/main/stable-diffusion-v2-1-Q8_0.gguf'
+}
+
+// Many steps so cancel has time to fire before completion
+const LONG_PARAMS = {
+  prompt: 'a red fox in a snowy forest',
+  steps: 50,
+  width: 256,
+  height: 256,
+  cfg_scale: 7.5,
+  seed: 42
+}
+
+const SHORT_PARAMS = {
+  prompt: 'a red fox',
+  steps: 2,
+  width: 256,
+  height: 256,
+  cfg_scale: 7.5,
+  seed: 1
+}
+
+async function setupModel (t) {
+  setupJsLogger(binding)
+
+  const [modelName, modelDir] = await ensureModel({
+    modelName: MODEL.name,
+    downloadUrl: MODEL.url
+  })
+
+  const loader = new FilesystemDL({ dirPath: modelDir })
+  const model = new ImgStableDiffusion(
+    {
+      loader,
+      logger: console,
+      diskPath: modelDir,
+      modelName
+    },
+    {
+      threads: 4,
+      device: useCpu ? 'cpu' : 'gpu',
+      prediction: 'v'
+    }
+  )
+
+  await model.load()
+
+  t.teardown(async () => {
+    await model.unload().catch(() => {})
+    await loader.close().catch(() => {})
+    try { binding.releaseLogger() } catch (_) {}
+  })
+
+  return { model }
+}
+
+test('idle | run: allowed, returns QvacResponse', { timeout: 600000, skip: isMobile }, async t => {
+  const { model } = await setupModel(t)
+  const response = await model.run(SHORT_PARAMS)
+  t.ok(response, 'run() returns a response')
+  t.ok(typeof response.onUpdate === 'function', 'response has onUpdate')
+  t.ok(typeof response.await === 'function', 'response has await')
+
+  const images = []
+  await response.onUpdate(data => {
+    if (data instanceof Uint8Array) images.push(data)
+  }).await()
+
+  t.ok(images.length > 0, 'run produces at least one image')
+})
+
+test('idle | cancel: allowed, no-op', { timeout: 600000, skip: isMobile }, async t => {
+  const { model } = await setupModel(t)
+  await model.cancel()
+  t.pass('cancel when idle does not throw')
+})
+
+test('run | cancel: cancels current job', { timeout: 600000, skip: isMobile }, async t => {
+  const { model } = await setupModel(t)
+  const response = await model.run(LONG_PARAMS)
+  const cancelPromise = model.cancel()
+  try {
+    await response.await()
+  } catch (err) {
+    if (!/cancel|aborted|stopp?ed/i.test(err?.message || '')) throw err
+  }
+  await cancelPromise
+  t.pass('cancel during run resolves and stops job')
+})
+
+test('run | run: second run() throws busy error', { timeout: 600000, skip: isMobile }, async t => {
+  const { model } = await setupModel(t)
+  const firstResponse = await model.run(LONG_PARAMS)
+
+  const result = await Promise.race([
+    model.run(SHORT_PARAMS)
+      .then(() => ({ kind: 'no-throw' }))
+      .catch(err => ({ kind: 'busy', err })),
+    firstResponse.await()
+      .then(() => ({ kind: 'first-done' }))
+      .catch(() => ({ kind: 'first-done' }))
+  ])
+
+  if (result.kind === 'busy') {
+    t.ok(
+      /already set or being processed/.test(result.err.message),
+      'second run() throws "already set or being processed"'
+    )
+  } else if (result.kind === 'first-done') {
+    t.comment('First job finished before second run() was rejected; skipping concurrency assertion')
+    t.pass('first job completed (concurrency assertion skipped)')
+  } else {
+    t.fail('second run() should have thrown busy error while first job was still active')
+  }
+
+  // Cancel to clean up the long job if still running
+  await model.cancel().catch(() => {})
+})
+
+test('cancel | run: can run again after cancel', { timeout: 600000, skip: isMobile }, async t => {
+  const { model } = await setupModel(t)
+
+  // Start and cancel a long job
+  const response1 = await model.run(LONG_PARAMS)
+  await model.cancel()
+  // Wait for the cancelled job to fully settle (resolve or reject)
+  await response1.onUpdate(() => {}).await().catch(() => {})
+
+  // Should be able to run again
+  const response2 = await model.run(SHORT_PARAMS)
+  const images = []
+  await response2.onUpdate(data => {
+    if (data instanceof Uint8Array) images.push(data)
+  }).await()
+
+  t.ok(images.length > 0, 'can run again after cancel')
+})
+
+// Keep event loop alive briefly to let pending async operations complete.
+// Prevents C++ destructors from running while async cleanup is still happening.
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -121,6 +121,10 @@ test('run | cancel: cancels current job', { timeout: 600000, skip: isMobile }, a
 test('run | run: second run() throws busy error', { timeout: 600000, skip: isMobile }, async t => {
   const { model } = await setupModel(t)
   const firstResponse = await model.run(LONG_PARAMS)
+  let firstError = null
+  if (typeof firstResponse.onError === 'function') {
+    firstResponse.onError(err => { firstError = err })
+  }
 
   const result = await Promise.race([
     model.run(SHORT_PARAMS)
@@ -143,8 +147,12 @@ test('run | run: second run() throws busy error', { timeout: 600000, skip: isMob
     t.fail('second run() should have thrown busy error while first job was still active')
   }
 
-  // Cancel to clean up the long job if still running
-  await model.cancel().catch(() => {})
+  const images = []
+  await firstResponse.onUpdate(data => {
+    if (data instanceof Uint8Array) images.push(data)
+  }).await()
+  t.ok(images.length > 0, 'first response completes with output')
+  t.ok(!firstError, 'first response did not fail')
 })
 
 test('cancel | run: can run again after cancel', { timeout: 600000, skip: isMobile }, async t => {

--- a/packages/lib-infer-diffusion/test/integration/generate-image-flux2.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-flux2.test.js
@@ -4,7 +4,6 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const os = require('bare-os')
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const binding = require('../../binding')
 const ImgStableDiffusion = require('../../index')
 const {
@@ -65,11 +64,8 @@ test('FLUX.2 klein txt2img — generates a valid PNG image', { timeout: 1800000,
   const modelPath = path.join(modelDir, downloadedModelName)
   t.ok(fs.existsSync(modelPath), 'Model file exists on disk')
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: modelDir,
       modelName: downloadedModelName,
@@ -153,7 +149,6 @@ test('FLUX.2 klein txt2img — generates a valid PNG image', { timeout: 1800000,
   } finally {
     console.log('\n=== Cleanup ===')
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     try {
       binding.releaseLogger()
     } catch (_) {}

--- a/packages/lib-infer-diffusion/test/integration/generate-image-sd3.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-sd3.test.js
@@ -4,7 +4,6 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const os = require('bare-os')
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const binding = require('../../binding')
 const ImgStableDiffusion = require('../../index')
 const {
@@ -43,11 +42,8 @@ test('SD3 Medium txt2img — generates a valid PNG image', { timeout: 900000, sk
   const modelPath = path.join(modelDir, downloadedModelName)
   t.ok(fs.existsSync(modelPath), 'Model file exists on disk')
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: modelDir,
       modelName: downloadedModelName
@@ -133,7 +129,6 @@ test('SD3 Medium txt2img — generates a valid PNG image', { timeout: 900000, sk
   } finally {
     console.log('\n=== Cleanup ===')
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     try {
       binding.releaseLogger()
     } catch (_) {}

--- a/packages/lib-infer-diffusion/test/integration/generate-image-sdxl.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-sdxl.test.js
@@ -4,7 +4,6 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const os = require('bare-os')
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const binding = require('../../binding')
 const ImgStableDiffusion = require('../../index')
 const {
@@ -43,11 +42,8 @@ test('SDXL txt2img — generates a valid PNG image', { timeout: 900000, skip: is
   const modelPath = path.join(modelDir, downloadedModelName)
   t.ok(fs.existsSync(modelPath), 'Model file exists on disk')
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: modelDir,
       modelName: downloadedModelName
@@ -131,7 +127,6 @@ test('SDXL txt2img — generates a valid PNG image', { timeout: 900000, skip: is
   } finally {
     console.log('\n=== Cleanup ===')
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     try {
       binding.releaseLogger()
     } catch (_) {}

--- a/packages/lib-infer-diffusion/test/integration/generate-image.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image.test.js
@@ -3,7 +3,6 @@
 const fs = require('bare-fs')
 const path = require('bare-path')
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const binding = require('../../binding')
 const ImgStableDiffusion = require('../../index')
 const {
@@ -38,11 +37,8 @@ test('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000 }, async
   const modelPath = path.join(modelDir, downloadedModelName)
   t.ok(fs.existsSync(modelPath), 'Model file exists on disk')
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
-
   const model = new ImgStableDiffusion(
     {
-      loader,
       logger: console,
       diskPath: modelDir,
       modelName: downloadedModelName
@@ -127,7 +123,6 @@ test('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000 }, async
   } finally {
     console.log('\n=== Cleanup ===')
     await model.unload()
-    await loader.close()
     try {
       binding.releaseLogger()
     } catch (_) {}

--- a/packages/lib-infer-diffusion/test/integration/model-loading.test.js
+++ b/packages/lib-infer-diffusion/test/integration/model-loading.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const os = require('bare-os')
 
 const ImgStableDiffusion = require('../../index.js')
@@ -24,7 +23,6 @@ test('model loading - load and unload', { timeout: 600_000 }, async t => {
     downloadUrl: DEFAULT_MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
   const config = {
     threads: '4',
     device: useCpu ? 'cpu' : 'gpu',
@@ -32,24 +30,19 @@ test('model loading - load and unload', { timeout: 600_000 }, async t => {
   }
 
   const addon = new ImgStableDiffusion({
-    loader,
     modelName: downloadedModelName,
     diskPath: modelDir,
     logger: console
   }, config)
 
-  try {
-    await addon.load()
-    t.pass('model loaded successfully')
+  await addon.load()
+  t.pass('model loaded successfully')
 
-    await addon.unload()
-    t.pass('model unloaded successfully')
+  await addon.unload()
+  t.pass('model unloaded successfully')
 
-    await addon.unload().catch(() => {})
-    t.pass('second unload is idempotent')
-  } finally {
-    await loader.close().catch(() => {})
-  }
+  await addon.unload().catch(() => {})
+  t.pass('second unload is idempotent')
 })
 
 // Keep event loop alive briefly to let pending async operations complete

--- a/packages/lib-infer-diffusion/test/mobile/integration.auto.cjs
+++ b/packages/lib-infer-diffusion/test/mobile/integration.auto.cjs
@@ -6,6 +6,10 @@ require('./integration-runtime.cjs')
 
 /* global runIntegrationModule */
 
+async function runApiBehaviorTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/api-behavior.test.js', options)
+}
+
 async function runGenerateImageFlux2Test (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/generate-image-flux2.test.js', options)
 }


### PR DESCRIPTION
## What problem does this PR solve?

- JS layer didn't follow the LLM addon patterns (template method, boolean guard, exclusive run, `return await`)
- Separate `run()` and `img2img()` methods were confusing — should be a single entry point
- WeightsProvider was imported and initialized but unnecessary (FilesystemDL doesn't support downloads)
- No test coverage for cancel/busy/idle state transitions
- Buffer config coercion passed `"undefined"` strings when optional config values were missing
- Orphaned `unloadWeights()` method in addon.js
- README overstated supported models and had stale download/progress docs
- `docs/architecture.md` referenced WeightsProvider, Hyperdrive, and separate txt2img/img2img/txt2vid methods

## How does it solve it?

**JS layer (index.js):**
- Rename `run()` to `_runInternal()` (BaseInference template method pattern)
- Unify `txt2img` and `img2img` into single `run(params)` — mode auto-detected via `params.init_image`
- Replace 30ms timer guard with `_hasActiveResponse` boolean
- Remove WeightsProvider — files must already be on disk at `diskPath`
- Remove `_downloadWeights()`, `_getWeightFiles()`, `_runGeneration()`, `img2img()`
- Add `return await` to `_withExclusiveRun` calls (async stack trace alignment with LLM addon)
- Add `finalized.catch(() => {})` unhandled rejection guard
- Reset `_hasActiveResponse` in `unload()`

**Types (index.d.ts):**
- Unified `GenerationParams` with optional `init_image` and `strength` fields
- Single `run(params: GenerationParams)` — removed `img2img()`, `downloadWeights()`
- Narrowed `Addon.runJob` mode to `'txt2img' | 'img2img'`
- Removed stale `DownloadWeightsOptions`, `DownloadResult` interfaces
- Simplified `_load()` / `load()` signatures (no download args)

**addon.js:**
- Filter `undefined` values in config coercion (prevents `String(undefined)` -> `"undefined"`)
- Remove orphaned `unloadWeights()` method

**Tests:**
- Add `api-behavior.test.js` with 5 cancel/busy/idle tests matching LLM addon pattern
- Cancel tests fire `model.cancel()` inside `onUpdate` callback after first progress tick
- `run | run` test verifies first in-flight job still completes after second is rejected

**Docs:**
- README: mark `loader` as optional (retained for type compatibility), add `t5XxlModel` to constructor table, remove stale download/progress wording from `load()`
- `docs/architecture.md`: replace WeightsProvider/Hyperdrive references with disk-local contract, update class diagrams, layer diagrams, decisions 3 & 4, parameter schema

## How was it tested?

- Full integration test suite on combined branch `tmp-diffusion-cancel-fix`
- All 5 API behavior tests pass when paired with the native cancel fix (#782)
- Lint, TypeScript DTS check, load/unload example all pass locally

## CI Evidence

**Before (without #782 C++ fix):** https://github.com/tetherto/qvac/actions/runs/22869760943

The cancel tests fail on every platform because the C++ abort callback fix (#782) is not in the base branch:

| Platform | "run then cancel" test | "cancel then run" test | Exit |
|----------|----------------------|----------------------|------|
| **linux-x64** | Timed out (10 min) | Never reached | 134 |
| **linux-arm64** | Timed out (10 min) | Never reached | 134 |
| **darwin-arm64** | SIGABRT (Metal encoder) | Never reached | 134 |
| **darwin-x64** | Ran to completion (228s) | **SIGSEGV** - segfault on reuse | 139 |
| **win32-x64** | Passed (8s) | **Crashed** on reuse | 1 |

**After (with #782 C++ fix):** https://github.com/tetherto/qvac/actions/runs/22879138137

All 5 cancel/reuse tests pass on every platform that reaches them. Individual job failures are from pre-existing FLUX.2/SD3 generation timeouts on slow CPU runners (unrelated — workflow uses `continue-on-error: true`).

| Platform | "run\|cancel" | "cancel\|run" | All 5 cancel tests | Job failure reason |
|----------|--------------|--------------|--------------------|--------------------|
| **darwin-arm64** | 5.7s | 14.4s | **All pass** | None — clean pass |
| **darwin-x64** | 9.4s | 35.6s | **All pass** | FLUX.2 timeout (30 min) |
| **linux-arm64** | ~15s | 64.2s | **All pass** | FLUX.2 timeout (30 min) |
| **linux-x64** | Pass | Pass | **All pass** | SD3 timeout (10 min) |
| **win32-x64** | Not reached | Not reached | Not reached | FLUX.2 model load 755s |

darwin-arm64 is the clean reference — all tests pass end-to-end including FLUX.2/SD3.

## Dependencies

- Depends on #782 for the cancel tests to pass (native abort support + compute buffer + freeParamsImmediately fix)

## Breaking Changes

- `img2img()` method removed — use `run({ init_image, strength, ... })` instead
- `downloadWeights()` no longer overridden — base class throws NOT_IMPLEMENTED (files must be on disk)

## API Changes

- Single `run(params: GenerationParams)` replaces both `run()` and `img2img()`
- Mode auto-detected: `init_image` present → img2img, otherwise txt2img
- `loader` constructor arg is now optional (not used internally)
- `load()` takes no arguments (download/progress params removed)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213604403137963
  - https://app.asana.com/0/0/1213559015743997