### PR TITLE
doc: trigger npm publish (@qvac/transcription-whispercpp)

### DIFF
--- a/packages/qvac-lib-infer-whispercpp/README.md
+++ b/packages/qvac-lib-infer-whispercpp/README.md
@@ -546,3 +546,4 @@ This project is licensed under the Apache-2.0 License – see the LICENSE file f
 
 For questions or issues, please open an issue on the GitHub repository.
 
+


### PR DESCRIPTION
README-only change (trailing newline) to trigger on-merge / npm publish for `release-qvac-lib-infer-whispercpp-0.5.4`.

Made with [Cursor](https://cursor.com)