### PR TITLE
fix: remove trailing blank line in addon.js to pass standard lint

### DIFF
--- a/packages/lib-infer-diffusion/addon.js
+++ b/packages/lib-infer-diffusion/addon.js
@@ -90,4 +90,3 @@ function notifyProcessExit (binding) {
 }
 
 module.exports = { SdInterface, notifyProcessExit }
-


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `sanity-checks` CI fails because `addon.js` has a trailing blank line that violates `standard` lint rule `no-multiple-empty-lines`.

## 📝 How does it solve it?

- Remove the trailing blank line at end of `packages/lib-infer-diffusion/addon.js`.