### PR TITLE
fix(ci): gate ts-checks behind verify label and add prebuild dependency

### DIFF
--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -61,7 +61,6 @@ jobs:
       workdir: packages/lib-infer-diffusion
 
   ts-checks:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -90,6 +89,7 @@ jobs:
         run: npm run test:dts
 
   prebuild:
+    needs: sanity-checks
     if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -61,6 +61,7 @@ jobs:
       workdir: packages/lib-infer-diffusion
 
   ts-checks:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -59,6 +59,7 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   ts-checks:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -61,6 +61,7 @@ jobs:
       workdir: packages/qvac-lib-infer-llamacpp-llm
 
   ts-checks:
+    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What problem does this PR solve?

- `ts-checks` in LLM and embed on-PR workflows runs unconditionally on every PR, wasting CI minutes when the `verify` label hasn't been added
- Diffusion `prebuild` job doesn't wait for `sanity-checks` to pass before starting

## How does it solve it?

- Add `verify` label conditional to `ts-checks` in LLM, embed, and diffusion on-PR workflows so type declaration checks only run when the `verify` label is added, consistent with all other CI jobs
- Add `needs: sanity-checks` to diffusion `prebuild` so it waits for sanity checks before building