### PR TITLE
fix[notask|skiplog]: refactor download tests to use dedicated executor

### DIFF
--- a/packages/sdk/tests-qvac/tests/desktop/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/desktop/consumer.ts
@@ -343,7 +343,7 @@ export const executor = createExecutor({
     new KvCacheExecutor(resources),
     new ParakeetExecutor(resources),
     new VisionExecutor(resources),
-    new DownloadExecutor(resources),
+    new DownloadExecutor(),
   ],
   profiling: {
     init: () => profiler.enable({ mode: "summary", includeServerBreakdown: true }),

--- a/packages/sdk/tests-qvac/tests/download-tests.ts
+++ b/packages/sdk/tests-qvac/tests/download-tests.ts
@@ -3,7 +3,8 @@ import type { TestDefinition } from "@tetherto/qvac-test-suite";
 export const downloadCancelIsolation: TestDefinition = {
   testId: "download-cancel-isolation",
   params: { cancelAtPercent: 1 },
-  expectation: { validation: "custom" },
+  // expectation is ignored in test executor, it does validation in the executor itself.
+  expectation: { validation: "custom", validator: () => true },
   metadata: {
     category: "download",
     dependency: "none",

--- a/packages/sdk/tests-qvac/tests/mobile/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/mobile/consumer.ts
@@ -357,7 +357,7 @@ export const executor = createExecutor({
     new KvCacheExecutor(resources),
     new MobileParakeetExecutor(resources),
     new MobileVisionExecutor(resources),
-    new DownloadExecutor(resources),
+    new DownloadExecutor(),
   ],
   profiling: {
     init: () => profiler.enable({ mode: "summary", includeServerBreakdown: true }),


### PR DESCRIPTION
## What problem does this PR solve?

Download tests relied on `model-manager.ts` and generic validation logic,
making them hard to maintain and extend.

## How does it solve it?

- Add `DownloadExecutor` with self-contained validation
- Move download test expectations to `custom` validator (executor handles validation internally)
- Remove `model-manager.ts` — no longer needed

## How was it tested?

- `bun run clean && tsc` compiles without errors
- Download tests pass locally