### PR TITLE
fix[notask]: add prepare script to cli package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "directory": "packages/cli"
   },
   "scripts": {
+    "prepare": "npm run build",
     "build": "rm -rf dist && tsc",
     "build:watch": "tsc --watch",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/cli` publishes empty dist because the TypeScript build isn't triggered before `npm publish`
- The `prepare` lifecycle hook was missed when the package was converted to TypeScript

## 📝 How does it solve it?

- Adds `"prepare": "npm run build"` script so the TypeScript compilation runs automatically before publish
