### PR TITLE
fix: cancel race when job already dequeued by worker thread

### DIFF
--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
@@ -177,7 +177,7 @@ public:
 
     // Queued: remove directly. Skip modelCancel_ to avoid stale stop flags.
     if (job_.has_value() && (matchAny || job_->jobId == jobId.value())) {
-      auto id = job_->jobId;
+      JobId id = job_->jobId;
       job_.reset();
       outputQueue_->queueException(id, std::runtime_error("Job cancelled"));
       return;

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JobRunner.hpp
@@ -54,6 +54,7 @@ class JobRunner {
   mutable std::timed_mutex mtx_;
   mutable std::condition_variable_any processCv_;
   std::optional<PendingJob> job_;
+  std::optional<JobId> activeJobId_;
   JobId nextJobId_{1};
   mutable std::thread processingThread_;
   mutable std::atomic_bool running_ = false;
@@ -65,7 +66,7 @@ class JobRunner {
     if (!lock.owns_lock()) {
       lock.lock();
     }
-    job_.reset();
+    activeJobId_.reset();
   }
 
   void process() {
@@ -87,6 +88,8 @@ class JobRunner {
         ready_ = false;
         processingSync_.setActive(true);
         currentJob = std::move(*job_);
+        job_.reset();
+        activeJobId_ = currentJob->jobId;
 
         // Unlock main lock to ensure cancel() can acquire without blocking
         lock.unlock();
@@ -164,23 +167,28 @@ public:
   }
 
   void cancel(std::optional<JobId> jobId = std::nullopt) {
-    std::scoped_lock lock{mtx_};
+    std::unique_lock lock{mtx_};
     if (modelCancel_ == nullptr) {
       QLOG(logger::Priority::WARNING, "Model does not support cancellation");
       return;
     }
-    if (job_.has_value() &&
-        (!jobId.has_value() || job_->jobId == jobId.value())) {
-      const auto activeJobId = job_->jobId;
-      modelCancel_->cancel();
-      processingSync_.waitInactive();
+
+    const bool matchAny = !jobId.has_value();
+
+    // Queued: remove directly. Skip modelCancel_ to avoid stale stop flags.
+    if (job_.has_value() && (matchAny || job_->jobId == jobId.value())) {
+      auto id = job_->jobId;
       job_.reset();
-      if (ready_.load()) {
-        // If the worker has not taken the job yet (ready_ == true, still in
-        // wait), it will never run queueJobEnded. Signal finished now.
-        outputQueue_->queueException(
-            activeJobId, std::runtime_error("Job cancelled"));
-      }
+      outputQueue_->queueException(id, std::runtime_error("Job cancelled"));
+      return;
+    }
+
+    // Active: signal model, unlock before wait (finalizeJob re-acquires mtx_).
+    if (activeJobId_.has_value() &&
+        (matchAny || activeJobId_.value() == jobId.value())) {
+      modelCancel_->cancel();
+      lock.unlock();
+      processingSync_.waitInactive();
     }
   }
 };

--- a/packages/qvac-lib-inference-addon-cpp/tests/job_runner_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/job_runner_test.cpp
@@ -537,7 +537,8 @@ TEST_F(JobRunnerTest, StaleCancelDoesNotClearNewerAcceptedJob) {
 }
 
 TEST_F(JobRunnerTest, CancelWhileActivelyProcessing_ModelReceivesStop) {
-  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{2000});
+  model_ =
+      std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{2000});
   outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
   jobRunner_ =
       std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
@@ -601,4 +602,3 @@ TEST_F(JobRunnerTest, StaleCancelDoesNotKillActiveJob) {
 }
 
 } // namespace qvac_lib_inference_addon_cpp
-

--- a/packages/qvac-lib-inference-addon-cpp/tests/job_runner_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/job_runner_test.cpp
@@ -536,4 +536,69 @@ TEST_F(JobRunnerTest, StaleCancelDoesNotClearNewerAcceptedJob) {
   EXPECT_FALSE(sawWrongJob2Cancel);
 }
 
+TEST_F(JobRunnerTest, CancelWhileActivelyProcessing_ModelReceivesStop) {
+  model_ = std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{2000});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  EXPECT_TRUE(jobRunner_->runJob(std::string("long job")));
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{2};
+  while (!model_->isProcessing() &&
+         std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{1});
+  }
+  ASSERT_TRUE(model_->isProcessing());
+
+  auto cancel_future =
+      std::async(std::launch::async, [this]() { jobRunner_->cancel(); });
+
+  auto status = cancel_future.wait_for(std::chrono::seconds{3});
+  ASSERT_NE(status, std::future_status::timeout)
+      << "cancel() hung — model never received stop signal";
+
+  EXPECT_FALSE(model_->isProcessing());
+
+  EXPECT_TRUE(jobRunner_->runJob(std::string("follow-up")));
+  EXPECT_TRUE(
+      model_->waitForProcessingToComplete(std::chrono::milliseconds{3000}));
+}
+
+TEST_F(JobRunnerTest, StaleCancelDoesNotKillActiveJob) {
+  model_ =
+      std::make_unique<JobRunnerTestModel>(std::chrono::milliseconds{2000});
+  outputQueue_ = std::make_shared<OutputQueue>(*callback_, *model_);
+  jobRunner_ =
+      std::make_unique<JobRunner>(outputQueue_, model_.get(), model_.get());
+  jobRunner_->start();
+
+  EXPECT_TRUE(jobRunner_->runJob(std::string("job-1")));
+  std::this_thread::sleep_for(std::chrono::milliseconds{50});
+  jobRunner_->cancel();
+  std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+  EXPECT_TRUE(jobRunner_->runJob(std::string("job-2")));
+
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{2};
+  while (!model_->isProcessing() &&
+         std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{1});
+  }
+  ASSERT_TRUE(model_->isProcessing());
+
+  // cancel(1) targets job-1; job-2 (id=2) must not be affected
+  jobRunner_->cancel(1);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds{50});
+  EXPECT_TRUE(model_->isProcessing())
+      << "Stale cancel(1) should not have killed active job-2";
+
+  jobRunner_->cancel();
+  EXPECT_TRUE(
+      model_->waitForProcessingToComplete(std::chrono::milliseconds{3000}));
+}
+
 } // namespace qvac_lib_inference_addon_cpp
