### PR TITLE
doc: trigger npm publish (@qvac/tts-onnx)

### DIFF
--- a/packages/qvac-lib-infer-onnx-tts/README.md
+++ b/packages/qvac-lib-infer-onnx-tts/README.md
@@ -574,3 +574,4 @@ Contributions are welcome! Please feel free to submit a Pull Request. For major 
 This project is licensed under the Apache-2.0 License - see the [LICENSE](./LICENSE) file for details.
 
 _For questions or issues, please open an issue on the GitHub repository._
+


### PR DESCRIPTION
README-only change (trailing newline) to trigger on-merge / npm publish for `release-qvac-lib-infer-onnx-tts-0.7.1`.

Made with [Cursor](https://cursor.com)