### PR TITLE
doc: clean up infer-base README installation section

### DIFF
--- a/packages/qvac-lib-decoder-audio/README.md
+++ b/packages/qvac-lib-decoder-audio/README.md
@@ -45,21 +45,6 @@ Ensure that the [`Bare`](#glossary) Runtime is installed globally on your system
 npm install -g bare@latest
 ```
 
-Before proceeding with the installation, please generate a **classic GitHub Personal Access Token (PAT)** with the `read:packages` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-```bash
-export NPM_TOKEN=your_personal_access_token
-```
-
-Next, create a `.npmrc` file in the root of your project with the following content:
-
-```ini
-@tetherto:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
-```
-
-This configuration ensures secure access to GitHub Packages when installing scoped packages.
-
 ### Installing the Package
 
 Install the latest version of the decoder addon with the following command:

--- a/packages/qvac-lib-decoder-audio/package.json
+++ b/packages/qvac-lib-decoder-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/decoder-audio",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "",
   "license": "Apache-2.0",
   "author": "Tether",

--- a/packages/qvac-lib-dl-base/README.md
+++ b/packages/qvac-lib-dl-base/README.md
@@ -4,21 +4,6 @@ This is the base class for QVAC dataloader libraries. It aims to provide a commo
 
 ## Installation
 
-Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-```bash
-export NPM_TOKEN=your_personal_access_token
-```
-
-Next, create a `.npmrc` file in the root of your project with the following content:
-
-```ini
-@qvac:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken={NPM_TOKEN}
-```
-
-This configuration ensures secure access to NPM Packages when installing scoped packages.
-
 ```bash
 npm i @qvac/dl-base
 ```

--- a/packages/qvac-lib-dl-base/package.json
+++ b/packages/qvac-lib-dl-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/dl-base",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Base dataloader class for QVAC",
   "main": "index.js",
   "scripts": {

--- a/packages/qvac-lib-dl-filesystem/README.md
+++ b/packages/qvac-lib-dl-filesystem/README.md
@@ -82,21 +82,6 @@ class MyModel {
 
 1. Install dependencies:
 
-    Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-    
-    ```bash
-    export NPM_TOKEN=your_personal_access_token
-    ```
-    
-    Next, create a `.npmrc` file in the root of your project with the following content:
-    
-    ```ini
-    @qvac:registry=https://registry.npmjs.org/
-    //registry.npmjs.org/:_authToken={NPM_TOKEN}
-    ```
-    
-    This configuration ensures secure access to NPM Packages when installing scoped packages.
-
    ```bash
    npm install
    ```

--- a/packages/qvac-lib-dl-filesystem/package.json
+++ b/packages/qvac-lib-dl-filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/dl-filesystem",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/qvac-lib-dl-hyperdrive/README.md
+++ b/packages/qvac-lib-dl-hyperdrive/README.md
@@ -205,21 +205,6 @@ This repository includes a script that allows you to serve files from a specifie
 ## Development
 
 1. Install dependencies:
-   Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-    ```bash
-    export NPM_TOKEN=your_personal_access_token
-    ```
-    
-    Next, create a `.npmrc` file in the root of your project with the following content:
-    
-    ```ini
-    @qvac:registry=https://registry.npmjs.org/
-    //registry.npmjs.org/:_authToken={NPM_TOKEN}
-    ```
-    
-    This configuration ensures secure access to NPM Packages when installing scoped packages.
-
    ```bash
    npm install
    ```

--- a/packages/qvac-lib-dl-hyperdrive/package.json
+++ b/packages/qvac-lib-dl-hyperdrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/dl-hyperdrive",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/qvac-lib-infer-base/README.md
+++ b/packages/qvac-lib-infer-base/README.md
@@ -6,21 +6,6 @@ This package also exports `QvacResponse`, the response class used by all QVAC in
 
 ## Installation
 
-Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-```bash
-export NPM_TOKEN=your_personal_access_token
-```
-
-Next, create a `.npmrc` file in the root of your project with the following content:
-
-```ini
-@qvac:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken={NPM_TOKEN}
-```
-
-This configuration ensures secure access to NPM Packages when installing scoped packages.
-
 ```bash
 npm install @qvac/infer-base
 ```
@@ -90,12 +75,12 @@ const finalOutputs = await response.await()
 For detailed QvacResponse documentation, see the response class implementation.
 
 The subclass must implement the following methods:
+
 - `getApiDefinition()`: Returns the API definition for the current environment.
 - `_load()`: Loads the model configuration to the addon.
 - `_loadNew(config, loader, close, reportProgressCallback)`: Loads new configuration and weights.
 - `_loadWeights(loader, close, reportProgressCallback)`: Loads model weights from the provided loader. (Optional)
 - `_unloadWeights()`: Unloads the model weights from memory. (Optional)
-
 
 ## API
 

--- a/packages/qvac-lib-infer-base/package.json
+++ b/packages/qvac-lib-infer-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/infer-base",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Base class for inference clients",
   "main": "index.js",
   "scripts": {

--- a/packages/qvac-lib-infer-onnx-tts/README.md
+++ b/packages/qvac-lib-infer-onnx-tts/README.md
@@ -89,21 +89,6 @@ Note : Make sure the Bare version is `>= 1.17.3`. Check this using:
 bare -v
 ```
 
-Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-```bash
-export NPM_TOKEN=your_personal_access_token
-```
-
-Next, create a `.npmrc` file in the root of your project with the following content:
-
-```ini
-@qvac:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken={NPM_TOKEN}
-```
-
-This configuration ensures secure access to NPM Packages when installing scoped packages.
-
 ### Installing the Package
 
 Install the latest TTS package:

--- a/packages/qvac-lib-infer-onnx-tts/package.json
+++ b/packages/qvac-lib-infer-onnx-tts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-onnx",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Text to Speech (TTS) addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-whispercpp/README.md
+++ b/packages/qvac-lib-infer-whispercpp/README.md
@@ -54,21 +54,6 @@ Note : Make sure the Bare version is `>= 1.24.2`. Check this using :
 bare -v
 ```
 
-Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-```bash
-export NPM_TOKEN=your_personal_access_token
-```
-
-Next, create a `.npmrc` file in the root of your project with the following content:
-
-```ini
-@qvac:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken={NPM_TOKEN}
-```
-
-This configuration ensures secure access to NPM Packages when installing scoped packages.
-
 ### Installing the Package
 
 Install the latest development version (adjust package name based on desired model/quantization):

--- a/packages/qvac-lib-infer-whispercpp/package.json
+++ b/packages/qvac-lib-infer-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-langdetect-text-cld2/README.md
+++ b/packages/qvac-lib-langdetect-text-cld2/README.md
@@ -122,21 +122,6 @@ async function detectVariousScripts() {
 
 1. Install dependencies:
 
- Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-  ```bash
-  export NPM_TOKEN=your_personal_access_token
-  ```
-
- Next, create a `.npmrc` file in the root of your project with the following content:
-
-  ```ini
-  @qvac:registry=https://registry.npmjs.org/
-  //registry.npmjs.org/:_authToken={NPM_TOKEN}
-  ```
-
- This configuration ensures secure access to NPM Packages when installing scoped packages.
-
 ```bash
 npm install
 ```

--- a/packages/qvac-lib-langdetect-text-cld2/package.json
+++ b/packages/qvac-lib-langdetect-text-cld2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/langdetect-text-cld2",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Language detection using CLD2 with same API as @qvac/langdetect-text",
   "type": "module",
   "main": "index.js",

--- a/packages/qvac-lib-langdetect-text/README.md
+++ b/packages/qvac-lib-langdetect-text/README.md
@@ -53,21 +53,6 @@ const langs = langDetect.detectMultiple(text, 3);
 
 1. Install dependencies:
 
- Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-  ```bash
-  export NPM_TOKEN=your_personal_access_token
-  ```
-
- Next, create a `.npmrc` file in the root of your project with the following content:
-
-  ```ini
-  @qvac:registry=https://registry.npmjs.org/
-  //registry.npmjs.org/:_authToken={NPM_TOKEN}
-  ```
-
- This configuration ensures secure access to NPM Packages when installing scoped packages.
-
 ```bash
 npm install
 ```

--- a/packages/qvac-lib-langdetect-text/package.json
+++ b/packages/qvac-lib-langdetect-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/langdetect-text",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/qvac-lib-registry-server/client/README.md
+++ b/packages/qvac-lib-registry-server/client/README.md
@@ -139,11 +139,9 @@ The package includes a CLI for querying and downloading models from the registry
 
 ### Install
 
-The package is hosted on npm. Configure npm to use the registry for the `@qvac` scope, then install globally:
+The package is hosted on npm. Install globally:
 
 ```bash
-echo "@qvac:registry=https://registry.npmjs.org" >> ~/.npmrc
-echo "//registry.npmjs.org/:_authToken=YOUR_NPM_TOKEN" >> ~/.npmrc
 npm install -g @qvac/registry-client
 ```
 

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -16,21 +16,6 @@ A JavaScript library for Retrieval-Augmented Generation (RAG) within the QVAC ec
 
 ## Installation
 
-Before proceeding with the installation, please generate a **granular Personal Access Token (PAT)** with the `read-only` scope. Once generated, add the token to your environment variables using the name `NPM_TOKEN`.
-
-```bash
-export NPM_TOKEN=your_personal_access_token
-```
-
-Next, create a `.npmrc` file in the root of your project with the following content:
-
-```ini
-@qvac:registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken={NPM_TOKEN}
-```
-
-This configuration ensures secure access to NPM Packages when installing scoped packages.
-
 ```bash
 npm install @qvac/rag
 ```

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "index.js",
   "scripts": {
     "lint": "standard",


### PR DESCRIPTION
## Summary
- Remove outdated NPM token/PAT setup instructions from the `qvac-lib-infer-base` README that are no longer needed for installation
- Fix minor markdown formatting (blank line before list, remove extra blank line)

