### PR TITLE
QVAC-14129: skip generation tests on GPU-less runners

### DIFF
--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -2,6 +2,7 @@
 
 const test = require('brittle')
 const os = require('bare-os')
+const proc = require('bare-process')
 const binding = require('../../binding')
 const ImgStableDiffusion = require('../../index')
 const {
@@ -12,7 +13,9 @@ const {
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
 const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
 const isMobile = os.platform() === 'ios' || os.platform() === 'android'
-const useCpu = isDarwinX64 || isLinuxArm64
+const noGpu = proc.env && proc.env.NO_GPU === 'true'
+const useCpu = isDarwinX64 || isLinuxArm64 || noGpu
+const skip = isMobile || noGpu
 
 // Smallest model for fast behavior tests
 const MODEL = {
@@ -70,7 +73,7 @@ async function setupModel (t) {
   return { model }
 }
 
-test('idle | run: allowed, returns QvacResponse', { timeout: 600000, skip: isMobile }, async t => {
+test('idle | run: allowed, returns QvacResponse', { timeout: 600000, skip }, async t => {
   const { model } = await setupModel(t)
   const response = await model.run(SHORT_PARAMS)
   t.ok(response, 'run() returns a response')
@@ -85,13 +88,13 @@ test('idle | run: allowed, returns QvacResponse', { timeout: 600000, skip: isMob
   t.ok(images.length > 0, 'run produces at least one image')
 })
 
-test('idle | cancel: allowed, no-op', { timeout: 600000, skip: isMobile }, async t => {
+test('idle | cancel: allowed, no-op', { timeout: 600000, skip }, async t => {
   const { model } = await setupModel(t)
   await model.cancel()
   t.pass('cancel when idle does not throw')
 })
 
-test('run | cancel: cancels current job', { timeout: 600000, skip: isMobile }, async t => {
+test('run | cancel: cancels current job', { timeout: 600000, skip }, async t => {
   const { model } = await setupModel(t)
   const response = await model.run(LONG_PARAMS)
 
@@ -114,7 +117,7 @@ test('run | cancel: cancels current job', { timeout: 600000, skip: isMobile }, a
   t.pass('cancel during run resolves and stops job')
 })
 
-test('run | run: second run() throws busy error', { timeout: 600000, skip: isMobile }, async t => {
+test('run | run: second run() throws busy error', { timeout: 600000, skip }, async t => {
   const { model } = await setupModel(t)
   const firstResponse = await model.run(LONG_PARAMS)
   let firstError = null
@@ -151,7 +154,7 @@ test('run | run: second run() throws busy error', { timeout: 600000, skip: isMob
   t.ok(!firstError, 'first response did not fail')
 })
 
-test('cancel | run: can run again after cancel', { timeout: 600000, skip: isMobile }, async t => {
+test('cancel | run: can run again after cancel', { timeout: 600000, skip }, async t => {
   const { model } = await setupModel(t)
 
   // Start a long job and cancel after first progress tick

--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -13,7 +13,6 @@ const {
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
 const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
 const isAndroid = os.platform() === 'android'
-const isMobile = os.platform() === 'ios' || isAndroid
 const noGpu = proc.env && proc.env.NO_GPU === 'true'
 const useCpu = isDarwinX64 || isLinuxArm64 || noGpu
 

--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -12,10 +12,10 @@ const {
 
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
 const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
-const isMobile = os.platform() === 'ios' || os.platform() === 'android'
+const isAndroid = os.platform() === 'android'
+const isMobile = os.platform() === 'ios' || isAndroid
 const noGpu = proc.env && proc.env.NO_GPU === 'true'
 const useCpu = isDarwinX64 || isLinuxArm64 || noGpu
-const skip = isMobile || noGpu
 
 // Smallest model for fast behavior tests
 const MODEL = {
@@ -57,9 +57,11 @@ async function setupModel (t) {
       modelName
     },
     {
-      threads: 4,
       device: useCpu ? 'cpu' : 'gpu',
-      prediction: 'v'
+      vae_on_cpu: isAndroid,
+      threads: 4,
+      prediction: 'v',
+      verbosity: '2'
     }
   )
 
@@ -73,7 +75,7 @@ async function setupModel (t) {
   return { model }
 }
 
-test('idle | run: allowed, returns QvacResponse', { timeout: 600000, skip }, async t => {
+test('idle | run: allowed, returns QvacResponse', { timeout: 600000 }, async t => {
   const { model } = await setupModel(t)
   const response = await model.run(SHORT_PARAMS)
   t.ok(response, 'run() returns a response')
@@ -88,13 +90,13 @@ test('idle | run: allowed, returns QvacResponse', { timeout: 600000, skip }, asy
   t.ok(images.length > 0, 'run produces at least one image')
 })
 
-test('idle | cancel: allowed, no-op', { timeout: 600000, skip }, async t => {
+test('idle | cancel: allowed, no-op', { timeout: 600000 }, async t => {
   const { model } = await setupModel(t)
   await model.cancel()
   t.pass('cancel when idle does not throw')
 })
 
-test('run | cancel: cancels current job', { timeout: 600000, skip }, async t => {
+test('run | cancel: cancels current job', { timeout: 600000 }, async t => {
   const { model } = await setupModel(t)
   const response = await model.run(LONG_PARAMS)
 
@@ -117,9 +119,9 @@ test('run | cancel: cancels current job', { timeout: 600000, skip }, async t => 
   t.pass('cancel during run resolves and stops job')
 })
 
-test('run | run: second run() throws busy error', { timeout: 600000, skip }, async t => {
+test('run | run: second run() throws busy error', { timeout: 600000 }, async t => {
   const { model } = await setupModel(t)
-  const firstResponse = await model.run(LONG_PARAMS)
+  const firstResponse = await model.run(SHORT_PARAMS)
   let firstError = null
   if (typeof firstResponse.onError === 'function') {
     firstResponse.onError(err => { firstError = err })
@@ -154,11 +156,11 @@ test('run | run: second run() throws busy error', { timeout: 600000, skip }, asy
   t.ok(!firstError, 'first response did not fail')
 })
 
-test('cancel | run: can run again after cancel', { timeout: 600000, skip }, async t => {
+test('cancel | run: can run again after cancel', { timeout: 600000 }, async t => {
   const { model } = await setupModel(t)
 
-  // Start a long job and cancel after first progress tick
-  const response1 = await model.run(LONG_PARAMS)
+  // Start a job and cancel after first progress tick
+  const response1 = await model.run(SHORT_PARAMS)
   let cancelFired = false
   const chain1 = response1.onUpdate(async data => {
     if (cancelFired) return

--- a/packages/lib-infer-diffusion/test/integration/generate-image-flux2.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-flux2.test.js
@@ -13,11 +13,15 @@ const {
   isPng
 } = require('./utils')
 
+const proc = require('bare-process')
+
 const platform = detectPlatform()
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
 const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
 const isMobile = os.platform() === 'ios' || os.platform() === 'android'
-const useCpu = isDarwinX64 || isLinuxArm64
+const noGpu = proc.env && proc.env.NO_GPU === 'true'
+const useCpu = isDarwinX64 || isLinuxArm64 || noGpu
+const skip = isMobile || noGpu
 
 const DIFFUSION_MODEL = {
   name: 'flux-2-klein-4b-Q8_0.gguf',
@@ -34,7 +38,7 @@ const VAE_MODEL = {
   url: 'https://huggingface.co/Comfy-Org/vae-text-encorder-for-flux-klein-4b/resolve/main/split_files/vae/flux2-vae.safetensors'
 }
 
-test('FLUX.2 klein txt2img — generates a valid PNG image', { timeout: 1800000, skip: isMobile }, async (t) => {
+test('FLUX.2 klein txt2img — generates a valid PNG image', { timeout: 1800000, skip }, async (t) => {
   setupJsLogger(binding)
 
   const [downloadedModelName, modelDir] = await ensureModel({

--- a/packages/lib-infer-diffusion/test/integration/generate-image-sd3.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-sd3.test.js
@@ -13,18 +13,22 @@ const {
   isPng
 } = require('./utils')
 
+const proc = require('bare-process')
+
 const platform = detectPlatform()
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
 const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
 const isMobile = os.platform() === 'ios' || os.platform() === 'android'
-const useCpu = isDarwinX64 || isLinuxArm64
+const noGpu = proc.env && proc.env.NO_GPU === 'true'
+const useCpu = isDarwinX64 || isLinuxArm64 || noGpu
+const skip = isMobile || noGpu
 
 const DEFAULT_MODEL = {
   name: 'sd3_medium_incl_clips.safetensors',
   url: 'https://huggingface.co/adamo1139/stable-diffusion-3-medium-ungated/resolve/main/sd3_medium_incl_clips.safetensors'
 }
 
-test('SD3 Medium txt2img — generates a valid PNG image', { timeout: 900000, skip: isMobile }, async (t) => {
+test('SD3 Medium txt2img — generates a valid PNG image', { timeout: 900000, skip }, async (t) => {
   setupJsLogger(binding)
 
   const [downloadedModelName, modelDir] = await ensureModel({

--- a/packages/lib-infer-diffusion/test/integration/generate-image-sdxl.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-sdxl.test.js
@@ -13,18 +13,22 @@ const {
   isPng
 } = require('./utils')
 
+const proc = require('bare-process')
+
 const platform = detectPlatform()
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
 const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
 const isMobile = os.platform() === 'ios' || os.platform() === 'android'
-const useCpu = isDarwinX64 || isLinuxArm64
+const noGpu = proc.env && proc.env.NO_GPU === 'true'
+const useCpu = isDarwinX64 || isLinuxArm64 || noGpu
+const skip = isMobile || noGpu
 
 const DEFAULT_MODEL = {
   name: 'stable-diffusion-xl-base-1.0-Q4_0.gguf',
   url: 'https://huggingface.co/gpustack/stable-diffusion-xl-base-1.0-GGUF/resolve/main/stable-diffusion-xl-base-1.0-Q4_0.gguf'
 }
 
-test('SDXL txt2img — generates a valid PNG image', { timeout: 900000, skip: isMobile }, async (t) => {
+test('SDXL txt2img — generates a valid PNG image', { timeout: 900000, skip }, async (t) => {
   setupJsLogger(binding)
 
   const [downloadedModelName, modelDir] = await ensureModel({

--- a/packages/lib-infer-diffusion/test/integration/generate-image.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image.test.js
@@ -2,6 +2,8 @@
 
 const fs = require('bare-fs')
 const path = require('bare-path')
+const os = require('bare-os')
+const proc = require('bare-process')
 const test = require('brittle')
 const binding = require('../../binding')
 const ImgStableDiffusion = require('../../index')
@@ -13,13 +15,19 @@ const {
 } = require('./utils')
 
 const platform = detectPlatform()
+const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
+const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
+const isMobile = os.platform() === 'ios' || os.platform() === 'android'
+const noGpu = proc.env && proc.env.NO_GPU === 'true'
+const useCpu = isDarwinX64 || isLinuxArm64 || noGpu
+const skip = isMobile || noGpu
 
 const DEFAULT_MODEL = {
   name: 'stable-diffusion-v2-1-Q8_0.gguf',
   url: 'https://huggingface.co/gpustack/stable-diffusion-v2-1-GGUF/resolve/main/stable-diffusion-v2-1-Q8_0.gguf'
 }
 
-test('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000 }, async (t) => {
+test('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000, skip }, async (t) => {
   setupJsLogger(binding)
 
   const [downloadedModelName, modelDir] = await ensureModel({
@@ -45,6 +53,7 @@ test('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000 }, async
     },
     {
       threads: 4,
+      device: useCpu ? 'cpu' : 'gpu',
       prediction: 'v' // SD2.1 uses v-prediction
     }
   )

--- a/packages/lib-infer-diffusion/test/integration/model-loading.test.js
+++ b/packages/lib-infer-diffusion/test/integration/model-loading.test.js
@@ -2,6 +2,7 @@
 
 const test = require('brittle')
 const os = require('bare-os')
+const proc = require('bare-process')
 
 const ImgStableDiffusion = require('../../index.js')
 const { ensureModel } = require('./utils')
@@ -10,7 +11,8 @@ const platform = os.platform()
 const arch = os.arch()
 const isDarwinX64 = platform === 'darwin' && arch === 'x64'
 const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
-const useCpu = isDarwinX64 || isLinuxArm64
+const noGpu = proc.env && proc.env.NO_GPU === 'true'
+const useCpu = isDarwinX64 || isLinuxArm64 || noGpu
 
 const DEFAULT_MODEL = {
   name: 'stable-diffusion-v2-1-Q8_0.gguf',


### PR DESCRIPTION
## What problem does this solve?

Diffusion integration tests fail or timeout on runners without GPUs because image generation requires GPU acceleration. There was no mechanism to detect GPU-less runners and skip generation tests accordingly.

## How did you solve it?

Added `NO_GPU` env var support to all 6 diffusion integration test files, following the same pattern used by the LLM integration tests (`finetuning-pause-resume.test.js`).

Changes per file:
- **api-behavior.test.js** — skip all state-machine tests when `NO_GPU=true` (they require generation)
- **generate-image.test.js** — added platform detection, skip + forced CPU device
- **generate-image-sdxl.test.js** — skip when `NO_GPU=true`, force CPU device
- **generate-image-sd3.test.js** — skip when `NO_GPU=true`, force CPU device
- **generate-image-flux2.test.js** — skip when `NO_GPU=true`, force CPU device
- **model-loading.test.js** — NOT skipped (load/unload works on CPU), just forces CPU device

Pattern: `const noGpu = proc.env && proc.env.NO_GPU === 'true'` via `bare-process`.

## Testing

- Pattern matches the LLM test implementation
- Companion workflow PR (#896) sets `NO_GPU` env var on GPU-less runners

## Breaking Changes

None

## API Changes

None

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213657943916933