### PR TITLE
chore[notask|skiplog]: trigger CLI release 0.2.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.1.3",
+  "version": "0.2.2",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- release was broken - workflow didn't have npm install

## 📝 How does it solve it?

- workflow was fixed in main
