### PR TITLE
fix(llm,embed): resolve exit 139 SIGSEGV and expose contextSlides stat

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/js-interface/binding.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/js-interface/binding.cpp
@@ -1,6 +1,17 @@
 #include <bare.h>
 
 #include "../addon/AddonJs.hpp"
+#include "../model-interface/LlamaLazyInitializeBackend.hpp"
+
+// Explicitly unload all dynamically-loaded GPU backend libraries and free
+// the llama backend. Called from JS at process exit (Bare 'exit' event)
+// before the runtime dlclose's this addon, ensuring backend destructors
+// run while ggml state is still alive.
+static js_value_t*
+shutdownBackends(js_env_t* /*env*/, js_callback_info_t* /*info*/) {
+  LlamaLazyInitializeBackend::shutdownBackends();
+  return nullptr;
+}
 
 js_value_t*
 qvacLibInferLlamacppEmbedExports(js_env_t* env, js_value_t* exports) {
@@ -27,6 +38,7 @@ qvacLibInferLlamacppEmbedExports(js_env_t* env, js_value_t* exports) {
     qvac_lib_inference_addon_cpp::JsInterface::destroyInstance)
   V("setLogger", qvac_lib_inference_addon_cpp::JsInterface::setLogger)
   V("releaseLogger", qvac_lib_inference_addon_cpp::JsInterface::releaseLogger)
+  V("shutdownBackends", shutdownBackends)
 #undef V
 // NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/js-interface/binding.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/js-interface/binding.cpp
@@ -1,6 +1,26 @@
+#include <cstdlib>
+
 #include <bare.h>
 
 #include "../addon/AddonJs.hpp"
+
+// Immediately terminate the process, skipping static destructors and atexit
+// handlers. Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.)
+// register static destructors that SIGSEGV during normal exit when they
+// reference the partially-destroyed ggml backend registry. Calling _Exit()
+// from JS (before the runtime dlclose's this addon) avoids the crash.
+// The OS reclaims all process resources.
+static js_value_t* forceExit(js_env_t* env, js_callback_info_t* info) {
+  int32_t code = 0;
+  size_t argc = 1;
+  js_value_t* argv[1];
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) == 0 &&
+      argc > 0) {
+    js_get_value_int32(env, argv[0], &code);
+  }
+  _Exit(code);
+  return nullptr; // unreachable
+}
 
 js_value_t*
 qvacLibInferLlamacppEmbedExports(js_env_t* env, js_value_t* exports) {
@@ -27,6 +47,7 @@ qvacLibInferLlamacppEmbedExports(js_env_t* env, js_value_t* exports) {
     qvac_lib_inference_addon_cpp::JsInterface::destroyInstance)
   V("setLogger", qvac_lib_inference_addon_cpp::JsInterface::setLogger)
   V("releaseLogger", qvac_lib_inference_addon_cpp::JsInterface::releaseLogger)
+  V("forceExit", forceExit)
 #undef V
 // NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/js-interface/binding.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/js-interface/binding.cpp
@@ -1,26 +1,6 @@
-#include <cstdlib>
-
 #include <bare.h>
 
 #include "../addon/AddonJs.hpp"
-
-// Immediately terminate the process, skipping static destructors and atexit
-// handlers. Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.)
-// register static destructors that SIGSEGV during normal exit when they
-// reference the partially-destroyed ggml backend registry. Calling _Exit()
-// from JS (before the runtime dlclose's this addon) avoids the crash.
-// The OS reclaims all process resources.
-static js_value_t* forceExit(js_env_t* env, js_callback_info_t* info) {
-  int32_t code = 0;
-  size_t argc = 1;
-  js_value_t* argv[1];
-  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) == 0 &&
-      argc > 0) {
-    js_get_value_int32(env, argv[0], &code);
-  }
-  _Exit(code);
-  return nullptr; // unreachable
-}
 
 js_value_t*
 qvacLibInferLlamacppEmbedExports(js_env_t* env, js_value_t* exports) {
@@ -47,7 +27,6 @@ qvacLibInferLlamacppEmbedExports(js_env_t* env, js_value_t* exports) {
     qvac_lib_inference_addon_cpp::JsInterface::destroyInstance)
   V("setLogger", qvac_lib_inference_addon_cpp::JsInterface::setLogger)
   V("releaseLogger", qvac_lib_inference_addon_cpp::JsInterface::releaseLogger)
-  V("forceExit", forceExit)
 #undef V
 // NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -69,19 +69,28 @@ void LlamaLazyInitializeBackend::decrementRefCount() {
   std::lock_guard<std::mutex> lock(g_initMutex);
   if (g_refCount > 0) {
     g_refCount--;
-    if (g_refCount == 0 && g_initialized) {
-      shutdownLocked();
-    }
+    // Intentionally never call shutdownBackends() here. The backend is
+    // process-global state and ggml does not support clean re-initialization
+    // after unloading backends. Shutdown is handled at process exit via
+    // shutdownBackends() called from the JS layer.
   }
 }
 
