### PR TITLE
DEVOPS-1612 feat: migrate workflow secrets to GitHub environment

### DIFF
--- a/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/benchmark-chatterbox-qvac-lib-infer-onnx-tts.yml
@@ -72,6 +72,7 @@ jobs:
   benchmark-chatterbox:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'onnx-tts-v'))
     runs-on: macos-14-xlarge
+    environment: release
     timeout-minutes: 180
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/benchmark-ocr-onnx.yml
+++ b/.github/workflows/benchmark-ocr-onnx.yml
@@ -62,6 +62,7 @@ jobs:
     needs: setup
     if: needs.setup.outputs.qvac_needed == 'true'
     runs-on: ubuntu-24.04
+    environment: release
     timeout-minutes: 120
     name: Build QVAC addon
 
@@ -174,6 +175,7 @@ jobs:
       needs.setup.result == 'success' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-24.04
+    environment: release
     timeout-minutes: 180
     name: Text Spotting Benchmark
 

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-embed.yml
@@ -136,6 +136,7 @@ permissions:
 jobs:
   benchmark:
     runs-on: ai-run-linux-gpu
+    environment: release
     timeout-minutes: 180
     name: "Benchmark ${{ inputs.gguf_model }}"
 

--- a/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-llamacpp-llm.yml
@@ -180,6 +180,7 @@ permissions:
 jobs:
   benchmark:
     runs-on: ai-run-linux-gpu
+    environment: release
     timeout-minutes: 180
     name: "Benchmark ${{ inputs.gguf_model }}"
 

--- a/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-nmtcpp.yml
@@ -184,6 +184,7 @@ jobs:
     needs: setup
     if: needs.setup.outputs.qvac_needed == 'true'
     runs-on: ubuntu-24.04
+    environment: release
     timeout-minutes: 60
     name: Build QVAC addon
 
@@ -321,6 +322,7 @@ jobs:
       needs.setup.result == 'success' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-24.04
+    environment: release
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/benchmark-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-parakeet.yml
@@ -119,6 +119,7 @@ jobs:
   benchmark-parakeet:
     needs: generate-matrix
     runs-on: ai-run-linux
+    environment: release
     timeout-minutes: 1440
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/benchmark-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/benchmark-qvac-lib-infer-whispercpp.yml
@@ -222,6 +222,7 @@ jobs:
   benchmark-whispercpp:
     needs: generate-matrix
     runs-on: ubuntu-latest
+    environment: release
     timeout-minutes: 1440
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/benchmark-supertonic-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/benchmark-supertonic-qvac-lib-infer-onnx-tts.yml
@@ -54,6 +54,7 @@ jobs:
   benchmark-supertonic:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'onnx-tts-v'))
     runs-on: macos-14-xlarge
+    environment: release
     timeout-minutes: 180
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
@@ -54,6 +54,7 @@ permissions:
 jobs:
   cpp-tests:
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}-cpp-tests
 
     permissions:

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   cpp-tests:
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}-cpp-tests
     permissions:
       contents: read

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
@@ -38,6 +38,7 @@ permissions:
 jobs:
   cpp-tests:
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}-cpp-tests
     permissions:
       contents: read

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -50,6 +50,7 @@ jobs:
             runner: ai-run-windows11-gpu
 
     runs-on: ${{ matrix.runner || matrix.os }}
