### PR TITLE
chore[notask]: backmerge release @qvac/cli v0.2.2

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,4 +1,28 @@
-# Changelog 
+# Changelog
+
+## [0.2.2]
+
+Release Date: 2026-03-19
+
+## 🔌 API
+
+- Add OpenAI-compatible REST API server (qvac serve) - Part I. (see PR [#753](https://github.com/tetherto/qvac/pull/753)) - See [API changes](./changelog/0.2.2/api.md)
+- Bump LLM/embed addons and wire per-request generation params. (see PR [#895](https://github.com/tetherto/qvac/pull/895))
+- Add POST /v1/audio/transcriptions to qvac serve OpenAI adapter. (see PR [#915](https://github.com/tetherto/qvac/pull/915)) - See [API changes](./changelog/0.2.2/api.md)
+
+## 🐞 Fixes
+
+- Resolve Windows EFTYPE error when spawning bare-pack. (see PR [#949](https://github.com/tetherto/qvac/pull/949))
+- Normalize composite JSON Schema types in tool parameter validation. (see PR [#964](https://github.com/tetherto/qvac/pull/964))
+
+## 🧹 Chores
+
+- Rename qvac-cli package to cli. (see PR [#644](https://github.com/tetherto/qvac/pull/644))
+- Migrate CLI package from JavaScript to TypeScript. (see PR [#722](https://github.com/tetherto/qvac/pull/722))
+
+## ⚙️ Infrastructure
+
+- Add explicit build step to CLI publish workflow. (see PR [#1010](https://github.com/tetherto/qvac/pull/1010))
 
 ## [0.1.3]
 
@@ -37,4 +61,3 @@ Release Date: 2026-02-11
 ### ⚙️ Infrastructure
 
 - Add GPR scope rewrite action and rename CLI to @qvac/cli. (see PR [#230](https://github.com/tetherto/qvac/pull/230))
-

--- a/packages/cli/changelog/0.2.2/CHANGELOG.md
+++ b/packages/cli/changelog/0.2.2/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog v0.2.2
+
+Release Date: 2026-03-19
+
+## 🔌 API
+
+- Add OpenAI-compatible REST API server (qvac serve) - Part I. (see PR [#753](https://github.com/tetherto/qvac/pull/753)) - See [API changes](./api.md)
+- Bump LLM/embed addons and wire per-request generation params. (see PR [#895](https://github.com/tetherto/qvac/pull/895))
+- Add POST /v1/audio/transcriptions to qvac serve OpenAI adapter. (see PR [#915](https://github.com/tetherto/qvac/pull/915)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Resolve Windows EFTYPE error when spawning bare-pack. (see PR [#949](https://github.com/tetherto/qvac/pull/949))
+- Normalize composite JSON Schema types in tool parameter validation. (see PR [#964](https://github.com/tetherto/qvac/pull/964))
+
+## 🧹 Chores
+
+- Rename qvac-cli package to cli. (see PR [#644](https://github.com/tetherto/qvac/pull/644))
+- Migrate CLI package from JavaScript to TypeScript. (see PR [#722](https://github.com/tetherto/qvac/pull/722))
+
+## ⚙️ Infrastructure
+
+- Add explicit build step to CLI publish workflow. (see PR [#1010](https://github.com/tetherto/qvac/pull/1010))

--- a/packages/cli/changelog/0.2.2/api.md
+++ b/packages/cli/changelog/0.2.2/api.md
@@ -1,0 +1,107 @@
+# 🔌 API Changes v0.2.2
+
+## Add OpenAI-compatible REST API server (qvac serve) - Part I
+
+PR: [#753](https://github.com/tetherto/qvac/pull/753)
+
+```
+src/serve/
+├── index.ts                  # HTTP server, middleware, adapter dispatch
+├── config.ts                 # Config parsing, model constant resolution
+├── http.ts                   # HTTP/SSE helpers
+├── core/
+│   ├── sdk.ts                # SDK wrapper (dynamic import + version check)
+│   ├── model-registry.ts     # In-memory model state tracking
+│   └── lifecycle.ts          # Model preload/load/unload/shutdown
+└── adapters/
+    ├── types.ts              # APIAdapter interface
+    └── openai/
+        ├── index.ts          # OpenAI adapter entry
+        ├── translate.ts      # Message/tool format translation
+        └── routes/
+            ├── models.ts
+            ├── chat.ts
+            └── embeddings.ts
+```
+
+```
+@qvac/sdk 0.6.0 is too old for this version of @qvac/cli.
+Minimum required: 0.7.0. Run: npm install @qvac/sdk@latest
+```
+
+```json
+{
+  "serve": {
+    "models": {
+      "llm": { "model": "QWEN3_600M_INST_Q4", "config": { "ctx_size": 8192 } },
+      "embed": "EMBEDDINGGEMMA_300M_Q4_0"
+    }
+  }
+}
+```
+
+```
+qvac serve openai [options]
+  -c, --config <path>    Config file path
+  -p, --port <number>    Port (default: 11434)
+  -H, --host <address>   Host (default: 127.0.0.1)
+  --model <alias>        Model to preload (repeatable)
+  --api-key <key>        Require Bearer token auth
+  --cors                 Enable CORS headers
+  -v, --verbose          Detailed output
+```
+
+---
+
+## Add POST /v1/audio/transcriptions to qvac serve OpenAI adapter
+
+PR: [#915](https://github.com/tetherto/qvac/pull/915)
+
+```bash
+# JSON response (default)
+curl -s http://127.0.0.1:11434/v1/audio/transcriptions \
+  -F "file=@audio.wav" \
+  -F "model=whisper-large-v3-turbo" \
+  -F "response_format=json" | jq .
+# → {"text": "transcribed text here"}
+
+# Plain text response
+curl -s http://127.0.0.1:11434/v1/audio/transcriptions \
+  -F "file=@audio.wav" \
+  -F "model=whisper-small-en" \
+  -F "response_format=text"
+# → transcribed text here
+```
+
+```json
+{
+  "serve": {
+    "models": {
+      "qwen3-0.6b": {
+        "model": "QWEN3_600M_INST_Q4",
+        "default": true,
+        "preload": false,
+        "config": { "tools": true }
+      },
+      "gte-large": {
+        "model": "GTE_LARGE_FP16",
+        "default": true,
+        "preload": false
+      },
+      "whisper": {
+        "model": "WHISPER_TINY",
+        "default": true,
+        "preload": true,
+        "config": {
+          "audio_format": "f32le",
+          "language": "en",
+          "strategy": "greedy",
+          "n_threads": 4,
+          "suppress_blank": true,
+          "contextParams": { "use_gpu": true }
+        }
+      }
+    }
+  }
+}
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.1.3",
+  "version": "0.2.2",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Merges the `release-cli-0.2.2` branch back into `main` after GPR publish, triggering npm publish.

## 📝 How does it solve it?

- Backmerge of release branch containing CLI v0.2.2 release changes.
