### PR TITLE
release(qvac-registry-schema): v0.1.2

### DIFF
--- a/packages/qvac-lib-registry-server/shared/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/shared/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.2]
+
+Release Date: 2026-03-19
+
+### 🐛 Bug Fixes
+
+- Add `QVAC_S3_BUCKET` to `ENV_KEYS` — previously missing, causing `getS3Bucket()` in downstream consumers to silently return `null`
+
+### 📦 Packaging
+
+- Include LICENSE and NOTICE files in published package
+
 ## [0.1.1]
 
 Release Date: 2026-02-13

--- a/packages/qvac-lib-registry-server/shared/package.json
+++ b/packages/qvac-lib-registry-server/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-schema",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "HyperDB schema and database wrapper for QVAC Registry",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
## What problem does this PR solve?

`ENV_KEYS.QVAC_S3_BUCKET` was missing from the published `@qvac/registry-schema` package, causing `config.getS3Bucket()` to silently return `null` even when the env var was correctly set. This broke S3-sourced model uploads on all registry servers.

## How does it solve it?

- Adds `QVAC_S3_BUCKET` to `ENV_KEYS` in `constants.js` (already on `main` since #413)
- Bumps version to `0.1.2`
- Includes LICENSE and NOTICE files in the published package

## Breaking changes

None.