### PR TITLE
chore[notask]: release @qvac/cli v0.2.0

### DIFF
--- a/packages/cli/NOTICE
+++ b/packages/cli/NOTICE
@@ -12,11 +12,11 @@ JavaScript Dependencies
 
 --- apache-2.0 (Apache License 2.0) ---
 
-  b4a@1.7.5
+  b4a@1.8.0
     https://github.com/holepunchto/b4a
   bare-addon-resolve@1.10.0
     https://github.com/holepunchto/bare-addon-resolve
-  bare-buffer@3.4.4
+  bare-buffer@3.5.0
     https://github.com/holepunchto/bare-buffer
   bare-bundle@1.10.0
     https://github.com/holepunchto/bare-bundle
@@ -24,7 +24,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-bundle-id
   bare-events@2.8.2
     https://github.com/holepunchto/bare-events
-  bare-fs@4.5.4
+  bare-fs@4.5.5
     https://github.com/holepunchto/bare-fs
   bare-module-lexer@1.4.7
     https://github.com/holepunchto/bare-module-lexer
@@ -32,7 +32,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-module-resolve
   bare-module-traverse@2.0.1
     https://github.com/holepunchto/bare-module-traverse
-  bare-os@3.6.2
+  bare-os@3.7.1
     https://github.com/holepunchto/bare-os
   bare-pack@2.0.0
     https://github.com/holepunchto/bare-pack
@@ -40,7 +40,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-path
   bare-semver@1.0.2
     https://github.com/holepunchto/bare-semver
-  bare-stream@2.7.0
+  bare-stream@2.8.0
     https://github.com/holepunchto/bare-stream
   bare-url@2.3.2
     https://github.com/holepunchto/bare-url
@@ -77,6 +77,8 @@ JavaScript Dependencies
     https://github.com/holepunchto/sodium-native
   streamx@2.23.0
     https://github.com/mafintosh/streamx
+  teex@1.0.1
+    https://github.com/mafintosh/teex
   tsx@4.21.0
     https://github.com/privatenumber/tsx
 

--- a/packages/cli/changelog/0.2.0/CHANGELOG.md
+++ b/packages/cli/changelog/0.2.0/CHANGELOG.md
@@ -1,14 +1,12 @@
-# Changelog
-
-## [0.2.0]
+# Changelog v0.2.0
 
 Release Date: 2026-03-18
 
 ## 🔌 API
 
