### PR TITLE
chore: fix changelog date typo

### DIFF
--- a/packages/qvac-lib-langdetect-text-cld2/CHANGELOG.md
+++ b/packages/qvac-lib-langdetect-text-cld2/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2024-03-04
+## [0.1.0] - 2025-03-04
 
 ### Added
 - Initial release of @qvac/langdetect-text-cld2


### PR DESCRIPTION
Fix year typo in CHANGELOG.md (2024 → 2025)