### PR TITLE
QVAC-14327 fix: add missing `nodemon` package to `devDependencies`

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -151,6 +151,7 @@
     "globals": "^16.3.0",
     "husky": "^9.1.7",
     "hyperdb": "^4.16.1",
+    "nodemon": "^3.1.14",
     "pear-pipe": "^1.0.6",
     "prettier": "^3.6.2",
     "react-native-bare-kit": "^0.11.5",


### PR DESCRIPTION
## Summary

Add missing `nodemon` package to `devDependencies`, which is used by the `watch` script.

## Files changed

| File                        | Change                                               |
| -----------------------------| ------------------------------------------------------|
| `packages/sdk/package.json` | Modified - Upgraded `@qvac/llm-llamacpp` to `0.12.0` |