-- Add OpenAI-compatible REST API server (qvac serve) - Part I. (see PR [#753](https://github.com/tetherto/qvac/pull/753)) - See [API changes](./changelog/0.2.0/api.md)
+- Add OpenAI-compatible REST API server (qvac serve) - Part I. (see PR [#753](https://github.com/tetherto/qvac/pull/753)) - See [API changes](./api.md)
 - Bump LLM/embed addons and wire per-request generation params. (see PR [#895](https://github.com/tetherto/qvac/pull/895))
-- Add POST /v1/audio/transcriptions to qvac serve OpenAI adapter. (see PR [#915](https://github.com/tetherto/qvac/pull/915)) - See [API changes](./changelog/0.2.0/api.md)
+- Add POST /v1/audio/transcriptions to qvac serve OpenAI adapter. (see PR [#915](https://github.com/tetherto/qvac/pull/915)) - See [API changes](./api.md)
 
 ## 🐞 Fixes
 
@@ -19,3 +17,4 @@ Release Date: 2026-03-18
 
 - Rename qvac-cli package to cli. (see PR [#644](https://github.com/tetherto/qvac/pull/644))
 - Migrate CLI package from JavaScript to TypeScript. (see PR [#722](https://github.com/tetherto/qvac/pull/722))
+

--- a/packages/cli/changelog/0.2.0/api.md
+++ b/packages/cli/changelog/0.2.0/api.md
@@ -1,0 +1,201 @@
+# 🔌 API Changes v0.2.0
+
+## Add OpenAI-compatible REST API server (qvac serve) - Part I
+
+PR: [#753](https://github.com/tetherto/qvac/pull/753)
+
+```
+src/serve/
+├── index.ts                  # HTTP server, middleware, adapter dispatch
+├── config.ts                 # Config parsing, model constant resolution
+├── http.ts                   # HTTP/SSE helpers
+├── core/
+│   ├── sdk.ts                # SDK wrapper (dynamic import + version check)
+│   ├── model-registry.ts     # In-memory model state tracking
+│   └── lifecycle.ts          # Model preload/load/unload/shutdown
+└── adapters/
+    ├── types.ts              # APIAdapter interface
+    └── openai/
+        ├── index.ts          # OpenAI adapter entry
+        ├── translate.ts      # Message/tool format translation
+        └── routes/
+            ├── models.ts
+            ├── chat.ts
+            └── embeddings.ts
+```
+
+```
+@qvac/sdk 0.6.0 is too old for this version of @qvac/cli.
+Minimum required: 0.7.0. Run: npm install @qvac/sdk@latest
+```
+
+```json
+{
+  "serve": {
+    "models": {
+      "llm": { "model": "QWEN3_600M_INST_Q4", "config": { "ctx_size": 8192 } },
+      "embed": "EMBEDDINGGEMMA_300M_Q4_0"
+    }
+  }
+}
+```
+
+```
+qvac serve openai [options]
+  -c, --config <path>    Config file path
+  -p, --port <number>    Port (default: 11434)
+  -H, --host <address>   Host (default: 127.0.0.1)
+  --model <alias>        Model to preload (repeatable)
+  --api-key <key>        Require Bearer token auth
+  --cors                 Enable CORS headers
+  -v, --verbose          Detailed output
+```
+
+---
+
+## Add POST /v1/audio/transcriptions to qvac serve OpenAI adapter
+
+PR: [#915](https://github.com/tetherto/qvac/pull/915)
+
+```bash
+# JSON response (default)
+curl -s http://127.0.0.1:11434/v1/audio/transcriptions \
+  -F "file=@audio.wav" \
+  -F "model=whisper-large-v3-turbo" \
+  -F "response_format=json" | jq .
+# → {"text": "transcribed text here"}
+
+# Plain text response
+curl -s http://127.0.0.1:11434/v1/audio/transcriptions \
+  -F "file=@audio.wav" \
+  -F "model=whisper-small-en" \
+  -F "response_format=text"
+# → transcribed text here
+```
+
+```json
+{
+  "serve": {
+    "models": {
+      "qwen3-0.6b": {
+        "model": "QWEN3_600M_INST_Q4",
+        "default": true,
+        "preload": false,
+        "config": { "tools": true }
+      },
+      "gte-large": {
+        "model": "GTE_LARGE_FP16",
+        "default": true,
+        "preload": false
+      },
+      "whisper": {
+        "model": "WHISPER_TINY",
+        "default": true,
+        "preload": true,
+        "config": {
+          "audio_format": "f32le",
+          "language": "en",
+          "strategy": "greedy",
+          "n_threads": 4,
+          "suppress_blank": true,
+          "contextParams": { "use_gpu": true }
+        }
+      }
+    }
+  }
+}
+
+```
+
+```bash
+#!/usr/bin/env bash
+# Test transcription endpoint against a running qvac serve instance
+# Usage: ./test-transcription.sh [audio-file]
+#
+# Setup:
+#   bun run download-sample   # downloads samples/jfk.wav
+#   bun run serve              # start server in another terminal
+
+set -euo pipefail
+
+BASE="http://127.0.0.1:11434"
+AUDIO="${1:-samples/jfk.wav}"
+
+if [ ! -f "$AUDIO" ]; then
+  echo "Audio file not found: $AUDIO"
+  echo "Run: bun run download-sample"
+  exit 1
+fi
+
+echo "=== Using audio: $AUDIO ($(du -h "$AUDIO" | cut -f1) ) ==="
+echo ""
+
+# ── 1. JSON response (default) ──────────────────────────────
+echo "── 1. Transcribe → JSON response ──"
+curl -s "$BASE/v1/audio/transcriptions" \
+  -F "file=@$AUDIO" \
+  -F "model=whisper" | jq .
+echo ""
+
+# ── 2. Text response ────────────────────────────────────────
+echo "── 2. Transcribe → text response ──"
+curl -s "$BASE/v1/audio/transcriptions" \
+  -F "file=@$AUDIO" \
+  -F "model=whisper" \
+  -F "response_format=text"
+echo ""
+echo ""
+
+# ── 3. With prompt ───────────────────────────────────────────
+echo "── 3. Transcribe → with prompt ──"
+curl -s "$BASE/v1/audio/transcriptions" \
+  -F "file=@$AUDIO" \
+  -F "model=whisper" \
+  -F "prompt=President Kennedy speech about space exploration" | jq .
+echo ""
+
+# ── 4. Explicit json response_format ────────────────────────
+echo "── 4. Transcribe → explicit response_format=json ──"
+curl -s "$BASE/v1/audio/transcriptions" \
+  -F "file=@$AUDIO" \
+  -F "model=whisper" \
+  -F "response_format=json" | jq .
+echo ""
+
+# ── Error cases ──────────────────────────────────────────────
+
+echo "── 5. Error: missing file ──"
+curl -s "$BASE/v1/audio/transcriptions" \
+  -F "model=whisper" | jq .
+echo ""
+
+echo "── 6. Error: missing model ──"
+curl -s "$BASE/v1/audio/transcriptions" \
+  -F "file=@$AUDIO" | jq .
+echo ""
+
+echo "── 7. Error: unsupported response_format (srt) ──"
+curl -s "$BASE/v1/audio/transcriptions" \
+  -F "file=@$AUDIO" \
+  -F "model=whisper" \
+  -F "response_format=srt" | jq .
+echo ""
+
+echo "── 8. Error: unknown model ──"
+curl -s "$BASE/v1/audio/transcriptions" \
+  -F "file=@$AUDIO" \
+  -F "model=nonexistent" | jq .
+echo ""
+
+echo "── 9. Error: wrong content-type (JSON instead of multipart) ──"
+curl -s "$BASE/v1/audio/transcriptions" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"whisper-large-v3-turbo"}' | jq .
+echo ""
+
+echo "=== Done ==="
+
+```
+
+---
+

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What problem does this PR solve?

Release `@qvac/cli` v0.2.0 — first feature release of the OpenAI-compatible serve command.

## How does it solve it?

- Bump version from `0.1.3` to `0.2.0`
- Add changelog and NOTICE for v0.2.0

## Changes since v0.1.2

### API
- Add OpenAI-compatible REST API server (`qvac serve openai`) (#753)
- Wire per-request generation params (`temperature`, `max_tokens`, etc.) through SDK (#895)
- Add `POST /v1/audio/transcriptions` endpoint (#915)

### Fixes
- Resolve Windows EFTYPE error when spawning bare-pack (#949)
- Normalize composite JSON Schema types in tool parameter validation (#964)

### Chores
- Rename `qvac-cli` package to `cli` (#644)
- Migrate CLI from JavaScript to TypeScript (#722)
