### PR TITLE
Add permissions to cpp coverage workflow on parakeet

### DIFF
--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -161,6 +161,11 @@ jobs:
       workdir: ${{ needs.context.outputs.workdir }}
 
   cpp-tests-coverage:
+    permissions:
+      contents: read
+      packages: read
+      checks: write
+      pull-requests: write
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml


### PR DESCRIPTION
Add permissions to cpp coverage workflow on parakeet so to fix error

`[Invalid workflow file: .github/workflows/on-pr-qvac-lib-infer-parakeet.yml#L163](https://github.com/tetherto/qvac/actions/runs/23794526664/workflow)
The workflow is not valid. .github/workflows/on-pr-qvac-lib-infer-parakeet.yml (Line: 163, Col: 3): Error calling workflow 'tetherto/qvac/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml@69e41b0fa3ccf56ae6e6ea6e4b9a8bb9e3095268'. The nested job 'cpp-tests' is requesting 'checks: write, pull-requests: write', but is only allowed 'checks: read, pull-requests: read'.`