### PR TITLE
doc[notask]: replace @tetherto npm references with @qvac namespace in READMEs

### DIFF
--- a/packages/qvac-lib-decoder-audio/README.md
+++ b/packages/qvac-lib-decoder-audio/README.md
@@ -50,7 +50,7 @@ npm install -g bare@latest
 Install the latest version of the decoder addon with the following command:
 
 ```bash
-npm install @tetherto/qvac-lib-decoder-audio@latest
+npm install @qvac/decoder-audio@latest
 ```
 
 ## Usage
@@ -62,7 +62,7 @@ This library provides a simple workflow for decoding audio streams.
 To get started, import the decoder and create an instance:
 
 ```javascript
-const { FFmpegDecoder } = require('@tetherto/qvac-lib-decoder-audio')
+const { FFmpegDecoder } = require('@qvac/decoder-audio')
 
 const decoder = new FFmpegDecoder({
   config: {
@@ -150,7 +150,7 @@ npm init -y
 ### 2. Install the required dependencies:
    
 ```bash
-npm install bare-fs @tetherto/qvac-lib-decoder-audio
+npm install bare-fs @qvac/decoder-audio
 ```
 
 ### 3. Create a file named `example.js` and paste the following code:
@@ -159,7 +159,7 @@ npm install bare-fs @tetherto/qvac-lib-decoder-audio
 'use strict'
 
 const fs = require('bare-fs')
-const { FFmpegDecoder } = require('@tetherto/qvac-lib-decoder-audio')
+const { FFmpegDecoder } = require('@qvac/decoder-audio')
 
 const audioFilePath = './path/to/audio/file.ogg'
 const outputFilePath = './path/to/output/file.raw'

--- a/packages/qvac-lib-infer-llamacpp-llm/test/mobile/README.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/mobile/README.md
@@ -1,6 +1,6 @@
 # Mobile Testing for LLM Llamacpp
 
-This directory contains the mobile test configuration for the `@tetherto/llm-llamacpp` addon.
+This directory contains the mobile test configuration for the `@qvac/llm-llamacpp` addon.
 
 > ⚠️ **Note**: This test directory is included in the published npm package to support the mobile testing framework. These test files are NOT part of the public API and should only be used by the internal mobile testing infrastructure.
 

--- a/packages/qvac-lib-infer-nmtcpp/benchmarks/client/README.md
+++ b/packages/qvac-lib-infer-nmtcpp/benchmarks/client/README.md
@@ -31,7 +31,7 @@ Create a `config.yaml` file with the following structure:
 server:
   url: "http://localhost:8080/run"
   batch_size: 32
-  lib: "@tetherto/qvac-lib-inference-addon-mlc-marian-opus-q4f16"
+  lib: "@qvac/translation-marian-opus-q4f16"
 
 huggingface:
   token: "your_huggingface_token"

--- a/packages/qvac-lib-infer-nmtcpp/benchmarks/client/README.md
+++ b/packages/qvac-lib-infer-nmtcpp/benchmarks/client/README.md
@@ -31,7 +31,7 @@ Create a `config.yaml` file with the following structure:
 server:
   url: "http://localhost:8080/run"
   batch_size: 32
-  lib: "@qvac/translation-marian-opus-q4f16"
+  lib: "@qvac/translation-nmtcpp"
 
 huggingface:
   token: "your_huggingface_token"

--- a/packages/qvac-lib-infer-nmtcpp/benchmarks/server/README.md
+++ b/packages/qvac-lib-infer-nmtcpp/benchmarks/server/README.md
@@ -59,7 +59,7 @@ Sample request body:
 ```json
 {
   "inputs": ["Hello", "World"], // array of input strings to translate
-  "lib": "@qvac/translation-marian-opus-q4f16", // the library to use
+  "lib": "@qvac/translation-nmtcpp", // the library to use
   "version": "1.0.0", // the version of the library to use (optional)
   "link": "hyperdrive-link", // the hyperdrive link to the model files (optional)
   "params": {

--- a/packages/qvac-lib-infer-nmtcpp/benchmarks/server/README.md
+++ b/packages/qvac-lib-infer-nmtcpp/benchmarks/server/README.md
@@ -59,7 +59,7 @@ Sample request body:
 ```json
 {
   "inputs": ["Hello", "World"], // array of input strings to translate
-  "lib": "@tetherto/qvac-lib-inference-addon-mlc-marian-opus-q4f16", // the library to use
+  "lib": "@qvac/translation-marian-opus-q4f16", // the library to use
   "version": "1.0.0", // the version of the library to use (optional)
   "link": "hyperdrive-link", // the hyperdrive link to the model files (optional)
   "params": {

--- a/packages/qvac-lib-registry-server/README.md
+++ b/packages/qvac-lib-registry-server/README.md
@@ -9,11 +9,11 @@ Distributed model registry for QVAC. Download AI models for local inference, or 
 Use the client library to query and download models:
 
 ```bash
-npm install @tetherto/qvac-lib-registry-client
+npm install @qvac/registry-client
 ```
 
 ```javascript
-const { QVACRegistryClient } = require('@tetherto/qvac-lib-registry-client')
+const { QVACRegistryClient } = require('@qvac/registry-client')
 
 const client = new QVACRegistryClient({
   registryCoreKey: process.env.QVAC_REGISTRY_CORE_KEY

--- a/packages/rag/README.md
+++ b/packages/rag/README.md
@@ -49,7 +49,7 @@ npm install @qvac/llm-llamacpp
 # No additional dependencies. See example in `examples/direct-rag.js`
 
 # Option 2: Through runtime manager. See example in `examples/quickstart.js`
-npm install @tetherto/qvac-lib-rt @tetherto/qvac-lib-router-inference @tetherto/qvac-lib-manager-inference
+npm install @qvac/rt @qvac/router-inference @qvac/manager-inference
 ```
 
 **`HttpLlmAdapter`** - HTTP API integration (OpenAI, Anthropic, etc.)
@@ -75,7 +75,7 @@ npm install @qvac/embed-llamacpp
 # No additional dependencies. See example in `examples/direct-rag.js`
 
 # Option 2: Through runtime manager. See example in `examples/quickstart.js`
-npm install @tetherto/qvac-lib-rt @tetherto/qvac-lib-router-inference @tetherto/qvac-lib-manager-inference
+npm install @qvac/rt @qvac/router-inference @qvac/manager-inference
 ```
 
 **Custom Embedding Functions** - Any service you prefer
@@ -110,7 +110,7 @@ npm install @qvac/rag
 npm install corestore hyperdb hyperschema
 
 # LLM: QvacLlmAdapter
-npm install @tetherto/qvac-lib-rt @tetherto/qvac-lib-router-inference @tetherto/qvac-lib-manager-inference @qvac/llm-llamacpp
+npm install @qvac/rt @qvac/router-inference @qvac/manager-inference @qvac/llm-llamacpp
 
 # Embedding: QVAC Embedding Addon
 npm install @qvac/embed-llamacpp

--- a/packages/sdk/tests-qvac/README.md
+++ b/packages/sdk/tests-qvac/README.md
@@ -1,6 +1,6 @@
 # SDK Tests
 
-SDK dogfooding tests built on top of `@tetherto/qvac-test-suite`.
+SDK dogfooding tests built on top of `@qvac/test-suite`.
 
 ## Layout
 


### PR DESCRIPTION
## What problem does this PR solve?

Several READMEs still reference packages under the old `@tetherto` GitHub Package Registry scope instead of the public `@qvac` npm scope.

## How does it solve it?

Replaces all `@tetherto/…` package references with the correct `@qvac/…` names across 7 README files:

- `packages/rag/README.md` — `@qvac/rt`, `@qvac/router-inference`, `@qvac/manager-inference`
- `packages/qvac-lib-decoder-audio/README.md` — `@qvac/decoder-audio`
- `packages/sdk/tests-qvac/README.md` — `@qvac/test-suite`
- `packages/qvac-lib-registry-server/README.md` — `@qvac/registry-client`
- `packages/qvac-lib-infer-nmtcpp/benchmarks/server/README.md` — `@qvac/translation-marian-opus-q4f16`
- `packages/qvac-lib-infer-nmtcpp/benchmarks/client/README.md` — `@qvac/translation-marian-opus-q4f16`
- `packages/qvac-lib-infer-llamacpp-llm/test/mobile/README.md` — `@qvac/llm-llamacpp`
