### PR TITLE
 QVAC-13927 chore[skiplog]: qvac-sdk v0.8.0 release changelog and NOTICE

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,316 @@
 # Changelog
 
+## [0.8.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.8.0
+
+This release adds Parakeet as a new transcription engine alongside Whisper, decouples builtin plugins from the core load path for a cleaner architecture, adds CTC and Sortformer transcription models, introduces a built-in profiler for diagnosing performance, and brings Bergamot pivot translation support. Several addon logging and delegation bugs have also been resolved.
+
+---
+
+## 💥 Breaking Changes
+
+### Embedding Model Config Uses Structured Fields
+
+The embedding addon no longer accepts the raw tab-delimited config string. Use the structured fields instead.
+
+**Before:**
+
+```typescript
+await loadModel({
+  modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
+  modelType: "embeddings",
+  modelConfig: {
+    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
+  },
+});
+```
+
+**After:**
+
+```typescript
+await loadModel({
+  modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
+  modelType: "embeddings",
+  modelConfig: {
+    gpuLayers: 99,
+    device: "gpu",
+    batchSize: 1024,
+  },
+});
+```
+
+### Companion Model Sources Moved Into `modelConfig`
+
+Top-level companion source fields (`projectionModelSrc`, `vadModelSrc`, `srcVocabSrc`, `dstVocabSrc`) have been removed from `loadModel`. They now live inside `modelConfig`. The unused `toolFormat` field has also been removed.
+
+**Before:**
+
+```typescript
+await loadModel({
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
+  projectionModelSrc: ".../mmproj.gguf",
+});
+
+await loadModel({
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
+  vadModelSrc: ".../vad.bin",
+});
+
+await loadModel({
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
+  srcVocabSrc: ".../srcvocab.spm",
+  dstVocabSrc: ".../trgvocab.spm",
+});
+```
+
+**After:**
+
+```typescript
+await loadModel({
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
+  modelConfig: {
+    projectionModelSrc: ".../mmproj.gguf",
+  },
+});
+
+await loadModel({
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
+  modelConfig: {
+    vadModelSrc: ".../vad.bin",
+  },
+});
+
+await loadModel({
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
+  modelConfig: {
+    srcVocabSrc: ".../srcvocab.spm",
+    dstVocabSrc: ".../trgvocab.spm",
+  },
+});
+```
+
+Additionally, custom plugins must now provide a `loadConfigSchema`. For plugins that accept any config, use a passthrough schema:
+
+```typescript
+const myPlugin: QvacPlugin = {
+  modelType: "my-plugin",
+  displayName: "My Plugin",
+  addonPackage: "@my/addon",
+  loadConfigSchema: z.object({}).catchall(z.unknown()),
+  createModel: (params) => ({ model, loader }),
+  handlers: {},
+};
+```
+
+### Parakeet Model Constants Renamed
+
+All existing Parakeet model constants now include a variant prefix (`TDT_`) to distinguish them from the new CTC and Sortformer variants. This is a find-and-replace migration:
+
+| Old Constant | New Constant |
+|---|---|
+| `PARAKEET_ENCODER_*` | `PARAKEET_TDT_ENCODER_*` |
+| `PARAKEET_DECODER_*` | `PARAKEET_TDT_DECODER_*` |
+| `PARAKEET_VOCAB` | `PARAKEET_TDT_VOCAB` |
+| `PARAKEET_PREPROCESSOR_*` | `PARAKEET_TDT_PREPROCESSOR_*` |
+
+---
+
+## 🔌 New APIs
+
+### Parakeet Transcription Plugin
+
+NVIDIA Parakeet ONNX models are now supported as an alternative transcription engine alongside Whisper.cpp. Parakeet uses a multi-file model architecture (encoder, encoder-data, decoder, vocab, preprocessor) resolved through the QVAC Registry.
+
+```typescript
+import {
+  PARAKEET_TDT_ENCODER_FP32,
+  PARAKEET_TDT_ENCODER_DATA_FP32,
+  PARAKEET_TDT_DECODER_FP32,
+  PARAKEET_TDT_VOCAB,
+  PARAKEET_TDT_PREPROCESSOR_FP32,
+} from "@qvac/sdk";
+
+const modelId = await loadModel({
+  modelType: "parakeet",
+  modelSrc: PARAKEET_TDT_ENCODER_FP32,
+  modelConfig: {
+    parakeetEncoderSrc: PARAKEET_TDT_ENCODER_FP32,
+    parakeetEncoderDataSrc: PARAKEET_TDT_ENCODER_DATA_FP32,
+    parakeetDecoderSrc: PARAKEET_TDT_DECODER_FP32,
+    parakeetVocabSrc: PARAKEET_TDT_VOCAB,
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32,
+  },
+});
+
+const stream = transcribeStream({ modelId, audioInput: "./audio.mp3" });
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+}
+```
+
+Supports MP3, WAV, OGG, M4A, RAW, and FLAC audio formats. The plugin filters `[No speech detected]` chunks automatically, mirroring Whisper's `[BLANK_AUDIO]` filtering.
+
+### Bergamot Pivot Translation
+
+Translate between language pairs that don't have a direct model by chaining through a pivot language (typically English). Configure the pivot model inside `modelConfig`:
+
+```typescript
+await loadModel({
+  modelSrc: BERGAMOT_ES_EN,
+  modelType: "nmt",
+  modelConfig: {
+    engine: "Bergamot",
+    from: "es",
+    to: "it",
+    pivotModel: {
+      modelSrc: BERGAMOT_EN_IT,
+      beamsize: 4,
+      temperature: 0.3,
+      topk: 100,
+      normalize: 1,
+      lengthpenalty: 1.2,
+    },
+  },
+});
+```
+
+### SDK Profiler
+
+A built-in profiler lets you measure SDK operation performance at runtime. Enable it globally or on a per-call basis:
+
+```typescript
+import { profiler } from "@qvac/sdk";
+
+profiler.enable({
+  mode: "verbose",
+  includeServerBreakdown: true,
+});
+
+// Run operations, then export results
+console.log(profiler.exportSummary());
+console.log(profiler.exportTable());
+console.log(profiler.exportJSON({ includeRecentEvents: true }));
+
+profiler.disable();
+```
+
+Per-call profiling control is also available on `embed`, `completion`, `transcribe`, `translate`, `ragSearch`, and `invokePlugin`:
+
+```typescript
+await embed(
+  { modelId, text: "hello" },
+  { profiling: { enabled: true } },
+);
+```
+
+---
+
+## ✨ Features
+
+### CTC and Sortformer Transcription Models
+
+The SDK now supports two additional Parakeet model variants beyond the existing TDT models:
+
+**CTC transcription** for fast, streaming-friendly speech-to-text:
+
+```typescript
+const modelId = await loadModel({
+  modelSrc: PARAKEET_CTC_FP32_1,
+  modelType: "parakeet",
+  modelConfig: {
+    modelType: "ctc",
+    parakeetCtcModelSrc: PARAKEET_CTC_FP32_1,
+    parakeetCtcModelDataSrc: PARAKEET_CTC_DATA_FP32_1,
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
+const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+```
+
+**Sortformer diarization** for speaker identification:
+
+```typescript
+const modelId = await loadModel({
+  modelSrc: PARAKEET_SORTFORMER_FP32,
+  modelType: "parakeet",
+  modelConfig: {
+    modelType: "sortformer",
+    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32,
+  },
+});
+const diarization = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+// Returns: "Speaker 0: 0.00s - 4.24s\nSpeaker 1: 4.65s - 14.32s\n..."
+```
+
+### AfriqueGemma Support
+
+AfriqueGemma models for African language translation are now available through the SDK.
+
+### Profiler Operation Transport and Metrics
+
+The profiler now captures detailed load/download metrics and stream profiling data, giving deeper visibility into SDK operation performance.
+
+---
+
+## 🐞 Bug Fixes
+
+- **Addon logging fixed across all plugins** — Logging callbacks were not being properly attached to some addon plugins, resulting in missing addon-level logs. All plugins now correctly route native addon logs through the SDK logging system.
+- **Parakeet addon logger** now uses the correct `params.modelId` for log routing.
+- **RPC race condition** in `getRPCInstance` resolved — concurrent initialization calls no longer create duplicate worker instances.
+- **Delegated model unload** now correctly unloads the model on the provider device instead of only removing the local registry entry.
+- **Stale delegated model entries** are replaced on re-registration instead of accumulating.
+
+---
+
+## 📦 Model Changes
+
+### Added Models
+
+**OCR:**
+- `OCR_DETECTOR_DB_MOBILENET_V3_LARGE`
+- `OCR_DETECTOR_DB_RESNET50`
+- `OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL`
+- `OCR_RECOGNIZER_PARSEQ`
+
+**Parakeet (CTC):**
+- `PARAKEET_CTC_FP32`, `PARAKEET_CTC_DATA_FP32`, `PARAKEET_CTC_VOCAB`, `PARAKEET_CTC_INT8`, `PARAKEET_CTC_CONFIG`
+- `PARAKEET_CTC_FP32_1`, `PARAKEET_CTC_DATA_FP32_1`, `PARAKEET_CTC_TOKENIZER`
+
+**Parakeet (Sortformer / EOU):**
+- `PARAKEET_SORTFORMER_FP32`
+- `PARAKEET_EOU_ENCODER_FP32`, `PARAKEET_EOU_DECODER_FP32`, `PARAKEET_EOU_TOKENIZER`
+
+**Parakeet (TDT — renamed from unprefixed):**
+- `PARAKEET_TDT_ENCODER_FP32`, `PARAKEET_TDT_ENCODER_DATA_FP32`, `PARAKEET_TDT_DECODER_FP32`, `PARAKEET_TDT_VOCAB`, `PARAKEET_TDT_PREPROCESSOR_FP32`
+- `PARAKEET_TDT_ENCODER_INT8`, `PARAKEET_TDT_DECODER_INT8`, `PARAKEET_TDT_PREPROCESSOR_INT8`
+
+### Removed Models
+
+The following unprefixed Parakeet constants were replaced by their `TDT_` equivalents (see breaking changes):
+
+- `PARAKEET_ENCODER_FP32`, `PARAKEET_ENCODER_DATA_FP32`, `PARAKEET_DECODER_FP32`, `PARAKEET_VOCAB`, `PARAKEET_PREPROCESSOR_FP32`
+- `PARAKEET_ENCODER_INT8`, `PARAKEET_DECODER_INT8`, `PARAKEET_PREPROCESSOR_INT8`
+
+---
+
+## 🧹 Other Changes
+
+- Consolidated transcription schemas and shared ops into a unified structure.
+- Updated `@qvac/tts-onnx` to v0.6.1 and `@qvac/transcription-whispercpp` addon.
+- Aligned TTS plugin artifact patterns.
+- Ported Android E2E test workflow to the monorepo.
+- Improved changelog aggregation to prefer `CHANGELOG_LLM.md` when available.
+- Reorganized monorepo documentation structure.
+- Ported logging executor to direct assertions and added missing test handlers.
+- Enabled profiling in test-qvac desktop and mobile consumers.
+
 ## [0.7.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.7.0
