### PR TITLE
Fix/cicd security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/approval-worker.yml
+++ b/.github/workflows/approval-worker.yml
@@ -6,7 +6,10 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
-    
+
+permissions:
+  contents: read
+
 jobs:
   run-when-command:
     runs-on: ubuntu-latest

--- a/.github/workflows/approval-worker.yml
+++ b/.github/workflows/approval-worker.yml
@@ -47,7 +47,7 @@ jobs:
       pull-requests: write
       statuses: write
       issues: write
-    uses: tetherto/qvac-devops/.github/workflows/approval-check-worker.yml@monorepo_update
+    uses: tetherto/qvac-devops/.github/workflows/approval-check-worker.yml@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
     secrets: inherit
     with:
       pr_number: ${{ fromJSON(needs.run-when-command.outputs.number) }}

--- a/.github/workflows/benchmark-ocr-onnx.yml
+++ b/.github/workflows/benchmark-ocr-onnx.yml
@@ -234,7 +234,7 @@ jobs:
           sudo apt-get install -y mesa-vulkan-drivers
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -355,7 +355,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: needs.setup.outputs.qvac_needed == 'true'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/create-github-release-lib-infer-diffusion.yml
+++ b/.github/workflows/create-github-release-lib-infer-diffusion.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           tag_name: diffusion-cpp-v${{ steps.version.outputs.current }}
           name: ${{ inputs.release_name }} v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-ocr-onnx.yml
+++ b/.github/workflows/create-github-release-ocr-onnx.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           tag_name: ocr-onnx-v${{ steps.version.outputs.current }}
           name: QVAC OCR Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-nmtcpp.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           tag_name: v${{ steps.version.outputs.current }}
           name: QVAC NMT Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-onnx-tts.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           tag_name: v${{ steps.version.outputs.current }}
           name: QVAC TTS ONNX Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-onnx.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           tag_name: qvac-lib-infer-onnx-v${{ steps.version.outputs.current }}
           name: QVAC ONNX Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-parakeet.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           tag_name: v${{ steps.version.outputs.current }}
           name: QVAC Transcription Parakeet Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-whispercpp.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           tag_name: v${{ steps.version.outputs.current }}
           name: QVAC Transcription Whisper Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -75,7 +75,7 @@ jobs:
           echo "release_notes_path=${release_notes_path}" >> "${GITHUB_OUTPUT}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2
         with:
           tag_name: ${{ inputs.repo_name }}-v${{ inputs.published_version }}
           name: ${{ inputs.release_name }} v${{ inputs.published_version }}

--- a/.github/workflows/docs-deploy-notify.yml
+++ b/.github/workflows/docs-deploy-notify.yml
@@ -17,6 +17,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     if: false # DISABLED — see comment at top of file

--- a/.github/workflows/docs-generate-api.yml
+++ b/.github/workflows/docs-generate-api.yml
@@ -105,7 +105,7 @@ jobs:
             "${{ env.DOCS_DIR }}/src/lib/versions.ts"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "doc[notask]: generate API docs for v${{ steps.version.outputs.version }}"

--- a/.github/workflows/docs-generate-api.yml
+++ b/.github/workflows/docs-generate-api.yml
@@ -16,6 +16,9 @@ on:
   repository_dispatch:
     types: [generate-api-docs]
 
+permissions:
+  contents: read
+
 env:
   SDK_SUBPATH: "packages/sdk"
   DOCS_DIR: "docs/website"

--- a/.github/workflows/docs-post-merge-sync.yml
+++ b/.github/workflows/docs-post-merge-sync.yml
@@ -11,6 +11,9 @@ on:
       - 'packages/sdk/**'
       - 'docs/website/scripts/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: docs-post-merge-sync-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/integration-mobile-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-mobile-test-lib-infer-diffusion.yml
@@ -731,7 +731,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -319,7 +319,7 @@ jobs:
       # Model provisioning for mobile: presigned URLs so the app can download detector + all
       # recognizers at runtime (same set as desktop integration tests).
       - name: Configure AWS credentials for model download
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -790,7 +790,7 @@ jobs:
       # Kept as-is from your workflow (only paths above needed monorepo porting)
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
@@ -643,7 +643,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -699,7 +699,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -731,7 +731,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -360,7 +360,7 @@ jobs:
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -780,7 +780,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -722,7 +722,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -734,7 +734,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -163,7 +163,7 @@ jobs:
           sudo apt-get install -y mesa-vulkan-drivers
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/on-merge-lib-infer-diffusion.yml
+++ b/.github/workflows/on-merge-lib-infer-diffusion.yml
@@ -29,6 +29,9 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-merge-lib-infer-diffusion.yml
+++ b/.github/workflows/on-merge-lib-infer-diffusion.yml
@@ -85,7 +85,6 @@ jobs:
 
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -81,7 +81,6 @@ jobs:
 
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -25,6 +25,9 @@ on:
           - temp
           - latest
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -21,6 +21,9 @@ on:
           - latest
           - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -176,7 +176,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -84,7 +84,6 @@ jobs:
 
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
@@ -77,7 +77,6 @@ jobs:
 
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
@@ -21,7 +21,10 @@ on:
         options:
           - latest
           - dev
-          
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
@@ -29,6 +29,9 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
@@ -85,7 +85,6 @@ jobs:
 
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -24,6 +24,9 @@ on:
           - temp
           - latest
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -87,7 +87,6 @@ jobs:
 
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
@@ -78,7 +78,6 @@ jobs:
 
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
@@ -22,6 +22,9 @@ on:
           - latest
           - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
