### PR TITLE
fix: fix race condition in embed and diffusion download utilities

### DIFF
--- a/packages/lib-infer-diffusion/test/integration/utils.js
+++ b/packages/lib-infer-diffusion/test/integration/utils.js
@@ -38,12 +38,7 @@ async function downloadFile (url, dest) {
             return safeReject(unlinkErr)
           }
 
-          let redirectUrl = response.headers.location
-          // Handle relative redirects
-          if (redirectUrl.startsWith('/')) {
-            const originalUrl = new URL(url)
-            redirectUrl = `${originalUrl.protocol}//${originalUrl.host}${redirectUrl}`
-          }
+          const redirectUrl = new URL(response.headers.location, url).href
 
           downloadFile(redirectUrl, dest)
             .then(safeResolve)

--- a/packages/qvac-lib-infer-llamacpp-embed/examples/utils.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/examples/utils.js
@@ -19,28 +19,45 @@ async function downloadModel (url, filename) {
   console.log(`Downloading ${filename}...`)
 
   return new Promise((resolve, reject) => {
+    let resolved = false
+    const safeResolve = (val) => { if (!resolved) { resolved = true; resolve(val) } }
+    const safeReject = (err) => { if (!resolved) { resolved = true; reject(err) } }
+
     const fileStream = fs.createWriteStream(modelPath)
-    let downloaded = 0
+
+    fileStream.on('error', (err) => {
+      fileStream.destroy()
+      fs.unlink(modelPath, () => safeReject(err))
+    })
 
     const req = https.request(url, response => {
-      if (response.statusCode === 301 || response.statusCode === 302) {
+      if ([301, 302, 307, 308].includes(response.statusCode)) {
         fileStream.destroy()
         req.destroy()
         response.destroy()
-        fs.unlink(modelPath, () => {})
-        return downloadModel(response.headers.location, filename)
-          .then(resolve).catch(reject)
+        fs.unlink(modelPath, (unlinkErr) => {
+          if (unlinkErr && unlinkErr.code !== 'ENOENT') {
+            return safeReject(unlinkErr)
+          }
+
+          const redirectUrl = new URL(response.headers.location, url).href
+
+          downloadModel(redirectUrl, filename)
+            .then(safeResolve).catch(safeReject)
+        })
+        return
       }
 
       if (response.statusCode !== 200) {
         fileStream.destroy()
         req.destroy()
         response.destroy()
-        fs.unlink(modelPath, () => {})
-        return reject(new Error(`Download failed: ${response.statusCode}`))
+        fs.unlink(modelPath, () => safeReject(new Error(`Download failed: ${response.statusCode}`)))
+        return
       }
 
       const total = parseInt(response.headers['content-length'], 10)
+      let downloaded = 0
 
       response.on('data', chunk => {
         downloaded += chunk.length
@@ -52,20 +69,21 @@ async function downloadModel (url, filename) {
         }
       })
 
+      response.on('error', (err) => {
+        fileStream.destroy()
+        fs.unlink(modelPath, () => safeReject(err))
+      })
+
       response.pipe(fileStream)
       fileStream.on('close', () => {
-        fileStream.destroy()
-        req.destroy()
-        response.destroy()
         console.log('\nDownload complete!')
-        resolve([filename, modelDir])
+        safeResolve([filename, modelDir])
       })
     })
 
     req.on('error', err => {
       fileStream.destroy()
-      req.destroy()
-      fs.unlink(modelPath, () => reject(err))
+      fs.unlink(modelPath, () => safeReject(err))
     })
 
     req.end()

--- a/packages/qvac-lib-infer-llamacpp-embed/test/integration/utils.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/integration/utils.js
@@ -15,39 +15,53 @@ const FilesystemDL = require('@qvac/dl-filesystem')
  */
 async function downloadFile (url, dest) {
   return new Promise((resolve, reject) => {
+    let resolved = false
+    const safeResolve = () => { if (!resolved) { resolved = true; resolve() } }
+    const safeReject = (err) => { if (!resolved) { resolved = true; reject(err) } }
+
     const file = fs.createWriteStream(dest)
+
+    file.on('error', (err) => {
+      file.destroy()
+      fs.unlink(dest, () => safeReject(err))
+    })
+
     const req = https.request(url, (response) => {
-      // Handle redirects (301, 302, 307, 308 for Windows model download)
       if ([301, 302, 307, 308].includes(response.statusCode)) {
         file.destroy()
-        fs.unlink(dest, () => {}) // Clean up partial file
+        fs.unlink(dest, (unlinkErr) => {
+          if (unlinkErr && unlinkErr.code !== 'ENOENT') {
+            return safeReject(unlinkErr)
+          }
 
-        let redirectUrl = response.headers.location
-        // Handle relative redirects
-        if (redirectUrl.startsWith('/')) {
-          const originalUrl = new URL(url)
-          redirectUrl = `${originalUrl.protocol}//${originalUrl.host}${redirectUrl}`
-        }
+          const redirectUrl = new URL(response.headers.location, url).href
 
-        return downloadFile(redirectUrl, dest).then(resolve).catch(reject)
+          downloadFile(redirectUrl, dest)
+            .then(safeResolve).catch(safeReject)
+        })
+        return
       }
 
       if (response.statusCode !== 200) {
         file.destroy()
-        fs.unlink(dest, () => {})
-        return reject(new Error(`Download failed: ${response.statusCode}`))
+        fs.unlink(dest, () => safeReject(new Error(`Download failed: ${response.statusCode}`)))
+        return
       }
 
-      response.pipe(file)
-      file.on('finish', () => {
+      response.on('error', (err) => {
         file.destroy()
-        resolve()
+        fs.unlink(dest, () => safeReject(err))
+      })
+
+      response.pipe(file)
+      file.on('close', () => {
+        safeResolve()
       })
     })
 
     req.on('error', (err) => {
       file.destroy()
-      fs.unlink(dest, () => reject(err))
+      fs.unlink(dest, () => safeReject(err))
     })
 
     req.end()


### PR DESCRIPTION
## What problem does this PR solve?

The embed and diffusion packages have the same download utility race conditions that were fixed in the LLM package by PR #1019:

- **`qvac-lib-infer-llamacpp-embed/examples/utils.js`**: Had all the original bugs — fire-and-forget `fs.unlink`, only handled 301/302, no double-settlement guards, no fileStream/response error handlers
- **`qvac-lib-infer-llamacpp-embed/test/integration/utils.js`**: Fire-and-forget `fs.unlink`, no `safeResolve`/`safeReject` guards, no error handlers, used `finish` instead of `close`
- **`lib-infer-diffusion/test/integration/utils.js`**: Manual `startsWith('/')` redirect handling instead of `new URL()` constructor

## How does it solve it?

Port the proven download pattern from the LLM package (PR #1019):
- Wait for `fs.unlink` callback before recursing on redirect
- Add `safeResolve`/`safeReject` guards to prevent double settlement
- Handle 307/308 redirects in embed `examples/utils.js`
- Add `fileStream.on('error')` and `response.on('error')` handlers
- Use `new URL(location, base).href` for safer redirect resolution
- Use `close` event instead of `finish` for write completion

## How was it tested?

Code review — the changes are identical to the pattern already battle-tested in `qvac-lib-infer-llamacpp-llm/test/integration/utils.js` and validated end-to-end in PR #1019.

Made with [Cursor](https://cursor.com)