### PR TITLE
QVAC-14296 test[skiplog]: enable vision tests and add vision executor…

### DIFF
--- a/packages/sdk/tests-qvac/tests/desktop/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/desktop/consumer.ts
@@ -27,6 +27,8 @@ import {
   PARAKEET_CTC_DATA_FP32,
   PARAKEET_CTC_TOKENIZER,
   PARAKEET_SORTFORMER_FP32,
+  SMOLVLM2_500M_MULTIMODAL_Q8_0,
+  MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
 } from "@qvac/sdk";
 import * as path from "node:path";
 import { ResourceManager } from "../shared/resource-manager.js";
@@ -50,6 +52,7 @@ import { ModelInfoExecutor } from "../shared/executors/model-info-executor.js";
 import { ErrorExecutor } from "../shared/executors/error-executor.js";
 import { TtsExecutor } from "../shared/executors/tts-executor.js";
 import { ParakeetExecutor } from "./executors/parakeet-executor.js";
+import { VisionExecutor } from "./executors/vision-executor.js";
 
 const resources = new ResourceManager();
 
@@ -202,6 +205,16 @@ resources.define("parakeet-sortformer", {
   },
 });
 
+resources.define("vision", {
+  constant: SMOLVLM2_500M_MULTIMODAL_Q8_0,
+  type: "llm",
+  skipPreDownload: true,
+  config: {
+    ctx_size: 1024,
+    projectionModelSrc: MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
+  },
+});
+
 export const executor = createExecutor({
   handlers: [
     new ModelLoadingExecutor(resources),
@@ -225,5 +238,6 @@ export const executor = createExecutor({
     new HttpEmbeddingExecutor(resources),
     new KvCacheExecutor(resources),
     new ParakeetExecutor(resources),
+    new VisionExecutor(resources),
   ],
 });

--- a/packages/sdk/tests-qvac/tests/desktop/executors/vision-executor.ts
+++ b/packages/sdk/tests-qvac/tests/desktop/executors/vision-executor.ts
@@ -1,0 +1,70 @@
+import { completion } from "@qvac/sdk";
+import * as path from "node:path";
+import {
+  ValidationHelpers,
+  type TestResult,
+  type Expectation,
+} from "@tetherto/qvac-test-suite";
+import { AbstractModelExecutor } from "../../shared/executors/abstract-model-executor.js";
+import { visionTests } from "../../vision-tests.js";
+
+export class VisionExecutor extends AbstractModelExecutor<typeof visionTests> {
+  pattern = /^vision-/;
+
+  protected handlers = Object.fromEntries(
+    visionTests.map((test) => [test.testId, this.generic.bind(this)]),
+  ) as never;
+
+  private resolveAttachments(
+    history: Array<{ role: string; content: string; attachments?: Array<{ path: string }> }>,
+  ) {
+    return history.map((msg) => {
+      if (!msg.attachments?.length) return msg;
+      return {
+        ...msg,
+        attachments: msg.attachments.map((att) => {
+          const fileName = att.path.split("/").pop()!;
+          return { path: path.resolve(process.cwd(), "assets/images", fileName) };
+        }),
+      };
+    });
+  }
+
+  async generic(params: unknown, expectation: unknown): Promise<TestResult> {
+    const p = params as {
+      history: Array<{ role: string; content: string; attachments?: Array<{ path: string }> }>;
+      stream?: boolean;
+    };
+
+    const visionModelId = await this.resources.ensureLoaded("vision");
+    const history = this.resolveAttachments(p.history);
+
+    try {
+      const result = completion({
+        modelId: visionModelId,
+        history,
+        stream: p.stream ?? false,
+      });
+
+      let text: string;
+      if (p.stream) {
+        text = "";
+        for await (const token of result.tokenStream) {
+          text += token;
+        }
+      } else {
+        text = await result.text;
+      }
+
+      return ValidationHelpers.validate(text, expectation as Expectation);
+    } catch (error) {
+      const exp = expectation as Expectation;
+      if (exp.validation === "throws-error") {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        return ValidationHelpers.validate(errorMsg, exp);
+      }
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      return { passed: false, output: `Vision failed: ${errorMsg}` };
+    }
+  }
+}

--- a/packages/sdk/tests-qvac/tests/mobile/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/mobile/consumer.ts
@@ -12,11 +12,14 @@ import {
   PARAKEET_CTC_DATA_FP32,
   PARAKEET_CTC_TOKENIZER,
   PARAKEET_SORTFORMER_FP32,
+  SMOLVLM2_500M_MULTIMODAL_Q8_0,
+  MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
 } from "@qvac/sdk";
 import { ResourceManager } from "../shared/resource-manager.js";
 import { ModelLoadingExecutor } from "../shared/executors/model-loading-executor.js";
 import { MobileTranscriptionExecutor } from "./executors/transcription-executor.js";
 import { MobileParakeetExecutor } from "./executors/parakeet-executor.js";
+import { MobileVisionExecutor } from "./executors/vision-executor.js";
 
 const resources = new ResourceManager();
 
@@ -93,10 +96,21 @@ resources.define("parakeet-sortformer", {
   },
 });
 
+resources.define("vision", {
+  constant: SMOLVLM2_500M_MULTIMODAL_Q8_0,
+  type: "llm",
+  skipPreDownload: true,
+  config: {
+    ctx_size: 1024,
+    projectionModelSrc: MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
+  },
+});
+
 export const executor = createExecutor({
   handlers: [
     new ModelLoadingExecutor(resources),
     new MobileTranscriptionExecutor(resources),
     new MobileParakeetExecutor(resources),
+    new MobileVisionExecutor(resources),
   ],
 });

--- a/packages/sdk/tests-qvac/tests/mobile/executors/vision-executor.ts
+++ b/packages/sdk/tests-qvac/tests/mobile/executors/vision-executor.ts
@@ -1,0 +1,115 @@
+import { completion } from "@qvac/sdk";
+import {
+  AssetExecutor,
+  ValidationHelpers,
+  type TestResult,
+  type Expectation,
+} from "@tetherto/qvac-test-suite/mobile";
+import type { ResourceManager } from "../../shared/resource-manager.js";
+import { visionTests } from "../../vision-tests.js";
+
+export class MobileVisionExecutor extends AssetExecutor<typeof visionTests> {
+  pattern = /^vision-/;
+
+  protected handlers = Object.fromEntries(
+    visionTests.map((test) => [test.testId, this.generic.bind(this)]),
+  ) as never;
+  protected defaultHandler = undefined;
+
+  private imageAssets: Record<string, number> | null = null;
+
+  constructor(private resources: ResourceManager) {
+    super();
+  }
+
+  async setup(testId: string, context: unknown) {
+    const ctx = (context ?? {}) as Record<string, unknown>;
+    await this.resources.downloadAllOnce(console.log);
+    const dep = ctx.dependency as string | undefined;
+    if (dep && dep !== "none") {
+      await this.resources.evictAll();
+      await this.resources.ensureLoaded(dep);
+    }
+  }
+
+  async teardown() {
+    await this.resources.evictAll();
+  }
+
+  private async loadImageAssets() {
+    if (!this.imageAssets) {
+      // @ts-ignore - assets.ts is generated at consumer build time
+      const assets = await import("../../../../assets");
+      this.imageAssets = assets.images;
+    }
+    return this.imageAssets!;
+  }
+
+  private async resolveAttachments(
+    history: Array<{ role: string; content: string; attachments?: Array<{ path: string }> }>,
+  ) {
+    const images = await this.loadImageAssets();
+    const resolved = [];
+
+    for (const msg of history) {
+      if (!msg.attachments?.length) {
+        resolved.push(msg);
+        continue;
+      }
+
+      const resolvedAttachments = [];
+      for (const att of msg.attachments) {
+        const fileName = att.path.split("/").pop()!;
+        const assetModule = images[fileName];
+        if (!assetModule) {
+          throw new Error(`Image file not found in assets: ${fileName}`);
+        }
+        const imageUri = await this.resolveAsset(assetModule);
+        resolvedAttachments.push({ path: imageUri });
+      }
+
+      resolved.push({ ...msg, attachments: resolvedAttachments });
+    }
+
+    return resolved;
+  }
+
+  async generic(params: unknown, expectation: unknown): Promise<TestResult> {
+    const p = params as {
+      history: Array<{ role: string; content: string; attachments?: Array<{ path: string }> }>;
+      stream?: boolean;
+    };
+
+    const visionModelId = await this.resources.ensureLoaded("vision");
+
+    try {
+      const history = await this.resolveAttachments(p.history);
+
+      const result = completion({
+        modelId: visionModelId,
+        history,
+        stream: p.stream ?? false,
+      });
+
+      let text: string;
+      if (p.stream) {
+        text = "";
+        for await (const token of result.tokenStream) {
+          text += token;
+        }
+      } else {
+        text = await result.text;
+      }
+
+      return ValidationHelpers.validate(text, expectation as Expectation);
+    } catch (error) {
+      const exp = expectation as Expectation;
+      if (exp.validation === "throws-error") {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        return ValidationHelpers.validate(errorMsg, exp);
+      }
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      return { passed: false, output: `Vision failed: ${errorMsg}` };
+    }
+  }
+}

--- a/packages/sdk/tests-qvac/tests/test-definitions.ts
+++ b/packages/sdk/tests-qvac/tests/test-definitions.ts
@@ -19,6 +19,7 @@ import { bergamotTests } from "./bergamot-tests.js";
 import { shardedModelTests } from "./sharded-model-tests.js";
 import { httpEmbeddingTests } from "./http-embedding-tests.js";
 import { parakeetTests } from "./parakeet-tests.js";
+import { visionTests } from "./vision-tests.js";
 
 // Model loading tests
 export const modelLoadLlm: TestDefinition = {
@@ -196,6 +197,9 @@ export const tests = [
 
   // Parakeet transcription tests
   ...parakeetTests,
+
+  // Vision tests
+  ...visionTests,
 
   // Additional model tests
   modelSwitchLlm,

--- a/packages/sdk/tests-qvac/tests/vision-tests.ts
+++ b/packages/sdk/tests-qvac/tests/vision-tests.ts
@@ -1,12 +1,4 @@
-// Vision test definitions (DISABLED - SDK bug)
 import type { TestDefinition } from "@tetherto/qvac-test-suite";
-
-const visionSkipReason = {
-  reason:
-    'Vision model randomly crashes with "process: context overflow". Crash kills SDK, causing 87+ tests to timeout (66 min wasted).',
-  issue: "P0 bug reported to SDK team",
-  impact: "Critical - crashes entire test suite",
-};
 
 const createVisionTest = (
   testId: string,
@@ -35,7 +27,6 @@ const createVisionTest = (
     dependency: "vision",
     estimatedDurationMs: 20000,
   },
-  skip: visionSkipReason,
 });
 
 export const visionSimpleImage = createVisionTest(
@@ -144,7 +135,6 @@ const remainingVisionTests: TestDefinition[] = [
     dependency: "vision",
     estimatedDurationMs: 20000,
   },
-  skip: visionSkipReason,
 }));
 
 export const visionTests = [


### PR DESCRIPTION
…s for desktop and mobile

## What problem does this PR solve?

Vision test suite (15 tests) was fully disabled due to a P0 SDK bug (context overflow crash).
The bug has been resolved, but the tests and executors were never re-enabled.

## How does it solve it?

- Remove `visionSkipReason` and all skip assignments from `vision-tests.ts`
- Import and register `visionTests` in `test-definitions.ts`
- Add `VisionExecutor` (desktop) and `MobileVisionExecutor` (mobile) using `completion()` API with image attachments
- Define `vision` resource (SmolVLM2 500M Q8 + mmproj) in both desktop and mobile consumers
- Register vision executors in consumer handler arrays

Total test count: 284 → 299 (15 vision + 3 skipped)

## How was it tested?

- Verified `npm run build` compiles all new executor files without errors
- Confirmed `dist/` contains `vision-executor.js` for both desktop and mobile
- Confirmed producer loads 299 tests and filters 15 vision tests correctly
- iOS consumer integration pending full device run after build propagation
- iOS run vision tests: 15/15 passed
[vision-iOS.html](https://github.com/user-attachments/files/26084766/vision-iOS.html)
- Desktop Run vesion tests: 15/15 passed
[vision-desktop.html](https://github.com/user-attachments/files/26084779/vision-desktop.html)
- all Desktop test run on macOS
[all-desktop.html](https://github.com/user-attachments/files/26084792/all-desktop.html)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213728285524126