### PR TITLE
chore: clean up registry-server package.json dependencies

### DIFF
--- a/packages/qvac-lib-registry-server/package.json
+++ b/packages/qvac-lib-registry-server/package.json
@@ -81,13 +81,7 @@
     "ready-resource": "^1.2.0",
     "stream": "npm:bare-node-stream"
   },
-  "overrides": {
-    "minimatch": ">=3.1.3",
-    "ajv": "6.14.0",
-    "flatted": "^3.4.2"
-  },
   "devDependencies": {
-    "@qvac/error": "^0.1.0",
     "brittle": "^3.4.0",
     "dotenv": "^17.2.3",
     "standard": "^17.1.0",


### PR DESCRIPTION
## What problem does this PR solve?

`npm i --omit=dev` on the registry server fails with E404 for `@qvac/error` because npm resolves all packages (including devDependencies) before applying the omit filter. The `overrides` section is also dead weight since the package-lock.json was removed in #1176.

## How does it solve it?

- Remove `@qvac/error` from devDependencies — not imported anywhere in server code (only used in `client/`, which has its own `package.json` with this dependency)
- Remove the `overrides` section (`minimatch`, `ajv`, `flatted`) — npm overrides require a lockfile to take effect; this package has none since #1176

All remaining dependencies were audited. The other devDependencies (`brittle`, `dotenv`, `standard`, `zod`) are all actively used. Production dependencies including Bare runtime shims (`buffer`, `http`, `https`, `crypto`, `stream`, `readline`) are retained for Bare runtime compatibility.

## Breaking changes

None. Unit tests (26/26) and integration tests (20/20) pass.
