### PR TITLE
fix(ci): route macOS GPU diffusion tests to self-hosted baremetal runner

### DIFF
--- a/.github/workflows/integration-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-test-lib-infer-diffusion.yml
@@ -62,7 +62,7 @@ jobs:
           - os: mac-mini-m4
             platform: darwin
             arch: arm64
-            runner: [self-hosted, metal-gpu]
+            runner: mac-mini-m4-gpu
           - os: macos-15-large
             platform: darwin
             arch: x64

--- a/.github/workflows/integration-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-test-lib-infer-diffusion.yml
@@ -59,10 +59,10 @@ jobs:
             arch: arm64
             runner: ubuntu-22.04-arm
             no_gpu: 'true'
-          - os: macos-26-xlarge
+          - os: mac-mini-m4
             platform: darwin
             arch: arm64
-            runner: macos-26-xlarge
+            runner: [self-hosted, metal-gpu]
           - os: macos-15-large
             platform: darwin
             arch: x64


### PR DESCRIPTION
## Problem

The Stable Diffusion integration tests fail on macOS ARM64 GPU because
GitHub-hosted `macos-26-xlarge` runners use Apple's Virtualization
Framework, which exposes an "Apple Paravirtual Device" limited to
`MTLGPUFamilyApple5`. The diffusion addon requires `MTLGPUFamilyApple7`
or higher for SIMD group matrix multiplication and reduction operations.

Ref: https://github.com/ggml-org/llama.cpp/issues/4998#issuecomment-1896227769

## Solution

Route the macOS ARM64 GPU test to a self-hosted M4 Mac Mini registered
as a GitHub Actions runner with the `metal-gpu` label.

### Runner details
- **Machine:** Mac Mini (Mac16,10), Apple M4, 10-core, 16GB RAM
- **GPU family support:** MTLGPUFamilyApple9 (Apple7+ confirmed)
- **Runner name:** `mac-mini-m4-gpu`
- **Labels:** `self-hosted`, `macOS`, `ARM64`, `metal-gpu`
- **Service:** LaunchDaemon (persists across reboots, no GUI session required)

## Changes

- Updated matrix entry in `integration-tests-sd.yml`:
  - `runner: macos-26-xlarge` → `runner: [self-hosted, metal-gpu]`
  - `os: macos-26-xlarge` → `os: mac-mini-m4`

## Testing

- Runner registered and confirmed listening: `v2.332.0`
- Metal GPU family validated via `swift` inline check on the device
- No other matrix entries or workflow steps are affected