### PR TITLE
doc(llm): add release notes for v0.12.2

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/release-notes/v0.12.2.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/release-notes/v0.12.2.md
@@ -1,0 +1,17 @@
+# QVAC LLM Addon v0.12.2 Release Notes
+
+This release fixes antiprompt (reverse-prompt) detection for short stop sequences like `\n`, which is critical for translation workloads that rely on newline-based early stopping.
+
+## Bug Fixes
+
+### Antiprompt detection for short stop sequences
+
+Fixed a bug where `checkAntiprompt()` in both `TextLlmContext` and `MtmdLlmContext` only searched the last few characters of the decoded output buffer for the antiprompt string. For short antiprompts like `"\n"` (length 1), the search window was limited to 3 characters at the tail. However, a single llama.cpp token can decode to many characters, placing `"\n"` far from the string's tail end — causing the antiprompt to be missed entirely.
+
+The model would then run to `n_predict` (typically 256 tokens) instead of stopping after the first translated line, wasting compute and producing multi-line output that required post-processing to recover.
+
+The fix widens the search to the entire `kNPrev`-token decoded window (32 tokens by default), reliably catching the antiprompt regardless of where it appears in the decoded string. This only affects models that use the `reverse-prompt` configuration — in practice, the AfriqueGemma translation workflow where `"\n"` signals end of translation.
+
+## Pull Requests
+
+- [#869](https://github.com/tetherto/qvac/pull/869) - Add AfriqueGemma Flores-200 Benchmark Translators and Fix Antiprompt Issue


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The release branch `release-qvac-lib-infer-llamacpp-llm-0.12.2` is missing the `release-notes/v0.12.2.md` file required by the release workflow

## 📝 How does it solve it?

- Adds `release-notes/v0.12.2.md` with the changelog content for the antiprompt fix release, matching the convention used by other addon packages (e.g., nmtcpp)

Made with [Cursor](https://cursor.com)