### PR TITLE
chore[notask]: bump patch versions for security hardening releases

### DIFF
--- a/packages/qvac-lib-decoder-audio/CHANGELOG.md
+++ b/packages/qvac-lib-decoder-audio/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5]
+
+Security hardening release from comprehensive security audit.
+
+### Changed
+- Replace deprecated `istanbul` with `nyc` for code coverage (#1082)
+
+### Fixed
+- Fix coverage script to use `.nyc_output` directory for correct HTML report generation (#1082)
+
 ## [0.3.4]
 
 ### Added

--- a/packages/qvac-lib-decoder-audio/package.json
+++ b/packages/qvac-lib-decoder-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/decoder-audio",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "",
   "license": "Apache-2.0",
   "author": "Tether",

--- a/packages/qvac-lib-infer-onnx-tts/CHANGELOG.md
+++ b/packages/qvac-lib-infer-onnx-tts/CHANGELOG.md
@@ -14,9 +14,6 @@ Security hardening release from comprehensive security audit.
 - Validate `modelDir` path in benchmark server to prevent directory traversal outside allowed directories (#1103)
 - Remove filesystem paths from C++ error messages in `FileUtils.hpp` to prevent path leakage (#1105)
 
-### Not Yet Merged
-- Remove `error.message` from 500 error responses in benchmark server to prevent information disclosure (#1104 — pending review)
-
 ## [0.6.5]
 
 This release improves TypeScript support for consumers of the ONNX TTS package. Runtime statistics that the native addon already exposes when `opts.stats` is enabled are now described in `index.d.ts`, and `run()` is typed so inference responses carry structured output chunks.

--- a/packages/qvac-lib-infer-onnx-tts/CHANGELOG.md
+++ b/packages/qvac-lib-infer-onnx-tts/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.6]
+
+Security hardening release from comprehensive security audit.
+
+### Fixed
+- Add 1 MB request body size limit to benchmark server to prevent DoS via memory exhaustion (#1102)
+- Validate `modelDir` path in benchmark server to prevent directory traversal outside allowed directories (#1103)
+- Remove filesystem paths from C++ error messages in `FileUtils.hpp` to prevent path leakage (#1105)
+
+### Not Yet Merged
+- Remove `error.message` from 500 error responses in benchmark server to prevent information disclosure (#1104 — pending review)
+
 ## [0.6.5]
 
 This release improves TypeScript support for consumers of the ONNX TTS package. Runtime statistics that the native addon already exposes when `opts.stats` is enabled are now described in `index.d.ts`, and `run()` is typed so inference responses carry structured output chunks.

--- a/packages/qvac-lib-infer-onnx-tts/package.json
+++ b/packages/qvac-lib-infer-onnx-tts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-onnx",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Text to Speech (TTS) addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-parakeet/CHANGELOG.md
+++ b/packages/qvac-lib-infer-parakeet/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4]
+
+Security hardening release from comprehensive security audit.
+
+### Fixed
+- Add 500 MB buffer limit to audio accumulation to prevent OOM from unbounded buffering (#1080)
+- Add SHA-256 integrity verification to model download scripts using HuggingFace LFS checksums (#1081)
+- Sanitize error messages to remove filesystem paths from thrown errors (#1084)
+- Wrap job ID counter at `Number.MAX_SAFE_INTEGER` to prevent precision loss (#1085)
+- Harden benchmark server: add library allowlist, restrict file paths to allowed directories, remove dynamic `npm install`, add body size limit, restrict CORS to localhost (#1086)
+
+### Not Yet Merged
+- Bump onnxruntime from 1.21.0 to 1.24.2 to fix OOB read vulnerability (#1089 — pending CI)
+
 ## [0.2.3]
 
 ### Added

--- a/packages/qvac-lib-infer-parakeet/CHANGELOG.md
+++ b/packages/qvac-lib-infer-parakeet/CHANGELOG.md
@@ -16,9 +16,6 @@ Security hardening release from comprehensive security audit.
 - Wrap job ID counter at `Number.MAX_SAFE_INTEGER` to prevent precision loss (#1085)
 - Harden benchmark server: add library allowlist, restrict file paths to allowed directories, remove dynamic `npm install`, add body size limit, restrict CORS to localhost (#1086)
 
-### Not Yet Merged
-- Bump onnxruntime from 1.21.0 to 1.24.2 to fix OOB read vulnerability (#1089 — pending CI)
-
 ## [0.2.3]
 
 ### Added

--- a/packages/qvac-lib-infer-parakeet/package.json
+++ b/packages/qvac-lib-infer-parakeet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-parakeet",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "High-performance speech-to-text inference addon using NVIDIA Parakeet models for Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-whispercpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-whispercpp/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2]
+
+Security hardening release from comprehensive security audit.
+
+### Fixed
+- Replace global streaming state with per-instance map to eliminate race condition and dangling pointer risk (#1079)
+- Add 500 MB buffer limit to audio accumulation to prevent OOM from unbounded buffering (#1080)
+- Add SHA-256 integrity verification to model download scripts using HuggingFace LFS checksums (#1081)
+- Validate `suppress_regex` parameter — ban grouping constructs (parentheses) and enforce 512-char length limit to prevent ReDoS (#1083)
+- Sanitize error messages to remove filesystem paths from thrown errors (#1084)
+- Wrap job ID counter at `Number.MAX_SAFE_INTEGER` to prevent precision loss (#1085)
+- Harden benchmark server: add library allowlist, restrict file paths to allowed directories, remove dynamic `npm install`, add body size limit, restrict CORS to localhost (#1086)
+
 ## [0.5.1]
 
 This release documents runtime statistics and transcription output shapes in TypeScript so consumers can type `response.stats` and `run()` results against the native addon.

--- a/packages/qvac-lib-infer-whispercpp/package.json
+++ b/packages/qvac-lib-infer-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary

Bump patch versions and add changelog entries for all merged security audit fixes across four packages.

## Version Bumps

| Package | Old | New | Merged Fixes |
|---------|-----|-----|-------------|
| `@qvac/transcription-whispercpp` | 0.5.1 | 0.5.2 | 7 PRs (#1079, #1080, #1081, #1083, #1084, #1085, #1086) |
| `@qvac/transcription-parakeet` | 0.2.3 | 0.2.4 | 5 PRs (#1080, #1081, #1084, #1085, #1086) |
| `@qvac/tts-onnx` | 0.6.5 | 0.6.6 | 3 PRs (#1102, #1103, #1105) |
| `@qvac/decoder-audio` | 0.3.4 | 0.3.5 | 1 PR (#1082) |

Made with [Cursor](https://cursor.com)