### PR TITLE
chore(embed): bump version to 0.12.0 and update qvac-fabric to 7248.1.4

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.12.0] - 2026-03-13
+
+### Changed
+
+- Updated qvac-fabric dependency from 7248.1.3 to 7248.1.4.
+
 ## [0.11.3] - 2026-03-06
 
 ### Fixed

--- a/packages/qvac-lib-infer-llamacpp-embed/package.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "7248.1.3"
+      "version>=": "7248.1.4"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
## Summary

- Bumps `@qvac/embed-llamacpp` version from 0.11.3 to 0.12.0.
- Updates `qvac-fabric` vcpkg dependency from 7248.1.3 to 7248.1.4.
- Adds corresponding CHANGELOG.md entry for the 0.12.0 release.