+    environment: release
     name: cpp-tests-${{ matrix.platform }}-${{ matrix.arch }}
 
     env:

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -37,6 +37,7 @@ on:
 jobs:
   run-cpp-tests:
     runs-on: ${{ matrix.runner || matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-cpp-tests
     permissions:
       contents: read

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -49,6 +49,7 @@ jobs:
             runner: ai-run-windows11-gpu
 
     runs-on: ${{ matrix.runner || matrix.os }}
+    environment: release
     name: cpp-tests-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}
 
     env:

--- a/.github/workflows/integration-mobile-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-mobile-test-lib-infer-diffusion.yml
@@ -62,6 +62,7 @@ jobs:
   build-and-test:
     name: Build ${{ matrix.platform }} and Run E2E Tests
     runs-on: ${{ matrix.runner }}
+    environment: release
     timeout-minutes: 120
     continue-on-error: true # Don't block PR merges if tests fail
     permissions:

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -70,6 +70,7 @@ jobs:
   build-and-test:
     name: Build ${{ matrix.platform }} and Run E2E Tests
     runs-on: ${{ matrix.runner }}
+    environment: release
     timeout-minutes: 120
     continue-on-error: true # Don't block PR merges if tests fail
     permissions:

--- a/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
@@ -70,6 +70,7 @@ jobs:
   build-and-test:
     name: Build ${{ matrix.platform }} and Run E2E Tests
     runs-on: ${{ matrix.runner }}
+    environment: release
     timeout-minutes: 120
     permissions:
       contents: read

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -65,6 +65,7 @@ jobs:
   build-and-test:
     name: Build ${{ matrix.platform }} and Run E2E Tests
     runs-on: ${{ matrix.runner }}
+    environment: release
     timeout-minutes: 120
     continue-on-error: true  # Don't block PR merges if tests fail
     permissions:

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -62,6 +62,7 @@ jobs:
   build-and-test:
     name: Build ${{ matrix.platform }} and Run E2E Tests
     runs-on: ${{ matrix.runner }}
+    environment: release
     timeout-minutes: 120
     continue-on-error: true # Don't block PR merges if tests fail
     permissions:

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -70,6 +70,7 @@ jobs:
   build-and-test:
     name: Build ${{ matrix.platform }} and Run E2E Tests
     runs-on: ${{ matrix.runner }}
+    environment: release
     timeout-minutes: 120
     continue-on-error: true # Don't block PR merges if tests fail
     permissions:

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -74,6 +74,7 @@ jobs:
   build-and-test:
     name: Build ${{ matrix.platform }} and Run E2E Tests (${{ matrix.variant }})
     runs-on: ${{ matrix.runner }}
+    environment: release
     timeout-minutes: 210
     continue-on-error: true # Don't block PR merges if tests fail
     permissions:

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -74,6 +74,7 @@ jobs:
   build-and-test:
     name: Build ${{ matrix.platform }} and Run E2E Tests
     runs-on: ${{ matrix.runner }}
+    environment: release
     timeout-minutes: 120
     continue-on-error: true
     permissions:

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -70,6 +70,7 @@ jobs:
   build-and-test:
     name: Build ${{ matrix.platform }} and Run E2E Tests
     runs-on: ${{ matrix.runner }}
+    environment: release
     timeout-minutes: 120
     permissions:
       contents: read

--- a/.github/workflows/integration-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-test-lib-infer-diffusion.yml
@@ -38,6 +38,7 @@ jobs:
     timeout-minutes: ${{ matrix.timeout || 360 }}
     continue-on-error: true
     runs-on: ${{ matrix.runner }}
+    environment: release
     name: test-${{ matrix.platform }}-${{ matrix.arch }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-test-ocr-onnx.yml
+++ b/.github/workflows/integration-test-ocr-onnx.yml
@@ -47,6 +47,7 @@ jobs:
   run-integration-tests:
     continue-on-error: true
     runs-on: ${{ matrix.os }}
+    environment: release
     name: test-${{ matrix.platform }}-${{ matrix.arch }}
 
     env:

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-embed.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   run-integration-tests:
     runs-on: ${{ matrix.runner || matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}-integration-tests
     permissions:
       contents: read

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -40,6 +40,7 @@ jobs:
     timeout-minutes: ${{ matrix.timeout_minutes || 360 }}
     continue-on-error: true
     runs-on: ${{ matrix.runner }}
+    environment: release
     name: test-${{ matrix.platform }}-${{ matrix.arch }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -44,6 +44,7 @@ jobs:
   run-integration-tests:
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}-integration-tests
     permissions:
       contents: read

--- a/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
@@ -55,6 +55,7 @@ jobs:
   run-integration-tests:
     continue-on-error: true
     runs-on: ${{ matrix.os }}
+    environment: release
     name: test-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.os_version && format('-{0}', matrix.os_version) || '' }}-${{ matrix.variant }}
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
@@ -41,6 +41,7 @@ jobs:
     timeout-minutes: 60
     continue-on-error: true
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}-integration-tests
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
@@ -36,6 +36,7 @@ jobs:
     timeout-minutes: 60
     continue-on-error: true
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}-integration-tests
 
     env:

