### PR TITLE
docs: add trailing newline to llm package README

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/README.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/README.md
@@ -425,3 +425,4 @@ These tests validate the native implementation and help catch issues early in de
 This project is licensed under the Apache-2.0 [License](./LICENSE) – see the LICENSE file for details.
 
 _For questions or issues, please open an issue on the GitHub repository._
+


### PR DESCRIPTION
## Summary
- Adds a trailing newline to the `qvac-lib-infer-llamacpp-llm` README.md for consistent file formatting.

## Test plan
- [x] Verify the README renders correctly on GitHub.


Made with [Cursor](https://cursor.com)