### PR TITLE
feat[api]: typed RPC framework with plugin-aware callers

### DIFF
--- a/packages/sdk/client/api/cancel.ts
+++ b/packages/sdk/client/api/cancel.ts
@@ -1,6 +1,6 @@
-import { send } from "@/client/rpc/rpc-client";
-import { type CancelParams, type CancelRequest } from "@/schemas";
-import { InvalidResponseError, CancelFailedError } from "@/utils/errors-client";
+import type { CancelParams } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
+import { CancelFailedError } from "@/utils/errors-client";
 
 /**
  * Cancels an ongoing operation.
@@ -34,15 +34,7 @@ import { InvalidResponseError, CancelFailedError } from "@/utils/errors-client";
  * await cancel({ operation: "rag", workspace: "my-workspace" });
  */
 export async function cancel(params: CancelParams) {
-  const request: CancelRequest = {
-    type: "cancel",
-    ...params,
-  };
-
-  const response = await send(request);
-  if (response.type !== "cancel") {
-    throw new InvalidResponseError("cancel");
-  }
+  const response = await rpc.cancel.call(params);
 
   if (!response.success) {
     throw new CancelFailedError(response.error);

--- a/packages/sdk/client/api/completion-stream.ts
+++ b/packages/sdk/client/api/completion-stream.ts
@@ -1,16 +1,15 @@
-import { stream as streamRpc } from "@/client/rpc/rpc-client";
 import { getClientLogger } from "@/logging";
 import {
   completionStreamResponseSchema,
   type CompletionClientParams,
   type CompletionStats,
-  type CompletionStreamRequest,
   type McpClientInput,
   type Tool,
   type ToolCallEvent,
   type ToolCallWithCall,
   type RPCOptions,
 } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
 import { getMcpToolsWithHandlers } from "@/utils/mcp-adapter";
 import {
   attachHandlersToToolCalls,
@@ -147,8 +146,7 @@ export function completion(params: CompletionParams): {
         }
       }
 
-      const request: CompletionStreamRequest = {
-        type: "completionStream",
+      const input = {
         modelId: params.modelId,
         history: params.history,
         kvCache: params.kvCache,
@@ -157,18 +155,11 @@ export function completion(params: CompletionParams): {
         generationParams: params.generationParams,
       };
 
-      const responses: AsyncGenerator<unknown> = streamRpc(
-        request,
+      for await (const response of rpc.completionStream.stream(
+        input,
         params.rpcOptions,
-      );
-
-      for await (const response of responses) {
-        if (
-          response &&
-          typeof response === "object" &&
-          "type" in response &&
-          response.type === "completionStream"
-        ) {
+      )) {
+        {
           const streamResponse = completionStreamResponseSchema.parse(response);
 
           if (!streamResponse.done) {

--- a/packages/sdk/client/api/delete-cache.ts
+++ b/packages/sdk/client/api/delete-cache.ts
@@ -1,5 +1,4 @@
-import type { DeleteCacheRequest } from "@/schemas";
-import { send } from "@/client/rpc/rpc-client";
+import { rpc } from "@/client/rpc/caller";
 import {
   InvalidDeleteCacheParamsError,
   DeleteCacheFailedError,
@@ -28,30 +27,21 @@ import {
 export async function deleteCache(
   params: { all: true } | { kvCacheKey: string; modelId?: string },
 ) {
-  let req: DeleteCacheRequest;
-
-  if ("all" in params && params.all) {
-    req = {
-      type: "deleteCache",
-      all: true,
-    };
-  } else if ("kvCacheKey" in params) {
-    req = {
-      type: "deleteCache",
-      kvCacheKey: params.kvCacheKey,
-      modelId: params.modelId,
-    };
-  } else {
+  if (!("all" in params) && !("kvCacheKey" in params)) {
     throw new InvalidDeleteCacheParamsError();
   }
 
-  const response = await send(req);
+  const response =
+    "all" in params && params.all
+      ? await rpc.deleteCache.call({ all: true })
+      : await rpc.deleteCache.call({
+          kvCacheKey: (params as { kvCacheKey: string }).kvCacheKey,
+          modelId: (params as { kvCacheKey: string; modelId?: string }).modelId,
+        });
 
   if (!response.success && response.error) {
     throw new DeleteCacheFailedError(response.error);
   }
 
-  return {
-    success: response.success,
-  };
+  return { success: response.success };
 }

--- a/packages/sdk/client/api/delete-cache.ts
+++ b/packages/sdk/client/api/delete-cache.ts
@@ -1,4 +1,4 @@
-import type { DeleteCacheRequest, DeleteCacheResponse } from "@/schemas";
+import type { DeleteCacheRequest } from "@/schemas";
 import { send } from "@/client/rpc/rpc-client";
 import {
   InvalidDeleteCacheParamsError,
@@ -45,7 +45,7 @@ export async function deleteCache(
     throw new InvalidDeleteCacheParamsError();
   }
 
-  const response = (await send(req)) as DeleteCacheResponse;
+  const response = await send(req);
 
   if (!response.success && response.error) {
     throw new DeleteCacheFailedError(response.error);

--- a/packages/sdk/client/api/download-asset.ts
+++ b/packages/sdk/client/api/download-asset.ts
@@ -1,13 +1,12 @@
-import { send, stream } from "@/client/rpc/rpc-client";
 import {
   type DownloadAssetOptions as BaseDownloadAssetOptions,
   type RPCOptions,
   downloadAssetOptionsToRequestSchema,
 } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
 import {
   DownloadAssetFailedError,
   StreamEndedError,
-  InvalidResponseError,
 } from "@/utils/errors-client";
 
 export type DownloadAssetOptions = BaseDownloadAssetOptions;
@@ -55,30 +54,27 @@ export async function downloadAsset(
   const request = downloadAssetOptionsToRequestSchema.parse(options);
 
   if (options.onProgress) {
-    // Use streaming for progress updates
-    for await (const response of stream(request, rpcOptions)) {
+    for await (const response of rpc.downloadAsset.stream(
+      request,
+      rpcOptions,
+    )) {
       if (response.type === "modelProgress") {
         options.onProgress(response);
       } else if (response.type === "downloadAsset") {
         if (!response.success) {
           throw new DownloadAssetFailedError(response.error);
         }
-
         return response.assetId!;
       }
     }
     throw new StreamEndedError();
-  } else {
-    // Use regular send for simple downloading
-    const response = await send(request, rpcOptions);
-    if (response.type !== "downloadAsset") {
-      throw new InvalidResponseError("downloadAsset");
-    }
-
-    if (!response.success) {
-      throw new DownloadAssetFailedError(response.error);
-    }
-
-    return response.assetId!;
   }
+
+  const response = await rpc.downloadAsset.call(request, rpcOptions);
+
+  if (!response.success) {
+    throw new DownloadAssetFailedError(response.error);
+  }
+
+  return response.assetId!;
 }

--- a/packages/sdk/client/api/embed.ts
+++ b/packages/sdk/client/api/embed.ts
@@ -1,34 +1,11 @@
-import { send } from "@/client/rpc/rpc-client";
-import {
-  type EmbedParams,
-  type EmbedRequest,
-  type RPCOptions,
-} from "@/schemas";
-import { InvalidResponseError } from "@/utils/errors-client";
+import type { EmbedParams, RPCOptions } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
 
-/**
- * Generates embeddings for a single text using a specified model.
- *
- * @param params - The parameters for the embedding
- * @param params.modelId - The identifier of the embedding model to use
- * @param params.text - The input text to embed
- * @param options - Optional RPC options including per-call profiling
- * @throws {QvacErrorBase} When the response type is invalid or when the embedding fails
- */
 export async function embed(
   params: { modelId: string; text: string },
   options?: RPCOptions,
 ): Promise<number[]>;
 
-/**
- * Generates embeddings for multiple texts using a specified model.
- *
- * @param params - The parameters for the embedding
- * @param params.modelId - The identifier of the embedding model to use
- * @param params.text - The input texts to embed
- * @param options - Optional RPC options including per-call profiling
- * @throws {QvacErrorBase} When the response type is invalid or when the embedding fails
- */
 export async function embed(
   params: { modelId: string; text: string[] },
   options?: RPCOptions,
@@ -38,15 +15,6 @@ export async function embed(
   params: EmbedParams,
   options?: RPCOptions,
 ): Promise<number[] | number[][]> {
-  const request: EmbedRequest = {
-    type: "embed",
-    ...params,
-  };
-
-  const response = await send(request, options);
-  if (response.type !== "embed") {
-    throw new InvalidResponseError("embed");
-  }
-
+  const response = await rpc.embed.call(params, options);
   return response.embedding;
 }

--- a/packages/sdk/client/api/get-model-info.ts
+++ b/packages/sdk/client/api/get-model-info.ts
@@ -1,17 +1,7 @@
-import { type GetModelInfoRequest, type GetModelInfoParams } from "@/schemas";
-import { send } from "@/client/rpc/rpc-client";
-import { InvalidResponseError } from "@/utils/errors-client";
+import type { GetModelInfoParams } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
 
 export async function getModelInfo(params: GetModelInfoParams) {
-  const request: GetModelInfoRequest = {
-    type: "getModelInfo",
-    name: params.name,
-  };
-
-  const response = await send(request);
-  if (response.type !== "getModelInfo") {
-    throw new InvalidResponseError("getModelInfo");
-  }
-
+  const response = await rpc.getModelInfo.call({ name: params.name });
   return response.modelInfo;
 }

--- a/packages/sdk/client/api/invoke-plugin.ts
+++ b/packages/sdk/client/api/invoke-plugin.ts
@@ -2,7 +2,6 @@ import { send, stream } from "@/client/rpc/rpc-client";
 import type {
   PluginInvokeRequest,
   PluginInvokeStreamRequest,
-  PluginInvokeStreamResponse,
   RPCOptions,
 } from "@/schemas";
 import { InvalidResponseError } from "@/utils/errors-client";
@@ -54,7 +53,7 @@ export async function* invokePluginStream<
   };
 
   for await (const chunk of stream(request, rpcOptions)) {
-    const response = chunk as PluginInvokeStreamResponse;
+    const response = chunk;
     if (response.type !== "pluginInvokeStream") {
       throw new InvalidResponseError("pluginInvokeStream");
     }

--- a/packages/sdk/client/api/invoke-plugin.ts
+++ b/packages/sdk/client/api/invoke-plugin.ts
@@ -1,10 +1,5 @@
-import { send, stream } from "@/client/rpc/rpc-client";
-import type {
-  PluginInvokeRequest,
-  PluginInvokeStreamRequest,
-  RPCOptions,
-} from "@/schemas";
-import { InvalidResponseError } from "@/utils/errors-client";
+import type { RPCOptions } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
 
 export interface InvokePluginOptions<TParams = unknown> {
   modelId: string;
@@ -19,18 +14,14 @@ export async function invokePlugin<TResponse = unknown, TParams = unknown>(
   options: InvokePluginOptions<TParams>,
   rpcOptions?: RPCOptions,
 ): Promise<TResponse> {
-  const request: PluginInvokeRequest = {
-    type: "pluginInvoke",
-    modelId: options.modelId,
-    handler: options.handler,
-    params: options.params,
-  };
-
-  const response = await send(request, rpcOptions);
-
-  if (response.type !== "pluginInvoke") {
-    throw new InvalidResponseError("pluginInvoke");
-  }
+  const response = await rpc.pluginInvoke.call(
+    {
+      modelId: options.modelId,
+      handler: options.handler,
+      params: options.params,
+    },
+    rpcOptions,
+  );
 
   return response.result as TResponse;
 }
@@ -45,20 +36,16 @@ export async function* invokePluginStream<
   options: InvokePluginOptions<TParams>,
   rpcOptions?: RPCOptions,
 ): AsyncGenerator<TResponse> {
-  const request: PluginInvokeStreamRequest = {
-    type: "pluginInvokeStream",
-    modelId: options.modelId,
-    handler: options.handler,
-    params: options.params,
-  };
-
-  for await (const chunk of stream(request, rpcOptions)) {
-    const response = chunk;
-    if (response.type !== "pluginInvokeStream") {
-      throw new InvalidResponseError("pluginInvokeStream");
-    }
-    if (!response.done) {
-      yield response.result as TResponse;
+  for await (const chunk of rpc.pluginInvokeStream.stream(
+    {
+      modelId: options.modelId,
+      handler: options.handler,
+      params: options.params,
+    },
+    rpcOptions,
+  )) {
+    if (!chunk.done) {
+      yield chunk.result as TResponse;
     }
   }
 }

--- a/packages/sdk/client/api/load-model.ts
+++ b/packages/sdk/client/api/load-model.ts
@@ -1,4 +1,3 @@
-import { send, stream } from "@/client/rpc/rpc-client";
 import { startLoggingStreamForModel } from "@/client/logging-stream-registry";
 import {
   type LoadModelOptions,
@@ -9,11 +8,8 @@ import {
   isModelTypeAlias,
   normalizeModelType,
 } from "@/schemas";
-import {
-  ModelLoadFailedError,
-  StreamEndedError,
-  InvalidResponseError,
-} from "@/utils/errors-client";
+import { rpc } from "@/client/rpc/caller";
+import { ModelLoadFailedError, StreamEndedError } from "@/utils/errors-client";
 import { getClientLogger } from "@/logging";
 
 const logger = getClientLogger();
@@ -156,7 +152,6 @@ export async function loadModel(
 ): Promise<string> {
   const isReloadConfig = "modelId" in options && !("modelSrc" in options);
 
-  // Warn about deprecated alias usage
   if (!isReloadConfig && isModelTypeAlias(options.modelType)) {
     const canonical = normalizeModelType(options.modelType);
     logger.warn(
@@ -171,8 +166,7 @@ export async function loadModel(
   const onProgress = isReloadConfig ? undefined : options.onProgress;
 
   if (onProgress) {
-    // Use streaming for progress updates
-    for await (const response of stream(request, rpcOptions)) {
+    for await (const response of rpc.loadModel.stream(request, rpcOptions)) {
       if (response.type === "modelProgress") {
         onProgress(response);
       } else if (response.type === "loadModel") {
@@ -182,7 +176,6 @@ export async function loadModel(
 
         const modelId = response.modelId!;
 
-        // Start logging stream in the background if logger is provided, catch to avoid failing the entire loadModel operation
         if (modelLogger) {
           try {
             startLoggingStreamForModel(modelId, modelLogger);
@@ -200,11 +193,7 @@ export async function loadModel(
     throw new StreamEndedError();
   }
 
-  // Use regular send for simple loading
-  const response = await send(request, rpcOptions);
-  if (response.type !== "loadModel") {
-    throw new InvalidResponseError("loadModel");
-  }
+  const response = await rpc.loadModel.call(request, rpcOptions);
 
   if (!response.success) {
     throw new ModelLoadFailedError(response.error);

--- a/packages/sdk/client/api/logging-stream.ts
+++ b/packages/sdk/client/api/logging-stream.ts
@@ -1,10 +1,8 @@
-import { stream } from "@/client/rpc/rpc-client";
 import type {
   LoggingStreamResponse,
-  LoggingStreamRequest,
   LoggingParams,
 } from "@/schemas/logging-stream";
-import { InvalidResponseError } from "@/utils/errors-client";
+import { rpc } from "@/client/rpc/caller";
 
 /**
  * Opens a logging stream to receive real-time logs.
@@ -30,18 +28,5 @@ import { InvalidResponseError } from "@/utils/errors-client";
 export async function* loggingStream(
   params: LoggingParams,
 ): AsyncGenerator<LoggingStreamResponse> {
-  const request: LoggingStreamRequest = {
-    type: "loggingStream",
-    ...params,
-  };
-
-  const responseStream = stream(request);
-
-  for await (const response of responseStream) {
-    if (response.type !== "loggingStream") {
-      throw new InvalidResponseError("loggingStream");
-    }
-
-    yield response;
-  }
+  yield* rpc.loggingStream.stream(params);
 }

--- a/packages/sdk/client/api/ocr.ts
+++ b/packages/sdk/client/api/ocr.ts
@@ -1,11 +1,10 @@
 import {
   ocrStreamResponseSchema,
-  type OCRStreamRequest,
   type OCRClientParams,
   type OCRTextBlock,
   type OCRStats,
 } from "@/schemas";
-import { stream as streamRpc } from "@/client/rpc/rpc-client";
+import { rpc } from "@/client/rpc/caller";
 
 /**
  * Performs Optical Character Recognition (OCR) on an image to extract text.
@@ -36,13 +35,15 @@ export function ocr(params: OCRClientParams): {
   blocks: Promise<OCRTextBlock[]>;
   stats: Promise<OCRStats | undefined>;
 } {
-  const request: OCRStreamRequest = {
-    type: "ocrStream",
+  const input = {
     modelId: params.modelId,
     image:
       typeof params.image === "string"
-        ? { type: "filePath", value: params.image }
-        : { type: "base64", value: params.image.toString("base64") },
+        ? ({ type: "filePath", value: params.image } as const)
+        : ({
+            type: "base64",
+            value: params.image.toString("base64"),
+          } as const),
     ...(params.options && { options: params.options }),
   };
 
@@ -54,16 +55,14 @@ export function ocr(params: OCRClientParams): {
 
   if (params.stream) {
     const blockStream = (async function* () {
-      for await (const response of streamRpc(request)) {
-        if (response.type === "ocrStream") {
-          const streamResponse = ocrStreamResponseSchema.parse(response);
-          if (streamResponse.blocks && streamResponse.blocks.length > 0) {
-            yield streamResponse.blocks;
-          }
-          if (streamResponse.done) {
-            ocrStats = streamResponse.stats;
-            statsResolver(ocrStats);
-          }
+      for await (const response of rpc.ocrStream.stream(input)) {
+        const streamResponse = ocrStreamResponseSchema.parse(response);
+        if (streamResponse.blocks && streamResponse.blocks.length > 0) {
+          yield streamResponse.blocks;
+        }
+        if (streamResponse.done) {
+          ocrStats = streamResponse.stats;
+          statsResolver(ocrStats);
         }
       }
     })();
@@ -73,32 +72,30 @@ export function ocr(params: OCRClientParams): {
       blocks: Promise.resolve([]),
       stats: statsPromise,
     };
-  } else {
-    const blockStream = (async function* () {
-      // Empty generator for non-streaming mode
-    })();
-
-    const blocksPromise = (async () => {
-      let allBlocks: OCRTextBlock[] = [];
-      for await (const response of streamRpc(request)) {
-        if (response.type === "ocrStream") {
-          const streamResponse = ocrStreamResponseSchema.parse(response);
-          if (streamResponse.blocks) {
-            allBlocks = allBlocks.concat(streamResponse.blocks);
-          }
-          if (streamResponse.done) {
-            ocrStats = streamResponse.stats;
-            statsResolver(ocrStats);
-          }
-        }
-      }
-      return allBlocks;
-    })();
-
-    return {
-      blockStream,
-      blocks: blocksPromise,
-      stats: statsPromise,
-    };
   }
+
+  const blockStream = (async function* () {
+    // empty generator for non-streaming mode
+  })();
+
+  const blocksPromise = (async () => {
+    let allBlocks: OCRTextBlock[] = [];
+    for await (const response of rpc.ocrStream.stream(input)) {
+      const streamResponse = ocrStreamResponseSchema.parse(response);
+      if (streamResponse.blocks) {
+        allBlocks = allBlocks.concat(streamResponse.blocks);
+      }
+      if (streamResponse.done) {
+        ocrStats = streamResponse.stats;
+        statsResolver(ocrStats);
+      }
+    }
+    return allBlocks;
+  })();
+
+  return {
+    blockStream,
+    blocks: blocksPromise,
+    stats: statsPromise,
+  };
 }

--- a/packages/sdk/client/api/ping.ts
+++ b/packages/sdk/client/api/ping.ts
@@ -1,22 +1,5 @@
-import { type PingRequest } from "@/schemas";
-import { send } from "@/client/rpc/rpc-client";
-import { InvalidResponseError } from "@/utils/errors-client";
+import { rpc } from "@/client/rpc/caller";
 
-/**
- * Sends a ping request to the server and returns the pong response.
- *
- * @returns A promise that resolves to a pong response containing a number.
- * @throws {QvacErrorBase} When the response type is not "pong".
- */
 export async function ping() {
-  const request: PingRequest = {
-    type: "ping",
-  };
-
-  const response = await send(request);
-  if (response.type !== "pong") {
-    throw new InvalidResponseError("pong");
-  }
-
-  return response;
+  return rpc.ping.call({});
 }

--- a/packages/sdk/client/api/provide.ts
+++ b/packages/sdk/client/api/provide.ts
@@ -1,9 +1,6 @@
-import { type ProvideParams, type ProvideRequest } from "@/schemas";
-import { send } from "@/client/rpc/rpc-client";
-import {
-  InvalidResponseError,
-  ProviderStartFailedError,
-} from "@/utils/errors-client";
+import type { ProvideParams } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
+import { ProviderStartFailedError } from "@/utils/errors-client";
 
 /**
  * Starts a provider service that offers QVAC capabilities to remote peers.
@@ -16,16 +13,10 @@ import {
  * @throws {QvacErrorBase} When the response type is not "provide" or the request fails
  */
 export async function startQVACProvider(params: ProvideParams) {
-  const request: ProvideRequest = {
-    type: "provide",
+  const response = await rpc.provide.call({
     topic: params.topic,
     firewall: params.firewall,
-  };
-
-  const response = await send(request);
-  if (response.type !== "provide") {
-    throw new InvalidResponseError("provide");
-  }
+  });
 
   if (response.error) {
     throw new ProviderStartFailedError(response.error);

--- a/packages/sdk/client/api/rag.ts
+++ b/packages/sdk/client/api/rag.ts
@@ -1,6 +1,4 @@
-import { send, stream } from "@/client/rpc/rpc-client";
 import type {
-  RagRequest,
   RagChunkParams,
   RagDoc,
   RagIngestParams,
@@ -20,8 +18,8 @@ import type {
   RagDeleteWorkspaceParams,
   RPCOptions,
 } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
 import {
-  InvalidResponseError,
   InvalidOperationError,
   StreamEndedError,
   RAGChunkFailedError,
@@ -60,17 +58,10 @@ export async function ragChunk(
   params: RagChunkParams,
   options?: RPCOptions,
 ): Promise<RagDoc[]> {
-  const request: RagRequest = {
-    type: "rag",
-    operation: "chunk",
-    ...params,
-  };
-
-  const response = await send(request, options);
-
-  if (response.type !== "rag") {
-    throw new InvalidResponseError("rag");
-  }
+  const response = await rpc.rag.call(
+    { operation: "chunk", ...params },
+    options,
+  );
 
   if (!response.success) {
     throw new RAGChunkFailedError(response.error);
@@ -129,17 +120,15 @@ export async function ragIngest(
 ): Promise<{ processed: RagSaveEmbeddingsResult[]; droppedIndices: number[] }> {
   const { onProgress, ...requestParams } = params;
 
-  const request: RagRequest = {
-    type: "rag",
-    operation: "ingest",
+  const input = {
+    operation: "ingest" as const,
     ...requestParams,
     chunk: requestParams.chunk ?? true,
     withProgress: onProgress ? true : undefined,
   };
 
   if (onProgress) {
-    // Use streaming for progress updates
-    for await (const event of stream(request, options)) {
+    for await (const event of rpc.rag.stream(input, options)) {
       if (event.type === "rag:progress" && event.operation === "ingest") {
         const progress: RagProgressUpdate = event;
         onProgress(
@@ -165,10 +154,7 @@ export async function ragIngest(
     throw new StreamEndedError();
   }
 
-  const response = await send(request, options);
-  if (response.type !== "rag") {
-    throw new InvalidResponseError("rag");
-  }
+  const response = await rpc.rag.call(input, options);
 
   if (!response.success) {
     throw new RAGSaveFailedError(response.error);
@@ -224,15 +210,14 @@ export async function ragSaveEmbeddings(
 ): Promise<RagSaveEmbeddingsResult[]> {
   const { onProgress, ...requestParams } = params;
 
-  const request: RagRequest = {
-    type: "rag",
-    operation: "saveEmbeddings",
+  const input = {
+    operation: "saveEmbeddings" as const,
     ...requestParams,
     withProgress: onProgress ? true : undefined,
   };
 
   if (onProgress) {
-    for await (const event of stream(request, options)) {
+    for await (const event of rpc.rag.stream(input, options)) {
       if (
         event.type === "rag:progress" &&
         event.operation === "saveEmbeddings"
@@ -258,11 +243,7 @@ export async function ragSaveEmbeddings(
     throw new StreamEndedError();
   }
 
-  const response = await send(request, options);
-
-  if (response.type !== "rag") {
-    throw new InvalidResponseError("rag");
-  }
+  const response = await rpc.rag.call(input, options);
 
   if (!response.success) {
     throw new RAGSaveFailedError(response.error);
@@ -306,18 +287,15 @@ export async function ragSearch(
   params: RagSearchParams,
   options?: RPCOptions,
 ): Promise<RagSearchResult[]> {
-  const request: RagRequest = {
-    type: "rag",
-    operation: "search",
-    ...params,
-    topK: params.topK ?? 5,
-    n: params.n ?? 3,
-  };
-
-  const response = await send(request, options);
-  if (response.type !== "rag") {
-    throw new InvalidResponseError("rag");
-  }
+  const response = await rpc.rag.call(
+    {
+      operation: "search",
+      ...params,
+      topK: params.topK ?? 5,
+      n: params.n ?? 3,
+    },
+    options,
+  );
 
   if (!response.success) {
     throw new RAGSearchFailedError(response.error);
@@ -354,16 +332,10 @@ export async function ragDeleteEmbeddings(
   params: RagDeleteEmbeddingsParams,
   options?: RPCOptions,
 ): Promise<void> {
-  const request: RagRequest = {
-    type: "rag",
-    operation: "deleteEmbeddings",
-    ...params,
-  };
-
-  const response = await send(request, options);
-  if (response.type !== "rag") {
-    throw new InvalidResponseError("rag");
-  }
+  const response = await rpc.rag.call(
+    { operation: "deleteEmbeddings", ...params },
+    options,
+  );
 
   if (!response.success) {
     throw new RAGDeleteFailedError(response.error);
@@ -420,15 +392,14 @@ export async function ragReindex(
 ): Promise<RagReindexResult> {
   const { onProgress, ...requestParams } = params;
 
-  const request: RagRequest = {
-    type: "rag",
-    operation: "reindex",
+  const input = {
+    operation: "reindex" as const,
     ...requestParams,
     withProgress: onProgress ? true : undefined,
   };
 
   if (onProgress) {
-    for await (const event of stream(request, options)) {
+    for await (const event of rpc.rag.stream(input, options)) {
       if (event.type === "rag:progress" && event.operation === "reindex") {
         const progress: RagProgressUpdate = event;
         onProgress(
@@ -451,11 +422,7 @@ export async function ragReindex(
     throw new StreamEndedError();
   }
 
-  const response = await send(request, options);
-
-  if (response.type !== "rag") {
-    throw new InvalidResponseError("rag");
-  }
+  const response = await rpc.rag.call(input, options);
 
   if (!response.success) {
     throw new RAGSaveFailedError(response.error);
@@ -489,16 +456,7 @@ export async function ragReindex(
 export async function ragListWorkspaces(
   options?: RPCOptions,
 ): Promise<RagWorkspaceInfo[]> {
-  const request: RagRequest = {
-    type: "rag",
-    operation: "listWorkspaces",
-  };
-
-  const response = await send(request, options);
-
-  if (response.type !== "rag") {
-    throw new InvalidResponseError("rag");
-  }
+  const response = await rpc.rag.call({ operation: "listWorkspaces" }, options);
 
   if (!response.success) {
     throw new RAGListWorkspacesFailedError(response.error);
@@ -538,17 +496,10 @@ export async function ragCloseWorkspace(
   params?: RagCloseWorkspaceParams,
   options?: RPCOptions,
 ): Promise<void> {
-  const request: RagRequest = {
-    type: "rag",
-    operation: "closeWorkspace",
-    ...params,
-  };
-
-  const response = await send(request, options);
-
-  if (response.type !== "rag") {
-    throw new InvalidResponseError("rag");
-  }
+  const response = await rpc.rag.call(
+    { operation: "closeWorkspace", ...params },
+    options,
+  );
 
   if (!response.success) {
     throw new RAGCloseWorkspaceFailedError(response.error);
@@ -578,17 +529,10 @@ export async function ragDeleteWorkspace(
   params: RagDeleteWorkspaceParams,
   options?: RPCOptions,
 ): Promise<void> {
-  const request: RagRequest = {
-    type: "rag",
-    operation: "deleteWorkspace",
-    ...params,
-  };
-
-  const response = await send(request, options);
-
-  if (response.type !== "rag") {
-    throw new InvalidResponseError("rag");
-  }
+  const response = await rpc.rag.call(
+    { operation: "deleteWorkspace", ...params },
+    options,
+  );
 
   if (!response.success) {
     throw new RAGDeleteFailedError(response.error);

--- a/packages/sdk/client/api/registry.ts
+++ b/packages/sdk/client/api/registry.ts
@@ -1,11 +1,5 @@
-import type {
-  ModelRegistryListRequest,
-  ModelRegistrySearchRequest,
-  ModelRegistryGetModelRequest,
-  ModelRegistryEntry,
-  ModelRegistryEntryAddon,
-} from "@/schemas";
-import { send } from "@/client/rpc/rpc-client";
+import type { ModelRegistryEntry, ModelRegistryEntryAddon } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
 import { ModelRegistryQueryFailedError } from "@/utils/errors-client";
 
 export type { ModelRegistryEntry, ModelRegistryEntryAddon };
@@ -35,13 +29,8 @@ function validateRegistryResponse(
 }
 
 async function modelRegistryList(): Promise<ModelRegistryEntry[]> {
-  const request: ModelRegistryListRequest = {
-    type: "modelRegistryList",
-  };
-
-  const response = await send(request);
+  const response = await rpc.modelRegistryList.call({});
   validateRegistryResponse(response);
-
   return response.models!;
 }
 
@@ -49,15 +38,11 @@ async function modelRegistrySearch(
   params: ModelRegistrySearchParams = {},
 ): Promise<ModelRegistryEntry[]> {
   const { modelType, ...rest } = params;
-  const request: ModelRegistrySearchRequest = {
-    type: "modelRegistrySearch",
+  const response = await rpc.modelRegistrySearch.call({
     ...rest,
     addon: modelType ?? rest.addon,
-  };
-
-  const response = await send(request);
+  });
   validateRegistryResponse(response);
-
   return response.models!;
 }
 
@@ -65,18 +50,14 @@ async function modelRegistryGetModel(
   registryPath: string,
   registrySource: string,
 ): Promise<ModelRegistryEntry> {
-  const request: ModelRegistryGetModelRequest = {
-    type: "modelRegistryGetModel",
+  const response = await rpc.modelRegistryGetModel.call({
     registryPath,
     registrySource,
-  };
-
-  const response = await send(request);
+  });
   validateRegistryResponse(
     response,
     `Model not found: ${registrySource}/${registryPath}`,
   );
-
   return response.model!;
 }
 

--- a/packages/sdk/client/api/registry.ts
+++ b/packages/sdk/client/api/registry.ts
@@ -1,10 +1,7 @@
 import type {
   ModelRegistryListRequest,
-  ModelRegistryListResponse,
   ModelRegistrySearchRequest,
-  ModelRegistrySearchResponse,
   ModelRegistryGetModelRequest,
-  ModelRegistryGetModelResponse,
   ModelRegistryEntry,
   ModelRegistryEntryAddon,
 } from "@/schemas";
@@ -42,7 +39,7 @@ async function modelRegistryList(): Promise<ModelRegistryEntry[]> {
     type: "modelRegistryList",
   };
 
-  const response = (await send(request)) as ModelRegistryListResponse;
+  const response = await send(request);
   validateRegistryResponse(response);
 
   return response.models!;
@@ -58,7 +55,7 @@ async function modelRegistrySearch(
     addon: modelType ?? rest.addon,
   };
 
-  const response = (await send(request)) as ModelRegistrySearchResponse;
+  const response = await send(request);
   validateRegistryResponse(response);
 
   return response.models!;
@@ -74,7 +71,7 @@ async function modelRegistryGetModel(
     registrySource,
   };
 
-  const response = (await send(request)) as ModelRegistryGetModelResponse;
+  const response = await send(request);
   validateRegistryResponse(
     response,
     `Model not found: ${registrySource}/${registryPath}`,

--- a/packages/sdk/client/api/stop-provider.ts
+++ b/packages/sdk/client/api/stop-provider.ts
@@ -1,9 +1,6 @@
-import { type StopProvideParams, type StopProvideRequest } from "@/schemas";
-import { send } from "@/client/rpc/rpc-client";
-import {
-  InvalidResponseError,
-  ProviderStopFailedError,
-} from "@/utils/errors-client";
+import type { StopProvideParams } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
+import { ProviderStopFailedError } from "@/utils/errors-client";
 
 /**
  * Stops a running provider service and leaves the specified topic.
@@ -14,15 +11,7 @@ import {
  * @throws {QvacErrorBase} When the response type is not "stopProvide" or the request fails
  */
 export async function stopQVACProvider(params: StopProvideParams) {
-  const request: StopProvideRequest = {
-    type: "stopProvide",
-    topic: params.topic,
-  };
-
-  const response = await send(request);
-  if (response.type !== "stopProvide") {
-    throw new InvalidResponseError("stopProvide");
-  }
+  const response = await rpc.stopProvide.call({ topic: params.topic });
 
   if (response.error) {
     throw new ProviderStopFailedError(response.error);

--- a/packages/sdk/client/api/text-to-speech.ts
+++ b/packages/sdk/client/api/text-to-speech.ts
@@ -1,10 +1,9 @@
 import {
   ttsResponseSchema,
   type TtsClientParams,
-  type TtsRequest,
   type RPCOptions,
 } from "@/schemas";
-import { stream as streamRpc } from "@/client/rpc/rpc-client";
+import { rpc } from "@/client/rpc/caller";
 
 export function textToSpeech(
   params: TtsClientParams,
@@ -14,8 +13,7 @@ export function textToSpeech(
   buffer: Promise<number[]>;
   done: Promise<boolean>;
 } {
-  const request: TtsRequest = {
-    type: "textToSpeech",
+  const input = {
     modelId: params.modelId,
     inputType: params.inputType,
     text: params.text,
@@ -29,15 +27,13 @@ export function textToSpeech(
 
   if (params.stream) {
     const bufferStream = (async function* () {
-      for await (const response of streamRpc(request, options)) {
-        if (response.type === "textToSpeech") {
-          const streamResponse = ttsResponseSchema.parse(response);
-          if (streamResponse.buffer.length > 0) {
-            yield* streamResponse.buffer;
-          }
-          if (streamResponse.done) {
-            doneResolver(true);
-          }
+      for await (const response of rpc.textToSpeech.stream(input, options)) {
+        const streamResponse = ttsResponseSchema.parse(response);
+        if (streamResponse.buffer.length > 0) {
+          yield* streamResponse.buffer;
+        }
+        if (streamResponse.done) {
+          doneResolver(true);
         }
       }
     })();
@@ -47,29 +43,27 @@ export function textToSpeech(
       buffer: Promise.resolve([]),
       done: donePromise,
     };
-  } else {
-    const bufferStream = (async function* () {
-      //Empty generator for non-streaming mode
-    })();
-
-    const bufferPromise = (async () => {
-      let buffer: number[] = [];
-      for await (const response of streamRpc(request, options)) {
-        if (response.type === "textToSpeech") {
-          const streamResponse = ttsResponseSchema.parse(response);
-          buffer = buffer.concat(streamResponse.buffer);
-          if (streamResponse.done) {
-            doneResolver(true);
-          }
-        }
-      }
-      return buffer;
-    })();
-
-    return {
-      bufferStream,
-      buffer: bufferPromise,
-      done: donePromise,
-    };
   }
+
+  const bufferStream = (async function* () {
+    // empty generator for non-streaming mode
+  })();
+
+  const bufferPromise = (async () => {
+    let buffer: number[] = [];
+    for await (const response of rpc.textToSpeech.stream(input, options)) {
+      const streamResponse = ttsResponseSchema.parse(response);
+      buffer = buffer.concat(streamResponse.buffer);
+      if (streamResponse.done) {
+        doneResolver(true);
+      }
+    }
+    return buffer;
+  })();
+
+  return {
+    bufferStream,
+    buffer: bufferPromise,
+    done: donePromise,
+  };
 }

--- a/packages/sdk/client/api/transcribe.ts
+++ b/packages/sdk/client/api/transcribe.ts
@@ -1,10 +1,9 @@
 import {
   transcribeStreamResponseSchema,
-  type TranscribeStreamRequest,
   type TranscribeClientParams,
   type RPCOptions,
 } from "@/schemas";
-import { stream } from "@/client/rpc/rpc-client";
+import { rpc } from "@/client/rpc/caller";
 
 /**
  * This function streams audio transcription results in real-time, yielding
@@ -22,27 +21,27 @@ export async function* transcribeStream(
   params: TranscribeClientParams,
   options?: RPCOptions,
 ) {
-  const request: TranscribeStreamRequest = {
-    type: "transcribeStream",
+  const input = {
     modelId: params.modelId,
     audioChunk:
       typeof params.audioChunk === "string"
-        ? { type: "filePath", value: params.audioChunk }
-        : { type: "base64", value: params.audioChunk.toString("base64") },
+        ? ({ type: "filePath", value: params.audioChunk } as const)
+        : ({
+            type: "base64",
+            value: params.audioChunk.toString("base64"),
+          } as const),
     ...(params.prompt && { prompt: params.prompt }),
   };
 
-  for await (const response of stream(request, options)) {
-    if (response.type === "transcribeStream") {
-      const streamResponse = transcribeStreamResponseSchema.parse(response);
+  for await (const response of rpc.transcribeStream.stream(input, options)) {
+    const streamResponse = transcribeStreamResponseSchema.parse(response);
 
-      if (streamResponse.text) {
-        yield streamResponse.text;
-      }
+    if (streamResponse.text) {
+      yield streamResponse.text;
+    }
 
-      if (streamResponse.done) {
-        break;
-      }
+    if (streamResponse.done) {
+      break;
     }
   }
 }

--- a/packages/sdk/client/api/translate.ts
+++ b/packages/sdk/client/api/translate.ts
@@ -1,24 +1,19 @@
-import { stream as streamRpc } from "@/client/rpc/rpc-client";
 import {
   translateResponseSchema,
   normalizeModelType,
   ModelType,
-  type TranslateRequest,
   type TranslateClientParams,
   type TranslationStats,
   type RPCOptions,
 } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
 import { detectOne } from "@qvac/langdetect-text-cld2";
 import { TranslationFailedError } from "@/utils/errors-client";
 
-/**
- * Detects the source language if not provided for LLM models
- * @internal
- */
 async function detectSourceLanguage(
   text: string,
   providedLanguage: string | undefined,
-  isLlm: boolean
+  isLlm: boolean,
 ): Promise<string | undefined> {
   if (!isLlm) return undefined;
   if (providedLanguage) return providedLanguage;
@@ -89,82 +84,63 @@ export function translate(
     statsResolver = resolve;
   });
 
+  async function buildInput() {
+    const sourceLanguage = await detectSourceLanguage(
+      params.text as string,
+      isLlm ? (params as { from?: string }).from : undefined,
+      isLlm,
+    );
+    return {
+      ...params,
+      ...(isLlm && { from: sourceLanguage }),
+    };
+  }
+
   if (params.stream) {
     const tokenStream = (async function* () {
-      const sourceLanguage =  await detectSourceLanguage(
-        params.text as string,
-        isLlm ? (params as { from?: string }).from : undefined,
-       isLlm
-      );
+      const input = await buildInput();
 
-      const request: TranslateRequest = {
-        type: "translate",
-        ...params,
-        ...(isLlm && {
-          from: sourceLanguage,
-        }),
-      } as TranslateRequest;
-
-      for await (const response of streamRpc(request, options)) {
-        if (response.type === "translate") {
-          const streamResponse = translateResponseSchema.parse(response);
-          if (!streamResponse.done) {
-            yield streamResponse.token;
-          } else {
-            stats = streamResponse.stats;
-            statsResolver(stats);
-          }
+      for await (const response of rpc.translate.stream(input, options)) {
+        const streamResponse = translateResponseSchema.parse(response);
+        if (!streamResponse.done) {
+          yield streamResponse.token;
+        } else {
+          stats = streamResponse.stats;
+          statsResolver(stats);
         }
       }
     })();
 
-    const textPromise = Promise.resolve("");
-
     return {
       tokenStream,
-      text: textPromise,
-      stats: statsPromise,
-    };
-  } else {
-    const tokenStream = (async function* () {
-      //Empty generator for non-streaming mode
-    })();
-
-    const textPromise = (async () => {
-      const sourceLanguage = await detectSourceLanguage(
-        params.text as string,
-        isLlm ? (params as { from?: string }).from : undefined,
-        isLlm
-      );
-
-      const request: TranslateRequest = {
-        type: "translate",
-        ...params,
-        ...(isLlm && {
-          from: sourceLanguage,
-        }),
-      } as TranslateRequest;
-
-      let buffer = "";
-
-      for await (const response of streamRpc(request, options)) {
-        if (response.type === "translate") {
-          const streamResponse = translateResponseSchema.parse(response);
-          buffer += streamResponse.token;
-          if (streamResponse.done) {
-            stats = streamResponse.stats;
-            statsResolver(stats);
-          }
-        }
-      }
-
-      return buffer;
-    })();
-
-    return {
-      tokenStream,
-      text: textPromise,
+      text: Promise.resolve(""),
       stats: statsPromise,
     };
   }
+
+  const tokenStream = (async function* () {
+    // empty generator for non-streaming mode
+  })();
+
+  const textPromise = (async () => {
+    const input = await buildInput();
+    let buffer = "";
+
+    for await (const response of rpc.translate.stream(input, options)) {
+      const streamResponse = translateResponseSchema.parse(response);
+      buffer += streamResponse.token;
+      if (streamResponse.done) {
+        stats = streamResponse.stats;
+        statsResolver(stats);
+      }
+    }
+
+    return buffer;
+  })();
+
+  return {
+    tokenStream,
+    text: textPromise,
+    stats: statsPromise,
+  };
 }

--- a/packages/sdk/client/api/unload-model.ts
+++ b/packages/sdk/client/api/unload-model.ts
@@ -1,10 +1,8 @@
-import { type UnloadModelRequest, type UnloadModelParams } from "@/schemas";
-import { send, close } from "@/client/rpc/rpc-client";
+import type { UnloadModelParams } from "@/schemas";
+import { rpc } from "@/client/rpc/caller";
+import { close } from "@/client/rpc/rpc-client";
 import { stopLoggingStreamForModel } from "@/client/logging-stream-registry";
-import {
-  InvalidResponseError,
-  ModelUnloadFailedError,
-} from "@/utils/errors-client";
+import { ModelUnloadFailedError } from "@/utils/errors-client";
 import { getClientLogger } from "@/logging";
 
 const logger = getClientLogger();
@@ -22,16 +20,10 @@ const logger = getClientLogger();
  * @throws {QvacErrorBase} When the response type is invalid or when the unload operation fails
  */
 export async function unloadModel(params: UnloadModelParams) {
-  const request: UnloadModelRequest = {
-    type: "unloadModel",
+  const response = await rpc.unloadModel.call({
     modelId: params.modelId,
     clearStorage: params.clearStorage ?? false,
-  };
-
-  const response = await send(request);
-  if (response.type !== "unloadModel") {
-    throw new InvalidResponseError("unloadModel");
-  }
+  });
 
   if (!response.success) {
     throw new ModelUnloadFailedError(params.modelId);
@@ -39,7 +31,6 @@ export async function unloadModel(params: UnloadModelParams) {
 
   stopLoggingStreamForModel(params.modelId);
 
-  // Auto-close when no models remain AND no providers are active
   if (
     response.hasActiveModels === false &&
     response.hasActiveProviders === false

--- a/packages/sdk/client/rpc/caller.ts
+++ b/packages/sdk/client/rpc/caller.ts
@@ -5,36 +5,31 @@ import type {
   RequestType,
   RPCOptions,
 } from "@/schemas";
+import type { z } from "zod";
 
 type MapEntry<K extends RequestType> = RequestResponseMap[K];
 
-/**
- * Creates a typed caller for a specific RPC operation.
- *
- * Eliminates boilerplate in client API methods:
- * - Auto-injects the `type` discriminator field
- * - Returns the narrowed response type (no manual `response.type` check)
- * - Provides both `.call()` and `.stream()` based on the operation
- *
- * @example
- * ```typescript
- * const embedCaller = createCaller("embed");
- * const response = await embedCaller.call({ modelId, text });
- * // response is EmbedResponse — no cast, no type check
- * ```
- */
+// Distributes Omit over union members so each branch retains its own properties.
+// Standard Omit<A | B, K> collapses to only the common keys — this preserves both.
+type DistributiveOmit<T, K extends keyof never> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
 export function createCaller<K extends RequestType>(key: K) {
   type Req = MapEntry<K>["request"];
   type Res = MapEntry<K>["response"];
 
   return {
-    async call(input: Omit<Req, "type">, options?: RPCOptions): Promise<Res> {
+    async call(
+      input: DistributiveOmit<Req, "type">,
+      options?: RPCOptions,
+    ): Promise<Res> {
       const request = { ...input, type: key } as Req & Request;
       return send(request, options) as Promise<Res>;
     },
 
     async *stream(
-      input: Omit<Req, "type">,
+      input: DistributiveOmit<Req, "type">,
       options?: RPCOptions,
     ): AsyncGenerator<
       MapEntry<K> extends { progress: infer P } ? Res | P : Res
@@ -49,41 +44,135 @@ export function createCaller<K extends RequestType>(key: K) {
   };
 }
 
-/**
- * Pre-defined typed callers for all RPC operations.
- *
- * Use `rpc.<operation>.call(input)` for request-response or
- * `rpc.<operation>.stream(input)` for streaming.
- *
- * @example
- * ```typescript
- * import { rpc } from "@/client/rpc/caller";
- *
- * const pong = await rpc.ping.call({});
- * const embedRes = await rpc.embed.call({ modelId, text });
- * ```
- */
+// --- Pre-defined typed callers for all RPC operations ---
+
 export const rpc = {
+  // Core (always available)
   ping: createCaller("ping"),
   loadModel: createCaller("loadModel"),
-  completionStream: createCaller("completionStream"),
   unloadModel: createCaller("unloadModel"),
-  embed: createCaller("embed"),
   cancel: createCaller("cancel"),
-  provide: createCaller("provide"),
-  stopProvide: createCaller("stopProvide"),
+  getModelInfo: createCaller("getModelInfo"),
   deleteCache: createCaller("deleteCache"),
   downloadAsset: createCaller("downloadAsset"),
-  getModelInfo: createCaller("getModelInfo"),
-  transcribeStream: createCaller("transcribeStream"),
   loggingStream: createCaller("loggingStream"),
+
+  // Provider
+  provide: createCaller("provide"),
+  stopProvide: createCaller("stopProvide"),
+
+  // LLM plugin
+  completionStream: createCaller("completionStream"),
+
+  // Embedding plugin
+  embed: createCaller("embed"),
+
+  // Whisper plugin
+  transcribeStream: createCaller("transcribeStream"),
+
+  // NMT plugin
   translate: createCaller("translate"),
+
+  // TTS plugin
   textToSpeech: createCaller("textToSpeech"),
+
+  // OCR plugin
   ocrStream: createCaller("ocrStream"),
+
+  // RAG (requires embedding plugin)
   rag: createCaller("rag"),
+
+  // Generic plugin invoke
   pluginInvoke: createCaller("pluginInvoke"),
   pluginInvokeStream: createCaller("pluginInvokeStream"),
+
+  // Registry
   modelRegistryList: createCaller("modelRegistryList"),
   modelRegistrySearch: createCaller("modelRegistrySearch"),
   modelRegistryGetModel: createCaller("modelRegistryGetModel"),
 };
+
+// --- Plugin-specific caller groups ---
+// These re-export subsets of `rpc` grouped by the plugin they require.
+// Useful for tree-shaking or documenting which addon must be loaded.
+
+export const llmOps = {
+  completionStream: rpc.completionStream,
+} as const;
+
+export const embeddingOps = {
+  embed: rpc.embed,
+} as const;
+
+export const whisperOps = {
+  transcribeStream: rpc.transcribeStream,
+} as const;
+
+export const nmtOps = {
+  translate: rpc.translate,
+} as const;
+
+export const ttsOps = {
+  textToSpeech: rpc.textToSpeech,
+} as const;
+
+export const ocrOps = {
+  ocrStream: rpc.ocrStream,
+} as const;
+
+// --- Custom plugin caller factory ---
+
+/**
+ * Creates typed invoke/stream callers for a custom plugin handler.
+ *
+ * Wraps pluginInvoke/pluginInvokeStream with compile-time typed params
+ * and runtime Zod validation on the response.
+ *
+ * @example
+ * ```typescript
+ * const sentiment = createPluginCaller({
+ *   handler: "analyzeSentiment",
+ *   params: z.object({ text: z.string() }),
+ *   response: z.object({ score: z.number(), label: z.string() }),
+ * });
+ *
+ * const result = await sentiment.invoke(modelId, { text: "Great!" });
+ * // result: { score: number; label: string }
+ * ```
+ */
+export function createPluginCaller<
+  TParams extends z.ZodType,
+  TResponse extends z.ZodType,
+>(config: { handler: string; params: TParams; response: TResponse }) {
+  type Params = z.infer<TParams>;
+  type Res = z.infer<TResponse>;
+
+  return {
+    async invoke(
+      modelId: string,
+      params: Params,
+      options?: RPCOptions,
+    ): Promise<Res> {
+      const response = await rpc.pluginInvoke.call(
+        { modelId, handler: config.handler, params },
+        options,
+      );
+      return config.response.parse(response.result) as Res;
+    },
+
+    async *stream(
+      modelId: string,
+      params: Params,
+      options?: RPCOptions,
+    ): AsyncGenerator<Res> {
+      for await (const chunk of rpc.pluginInvokeStream.stream(
+        { modelId, handler: config.handler, params },
+        options,
+      )) {
+        if (!chunk.done) {
+          yield config.response.parse(chunk.result) as Res;
+        }
+      }
+    },
+  };
+}

--- a/packages/sdk/client/rpc/caller.ts
+++ b/packages/sdk/client/rpc/caller.ts
@@ -1,0 +1,89 @@
+import { send, stream } from "@/client/rpc/rpc-client";
+import type {
+  Request,
+  RequestResponseMap,
+  RequestType,
+  RPCOptions,
+} from "@/schemas";
+
+type MapEntry<K extends RequestType> = RequestResponseMap[K];
+
+/**
+ * Creates a typed caller for a specific RPC operation.
+ *
+ * Eliminates boilerplate in client API methods:
+ * - Auto-injects the `type` discriminator field
+ * - Returns the narrowed response type (no manual `response.type` check)
+ * - Provides both `.call()` and `.stream()` based on the operation
+ *
+ * @example
+ * ```typescript
+ * const embedCaller = createCaller("embed");
+ * const response = await embedCaller.call({ modelId, text });
+ * // response is EmbedResponse — no cast, no type check
+ * ```
+ */
+export function createCaller<K extends RequestType>(key: K) {
+  type Req = MapEntry<K>["request"];
+  type Res = MapEntry<K>["response"];
+
+  return {
+    async call(input: Omit<Req, "type">, options?: RPCOptions): Promise<Res> {
+      const request = { ...input, type: key } as Req & Request;
+      return send(request, options) as Promise<Res>;
+    },
+
+    async *stream(
+      input: Omit<Req, "type">,
+      options?: RPCOptions,
+    ): AsyncGenerator<
+      MapEntry<K> extends { progress: infer P } ? Res | P : Res
+    > {
+      const request = { ...input, type: key } as Req & Request;
+      for await (const chunk of stream(request, options)) {
+        yield chunk as MapEntry<K> extends { progress: infer P }
+          ? Res | P
+          : Res;
+      }
+    },
+  };
+}
+
+/**
+ * Pre-defined typed callers for all RPC operations.
+ *
+ * Use `rpc.<operation>.call(input)` for request-response or
+ * `rpc.<operation>.stream(input)` for streaming.
+ *
+ * @example
+ * ```typescript
+ * import { rpc } from "@/client/rpc/caller";
+ *
+ * const pong = await rpc.ping.call({});
+ * const embedRes = await rpc.embed.call({ modelId, text });
+ * ```
+ */
+export const rpc = {
+  ping: createCaller("ping"),
+  loadModel: createCaller("loadModel"),
+  completionStream: createCaller("completionStream"),
+  unloadModel: createCaller("unloadModel"),
+  embed: createCaller("embed"),
+  cancel: createCaller("cancel"),
+  provide: createCaller("provide"),
+  stopProvide: createCaller("stopProvide"),
+  deleteCache: createCaller("deleteCache"),
+  downloadAsset: createCaller("downloadAsset"),
+  getModelInfo: createCaller("getModelInfo"),
+  transcribeStream: createCaller("transcribeStream"),
+  loggingStream: createCaller("loggingStream"),
+  translate: createCaller("translate"),
+  textToSpeech: createCaller("textToSpeech"),
+  ocrStream: createCaller("ocrStream"),
+  rag: createCaller("rag"),
+  pluginInvoke: createCaller("pluginInvoke"),
+  pluginInvokeStream: createCaller("pluginInvokeStream"),
+  modelRegistryList: createCaller("modelRegistryList"),
+  modelRegistrySearch: createCaller("modelRegistrySearch"),
+  modelRegistryGetModel: createCaller("modelRegistryGetModel"),
+};

--- a/packages/sdk/client/rpc/rpc-client.ts
+++ b/packages/sdk/client/rpc/rpc-client.ts
@@ -5,6 +5,8 @@ import {
   PROFILING_TRAILER_KEY,
   type Request,
   type Response,
+  type ResponseFor,
+  type StreamResponseFor,
   type RPCOptions,
 } from "@/schemas";
 import { RPCError } from "./rpc-error";
@@ -99,13 +101,14 @@ export async function send<T extends Request>(
   request: T,
   options?: RPCOptions,
   rpc?: RPC,
-): Promise<Response> {
+): Promise<ResponseFor<T>> {
   const ctx = await prepareRPCContext(request.type, options?.profiling, rpc);
 
-  if (!ctx.profilingEnabled) {
-    return sendBase(request, ctx.rpc, options, ctx.signalDisable);
-  }
-  return sendProfiled(request, ctx.rpc, options);
+  const response = !ctx.profilingEnabled
+    ? await sendBase(request, ctx.rpc, options, ctx.signalDisable)
+    : await sendProfiled(request, ctx.rpc, options);
+
+  return response as ResponseFor<T>;
 }
 
 async function sendBase<T extends Request>(
@@ -212,14 +215,16 @@ export async function* stream<T extends Request>(
   request: T,
   options: RPCOptions = {},
   rpc?: RPC,
-): AsyncGenerator<Response> {
+): AsyncGenerator<StreamResponseFor<T>> {
   const ctx = await prepareRPCContext(request.type, options?.profiling, rpc);
 
-  if (!ctx.profilingEnabled) {
-    yield* streamBase(request, ctx.rpc, options, ctx.signalDisable);
-    return;
+  const source = !ctx.profilingEnabled
+    ? streamBase(request, ctx.rpc, options, ctx.signalDisable)
+    : streamProfiled(request, ctx.rpc, options);
+
+  for await (const response of source) {
+    yield response as StreamResponseFor<T>;
   }
-  yield* streamProfiled(request, ctx.rpc, options);
 }
 
 async function* streamBase<T extends Request>(

--- a/packages/sdk/schemas/index.ts
+++ b/packages/sdk/schemas/index.ts
@@ -74,3 +74,4 @@ export {
 } from "./model-types";
 export * from "./plugin";
 export * from "./registry";
+export * from "./rpc-types";

--- a/packages/sdk/schemas/rpc-types.ts
+++ b/packages/sdk/schemas/rpc-types.ts
@@ -1,0 +1,182 @@
+import type { Request, Response } from "./common";
+import type { PingRequest, PingResponse } from "./ping";
+import type {
+  LoadModelRequest,
+  LoadModelResponse,
+  ModelProgressUpdate,
+} from "./load-model";
+import type {
+  CompletionStreamRequest,
+  CompletionStreamResponse,
+} from "./completion-stream";
+import type { UnloadModelRequest, UnloadModelResponse } from "./unload-model";
+import type { EmbedRequest, EmbedResponse } from "./embed";
+import type { CancelRequest, CancelResponse } from "./cancel";
+import type { ProvideRequest, ProvideResponse } from "./provide";
+import type { StopProvideRequest, StopProvideResponse } from "./stop-provide";
+import type { DeleteCacheRequest, DeleteCacheResponse } from "./delete-cache";
+import type {
+  DownloadAssetRequest,
+  DownloadAssetResponse,
+} from "./download-asset";
+import type {
+  GetModelInfoRequest,
+  GetModelInfoResponse,
+} from "./get-model-info";
+import type {
+  TranscribeStreamRequest,
+  TranscribeStreamResponse,
+} from "./transcription";
+import type {
+  LoggingStreamRequest,
+  LoggingStreamResponse,
+} from "./logging-stream";
+import type { TranslateRequest, TranslateResponse } from "./translate";
+import type { TtsRequest, TtsResponse } from "./text-to-speech";
+import type { OCRStreamRequest, OCRStreamResponse } from "./ocr";
+import type { RagRequest, RagResponse, RagProgressUpdate } from "./rag";
+import type {
+  PluginInvokeRequest,
+  PluginInvokeResponse,
+  PluginInvokeStreamRequest,
+  PluginInvokeStreamResponse,
+} from "./plugin";
+import type {
+  ModelRegistryListRequest,
+  ModelRegistryListResponse,
+  ModelRegistrySearchRequest,
+  ModelRegistrySearchResponse,
+  ModelRegistryGetModelRequest,
+  ModelRegistryGetModelResponse,
+} from "./registry";
+
+/**
+ * Maps each RPC operation (keyed by the request's `type` discriminator) to its
+ * specific request, response, and optional progress types.
+ *
+ * Used by `ResponseFor<T>` and `StreamResponseFor<T>` to narrow return types
+ * from `send()` and `stream()`.
+ */
+export type RequestResponseMap = {
+  ping: {
+    request: PingRequest;
+    response: PingResponse;
+  };
+  loadModel: {
+    request: LoadModelRequest;
+    response: LoadModelResponse;
+    progress: ModelProgressUpdate;
+  };
+  completionStream: {
+    request: CompletionStreamRequest;
+    response: CompletionStreamResponse;
+  };
+  unloadModel: {
+    request: UnloadModelRequest;
+    response: UnloadModelResponse;
+  };
+  embed: {
+    request: EmbedRequest;
+    response: EmbedResponse;
+  };
+  cancel: {
+    request: CancelRequest;
+    response: CancelResponse;
+  };
+  provide: {
+    request: ProvideRequest;
+    response: ProvideResponse;
+  };
+  stopProvide: {
+    request: StopProvideRequest;
+    response: StopProvideResponse;
+  };
+  deleteCache: {
+    request: DeleteCacheRequest;
+    response: DeleteCacheResponse;
+  };
+  downloadAsset: {
+    request: DownloadAssetRequest;
+    response: DownloadAssetResponse;
+    progress: ModelProgressUpdate;
+  };
+  getModelInfo: {
+    request: GetModelInfoRequest;
+    response: GetModelInfoResponse;
+  };
+  transcribeStream: {
+    request: TranscribeStreamRequest;
+    response: TranscribeStreamResponse;
+  };
+  loggingStream: {
+    request: LoggingStreamRequest;
+    response: LoggingStreamResponse;
+  };
+  translate: {
+    request: TranslateRequest;
+    response: TranslateResponse;
+  };
+  textToSpeech: {
+    request: TtsRequest;
+    response: TtsResponse;
+  };
+  ocrStream: {
+    request: OCRStreamRequest;
+    response: OCRStreamResponse;
+  };
+  rag: {
+    request: RagRequest;
+    response: RagResponse;
+    progress: RagProgressUpdate;
+  };
+  pluginInvoke: {
+    request: PluginInvokeRequest;
+    response: PluginInvokeResponse;
+  };
+  pluginInvokeStream: {
+    request: PluginInvokeStreamRequest;
+    response: PluginInvokeStreamResponse;
+  };
+  modelRegistryList: {
+    request: ModelRegistryListRequest;
+    response: ModelRegistryListResponse;
+  };
+  modelRegistrySearch: {
+    request: ModelRegistrySearchRequest;
+    response: ModelRegistrySearchResponse;
+  };
+  modelRegistryGetModel: {
+    request: ModelRegistryGetModelRequest;
+    response: ModelRegistryGetModelResponse;
+  };
+};
+
+export type RequestType = keyof RequestResponseMap;
+
+/**
+ * Narrows the Response type based on a Request's `type` discriminator.
+ *
+ * When `T` is a specific request (e.g. `PingRequest`), resolves to the
+ * matching response (e.g. `PingResponse`). When `T` is the wide `Request`
+ * union, distributes and resolves to the full `Response` union.
+ */
+export type ResponseFor<T extends Request> = T extends {
+  type: infer K extends RequestType;
+}
+  ? RequestResponseMap[K]["response"]
+  : Response;
+
+/**
+ * Like `ResponseFor` but includes progress event types for streaming operations.
+ *
+ * Operations that support progress (loadModel, downloadAsset, rag) include
+ * their progress update type in the union. Non-progress operations resolve
+ * identically to `ResponseFor<T>`.
+ */
+export type StreamResponseFor<T extends Request> = T extends {
+  type: infer K extends RequestType;
+}
+  ? RequestResponseMap[K] extends { progress: infer P }
+    ? RequestResponseMap[K]["response"] | P
+    : RequestResponseMap[K]["response"]
+  : Response;

--- a/packages/sdk/server/rpc/handler-registry.ts
+++ b/packages/sdk/server/rpc/handler-registry.ts
@@ -1,4 +1,29 @@
-import { type Request } from "@/schemas";
+import {
+  type Request,
+  pingRequestSchema,
+  loadModelRequestSchema,
+  completionStreamRequestSchema,
+  unloadModelRequestSchema,
+  embedRequestSchema,
+  cancelRequestSchema,
+  provideRequestSchema,
+  stopProvideRequestSchema,
+  deleteCacheRequestSchema,
+  downloadAssetRequestSchema,
+  getModelInfoRequestSchema,
+  transcribeStreamRequestSchema,
+  loggingStreamRequestSchema,
+  translateRequestSchema,
+  ttsRequestSchema,
+  ocrStreamRequestSchema,
+  ragRequestSchema,
+  pluginInvokeRequestSchema,
+  pluginInvokeStreamRequestSchema,
+  modelRegistryListRequestSchema,
+  modelRegistrySearchRequestSchema,
+  modelRegistryGetModelRequestSchema,
+} from "@/schemas";
+import { reply, stream, type Router } from "./procedure";
 import { handleCompletionStream } from "@/server/rpc/handlers/completion-stream";
 import { handleDownloadAsset } from "@/server/rpc/handlers/download-asset";
 import { handleLoadModel } from "@/server/rpc/handlers/load-model";
@@ -29,7 +54,6 @@ import {
   handleModelRegistrySearch,
   handleModelRegistryGetModel,
 } from "@/server/rpc/handlers/registry";
-import type { HandlerEntry } from "./handler-utils";
 
 function ragSupportsProgress(request: Request): boolean {
   if (request.type !== "rag") return false;
@@ -42,63 +66,105 @@ function isModelDelegated(request: Request): boolean {
   return entry?.isDelegated ?? false;
 }
 
-export const registry: Record<string, HandlerEntry> = {
-  // Simple Reply handlers
-  ping: { type: "reply", handler: handlePing },
-  unloadModel: {
-    type: "reply",
+export const registry: Router = {
+  ping: reply({
+    input: pingRequestSchema,
+    handler: handlePing,
+  }),
+  unloadModel: reply({
+    input: unloadModelRequestSchema,
     handler: handleUnloadModel,
     delegatedHandler: handleUnloadModelDelegated,
     isDelegated: isModelDelegated,
-  },
-  embed: { type: "reply", handler: handleEmbed },
-  cancel: { type: "reply", handler: cancelHandler },
-  provide: { type: "reply", handler: provideHandler },
-  stopProvide: { type: "reply", handler: stopProvideHandler },
-  deleteCache: { type: "reply", handler: handleDeleteCache },
-  getModelInfo: { type: "reply", handler: handleGetModelInfo },
-  pluginInvoke: { type: "reply", handler: handlePluginInvoke },
-  modelRegistryList: { type: "reply", handler: handleModelRegistryList },
-  modelRegistrySearch: { type: "reply", handler: handleModelRegistrySearch },
-  modelRegistryGetModel: {
-    type: "reply",
+  }),
+  embed: reply({
+    input: embedRequestSchema,
+    handler: handleEmbed,
+  }),
+  cancel: reply({
+    input: cancelRequestSchema,
+    handler: cancelHandler,
+  }),
+  provide: reply({
+    input: provideRequestSchema,
+    handler: provideHandler,
+  }),
+  stopProvide: reply({
+    input: stopProvideRequestSchema,
+    handler: stopProvideHandler,
+  }),
+  deleteCache: reply({
+    input: deleteCacheRequestSchema,
+    handler: handleDeleteCache,
+  }),
+  getModelInfo: reply({
+    input: getModelInfoRequestSchema,
+    handler: handleGetModelInfo,
+  }),
+  pluginInvoke: reply({
+    input: pluginInvokeRequestSchema,
+    handler: handlePluginInvoke,
+  }),
+  modelRegistryList: reply({
+    input: modelRegistryListRequestSchema,
+    handler: handleModelRegistryList,
+  }),
+  modelRegistrySearch: reply({
+    input: modelRegistrySearchRequestSchema,
+    handler: handleModelRegistrySearch,
+  }),
+  modelRegistryGetModel: reply({
+    input: modelRegistryGetModelRequestSchema,
     handler: handleModelRegistryGetModel,
-  },
+  }),
 
-  // Simple Stream handlers
-  transcribeStream: { type: "stream", handler: handleTranscribeStream },
-  loggingStream: { type: "stream", handler: handleLoggingStream },
-  translate: { type: "stream", handler: handleTranslate },
-  textToSpeech: { type: "stream", handler: handleTextToSpeech },
-  ocrStream: { type: "stream", handler: handleOCRStream },
-  pluginInvokeStream: { type: "stream", handler: handlePluginInvokeStream },
-
-  // Handlers with delegation support
-  loadModel: {
-    type: "reply",
+  loadModel: reply({
+    input: loadModelRequestSchema,
     handler: handleLoadModel,
     delegatedHandler: handleLoadModelDelegated,
-    isDelegated: (r) => r.type === "loadModel" && !!r.delegate,
+    isDelegated: (r) =>
+      r.type === "loadModel" && "delegate" in r && !!r.delegate,
     supportsProgress: true,
-  },
+  }),
+  downloadAsset: reply({
+    input: downloadAssetRequestSchema,
+    handler: handleDownloadAsset,
+    supportsProgress: true,
+  }),
+  rag: reply({
+    input: ragRequestSchema,
+    handler: handleRag,
+    supportsProgress: ragSupportsProgress,
+  }),
 
-  completionStream: {
-    type: "stream",
+  completionStream: stream({
+    input: completionStreamRequestSchema,
     handler: handleCompletionStream,
     delegatedHandler: handleCompletionStreamDelegated,
     isDelegated: isModelDelegated,
-  },
-
-  // Handlers with progress support
-  downloadAsset: {
-    type: "reply",
-    handler: handleDownloadAsset,
-    supportsProgress: true,
-  },
-
-  rag: {
-    type: "reply",
-    handler: handleRag,
-    supportsProgress: ragSupportsProgress,
-  },
+  }),
+  transcribeStream: stream({
+    input: transcribeStreamRequestSchema,
+    handler: handleTranscribeStream,
+  }),
+  loggingStream: stream({
+    input: loggingStreamRequestSchema,
+    handler: handleLoggingStream,
+  }),
+  translate: stream({
+    input: translateRequestSchema,
+    handler: handleTranslate,
+  }),
+  textToSpeech: stream({
+    input: ttsRequestSchema,
+    handler: handleTextToSpeech,
+  }),
+  ocrStream: stream({
+    input: ocrStreamRequestSchema,
+    handler: handleOCRStream,
+  }),
+  pluginInvokeStream: stream({
+    input: pluginInvokeStreamRequestSchema,
+    handler: handlePluginInvokeStream,
+  }),
 };

--- a/packages/sdk/server/rpc/handler-utils.ts
+++ b/packages/sdk/server/rpc/handler-utils.ts
@@ -14,6 +14,7 @@ import {
 import { setSDKConfig } from "@/server/bare/registry/config-registry";
 import { setRuntimeContext } from "@/server/bare/registry/runtime-context-registry";
 import { type ServerProfiler } from "./profiling";
+import type { Procedure, ReplyProcedure, StreamProcedure } from "./procedure";
 
 function getProfilingMetaFromRequest(
   request: Request,
@@ -26,32 +27,19 @@ function getProfilingMetaFromRequest(
   return undefined;
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-type ReplyHandler = (
-  request: any,
-  ...args: any[]
-) => Promise<Response> | Response;
-type StreamHandler = (request: any, ...args: any[]) => AsyncGenerator<Response>;
-type ProgressHandler = (request: any, ...args: any[]) => Promise<Response>;
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
-export type HandlerEntry = {
-  type: "reply" | "stream";
-  handler: ReplyHandler | StreamHandler | ProgressHandler;
-  delegatedHandler?: ReplyHandler | StreamHandler | ProgressHandler;
-  isDelegated?: (request: Request) => boolean;
-  supportsProgress?: boolean | ((request: Request) => boolean);
-};
-
 async function executeReplyHandler(
   req: RPC.IncomingRequest,
   request: Request,
-  handler: ReplyHandler,
+  procedure: ReplyProcedure,
   profiler: ServerProfiler,
   isDelegated: boolean,
 ) {
   profiler.startHandler();
   try {
+    const handler = isDelegated
+      ? procedure.delegatedHandler!
+      : procedure.handler;
+
     let response: Response;
     if (isDelegated) {
       const profilingMeta = getProfilingMetaFromRequest(request);
@@ -73,16 +61,19 @@ async function executeReplyHandler(
 async function executeStreamHandler(
   req: RPC.IncomingRequest,
   request: Request,
-  handler: StreamHandler,
+  procedure: StreamProcedure,
   profiler: ServerProfiler,
   isDelegated: boolean,
 ) {
-  const stream = req.createResponseStream();
+  const responseStream = req.createResponseStream();
   profiler.startHandler();
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let generator: AsyncGenerator<Response, any, any>;
+    const handler = isDelegated
+      ? procedure.delegatedHandler!
+      : procedure.handler;
+
+    let generator: AsyncGenerator<Response>;
     if (isDelegated) {
       const profilingMeta = getProfilingMetaFromRequest(request);
       generator = handler(
@@ -93,36 +84,40 @@ async function executeStreamHandler(
       generator = handler(request);
     }
     for await (const response of generator) {
-      stream.write(profiler.serialize(response, false) + "\n", "utf-8");
+      responseStream.write(profiler.serialize(response, false) + "\n", "utf-8");
     }
     profiler.endHandler();
     const trailer = profiler.serialize();
     if (trailer) {
-      stream.write(trailer + "\n", "utf-8");
+      responseStream.write(trailer + "\n", "utf-8");
     }
 
-    stream.end();
+    responseStream.end();
   } catch (error) {
     profiler.endHandler();
-    sendStreamErrorResponse(stream, error, profiler);
+    sendStreamErrorResponse(responseStream, error, profiler);
   }
 }
 
 async function executeProgressHandler(
   req: RPC.IncomingRequest,
   request: Request,
-  handler: ProgressHandler,
+  procedure: ReplyProcedure,
   profiler: ServerProfiler,
   isDelegated: boolean,
 ) {
-  const stream = req.createResponseStream();
+  const responseStream = req.createResponseStream();
   profiler.startHandler();
 
   const progressCallback = (update: Response) => {
-    stream.write(profiler.serialize(update, false) + "\n", "utf-8");
+    responseStream.write(profiler.serialize(update, false) + "\n", "utf-8");
   };
 
   try {
+    const handler = isDelegated
+      ? procedure.delegatedHandler!
+      : procedure.handler;
+
     let response: Response;
     if (isDelegated) {
       const profilingMeta = getProfilingMetaFromRequest(request);
@@ -138,57 +133,45 @@ async function executeProgressHandler(
       response = await handler(request, progressCallback);
     }
     profiler.endHandler();
-    stream.write(profiler.serialize(response, true) + "\n", "utf-8");
-    stream.end();
+    responseStream.write(profiler.serialize(response, true) + "\n", "utf-8");
+    responseStream.end();
   } catch (error) {
     profiler.endHandler();
-    sendStreamErrorResponse(stream, error, profiler);
+    sendStreamErrorResponse(responseStream, error, profiler);
   }
 }
 
-// Unified handler executor with delegation and progress support
 export async function executeHandler(
   req: RPC.IncomingRequest,
   request: Request,
-  entry: HandlerEntry,
+  procedure: Procedure,
   profiler: ServerProfiler,
 ) {
   const isDelegated = !!(
-    entry.delegatedHandler && entry.isDelegated?.(request)
+    procedure.delegatedHandler && procedure.isDelegated?.(request)
   );
-  const handler = isDelegated ? entry.delegatedHandler! : entry.handler;
 
-  const wantsProgress =
-    "withProgress" in request &&
-    request.withProgress &&
-    (typeof entry.supportsProgress === "function"
-      ? entry.supportsProgress(request)
-      : entry.supportsProgress);
-
-  if (entry.type === "stream") {
-    await executeStreamHandler(
-      req,
-      request,
-      handler as StreamHandler,
-      profiler,
-      isDelegated,
-    );
-  } else if (wantsProgress) {
-    await executeProgressHandler(
-      req,
-      request,
-      handler as ProgressHandler,
-      profiler,
-      isDelegated,
-    );
+  if (procedure.mode === "stream") {
+    await executeStreamHandler(req, request, procedure, profiler, isDelegated);
   } else {
-    await executeReplyHandler(
-      req,
-      request,
-      handler as ReplyHandler,
-      profiler,
-      isDelegated,
-    );
+    const wantsProgress =
+      "withProgress" in request &&
+      request.withProgress &&
+      (typeof procedure.supportsProgress === "function"
+        ? procedure.supportsProgress(request)
+        : procedure.supportsProgress);
+
+    if (wantsProgress) {
+      await executeProgressHandler(
+        req,
+        request,
+        procedure,
+        profiler,
+        isDelegated,
+      );
+    } else {
+      await executeReplyHandler(req, request, procedure, profiler, isDelegated);
+    }
   }
 }
 

--- a/packages/sdk/server/rpc/procedure.ts
+++ b/packages/sdk/server/rpc/procedure.ts
@@ -1,0 +1,80 @@
+import type { z } from "zod";
+import type { Request, Response, ProfilingRequestMeta } from "@/schemas";
+
+export type DelegationOptions = {
+  profilingMeta?: ProfilingRequestMeta;
+};
+
+// --- Procedure types ---
+//
+// Handler signatures use `any` for request + extra params because:
+// 1. Handlers have specific request subtypes (contravariant with the wide Request union)
+// 2. Extra params vary by mode (progress callbacks, delegation options)
+// Type safety is enforced at registration time via the reply()/stream() helpers.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type ReplyProcedure = {
+  mode: "reply";
+  input: z.ZodSchema;
+  handler: (request: any, ...extra: any[]) => Promise<Response> | Response;
+  delegatedHandler?: (
+    request: any,
+    ...extra: any[]
+  ) => Promise<Response> | Response;
+  isDelegated?: (request: Request) => boolean;
+  supportsProgress?: boolean | ((request: Request) => boolean);
+};
+
+export type StreamProcedure = {
+  mode: "stream";
+  input: z.ZodSchema;
+  handler: (request: any, ...extra: any[]) => AsyncGenerator<Response>;
+  delegatedHandler?: (
+    request: any,
+    ...extra: any[]
+  ) => AsyncGenerator<Response>;
+  isDelegated?: (request: Request) => boolean;
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export type Procedure = ReplyProcedure | StreamProcedure;
+
+// --- Type-safe definition helpers ---
+//
+// These verify the handler's primary contract (request → response) at the call
+// site via generic inference, then widen to `Procedure` for storage. The `any`
+// in extra params is intentional — it accommodates progress callbacks and
+// delegation options without requiring handler signature changes.
+
+export function reply<
+  TInput extends Request,
+  TOutput extends Response,
+>(config: {
+  input: z.ZodSchema<TInput>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: (request: TInput, ...extra: any[]) => Promise<TOutput> | TOutput;
+  // Delegated handlers may accept a narrower request subtype (e.g.
+  // LoadModelSrcRequest vs full LoadModelRequest), so input is unconstrained.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delegatedHandler?: (...args: any[]) => Promise<TOutput> | TOutput;
+  isDelegated?: (request: Request) => boolean;
+  supportsProgress?: boolean | ((request: Request) => boolean);
+}): ReplyProcedure {
+  return { mode: "reply", ...config } as ReplyProcedure;
+}
+
+export function stream<
+  TInput extends Request,
+  TOutput extends Response,
+>(config: {
+  input: z.ZodSchema<TInput>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: (request: TInput, ...extra: any[]) => AsyncGenerator<TOutput>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delegatedHandler?: (...args: any[]) => AsyncGenerator<TOutput>;
+  isDelegated?: (request: Request) => boolean;
+}): StreamProcedure {
+  return { mode: "stream", ...config } as StreamProcedure;
+}
+
+export type Router = Record<string, Procedure>;


### PR DESCRIPTION
## Problem

The SDK's RPC layer had several type-safety and maintainability issues:

1. **Untyped handler registry** — server handlers were stored as `any`, losing type contracts
2. **Manual response type checks** — every client API method needed `if (response.type !== "foo") throw` boilerplate
3. **Manual request construction** — every API method manually injected `type: "completionStream"` etc.
4. **No plugin caller support** — custom plugin handlers had no way to create typed invoke/stream callers

## Solution

### 1. Type-level response narrowing (commit 1)

- **`RequestResponseMap`** — maps all 22 RPC operations to their request, response, and progress types
- **`ResponseFor<T>` / `StreamResponseFor<T>`** — utility types that narrow `send()` and `stream()` return types based on the request's `type` discriminator

### 2. Server-side procedure framework (commit 2)

- **`procedure.ts`** — defines `ReplyProcedure` and `StreamProcedure` types with `reply()` and `stream()` helpers
- **Handler registry migration** — replaced untyped `HandlerEntry` with typed `Procedure` objects
- **Handler dispatch** — `handler-utils.ts` now operates on typed `Procedure` objects, eliminating `any` casts

### 3. Client-side typed callers + full migration (commit 3)

- **`createCaller()`** — factory that creates typed `.call()` and `.stream()` methods, auto-injecting the `type` discriminator
- **`DistributiveOmit`** — correctly distributes `Omit` over union request types (loadModel, deleteCache, rag)
- **All 16 client API files migrated** — every API method now uses `rpc.*.call()` or `rpc.*.stream()`:
  - `ping`, `embed`, `getModelInfo` (migrated in commit 2)
  - `cancel`, `provide`, `stopProvide`, `unloadModel`, `loggingStream` (simple send/stream)
  - `deleteCache`, `invokePlugin`, `invokePluginStream`, `registry` (send with validation)
  - `downloadAsset`, `loadModel` (send/stream with progress)
  - `transcribe`, `translate`, `textToSpeech`, `ocr` (stream-heavy)
  - `rag` (8 functions with operation discriminator + progress)
  - `completion` (most complex — queues, tools, MCP)
- **Net reduction of ~120 lines** — eliminated manual `type` injection, `InvalidResponseError` checks, unused type imports

### 4. Plugin-aware caller infrastructure (commit 3)

- **`createPluginCaller()`** — typed factory for custom plugin handlers with Zod validation:
  ```typescript
  const sentiment = createPluginCaller({
    handler: "analyzeSentiment",
    params: z.object({ text: z.string() }),
    response: z.object({ score: z.number(), label: z.string() }),
  });
  const result = await sentiment.invoke(modelId, { text: "Great!" });
  ```
- **Plugin-grouped exports** — `llmOps`, `embeddingOps`, `whisperOps`, `nmtOps`, `ttsOps`, `ocrOps` group callers by the plugin they require

## What changed

| Area | Before | After |
|------|--------|-------|
| Client API methods | Manual `{ type: "foo", ...params }` + `if (response.type !== "foo") throw` | `rpc.foo.call(params)` — auto-injected type, narrowed response |
| Server handler registry | `Record<string, { type: "reply"\|"stream", handler: any }>` | `Router = Record<string, Procedure>` with `reply()`/`stream()` helpers |
| Handler dispatch | `handler as ReplyHandler` casts | Direct `procedure.handler(request)` |
| Plugin invoke | Generic `unknown` params/response | `createPluginCaller()` with Zod-validated types |
| Union request types | Broken `Omit<A\|B, K>` collapsed common keys | `DistributiveOmit` preserves per-branch properties |

## Testing

- `tsc --noEmit` — zero errors
- `eslint` — zero errors across all 20+ modified files
- `prettier --check` — all formatted

## Follow-up items (not in this PR)

- Standardize error handling (dual thrown-error vs in-band `success: false` pattern)
- Consider making RAG operations use per-operation callers instead of single `rag` caller with `operation` discriminator