### PR TITLE
release-qvac-lib-infer-llamacpp-embed-0.12.1

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/README.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/README.md
@@ -1,5 +1,6 @@
 # qvac-lib-infer-llamacpp-embed
 
+
 This native C++ addon, built using the `Bare` Runtime, simplifies running text embedding models to enable efficient generation of high-quality contextual text embeddings. It provides an easy interface to load, execute, and manage embedding model instances.
 
 ## Table of Contents


### PR DESCRIPTION
## Summary
- Release branch for `qvac-lib-infer-llamacpp-embed` v0.12.1