@@ -94,12 +405,7 @@ const model = await modelRegistryGetModel(registryPath, registrySource);
 Build custom model integrations with the new plugin architecture. Plugins support both request/reply and streaming patterns.
 
 ```typescript
-import {
-  invokePlugin,
-  invokePluginStream,
-  definePlugin,
-  defineHandler,
-} from "@qvac/sdk";
+import { invokePlugin, invokePluginStream, definePlugin, defineHandler } from "@qvac/sdk";
 
 // Invoke a plugin handler
 const result = await invokePlugin<MyResponse>({
@@ -162,7 +468,7 @@ const modelId = await loadModel({
     ttsLatentDenoiserSrc,
     ttsVoiceDecoderSrc,
     ttsVoiceSrc,
-    ttsSpeed: 1.0, // Playback speed
+    ttsSpeed: 1.0,           // Playback speed
     ttsNumInferenceSteps: 5, // Quality vs speed tradeoff
   },
 });
@@ -203,7 +509,7 @@ Map between engine names and addon types:
 import { resolveCanonicalEngine, getAddonFromEngine } from "@qvac/sdk";
 
 const engine = resolveCanonicalEngine("@qvac/llm-llamacpp"); // "llamacpp-completion"
-const addon = getAddonFromEngine("llamacpp-completion"); // "llm"
+const addon = getAddonFromEngine("llamacpp-completion");     // "llm"
 ```
 
 ---