-void LlamaLazyInitializeBackend::shutdownLocked() {
+void LlamaLazyInitializeBackend::shutdownBackends() {
+  std::lock_guard<std::mutex> lock(g_initMutex);
+  if (!g_initialized) {
+    return;
+  }
+
   // Explicitly unload all dynamically-loaded backend libraries (Vulkan,
   // Metal, DirectX, etc.) BEFORE freeing the llama backend. This triggers
   // their static destructors / atexit handlers while the ggml backend
   // registry is still alive and valid. Without this, those destructors
   // run during process exit in undefined order relative to the ggml
   // registry destruction, causing use-after-free (SIGSEGV / exit 139).
+  //
+  // Called once at process exit from the JS layer (Bare 'exit' event),
+  // before the runtime dlclose's the addon .so.
   //
   // Unload in reverse order to respect potential inter-backend dependencies.
   for (auto i = static_cast<int>(ggml_backend_reg_count()) - 1; i >= 0;

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -67,13 +67,14 @@ void LlamaLazyInitializeBackend::decrementRefCount() {
   std::lock_guard<std::mutex> lock(g_initMutex);
   if (g_refCount > 0) {
     g_refCount--;
-    if (g_refCount == 0 && g_initialized) {
-      QLOG_IF(
-          Priority::DEBUG, "Freeing backend (reference count reached zero)");
-      llama_backend_free();
-      g_initialized = false;
-      g_recordedBackendsDir.clear();
-    }
+    // Intentionally never call llama_backend_free(). The backend is
+    // process-global state: dynamically-loaded backend libraries (Vulkan,
+    // Metal, etc.) register static destructors that reference the ggml
+    // backend registry. Freeing the registry here causes use-after-free
+    // (SIGSEGV / exit 139) when those static destructors run at process
+    // exit. Keeping the backend alive is safe — the OS reclaims all
+    // memory on exit — and avoids repeated ggml_backend_load_all() calls
+    // that can corrupt the global registry on re-init.
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -3,6 +3,10 @@
 #include <filesystem>
 #include <string>
 
+#ifdef __linux__
+#include <stdlib.h> // on_exit (GNU/glibc extension)
+#endif
+
 #include <llama.h>
 
 #include "logging.hpp"
@@ -54,6 +58,18 @@ bool LlamaLazyInitializeBackend::initialize(const std::string& backendsDir) {
   }
 
   llama_backend_init();
+
+#ifdef __linux__
+  // Dynamically-loaded GPU backend libraries (especially Vulkan) register
+  // static destructors that can SIGSEGV during process exit when they
+  // reference the ggml backend registry after it has been partially
+  // destroyed. Skip static destructors by calling _Exit() with the
+  // original exit status. The OS reclaims all process resources on exit.
+  // on_exit() is a GNU/glibc extension available on Linux.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+  on_exit([](int status, void*) { _Exit(status); }, nullptr);
+#endif
+
   g_initialized = true;
   return true;
 }

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -3,12 +3,6 @@
 #include <filesystem>
 #include <string>
 
-#include <cstdlib>
-
-#ifdef __GLIBC__
-#include <stdlib.h> // on_exit (GNU/glibc extension)
-#endif
-
 #include <llama.h>
 
 #include "logging.hpp"
@@ -60,23 +54,6 @@ bool LlamaLazyInitializeBackend::initialize(const std::string& backendsDir) {
   }
 
   llama_backend_init();
-
-  // Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
-  // static destructors that can SIGSEGV during process exit when they
-  // reference the ggml backend registry after it has been partially
-  // destroyed. Skip static destructors by calling _Exit() at process exit.
-  // The OS reclaims all process resources on exit.
-#ifdef __GLIBC__
-  // on_exit() (GNU/glibc) preserves the original exit status.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-  on_exit([](int status, void*) { _Exit(status); }, nullptr);
-#else
-  // std::atexit does not receive the exit status, so we use _Exit(0).
-  // This is acceptable: on non-Linux the crash is intermittent and rare,
-  // and test failures surface via other mechanisms (assertions, exceptions)
-  // before atexit handlers run.
-  std::atexit([]() { _Exit(0); });
-#endif
 
   g_initialized = true;
   return true;

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <string>
 
+#include <ggml-backend.h>
 #include <llama.h>
 
 #include "logging.hpp"
@@ -68,15 +69,30 @@ void LlamaLazyInitializeBackend::decrementRefCount() {
   std::lock_guard<std::mutex> lock(g_initMutex);
   if (g_refCount > 0) {
     g_refCount--;
-    // Intentionally never call llama_backend_free(). The backend is
-    // process-global state: dynamically-loaded backend libraries (Vulkan,
-    // Metal, etc.) register static destructors that reference the ggml
-    // backend registry. Freeing the registry here causes use-after-free
-    // (SIGSEGV / exit 139) when those static destructors run at process
-    // exit. Keeping the backend alive is safe — the OS reclaims all
-    // memory on exit — and avoids repeated ggml_backend_load_all() calls
-    // that can corrupt the global registry on re-init.
+    if (g_refCount == 0 && g_initialized) {
+      shutdownLocked();
+    }
   }
+}
+
+void LlamaLazyInitializeBackend::shutdownLocked() {
+  // Explicitly unload all dynamically-loaded backend libraries (Vulkan,
+  // Metal, DirectX, etc.) BEFORE freeing the llama backend. This triggers
+  // their static destructors / atexit handlers while the ggml backend
+  // registry is still alive and valid. Without this, those destructors
+  // run during process exit in undefined order relative to the ggml
+  // registry destruction, causing use-after-free (SIGSEGV / exit 139).
+  //
+  // Unload in reverse order to respect potential inter-backend dependencies.
+  for (auto i = static_cast<int>(ggml_backend_reg_count()) - 1; i >= 0;
+       --i) {
+    ggml_backend_reg_t reg =
+        ggml_backend_reg_get(static_cast<size_t>(i));
+    ggml_backend_unload(reg);
+  }
+
+  llama_backend_free();
+  g_initialized = false;
 }
 
 LlamaBackendsHandle::LlamaBackendsHandle(const std::string& backendsDir)

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -3,7 +3,9 @@
 #include <filesystem>
 #include <string>
 
-#ifdef __linux__
+#include <cstdlib>
+
+#ifdef __GLIBC__
 #include <stdlib.h> // on_exit (GNU/glibc extension)
 #endif
 
@@ -59,15 +61,21 @@ bool LlamaLazyInitializeBackend::initialize(const std::string& backendsDir) {
 
   llama_backend_init();
 
-#ifdef __linux__
-  // Dynamically-loaded GPU backend libraries (especially Vulkan) register
+  // Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
   // static destructors that can SIGSEGV during process exit when they
   // reference the ggml backend registry after it has been partially
-  // destroyed. Skip static destructors by calling _Exit() with the
-  // original exit status. The OS reclaims all process resources on exit.
-  // on_exit() is a GNU/glibc extension available on Linux.
+  // destroyed. Skip static destructors by calling _Exit() at process exit.
+  // The OS reclaims all process resources on exit.
+#ifdef __GLIBC__
+  // on_exit() (GNU/glibc) preserves the original exit status.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
   on_exit([](int status, void*) { _Exit(status); }, nullptr);
+#else
+  // std::atexit does not receive the exit status, so we use _Exit(0).
+  // This is acceptable: on non-Linux the crash is intermittent and rare,
+  // and test failures surface via other mechanisms (assertions, exceptions)
+  // before atexit handlers run.
+  std::atexit([]() { _Exit(0); });
 #endif
 
   g_initialized = true;

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.hpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.hpp
@@ -36,9 +36,10 @@ public:
    * still alive), then free the llama backend. This prevents SIGSEGV at
    * process exit from static destructor ordering issues.
    *
-   * Must be called under g_initMutex.
+   * Called once at process exit from the JS layer, before the runtime
+   * unloads the addon. Must not be called while models are still active.
    */
-  static void shutdownLocked();
+  static void shutdownBackends();
 
 private:
   static std::mutex g_initMutex;

--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.hpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/model-interface/LlamaLazyInitializeBackend.hpp
@@ -25,9 +25,20 @@ public:
   static void incrementRefCount();
 
   /**
-   * Decrement the reference count and free backend if count reaches zero.
+   * Decrement the reference count. When it reaches zero, explicitly unloads
+   * all dynamically-loaded backends and frees the llama backend.
    */
   static void decrementRefCount();
+
+  /**
+   * Explicitly shut down the backend: unload all dynamically-loaded GPU
+   * backend libraries (triggering their destructors while ggml state is
+   * still alive), then free the llama backend. This prevents SIGSEGV at
+   * process exit from static destructor ordering issues.
+   *
+   * Must be called under g_initMutex.
+   */
+  static void shutdownLocked();
 
 private:
   static std::mutex g_initMutex;

--- a/packages/qvac-lib-infer-llamacpp-embed/binding.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/binding.js
@@ -1,1 +1,11 @@
-module.exports = require.addon()
+const binding = require.addon()
+
+// Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
+// static destructors that SIGSEGV during normal process exit when they
+// reference the partially-destroyed ggml backend registry. Call _Exit() from
+// the Bare 'exit' event (before the runtime dlclose's this addon) to skip
+// static destructors entirely. The OS reclaims all process resources.
+const Bare = require('bare-process')
+Bare.on('exit', (code) => binding.forceExit(code))
+
+module.exports = binding

--- a/packages/qvac-lib-infer-llamacpp-embed/binding.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/binding.js
@@ -1,11 +1,1 @@
-const binding = require.addon()
-
-// Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
-// static destructors that SIGSEGV during normal process exit when they
-// reference the partially-destroyed ggml backend registry. Call _Exit() from
-// the Bare 'exit' event (before the runtime dlclose's this addon) to skip
-// static destructors entirely. The OS reclaims all process resources.
-const Bare = require('bare-process')
-Bare.on('exit', (code) => binding.forceExit(code))
-
-module.exports = binding
+module.exports = require.addon()

--- a/packages/qvac-lib-infer-llamacpp-embed/binding.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/binding.js
@@ -1,1 +1,10 @@
-module.exports = require.addon()
+const binding = require.addon()
+
+// Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
+// static destructors that SIGSEGV during normal process exit. Explicitly
+// unload them here (while ggml state is still alive) before Bare dlclose's
+// the addon.
+const Bare = require('bare-process')
+Bare.on('exit', () => binding.shutdownBackends())
+
+module.exports = binding

--- a/packages/qvac-lib-infer-llamacpp-embed/test/unit/test_llama_lazy_init_backend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/unit/test_llama_lazy_init_backend.cpp
@@ -72,11 +72,11 @@ TEST_F(LlamaLazyInitializeBackendTest, RefCountOperations) {
     LlamaLazyInitializeBackend::decrementRefCount();
   });
 
-  // Backend is shut down when refcount reaches zero (explicit backend unload
-  // + llama_backend_free). Re-initialization should succeed.
+  // Backend remains initialized even after refcount reaches zero.
+  // Shutdown is handled at process exit from the JS layer, not on refcount 0.
   bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(canReinitialize)
-      << "Backend should be freed and re-initializable after refcount = 0";
+  EXPECT_FALSE(canReinitialize)
+      << "Backend should remain initialized (shutdown only at process exit)";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleConstruction) {
@@ -91,12 +91,12 @@ TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleConstruction) {
     EXPECT_FALSE(alreadyInitialized)
         << "Backend should already be initialized by handle";
   }
-  // Handle destroyed — refcount reached zero, backend shut down.
-  // Re-initialization should succeed.
-  bool canReinitialize =
-      LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(canReinitialize)
-      << "Backend should be freed after last handle destruction";
+  // Handle destroyed — refcount decremented but backend stays initialized.
+  // Shutdown only happens at process exit from the JS layer.
+  bool stillInitialized =
+      !LlamaLazyInitializeBackend::initialize(backendsDir);
+  EXPECT_TRUE(stillInitialized)
+      << "Backend should remain initialized after handle destruction";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleMoveConstruction) {
@@ -185,11 +185,11 @@ TEST_F(LlamaLazyInitializeBackendTest, RefCountReachesZero) {
     LlamaLazyInitializeBackend::decrementRefCount();
   });
 
-  // Backend is shut down when refcount reaches zero (explicit backend unload
-  // + llama_backend_free). Re-initialization should succeed.
+  // Backend remains initialized even after refcount reaches zero.
+  // Shutdown is handled at process exit from the JS layer, not on refcount 0.
   bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(canReinitialize)
-      << "Backend should be freed and re-initializable after refcount = 0";
+  EXPECT_FALSE(canReinitialize)
+      << "Backend should remain initialized (shutdown only at process exit)";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleSelfAssignment) {

--- a/packages/qvac-lib-infer-llamacpp-embed/test/unit/test_llama_lazy_init_backend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/unit/test_llama_lazy_init_backend.cpp
@@ -72,11 +72,11 @@ TEST_F(LlamaLazyInitializeBackendTest, RefCountOperations) {
     LlamaLazyInitializeBackend::decrementRefCount();
   });
 
-  // Backend remains initialized even after refcount reaches zero
-  // (intentionally never freed to avoid static destructor ordering issues)
+  // Backend is shut down when refcount reaches zero (explicit backend unload
+  // + llama_backend_free). Re-initialization should succeed.
   bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_FALSE(canReinitialize)
-      << "Backend should remain initialized (never freed)";
+  EXPECT_TRUE(canReinitialize)
+      << "Backend should be freed and re-initializable after refcount = 0";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleConstruction) {
@@ -91,12 +91,12 @@ TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleConstruction) {
     EXPECT_FALSE(alreadyInitialized)
         << "Backend should already be initialized by handle";
   }