--- a/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
@@ -131,6 +131,7 @@ jobs:
   Build:
     needs: setup
     runs-on: macos-14
+    environment: release
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -160,6 +160,7 @@ jobs:
       needs.publish-logic.outputs.publish_feature == 'true' ||
       needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
@@ -185,6 +186,7 @@ jobs:
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
     runs-on: ubuntu-latest
+    environment: release
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -262,6 +262,7 @@ jobs:
   benchmark:
     name: Trigger Benchmark (Whispercpp)
     runs-on: ubuntu-latest
+    environment: release
     needs: prebuild
     if: always() && needs.prebuild.outputs.should_run_tests == 'true'
     steps:

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -52,6 +52,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Run Sanity checks
         uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
@@ -90,6 +91,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -71,6 +71,7 @@ jobs:
        needs.authorize.outputs.allowed == 'true') ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
+    environment: release
     env:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/packages/ocr-onnx/vcpkg/cache,readwrite"
       PKG_DIR: packages/ocr-onnx

--- a/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
@@ -139,6 +139,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, context]
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Run Sanity checks
         uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -47,6 +47,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Run Sanity checks
         uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
@@ -84,6 +85,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -52,6 +52,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Run Sanity checks
         uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
@@ -90,6 +91,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -65,6 +65,7 @@ jobs:
     needs: [authorize, changes]
     if: always() && ((needs.changes.outputs.pkg == 'true' && needs.authorize.outputs.allowed == 'true') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Run Sanity checks
         uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
@@ -79,6 +80,7 @@ jobs:
     needs: [authorize, changes, sanity-checks]
     if: always() && needs.authorize.outputs.allowed == 'true' && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
+    environment: release
     defaults:
       run:
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
@@ -139,6 +139,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, context]
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Run Sanity checks
         uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -71,6 +71,7 @@ jobs:
        needs.authorize.outputs.allowed == 'true') ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
+    environment: release
     permissions:
       contents: read
     env:

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -139,6 +139,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, context]
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Run Sanity checks
         uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -139,6 +139,7 @@ jobs:
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, context]
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Run Sanity checks
         uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7

--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -180,6 +180,7 @@ jobs:
       needs.authorize.outputs.allowed == 'true' &&
       needs.changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
+    environment: release
     strategy:
       matrix:
         include: ${{ fromJSON(needs.changes.outputs.matrix) }}

--- a/.github/workflows/pr-models-validation-qvac-lib-registry-server.yml
+++ b/.github/workflows/pr-models-validation-qvac-lib-registry-server.yml
@@ -127,6 +127,7 @@ jobs:
       needs.authorize.outputs.allowed == 'true' &&
       needs.detect-changes.outputs.models_changed == 'true'
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
@@ -164,6 +165,7 @@ jobs:
       needs.authorize.outputs.allowed == 'true' &&
       needs.detect-changes.outputs.other_changed == 'true'
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
@@ -221,6 +223,7 @@ jobs:
       needs.validate-json.result == 'success' &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
+    environment: release
     env:
       QVAC_AUTOBASE_KEY: ${{ secrets.QVAC_AUTOBASE_KEY }}
       QVAC_REGISTRY_CORE_KEY: ${{ secrets.QVAC_REGISTRY_CORE_KEY }}
