### PR TITLE
chore: update docs references from hyperdrive to p2p examples

### DIFF
--- a/docs/website/content/docs/(latest)/sdk/examples/ai-tasks/completion.mdx
+++ b/docs/website/content/docs/(latest)/sdk/examples/ai-tasks/completion.mdx
@@ -46,7 +46,7 @@ The following script shows a basic example of completion:
 <Tab value="js" label="JavaScript" default>
 <WrapCode>
 
-```js file=<rootDir>/packages/sdk/dist/examples/llamacpp-hyperdrive.js title="completion.js" lineNumbers
+```js file=<rootDir>/packages/sdk/dist/examples/llamacpp-p2p.js title="completion.js" lineNumbers
 ```
 </WrapCode>
 </Tab>
@@ -54,7 +54,7 @@ The following script shows a basic example of completion:
 <Tab value="ts" label="TypeScript">
 <WrapCode>
 
-```ts file=<rootDir>/packages/sdk/examples/llamacpp-hyperdrive.ts title="completion.ts" lineNumbers
+```ts file=<rootDir>/packages/sdk/examples/llamacpp-p2p.ts title="completion.ts" lineNumbers
 ```
 </WrapCode>
 </Tab>

--- a/docs/website/content/docs/(latest)/sdk/examples/ai-tasks/text-embeddings.mdx
+++ b/docs/website/content/docs/(latest)/sdk/examples/ai-tasks/text-embeddings.mdx
@@ -33,7 +33,7 @@ The following script shows an example of embedding:
 <Tab value="js" label="JavaScript" default>
 <WrapCode>
 
-```js file=<rootDir>/packages/sdk/dist/examples/embed-hyperdrive.js title="text-embeddings.js" lineNumbers
+```js file=<rootDir>/packages/sdk/dist/examples/embed-p2p.js title="text-embeddings.js" lineNumbers
 ```
 </WrapCode>
 </Tab>
@@ -41,7 +41,7 @@ The following script shows an example of embedding:
 <Tab value="ts" label="TypeScript">
 <WrapCode>
 
-```ts file=<rootDir>/packages/sdk/examples/embed-hyperdrive.ts title="text-embeddings.ts" lineNumbers
+```ts file=<rootDir>/packages/sdk/examples/embed-p2p.ts title="text-embeddings.ts" lineNumbers
 ```
 </WrapCode>
 </Tab>


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Docs website still referenced the old `*-hyperdrive.ts` example filenames that were renamed to `*-p2p.ts` in #1118

## 📝 How does it solve it?

- Update `completion.mdx` references: `llamacpp-hyperdrive` → `llamacpp-p2p`
- Update `text-embeddings.mdx` references: `embed-hyperdrive` → `embed-p2p`