### PR TITLE
infra: pass QVAC_SDK_VERSION to test consumers

### DIFF
--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -76,6 +76,7 @@ jobs:
       MQTT_PORT: ${{ secrets.MQTT_PORT }}
       MQTT_USERNAME: ${{ secrets.MQTT_USERNAME }}
       MQTT_PASSWORD: ${{ secrets.MQTT_PASSWORD }}
+      QVAC_SDK_VERSION: ${{ format('{0}@{1}', inputs.test-version || github.ref_name, github.sha) }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -68,6 +68,7 @@ jobs:
       MQTT_PORT: ${{ secrets.MQTT_PORT }}
       MQTT_USERNAME: ${{ secrets.MQTT_USERNAME }}
       MQTT_PASSWORD: ${{ secrets.MQTT_PASSWORD }}
+      QVAC_SDK_VERSION: ${{ format('{0}@{1}', inputs.test-version || github.ref_name, github.sha) }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- Adds `QVAC_SDK_VERSION` env var to `test-desktop-sdk.yml` and `test-android-sdk.yml` job env blocks
- Value is `<ref>@<sha>` (e.g., `main@abc1234def` or `release-sdk-0.7.0@abc1234def`)
- The test-suite consumer reads this env var to include the SDK version in the HTML test report

Companion PR: https://github.com/tetherto/qvac-test-suite/pull/58 (test-suite side)

## Test plan

- [ ] Trigger `QVAC Tests (sdk)` workflow and verify the report shows the branch@sha as SDK version

Made with [Cursor](https://cursor.com)