@@ -279,6 +282,7 @@ jobs:
   smoke-test:
     needs: sync-staging
     runs-on: ubuntu-latest
+    environment: release
     env:
       QVAC_REGISTRY_CORE_KEY: ${{ secrets.QVAC_REGISTRY_CORE_KEY }}
     steps:

--- a/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
@@ -66,6 +66,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     steps:

--- a/.github/workflows/prebuilds-lib-infer-diffusion.yml
+++ b/.github/workflows/prebuilds-lib-infer-diffusion.yml
@@ -111,6 +111,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     env:
@@ -488,6 +489,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
@@ -542,6 +544,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/prebuilds-ocr-onnx.yml
+++ b/.github/workflows/prebuilds-ocr-onnx.yml
@@ -112,6 +112,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     env:
@@ -421,6 +422,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     needs: prebuild
@@ -577,6 +579,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -112,6 +112,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     env:
@@ -479,6 +480,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
@@ -521,6 +523,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -119,6 +119,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     env:
@@ -501,6 +502,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
@@ -555,6 +557,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -103,6 +103,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     env:
@@ -827,6 +828,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-24.04
+    environment: release
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
@@ -124,6 +124,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     env:
@@ -484,6 +485,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    environment: release
     needs: prebuild
     permissions:
       contents: write
@@ -612,6 +614,7 @@ jobs:
     outputs:
       published_version: ${{ steps.capture_version.outputs.published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
@@ -105,6 +105,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     env:
@@ -550,6 +551,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
@@ -102,6 +102,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     env:
@@ -495,6 +496,7 @@ jobs:
     outputs:
       published_version: ${{ steps.capture_version.outputs.published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -108,6 +108,7 @@ jobs:
             arch: x64
 
     runs-on: ${{ matrix.os }}
+    environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     env:
@@ -566,6 +567,7 @@ jobs:
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -92,6 +92,7 @@ jobs:
   detect-changes:
     needs: [authorize]
     runs-on: ubuntu-latest
+    environment: release
     if: needs.authorize.outputs.allowed == 'true'
     outputs:
       schema_changed: ${{ steps.filter.outputs.schema }}
@@ -212,6 +213,7 @@ jobs:
        needs.publish-logic.outputs.publish_main == 'true' ||
        needs.publish-logic.outputs.publish_tmp == 'true')
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
@@ -247,6 +249,7 @@ jobs:
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard-schema.result == 'success' || needs.release-merge-guard-schema.result == 'skipped')
     runs-on: ubuntu-latest
+    environment: release
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:
@@ -311,6 +314,7 @@ jobs:
       contents: read
       packages: read
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout base repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -379,6 +383,7 @@ jobs:
        needs.publish-logic.outputs.publish_main == 'true' ||
        needs.publish-logic.outputs.publish_tmp == 'true')
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
@@ -416,6 +421,7 @@ jobs:
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard-client.result == 'success' || needs.release-merge-guard-client.result == 'skipped')
     runs-on: ubuntu-latest
+    environment: release
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -82,6 +82,7 @@ jobs:
     needs: [authorize]
     if: needs.authorize.outputs.allowed == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
@@ -366,6 +367,7 @@ jobs:
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
     runs-on: ubuntu-latest
+    environment: release
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:

--- a/.github/workflows/repository-dispatch-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/repository-dispatch-qvac-lib-infer-whispercpp.yml
@@ -16,6 +16,7 @@ jobs:
   dispatch:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout merge commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/repository-dispatch-sdk.yml
+++ b/.github/workflows/repository-dispatch-sdk.yml
@@ -16,6 +16,7 @@ jobs:
   dispatch:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout merge commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/trigger-docs-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/trigger-docs-qvac-lib-infer-nmtcpp.yml
