### PR TITLE
doc[notask]: remove closed-source install instructions and align dependency names

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/README.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/README.md
@@ -36,7 +36,7 @@ This native C++ addon, built using the `Bare` Runtime, simplifies running text e
 
 **Dependencies:**
 - qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework
-- qvac-fabric-llm.cpp (≥7248.1.4): Inference engine
+- qvac-fabric-llm.cpp (≥7248.2.1): Inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
 - Linux requires Clang/LLVM 19 with libc++
 

--- a/packages/qvac-lib-infer-llamacpp-embed/README.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/README.md
@@ -36,7 +36,7 @@ This native C++ addon, built using the `Bare` Runtime, simplifies running text e
 
 **Dependencies:**
 - qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework
-- qvac-fabric-llm.cpp (≥7248.1.2): Inference engine
+- qvac-fabric-llm.cpp (≥7248.1.4): Inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
 - Linux requires Clang/LLVM 19 with libc++
 
@@ -50,21 +50,6 @@ Ensure that the `Bare` Runtime is installed globally on your system. If it's not
 ```bash
 npm install -g bare@latest
 ```
-
-Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-```bash
-export NPM_TOKEN=your_personal_access_token
-```
-
-Next, create a `.npmrc` file in the root of your project with the following content:
-
-```ini
-@qvac:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken={NPM_TOKEN}
-```
-
-This configuration ensures secure access to NPM Packages when installing scoped packages.
 
 ### Installing the Package
 

--- a/packages/qvac-lib-infer-llamacpp-embed/docs/architecture.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/docs/architecture.md
@@ -72,7 +72,7 @@ Tier 1: Platform targets for which prebuilds are provided as defined by the .git
 
 **Dependencies:**
 - qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework
-- qvac-fabric-llm.cpp (≥7248.1.4): Inference engine
+- qvac-fabric-llm.cpp (≥7248.2.1): Inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
 
 ---

--- a/packages/qvac-lib-infer-llamacpp-embed/docs/architecture.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/docs/architecture.md
@@ -72,7 +72,7 @@ Tier 1: Platform targets for which prebuilds are provided as defined by the .git
 
 **Dependencies:**
 - qvac-lib-inference-addon-cpp (≥1.1.2): C++ addon framework
-- llama.cpp (≥7248.1.0): Inference engine
+- qvac-fabric-llm.cpp (≥7248.1.4): Inference engine
 - Bare Runtime (≥1.24.0): JavaScript runtime
 
 ---


### PR DESCRIPTION
## Summary
- Remove PAT / NPM_TOKEN / .npmrc auth setup from README install section — not needed for public npm packages
- Update qvac-fabric-llm.cpp version from ≥7248.1.2 to ≥7248.1.4 in README to match vcpkg.json
- Fix architecture.md dependency name from `llama.cpp` to `qvac-fabric-llm.cpp` and update version to ≥7248.1.4
