### PR TITLE
QVAC-13799 feat: support named file paths for CTC and Sortformer in C++ addon

### DIFF
--- a/packages/qvac-lib-infer-parakeet/CHANGELOG.md
+++ b/packages/qvac-lib-infer-parakeet/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.11]
+
+### Changed
+- All model types (TDT, CTC, EOU, Sortformer) now require named file paths — buffer-based `_loadModelWeights` fallback removed
+- `_hasNamedPaths()` unified to cover all model types; `_hasAnyNamedPaths()` removed
+- `_load()` passes all named paths (TDT, CTC, EOU, Sortformer) to C++
+- `JSAdapter` parses CTC (`ctcModelPath`, `ctcModelDataPath`, `tokenizerPath`), EOU (`eouEncoderPath`, `eouDecoderPath`), and Sortformer (`sortformerPath`) path properties
+- `loadTDTSessions` requires `encoderPath` and `decoderPath`, removes buffer fallback
+- `loadCTCSessions` requires `ctcModelPath`, loads with C++-side temp staging for ONNX external data, reads tokenizer from `tokenizerPath`
+- `loadEOUSessions` requires `eouEncoderPath` and `eouDecoderPath`, reads tokenizer from `tokenizerPath`
+- `loadSortformerSessions` requires `sortformerPath`
+
 ## [0.1.10]
 
 ### Added

--- a/packages/qvac-lib-infer-parakeet/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/qvac-lib-infer-parakeet/addon/src/js-interface/JSAdapter.cpp
@@ -136,8 +136,8 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
   return config;
 }
 
