### PR TITLE
chore[mod]: remove unused istupakov parakeet-ctc models from registry

### DIFF
--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -5340,68 +5340,6 @@
     "notes": "Full INT8 quantization of https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx"
   },
   {
-    "source": "https://huggingface.co/istupakov/parakeet-ctc-0.6b-onnx/resolve/658f956396c5a6e41f23ed50838bdb7d1d1b6056/model.onnx",
-    "engine": "@qvac/transcription-parakeet",
-    "description": "Parakeet CTC 0.6B (graph)",
-    "quantization": "fp32",
-    "params": "0.6B",
-    "license": "CC-BY-4.0",
-    "tags": [
-      "transcription",
-      "parakeet",
-      "ctc",
-      "en"
-    ],
-    "notes": ""
-  },
-  {
-    "source": "https://huggingface.co/istupakov/parakeet-ctc-0.6b-onnx/resolve/658f956396c5a6e41f23ed50838bdb7d1d1b6056/model.onnx.data",
-    "engine": "@qvac/transcription-parakeet",
-    "description": "Parakeet CTC 0.6B (weights)",
-    "quantization": "fp32",
-    "params": "0.6B",
-    "license": "CC-BY-4.0",
-    "tags": [
-      "transcription",
-      "parakeet",
-      "ctc",
-      "en"
-    ],
-    "notes": ""
-  },
-  {
-    "source": "https://huggingface.co/istupakov/parakeet-ctc-0.6b-onnx/resolve/658f956396c5a6e41f23ed50838bdb7d1d1b6056/model.int8.onnx",
-    "engine": "@qvac/transcription-parakeet",
-    "description": "Parakeet CTC 0.6B (graph+weights INT8)",
-    "quantization": "int8",
-    "params": "0.6B",
-    "license": "CC-BY-4.0",
-    "tags": [
-      "transcription",
-      "parakeet",
-      "ctc",
-      "en",
-      "int8"
-    ],
-    "notes": ""
-  },
-  {
-    "source": "https://huggingface.co/istupakov/parakeet-ctc-0.6b-onnx/resolve/658f956396c5a6e41f23ed50838bdb7d1d1b6056/vocab.txt",
-    "engine": "@qvac/transcription-parakeet",
-    "link": "https://huggingface.co/istupakov/parakeet-ctc-0.6b-onnx",
-    "description": "Parakeet CTC 0.6B vocabulary",
-    "quantization": "",
-    "params": "0.6B",
-    "license": "CC-BY-4.0",
-    "tags": [
-      "transcription",
-      "parakeet",
-      "vocab",
-      "en"
-    ],
-    "notes": ""
-  },
-  {
     "source": "https://huggingface.co/onnx-community/parakeet-ctc-0.6b-ONNX/resolve/7df2cab7aed886b8b7f80d68a8214007e4847601/onnx/model.onnx",
     "engine": "@qvac/transcription-parakeet",
     "link": "https://huggingface.co/onnx-community/parakeet-ctc-0.6b-ONNX",
@@ -5446,22 +5384,6 @@
       "parakeet",
       "ctc",
       "tokenizer",
-      "en"
-    ],
-    "notes": ""
-  },
-  {
-    "source": "https://huggingface.co/istupakov/parakeet-ctc-0.6b-onnx/resolve/658f956396c5a6e41f23ed50838bdb7d1d1b6056/config.json",
-    "engine": "@qvac/transcription-parakeet",
-    "link": "https://huggingface.co/istupakov/parakeet-ctc-0.6b-onnx",
-    "description": "Parakeet CTC 0.6B config",
-    "quantization": "",
-    "params": "0.6B",
-    "license": "CC-BY-4.0",
-    "tags": [
-      "transcription",
-      "parakeet",
-      "config",
       "en"
     ],
     "notes": ""


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The registry contains two sets of Parakeet CTC 0.6B models from different ONNX exporters 

## 🛠️ How does it solve it?

- Removes the 5 `istupakov` CTC entries from `models.prod.json`:
  - `model.onnx` (fp32 graph)
  - `model.onnx.data` (fp32 weights)
  - `model.int8.onnx` (int8)
  - `vocab.txt`
  - `config.json`
- The `onnx-community` CTC entries (model.onnx, model.onnx_data, tokenizer.json) remain untouched
- After sync, running `update-models` in the SDK will regenerate clean constant names without `_1` suffixes

## 📦 Models

### Removed models

```
istupakov/parakeet-ctc-0.6b-onnx/model.onnx (fp32)
istupakov/parakeet-ctc-0.6b-onnx/model.onnx.data (fp32)
istupakov/parakeet-ctc-0.6b-onnx/model.int8.onnx (int8)
istupakov/parakeet-ctc-0.6b-onnx/vocab.txt
istupakov/parakeet-ctc-0.6b-onnx/config.json
```

## 🧪 How was it tested?

- Validated `models.prod.json` parses as valid JSON after changes
- Verified no `istupakov/parakeet-ctc` references remain
- Confirmed onnx-community CTC entries are untouched


Made with [Cursor](https://cursor.com)