### PR TITLE
fix[notask]: update darwin-arm64 runner to macos-15 for nmtcpp prebuilds

### DIFF
--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -63,7 +63,7 @@ jobs:
           - os: macos-14
             platform: darwin
             arch: x64
-          - os: macos-14
+          - os: macos-15
             platform: darwin
             arch: arm64
           - os: macos-26


### PR DESCRIPTION
## Summary
- Update the macOS runner for darwin-arm64 nmtcpp prebuilds from macos-14 to macos-15

## Test plan
- [ ] Verify darwin-arm64 prebuild completes successfully on macos-15 runner