### PR TITLE
doc: trigger npm publish (@qvac/decoder-audio)

### DIFF
--- a/packages/qvac-lib-decoder-audio/README.md
+++ b/packages/qvac-lib-decoder-audio/README.md
@@ -247,3 +247,4 @@ Coverage reports are generated in the 'coverage/unit/' directory. Open the corre
 This project is licensed under the Apache-2.0 License – see the [LICENSE](LICENSE) file for details.
 
 *For questions or issues, please open an issue on the GitHub repository.*
+


### PR DESCRIPTION
README-only change to trigger on-merge / npm publish for `release-qvac-lib-decoder-audio-0.3.6`.

Made with [Cursor](https://cursor.com)