### PR TITLE
fix[notask|skiplog]: align translation stats properties with SDK schema

### DIFF
--- a/packages/sdk/tests-qvac/tests/shared/executors/translation-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/translation-executor.ts
@@ -127,13 +127,13 @@ export class TranslationExecutor extends AbstractModelExecutor<typeof allTests> 
       if (!stats) {
         return { passed: false, output: `Translation OK but stats were undefined. Text: "${translatedText}"` };
       }
-      if (typeof stats.processedTokens !== "number" || typeof stats.processingTime !== "number") {
+      if (typeof stats.totalTokens !== "number" || typeof stats.totalTime !== "number") {
         return { passed: false, output: `Stats missing fields. Got: ${JSON.stringify(stats)}` };
       }
 
       return {
         passed: true,
-        output: `Text: "${translatedText}", tokens: ${stats.processedTokens}, time: ${stats.processingTime}ms`,
+        output: `Text: "${translatedText}", tokens: ${stats.totalTokens}, time: ${stats.totalTime}ms`,
       };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## What problem does this PR solve?

Translation stats test (`translation-executor.ts`) fails `tsc` compilation in CI because it references
`processedTokens` and `processingTime` — properties that were renamed in `translationStatsSchema`.

## How does it solve it?

Rename the two stale property references to match the current SDK schema:

- `stats.processedTokens` → `stats.totalTokens`
- `stats.processingTime` → `stats.totalTime`

## How was it tested?

- `bun run clean && tsc` passes without errors
- Property names match `translationStatsSchema` in `packages/sdk/schemas/translate.ts`