### PR TITLE
fix[notask]: bump whisper-cpp from 1.7.5.1 to 1.7.6 to address CVE-2025-14569

### DIFF
--- a/packages/qvac-lib-infer-whispercpp/addon/src/model-interface/whisper.cpp/WhisperHandlers.cpp
+++ b/packages/qvac-lib-infer-whispercpp/addon/src/model-interface/whisper.cpp/WhisperHandlers.cpp
@@ -426,9 +426,9 @@ const std::unordered_map<std::string, HandlerFunction<whisper_full_params>>
            params.vad = true;
          }},
         {"seed",
-         [](whisper_full_params& params, const JSValueVariant& value) {
-           int seed = static_cast<int>(std::get<double>(value));
-           params.seed = seed;
+         []([[maybe_unused]] whisper_full_params& params,
+            [[maybe_unused]] const JSValueVariant& value) {
+           // whisper_full_params.seed was removed in whisper.cpp >= 1.7.6
          }},
 };
 

--- a/packages/qvac-lib-infer-whispercpp/vcpkg.json
+++ b/packages/qvac-lib-infer-whispercpp/vcpkg.json
@@ -25,7 +25,7 @@
   "overrides": [
     {
       "name": "whisper-cpp",
-      "version": "1.7.5.1"
+      "version": "1.7.6"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Bump whisper-cpp vcpkg dependency from 1.7.5.1 to 1.7.6 (latest available in the private registry)
- Adapt `WhisperHandlers.cpp` for API change: `whisper_full_params.seed` was removed in 1.7.6

## Problem

[CVE-2025-14569](https://nvd.nist.gov/vuln/detail/CVE-2025-14569) documents a use-after-free vulnerability in whisper.cpp's `read_audio_data` function (CVSS 4.8). While the vulnerability is in CLI example code (not the `libwhisper` library we link), staying on an outdated version misses general stability and security fixes.

## Solution

**`vcpkg.json`:**
```diff
- "version": "1.7.5.1"
+ "version": "1.7.6"
```

**`WhisperHandlers.cpp`:** The `seed` field was removed from `whisper_full_params` in 1.7.6. Updated the handler to a no-op:
```cpp
{"seed",
 []([[maybe_unused]] whisper_full_params& params,
    [[maybe_unused]] const JSValueVariant& value) {
   // whisper_full_params.seed was removed in whisper.cpp >= 1.7.6
 }},
```

**Note on Issue #7 (ONNX Runtime OOB read):** The private vcpkg registry currently only has onnxruntime 1.21.0. The fix requires > 1.23.2 — this needs a registry-level port update and is tracked separately.

## How was it tested?

- **Full rebuild:** Clean `bare-make generate && bare-make build && bare-make install` with 1.7.6 — compiles and links successfully (OpenMP dependency resolved via `libomp`)
- **Unit tests (before & after):** 24/24 pass, 90/90 assertions
- **SDK integration (before & after):** `whispercpp-filesystem.ts` produces identical transcription output (Alice in Wonderland passage)

Made with [Cursor](https://cursor.com)