### PR TITLE
fix: use object config format in nativelog example

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/examples/nativelog.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/examples/nativelog.js
@@ -47,7 +47,7 @@ async function main () {
     diskPath: dirPath,
     modelName
   }
-  const config = '-ngl\t25\nverbosity\t2'
+  const config = { device: 'gpu', gpu_layers: '25', verbosity: '2' }
 
   // 5. Loading model
   const model = new GGMLBert(args, config)


### PR DESCRIPTION
## Summary

- The `examples/nativelog.js` file was using the legacy tab-delimited string config format (`'-ngl\t25\nverbosity\t2'`), while the addon expects an object map with string values. Updated it to use the correct object format (`{ device: 'gpu', gpu_layers: '25', verbosity: '2' }`), consistent with the other examples, tests, and README.

## How it was tested

- Verifified `examples/nativelog.js` runs correctly with the updated config format