### PR TITLE
DEVOPS-1605 fix: workflow permission and secrets errors after H3 reduction

### DIFF
--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -125,6 +125,10 @@ jobs:
 
   mobile-integration-tests:
     needs: publish-logic
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
     if: |
       needs.publish-logic.outputs.publish_main == 'true' ||
       needs.publish-logic.outputs.publish_release == 'true' ||

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
@@ -192,7 +192,6 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
-    secrets:
     with:
       repo_name: "onnx-tts"
       release_name: "QVAC TTS ONNX Addon"
@@ -241,6 +240,10 @@ jobs:
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
     needs: prebuild
     if: needs.prebuild.outputs.should_run_tests == 'true'
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
     secrets:
       ANDROID_DEVICE_POOL_ARN_ONNX_TTS: ${{ secrets.ANDROID_DEVICE_POOL_ARN_ONNX_TTS }}
       APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}

--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -238,6 +238,10 @@ jobs:
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
     needs: prebuild
     if: needs.prebuild.outputs.should_run_tests == 'true'
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
     secrets:
       ANDROID_DEVICE_POOL_ARN_PARAKEET: ${{ secrets.ANDROID_DEVICE_POOL_ARN_PARAKEET }}
       APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -238,6 +238,10 @@ jobs:
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
     needs: prebuild
     if: needs.prebuild.outputs.should_run_tests == 'true'
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
     secrets:
       ANDROID_DEVICE_POOL_ARN_WHISPERCPP: ${{ secrets.ANDROID_DEVICE_POOL_ARN_WHISPERCPP }}
       APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}

--- a/.github/workflows/on-pr-close-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-close-lib-infer-diffusion.yml
@@ -50,6 +50,8 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
 
   delete-npm-versions-trigger:
+    permissions:
+      packages: write
     uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/on-pr-close-ocr-onnx.yml
+++ b/.github/workflows/on-pr-close-ocr-onnx.yml
@@ -47,6 +47,8 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
   delete-npm-versions-trigger:
+    permissions:
+      packages: write
     uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/on-pr-close-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-decoder-audio.yml
@@ -55,6 +55,8 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
 
   delete-npm-versions-trigger:
+    permissions:
+      packages: write
     uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-onnx-tts.yml
@@ -55,6 +55,8 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
 
   delete-npm-versions-trigger:
+    permissions:
+      packages: write
     uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-onnx.yml
@@ -47,6 +47,8 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
   delete-npm-versions-trigger:
+    permissions:
+      packages: write
     uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-parakeet.yml
@@ -55,6 +55,8 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
 
   delete-npm-versions-trigger:
+    permissions:
+      packages: write
     uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -43,6 +43,17 @@ on:
         required: false
         type: string
         default: "packages/qvac-lib-infer-llamacpp-embed"
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      MODEL_S3_BUCKET:
+        required: true
+      NPM_TOKEN:
+        required: true
+      PAT_TOKEN:
+        required: true
     outputs:
       published_version:
         description: "Version published to registry"

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -50,6 +50,17 @@ on:
         required: false
         type: string
         default: "packages/qvac-lib-infer-llamacpp-llm"
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      MODEL_S3_BUCKET:
+        required: true
+      NPM_TOKEN:
+        required: true
+      PAT_TOKEN:
+        required: true
     outputs:
       published_version:
         description: "The version that was published"


### PR DESCRIPTION
## Summary
- Add missing `secrets:` declarations to `prebuilds-llamacpp-{llm,embed}` `workflow_call` blocks — callers passed 5 secrets (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, MODEL_S3_BUCKET, NPM_TOKEN, PAT_TOKEN) that were never declared
- Remove empty `secrets:` block from `on-merge-onnx-tts` that caused `Unexpected value ''` YAML parse error
- Add `pull-requests: write` to `mobile-integration-tests` jobs in 4 `on-merge` workflows — called mobile test workflows request `pull-requests: write` internally but callers only granted `read` at workflow level
- Add `packages: write` to `delete-npm-versions-trigger` jobs in 6 `on-pr-close` workflows — `public-delete-npm-versions.yml` (qvac-devops@v1.1.7) needs `packages: write` to delete GPR versions

## Root cause
The H3 permission reduction PR tightened workflow-level permissions to `contents: read` but missed granting job-level write permissions where called reusable workflows require them.

## Files changed (12)

| Fix | Files |
|-----|-------|
| Missing `secrets:` in `workflow_call` | `prebuilds-llamacpp-{llm,embed}.yml` (2) |
| Empty `secrets:` block | `on-merge-onnx-tts.yml` (1) |
| `pull-requests: write` escalation | `on-merge-{decoder-audio,whispercpp,onnx-tts,parakeet}.yml` (4) |
| `packages: write` for GPR delete | `on-pr-close-{diffusion,ocr-onnx,decoder-audio,onnx-tts,onnx,parakeet}.yml` (6) |

## Validation
- Cross-referenced all 113 workflows against `qvac-devops@v1.1.7` composite actions and reusable workflows
- Zero empty secrets blocks remaining
- All `publish-library-to-gpr` callers have `packages: write`
- All `publish-library-to-npm` callers pass `NPM_TOKEN`
- All mobile test callers grant `pull-requests: write`
- All `delete-npm-versions-trigger` jobs grant `packages: write`

## Test plan
- [ ] Verify all 6 reported GitHub validation errors are resolved
- [ ] Merge a PR to trigger `on-merge-qvac-lib-infer-onnx-tts` — confirm no YAML parse error
- [ ] Merge to main for llamacpp-llm or embed — confirm prebuilds workflow receives AWS secrets
- [ ] Close a PR for one of the 6 fixed on-pr-close packages — confirm GPR version deletion succeeds
- [ ] Trigger mobile integration tests from on-merge — confirm no permission escalation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)