### PR TITLE
fix[notask|skiplog]: Prevent bare runtime import leaks in rpc handler paths

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -198,7 +198,7 @@ jobs:
         continue-on-error: true
         run: |
           deps=$(jq -r '([.dependencies, .devDependencies] | map(select(type=="object")) | add // {}) | to_entries[] | .value' package.json)
-          if echo "$deps" | grep -Eq '^(git\+https:\/\/github.com|[0-9]+\.[0-9]+\.[0-9]+-(dev|tmp)[^"]*'; then
+          if echo "$deps" | grep -Eq '^(git\+https:\/\/github.com|[0-9]+\.[0-9]+\.[0-9]+-(dev|tmp)[^"]*)$'; then
             echo "::error title=Disallowed dependency detected::Do not use git URLs or dev/tmp versions in dependencies"
             exit 1
           fi

--- a/packages/sdk/server/bare/delegate-rpc-client.ts
+++ b/packages/sdk/server/bare/delegate-rpc-client.ts
@@ -11,6 +11,7 @@ import {
   cacheDelegationConnectionTime,
   clearPeerConnectionTracking,
 } from "@/server/rpc/profiling/delegation-profiler";
+import { getNextCommandId } from "@/server/rpc/rpc-utils";
 
 const logger = getServerLogger();
 
@@ -28,7 +29,6 @@ const activeConnections = new Map<ConnectionKey, Connection>();
 // Track whether the global connection handler has been registered
 let connectionHandlerRegistered = false;
 const HEALTH_CHECK_TIMEOUT_MS = 1500;
-import { getNextCommandId } from "@/server/rpc/delegate-utils";
 
 function isHeartbeatResponse(payload: unknown): payload is { type: "heartbeat" } {
   return (

--- a/packages/sdk/server/rpc/delegate-transport.ts
+++ b/packages/sdk/server/rpc/delegate-transport.ts
@@ -55,7 +55,7 @@ export type ResponseWithDelegation = Response & {
 
 const logger = getServerLogger();
 
-import { getNextCommandId } from "@/server/rpc/delegate-utils";
+import { getNextCommandId } from "@/server/rpc/rpc-utils";
 
 function checkAndThrowError(response: Response): void {
   if (response.type === "error") {

--- a/packages/sdk/server/rpc/delegate-utils.ts
+++ b/packages/sdk/server/rpc/delegate-utils.ts
@@ -1,6 +1,0 @@
-let commandCounter = 0;
-
-export function getNextCommandId(): number {
-  commandCounter = (commandCounter + 1) % Number.MAX_SAFE_INTEGER;
-  return commandCounter;
-}

--- a/packages/sdk/server/rpc/handler-utils.ts
+++ b/packages/sdk/server/rpc/handler-utils.ts
@@ -15,15 +15,7 @@ import { setSDKConfig } from "@/server/bare/registry/config-registry";
 import { setRuntimeContext } from "@/server/bare/registry/runtime-context-registry";
 import { type ServerProfiler } from "./profiling";
 import { nowMs } from "@/profiling/clock";
-
-export function isTerminalChunk(value: unknown): value is { done: true } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "done" in value &&
-    (value as { done: unknown }).done === true
-  );
-}
+import { isTerminalChunk } from "./rpc-utils";
 
 function getProfilingMetaFromRequest(
   request: Request,

--- a/packages/sdk/server/rpc/profiling/operation-wrappers.ts
+++ b/packages/sdk/server/rpc/profiling/operation-wrappers.ts
@@ -13,7 +13,7 @@ import {
 import { nowMs, generateProfileId } from "@/profiling/clock";
 import { record, shouldProfile } from "@/profiling/controller";
 import { buildOperationEvent } from "./operation-metrics";
-import { isTerminalChunk } from "../handler-utils";
+import { isTerminalChunk } from "../rpc-utils";
 
 type ResponseWithOperationEvent<T> = T & { [OPERATION_EVENT_KEY]?: OperationEvent };
 

--- a/packages/sdk/server/rpc/rpc-utils.ts
+++ b/packages/sdk/server/rpc/rpc-utils.ts
@@ -1,0 +1,15 @@
+let commandCounter = 0;
+
+export function getNextCommandId(): number {
+  commandCounter = (commandCounter + 1) % Number.MAX_SAFE_INTEGER;
+  return commandCounter;
+}
+
+export function isTerminalChunk(value: unknown): value is { done: true } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "done" in value &&
+    (value as { done: unknown }).done === true
+  );
+}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Unit tests failed with `ReferenceError: Bare is not defined` due to an RPC import chain pulling Bare-only modules into test-time paths.
- SDK PR dependency validation emitted `grep: Unmatched ( or \(` because the regex in the workflow check was malformed.

## 📝 How does it solve it?

- Introduces a runtime-neutral RPC utility module (`rpc-utils`) for shared helpers used across transport/handler/profiling paths.
- Moves shared helpers (`getNextCommandId`, `isTerminalChunk`) into that module and updates all call sites.
- Fixes the dependency-check regex in `pr-checks-sdk-pod.yml` by closing and anchoring the expression correctly.

## 🧪 How was it tested?

- build and unit tests now pass
- pod check passes for this pr