### PR TITLE
QVAC-13200 feat(onnx): Refactor OCR addon to use onnx-base

### DIFF
--- a/packages/ocr-onnx/CHANGELOG.md
+++ b/packages/ocr-onnx/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0]
+2026-03-11
+
+### Changed
+
+- Refactored OCR addon to use `@qvac/onnx` shared ONNX Runtime base package instead of bundling ONNX Runtime directly.
+- Replaced direct `onnxruntime` vcpkg dependency with `qvac-onnx` CMake package from `@qvac/onnx`.
+- Switched from `ORTCHAR_T*` to `std::string&` for model path parameters across Pipeline, detection, and recognition steps.
+- Simplified ONNX session management using `onnx_addon::Session` wrapper instead of raw `Ort::Session`.
+- Replaced raw `Ort::Value` tensor handling with `onnx_addon::InputTensor`/`onnx_addon::OutputTensor` abstractions.
+- Removed custom symbol hiding (version scripts, exported symbols) — now handled by `@qvac/onnx` shared module.
+- Simplified vcpkg configuration by removing bundled ONNX Runtime dependencies.
+
 ## [0.2.0]
 2026-03-04
 

--- a/packages/ocr-onnx/CMakeLists.txt
+++ b/packages/ocr-onnx/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 option(BUILD_TESTING "Build tests" OFF)
-option(ENABLE_XNNPACK "Enable XNNPack execution provider" ON)
+option(MOBILE_DYNAMIC_LINK "Use dynamic linking for ONNX Runtime on mobile" ON)
 
 # Force Apple Clang instead of Homebrew LLVM
 if(APPLE)
@@ -66,10 +66,6 @@ if(BUILD_TESTING)
   list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
 
-if(ENABLE_XNNPACK)
-  list(APPEND VCPKG_MANIFEST_FEATURES "xnnpack")
-endif()
-
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
 find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
@@ -104,22 +100,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-# Note: We use a linker version script (symbols.map) to hide internal symbols
-# instead of visibility presets, so that bare_* symbols remain exportable.
-
-
-
 
 
 find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS "qvac-lib-inference-addon-cpp/JsInterface.hpp")
 find_package(OpenCV REQUIRED)
-find_package(onnxruntime CONFIG REQUIRED)
+set(qvac-onnx_DIR "${CMAKE_CURRENT_SOURCE_DIR}/node_modules/@qvac/onnx/prebuilds/share/qvac-onnx/cmake")
+find_package(qvac-onnx CONFIG REQUIRED)
 
 add_bare_module(qvac-lib-inference-addon-onnx-ocr-fasttext EXPORTS)
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  target_link_options(${qvac-lib-inference-addon-onnx-ocr-fasttext}_module PRIVATE -Wl,--exclude-libs,ALL)
-endif()
 
 target_sources(
   ${qvac-lib-inference-addon-onnx-ocr-fasttext}
@@ -140,30 +128,37 @@ target_include_directories(
     ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS}
     addon
 )
-target_link_libraries(
-  ${qvac-lib-inference-addon-onnx-ocr-fasttext}
-  PRIVATE
-    ${OpenCV_LIBS}
-    onnxruntime::onnxruntime_static
-)
 
