### PR TITLE
DEVOPS-1608: pinning all third party actions with SHA

### DIFF
--- a/.github/workflows/benchmark-ocr-onnx.yml
+++ b/.github/workflows/benchmark-ocr-onnx.yml
@@ -234,7 +234,7 @@ jobs:
           sudo apt-get install -y mesa-vulkan-drivers
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -355,7 +355,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: needs.setup.outputs.qvac_needed == 'true'
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
@@ -177,7 +177,7 @@ jobs:
         continue-on-error: true
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
         if: always() && steps.check-test-results.outputs.exists == 'true'
         with:
           files: ${{ env.WORKDIR }}/build/addon/test/unit/cpp-test-results.xml

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
@@ -207,7 +207,7 @@ jobs:
         continue-on-error: true
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
         if: always() && steps.check-test-results.outputs.exists == 'true'
         with:
           files: ${{ env.PKG_DIR }}/build/cpp-test-results.xml

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
@@ -194,7 +194,7 @@ jobs:
         continue-on-error: true
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@2ceeed2b8f26e15b06c3846719f75354febd9e7b # v2
         if: always() && steps.check-test-results.outputs.exists == 'true'
         with:
           files: ${{ env.WORKDIR }}/build/addon/tests/cpp-test-results.xml

--- a/.github/workflows/create-github-release-lib-infer-diffusion.yml
+++ b/.github/workflows/create-github-release-lib-infer-diffusion.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: diffusion-cpp-v${{ steps.version.outputs.current }}
           name: ${{ inputs.release_name }} v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-ocr-onnx.yml
