### PR TITLE
ci(diffusion): update macOS arm64 runner to macos-26-xlarge

### DIFF
--- a/.github/workflows/integration-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-test-lib-infer-diffusion.yml
@@ -59,10 +59,10 @@ jobs:
             arch: arm64
             runner: ubuntu-22.04-arm
             no_gpu: 'true'
-          - os: macos-15-xlarge
+          - os: macos-26-xlarge
             platform: darwin
             arch: arm64
-            runner: macos-15-xlarge
+            runner: macos-26-xlarge
           - os: macos-15-large
             platform: darwin
             arch: x64


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The diffusion integration test workflow uses the `macos-15-xlarge` runner for darwin-arm64, which is being replaced by `macos-26-xlarge`

## 📝 How does it solve it?

- Updates the `macos-15-xlarge` runner to `macos-26-xlarge` in `integration-test-lib-infer-diffusion.yml` for the darwin-arm64 matrix entry

## 🧪 How was it tested?

- Validated `macos-26-xlarge` runner on diffusion integration tests via `on-pr` pipeline (prebuild → integration test): [run 23064896864](https://github.com/tetherto/qvac/actions/runs/23064896864/job/67001846900) — darwin-arm64 job passed
- Validated with NO_GPU test changes via standalone integration test: [run 23071608748](https://github.com/tetherto/qvac/actions/runs/23071608748) — darwin-arm64 job passed

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213657943916937