### PR TITLE
feat(llm): expose contextSlides stat from C++ runtime stats

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.12.3] - 2026-03-17
+
+### Added
+
+#### `contextSlides` runtime stat
+
+`runtimeStats()` now includes a `contextSlides` counter that reports how many times the KV cache context window was slid during inference. This replaces the previous approach of parsing log messages to detect sliding context events, providing a reliable, structured stat for downstream consumers.
+
+#### `RuntimeStats` TypeScript interface
+
+Added a `RuntimeStats` type to `index.d.ts` covering all stats keys returned by the C++ addon: `TTFT`, `TPS`, `CacheTokens`, `generatedTokens`, `promptTokens`, and `contextSlides`.
+
 ## [0.12.2] - 2026-03-13
 
 This release fixes antiprompt (reverse-prompt) detection for short stop sequences like `\n`, which is critical for translation workloads that rely on newline-based early stopping.

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -425,12 +425,15 @@ qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {
   int32_t promptTokens = state_->lastRunWasPrefill_ ? 0 : perfData.n_p_eval;
   llama_perf_context_reset(state_->llmContext_->getCtx());
 
+  int32_t contextSlides = state_->llmContext_->getNSlides();
+
   return {
       {"TTFT", timeToFirstToken},
       {"TPS", tokensPerSecond},
       {"CacheTokens", state_->llmContext_->getNPast()},
       {"generatedTokens", generatedTokens},
-      {"promptTokens", promptTokens}};
+      {"promptTokens", promptTokens},
+      {"contextSlides", static_cast<int64_t>(contextSlides)}};
 }
 
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static,readability-function-cognitive-complexity)

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -348,6 +348,9 @@ std::string LlamaModel::processPrompt(const Prompt& prompt) {
 std::string LlamaModel::processPromptImpl(const Prompt& prompt) {
   state_->lastRunWasPrefill_ = prompt.prefill;
 
+  // Reset per-inference slide counter so it doesn't leak across runs
+  state_->llmContext_->resetNSlides();
+
   for (const auto& media : prompt.media) {
     loadMedia(media);
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
@@ -201,6 +201,11 @@ public:
   virtual void setNDiscarded(llama_pos nDiscarded) = 0;
 
   /**
+   * Get the number of context slides (discards) that have occurred.
+   */
+  [[nodiscard]] virtual int32_t getNSlides() const = 0;
+
+  /**
    * The load media method. It loads the media from memory buffer.
    * Default implementation does nothing (for text-only contexts).
    * Override in multimodal contexts to provide media loading functionality.

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
@@ -206,6 +206,11 @@ public:
   [[nodiscard]] virtual int32_t getNSlides() const = 0;
 
   /**
+   * Reset the slide counter to zero. Called at the start of each inference.
+   */
+  virtual void resetNSlides() = 0;
+
+  /**
    * The load media method. It loads the media from memory buffer.
    * Default implementation does nothing (for text-only contexts).
    * Override in multimodal contexts to provide media loading functionality.

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -554,8 +554,11 @@ void MtmdLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
-  // Reset slide counter
-  nSlides_ = 0;
+  // Reset slide counter (only when full stats reset is requested;
+  // runtimeStats() reads nSlides_ after a resetState(false) call)
+  if (resetStats) {
+    nSlides_ = 0;
+  }
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -240,6 +240,7 @@ bool MtmdLlmContext::evalMessageWithTools(
       llama_memory_seq_add(
           mem, 0, firstMsgTokens_ + nDiscarded_, nPast_, -nDiscarded_);
       nPast_ -= nDiscarded_;
+      ++nSlides_;
       QLOG_IF(
           Priority::DEBUG,
           string_format(
@@ -252,6 +253,7 @@ bool MtmdLlmContext::evalMessageWithTools(
       auto* mem = llama_get_memory(lctx_);
       llama_memory_seq_rm(mem, 0, firstMsgTokens_, nPast_);
       nPast_ = firstMsgTokens_;
+      ++nSlides_;
       QLOG_IF(
           Priority::DEBUG,
           string_format(
@@ -337,6 +339,7 @@ void MtmdLlmContext::applyContextDiscard() {
   llama_memory_seq_add(
       mem, 0, firstMsgTokens_ + nDiscarded_, nPast_, -nDiscarded_);
   nPast_ -= nDiscarded_;
+  ++nSlides_;
   QLOG_IF(
       Priority::DEBUG,
       string_format(
@@ -476,6 +479,8 @@ void MtmdLlmContext::setNDiscarded(llama_pos nDiscarded) {
   this->nDiscarded_ = nDiscarded;
 }
 
+int32_t MtmdLlmContext::getNSlides() const { return nSlides_; }
+
 void MtmdLlmContext::loadMedia(const std::vector<uint8_t>& media) {
   if (media.empty()) {
     resetMedia();
@@ -548,6 +553,9 @@ void MtmdLlmContext::resetState(bool resetStats) {
 
   // Reset the first msg token length
   firstMsgTokens_ = 0;
+
+  // Reset slide counter
+  nSlides_ = 0;
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -480,6 +480,7 @@ void MtmdLlmContext::setNDiscarded(llama_pos nDiscarded) {
 }
 
 int32_t MtmdLlmContext::getNSlides() const { return nSlides_; }
+void MtmdLlmContext::resetNSlides() { nSlides_ = 0; }
 
 void MtmdLlmContext::loadMedia(const std::vector<uint8_t>& media) {
   if (media.empty()) {
@@ -554,11 +555,9 @@ void MtmdLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
-  // Reset slide counter (only when full stats reset is requested;
-  // runtimeStats() reads nSlides_ after a resetState(false) call)
-  if (resetStats) {
-    nSlides_ = 0;
-  }
+  // nSlides_ is intentionally NOT reset here — it's reset at the start
+  // of each inference run via resetNSlides(), so runtimeStats() can
+  // read the correct per-inference value after resetState(false).
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -555,9 +555,12 @@ void MtmdLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
-  // nSlides_ is intentionally NOT reset here — it's reset at the start
-  // of each inference run via resetNSlides(), so runtimeStats() can
-  // read the correct per-inference value after resetState(false).
+  // On partial reset (resetStats=false), preserve nSlides_ so
+  // runtimeStats() can read the per-inference value.
+  // On full reset (resetStats=true), clear it along with perf stats.
+  if (resetStats) {
+    nSlides_ = 0;
+  }
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
@@ -115,6 +115,8 @@ public:
    */
   void setNDiscarded(llama_pos nDiscarded) override;
 
+  [[nodiscard]] int32_t getNSlides() const override;
+
   /**
    * The load media method. It loads the media from memory buffer.
    *
@@ -198,6 +200,7 @@ private:
   llama_pos nPast_ = 0;
   llama_pos nDiscarded_ = 0;
   llama_pos firstMsgTokens_ = 0;
+  int32_t nSlides_ = 0;
 
   // UTF-8 token buffer for handling incomplete emoji sequences
   qvac_lib_inference_addon_llama::UTF8TokenBuffer utf8Buffer_;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
@@ -116,6 +116,7 @@ public:
   void setNDiscarded(llama_pos nDiscarded) override;
 
   [[nodiscard]] int32_t getNSlides() const override;
+  void resetNSlides() override;
 
   /**
    * The load media method. It loads the media from memory buffer.

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -283,6 +283,7 @@ bool TextLlmContext::evalMessageWithTools(
       llama_memory_seq_add(
           mem, 0, firstMsgTokens_ + nDiscarded_, nPast_, -nDiscarded_);
       nPast_ -= nDiscarded_;
+      ++nSlides_;
       QLOG_IF(
           Priority::DEBUG,
           string_format(
@@ -295,6 +296,7 @@ bool TextLlmContext::evalMessageWithTools(
       auto* mem = llama_get_memory(lctx_);
       llama_memory_seq_rm(mem, 0, firstMsgTokens_, nPast_);
       nPast_ = firstMsgTokens_;
+      ++nSlides_;
       QLOG_IF(
           Priority::DEBUG,
           string_format(
@@ -384,6 +386,7 @@ void TextLlmContext::applyContextDiscard() {
   llama_memory_seq_add(
       mem, 0, firstMsgTokens_ + nDiscarded_, nPast_, -nDiscarded_);
   nPast_ -= nDiscarded_;
+  ++nSlides_;
   QLOG_IF(
       Priority::DEBUG,
       string_format(
@@ -530,6 +533,9 @@ void TextLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
+  // Reset slide counter
+  nSlides_ = 0;
+
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();
 
@@ -563,6 +569,8 @@ void TextLlmContext::setFirstMsgTokens(llama_pos firstMsgTokens) {
 void TextLlmContext::setNDiscarded(llama_pos nDiscarded) {
   this->nDiscarded_ = nDiscarded;
 }
+
+int32_t TextLlmContext::getNSlides() const { return nSlides_; }
 
 llama_pos TextLlmContext::removeLastNTokens(llama_pos count) {
   // Validate input

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -533,8 +533,11 @@ void TextLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
-  // Reset slide counter
-  nSlides_ = 0;
+  // Reset slide counter (only when full stats reset is requested;
+  // runtimeStats() reads nSlides_ after a resetState(false) call)
+  if (resetStats) {
+    nSlides_ = 0;
+  }
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -533,11 +533,9 @@ void TextLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
-  // Reset slide counter (only when full stats reset is requested;
-  // runtimeStats() reads nSlides_ after a resetState(false) call)
-  if (resetStats) {
-    nSlides_ = 0;
-  }
+  // nSlides_ is intentionally NOT reset here — it's reset at the start
+  // of each inference run via resetNSlides(), so runtimeStats() can
+  // read the correct per-inference value after resetState(false).
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();
@@ -574,6 +572,7 @@ void TextLlmContext::setNDiscarded(llama_pos nDiscarded) {
 }
 
 int32_t TextLlmContext::getNSlides() const { return nSlides_; }
+void TextLlmContext::resetNSlides() { nSlides_ = 0; }
 
 llama_pos TextLlmContext::removeLastNTokens(llama_pos count) {
   // Validate input

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -533,9 +533,12 @@ void TextLlmContext::resetState(bool resetStats) {
   // Reset the first msg token length
   firstMsgTokens_ = 0;
 
-  // nSlides_ is intentionally NOT reset here — it's reset at the start
-  // of each inference run via resetNSlides(), so runtimeStats() can
-  // read the correct per-inference value after resetState(false).
+  // On partial reset (resetStats=false), preserve nSlides_ so
+  // runtimeStats() can read the per-inference value.
+  // On full reset (resetStats=true), clear it along with perf stats.
+  if (resetStats) {
+    nSlides_ = 0;
+  }
 
   // Clear UTF-8 buffer when resetting state
   utf8Buffer_.clear();

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
@@ -108,6 +108,8 @@ public:
    */
   void setNDiscarded(llama_pos nDiscarded) override;
 
+  [[nodiscard]] int32_t getNSlides() const override;
+
   /**
    * The reset state method. It resets the context.
    *
@@ -168,6 +170,7 @@ private:
   llama_pos nPast_ = 0;
   llama_pos nDiscarded_ = 0;
   llama_pos firstMsgTokens_ = 0;
+  int32_t nSlides_ = 0;
   ThreadPoolPtr threadpool_;
   ThreadPoolPtr threadpoolBatch_;
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
@@ -109,6 +109,7 @@ public:
   void setNDiscarded(llama_pos nDiscarded) override;
 
   [[nodiscard]] int32_t getNSlides() const override;
+  void resetNSlides() override;
 
   /**
    * The reset state method. It resets the context.

--- a/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
@@ -115,6 +115,15 @@ export interface DownloadWeightsOptions {
   closeLoader?: boolean
 }
 
+export interface RuntimeStats {
+  TTFT: number
+  TPS: number
+  CacheTokens: number
+  generatedTokens: number
+  promptTokens: number
+  contextSlides: number
+}
+
 export interface DownloadResult {
   filePath: string | null
   error: boolean

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
@@ -5,7 +5,6 @@ const path = require('bare-path')
 const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
-const { attachSpecLogger } = require('./spec-logger')
 const os = require('bare-os')
 
 const platform = os.platform()
@@ -57,13 +56,6 @@ async function setupModel (t, overrides = {}) {
   })
 
   const loader = new FilesystemDL({ dirPath })
-  const specLogger = attachSpecLogger({ forwardToConsole: true })
-  let loggerReleased = false
-  function releaseLogger () {
-    if (loggerReleased) return
-    loggerReleased = true
-    specLogger.release()
-  }
 
   const baseConfig = {
     device: useCpu ? 'cpu' : 'gpu',
@@ -87,15 +79,9 @@ async function setupModel (t, overrides = {}) {
   try {
     await model.load()
   } catch (err) {
-    releaseLogger()
     await loader.close().catch(() => {})
     throw err
   }
-
-  // Clear any late C++ log callbacks from previous tests that arrived during model setup.
-  // model.load() is a long async operation that yields many times, guaranteeing all
-  // pending callbacks from prior tests have been processed by this point.
-  specLogger.logs.length = 0
 
   t.teardown(async () => {
     // Guard against model.unload() hanging after context overflow (seen on darwin-arm64 CI).
@@ -104,10 +90,9 @@ async function setupModel (t, overrides = {}) {
     const unloadTimeout = new Promise(resolve => setTimeout(resolve, 30_000))
     await Promise.race([unloadDone, unloadTimeout])
     await loader.close().catch(() => {})
-    releaseLogger()
   })
 
-  return { model, dirPath, logs: specLogger.logs }
+  return { model, dirPath }
 }
 
 async function runAndCollect (model, prompt) {
@@ -124,29 +109,12 @@ async function runAndCollect (model, prompt) {
   } finally {
     clearInterval(ticker)
   }
-  // Native log callbacks (JsLogger) and output/completion callbacks (OutputCallbackJs)
-  // are delivered via separate uv_async handles with no ordering guarantee. Yield to the
-  // event loop so any pending log callbacks are processed before the caller reads the
-  // shared logs array.
-  await new Promise(resolve => setTimeout(resolve, 50))
   return { text: chunks.join(''), stats: response.stats }
 }
 
 function buildPrompt (sessionPath, messages) {
   if (!sessionPath) return messages
   return [{ role: 'session', content: sessionPath }, ...messages]
-}
-
-function countDiscardLogs (logs) {
-  return logs.filter(entry =>
-    entry.includes('discarded') && entry.includes('tokens after the first message')
-  ).length
-}
-
-function countPrefillDiscardLogs (logs) {
-  return logs.filter(entry =>
-    entry.includes('Prefill step: discarded')
-  ).length
 }
 
 function expectedSlides (nPredict, nDiscarded) {
@@ -162,7 +130,7 @@ test('Basic generation sliding', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
     n_discarded: '32'
   })
@@ -171,10 +139,8 @@ test('Basic generation sliding', {
 
   t.is(stats.promptTokens, PROMPT_TOKENS, `prompt tokenizes to ${PROMPT_TOKENS} tokens`)
   t.is(stats.generatedTokens, SLIDE_PREDICT, 'model generated exactly n_predict tokens')
-
-  const discardCount = countDiscardLogs(logs)
   t.is(
-    discardCount,
+    stats.contextSlides,
     expectedSlides(SLIDE_PREDICT, 32),
     'slide count matches expected n_predict / n_discarded'
   )
@@ -185,7 +151,7 @@ test('Generation fails with context overflow when sliding disabled', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
     n_discarded: '0'
   })
@@ -201,8 +167,6 @@ test('Generation fails with context overflow when sliding disabled', {
     )
   }
 
-  t.is(countDiscardLogs(logs), 0, 'no discard events when n_discarded=0')
-
   // sleep for 10 seconds to allow the model to cleanup
   await new Promise(resolve => setTimeout(resolve, 10000))
 })
@@ -212,7 +176,7 @@ test('Many slides with small n_discarded', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(MANY_SLIDES_PREDICT),
     n_discarded: '16'
   })
@@ -221,10 +185,8 @@ test('Many slides with small n_discarded', {
 
   t.is(stats.promptTokens, PROMPT_TOKENS, `prompt tokenizes to ${PROMPT_TOKENS} tokens`)
   t.is(stats.generatedTokens, MANY_SLIDES_PREDICT, 'model generated exactly n_predict tokens')
-
-  const discardCount = countDiscardLogs(logs)
   t.is(
-    discardCount,
+    stats.contextSlides,
     expectedSlides(MANY_SLIDES_PREDICT, 16),
     'slide count matches expected n_predict / n_discarded'
   )
@@ -235,7 +197,7 @@ test('Large n_discarded is clamped to fit available context space', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
     n_discarded: '99999'
   })
@@ -244,10 +206,8 @@ test('Large n_discarded is clamped to fit available context space', {
 
   t.is(stats.promptTokens, PROMPT_TOKENS, `prompt tokenizes to ${PROMPT_TOKENS} tokens`)
   t.is(stats.generatedTokens, SLIDE_PREDICT, 'model generated exactly n_predict tokens')
-
-  const discardCount = countDiscardLogs(logs)
   t.is(
-    discardCount,
+    stats.contextSlides,
     expectedSlides(SLIDE_PREDICT, 99999),
     'slide count matches expected n_predict / clamped n_discarded'
   )
@@ -258,7 +218,7 @@ test('Sliding context works with minimal n_discarded of 1', {
   timeout: 900_000,
   skip
 }, async t => {
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: String(SLIDE_PREDICT),
     n_discarded: '1'
   })
@@ -267,10 +227,8 @@ test('Sliding context works with minimal n_discarded of 1', {
 
   t.is(stats.promptTokens, PROMPT_TOKENS, `prompt tokenizes to ${PROMPT_TOKENS} tokens`)
   t.is(stats.generatedTokens, SLIDE_PREDICT, 'model generated exactly n_predict tokens')
-
-  const discardCount = countDiscardLogs(logs)
   t.is(
-    discardCount,
+    stats.contextSlides,
     expectedSlides(SLIDE_PREDICT, 1),
     'slide count matches expected n_predict / n_discarded'
   )
@@ -292,7 +250,7 @@ test('Cached follow-up discards middle tokens to fit new message', {
     'sliding-prefill-branch1.bin'
   )
 
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: '200',
     n_discarded: '64'
   })
@@ -302,17 +260,12 @@ test('Cached follow-up discards middle tokens to fit new message', {
   t.is(first.stats.promptTokens, PROMPT_TOKENS, 'first run: prompt tokens match')
   t.ok(first.stats.generatedTokens > 0, 'first run: generated output')
 
-  const generationSlides = countDiscardLogs(logs)
+  const slidesAfterFirstRun = first.stats.contextSlides
 
   // Second run: follow-up message triggers prefill discard
   const second = await runAndCollect(model, buildPrompt(cachePath, [FOLLOW_UP_MSG]))
   t.ok(second.stats.generatedTokens > 0, 'second run: generated output after prefill discard')
-
-  const prefillDiscards = countPrefillDiscardLogs(logs)
-  t.ok(prefillDiscards > 0, 'prefill discard log appeared')
-
-  const totalDiscards = countDiscardLogs(logs)
-  t.ok(totalDiscards >= generationSlides, 'total discards include prefill discard')
+  t.ok(second.stats.contextSlides > slidesAfterFirstRun, 'prefill discard incremented slide count')
 })
 
 // n_discarded=250 (clamped to 211), n_predict=200
@@ -331,7 +284,7 @@ test('Cached follow-up clears all middle tokens when discard window is exhausted
     'sliding-prefill-branch2.bin'
   )
 
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: '200',
     n_discarded: '250'
   })
@@ -341,12 +294,12 @@ test('Cached follow-up clears all middle tokens when discard window is exhausted
   t.is(first.stats.promptTokens, PROMPT_TOKENS, 'first run: prompt tokens match')
   t.ok(first.stats.generatedTokens > 0, 'first run: generated output')
 
+  const slidesAfterFirstRun = first.stats.contextSlides
+
   // Second run: follow-up triggers full middle token discard
   const second = await runAndCollect(model, buildPrompt(cachePath, [FOLLOW_UP_MSG]))
   t.ok(second.stats.generatedTokens > 0, 'second run: generated output after full middle token discard')
-
-  const prefillDiscards = countPrefillDiscardLogs(logs)
-  t.ok(prefillDiscards > 0, 'prefill discard log appeared')
+  t.ok(second.stats.contextSlides > slidesAfterFirstRun, 'full middle token discard incremented slide count')
 })
 
 // n_discarded=0, n_predict=200
@@ -366,7 +319,7 @@ test('Cached follow-up overflows when sliding is disabled and context is full', 
     'sliding-prefill-branch3.bin'
   )
 
-  const { model, logs } = await setupModel(t, {
+  const { model } = await setupModel(t, {
     n_predict: '200',
     n_discarded: '0'
   })
@@ -375,6 +328,7 @@ test('Cached follow-up overflows when sliding is disabled and context is full', 
   const first = await runAndCollect(model, buildPrompt(cachePath, STORY_PROMPT))
   t.is(first.stats.promptTokens, PROMPT_TOKENS, 'first run: prompt tokens match')
   t.ok(first.stats.generatedTokens > 0, 'first run: generated output')
+  t.is(first.stats.contextSlides, 0, 'first run: no slides when n_discarded=0')
 
   // Second run: follow-up triggers context overflow (no discard possible)
   try {
@@ -387,8 +341,6 @@ test('Cached follow-up overflows when sliding is disabled and context is full', 
       `context overflow error surfaced: "${msg.slice(0, 120)}"`
     )
   }
-
-  t.is(countPrefillDiscardLogs(logs), 0, 'no prefill discard logs when n_discarded=0')
 
   // sleep for 10 seconds to allow the model to cleanup
   await new Promise(resolve => setTimeout(resolve, 10000))

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
@@ -95,8 +95,8 @@ async function setupModel (t, overrides = {}) {
   return { model, dirPath }
 }
 
-async function runAndCollect (model, prompt) {
-  const response = await model.run(prompt)
+async function runAndCollect (model, prompt, runOptions) {
+  const response = await model.run(prompt, runOptions)
   const chunks = []
   response.onUpdate(data => { chunks.push(data) })
   // Bare runtime on arm64 may not drain promise microtasks from native addon
@@ -234,13 +234,15 @@ test('Sliding context works with minimal n_discarded of 1', {
   )
 })
 
-// n_discarded=64, n_predict=200
+// n_discarded=64, n_predict=200 (first run), n_predict=10 (second run)
 // First run: n_past = 44 + 200 = 244, firstMsgTokens = 44
 // Second run follow-up (~20 tokens):
 //   n_past + nTokens = 244 + ~20 = ~264 >= 256 (outer condition)
 //   leftTokens = 244 - 44 - 64 = 136 >= 0
 //   n_past + nTokens - n_discarded = ~264 - 64 = ~200 < 256
 // :> discards n_discarded (64) tokens after first message
+// Second run uses predict=10 via generationParams so generation can't
+// reach the context limit — any contextSlides must come from prefill.
 test('Cached follow-up discards middle tokens to fit new message', {
   timeout: 900_000,
   skip
@@ -259,22 +261,27 @@ test('Cached follow-up discards middle tokens to fit new message', {
   const first = await runAndCollect(model, buildPrompt(cachePath, STORY_PROMPT))
   t.is(first.stats.promptTokens, PROMPT_TOKENS, 'first run: prompt tokens match')
   t.ok(first.stats.generatedTokens > 0, 'first run: generated output')
+  t.is(first.stats.contextSlides, 0, 'first run: no slides (n_past 244 < n_ctx 256)')
 
-  const slidesAfterFirstRun = first.stats.contextSlides
-
-  // Second run: follow-up message triggers prefill discard
-  const second = await runAndCollect(model, buildPrompt(cachePath, [FOLLOW_UP_MSG]))
+  // Second run: low predict so only prefill discard can cause slides
+  // After prefill discard: n_past ~200, generate 10 → ~210 < 256 (no generation sliding)
+  const second = await runAndCollect(
+    model,
+    buildPrompt(cachePath, [FOLLOW_UP_MSG]),
+    { generationParams: { predict: 10 } }
+  )
   t.ok(second.stats.generatedTokens > 0, 'second run: generated output after prefill discard')
-  t.ok(second.stats.contextSlides > slidesAfterFirstRun, 'prefill discard incremented slide count')
+  t.is(second.stats.contextSlides, 1, 'exactly one prefill discard slide')
 })
 
-// n_discarded=250 (clamped to 211), n_predict=200
+// n_discarded=250 (clamped to 211), n_predict=200 (first run), predict=10 (second run)
 // First run: n_past = 244, firstMsgTokens = 44, n_discarded = 211
 // Second run follow-up (~20 tokens):
 //   leftTokens = 244 - 44 - 211 = -11 < 0
 //   firstMsgTokens + nTokens = 44 + ~20 = ~64 < 256
 //   n_discarded = 211 > 0
 // :> removes all middle tokens from pos 44 to 244
+// Second run uses predict=10 so generation can't cause slides.
 test('Cached follow-up clears all middle tokens when discard window is exhausted', {
   timeout: 900_000,
   skip
@@ -293,13 +300,17 @@ test('Cached follow-up clears all middle tokens when discard window is exhausted
   const first = await runAndCollect(model, buildPrompt(cachePath, STORY_PROMPT))
   t.is(first.stats.promptTokens, PROMPT_TOKENS, 'first run: prompt tokens match')
   t.ok(first.stats.generatedTokens > 0, 'first run: generated output')
+  t.is(first.stats.contextSlides, 0, 'first run: no slides (n_past 244 < n_ctx 256)')
 
-  const slidesAfterFirstRun = first.stats.contextSlides
-
-  // Second run: follow-up triggers full middle token discard
-  const second = await runAndCollect(model, buildPrompt(cachePath, [FOLLOW_UP_MSG]))
+  // Second run: low predict so only prefill full-middle-discard can cause slides
+  // After discard: n_past = 44 (firstMsgTokens), generate 10 → 54 < 256
+  const second = await runAndCollect(
+    model,
+    buildPrompt(cachePath, [FOLLOW_UP_MSG]),
+    { generationParams: { predict: 10 } }
+  )
   t.ok(second.stats.generatedTokens > 0, 'second run: generated output after full middle token discard')
-  t.ok(second.stats.contextSlides > slidesAfterFirstRun, 'full middle token discard incremented slide count')
+  t.is(second.stats.contextSlides, 1, 'exactly one full middle token discard slide')
 })
 
 // n_discarded=0, n_predict=200

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
@@ -65,7 +65,7 @@ async function setupModel (t, overrides = {}) {
     temp: '0.9',
     top_p: '0.95',
     seed: '42',
-    verbosity: '3'
+    verbosity: '2'
   }
 
   const model = new LlmLlamacpp({


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Sliding context tests relied on fragile log-based assertions (parsing C++ log output for "sliding context" messages)
- Log format changes in llamacpp upstream could silently break tests
- No programmatic way to verify context sliding occurred

## 📝 How does it solve it?

- Add `nSlides_` counter to `TextLlmContext` and `MtmdLlmContext` — incremented each time the KV cache slides
- Expose `contextSlides` in the runtime stats object returned after inference (`stats.contextSlides`)
- Preserve `nSlides_` across `resetState(false)` so stats survive context resets during generation
- Rewrite sliding-context integration tests to assert on `stats.contextSlides` instead of parsing log output

## 🧪 How was it tested?

- Local linux-x64: sliding-context tests pass consistently (8/8)
- Stats correctly report 0 slides for short prompts, >0 slides for context-overflow scenarios

Asana Task: https://app.asana.com/1/45238840754660/project/1212638335655939/task/1213746957445532?focus=true