### PR TITLE
QVAC-14128: add NO_GPU env var for GPU-less runners

### DIFF
--- a/.github/workflows/integration-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-test-lib-infer-diffusion.yml
@@ -32,6 +32,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       WORKDIR: packages/lib-infer-diffusion
+      NO_GPU: ${{ matrix.no_gpu || 'false' }}
     permissions:
       contents: read
       packages: read
@@ -43,6 +44,7 @@ jobs:
             platform: linux
             arch: x64
             runner: ubuntu-22.04
+            no_gpu: 'true'
           - os: ubuntu-24.04
             platform: linux
             arch: x64
@@ -51,10 +53,12 @@ jobs:
             platform: linux
             arch: arm64
             runner: ubuntu-24.04-arm
+            no_gpu: 'true'
           - os: ubuntu-22.04-arm
             platform: linux
             arch: arm64
             runner: ubuntu-22.04-arm
+            no_gpu: 'true'
           - os: macos-15-xlarge
             platform: darwin
             arch: arm64
@@ -63,6 +67,7 @@ jobs:
             platform: darwin
             arch: x64
             runner: macos-15-large
+            no_gpu: 'true'
           - os: windows-11
             platform: win32
             arch: x64


### PR DESCRIPTION
## What problem does this solve?

Diffusion integration tests currently run on all runners including those without GPUs, causing timeouts and failures on GPU-less runners (ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm, macos-15-large).

## How did you solve it?

Added `NO_GPU` environment variable to the diffusion integration test workflow, following the same pattern used by the LLM integration tests. Runners without GPUs are marked with `no_gpu: 'true'` in the matrix, and the `NO_GPU` env var is set to `${{ matrix.no_gpu || 'false' }}`.

Runners marked as `no_gpu: 'true'`:
- ubuntu-22.04 (linux-x64, no GPU)
- ubuntu-24.04-arm (linux-arm64, no GPU)
- ubuntu-22.04-arm (linux-arm64, no GPU)
- macos-15-large (darwin-x64, no GPU)

Runners with GPUs (unchanged):
- ai-run-linux-gpu (Vulkan GPU)
- macos-15-xlarge (Metal GPU)
- ai-run-windows11-gpu (Tesla T4 via Vulkan)

## Testing

- Verified the pattern matches the LLM workflow (`integration-test-qvac-lib-infer-llamacpp-llm.yml`)
- Companion PR with test-side changes on `feature-media-generation` branch reads this env var to skip/force-CPU

## Breaking Changes

None — only adds a new env var. Existing test behavior is unchanged until the test-side changes land.

## API Changes

None

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213658049060719