### PR TITLE
poc[api]: SDK finetuning integration — Option B (no separate pause/resume API)

### DIFF
--- a/packages/sdk/client/api/finetune.ts
+++ b/packages/sdk/client/api/finetune.ts
@@ -1,0 +1,112 @@
+import { stream as streamRpc } from "@/client/rpc/rpc-client";
+import {
+  finetuneResponseSchema,
+  finetuneProgressSchema,
+  type FinetuningOptions,
+  type FinetuneRequest,
+  type FinetuneResponse,
+  type FinetuneProgress,
+  type RPCOptions,
+} from "@/schemas";
+
+type FinetuneParams = FinetuningOptions & {
+  modelId: string;
+  rpcOptions?: RPCOptions;
+};
+
+export interface FinetuneHandle {
+  progressStream: AsyncGenerator<FinetuneProgress>;
+  result: Promise<FinetuneResponse>;
+}
+
+export function finetune(params: FinetuneParams): FinetuneHandle {
+  const { rpcOptions, ...rest } = params;
+
+  let resultResolver: (value: FinetuneResponse) => void = () => {};
+  let resultRejecter: (error: unknown) => void = () => {};
+  const resultPromise = new Promise<FinetuneResponse>((resolve, reject) => {
+    resultResolver = resolve;
+    resultRejecter = reject;
+  });
+
+  resultPromise.catch(() => {});
+
+  const progressQueue: FinetuneProgress[] = [];
+  let progressDone = false;
+  let progressResolve: (() => void) | null = null;
+  let streamError: Error | null = null;
+
+  const processResponses = async () => {
+    const request: FinetuneRequest = {
+      type: "finetune",
+      ...rest,
+    };
+
+    const responses: AsyncGenerator<unknown> = streamRpc(request, rpcOptions);
+
+    for await (const response of responses) {
+      if (!response || typeof response !== "object" || !("type" in response)) {
+        continue;
+      }
+
+      if (response.type === "finetuneProgress") {
+        const progress = finetuneProgressSchema.parse(response);
+        progressQueue.push(progress);
+        if (progressResolve) {
+          progressResolve();
+          progressResolve = null;
+        }
+      } else if (response.type === "finetune") {
+        const result = finetuneResponseSchema.parse(response);
+        resultResolver(result);
+        progressDone = true;
+        if (progressResolve) {
+          progressResolve();
+          progressResolve = null;
+        }
+      }
+    }
+
+    // If we exited the loop without a finetune response, signal done
+    if (!progressDone) {
+      progressDone = true;
+      if (progressResolve) {
+        progressResolve();
+        progressResolve = null;
+      }
+    }
+  };
+
+  void processResponses().catch((error) => {
+    const err = error instanceof Error ? error : new Error(String(error));
+    streamError = err;
+    resultRejecter(err);
+    progressDone = true;
+    if (progressResolve) {
+      progressResolve();
+      progressResolve = null;
+    }
+  });
+
+  const progressStream = (async function* () {
+    while (true) {
+      if (progressQueue.length > 0) {
+        yield progressQueue.shift()!;
+      } else if (progressDone) {
+        if (streamError !== null) {
+          throw streamError as Error;
+        }
+        break;
+      } else {
+        await new Promise<void>((resolve) => {
+          progressResolve = resolve;
+        });
+      }
+    }
+  })();
+
+  return {
+    progressStream,
+    result: resultPromise,
+  };
+}

--- a/packages/sdk/client/api/index.ts
+++ b/packages/sdk/client/api/index.ts
@@ -9,6 +9,7 @@ export { transcribe, transcribeStream } from "./transcribe";
 export { embed } from "./embed";
 export { translate } from "./translate";
 export { cancel } from "./cancel";
