### PR TITLE
fix: pin addon-cpp >= 1.1.4 in NMT and OCR to pick up cancel race fix

### DIFF
--- a/packages/ocr-onnx/vcpkg.json
+++ b/packages/ocr-onnx/vcpkg.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.0.0"
+      "version>=": "1.1.4"
     },
     {
       "name": "qvac-lint-cpp",

--- a/packages/qvac-lib-infer-nmtcpp/vcpkg.json
+++ b/packages/qvac-lib-infer-nmtcpp/vcpkg.json
@@ -3,7 +3,7 @@
     "bergamot-translator",
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.1.2"
+      "version>=": "1.1.4"
     },
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## Summary
- Pin qvac-lib-inference-addon-cpp to >= 1.1.4 in OCR (ocr-onnx) and NMT (qvac-lib-infer-nmtcpp) packages
- Ensures both packages pick up the cancel race fix from v1.1.4 and skip the broken v1.1.3 API

## Details
- OCR: 1.0.0 → 1.1.4
- NMT: 1.1.2 → 1.1.4

No logic changes required — v1.1.4 maintains the same C++ API as v1.1.2.

## Test plan
- [ ] Verify OCR addon builds with addon-cpp 1.1.4
- [ ] Verify NMT addon builds with addon-cpp 1.1.4
- [ ] Run integration tests for both packages