### PR TITLE
doc[notask]: remove stale img2img references from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Legend:
 | lib-decoder-audio | Audio decoder library leveraging FFmpeg for efficient audio decoding as preprocessing step for other addons | Addon |
 | lib-infer-llamacpp-embed | Native C++ addon for running text embedding models to generate high-quality contextual embeddings | Addon |
 | lib-infer-llamacpp-llm | Native C++ addon for running Large Language Models (LLMs) within QVAC runtime applications | Addon |
-| lib-infer-diffusion | Native C++ addon for text-to-image and image-to-image generation using stable-diffusion.cpp | Addon |
+| lib-infer-diffusion | Native C++ addon for text-to-image generation using stable-diffusion.cpp | Addon |
 | lib-infer-nmtcpp | Library for running various translation models supporting OPUS, Bergamot, and IndicTrans backends | Addon |
 | lib-infer-onnx | Bare addon for ONNX Runtime session management | Addon |
 | lib-infer-onnx-tts | Text-to-Speech (TTS) library using Chatterbox and Supertonic neural TTS model via ONNX Runtime | Addon |

--- a/packages/lib-infer-diffusion/README.md
+++ b/packages/lib-infer-diffusion/README.md
@@ -1,6 +1,6 @@
 # qvac-lib-infer-stable-diffusion-cpp
 
-Native C++ addon for text-to-image and image-to-image generation using [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp), built for the Bare Runtime. Supports **Stable Diffusion 1.x / 2.x / XL / 3** and **FLUX.2 [klein]**.
+Native C++ addon for text-to-image generation using [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp), built for the Bare Runtime. Supports **Stable Diffusion 1.x / 2.x / XL / 3** and **FLUX.2 [klein]**.
 
 ## Table of Contents
 

--- a/packages/lib-infer-diffusion/docs/architecture.md
+++ b/packages/lib-infer-diffusion/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Documentation
 
-**Package:** `@qvac/img-stable-diffusion-cpp` v0.1.0  
+**Package:** `@qvac/diffusion-cpp` v0.1.0  
 **Stack:** JavaScript, C++20, stable-diffusion.cpp, Bare Runtime, CMake, vcpkg  
 **License:** Apache-2.0
 
@@ -38,12 +38,12 @@
 
 ## Purpose
 
-`@qvac/img-stable-diffusion-cpp` is a cross-platform npm package providing diffusion model inference for Bare runtime applications. It wraps stable-diffusion.cpp in a JavaScript-friendly API, enabling local image and video generation on desktop and mobile with CPU/GPU acceleration.
+`@qvac/diffusion-cpp` is a cross-platform npm package providing diffusion model inference for Bare runtime applications. It wraps stable-diffusion.cpp in a JavaScript-friendly API, enabling local image generation on desktop and mobile with CPU/GPU acceleration.
 
 **Core value:**
 - High-level JavaScript API for diffusion model inference
 - Progress callback during generation steps
-- Text-to-image and image-to-image generation via single `run()` API
+- Text-to-image generation via `run()` API
 - Disk-local model files (no download/streaming layer)
 
 ## Key Features
@@ -87,7 +87,7 @@ graph TB
     end
     
     subgraph "Inference Addons"
-        IMG[img-stable-diffusion-cpp<br/>Image/Video Gen]
+        IMG[diffusion-cpp<br/>Image Gen]
         LLM[llm-llamacpp<br/>LLMs]
         EMBED[embed-llamacpp<br/>Embeddings]
         WHISPER[whispercpp<br/>STT]

--- a/packages/lib-infer-diffusion/docs/architecture.md
+++ b/packages/lib-infer-diffusion/docs/architecture.md
@@ -54,7 +54,7 @@
 - **GPU acceleration**: Metal, Vulkan, OpenCL
 - **Quantized models**: GGUF, safetensors, checkpoint formats
 - **Diffusion models**: SD1.x, SD2.x, SDXL, SD3, FLUX.2 [klein]
-- **Generation modes**: txt2img, img2img (auto-detected via `init_image` parameter)
+- **Generation modes**: txt2img
 
 ## Target Platforms
 
@@ -629,7 +629,7 @@ Need to pass complex generation parameters from JavaScript to C++:
 - Prompt and negative prompt
 - Image dimensions (width, height)
 - Sampling parameters (steps, cfg_scale, sampler, seed)
-- Optional inputs (init image for img2img, LoRA configs, ControlNet)
+- Optional inputs (LoRA configs, ControlNet)
 
 ### Decision
 
@@ -669,12 +669,8 @@ interface GenerationParams {
   batch_count?: number;       // default: 1
   vae_tiling?: boolean;       // Enable VAE tiling (for large images)
   cache_preset?: string;      // 'slow' | 'medium' | 'fast' | 'ultra'
-  init_image?: Uint8Array;    // PNG/JPEG bytes — if provided, runs img2img
-  strength?: number;          // img2img: 0.0 = keep source, 1.0 = full redraw
 }
 ```
-
-Mode is determined automatically: if `init_image` is provided, runs img2img; otherwise txt2img.
 
 ---
 

--- a/packages/lib-infer-diffusion/docs/data-flows-detailed.md
+++ b/packages/lib-infer-diffusion/docs/data-flows-detailed.md
@@ -1,6 +1,6 @@
 # Detailed Data Flows
 
-This document contains detailed diagrams showing how data moves through the `@qvac/img-stable-diffusion-cpp` system.
+This document contains detailed diagrams showing how data moves through the `@qvac/diffusion-cpp` system.
 
 **Audience:** Developers debugging complex behavior, contributors understanding system interactions.
 


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Several docs still claim img2img is a supported generation mode — it is not yet wired in the JS layer
- Architecture and data-flow docs still reference the old package name `@qvac/img-stable-diffusion-cpp` (now `@qvac/diffusion-cpp`)

## 📝 How does it solve it?

- Remove "and image-to-image" from root `README.md` diffusion addon description
- Remove "and image-to-image" from addon `README.md` opening line
- Remove img2img references from `docs/architecture.md` (generation modes, feature list, optional inputs, code example)
- Replace old package name `@qvac/img-stable-diffusion-cpp` → `@qvac/diffusion-cpp` in `docs/architecture.md` and `docs/data-flows-detailed.md`
- Remove "image/video" from architecture diagram label

## 🧪 How was it tested?

- Grep confirms no remaining stale `img2img`, `image-to-image`, `image/video`, or `img-stable-diffusion-cpp` references in affected files
- Docs-only change, no code affected