### PR TITLE
fix: handle absolute companion model paths in diffusion addon

### DIFF
--- a/packages/lib-infer-diffusion/index.js
+++ b/packages/lib-infer-diffusion/index.js
@@ -72,14 +72,15 @@ class ImgStableDiffusion extends BaseInference {
       // for SD3 split) the caller is using a pure diffusion GGUF that must be
       // loaded via diffusion_model_path.
       const isSplitLayout = !!this._llmModel || !!this._t5XxlModel
+      const resolve = (name) => name ? (path.isAbsolute(name) ? name : path.join(this._diskPath, name)) : ''
       const configurationParams = {
-        path: isSplitLayout ? '' : path.join(this._diskPath, this._modelName),
-        diffusionModelPath: isSplitLayout ? path.join(this._diskPath, this._modelName) : '',
-        clipLPath: this._clipLModel ? path.join(this._diskPath, this._clipLModel) : '',
-        clipGPath: this._clipGModel ? path.join(this._diskPath, this._clipGModel) : '',
-        t5XxlPath: this._t5XxlModel ? path.join(this._diskPath, this._t5XxlModel) : '',
-        llmPath: this._llmModel ? path.join(this._diskPath, this._llmModel) : '',
-        vaePath: this._vaeModel ? path.join(this._diskPath, this._vaeModel) : '',
+        path: isSplitLayout ? '' : resolve(this._modelName),
+        diffusionModelPath: isSplitLayout ? resolve(this._modelName) : '',
+        clipLPath: resolve(this._clipLModel),
+        clipGPath: resolve(this._clipGModel),
+        t5XxlPath: resolve(this._t5XxlModel),
+        llmPath: resolve(this._llmModel),
+        vaePath: resolve(this._vaeModel),
         config: this._config
       }
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The diffusion addon's `_load()` always joined companion model paths (clipL, clipG, t5Xxl, llm, vae) with `diskPath` using `path.join()`. When the SDK's `resolveConfig()` passes already-absolute paths for companion models, this produces broken double-joined paths (e.g., `/cache/models//cache/models/clip-l.gguf`).

## 📝 How does it solve it?

- Adds a `resolve()` helper that checks `path.isAbsolute(name)` before joining:
  - Absolute paths: passed through unchanged
  - Relative paths: joined with `diskPath` as before
  - Falsy values (null/undefined): return empty string
- Uses `bare-path` which works cross-platform (desktop, Android, iOS, Windows)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213766835037452