+++ b/.github/workflows/create-github-release-ocr-onnx.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ocr-onnx-v${{ steps.version.outputs.current }}
           name: QVAC OCR Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-nmtcpp.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: v${{ steps.version.outputs.current }}
           name: QVAC NMT Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-onnx-tts.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: v${{ steps.version.outputs.current }}
           name: QVAC TTS ONNX Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-onnx.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: qvac-lib-infer-onnx-v${{ steps.version.outputs.current }}
           name: QVAC ONNX Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-parakeet.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: v${{ steps.version.outputs.current }}
           name: QVAC Transcription Parakeet Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/create-github-release-qvac-lib-infer-whispercpp.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.version.outputs.bumped == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: v${{ steps.version.outputs.current }}
           name: QVAC Transcription Whisper Addon v${{ steps.version.outputs.current }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -75,7 +75,7 @@ jobs:
           echo "release_notes_path=${release_notes_path}" >> "${GITHUB_OUTPUT}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ inputs.repo_name }}-v${{ inputs.published_version }}
           name: ${{ inputs.release_name }} v${{ inputs.published_version }}

--- a/.github/workflows/docs-generate-api.yml
+++ b/.github/workflows/docs-generate-api.yml
@@ -69,7 +69,7 @@ jobs:
           echo "✅ Cloned $SDK_REPO into sdk-source"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies (docs)
         working-directory: ${{ env.DOCS_DIR }}
@@ -102,7 +102,7 @@ jobs:
             "${{ env.DOCS_DIR }}/src/lib/versions.ts"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "doc[notask]: generate API docs for v${{ steps.version.outputs.version }}"

--- a/.github/workflows/docs-post-merge-sync.yml
+++ b/.github/workflows/docs-post-merge-sync.yml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install docs dependencies
         working-directory: docs/website

--- a/.github/workflows/docs-website-pr-checks.yml
+++ b/.github/workflows/docs-website-pr-checks.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 

--- a/.github/workflows/integration-mobile-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-mobile-test-lib-infer-diffusion.yml
@@ -406,7 +406,7 @@ jobs:
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate Android project
         if: matrix.platform == 'Android'
@@ -731,7 +731,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -319,7 +319,7 @@ jobs:
       # Model provisioning for mobile: presigned URLs so the app can download detector + all
       # recognizers at runtime (same set as desktop integration tests).
       - name: Configure AWS credentials for model download
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -465,7 +465,7 @@ jobs:
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate Android project
         if: matrix.platform == 'Android'
@@ -790,7 +790,7 @@ jobs:
       # Kept as-is from your workflow (only paths above needed monorepo porting)
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
@@ -318,7 +318,7 @@ jobs:
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate Android project
         if: matrix.platform == 'Android'
@@ -643,7 +643,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -403,7 +403,7 @@ jobs:
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate Android project
         if: matrix.platform == 'Android'
@@ -699,7 +699,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -406,7 +406,7 @@ jobs:
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate Android project
         if: matrix.platform == 'Android'
@@ -731,7 +731,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -360,7 +360,7 @@ jobs:
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -547,7 +547,7 @@ jobs:
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate Android project
         if: matrix.platform == 'Android'

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -452,7 +452,7 @@ jobs:
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate Android project
         if: matrix.platform == 'Android'
@@ -780,7 +780,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -418,7 +418,7 @@ jobs:
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate Android project
         if: matrix.platform == 'Android'
@@ -722,7 +722,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -409,7 +409,7 @@ jobs:
 
       - name: Setup Android SDK
         if: matrix.platform == 'Android'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate Android project
         if: matrix.platform == 'Android'
@@ -734,7 +734,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -163,7 +163,7 @@ jobs:
           sudo apt-get install -y mesa-vulkan-drivers
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       pkg: ${{ steps.filter.outputs.pkg }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -124,7 +124,7 @@ jobs:
 
       - if: ${{ matrix.platform == 'android' }}
         name: Setup Android NDK
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@2817442ee7c3346c1eb7d2ec60263c93206ba14f # v1
         with:
           ndk-version: r27c
           add-to-path: true

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -89,7 +89,7 @@ jobs:
           git fetch origin ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
           bun-version: latest
 

--- a/.github/workflows/repository-dispatch-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/repository-dispatch-qvac-lib-infer-whispercpp.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Repository Dispatch
         if: steps.changed.outputs.readme_changed == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
           repository: tetherto/qvac-docs

--- a/.github/workflows/repository-dispatch-sdk.yml
+++ b/.github/workflows/repository-dispatch-sdk.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Repository Dispatch
         if: steps.changed.outputs.readme_changed == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
           repository: tetherto/qvac-docs

--- a/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-qvac-lib-infer-nmtcpp.yml
@@ -76,7 +76,7 @@ jobs:
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@fb7eb401298e393da51cdcb2feb1ed0183619014 # v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           node-version: 22
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
@@ -96,7 +96,7 @@ jobs:
           java-version: "17"
           distribution: "temurin"
 
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
       - name: Generate runId
         id: runid
@@ -245,7 +245,7 @@ jobs:
           path: ./apk
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -418,7 +418,7 @@ jobs:
         with:
           node-version: 22
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
@@ -539,7 +539,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -636,7 +636,7 @@ jobs:
 
       - name: Download baseline results
         id: download-baseline
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         continue-on-error: true
         with:
           workflow: test-android-sdk.yml

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           node-version: 22
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
@@ -434,7 +434,7 @@ jobs:
 
       - name: Download baseline results
         id: download-baseline
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         continue-on-error: true
         with:
           workflow: test-desktop-sdk.yml

--- a/.github/workflows/trigger-docs-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/trigger-docs-qvac-lib-infer-nmtcpp.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Repository Dispatch
         if: steps.changed.outputs.readme_changed == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
           repository: tetherto/qvac-docs

--- a/.github/workflows/trigger-docs-sdk.yml
+++ b/.github/workflows/trigger-docs-sdk.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Repository Dispatch
         if: steps.changed.outputs.readme_changed == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
           repository: tetherto/qvac-docs


### PR DESCRIPTION
## Summary

This PR pins mutable third-party GitHub Actions in `.github/workflows` to immutable commit SHAs to reduce supply-chain risk and address the **“Third-Party Actions Pinned by Mutable Tag”** finding.

Priority was given to higher-risk actions (release creation, PR automation, AWS credential handling), followed by pinning all remaining in-scope third-party actions to ensure consistency across workflows.

---

## What Changed

Replaced mutable tags (e.g., `@v2`, `@v3`, `@v4`, `@v6`) with commit SHA pins for the following actions:

- `softprops/action-gh-release`
- `peter-evans/create-pull-request`
- `aws-actions/configure-aws-credentials`
- `dorny/paths-filter`
- `oven-sh/setup-bun`
- `dawidd6/action-download-artifact`
- `android-actions/setup-android`
- `EnricoMi/publish-unit-test-result-action`
- `peter-evans/repository-dispatch`
- `nttld/setup-ndk`

For maintainability, the intended major version is preserved via inline comments (e.g., `# v6`) to simplify future upgrades.

---

## Validation

- Resolved and verified pinned SHAs against upstream GitHub tag references  
- Successfully parsed all `.github/workflows` YAML files  
- Confirmed no remaining live mutable third-party action references for targeted actions  
- Verified the only remaining mutable tag reference exists in a **commented-out line** (`vulkaninfo.yml`) and is not executed  

---

## Notes

- `actionlint` and `yamllint` were not available in the local environment, so full workflow linting was not executed  
- `git diff --check` reports trailing whitespace due to existing **CRLF line endings** in some workflow files — this is formatting noise, not a functional issue  

---

## Why

Pinning GitHub Actions to immutable SHAs prevents unexpected upstream tag changes from altering workflow behavior.

This is particularly critical for actions that:
- Create GitHub releases  
- Create pull requests using repository tokens  
- Configure AWS credentials  

This change aligns with GitHub Actions hardening best practices and reduces overall supply-chain exposure.