-# Use version script to hide internal symbols (including ONNX runtime)
-# This prevents symbol conflicts when multiple ONNX-based addons are loaded
-# Note: We target the _module shared library, not the object library
-if(UNIX AND NOT APPLE)
-  target_link_options(
+if((ANDROID OR (APPLE AND CMAKE_SYSTEM_NAME STREQUAL "iOS")) AND NOT MOBILE_DYNAMIC_LINK)
+  # Mobile (static): each addon embeds ONNX Runtime
+  target_link_libraries(
+    ${qvac-lib-inference-addon-onnx-ocr-fasttext}
+    PRIVATE
+      ${OpenCV_LIBS}
+      qvac-onnx::qvac-onnx-static
+  )
+else()
+  # Desktop and mobile (dynamic): link against @qvac/onnx.bare shared module
+  include_bare_module("@qvac/onnx" qvac_onnx_target PREBUILD)
+
+  target_link_libraries(
+    ${qvac-lib-inference-addon-onnx-ocr-fasttext}
+    PRIVATE
+      ${OpenCV_LIBS}
+      qvac-onnx::headers
+  )
+  target_link_libraries(
     ${qvac-lib-inference-addon-onnx-ocr-fasttext}_module
     PRIVATE
-      -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map
+      ${qvac_onnx_target}_module
   )
-elseif(APPLE)
-  # macOS uses -exported_symbols_list instead of version script
-  target_link_options(
-    ${qvac-lib-inference-addon-onnx-ocr-fasttext}_module
-    PRIVATE
-      -Wl,-exported_symbol,_bare_get_module_name_v0
-      -Wl,-exported_symbol,_bare_register_module_v0
-  )
+
+  # Install @qvac/onnx.bare as companion library
+  bare_target(host)
+  bare_module_target("." _unused NAME addon_name)
+  install(FILES $<TARGET_FILE:${qvac_onnx_target}_module>
+    DESTINATION ${host}/${addon_name}
+    RENAME qvac__onnx@0.bare)
 endif()
 
 target_compile_definitions(
@@ -187,7 +182,7 @@ endfunction()
 if(ANDROID)
   find_package(Vulkan REQUIRED)
   target_link_libraries(${qvac-lib-inference-addon-onnx-ocr-fasttext} PRIVATE ${Vulkan_LIBRARY} log)
-  
+
   # Strip vcpkg installed binaries for Android builds
   find_program(LLVM_STRIP llvm-strip)
 
@@ -195,14 +190,11 @@ if(ANDROID)
     message(WARNING "-- llvm-strip not found. Skipping library stripping for Android build.")
   else()
     message("-- llvm-strip found: ${LLVM_STRIP}")
-    set(LIBRARIES_TO_STRIP_IN_LIB_DIR libonnx.a libprotobuf.a libprotoc.a)
     set(LIBRARIES_TO_STRIP_IN_SDK_DIR libopencv_calib3d4.a libopencv_core4.a libopencv_imgproc4.a libopencv_objdetect4.a)
 
     set(VCPKG_INSTALLED_DIR "${CMAKE_BINARY_DIR}/_vcpkg/${VCPKG_TARGET_TRIPLET}")
-    set(LIBS_DIR_PATH "${VCPKG_INSTALLED_DIR}/lib")
     set(SDK_DIR_PATH "${VCPKG_INSTALLED_DIR}/sdk/native/staticlibs/${CMAKE_ANDROID_ARCH_ABI}")
 
-    strip_libraries(${LIBS_DIR_PATH} "${LIBRARIES_TO_STRIP_IN_LIB_DIR}")
     strip_libraries(${SDK_DIR_PATH} "${LIBRARIES_TO_STRIP_IN_SDK_DIR}")
   endif()
 endif()
@@ -242,7 +234,7 @@ if(BUILD_TESTING)
     )
     target_link_libraries(
         pipeline
-        PRIVATE ${OpenCV_LIBS} onnxruntime::onnxruntime_static
+        PRIVATE ${OpenCV_LIBS} qvac-onnx::headers
     )
 
     add_executable(unit_tests test/lang_test.cpp)

--- a/packages/ocr-onnx/addon/addon/AddonCpp.hpp
+++ b/packages/ocr-onnx/addon/addon/AddonCpp.hpp
@@ -39,7 +39,8 @@ inline AddonInstance createInstance(
   std::unique_ptr<OutputCallBackInterface> callback =
       std::make_unique<OutputCallBackCpp>(std::move(outHandlers));
 
-  auto addon = std::make_unique<AddonCpp>(std::move(callback), std::move(model));
+  auto addon =
+      std::make_unique<AddonCpp>(std::move(callback), std::move(model));
 
   return {std::move(addon), std::move(outHandler)};
 }

--- a/packages/ocr-onnx/addon/addon/AddonCpp.hpp
+++ b/packages/ocr-onnx/addon/addon/AddonCpp.hpp
@@ -22,9 +22,9 @@ struct AddonInstance {
 /// @brief Creates a pure C++ Addon (no Js dependencies). Can be used on CLI or
 /// C++ tests.
 inline AddonInstance createInstance(
-    const ORTCHAR_T* pathDetector, const ORTCHAR_T* pathRecognizer,
+    const std::string& pathDetector, const std::string& pathRecognizer,
     std::span<const std::string> langList, bool useGPU = false,
-    int timeout = Pipeline::DEFAULT_PIPELINE_TIMEOUT_SECONDS,
+    int timeout = DEFAULT_PIPELINE_TIMEOUT_SECONDS,
     const Pipeline::Config& config = Pipeline::Config{}) {
   using namespace qvac_lib_inference_addon_cpp;
   using namespace std;

--- a/packages/ocr-onnx/addon/addon/AddonCpp.hpp
+++ b/packages/ocr-onnx/addon/addon/AddonCpp.hpp
@@ -27,20 +27,19 @@ inline AddonInstance createInstance(
     int timeout = DEFAULT_PIPELINE_TIMEOUT_SECONDS,
     const Pipeline::Config& config = Pipeline::Config{}) {
   using namespace qvac_lib_inference_addon_cpp;
-  using namespace std;
 
-  auto model = make_unique<Pipeline>(
+  auto model = std::make_unique<Pipeline>(
       pathDetector, pathRecognizer, langList, useGPU, timeout, config);
 
   auto outHandler =
-      make_shared<out_handl::CppQueuedOutputHandler<Pipeline::Output>>();
+      std::make_shared<out_handl::CppQueuedOutputHandler<Pipeline::Output>>();
   out_handl::OutputHandlers<out_handl::OutputHandlerInterface<void>>
       outHandlers;
   outHandlers.add(outHandler);
-  unique_ptr<OutputCallBackInterface> callback =
-      make_unique<OutputCallBackCpp>(std::move(outHandlers));
+  std::unique_ptr<OutputCallBackInterface> callback =
+      std::make_unique<OutputCallBackCpp>(std::move(outHandlers));
 
-  auto addon = make_unique<AddonCpp>(std::move(callback), std::move(model));
+  auto addon = std::make_unique<AddonCpp>(std::move(callback), std::move(model));
 
   return {std::move(addon), std::move(outHandler)};
 }

--- a/packages/ocr-onnx/addon/addon/AddonJs.hpp
+++ b/packages/ocr-onnx/addon/addon/AddonJs.hpp
@@ -105,25 +105,8 @@ private:
 };
 
 namespace {
-auto getPath(js_env_t* env, qvac_lib_inference_addon_cpp::js::String path) {
-  if constexpr (std::is_same_v<ORTCHAR_T, char>) {
-    return path.as<std::string>(env);
-  } else if constexpr (
-      std::is_same_v<ORTCHAR_T, wchar_t> && sizeof(wchar_t) == 2) {
-    size_t length = 0;
-    JS(js_get_value_string_utf16le(env, path, nullptr, 0, &length));
-    std::wstring str(length, '\0');
-    JS(js_get_value_string_utf16le(
-        env,
-        path,
-        reinterpret_cast<uint16_t*>(
-            str.data()) /* NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-                         */
-        ,
-        length,
-        nullptr));
-    return str;
-  }
+std::string getPath(js_env_t* env, qvac_lib_inference_addon_cpp::js::String path) {
+  return path.as<std::string>(env);
 }
 } // namespace
 
@@ -223,8 +206,8 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   }
 
   auto model = make_unique<Pipeline>(
-      pathDetector.c_str(),
-      pathRecognizer.c_str(),
+      pathDetector,
+      pathRecognizer,
       std::span<const std::string>(langList),
       useGPU,
       timeout,

--- a/packages/ocr-onnx/addon/addon/AddonJs.hpp
+++ b/packages/ocr-onnx/addon/addon/AddonJs.hpp
@@ -105,7 +105,8 @@ private:
 };
 
 namespace {
-std::string getPath(js_env_t* env, qvac_lib_inference_addon_cpp::js::String path) {
+std::string
+getPath(js_env_t* env, qvac_lib_inference_addon_cpp::js::String path) {
   return path.as<std::string>(env);
 }
 } // namespace
@@ -214,10 +215,12 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
 
   out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface> outHandlers;
   outHandlers.add(std::make_shared<PipelineOutputHandler>());
-  std::unique_ptr<OutputCallBackInterface> callback = std::make_unique<OutputCallBackJs>(
-      env, args[0], args[2], std::move(outHandlers));
+  std::unique_ptr<OutputCallBackInterface> callback =
+      std::make_unique<OutputCallBackJs>(
+          env, args[0], args[2], std::move(outHandlers));
 
-  auto addon = std::make_unique<AddonJs>(env, std::move(callback), std::move(model));
+  auto addon =
+      std::make_unique<AddonJs>(env, std::move(callback), std::move(model));
 
   return JsInterface::createInstance(env, std::move(addon));
 }

--- a/packages/ocr-onnx/addon/addon/AddonJs.hpp
+++ b/packages/ocr-onnx/addon/addon/AddonJs.hpp
@@ -112,7 +112,6 @@ std::string getPath(js_env_t* env, qvac_lib_inference_addon_cpp::js::String path
 
 inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   using namespace qvac_lib_inference_addon_cpp;
-  using namespace std;
 
   auto args = js::getArguments(env, info);
   if (args.size() != 4) {
@@ -205,7 +204,7 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
     config.straightenPages = optStraighten->as<bool>(env);
   }
 
-  auto model = make_unique<Pipeline>(
+  auto model = std::make_unique<Pipeline>(
       pathDetector,
       pathRecognizer,
       std::span<const std::string>(langList),
@@ -214,11 +213,11 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
       config);
 
   out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface> outHandlers;
-  outHandlers.add(make_shared<PipelineOutputHandler>());
-  unique_ptr<OutputCallBackInterface> callback = make_unique<OutputCallBackJs>(
+  outHandlers.add(std::make_shared<PipelineOutputHandler>());
+  std::unique_ptr<OutputCallBackInterface> callback = std::make_unique<OutputCallBackJs>(
       env, args[0], args[2], std::move(outHandlers));
 
-  auto addon = make_unique<AddonJs>(env, std::move(callback), std::move(model));
+  auto addon = std::make_unique<AddonJs>(env, std::move(callback), std::move(model));
 
   return JsInterface::createInstance(env, std::move(addon));
 }
@@ -226,7 +225,6 @@ JSCATCH
 
 inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
   using namespace qvac_lib_inference_addon_cpp;
-  using namespace std;
 
   auto args = js::getArguments(env, info);
   if (args.size() != 2) {

--- a/packages/ocr-onnx/addon/pipeline/Pipeline.cpp
+++ b/packages/ocr-onnx/addon/pipeline/Pipeline.cpp
@@ -46,7 +46,7 @@ cv::Mat decodeEncodedImage(const std::vector<uint8_t>& data) {
 } // namespace
 
 Pipeline::Pipeline(
-    const ORTCHAR_T* pathDetector, const ORTCHAR_T* pathRecognizer,
+    const std::string& pathDetector, const std::string& pathRecognizer,
     std::span<const std::string> langList, bool useGPU, int timeout,
     const PipelineConfig& config)
     : config_(config),

--- a/packages/ocr-onnx/addon/pipeline/Pipeline.cpp
+++ b/packages/ocr-onnx/addon/pipeline/Pipeline.cpp
@@ -49,8 +49,7 @@ Pipeline::Pipeline(
     const std::string& pathDetector, const std::string& pathRecognizer,
     std::span<const std::string> langList, bool useGPU, int timeout,
     const PipelineConfig& config)
-    : config_(config),
-      timeout_(timeout) {
+    : config_(config), timeout_(timeout) {
 
   std::string modeStr = (config.mode == PipelineMode::DOCTR) ? "DOCTR" : "EASYOCR";
   QLOG(qvac_lib_inference_addon_cpp::logger::Priority::INFO,

--- a/packages/ocr-onnx/addon/pipeline/Pipeline.hpp
+++ b/packages/ocr-onnx/addon/pipeline/Pipeline.hpp
@@ -85,8 +85,8 @@ public:
   using Config = PipelineConfig;
 
   Pipeline(
-      const ORTCHAR_T* pathDetector, const ORTCHAR_T* pathRecognizer,
-      std::span<const std::string> langList, bool useGPU = true,
+      const std::string& pathDetector, const std::string& pathRecognizer,
+      std::span<const std::string> langList, bool useGPU = false,
       int timeout = DEFAULT_PIPELINE_TIMEOUT_SECONDS,
       const PipelineConfig& config = PipelineConfig{});
 

--- a/packages/ocr-onnx/addon/pipeline/StepDetectionInference.cpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDetectionInference.cpp
@@ -32,8 +32,9 @@ constexpr double PIXEL_INTENSITY_MAX = 255.0;
  *
  * @throws std::runtime_error if the Detector inference results are not in expected format
  */
-std::pair<cv::Mat, cv::Mat> extractOutputFromOrtValue(onnx_addon::OutputTensor &outTensor) {
-  auto *outData = outTensor.asMutable<float>();
+std::pair<cv::Mat, cv::Mat>
+extractOutputFromOrtValue(onnx_addon::OutputTensor& outTensor) {
+  auto* outData = outTensor.asMutable<float>();
   const auto& outputShape = outTensor.shape;
 
   if (outputShape.size() != 4) {
@@ -145,8 +146,7 @@ void normalizeMeanVariance(cv::Mat &inputImage,
 
 StepDetectionInference::StepDetectionInference(
     const std::string& pathDetector, bool useGPU, float magRatio)
-    : magRatio_(magRatio),
-      session_(pathDetector, [&] {
+    : magRatio_(magRatio), session_(pathDetector, [&] {
         onnx_addon::SessionConfig cfg;
         cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU
                               : onnx_addon::ExecutionProvider::CPU;
@@ -154,7 +154,8 @@ StepDetectionInference::StepDetectionInference(
         return cfg;
       }()) {}
 
-std::vector<onnx_addon::OutputTensor> StepDetectionInference::runInference(cv::Mat inputBlob) {
+std::vector<onnx_addon::OutputTensor>
+StepDetectionInference::runInference(cv::Mat inputBlob) {
   int dims = inputBlob.dims;
   std::vector<int64_t> inputShape(dims);
   for (int i = 0; i < dims; i++) {

--- a/packages/ocr-onnx/addon/pipeline/StepDetectionInference.cpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDetectionInference.cpp
@@ -32,11 +32,9 @@ constexpr double PIXEL_INTENSITY_MAX = 255.0;
  *
  * @throws std::runtime_error if the Detector inference results are not in expected format
  */
-std::pair<cv::Mat, cv::Mat> extractOutputFromOrtValue(Ort::Value &outTensor) {
-  auto *outData = outTensor.GetTensorMutableData<float>();
-  Ort::TypeInfo typeInfo = outTensor.GetTypeInfo();
-  auto tensorInfo = typeInfo.GetTensorTypeAndShapeInfo();
-  std::vector<int64_t> outputShape = tensorInfo.GetShape();
+std::pair<cv::Mat, cv::Mat> extractOutputFromOrtValue(onnx_addon::OutputTensor &outTensor) {
+  auto *outData = outTensor.asMutable<float>();
+  const auto& outputShape = outTensor.shape;
 
   if (outputShape.size() != 4) {
     throw std::runtime_error("Expected output tensor with 4 dimensions, got " + std::to_string(outputShape.size()));
@@ -146,33 +144,32 @@ void normalizeMeanVariance(cv::Mat &inputImage,
 } // namespace
 
 StepDetectionInference::StepDetectionInference(
-    const ORTCHAR_T* pathDetector, bool useGPU, float magRatio)
+    const std::string& pathDetector, bool useGPU, float magRatio)
     : magRatio_(magRatio),
-      ortSession_(getSharedOrtEnv(), pathDetector, getOrtSessionOptions(useGPU)) {}
+      session_(pathDetector, [&] {
+        onnx_addon::SessionConfig cfg;
+        cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU
+                              : onnx_addon::ExecutionProvider::CPU;
+        cfg.optimization = onnx_addon::GraphOptimizationLevel::EXTENDED;
+        return cfg;
+      }()) {}
 
-std::vector<Ort::Value> StepDetectionInference::runInference(cv::Mat inputBlob) {
+std::vector<onnx_addon::OutputTensor> StepDetectionInference::runInference(cv::Mat inputBlob) {
   int dims = inputBlob.dims;
   std::vector<int64_t> inputShape(dims);
   for (int i = 0; i < dims; i++) {
     inputShape[i] = inputBlob.size[i];
   }
-  size_t inputTensorSize = inputBlob.total();
   assert(sizeof(float) == inputBlob.elemSize());
-  auto *inputData = inputBlob.ptr<float>();
 
-  Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  Ort::Value inputTensor = Ort::Value::CreateTensor<float>(memoryInfo, inputData, inputTensorSize, inputShape.data(), inputShape.size());
+  onnx_addon::InputTensor input;
+  input.name = "input";
+  input.shape = inputShape;
+  input.type = onnx_addon::TensorType::FLOAT32;
+  input.data = inputBlob.ptr<float>();
+  input.dataSize = inputBlob.total() * sizeof(float);
 
-  constexpr std::array<const char*, 1> inputNames = {"input"};
-  constexpr std::array<const char*, 2> outputNames = {"output", "feature"};
-
-  return ortSession_.Run(
-      Ort::RunOptions{nullptr},
-      inputNames.data(),
-      &inputTensor,
-      1,
-      outputNames.data(),
-      2);
+  return session_.run(input);
 }
 
 StepDetectionInference::Output StepDetectionInference::process(const StepDetectionInference::Input &input) {
@@ -205,7 +202,7 @@ StepDetectionInference::Output StepDetectionInference::process(const StepDetecti
   QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, "[DetectionInference] Running ONNX inference...");
   ALOG_DEBUG(std::string("[DetectionInference] Running ONNX inference..."));
   auto t0 = std::chrono::high_resolution_clock::now();
-  std::vector<Ort::Value> outputTensors = runInference(inputBlob);
+  std::vector<onnx_addon::OutputTensor> outputTensors = runInference(inputBlob);
   auto t1 = std::chrono::high_resolution_clock::now();
   auto detectionMs = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
   std::string inferenceMsg = "[DetectionInference] ONNX inference: " + std::to_string(detectionMs) + " ms";

--- a/packages/ocr-onnx/addon/pipeline/StepDetectionInference.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDetectionInference.hpp
@@ -15,6 +15,11 @@ public:
   explicit StepDetectionInference(
       const std::string& pathDetector, bool useGPU = false, float magRatio = 1.5F);
 
+#if defined(_WIN32) || defined(_WIN64)
+  // On Windows, defer session destruction to avoid the ORT global-state crash.
+  ~StepDetectionInference() { deferWindowsSessionLeak(std::move(session_)); }
+#endif
+
   CONSTRUCT_FROM_TUPLE(StepDetectionInference)
 
   /**

--- a/packages/ocr-onnx/addon/pipeline/StepDetectionInference.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDetectionInference.hpp
@@ -2,7 +2,7 @@
 
 #include "Steps.hpp"
 
-#include <onnxruntime_cxx_api.h>
+#include <qvac-onnx/OnnxSession.hpp>
 #include <opencv2/imgproc.hpp>
 
 namespace qvac_lib_inference_addon_onnx_ocr_fasttext {
@@ -13,7 +13,7 @@ public:
   using Output = StepDetectionInferenceOutput;
 
   explicit StepDetectionInference(
-      const ORTCHAR_T* pathDetector, bool useGPU = false, float magRatio = 1.5F);
+      const std::string& pathDetector, bool useGPU = false, float magRatio = 1.5F);
 
   CONSTRUCT_FROM_TUPLE(StepDetectionInference)
 
@@ -33,15 +33,15 @@ public:
 
 private:
   float magRatio_;
-  Ort::Session ortSession_{nullptr};
+  onnx_addon::OnnxSession session_;
 
   /**
    * @brief runs ONNX inference on an image
    *
    * @param inputBlob : detector input
-   * @return std::vector<Ort::Value> : ONNX inference results
+   * @return std::vector<onnx_addon::OutputTensor> : ONNX inference results
    */
-  std::vector<Ort::Value> runInference(cv::Mat inputBlob);
+  std::vector<onnx_addon::OutputTensor> runInference(cv::Mat inputBlob);
 };
 
 } // namespace qvac_lib_inference_addon_onnx_ocr_fasttext

--- a/packages/ocr-onnx/addon/pipeline/StepDetectionInference.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDetectionInference.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Steps.hpp"
-
-#include <qvac-onnx/OnnxSession.hpp>
 #include <opencv2/imgproc.hpp>
+#include <qvac-onnx/OnnxSession.hpp>
+
+#include "Steps.hpp"
 
 namespace qvac_lib_inference_addon_onnx_ocr_fasttext {
 
@@ -13,7 +13,8 @@ public:
   using Output = StepDetectionInferenceOutput;
 
   explicit StepDetectionInference(
-      const std::string& pathDetector, bool useGPU = false, float magRatio = 1.5F);
+      const std::string& pathDetector, bool useGPU = false,
+      float magRatio = 1.5F);
 
 #if defined(_WIN32) || defined(_WIN64)
   // On Windows, defer session destruction to avoid the ORT global-state crash.

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.cpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.cpp
@@ -40,7 +40,8 @@ float boxScore(const cv::Mat& probMap, const cv::Rect& bbox) {
 
 } // namespace
 
-StepDoctrDetection::StepDoctrDetection(const std::string& pathDetector, bool useGPU)
+StepDoctrDetection::StepDoctrDetection(
+    const std::string& pathDetector, bool useGPU)
     : session_(pathDetector, [&] {
         onnx_addon::SessionConfig cfg;
         cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.cpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.cpp
@@ -40,8 +40,14 @@ float boxScore(const cv::Mat& probMap, const cv::Rect& bbox) {
 
 } // namespace
 
-StepDoctrDetection::StepDoctrDetection(const ORTCHAR_T* pathDetector, bool useGPU)
-    : ortSession_(getSharedOrtEnv(), pathDetector, getOrtSessionOptions(useGPU)) {
+StepDoctrDetection::StepDoctrDetection(const std::string& pathDetector, bool useGPU)
+    : session_(pathDetector, [&] {
+        onnx_addon::SessionConfig cfg;
+        cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU
+                              : onnx_addon::ExecutionProvider::CPU;
+        cfg.optimization = onnx_addon::GraphOptimizationLevel::EXTENDED;
+        return cfg;
+      }()) {
   QLOG(qvac_lib_inference_addon_cpp::logger::Priority::INFO,
        "[DoctrDetection] ONNX session created");
   ALOG_INFO(std::string("[DoctrDetection] ONNX session created"));
@@ -105,33 +111,20 @@ cv::Mat StepDoctrDetection::runInference(const cv::Mat& preprocessed) {
   }
 
   std::vector<int64_t> inputShape = {1, numChannels, height, width};
-  size_t inputTensorSize = inputData.size();
 
-  Ort::MemoryInfo memInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
-      memInfo, inputData.data(), inputTensorSize, inputShape.data(), inputShape.size());
+  onnx_addon::InputTensor inputTensor;
+  inputTensor.name = session_.getInputInfo()[0].name;
+  inputTensor.shape = inputShape;
+  inputTensor.type = onnx_addon::TensorType::FLOAT32;
+  inputTensor.data = inputData.data();
+  inputTensor.dataSize = inputData.size() * sizeof(float);
 
-  // Get input/output names from the model dynamically
-  Ort::AllocatorWithDefaultOptions allocator;
-  auto inputName = ortSession_.GetInputNameAllocated(0, allocator);
-  auto outputName = ortSession_.GetOutputNameAllocated(0, allocator);
-
-  const char* inputNames[] = {inputName.get()};
-  const char* outputNames[] = {outputName.get()};
-
-  std::array<Ort::Value, 1> inputTensors = {std::move(inputTensor)};
-
-  auto outputTensors = ortSession_.Run(
-      Ort::RunOptions{nullptr},
-      inputNames, inputTensors.data(), 1,
-      outputNames, 1);
+  auto outputTensors = session_.run(inputTensor);
 
   // Extract probability map from output
-  Ort::Value& outTensor = outputTensors[0];
-  auto* outData = outTensor.GetTensorMutableData<float>();
-  auto typeInfo = outTensor.GetTypeInfo();
-  auto tensorInfo = typeInfo.GetTensorTypeAndShapeInfo();
-  std::vector<int64_t> outShape = tensorInfo.GetShape();
+  auto& outTensor = outputTensors[0];
+  auto* outData = outTensor.asMutable<float>();
+  const auto& outShape = outTensor.shape;
 
   {
     std::string shapeStr = "[";

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Steps.hpp"
-
-#include <qvac-onnx/OnnxSession.hpp>
 #include <opencv2/imgproc.hpp>
+#include <qvac-onnx/OnnxSession.hpp>
+
+#include "Steps.hpp"
 
 namespace qvac_lib_inference_addon_onnx_ocr_fasttext {
 
@@ -18,7 +18,8 @@ public:
   static constexpr float UNCLIP_RATIO = 1.5F;
   static constexpr int MIN_SIZE_BOX = 2;
 
-  explicit StepDoctrDetection(const std::string& pathDetector, bool useGPU = false);
+  explicit StepDoctrDetection(
+      const std::string& pathDetector, bool useGPU = false);
 
 #if defined(_WIN32) || defined(_WIN64)
   // On Windows, defer session destruction to avoid the ORT global-state crash.

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.hpp
@@ -20,6 +20,11 @@ public:
 
   explicit StepDoctrDetection(const std::string& pathDetector, bool useGPU = false);
 
+#if defined(_WIN32) || defined(_WIN64)
+  // On Windows, defer session destruction to avoid the ORT global-state crash.
+  ~StepDoctrDetection() { deferWindowsSessionLeak(std::move(session_)); }
+#endif
+
   Output process(const Input& input);
 
 private:

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrDetection.hpp
@@ -2,7 +2,7 @@
 
 #include "Steps.hpp"
 
-#include <onnxruntime_cxx_api.h>
+#include <qvac-onnx/OnnxSession.hpp>
 #include <opencv2/imgproc.hpp>
 
 namespace qvac_lib_inference_addon_onnx_ocr_fasttext {
@@ -18,17 +18,12 @@ public:
   static constexpr float UNCLIP_RATIO = 1.5F;
   static constexpr int MIN_SIZE_BOX = 2;
 
-  explicit StepDoctrDetection(const ORTCHAR_T* pathDetector, bool useGPU = true);
-
-#if defined(_WIN32) || defined(_WIN64)
-  // On Windows, defer session destruction to avoid the ORT global-state crash.
-  ~StepDoctrDetection() { deferWindowsSessionLeak(std::move(ortSession_)); }
-#endif
+  explicit StepDoctrDetection(const std::string& pathDetector, bool useGPU = false);
 
   Output process(const Input& input);
 
 private:
-  Ort::Session ortSession_{nullptr};
+  onnx_addon::OnnxSession session_;
 
   // Preprocess: resize with aspect ratio + pad to 1024x1024, normalize with docTR stats
   // Returns: {preprocessed mat, scale, newW, newH, padLeft, padTop}

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.cpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.cpp
@@ -82,10 +82,16 @@ std::vector<std::string> parseVocabToChars(const std::string& vocab) {
 
 } // namespace
 
-StepDoctrRecognition::StepDoctrRecognition(const ORTCHAR_T* pathRecognizer,
+StepDoctrRecognition::StepDoctrRecognition(const std::string& pathRecognizer,
                                            bool useGPU, int batchSize,
                                            DecodingMethod decoding)
-    : ortSession_(getSharedOrtEnv(), pathRecognizer, getOrtSessionOptions(useGPU)),
+    : session_(pathRecognizer, [&] {
+        onnx_addon::SessionConfig cfg;
+        cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU
+                              : onnx_addon::ExecutionProvider::CPU;
+        cfg.optimization = onnx_addon::GraphOptimizationLevel::EXTENDED;
+        return cfg;
+      }()),
       batchSize_(batchSize),
       decodingMethod_(decoding),
       vocabChars_(parseVocabToChars(VOCAB)) {
@@ -166,33 +172,19 @@ cv::Mat StepDoctrRecognition::runBatchInference(const std::vector<cv::Mat>& imag
   }
 
   std::vector<int64_t> inputShape = {batchSz, numChannels, height, width};
-  size_t inputTensorSize = batchData.size();
 
-  Ort::MemoryInfo memInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
-      memInfo, batchData.data(), inputTensorSize, inputShape.data(), inputShape.size());
+  onnx_addon::InputTensor inputTensor;
+  inputTensor.name = session_.getInputInfo()[0].name;
+  inputTensor.shape = inputShape;
+  inputTensor.type = onnx_addon::TensorType::FLOAT32;
+  inputTensor.data = batchData.data();
+  inputTensor.dataSize = batchData.size() * sizeof(float);
 
-  // Get input/output names from the model dynamically
-  Ort::AllocatorWithDefaultOptions allocator;
-  auto inputName = ortSession_.GetInputNameAllocated(0, allocator);
-  auto outputName = ortSession_.GetOutputNameAllocated(0, allocator);
-
-  const char* inputNames[] = {inputName.get()};
-  const char* outputNames[] = {outputName.get()};
-
-  std::array<Ort::Value, 1> inputTensors = {std::move(inputTensor)};
-
-  auto outputTensors = ortSession_.Run(
-      Ort::RunOptions{nullptr},
-      inputNames, inputTensors.data(), 1,
-      outputNames, 1);
+  auto outputTensors = session_.run(inputTensor);
 
   // Extract predictions
-  Ort::Value& predsTensor = outputTensors[0];
-  auto* predsData = predsTensor.GetTensorMutableData<float>();
-  auto typeInfo = predsTensor.GetTypeInfo();
-  auto tensorInfo = typeInfo.GetTensorTypeAndShapeInfo();
-  std::vector<int64_t> predsShape = tensorInfo.GetShape();
+  const auto& predsTensor = outputTensors[0];
+  const auto& predsShape = predsTensor.shape;
 
   auto predsDims = static_cast<int>(predsShape.size());
   std::vector<int> cvSizes(predsDims);
@@ -216,7 +208,7 @@ cv::Mat StepDoctrRecognition::runBatchInference(const std::vector<cv::Mat>& imag
                              std::to_string(predsDims) + " dimensions");
   }
 
-  cv::Mat preds(predsDims, cvSizes.data(), CV_32F, predsData);
+  cv::Mat preds(predsDims, cvSizes.data(), CV_32F, const_cast<float*>(predsTensor.as<float>()));
   return preds.clone();
 }
 

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.cpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.cpp
@@ -82,18 +82,19 @@ std::vector<std::string> parseVocabToChars(const std::string& vocab) {
 
 } // namespace
 
-StepDoctrRecognition::StepDoctrRecognition(const std::string& pathRecognizer,
-                                           bool useGPU, int batchSize,
-                                           DecodingMethod decoding)
-    : session_(pathRecognizer, [&] {
-        onnx_addon::SessionConfig cfg;
-        cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU
-                              : onnx_addon::ExecutionProvider::CPU;
-        cfg.optimization = onnx_addon::GraphOptimizationLevel::EXTENDED;
-        return cfg;
-      }()),
-      batchSize_(batchSize),
-      decodingMethod_(decoding),
+StepDoctrRecognition::StepDoctrRecognition(
+    const std::string& pathRecognizer, bool useGPU, int batchSize,
+    DecodingMethod decoding)
+    : session_(
+          pathRecognizer,
+          [&] {
+            onnx_addon::SessionConfig cfg;
+            cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU
+                                  : onnx_addon::ExecutionProvider::CPU;
+            cfg.optimization = onnx_addon::GraphOptimizationLevel::EXTENDED;
+            return cfg;
+          }()),
+      batchSize_(batchSize), decodingMethod_(decoding),
       vocabChars_(parseVocabToChars(VOCAB)) {
   std::string decodingStr = (decoding == DecodingMethod::CTC) ? "CTC" : "ATTENTION";
   QLOG(qvac_lib_inference_addon_cpp::logger::Priority::INFO,
@@ -208,7 +209,11 @@ cv::Mat StepDoctrRecognition::runBatchInference(const std::vector<cv::Mat>& imag
                              std::to_string(predsDims) + " dimensions");
   }
 
-  cv::Mat preds(predsDims, cvSizes.data(), CV_32F, const_cast<float*>(predsTensor.as<float>()));
+  cv::Mat preds(
+      predsDims,
+      cvSizes.data(),
+      CV_32F,
+      const_cast<float*>(predsTensor.as<float>()));
   return preds.clone();
 }
 

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "Steps.hpp"
-
-#include <qvac-onnx/OnnxSession.hpp>
-#include <opencv2/imgproc.hpp>
-
 #include <atomic>
 #include <string>
 #include <vector>
+
+#include <opencv2/imgproc.hpp>
+#include <qvac-onnx/OnnxSession.hpp>
+
+#include "Steps.hpp"
 
 namespace qvac_lib_inference_addon_onnx_ocr_fasttext {
 
@@ -21,9 +21,9 @@ public:
   static constexpr int RECOG_HEIGHT = 32;
   static constexpr int RECOG_WIDTH = 128;
 
-  StepDoctrRecognition(const std::string& pathRecognizer, bool useGPU = false,
-                       int batchSize = 32,
-                       DecodingMethod decoding = DecodingMethod::CTC);
+  StepDoctrRecognition(
+      const std::string& pathRecognizer, bool useGPU = false,
+      int batchSize = 32, DecodingMethod decoding = DecodingMethod::CTC);
 
 #if defined(_WIN32) || defined(_WIN64)
   // On Windows, defer session destruction to avoid the ORT global-state crash.

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.hpp
@@ -27,7 +27,7 @@ public:
 
 #if defined(_WIN32) || defined(_WIN64)
   // On Windows, defer session destruction to avoid the ORT global-state crash.
-  ~StepDoctrRecognition() { deferWindowsSessionLeak(std::move(ortSession_)); }
+  ~StepDoctrRecognition() { deferWindowsSessionLeak(std::move(session_)); }
 #endif
 
   /**

--- a/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepDoctrRecognition.hpp
@@ -2,7 +2,7 @@
 
 #include "Steps.hpp"
 
-#include <onnxruntime_cxx_api.h>
+#include <qvac-onnx/OnnxSession.hpp>
 #include <opencv2/imgproc.hpp>
 
 #include <atomic>
@@ -21,7 +21,7 @@ public:
   static constexpr int RECOG_HEIGHT = 32;
   static constexpr int RECOG_WIDTH = 128;
 
-  StepDoctrRecognition(const ORTCHAR_T* pathRecognizer, bool useGPU = true,
+  StepDoctrRecognition(const std::string& pathRecognizer, bool useGPU = false,
                        int batchSize = 32,
                        DecodingMethod decoding = DecodingMethod::CTC);
 
@@ -42,7 +42,7 @@ private:
     float bestProb;
   };
 
-  Ort::Session ortSession_{nullptr};
+  onnx_addon::OnnxSession session_;
   int batchSize_;
   DecodingMethod decodingMethod_;
 

--- a/packages/ocr-onnx/addon/pipeline/StepRecognizeText.cpp
+++ b/packages/ocr-onnx/addon/pipeline/StepRecognizeText.cpp
@@ -494,13 +494,15 @@ StepRecognizeText::StepRecognizeText(
     const std::string& pathRecognizer, std::span<const std::string> langList,
     bool useGPU, const Config& config)
     : config_(config),
-      session_(pathRecognizer, [&] {
-        onnx_addon::SessionConfig cfg;
-        cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU
-                              : onnx_addon::ExecutionProvider::CPU;
-        cfg.optimization = onnx_addon::GraphOptimizationLevel::EXTENDED;
-        return cfg;
-      }()),
+      session_(
+          pathRecognizer,
+          [&] {
+            onnx_addon::SessionConfig cfg;
+            cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU
+                                  : onnx_addon::ExecutionProvider::CPU;
+            cfg.optimization = onnx_addon::GraphOptimizationLevel::EXTENDED;
+            return cfg;
+          }()),
       isLeftToRightScript_{true} {
   QLOG(qvac_lib_inference_addon_cpp::logger::Priority::INFO, "[Recognition] Constructor: ONNX session created, validating languages...");
   ALOG_INFO(std::string("[Recognition] Constructor: ONNX session created, validating languages..."));
@@ -782,7 +784,11 @@ cv::Mat StepRecognizeText::runInferenceOnImg(const cv::Mat &img) {
     cvSizes[i] = static_cast<int>(predsShape[i]);
   }
 
-  cv::Mat preds(predsDims, cvSizes.data(), CV_32F, const_cast<float*>(predsTensor.as<float>()));
+  cv::Mat preds(
+      predsDims,
+      cvSizes.data(),
+      CV_32F,
+      const_cast<float*>(predsTensor.as<float>()));
 
   return preds.clone();
 }
@@ -836,7 +842,11 @@ cv::Mat StepRecognizeText::runBatchInference(const std::vector<cv::Mat> &images,
     cvSizes[i] = static_cast<int>(predsShape[i]);
   }
 
-  cv::Mat preds(predsDims, cvSizes.data(), CV_32F, const_cast<float*>(predsTensor.as<float>()));
+  cv::Mat preds(
+      predsDims,
+      cvSizes.data(),
+      CV_32F,
+      const_cast<float*>(predsTensor.as<float>()));
   auto t1 = std::chrono::high_resolution_clock::now();
   auto batchMs = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
   QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,

--- a/packages/ocr-onnx/addon/pipeline/StepRecognizeText.cpp
+++ b/packages/ocr-onnx/addon/pipeline/StepRecognizeText.cpp
@@ -491,10 +491,16 @@ std::array<cv::Point2f, 4> rotateBox(const std::array<cv::Point2f, 4> &box, int 
 } // end unnamed namespace
 
 StepRecognizeText::StepRecognizeText(
-    const ORTCHAR_T* pathRecognizer, std::span<const std::string> langList,
+    const std::string& pathRecognizer, std::span<const std::string> langList,
     bool useGPU, const Config& config)
     : config_(config),
-      ortSession_(getSharedOrtEnv(), pathRecognizer, getOrtSessionOptions(useGPU)),
+      session_(pathRecognizer, [&] {
+        onnx_addon::SessionConfig cfg;
+        cfg.provider = useGPU ? onnx_addon::ExecutionProvider::AUTO_GPU
+                              : onnx_addon::ExecutionProvider::CPU;
+        cfg.optimization = onnx_addon::GraphOptimizationLevel::EXTENDED;
+        return cfg;
+      }()),
       isLeftToRightScript_{true} {
   QLOG(qvac_lib_inference_addon_cpp::logger::Priority::INFO, "[Recognition] Constructor: ONNX session created, validating languages...");
   ALOG_INFO(std::string("[Recognition] Constructor: ONNX session created, validating languages..."));
@@ -756,30 +762,19 @@ cv::Mat StepRecognizeText::runInferenceOnImg(const cv::Mat &img) {
   for (int i = 0; i < dims; i++) {
     imageShape[i] = inputBlob.size[i];
   }
-  size_t imageTensorSize = inputBlob.total();
   assert(sizeof(float) == inputBlob.elemSize());
-  auto *imageData = inputBlob.ptr<float>();
-  Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  Ort::Value imageTensor = Ort::Value::CreateTensor<float>(memoryInfo, imageData, imageTensorSize, imageShape.data(), imageShape.size());
 
-  constexpr std::array<const char*, 1> inputNames = {"image"};
-  constexpr std::array<const char*, 1> outputNames = {"output"};
+  onnx_addon::InputTensor input;
+  input.name = "image";
+  input.shape = imageShape;
+  input.type = onnx_addon::TensorType::FLOAT32;
+  input.data = inputBlob.ptr<float>();
+  input.dataSize = inputBlob.total() * sizeof(float);
 
-  std::array<Ort::Value, 1> inputTensors = {std::move(imageTensor)};
+  auto outputTensors = session_.run(input);
 
-  auto outputTensors = ortSession_.Run(
-      Ort::RunOptions{nullptr},
-      inputNames.data(),
-      inputTensors.data(),
-      1,
-      outputNames.data(),
-      1);
-
-  Ort::Value &predsTensor = outputTensors[0];
-  auto *predsData = predsTensor.GetTensorMutableData<float>();
-  Ort::TypeInfo typeInfo = predsTensor.GetTypeInfo();
-  auto tensorInfo = typeInfo.GetTensorTypeAndShapeInfo();
-  std::vector<int64_t> predsShape = tensorInfo.GetShape();
+  const auto& predsTensor = outputTensors[0];
+  const auto& predsShape = predsTensor.shape;
 
   auto predsDims = static_cast<int>(predsShape.size());
   std::vector<int> cvSizes(predsDims);
@@ -787,7 +782,7 @@ cv::Mat StepRecognizeText::runInferenceOnImg(const cv::Mat &img) {
     cvSizes[i] = static_cast<int>(predsShape[i]);
   }
 
-  cv::Mat preds(predsDims, cvSizes.data(), CV_32F, predsData);
+  cv::Mat preds(predsDims, cvSizes.data(), CV_32F, const_cast<float*>(predsTensor.as<float>()));
 
   return preds.clone();
 }
@@ -822,30 +817,18 @@ cv::Mat StepRecognizeText::runBatchInference(const std::vector<cv::Mat> &images,
   }
 
   std::vector<int64_t> inputShape = {batchSize, numChannels, height, width};
-  size_t inputTensorSize = batchSize * numChannels * height * width;
 
-  Ort::MemoryInfo memoryInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
-      memoryInfo, batchData.data(), inputTensorSize, inputShape.data(), inputShape.size());
+  onnx_addon::InputTensor input;
+  input.name = "image";
+  input.shape = inputShape;
+  input.type = onnx_addon::TensorType::FLOAT32;
+  input.data = batchData.data();
+  input.dataSize = batchData.size() * sizeof(float);
 
-  constexpr std::array<const char*, 1> inputNames = {"image"};
-  constexpr std::array<const char*, 1> outputNames = {"output"};
+  auto outputTensors = session_.run(input);
 
-  std::array<Ort::Value, 1> inputTensors = {std::move(inputTensor)};
-
-  auto outputTensors = ortSession_.Run(
-      Ort::RunOptions{nullptr},
-      inputNames.data(),
-      inputTensors.data(),
-      1,
-      outputNames.data(),
-      1);
-
-  Ort::Value &predsTensor = outputTensors[0];
-  auto *predsData = predsTensor.GetTensorMutableData<float>();
-  Ort::TypeInfo typeInfo = predsTensor.GetTypeInfo();
-  auto tensorInfo = typeInfo.GetTensorTypeAndShapeInfo();
-  std::vector<int64_t> predsShape = tensorInfo.GetShape();
+  const auto& predsTensor = outputTensors[0];
+  const auto& predsShape = predsTensor.shape;
 
   auto predsDims = static_cast<int>(predsShape.size());
   std::vector<int> cvSizes(predsDims);
@@ -853,7 +836,7 @@ cv::Mat StepRecognizeText::runBatchInference(const std::vector<cv::Mat> &images,
     cvSizes[i] = static_cast<int>(predsShape[i]);
   }
 
-  cv::Mat preds(predsDims, cvSizes.data(), CV_32F, predsData);
+  cv::Mat preds(predsDims, cvSizes.data(), CV_32F, const_cast<float*>(predsTensor.as<float>()));
   auto t1 = std::chrono::high_resolution_clock::now();
   auto batchMs = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
   QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,

--- a/packages/ocr-onnx/addon/pipeline/StepRecognizeText.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepRecognizeText.hpp
@@ -50,6 +50,11 @@ public:
       const std::string& pathRecognizer, std::span<const std::string> langList,
       bool useGPU = false, const Config& config = Config{});
 
+#if defined(_WIN32) || defined(_WIN64)
+  // On Windows, defer session destruction to avoid the ORT global-state crash.
+  ~StepRecognizeText() { deferWindowsSessionLeak(std::move(session_)); }
+#endif
+
   CONSTRUCT_FROM_TUPLE(StepRecognizeText)
 
   /**

--- a/packages/ocr-onnx/addon/pipeline/StepRecognizeText.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepRecognizeText.hpp
@@ -2,7 +2,7 @@
 
 #include "Steps.hpp"
 
-// #include <onnxruntime_cxx_api.h>
+#include <qvac-onnx/OnnxSession.hpp>
 #include <opencv2/imgproc.hpp>
 
 #include <array>
@@ -47,7 +47,7 @@ public:
   };
 
   StepRecognizeText(
-      const ORTCHAR_T* pathRecognizer, std::span<const std::string> langList,
+      const std::string& pathRecognizer, std::span<const std::string> langList,
       bool useGPU = false, const Config& config = Config{});
 
   CONSTRUCT_FROM_TUPLE(StepRecognizeText)
@@ -64,7 +64,7 @@ public:
 
 private:
   Config config_;
-  Ort::Session ortSession_{nullptr};
+  onnx_addon::OnnxSession session_;
 
   std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter_;
   std::u32string_view utf32Characters_;

--- a/packages/ocr-onnx/addon/pipeline/StepRecognizeText.hpp
+++ b/packages/ocr-onnx/addon/pipeline/StepRecognizeText.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-#include "Steps.hpp"
-
-#include <qvac-onnx/OnnxSession.hpp>
-#include <opencv2/imgproc.hpp>
-
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -14,6 +9,11 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <opencv2/imgproc.hpp>
+#include <qvac-onnx/OnnxSession.hpp>
+
+#include "Steps.hpp"
 
 namespace qvac_lib_inference_addon_onnx_ocr_fasttext {
 

--- a/packages/ocr-onnx/addon/pipeline/Steps.cpp
+++ b/packages/ocr-onnx/addon/pipeline/Steps.cpp
@@ -28,11 +28,13 @@ namespace {
 // causing SIGSEGV on all subsequent session destructions (ORT bug).
 // By moving sessions here and never calling delete, we bypass the broken
 // destructor.  The OS reclaims all memory when the process exits.
-std::vector<onnx_addon::OnnxSession*> windowsLeakedSessions; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+std::vector<onnx_addon::OnnxSession*>
+    windowsLeakedSessions; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 } // namespace
 
 void deferWindowsSessionLeak(onnx_addon::OnnxSession session) {
-  windowsLeakedSessions.push_back(new onnx_addon::OnnxSession(std::move(session))); // NOLINT(cppcoreguidelines-owning-memory)
+  windowsLeakedSessions.push_back(new onnx_addon::OnnxSession(
+      std::move(session))); // NOLINT(cppcoreguidelines-owning-memory)
 }
 #endif
 

--- a/packages/ocr-onnx/addon/pipeline/Steps.cpp
+++ b/packages/ocr-onnx/addon/pipeline/Steps.cpp
@@ -1,21 +1,10 @@
 #include "Steps.hpp"
 
-#include <algorithm>
 #include <cmath>
-#include <cstdio>
-#include <iostream>
 #include <sstream>
 #include <string>
-#include <vector>
 
 #include <opencv2/opencv.hpp>
-
-#include "AndroidLog.hpp"
-#include "qvac-lib-inference-addon-cpp/Logger.hpp"
-
-#if defined(_WIN32) || defined(_WIN64)
-#include <dml_provider_factory.h>
-#endif
 
 namespace qvac_lib_inference_addon_onnx_ocr_fasttext {
 
@@ -31,154 +20,6 @@ std::string InferredText::toString() const {
   stringStream << "]";
   return stringStream.str();
 };
-
-Ort::SessionOptions getOrtSessionOptions(bool useGPU) {
-  const std::string initMsg =
-      "[ORT] getOrtSessionOptions called with useGPU=" + std::to_string(useGPU);
-  QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, initMsg);
-  ALOG_DEBUG(initMsg);
-  Ort::SessionOptions sessionOptions;
-  sessionOptions.SetGraphOptimizationLevel(
-      GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
-
-  const auto providers = Ort::GetAvailableProviders();
-  // Log available execution providers for debugging
-  std::stringstream providersMsg;
-  providersMsg << "[ORT] Available execution providers: ";
-  for (size_t i = 0; i < providers.size(); ++i) {
-    providersMsg << providers[i];
-    if (i < providers.size() - 1) {
-      providersMsg << ", ";
-    }
-  }
-  QLOG(
-      qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
-      providersMsg.str());
-  ALOG_DEBUG(providersMsg.str());
-
-  if (!useGPU) {
-    std::string cpuMsg = "[ORT] CPU-only mode configured. ";
-
-    try {
-      const bool xnnpackAvailable =
-          std::find(
-              providers.begin(), providers.end(), "XnnpackExecutionProvider") !=
-          providers.end();
-
-#if !(defined(_WIN32) || defined(_WIN64))
-      if (xnnpackAvailable) {
-        // Pass empty options so XNNPACK inherits ORT's thread pool rather than
-        // creating its own pthreadpool.  Without this, XNNPACK's pool is not
-        // tied to the session lifetime and can cause hangs on destruction.
-        // See: https://onnxruntime.ai/docs/execution-providers/Xnnpack-ExecutionProvider.html
-        // XNNPACK's NHWC layout transformer creates fused nodes in the
-        // com.ms.internal.nhwc domain whose schemas are not registered.
-        // ORT_ENABLE_EXTENDED triggers the NhwcTransformer which produces
-        // these nodes, so we must drop to BASIC when XNNPACK is active.
-        sessionOptions.SetGraphOptimizationLevel(
-            GraphOptimizationLevel::ORT_ENABLE_BASIC);
-        sessionOptions.AppendExecutionProvider("XNNPACK", {});
-        cpuMsg.append("XNNPack EP appended (graph opt lowered to BASIC).");
-      } else {
-        cpuMsg.append("XNNPack EP not available.");
-      }
-#else
-      (void)xnnpackAvailable;
-      // XNNPACK causes session-destruction crashes on Windows; use the CPU EP only.
-      cpuMsg.append("XNNPack EP skipped on Windows; using CPU EP.");
-#endif
-    } catch (const std::exception& e) {
-      cpuMsg.append("Failed to append XNNPack: " + std::string(e.what()));
-    }
-
-    QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, cpuMsg);
-    ALOG_DEBUG(cpuMsg);
-
-    return sessionOptions;
-  }
-
-#ifdef __ANDROID__
-  try {
-    const bool nnapiAvailable =
-        std::find(
-            providers.begin(), providers.end(), "NnapiExecutionProvider") !=
-        providers.end();
-
-    if (nnapiAvailable) {
-      uint32_t nnapiFlags = NNAPI_FLAG_USE_FP16 | NNAPI_FLAG_CPU_DISABLED;
-      Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_Nnapi(
-          sessionOptions, nnapiFlags));
-    }
-  } catch (const std::exception& e) {
-    const std::string errMsg =
-        std::string("Error setting up NNAPI provider: ") + e.what();
-    QLOG(qvac_lib_inference_addon_cpp::logger::Priority::ERROR, errMsg);
-    ALOG_ERROR(errMsg);
-  }
-
-#elif defined(__APPLE__)
-  try {
-    const bool coremlAvailable =
-        std::find(
-            providers.begin(), providers.end(), "CoreMLExecutionProvider") !=
-        providers.end();
-
-    QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG,
-         std::string("[ORT] CoreML available: ") + (coremlAvailable ? "yes" : "no"));
-    if (coremlAvailable) {
-      sessionOptions.AppendExecutionProvider("CoreML");
-      QLOG(qvac_lib_inference_addon_cpp::logger::Priority::DEBUG, "[ORT] CoreML execution provider added");
-    }
-  } catch (const std::exception& e) {
-    QLOG(qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-         std::string("Error setting up CoreML provider: ") + e.what());
-  }
-
-#elif defined(_WIN32) || defined(_WIN64)
-
-  try {
-    const bool DmlExecutionProvider =
-        std::find(providers.begin(), providers.end(), "DmlExecutionProvider") !=
-        providers.end();
-    if (DmlExecutionProvider) {
-      sessionOptions.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
-      sessionOptions.DisableMemPattern();
-      Ort::ThrowOnError(
-          OrtSessionOptionsAppendExecutionProvider_DML(sessionOptions, 0));
-      QLOG(qvac_lib_inference_addon_cpp::logger::Priority::INFO, "Using DirectML execution provider");
-    }
-  } catch (const std::exception& e) {
-    QLOG(qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-         std::string("Error setting up DirectML provider: ") + e.what());
-  }
-
-#endif
-
-  return sessionOptions;
-}
-
-Ort::Env& getSharedOrtEnv() {
-  static Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "OnnxOcr");
-  return env;
-}
-
-#if defined(_WIN32) || defined(_WIN64)
-namespace {
-// Raw owning pointers that are intentionally never deleted.
-// ~Ort::Session() on Windows corrupts global ORT state after the first call,
-// causing SIGSEGV on all subsequent session destructions (ORT bug).
-// By moving sessions here and never calling delete, we bypass the broken
-// destructor.  The OS reclaims all memory when the process exits.
-std::vector<Ort::Session*> windowsLeakedSessions; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-} // namespace
-
-void deferWindowsSessionLeak(Ort::Session session) {
-  // Heap-allocate via move-construction so the OrtSession* handle transfers
-  // to the new object.  The raw pointer is stored but never freed, preventing
-  // ~Ort::Session() from running and avoiding the Windows crash.
-  windowsLeakedSessions.push_back(new Ort::Session(std::move(session))); // NOLINT(cppcoreguidelines-owning-memory)
-}
-#endif
 
 cv::Mat fourPointTransform(const cv::Mat &image, const std::array<cv::Point2f, 4> &rect) {
   cv::Point2f topLeft = rect[0];

--- a/packages/ocr-onnx/addon/pipeline/Steps.cpp
+++ b/packages/ocr-onnx/addon/pipeline/Steps.cpp
@@ -21,6 +21,21 @@ std::string InferredText::toString() const {
   return stringStream.str();
 };
 
+#if defined(_WIN32) || defined(_WIN64)
+namespace {
+// Raw owning pointers that are intentionally never deleted.
+// ~Ort::Session() on Windows corrupts global ORT state after the first call,
+// causing SIGSEGV on all subsequent session destructions (ORT bug).
+// By moving sessions here and never calling delete, we bypass the broken
+// destructor.  The OS reclaims all memory when the process exits.
+std::vector<onnx_addon::OnnxSession*> windowsLeakedSessions; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+} // namespace
+
+void deferWindowsSessionLeak(onnx_addon::OnnxSession session) {
+  windowsLeakedSessions.push_back(new onnx_addon::OnnxSession(std::move(session))); // NOLINT(cppcoreguidelines-owning-memory)
+}
+#endif
+
 cv::Mat fourPointTransform(const cv::Mat &image, const std::array<cv::Point2f, 4> &rect) {
   cv::Point2f topLeft = rect[0];
   cv::Point2f topRight = rect[1];

--- a/packages/ocr-onnx/addon/pipeline/Steps.hpp
+++ b/packages/ocr-onnx/addon/pipeline/Steps.hpp
@@ -8,6 +8,8 @@
 #include <variant>
 #include <tuple>
 
+#include <qvac-onnx/OnnxSession.hpp>
+
 /* NOLINTBEGIN(cppcoreguidelines-macro-usage) */
 #define CONSTRUCT_FROM_TUPLE(Class)                          template <class... Ts>                                   explicit Class(std::tuple<Ts...>&& tup)                      : Class(std::move(tup), std::index_sequence_for<Ts...>{})       { } /* NOLINT(cppcoreguidelines-rvalue-reference-param-not-moved) */                                                                                                               template <class Tuple, size_t... Is>                     Class(Tuple&& tup, std::index_sequence<Is...>)               : Class(std::forward<decltype(std::get<Is>(tup))>(std::get<Is>(tup))...)     { } /* NOLINT(cppcoreguidelines-missing-std-forward,cppcoreguidelines-rvalue-reference-param-not-moved) */
 /* NOLINTEND(cppcoreguidelines-macro-usage) */
@@ -69,5 +71,14 @@ struct StepDoctrDetectionOutput {
 };
 
 cv::Mat fourPointTransform(const cv::Mat &image, const std::array<cv::Point2f, 4> &rect);
+
+#if defined(_WIN32) || defined(_WIN64)
+// On Windows, ~Ort::Session() corrupts global ORT state after the 1st call, a known
+// ORT bug, causing SIGSEGV on all subsequent session destructions.  Work around it by
+// moving the session into a heap-allocated object via a raw (non-owning) pointer that is
+// intentionally never deleted. The OS reclaims the memory when the process exits.
+// Call this from step destructors instead of letting OnnxSession be destroyed normally.
+void deferWindowsSessionLeak(onnx_addon::OnnxSession session);
+#endif
 
 }

--- a/packages/ocr-onnx/addon/pipeline/Steps.hpp
+++ b/packages/ocr-onnx/addon/pipeline/Steps.hpp
@@ -1,16 +1,10 @@
 #pragma once
 
-#include <onnxruntime_c_api.h>
-#include <onnxruntime_cxx_api.h>
-
-#ifdef __ANDROID__
-#include <onnxruntime/nnapi_provider_factory.h>
-#endif
-
 #include <opencv2/imgproc.hpp>
 
 #include <cstddef>
 #include <optional>
+#include <string>
 #include <variant>
 #include <tuple>
 
@@ -74,20 +68,6 @@ struct StepDoctrDetectionOutput {
   int padTop{0};    // Top padding offset (symmetric padding)
 };
 
-Ort::SessionOptions getOrtSessionOptions(bool useGPU = false);
-
-// Shared ONNX Runtime environment (one per process, as recommended by ONNX Runtime).
-Ort::Env& getSharedOrtEnv();
-
 cv::Mat fourPointTransform(const cv::Mat &image, const std::array<cv::Point2f, 4> &rect);
-
-#if defined(_WIN32) || defined(_WIN64)
-// On Windows, ~Ort::Session() corrupts global ORT state after the 1st call — a known
-// ORT bug — causing SIGSEGV on all subsequent session destructions.  Work around it by
-// moving the session into a heap-allocated object via a raw (non-owning) pointer that is
-// intentionally never deleted.  The OS reclaims the memory when the process exits.
-// Call this from step destructors instead of letting Ort::Session be destroyed normally.
-void deferWindowsSessionLeak(Ort::Session session);
-#endif
 
 }

--- a/packages/ocr-onnx/addon/pipeline/Steps.hpp
+++ b/packages/ocr-onnx/addon/pipeline/Steps.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <opencv2/imgproc.hpp>
-
 #include <cstddef>
 #include <optional>
 #include <string>
-#include <variant>
 #include <tuple>
+#include <variant>
 
+#include <opencv2/imgproc.hpp>
 #include <qvac-onnx/OnnxSession.hpp>
 
 /* NOLINTBEGIN(cppcoreguidelines-macro-usage) */
@@ -73,11 +72,12 @@ struct StepDoctrDetectionOutput {
 cv::Mat fourPointTransform(const cv::Mat &image, const std::array<cv::Point2f, 4> &rect);
 
 #if defined(_WIN32) || defined(_WIN64)
-// On Windows, ~Ort::Session() corrupts global ORT state after the 1st call, a known
-// ORT bug, causing SIGSEGV on all subsequent session destructions.  Work around it by
-// moving the session into a heap-allocated object via a raw (non-owning) pointer that is
-// intentionally never deleted. The OS reclaims the memory when the process exits.
-// Call this from step destructors instead of letting OnnxSession be destroyed normally.
+// On Windows, ~Ort::Session() corrupts global ORT state after the 1st call, a
+// known ORT bug, causing SIGSEGV on all subsequent session destructions.  Work
+// around it by moving the session into a heap-allocated object via a raw
+// (non-owning) pointer that is intentionally never deleted. The OS reclaims the
+// memory when the process exits. Call this from step destructors instead of
+// letting OnnxSession be destroyed normally.
 void deferWindowsSessionLeak(onnx_addon::OnnxSession session);
 #endif
 

--- a/packages/ocr-onnx/binding.js
+++ b/packages/ocr-onnx/binding.js
@@ -1,1 +1,6 @@
+// Pre-load @qvac/onnx so its .bare module is registered with the bare runtime
+// before our addon triggers Windows delay-load resolution of qvac__onnx@0.bare
+// (bare_module_find requires modules to be already loaded).
+require('@qvac/onnx')
+
 module.exports = require.addon()

--- a/packages/ocr-onnx/package.json
+++ b/packages/ocr-onnx/package.json
@@ -73,7 +73,7 @@
     "@qvac/dl-hyperdrive": "^0.1.0",
     "@qvac/error": "^0.1.0",
     "@qvac/infer-base": "^0.1.0",
-    "@qvac/onnx": "^0.12.9",
+    "@qvac/onnx": "^0.12.11",
     "@qvac/response": "^0.1.2",
     "bare-fetch": "^2.5.1",
     "bare-fs": "^4.5.1",

--- a/packages/ocr-onnx/package.json
+++ b/packages/ocr-onnx/package.json
@@ -73,7 +73,7 @@
     "@qvac/dl-hyperdrive": "^0.1.0",
     "@qvac/error": "^0.1.0",
     "@qvac/infer-base": "^0.1.0",
-    "@qvac/onnx": "^0.12.11",
+    "@qvac/onnx": "^0.12.12",
     "@qvac/response": "^0.1.2",
     "bare-fetch": "^2.5.1",
     "bare-fs": "^4.5.1",

--- a/packages/ocr-onnx/package.json
+++ b/packages/ocr-onnx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-onnx",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OCR addon for qvac",
   "addon": true,
   "engines": {
@@ -73,6 +73,7 @@
     "@qvac/dl-hyperdrive": "^0.1.0",
     "@qvac/error": "^0.1.0",
     "@qvac/infer-base": "^0.1.0",
+    "@qvac/onnx": "^0.12.9",
     "@qvac/response": "^0.1.2",
     "bare-fetch": "^2.5.1",
     "bare-fs": "^4.5.1",

--- a/packages/ocr-onnx/vcpkg-configuration.json
+++ b/packages/ocr-onnx/vcpkg-configuration.json
@@ -11,8 +11,6 @@
       "repository": "https://github.com/microsoft/vcpkg",
       "packages": [
         "opencv4",
-        "directx-headers",
-        "flatbuffers",
         "gtk3",
         "libjpeg-turbo",
         "libpng",
@@ -30,7 +28,6 @@
         "libepoxy",
         "liblzma",
         "pango",
-        "utf8-range",
         "vcpkg-tool-meson",
         "at-spi2-core",
         "dbus",
@@ -60,25 +57,7 @@
         "libxcrypt",
         "lz4",
         "zstd",
-        "benchmark",
-        "boost-config",
-        "boost-mp11",
-        "cxxopts",
-        "date",
-        "dlpack",
-        "ms-gsl",
-        "nlohmann-json",
-        "optional-lite",
-        "re2",
-        "safeint",
-        "boost-cmake",
-        "boost-headers",
-        "boost-uninstall",
-        "vcpkg-boost",
-        "mimalloc",
-        "wil",
-        "gtest",
-        "fxdiv"
+        "gtest"
       ]
     }
   ]

--- a/packages/ocr-onnx/vcpkg.json
+++ b/packages/ocr-onnx/vcpkg.json
@@ -3,31 +3,6 @@
   "version": "0.1.14",
   "dependencies": [
     {
-      "name": "onnxruntime",
-      "features": [
-        "nnapi-ep"
-      ],
-      "platform": "android"
-    },
-    {
-      "name": "onnxruntime",
-      "features": [
-        "dml-ep"
-      ],
-      "platform": "windows"
-    },
-    {
-      "name": "onnxruntime",
-      "features": [
-        "coreml-ep"
-      ],
-      "platform": "osx | ios"
-    },
-    {
-      "name": "onnxruntime",
-      "platform": "!(android | osx | ios | windows)"
-    },
-    {
       "name": "opencv4",
       "default-features": false,
       "features": [
@@ -53,23 +28,6 @@
       "dependencies": [
         "gtest"
       ]
-    },
-    "xnnpack": {
-      "description": "Enable XNNPack execution provider for optimized CPU inference",
-      "dependencies": [
-        {
-          "name": "onnxruntime",
-          "features": [
-            "xnnpack-ep"
-          ]
-        }
-      ]
     }
-  },
-  "overrides": [
-    {
-      "name": "flatbuffers",
-      "version": "23.5.26"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?
- OCR addon has its own statically linked ONNX runtime

## 📝 How does it solve it?
- Refactored OCR addon to use `@qvac/onnx` shared ONNX Runtime base package instead of bundling ONNX Runtime directly.
- Replaced direct `onnxruntime` vcpkg dependency with `qvac-onnx` CMake package from `@qvac/onnx`.
- Switched from `ORTCHAR_T*` to `std::string&` for model path parameters across Pipeline, detection, and recognition steps.
- Simplified ONNX session management using `onnx_addon::Session` wrapper instead of raw `Ort::Session`.
- Replaced raw `Ort::Value` tensor handling with `onnx_addon::InputTensor`/`onnx_addon::OutputTensor` abstractions.
- Removed custom symbol hiding (version scripts, exported symbols) — now handled by `@qvac/onnx` shared module.
- Simplified vcpkg configuration by removing bundled ONNX Runtime dependencies.

## 🧪 How was it tested?
- Local testing on linux and android. CI results: https://github.com/tetherto/qvac/actions/runs/22991481043