### PR TITLE
feat: add RuntimeStats TypeScript interface to embed addon

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.12.1] - 2026-03-18
+
+### Added
+
+#### `RuntimeStats` TypeScript interface
+
+Added a `RuntimeStats` type to `index.d.ts` covering all stats keys returned by the C++ addon: `total_tokens`, `total_time_ms`, `tokens_per_second`, `batch_size`, and `context_size`.
+
 ## [0.12.0] - 2026-03-13
 
 ### Changed

--- a/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### `RuntimeStats` TypeScript interface
 
-Added a `RuntimeStats` type to `index.d.ts` covering all stats keys returned by the C++ addon: `total_tokens`, `total_time_ms`, `tokens_per_second`, `batch_size`, and `context_size`.
+Added a `RuntimeStats` type to `index.d.ts` covering all stats keys returned by the C++ addon: `total_tokens`, `total_time_ms`, `tokens_per_second` (optional — only present when processing time > 0), `batch_size`, and `context_size`.
 
 ## [0.12.0] - 2026-03-13
 

--- a/packages/qvac-lib-infer-llamacpp-embed/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-embed/index.d.ts
@@ -70,7 +70,7 @@ export interface AddonConfigurationParams {
 export interface RuntimeStats {
   total_tokens: number
   total_time_ms: number
-  tokens_per_second: number
+  tokens_per_second?: number
   batch_size: number
   context_size: number
 }

--- a/packages/qvac-lib-infer-llamacpp-embed/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-embed/index.d.ts
@@ -67,6 +67,14 @@ export interface AddonConfigurationParams {
   backendsDir?: string
 }
 
+export interface RuntimeStats {
+  total_tokens: number
+  total_time_ms: number
+  tokens_per_second: number
+  batch_size: number
+  context_size: number
+}
+
 export default class GGMLBert extends BaseInference {
   protected addon: Addon
   

--- a/packages/qvac-lib-infer-llamacpp-embed/package.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## What problem does this PR solve?

- The embed addon's C++ `BertModel::runtimeStats()` returns structured stats but there was no TypeScript type for consumers to reference.
- Mirrors the `RuntimeStats` type added to the LLM addon in PR #937.

## How does it solve it?

- Adds a `RuntimeStats` interface to `index.d.ts` with all 5 keys returned by the C++ addon: `total_tokens`, `total_time_ms`, `tokens_per_second`, `batch_size`, `context_size`.
- Bumps version to 0.12.1 with changelog entry.

## API Changes

```typescript
import { RuntimeStats } from '@qvac/embed-llamacpp'

// Stats object shape returned by the C++ addon
const stats: RuntimeStats = {
  total_tokens: 128,
  total_time_ms: 45.2,
  tokens_per_second: 2831.9,
  batch_size: 512,
  context_size: 8192
}
```