### PR TITLE
fix[notask]: normalize composite JSON Schema types in tool parameter validation

### DIFF
--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -74,10 +74,33 @@ export function openaiToolsToSdk (tools: OpenAITool[] | undefined): SDKTool[] | 
         type: 'function',
         name: fn.name,
         description: fn.description ?? '',
-        parameters: fn.parameters ?? { type: 'object', properties: {} }
+        parameters: normalizeToolParameters(fn.parameters ?? { type: 'object', properties: {} })
       }
     })
     .filter((t): t is SDKTool => t !== null)
+}
+
+const VALID_TYPES = new Set(['string', 'number', 'integer', 'boolean', 'object', 'array'])
+
+function normalizeToolParameters (params: Record<string, unknown>): Record<string, unknown> {
+  const props = params['properties'] as Record<string, Record<string, unknown>> | undefined
+  if (!props) return params
+
+  const normalized: Record<string, Record<string, unknown>> = {}
+  for (const [key, prop] of Object.entries(props)) {
+    normalized[key] = { ...prop, type: normalizeType(prop['type']) }
+  }
+
+  return { ...params, properties: normalized }
+}
+
+function normalizeType (type: unknown): string {
+  if (typeof type === 'string' && VALID_TYPES.has(type)) return type
+  if (Array.isArray(type)) {
+    const primary = type.find((t): t is string => typeof t === 'string' && t !== 'null' && VALID_TYPES.has(t))
+    return primary ?? 'string'
+  }
+  return 'string'
 }
 
 export function sdkToolCallsToOpenai (toolCalls: SDKToolCall[] | null | undefined): OpenAIToolCall[] | undefined {

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -144,6 +144,97 @@ describe('openaiToolsToSdk', () => {
     assert.equal(result[0]!.name, 'fn_a')
     assert.equal(result[1]!.name, 'fn_b')
   })
+
+  it('normalizes composite types like ["string", "null"] to "string"', () => {
+    const tools = [{
+      type: 'function',
+      function: {
+        name: 'read_file',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: {
+            path: { type: ['string', 'null'], description: 'File path' },
+            glob: { type: ['string', 'null'], description: 'Glob pattern' }
+          },
+          required: ['path']
+        }
+      }
+    }]
+    const result = openaiToolsToSdk(tools)
+    assert.ok(result)
+    const props = result[0]!.parameters as { properties: Record<string, { type: string }> }
+    assert.equal(props.properties['path']!.type, 'string')
+    assert.equal(props.properties['glob']!.type, 'string')
+  })
+
+  it('normalizes ["integer", "null"] to "integer"', () => {
+    const tools = [{
+      type: 'function',
+      function: {
+        name: 'fetch',
+        description: 'Fetch data',
+        parameters: {
+          type: 'object',
+          properties: {
+            limit: { type: ['integer', 'null'] }
+          }
+        }
+      }
+    }]
+    const result = openaiToolsToSdk(tools)
+    assert.ok(result)
+    const props = result[0]!.parameters as { properties: Record<string, { type: string }> }
+    assert.equal(props.properties['limit']!.type, 'integer')
+  })
+
+  it('falls back to "string" for unrecognized types', () => {
+    const tools = [{
+      type: 'function',
+      function: {
+        name: 'test',
+        description: 'Test',
+        parameters: {
+          type: 'object',
+          properties: {
+            field: { type: 'unknown_type' }
+          }
+        }
+      }
+    }]
+    const result = openaiToolsToSdk(tools)
+    assert.ok(result)
+    const props = result[0]!.parameters as { properties: Record<string, { type: string }> }
+    assert.equal(props.properties['field']!.type, 'string')
+  })
+
+  it('preserves valid simple types unchanged', () => {
+    const tools = [{
+      type: 'function',
+      function: {
+        name: 'test',
+        description: 'Test',
+        parameters: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            count: { type: 'number' },
+            enabled: { type: 'boolean' },
+            items: { type: 'array' },
+            config: { type: 'object' }
+          }
+        }
+      }
+    }]
+    const result = openaiToolsToSdk(tools)
+    assert.ok(result)
+    const props = result[0]!.parameters as { properties: Record<string, { type: string }> }
+    assert.equal(props.properties['name']!.type, 'string')
+    assert.equal(props.properties['count']!.type, 'number')
+    assert.equal(props.properties['enabled']!.type, 'boolean')
+    assert.equal(props.properties['items']!.type, 'array')
+    assert.equal(props.properties['config']!.type, 'object')
+  })
 })
 
 describe('sdkToolCallsToOpenai', () => {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

OpenAI-compatible clients like LangChain Deep Agents send tool schemas with composite JSON Schema types (e.g. `["string", "null"]` for nullable parameters). The SDK's `toolSchema` Zod validation only accepts simple type strings (`"string"`, `"number"`, etc.), causing `Invalid tool schema` errors that reject valid tool-calling requests.

## 🛠 How does it solve it?

- Adds a normalization step in the CLI's OpenAI translation layer (`openaiToolsToSdk`) that converts composite types to their primary type before passing them to the SDK
- `["string", "null"]` → `"string"`, `["integer", "null"]` → `"integer"`, etc.
- Falls back to `"string"` for unrecognized types
- Keeps the SDK's strict validation untouched — the fix is at the adapter boundary

## 🧪 Testing

- 9 unit tests covering: simple types preserved, composite types normalized, unrecognized types fallback, empty/undefined inputs
- Validated with LangChain Deep Agents CLI (13 tools with nullable params) against local QVAC serve

## 📦 Packages affected

- `@qvac/cli`


## Demo


https://github.com/user-attachments/assets/09605265-d36f-4c26-93a0-c6d5f3466de7


