### PR TITLE
QVAC-16558 chore[skiplog]: backmerge rag v0.4.4 release, changelog & NOTICE

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4]
+
+### Changed
+
+- README: replaced `@tetherto` npm references with `@qvac` namespace references.
+- Dependencies: bumped `bare-crypto` to `^1.13.4` and cleaned up RAG package dependency declarations.
+
 ## [0.4.3]
 
 ### Changed

--- a/packages/rag/NOTICE
+++ b/packages/rag/NOTICE
@@ -17,37 +17,45 @@ JavaScript Dependencies
   @qvac/error@0.1.1
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
-  b4a@1.7.4
+  b4a@1.8.0
     https://github.com/holepunchto/b4a
   bare-addon-resolve@1.10.0
     https://github.com/holepunchto/bare-addon-resolve
+  bare-ansi-escapes@2.2.3
+    https://github.com/holepunchto/bare-ansi-escapes
+  bare-assert@1.2.0
+    https://github.com/holepunchto/bare-assert
   bare-events@2.4.2
     https://github.com/holepunchto/bare-events
   bare-events@2.8.2
     https://github.com/holepunchto/bare-events
-  bare-fs@4.5.4
+  bare-fs@4.5.6
     https://github.com/holepunchto/bare-fs
+  bare-inspect@3.1.4
+    https://github.com/holepunchto/bare-inspect
   bare-module-resolve@1.12.1
     https://github.com/holepunchto/bare-module-resolve
-  bare-os@3.6.2
+  bare-os@3.8.6
     https://github.com/holepunchto/bare-os
   bare-path@3.0.0
     https://github.com/holepunchto/bare-path
   bare-semver@1.0.2
     https://github.com/holepunchto/bare-semver
-  bare-stream@2.7.0
+  bare-stream@2.11.0
     https://github.com/holepunchto/bare-stream
-  bare-url@2.3.2
+  bare-type@1.1.0
+    https://github.com/holepunchto/bare-type
+  bare-url@2.4.0
     https://github.com/holepunchto/bare-url
   blind-relay@1.4.0
     https://github.com/holepunchto/blind-relay
-  compact-encoding@2.18.0
-    https://github.com/compact-encoding/compact-encoding
+  compact-encoding@2.19.2
+    https://github.com/holepunchto/compact-encoding
   events-universal@1.0.1
     https://github.com/holepunchto/events-universal
   hypercore-id-encoding@1.3.0
     https://github.com/holepunchto/hypercore-id-encoding
-  hyperschema@1.19.1
+  hyperschema@1.20.1
     https://github.com/holepunchto/hyperschema
   noise-handshake@4.2.0
     https://github.com/holepunchto/noise-handshake
@@ -79,7 +87,7 @@ JavaScript Dependencies
 
   bogon@1.2.0
     https://github.com/mafintosh/bogon
-  dht-rpc@6.26.1
+  dht-rpc@6.26.3
     https://github.com/mafintosh/dht-rpc
   fast-fifo@1.3.2
     https://github.com/mafintosh/fast-fifo
@@ -89,7 +97,7 @@ JavaScript Dependencies
     https://github.com/mafintosh/generate-string
   hypercore-crypto@3.6.1
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.29.0
+  hyperdht@6.29.6
     https://github.com/holepunchto/hyperdht
   is-property@1.0.2
     https://github.com/mikolalysenko/is-property
@@ -105,18 +113,20 @@ JavaScript Dependencies
     https://github.com/holepunchto/ready-resource
   record-cache@1.2.0
     https://github.com/mafintosh/record-cache
-  safety-catch@1.0.2
+  safety-catch@1.0.3
     https://github.com/mafintosh/safety-catch
   signal-promise@1.0.3
     https://github.com/mafintosh/signal-promise
-  sodium-native@5.0.10
+  sodium-native@5.1.0
     https://github.com/holepunchto/sodium-native
   sodium-secretstream@1.2.0
     https://github.com/mafintosh/sodium-secretstream
   sodium-universal@5.0.1
     https://github.com/holepunchto/sodium-universal
-  streamx@2.23.0
+  streamx@2.25.0
     https://github.com/mafintosh/streamx
+  teex@1.0.1
+    https://github.com/mafintosh/teex
   time-ordered-set@2.0.1
     https://github.com/mafintosh/time-ordered-set
   timeout-refresh@2.0.1

--- a/packages/rag/changelog/0.4.4/CHANGELOG.md
+++ b/packages/rag/changelog/0.4.4/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.4.4
+
+Release Date: 2026-04-01
+
+## 📘 Docs
+
+- Replace @tetherto npm references with @qvac namespace in READMEs. (see PR [#1247](https://github.com/tetherto/qvac/pull/1247))
+
+## 🧹 Chores
+
+- Bump bare-crypto to ^1.13.4 and clean up rag dependency declarations. (see PR [#1253](https://github.com/tetherto/qvac/pull/1253))
+

--- a/packages/rag/changelog/0.4.4/CHANGELOG_LLM.md
+++ b/packages/rag/changelog/0.4.4/CHANGELOG_LLM.md
@@ -1,0 +1,17 @@
+# QVAC RAG v0.4.4 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.4.4
+
+This release focuses on dependency hygiene and package namespace consistency for the RAG library. It aligns documentation with the `@qvac` npm scope and updates core crypto dependency declarations to match current runtime expectations.
+
+---
+
+## 📘 Documentation
+
+README references have been updated from the legacy `@tetherto` namespace to `@qvac`, reducing installation confusion and ensuring examples match currently published package names.
+
+---
+
+## 🧹 Maintenance
+
+`bare-crypto` dependency declarations were updated to `^1.13.4`, and related `package.json` cleanup was applied in the RAG package. This keeps dependency metadata aligned with the current SDK pod ecosystem and reduces drift across package manifests.

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "index.js",
   "scripts": {
     "lint": "standard",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Backmerge release branch changes (changelog, NOTICE, version bump) into main

## 📝 How does it solve it?

- Merges v0.4.4 release prep (changelog, CHANGELOG_LLM.md, NOTICE, version bump) from `release-sdk-0.4.4` into `main`