### PR TITLE
fix[notask]: use params.modelId in parakeet addon logger calls

### DIFF
--- a/packages/sdk/server/bare/plugins/parakeet-transcription/plugin.ts
+++ b/packages/sdk/server/bare/plugins/parakeet-transcription/plugin.ts
@@ -169,8 +169,8 @@ function createParakeetModel(
 
   const { dirPath } = parseModelPath(primaryPath);
   const loader = new FilesystemDL({ dirPath });
-  const logger = createStreamLogger(modelId, ModelType.parakeetTranscription);
-  registerAddonLogger(modelId, ModelType.parakeetTranscription, logger);
+  const logger = createStreamLogger(params.modelId, ModelType.parakeetTranscription);
+  registerAddonLogger(params.modelId, ModelType.parakeetTranscription, logger);
 
   const addonConfig: TranscriptionParakeetConfig = {
     path: dirPath,


### PR DESCRIPTION
**What problem does this PR solve?**

Lint CI was failing on parakeet-transcription/plugin.ts — createStreamLogger and registerAddonLogger were called with modelId, a variable that doesn't exist in the function scope, instead of params.modelId from the CreateModelParams argument.

**How does it solve it?**

Replace the bare modelId identifier with params.modelId on both call sites inside createParakeetModel.

**How was it tested?**
```
bun run lint passes with 0 errors and 0 warnings

```