### PR TITLE
release(registry-client): v0.3.0

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.3.0]
+
+Release Date: 2026-03-24
+
+### ✨ Features
+
+- Add download profiler for registry blob performance diagnostics — measures per-peer throughput, block timing, and connection stats for troubleshooting slow downloads (#1040)
+
+### 🐛 Fixed
+
+- Lazy-load Node.js builtins (`perf_hooks`, `worker_threads`) in profiler module for Bare runtime compatibility (#1096)
+- Update package.json repository URLs to point to the monorepo (#1088)
+
 ## [0.2.1]
 
 Release Date: 2026-03-16

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## What problem does this PR solve?

Cuts a new registry-client release (0.3.0) covering changes merged since v0.2.1: download profiler for blob performance diagnostics, Bare runtime compatibility fix in profiler, and monorepo URL corrections.

## How does it solve it?

Version bump to 0.3.0 in package.json and changelog update covering all 3 commits since v0.2.1.

## Breaking changes

None.