### PR TITLE
release(qvac-sdk): v0.7.1

### DIFF
--- a/packages/qvac-sdk/CHANGELOG.md
+++ b/packages/qvac-sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.7.1
+
+Release Date: 2026-03-16
+
+## 🐞 Fixes
+
+- Restore registry download throughput by adding bulk block prefetch before streaming. (see PR [#835](https://github.com/tetherto/qvac/pull/835))
+- Clear blob blocks from corestore after successful download to reclaim disk space. (see PR [#835](https://github.com/tetherto/qvac/pull/835))
+- Fix stream cleanup to trigger automatically when consumer finishes reading. (see PR [#835](https://github.com/tetherto/qvac/pull/835))
+
+## 🧹 Chores
+
+- Bump @qvac/registry-client to ^0.2.1. (see PR [#921](https://github.com/tetherto/qvac/pull/921))
+
 ## v0.7.0
 
 Release Date: 2026-02-27

--- a/packages/qvac-sdk/bun.lock
+++ b/packages/qvac-sdk/bun.lock
@@ -13,7 +13,7 @@
         "@qvac/logging": "^0.1.0",
         "@qvac/ocr-onnx": "^0.1.5",
         "@qvac/rag": "^0.4.2",
-        "@qvac/registry-client": "^0.2.0",
+        "@qvac/registry-client": "^0.2.1",
         "@qvac/transcription-whispercpp": "^0.3.17",
         "@qvac/translation-nmtcpp": "^0.3.9",
         "@qvac/tts-onnx": "^0.5.4",
@@ -531,7 +531,7 @@
 
     "@qvac/rag": ["@qvac/rag@0.4.2", "", { "dependencies": { "@qvac/error": "^0.1.0", "bare-crypto": "^1.11.2", "hyperdht": "^6.23.0", "ready-resource": "^1.1.2", "uuid-random": "^1.3.2", "zod": "^4.1.13" }, "peerDependencies": { "bare-fetch": "^2.5.0", "hyperdb": "^4.19.0", "hyperschema": "^1.13.0", "llm-splitter": "^0.2.0" }, "optionalPeers": ["bare-fetch", "hyperdb", "hyperschema", "llm-splitter"] }, "sha512-vjDhgv5AG/n3d8dI0K9iS5xGhxHfnX+mzaefBnuaIDatf/z1PNm6c4d91j8jDNGprrBAz23pj4po0wUlFZe+ig=="],
 
-    "@qvac/registry-client": ["@qvac/registry-client@0.2.0", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/registry-schema": "^0.1.1", "b4a": "^1.6.7", "bare-fs": "^4.5.2", "bare-os": "^3.6.2", "bare-path": "^3.0.0", "bare-process": "^4.2.2", "corestore": "^7.4.5", "hyperblobs": "^2.8.0", "hypercore-id-encoding": "^1.3.0", "hyperdb": "^4.16.1", "hyperswarm": "^4.14.0", "paparam": "^1.10.0", "ready-resource": "^1.0.1" }, "bin": { "qvac-registry": "bin/cli.js" } }, "sha512-ZdcKKIy7wAYbeh7iRNW9Wn2LUZNPPTihvwQN1yCNDx7n835DKqw8xy9396giikkNzXiT3RMf8mnccWldjmHnwg=="],
+    "@qvac/registry-client": ["@qvac/registry-client@0.2.1", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/registry-schema": "^0.1.1", "b4a": "^1.6.7", "bare-fs": "^4.5.2", "bare-os": "^3.6.2", "bare-path": "^3.0.0", "bare-process": "^4.2.2", "corestore": "^7.4.5", "hyperblobs": "^2.8.0", "hypercore-id-encoding": "^1.3.0", "hyperdb": "^4.16.1", "hyperswarm": "^4.14.0", "paparam": "^1.10.0", "ready-resource": "^1.0.1" }, "bin": { "qvac-registry": "bin/cli.js" } }, "sha512-ekT7MvFbX1MjTusS+Z/kbw1rLI5k9mpw41gNZv3rvL1ZDTfjuJ++iRYDUDZO9wT5ehyqChVwsPjoDuBiZpcC3A=="],
 
     "@qvac/registry-schema": ["@qvac/registry-schema@0.1.1", "", { "dependencies": { "hyperdb": "^4.16.0", "hyperdispatch": "^1.4.0", "hyperschema": "^1.13.0", "ready-resource": "^1.2.0" } }, "sha512-Mm0zQqc/KTplE2wtdFseSd2995H4RK0hAW63ZDE/9TXfCxuW0medjcpVOXVGFoI+mkTM2cxubcO/eJvJlZih1A=="],
 

--- a/packages/qvac-sdk/changelog/0.7.1/CHANGELOG.md
+++ b/packages/qvac-sdk/changelog/0.7.1/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog v0.7.1
+
+Release Date: 2026-03-16
+
+## 🐞 Fixes
+
+- Restore registry download throughput by adding bulk block prefetch before streaming. (see PR [#835](https://github.com/tetherto/qvac/pull/835))
+- Clear blob blocks from corestore after successful download to reclaim disk space. (see PR [#835](https://github.com/tetherto/qvac/pull/835))
+- Fix stream cleanup to trigger automatically when consumer finishes reading. (see PR [#835](https://github.com/tetherto/qvac/pull/835))
+
+## 🧹 Chores
+
+- Bump @qvac/registry-client to ^0.2.1. (see PR [#921](https://github.com/tetherto/qvac/pull/921))

--- a/packages/qvac-sdk/package.json
+++ b/packages/qvac-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",
@@ -123,7 +123,7 @@
     "@qvac/transcription-whispercpp": "^0.3.17",
     "@qvac/translation-nmtcpp": "^0.3.9",
     "@qvac/tts-onnx": "^0.5.4",
-    "@qvac/registry-client": "^0.2.0",
+    "@qvac/registry-client": "^0.2.1",
     "fast-safe-stringify": "2.1.1",
     "which-runtime": "^1.3.2",
     "zod": "^4.0.17"


### PR DESCRIPTION
## What problem does this PR solve?

Patch release for qvac-sdk to pick up `@qvac/registry-client` v0.2.1 which fixes download throughput and corestore disk space growth.

## How does it solve it?

- Bumps `@qvac/registry-client` from `^0.2.0` to `^0.2.1`
- Bumps SDK version from `0.7.0` to `0.7.1`
- Updates `bun.lock`

Based on the `release-qvac-sdk-0.7.0` branch — only includes the dependency bump, no other changes from `main`.