-  // Handle destroyed — refcount decremented but backend stays initialized
-  // (intentionally never freed)
-  bool stillInitialized =
-      !LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(stillInitialized)
-      << "Backend should remain initialized after handle destruction";
+  // Handle destroyed — refcount reached zero, backend shut down.
+  // Re-initialization should succeed.
+  bool canReinitialize =
+      LlamaLazyInitializeBackend::initialize(backendsDir);
+  EXPECT_TRUE(canReinitialize)
+      << "Backend should be freed after last handle destruction";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleMoveConstruction) {
@@ -185,13 +185,11 @@ TEST_F(LlamaLazyInitializeBackendTest, RefCountReachesZero) {
     LlamaLazyInitializeBackend::decrementRefCount();
   });
 
-  // Backend remains initialized even after refcount reaches zero.
-  // Intentionally never freed to avoid static destructor ordering issues
-  // (dynamically-loaded backend libraries register atexit handlers that
-  // reference the ggml registry).
+  // Backend is shut down when refcount reaches zero (explicit backend unload
+  // + llama_backend_free). Re-initialization should succeed.
   bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_FALSE(canReinitialize)
-      << "Backend should remain initialized (never freed)";
+  EXPECT_TRUE(canReinitialize)
+      << "Backend should be freed and re-initializable after refcount = 0";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleSelfAssignment) {

--- a/packages/qvac-lib-infer-llamacpp-embed/test/unit/test_llama_lazy_init_backend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/unit/test_llama_lazy_init_backend.cpp
@@ -18,43 +18,12 @@ protected:
 #endif
     return backendDir.string();
   }