+export { finetune, type FinetuneHandle } from "./finetune";
 export { startQVACProvider } from "./provide";
 export { stopQVACProvider } from "./stop-provider";
 export {

--- a/packages/sdk/examples/llamacpp-finetune.ts
+++ b/packages/sdk/examples/llamacpp-finetune.ts
@@ -43,6 +43,8 @@ import {
   completion,
 } from "@qvac/sdk";
 import process from "bare-process";
+import fs from "bare-fs";
+import path from "bare-path";
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -120,6 +122,24 @@ async function demoCancel(modelId: string) {
   console.log("Checkpoints cleared — cannot resume after cancel.\n");
 }
 
+function findPauseCheckpoint(dir: string): string | null {
+  if (!fs.existsSync(dir)) return null;
+  const entries = fs.readdirSync(dir) as string[];
+  const checkpoints = entries.filter((f: string) => f.startsWith("pause_checkpoint_step_"));
+  if (checkpoints.length === 0) return null;
+  checkpoints.sort((a: string, b: string) => {
+    const stepA = parseInt(a.match(/pause_checkpoint_step_(\d+)/)?.[1] ?? "0");
+    const stepB = parseInt(b.match(/pause_checkpoint_step_(\d+)/)?.[1] ?? "0");
+    return stepB - stepA;
+  });
+  return path.join(dir, checkpoints[0]!);
+}
+
+const inferencePrompt = [
+  { role: "system" as const, content: "You are a helpful healthcare assistant." },
+  { role: "user" as const, content: "Do nurses' involvement in patient education improve outcomes?" },
+];
+
 async function demoPauseResume(modelId: string) {
   console.log("\n=== Pause/Resume Demo ===");
   console.log("Starting finetuning (will pause after a few steps)...");
@@ -134,7 +154,6 @@ async function demoPauseResume(modelId: string) {
 
     if (stepCount >= pauseAfterSteps) {
       console.log(`\nPausing after ${stepCount} steps...`);
-      // Pause — saves checkpoint, can resume later
       // cancel() with reset: false acts as pause for finetune jobs
       await cancel({ operation: "inference", modelId, reset: false });
       break;
@@ -142,24 +161,64 @@ async function demoPauseResume(modelId: string) {
   }
 
   const pauseResult = await handle.result;
-  console.log(`Pause result: ${pauseResult.status}`); // → "PAUSED"
+  console.log(`Pause result: ${pauseResult.status}`);
 
   if (pauseResult.stats) {
     console.log("Stats at pause:", JSON.stringify(pauseResult.stats, null, 2));
   }
 
-  // (Optional) Run inference while paused
-  console.log("\nRunning inference while finetuning is paused...");
-  const { text: inferText } = completion({
-    modelId,
-    history: [{ role: "user", content: "What is 2+2?" }],
+  // Find the pause checkpoint's LoRA adapter
+  const pauseCheckpointPath = findPauseCheckpoint(checkpointDir);
+  if (!pauseCheckpointPath) {
+    throw new Error(`No pause checkpoint found in ${checkpointDir}`);
+  }
+  const loraAdapterPath = path.join(pauseCheckpointPath, "model.gguf");
+  console.log(`\nPause checkpoint found: ${pauseCheckpointPath}`);
+  console.log(`LoRA adapter path: ${loraAdapterPath}`);
+
+  // Step 1: Inference WITH the checkpoint's LoRA adapter
+  // This demonstrates partial fine-tuning effect
+  console.log("\n--- Inference with LoRA adapter (partial fine-tuning) ---");
+  const loraModelId = await loadModel({
+    modelType: "llm",
+    modelSrc: modelPath,
+    modelConfig: {
+      device: "cpu",
+      ctx_size: 4096,
+      lora: loraAdapterPath,
+    },
+  });
+
+  const { text: loraText } = completion({
+    modelId: loraModelId,
+    history: inferencePrompt,
     stream: false,
   });
-  console.log("Inference response:", await inferText);
+  console.log("With LoRA:", await loraText);
+  await unloadModel({ modelId: loraModelId });
 
-  // Resume — just call finetune() again with the same params
+  // Step 2: Inference WITHOUT LoRA (base model comparison)
+  console.log("\n--- Inference without LoRA (base model) ---");
+  const baseModelId = await loadModel({
+    modelType: "llm",
+    modelSrc: modelPath,
+    modelConfig: {
+      device: "cpu",
+      ctx_size: 4096,
+    },
+  });
+
+  const { text: baseText } = completion({
+    modelId: baseModelId,
+    history: inferencePrompt,
+    stream: false,
+  });
+  console.log("Without LoRA:", await baseText);
+  await unloadModel({ modelId: baseModelId });
+
+  // Step 3: Resume finetuning on the ORIGINAL model (never unloaded)
   // The addon auto-detects the checkpoint in checkpointSaveDir
-  console.log("\nResuming finetuning from checkpoint...");
+  console.log("\n--- Resuming finetuning from checkpoint ---");
   const resumed = finetune({ modelId, ...finetuneOptions });
 
   for await (const tick of resumed.progressStream) {
@@ -167,7 +226,7 @@ async function demoPauseResume(modelId: string) {
   }
 
   const resumeResult = await resumed.result;
-  console.log(`\nResume result: ${resumeResult.status}`); // → "COMPLETED"
+  console.log(`\nResume result: ${resumeResult.status}`);
 
   if (resumeResult.stats) {
     console.log("Final stats:", JSON.stringify(resumeResult.stats, null, 2));

--- a/packages/sdk/examples/llamacpp-finetune.ts
+++ b/packages/sdk/examples/llamacpp-finetune.ts
@@ -135,8 +135,8 @@ async function demoPauseResume(modelId: string) {
     if (stepCount >= pauseAfterSteps) {
       console.log(`\nPausing after ${stepCount} steps...`);
       // Pause — saves checkpoint, can resume later
-      // cancel() without reset acts as pause for finetune jobs
-      await cancel({ operation: "inference", modelId });
+      // cancel() with reset: false acts as pause for finetune jobs
+      await cancel({ operation: "inference", modelId, reset: false });
       break;
     }
   }

--- a/packages/sdk/examples/llamacpp-finetune.ts
+++ b/packages/sdk/examples/llamacpp-finetune.ts
@@ -1,0 +1,256 @@
+/**
+ * LLM LoRA Finetuning Example (Option B — no separate resume/cancel API)
+ *
+ * Demonstrates the full finetuning lifecycle using the SDK:
+ *   1. Load a model
+ *   2. Start finetuning with progress streaming
+ *   3. Pause and resume via checkpoint auto-detection
+ *   4. Cancel (hard cancel — clears checkpoints)
+ *   5. Load the finetuned adapter for inference
+ *
+ * Parameters match the addon's tested examples (qvac-lib-infer-llamacpp-llm).
+ *
+ * Usage:
+ *   # Full run (no pause):
+ *   bun run bare:example examples/llamacpp-finetune.ts -- \
+ *     --model /models/Qwen3-0.6B-Q8_0.gguf \
+ *     --dataset /data/train.jsonl \
+ *     --eval-dataset /data/eval.jsonl \
+ *     --output /output/lora
+ *
+ *   # Pause/resume demo (pauses after 5 steps, then resumes):
+ *   bun run bare:example examples/llamacpp-finetune.ts -- \
+ *     --model /models/Qwen3-0.6B-Q8_0.gguf \
+ *     --dataset /data/train.jsonl \
+ *     --eval-dataset /data/eval.jsonl \
+ *     --output /output/lora \
+ *     --pause-after 5
+ *
+ *   # Cancel demo (cancels after 3 steps — clears checkpoints):
+ *   bun run bare:example examples/llamacpp-finetune.ts -- \
+ *     --model /models/Qwen3-0.6B-Q8_0.gguf \
+ *     --dataset /data/train.jsonl \
+ *     --eval-dataset /data/eval.jsonl \
+ *     --output /output/lora \
+ *     --cancel-after 3
+ */
+
+import {
+  loadModel,
+  finetune,
+  cancel,
+  unloadModel,
+  completion,
+} from "@qvac/sdk";
+import process from "bare-process";
+
+// Parse CLI args
+const args = process.argv.slice(2);
+function getArg(name: string, fallback: string): string {
+  const idx = args.indexOf(`--${name}`);
+  if (idx !== -1 && args[idx + 1]) return args[idx + 1]!;
+  return fallback;
+}
+const modelPath: string = getArg("model", "/models/Qwen3-0.6B-Q8_0.gguf");
+const datasetPath: string = getArg("dataset", "/data/train.jsonl");
+const evalDatasetPath: string = getArg("eval-dataset", "");
+const outputDir: string = getArg("output", "/output/lora");
+const checkpointDir: string = getArg("checkpoint-dir", "./lora_checkpoints");
+const pauseAfterSteps: number = parseInt(getArg("pause-after", "0"), 10);
+const cancelAfterSteps: number = parseInt(getArg("cancel-after", "0"), 10);
+
+// Matches addon example parameters from qvac-lib-infer-llamacpp-llm
+const finetuneOptions = {
+  trainDatasetDir: datasetPath,
+  validation: evalDatasetPath
+    ? { type: "dataset" as const, path: evalDatasetPath }
+    : { type: "split" as const, fraction: 0.25 },
+  outputParametersDir: outputDir,
+  numberOfEpochs: 2,
+  learningRate: 1e-5,
+  lrMin: 1e-8,
+  contextLength: 512,
+  loraModules: "attn_q,attn_k,attn_v,attn_o,ffn_gate,ffn_up,ffn_down",
+  assistantLossOnly: true,
+  checkpointSaveSteps: 10,
+  checkpointSaveDir: checkpointDir,
+};
+
+function logProgress(tick: {
+  is_train: boolean;
+  global_steps: number;
+  current_epoch: number;
+  current_batch: number;
+  total_batches: number;
+  loss: number;
+  accuracy: number;
+  elapsed_ms: number;
+  eta_ms: number;
+}) {
+  const mode = tick.is_train ? "train" : "val";
+  console.log(
+    `[${mode}] step ${tick.global_steps} | ` +
+      `epoch ${tick.current_epoch} batch ${tick.current_batch}/${tick.total_batches} | ` +
+      `loss: ${tick.loss.toFixed(4)} | acc: ${tick.accuracy.toFixed(4)} | ` +
+      `elapsed: ${(tick.elapsed_ms / 1000).toFixed(1)}s | eta: ${(tick.eta_ms / 1000).toFixed(1)}s`,
+  );
+}
+
+async function demoCancel(modelId: string) {
+  console.log("\n=== Cancel Demo ===");
+  console.log("Starting finetuning (will cancel after a few steps)...");
+
+  const handle = finetune({ modelId, ...finetuneOptions });
+  let stepCount = 0;
+
+  for await (const tick of handle.progressStream) {
+    logProgress(tick);
+    stepCount++;
+
+    if (stepCount >= cancelAfterSteps) {
+      console.log(`\nHard-cancelling after ${stepCount} steps...`);
+      // Cancel with reset: true — clears checkpoints, cannot resume
+      await cancel({ operation: "inference", modelId, reset: true });
+      break;
+    }
+  }
+
+  const result = await handle.result;
+  console.log(`Result: ${result.status}`); // → "CANCELLED"
+  console.log("Checkpoints cleared — cannot resume after cancel.\n");
+}
+
+async function demoPauseResume(modelId: string) {
+  console.log("\n=== Pause/Resume Demo ===");
+  console.log("Starting finetuning (will pause after a few steps)...");
+
+  // Start finetuning
+  const handle = finetune({ modelId, ...finetuneOptions });
+  let stepCount = 0;
+
+  for await (const tick of handle.progressStream) {
+    logProgress(tick);
+    stepCount++;
+
+    if (stepCount >= pauseAfterSteps) {
+      console.log(`\nPausing after ${stepCount} steps...`);
+      // Pause — saves checkpoint, can resume later
+      // cancel() without reset acts as pause for finetune jobs
+      await cancel({ operation: "inference", modelId });
+      break;
+    }
+  }
+
+  const pauseResult = await handle.result;
+  console.log(`Pause result: ${pauseResult.status}`); // → "PAUSED"
+
+  if (pauseResult.stats) {
+    console.log("Stats at pause:", JSON.stringify(pauseResult.stats, null, 2));
+  }
+
+  // (Optional) Run inference while paused
+  console.log("\nRunning inference while finetuning is paused...");
+  const { text: inferText } = completion({
+    modelId,
+    history: [{ role: "user", content: "What is 2+2?" }],
+    stream: false,
+  });
+  console.log("Inference response:", await inferText);
+
+  // Resume — just call finetune() again with the same params
+  // The addon auto-detects the checkpoint in checkpointSaveDir
+  console.log("\nResuming finetuning from checkpoint...");
+  const resumed = finetune({ modelId, ...finetuneOptions });
+
+  for await (const tick of resumed.progressStream) {
+    logProgress(tick);
+  }
+
+  const resumeResult = await resumed.result;
+  console.log(`\nResume result: ${resumeResult.status}`); // → "COMPLETED"
+
+  if (resumeResult.stats) {
+    console.log("Final stats:", JSON.stringify(resumeResult.stats, null, 2));
+  }
+}
+
+async function demoFullRun(modelId: string) {
+  console.log("\n=== Full Finetuning Run ===");
+  const handle = finetune({ modelId, ...finetuneOptions });
+
+  for await (const tick of handle.progressStream) {
+    logProgress(tick);
+  }
+
+  const result = await handle.result;
+  console.log(`\nResult: ${result.status}`); // → "COMPLETED"
+
+  if (result.stats) {
+    console.log("Stats:", JSON.stringify(result.stats, null, 2));
+  }
+}
+
+async function main() {
+  // ──────────────────────────────────────────────
+  // 1. Load the base model
+  // ──────────────────────────────────────────────
+  console.log("Loading model...");
+  const modelId = await loadModel({
+    modelType: "llm",
+    modelSrc: modelPath,
+    modelConfig: {
+      device: "cpu",
+      ctx_size: 512,
+    },
+  });
+  console.log(`Model loaded: ${modelId}`);
+
+  // ──────────────────────────────────────────────
+  // 2. Run the appropriate demo
+  // ──────────────────────────────────────────────
+  if (cancelAfterSteps > 0) {
+    await demoCancel(modelId);
+  } else if (pauseAfterSteps > 0) {
+    await demoPauseResume(modelId);
+  } else {
+    await demoFullRun(modelId);
+  }
+
+  // ──────────────────────────────────────────────
+  // 3. Load the finetuned adapter for inference
+  // ──────────────────────────────────────────────
+  if (cancelAfterSteps === 0) {
+    console.log("\n=== Inference with Finetuned Adapter ===");
+    await unloadModel({ modelId });
+
+    console.log("Loading model with LoRA adapter...");
+    const ftModelId = await loadModel({
+      modelType: "llm",
+      modelSrc: modelPath,
+      modelConfig: {
+        device: "cpu",
+        ctx_size: 128,
+        lora: `${outputDir}/trained-lora-adapter.gguf`,
+      },
+    });
+
+    const { text } = completion({
+      modelId: ftModelId,
+      history: [{ role: "user", content: "Hello, how are you?" }],
+      stream: false,
+    });
+    console.log("Response:", await text);
+
+    await unloadModel({ modelId: ftModelId });
+  } else {
+    await unloadModel({ modelId });
+  }
+
+  console.log("\nDone!");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -13,6 +13,8 @@ export {
   embed,
   translate,
   cancel,
+  finetune,
+  type FinetuneHandle,
   ragChunk,
   ragIngest,
   ragSaveEmbeddings,
@@ -87,6 +89,11 @@ export {
   SDK_DEFAULT_PLUGINS,
   type BuiltinPlugin,
   type ProfilerMode,
+  type FinetuningOptions,
+  type FinetuneProgress,
+  type FinetuneStats,
+  type FinetuneStatus,
+  type FinetuneValidation,
 } from "./schemas";
 
 export { type ToolInput, type ToolHandler } from "./utils/tool-helpers";

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -119,10 +119,10 @@
   "dependencies": {
     "@qvac/decoder-audio": "^0.3.3",
     "@qvac/dl-filesystem": "^0.2.0",
-    "@qvac/embed-llamacpp": "^0.12.0",
+    "@qvac/embed-llamacpp": "^0.13.0",
     "@qvac/error": "^0.1.1",
     "@qvac/langdetect-text-cld2": "0.3.0",
-    "@qvac/llm-llamacpp": "^0.12.1",
+    "@qvac/llm-llamacpp": "^0.14.0",
     "@qvac/logging": "^0.1.0",
     "@qvac/ocr-onnx": "^0.2.0",
     "@qvac/rag": "^0.4.2",

--- a/packages/sdk/schemas/cancel.ts
+++ b/packages/sdk/schemas/cancel.ts
@@ -10,7 +10,7 @@ export const cancelInferenceBaseSchema = z.object({
 
 const cancelInferenceParamsSchema = cancelInferenceBaseSchema.extend({
   operation: z.literal("inference"),
-  reset: z.boolean().optional(),
+  reset: z.boolean().default(true),
 });
 
 const cancelDownloadParamsSchema = z.object({

--- a/packages/sdk/schemas/cancel.ts
+++ b/packages/sdk/schemas/cancel.ts
@@ -10,6 +10,7 @@ export const cancelInferenceBaseSchema = z.object({
 
 const cancelInferenceParamsSchema = cancelInferenceBaseSchema.extend({
   operation: z.literal("inference"),
+  reset: z.boolean().optional(),
 });
 
 const cancelDownloadParamsSchema = z.object({

--- a/packages/sdk/schemas/common.ts
+++ b/packages/sdk/schemas/common.ts
@@ -64,6 +64,11 @@ import {
   modelRegistryGetModelRequestSchema,
   modelRegistryGetModelResponseSchema,
 } from "./registry";
+import {
+  finetuneRequestSchema,
+  finetuneResponseSchema,
+  finetuneProgressSchema,
+} from "./finetune";
 
 export const requestSchema = z.union([
   pingRequestSchema,
@@ -88,6 +93,7 @@ export const requestSchema = z.union([
   modelRegistryListRequestSchema,
   modelRegistrySearchRequestSchema,
   modelRegistryGetModelRequestSchema,
+  finetuneRequestSchema,
 ]);
 
 export const responseSchema = z.discriminatedUnion("type", [
@@ -116,6 +122,8 @@ export const responseSchema = z.discriminatedUnion("type", [
   modelRegistryListResponseSchema,
   modelRegistrySearchResponseSchema,
   modelRegistryGetModelResponseSchema,
+  finetuneResponseSchema,
+  finetuneProgressSchema,
 ]);
 
 export const rpcOptionsSchema = z.object({

--- a/packages/sdk/schemas/finetune.ts
+++ b/packages/sdk/schemas/finetune.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+
+// ============================================
+// Validation
+// ============================================
+
+const finetuneValidationNoneSchema = z.object({
+  type: z.literal("none"),
+});
+
+const finetuneValidationSplitSchema = z.object({
+  type: z.literal("split"),
+  fraction: z.number().min(0).max(1).optional(),
+});
+
+const finetuneValidationDatasetSchema = z.object({
+  type: z.literal("dataset"),
+  path: z.string(),
+});
+
+export const finetuneValidationSchema = z.discriminatedUnion("type", [
+  finetuneValidationNoneSchema,
+  finetuneValidationSplitSchema,
+  finetuneValidationDatasetSchema,
+]);
+
+// ============================================
+// Finetuning Options
+// ============================================
+
+export const finetuningOptionsSchema = z.object({
+  trainDatasetDir: z.string(),
+  validation: finetuneValidationSchema,
+  outputParametersDir: z.string(),
+  numberOfEpochs: z.number().int().positive().optional(),
+  learningRate: z.number().positive().optional(),
+  contextLength: z.number().int().positive().optional(),
+  batchSize: z.number().int().positive().optional(),
+  microBatchSize: z.number().int().positive().optional(),
+  assistantLossOnly: z.boolean().optional(),
+  loraModules: z.string().optional(),
+  loraRank: z.number().int().positive().optional(),
+  loraAlpha: z.number().positive().optional(),
+  loraInitStd: z.number().positive().optional(),
+  loraSeed: z.number().int().nonnegative().optional(),
+  checkpointSaveDir: z.string().optional(),
+  checkpointSaveSteps: z.number().int().nonnegative().optional(),
+  chatTemplatePath: z.string().optional(),
+  lrScheduler: z.enum(["constant", "cosine", "linear"]).optional(),
+  lrMin: z.number().nonnegative().optional(),
+  warmupRatio: z.number().min(0).max(1).optional(),
+  warmupSteps: z.number().int().nonnegative().optional(),
+  weightDecay: z.number().nonnegative().optional(),
+});
+
+// ============================================
+// Request / Response
+// ============================================
+
+export const finetuneRequestSchema = z.object({
+  type: z.literal("finetune"),
+  modelId: z.string(),
+}).merge(finetuningOptionsSchema);
+
+export const finetuneStatusSchema = z.enum(["COMPLETED", "PAUSED", "CANCELLED"]);
+
+export const finetuneStatsSchema = z.object({
+  train_loss: z.number().optional(),
+  train_loss_uncertainty: z.number().optional(),
+  val_loss: z.number().optional(),
+  val_loss_uncertainty: z.number().optional(),
+  train_accuracy: z.number().optional(),
+  train_accuracy_uncertainty: z.number().optional(),
+  val_accuracy: z.number().optional(),
+  val_accuracy_uncertainty: z.number().optional(),
+  learning_rate: z.number().optional(),
+  global_steps: z.number(),
+  epochs_completed: z.number(),
+});
+
+export const finetuneProgressSchema = z.object({
+  type: z.literal("finetuneProgress"),
+  is_train: z.boolean(),
+  loss: z.number(),
+  loss_uncertainty: z.number().nullable(),
+  accuracy: z.number(),
+  accuracy_uncertainty: z.number().nullable(),
+  global_steps: z.number(),
+  current_epoch: z.number(),
+  current_batch: z.number(),
+  total_batches: z.number(),
+  elapsed_ms: z.number(),
+  eta_ms: z.number(),
+});
+
+export const finetuneResponseSchema = z.object({
+  type: z.literal("finetune"),
+  status: finetuneStatusSchema,
+  stats: finetuneStatsSchema.optional(),
+});
+
+// ============================================
+// Types
+// ============================================
+
+export type FinetuneValidation = z.infer<typeof finetuneValidationSchema>;
+export type FinetuningOptions = z.infer<typeof finetuningOptionsSchema>;
+export type FinetuneRequest = z.infer<typeof finetuneRequestSchema>;
+export type FinetuneResponse = z.infer<typeof finetuneResponseSchema>;
+export type FinetuneProgress = z.infer<typeof finetuneProgressSchema>;
+export type FinetuneStats = z.infer<typeof finetuneStatsSchema>;
+export type FinetuneStatus = z.infer<typeof finetuneStatusSchema>;

--- a/packages/sdk/schemas/index.ts
+++ b/packages/sdk/schemas/index.ts
@@ -72,5 +72,6 @@ export {
   isCanonicalModelType,
   isModelTypeAlias,
 } from "./model-types";
+export * from "./finetune";
 export * from "./plugin";
 export * from "./registry";

--- a/packages/sdk/server/bare/ops/cancel.ts
+++ b/packages/sdk/server/bare/ops/cancel.ts
@@ -5,7 +5,11 @@ import {
 } from "@/schemas";
 import { ModelNotLoadedError } from "@/utils/errors-server";
 
-export async function cancel(params: CancelInferenceBaseParams) {
+interface CancelOptions extends CancelInferenceBaseParams {
+  reset?: boolean | undefined;
+}
+
+export async function cancel(params: CancelOptions) {
   const { modelId } = cancelInferenceBaseSchema.parse(params);
   const model = getModel(modelId);
 
@@ -13,7 +17,18 @@ export async function cancel(params: CancelInferenceBaseParams) {
     throw new ModelNotLoadedError(modelId);
   }
 
-  if (model.addon && model.addon.cancel) {
-    await model.addon.cancel();
+  if (params.reset) {
+    // Hard cancel — clears checkpoints, cannot resume
+    if (model.addon && model.addon.cancel) {
+      await model.addon.cancel();
+    }
+  } else {
+    // Pause — saves checkpoint, can resume later
+    const pausable = model as { pause?: () => Promise<void> };
+    if (typeof pausable.pause === "function") {
+      await pausable.pause();
+    } else if (model.addon && model.addon.cancel) {
+      await model.addon.cancel();
+    }
   }
 }

--- a/packages/sdk/server/bare/ops/cancel.ts
+++ b/packages/sdk/server/bare/ops/cancel.ts
@@ -6,7 +6,7 @@ import {
 import { ModelNotLoadedError } from "@/utils/errors-server";
 
 interface CancelOptions extends CancelInferenceBaseParams {
-  reset?: boolean | undefined;
+  reset?: boolean;
 }
 
 export async function cancel(params: CancelOptions) {
@@ -17,13 +17,15 @@ export async function cancel(params: CancelOptions) {
     throw new ModelNotLoadedError(modelId);
   }
 
-  if (params.reset) {
-    // Hard cancel — clears checkpoints, cannot resume
+  // Default: hard cancel (reset=true) — preserves existing behavior
+  // Pause: reset=false — saves checkpoint, can resume later
+  const reset = params.reset !== false;
+
+  if (reset) {
     if (model.addon && model.addon.cancel) {
       await model.addon.cancel();
     }
   } else {
-    // Pause — saves checkpoint, can resume later
     const pausable = model as { pause?: () => Promise<void> };
     if (typeof pausable.pause === "function") {
       await pausable.pause();

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
@@ -1,0 +1,150 @@
+import type {
+  FinetuneRequest,
+  FinetuneResponse,
+  FinetuneProgress,
+  FinetuneStats,
+} from "@/schemas";
+import {
+  getModel,
+  type AnyModel,
+} from "@/server/bare/registry/model-registry";
+import { getServerLogger } from "@/logging";
+
+const logger = getServerLogger();
+
+interface FinetuneProgressStats {
+  is_train: boolean;
+  loss: number;
+  loss_uncertainty: number;
+  accuracy: number;
+  accuracy_uncertainty: number;
+  global_steps: number;
+  current_epoch: number;
+  current_batch: number;
+  total_batches: number;
+  elapsed_ms: number;
+  eta_ms: number;
+}
+
+interface FinetuneHandle {
+  on(event: "stats", cb: (stats: FinetuneProgressStats) => void): this;
+  removeListener(
+    event: "stats",
+    cb: (stats: FinetuneProgressStats) => void,
+  ): this;
+  await(): Promise<{ op: string; status: "COMPLETED" | "PAUSED"; stats?: unknown }>;
+}
+
+function getFinetuneFn(model: AnyModel) {
+  const fn = (model as Record<string, unknown>)["finetune"];
+  return typeof fn === "function"
+    ? (fn as (options: Record<string, unknown>) => Promise<FinetuneHandle>)
+    : undefined;
+}
+
+export async function* finetune(
+  request: FinetuneRequest,
+): AsyncGenerator<FinetuneProgress | FinetuneResponse> {
+  const model = getModel(request.modelId);
+  const finetuneFn = getFinetuneFn(model);
+
+  if (!finetuneFn) {
+    throw new Error(
+      `Model ${request.modelId} does not support finetuning`,
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { type: _type, modelId: _modelId, ...finetuneOptions } = request;
+
+  logger.info(`Starting finetune for model ${request.modelId}`);
+
+  const handle = await finetuneFn.call(model, finetuneOptions as Record<string, unknown>);
+
+  // Accumulate stats from progress events for the final result
+  let lastStats: FinetuneStats = { global_steps: 0, epochs_completed: 0 };
+
+  // Set up progress event forwarding via a queue
+  const progressQueue: FinetuneProgress[] = [];
+  let progressResolve: (() => void) | null = null;
+  let handleDone = false;
+
+  const onStats = (stats: FinetuneProgressStats) => {
+    const progress: FinetuneProgress = {
+      type: "finetuneProgress" as const,
+      ...stats,
+    };
+    progressQueue.push(progress);
+
+    // Accumulate stats for final result
+    if (stats.is_train) {
+      lastStats = {
+        ...lastStats,
+        train_loss: stats.loss,
+        train_loss_uncertainty: stats.loss_uncertainty,
+        train_accuracy: stats.accuracy,
+        train_accuracy_uncertainty: stats.accuracy_uncertainty,
+        learning_rate: lastStats.learning_rate,
+        global_steps: stats.global_steps,
+        epochs_completed: stats.current_epoch,
+      };
+    } else {
+      lastStats = {
+        ...lastStats,
+        val_loss: stats.loss,
+        val_loss_uncertainty: stats.loss_uncertainty,
+        val_accuracy: stats.accuracy,
+        val_accuracy_uncertainty: stats.accuracy_uncertainty,
+        global_steps: stats.global_steps,
+        epochs_completed: stats.current_epoch,
+      };
+    }
+
+    if (progressResolve) {
+      progressResolve();
+      progressResolve = null;
+    }
+  };
+
+  handle.on("stats", onStats);
+
+  // Await the finetune result in the background
+  const resultPromise = handle.await().then((result) => {
+    handleDone = true;
+    if (progressResolve) {
+      progressResolve();
+      progressResolve = null;
+    }
+    return result;
+  });
+
+  // Yield progress events as they come in
+  while (!handleDone) {
+    if (progressQueue.length > 0) {
+      yield progressQueue.shift()!;
+    } else {
+      await new Promise<void>((resolve) => {
+        progressResolve = resolve;
+      });
+    }
+  }
+
+  // Drain remaining progress events
+  while (progressQueue.length > 0) {
+    yield progressQueue.shift()!;
+  }
+
+  handle.removeListener("stats", onStats);
+
+  const result = await resultPromise;
+
+  logger.info(
+    `Finetune completed for model ${request.modelId} with status: ${result.status}`,
+  );
+
+  yield {
+    type: "finetune" as const,
+    status: result.status,
+    stats: lastStats,
+  };
+}

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import LlmLlamacpp, { type Loader as LlmLoader } from "@qvac/llm-llamacpp";
 import llmAddonLogging from "@qvac/llm-llamacpp/addonLogging";
 import {
@@ -5,6 +6,9 @@ import {
   defineHandler,
   completionStreamRequestSchema,
   completionStreamResponseSchema,
+  finetuneRequestSchema,
+  finetuneResponseSchema,
+  finetuneProgressSchema,
   translateRequestSchema,
   translateResponseSchema,
   ModelType,
@@ -24,6 +28,7 @@ import { parseModelPath } from "@/server/utils";
 import FilesystemDL from "@qvac/dl-filesystem";
 import { asLoader } from "@/server/bare/utils/loader-adapter";
 import { completion } from "@/server/bare/plugins/llamacpp-completion/ops/completion-stream";
+import { finetune } from "@/server/bare/plugins/llamacpp-completion/ops/finetune";
 import { translate } from "@/server/bare/ops/translate";
 
 function transformLlmConfig(llmConfig: LlmConfig) {
@@ -206,6 +211,16 @@ export const llmPlugin = definePlugin({
           done: true,
           ...(stats && { stats }),
         };
+      },
+    }),
+
+    finetune: defineHandler({
+      requestSchema: finetuneRequestSchema,
+      responseSchema: z.union([finetuneResponseSchema, finetuneProgressSchema]),
+      streaming: true,
+
+      handler: async function* (request) {
+        yield* finetune(request);
       },
     }),
   },

--- a/packages/sdk/server/rpc/handler-registry.ts
+++ b/packages/sdk/server/rpc/handler-registry.ts
@@ -29,6 +29,7 @@ import {
   handleModelRegistrySearch,
   handleModelRegistryGetModel,
 } from "@/server/rpc/handlers/registry";
+import { handleFinetune } from "@/server/rpc/handlers/finetune";
 import type { HandlerEntry } from "./handler-utils";
 
 function ragSupportsProgress(request: Request): boolean {
@@ -66,6 +67,7 @@ export const registry: Record<string, HandlerEntry> = {
   },
 
   // Simple Stream handlers
+  finetune: { type: "stream", handler: handleFinetune },
   transcribeStream: { type: "stream", handler: handleTranscribeStream },
   loggingStream: { type: "stream", handler: handleLoggingStream },
   translate: { type: "stream", handler: handleTranslate },

--- a/packages/sdk/server/rpc/handlers/cancelHandler.ts
+++ b/packages/sdk/server/rpc/handlers/cancelHandler.ts
@@ -15,7 +15,7 @@ export async function cancelHandler(
   try {
     switch (request.operation) {
       case "inference":
-        await cancel({ modelId: request.modelId });
+        await cancel({ modelId: request.modelId, reset: request.reset });
         break;
       case "downloadAsset": {
         const cancelDownload = createCancelFunction(

--- a/packages/sdk/server/rpc/handlers/finetune.ts
+++ b/packages/sdk/server/rpc/handlers/finetune.ts
@@ -1,0 +1,11 @@
+import type { FinetuneRequest, FinetuneResponse, FinetuneProgress } from "@/schemas";
+import { dispatchPluginStream } from "@/server/rpc/handlers/plugin-dispatch";
+
+export async function* handleFinetune(
+  request: FinetuneRequest,
+): AsyncGenerator<FinetuneProgress | FinetuneResponse> {
+  yield* dispatchPluginStream<
+    FinetuneRequest,
+    FinetuneProgress | FinetuneResponse
+  >(request.modelId, "finetune", request);
+}

--- a/packages/sdk/server/rpc/handlers/index.ts
+++ b/packages/sdk/server/rpc/handlers/index.ts
@@ -21,9 +21,11 @@ import {
   handleModelRegistrySearch,
   handleModelRegistryGetModel,
 } from "./registry";
+import { handleFinetune } from "./finetune";
 
 export const handlers = {
   ping: handlePing,
+  finetune: handleFinetune,
   completionStream: handleCompletionStream,
   downloadAsset: handleDownloadAsset,
   deleteCache: handleDeleteCache,

--- a/packages/sdk/test/unit/finetune-schema.test.ts
+++ b/packages/sdk/test/unit/finetune-schema.test.ts
@@ -1,0 +1,362 @@
+// @ts-expect-error brittle has no type declarations
+import test from "brittle";
+import {
+  finetuningOptionsSchema,
+  finetuneValidationSchema,
+  finetuneRequestSchema,
+  finetuneResponseSchema,
+  finetuneProgressSchema,
+  finetuneStatsSchema,
+  finetuneStatusSchema,
+} from "@/schemas/finetune";
+import { cancelRequestSchema } from "@/schemas/cancel";
+
+// ─── Validation schema ──────────────────────────────────────────
+
+test("finetuneValidationSchema: accepts type=none", (t) => {
+  const result = finetuneValidationSchema.safeParse({ type: "none" });
+  t.is(result.success, true);
+});
+
+test("finetuneValidationSchema: accepts type=split with fraction", (t) => {
+  const result = finetuneValidationSchema.safeParse({
+    type: "split",
+    fraction: 0.1,
+  });
+  t.is(result.success, true);
+});
+
+test("finetuneValidationSchema: accepts type=split without fraction", (t) => {
+  const result = finetuneValidationSchema.safeParse({ type: "split" });
+  t.is(result.success, true);
+});
+
+test("finetuneValidationSchema: accepts type=dataset with path", (t) => {
+  const result = finetuneValidationSchema.safeParse({
+    type: "dataset",
+    path: "/data/eval.jsonl",
+  });
+  t.is(result.success, true);
+});
+
+test("finetuneValidationSchema: rejects type=dataset without path", (t) => {
+  const result = finetuneValidationSchema.safeParse({ type: "dataset" });
+  t.is(result.success, false);
+});
+
+test("finetuneValidationSchema: rejects invalid type", (t) => {
+  const result = finetuneValidationSchema.safeParse({ type: "invalid" });
+  t.is(result.success, false);
+});
+
+test("finetuneValidationSchema: rejects fraction > 1", (t) => {
+  const result = finetuneValidationSchema.safeParse({
+    type: "split",
+    fraction: 1.5,
+  });
+  t.is(result.success, false);
+});
+
+test("finetuneValidationSchema: rejects fraction < 0", (t) => {
+  const result = finetuneValidationSchema.safeParse({
+    type: "split",
+    fraction: -0.1,
+  });
+  t.is(result.success, false);
+});
+
+// ─── Options schema ─────────────────────────────────────────────
+
+test("finetuningOptionsSchema: accepts minimal valid options", (t) => {
+  const result = finetuningOptionsSchema.safeParse({
+    trainDatasetDir: "/data/train.jsonl",
+    validation: { type: "none" },
+    outputParametersDir: "/output/lora",
+  });
+  t.is(result.success, true);
+});
+
+test("finetuningOptionsSchema: accepts full options", (t) => {
+  const result = finetuningOptionsSchema.safeParse({
+    trainDatasetDir: "/data/train.jsonl",
+    validation: { type: "split", fraction: 0.05 },
+    outputParametersDir: "/output/lora",
+    numberOfEpochs: 2,
+    learningRate: 1e-4,
+    contextLength: 128,
+    batchSize: 128,
+    microBatchSize: 32,
+    assistantLossOnly: true,
+    loraModules: "attn_q,attn_k,attn_v",
+    loraRank: 8,
+    loraAlpha: 16,
+    loraInitStd: 0.02,
+    loraSeed: 42,
+    checkpointSaveDir: "./checkpoints",
+    checkpointSaveSteps: 100,
+    chatTemplatePath: "/templates/chat.jinja",
+    lrScheduler: "cosine",
+    lrMin: 0,
+    warmupRatio: 0.1,
+    warmupSteps: 10,
+    weightDecay: 0.01,
+  });
+  t.is(result.success, true);
+});
+
+test("finetuningOptionsSchema: rejects missing trainDatasetDir", (t) => {
+  const result = finetuningOptionsSchema.safeParse({
+    validation: { type: "none" },
+    outputParametersDir: "/output/lora",
+  });
+  t.is(result.success, false);
+});
+
+test("finetuningOptionsSchema: rejects negative learningRate", (t) => {
+  const result = finetuningOptionsSchema.safeParse({
+    trainDatasetDir: "/data/train.jsonl",
+    validation: { type: "none" },
+    outputParametersDir: "/output/lora",
+    learningRate: -0.001,
+  });
+  t.is(result.success, false);
+});
+
+test("finetuningOptionsSchema: rejects zero numberOfEpochs", (t) => {
+  const result = finetuningOptionsSchema.safeParse({
+    trainDatasetDir: "/data/train.jsonl",
+    validation: { type: "none" },
+    outputParametersDir: "/output/lora",
+    numberOfEpochs: 0,
+  });
+  t.is(result.success, false);
+});
+
+test("finetuningOptionsSchema: rejects invalid lrScheduler", (t) => {
+  const result = finetuningOptionsSchema.safeParse({
+    trainDatasetDir: "/data/train.jsonl",
+    validation: { type: "none" },
+    outputParametersDir: "/output/lora",
+    lrScheduler: "exponential",
+  });
+  t.is(result.success, false);
+});
+
+test("finetuningOptionsSchema: accepts all lrScheduler values", (t) => {
+  for (const scheduler of ["constant", "cosine", "linear"]) {
+    const result = finetuningOptionsSchema.safeParse({
+      trainDatasetDir: "/data/train.jsonl",
+      validation: { type: "none" },
+      outputParametersDir: "/output/lora",
+      lrScheduler: scheduler,
+    });
+    t.is(result.success, true, `lrScheduler: ${scheduler}`);
+  }
+});
+
+// ─── Request schema ─────────────────────────────────────────────
+
+test("finetuneRequestSchema: accepts valid request", (t) => {
+  const result = finetuneRequestSchema.safeParse({
+    type: "finetune",
+    modelId: "model-123",
+    trainDatasetDir: "/data/train.jsonl",
+    validation: { type: "split", fraction: 0.05 },
+    outputParametersDir: "/output/lora",
+    numberOfEpochs: 2,
+    learningRate: 1e-4,
+  });
+  t.is(result.success, true);
+});
+
+test("finetuneRequestSchema: rejects missing modelId", (t) => {
+  const result = finetuneRequestSchema.safeParse({
+    type: "finetune",
+    trainDatasetDir: "/data/train.jsonl",
+    validation: { type: "none" },
+    outputParametersDir: "/output/lora",
+  });
+  t.is(result.success, false);
+});
+
+test("finetuneRequestSchema: rejects wrong type literal", (t) => {
+  const result = finetuneRequestSchema.safeParse({
+    type: "completion",
+    modelId: "model-123",
+    trainDatasetDir: "/data/train.jsonl",
+    validation: { type: "none" },
+    outputParametersDir: "/output/lora",
+  });
+  t.is(result.success, false);
+});
+
+// ─── Response / status / stats schemas ──────────────────────────
+
+test("finetuneStatusSchema: accepts valid statuses", (t) => {
+  t.is(finetuneStatusSchema.safeParse("COMPLETED").success, true);
+  t.is(finetuneStatusSchema.safeParse("PAUSED").success, true);
+  t.is(finetuneStatusSchema.safeParse("CANCELLED").success, true);
+});
+
+test("finetuneStatusSchema: rejects invalid status", (t) => {
+  t.is(finetuneStatusSchema.safeParse("RUNNING").success, false);
+  t.is(finetuneStatusSchema.safeParse("").success, false);
+});
+
+test("finetuneResponseSchema: accepts completed with stats", (t) => {
+  const result = finetuneResponseSchema.safeParse({
+    type: "finetune",
+    status: "COMPLETED",
+    stats: {
+      train_loss: 0.5,
+      val_loss: 0.6,
+      global_steps: 100,
+      epochs_completed: 2,
+    },
+  });
+  t.is(result.success, true);
+});
+
+test("finetuneResponseSchema: accepts paused without stats", (t) => {
+  const result = finetuneResponseSchema.safeParse({
+    type: "finetune",
+    status: "PAUSED",
+  });
+  t.is(result.success, true);
+});
+
+test("finetuneResponseSchema: accepts cancelled", (t) => {
+  const result = finetuneResponseSchema.safeParse({
+    type: "finetune",
+    status: "CANCELLED",
+  });
+  t.is(result.success, true);
+});
+
+// ─── Progress schema ────────────────────────────────────────────
+
+test("finetuneProgressSchema: accepts valid progress", (t) => {
+  const result = finetuneProgressSchema.safeParse({
+    type: "finetuneProgress",
+    is_train: true,
+    loss: 0.5432,
+    loss_uncertainty: 0.01,
+    accuracy: 0.85,
+    accuracy_uncertainty: 0.02,
+    global_steps: 50,
+    current_epoch: 1,
+    current_batch: 10,
+    total_batches: 100,
+    elapsed_ms: 5000,
+    eta_ms: 15000,
+  });
+  t.is(result.success, true);
+});
+
+test("finetuneProgressSchema: accepts null uncertainty values", (t) => {
+  const result = finetuneProgressSchema.safeParse({
+    type: "finetuneProgress",
+    is_train: true,
+    loss: 0.5432,
+    loss_uncertainty: null,
+    accuracy: 0.85,
+    accuracy_uncertainty: null,
+    global_steps: 50,
+    current_epoch: 1,
+    current_batch: 10,
+    total_batches: 100,
+    elapsed_ms: 5000,
+    eta_ms: 15000,
+  });
+  t.is(result.success, true);
+});
+
+test("finetuneProgressSchema: rejects missing fields", (t) => {
+  const result = finetuneProgressSchema.safeParse({
+    type: "finetuneProgress",
+    is_train: true,
+    loss: 0.5,
+    // missing required fields
+  });
+  t.is(result.success, false);
+});
+
+// ─── Stats schema ───────────────────────────────────────────────
+
+test("finetuneStatsSchema: accepts minimal stats", (t) => {
+  const result = finetuneStatsSchema.safeParse({
+    global_steps: 100,
+    epochs_completed: 2,
+  });
+  t.is(result.success, true);
+});
+
+test("finetuneStatsSchema: accepts full stats", (t) => {
+  const result = finetuneStatsSchema.safeParse({
+    train_loss: 0.3,
+    train_loss_uncertainty: 0.01,
+    val_loss: 0.4,
+    val_loss_uncertainty: 0.02,
+    train_accuracy: 0.9,
+    train_accuracy_uncertainty: 0.01,
+    val_accuracy: 0.85,
+    val_accuracy_uncertainty: 0.02,
+    learning_rate: 1e-4,
+    global_steps: 200,
+    epochs_completed: 4,
+  });
+  t.is(result.success, true);
+});
+
+// ─── Cancel schema with reset ───────────────────────────────────
+
+test("cancelRequestSchema: accepts inference cancel without reset", (t) => {
+  const result = cancelRequestSchema.safeParse({
+    type: "cancel",
+    operation: "inference",
+    modelId: "model-123",
+  });
+  t.is(result.success, true);
+});
+
+test("cancelRequestSchema: accepts inference cancel with reset=true", (t) => {
+  const result = cancelRequestSchema.safeParse({
+    type: "cancel",
+    operation: "inference",
+    modelId: "model-123",
+    reset: true,
+  });
+  t.is(result.success, true);
+});
+
+test("cancelRequestSchema: accepts inference cancel with reset=false", (t) => {
+  const result = cancelRequestSchema.safeParse({
+    type: "cancel",
+    operation: "inference",
+    modelId: "model-123",
+    reset: false,
+  });
+  t.is(result.success, true);
+});
+
+test("cancelRequestSchema: download cancel still works with clearCache", (t) => {
+  const result = cancelRequestSchema.safeParse({
+    type: "cancel",
+    operation: "downloadAsset",
+    downloadKey: "key-123",
+    clearCache: true,
+  });
+  t.is(result.success, true);
+});
+
+test("cancelRequestSchema: download cancel does not accept reset", (t) => {
+  const result = cancelRequestSchema.safeParse({
+    type: "cancel",
+    operation: "downloadAsset",
+    downloadKey: "key-123",
+    reset: true,
+  });
+  // reset is not part of downloadAsset params — intersection should still pass
+  // since z.intersection doesn't strip unknown keys on the params side
+  t.is(result.success, true);
+});


### PR DESCRIPTION
**Note**: This is a PoC for side-by-side comparison. See also: Option A (#1138).
**Pitch**: https://docs.google.com/document/d/1gAq3Ju0kqFgCp8R_7XEDg7EiIBOiX-5drl5tBAuUznM/edit?usp=sharing

## 🎯 What problem does this PR solve?

- QVAC SDK has no finetuning support — users cannot start, pause/resume, or cancel LoRA finetuning from the SDK
- Need to evaluate API design options before committing to a public API

## 📝 How does it solve it?

- **Option B**: Reuses existing `cancel()` for pause/cancel control
  - `finetune({ modelId, ...options })` — starts or resumes training (addon auto-detects checkpoint), returns `{ progressStream, result }`
  - `cancel({ operation: "inference", modelId, reset: false })` — pause (saves checkpoint), returns `Promise<void>`
  - `cancel({ operation: "inference", modelId })` — hard cancel (default, preserves existing behavior), returns `Promise<void>`
- Adds `reset` field to cancel schema for inference operations (defaults to `true` for backward compat)
- Full wiring: schemas → client API → plugin ops → RPC handlers → handler-registry
- Parameters match addon's tested examples (Qwen3-0.6B, lr=1e-5, contextLength=512, etc.)

## 🧪 How was it tested?

All three operations tested end-to-end on linux-x64 with `Qwen3-0.6B-Q8_0.gguf`:

- **Full run**: 192 steps, 2 epochs → COMPLETED (train_loss: 1.17, val_loss: 0.98), LoRA adapter inference verified
- **Pause/resume**: Paused at step 10 → PAUSED with stats. Found checkpoint LoRA adapter (`pause_checkpoint_step_00000010/model.gguf`). Inference WITH LoRA produced detailed healthcare-focused response (5 numbered points). Inference WITHOUT LoRA produced shorter generic response — confirming partial fine-tuning effect. Resumed from step 11 on the original model (never unloaded), completed all training → COMPLETED
- **Cancel**: Cancelled at step 3 → training stopped cleanly, process exited normally
- Unit tests: 32/32 pass (schema validation for all op variants)
- Build: clean (lint + typecheck + compile)

### How to run the PoC

**Prerequisites:**
- [Bare runtime](https://bare.pears.com) (`bare` CLI)
- A GGUF model file (tested with `Qwen3-0.6B-Q8_0.gguf`)
- Training data in JSONL format — sample datasets are in `packages/qvac-lib-infer-llamacpp-llm/examples/input/`:
  - `small_train_HF.jsonl` — small training set
  - `small_eval_HF.jsonl` — small evaluation set

```bash
cd packages/sdk
bun install
bun run build

# Set paths to your model and training data
export MODEL=/path/to/Qwen3-0.6B-Q8_0.gguf
export TRAIN=../qvac-lib-infer-llamacpp-llm/examples/input/small_train_HF.jsonl
export EVAL=../qvac-lib-infer-llamacpp-llm/examples/input/small_eval_HF.jsonl

# Full run
bun run bare:example dist/examples/llamacpp-finetune.js -- \
  --model "$MODEL" \
  --dataset "$TRAIN" \
  --eval-dataset "$EVAL" \
  --output /tmp/finetune-poc/lora \
  --checkpoint-dir /tmp/finetune-poc/checkpoints

# Pause/resume (pauses after 10 steps, loads checkpoint LoRA for inference, then resumes)
bun run bare:example dist/examples/llamacpp-finetune.js -- \
  --model "$MODEL" \
  --dataset "$TRAIN" \
  --eval-dataset "$EVAL" \
  --output /tmp/finetune-poc/lora \
  --checkpoint-dir /tmp/finetune-poc/checkpoints \
  --pause-after 10

# Cancel (hard cancel after 3 steps)
bun run bare:example dist/examples/llamacpp-finetune.js -- \
  --model "$MODEL" \
  --dataset "$TRAIN" \
  --eval-dataset "$EVAL" \
  --output /tmp/finetune-poc/lora \
  --checkpoint-dir /tmp/finetune-poc/checkpoints \
  --cancel-after 3
```

Unit tests: `bun run test:unit`

## 🔌 API Changes

```typescript
import { finetune, cancel } from "@qvac/sdk";

// Start finetuning (or resume from checkpoint)
const handle = finetune({
  modelId,
  trainDatasetDir: "/data/train.jsonl",
  validation: { type: "split", fraction: 0.25 },
  outputParametersDir: "/output/lora",
  numberOfEpochs: 2,
  learningRate: 1e-5,
  contextLength: 512,
});

// Stream progress
for await (const tick of handle.progressStream) {
  console.log(`step ${tick.global_steps} loss: ${tick.loss}`);
}

// Pause (saves checkpoint) — explicit reset: false
await cancel({ operation: "inference", modelId, reset: false });

// Hard cancel (default — preserves existing cancel behavior)
await cancel({ operation: "inference", modelId });

// Get final result
const result = await handle.result;
// result.status: "COMPLETED" | "PAUSED" | "CANCELLED"
```

### Key differences from Option A (#1138)

| Aspect | Option B (this PR) | Option A (#1138) |
|--------|-------------------|-----------------|
| Pause | `cancel({ ..., reset: false })` | `finetune({ op: "pause", modelId })` |
| Cancel | `cancel({ ..., modelId })` | `finetune({ op: "cancel", modelId })` |
| Schema | `reset` field on cancel request | `op` discriminator on finetune request |
| cancel.ts | Modified with reset/pause logic | No changes |
| Self-contained | No (shares cancel path) | Yes |