-auto JSAdapter::loadModelParams(js::Object modelParamsObj, js_env_t *env,
-                                ParakeetConfig &parakeetConfig)
+auto JSAdapter::loadModelParams(
+    js::Object modelParamsObj, js_env_t* env, ParakeetConfig& parakeetConfig)
     -> ParakeetConfig {
   auto threadsOpt = modelParamsObj.getOptionalProperty<js::Number>(env, "maxThreads");
   if (threadsOpt.has_value()) {

--- a/packages/qvac-lib-infer-parakeet/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/qvac-lib-infer-parakeet/addon/src/js-interface/JSAdapter.cpp
@@ -11,7 +11,8 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
     -> ParakeetConfig {
   ParakeetConfig config;
 
-  auto modelPathOpt = jsObject.getOptionalProperty<js::String>(env, "modelPath");
+  auto modelPathOpt =
+      jsObject.getOptionalProperty<js::String>(env, "modelPath");
   if (modelPathOpt.has_value()) {
     config.modelPath = modelPathOpt.value().as<std::string>(env);
   }
@@ -21,7 +22,8 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
     config.modelPath = pathOpt.value().as<std::string>(env);
   }
 
-  auto modelTypeOpt = jsObject.getOptionalProperty<js::String>(env, "modelType");
+  auto modelTypeOpt =
+      jsObject.getOptionalProperty<js::String>(env, "modelType");
   if (modelTypeOpt.has_value()) {
     std::string typeStr = modelTypeOpt.value().as<std::string>(env);
     if (typeStr == "ctc") {
@@ -45,7 +47,8 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
     config.useGPU = gpuOpt.value().as<bool>(env);
   }
 
-  auto sampleRateOpt = jsObject.getOptionalProperty<js::Number>(env, "sampleRate");
+  auto sampleRateOpt =
+      jsObject.getOptionalProperty<js::Number>(env, "sampleRate");
   if (sampleRateOpt.has_value()) {
     config.sampleRate = sampleRateOpt.value().as<int32_t>(env);
   }
@@ -136,10 +139,11 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
   return config;
 }
 
-auto JSAdapter::loadModelParams(
-    js::Object modelParamsObj, js_env_t* env, ParakeetConfig& parakeetConfig)
+auto JSAdapter::loadModelParams(js::Object modelParamsObj, js_env_t *env,
+                                ParakeetConfig &parakeetConfig)
     -> ParakeetConfig {
-  auto threadsOpt = modelParamsObj.getOptionalProperty<js::Number>(env, "maxThreads");
+  auto threadsOpt =
+      modelParamsObj.getOptionalProperty<js::Number>(env, "maxThreads");
   if (threadsOpt.has_value()) {
     parakeetConfig.maxThreads = threadsOpt.value().as<int32_t>(env);
   }
@@ -152,15 +156,17 @@ auto JSAdapter::loadModelParams(
   return parakeetConfig;
 }
 
-auto JSAdapter::loadAudioParams(
-    js::Object audioParamsObj, js_env_t* env, ParakeetConfig& parakeetConfig)
+auto JSAdapter::loadAudioParams(js::Object audioParamsObj, js_env_t *env,
+                                ParakeetConfig &parakeetConfig)
     -> ParakeetConfig {
-  auto sampleRateOpt = audioParamsObj.getOptionalProperty<js::Number>(env, "sampleRate");
+  auto sampleRateOpt =
+      audioParamsObj.getOptionalProperty<js::Number>(env, "sampleRate");
   if (sampleRateOpt.has_value()) {
     parakeetConfig.sampleRate = sampleRateOpt.value().as<int32_t>(env);
   }
 
-  auto channelsOpt = audioParamsObj.getOptionalProperty<js::Number>(env, "channels");
+  auto channelsOpt =
+      audioParamsObj.getOptionalProperty<js::Number>(env, "channels");
   if (channelsOpt.has_value()) {
     parakeetConfig.channels = channelsOpt.value().as<int32_t>(env);
   }
@@ -168,9 +174,8 @@ auto JSAdapter::loadAudioParams(
   return parakeetConfig;
 }
 
-void JSAdapter::loadMap(
-    js::Object jsObject, js_env_t* env,
-    std::map<std::string, JSValueVariant>& output) {
+void JSAdapter::loadMap(js::Object jsObject, js_env_t *env,
+                        std::map<std::string, JSValueVariant> &output) {
   js_value_t* propNames = nullptr;
   JS(js_get_property_names(env, jsObject, &propNames));
 

--- a/packages/qvac-lib-infer-parakeet/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/qvac-lib-infer-parakeet/addon/src/js-interface/JSAdapter.cpp
@@ -11,19 +11,16 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
     -> ParakeetConfig {
   ParakeetConfig config;
 
-  // Get modelPath (required)
   auto modelPathOpt = jsObject.getOptionalProperty<js::String>(env, "modelPath");
   if (modelPathOpt.has_value()) {
     config.modelPath = modelPathOpt.value().as<std::string>(env);
   }
 
-  // Also try "path" key for compatibility with JsInterface
   auto pathOpt = jsObject.getOptionalProperty<js::String>(env, "path");
   if (pathOpt.has_value()) {
     config.modelPath = pathOpt.value().as<std::string>(env);
   }
 
-  // Get modelType
   auto modelTypeOpt = jsObject.getOptionalProperty<js::String>(env, "modelType");
   if (modelTypeOpt.has_value()) {
     std::string typeStr = modelTypeOpt.value().as<std::string>(env);
@@ -38,51 +35,43 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
     }
   }
 
-  // Get maxThreads
   auto threadsOpt = jsObject.getOptionalProperty<js::Number>(env, "maxThreads");
   if (threadsOpt.has_value()) {
     config.maxThreads = threadsOpt.value().as<int32_t>(env);
   }
 
-  // Get useGPU
   auto gpuOpt = jsObject.getOptionalProperty<js::Boolean>(env, "useGPU");
   if (gpuOpt.has_value()) {
     config.useGPU = gpuOpt.value().as<bool>(env);
   }
 
-  // Get sampleRate
   auto sampleRateOpt = jsObject.getOptionalProperty<js::Number>(env, "sampleRate");
   if (sampleRateOpt.has_value()) {
     config.sampleRate = sampleRateOpt.value().as<int32_t>(env);
   }
 
-  // Get channels
   auto channelsOpt = jsObject.getOptionalProperty<js::Number>(env, "channels");
   if (channelsOpt.has_value()) {
     config.channels = channelsOpt.value().as<int32_t>(env);
   }
 
-  // Get captionEnabled
   auto captionOpt =
       jsObject.getOptionalProperty<js::Boolean>(env, "captionEnabled");
   if (captionOpt.has_value()) {
     config.captionEnabled = captionOpt.value().as<bool>(env);
   }
 
-  // Get timestampsEnabled
   auto timestampsOpt =
       jsObject.getOptionalProperty<js::Boolean>(env, "timestampsEnabled");
   if (timestampsOpt.has_value()) {
     config.timestampsEnabled = timestampsOpt.value().as<bool>(env);
   }
 
-  // Get seed
   auto seedOpt = jsObject.getOptionalProperty<js::Number>(env, "seed");
   if (seedOpt.has_value()) {
     config.seed = seedOpt.value().as<int32_t>(env);
   }
 
-  // Get individual file paths
   auto encoderPathOpt =
       jsObject.getOptionalProperty<js::String>(env, "encoderPath");
   if (encoderPathOpt.has_value()) {
@@ -108,8 +97,37 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
   if (preprocessorPathOpt.has_value()) {
     config.preprocessorPath = preprocessorPathOpt.value().as<std::string>(env);
   }
+  auto ctcModelPathOpt =
+      jsObject.getOptionalProperty<js::String>(env, "ctcModelPath");
+  if (ctcModelPathOpt.has_value()) {
+    config.ctcModelPath = ctcModelPathOpt.value().as<std::string>(env);
+  }
+  auto ctcModelDataPathOpt =
+      jsObject.getOptionalProperty<js::String>(env, "ctcModelDataPath");
+  if (ctcModelDataPathOpt.has_value()) {
+    config.ctcModelDataPath = ctcModelDataPathOpt.value().as<std::string>(env);
+  }
+  auto tokenizerPathOpt =
+      jsObject.getOptionalProperty<js::String>(env, "tokenizerPath");
+  if (tokenizerPathOpt.has_value()) {
+    config.tokenizerPath = tokenizerPathOpt.value().as<std::string>(env);
+  }
+  auto eouEncoderPathOpt =
+      jsObject.getOptionalProperty<js::String>(env, "eouEncoderPath");
+  if (eouEncoderPathOpt.has_value()) {
+    config.eouEncoderPath = eouEncoderPathOpt.value().as<std::string>(env);
+  }
+  auto eouDecoderPathOpt =
+      jsObject.getOptionalProperty<js::String>(env, "eouDecoderPath");
+  if (eouDecoderPathOpt.has_value()) {
+    config.eouDecoderPath = eouDecoderPathOpt.value().as<std::string>(env);
+  }
+  auto sortformerPathOpt =
+      jsObject.getOptionalProperty<js::String>(env, "sortformerPath");
+  if (sortformerPathOpt.has_value()) {
+    config.sortformerPath = sortformerPathOpt.value().as<std::string>(env);
+  }
 
-  // Check for nested config object
   auto innerConfigOpt = jsObject.getOptionalProperty<js::Object>(env, "config");
   if (innerConfigOpt.has_value()) {
     loadModelParams(innerConfigOpt.value(), env, config);
@@ -121,13 +139,11 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
 auto JSAdapter::loadModelParams(js::Object modelParamsObj, js_env_t *env,
                                 ParakeetConfig &parakeetConfig)
     -> ParakeetConfig {
-  // Get maxThreads from nested config
   auto threadsOpt = modelParamsObj.getOptionalProperty<js::Number>(env, "maxThreads");
   if (threadsOpt.has_value()) {
     parakeetConfig.maxThreads = threadsOpt.value().as<int32_t>(env);
   }
 
-  // Get useGPU from nested config
   auto gpuOpt = modelParamsObj.getOptionalProperty<js::Boolean>(env, "useGPU");
   if (gpuOpt.has_value()) {
     parakeetConfig.useGPU = gpuOpt.value().as<bool>(env);
@@ -139,13 +155,11 @@ auto JSAdapter::loadModelParams(js::Object modelParamsObj, js_env_t *env,
 auto JSAdapter::loadAudioParams(
     js::Object audioParamsObj, js_env_t* env, ParakeetConfig& parakeetConfig)
     -> ParakeetConfig {
-  // Get sampleRate
   auto sampleRateOpt = audioParamsObj.getOptionalProperty<js::Number>(env, "sampleRate");
   if (sampleRateOpt.has_value()) {
     parakeetConfig.sampleRate = sampleRateOpt.value().as<int32_t>(env);
   }
 
-  // Get channels
   auto channelsOpt = audioParamsObj.getOptionalProperty<js::Number>(env, "channels");
   if (channelsOpt.has_value()) {
     parakeetConfig.channels = channelsOpt.value().as<int32_t>(env);
@@ -157,7 +171,6 @@ auto JSAdapter::loadAudioParams(
 void JSAdapter::loadMap(
     js::Object jsObject, js_env_t* env,
     std::map<std::string, JSValueVariant>& output) {
-  // Get property names
   js_value_t* propNames = nullptr;
   JS(js_get_property_names(env, jsObject, &propNames));
 
@@ -192,7 +205,6 @@ void JSAdapter::loadMap(
       break;
     }
     default:
-      // Skip unsupported types
       break;
     }
   }

--- a/packages/qvac-lib-infer-parakeet/addon/src/model-interface/parakeet/ParakeetConfig.hpp
+++ b/packages/qvac-lib-infer-parakeet/addon/src/model-interface/parakeet/ParakeetConfig.hpp
@@ -6,35 +6,43 @@
 
 namespace qvac_lib_infer_parakeet {
 
-/**
- * Configuration for Parakeet model
- */
 struct ParakeetConfig {
-  std::string modelPath;                // Path to model directory
-  std::string encoderPath;              // Absolute path to encoder ONNX file
-  std::string encoderDataPath;  // Absolute path to encoder external data file
-  std::string decoderPath;      // Absolute path to decoder ONNX file
-  std::string vocabPath;        // Absolute path to vocabulary file
-  std::string preprocessorPath; // Absolute path to preprocessor ONNX file
+  std::string modelPath;
+  std::string encoderPath;
+  std::string encoderDataPath;
+  std::string decoderPath;
+  std::string vocabPath;
+  std::string preprocessorPath;
+  std::string ctcModelPath;
+  std::string ctcModelDataPath;
+  std::string tokenizerPath;
+  std::string eouEncoderPath;
+  std::string eouDecoderPath;
+  std::string sortformerPath;
   ModelType modelType = ModelType::TDT;
-  int maxThreads = 4;                   // Maximum CPU threads to use
-  bool useGPU = false;                  // Enable GPU acceleration
-  int sampleRate = 16000;               // Audio sample rate
-  int channels = 1;                     // Number of audio channels
-  bool captionEnabled = false;          // Enable caption/subtitle mode
-  bool timestampsEnabled = true;        // Include timestamps in output
-  int seed = -1;                        // Random seed (-1 for random)
+  int maxThreads = 4;
+  bool useGPU = false;
+  int sampleRate = 16000;
+  int channels = 1;
+  bool captionEnabled = false;
+  bool timestampsEnabled = true;
+  int seed = -1;
 
   ParakeetConfig() = default;
 
   explicit ParakeetConfig(const std::string& path) : modelPath(path) {}
 
-  // Comparison for config change detection
   bool operator==(const ParakeetConfig& other) const {
     return modelPath == other.modelPath && encoderPath == other.encoderPath &&
            encoderDataPath == other.encoderDataPath &&
            decoderPath == other.decoderPath && vocabPath == other.vocabPath &&
            preprocessorPath == other.preprocessorPath &&
+           ctcModelPath == other.ctcModelPath &&
+           ctcModelDataPath == other.ctcModelDataPath &&
+           tokenizerPath == other.tokenizerPath &&
+           eouEncoderPath == other.eouEncoderPath &&
+           eouDecoderPath == other.eouDecoderPath &&
+           sortformerPath == other.sortformerPath &&
            modelType == other.modelType && maxThreads == other.maxThreads &&
            useGPU == other.useGPU && sampleRate == other.sampleRate &&
            channels == other.channels &&
@@ -48,4 +56,3 @@ struct ParakeetConfig {
 };
 
 } // namespace qvac_lib_infer_parakeet
-

--- a/packages/qvac-lib-infer-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
+++ b/packages/qvac-lib-infer-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
@@ -561,20 +561,19 @@ void ParakeetModel::loadCTCSessions(Ort::SessionOptions& session_options) {
   bool hasExternalData = !cfg_.ctcModelDataPath.empty() &&
                          std::filesystem::exists(cfg_.ctcModelDataPath);
 
-    if (hasExternalData) {
+  if (hasExternalData) {
     auto stagingDir =
         std::filesystem::temp_directory_path() /
-        ("parakeet_ctc_" +
-         std::to_string(reinterpret_cast<uintptr_t>(this)));
+        ("parakeet_ctc_" + std::to_string(reinterpret_cast<uintptr_t>(this)));
     std::filesystem::create_directories(stagingDir);
 
     auto modelLink = stagingDir / "model.onnx";
     std::filesystem::create_symlink(cfg_.ctcModelPath, modelLink);
     // ONNX exports use either model.onnx_data or model.onnx.data — create both
-    std::filesystem::create_symlink(cfg_.ctcModelDataPath,
-                                    stagingDir / "model.onnx_data");
-    std::filesystem::create_symlink(cfg_.ctcModelDataPath,
-                                    stagingDir / "model.onnx.data");
+    std::filesystem::create_symlink(
+        cfg_.ctcModelDataPath, stagingDir / "model.onnx_data");
+    std::filesystem::create_symlink(
+        cfg_.ctcModelDataPath, stagingDir / "model.onnx.data");
 
     try {
       ctc_session_ = std::make_unique<Ort::Session>(
@@ -663,8 +662,8 @@ void ParakeetModel::loadSortformerSessions(
       "Loading Sortformer session...");
 #ifdef _WIN32
   std::wstring wPath(cfg_.sortformerPath.begin(), cfg_.sortformerPath.end());
-  sortformer_session_ = std::make_unique<Ort::Session>(
-      *ort_env_, wPath.c_str(), session_options);
+  sortformer_session_ =
+      std::make_unique<Ort::Session>(*ort_env_, wPath.c_str(), session_options);
 #else
   sortformer_session_ = std::make_unique<Ort::Session>(
       *ort_env_, cfg_.sortformerPath.c_str(), session_options);

--- a/packages/qvac-lib-infer-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
+++ b/packages/qvac-lib-infer-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
@@ -549,35 +549,32 @@ void ParakeetModel::warmup() {
 // ═════════════════════════════════════════════════════════════════════════════
 
 void ParakeetModel::loadCTCSessions(Ort::SessionOptions& session_options) {
-  auto modelIt = model_weights_.find("model.onnx");
-  if (modelIt == model_weights_.end()) {
-    QLOG(
-        qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-        "CTC model weights not found");
+  if (cfg_.ctcModelPath.empty()) {
     throw errors::makeStatus(
-        errors::Code::CTCModelNotLoaded, "CTC model weights not found");
+        errors::Code::CTCModelNotLoaded, "ctcModelPath is required");
   }
 
   QLOG(
       qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
       "Loading CTC model session...");
 
-  std::string modelPath = cfg_.modelPath + "/model.onnx";
-  std::string modelDataPath = cfg_.modelPath + "/model.onnx_data";
-  bool hasExternalData = std::filesystem::exists(modelDataPath);
+  bool hasExternalData = !cfg_.ctcModelDataPath.empty() &&
+                         std::filesystem::exists(cfg_.ctcModelDataPath);
 
-  if (hasExternalData) {
+    if (hasExternalData) {
     auto stagingDir =
         std::filesystem::temp_directory_path() /
-        ("parakeet_ctc_" + std::to_string(reinterpret_cast<uintptr_t>(this)));
+        ("parakeet_ctc_" +
+         std::to_string(reinterpret_cast<uintptr_t>(this)));
     std::filesystem::create_directories(stagingDir);
 
     auto modelLink = stagingDir / "model.onnx";
-    auto dataLink = stagingDir / "model.onnx_data";
-    std::filesystem::create_symlink(
-        std::filesystem::absolute(modelPath), modelLink);
-    std::filesystem::create_symlink(
-        std::filesystem::absolute(modelDataPath), dataLink);
+    std::filesystem::create_symlink(cfg_.ctcModelPath, modelLink);
+    // ONNX exports use either model.onnx_data or model.onnx.data — create both
+    std::filesystem::create_symlink(cfg_.ctcModelDataPath,
+                                    stagingDir / "model.onnx_data");
+    std::filesystem::create_symlink(cfg_.ctcModelDataPath,
+                                    stagingDir / "model.onnx.data");
 
     try {
       ctc_session_ = std::make_unique<Ort::Session>(
@@ -588,181 +585,152 @@ void ParakeetModel::loadCTCSessions(Ort::SessionOptions& session_options) {
     }
     std::filesystem::remove_all(stagingDir);
   } else {
+#ifdef _WIN32
+    std::wstring wPath(cfg_.ctcModelPath.begin(), cfg_.ctcModelPath.end());
     ctc_session_ = std::make_unique<Ort::Session>(
-        *ort_env_,
-        modelIt->second.data(),
-        modelIt->second.size(),
-        session_options);
+        *ort_env_, wPath.c_str(), session_options);
+#else
+    ctc_session_ = std::make_unique<Ort::Session>(
+        *ort_env_, cfg_.ctcModelPath.c_str(), session_options);
+#endif
+  }
+
+  if (!cfg_.tokenizerPath.empty() && vocab_.empty()) {
+    std::ifstream file(cfg_.tokenizerPath, std::ios::binary);
+    if (file.is_open()) {
+      std::vector<uint8_t> data(
+          (std::istreambuf_iterator<char>(file)),
+          std::istreambuf_iterator<char>());
+      loadTokenizerJson(data);
+    }
   }
 }
 
 void ParakeetModel::loadEOUSessions(Ort::SessionOptions& session_options) {
-  auto encoderIt = model_weights_.find("encoder.onnx");
-  if (encoderIt == model_weights_.end()) {
-    QLOG(
-        qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-        "EOU encoder weights not found");
+  if (cfg_.eouEncoderPath.empty()) {
     throw errors::makeStatus(
-        errors::Code::EOUEncoderNotLoaded, "EOU encoder weights not found");
+        errors::Code::EOUEncoderNotLoaded, "eouEncoderPath is required");
+  }
+  if (cfg_.eouDecoderPath.empty()) {
+    throw errors::makeStatus(
+        errors::Code::EOUDecoderNotLoaded, "eouDecoderPath is required");
   }
 
   QLOG(
       qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
       "Loading EOU encoder session...");
+#ifdef _WIN32
+  std::wstring wEncPath(cfg_.eouEncoderPath.begin(), cfg_.eouEncoderPath.end());
   encoder_session_ = std::make_unique<Ort::Session>(
-      *ort_env_,
-      encoderIt->second.data(),
-      encoderIt->second.size(),
-      session_options);
-
-  auto decoderIt = model_weights_.find("decoder_joint.onnx");
-  if (decoderIt == model_weights_.end()) {
-    QLOG(
-        qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-        "EOU decoder weights not found");
-    throw errors::makeStatus(
-        errors::Code::EOUDecoderNotLoaded, "EOU decoder weights not found");
-  }
+      *ort_env_, wEncPath.c_str(), session_options);
+#else
+  encoder_session_ = std::make_unique<Ort::Session>(
+      *ort_env_, cfg_.eouEncoderPath.c_str(), session_options);
+#endif
 
   QLOG(
       qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
       "Loading EOU decoder session...");
+#ifdef _WIN32
+  std::wstring wDecPath(cfg_.eouDecoderPath.begin(), cfg_.eouDecoderPath.end());
   decoder_session_ = std::make_unique<Ort::Session>(
-      *ort_env_,
-      decoderIt->second.data(),
-      decoderIt->second.size(),
-      session_options);
+      *ort_env_, wDecPath.c_str(), session_options);
+#else
+  decoder_session_ = std::make_unique<Ort::Session>(
+      *ort_env_, cfg_.eouDecoderPath.c_str(), session_options);
+#endif
+
+  if (!cfg_.tokenizerPath.empty() && vocab_.empty()) {
+    std::ifstream file(cfg_.tokenizerPath, std::ios::binary);
+    if (file.is_open()) {
+      std::vector<uint8_t> data(
+          (std::istreambuf_iterator<char>(file)),
+          std::istreambuf_iterator<char>());
+      loadTokenizerJson(data);
+    }
+  }
 }
 
 void ParakeetModel::loadSortformerSessions(
     Ort::SessionOptions& session_options) {
-  auto modelIt = model_weights_.find("sortformer.onnx");
-  if (modelIt == model_weights_.end()) {
-    QLOG(
-        qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-        "Sortformer model weights not found");
+  if (cfg_.sortformerPath.empty()) {
     throw errors::makeStatus(
-        errors::Code::SortformerNotLoaded,
-        "Sortformer model weights not found");
+        errors::Code::SortformerNotLoaded, "sortformerPath is required");
   }
 
   QLOG(
       qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
       "Loading Sortformer session...");
+#ifdef _WIN32
+  std::wstring wPath(cfg_.sortformerPath.begin(), cfg_.sortformerPath.end());
   sortformer_session_ = std::make_unique<Ort::Session>(
-      *ort_env_,
-      modelIt->second.data(),
-      modelIt->second.size(),
-      session_options);
+      *ort_env_, wPath.c_str(), session_options);
+#else
+  sortformer_session_ = std::make_unique<Ort::Session>(
+      *ort_env_, cfg_.sortformerPath.c_str(), session_options);
+#endif
 }
 
 void ParakeetModel::loadTDTSessions(Ort::SessionOptions& session_options) {
-  const bool useNamedPaths = !cfg_.encoderPath.empty();
-  std::filesystem::path stagingDir;
+  if (cfg_.encoderPath.empty()) {
+    throw errors::makeStatus(
+        errors::Code::EncoderNotLoaded, "encoderPath is required");
+  }
+  if (cfg_.decoderPath.empty()) {
+    throw errors::makeStatus(
+        errors::Code::DecoderNotLoaded, "decoderPath is required");
+  }
 
-  if (useNamedPaths) {
-    QLOG(
-        qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
-        "Loading encoder from path: " + cfg_.encoderPath);
+  QLOG(
+      qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
+      "Loading encoder from path: " + cfg_.encoderPath);
 
-    bool hasExternalData = !cfg_.encoderDataPath.empty() &&
-                           std::filesystem::exists(cfg_.encoderDataPath);
+  bool hasExternalData = !cfg_.encoderDataPath.empty() &&
+                         std::filesystem::exists(cfg_.encoderDataPath);
 
-    if (hasExternalData) {
-      stagingDir =
-          std::filesystem::temp_directory_path() /
-          ("parakeet_enc_" + std::to_string(reinterpret_cast<uintptr_t>(this)));
-      std::filesystem::create_directories(stagingDir);
+  if (hasExternalData) {
+    auto stagingDir =
+        std::filesystem::temp_directory_path() /
+        ("parakeet_enc_" + std::to_string(reinterpret_cast<uintptr_t>(this)));
+    std::filesystem::create_directories(stagingDir);
 
-      auto encLink = stagingDir / "encoder-model.onnx";
-      auto dataLink = stagingDir / "encoder-model.onnx.data";
-      std::filesystem::create_symlink(cfg_.encoderPath, encLink);
-      std::filesystem::create_symlink(cfg_.encoderDataPath, dataLink);
+    auto encLink = stagingDir / "encoder-model.onnx";
+    auto dataLink = stagingDir / "encoder-model.onnx.data";
+    std::filesystem::create_symlink(cfg_.encoderPath, encLink);
+    std::filesystem::create_symlink(cfg_.encoderDataPath, dataLink);
 
-      try {
-        encoder_session_ = std::make_unique<Ort::Session>(
-            *ort_env_, encLink.c_str(), session_options);
-      } catch (...) {
-        std::filesystem::remove_all(stagingDir);
-        throw;
-      }
+    try {
+      encoder_session_ = std::make_unique<Ort::Session>(
+          *ort_env_, encLink.c_str(), session_options);
+    } catch (...) {
       std::filesystem::remove_all(stagingDir);
-      stagingDir.clear();
-    } else {
-#ifdef _WIN32
-      std::wstring wPath(cfg_.encoderPath.begin(), cfg_.encoderPath.end());
-      encoder_session_ = std::make_unique<Ort::Session>(
-          *ort_env_, wPath.c_str(), session_options);
-#else
-      encoder_session_ = std::make_unique<Ort::Session>(
-          *ort_env_, cfg_.encoderPath.c_str(), session_options);
-#endif
+      throw;
     }
+    std::filesystem::remove_all(stagingDir);
   } else {
-    auto encoderIt = model_weights_.find("encoder-model.onnx");
-    if (encoderIt == model_weights_.end()) {
-      QLOG(
-          qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-          "Encoder model weights not found");
-      throw errors::makeStatus(
-          errors::Code::EncoderNotLoaded, "Encoder model weights not found");
-    }
-
-    QLOG(
-        qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
-        "Loading encoder session...");
-
-    std::string encoderPath = cfg_.modelPath + "/encoder-model.onnx";
-    std::string encoderDataPath = cfg_.modelPath + "/encoder-model.onnx.data";
-    bool hasExternalData = std::filesystem::exists(encoderDataPath);
-
-    if (hasExternalData) {
 #ifdef _WIN32
-      std::wstring wEncoderPath(encoderPath.begin(), encoderPath.end());
-      encoder_session_ = std::make_unique<Ort::Session>(
-          *ort_env_, wEncoderPath.c_str(), session_options);
+    std::wstring wPath(cfg_.encoderPath.begin(), cfg_.encoderPath.end());
+    encoder_session_ = std::make_unique<Ort::Session>(
+        *ort_env_, wPath.c_str(), session_options);
 #else
-      encoder_session_ = std::make_unique<Ort::Session>(
-          *ort_env_, encoderPath.c_str(), session_options);
+    encoder_session_ = std::make_unique<Ort::Session>(
+        *ort_env_, cfg_.encoderPath.c_str(), session_options);
 #endif
-    } else {
-      encoder_session_ = std::make_unique<Ort::Session>(
-          *ort_env_,
-          encoderIt->second.data(),
-          encoderIt->second.size(),
-          session_options);
-    }
   }
 
   QLOG(
       qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
       "Loading decoder session...");
-  if (useNamedPaths && !cfg_.decoderPath.empty()) {
 #ifdef _WIN32
-    std::wstring wPath(cfg_.decoderPath.begin(), cfg_.decoderPath.end());
-    decoder_session_ = std::make_unique<Ort::Session>(
-        *ort_env_, wPath.c_str(), session_options);
+  std::wstring wDecoderPath(cfg_.decoderPath.begin(), cfg_.decoderPath.end());
+  decoder_session_ = std::make_unique<Ort::Session>(
+      *ort_env_, wDecoderPath.c_str(), session_options);
 #else
-    decoder_session_ = std::make_unique<Ort::Session>(
-        *ort_env_, cfg_.decoderPath.c_str(), session_options);
+  decoder_session_ = std::make_unique<Ort::Session>(
+      *ort_env_, cfg_.decoderPath.c_str(), session_options);
 #endif
-  } else {
-    auto decoderIt = model_weights_.find("decoder_joint-model.onnx");
-    if (decoderIt == model_weights_.end()) {
-      QLOG(
-          qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-          "Decoder model weights not found");
-      throw errors::makeStatus(
-          errors::Code::DecoderNotLoaded, "Decoder model weights not found");
-    }
-    decoder_session_ = std::make_unique<Ort::Session>(
-        *ort_env_,
-        decoderIt->second.data(),
-        decoderIt->second.size(),
-        session_options);
-  }
 
-  if (useNamedPaths && !cfg_.preprocessorPath.empty()) {
+  if (!cfg_.preprocessorPath.empty()) {
     QLOG(
         qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
         "Loading preprocessor session...");
@@ -775,21 +743,9 @@ void ParakeetModel::loadTDTSessions(Ort::SessionOptions& session_options) {
     preprocessor_session_ = std::make_unique<Ort::Session>(
         *ort_env_, cfg_.preprocessorPath.c_str(), session_options);
 #endif
-  } else {
-    auto preprocessorIt = model_weights_.find("preprocessor.onnx");
-    if (preprocessorIt != model_weights_.end()) {
-      QLOG(
-          qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
-          "Loading preprocessor session...");
-      preprocessor_session_ = std::make_unique<Ort::Session>(
-          *ort_env_,
-          preprocessorIt->second.data(),
-          preprocessorIt->second.size(),
-          session_options);
-    }
   }
 
-  if (useNamedPaths && vocab_.empty() && !cfg_.vocabPath.empty()) {
+  if (vocab_.empty() && !cfg_.vocabPath.empty()) {
     std::ifstream vocabFile(cfg_.vocabPath, std::ios::binary);
     if (vocabFile.is_open()) {
       std::vector<uint8_t> vocabData(

--- a/packages/qvac-lib-infer-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
+++ b/packages/qvac-lib-infer-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
@@ -550,8 +550,8 @@ void ParakeetModel::warmup() {
 
 void ParakeetModel::loadCTCSessions(Ort::SessionOptions& session_options) {
   if (cfg_.ctcModelPath.empty()) {
-    throw errors::makeStatus(
-        errors::Code::CTCModelNotLoaded, "ctcModelPath is required");
+    throw errors::makeStatus(errors::Code::CTCModelNotLoaded,
+                             "ctcModelPath is required");
   }
 
   QLOG(
@@ -570,10 +570,10 @@ void ParakeetModel::loadCTCSessions(Ort::SessionOptions& session_options) {
     auto modelLink = stagingDir / "model.onnx";
     std::filesystem::create_symlink(cfg_.ctcModelPath, modelLink);
     // ONNX exports use either model.onnx_data or model.onnx.data — create both
-    std::filesystem::create_symlink(
-        cfg_.ctcModelDataPath, stagingDir / "model.onnx_data");
-    std::filesystem::create_symlink(
-        cfg_.ctcModelDataPath, stagingDir / "model.onnx.data");
+    std::filesystem::create_symlink(cfg_.ctcModelDataPath,
+                                    stagingDir / "model.onnx_data");
+    std::filesystem::create_symlink(cfg_.ctcModelDataPath,
+                                    stagingDir / "model.onnx.data");
 
     try {
       ctc_session_ = std::make_unique<Ort::Session>(
@@ -586,8 +586,8 @@ void ParakeetModel::loadCTCSessions(Ort::SessionOptions& session_options) {
   } else {
 #ifdef _WIN32
     std::wstring wPath(cfg_.ctcModelPath.begin(), cfg_.ctcModelPath.end());
-    ctc_session_ = std::make_unique<Ort::Session>(
-        *ort_env_, wPath.c_str(), session_options);
+    ctc_session_ = std::make_unique<Ort::Session>(*ort_env_, wPath.c_str(),
+                                                  session_options);
 #else
     ctc_session_ = std::make_unique<Ort::Session>(
         *ort_env_, cfg_.ctcModelPath.c_str(), session_options);
@@ -597,9 +597,8 @@ void ParakeetModel::loadCTCSessions(Ort::SessionOptions& session_options) {
   if (!cfg_.tokenizerPath.empty() && vocab_.empty()) {
     std::ifstream file(cfg_.tokenizerPath, std::ios::binary);
     if (file.is_open()) {
-      std::vector<uint8_t> data(
-          (std::istreambuf_iterator<char>(file)),
-          std::istreambuf_iterator<char>());
+      std::vector<uint8_t> data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
       loadTokenizerJson(data);
     }
   }
@@ -607,12 +606,12 @@ void ParakeetModel::loadCTCSessions(Ort::SessionOptions& session_options) {
 
 void ParakeetModel::loadEOUSessions(Ort::SessionOptions& session_options) {
   if (cfg_.eouEncoderPath.empty()) {
-    throw errors::makeStatus(
-        errors::Code::EOUEncoderNotLoaded, "eouEncoderPath is required");
+    throw errors::makeStatus(errors::Code::EOUEncoderNotLoaded,
+                             "eouEncoderPath is required");
   }
   if (cfg_.eouDecoderPath.empty()) {
-    throw errors::makeStatus(
-        errors::Code::EOUDecoderNotLoaded, "eouDecoderPath is required");
+    throw errors::makeStatus(errors::Code::EOUDecoderNotLoaded,
+                             "eouDecoderPath is required");
   }
 
   QLOG(
@@ -620,8 +619,8 @@ void ParakeetModel::loadEOUSessions(Ort::SessionOptions& session_options) {
       "Loading EOU encoder session...");
 #ifdef _WIN32
   std::wstring wEncPath(cfg_.eouEncoderPath.begin(), cfg_.eouEncoderPath.end());
-  encoder_session_ = std::make_unique<Ort::Session>(
-      *ort_env_, wEncPath.c_str(), session_options);
+  encoder_session_ = std::make_unique<Ort::Session>(*ort_env_, wEncPath.c_str(),
+                                                    session_options);
 #else
   encoder_session_ = std::make_unique<Ort::Session>(
       *ort_env_, cfg_.eouEncoderPath.c_str(), session_options);
@@ -632,8 +631,8 @@ void ParakeetModel::loadEOUSessions(Ort::SessionOptions& session_options) {
       "Loading EOU decoder session...");
 #ifdef _WIN32
   std::wstring wDecPath(cfg_.eouDecoderPath.begin(), cfg_.eouDecoderPath.end());
-  decoder_session_ = std::make_unique<Ort::Session>(
-      *ort_env_, wDecPath.c_str(), session_options);
+  decoder_session_ = std::make_unique<Ort::Session>(*ort_env_, wDecPath.c_str(),
+                                                    session_options);
 #else
   decoder_session_ = std::make_unique<Ort::Session>(
       *ort_env_, cfg_.eouDecoderPath.c_str(), session_options);
@@ -642,9 +641,8 @@ void ParakeetModel::loadEOUSessions(Ort::SessionOptions& session_options) {
   if (!cfg_.tokenizerPath.empty() && vocab_.empty()) {
     std::ifstream file(cfg_.tokenizerPath, std::ios::binary);
     if (file.is_open()) {
-      std::vector<uint8_t> data(
-          (std::istreambuf_iterator<char>(file)),
-          std::istreambuf_iterator<char>());
+      std::vector<uint8_t> data((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
       loadTokenizerJson(data);
     }
   }
@@ -653,8 +651,8 @@ void ParakeetModel::loadEOUSessions(Ort::SessionOptions& session_options) {
 void ParakeetModel::loadSortformerSessions(
     Ort::SessionOptions& session_options) {
   if (cfg_.sortformerPath.empty()) {
-    throw errors::makeStatus(
-        errors::Code::SortformerNotLoaded, "sortformerPath is required");
+    throw errors::makeStatus(errors::Code::SortformerNotLoaded,
+                             "sortformerPath is required");
   }
 
   QLOG(
@@ -672,17 +670,16 @@ void ParakeetModel::loadSortformerSessions(
 
 void ParakeetModel::loadTDTSessions(Ort::SessionOptions& session_options) {
   if (cfg_.encoderPath.empty()) {
-    throw errors::makeStatus(
-        errors::Code::EncoderNotLoaded, "encoderPath is required");
+    throw errors::makeStatus(errors::Code::EncoderNotLoaded,
+                             "encoderPath is required");
   }
   if (cfg_.decoderPath.empty()) {
-    throw errors::makeStatus(
-        errors::Code::DecoderNotLoaded, "decoderPath is required");
+    throw errors::makeStatus(errors::Code::DecoderNotLoaded,
+                             "decoderPath is required");
   }
 
-  QLOG(
-      qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
-      "Loading encoder from path: " + cfg_.encoderPath);
+  QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
+       "Loading encoder from path: " + cfg_.encoderPath);
 
   bool hasExternalData = !cfg_.encoderDataPath.empty() &&
                          std::filesystem::exists(cfg_.encoderDataPath);
@@ -709,17 +706,16 @@ void ParakeetModel::loadTDTSessions(Ort::SessionOptions& session_options) {
   } else {
 #ifdef _WIN32
     std::wstring wPath(cfg_.encoderPath.begin(), cfg_.encoderPath.end());
-    encoder_session_ = std::make_unique<Ort::Session>(
-        *ort_env_, wPath.c_str(), session_options);
+    encoder_session_ = std::make_unique<Ort::Session>(*ort_env_, wPath.c_str(),
+                                                      session_options);
 #else
     encoder_session_ = std::make_unique<Ort::Session>(
         *ort_env_, cfg_.encoderPath.c_str(), session_options);
 #endif
   }
 
-  QLOG(
-      qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
-      "Loading decoder session...");
+  QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
+       "Loading decoder session...");
 #ifdef _WIN32
   std::wstring wDecoderPath(cfg_.decoderPath.begin(), cfg_.decoderPath.end());
   decoder_session_ = std::make_unique<Ort::Session>(

--- a/packages/qvac-lib-infer-parakeet/index.js
+++ b/packages/qvac-lib-infer-parakeet/index.js
@@ -130,7 +130,7 @@ class TranscriptionParakeet extends BaseInference {
     const modelPath = this._config.path || this._getModelFilePath()
 
     // When using named path overrides, skip directory-level validation
-    if (this._hasAnyNamedPaths()) {
+    if (this._hasNamedPaths()) {
       const modelType = this.params.modelType || 'tdt'
       const requiredFiles = getRequiredModelFiles(modelType)
       for (const file of requiredFiles) {
@@ -212,29 +212,19 @@ class TranscriptionParakeet extends BaseInference {
   }
 
   /**
-   * Whether TDT individual file paths have been provided via named config params.
-   * Only TDT paths are checked because the C++ addon can load directly from these.
-   * CTC/EOU/Sortformer named paths are handled by _resolveFilePath during
-   * JS-side weight loading.
+   * Whether individual file paths have been provided for any model type.
+   * When true, C++ loads directly from these paths (skip JS weight loading).
    * @returns {boolean}
    * @private
    */
   _hasNamedPaths () {
-    return !!(this._config.encoderPath || this._config.encoderDataPath ||
-      this._config.decoderPath || this._config.vocabPath || this._config.preprocessorPath)
-  }
-
-  /**
-   * Whether any named paths (TDT or CTC/EOU/Sortformer) have been provided.
-   * Used for validation to skip directory-level checks when individual paths are given.
-   * @returns {boolean}
-   * @private
-   */
-  _hasAnyNamedPaths () {
-    return this._hasNamedPaths() ||
-      !!(this._config.ctcModelPath || this._config.ctcModelDataPath ||
-        this._config.tokenizerPath || this._config.eouEncoderPath ||
-        this._config.eouDecoderPath || this._config.sortformerPath)
+    return !!(
+      this._config.encoderPath || this._config.encoderDataPath ||
+      this._config.decoderPath || this._config.vocabPath || this._config.preprocessorPath ||
+      this._config.ctcModelPath || this._config.ctcModelDataPath || this._config.tokenizerPath ||
+      this._config.eouEncoderPath || this._config.eouDecoderPath ||
+      this._config.sortformerPath
+    )
   }
 
   /**
@@ -262,24 +252,27 @@ class TranscriptionParakeet extends BaseInference {
       seed: this.params.seed ?? -1
     }
 
-    // TDT named paths are passed to C++ which loads directly from disk
+    // Pass individual file paths to C++ which loads directly from disk
     if (this._hasNamedPaths()) {
+      // TDT
       if (this._config.encoderPath) configurationParams.encoderPath = this._config.encoderPath
       if (this._config.encoderDataPath) configurationParams.encoderDataPath = this._config.encoderDataPath
       if (this._config.decoderPath) configurationParams.decoderPath = this._config.decoderPath
       if (this._config.vocabPath) configurationParams.vocabPath = this._config.vocabPath
       if (this._config.preprocessorPath) configurationParams.preprocessorPath = this._config.preprocessorPath
+      // CTC
+      if (this._config.ctcModelPath) configurationParams.ctcModelPath = this._config.ctcModelPath
+      if (this._config.ctcModelDataPath) configurationParams.ctcModelDataPath = this._config.ctcModelDataPath
+      if (this._config.tokenizerPath) configurationParams.tokenizerPath = this._config.tokenizerPath
+      // EOU
+      if (this._config.eouEncoderPath) configurationParams.eouEncoderPath = this._config.eouEncoderPath
+      if (this._config.eouDecoderPath) configurationParams.eouDecoderPath = this._config.eouDecoderPath
+      // Sortformer
+      if (this._config.sortformerPath) configurationParams.sortformerPath = this._config.sortformerPath
     }
 
     this.logger.info('Creating Parakeet addon with configuration:', configurationParams)
     this.addon = this._createAddon(configurationParams)
-
-    // TDT with named paths: C++ loads directly from file paths, skip JS weight loading.
-    // CTC/EOU/Sortformer (with or without named paths): JS loads weights via
-    // _loadModelWeights which uses _resolveFilePath to handle custom paths.
-    if (!this._hasNamedPaths()) {
-      await this._loadModelWeights(modelPath, modelType)
-    }
 
     // Activate the model
     await this.addon.activate()
@@ -441,7 +434,7 @@ class TranscriptionParakeet extends BaseInference {
    * @private
    */
   async _downloadWeights (reportProgressCallback, opts) {
-    if (this._hasAnyNamedPaths()) {
+    if (this._hasNamedPaths()) {
       this.logger.info('File paths provided via config, skipping WeightsProvider download')
       if (opts.closeLoader) {
         await this.weightsProvider.loader.close()

--- a/packages/qvac-lib-infer-parakeet/package.json
+++ b/packages/qvac-lib-infer-parakeet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-parakeet",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "High-performance speech-to-text inference addon using NVIDIA Parakeet models for Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-parakeet/test/integration/accuracy-multilang.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/accuracy-multilang.test.js
@@ -20,7 +20,7 @@ const {
   getTestPaths,
   validateAccuracy,
   ensureModel,
-  readFileChunked,
+  getNamedPathsConfig,
   isMobile
 } = require('./helpers.js')
 
@@ -106,7 +106,8 @@ async function runLanguageTest (t, langConfig, loggerBinding) {
     maxThreads: 4,
     useGPU: false,
     sampleRate: 16000,
-    channels: 1
+    channels: 1,
+    ...getNamedPathsConfig('tdt', modelPath)
   }
 
   // Track transcription
@@ -139,28 +140,6 @@ async function runLanguageTest (t, langConfig, loggerBinding) {
 
   try {
     parakeet = new ParakeetInterface(binding, config, outputCallback)
-
-    // Load model weights
-    const modelFiles = [
-      'encoder-model.onnx',
-      'encoder-model.onnx.data',
-      'decoder_joint-model.onnx',
-      'vocab.txt',
-      'preprocessor.onnx'
-    ]
-
-    for (const file of modelFiles) {
-      const filePath = path.join(modelPath, file)
-      if (fs.existsSync(filePath)) {
-        const chunks = []
-        for (const buffer of readFileChunked(filePath)) {
-          chunks.push(buffer)
-        }
-        const fullBuffer = Buffer.concat(chunks)
-        const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-        await parakeet.loadWeights({ filename: file, chunk, completed: true })
-      }
-    }
 
     await parakeet.activate()
 

--- a/packages/qvac-lib-infer-parakeet/test/integration/addon-multimodel.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/addon-multimodel.test.js
@@ -9,7 +9,7 @@ const {
   setupJsLogger,
   getTestPaths,
   ensureModelForType,
-  readFileChunked
+  getNamedPathsConfig
 } = require('./helpers.js')
 
 const { samplesDir } = getTestPaths()
@@ -22,22 +22,6 @@ function loadAudioSample () {
   const audio = new Float32Array(pcm.length)
   for (let i = 0; i < pcm.length; i++) audio[i] = pcm[i] / 32768.0
   return audio
-}
-
-function loadWeightsFromDir (parakeet, modelDir, files) {
-  const promises = []
-  for (const file of files) {
-    const filePath = path.join(modelDir, file)
-    if (!fs.existsSync(filePath)) continue
-    const chunks = []
-    for (const buffer of readFileChunked(filePath)) {
-      chunks.push(buffer)
-    }
-    const fullBuffer = Buffer.concat(chunks)
-    const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-    promises.push(parakeet.loadWeights({ filename: file, chunk, completed: true }))
-  }
-  return Promise.all(promises)
 }
 
 test('CTC desktop integration — English transcription', { timeout: 600000 }, async (t) => {
@@ -67,7 +51,8 @@ test('CTC desktop integration — English transcription', { timeout: 600000 }, a
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('ctc', modelDir)
     }, (_, event, __, output, error) => {
       if (event === 'Output' && output) {
         const segments = Array.isArray(output) ? output : [output]
@@ -82,7 +67,6 @@ test('CTC desktop integration — English transcription', { timeout: 600000 }, a
       if (error) console.error('[ctc] Error:', error)
     })
 
-    await loadWeightsFromDir(parakeet, modelDir, ['model.onnx', 'model.onnx_data', 'tokenizer.json'])
     await parakeet.activate()
 
     await parakeet.append({ type: 'audio', data: audio.buffer })
@@ -130,7 +114,8 @@ test('EOU desktop integration — streaming transcription', { timeout: 600000 },
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('eou', modelDir)
     }, (_, event, __, output, error) => {
       if (event === 'Output' && output) {
         const segments = Array.isArray(output) ? output : [output]
@@ -145,7 +130,6 @@ test('EOU desktop integration — streaming transcription', { timeout: 600000 },
       if (error) console.error('[eou] Error:', error)
     })
 
-    await loadWeightsFromDir(parakeet, modelDir, ['encoder.onnx', 'decoder_joint.onnx', 'tokenizer.json'])
     await parakeet.activate()
 
     await parakeet.append({ type: 'audio', data: audio.buffer })
@@ -193,7 +177,8 @@ test('Sortformer desktop integration — speaker diarization', { timeout: 600000
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('sortformer', modelDir)
     }, (_, event, __, output, error) => {
       if (event === 'Output' && output) {
         const segments = Array.isArray(output) ? output : [output]
@@ -208,7 +193,6 @@ test('Sortformer desktop integration — speaker diarization', { timeout: 600000
       if (error) console.error('[sortformer] Error:', error)
     })
 
-    await loadWeightsFromDir(parakeet, modelDir, ['sortformer.onnx'])
     await parakeet.activate()
 
     await parakeet.append({ type: 'audio', data: audio.buffer })

--- a/packages/qvac-lib-infer-parakeet/test/integration/addon.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/addon.test.js
@@ -11,7 +11,7 @@ const {
   getTestPaths,
   validateAccuracy,
   ensureModel,
-  readFileChunked
+  getNamedPathsConfig
 } = require('./helpers.js')
 
 const platform = detectPlatform()
@@ -60,7 +60,8 @@ test('English transcription and WER verification', { timeout: 300000 }, async (t
     maxThreads: 4,
     useGPU: false,
     sampleRate: 16000,
-    channels: 1
+    channels: 1,
+    ...getNamedPathsConfig('tdt', modelPath)
   }
 
   // Track transcription results
@@ -90,35 +91,6 @@ test('English transcription and WER verification', { timeout: 300000 }, async (t
     console.log('\n=== Creating instance and loading model ===')
     parakeet = new ParakeetInterface(binding, config, outputCallback)
 
-    // Load model weights
-    const modelFiles = [
-      'encoder-model.onnx',
-      'encoder-model.onnx.data',
-      'decoder_joint-model.onnx',
-      'vocab.txt',
-      'preprocessor.onnx'
-    ]
-
-    for (const file of modelFiles) {
-      const filePath = path.join(modelPath, file)
-      if (fs.existsSync(filePath)) {
-        const stat = fs.statSync(filePath)
-        const fileSize = stat.size
-
-        // Read file in chunks to handle bare-fs large file limitations,
-        // then concatenate and pass as single buffer for reliable native loading
-        const chunks = []
-        for (const buffer of readFileChunked(filePath)) {
-          chunks.push(buffer)
-        }
-        const fullBuffer = Buffer.concat(chunks)
-        const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-        await parakeet.loadWeights({ filename: file, chunk, completed: true })
-        console.log(`   Loaded ${file} (${(fileSize / 1024 / 1024).toFixed(2)} MB)`)
-      }
-    }
-
-    // Activate
     await parakeet.activate()
     console.log('   Model activated')
 

--- a/packages/qvac-lib-infer-parakeet/test/integration/cold-start-timing.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/cold-start-timing.test.js
@@ -23,7 +23,7 @@ const {
   setupJsLogger,
   getTestPaths,
   ensureModel,
-  readFileChunked,
+  getNamedPathsConfig,
   isMobile
 } = require('./helpers.js')
 
@@ -85,7 +85,8 @@ test('Cold start timing: first vs subsequent transcription times', { timeout: 60
     maxThreads: 4,
     useGPU: false,
     sampleRate: 16000,
-    channels: 1
+    channels: 1,
+    ...getNamedPathsConfig('tdt', modelPath)
   }
 
   // Track results for each run
@@ -109,28 +110,6 @@ test('Cold start timing: first vs subsequent transcription times', { timeout: 60
     const loadStartTime = getTimeMs()
 
     parakeet = new ParakeetInterface(binding, config, outputCallback)
-
-    // Load model weights
-    const modelFiles = [
-      'encoder-model.onnx',
-      'encoder-model.onnx.data',
-      'decoder_joint-model.onnx',
-      'vocab.txt',
-      'preprocessor.onnx'
-    ]
-
-    for (const file of modelFiles) {
-      const filePath = path.join(modelPath, file)
-      if (fs.existsSync(filePath)) {
-        const chunks = []
-        for (const buffer of readFileChunked(filePath)) {
-          chunks.push(buffer)
-        }
-        const fullBuffer = Buffer.concat(chunks)
-        const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-        await parakeet.loadWeights({ filename: file, chunk, completed: true })
-      }
-    }
 
     console.log('🔄 Activating model...')
     await parakeet.activate()
@@ -340,34 +319,13 @@ test('Fresh instance timing: new model per transcription (app restart simulation
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('tdt', modelPath)
     }
 
     let parakeet = null
     try {
       parakeet = new ParakeetInterface(binding, config, outputCallback)
-
-      // Load weights
-      const modelFiles = [
-        'encoder-model.onnx',
-        'encoder-model.onnx.data',
-        'decoder_joint-model.onnx',
-        'vocab.txt',
-        'preprocessor.onnx'
-      ]
-
-      for (const file of modelFiles) {
-        const filePath = path.join(modelPath, file)
-        if (fs.existsSync(filePath)) {
-          const chunks = []
-          for (const buffer of readFileChunked(filePath)) {
-            chunks.push(buffer)
-          }
-          const fullBuffer = Buffer.concat(chunks)
-          const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-          await parakeet.loadWeights({ filename: file, chunk, completed: true })
-        }
-      }
 
       const loadTime = getTimeMs() - instanceStartTime
 

--- a/packages/qvac-lib-infer-parakeet/test/integration/corrupted-model.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/corrupted-model.test.js
@@ -6,7 +6,7 @@ const fs = require('bare-fs')
 const os = require('bare-os')
 const binding = require('../../binding')
 const { ParakeetInterface } = require('../../parakeet')
-const { setupJsLogger, isMobile } = require('./helpers.js')
+const { setupJsLogger, getNamedPathsConfig, isMobile } = require('./helpers.js')
 
 /**
  * Helper function to create a test directory with corrupted model files
@@ -99,30 +99,13 @@ test('Corrupted model files should emit Error event to JavaScript', { timeout: 6
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('tdt', modelDir)
     }
 
     parakeet = new ParakeetInterface(binding, config, outputCallback)
 
-    // Load corrupted files
-    const files = [
-      'encoder-model.onnx',
-      'encoder-model.onnx.data',
-      'decoder_joint-model.onnx',
-      'vocab.txt',
-      'preprocessor.onnx'
-    ]
-
-    for (const file of files) {
-      const filePath = path.join(modelDir, file)
-      if (fs.existsSync(filePath)) {
-        const content = fs.readFileSync(filePath)
-        const chunk = new Uint8Array(content.buffer, content.byteOffset, content.byteLength)
-        await parakeet.loadWeights({ filename: file, chunk, completed: true })
-      }
-    }
-
-    // Try to activate - this should trigger model loading and fail
+    // Try to activate - this should trigger model loading and fail on corrupted files
     await parakeet.activate()
 
     // Wait for error event with timeout
@@ -228,20 +211,13 @@ test('Empty model files should emit Error event to JavaScript', { timeout: 60000
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('tdt', modelDir)
     }
 
     parakeet = new ParakeetInterface(binding, config, outputCallback)
 
-    // Load empty files
-    for (const file of files) {
-      const filePath = path.join(modelDir, file)
-      const content = fs.readFileSync(filePath)
-      const chunk = new Uint8Array(content.buffer, content.byteOffset, content.byteLength)
-      await parakeet.loadWeights({ filename: file, chunk, completed: true })
-    }
-
-    // Try to activate
+    // Try to activate - C++ will load empty files from named paths and fail
     await parakeet.activate()
 
     // Wait for error event with timeout
@@ -334,28 +310,13 @@ test('Truncated model files should emit Error event to JavaScript', { timeout: 6
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('tdt', modelDir)
     }
 
     parakeet = new ParakeetInterface(binding, config, outputCallback)
 
-    // Load truncated files
-    const files = [
-      'encoder-model.onnx',
-      'encoder-model.onnx.data',
-      'decoder_joint-model.onnx',
-      'vocab.txt',
-      'preprocessor.onnx'
-    ]
-
-    for (const file of files) {
-      const filePath = path.join(modelDir, file)
-      const content = fs.readFileSync(filePath)
-      const chunk = new Uint8Array(content.buffer, content.byteOffset, content.byteLength)
-      await parakeet.loadWeights({ filename: file, chunk, completed: true })
-    }
-
-    // Try to activate
+    // Try to activate - C++ will load truncated files from named paths and fail
     await parakeet.activate()
 
     // Wait for error event with timeout

--- a/packages/qvac-lib-infer-parakeet/test/integration/helpers.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/helpers.js
@@ -555,6 +555,43 @@ async function ensureModelForType (modelType) {
   return targetPath
 }
 
+/**
+ * Build the named-paths config properties for a given model type.
+ * C++ loads directly from these paths (no JS buffer loading needed).
+ * @param {string} modelType - 'tdt', 'ctc', 'eou', or 'sortformer'
+ * @param {string} modelDir - absolute path to the model directory
+ * @returns {Object} named path config properties to spread into ParakeetInterface config
+ */
+function getNamedPathsConfig (modelType, modelDir) {
+  switch (modelType) {
+    case 'ctc':
+      return {
+        ctcModelPath: path.join(modelDir, 'model.onnx'),
+        ctcModelDataPath: path.join(modelDir, 'model.onnx_data'),
+        tokenizerPath: path.join(modelDir, 'tokenizer.json')
+      }
+    case 'eou':
+      return {
+        eouEncoderPath: path.join(modelDir, 'encoder.onnx'),
+        eouDecoderPath: path.join(modelDir, 'decoder_joint.onnx'),
+        tokenizerPath: path.join(modelDir, 'tokenizer.json')
+      }
+    case 'sortformer':
+      return {
+        sortformerPath: path.join(modelDir, 'sortformer.onnx')
+      }
+    case 'tdt':
+    default:
+      return {
+        encoderPath: path.join(modelDir, 'encoder-model.onnx'),
+        encoderDataPath: path.join(modelDir, 'encoder-model.onnx.data'),
+        decoderPath: path.join(modelDir, 'decoder_joint-model.onnx'),
+        vocabPath: path.join(modelDir, 'vocab.txt'),
+        preprocessorPath: path.join(modelDir, 'preprocessor.onnx')
+      }
+  }
+}
+
 module.exports = {
   detectPlatform,
   waitUntilIdle,
@@ -570,6 +607,7 @@ module.exports = {
   ensureModel,
   ensureModelForType,
   readFileChunked,
+  getNamedPathsConfig,
   isMobile,
   platform,
   arch,

--- a/packages/qvac-lib-infer-parakeet/test/integration/individual-file-paths.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/individual-file-paths.test.js
@@ -10,8 +10,7 @@ const {
   setupJsLogger,
   getTestPaths,
   validateAccuracy,
-  ensureModel,
-  readFileChunked
+  ensureModel
 } = require('./helpers.js')
 
 const platform = detectPlatform()
@@ -20,15 +19,14 @@ const { modelPath, samplesDir } = getTestPaths()
 const expectedText = 'Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do. Once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it. And what is the use of a book thought Alice without pictures or conversations'
 
 /**
- * Test both directory-based and individual file path loading methods,
- * verifying each produces correct transcription output and that both
- * methods yield equivalent results.
+ * Verify that explicit individual file paths produce correct transcriptions.
+ * All model types now require named paths — C++ loads directly from disk.
  */
-test('Directory and individual file path loading both produce correct transcriptions', { timeout: 600000 }, async (t) => {
+test('Individual file paths produce correct transcription', { timeout: 600000 }, async (t) => {
   const loggerBinding = setupJsLogger(binding)
 
   console.log('\n' + '='.repeat(60))
-  console.log('DIRECTORY vs INDIVIDUAL FILE PATHS TEST')
+  console.log('INDIVIDUAL FILE PATHS TEST')
   console.log('='.repeat(60))
   console.log(` Platform: ${platform}`)
   console.log(` Model path: ${modelPath}`)
@@ -61,64 +59,49 @@ test('Directory and individual file path loading both produce correct transcript
   }
   console.log(`Audio duration: ${(audioData.length / 16000).toFixed(2)}s\n`)
 
-  let directoryText = ''
-  let filePathText = ''
+  const transcriptions = []
+  let outputResolve = null
+  const outputPromise = new Promise(resolve => { outputResolve = resolve })
 
-  // ──────────────────────────────────────────────────────────
-  // Run 1 — Directory-based loading (buffer weight streaming)
-  // ──────────────────────────────────────────────────────────
-  console.log('=== Run 1: Directory-based loading ===')
-  {
-    const transcriptions = []
-    let outputResolve = null
-    const outputPromise = new Promise(resolve => { outputResolve = resolve })
-
-    function outputCallback (handle, event, id, output, error) {
-      if (event === 'Output' && Array.isArray(output)) {
-        for (const segment of output) {
-          if (segment && segment.text) transcriptions.push(segment)
-        }
-        if (transcriptions.length > 0 && outputResolve) {
-          outputResolve()
-          outputResolve = null
-        }
+  function outputCallback (handle, event, id, output, error) {
+    if (event === 'Output' && Array.isArray(output)) {
+      for (const segment of output) {
+        if (segment && segment.text) transcriptions.push(segment)
+      }
+      if (transcriptions.length > 0 && outputResolve) {
+        outputResolve()
+        outputResolve = null
       }
     }
+  }
 
-    const config = {
-      modelPath,
-      modelType: 'tdt',
-      maxThreads: 4,
-      useGPU: false,
-      sampleRate: 16000,
-      channels: 1
-    }
+  console.log(`  encoderPath:      ${encoderPath}`)
+  console.log(`  encoderDataPath:  ${encoderDataPath}`)
+  console.log(`  decoderPath:      ${decoderPath}`)
+  console.log(`  vocabPath:        ${vocabPath}`)
+  console.log(`  preprocessorPath: ${preprocessorPath}\n`)
 
-    const parakeet = new ParakeetInterface(binding, config, outputCallback)
+  const config = {
+    modelPath,
+    modelType: 'tdt',
+    maxThreads: 4,
+    useGPU: false,
+    sampleRate: 16000,
+    channels: 1,
+    encoderPath,
+    encoderDataPath,
+    decoderPath,
+    vocabPath,
+    preprocessorPath
+  }
 
-    const modelFiles = [
-      'encoder-model.onnx',
-      'encoder-model.onnx.data',
-      'decoder_joint-model.onnx',
-      'vocab.txt',
-      'preprocessor.onnx'
-    ]
+  let parakeet = null
 
-    for (const file of modelFiles) {
-      const filePath = path.join(modelPath, file)
-      if (fs.existsSync(filePath)) {
-        const chunks = []
-        for (const buffer of readFileChunked(filePath)) {
-          chunks.push(buffer)
-        }
-        const fullBuffer = Buffer.concat(chunks)
-        const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-        await parakeet.loadWeights({ filename: file, chunk, completed: true })
-      }
-    }
+  try {
+    parakeet = new ParakeetInterface(binding, config, outputCallback)
 
     await parakeet.activate()
-    console.log('   Model activated (directory-based)')
+    console.log('  Model activated\n')
 
     await parakeet.append({ type: 'audio', data: audioData.buffer })
     await parakeet.append({ type: 'end of job' })
@@ -127,108 +110,27 @@ test('Directory and individual file path loading both produce correct transcript
     await outputPromise
     clearTimeout(timeout)
 
-    directoryText = transcriptions.map(s => s.text).join(' ').trim()
-    console.log(`   Text: "${directoryText.substring(0, 80)}..."`)
+    const fullText = transcriptions.map(s => s.text).join(' ').trim()
+    console.log(`  Text: "${fullText.substring(0, 100)}..."`)
 
-    t.ok(transcriptions.length > 0, `Directory: should produce segments (got ${transcriptions.length})`)
-    t.ok(directoryText.length > 0, `Directory: should produce text (got ${directoryText.length} chars)`)
+    t.ok(transcriptions.length > 0, `Should produce segments (got ${transcriptions.length})`)
+    t.ok(fullText.length > 0, `Should produce text (got ${fullText.length} chars)`)
 
-    const werResult = validateAccuracy(expectedText, directoryText, 0.3)
-    console.log(`   WER: ${werResult.werPercent}`)
-    t.ok(werResult.wer <= 0.3, `Directory: WER should be <= 30% (got ${werResult.werPercent})`)
+    const werResult = validateAccuracy(expectedText, fullText, 0.3)
+    console.log(`  WER: ${werResult.werPercent}`)
+    t.ok(werResult.wer <= 0.3, `WER should be <= 30% (got ${werResult.werPercent})`)
 
-    try { parakeet.destroyInstance() } catch (e) {}
-    console.log('   Instance destroyed\n')
-  }
-
-  // Allow native resources to be fully released
-  await new Promise(resolve => setTimeout(resolve, 1000))
-
-  // ──────────────────────────────────────────────────────────
-  // Run 2 — Individual file path loading (direct ONNX load)
-  // ──────────────────────────────────────────────────────────
-  console.log('=== Run 2: Individual file paths loading ===')
-  console.log(`   encoderPath: ${encoderPath}`)
-  console.log(`   encoderDataPath: ${encoderDataPath}`)
-  console.log(`   decoderPath: ${decoderPath}`)
-  console.log(`   vocabPath: ${vocabPath}`)
-  console.log(`   preprocessorPath: ${preprocessorPath}`)
-  {
-    const transcriptions = []
-    let outputResolve = null
-    const outputPromise = new Promise(resolve => { outputResolve = resolve })
-
-    function outputCallback (handle, event, id, output, error) {
-      if (event === 'Output' && Array.isArray(output)) {
-        for (const segment of output) {
-          if (segment && segment.text) transcriptions.push(segment)
-        }
-        if (transcriptions.length > 0 && outputResolve) {
-          outputResolve()
-          outputResolve = null
-        }
-      }
+    console.log('\n' + '='.repeat(60))
+    console.log('TEST SUMMARY')
+    console.log('='.repeat(60))
+    console.log(`  Segments: ${transcriptions.length}`)
+    console.log(`  Text length: ${fullText.length} chars`)
+    console.log(`  WER: ${werResult.werPercent}`)
+    console.log('='.repeat(60) + '\n')
+  } finally {
+    if (parakeet) {
+      try { parakeet.destroyInstance() } catch (e) {}
     }
-
-    const config = {
-      modelPath,
-      modelType: 'tdt',
-      maxThreads: 4,
-      useGPU: false,
-      sampleRate: 16000,
-      channels: 1,
-      encoderPath,
-      encoderDataPath,
-      decoderPath,
-      vocabPath,
-      preprocessorPath
-    }
-
-    const parakeet = new ParakeetInterface(binding, config, outputCallback)
-
-    // No loadWeights() needed — C++ addon loads directly from file paths
-    await parakeet.activate()
-    console.log('   Model activated (individual file paths)')
-
-    await parakeet.append({ type: 'audio', data: audioData.buffer })
-    await parakeet.append({ type: 'end of job' })
-
-    const timeout = setTimeout(() => { if (outputResolve) { outputResolve(); outputResolve = null } }, 600000)
-    await outputPromise
-    clearTimeout(timeout)
-
-    filePathText = transcriptions.map(s => s.text).join(' ').trim()
-    console.log(`   Text: "${filePathText.substring(0, 80)}..."`)
-
-    t.ok(transcriptions.length > 0, `File paths: should produce segments (got ${transcriptions.length})`)
-    t.ok(filePathText.length > 0, `File paths: should produce text (got ${filePathText.length} chars)`)
-
-    const werResult = validateAccuracy(expectedText, filePathText, 0.3)
-    console.log(`   WER: ${werResult.werPercent}`)
-    t.ok(werResult.wer <= 0.3, `File paths: WER should be <= 30% (got ${werResult.werPercent})`)
-
-    try { parakeet.destroyInstance() } catch (e) {}
-    console.log('   Instance destroyed\n')
+    try { loggerBinding.releaseLogger() } catch (e) {}
   }
-
-  // ──────────────────────────────────────────────────────────
-  // Compare results from both methods
-  // ──────────────────────────────────────────────────────────
-  console.log('=== Comparison ===')
-  const werBetween = validateAccuracy(directoryText, filePathText, 0.05)
-  console.log(`   Directory:   "${directoryText.substring(0, 80)}..."`)
-  console.log(`   File paths:  "${filePathText.substring(0, 80)}..."`)
-  console.log(`   WER between: ${werBetween.werPercent}`)
-
-  t.ok(werBetween.wer <= 0.05, `Both methods should produce near-identical output (WER: ${werBetween.werPercent})`)
-
-  console.log('\n' + '='.repeat(60))
-  console.log('TEST SUMMARY')
-  console.log('='.repeat(60))
-  console.log(`  Directory:      ${directoryText.length} chars, WER ${validateAccuracy(expectedText, directoryText, 0.3).werPercent}`)
-  console.log(`  File paths:     ${filePathText.length} chars, WER ${validateAccuracy(expectedText, filePathText, 0.3).werPercent}`)
-  console.log(`  Cross-method:   WER ${werBetween.werPercent}`)
-  console.log('='.repeat(60) + '\n')
-
-  try { loggerBinding.releaseLogger() } catch (e) {}
 })

--- a/packages/qvac-lib-infer-parakeet/test/integration/live-stream-simulation.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/live-stream-simulation.test.js
@@ -19,7 +19,7 @@ const {
   setupJsLogger,
   getTestPaths,
   ensureModel,
-  readFileChunked,
+  getNamedPathsConfig,
   isMobile
 } = require('./helpers.js')
 
@@ -110,7 +110,8 @@ test('Live stream simulation: chunked audio feeding', { timeout: 300000 }, async
     maxThreads: 4,
     useGPU: false,
     sampleRate: 16000,
-    channels: 1
+    channels: 1,
+    ...getNamedPathsConfig('tdt', modelPath)
   }
 
   // Track results
@@ -150,28 +151,6 @@ test('Live stream simulation: chunked audio feeding', { timeout: 300000 }, async
 
   try {
     parakeet = new ParakeetInterface(binding, config, outputCallback)
-
-    // Load model weights
-    const modelFiles = [
-      'encoder-model.onnx',
-      'encoder-model.onnx.data',
-      'decoder_joint-model.onnx',
-      'vocab.txt',
-      'preprocessor.onnx'
-    ]
-
-    for (const file of modelFiles) {
-      const filePath = path.join(modelPath, file)
-      if (fs.existsSync(filePath)) {
-        const chunks = []
-        for (const buffer of readFileChunked(filePath)) {
-          chunks.push(buffer)
-        }
-        const fullBuffer = Buffer.concat(chunks)
-        const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-        await parakeet.loadWeights({ filename: file, chunk, completed: true })
-      }
-    }
 
     await parakeet.activate()
     console.log('Model activated, starting live stream simulation...\n')
@@ -286,7 +265,8 @@ test('Rapid chunk feeding: stress test with no delay', { timeout: 300000 }, asyn
     maxThreads: 4,
     useGPU: false,
     sampleRate: 16000,
-    channels: 1
+    channels: 1,
+    ...getNamedPathsConfig('tdt', modelPath)
   }
 
   // Track results
@@ -312,28 +292,6 @@ test('Rapid chunk feeding: stress test with no delay', { timeout: 300000 }, asyn
 
   try {
     parakeet = new ParakeetInterface(binding, config, outputCallback)
-
-    // Load model weights
-    const modelFiles = [
-      'encoder-model.onnx',
-      'encoder-model.onnx.data',
-      'decoder_joint-model.onnx',
-      'vocab.txt',
-      'preprocessor.onnx'
-    ]
-
-    for (const file of modelFiles) {
-      const filePath = path.join(modelPath, file)
-      if (fs.existsSync(filePath)) {
-        const chunks = []
-        for (const buffer of readFileChunked(filePath)) {
-          chunks.push(buffer)
-        }
-        const fullBuffer = Buffer.concat(chunks)
-        const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-        await parakeet.loadWeights({ filename: file, chunk, completed: true })
-      }
-    }
 
     await parakeet.activate()
 
@@ -450,35 +408,14 @@ test('Variable chunk sizes: small to large chunks', { timeout: 300000 }, async (
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('tdt', modelPath)
     }
 
     let parakeet = null
 
     try {
       parakeet = new ParakeetInterface(binding, config, outputCallback)
-
-      // Load model weights
-      const modelFiles = [
-        'encoder-model.onnx',
-        'encoder-model.onnx.data',
-        'decoder_joint-model.onnx',
-        'vocab.txt',
-        'preprocessor.onnx'
-      ]
-
-      for (const file of modelFiles) {
-        const filePath = path.join(modelPath, file)
-        if (fs.existsSync(filePath)) {
-          const chunks = []
-          for (const buffer of readFileChunked(filePath)) {
-            chunks.push(buffer)
-          }
-          const fullBuffer = Buffer.concat(chunks)
-          const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-          await parakeet.loadWeights({ filename: file, chunk, completed: true })
-        }
-      }
 
       await parakeet.activate()
 

--- a/packages/qvac-lib-infer-parakeet/test/integration/multiple-transcriptions.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/multiple-transcriptions.test.js
@@ -10,7 +10,7 @@ const {
   setupJsLogger,
   getTestPaths,
   ensureModel,
-  readFileChunked,
+  getNamedPathsConfig,
   isMobile
 } = require('./helpers.js')
 
@@ -55,7 +55,8 @@ test('Multiple consecutive transcriptions should work without errors', { timeout
     maxThreads: 4,
     useGPU: false,
     sampleRate: 16000,
-    channels: 1
+    channels: 1,
+    ...getNamedPathsConfig('tdt', modelPath)
   }
 
   let parakeet = null
@@ -77,33 +78,6 @@ test('Multiple consecutive transcriptions should work without errors', { timeout
 
     parakeet = new ParakeetInterface(binding, config, outputCallback)
 
-    // Load model weights once
-    const modelFiles = [
-      'encoder-model.onnx',
-      'encoder-model.onnx.data',
-      'decoder_joint-model.onnx',
-      'vocab.txt',
-      'preprocessor.onnx'
-    ]
-
-    for (const file of modelFiles) {
-      const filePath = path.join(modelPath, file)
-      if (fs.existsSync(filePath)) {
-        const stat = fs.statSync(filePath)
-        const fileSize = stat.size
-
-        const chunks = []
-        for (const buffer of readFileChunked(filePath)) {
-          chunks.push(buffer)
-        }
-        const fullBuffer = Buffer.concat(chunks)
-        const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-        await parakeet.loadWeights({ filename: file, chunk, completed: true })
-        console.log(`   Loaded ${file} (${(fileSize / 1024 / 1024).toFixed(2)} MB)`)
-      }
-    }
-
-    // Activate
     await parakeet.activate()
     console.log('   Model activated\n')
 
@@ -277,34 +251,13 @@ test('Fresh model instance per transcription (app restart simulation)', { timeou
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('tdt', modelPath)
     }
 
     let parakeet = null
     try {
       parakeet = new ParakeetInterface(binding, config, outputCallback)
-
-      // Load weights
-      const modelFiles = [
-        'encoder-model.onnx',
-        'encoder-model.onnx.data',
-        'decoder_joint-model.onnx',
-        'vocab.txt',
-        'preprocessor.onnx'
-      ]
-
-      for (const file of modelFiles) {
-        const filePath = path.join(modelPath, file)
-        if (fs.existsSync(filePath)) {
-          const chunks = []
-          for (const buffer of readFileChunked(filePath)) {
-            chunks.push(buffer)
-          }
-          const fullBuffer = Buffer.concat(chunks)
-          const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-          await parakeet.loadWeights({ filename: file, chunk, completed: true })
-        }
-      }
 
       const loadTime = Date.now() - instanceStartTime
 

--- a/packages/qvac-lib-infer-parakeet/test/integration/named-paths-all-models.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/named-paths-all-models.test.js
@@ -12,7 +12,7 @@ const {
   getTestPaths,
   ensureModel,
   ensureModelForType,
-  readFileChunked
+  getNamedPathsConfig
 } = require('./helpers.js')
 
 function createLoader () {
@@ -29,22 +29,6 @@ function loadAudioSample () {
   const audio = new Float32Array(pcm.length)
   for (let i = 0; i < pcm.length; i++) audio[i] = pcm[i] / 32768.0
   return audio
-}
-
-function loadWeightsFromDir (parakeet, modelDir, files) {
-  const promises = []
-  for (const file of files) {
-    const filePath = path.join(modelDir, file)
-    if (!fs.existsSync(filePath)) continue
-    const chunks = []
-    for (const buffer of readFileChunked(filePath)) {
-      chunks.push(buffer)
-    }
-    const fullBuffer = Buffer.concat(chunks)
-    const chunk = new Uint8Array(fullBuffer.buffer, fullBuffer.byteOffset, fullBuffer.byteLength)
-    promises.push(parakeet.loadWeights({ filename: file, chunk, completed: true }))
-  }
-  return Promise.all(promises)
 }
 
 // ── Constructor / validation tests ──────────────────────────────────────────
@@ -103,7 +87,8 @@ test('CTC with named file paths — full load and transcription', { timeout: 600
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('ctc', modelDir)
     }, (_, event, __, output, error) => {
       if (event === 'Output' && output) {
         const segments = Array.isArray(output) ? output : [output]
@@ -118,7 +103,6 @@ test('CTC with named file paths — full load and transcription', { timeout: 600
       if (error) console.error('[ctc-named] Error:', error)
     })
 
-    await loadWeightsFromDir(parakeet, modelDir, ['model.onnx', 'model.onnx_data', 'tokenizer.json'])
     await parakeet.activate()
 
     await parakeet.append({ type: 'audio', data: audio.buffer })
@@ -193,7 +177,8 @@ test('EOU with named file paths — full load and transcription', { timeout: 600
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('eou', modelDir)
     }, (_, event, __, output, error) => {
       if (event === 'Output' && output) {
         const segments = Array.isArray(output) ? output : [output]
@@ -208,7 +193,6 @@ test('EOU with named file paths — full load and transcription', { timeout: 600
       if (error) console.error('[eou-named] Error:', error)
     })
 
-    await loadWeightsFromDir(parakeet, modelDir, ['encoder.onnx', 'decoder_joint.onnx', 'tokenizer.json'])
     await parakeet.activate()
 
     await parakeet.append({ type: 'audio', data: audio.buffer })
@@ -276,7 +260,8 @@ test('Sortformer with named file paths — full load and diarization', { timeout
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('sortformer', modelDir)
     }, (_, event, __, output, error) => {
       if (event === 'Output' && output) {
         const segments = Array.isArray(output) ? output : [output]
@@ -291,7 +276,6 @@ test('Sortformer with named file paths — full load and diarization', { timeout
       if (error) console.error('[sf-named] Error:', error)
     })
 
-    await loadWeightsFromDir(parakeet, modelDir, ['sortformer.onnx'])
     await parakeet.activate()
 
     await parakeet.append({ type: 'audio', data: audio.buffer })

--- a/packages/qvac-lib-infer-parakeet/test/integration/named-paths-all-models.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/named-paths-all-models.test.js
@@ -73,8 +73,7 @@ test('CTC with named file paths — constructor accepts and validates', { timeou
 
   const model = new TranscriptionParakeet(args, config)
   t.ok(model, 'CTC model created with named paths (no directory throw)')
-  t.ok(model._hasAnyNamedPaths(), '_hasAnyNamedPaths returns true for CTC paths')
-  t.ok(!model._hasNamedPaths(), '_hasNamedPaths returns false (TDT-only)')
+  t.ok(model._hasNamedPaths(), '_hasNamedPaths returns true for CTC paths')
 
   const resolved = model._resolveFilePath('', 'model.onnx')
   t.is(resolved, ctcModelPath, '_resolveFilePath maps model.onnx to ctcModelPath')
@@ -164,8 +163,7 @@ test('EOU with named file paths — constructor accepts and validates', { timeou
 
   const model = new TranscriptionParakeet(args, config)
   t.ok(model, 'EOU model created with named paths (no directory throw)')
-  t.ok(model._hasAnyNamedPaths(), '_hasAnyNamedPaths returns true for EOU paths')
-  t.ok(!model._hasNamedPaths(), '_hasNamedPaths returns false (TDT-only)')
+  t.ok(model._hasNamedPaths(), '_hasNamedPaths returns true for EOU paths')
 
   const resolved = model._resolveFilePath('', 'encoder.onnx')
   t.is(resolved, eouEncoderPath, '_resolveFilePath maps encoder.onnx to eouEncoderPath')
@@ -251,8 +249,7 @@ test('Sortformer with named file paths — constructor accepts and validates', {
 
   const model = new TranscriptionParakeet(args, config)
   t.ok(model, 'Sortformer model created with named paths (no directory throw)')
-  t.ok(model._hasAnyNamedPaths(), '_hasAnyNamedPaths returns true for Sortformer paths')
-  t.ok(!model._hasNamedPaths(), '_hasNamedPaths returns false (TDT-only)')
+  t.ok(model._hasNamedPaths(), '_hasNamedPaths returns true for Sortformer paths')
 
   const resolved = model._resolveFilePath('', 'sortformer.onnx')
   t.is(resolved, sortformerPath, '_resolveFilePath maps sortformer.onnx to sortformerPath')
@@ -340,7 +337,6 @@ test('TDT with named file paths — verify existing flow still works', { timeout
   const model = new TranscriptionParakeet(args, config)
   t.ok(model, 'TDT model created with named paths')
   t.ok(model._hasNamedPaths(), '_hasNamedPaths returns true for TDT paths')
-  t.ok(model._hasAnyNamedPaths(), '_hasAnyNamedPaths also returns true')
 
   const resolved = model._resolveFilePath('', 'encoder-model.onnx')
   t.is(resolved, path.join(modelPath, 'encoder-model.onnx'), '_resolveFilePath maps correctly')

--- a/packages/qvac-lib-infer-parakeet/test/mobile/integration.auto.cjs
+++ b/packages/qvac-lib-infer-parakeet/test/mobile/integration.auto.cjs
@@ -6,6 +6,7 @@ const path = require('bare-path')
 const fetch = require('bare-fetch')
 
 const HF_BASE = 'https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx/resolve/main'
+const PREPROCESSOR_URL = 'https://huggingface.co/ysdede/parakeet-tdt-0.6b-v2-onnx/resolve/main/nemo128.onnx'
 const MODEL_FILES = ['vocab.txt', 'encoder-model.onnx', 'decoder_joint-model.onnx', 'encoder-model.onnx.data']
 
 async function downloadFile (url, destPath, name) {
@@ -96,6 +97,13 @@ async function runTranscriptionTest (dirPath, getAssetPath) { // eslint-disable-
         continue
       }
       await downloadFile(`${HF_BASE}/${name}`, dest, name)
+    }
+
+    const prepDest = path.join(modelDir, 'preprocessor.onnx')
+    if (!fs.existsSync(prepDest)) {
+      await downloadFile(PREPROCESSOR_URL, prepDest, 'preprocessor.onnx')
+    } else {
+      console.log('[test] preprocessor.onnx: cached')
     }
 
     let result = null

--- a/packages/qvac-lib-infer-parakeet/test/mobile/integration.auto.cjs
+++ b/packages/qvac-lib-infer-parakeet/test/mobile/integration.auto.cjs
@@ -36,6 +36,40 @@ async function downloadFile (url, destPath, name) {
 }
 
 /**
+ * Build named-paths config for a given model type and directory.
+ * C++ loads directly from these paths (no JS buffer loading needed).
+ */
+function getNamedPathsConfig (modelType, modelDir) {
+  switch (modelType) {
+    case 'ctc':
+      return {
+        ctcModelPath: path.join(modelDir, 'model.onnx'),
+        ctcModelDataPath: path.join(modelDir, 'model.onnx_data'),
+        tokenizerPath: path.join(modelDir, 'tokenizer.json')
+      }
+    case 'eou':
+      return {
+        eouEncoderPath: path.join(modelDir, 'encoder.onnx'),
+        eouDecoderPath: path.join(modelDir, 'decoder_joint.onnx'),
+        tokenizerPath: path.join(modelDir, 'tokenizer.json')
+      }
+    case 'sortformer':
+      return {
+        sortformerPath: path.join(modelDir, 'sortformer.onnx')
+      }
+    case 'tdt':
+    default:
+      return {
+        encoderPath: path.join(modelDir, 'encoder-model.onnx'),
+        encoderDataPath: path.join(modelDir, 'encoder-model.onnx.data'),
+        decoderPath: path.join(modelDir, 'decoder_joint-model.onnx'),
+        vocabPath: path.join(modelDir, 'vocab.txt'),
+        preprocessorPath: path.join(modelDir, 'preprocessor.onnx')
+      }
+  }
+}
+
+/**
  * Downloads model from HuggingFace and runs transcription
  */
 async function runTranscriptionTest (dirPath, getAssetPath) { // eslint-disable-line no-unused-vars
@@ -73,7 +107,8 @@ async function runTranscriptionTest (dirPath, getAssetPath) { // eslint-disable-
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig('tdt', modelDir)
     }, (_, event, __, output, error) => {
       if (event === 'Output' && output) {
         const segments = Array.isArray(output) ? output : [output]
@@ -87,18 +122,6 @@ async function runTranscriptionTest (dirPath, getAssetPath) { // eslint-disable-
       }
     })
 
-    // ONNX external data files (e.g. encoder-model.onnx.data) are too large to
-    // load into JS memory (~2.4 GB). Send a 1-byte dummy so the C++ side
-    // registers the filename, then it resolves the actual data from disk via
-    // the model path when creating the ONNX Runtime session.
-    for (const filename of MODEL_FILES) {
-      const filePath = path.join(modelDir, filename)
-      if (!fs.existsSync(filePath)) continue
-      const chunk = filename.endsWith('.data')
-        ? new Uint8Array([0])
-        : new Uint8Array(fs.readFileSync(filePath))
-      await parakeet.loadWeights({ filename, chunk, completed: true })
-    }
     await parakeet.activate()
 
     await new Promise(r => setTimeout(r, 500))
@@ -194,7 +217,8 @@ async function runModelTest (opts) {
       maxThreads: 4,
       useGPU: false,
       sampleRate: 16000,
-      channels: 1
+      channels: 1,
+      ...getNamedPathsConfig(modelType, modelDir)
     }, (_, event, __, output, error) => {
       if (event === 'Output' && output) {
         const segments = Array.isArray(output) ? output : [output]
@@ -208,16 +232,6 @@ async function runModelTest (opts) {
       }
     })
 
-    // ONNX external data files are loaded from disk by the C++ side;
-    // send a 1-byte dummy so the filename is registered.
-    for (const file of files) {
-      const filePath = path.join(modelDir, file.name)
-      if (!fs.existsSync(filePath)) continue
-      const chunk = file.skipRead
-        ? new Uint8Array([0])
-        : new Uint8Array(fs.readFileSync(filePath))
-      await parakeet.loadWeights({ filename: file.name, chunk, completed: true })
-    }
     await parakeet.activate()
 
     await new Promise(r => setTimeout(r, 500))


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- CTC, EOU, and Sortformer models relied on JS-side buffered weight loading which fails when ONNX models reference external data files
- Only TDT supported direct file path loading from C++
- Buffer-based fallback was dead code from the SDK's perspective

## 📝 How does it solve it?

- Add named path fields to `ParakeetConfig`: `ctcModelPath`, `ctcModelDataPath`, `tokenizerPath`, `eouEncoderPath`, `eouDecoderPath`, `sortformerPath`
- `JSAdapter` parses all new path properties from JS config
- All four load functions now require named paths — buffer-based `_loadModelWeights` fallback removed:
  - `loadTDTSessions`: requires `encoderPath`, `decoderPath`
  - `loadCTCSessions`: requires `ctcModelPath` (temp staging for external data, cleaned up immediately)
  - `loadEOUSessions`: requires `eouEncoderPath`, `eouDecoderPath`
  - `loadSortformerSessions`: requires `sortformerPath`
- CTC and EOU read tokenizer from `tokenizerPath` directly from disk
- `_hasNamedPaths()` unified for all model types; `_hasAnyNamedPaths()` removed
- `_load()` passes all named paths to C++, no `_loadModelWeights` call

## 🧪 How was it tested?

- TDT: end-to-end with registry models, no regression
- CTC: end-to-end with HuggingFace HTTP models, loads from individual file paths
- Sortformer: end-to-end diarization + per-segment TDT transcription with registry model
- All on macOS arm64. Zero staging directories in cache after running all examples.

**Depends on:** [#586](https://github.com/tetherto/qvac/pull/586) (merged)
**Required by:** [#811](https://github.com/tetherto/qvac/pull/811) (SDK CTC/Sortformer support)