@@ -16,6 +16,7 @@ jobs:
   dispatch:
     if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'main' || startsWith(github.event.pull_request.base.ref, 'release-'))
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout merge commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/trigger-docs-sdk.yml
+++ b/.github/workflows/trigger-docs-sdk.yml
@@ -16,6 +16,7 @@ jobs:
   dispatch:
     if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'main' || startsWith(github.event.pull_request.base.ref, 'release-'))
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout merge commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -129,6 +129,7 @@ jobs:
     needs: [build, publish-logic]
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -162,6 +163,7 @@ jobs:
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
     runs-on: ubuntu-latest
+    environment: release
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:
@@ -205,6 +207,7 @@ jobs:
     needs: [build, publish-logic]
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -236,6 +239,7 @@ jobs:
     needs: [build, publish-logic]
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-error.yml
+++ b/.github/workflows/trigger-reusable-lib-error.yml
@@ -102,6 +102,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -153,6 +154,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -175,6 +177,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-logging.yml
+++ b/.github/workflows/trigger-reusable-lib-logging.yml
@@ -102,6 +102,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -153,6 +154,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -175,6 +177,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
@@ -92,6 +92,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -144,6 +145,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -166,6 +168,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
@@ -102,6 +102,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -153,6 +154,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -175,6 +177,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
@@ -102,6 +102,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -153,6 +154,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -175,6 +177,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
@@ -102,6 +102,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -153,6 +154,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -175,6 +177,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
@@ -102,6 +102,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -153,6 +154,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -175,6 +177,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
@@ -39,6 +39,7 @@ jobs:
   test:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -141,6 +142,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -179,6 +181,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -201,6 +204,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
@@ -102,6 +102,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -153,6 +154,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -175,6 +177,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/trigger-reusable-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-rag.yml
@@ -102,6 +102,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_main == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -153,6 +154,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_feature == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -175,6 +177,7 @@ jobs:
     needs: publish-logic
     if: needs.publish-logic.outputs.publish_tmp == 'true'
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary
- Add `environment: release` to **127 jobs across 73 workflow files** so secrets resolve from the `release` GitHub environment
- Every job with `runs-on:` that references real secrets (`PAT_TOKEN`, `NPM_TOKEN`, `AWS_*`, `HF_TOKEN`, `QVAC_*`, etc.) now has the environment
- `authorize` jobs are excluded (they only use `github.token`)

## What this enables
- Centralized secret rotation — update once in the `release` environment, all workflows pick it up
- Environment-level required reviewers gate all secret-using jobs
- Audit trail of environment deployments in GitHub UI

## Categorization

| Category | Files | Jobs | Action |
|----------|-------|------|--------|
| Direct-trigger workflows | 73 | 127 | `environment: release` added |
| `workflow_call`-only reusable workflows | 4 | — | Skipped (secrets passed by caller) |
| `uses:` caller-only workflows | 11 | — | Cannot add (GitHub spec limitation) |

## Environment prerequisites
- [x] `release` environment created in GitHub repo settings
- [x] All secrets duplicated into the `release` environment
- [x] Branch restrictions **removed** (required for PR workflows on feature/fork branches)
- [x] Required reviewers enabled (gates all secret-using jobs)

## Validation
- Scanned all 113 workflow files
- Every `runs-on:` job referencing real secrets has `environment: release`
- Zero `authorize` jobs modified
- All edits are single-line `environment: release` additions (127 insertions, 0 deletions)

## Test plan
- [ ] Open a PR — confirm jobs pause for environment approval, then run after approval
- [ ] Merge to main — confirm on-merge publish pipeline works (secrets resolve from environment)
- [ ] `workflow_dispatch` on a prebuilds workflow — confirm secrets resolve
- [ ] Verify environment deployment history shows in GitHub UI under Environments > release

🤖 Generated with [Claude Code](https://claude.com/claude-code)