### PR TITLE
fix[notask]: add release PR title exception to validator

### DIFF
--- a/scripts/sdk/validator.cjs
+++ b/scripts/sdk/validator.cjs
@@ -51,6 +51,10 @@ const VALIDATION_EXCEPTIONS = [
     name: "Squash commits",
     test: (message) => message.startsWith("squash!"),
   },
+  {
+    name: "Release PRs",
+    test: (message) => /^release\(.+\):\s+v?\d+\.\d+\.\d+/.test(message),
+  },
 ];
 
 /**
@@ -248,6 +252,10 @@ function validatePR(title, body) {
   const trimmedTitle = title.trim();
   if (!trimmedTitle) {
     return { valid: false, error: "PR title cannot be empty" };
+  }
+
+  if (shouldSkipValidation(trimmedTitle)) {
+    return { valid: true };
   }
 
   // Try matching with ticket first


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- PR validation rejects release PR titles like `release(qvac-cli): v0.2.1`
- The `validatePR` function had no exception handling, unlike `validateCommit` which already uses `shouldSkipValidation`

## 📝 How does it solve it?

- Adds a "Release PRs" entry to `VALIDATION_EXCEPTIONS` matching the `release(<package>): v<version>` pattern
- Wires `shouldSkipValidation` into `validatePR` so the same exception mechanism works for both commits and PRs
