### PR TITLE
QVAC-13932 feat: Enable profiling in test-qvac desktop and mobile consumers

### DIFF
--- a/packages/sdk/server/rpc/handlers/rag.ts
+++ b/packages/sdk/server/rpc/handlers/rag.ts
@@ -27,7 +27,7 @@ interface HandlerOptions {
 
 registerOperationMetrics<
   { operation?: string; workspace?: string },
-  { processed?: number; results?: unknown[] }
+  { processed?: unknown[]; results?: unknown[] }
 >({
   op: "rag",
   kind: "handler",
@@ -39,7 +39,7 @@ registerOperationMetrics<
   },
   fromResult: (res) => {
     const gauges: Record<string, number> = {};
-    if (res.processed !== undefined) gauges["processed"] = res.processed;
+    if (res.processed !== undefined) gauges["processed"] = res.processed.length;
     if (res.results !== undefined) gauges["resultsCount"] = res.results.length;
     return Object.keys(gauges).length > 0 ? gauges : undefined;
   },

--- a/packages/sdk/tests-qvac/package.json
+++ b/packages/sdk/tests-qvac/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@qvac/sdk": "file:..",
-    "@tetherto/qvac-test-suite": "0.3.0",
+    "@tetherto/qvac-test-suite": "0.4.0",
     "mqtt": "^5.14.1",
     "react-native-bare-kit": "^0.11.4"
   },

--- a/packages/sdk/tests-qvac/tests/desktop/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/desktop/consumer.ts
@@ -1,5 +1,6 @@
 import { createExecutor } from "@tetherto/qvac-test-suite";
 import {
+  profiler,
   LLAMA_3_2_1B_INST_Q4_0,
   GTE_LARGE_FP16,
   GTE_LARGE_335M_FP16_SHARD,
@@ -226,4 +227,8 @@ export const executor = createExecutor({
     new KvCacheExecutor(resources),
     new ParakeetExecutor(resources),
   ],
+  profiling: {
+    init: () => profiler.enable({ mode: "summary", includeServerBreakdown: true }),
+    exportData: () => profiler.exportJSON(),
+  },
 });

--- a/packages/sdk/tests-qvac/tests/mobile/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/mobile/consumer.ts
@@ -1,5 +1,6 @@
 import { createExecutor } from "@tetherto/qvac-test-suite/mobile";
 import {
+  profiler,
   LLAMA_3_2_1B_INST_Q4_0,
   GTE_LARGE_FP16,
   WHISPER_TINY,
@@ -99,4 +100,8 @@ export const executor = createExecutor({
     new MobileTranscriptionExecutor(resources),
     new MobileParakeetExecutor(resources),
   ],
+  profiling: {
+    init: () => profiler.enable({ mode: "summary", includeServerBreakdown: true }),
+    exportData: () => profiler.exportJSON(),
+  },
 });


### PR DESCRIPTION
## What problem does this PR solve?
The test-qvac consumers weren't collecting profiling data during test runs.

## How does it solve it?
- Upgrades `@tetherto/qvac-test-suite` to `0.4.0` which supports profiling hooks
- Adds profiling config to desktop and mobile consumers with `init()` and `exportData()` callbacks
- Fixes a bug in RAG profiler metrics where processed was recording an array instead of its length

## How was it tested?
- Ran full desktop test suite
- Confirmed profiling data exports successfully
- Checked HTML report includes profiler metrics section
<img width="711" height="901" alt="image" src="https://github.com/user-attachments/assets/ab902a77-435f-4098-af9f-39ca3aae43fe" />
