### PR TITLE
QVAC-13822 infra: run TTS benchmarks only on package publish, not on PR close

### DIFF
--- a/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
@@ -62,18 +62,12 @@ on:
         type: boolean
         default: false
 
-  pull_request:
-    types: [closed]
-    paths:
-      - "packages/qvac-lib-infer-onnx-tts/**"
-  # path filter not supported for release events, so we will check inside the job if the release is for a relevant package
-  # release:
-  #   types: [published]
-
+  release:
+    types: [published]
 
 jobs:
   benchmark-chatterbox:
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'onnx-tts-v'))
     runs-on: macos-14-xlarge
     timeout-minutes: 180
     env:
@@ -136,8 +130,16 @@ jobs:
 
       - name: Determine addon version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.addon_version }}
         run: |
-          VERSION="${{ github.event.inputs.addon_version || 'latest' }}"
+          if [ "$EVENT_NAME" = "release" ]; then
+            VERSION="${RELEASE_TAG#onnx-tts-v}"
+          else
+            VERSION="${INPUT_VERSION:-latest}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Addon version to benchmark: $VERSION"
 

--- a/.github/workflows/benchmark-supertonic-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/benchmark-supertonic-qvac-lib-infer-onnx-tts.yml
@@ -44,14 +44,12 @@ on:
         type: boolean
         default: true
 
-  pull_request:
-    types: [closed]
-    paths:
-      - "packages/qvac-lib-infer-onnx-tts/**"
+  release:
+    types: [published]
 
 jobs:
   benchmark-supertonic:
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'onnx-tts-v'))
     runs-on: macos-14-xlarge
     timeout-minutes: 180
     env:
@@ -104,8 +102,16 @@ jobs:
 
       - name: Determine addon version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.addon_version }}
         run: |
-          VERSION="${{ github.event.inputs.addon_version || 'latest' }}"
+          if [ "$EVENT_NAME" = "release" ]; then
+            VERSION="${RELEASE_TAG#onnx-tts-v}"
+          else
+            VERSION="${INPUT_VERSION:-latest}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Update addon version in package.json


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Supertonic and Chatterbox benchmarks ran on **every PR close** that touched `packages/qvac-lib-infer-onnx-tts/**`, so CI ran often without a new published package.
- That made it harder to use benchmark results to assess quality of a **newly published** `@qvac/tts-onnx` version.

## 📝 How does it solve it?

- **Trigger**: Replaced `pull_request` (closed) with `release: types: [published]`. Benchmarks still run on `workflow_dispatch` (manual).
- **Scope**: Job runs only when the release tag starts with `onnx-tts-v` (TTS addon releases), so other repo releases do not trigger these benchmarks.
- **Version**: When triggered by a release, addon version is taken from the release tag (e.g. `onnx-tts-v1.2.3` → `1.2.3`); on manual run, the existing `addon_version` input (default `latest`) is used.

## 🧪 How was it tested?

- YAML validated by push (Actions load workflows).
- Manual run via **Run workflow** (workflow_dispatch) to confirm the job runs and version step uses input/default.