### PR TITLE
QVAC-13815 fix[parakeet]: reload() passes named paths; bump 0.2.1

### DIFF
--- a/packages/qvac-lib-infer-parakeet/CHANGELOG.md
+++ b/packages/qvac-lib-infer-parakeet/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2026-03-18
+## [0.2.1]
 
 This release fixes `reload()` for setups that use per-file model paths (TDT, CTC, EOU, Sortformer), so the native addon keeps receiving the same paths after a reload as on the initial load.
 

--- a/packages/qvac-lib-infer-parakeet/CHANGELOG.md
+++ b/packages/qvac-lib-infer-parakeet/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-03-18
+
+This release fixes `reload()` for setups that use per-file model paths (TDT, CTC, EOU, Sortformer), so the native addon keeps receiving the same paths after a reload as on the initial load.
+
+## Bug Fixes
+
+### reload() missing named path passthrough
+
+`reload()` rebuilt configuration without the individual file paths (`encoderPath`, `decoderPath`, `vocabPath`, and the other named path fields). After `reload()`, the addon no longer saw those paths and could not load the model correctly. `reload()` now builds configuration through the same `_buildConfigurationParams()` helper as `_load()`, so named paths are always included. When named paths are in use, `reload()` also skips streaming weights via `_loadModelWeights`, matching initial load behavior and avoiding redundant large file reads.
+
+## Added
+
+### Integration coverage for reload with named paths
+
+A new integration test exercises `TranscriptionParakeet` with TDT named paths: transcribe, call `reload()` with updated `parakeetConfig`, then transcribe again and verify output quality.
+
 ## [0.2.0]
 
 ### Changed

--- a/packages/qvac-lib-infer-parakeet/index.js
+++ b/packages/qvac-lib-infer-parakeet/index.js
@@ -227,15 +227,11 @@ class TranscriptionParakeet extends BaseInference {
   }
 
   /**
-   * Load model, weights, and activate addon.
-   * @param {boolean} [closeLoader=false] - Close loader when done.
-   * @param {Function} [reportProgressCallback] - Hook for progress updates.
+   * Build native addon configuration (shared by _load and reload).
+   * @returns {Object} configurationParams for createInstance / reload / activate
+   * @private
    */
