### PR TITLE
doc: trigger npm publish (@qvac/rag)

### DIFF
--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -455,3 +455,4 @@ npm test
 This project is licensed under the Apache-2.0 License – see the [LICENSE](https://github.com/tetherto/qvac-lib-rag/blob/main/LICENSE) file for details.
 
 For any questions or issues, please open an issue on the GitHub repository.
+


### PR DESCRIPTION
README-only change to trigger on-merge / npm publish for `release-rag-0.4.3`.

Made with [Cursor](https://cursor.com)