### PR TITLE
feat[notask]: decouple registry blob download from file write

### DIFF
--- a/packages/qvac-lib-registry-server/client/index.d.ts
+++ b/packages/qvac-lib-registry-server/client/index.d.ts
@@ -41,12 +41,15 @@ export interface QVACDownloadOptions {
   timeout?: number
   peerTimeout?: number
   outputFile?: string
+  prefetch?: boolean
+  onProgress?: (progress: { downloaded: number, total: number }) => void
 }
 
 export interface QVACBlobDownloadOptions {
   timeout?: number
   outputFile?: string
-  onProgress?: (progress: { downloaded: number, total: number, cachedBlocks: number, totalBlocks: number }) => void
+  prefetch?: boolean
+  onProgress?: (progress: { downloaded: number, total: number, cachedBlocks?: number, totalBlocks?: number }) => void
   signal?: AbortSignal
 }
 

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -247,14 +247,46 @@ class QVACRegistryClient extends ReadyResource {
 
       const totalSize = model.blobBinding.byteLength
 
+      const rangeDownload = core.download({
+        start: model.blobBinding.blockOffset,
+        length: model.blobBinding.blockLength
+      })
+
       let artifact
       if (options.outputFile) {
         await this._streamBlobToFile(blobs, core, model.blobBinding, options.outputFile, options)
         artifact = { path: options.outputFile, totalSize }
 
+        rangeDownload.destroy()
         if (blobs) await blobs.close()
         if (core) await core.close()
       } else {
+        if (options.prefetch) {
+          let downloadedBytes = 0
+          const progressHandler = (index, bytes) => {
+            if (index >= model.blobBinding.blockOffset && index < model.blobBinding.blockOffset + model.blobBinding.blockLength) {
+              downloadedBytes += bytes
+              if (options.onProgress) {
+                options.onProgress({
+                  downloaded: Math.min(downloadedBytes, totalSize),
+                  total: totalSize
+                })
+              }
+            }
+          }
+
+          core.on('download', progressHandler)
+          try {
+            await rangeDownload.done()
+          } finally {
+            core.off('download', progressHandler)
+          }
+
+          this.logger.debug('Prefetch complete, all blocks in local storage', {
+            byteLength: totalSize
+          })
+        }
+
         const stream = blobs.createReadStream(model.blobBinding, {
           wait: true,
           timeout: options.timeout || 30000
@@ -262,6 +294,7 @@ class QVACRegistryClient extends ReadyResource {
         artifact = { stream, totalSize }
 
         const cleanup = async () => {
+          rangeDownload.destroy()
           if (blobs) {
             try {
               await blobs.close()
@@ -359,14 +392,46 @@ class QVACRegistryClient extends ReadyResource {
       }
       const totalSize = blobBinding.byteLength
 
+      const rangeDownload = core.download({
+        start: pointer.blockOffset,
+        length: pointer.blockLength
+      })
+
       let artifact
       if (options.outputFile) {
         await this._streamBlobToFile(blobs, core, pointer, options.outputFile, options)
         artifact = { path: options.outputFile, totalSize }
 
+        rangeDownload.destroy()
         if (blobs) await blobs.close()
         if (core) await core.close()
       } else {
+        if (options.prefetch) {
+          let downloadedBytes = 0
+          const progressHandler = (index, bytes) => {
+            if (index >= pointer.blockOffset && index < pointer.blockOffset + pointer.blockLength) {
+              downloadedBytes += bytes
+              if (options.onProgress) {
+                options.onProgress({
+                  downloaded: Math.min(downloadedBytes, totalSize),
+                  total: totalSize
+                })
+              }
+            }
+          }
+
+          core.on('download', progressHandler)
+          try {
+            await rangeDownload.done()
+          } finally {
+            core.off('download', progressHandler)
+          }
+
+          this.logger.debug('Prefetch complete, all blocks in local storage', {
+            byteLength: totalSize
+          })
+        }
+
         const stream = blobs.createReadStream(pointer, {
           wait: true,
           timeout: options.timeout || 30000
@@ -374,6 +439,7 @@ class QVACRegistryClient extends ReadyResource {
         artifact = { stream, totalSize }
 
         const cleanup = async () => {
+          rangeDownload.destroy()
           if (blobs) {
             try { await blobs.close() } catch (e) {
               this.logger.warn('Error closing blob instance', { error: e.message })
@@ -450,6 +516,11 @@ class QVACRegistryClient extends ReadyResource {
 
     core.on('download', progressHandler)
 
+    const rangeDownload = core.download({
+      start: blobPointer.blockOffset,
+      length: blobPointer.blockLength
+    })
+
     const stream = blobs.createReadStream(blobPointer, {
       wait: true,
       timeout: options.timeout || 30000
@@ -482,6 +553,7 @@ class QVACRegistryClient extends ReadyResource {
         }
       })
     } finally {
+      rangeDownload.destroy()
       core.off('download', progressHandler)
     }
   }

--- a/packages/sdk/examples/llamacpp-hyperdrive.ts
+++ b/packages/sdk/examples/llamacpp-hyperdrive.ts
@@ -9,12 +9,26 @@ import {
 
 try {
   // First just cache the model
+  let lastBytes = 0;
+  let lastTime = Date.now();
   await downloadAsset({
     assetSrc: LLAMA_3_2_1B_INST_Q4_0,
     onProgress: (progress) => {
-      console.log(progress);
+      const now = Date.now();
+      const elapsed = (now - lastTime) / 1000;
+      if (elapsed >= 1) {
+        const speed = (progress.downloaded - lastBytes) / elapsed / 1024 / 1024;
+        const totalMB = progress.total / 1024 / 1024;
+        const downloadedMB = progress.downloaded / 1024 / 1024;
+        process.stdout.write(
+          `\r${downloadedMB.toFixed(1)} / ${totalMB.toFixed(1)} MB  ${progress.percentage}%  ${speed.toFixed(1)} MB/s   `,
+        );
+        lastBytes = progress.downloaded;
+        lastTime = now;
+      }
     },
   });
+  console.log();
 
   // Then load it in memory from cache
   const modelId = await loadModel({

--- a/packages/sdk/server/rpc/handlers/load-model/registry.ts
+++ b/packages/sdk/server/rpc/handlers/load-model/registry.ts
@@ -125,9 +125,27 @@ async function downloadSingleFileFromRegistry(
 
   let readStream: Readable;
 
+  const onProgress = progressCallback
+    ? (progress: { downloaded: number; total: number }) => {
+        progressCallback({
+          type: "modelProgress",
+          downloaded: progress.downloaded,
+          total: expectedSize || progress.total,
+          percentage: expectedSize
+            ? calculatePercentage(progress.downloaded, expectedSize)
+            : 0,
+          downloadKey,
+        });
+      }
+    : undefined;
+
   if (blobBinding) {
     logger.info(`📥 Downloading blob directly: ${modelFileName}`);
-    const result = await client.downloadBlob(blobBinding, { timeout: REGISTRY_STREAM_TIMEOUT_MS });
+    const result = await client.downloadBlob(blobBinding, {
+      timeout: REGISTRY_STREAM_TIMEOUT_MS,
+      prefetch: true,
+      ...(onProgress && { onProgress }),
+    });
     if (!("stream" in result.artifact)) {
       throw new RegistryDownloadFailedError(
         `No stream returned for blob ${modelFileName}`,
@@ -138,6 +156,8 @@ async function downloadSingleFileFromRegistry(
     logger.info(`📥 Downloading from registry: ${registryPath}`);
     const result = await client.downloadModel(registryPath, registrySource, {
       timeout: REGISTRY_STREAM_TIMEOUT_MS,
+      prefetch: true,
+      ...(onProgress && { onProgress }),
     });
     if (!("stream" in result.artifact)) {
       throw new RegistryDownloadFailedError(
@@ -147,29 +167,14 @@ async function downloadSingleFileFromRegistry(
     readStream = result.artifact.stream as unknown as Readable;
   }
 
+  if (signal?.aborted) {
+    throw new DownloadCancelledError();
+  }
+
   const dir = path.dirname(modelPath);
   await fsPromises.mkdir(dir, { recursive: true });
 
   const writeStream = fs.createWriteStream(modelPath) as unknown as Writable;
-
-  let downloadedBytes = 0;
-
-  readStream.on("data", (chunk: unknown) => {
-    const buffer = chunk as Buffer;
-    downloadedBytes += buffer.length;
-
-    if (progressCallback) {
-      progressCallback({
-        type: "modelProgress",
-        downloaded: downloadedBytes,
-        total: expectedSize || downloadedBytes,
-        percentage: expectedSize
-          ? calculatePercentage(downloadedBytes, expectedSize)
-          : 0,
-        downloadKey,
-      });
-    }
-  });
 
   readStream.pipe(writeStream);
 


### PR DESCRIPTION
**Note**: Draft PR — experimental changes for testing.

## 🎯 What problem does this PR solve?

- Model downloads via the registry client stream P2P network data directly into a file via `pipe()`, causing disk I/O backpressure to throttle the P2P download speed

## 📝 How does it solve it?

- Adds a `prefetch` option to registry client's `downloadBlob` and `downloadModel` methods
- When `prefetch: true`, awaits `rangeDownload.done()` to pull all Hypercore blocks into local storage before creating the read stream
- SDK's `downloadSingleFileFromRegistry` now uses `prefetch: true` + `onProgress` callback for progress during the network phase
- File write from local storage runs at full disk speed with no network dependency
- Updated `QVACBlobDownloadOptions` and `QVACDownloadOptions` type definitions

## 🧪 How was it tested?

- Manual test: ran `llamacpp-hyperdrive.ts` example with download speed logging against a ~770MB model