### PR TITLE
DEVOPS-1610 fix: scope concurrency groups to prevent cross-package cancellation

### DIFF
--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -23,7 +23,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
- Fix concurrency group collision between `on-pr-qvac-lib-infer-llamacpp-embed.yml` and `on-pr-qvac-lib-infer-nmtcpp.yml`
- Both used `pr-${{ github.event.pull_request.number || github.sha }}` as the group key — missing `${{ github.workflow }}-` prefix
- A PR touching both packages caused one workflow to cancel the other

## Root cause
When the concurrency controls were added (DEVOPS-16100), these two files used `pr-<PR#>` without the workflow name, creating an identical concurrency group. All other workflows correctly included `${{ github.workflow }}-` which expands to the unique workflow `name:` field.

## Fix
```diff
- group: pr-${{ github.event.pull_request.number || github.sha }}
+ group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
```

## Validation
- Simulated concurrency group expansion across all 113 workflows for both PR and push contexts
- Zero collisions — every workflow resolves to a unique group
- All workflow `name:` fields are unique (verified)

## Test plan
- [ ] Open a PR that touches both `packages/qvac-lib-infer-llamacpp-embed/` and `packages/qvac-lib-infer-nmtcpp/`
- [ ] Confirm both PR workflows run to completion without cancelling each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)