### PR TITLE
chore(registry): bump @qvac/registry-schema to ^0.1.2 in server and client

### DIFF
--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/registry-schema": "^0.1.1",
+    "@qvac/registry-schema": "^0.1.2",
     "b4a": "^1.6.7",
     "bare-fs": "^4.5.2",
     "bare-os": "^3.6.2",
@@ -62,8 +62,8 @@
     "corestore": "^7.4.5",
     "hyperblobs": "^2.8.0",
     "hypercore-id-encoding": "^1.3.0",
-    "hyperdb": "^4.16.1",
     "hypercore-stats": "^2.4.0",
+    "hyperdb": "^4.16.1",
     "hyperswarm": "^4.14.0",
     "hyperswarm-stats": "^1.3.0",
     "paparam": "^1.10.0",

--- a/packages/qvac-lib-registry-server/package.json
+++ b/packages/qvac-lib-registry-server/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/client-s3": "^3.998.0",
     "@huggingface/gguf": "^0.3.3",
     "@huggingface/hub": "^2.4.1",
-    "@qvac/registry-schema": "^0.1.1",
+    "@qvac/registry-schema": "^0.1.2",
     "autobase": "^7.18.1",
     "b4a": "^1.6.7",
     "blind-peer": "^2.9.4",


### PR DESCRIPTION
## What problem does this PR solve?

Server and client were pinned to `@qvac/registry-schema@0.1.1` via lockfile, missing changes shipped in 0.1.2.

## How does it solve it?

- Bumps `@qvac/registry-schema` from `^0.1.1` to `^0.1.2` in both `packages/qvac-lib-registry-server/package.json` and `packages/qvac-lib-registry-server/client/package.json`
- Updates server `package-lock.json` to resolve 0.1.2

## Breaking changes

None.