### PR TITLE
fix[notask]: add explicit build step to CLI publish workflow

### DIFF
--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -1,6 +1,4 @@
 name: General CI/CD (cli)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 permissions:
   contents: write
@@ -29,6 +27,9 @@ on:
         required: false
         type: string
 
+env:
+  WORKDIR: packages/cli
+
 jobs:
   release-merge-guard:
     name: Release Merge Guard
@@ -51,6 +52,32 @@ jobs:
           package-slug: cli
           package-json-path: packages/cli/package.json
           changelog-path: packages/cli/CHANGELOG.md
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ${{ env.WORKDIR }}
+
+      - name: Build
+        run: npm run build
+        working-directory: ${{ env.WORKDIR }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: cli-dist
+          path: ${{ env.WORKDIR }}/dist/
+          retention-days: 1
 
   publish-logic:
     runs-on: ubuntu-latest
@@ -101,7 +128,7 @@ jobs:
           echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
 
   publish-main-gpr-dev:
-    needs: publish-logic
+    needs: [build, publish-logic]
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -111,6 +138,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: cli-dist
+          path: ${{ env.WORKDIR }}/dist/
 
       - name: Rewrite SDK scope for GPR
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
@@ -126,22 +159,38 @@ jobs:
           name-suffix: "-mono"
 
   publish-release-npm:
-    needs: [publish-logic]
+    needs: [build, publish-logic, release-merge-guard]
+    if: needs.publish-logic.outputs.publish_release == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:
       contents: write
       packages: write
       id-token: write
-    if: needs.publish-logic.outputs.publish_release == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@monorepo_update
-    secrets: inherit
-    with:
-      workdir: packages/cli
-      repo_name: "cli"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-  # Create GitHub release only for actual releases (after NPM publish)
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: cli-dist
+          path: ${{ env.WORKDIR }}/dist/
+
+      - name: Publish to NPM
+        id: publish
+        uses: ./.github/actions/publish-library-to-npm
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+          repo_name: cli
+          workdir: ${{ env.WORKDIR }}
+
   publish-release:
     needs: [publish-release-npm]
-    if:  needs.publish-release-npm.result == 'success' && needs.publish-release-npm.outputs.published_version != ''
+    if: needs.publish-release-npm.result == 'success' && needs.publish-release-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
@@ -154,7 +203,7 @@ jobs:
       workdir: "packages/cli"
 
   publish-feature-gpr:
-    needs: publish-logic
+    needs: [build, publish-logic]
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -164,6 +213,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: cli-dist
+          path: ${{ env.WORKDIR }}/dist/
 
       - name: Rewrite SDK scope for GPR
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
@@ -179,7 +234,7 @@ jobs:
           name-suffix: "-mono"
 
   publish-tmp-gpr:
-    needs: publish-logic
+    needs: [build, publish-logic]
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -189,6 +244,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: cli-dist
+          path: ${{ env.WORKDIR }}/dist/
 
       - name: Rewrite SDK scope for GPR
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 22
 
       - name: Install dependencies
         run: npm install

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,6 @@
     "directory": "packages/cli"
   },
   "scripts": {
-    "prepare": "npm run build",
     "build": "rm -rf dist && tsc",
     "build:watch": "tsc --watch",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- CLI publish workflow calls `npm publish` without installing dependencies or building
- The `prepare` lifecycle hook triggers `tsc` which fails because `@types/node` and `typescript` (devDependencies) are not installed in CI
- This results in `Cannot find type definition file for 'node'` and an empty/broken published package

## 📝 How does it solve it?

Follows the same pattern as the SDK publish workflow (`publish-sdk.yml`):

- Adds a dedicated `build` job that installs dependencies, runs `tsc`, and uploads `dist/` as a GitHub Actions artifact
- Each publish job (`publish-main-gpr-dev`, `publish-release-npm`, `publish-feature-gpr`, `publish-tmp-gpr`) now depends on `build` and downloads the pre-built `dist/` artifact before publishing
- Replaces the reusable workflow call (`public-reusable-npm.yml`) with a regular job using the local `publish-library-to-npm` action (same as SDK) so we can inject the artifact download step
- Removes the `prepare` lifecycle hook from `package.json` since CI now handles the build explicitly

This supersedes #1008 which can be closed.
