### PR TITLE
fix[notask]: use prepublishOnly instead of prepare in cli package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
     "directory": "packages/cli"
   },
   "scripts": {
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "build": "rm -rf dist && tsc",
     "build:watch": "tsc --watch",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `prepare` runs during `npm install` in CI, before devDependencies (`@types/node`, `typescript`) are available
- `tsc` fails with `Cannot find type definition file for 'node'`
- Since `build` does `rm -rf dist && tsc`, a failed `tsc` leaves `dist/` deleted, breaking the `bin` entry

## 📝 How does it solve it?

- Replaces `prepare` with `prepublishOnly`, which only runs before `npm publish` / `npm pack` — not during `npm install`

Made with [Cursor](https://cursor.com)