### PR TITLE
ci[notask]: enable linux-x64 C++ tests with coverage for diffusion addon

### DIFF
--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -33,6 +33,9 @@ jobs:
           - os: macos-14
             platform: darwin
             arch: arm64
+          - os: ubuntu-24.04
+            platform: linux
+            arch: x64
           - os: windows-11
             platform: windows
             runner: ai-run-windows11-gpu


### PR DESCRIPTION
## What problem does this PR solve?

- The cpp-tests-diffusion workflow has linux-specific steps (LLVM 19, Vulkan SDK, coverage build/report/upload) already gated on `matrix.os == 'ubuntu-24.04'`, but no linux-x64 matrix entry to activate them
- Without linux-x64 in the matrix, C++ coverage reports are never generated for the diffusion addon

## How does it solve it?

- Add `ubuntu-24.04` / `linux` / `x64` to the cpp-tests-diffusion matrix
- All conditional steps are already in place and will now execute for this platform

## How was it tested?

- [ ] Workflow dispatch on this branch to verify linux-x64 cpp tests run and coverage is generated