+


### PR DESCRIPTION
## Issue
`JobRunner::cancel()` uses `job_.has_value()` to decide whether to cancel. But the worker thread moves job_ into a local variable before starting inference — so by the time `cancel() `acquires the lock, `job_ is` empty. Cancel sees "no job" and returns without signaling the model to stop.

#### Scenario:

- User sends a completion request — model starts generating.
- User calls `cancel()` — SDK returns success, but native cancel is a no-op because the worker already dequeued job_.
- Model keeps running. The `stopGeneration_ `flag is never set, so inference continues until the model finishes naturally (or hits a token limit).
- User sends the next completion request — runJob() returns false because the model still thinks a job is active. The app appears stuck.
- The model continues generating, the JS side thinks cancel succeeded, and subsequent `run()` calls are rejected with "a job is already set or being processed" until the original inference finishes naturally.

This affects every addon built on **_qvac-lib-inference-addon-cpp_** (LLM, whisper, TTS, embed, etc.) when cancel arrives after the worker dequeues but before processing completes.


## Solution
Added `activeJobId_` to track which job the worker is currently processing, separately from the queued `job_`. Split `cancel()` into two paths:

- Queued: `job_` still present — remove it, queue error event, return. Does not call `modelCancel_->cancel()` to avoid setting a stale stop flag.
- Active: `job_` empty but `activeJobId_` matches — call `modelCancel_->cancel()`, release mutex, wait for worker to finish via `processingSync_.waitInactive()`.
- Supporting changes:

`process()` now explicitly resets `job_` at dequeue and sets `activeJobId_` atomically under the lock.
`finalizeJob()` clears only `activeJobId_` (not `job_`), preventing a race where a newly queued follow-up job could be wiped during cleanup.
`cancel()` uses `unique_lock` and releases before waitInactive() to avoid deadlock with `finalizeJob()` re-acquiring mtx_.
No API changes. All existing callers (`AddonCpp::cancelJob`, `AddonJs::cancelJob`, SDK cancelHandler) work without modification.


## Test plan

Existing 53 unit tests pass (no regressions)
New:
`CancelWhileActivelyProcessing_ModelReceivesStop`: cancel during active processing stops the model and allows follow-up job
`StaleCancelDoesNotKillActiveJob`: cancel(oldId)does not affect a newer active job

Full suite run 3x with
- repeat until-fail:3
- no flakes