-  async _load (closeLoader = false, reportProgressCallback) {
-    this.logger.debug('Loader ready')
-
-    await this.downloadWeights(reportProgressCallback, { closeLoader })
-
+  _buildConfigurationParams () {
     const modelPath = this._config.path || this._getModelFilePath()
     const modelType = this.params.modelType || 'tdt'
 
@@ -251,24 +247,34 @@ class TranscriptionParakeet extends BaseInference {
       seed: this.params.seed ?? -1
     }
 
-    // Pass individual file paths to C++ which loads directly from disk
     if (this._hasNamedPaths()) {
-      // TDT
       if (this._config.encoderPath) configurationParams.encoderPath = this._config.encoderPath
       if (this._config.encoderDataPath) configurationParams.encoderDataPath = this._config.encoderDataPath
       if (this._config.decoderPath) configurationParams.decoderPath = this._config.decoderPath
       if (this._config.vocabPath) configurationParams.vocabPath = this._config.vocabPath
       if (this._config.preprocessorPath) configurationParams.preprocessorPath = this._config.preprocessorPath
-      // CTC
       if (this._config.ctcModelPath) configurationParams.ctcModelPath = this._config.ctcModelPath
       if (this._config.ctcModelDataPath) configurationParams.ctcModelDataPath = this._config.ctcModelDataPath
       if (this._config.tokenizerPath) configurationParams.tokenizerPath = this._config.tokenizerPath
-      // EOU
       if (this._config.eouEncoderPath) configurationParams.eouEncoderPath = this._config.eouEncoderPath
       if (this._config.eouDecoderPath) configurationParams.eouDecoderPath = this._config.eouDecoderPath
-      // Sortformer
       if (this._config.sortformerPath) configurationParams.sortformerPath = this._config.sortformerPath
     }
+
+    return configurationParams
+  }
+
+  /**
+   * Load model, weights, and activate addon.
+   * @param {boolean} [closeLoader=false] - Close loader when done.
+   * @param {Function} [reportProgressCallback] - Hook for progress updates.
+   */
+  async _load (closeLoader = false, reportProgressCallback) {
+    this.logger.debug('Loader ready')
+
+    await this.downloadWeights(reportProgressCallback, { closeLoader })
+
+    const configurationParams = this._buildConfigurationParams()
 
     this.logger.info('Creating Parakeet addon with configuration:', configurationParams)
     this.addon = this._createAddon(configurationParams)
@@ -442,25 +448,17 @@ class TranscriptionParakeet extends BaseInference {
         this.params = { ...this.params, ...newConfig.parakeetConfig }
       }
 
-      const modelPath = this._config.path || this._getModelFilePath()
-      const modelType = this.params.modelType || 'tdt'
-
-      const configurationParams = {
-        modelPath,
-        modelType,
-        maxThreads: this.params.maxThreads || 4,
-        useGPU: this.params.useGPU || false,
-        sampleRate: this.params.sampleRate || 16000,
-        channels: this.params.channels || 1,
-        captionEnabled: this.params.captionEnabled || false,
-        timestampsEnabled: this.params.timestampsEnabled !== false, // default true
-        seed: this.params.seed ?? -1
-      }
+      const configurationParams = this._buildConfigurationParams()
 
       await this.cancel()
       this._failAndClearActiveResponse('Model was reloaded')
       await this.addon.reload(configurationParams)
-      await this._loadModelWeights(modelPath, modelType)
+      if (!this._hasNamedPaths()) {
+        await this._loadModelWeights(
+          configurationParams.modelPath,
+          configurationParams.modelType
+        )
+      }
       await this.addon.activate()
 
       this.logger.debug('Addon reloaded and activated successfully')

--- a/packages/qvac-lib-infer-parakeet/package.json
+++ b/packages/qvac-lib-infer-parakeet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-parakeet",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "High-performance speech-to-text inference addon using NVIDIA Parakeet models for Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-parakeet/test/integration/named-paths-reload.test.js
+++ b/packages/qvac-lib-infer-parakeet/test/integration/named-paths-reload.test.js
@@ -1,0 +1,96 @@
+'use strict'
+
+const test = require('brittle')
+const path = require('bare-path')
+const fs = require('bare-fs')
+const binding = require('../../binding')
+const TranscriptionParakeet = require('../../index.js')
+const FakeDL = require('../mocks/loader.fake.js')
+const {
+  setupJsLogger,
+  getTestPaths,
+  ensureModel,
+  getNamedPathsConfig,
+  createAudioStream,
+  validateAccuracy
+} = require('./helpers.js')
+
+const { modelPath, samplesDir } = getTestPaths()
+
+const expectedText = 'Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do. Once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it. And what is the use of a book thought Alice without pictures or conversations'
+
+test('Named paths: reload preserves file paths and transcription still works', { timeout: 600000 }, async (t) => {
+  const loggerBinding = setupJsLogger(binding)
+  let model = null
+
+  try {
+    await ensureModel(modelPath)
+
+    const samplePath = path.join(samplesDir, 'sample.raw')
+    if (!fs.existsSync(samplePath)) {
+      t.pass('Test skipped - sample audio not found')
+      return
+    }
+
+    const modelName = path.basename(modelPath)
+    const diskPath = path.dirname(modelPath)
+
+    const config = {
+      path: modelPath,
+      ...getNamedPathsConfig('tdt', modelPath),
+      parakeetConfig: {
+        modelType: 'tdt',
+        maxThreads: 4,
+        useGPU: false
+      }
+    }
+
+    model = new TranscriptionParakeet(
+      {
+        modelName,
+        diskPath,
+        loader: new FakeDL({}),
+        exclusiveRun: true
+      },
+      config
+    )
+
+    await model.load()
+
+    async function transcribeToText () {
+      const segments = []
+      const audioStream = createAudioStream(samplePath)
+      const response = await model.run(audioStream)
+      await response
+        .onUpdate((outputArr) => {
+          const items = Array.isArray(outputArr) ? outputArr : [outputArr]
+          for (const seg of items) {
+            if (seg && seg.text) segments.push(seg)
+          }
+        })
+        .await()
+      return segments.map(s => s.text).join(' ').trim().replace(/\s+/g, ' ')
+    }
+
+    const textBefore = await transcribeToText()
+    t.ok(textBefore.length > 50, 'Transcription after load should produce text')
+    const werBefore = validateAccuracy(expectedText, textBefore, 0.35)
+    t.ok(werBefore.wer <= 0.35, `WER after load OK (got ${werBefore.werPercent})`)
+
+    await model.reload({ parakeetConfig: { maxThreads: 4 } })
+
+    const textAfter = await transcribeToText()
+    t.ok(textAfter.length > 50, 'Transcription after reload should produce text')
+    const werAfter = validateAccuracy(expectedText, textAfter, 0.35)
+    t.ok(werAfter.wer <= 0.35, `WER after reload OK (got ${werAfter.werPercent})`)
+  } finally {
+    if (model) {
+      try {
+        await model.unload()
+      } catch (e) {}
+    }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {}
+  }
+})


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- `reload()` rebuilt native config **without** per-file paths (`encoderPath`, `decoderPath`, etc.) that `_load()` already sent.
- Apps using named paths could load once, then break or misbehave after `reload()` (e.g. `activate()` / C++ load expects those paths).

## 📝 How does it solve it?

- Added `_buildConfigurationParams()` shared by `_load()` and `reload()` so named paths are always included when configured.
- On `reload()`, skip `_loadModelWeights()` when using named paths (same idea as initial load: C++ reads from disk paths).
- **v0.2.1** + `CHANGELOG.md` entry for the release workflow.

## 🧪 How was it tested?

- New integration test `test/integration/named-paths-reload.test.js`: TDT + named paths → transcribe → `reload({ parakeetConfig: { maxThreads: 2 } })` (different from initial `maxThreads: 4`) → assert merged params + second transcription with WER check.
- `npm run test:integration` / `bare test/integration/named-paths-reload.test.js` (with model + `sample.raw` present).