### PR TITLE
fix(diffusion): increase model load timeout to 180s

### DIFF
--- a/packages/lib-infer-diffusion/test/integration/generate-image-flux2.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-flux2.test.js
@@ -92,7 +92,7 @@ test('FLUX.2 klein txt2img — generates a valid PNG image', { timeout: 1800000,
     await model.load()
     const loadMs = Date.now() - tLoad
     console.log(`Loaded in ${(loadMs / 1000).toFixed(1)}s`)
-    t.ok(loadMs < 120000, `Model loaded within 120s (took ${(loadMs / 1000).toFixed(1)}s)`)
+    t.ok(loadMs < 180000, `Model loaded within 180s (took ${(loadMs / 1000).toFixed(1)}s)`)
 
     // ── Generate ──────────────────────────────────────────────────────────────
     console.log('\n=== Generating image ===')

--- a/packages/lib-infer-diffusion/test/integration/generate-image-sd3.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-sd3.test.js
@@ -70,7 +70,7 @@ test('SD3 Medium txt2img — generates a valid PNG image', { timeout: 900000, sk
     await model.load()
     const loadMs = Date.now() - tLoad
     console.log(`Loaded in ${(loadMs / 1000).toFixed(1)}s`)
-    t.ok(loadMs < 120000, `Model loaded within 120s (took ${(loadMs / 1000).toFixed(1)}s)`)
+    t.ok(loadMs < 180000, `Model loaded within 180s (took ${(loadMs / 1000).toFixed(1)}s)`)
 
     // ── Generate ──────────────────────────────────────────────────────────────
     console.log('\n=== Generating image ===')

--- a/packages/lib-infer-diffusion/test/integration/generate-image-sdxl.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-sdxl.test.js
@@ -69,7 +69,7 @@ test('SDXL txt2img — generates a valid PNG image', { timeout: 900000, skip }, 
     await model.load()
     const loadMs = Date.now() - tLoad
     console.log(`Loaded in ${(loadMs / 1000).toFixed(1)}s`)
-    t.ok(loadMs < 120000, `Model loaded within 120s (took ${(loadMs / 1000).toFixed(1)}s)`)
+    t.ok(loadMs < 180000, `Model loaded within 180s (took ${(loadMs / 1000).toFixed(1)}s)`)
 
     // ── Generate ──────────────────────────────────────────────────────────────
     console.log('\n=== Generating image ===')

--- a/packages/lib-infer-diffusion/test/integration/generate-image.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image.test.js
@@ -68,7 +68,7 @@ test('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000, skip },
     await model.load()
     const loadMs = Date.now() - tLoad
     console.log(`Loaded in ${(loadMs / 1000).toFixed(1)}s`)
-    t.ok(loadMs < 120000, `Model loaded within 120s (took ${(loadMs / 1000).toFixed(1)}s)`)
+    t.ok(loadMs < 180000, `Model loaded within 180s (took ${(loadMs / 1000).toFixed(1)}s)`)
 
     // ── Generate ──────────────────────────────────────────────────────────────
     console.log('\n=== Generating image ===')


### PR DESCRIPTION
## Summary
- Increases diffusion model load assertion from 120s to 180s across all 4 generate-image test files
- CPU-only runners can exceed the 2-minute threshold, causing spurious failures

## Test plan
- [ ] Verify CI diffusion integration tests pass without load timeout failures

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213669782827213