### PR TITLE
fix[notask]: Install Bare runtime for rag unit tests in sdk-pod PR checks

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -255,6 +255,10 @@ jobs:
       - name: Install dependencies
         run: ${{ matrix.pkg_manager }} install
 
+      - name: Install Bare runtime
+        if: matrix.package == 'rag'
+        run: npm install -g bare
+
       # All script steps use npm run --if-present (bun lacks --if-present).
       # npm run just reads package.json scripts — works regardless of installer.
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?
- `@qvac/rag` unit tests run with `brittle-bare`, which requires the bare runtime binary
- In `pr-checks-sdk-pod.yml`, CI did not install bare, so RAG unit tests failed with `/usr/bin/env: 'bare': No such file or directory`

## 📝 How does it solve it?
- Update `.github/workflows/pr-checks-sdk-pod.yml` in the `check (${{ matrix.package }})` job
Add a conditional step to install bare runtime before tests for `rag` only:
