### PR TITLE
fix[notask]: Freeze sdk deps installs in publish and sdk-pod checks

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -253,7 +253,13 @@ jobs:
           fi
 
       - name: Install dependencies
-        run: ${{ matrix.pkg_manager }} install
+        shell: bash
+        run: |
+          if [ "${{ matrix.package }}" = "sdk" ]; then
+            bun install --frozen-lockfile
+          else
+            ${{ matrix.pkg_manager }} install
+          fi
 
       - name: Install Bare runtime
         if: matrix.package == 'rag'

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -119,10 +119,6 @@ jobs:
         run: |
           echo "Configuring scoped registry for @tetherto and @qvac packages..."
           set -eu
-          
-          # Remove stale lock file to force fresh registry resolution
-          rm -f bun.lock
-          
           echo "Writing .npmrc for dual registry install…"
           cat > .npmrc <<NPMRC
           registry=https://registry.npmjs.org/
@@ -151,7 +147,7 @@ jobs:
           EOF
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
         working-directory: ${{ env.WORKDIR }}
 
       - name: Modify package name for branch-based builds


### PR DESCRIPTION
## 🎯 What problem does this PR solve?
- SDK CI installs were non-deterministic.
- Fresh resolution caused dependency drift and breakage in SDK checks.

## 📝 How does it solve it?
- `publish-sdk.yml`
  - Removed `rm -f bun.lock`.
  - Switched install to `bun install --frozen-lockfile`.
- `pr-checks-sdk-pod.yml`
  - Updated install logic:
    - sdk package: `bun install --frozen-lockfile`
    - other packages: `${{ matrix.pkg_manager }}` install