### PR TITLE
doc: trigger npm publish (@qvac/registry-client)

### DIFF
--- a/packages/qvac-lib-registry-server/client/README.md
+++ b/packages/qvac-lib-registry-server/client/README.md
@@ -371,3 +371,4 @@ async function handleErrors () {
 ## License
 
 Apache-2.0
+


### PR DESCRIPTION
README-only change to trigger on-merge / npm publish for `release-qvac-registry-client-0.3.1`.

Made with [Cursor](https://cursor.com)