### PR TITLE
fix[notask]: remove error.message from 500 responses in TTS benchmark server

### DIFF
--- a/packages/qvac-lib-infer-onnx-tts/benchmarks/server/src/server.js
+++ b/packages/qvac-lib-infer-onnx-tts/benchmarks/server/src/server.js
@@ -33,8 +33,7 @@ const handleError = (error, res) => {
 
   res.statusCode = 500
   res.end(JSON.stringify({
-    error: ERRORS.UNEXPECTED_ERROR,
-    details: error.message
+    error: ERRORS.UNEXPECTED_ERROR
   }))
 }
 


### PR DESCRIPTION
## Summary
- Remove `details: error.message` from 500 error responses to prevent leaking internal file paths, stack traces, or library-specific information

## How was it tested?
- Unit tests (before & after): 21/21 pass, 63/63 assertions

Made with [Cursor](https://cursor.com)