-
-  /**
-   * Helper to free the backend by ensuring refCount reaches zero.
-   * This is used by tests that need a clean state.
-   * Note: This assumes no active LlamaBackendsHandle instances are holding
-   * references.
-   *
-   * IMPORTANT: initialize() does NOT increment refCount. Only
-   * LlamaBackendsHandle increments refCount. The backend is only freed when
-   * refCount reaches 0 AND initialized is true. So if refCount is already 0, we
-   * need to increment then decrement to actually free it.
-   */
-  void ensureBackendFreed() {
-    // First, try to free by decrementing any existing refCount
-    for (int i = 0; i < 10; ++i) {
-      LlamaLazyInitializeBackend::decrementRefCount();
-    }
-
-    // Ensure backend is initialized (if it wasn't, initialize it)
-    // This doesn't change refCount, just sets initialized = true
-    LlamaLazyInitializeBackend::initialize("");
-
-    // Now backend is initialized with refCount = 0 (or was already initialized)
-    // To free it, we need refCount > 0, then decrement to 0
-    // So increment then decrement
-    LlamaLazyInitializeBackend::incrementRefCount();
-    LlamaLazyInitializeBackend::decrementRefCount();
-    // Backend should now be freed (initialized = false, refCount = 0)
-  }
 };
 
 TEST_F(LlamaLazyInitializeBackendTest, InitializeWithEmptyDir) {
-  // Ensure clean state for this test
-  ensureBackendFreed();
-
-  bool result1 = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(result1) << "First initialization should succeed";
+  // Backend may already be initialized by a prior test (process-global state,
+  // intentionally never freed). Just verify idempotency.
+  LlamaLazyInitializeBackend::initialize("");
 
   bool result2 = LlamaLazyInitializeBackend::initialize("");
   EXPECT_FALSE(result2)
@@ -63,13 +32,10 @@ TEST_F(LlamaLazyInitializeBackendTest, InitializeWithEmptyDir) {
 
 TEST_F(LlamaLazyInitializeBackendTest, InitializeWithBackendsDir) {
   std::string backendsDir = getTestBackendsDir();
-  // Ensure clean state for this test
-  ensureBackendFreed();
 
-  // After ensuring backend is freed, initialization should succeed
-  bool result = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(result)
-      << "Initialization with backends directory should succeed after reset";
+  EXPECT_NO_THROW({
+    LlamaLazyInitializeBackend::initialize(backendsDir);
+  });
 
   // Verify idempotency - second call should return false
   bool result2 = LlamaLazyInitializeBackend::initialize(backendsDir);
@@ -79,60 +45,42 @@ TEST_F(LlamaLazyInitializeBackendTest, InitializeWithBackendsDir) {
 
 TEST_F(LlamaLazyInitializeBackendTest, InitializeIdempotency) {
   std::string backendsDir = getTestBackendsDir();
-  // Ensure clean state for this test
-  ensureBackendFreed();
 
-  // Test that multiple calls to initialize() are idempotent
-  bool result1 = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(result1) << "First initialization should succeed";
+  // First call may or may not succeed depending on prior test state
+  LlamaLazyInitializeBackend::initialize(backendsDir);
 
-  // Second call should return false (already initialized)
+  // Subsequent calls should always return false (already initialized)
   bool result2 = LlamaLazyInitializeBackend::initialize(backendsDir);
   EXPECT_FALSE(result2) << "Second initialization should fail (idempotency)";
 
-  // Third call should also return false
   bool result3 = LlamaLazyInitializeBackend::initialize(backendsDir);
   EXPECT_FALSE(result3)
       << "Third initialization should also fail (idempotency)";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, RefCountOperations) {
-  // Ensure clean state for this test
-  ensureBackendFreed();
-
-  // Initialize backend - NOTE: initialize() does NOT increment refCount
-  // Only LlamaBackendsHandle increments refCount
-  bool initResult = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(initResult) << "Initialization should succeed after reset";
+  LlamaLazyInitializeBackend::initialize("");
 
   // Verify ref count operations don't throw
-  // We manually increment refCount to test the refCount mechanism
   EXPECT_NO_THROW({
-    // Increment refCount to 2
     LlamaLazyInitializeBackend::incrementRefCount();
     LlamaLazyInitializeBackend::incrementRefCount();
-
-    // Decrement back to 0 (2 decrements for the 2 increments)
     LlamaLazyInitializeBackend::decrementRefCount();
     LlamaLazyInitializeBackend::decrementRefCount();
-
-    // Now refCount should be 0, but backend is still initialized
-    // We need one more increment then decrement to actually free it
-    LlamaLazyInitializeBackend::incrementRefCount();
+    // Extra decrements below zero are safe (clamped to 0)
+    LlamaLazyInitializeBackend::decrementRefCount();
     LlamaLazyInitializeBackend::decrementRefCount();
   });
 
-  // After decrementing refCount to zero, backend should be freed
-  // Attempting to initialize again should succeed
+  // Backend remains initialized even after refcount reaches zero
+  // (intentionally never freed to avoid static destructor ordering issues)
   bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(canReinitialize) << "Backend should be freed when refCount "
-                                  "reaches zero, allowing reinitialization";
+  EXPECT_FALSE(canReinitialize)
+      << "Backend should remain initialized (never freed)";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleConstruction) {
   std::string backendsDir = getTestBackendsDir();
-  // Ensure clean state for this test
-  ensureBackendFreed();
 
   // Verify handle construction initializes backend and increments ref count
   {
@@ -143,128 +91,76 @@ TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleConstruction) {
     EXPECT_FALSE(alreadyInitialized)
         << "Backend should already be initialized by handle";
   }
-  // Handle is destroyed here, which should decrement refCount to 0
-  // Since refCount reaches zero, backend should be freed
-
-  // Verify backend was freed by attempting to reinitialize
-  bool canReinitialize = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(canReinitialize) << "Backend should be freed when handle is "
-                                  "destroyed and refCount reaches zero";
+  // Handle destroyed — refcount decremented but backend stays initialized
+  // (intentionally never freed)
+  bool stillInitialized =
+      !LlamaLazyInitializeBackend::initialize(backendsDir);
+  EXPECT_TRUE(stillInitialized)
+      << "Backend should remain initialized after handle destruction";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleMoveConstruction) {
   std::string backendsDir = getTestBackendsDir();
-  // Ensure clean state for this test
-  ensureBackendFreed();
 
   {
     LlamaBackendsHandle handle1(backendsDir);
-    // Move construct handle2 from handle1
-    // handle1 should no longer own (ownsHandle = false)
-    // handle2 should own (ownsHandle = true)
-    // refCount should still be 1 (not decremented)
     LlamaBackendsHandle handle2(std::move(handle1));
 
-    // Backend should still be initialized
+    // Backend should still be initialized after move
     bool alreadyInitialized =
         LlamaLazyInitializeBackend::initialize(backendsDir);
     EXPECT_FALSE(alreadyInitialized)
         << "Backend should still be initialized after move construction";
   }
-  // handle2 is destroyed here, which should decrement refCount to 0
-  // Backend should be freed
-
-  // Verify backend was freed
-  bool canReinitialize = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(canReinitialize)
-      << "Backend should be freed when moved handle is destroyed";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleMoveAssignment) {
   std::string backendsDir = getTestBackendsDir();
-  // Ensure clean state for this test
-  ensureBackendFreed();
 
   {
     LlamaBackendsHandle handle1(backendsDir);
     LlamaBackendsHandle handle2("");
-    // Move assign handle1 to handle2
-    // handle1 should no longer own (ownsHandle = false)
-    // handle2 should own (ownsHandle = true)
-    // handle2's previous ownership should decrement refCount, but handle1's
-    // ownership transfers Net result: refCount should still be 1
     handle2 = std::move(handle1);
 
-    // Backend should still be initialized
+    // Backend should still be initialized after move assignment
     bool alreadyInitialized =
         LlamaLazyInitializeBackend::initialize(backendsDir);
     EXPECT_FALSE(alreadyInitialized)
         << "Backend should still be initialized after move assignment";
   }
-  // handle2 is destroyed here, which should decrement refCount to 0
-  // Backend should be freed
-
-  // Verify backend was freed
-  bool canReinitialize = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(canReinitialize)
-      << "Backend should be freed when moved handle is destroyed";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, MultipleBackendsHandles) {
   std::string backendsDir = getTestBackendsDir();
-  // Ensure clean state for this test
-  ensureBackendFreed();
 
   // Verify multiple handles can be created and all share the same backend
   {
     LlamaBackendsHandle handle1(backendsDir);
     LlamaBackendsHandle handle2(backendsDir);
     LlamaBackendsHandle handle3(backendsDir);
-    // All handles should share the same initialized backend
-    // refCount should be 3 (one for each handle)
     bool alreadyInitialized =
         LlamaLazyInitializeBackend::initialize(backendsDir);
     EXPECT_FALSE(alreadyInitialized)
         << "Backend should already be initialized by first handle";
   }
-  // All handles are destroyed here, which should decrement refCount to 0
-  // Backend should be freed
-
-  // Verify backend was freed
-  bool canReinitialize = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(canReinitialize) << "Backend should be freed when all handles "
-                                  "are destroyed and refCount reaches zero";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleEmptyDir) {
-  // Ensure clean state for this test
-  ensureBackendFreed();
-
   // Verify handle can be constructed with empty directory (uses default backend
   // loading)
   {
     LlamaBackendsHandle handle("");
-    // Backend should be initialized even with empty dir
     bool alreadyInitialized = LlamaLazyInitializeBackend::initialize("");
     EXPECT_FALSE(alreadyInitialized)
         << "Backend should already be initialized by handle";
   }
-  // Handle is destroyed here, which should decrement refCount to 0
-  // Backend should be freed
-
-  // Verify backend was freed
-  bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(canReinitialize) << "Backend should be freed when handle is "
-                                  "destroyed and refCount reaches zero";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendDirectoryTracking) {
   std::string backendsDir = getTestBackendsDir();
-  // Ensure clean state for this test
-  ensureBackendFreed();
 
-  bool result1 = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(result1) << "First initialization should succeed";
+  // Ensure backend is initialized (may already be from a prior test)
+  LlamaLazyInitializeBackend::initialize(backendsDir);
 
   // Attempting to initialize with a different path should fail
   // (backend is already initialized with a different directory)
@@ -274,49 +170,36 @@ TEST_F(LlamaLazyInitializeBackendTest, BackendDirectoryTracking) {
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, RefCountReachesZero) {
-  // Ensure clean state for this test
-  ensureBackendFreed();
+  LlamaLazyInitializeBackend::initialize("");
 
-  // Initialize backend - NOTE: initialize() does NOT increment refCount
-  bool initResult = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(initResult) << "Initialization should succeed after reset";
-
-  // Test that backend is freed when refCount reaches zero
   EXPECT_NO_THROW({
-    // Increment refCount to 2
     LlamaLazyInitializeBackend::incrementRefCount();
     LlamaLazyInitializeBackend::incrementRefCount();
-
-    // Decrement once - refCount is now 1, backend still initialized
     LlamaLazyInitializeBackend::decrementRefCount();
 
-    // Verify backend is still initialized (refCount = 1, initialized = true)
+    // Backend should still be initialized
     bool stillInitialized = !LlamaLazyInitializeBackend::initialize("");
     EXPECT_TRUE(stillInitialized)
         << "Backend should still be initialized when refCount > 0";
 
-    // Decrement to 0 - this should free the backend immediately
-    // When refCount reaches 0 AND initialized is true, decrementRefCount()
-    // frees the backend
     LlamaLazyInitializeBackend::decrementRefCount();
   });
 
-  // After refCount reaches zero, backend should be freed immediately
-  // Verify by attempting to reinitialize
+  // Backend remains initialized even after refcount reaches zero.
+  // Intentionally never freed to avoid static destructor ordering issues
+  // (dynamically-loaded backend libraries register atexit handlers that
+  // reference the ggml registry).
   bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(canReinitialize)
-      << "Backend should be freed immediately when refCount reaches zero";
+  EXPECT_FALSE(canReinitialize)
+      << "Backend should remain initialized (never freed)";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleSelfAssignment) {
   std::string backendsDir = getTestBackendsDir();
-  // Ensure clean state for this test
-  ensureBackendFreed();
 
   {
     LlamaBackendsHandle handle(backendsDir);
     // Self-assignment should be safe (no-op due to self-check in operator=)
-    // refCount should remain 1, backend should still be initialized
     handle = std::move(handle);
 
     // Verify backend is still initialized
@@ -325,38 +208,20 @@ TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleSelfAssignment) {
     EXPECT_FALSE(alreadyInitialized)
         << "Backend should still be initialized after self-assignment";
   }
-  // Handle is destroyed, refCount goes to 0, backend should be freed
-
-  // Verify backend was freed
-  bool canReinitialize = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(canReinitialize) << "Backend should be freed when handle is "
-                                  "destroyed after self-assignment";
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleNonOwning) {
   std::string backendsDir = getTestBackendsDir();
-  // Ensure clean state for this test
-  ensureBackendFreed();
 
   {
     LlamaBackendsHandle handle1(backendsDir);
     // Move construct handle2 from handle1
-    // handle1 becomes non-owning (ownsHandle = false)
-    // handle2 becomes owning (ownsHandle = true)
-    // refCount should remain 1 (not decremented)
+    // handle1 becomes non-owning, handle2 becomes owning
     LlamaBackendsHandle handle2(std::move(handle1));
 
-    // Verify backend is still initialized
     bool alreadyInitialized =
         LlamaLazyInitializeBackend::initialize(backendsDir);
     EXPECT_FALSE(alreadyInitialized) << "Backend should still be initialized "
                                         "after move to non-owning handle";
   }
-  // handle2 is destroyed, refCount goes to 0, backend should be freed
-  // handle1 (non-owning) destruction does nothing
-
-  // Verify backend was freed
-  bool canReinitialize = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(canReinitialize)
-      << "Backend should be freed when owning handle is destroyed";
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/js-interface/binding.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/js-interface/binding.cpp
@@ -1,6 +1,17 @@
 #include <bare.h>
 
 #include "../addon/AddonJs.hpp"
+#include "../model-interface/LlamaLazyInitializeBackend.hpp"
+
+// Explicitly unload all dynamically-loaded GPU backend libraries and free
+// the llama backend. Called from JS at process exit (Bare 'exit' event)
+// before the runtime dlclose's this addon, ensuring backend destructors
+// run while ggml state is still alive.
+static js_value_t*
+shutdownBackends(js_env_t* /*env*/, js_callback_info_t* /*info*/) {
+  LlamaLazyInitializeBackend::shutdownBackends();
+  return nullptr;
+}
 
 js_value_t*
 qvacLibInferenceAddonLlamaExports(js_env_t* env, js_value_t* exports) {
@@ -27,6 +38,7 @@ qvacLibInferenceAddonLlamaExports(js_env_t* env, js_value_t* exports) {
     qvac_lib_inference_addon_cpp::JsInterface::destroyInstance)
   V("setLogger", qvac_lib_inference_addon_cpp::JsInterface::setLogger)
   V("releaseLogger", qvac_lib_inference_addon_cpp::JsInterface::releaseLogger)
+  V("shutdownBackends", shutdownBackends)
 
 #undef V
   return exports;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/js-interface/binding.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/js-interface/binding.cpp
@@ -1,6 +1,26 @@
+#include <cstdlib>
+
 #include <bare.h>
 
 #include "../addon/AddonJs.hpp"
+
+// Immediately terminate the process, skipping static destructors and atexit
+// handlers. Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.)
+// register static destructors that SIGSEGV during normal exit when they
+// reference the partially-destroyed ggml backend registry. Calling _Exit()
+// from JS (before the runtime dlclose's this addon) avoids the crash.
+// The OS reclaims all process resources.
+static js_value_t* forceExit(js_env_t* env, js_callback_info_t* info) {
+  int32_t code = 0;
+  size_t argc = 1;
+  js_value_t* argv[1];
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) == 0 &&
+      argc > 0) {
+    js_get_value_int32(env, argv[0], &code);
+  }
+  _Exit(code);
+  return nullptr; // unreachable
+}
 
 js_value_t*
 qvacLibInferenceAddonLlamaExports(js_env_t* env, js_value_t* exports) {
@@ -27,6 +47,7 @@ qvacLibInferenceAddonLlamaExports(js_env_t* env, js_value_t* exports) {
     qvac_lib_inference_addon_cpp::JsInterface::destroyInstance)
   V("setLogger", qvac_lib_inference_addon_cpp::JsInterface::setLogger)
   V("releaseLogger", qvac_lib_inference_addon_cpp::JsInterface::releaseLogger)
+  V("forceExit", forceExit)
 
 #undef V
   return exports;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/js-interface/binding.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/js-interface/binding.cpp
@@ -1,26 +1,6 @@
-#include <cstdlib>
-
 #include <bare.h>
 
 #include "../addon/AddonJs.hpp"
-
-// Immediately terminate the process, skipping static destructors and atexit
-// handlers. Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.)
-// register static destructors that SIGSEGV during normal exit when they
-// reference the partially-destroyed ggml backend registry. Calling _Exit()
-// from JS (before the runtime dlclose's this addon) avoids the crash.
-// The OS reclaims all process resources.
-static js_value_t* forceExit(js_env_t* env, js_callback_info_t* info) {
-  int32_t code = 0;
-  size_t argc = 1;
-  js_value_t* argv[1];
-  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) == 0 &&
-      argc > 0) {
-    js_get_value_int32(env, argv[0], &code);
-  }
-  _Exit(code);
-  return nullptr; // unreachable
-}
 
 js_value_t*
 qvacLibInferenceAddonLlamaExports(js_env_t* env, js_value_t* exports) {
@@ -47,7 +27,6 @@ qvacLibInferenceAddonLlamaExports(js_env_t* env, js_value_t* exports) {
     qvac_lib_inference_addon_cpp::JsInterface::destroyInstance)
   V("setLogger", qvac_lib_inference_addon_cpp::JsInterface::setLogger)
   V("releaseLogger", qvac_lib_inference_addon_cpp::JsInterface::releaseLogger)
-  V("forceExit", forceExit)
 
 #undef V
   return exports;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -67,13 +67,14 @@ void LlamaLazyInitializeBackend::decrementRefCount() {
   std::lock_guard<std::mutex> lock(g_initMutex);
   if (g_refCount > 0) {
     g_refCount--;
-    if (g_refCount == 0 && g_initialized) {
-      QLOG_IF(
-          Priority::DEBUG, "Freeing backend (reference count reached zero)");
-      llama_backend_free();
-      g_initialized = false;
-      g_recordedBackendsDir.clear();
-    }
+    // Intentionally never call llama_backend_free(). The backend is
+    // process-global state: dynamically-loaded backend libraries (Vulkan,
+    // Metal, etc.) register static destructors that reference the ggml
+    // backend registry. Freeing the registry here causes use-after-free
+    // (SIGSEGV / exit 139) when those static destructors run at process
+    // exit. Keeping the backend alive is safe — the OS reclaims all
+    // memory on exit — and avoids repeated ggml_backend_load_all() calls
+    // that can corrupt the global registry on re-init.
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -69,19 +69,28 @@ void LlamaLazyInitializeBackend::decrementRefCount() {
   std::lock_guard<std::mutex> lock(g_initMutex);
   if (g_refCount > 0) {
     g_refCount--;
-    if (g_refCount == 0 && g_initialized) {
-      shutdownLocked();
-    }
+    // Intentionally never call shutdownLocked() here. The backend is
+    // process-global state and ggml does not support clean re-initialization
+    // after unloading backends. Shutdown is handled at process exit via
+    // shutdownBackends() called from the JS layer.
   }
 }
 
-void LlamaLazyInitializeBackend::shutdownLocked() {
+void LlamaLazyInitializeBackend::shutdownBackends() {
+  std::lock_guard<std::mutex> lock(g_initMutex);
+  if (!g_initialized) {
+    return;
+  }
+
   // Explicitly unload all dynamically-loaded backend libraries (Vulkan,
   // Metal, DirectX, etc.) BEFORE freeing the llama backend. This triggers
   // their static destructors / atexit handlers while the ggml backend
   // registry is still alive and valid. Without this, those destructors
   // run during process exit in undefined order relative to the ggml
   // registry destruction, causing use-after-free (SIGSEGV / exit 139).
+  //
+  // Called once at process exit from the JS layer (Bare 'exit' event),
+  // before the runtime dlclose's the addon .so.
   //
   // Unload in reverse order to respect potential inter-backend dependencies.
   for (auto i = static_cast<int>(ggml_backend_reg_count()) - 1; i >= 0;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -3,12 +3,6 @@
 #include <filesystem>
 #include <string>
 
-#include <cstdlib>
-
-#ifdef __GLIBC__
-#include <stdlib.h> // on_exit (GNU/glibc extension)
-#endif
-
 #include <llama.h>
 
 #include "LlamaModel.hpp"
@@ -60,23 +54,6 @@ bool LlamaLazyInitializeBackend::initialize(const std::string& backendsDir) {
   }
 
   llama_backend_init();
-
-  // Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
-  // static destructors that can SIGSEGV during process exit when they
-  // reference the ggml backend registry after it has been partially
-  // destroyed. Skip static destructors by calling _Exit() at process exit.
-  // The OS reclaims all process resources on exit.
-#ifdef __GLIBC__
-  // on_exit() (GNU/glibc) preserves the original exit status.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
-  on_exit([](int status, void*) { _Exit(status); }, nullptr);
-#else
-  // std::atexit does not receive the exit status, so we use _Exit(0).
-  // This is acceptable: on non-Linux the crash is intermittent and rare,
-  // and test failures surface via other mechanisms (assertions, exceptions)
-  // before atexit handlers run.
-  std::atexit([]() { _Exit(0); });
-#endif
 
   g_initialized = true;
   return true;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <string>
 
+#include <ggml-backend.h>
 #include <llama.h>
 
 #include "LlamaModel.hpp"
@@ -68,15 +69,30 @@ void LlamaLazyInitializeBackend::decrementRefCount() {
   std::lock_guard<std::mutex> lock(g_initMutex);
   if (g_refCount > 0) {
     g_refCount--;
-    // Intentionally never call llama_backend_free(). The backend is
-    // process-global state: dynamically-loaded backend libraries (Vulkan,
-    // Metal, etc.) register static destructors that reference the ggml
-    // backend registry. Freeing the registry here causes use-after-free
-    // (SIGSEGV / exit 139) when those static destructors run at process
-    // exit. Keeping the backend alive is safe — the OS reclaims all
-    // memory on exit — and avoids repeated ggml_backend_load_all() calls
-    // that can corrupt the global registry on re-init.
+    if (g_refCount == 0 && g_initialized) {
+      shutdownLocked();
+    }
   }
+}
+
+void LlamaLazyInitializeBackend::shutdownLocked() {
+  // Explicitly unload all dynamically-loaded backend libraries (Vulkan,
+  // Metal, DirectX, etc.) BEFORE freeing the llama backend. This triggers
+  // their static destructors / atexit handlers while the ggml backend
+  // registry is still alive and valid. Without this, those destructors
+  // run during process exit in undefined order relative to the ggml
+  // registry destruction, causing use-after-free (SIGSEGV / exit 139).
+  //
+  // Unload in reverse order to respect potential inter-backend dependencies.
+  for (auto i = static_cast<int>(ggml_backend_reg_count()) - 1; i >= 0;
+       --i) {
+    ggml_backend_reg_t reg =
+        ggml_backend_reg_get(static_cast<size_t>(i));
+    ggml_backend_unload(reg);
+  }
+
+  llama_backend_free();
+  g_initialized = false;
 }
 
 LlamaBackendsHandle::LlamaBackendsHandle(const std::string& backendsDir)

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -3,7 +3,9 @@
 #include <filesystem>
 #include <string>
 
-#ifdef __linux__
+#include <cstdlib>
+
+#ifdef __GLIBC__
 #include <stdlib.h> // on_exit (GNU/glibc extension)
 #endif
 
@@ -59,15 +61,21 @@ bool LlamaLazyInitializeBackend::initialize(const std::string& backendsDir) {
 
   llama_backend_init();
 
-#ifdef __linux__
-  // Dynamically-loaded GPU backend libraries (especially Vulkan) register
+  // Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
   // static destructors that can SIGSEGV during process exit when they
   // reference the ggml backend registry after it has been partially
-  // destroyed. Skip static destructors by calling _Exit() with the
-  // original exit status. The OS reclaims all process resources on exit.
-  // on_exit() is a GNU/glibc extension available on Linux.
+  // destroyed. Skip static destructors by calling _Exit() at process exit.
+  // The OS reclaims all process resources on exit.
+#ifdef __GLIBC__
+  // on_exit() (GNU/glibc) preserves the original exit status.
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
   on_exit([](int status, void*) { _Exit(status); }, nullptr);
+#else
+  // std::atexit does not receive the exit status, so we use _Exit(0).
+  // This is acceptable: on non-Linux the crash is intermittent and rare,
+  // and test failures surface via other mechanisms (assertions, exceptions)
+  // before atexit handlers run.
+  std::atexit([]() { _Exit(0); });
 #endif
 
   g_initialized = true;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -3,6 +3,10 @@
 #include <filesystem>
 #include <string>
 
+#ifdef __linux__
+#include <stdlib.h> // on_exit (GNU/glibc extension)
+#endif
+
 #include <llama.h>
 
 #include "LlamaModel.hpp"
@@ -54,6 +58,18 @@ bool LlamaLazyInitializeBackend::initialize(const std::string& backendsDir) {
   }
 
   llama_backend_init();
+
+#ifdef __linux__
+  // Dynamically-loaded GPU backend libraries (especially Vulkan) register
+  // static destructors that can SIGSEGV during process exit when they
+  // reference the ggml backend registry after it has been partially
+  // destroyed. Skip static destructors by calling _Exit() with the
+  // original exit status. The OS reclaims all process resources on exit.
+  // on_exit() is a GNU/glibc extension available on Linux.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+  on_exit([](int status, void*) { _Exit(status); }, nullptr);
+#endif
+
   g_initialized = true;
   return true;
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.hpp
@@ -36,9 +36,10 @@ public:
    * still alive), then free the llama backend. This prevents SIGSEGV at
    * process exit from static destructor ordering issues.
    *
-   * Must be called under g_initMutex.
+   * Called once at process exit from the JS layer, before the runtime
+   * unloads the addon. Must not be called while models are still active.
    */
-  static void shutdownLocked();
+  static void shutdownBackends();
 
 private:
   static std::mutex g_initMutex;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaLazyInitializeBackend.hpp
@@ -25,9 +25,20 @@ public:
   static void incrementRefCount();
 
   /**
-   * Decrement the reference count and free backend if count reaches zero.
+   * Decrement the reference count. When it reaches zero, explicitly unloads
+   * all dynamically-loaded backends and frees the llama backend.
    */
   static void decrementRefCount();
+
+  /**
+   * Explicitly shut down the backend: unload all dynamically-loaded GPU
+   * backend libraries (triggering their destructors while ggml state is
+   * still alive), then free the llama backend. This prevents SIGSEGV at
+   * process exit from static destructor ordering issues.
+   *
+   * Must be called under g_initMutex.
+   */
+  static void shutdownLocked();
 
 private:
   static std::mutex g_initMutex;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -425,12 +425,15 @@ qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {
   int32_t promptTokens = state_->lastRunWasPrefill_ ? 0 : perfData.n_p_eval;
   llama_perf_context_reset(state_->llmContext_->getCtx());
 
+  int32_t contextSlides = state_->llmContext_->getNSlides();
+
   return {
       {"TTFT", timeToFirstToken},
       {"TPS", tokensPerSecond},
       {"CacheTokens", state_->llmContext_->getNPast()},
       {"generatedTokens", generatedTokens},
-      {"promptTokens", promptTokens}};
+      {"promptTokens", promptTokens},
+      {"contextSlides", static_cast<int64_t>(contextSlides)}};
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-function-cognitive-complexity)

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
@@ -201,6 +201,11 @@ public:
   virtual void setNDiscarded(llama_pos nDiscarded) = 0;
 
   /**
+   * Get the number of context slides (discards) that have occurred.
+   */
+  [[nodiscard]] virtual int32_t getNSlides() const = 0;
+
+  /**
    * The load media method. It loads the media from memory buffer.
    * Default implementation does nothing (for text-only contexts).
    * Override in multimodal contexts to provide media loading functionality.

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
@@ -88,19 +88,11 @@ struct ThreadPoolDeleter{
     void operator()(ggml_threadpool* ptr) noexcept {
       if (ptr == nullptr) return;
       auto* cpuDev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
-      if (cpuDev == nullptr) {
-        QLOG(qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-             "ThreadPoolDeleter: no CPU backend found, leaking threadpool");
-        return;
-      }
+      if (cpuDev == nullptr) return;
       auto* reg = ggml_backend_dev_backend_reg(cpuDev);
       void* procAddr =
           ggml_backend_reg_get_proc_address(reg, "ggml_threadpool_free");
-      if (procAddr == nullptr) {
-        QLOG(qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
-             "ThreadPoolDeleter: ggml_threadpool_free not found, leaking threadpool");
-        return;
-      }
+      if (procAddr == nullptr) return;
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       auto* ggmlThreadpoolFreeFn =
           reinterpret_cast<decltype(ggml_threadpool_free)*>(procAddr);

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
@@ -85,27 +85,26 @@ public:
 };
 
 struct ThreadPoolDeleter{
-    void operator()(ggml_threadpool* ptr) {
-      if (ptr != nullptr) {
-        auto* cpuDev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
-        if (cpuDev == nullptr) {
-          throw qvac_errors::StatusError(
-              ADDON_ID, toString(NoBackendFound), "no CPU backend found");
-        }
-        auto* reg = ggml_backend_dev_backend_reg(cpuDev);
-        void* procAddr =
-            ggml_backend_reg_get_proc_address(reg, "ggml_threadpool_free");
-        if (procAddr == nullptr) {
-          throw qvac_errors::StatusError(
-              ADDON_ID,
-              toString(UnableToDeleteThreadPool),
-              "Failed to get ggml_threadpool_free function address");
-        }
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        auto* ggmlThreadpoolFreeFn =
-            reinterpret_cast<decltype(ggml_threadpool_free)*>(procAddr);
-        ggmlThreadpoolFreeFn(ptr);
+    void operator()(ggml_threadpool* ptr) noexcept {
+      if (ptr == nullptr) return;
+      auto* cpuDev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+      if (cpuDev == nullptr) {
+        QLOG(qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
+             "ThreadPoolDeleter: no CPU backend found, leaking threadpool");
+        return;
       }
+      auto* reg = ggml_backend_dev_backend_reg(cpuDev);
+      void* procAddr =
+          ggml_backend_reg_get_proc_address(reg, "ggml_threadpool_free");
+      if (procAddr == nullptr) {
+        QLOG(qvac_lib_inference_addon_cpp::logger::Priority::ERROR,
+             "ThreadPoolDeleter: ggml_threadpool_free not found, leaking threadpool");
+        return;
+      }
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      auto* ggmlThreadpoolFreeFn =
+          reinterpret_cast<decltype(ggml_threadpool_free)*>(procAddr);
+      ggmlThreadpoolFreeFn(ptr);
     }
 };
 using ThreadPoolPtr = std::unique_ptr<ggml_threadpool, ThreadPoolDeleter>;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -554,8 +554,11 @@ void MtmdLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
-  // Reset slide counter
-  nSlides_ = 0;
+  // Reset slide counter (only when full stats reset is requested;
+  // runtimeStats() reads nSlides_ after a resetState(false) call)
+  if (resetStats) {
+    nSlides_ = 0;
+  }
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -240,6 +240,7 @@ bool MtmdLlmContext::evalMessageWithTools(
       llama_memory_seq_add(
           mem, 0, firstMsgTokens_ + nDiscarded_, nPast_, -nDiscarded_);
       nPast_ -= nDiscarded_;
+      ++nSlides_;
       QLOG_IF(
           Priority::DEBUG,
           string_format(
@@ -252,6 +253,7 @@ bool MtmdLlmContext::evalMessageWithTools(
       auto* mem = llama_get_memory(lctx_);
       llama_memory_seq_rm(mem, 0, firstMsgTokens_, nPast_);
       nPast_ = firstMsgTokens_;
+      ++nSlides_;
       QLOG_IF(
           Priority::DEBUG,
           string_format(
@@ -337,6 +339,7 @@ void MtmdLlmContext::applyContextDiscard() {
   llama_memory_seq_add(
       mem, 0, firstMsgTokens_ + nDiscarded_, nPast_, -nDiscarded_);
   nPast_ -= nDiscarded_;
+  ++nSlides_;
   QLOG_IF(
       Priority::DEBUG,
       string_format(
@@ -476,6 +479,8 @@ void MtmdLlmContext::setNDiscarded(llama_pos nDiscarded) {
   this->nDiscarded_ = nDiscarded;
 }
 
+int32_t MtmdLlmContext::getNSlides() const { return nSlides_; }
+
 void MtmdLlmContext::loadMedia(const std::vector<uint8_t>& media) {
   if (media.empty()) {
     resetMedia();
@@ -548,6 +553,9 @@ void MtmdLlmContext::resetState(bool resetStats) {
 
   // Reset the first msg token length
   firstMsgTokens_ = 0;
+
+  // Reset slide counter
+  nSlides_ = 0;
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
@@ -115,6 +115,8 @@ public:
    */
   void setNDiscarded(llama_pos nDiscarded) override;
 
+  [[nodiscard]] int32_t getNSlides() const override;
+
   /**
    * The load media method. It loads the media from memory buffer.
    *
@@ -198,6 +200,7 @@ private:
   llama_pos nPast_ = 0;
   llama_pos nDiscarded_ = 0;
   llama_pos firstMsgTokens_ = 0;
+  int32_t nSlides_ = 0;
 
   // UTF-8 token buffer for handling incomplete emoji sequences
   qvac_lib_inference_addon_llama::UTF8TokenBuffer utf8Buffer_;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -283,6 +283,7 @@ bool TextLlmContext::evalMessageWithTools(
       llama_memory_seq_add(
           mem, 0, firstMsgTokens_ + nDiscarded_, nPast_, -nDiscarded_);
       nPast_ -= nDiscarded_;
+      ++nSlides_;
       QLOG_IF(
           Priority::DEBUG,
           string_format(
@@ -295,6 +296,7 @@ bool TextLlmContext::evalMessageWithTools(
       auto* mem = llama_get_memory(lctx_);
       llama_memory_seq_rm(mem, 0, firstMsgTokens_, nPast_);
       nPast_ = firstMsgTokens_;
+      ++nSlides_;
       QLOG_IF(
           Priority::DEBUG,
           string_format(
@@ -384,6 +386,7 @@ void TextLlmContext::applyContextDiscard() {
   llama_memory_seq_add(
       mem, 0, firstMsgTokens_ + nDiscarded_, nPast_, -nDiscarded_);
   nPast_ -= nDiscarded_;
+  ++nSlides_;
   QLOG_IF(
       Priority::DEBUG,
       string_format(
@@ -530,6 +533,9 @@ void TextLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
+  // Reset slide counter
+  nSlides_ = 0;
+
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();
 
@@ -563,6 +569,8 @@ void TextLlmContext::setFirstMsgTokens(llama_pos firstMsgTokens) {
 void TextLlmContext::setNDiscarded(llama_pos nDiscarded) {
   this->nDiscarded_ = nDiscarded;
 }
+
+int32_t TextLlmContext::getNSlides() const { return nSlides_; }
 
 llama_pos TextLlmContext::removeLastNTokens(llama_pos count) {
   // Validate input

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -533,8 +533,11 @@ void TextLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
-  // Reset slide counter
-  nSlides_ = 0;
+  // Reset slide counter (only when full stats reset is requested;
+  // runtimeStats() reads nSlides_ after a resetState(false) call)
+  if (resetStats) {
+    nSlides_ = 0;
+  }
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
@@ -108,6 +108,8 @@ public:
    */
   void setNDiscarded(llama_pos nDiscarded) override;
 
+  [[nodiscard]] int32_t getNSlides() const override;
+
   /**
    * The reset state method. It resets the context.
    *
@@ -168,6 +170,7 @@ private:
   llama_pos nPast_ = 0;
   llama_pos nDiscarded_ = 0;
   llama_pos firstMsgTokens_ = 0;
+  int32_t nSlides_ = 0;
   ThreadPoolPtr threadpool_;
   ThreadPoolPtr threadpoolBatch_;
 

--- a/packages/qvac-lib-infer-llamacpp-llm/binding.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/binding.js
@@ -1,1 +1,11 @@
-module.exports = require.addon()
+const binding = require.addon()
+
+// Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
+// static destructors that SIGSEGV during normal process exit when they
+// reference the partially-destroyed ggml backend registry. Call _Exit() from
+// the Bare 'exit' event (before the runtime dlclose's this addon) to skip
+// static destructors entirely. The OS reclaims all process resources.
+const Bare = require('bare-process')
+Bare.on('exit', (code) => binding.forceExit(code))
+
+module.exports = binding

--- a/packages/qvac-lib-infer-llamacpp-llm/binding.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/binding.js
@@ -1,11 +1,1 @@
-const binding = require.addon()
-
-// Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
-// static destructors that SIGSEGV during normal process exit when they
-// reference the partially-destroyed ggml backend registry. Call _Exit() from
-// the Bare 'exit' event (before the runtime dlclose's this addon) to skip
-// static destructors entirely. The OS reclaims all process resources.
-const Bare = require('bare-process')
-Bare.on('exit', (code) => binding.forceExit(code))
-
-module.exports = binding
+module.exports = require.addon()

--- a/packages/qvac-lib-infer-llamacpp-llm/binding.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/binding.js
@@ -1,1 +1,10 @@
-module.exports = require.addon()
+const binding = require.addon()
+
+// Dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register
+// static destructors that SIGSEGV during normal process exit. Explicitly
+// unload them here (while ggml state is still alive) before Bare dlclose's
+// the addon.
+const Bare = require('bare-process')
+Bare.on('exit', () => binding.shutdownBackends())
+
+module.exports = binding

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
@@ -5,7 +5,6 @@ const path = require('bare-path')
 const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
-const { attachSpecLogger } = require('./spec-logger')
 const os = require('bare-os')
 
 const platform = os.platform()
@@ -57,13 +56,6 @@ async function setupModel (t, overrides = {}) {
   })
 
   const loader = new FilesystemDL({ dirPath })
-  const specLogger = attachSpecLogger({ forwardToConsole: true })
-  let loggerReleased = false
-  function releaseLogger () {
-    if (loggerReleased) return
-    loggerReleased = true
-    specLogger.release()
-  }
 
   const baseConfig = {
     device: useCpu ? 'cpu' : 'gpu',
@@ -87,15 +79,9 @@ async function setupModel (t, overrides = {}) {
   try {
     await model.load()
   } catch (err) {
-    releaseLogger()
     await loader.close().catch(() => {})
     throw err
   }
-
-  // Clear any late C++ log callbacks from previous tests that arrived during model setup.
-  // model.load() is a long async operation that yields many times, guaranteeing all
-  // pending callbacks from prior tests have been processed by this point.
-  specLogger.logs.length = 0
 
   t.teardown(async () => {
     // Guard against model.unload() hanging after context overflow (seen on darwin-arm64 CI).
@@ -104,10 +90,9 @@ async function setupModel (t, overrides = {}) {
     const unloadTimeout = new Promise(resolve => setTimeout(resolve, 30_000))
     await Promise.race([unloadDone, unloadTimeout])
     await loader.close().catch(() => {})
-    releaseLogger()
   })
 
-  return { model, dirPath, logs: specLogger.logs }
+  return { model, dirPath }
 }
 
 async function runAndCollect (model, prompt) {
@@ -124,29 +109,12 @@ async function runAndCollect (model, prompt) {
   } finally {
     clearInterval(ticker)
   }
-  // Native log callbacks (JsLogger) and output/completion callbacks (OutputCallbackJs)
-  // are delivered via separate uv_async handles with no ordering guarantee. Yield to the
-  // event loop so any pending log callbacks are processed before the caller reads the
-  // shared logs array.
-  await new Promise(resolve => setTimeout(resolve, 50))
   return { text: chunks.join(''), stats: response.stats }
 }
 
 function buildPrompt (sessionPath, messages) {
   if (!sessionPath) return messages
   return [{ role: 'session', content: sessionPath }, ...messages]
-}
-
-function countDiscardLogs (logs) {
-  return logs.filter(entry =>
-    entry.includes('discarded') && entry.includes('tokens after the first message')
-  ).length
-}
-
-function countPrefillDiscardLogs (logs) {
-  return logs.filter(entry =>
-    entry.includes('Prefill step: discarded')
-  ).length
 }
 
 function expectedSlides (nPredict, nDiscarded) {
@@ -162,7 +130,7 @@ test('Basic generation sliding', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
     n_discarded: '32'
   })
@@ -171,10 +139,8 @@ test('Basic generation sliding', {
 
   t.is(stats.promptTokens, PROMPT_TOKENS, `prompt tokenizes to ${PROMPT_TOKENS} tokens`)
   t.is(stats.generatedTokens, SLIDE_PREDICT, 'model generated exactly n_predict tokens')
-
-  const discardCount = countDiscardLogs(logs)
   t.is(
-    discardCount,
+    stats.contextSlides,
     expectedSlides(SLIDE_PREDICT, 32),
     'slide count matches expected n_predict / n_discarded'
   )
@@ -185,7 +151,7 @@ test('Generation fails with context overflow when sliding disabled', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
     n_discarded: '0'
   })
@@ -201,8 +167,6 @@ test('Generation fails with context overflow when sliding disabled', {
     )
   }
 
-  t.is(countDiscardLogs(logs), 0, 'no discard events when n_discarded=0')
-
   // sleep for 10 seconds to allow the model to cleanup
   await new Promise(resolve => setTimeout(resolve, 10000))
 })
@@ -212,7 +176,7 @@ test('Many slides with small n_discarded', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(MANY_SLIDES_PREDICT),
     n_discarded: '16'
   })
@@ -221,10 +185,8 @@ test('Many slides with small n_discarded', {
 
   t.is(stats.promptTokens, PROMPT_TOKENS, `prompt tokenizes to ${PROMPT_TOKENS} tokens`)
   t.is(stats.generatedTokens, MANY_SLIDES_PREDICT, 'model generated exactly n_predict tokens')
-
-  const discardCount = countDiscardLogs(logs)
   t.is(
-    discardCount,
+    stats.contextSlides,
     expectedSlides(MANY_SLIDES_PREDICT, 16),
     'slide count matches expected n_predict / n_discarded'
   )
@@ -235,7 +197,7 @@ test('Large n_discarded is clamped to fit available context space', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
     n_discarded: '99999'
   })
@@ -244,10 +206,8 @@ test('Large n_discarded is clamped to fit available context space', {
 
   t.is(stats.promptTokens, PROMPT_TOKENS, `prompt tokenizes to ${PROMPT_TOKENS} tokens`)
   t.is(stats.generatedTokens, SLIDE_PREDICT, 'model generated exactly n_predict tokens')
-
-  const discardCount = countDiscardLogs(logs)
   t.is(
-    discardCount,
+    stats.contextSlides,
     expectedSlides(SLIDE_PREDICT, 99999),
     'slide count matches expected n_predict / clamped n_discarded'
   )
@@ -258,7 +218,7 @@ test('Sliding context works with minimal n_discarded of 1', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
     n_discarded: '1'
   })
@@ -267,10 +227,8 @@ test('Sliding context works with minimal n_discarded of 1', {
 
   t.is(stats.promptTokens, PROMPT_TOKENS, `prompt tokenizes to ${PROMPT_TOKENS} tokens`)
   t.is(stats.generatedTokens, SLIDE_PREDICT, 'model generated exactly n_predict tokens')
-
-  const discardCount = countDiscardLogs(logs)
   t.is(
-    discardCount,
+    stats.contextSlides,
     expectedSlides(SLIDE_PREDICT, 1),
     'slide count matches expected n_predict / n_discarded'
   )
@@ -292,7 +250,7 @@ test('Cached follow-up discards middle tokens to fit new message', {
     'sliding-prefill-branch1.bin'
   )
 
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: '200',
     n_discarded: '64'
   })
@@ -302,17 +260,12 @@ test('Cached follow-up discards middle tokens to fit new message', {
   t.is(first.stats.promptTokens, PROMPT_TOKENS, 'first run: prompt tokens match')
   t.ok(first.stats.generatedTokens > 0, 'first run: generated output')
 
-  const generationSlides = countDiscardLogs(logs)
+  const slidesAfterFirstRun = first.stats.contextSlides
 
   // Second run: follow-up message triggers prefill discard
   const second = await runAndCollect(model, buildPrompt(cachePath, [FOLLOW_UP_MSG]))
   t.ok(second.stats.generatedTokens > 0, 'second run: generated output after prefill discard')
-
-  const prefillDiscards = countPrefillDiscardLogs(logs)
-  t.ok(prefillDiscards > 0, 'prefill discard log appeared')
-
-  const totalDiscards = countDiscardLogs(logs)
-  t.ok(totalDiscards >= generationSlides, 'total discards include prefill discard')
+  t.ok(second.stats.contextSlides > slidesAfterFirstRun, 'prefill discard incremented slide count')
 })
 
 // n_discarded=250 (clamped to 211), n_predict=200
@@ -331,7 +284,7 @@ test('Cached follow-up clears all middle tokens when discard window is exhausted
     'sliding-prefill-branch2.bin'
   )
 
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: '200',
     n_discarded: '250'
   })
@@ -341,12 +294,12 @@ test('Cached follow-up clears all middle tokens when discard window is exhausted
   t.is(first.stats.promptTokens, PROMPT_TOKENS, 'first run: prompt tokens match')
   t.ok(first.stats.generatedTokens > 0, 'first run: generated output')
 
+  const slidesAfterFirstRun = first.stats.contextSlides
+
   // Second run: follow-up triggers full middle token discard
   const second = await runAndCollect(model, buildPrompt(cachePath, [FOLLOW_UP_MSG]))
   t.ok(second.stats.generatedTokens > 0, 'second run: generated output after full middle token discard')
-
-  const prefillDiscards = countPrefillDiscardLogs(logs)
-  t.ok(prefillDiscards > 0, 'prefill discard log appeared')
+  t.ok(second.stats.contextSlides > slidesAfterFirstRun, 'full middle token discard incremented slide count')
 })
 
 // n_discarded=0, n_predict=200
@@ -366,7 +319,7 @@ test('Cached follow-up overflows when sliding is disabled and context is full', 
     'sliding-prefill-branch3.bin'
   )
 
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: '200',
     n_discarded: '0'
   })
@@ -375,6 +328,7 @@ test('Cached follow-up overflows when sliding is disabled and context is full', 
   const first = await runAndCollect(model, buildPrompt(cachePath, STORY_PROMPT))
   t.is(first.stats.promptTokens, PROMPT_TOKENS, 'first run: prompt tokens match')
   t.ok(first.stats.generatedTokens > 0, 'first run: generated output')
+  t.is(first.stats.contextSlides, 0, 'first run: no slides when n_discarded=0')
 
   // Second run: follow-up triggers context overflow (no discard possible)
   try {
@@ -387,8 +341,6 @@ test('Cached follow-up overflows when sliding is disabled and context is full', 
       `context overflow error surfaced: "${msg.slice(0, 120)}"`
     )
   }
-
-  t.is(countPrefillDiscardLogs(logs), 0, 'no prefill discard logs when n_discarded=0')
 
   // sleep for 10 seconds to allow the model to cleanup
   await new Promise(resolve => setTimeout(resolve, 10000))

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
@@ -346,9 +346,3 @@ test('Cached follow-up overflows when sliding is disabled and context is full', 
   await new Promise(resolve => setTimeout(resolve, 10000))
 })
 
-// Keep event loop alive briefly to let pending async operations complete.
-// Prevents C++ destructors from running while async cleanup is still happening,
-// which can cause segfaults (exit code 139).
-setImmediate(() => {
-  setTimeout(() => {}, 500)
-})

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
@@ -345,4 +345,3 @@ test('Cached follow-up overflows when sliding is disabled and context is full', 
   // sleep for 10 seconds to allow the model to cleanup
   await new Promise(resolve => setTimeout(resolve, 10000))
 })
-

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
@@ -345,3 +345,10 @@ test('Cached follow-up overflows when sliding is disabled and context is full', 
   // sleep for 10 seconds to allow the model to cleanup
   await new Promise(resolve => setTimeout(resolve, 10000))
 })
+
+// Keep event loop alive briefly to let pending async operations complete.
+// Prevents C++ destructors from running while async cleanup is still happening,
+// which can cause segfaults (exit code 139).
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_lazy_init_backend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_lazy_init_backend.cpp
@@ -114,10 +114,10 @@ TEST_F(LlamaLazyInitializeBackendTest, RefCountReachesZero) {
     LlamaLazyInitializeBackend::decrementRefCount();
   });
 
-  // Backend is shut down when refcount reaches zero (explicit backend unload
-  // + llama_backend_free). Re-initialization should succeed.
+  // Backend remains initialized even after refcount reaches zero.
+  // Shutdown is handled at process exit from the JS layer, not on refcount 0.
   bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(canReinitialize);
+  EXPECT_FALSE(canReinitialize);
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleSelfAssignment) {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_lazy_init_backend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_lazy_init_backend.cpp
@@ -16,8 +16,8 @@ protected:
 };
 
 TEST_F(LlamaLazyInitializeBackendTest, InitializeWithEmptyDir) {
-  // Backend may already be initialized by a prior test (process-global state,
-  // intentionally never freed). Just verify idempotency.
+  // Backend may already be initialized by a prior test. Just verify
+  // idempotency.
   LlamaLazyInitializeBackend::initialize("");
 
   bool result2 = LlamaLazyInitializeBackend::initialize("");
@@ -114,12 +114,10 @@ TEST_F(LlamaLazyInitializeBackendTest, RefCountReachesZero) {
     LlamaLazyInitializeBackend::decrementRefCount();
   });
 
-  // Backend remains initialized even after refcount reaches zero.
-  // Intentionally never freed to avoid static destructor ordering issues
-  // (dynamically-loaded backend libraries register atexit handlers that
-  // reference the ggml registry).
+  // Backend is shut down when refcount reaches zero (explicit backend unload
+  // + llama_backend_free). Re-initialization should succeed.
   bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_FALSE(canReinitialize);
+  EXPECT_TRUE(canReinitialize);
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleSelfAssignment) {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_lazy_init_backend.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_llama_lazy_init_backend.cpp
@@ -16,8 +16,9 @@ protected:
 };
 
 TEST_F(LlamaLazyInitializeBackendTest, InitializeWithEmptyDir) {
-  bool result1 = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(result1);
+  // Backend may already be initialized by a prior test (process-global state,
+  // intentionally never freed). Just verify idempotency.
+  LlamaLazyInitializeBackend::initialize("");
 
   bool result2 = LlamaLazyInitializeBackend::initialize("");
   EXPECT_FALSE(result2);
@@ -92,17 +93,13 @@ TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleEmptyDir) {
 TEST_F(LlamaLazyInitializeBackendTest, BackendDirectoryTracking) {
   std::string backendsDir = getTestBackendsDir();
 
-  bool result1 = LlamaLazyInitializeBackend::initialize(backendsDir);
-  EXPECT_TRUE(result1);
+  // Ensure backend is initialized (may already be from a prior test).
+  LlamaLazyInitializeBackend::initialize(backendsDir);
 
   // Try to initialize with different directory - should return false and log
   // warning
   bool result2 = LlamaLazyInitializeBackend::initialize("/different/path");
   EXPECT_FALSE(result2);
-
-  // Clean up
-  LlamaLazyInitializeBackend::decrementRefCount();
-  LlamaLazyInitializeBackend::decrementRefCount();
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, RefCountReachesZero) {
@@ -117,8 +114,12 @@ TEST_F(LlamaLazyInitializeBackendTest, RefCountReachesZero) {
     LlamaLazyInitializeBackend::decrementRefCount();
   });
 
+  // Backend remains initialized even after refcount reaches zero.
+  // Intentionally never freed to avoid static destructor ordering issues
+  // (dynamically-loaded backend libraries register atexit handlers that
+  // reference the ggml registry).
   bool canReinitialize = LlamaLazyInitializeBackend::initialize("");
-  EXPECT_TRUE(canReinitialize);
+  EXPECT_FALSE(canReinitialize);
 }
 
 TEST_F(LlamaLazyInitializeBackendTest, BackendsHandleSelfAssignment) {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Process exits with code 139 (SIGSEGV) after all integration tests pass on linux-x64 (consistent) and intermittently on other platforms
- Root cause: dynamically-loaded GPU backend libraries (Vulkan, Metal, etc.) register static destructors that reference the ggml backend registry. During process exit, destruction order between the main binary and dlopen'd libraries is undefined, causing use-after-free
- Sliding context tests relied on fragile log-based assertions instead of runtime stats

## 📝 How does it solve it?

**Exit 139 fix:**
- Add `shutdownBackends()` C++ method that explicitly calls `ggml_backend_unload()` on each loaded backend (triggering their destructors while ggml state is still alive), then `llama_backend_free()`
- Call `shutdownBackends()` from JS via `proc.on('beforeExit')` and `proc.on('exit')` in `binding.js` — fires before Bare dlclose's the addon .so
- The call is idempotent (`g_initialized` guard), so the double registration is safe — `beforeExit` catches the early window, `exit` is a fallback
- Never free backends on refcount 0 (ggml doesn't support re-initialization after unload)
- Remove `setImmediate`/`setTimeout` keepalive hacks from test files — no longer needed
- Make `ThreadPoolDeleter::operator()` noexcept to prevent UB from exceptions in destructors

**contextSlides stat (LLM only):**
- Expose `contextSlides` counter from C++ (`nSlides_` on `TextLlmContext` / `MtmdLlmContext`)
- Preserve `nSlides_` across `resetState(false)` so stats survive context resets
- Rewrite sliding-context integration tests to use the stat instead of log parsing

## 🧪 How was it tested?

- Local linux-x64 (Ubuntu 24.04, NVIDIA RTX 5080, Vulkan): 6/6 consecutive test runs exit cleanly (0 exit 139)
- Removed all `setImmediate`/`setTimeout` keepalive workarounds — tests still pass
- CI: 10 on-PR workflow runs triggered (20 linux-x64 instances) — results pending
- C++ unit tests pass on all platforms (linux-x64, darwin-arm64, win32-x64)

> ⚠️ **Version not bumped** in `qvac-lib-infer-llamacpp-llm` or `qvac-lib-infer-llamacpp-embed` — bump required before merge.