@@ -25,6 +25,9 @@ on:
           - temp
           - latest
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -78,7 +78,6 @@ jobs:
 
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -22,6 +22,9 @@ on:
           - latest
           - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -78,7 +78,6 @@ jobs:
 
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -22,6 +22,9 @@ on:
           - latest
           - dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -19,6 +19,10 @@ on:
 
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -20,16 +20,77 @@ on:
   workflow_call:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
 
 env:
   PKG_DIR: packages/lib-infer-diffusion
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   sanity-checks:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
@@ -42,8 +103,8 @@ jobs:
           workdir: packages/lib-infer-diffusion
 
   cpp-tests:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: sanity-checks
+    needs: [sanity-checks, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/cpp-tests-diffusion.yml
     secrets: inherit
     with:
@@ -52,7 +113,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   cpp-lint:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
     secrets: inherit
     with:
@@ -61,7 +123,8 @@ jobs:
       workdir: packages/lib-infer-diffusion
 
   ts-checks:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -90,8 +153,8 @@ jobs:
         run: npm run test:dts
 
   prebuild:
-    needs: sanity-checks
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: [sanity-checks, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     permissions:
       contents: write
       packages: write
@@ -105,8 +168,8 @@ jobs:
       tag: pr-${{ github.event.pull_request.number }}
 
   run-integration-tests:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: prebuild
+    needs: [prebuild, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-test-lib-infer-diffusion.yml
     secrets: inherit
     with:
@@ -114,8 +177,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   run-mobile-integration-tests:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: prebuild
+    needs: [prebuild, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-mobile-test-lib-infer-diffusion.yml
     secrets: inherit
     with:
@@ -132,8 +195,9 @@ jobs:
         cpp-tests,
         cpp-lint,
         ts-checks,
+        authorize,
       ]
-    if: always()
+    if: always() && needs.authorize.outputs.allowed == 'true'
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -19,11 +19,71 @@ on:
   workflow_call:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   # Gate the workflow so label events (and other PR_target quirks) don't trigger unrelated packages.
   changes:
     runs-on: ubuntu-latest
@@ -45,11 +105,12 @@ jobs:
               - ".github/workflows/*ocr*.yml"
 
   sanity-checks:
-    needs: changes
+    needs: [changes, authorize]
     if: |
-      (needs.changes.outputs.pkg == 'true' &&
+      needs.authorize.outputs.allowed == 'true' &&
+      ((needs.changes.outputs.pkg == 'true' &&
        contains(format(' {0} ', join(github.event.pull_request.labels.*.name, ' ')), ' verify ')) ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -140,8 +201,8 @@ jobs:
           fi
 
   cpp-lint:
-    needs: changes
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: [changes, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
     secrets: inherit
     with:
@@ -150,13 +211,17 @@ jobs:
       workdir: packages/ocr-onnx
 
   prebuild:
-    needs: [changes]
+    needs: [changes, authorize]
     if: |
+      needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch') &&
       (
         github.event_name == 'workflow_dispatch' ||
         contains(format(' {0} ', join(github.event.pull_request.labels.*.name, ' ')), ' verify ')
       )
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/prebuilds-ocr-onnx.yml
     secrets: inherit
     with:
@@ -165,8 +230,9 @@ jobs:
       publish_target: "gpr"
 
   run-integration-tests:
-    needs: [changes, prebuild]
+    needs: [changes, prebuild, authorize]
     if: |
+      needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch') &&
       (
         github.event_name == 'workflow_dispatch' ||
@@ -179,8 +245,9 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
   run-mobile-integration-tests:
-    needs: [changes, prebuild]
+    needs: [changes, prebuild, authorize]
     if: |
+      needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch') &&
       (
         github.event_name == 'workflow_dispatch' ||
@@ -193,8 +260,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
   merge-guard:
-    needs: [changes, sanity-checks, prebuild, run-integration-tests, run-mobile-integration-tests]
-    if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
+    needs: [changes, sanity-checks, prebuild, run-integration-tests, run-mobile-integration-tests, authorize]
+    if: always() && needs.authorize.outputs.allowed == 'true' && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -18,6 +18,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
@@ -51,13 +51,74 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
-  checks: write
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   context:
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true'
     name: Resolve Context
     runs-on: ubuntu-latest
     outputs:
@@ -120,7 +181,8 @@ jobs:
           echo "  workdir=$workdir"
 
   release-notes-check:
-    needs: context
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true'
     permissions:
       contents: read
       pull-requests: read
@@ -132,7 +194,8 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   sanity-checks:
-    needs: context
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
@@ -145,8 +208,8 @@ jobs:
           workdir: ${{ needs.context.outputs.workdir }}
 
   run-integration-tests:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true' && (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-test-qvac-lib-decoder-audio.yml
     secrets: inherit
     with:
@@ -155,8 +218,8 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   run-mobile-integration-tests:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true' && (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
     secrets: inherit
     with:
@@ -165,8 +228,8 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   merge-guard:
-    needs: [release-notes-check, sanity-checks, run-integration-tests, run-mobile-integration-tests]
-    if: always()
+    needs: [authorize, release-notes-check, sanity-checks, run-integration-tests, run-mobile-integration-tests]
+    if: always() && needs.authorize.outputs.allowed == 'true'
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.release-notes-check.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
@@ -70,23 +70,38 @@ jobs:
     steps:
       - id: ctx
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HAS_VERIFY: ${{ contains(github.event.pull_request.labels.*.name, 'verify') }}
+          INPUT_WORKDIR: ${{ inputs.workdir }}
+          INPUT_REPO: ${{ inputs.repository }}
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_VERIFY: ${{ inputs.run_verify }}
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          DEFAULT_WORKDIR="packages/qvac-lib-decoder-audio"
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "workflow_call" ]]; then
-            workdir="${{ inputs.workdir || 'packages/qvac-lib-decoder-audio' }}"
-            repo="${{ inputs.repository || github.repository }}"
-            ref="${{ inputs.ref || github.ref_name }}"
-            run_verify="${{ inputs.run_verify }}"
-            base_sha="${{ github.sha }}"
-            head_sha="${{ github.sha }}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "workflow_call" ]]; then
+            workdir="${INPUT_WORKDIR:-$DEFAULT_WORKDIR}"
+            repo="${INPUT_REPO:-$REPO}"
+            ref="${INPUT_REF:-$REF_NAME}"
+            run_verify="$INPUT_VERIFY"
+            base_sha="$SHA"
+            head_sha="$SHA"
           else
-            workdir="packages/qvac-lib-decoder-audio"
-            repo="${{ github.event.pull_request.head.repo.full_name }}"
-            ref="${{ github.event.pull_request.head.ref }}"
-            run_verify="${{ contains(github.event.pull_request.labels.*.name, 'verify') }}"
-            base_sha="${{ github.event.pull_request.base.sha }}"
-            head_sha="${{ github.event.pull_request.head.sha }}"
+            workdir="$DEFAULT_WORKDIR"
+            repo="$HEAD_REPO"
+            ref="$HEAD_REF"
+            run_verify="$HAS_VERIFY"
+            base_sha="$BASE_SHA"
+            head_sha="$HEAD_SHA"
           fi
 
           echo "repository=$repo" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -18,17 +18,78 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
 
 concurrency:
   group: pr-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   sanity-checks:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
@@ -41,7 +102,8 @@ jobs:
           workdir: packages/qvac-lib-infer-llamacpp-embed
 
   cpp-lint:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
     secrets: inherit
     with:
@@ -50,8 +112,8 @@ jobs:
       workdir: packages/qvac-lib-infer-llamacpp-embed
 
   cpp-tests:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: sanity-checks
+    needs: [sanity-checks, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/cpp-tests-embed.yml
     secrets: inherit
     with:
@@ -59,7 +121,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   ts-checks:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -88,8 +151,11 @@ jobs:
         run: npm run test:dts
 
   prebuild:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: sanity-checks
+    needs: [sanity-checks, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
     secrets: inherit
     with:
@@ -99,8 +165,8 @@ jobs:
       publish_target: 'gpr'
 
   integration-tests:
-    needs: prebuild
-    if:  contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: [prebuild, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
     secrets: inherit
     with:
@@ -108,8 +174,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   run-mobile-integration-tests:
-    if:  contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: prebuild
+    needs: [prebuild, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
     secrets: inherit
     with:
@@ -117,8 +183,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   merge-guard:
-    needs: [sanity-checks, cpp-lint, cpp-tests, prebuild, integration-tests, run-mobile-integration-tests, ts-checks]
-    if: always()
+    needs: [sanity-checks, cpp-lint, cpp-tests, prebuild, integration-tests, run-mobile-integration-tests, ts-checks, authorize]
+    if: always() && needs.authorize.outputs.allowed == 'true'
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -19,6 +19,10 @@ on:
   
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -20,16 +20,77 @@ on:
   workflow_call:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
 
 env:
   PKG_DIR: packages/qvac-lib-infer-llamacpp-llm
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   sanity-checks:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true' && (contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
@@ -42,8 +103,8 @@ jobs:
           workdir: packages/qvac-lib-infer-llamacpp-llm
 
   cpp-tests:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: sanity-checks
+    if: needs.authorize.outputs.allowed == 'true' && (contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
+    needs: [authorize, sanity-checks]
     uses: ./.github/workflows/cpp-tests-llm.yml
     secrets: inherit
     with:
@@ -52,7 +113,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   cpp-lint:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    if: needs.authorize.outputs.allowed == 'true' && (contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
+    needs: authorize
     uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
     secrets: inherit
     with:
@@ -61,7 +123,8 @@ jobs:
       workdir: packages/qvac-lib-infer-llamacpp-llm
 
   ts-checks:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    if: needs.authorize.outputs.allowed == 'true' && (contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
+    needs: authorize
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -90,8 +153,8 @@ jobs:
         run: npm run test:dts
 
   prebuild:
-    needs: sanity-checks
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: [authorize, sanity-checks]
+    if: needs.authorize.outputs.allowed == 'true' && (contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     permissions:
       contents: write
       packages: write
@@ -105,8 +168,8 @@ jobs:
       tag: pr-${{ github.event.pull_request.number }}
 
   run-integration-tests:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: prebuild
+    if: needs.authorize.outputs.allowed == 'true' && (contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
+    needs: [authorize, prebuild]
     uses: ./.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
     secrets: inherit
     with:
@@ -114,8 +177,8 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   run-mobile-integration-tests:
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: prebuild
+    if: needs.authorize.outputs.allowed == 'true' && (contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
+    needs: [authorize, prebuild]
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
     secrets: inherit
     with:
@@ -125,6 +188,7 @@ jobs:
   merge-guard:
     needs:
       [
+        authorize,
         run-integration-tests,
         run-mobile-integration-tests,
         sanity-checks,
@@ -133,7 +197,7 @@ jobs:
         cpp-lint,
         ts-checks,
       ]
-    if: always()
+    if: always() && needs.authorize.outputs.allowed == 'true'
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -22,14 +22,74 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
 
 env:
   PKG_DIR: packages/qvac-lib-infer-nmtcpp
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   changes:
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -46,8 +106,8 @@ jobs:
               - ".github/workflows/*nmtcpp*.yml"
 
   sanity-checks:
-    needs: changes
-    if: always() && ((needs.changes.outputs.pkg == 'true' && contains(github.event.pull_request.labels.*.name, 'verify')) || github.event_name == 'workflow_dispatch')
+    needs: [changes, authorize]
+    if: always() && needs.authorize.outputs.allowed == 'true' && ((needs.changes.outputs.pkg == 'true' && contains(github.event.pull_request.labels.*.name, 'verify')) || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
@@ -60,8 +120,8 @@ jobs:
           workdir: packages/qvac-lib-infer-nmtcpp
 
   ts-checks:
-    needs: [changes, sanity-checks]
-    if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
+    needs: [changes, sanity-checks, authorize]
+    if: always() && needs.authorize.outputs.allowed == 'true' && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -93,9 +153,9 @@ jobs:
         run: npm run test:dts
 
   cpp-lint:
-    needs: [changes, sanity-checks]
+    needs: [changes, sanity-checks, authorize]
     if: |
-      always() &&
+      always() && needs.authorize.outputs.allowed == 'true' &&
       ((needs.changes.outputs.pkg == 'true' &&
         contains(github.event.pull_request.labels.*.name, 'verify')) ||
        github.event_name == 'workflow_dispatch')
@@ -107,9 +167,9 @@ jobs:
       workdir: packages/qvac-lib-infer-nmtcpp
 
   cpp-tests:
-    needs: [changes, sanity-checks]
+    needs: [changes, sanity-checks, authorize]
     if: |
-      always() &&
+      always() && needs.authorize.outputs.allowed == 'true' &&
       ((needs.changes.outputs.pkg == 'true' &&
         contains(github.event.pull_request.labels.*.name, 'verify')) ||
        github.event_name == 'workflow_dispatch')
@@ -120,14 +180,17 @@ jobs:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
 
   prebuild:
-    needs: [changes, sanity-checks]
+    needs: [changes, sanity-checks, authorize]
     if: |
-      always() &&
+      always() && needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch') &&
       (
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'verify')
       )
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
     secrets: inherit
     with:
@@ -137,9 +200,9 @@ jobs:
       publish_target: "gpr"
 
   run-integration-tests:
-    needs: [changes, sanity-checks, prebuild]
+    needs: [changes, sanity-checks, prebuild, authorize]
     if: |
-      always() &&
+      always() && needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch') &&
       (
         github.event_name == 'workflow_dispatch' ||
@@ -152,9 +215,9 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   run-mobile-integration-tests:
-    needs: [changes, sanity-checks, prebuild]
+    needs: [changes, sanity-checks, prebuild, authorize]
     if: |
-      always() &&
+      always() && needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch') &&
       (
         github.event_name == 'workflow_dispatch' ||
@@ -177,8 +240,9 @@ jobs:
         prebuild,
         run-integration-tests,
         run-mobile-integration-tests,
+        authorize,
       ]
-    if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
+    if: always() && needs.authorize.outputs.allowed == 'true' && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.cpp-tests.result == 'success' && needs.ts-checks.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
@@ -51,13 +51,74 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
-  checks: write
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   context:
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true'
     name: Resolve Context
     runs-on: ubuntu-latest
     outputs:
@@ -107,7 +168,8 @@ jobs:
           echo "  workdir=$workdir"
 
   release-notes-check:
-    needs: context
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true'
     permissions:
       contents: read
       pull-requests: read
@@ -119,7 +181,8 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   sanity-checks:
-    needs: context
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
@@ -132,8 +195,8 @@ jobs:
           workdir: ${{ needs.context.outputs.workdir }}
 
   cpp-lint:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true' && (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
     secrets: inherit
     with:
@@ -142,8 +205,8 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   cpp-tests-coverage:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true' && (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
     secrets: inherit
     with:
@@ -152,8 +215,11 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   prebuild:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true' && (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
     secrets: inherit
     with:
@@ -163,8 +229,8 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   run-integration-tests:
-    needs: [context, prebuild]
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context, prebuild]
+    if: needs.authorize.outputs.allowed == 'true' && (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
     secrets: inherit
     with:
@@ -173,8 +239,8 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   run-mobile-integration-tests:
-    needs: [context, prebuild]
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context, prebuild]
+    if: needs.authorize.outputs.allowed == 'true' && (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
     secrets: inherit
     with:
@@ -185,6 +251,7 @@ jobs:
   merge-guard:
     needs:
       [
+        authorize,
         release-notes-check,
         sanity-checks,
         cpp-lint,
@@ -193,7 +260,7 @@ jobs:
         run-integration-tests,
         run-mobile-integration-tests,
       ]
-    if: always()
+    if: always() && needs.authorize.outputs.allowed == 'true'
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.release-notes-check.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -19,11 +19,71 @@ on:
   workflow_call:
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   # Gate the workflow so label events (and other PR_target quirks) don't trigger unrelated packages.
   changes:
     runs-on: ubuntu-latest
@@ -45,11 +105,12 @@ jobs:
               - ".github/workflows/*qvac-lib-infer-onnx*.yml"
 
   sanity-checks:
-    needs: changes
+    needs: [changes, authorize]
     if: |
-      (needs.changes.outputs.pkg == 'true' &&
+      needs.authorize.outputs.allowed == 'true' &&
+      ((needs.changes.outputs.pkg == 'true' &&
        contains(format(' {0} ', join(github.event.pull_request.labels.*.name, ' ')), ' verify ')) ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -140,8 +201,8 @@ jobs:
           fi
 
   cpp-lint:
-    needs: changes
-    if: contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: [changes, authorize]
+    if: needs.authorize.outputs.allowed == 'true' && (contains( github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
     secrets: inherit
     with:
@@ -150,13 +211,17 @@ jobs:
       workdir: packages/qvac-lib-infer-onnx
 
   prebuild:
-    needs: [sanity-checks, cpp-lint]
+    needs: [sanity-checks, cpp-lint, authorize]
     if: |
+      needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true') &&
       (
         github.event_name == 'workflow_dispatch' ||
         contains(format(' {0} ', join(github.event.pull_request.labels.*.name, ' ')), ' verify ')
       )
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
     secrets: inherit
     with:
@@ -165,8 +230,8 @@ jobs:
       publish_target: "gpr"
 
   merge-guard:
-    needs: [changes, sanity-checks, prebuild]
-    if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
+    needs: [changes, sanity-checks, prebuild, authorize]
+    if: always() && needs.authorize.outputs.allowed == 'true' && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -18,6 +18,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -70,23 +70,38 @@ jobs:
     steps:
       - id: ctx
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HAS_VERIFY: ${{ contains(github.event.pull_request.labels.*.name, 'verify') }}
+          INPUT_WORKDIR: ${{ inputs.workdir }}
+          INPUT_REPO: ${{ inputs.repository }}
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_VERIFY: ${{ inputs.run_verify }}
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          DEFAULT_WORKDIR="packages/qvac-lib-infer-parakeet"
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "workflow_call" ]]; then
-            workdir="${{ inputs.workdir || 'packages/qvac-lib-infer-parakeet' }}"
-            repo="${{ inputs.repository || github.repository }}"
-            ref="${{ inputs.ref || github.ref_name }}"
-            run_verify="${{ inputs.run_verify }}"
-            base_sha="${{ github.sha }}"
-            head_sha="${{ github.sha }}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "workflow_call" ]]; then
+            workdir="${INPUT_WORKDIR:-$DEFAULT_WORKDIR}"
+            repo="${INPUT_REPO:-$REPO}"
+            ref="${INPUT_REF:-$REF_NAME}"
+            run_verify="$INPUT_VERIFY"
+            base_sha="$SHA"
+            head_sha="$SHA"
           else
-            workdir="packages/qvac-lib-infer-parakeet"
-            repo="${{ github.event.pull_request.head.repo.full_name }}"
-            ref="${{ github.event.pull_request.head.ref }}"
-            run_verify="${{ contains(github.event.pull_request.labels.*.name, 'verify') }}"
-            base_sha="${{ github.event.pull_request.base.sha }}"
-            head_sha="${{ github.event.pull_request.head.sha }}"
+            workdir="$DEFAULT_WORKDIR"
+            repo="$HEAD_REPO"
+            ref="$HEAD_REF"
+            run_verify="$HAS_VERIFY"
+            base_sha="$BASE_SHA"
+            head_sha="$HEAD_SHA"
           fi
 
           echo "repository=$repo" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -51,13 +51,74 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
-  checks: write
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   context:
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true'
     name: Resolve Context
     runs-on: ubuntu-latest
     outputs:
@@ -120,7 +181,8 @@ jobs:
           echo "  workdir=$workdir"
 
   sanity-checks:
-    needs: context
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
@@ -133,7 +195,8 @@ jobs:
           workdir: ${{ needs.context.outputs.workdir }}
 
   release-notes-check:
-    needs: context
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true'
     uses: ./.github/workflows/release-notes-check-qvac-lib-infer-parakeet.yml
     secrets: inherit
     with:
@@ -142,8 +205,10 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   cpp-lint:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
     secrets: inherit
     with:
@@ -152,8 +217,10 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   cpp-tests-coverage:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
     secrets: inherit
     with:
@@ -161,8 +228,13 @@ jobs:
       ref: ${{ needs.context.outputs.ref }}
 
   prebuild:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
     secrets: inherit
     with:
@@ -172,8 +244,10 @@ jobs:
       publish_target: 'gpr'
 
   run-integration-tests:
-    needs: [context, prebuild]
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context, prebuild]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
     secrets: inherit
     with:
@@ -182,8 +256,10 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   run-mobile-integration-tests:
-    needs: [context, prebuild]
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context, prebuild]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
     secrets: inherit
     with:
@@ -191,8 +267,8 @@ jobs:
       ref: ${{ needs.context.outputs.ref }}
 
   merge-guard:
-    needs: [sanity-checks, release-notes-check, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
-    if: always()
+    needs: [authorize, sanity-checks, release-notes-check, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
+    if: always() && needs.authorize.outputs.allowed == 'true'
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.release-notes-check.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -51,13 +51,74 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
-  packages: write
-  checks: write
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   context:
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true'
     name: Resolve Context
     runs-on: ubuntu-latest
     outputs:
@@ -120,8 +181,10 @@ jobs:
           echo "  workdir=$workdir"
 
   sanity-checks:
-    if: contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
-    needs: context
+    needs: [authorize, context]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - name: Run Sanity checks
@@ -134,7 +197,8 @@ jobs:
           workdir: ${{ needs.context.outputs.workdir }}
 
   release-notes-check:
-    needs: context
+    needs: [authorize, context]
+    if: needs.authorize.outputs.allowed == 'true'
     uses: ./.github/workflows/release-notes-check-qvac-lib-infer-whispercpp.yml
     secrets: inherit
     with:
@@ -143,8 +207,10 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   cpp-lint:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@monorepo_update
     secrets: inherit
     with:
@@ -153,8 +219,10 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   cpp-tests-coverage:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
     secrets: inherit
     with:
@@ -162,8 +230,13 @@ jobs:
       ref: ${{ needs.context.outputs.ref }}
 
   prebuild:
-    needs: context
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
+    permissions:
+      contents: write
+      packages: write
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
     secrets: inherit
     with:
@@ -173,8 +246,10 @@ jobs:
       publish_target: 'gpr'
 
   run-integration-tests:
-    needs: [context, prebuild]
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context, prebuild]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
     secrets: inherit
     with:
@@ -183,8 +258,10 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   run-mobile-integration-tests:
-    needs: [context, prebuild]
-    if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
+    needs: [authorize, context, prebuild]
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
     secrets: inherit
     with:
@@ -192,8 +269,8 @@ jobs:
       ref: ${{ needs.context.outputs.ref }}
 
   merge-guard:
-    needs: [sanity-checks, release-notes-check, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
-    if: always()
+    needs: [authorize, sanity-checks, release-notes-check, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
+    if: always() && needs.authorize.outputs.allowed == 'true'
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@monorepo_update
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.release-notes-check.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -70,23 +70,38 @@ jobs:
     steps:
       - id: ctx
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HAS_VERIFY: ${{ contains(github.event.pull_request.labels.*.name, 'verify') }}
+          INPUT_WORKDIR: ${{ inputs.workdir }}
+          INPUT_REPO: ${{ inputs.repository }}
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_VERIFY: ${{ inputs.run_verify }}
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          DEFAULT_WORKDIR="packages/qvac-lib-infer-whispercpp"
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "workflow_call" ]]; then
-            workdir="${{ inputs.workdir || 'packages/qvac-lib-infer-whispercpp' }}"
-            repo="${{ inputs.repository || github.repository }}"
-            ref="${{ inputs.ref || github.ref_name }}"
-            run_verify="${{ inputs.run_verify }}"
-            base_sha="${{ github.sha }}"
-            head_sha="${{ github.sha }}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$EVENT_NAME" == "workflow_call" ]]; then
+            workdir="${INPUT_WORKDIR:-$DEFAULT_WORKDIR}"
+            repo="${INPUT_REPO:-$REPO}"
+            ref="${INPUT_REF:-$REF_NAME}"
+            run_verify="$INPUT_VERIFY"
+            base_sha="$SHA"
+            head_sha="$SHA"
           else
-            workdir="packages/qvac-lib-infer-whispercpp"
-            repo="${{ github.event.pull_request.head.repo.full_name }}"
-            ref="${{ github.event.pull_request.head.ref }}"
-            run_verify="${{ contains(github.event.pull_request.labels.*.name, 'verify') }}"
-            base_sha="${{ github.event.pull_request.base.sha }}"
-            head_sha="${{ github.event.pull_request.head.sha }}"
+            workdir="$DEFAULT_WORKDIR"
+            repo="$HEAD_REPO"
+            ref="$HEAD_REF"
+            run_verify="$HAS_VERIFY"
+            base_sha="$BASE_SHA"
+            head_sha="$HEAD_SHA"
           fi
 
           echo "repository=$repo" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-models-validation-qvac-lib-registry-server.yml
+++ b/.github/workflows/pr-models-validation-qvac-lib-registry-server.yml
@@ -17,6 +17,10 @@ on:
       - "packages/qvac-lib-registry-server/**"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   PKG_DIR: packages/qvac-lib-registry-server
   MODELS_FILE: packages/qvac-lib-registry-server/data/models.prod.json

--- a/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
@@ -2,6 +2,7 @@ name: Test pipeline for PRs (Inference-addon-cpp)
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request_target:
@@ -16,8 +17,70 @@ env:
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/packages/qvac-lib-inference-addon-cpp/vcpkg/cache,readwrite"
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   run-unit-tests:
-    if: contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch'
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true' && (contains(github.event.pull_request.labels.*.name, 'verify') || github.event_name == 'workflow_dispatch')
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +122,7 @@ jobs:
         uses: tetherto/qvac-devops/.github/actions/yamlfmt@monorepo_update
         with:
           workdir: ${{ env.PKG_DIR }}
-        
+
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
@@ -11,6 +11,10 @@ on:
       - "packages/qvac-lib-inference-addon-cpp/**"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   PKG_DIR: packages/qvac-lib-inference-addon-cpp
   VCPKG_CACHE_DIR: ${{ github.workspace }}/packages/qvac-lib-inference-addon-cpp/vcpkg/cache

--- a/.github/workflows/pr-validation-sdk-pod.yml
+++ b/.github/workflows/pr-validation-sdk-pod.yml
@@ -19,6 +19,9 @@ on:
       - feature-*
       - tmp-*
 
+permissions:
+  contents: read
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation-sdk-pod.yml
+++ b/.github/workflows/pr-validation-sdk-pod.yml
@@ -19,6 +19,10 @@ on:
       - feature-*
       - tmp-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/prebuilds-lib-infer-diffusion.yml
+++ b/.github/workflows/prebuilds-lib-infer-diffusion.yml
@@ -486,7 +486,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
@@ -541,7 +541,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: 'latest'

--- a/.github/workflows/prebuilds-ocr-onnx.yml
+++ b/.github/workflows/prebuilds-ocr-onnx.yml
@@ -537,7 +537,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
@@ -570,7 +570,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -465,7 +465,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
@@ -507,7 +507,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -499,7 +499,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
@@ -555,7 +555,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: 'latest'

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -788,7 +788,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
@@ -816,7 +816,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
@@ -572,7 +572,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
@@ -603,7 +603,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
@@ -517,7 +517,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
@@ -550,7 +550,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
@@ -439,7 +439,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
@@ -494,7 +494,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: 'latest'

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -498,7 +498,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
@@ -559,7 +559,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -93,7 +93,6 @@ jobs:
 
   release-merge-guard-schema:
     name: Release Merge Guard (Schema)
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-qvac-registry-schema') &&
@@ -115,7 +114,6 @@ jobs:
 
   release-merge-guard-client:
     name: Release Merge Guard (Client)
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-qvac-registry-client') &&

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -283,7 +283,7 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
 
       - name: Publish to GitHub Package Registry
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           workdir: ${{ env.PKG_DIR }}/shared
@@ -321,7 +321,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
@@ -458,7 +458,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
 
       - name: Publish to GitHub Package Registry
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           workdir: ${{ env.PKG_DIR }}/client
@@ -498,7 +498,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -23,12 +23,74 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 env:
   PKG_DIR: packages/qvac-lib-registry-server
   NAME_SUFFIX: "-mono"
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+      has_write: ${{ steps.perm.outputs.has-permission }}
+    steps:
+      - name: Check actor write permission
+        id: perm
+        uses: scherermichael-oss/action-has-permission@17f29510f1bf987b916c8cbb451566a56eed23f1
+        with:
+          required-permission: write
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check authorization
+        id: check
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+        run: |
+          if [ "$EVENT" = "workflow_dispatch" ] || [ "$EVENT" = "workflow_call" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_WRITE" = "1" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$HAS_LABEL" = "true" ]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::External fork PR without safe-to-test label — skipping"
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  strip-label:
+    needs: authorize
+    if: |
+      needs.authorize.outputs.has_write != '1' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove safe-to-test label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X DELETE "repos/${REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
+
   release-merge-guard-schema:
     name: Release Merge Guard (Schema)
     continue-on-error: true
@@ -74,8 +136,11 @@ jobs:
           changelog-path: packages/qvac-lib-registry-server/client/CHANGELOG.md
 
   detect-changes:
+    needs: authorize
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify')
+    if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify'))
     outputs:
       schema_changed: ${{ steps.filter.outputs.schema }}
       client_changed: ${{ steps.filter.outputs.client }}
@@ -137,8 +202,11 @@ jobs:
           fi
 
   publish-logic:
+    needs: authorize
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify')
+    if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify'))
     outputs:
       publish_main: ${{ steps.logic.outputs.publish_main }}
       publish_release: ${{ steps.logic.outputs.publish_release }}
@@ -186,8 +254,9 @@ jobs:
           echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
 
   publish-schema-gpr:
-    needs: [detect-changes, publish-logic]
+    needs: [detect-changes, publish-logic, authorize]
     if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify')) &&
       needs.detect-changes.outputs.schema_changed == 'true' &&
       (needs.publish-logic.outputs.publish_feature == 'true' ||
@@ -222,8 +291,9 @@ jobs:
           name-suffix: ${{ env.NAME_SUFFIX }}
 
   publish-schema-npm:
-    needs: [detect-changes, publish-logic]
+    needs: [detect-changes, publish-logic, authorize]
     if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify')) &&
       needs.detect-changes.outputs.schema_changed == 'true' &&
       needs.publish-logic.outputs.publish_release == 'true'
@@ -261,8 +331,9 @@ jobs:
 
   publish-schema:
     name: Publish Schema (meta)
-    needs: [publish-schema-gpr, publish-schema-npm]
+    needs: [publish-schema-gpr, publish-schema-npm, authorize]
     if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify')) &&
       (needs.publish-schema-gpr.result == 'success' || needs.publish-schema-gpr.result == 'skipped') &&
       (needs.publish-schema-npm.result == 'success' || needs.publish-schema-npm.result == 'skipped')
@@ -271,8 +342,10 @@ jobs:
       - run: echo "Schema publish completed or skipped."
 
   publish-schema-release:
-    needs: [publish-schema-npm]
-    if: needs.publish-schema-npm.result == 'success' && needs.publish-schema-npm.outputs.published_version != ''
+    needs: [publish-schema-npm, authorize]
+    if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      needs.publish-schema-npm.result == 'success' && needs.publish-schema-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
@@ -285,8 +358,9 @@ jobs:
       workdir: "packages/qvac-lib-registry-server/shared"
 
   lint-and-test:
-    needs: detect-changes
+    needs: [detect-changes, authorize]
     if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify')) &&
       needs.detect-changes.outputs.client_changed == 'true'
     permissions:
@@ -353,8 +427,9 @@ jobs:
         run: npm run typecheck
 
   publish-client-gpr:
-    needs: [detect-changes, publish-logic, lint-and-test]
+    needs: [detect-changes, publish-logic, lint-and-test, authorize]
     if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify')) &&
       needs.detect-changes.outputs.client_changed == 'true' &&
       (needs.publish-logic.outputs.publish_feature == 'true' ||
@@ -391,8 +466,9 @@ jobs:
           name-suffix: ${{ env.NAME_SUFFIX }}
 
   publish-client-npm:
-    needs: [detect-changes, publish-logic, lint-and-test]
+    needs: [detect-changes, publish-logic, lint-and-test, authorize]
     if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'verify')) &&
       needs.detect-changes.outputs.client_changed == 'true' &&
       needs.publish-logic.outputs.publish_release == 'true'
@@ -431,8 +507,10 @@ jobs:
           git-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-client-release:
-    needs: [publish-client-npm]
-    if: needs.publish-client-npm.result == 'success' && needs.publish-client-npm.outputs.published_version != ''
+    needs: [publish-client-npm, authorize]
+    if: |
+      (needs.authorize.outputs.allowed == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      needs.publish-client-npm.result == 'success' && needs.publish-client-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -21,6 +21,9 @@ on:
       - "packages/qvac-lib-registry-server/client/**"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -343,7 +343,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || needs.publish-logic.outputs.gpr_tag || 'dev'}}
@@ -372,7 +372,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -31,6 +31,9 @@ on:
         required: false
         default: "dev"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 env:
   WORKDIR: packages/sdk
 

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -41,7 +41,6 @@ permissions:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
@@ -76,7 +76,7 @@ jobs:
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7  # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -62,6 +62,9 @@ on:
       AWS_SECRET_ACCESS_KEY:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ai-run-linux

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -248,7 +248,7 @@ jobs:
           path: ./apk
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -542,7 +542,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -53,6 +53,9 @@ on:
       PAT_TOKEN:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   test-desktop:
     strategy:

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -33,7 +33,6 @@ env:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -149,7 +149,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -224,7 +224,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -255,7 +255,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-error.yml
+++ b/.github/workflows/trigger-reusable-lib-error.yml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-error.yml
+++ b/.github/workflows/trigger-reusable-lib-error.yml
@@ -32,7 +32,6 @@ on:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/trigger-reusable-lib-logging.yml
+++ b/.github/workflows/trigger-reusable-lib-logging.yml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-logging.yml
+++ b/.github/workflows/trigger-reusable-lib-logging.yml
@@ -32,7 +32,6 @@ on:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
@@ -103,7 +103,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -154,7 +154,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -176,7 +176,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
@@ -22,7 +22,6 @@ on:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
@@ -32,7 +32,6 @@ on:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
@@ -32,7 +32,6 @@ on:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -162,7 +162,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -184,7 +184,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
@@ -31,7 +31,6 @@ on:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
@@ -32,7 +32,6 @@ on:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
@@ -151,7 +151,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -187,7 +187,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -209,7 +209,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
@@ -32,7 +32,6 @@ on:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/trigger-reusable-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-rag.yml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@monorepo_update
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@08479e5599445272d410398ff94f8e44991ddcb5  # monorepo_update
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-rag.yml
@@ -32,7 +32,6 @@ on:
 jobs:
   release-merge-guard:
     name: Release Merge Guard
-    continue-on-error: true
     if: >-
       github.event_name == 'push' &&
       startsWith(github.ref_name, 'release-') &&

--- a/.github/workflows/vulkaninfo.yml
+++ b/.github/workflows/vulkaninfo.yml
@@ -1,6 +1,9 @@
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   # build-win11-nvidia-image:
   #   runs-on:  generator-windows11


### PR DESCRIPTION

Commit | Finding | Scope
-- | -- | --
6992df7 | C1 | Expression injection fix -- moved head.ref from inline ${{ }} to env: in 3 context jobs
dd2b237 | C2 + H1 + H3 | Authorization gate + strip-label added to 4 newer-style PR workflows (parakeet, whispercpp, decoder-audio, onnx-tts). Permissions restricted to contents: read
112bdcb | H1 + H3 | Authorization gate added to remaining 8 PR workflows (llamacpp-llm, ocr-onnx, onnx, diffusion, nmtcpp, llamacpp-embed, pr-test, publish-registry-server)
72e8b39 | H2 | 68 security-critical external action refs pinned from @monorepo_update to SHA 08479e55 across 32 files
e55b2be | H3 + M3 + M5 | permissions: contents: read added to 8 standalone workflows. Dependabot config created. continue-on-error removed from 22 merge-guard jobs
5fa6575 | M2 + M4 | 25 third-party action refs SHA-pinned (softprops, aws-actions, peter-evans). Concurrency controls added to 19 workflows

