### PR TITLE
chore[notask|skiplog]: release qvac-cli v0.2.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.1.3",
+  "version": "0.2.1",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/cli` package published on npm has empty dist due to missing `prepare` script
- Republish with version bump to `0.2.1` now that the prepare fix is in main

## 📝 How does it solve it?

- Bumps `@qvac/cli` version from `0.1.3` → `0.2.1` to trigger a new publish cycle with the correct build output
- Base includes the prepare script fix (#1005)