@@ -305,7 +611,6 @@ await ragSaveEmbeddings({
 ```
 
 Other RAG changes:
-
 - `ragSaveEmbeddings` no longer returns `droppedIndices`
 - `ragDeleteEmbeddings` now returns `void` instead of `boolean` (throws on failure)
 - `ragDeleteEmbeddings` no longer requires `modelId` (uses cached workspace)
@@ -371,7 +676,7 @@ const modelId = await loadModel({
   modelSrc: MARIAN_OPUS_EN_IT_Q0F32,
   modelType: "nmt",
   modelConfig: {
-    engine: "Opus", // Required: "Opus" | "Bergamot" | "IndicTrans"
+    engine: "Opus",  // Required: "Opus" | "Bergamot" | "IndicTrans"
     from: "en",
     to: "it",
   },
@@ -396,7 +701,7 @@ const modelId = await loadModel({
     engine: "Bergamot",
     from: "en",
     to: "fr",
-    normalize: 1, // Bergamot-specific option
+    normalize: 1,  // Bergamot-specific option
   },
 });
 
@@ -439,11 +744,7 @@ const result = await blocks;
 await done;
 
 // Or stream blocks as they're detected
-const { blockStream, done } = ocr({
-  modelId,
-  image: imageBuffer,
-  stream: true,
-});
+const { blockStream, done } = ocr({ modelId, image: imageBuffer, stream: true });
 for await (const blocks of blockStream) {
   console.log(blocks);
   // [{ text: "Hello", bbox: [10, 20, 100, 50], confidence: 0.95 }]
@@ -457,8 +758,7 @@ Load large models split across multiple files, from URLs or archives.
 ```typescript
 // Pattern-based sharded URLs (auto-detects shard pattern)
 await loadModel({
-  modelSrc:
-    "https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf",
+  modelSrc: "https://huggingface.co/user/model/resolve/main/model-00001-of-00003.gguf",
   modelType: "llm",
 });
 
@@ -579,10 +879,10 @@ The SDK searches for configuration in this order:
 
 #### Supported Formats
 
-| Format     | Filename           | Notes                         |
-| ---------- | ------------------ | ----------------------------- |
-| JSON       | `qvac.config.json` | Simplest option               |
-| JavaScript | `qvac.config.js`   | Use `export default`          |
+| Format     | Filename           | Notes                        |
+| ---------- | ------------------ | ---------------------------- |
+| JSON       | `qvac.config.json` | Simplest option              |
+| JavaScript | `qvac.config.js`   | Use `export default`         |
 | TypeScript | `qvac.config.ts`   | Fully typed with `QvacConfig` |
 
 **TypeScript example:**
@@ -603,7 +903,7 @@ export default config;
 
 1. Remove all `setConfig()` calls from your code
 2. Create a config file in your project root
-3. _(Optional)_ For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
+3. *(Optional)* For non-standard locations, set `QVAC_CONFIG_PATH` before importing the SDK
 
 ---
 
@@ -613,14 +913,14 @@ Some model constants have been renamed for clarity, and duplicate constants have
 
 **Changes:**
 
-| Before                     | After                                      |
-| -------------------------- | ------------------------------------------ |
-| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                         |
-| `WHISPER_NORWEGIAN_TINY_1` | _(removed — use `WHISPER_NORWEGIAN_TINY`)_ |
-| `WHISPER_TINY_SILERO`      | _(removed — use `WHISPER_TINY`)_           |
-| `MARIAN_OPUS_EN_FR_Q4_0_1` | _(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)_ |
-| `MARIAN_OPUS_FR_EN_Q4_0_1` | _(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)_ |
-| `MARIAN_OPUS_IT_EN`        | _(removed — use `MARIAN_OPUS_EN_IT`)_      |
+| Before                     | After                                             |
+| -------------------------- | ------------------------------------------------- |
+| `WHISPER_SMALL`            | `WHISPER_SMALL_Q8`                                |
+| `WHISPER_NORWEGIAN_TINY_1` | *(removed — use `WHISPER_NORWEGIAN_TINY`)*        |
+| `WHISPER_TINY_SILERO`      | *(removed — use `WHISPER_TINY`)*                  |
+| `MARIAN_OPUS_EN_FR_Q4_0_1` | *(removed — use `MARIAN_OPUS_EN_FR_Q4_0`)*        |
+| `MARIAN_OPUS_FR_EN_Q4_0_1` | *(removed — use `MARIAN_OPUS_FR_EN_Q4_0`)*        |
+| `MARIAN_OPUS_IT_EN`        | *(removed — use `MARIAN_OPUS_EN_IT`)*             |
 
 All model metadata and hyperdrive keys remain unchanged—only the constant names were affected.
 

--- a/packages/sdk/NOTICE
+++ b/packages/sdk/NOTICE
@@ -37,12 +37,36 @@ Additional requirements per license Section 1.b.i:
   must prominently display "Built with Llama" on a related website,
   user interface, blog post, about page, or product documentation.
 
+# Model Use Restrictions (Open RAIL++-M)
+
+As a user of the QVAC SDK and its associated model registry, you agree not to use the Model or its Derivatives:
+
+1. **Illegal Acts:** In any way that violates any applicable national, federal, state, local or international law or regulation.
+2. **Harm to Minors:** For the purpose of exploiting, harming or attempting to exploit or harm minors in any way.
+3. **Malicious Content:** To generate or disseminate verifiably false information and/or content with the purpose of harming others.
+4. **Personal Data:** To generate or disseminate personal identifiable information that can be used to harm an individual.
+5. **Defamation & Harassment:** To defame, disparage or otherwise harass others.
+6. **Automated Decisions:** For fully automated decision making that adversely impacts an individual's legal rights or otherwise creates or modifies a binding, enforceable obligation.
+7. **Discrimination:** For any use intended to or which has the effect of discriminating against or harming individuals or groups based on online or offline social behavior or known or predicted personal or personality characteristics.
+8. **Exploitation:** To exploit any of the vulnerabilities of a specific group of persons based on their age, social, physical or mental characteristics, in order to materially distort the behavior of a person pertaining to such group in a manner that causes or is likely to cause that person or another person physical or psychological harm.
+9. **Medical Advice:** To provide medical advice and medical results interpretation.
+10. **Justice & Law Enforcement:** To generate or disseminate information for use by administration of justice, law enforcement, immigration or asylum processes, such as predicting an individual will commit fraud/crime commitment (e.g. by text profiling, drawing causal relationships between assertions made in documents, indiscriminate and untargeted scraping).
+
+---
+*Note: These restrictions must be included in any distribution of the Model or Derivatives thereof to your end-users.*
+
 =========================================================================
 Third-Party Model Licenses
 =========================================================================
 
 --- apache-2.0 (Apache License 2.0) ---
 
+  crnn_mobilenet_v3_small
+    https://github.com/felixdittrich92/OnnxTR
+  db_mobilenet_v3_large
+    https://github.com/felixdittrich92/OnnxTR
+  db_resnet50
+    https://github.com/felixdittrich92/OnnxTR
   de-tiny-ggml-model-f16
     https://huggingface.co/primeline/whisper-tiny-german-1224
   detector_craft
@@ -51,6 +75,10 @@ Third-Party Model Licenses
     https://huggingface.co/jmb95/laser-dolphin-mixtral-2x7b-dpo-GGUF
   en-base-ggml-model-f16
     https://huggingface.co/openai/whisper-base
+  FLUX.2-klein-4B
+    https://huggingface.co/black-forest-labs/FLUX.2-klein-4B
+  FLUX.2-klein-4B-GGUF
+    https://huggingface.co/unsloth/FLUX.2-klein-4B-GGUF
   fr-base-ggml-model-f16
     https://huggingface.co/personalizedrefrigerator/whisper-base-fr
   fr-tiny-ggml-model-f16
@@ -95,6 +123,8 @@ Third-Party Model Licenses
     https://huggingface.co/Helsinki-NLP/opus-mt-roa-en
   ggml-opus-roa-en
     https://huggingface.co/Helsinki-NLP/opus-mt-roa-en
+  gpt-oss-120b-Q4_K_M-00001-of-00002
+    https://huggingface.co/unsloth/gpt-oss-120b-GGUF
   gpt-oss-20b-GGUF
     https://huggingface.co/unsloth/gpt-oss-20b-GGUF
   it-base-ggml-model-f16
@@ -107,10 +137,14 @@ Third-Party Model Licenses
     https://huggingface.co/CheeLi03/whisper-tiny-ja-puct-4k
   laser-dolphin-mixtral-2x7b-dpo-GGUF
     https://huggingface.co/jmb95/laser-dolphin-mixtral-2x7b-dpo-GGUF
+  LightOnOCR-2-1B-ocr-soup-GGUF
+    https://huggingface.co/noctrex/LightOnOCR-2-1B-ocr-soup-GGUF
   Llama_3.2_1B_Intruct_Tool_Calling_V2-GGUF
     https://huggingface.co/mav23/Llama_3.2_1B_Intruct_Tool_Calling_V2-GGUF
   nb-tiny-ggml-model
     https://huggingface.co/NbAiLab/nb-whisper-tiny
+  parseq
+    https://github.com/felixdittrich92/OnnxTR
   pt-base-ggml-model-f16
     https://huggingface.co/mariana-coelho-9/whisper-base-pt
   Qwen3-0.6B-GGUF
@@ -119,6 +153,8 @@ Third-Party Model Licenses
     https://huggingface.co/unsloth/Qwen3-1.7B-GGUF
   Qwen3-1.7B-Q4_0-00001-of-00005
     https://huggingface.co/unsloth/Qwen3-1.7B-GGUF
+  Qwen3-4B-GGUF
+    https://huggingface.co/unsloth/Qwen3-4B-GGUF
   Qwen3-4B-Q4_0-00001-of-00005
     https://huggingface.co/unsloth/Qwen3-4B-GGUF
   Qwen3-4B-Q4_K_M
@@ -168,8 +204,12 @@ Third-Party Model Licenses
 
 --- cc-by-4.0 (Creative Commons Attribution 4.0 International) ---
 
+  AfriqueGemma-4B-GGUF
+    https://huggingface.co/mradermacher/AfriqueGemma-4B-GGUF
   decoder_joint-model
     https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
+  diar_streaming_sortformer_4spk-v2-onnx
+    https://huggingface.co/cgus/diar_streaming_sortformer_4spk-v2-onnx
   encoder-model
     https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
   ggml-opus-en-de
@@ -180,6 +220,10 @@ Third-Party Model Licenses
     https://huggingface.co/Helsinki-NLP/opus-mt-ru-en
   ggml-opus-zh-en
     https://huggingface.co/Helsinki-NLP/opus-mt-zh-en
+  parakeet-ctc-0.6b-ONNX
+    https://huggingface.co/onnx-community/parakeet-ctc-0.6b-ONNX
+  parakeet-rs
+    https://huggingface.co/altunenes/parakeet-rs
   parakeet-tdt-0.6b-v3-onnx
     https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
   preprocessor
@@ -208,6 +252,12 @@ Third-Party Model Licenses
 
 --- mit (MIT License) ---
 
+  bitnet_b1_58-3B-TQ2_0
+    https://huggingface.co/1bitLLM/bitnet_b1_58-3B
+  bitnet_b1_58-large-TQ2_0
+    https://huggingface.co/1bitLLM/bitnet_b1_58-large
+  bitnet_b1_58-xl-TQ2_0
+    https://huggingface.co/1bitLLM/bitnet_b1_58-xl
   chatterbox-multilingual-ONNX
     https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX
   chatterbox-turbo-ONNX
@@ -287,6 +337,13 @@ Third-Party Model Licenses
   Supertonic-TTS-ONNX
     https://huggingface.co/onnx-community/Supertonic-TTS-ONNX
 
+--- openrail++ ---
+
+  stable-diffusion-v2-1-GGUF
+    https://huggingface.co/gpustack/stable-diffusion-v2-1-GGUF
+  stable-diffusion-xl-base-1.0-GGUF
+    https://huggingface.co/gpustack/stable-diffusion-xl-base-1.0-GGUF
+
 =========================================================================
 Modification Notice
 =========================================================================
@@ -299,334 +356,3 @@ the underlying models.
 
 Source URLs for original weights are recorded in each model's
 metadata entry within the registry.
-
-=========================================================================
-JavaScript Dependencies
-=========================================================================
-
---- apache-2.0 (Apache License 2.0) ---
-
-  @hyperswarm/secret-stream@6.9.1
-    https://github.com/holepunchto/hyperswarm-secret-stream
-  @qvac/decoder-audio@0.3.3
-  @qvac/dl-base@0.2.0
-  @qvac/dl-filesystem@0.2.0
-  @qvac/dl-hyperdrive@0.2.0
-  @qvac/embed-llamacpp@0.10.7
-    https://github.com/tetherto/qvac-lib-infer-llamacpp-embed
-  @qvac/error@0.1.1
-  @qvac/infer-base@0.1.1
-  @qvac/infer-base@0.2.2
-  @qvac/langdetect-text@0.1.1
-  @qvac/llm-llamacpp@0.8.9
-    https://github.com/tetherto/qvac-lib-infer-llamacpp-llm
-  @qvac/logging@0.1.0
-  @qvac/ocr-onnx@0.1.7
-    https://github.com/tetherto/qvac-lib-inference-addon-onnx-ocr-fasttext
-  @qvac/rag@0.4.2
-  @qvac/registry-client@0.2.0
-  @qvac/registry-schema@0.1.1
-  @qvac/response@0.1.2
-  @qvac/transcription-whispercpp@0.3.18
-    https://github.com/tetherto/qvac-lib-infer-whispercpp
-  @qvac/translation-nmtcpp@0.3.9
-    https://github.com/tetherto/qvac-lib-infer-nmtcpp
-  @qvac/tts-onnx@0.5.4
-  adaptive-timeout@1.0.1
-    https://github.com/holepunchto/adaptive-timeout
-  b4a@1.7.5
-    https://github.com/holepunchto/b4a
-  bare-abort-controller@1.0.0
-    https://github.com/holepunchto/bare-abort-controller
-  bare-addon-resolve@1.10.0
-    https://github.com/holepunchto/bare-addon-resolve
-  bare-ansi-escapes@2.2.3
-    https://github.com/holepunchto/bare-ansi-escapes
-  bare-assert@1.2.0
-    https://github.com/holepunchto/bare-assert
-  bare-buffer@3.4.4
-    https://github.com/holepunchto/bare-buffer
-  bare-bundle@1.10.0
-    https://github.com/holepunchto/bare-bundle
-  bare-channel@5.2.3
-    https://github.com/holepunchto/bare-channel
-  bare-crypto@1.13.0
-    https://github.com/holepunchto/bare-crypto
-  bare-dns@2.1.4
-    https://github.com/holepunchto/bare-dns
-  bare-env@3.0.0
-    https://github.com/holepunchto/bare-env
-  bare-events@2.4.2
-    https://github.com/holepunchto/bare-events
-  bare-events@2.8.2
-    https://github.com/holepunchto/bare-events
-  bare-fetch@2.5.1
-    https://github.com/holepunchto/bare-fetch
-  bare-ffmpeg@1.1.0
-    https://github.com/holepunchto/bare-ffmpeg
-  bare-form-data@1.1.6
-    https://github.com/holepunchto/bare-form-data
-  bare-fs@4.5.4
-    https://github.com/holepunchto/bare-fs
-  bare-hrtime@2.1.1
-    https://github.com/holepunchto/bare-hrtime
-  bare-http-parser@1.0.1
-    https://github.com/holepunchto/bare-http-parser
-  bare-http1@4.2.3
-    https://github.com/holepunchto/bare-http1
-  bare-https@2.1.2
-    https://github.com/holepunchto/bare-https
-  bare-inspect@3.1.4
-    https://github.com/holepunchto/bare-inspect
-  bare-lief@0.1.4
-    https://github.com/holepunchto/bare-lief
-  bare-link@2.1.10
-    https://github.com/holepunchto/bare-link
-  bare-module@6.1.3
-    https://github.com/holepunchto/bare-module
-  bare-module-lexer@1.4.7
-    https://github.com/holepunchto/bare-module-lexer
-  bare-module-resolve@1.12.1
-    https://github.com/holepunchto/bare-module-resolve
-  bare-module-traverse@2.0.1
-    https://github.com/holepunchto/bare-module-traverse
-  bare-net@2.2.0
-    https://github.com/holepunchto/bare-net
-  bare-node-stream@1.0.0
-    https://github.com/holepunchto/bare-node
-  bare-node-worker-threads@1.0.0
-    https://github.com/holepunchto/bare-node
-  bare-os@3.6.2
-    https://github.com/holepunchto/bare-os
-  bare-path@3.0.0
-    https://github.com/holepunchto/bare-path
-  bare-pipe@4.1.3
-    https://github.com/holepunchto/bare-pipe
-  bare-process@4.2.2
-    https://github.com/holepunchto/bare-process
-  bare-rpc@1.1.0
-    https://github.com/holepunchto/bare-rpc
-  bare-runtime@1.27.0
-    https://github.com/holepunchto/bare-runtime
-  bare-runtime-darwin-arm64@1.27.0
-    https://github.com/holepunchto/bare-runtime
-  bare-semver@1.0.2
-    https://github.com/holepunchto/bare-semver
-  bare-signals@4.2.0
-    https://github.com/holepunchto/bare-signals
-  bare-stream@2.8.0
-    https://github.com/holepunchto/bare-stream
-  bare-structured-clone@1.5.2
-    https://github.com/holepunchto/bare-structured-clone
-  bare-subprocess@5.2.2
-    https://github.com/holepunchto/bare-subprocess
-  bare-tcp@2.2.7
-    https://github.com/holepunchto/bare-tcp
-  bare-thread@1.1.6
-    https://github.com/holepunchto/bare-thread
-  bare-tls@2.1.7
-    https://github.com/holepunchto/bare-tls
-  bare-tty@5.0.3
-    https://github.com/holepunchto/bare-tty
-  bare-type@1.1.0
-    https://github.com/holepunchto/bare-type
-  bare-url@2.3.2
-    https://github.com/holepunchto/bare-url
-  bare-worker@4.1.6
-    https://github.com/holepunchto/bare-worker
-  bare-zlib@1.3.1
-    https://github.com/holepunchto/bare-zlib
-  blind-relay@1.4.0
-    https://github.com/holepunchto/blind-relay
-  compact-encoding@2.19.0
-    https://github.com/compact-encoding/compact-encoding
-  device-file@2.3.1
-    https://github.com/holepunchto/device-file
-  events-universal@1.0.1
-    https://github.com/holepunchto/events-universal
-  fd-lock@2.1.1
-    https://github.com/holepunchto/fd-lock
-  fs-native-extensions@1.4.5
-    https://github.com/holepunchto/fs-native-extensions
-  hyperblobs@2.9.0
-    https://github.com/holepunchto/hyperblobs
-  hypercore-errors@1.5.0
-    https://github.com/holepunchto/hypercore-errors
-  hypercore-id-encoding@1.3.0
-    https://github.com/holepunchto/hypercore-id-encoding
-  hypercore-storage@2.4.1
-  hyperdb@4.22.3
-    https://github.com/holepunchto/hyperdb
-  hyperdispatch@1.4.4
-    https://github.com/holepunchto/hyperdispatch
-  hyperdrive@13.3.0
-    https://github.com/holepunchto/hyperdrive
-  hyperschema@1.20.1
-    https://github.com/holepunchto/hyperschema
-  index-encoder@3.4.0
-    https://github.com/holepunchto/index-encoder
-  mirror-drive@1.12.0
-    https://github.com/holepunchto/mirror-drive
-  noise-handshake@4.2.0
-    https://github.com/holepunchto/noise-handshake
-  paparam@1.10.0
-    https://github.com/holepunchto/paparam
-  quickbit-native@2.4.8
-    https://github.com/holepunchto/quickbit-native
-  rache@1.0.0
-    https://github.com/holepunchto/rache
-  refcounter@1.0.0
-    https://github.com/holepunchto/refcounter
-  require-addon@1.2.0
-    https://github.com/holepunchto/require-addon
-  require-asset@1.2.1
-    https://github.com/holepunchto/require-asset
-  resource-on-exit@1.0.0
-    https://github.com/holepunchto/bare-teardown
-  rocksdb-native@3.13.0
-    https://github.com/holepunchto/rocksdb-native
-  scope-lock@1.2.4
-    https://github.com/holepunchto/scope-lock
-  simdle-native@1.3.9
-    https://github.com/holepunchto/simdle-native
-  sub-encoder@2.1.3
-    https://github.com/holepunchto/sub-encoder
-  text-decoder@1.2.7
-    https://github.com/holepunchto/text-decoder
-  udx-native@1.19.2
-    https://github.com/holepunchto/udx-native
-  unslab@1.3.0
-    https://github.com/holepunchto/unslab
-  which-runtime@1.3.2
-    https://github.com/holepunchto/which-runtime
-
---- isc (ISC License) ---
-
-  @qvac/util-transcription@0.1.5
-    https://github.com/tetherto/qvac-util-transcription
-  bits-to-bytes@1.3.0
-    https://github.com/holepunchto/bits-to-bytes
-  compact-encoding-bitfield@1.0.0
-    https://github.com/compact-encoding/compact-encoding-bitfield
-  compact-encoding-net@1.2.0
-    https://github.com/compact-encoding/compact-encoding-net
-  nanoassert@2.0.0
-    https://github.com/emilbayes/nanoassert
-  noise-curve-ed@2.1.0
-    https://github.com/chm-diederichs/noise-curve-ed
-  quickbit-universal@2.2.0
-    https://github.com/holepunchto/quickbit-universal
-  simdle-universal@1.1.2
-    https://github.com/holepunchto/simdle-universal
-
---- mit (MIT License) ---
-
-  big-sparse-array@1.0.3
-    https://github.com/mafintosh/big-sparse-array
-  binary-stream-equals@1.0.0
-    https://github.com/mafintosh/binary-stream-equals
-  bogon@1.2.0
-    https://github.com/mafintosh/bogon
-  codecs@3.1.0
-    https://github.com/mafintosh/codecs
-  corestore@7.8.0
-    https://github.com/holepunchto/corestore
-  debounceify@1.1.0
-    https://github.com/mafintosh/debounceify
-  dht-rpc@6.26.2
-    https://github.com/mafintosh/dht-rpc
-  events@3.3.0
-    https://github.com/Gozala/events
-  fast-fifo@1.3.2
-    https://github.com/mafintosh/fast-fifo
-  fast-safe-stringify@2.1.1
-    https://github.com/davidmarkclements/fast-safe-stringify
-  flat-tree@1.13.0
-    https://github.com/mafintosh/flat-tree
-  generate-object-property@2.0.0
-    https://github.com/mafintosh/generate-object-property
-  generate-string@1.0.1
-    https://github.com/mafintosh/generate-string
-  hyperbee@2.27.3
-    https://github.com/holepunchto/hyperbee
-  hypercore@11.26.0
-    https://github.com/holepunchto/hypercore
-  hypercore-crypto@3.6.1
-    https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.29.0
-    https://github.com/holepunchto/hyperdht
-  hyperswarm@4.16.0
-    https://github.com/holepunchto/hyperswarm
-  is-options@1.0.2
-    https://github.com/mafintosh/is-options
-  is-property@1.0.2
-    https://github.com/mikolalysenko/is-property
-  kademlia-routing-table@1.0.6
-    https://github.com/mafintosh/kademlia-routing-table
-  llm-splitter@0.2.0
-    https://github.com/nearform/llm-splitter
-  mutexify@1.4.0
-    https://github.com/mafintosh/mutexify
-  nat-sampler@1.0.1
-    https://github.com/mafintosh/nat-sampler
-  protocol-buffers-encodings@1.2.0
-    https://github.com/mafintosh/protocol-buffers-encodings
-  protomux@3.10.1
-    https://github.com/mafintosh/protomux
-  queue-tick@1.0.1
-    https://github.com/mafintosh/queue-tick
-  random-array-iterator@1.0.0
-    https://github.com/mafintosh/random-array-iterator
-  ready-resource@1.2.0
-    https://github.com/holepunchto/ready-resource
-  record-cache@1.2.0
-    https://github.com/mafintosh/record-cache
-  resolve-reject-promise@1.1.0
-    https://github.com/mafintosh/resolve-reject-promise
-  safety-catch@1.0.2
-    https://github.com/mafintosh/safety-catch
-  same-data@1.0.0
-    https://github.com/mafintosh/same-data
-  shuffled-priority-queue@2.1.0
-    https://github.com/mafintosh/shuffled-priority-queue
-  signal-promise@1.0.3
-    https://github.com/mafintosh/signal-promise
-  signed-varint@2.0.1
-    https://github.com/dominictarr/signed-varint
-  sodium-native@5.0.10
-    https://github.com/holepunchto/sodium-native
-  sodium-secretstream@1.2.0
-    https://github.com/mafintosh/sodium-secretstream
-  sodium-universal@5.0.1
-    https://github.com/holepunchto/sodium-universal
-  speedometer@1.1.0
-    https://github.com/mafintosh/speedometer
-  streamx@2.23.0
-    https://github.com/mafintosh/streamx
-  tar-stream@3.1.7
-    https://github.com/mafintosh/tar-stream
-  teex@1.0.1
-    https://github.com/mafintosh/teex
-  test-tmp@1.4.0
-    https://github.com/mafintosh/test-tmp
-  time-ordered-set@2.0.1
-    https://github.com/mafintosh/time-ordered-set
-  timeout-refresh@2.0.1
-    https://github.com/mafintosh/timeout-refresh
-  tinyld@1.3.4
-    https://github.com/komodojp/tinyld
-  unix-path-resolve@1.0.2
-    https://github.com/mafintosh/unix-path-resolve
-  unordered-set@2.0.1
-    https://github.com/mafintosh/unordered-set
-  uuid-random@1.3.2
-    https://github.com/jchook/uuid-random
-  varint@5.0.0
-    https://github.com/chrisdickinson/varint
-  xache@1.2.1
-    https://github.com/mafintosh/xache
-  z32@1.1.0
-    https://github.com/mafintosh/z32
-  zod@4.3.6
-    https://github.com/colinhacks/zod
-

--- a/packages/sdk/changelog/0.8.0/CHANGELOG.md
+++ b/packages/sdk/changelog/0.8.0/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog v0.8.0
+
+Release Date: 2026-03-20
+
+## ✨ Features
+
+- Add Parakeet transcription plugin. (see PR [#366](https://github.com/tetherto/qvac/pull/366)) - See [API changes](./api.md)
+- Decouple Builtin Plugins from Core Load Path. (see PR [#774](https://github.com/tetherto/qvac/pull/774)) - See [breaking changes](./breaking.md)
+- Add CTC and Sortformer model support to SDK. (see PR [#811](https://github.com/tetherto/qvac/pull/811)) - See [breaking changes](./breaking.md)
+- Add AfriqueGemma support. (see PR [#861](https://github.com/tetherto/qvac/pull/861))
+- Profiler Operation Transport + Load/Download Metrics + Stream Profiling. (see PR [#899](https://github.com/tetherto/qvac/pull/899))
+- Enable profiling in test-qvac desktop and mobile consumers. (see PR [#965](https://github.com/tetherto/qvac/pull/965))
+
+## 🔌 API
+
+- Add Bergamot pivot translation support. (see PR [#834](https://github.com/tetherto/qvac/pull/834)) - See [API changes](./api.md)
+- SDK Profiler. (see PR [#836](https://github.com/tetherto/qvac/pull/836)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Make SDK support latest LLM and Embedding add-ons. (see PR [#669](https://github.com/tetherto/qvac/pull/669)) - See [breaking changes](./breaking.md)
+- Support multiple validator tags and add [updated] section to model history. (see PR [#778](https://github.com/tetherto/qvac/pull/778))
+- Race condition in getRPCInstance. (see PR [#862](https://github.com/tetherto/qvac/pull/862))
+- Fix addon logging on all plugins. (see PR [#870](https://github.com/tetherto/qvac/pull/870))
+- Use params.modelId in parakeet addon logger calls. (see PR [#916](https://github.com/tetherto/qvac/pull/916))
+- Unload delegated model on provider device. (see PR [#924](https://github.com/tetherto/qvac/pull/924))
+- Replace stale delegated model registry entry on re-registration. (see PR [#928](https://github.com/tetherto/qvac/pull/928))
+
+## 📦 Models
+
+- Update SDK constant models. (see PR [#771](https://github.com/tetherto/qvac/pull/771)) - See [model changes](./models.md)
+
+## 📘 Docs
+
+- Reorganize monorepo docs structure. (see PR [#785](https://github.com/tetherto/qvac/pull/785))
+
+## 🧪 Tests
+
+- Port logging executor to direct assertions and add missing test handlers. (see PR [#982](https://github.com/tetherto/qvac/pull/982))
+
+## 🧹 Chores
+
+- Consolidate transcription schemas and shared ops. (see PR [#677](https://github.com/tetherto/qvac/pull/677))
+- Update @qvac/tts-onnx to v0.6.1. (see PR [#854](https://github.com/tetherto/qvac/pull/854))
+- Update whispercpp addon version in sdk. (see PR [#860](https://github.com/tetherto/qvac/pull/860))
+- TTS Plugin Artifacts Pattern Alignment. (see PR [#871](https://github.com/tetherto/qvac/pull/871))
+
+## ⚙️ Infrastructure
+
+- Port android e2e test workflow to monorepo. (see PR [#544](https://github.com/tetherto/qvac/pull/544))
+- Prefer CHANGELOG_LLM.md in root changelog aggregation. (see PR [#777](https://github.com/tetherto/qvac/pull/777))
+

--- a/packages/sdk/changelog/0.8.0/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.8.0/CHANGELOG_LLM.md
@@ -1,0 +1,310 @@
+# QVAC SDK v0.8.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.8.0
+
+This release adds Parakeet as a new transcription engine alongside Whisper, decouples builtin plugins from the core load path for a cleaner architecture, adds CTC and Sortformer transcription models, introduces a built-in profiler for diagnosing performance, and brings Bergamot pivot translation support. Several addon logging and delegation bugs have also been resolved.
+
+---
+
+## 💥 Breaking Changes
+
+### Embedding Model Config Uses Structured Fields
+
+The embedding addon no longer accepts the raw tab-delimited config string. Use the structured fields instead.
+
+**Before:**
+
+```typescript
+await loadModel({
+  modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
+  modelType: "embeddings",
+  modelConfig: {
+    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
+  },
+});
+```
+
+**After:**
+
+```typescript
+await loadModel({
+  modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
+  modelType: "embeddings",
+  modelConfig: {
+    gpuLayers: 99,
+    device: "gpu",
+    batchSize: 1024,
+  },
+});
+```
+
+### Companion Model Sources Moved Into `modelConfig`
+
+Top-level companion source fields (`projectionModelSrc`, `vadModelSrc`, `srcVocabSrc`, `dstVocabSrc`) have been removed from `loadModel`. They now live inside `modelConfig`. The unused `toolFormat` field has also been removed.
+
+**Before:**
+
+```typescript
+await loadModel({
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
+  projectionModelSrc: ".../mmproj.gguf",
+});
+
+await loadModel({
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
+  vadModelSrc: ".../vad.bin",
+});
+
+await loadModel({
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
+  srcVocabSrc: ".../srcvocab.spm",
+  dstVocabSrc: ".../trgvocab.spm",
+});
+```
+
+**After:**
+
+```typescript
+await loadModel({
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
+  modelConfig: {
+    projectionModelSrc: ".../mmproj.gguf",
+  },
+});
+
+await loadModel({
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
+  modelConfig: {
+    vadModelSrc: ".../vad.bin",
+  },
+});
+
+await loadModel({
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
+  modelConfig: {
+    srcVocabSrc: ".../srcvocab.spm",
+    dstVocabSrc: ".../trgvocab.spm",
+  },
+});
+```
+
+Additionally, custom plugins must now provide a `loadConfigSchema`. For plugins that accept any config, use a passthrough schema:
+
+```typescript
+const myPlugin: QvacPlugin = {
+  modelType: "my-plugin",
+  displayName: "My Plugin",
+  addonPackage: "@my/addon",
+  loadConfigSchema: z.object({}).catchall(z.unknown()),
+  createModel: (params) => ({ model, loader }),
+  handlers: {},
+};
+```
+
+### Parakeet Model Constants Renamed
+
+All existing Parakeet model constants now include a variant prefix (`TDT_`) to distinguish them from the new CTC and Sortformer variants. This is a find-and-replace migration:
+
+| Old Constant | New Constant |
+|---|---|
+| `PARAKEET_ENCODER_*` | `PARAKEET_TDT_ENCODER_*` |
+| `PARAKEET_DECODER_*` | `PARAKEET_TDT_DECODER_*` |
+| `PARAKEET_VOCAB` | `PARAKEET_TDT_VOCAB` |
+| `PARAKEET_PREPROCESSOR_*` | `PARAKEET_TDT_PREPROCESSOR_*` |
+
+---
+
+## 🔌 New APIs
+
+### Parakeet Transcription Plugin
+
+NVIDIA Parakeet ONNX models are now supported as an alternative transcription engine alongside Whisper.cpp. Parakeet uses a multi-file model architecture (encoder, encoder-data, decoder, vocab, preprocessor) resolved through the QVAC Registry.
+
+```typescript
+import {
+  PARAKEET_TDT_ENCODER_FP32,
+  PARAKEET_TDT_ENCODER_DATA_FP32,
+  PARAKEET_TDT_DECODER_FP32,
+  PARAKEET_TDT_VOCAB,
+  PARAKEET_TDT_PREPROCESSOR_FP32,
+} from "@qvac/sdk";
+
+const modelId = await loadModel({
+  modelType: "parakeet",
+  modelSrc: PARAKEET_TDT_ENCODER_FP32,
+  modelConfig: {
+    parakeetEncoderSrc: PARAKEET_TDT_ENCODER_FP32,
+    parakeetEncoderDataSrc: PARAKEET_TDT_ENCODER_DATA_FP32,
+    parakeetDecoderSrc: PARAKEET_TDT_DECODER_FP32,
+    parakeetVocabSrc: PARAKEET_TDT_VOCAB,
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32,
+  },
+});
+
+const stream = transcribeStream({ modelId, audioInput: "./audio.mp3" });
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+}
+```
+
+Supports MP3, WAV, OGG, M4A, RAW, and FLAC audio formats. The plugin filters `[No speech detected]` chunks automatically, mirroring Whisper's `[BLANK_AUDIO]` filtering.
+
+### Bergamot Pivot Translation
+
+Translate between language pairs that don't have a direct model by chaining through a pivot language (typically English). Configure the pivot model inside `modelConfig`:
+
+```typescript
+await loadModel({
+  modelSrc: BERGAMOT_ES_EN,
+  modelType: "nmt",
+  modelConfig: {
+    engine: "Bergamot",
+    from: "es",
+    to: "it",
+    pivotModel: {
+      modelSrc: BERGAMOT_EN_IT,
+      beamsize: 4,
+      temperature: 0.3,
+      topk: 100,
+      normalize: 1,
+      lengthpenalty: 1.2,
+    },
+  },
+});
+```
+
+### SDK Profiler
+
+A built-in profiler lets you measure SDK operation performance at runtime. Enable it globally or on a per-call basis:
+
+```typescript
+import { profiler } from "@qvac/sdk";
+
+profiler.enable({
+  mode: "verbose",
+  includeServerBreakdown: true,
+});
+
+// Run operations, then export results
+console.log(profiler.exportSummary());
+console.log(profiler.exportTable());
+console.log(profiler.exportJSON({ includeRecentEvents: true }));
+
+profiler.disable();
+```
+
+Per-call profiling control is also available on `embed`, `completion`, `transcribe`, `translate`, `ragSearch`, and `invokePlugin`:
+
+```typescript
+await embed(
+  { modelId, text: "hello" },
+  { profiling: { enabled: true } },
+);
+```
+
+---
+
+## ✨ Features
+
+### CTC and Sortformer Transcription Models
+
+The SDK now supports two additional Parakeet model variants beyond the existing TDT models:
+
+**CTC transcription** for fast, streaming-friendly speech-to-text:
+
+```typescript
+const modelId = await loadModel({
+  modelSrc: PARAKEET_CTC_FP32_1,
+  modelType: "parakeet",
+  modelConfig: {
+    modelType: "ctc",
+    parakeetCtcModelSrc: PARAKEET_CTC_FP32_1,
+    parakeetCtcModelDataSrc: PARAKEET_CTC_DATA_FP32_1,
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
+const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+```
+
+**Sortformer diarization** for speaker identification:
+
+```typescript
+const modelId = await loadModel({
+  modelSrc: PARAKEET_SORTFORMER_FP32,
+  modelType: "parakeet",
+  modelConfig: {
+    modelType: "sortformer",
+    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32,
+  },
+});
+const diarization = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+// Returns: "Speaker 0: 0.00s - 4.24s\nSpeaker 1: 4.65s - 14.32s\n..."
+```
+
+### AfriqueGemma Support
+
+AfriqueGemma models for African language translation are now available through the SDK.
+
+### Profiler Operation Transport and Metrics
+
+The profiler now captures detailed load/download metrics and stream profiling data, giving deeper visibility into SDK operation performance.
+
+---
+
+## 🐞 Bug Fixes
+
+- **Addon logging fixed across all plugins** — Logging callbacks were not being properly attached to some addon plugins, resulting in missing addon-level logs. All plugins now correctly route native addon logs through the SDK logging system.
+- **Parakeet addon logger** now uses the correct `params.modelId` for log routing.
+- **RPC race condition** in `getRPCInstance` resolved — concurrent initialization calls no longer create duplicate worker instances.
+- **Delegated model unload** now correctly unloads the model on the provider device instead of only removing the local registry entry.
+- **Stale delegated model entries** are replaced on re-registration instead of accumulating.
+
+---
+
+## 📦 Model Changes
+
+### Added Models
+
+**OCR:**
+- `OCR_DETECTOR_DB_MOBILENET_V3_LARGE`
+- `OCR_DETECTOR_DB_RESNET50`
+- `OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL`
+- `OCR_RECOGNIZER_PARSEQ`
+
+**Parakeet (CTC):**
+- `PARAKEET_CTC_FP32`, `PARAKEET_CTC_DATA_FP32`, `PARAKEET_CTC_VOCAB`, `PARAKEET_CTC_INT8`, `PARAKEET_CTC_CONFIG`
+- `PARAKEET_CTC_FP32_1`, `PARAKEET_CTC_DATA_FP32_1`, `PARAKEET_CTC_TOKENIZER`
+
+**Parakeet (Sortformer / EOU):**
+- `PARAKEET_SORTFORMER_FP32`
+- `PARAKEET_EOU_ENCODER_FP32`, `PARAKEET_EOU_DECODER_FP32`, `PARAKEET_EOU_TOKENIZER`
+
+**Parakeet (TDT — renamed from unprefixed):**
+- `PARAKEET_TDT_ENCODER_FP32`, `PARAKEET_TDT_ENCODER_DATA_FP32`, `PARAKEET_TDT_DECODER_FP32`, `PARAKEET_TDT_VOCAB`, `PARAKEET_TDT_PREPROCESSOR_FP32`
+- `PARAKEET_TDT_ENCODER_INT8`, `PARAKEET_TDT_DECODER_INT8`, `PARAKEET_TDT_PREPROCESSOR_INT8`
+
+### Removed Models
+
+The following unprefixed Parakeet constants were replaced by their `TDT_` equivalents (see breaking changes):
+
+- `PARAKEET_ENCODER_FP32`, `PARAKEET_ENCODER_DATA_FP32`, `PARAKEET_DECODER_FP32`, `PARAKEET_VOCAB`, `PARAKEET_PREPROCESSOR_FP32`
+- `PARAKEET_ENCODER_INT8`, `PARAKEET_DECODER_INT8`, `PARAKEET_PREPROCESSOR_INT8`
+
+---
+
+## 🧹 Other Changes
+
+- Consolidated transcription schemas and shared ops into a unified structure.
+- Updated `@qvac/tts-onnx` to v0.6.1 and `@qvac/transcription-whispercpp` addon.
+- Aligned TTS plugin artifact patterns.
+- Ported Android E2E test workflow to the monorepo.
+- Improved changelog aggregation to prefer `CHANGELOG_LLM.md` when available.
+- Reorganized monorepo documentation structure.
+- Ported logging executor to direct assertions and added missing test handlers.
+- Enabled profiling in test-qvac desktop and mobile consumers.

--- a/packages/sdk/changelog/0.8.0/api.md
+++ b/packages/sdk/changelog/0.8.0/api.md
@@ -1,0 +1,108 @@
+# 🔌 API Changes v0.8.0
+
+## Add Parakeet Transcription Plugin
+
+PR: [#366](https://github.com/tetherto/qvac/pull/366)
+
+A new `parakeet-transcription` plugin brings NVIDIA Parakeet ONNX speech-to-text as an alternative to Whisper.cpp. Parakeet uses four model files (encoder, encoder-data, decoder, vocab, preprocessor) resolved via the QVAC Registry.
+
+```typescript
+import {
+  PARAKEET_TDT_ENCODER_FP32,
+  PARAKEET_TDT_ENCODER_DATA_FP32,
+  PARAKEET_TDT_DECODER_FP32,
+  PARAKEET_TDT_VOCAB,
+  PARAKEET_TDT_PREPROCESSOR_FP32,
+} from "@qvac/sdk";
+
+const modelId = await loadModel({
+  modelType: "parakeet",
+  modelSrc: PARAKEET_TDT_ENCODER_FP32,
+  modelConfig: {
+    parakeetEncoderSrc: PARAKEET_TDT_ENCODER_FP32,
+    parakeetEncoderDataSrc: PARAKEET_TDT_ENCODER_DATA_FP32,
+    parakeetDecoderSrc: PARAKEET_TDT_DECODER_FP32,
+    parakeetVocabSrc: PARAKEET_TDT_VOCAB,
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_FP32,
+  },
+});
+
+const stream = transcribeStream({ modelId, audioInput: "./audio.mp3" });
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+}
+```
+
+Supports MP3, WAV, OGG, M4A, RAW, and FLAC audio formats.
+
+---
+
+## Add Bergamot pivot translation support
+
+PR: [#834](https://github.com/tetherto/qvac/pull/834)
+
+```typescript
+  // New pivot translation API usage
+  await loadModel({
+    modelSrc: BERGAMOT_ES_EN,  // Primary: Spanish → English
+    modelType: "nmt",
+    modelConfig: {
+      engine: "Bergamot",
+      from: "es",
+      to: "it",  // Final target language
+      // New pivotModel configuration
+      pivotModel: {
+        modelSrc: BERGAMOT_EN_IT,  // Pivot: English → Italian
+        beamsize: 4,
+        temperature: 0.3,
+        topk: 100,
+        normalize: 1,
+        lengthpenalty: 1.2,
+      }
+    }
+  });
+  ```
+
+---
+
+## SDK Profiler
+
+PR: [#836](https://github.com/tetherto/qvac/pull/836)
+
+```typescript
+import { profiler } from "@qvac/sdk";
+
+// Runtime control
+profiler.enable({
+  mode: "verbose", // "summary" | "verbose"
+  includeServerBreakdown: true,
+});
+
+// ... run operations ...
+
+console.log(profiler.exportSummary());
+console.log(profiler.exportTable());
+console.log(profiler.exportJSON({ includeRecentEvents: true }));
+
+profiler.disable();
+
+// Per-call control
+await embed(
+  { modelId: "m1", text: "hello" },
+  { profiling: { enabled: true } },
+);
+
+await completion(
+  { modelId: "m1", history: [{ role: "user", content: "Hello" }] },
+  { profiling: { enabled: false } },
+);
+
+// Additional client APIs now accept RPC options passthrough
+await invokePlugin({ modelId: "m1", handler: "h", params: {} }, { profiling: { enabled: true } });
+await ragSearch({ workspace: "default", query: "q" }, { profiling: { enabled: true } });
+await transcribe({ modelId: "m1", audioChunk: "..." }, { profiling: { enabled: true } });
+await translate({ modelId: "m1", text: "hello" }, { profiling: { enabled: true } });
+```
+
+---
+

--- a/packages/sdk/changelog/0.8.0/breaking.md
+++ b/packages/sdk/changelog/0.8.0/breaking.md
@@ -1,0 +1,250 @@
+# 💥 Breaking Changes v0.8.0
+
+## Make SDK support latest LLM and Embedding add-ons
+
+PR: [#669](https://github.com/tetherto/qvac/pull/669)
+
+**BEFORE:**
+**
+```ts
+await loadModel({
+  modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
+  modelType: "embeddings",
+  modelConfig: {
+    rawConfig: "-ngl\t99\n-dev\tgpu\n--batch_size\t1024",
+  },
+});
+```
+
+**
+
+**AFTER:**
+**
+```ts
+await loadModel({
+  modelSrc: EMBEDDINGS_NOMIC_EMBED_TEXT_V1_5,
+  modelType: "embeddings",
+  modelConfig: {
+    gpuLayers: 99,
+    device: "gpu",
+    batchSize: 1024,
+  },
+});
+```
+
+---
+
+## Decouple Builtin Plugins from Core Load Path
+
+PR: [#774](https://github.com/tetherto/qvac/pull/774)
+
+**BEFORE:**
+**
+
+```typescript
+// Top-level companion source fields were accepted
+await loadModel({
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
+  projectionModelSrc: ".../mmproj.gguf",
+  toolFormat: "json",
+});
+
+await loadModel({
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
+  vadModelSrc: ".../vad.bin",
+});
+
+await loadModel({
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
+  srcVocabSrc: ".../srcvocab.spm",
+  dstVocabSrc: ".../trgvocab.spm",
+});
+
+// Custom plugins could omit loadConfigSchema
+const myPlugin: QvacPlugin = {
+  modelType: "my-plugin",
+  displayName: "My Plugin",
+  addonPackage: "@my/addon",
+  createModel: (params) => ({ model, loader }),
+  handlers: {},
+};
+```
+
+**
+
+**AFTER:**
+**
+
+```typescript
+// Companion source fields must live in modelConfig
+// toolFormat removed (was dead code - defined in schema but never consumed)
+await loadModel({
+  modelType: "llm",
+  modelSrc: ".../model.gguf",
+  modelConfig: {
+    projectionModelSrc: ".../mmproj.gguf",
+  },
+});
+
+await loadModel({
+  modelType: "whisper",
+  modelSrc: ".../model.bin",
+  modelConfig: {
+    vadModelSrc: ".../vad.bin",
+  },
+});
+
+await loadModel({
+  modelType: "nmt",
+  modelSrc: ".../model.intgemm.alphas.bin",
+  modelConfig: {
+    srcVocabSrc: ".../srcvocab.spm",
+    dstVocabSrc: ".../trgvocab.spm",
+  },
+});
+
+await loadModel({
+  modelType: "parakeet",
+  modelSrc: ".../encoder.onnx",
+  modelConfig: {
+    parakeetEncoderSrc: ".../encoder.onnx",
+    parakeetDecoderSrc: ".../decoder.onnx",
+    parakeetVocabSrc: ".../vocab.txt",
+    parakeetPreprocessorSrc: ".../preprocessor.onnx",
+  },
+});
+
+// loadConfigSchema is now REQUIRED for all plugins (built-in and custom)
+// For plugins that accept any config, use a passthrough schema:
+const myPlugin: QvacPlugin = {
+  modelType: "my-plugin",
+  displayName: "My Plugin",
+  addonPackage: "@my/addon",
+  loadConfigSchema: z.object({}).catchall(z.unknown()),
+  createModel: (params) => ({ model, loader }),
+  handlers: {},
+};
+```
+
+---
+
+## Add CTC and Sortformer model support to SDK
+
+PR: [#811](https://github.com/tetherto/qvac/pull/811)
+
+**BEFORE:**
+**
+
+```typescript
+import {
+  PARAKEET_ENCODER_FP32,
+  PARAKEET_ENCODER_DATA_FP32,
+  PARAKEET_DECODER_FP32,
+  PARAKEET_VOCAB,
+  PARAKEET_PREPROCESSOR_FP32,
+} from "@qvac/sdk";
+```
+
+**
+
+**AFTER:**
+**
+
+```typescript
+import {
+  PARAKEET_TDT_ENCODER_FP32,
+  PARAKEET_TDT_ENCODER_DATA_FP32,
+  PARAKEET_TDT_DECODER_FP32,
+  PARAKEET_TDT_VOCAB,
+  PARAKEET_TDT_PREPROCESSOR_FP32,
+} from "@qvac/sdk";
+```
+
+All 8 existing Parakeet model constants are renamed with a variant prefix (`TDT_`). Find-and-replace migration: `PARAKEET_ENCODER` → `PARAKEET_TDT_ENCODER`, `PARAKEET_DECODER` → `PARAKEET_TDT_DECODER`, `PARAKEET_VOCAB` → `PARAKEET_TDT_VOCAB`, `PARAKEET_PREPROCESSOR` → `PARAKEET_TDT_PREPROCESSOR`.
+
+## 🔌 API Changes
+
+### CTC transcription
+
+```typescript
+import {
+  PARAKEET_CTC_FP32_1,
+  PARAKEET_CTC_DATA_FP32_1,
+  PARAKEET_CTC_TOKENIZER,
+} from "@qvac/sdk";
+
+const modelId = await loadModel({
+  modelSrc: PARAKEET_CTC_FP32_1,
+  modelType: "parakeet",
+  modelConfig: {
+    modelType: "ctc",
+    parakeetCtcModelSrc: PARAKEET_CTC_FP32_1,
+    parakeetCtcModelDataSrc: PARAKEET_CTC_DATA_FP32_1,
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
+const text = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+```
+
+### Sortformer diarization
+
+```typescript
+const modelId = await loadModel({
+  modelSrc: PARAKEET_SORTFORMER_FP32,
+  modelType: "parakeet",
+  modelConfig: {
+    modelType: "sortformer",
+    parakeetSortformerSrc: PARAKEET_SORTFORMER_FP32,
+  },
+});
+const diarization = await transcribe({ modelId, audioChunk: "/path/to/audio.wav" });
+// Returns: "Speaker 0: 0.00s - 4.24s\nSpeaker 1: 4.65s - 14.32s\n..."
+```
+
+## 📦 Models
+
+### Added models
+
+```
+PARAKEET_TDT_ENCODER_FP32
+PARAKEET_TDT_ENCODER_DATA_FP32
+PARAKEET_TDT_DECODER_FP32
+PARAKEET_TDT_VOCAB
+PARAKEET_TDT_PREPROCESSOR_FP32
+PARAKEET_TDT_ENCODER_INT8
+PARAKEET_TDT_DECODER_INT8
+PARAKEET_TDT_PREPROCESSOR_INT8
+PARAKEET_CTC_FP32
+PARAKEET_CTC_DATA_FP32
+PARAKEET_CTC_VOCAB
+PARAKEET_CTC_INT8
+PARAKEET_CTC_CONFIG
+PARAKEET_CTC_FP32_1
+PARAKEET_CTC_DATA_FP32_1
+PARAKEET_CTC_TOKENIZER
+PARAKEET_SORTFORMER_FP32
+PARAKEET_EOU_ENCODER_FP32
+PARAKEET_EOU_DECODER_FP32
+PARAKEET_EOU_TOKENIZER
+```
+
+### Removed models
+
+```
+PARAKEET_ENCODER_FP32
+PARAKEET_ENCODER_DATA_FP32
+PARAKEET_DECODER_FP32
+PARAKEET_VOCAB
+PARAKEET_PREPROCESSOR_FP32
+PARAKEET_ENCODER_INT8
+PARAKEET_DECODER_INT8
+PARAKEET_PREPROCESSOR_INT8
+```
+
+**Depends on:** [#586](https://github.com/tetherto/qvac/pull/586) (Parakeet addon CTC/Sortformer support) — ✅ merged
+
+---
+

--- a/packages/sdk/changelog/0.8.0/models.md
+++ b/packages/sdk/changelog/0.8.0/models.md
@@ -1,0 +1,16 @@
+# 📦 Model Changes v0.8.0
+
+## Added Models
+
+```
+OCR_DETECTOR_DB_MOBILENET_V3_LARGE
+OCR_DETECTOR_DB_RESNET50
+OCR_RECOGNIZER_CRNN_MOBILENET_V3_SMALL
+OCR_RECOGNIZER_PARSEQ
+```
+
+---
+
+### Related PRs
+
+- [#771](https://github.com/tetherto/qvac/pull/771) - Update SDK constant models

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- SDK v0.8.0 release needs changelog, NOTICE, and version bump

## 📝 How does it solve it?

- Bump `package.json` version from 0.7.0 to 0.8.0
- Generate changelog for 0.8.0 covering 21 PRs (features, breaking changes, API additions, bug fixes, model changes)
- Generate human-readable `CHANGELOG_LLM.md` release notes
- Rebuild root `CHANGELOG.md` aggregation
- Regenerate `NOTICE` file with updated model attributions