### PR TITLE
QVAC-13614 feat: integrate OCR addon with diagnostics contributor pattern

### DIFF
--- a/packages/ocr-onnx/index.js
+++ b/packages/ocr-onnx/index.js
@@ -25,6 +25,18 @@ class ONNXOcr extends ONNXBase {
   constructor ({ params, ...args }) {
     super(args)
     this.params = params
+    this._packageName = '@qvac/ocr-onnx'
+    this._packageVersion = require('./package.json').version
+  }
+
+  _getDiagnosticsJSON () {
+    return JSON.stringify({
+      status: this.state.destroyed ? 'destroyed' : (this.state.configLoaded ? 'loaded' : 'not_loaded'),
+      langList: this.params?.langList || [],
+      useGPU: this.params?.useGPU || false,
+      pipelineMode: this.params?.pipelineMode || 'easyocr',
+      timeout: this.params?.timeout
+    })
   }
 
   /**

--- a/packages/ocr-onnx/index.js
+++ b/packages/ocr-onnx/index.js
@@ -32,10 +32,7 @@ class ONNXOcr extends ONNXBase {
   _getDiagnosticsJSON () {
     return JSON.stringify({
       status: this.state.destroyed ? 'destroyed' : (this.state.configLoaded ? 'loaded' : 'not_loaded'),
-      langList: this.params?.langList || [],
-      useGPU: this.params?.useGPU || false,
-      pipelineMode: this.params?.pipelineMode || 'easyocr',
-      timeout: this.params?.timeout
+      params: this.params
     })
   }
 

--- a/packages/ocr-onnx/package.json
+++ b/packages/ocr-onnx/package.json
@@ -79,6 +79,9 @@
     "bare-path": "^3.0.0",
     "bare-process": "^4.2.1"
   },
+  "optionalDependencies": {
+    "@qvac/diagnostics": "^0.1.0"
+  },
   "exports": {
     "./package": "./package.json",
     ".": "./index.js",

--- a/packages/ocr-onnx/test/unit/diagnostics.test.js
+++ b/packages/ocr-onnx/test/unit/diagnostics.test.js
@@ -25,10 +25,7 @@ class TestOCR {
   _getDiagnosticsJSON () {
     return JSON.stringify({
       status: this.state.destroyed ? 'destroyed' : (this.state.configLoaded ? 'loaded' : 'not_loaded'),
-      langList: this.params?.langList || [],
-      useGPU: this.params?.useGPU || false,
-      pipelineMode: this.params?.pipelineMode || 'easyocr',
-      timeout: this.params?.timeout
+      params: this.params
     })
   }
 }
@@ -61,24 +58,20 @@ test('_getDiagnosticsJSON returns valid JSON string', t => {
 })
 
 test('_getDiagnosticsJSON includes expected fields', t => {
-  const ocr = new TestOCR({
-    params: {
-      langList: ['en', 'fr'],
-      useGPU: true,
-      pipelineMode: 'doctr',
-      timeout: 60
-    }
-  })
+  const params = {
+    langList: ['en', 'fr'],
+    useGPU: true,
+    pipelineMode: 'doctr',
+    timeout: 60
+  }
+  const ocr = new TestOCR({ params })
   const parsed = JSON.parse(ocr._getDiagnosticsJSON())
   t.ok('status' in parsed, 'should include status field')
-  t.ok('langList' in parsed, 'should include langList field')
-  t.ok('useGPU' in parsed, 'should include useGPU field')
-  t.ok('pipelineMode' in parsed, 'should include pipelineMode field')
-  t.ok('timeout' in parsed, 'should include timeout field')
-  t.alike(parsed.langList, ['en', 'fr'], 'langList should match params')
-  t.is(parsed.useGPU, true, 'useGPU should match params')
-  t.is(parsed.pipelineMode, 'doctr', 'pipelineMode should match params')
-  t.is(parsed.timeout, 60, 'timeout should match params')
+  t.ok('params' in parsed, 'should include params field')
+  t.alike(parsed.params.langList, ['en', 'fr'], 'langList should match params')
+  t.is(parsed.params.useGPU, true, 'useGPU should match params')
+  t.is(parsed.params.pipelineMode, 'doctr', 'pipelineMode should match params')
+  t.is(parsed.params.timeout, 60, 'timeout should match params')
 })
 
 test('_getDiagnosticsJSON status reflects state correctly', t => {
@@ -93,12 +86,11 @@ test('_getDiagnosticsJSON status reflects state correctly', t => {
   t.is(JSON.parse(ocr._getDiagnosticsJSON()).status, 'destroyed', 'should be destroyed when destroyed=true')
 })
 
-test('_getDiagnosticsJSON uses defaults when params fields are absent', t => {
-  const ocr = new TestOCR({ params: {} })
+test('_getDiagnosticsJSON passes through all params', t => {
+  const ocr = new TestOCR({ params: { langList: ['en'], custom: 'value' } })
   const parsed = JSON.parse(ocr._getDiagnosticsJSON())
-  t.alike(parsed.langList, [], 'langList defaults to empty array')
-  t.is(parsed.useGPU, false, 'useGPU defaults to false')
-  t.is(parsed.pipelineMode, 'easyocr', 'pipelineMode defaults to easyocr')
+  t.alike(parsed.params.langList, ['en'], 'langList passed through')
+  t.is(parsed.params.custom, 'value', 'custom params passed through')
 })
 
 test('round-trip: registerAddon with OCR callback, generateReport shows addon', { skip: !diagnostics }, t => {
@@ -128,7 +120,7 @@ test('round-trip: registerAddon with OCR callback, generateReport shows addon', 
 
   const addonDiag = JSON.parse(report.addons[0].diagnostics)
   t.ok('status' in addonDiag, 'diagnostics should include status')
-  t.ok('langList' in addonDiag, 'diagnostics should include langList')
+  t.ok('params' in addonDiag, 'diagnostics should include params')
 
   diagnostics.reset()
 })

--- a/packages/ocr-onnx/test/unit/diagnostics.test.js
+++ b/packages/ocr-onnx/test/unit/diagnostics.test.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const test = require('brittle')
+const diagnostics = require('../../../qvac-lib-diagnostics')
+
+// Minimal test class that replicates the ONNXOcr constructor fields and
+// _getDiagnosticsJSON method without requiring native bindings.
+// This mirrors the exact implementation in index.js.
+class TestOCR {
+  constructor ({ params }) {
+    this.params = params
+    this.state = {
+      configLoaded: false,
+      weightsLoaded: false,
+      destroyed: false
+    }
+    this._packageName = '@qvac/ocr-onnx'
+    this._packageVersion = require('../../package.json').version
+  }
+
+  _getDiagnosticsJSON () {
+    return JSON.stringify({
+      status: this.state.destroyed ? 'destroyed' : (this.state.configLoaded ? 'loaded' : 'not_loaded'),
+      langList: this.params?.langList || [],
+      useGPU: this.params?.useGPU || false,
+      pipelineMode: this.params?.pipelineMode || 'easyocr',
+      timeout: this.params?.timeout
+    })
+  }
+}
+
+test('ONNXOcr constructor sets _packageName', t => {
+  const ocr = new TestOCR({ params: { langList: ['en'] } })
+  t.is(ocr._packageName, '@qvac/ocr-onnx', '_packageName should be @qvac/ocr-onnx')
+})
+
+test('ONNXOcr constructor sets _packageVersion from package.json', t => {
+  const ocr = new TestOCR({ params: { langList: ['en'] } })
+  const pkg = require('../../package.json')
+  t.is(ocr._packageVersion, pkg.version, '_packageVersion should match package.json version')
+  t.ok(typeof ocr._packageVersion === 'string', '_packageVersion should be a string')
+  t.ok(ocr._packageVersion.length > 0, '_packageVersion should not be empty')
+})
+
+test('_getDiagnosticsJSON returns valid JSON string', t => {
+  const ocr = new TestOCR({ params: { langList: ['en'] } })
+  const result = ocr._getDiagnosticsJSON()
+  t.ok(typeof result === 'string', '_getDiagnosticsJSON should return a string')
+  let parsed
+  try {
+    parsed = JSON.parse(result)
+  } catch (e) {
+    t.fail('_getDiagnosticsJSON should return valid JSON')
+    return
+  }
+  t.ok(parsed, 'parsed JSON should be truthy')
+})
+
+test('_getDiagnosticsJSON includes expected fields', t => {
+  const ocr = new TestOCR({
+    params: {
+      langList: ['en', 'fr'],
+      useGPU: true,
+      pipelineMode: 'doctr',
+      timeout: 60
+    }
+  })
+  const parsed = JSON.parse(ocr._getDiagnosticsJSON())
+  t.ok('status' in parsed, 'should include status field')
+  t.ok('langList' in parsed, 'should include langList field')
+  t.ok('useGPU' in parsed, 'should include useGPU field')
+  t.ok('pipelineMode' in parsed, 'should include pipelineMode field')
+  t.ok('timeout' in parsed, 'should include timeout field')
+  t.alike(parsed.langList, ['en', 'fr'], 'langList should match params')
+  t.is(parsed.useGPU, true, 'useGPU should match params')
+  t.is(parsed.pipelineMode, 'doctr', 'pipelineMode should match params')
+  t.is(parsed.timeout, 60, 'timeout should match params')
+})
+
+test('_getDiagnosticsJSON status reflects state correctly', t => {
+  const ocr = new TestOCR({ params: { langList: ['en'] } })
+
+  t.is(JSON.parse(ocr._getDiagnosticsJSON()).status, 'not_loaded', 'should be not_loaded initially')
+
+  ocr.state.configLoaded = true
+  t.is(JSON.parse(ocr._getDiagnosticsJSON()).status, 'loaded', 'should be loaded when configLoaded=true')
+
+  ocr.state.destroyed = true
+  t.is(JSON.parse(ocr._getDiagnosticsJSON()).status, 'destroyed', 'should be destroyed when destroyed=true')
+})
+
+test('_getDiagnosticsJSON uses defaults when params fields are absent', t => {
+  const ocr = new TestOCR({ params: {} })
+  const parsed = JSON.parse(ocr._getDiagnosticsJSON())
+  t.alike(parsed.langList, [], 'langList defaults to empty array')
+  t.is(parsed.useGPU, false, 'useGPU defaults to false')
+  t.is(parsed.pipelineMode, 'easyocr', 'pipelineMode defaults to easyocr')
+})
+
+test('round-trip: registerAddon with OCR callback, generateReport shows addon', t => {
+  diagnostics.reset()
+
+  const ocr = new TestOCR({
+    params: {
+      langList: ['en'],
+      useGPU: false,
+      pipelineMode: 'easyocr',
+      timeout: 120
+    }
+  })
+
+  diagnostics.registerAddon({
+    name: ocr._packageName,
+    version: ocr._packageVersion,
+    getDiagnostics: () => ocr._getDiagnosticsJSON()
+  })
+
+  const report = diagnostics.generateReport({ app: { name: 'test-app', version: '1.0.0' } })
+
+  t.is(report.addons.length, 1, 'report should have one addon')
+  t.is(report.addons[0].name, '@qvac/ocr-onnx', 'addon name should be @qvac/ocr-onnx')
+  t.is(report.addons[0].version, ocr._packageVersion, 'addon version should match package version')
+  t.ok(typeof report.addons[0].diagnostics === 'string', 'diagnostics should be a string')
+
+  const addonDiag = JSON.parse(report.addons[0].diagnostics)
+  t.ok('status' in addonDiag, 'diagnostics should include status')
+  t.ok('langList' in addonDiag, 'diagnostics should include langList')
+
+  diagnostics.reset()
+})

--- a/packages/ocr-onnx/test/unit/diagnostics.test.js
+++ b/packages/ocr-onnx/test/unit/diagnostics.test.js
@@ -1,7 +1,11 @@
 'use strict'
 
 const test = require('brittle')
-const diagnostics = require('../../../qvac-lib-diagnostics')
+
+let diagnostics
+try { diagnostics = require('@qvac/diagnostics') } catch (e) {
+  try { diagnostics = require('../../../qvac-lib-diagnostics') } catch (e) { diagnostics = null }
+}
 
 // Minimal test class that replicates the ONNXOcr constructor fields and
 // _getDiagnosticsJSON method without requiring native bindings.
@@ -97,7 +101,7 @@ test('_getDiagnosticsJSON uses defaults when params fields are absent', t => {
   t.is(parsed.pipelineMode, 'easyocr', 'pipelineMode defaults to easyocr')
 })
 
-test('round-trip: registerAddon with OCR callback, generateReport shows addon', t => {
+test('round-trip: registerAddon with OCR callback, generateReport shows addon', { skip: !diagnostics }, t => {
   diagnostics.reset()
 
   const ocr = new TestOCR({

--- a/packages/ocr-onnx/test/unit/diagnostics.test.js
+++ b/packages/ocr-onnx/test/unit/diagnostics.test.js
@@ -3,9 +3,7 @@
 const test = require('brittle')
 
 let diagnostics
-try { diagnostics = require('@qvac/diagnostics') } catch (e) {
-  try { diagnostics = require('../../../qvac-lib-diagnostics') } catch (e) { diagnostics = null }
-}
+try { diagnostics = require('@qvac/diagnostics') } catch (e) { diagnostics = null }
 
 // Minimal test class that replicates the ONNXOcr constructor fields and
 // _getDiagnosticsJSON method without requiring native bindings.


### PR DESCRIPTION
## Summary

- Add `_packageName`, `_packageVersion`, and `_getDiagnosticsJSON()` to `ONNXOcr` class
- Add `@qvac/diagnostics` as optional dependency in `ocr-onnx/package.json`
- Add unit tests (7 tests, 23 assertions) covering diagnostics fields, JSON serialization, state reflection, and round-trip registration

## Changes

### `packages/ocr-onnx/index.js`
- Constructor sets `this._packageName = '@qvac/ocr-onnx'` and `this._packageVersion` from package.json
- New `_getDiagnosticsJSON()` method returns `{ status, params }` as JSON string
- Status reflects lifecycle: `not_loaded` → `loaded` → `destroyed`
- BaseInference (from PR #796) automatically calls this during `load()`/`destroy()`

### `packages/ocr-onnx/package.json`
- Added `@qvac/diagnostics` as optional dependency — zero impact if not installed

### `packages/ocr-onnx/test/unit/diagnostics.test.js`
- Uses stub `TestOCR` class to test without native bindings
- Round-trip test with `@qvac/diagnostics` skips gracefully when package unavailable

## Test plan

- [x] Unit tests pass locally (`npm run test:unit` in ocr-onnx)
- [x] CI sanity-checks pass
- [x] CI cpp-lint passes
- [x] All 8 prebuilds pass (linux-x64, linux-arm64, darwin-arm64, win32-x64, android-arm64, ios-arm64, ios-arm64-simulator, ios-x64-simulator)
- [x] All integration tests pass (linux-x64, linux-arm64, darwin-arm64, win32-x64)
- [x] iOS E2E passes
- [ ] Android E2E — known flaky, continue-on-error

Depends on: #796 (already merged)
Asana: https://app.asana.com/0/0/1213441152822598
