### PR TITLE
doc: trigger npm publish (@qvac/langdetect-text-cld2)

### DIFF
--- a/packages/qvac-lib-langdetect-text-cld2/README.md
+++ b/packages/qvac-lib-langdetect-text-cld2/README.md
@@ -145,3 +145,4 @@ npm test
 This project is licensed under the Apache-2.0 License - see the LICENSE file for details.
 
 For any questions or issues, please open an issue on the GitHub repository.
+


### PR DESCRIPTION
README-only change to trigger on-merge / npm publish for `release-qvac-lib-langdetect-text-cld2-0.3.1`.

Made with [Cursor](https://cursor.com)