### PR TITLE
fix: un-deprecate models that are back in config during sync

### DIFF
--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -5353,6 +5353,7 @@
       "ctc",
       "en"
     ],
+    "deprecated": false,
     "notes": "onnx-community export, uses model.onnx_data naming"
   },
   {
@@ -5369,6 +5370,7 @@
       "ctc",
       "en"
     ],
+    "deprecated": false,
     "notes": "onnx-community export, external data for model.onnx"
   },
   {
@@ -5386,6 +5388,7 @@
       "tokenizer",
       "en"
     ],
+    "deprecated": false,
     "notes": ""
   },
   {
@@ -5403,6 +5406,7 @@
       "decoder",
       "en"
     ],
+    "deprecated": false,
     "notes": ""
   },
   {
@@ -5420,6 +5424,7 @@
       "encoder",
       "en"
     ],
+    "deprecated": false,
     "notes": ""
   },
   {
@@ -5437,6 +5442,7 @@
       "tokenizer",
       "en"
     ],
+    "deprecated": false,
     "notes": ""
   },
   {
@@ -5454,6 +5460,7 @@
       "4spk",
       "en"
     ],
+    "deprecated": false,
     "notes": ""
   },
   {

--- a/packages/qvac-lib-registry-server/scripts/sync-models.js
+++ b/packages/qvac-lib-registry-server/scripts/sync-models.js
@@ -119,6 +119,11 @@ async function syncModels () {
             // Include deprecation fields
             if (entry.deprecated !== undefined) {
               updateRequest.deprecated = entry.deprecated
+            } else if (existing.deprecated) {
+              // Un-deprecate: model is in config without deprecated flag but is deprecated in DB
+              updateRequest.deprecated = false
+              updateRequest.deprecatedAt = ''
+              updateRequest.deprecationReason = ''
             }
             if (entry.deprecatedAt) {
               updateRequest.deprecatedAt = entry.deprecatedAt
@@ -189,6 +194,8 @@ function needsMetadataUpdate (config, existing, sourceInfo) {
     (config.params || '') !== (existing.params || '') ||
     (config.notes || '') !== (existing.notes || '') ||
     JSON.stringify(config.tags || []) !== JSON.stringify(existing.tags || []) ||
+    // Un-deprecate: model is deprecated in DB but config doesn't mark it deprecated
+    (existing.deprecated && config.deprecated === undefined) ||
     (config.deprecated !== undefined && config.deprecated !== existing.deprecated) ||
     (config.replacedBy !== undefined && config.replacedBy !== (existing.replacedBy || '')) ||
     (config.deprecationReason !== undefined && config.deprecationReason !== (existing.deprecationReason || ''))


### PR DESCRIPTION
## Summary

- Fix `needsMetadataUpdate` in `sync-models.js` to detect when a model is deprecated in the DB but present in `models.prod.json` without an explicit `deprecated` field — triggering an update to clear the flag
- When building the update request, explicitly set `deprecated: false`, `deprecatedAt: ''`, and `deprecationReason: ''` for models being un-deprecated
- Add `"deprecated": false` to 7 affected parakeet model entries (onnx-community CTC, altunenes EOU, cgus Sortformer) so the next sync run explicitly clears their deprecated status in the live registry

## Context

After PR #891 removed istupakov CTC entries, running `update-models` showed that onnx-community CTC, EOU, and Sortformer parakeet models were also missing — even though they are still in `models.prod.json`.

**Root cause:** `findModels({})` in the registry client filters out deprecated models by default. These models were deprecated in the DB at some point and the sync workflow never un-deprecated them because `needsMetadataUpdate` only checked `config.deprecated !== undefined` — which is `false` when the JSON entry simply doesn't have a `deprecated` field.

The sync was reporting them as "Skipped" (metadata matches) while they remained deprecated in the DB and invisible to `update-models`.

## Tested with script

```javascript
'use strict'

const QVACRegistryClient = require('../client/lib/client')
const RegistryConfig = require('../lib/config')
const logger = require('../lib/logger')

async function main () {
  const config = new RegistryConfig({ logger })
  const registryCoreKey = config.getRegistryCoreKey()

  if (!registryCoreKey) {
    console.error('QVAC_REGISTRY_CORE_KEY not set')
    process.exit(1)
  }

  const client = new QVACRegistryClient({ registryCoreKey, logger })
  await client.ready()

  try {
    const all = await client.findModels({}, { includeDeprecated: true })
    const active = await client.findModels({})

    const allPaths = new Set(all.map(m => m.path))
    const activePaths = new Set(active.map(m => m.path))

    const deprecated = all.filter(m => !activePaths.has(m.path))

    console.log(`\nTotal models (includeDeprecated=true): ${all.length}`)
    console.log(`Active models (includeDeprecated=false): ${active.length}`)
    console.log(`Deprecated (filtered out): ${deprecated.length}`)

    const parakeetAll = all.filter(m => m.engine === '@qvac/transcription-parakeet')
    const parakeetActive = active.filter(m => m.engine === '@qvac/transcription-parakeet')
    const parakeetDeprecated = parakeetAll.filter(m => !activePaths.has(m.path))

    console.log(`\n=== Parakeet Models ===`)
    console.log(`Total parakeet (all): ${parakeetAll.length}`)
    console.log(`Active parakeet: ${parakeetActive.length}`)
    console.log(`Deprecated parakeet: ${parakeetDeprecated.length}`)

    if (parakeetDeprecated.length > 0) {
      console.log(`\nDeprecated parakeet models:`)
      for (const m of parakeetDeprecated) {
        console.log(`  - ${m.path}`)
        console.log(`    source=${m.source} deprecated=${m.deprecated} deprecatedAt=${m.deprecatedAt || 'N/A'}`)
        console.log(`    reason=${m.deprecationReason || 'N/A'}`)
      }
    }

    if (parakeetActive.length > 0) {
      console.log(`\nActive parakeet models:`)
      for (const m of parakeetActive) {
        console.log(`  - ${m.path} (source=${m.source})`)
      }
    }

    // Also check: models with deprecated=true that are still in the "all" set
    const explicitlyDeprecated = all.filter(m => m.deprecated === true)
    console.log(`\n=== All Explicitly Deprecated Models ===`)
    console.log(`Count: ${explicitlyDeprecated.length}`)
    for (const m of explicitlyDeprecated) {
      console.log(`  - ${m.path} (engine=${m.engine}, source=${m.source})`)
    }
  } finally {
    await client.close()
  }
}

main()
  .then(() => process.exit(0))
  .catch(err => {
    console.error('Error:', err)
    process.exit(1)
  })
```