### PR TITLE
fix[sdk]: dedupe semantically identical tool calls

### DIFF
--- a/packages/sdk/server/utils/tool-parser.ts
+++ b/packages/sdk/server/utils/tool-parser.ts
@@ -1,5 +1,34 @@
 import type { Tool, ToolCall, ToolCallError } from "@/schemas";
 
+function stableJsonStringifyForDedupe(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJsonStringifyForDedupe).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  const parts = keys.map(
+    (k) => `${JSON.stringify(k)}:${stableJsonStringifyForDedupe(record[k])}`,
+  );
+  return `{${parts.join(",")}}`;
+}
+
+function dedupeSemanticallyIdenticalToolCalls(calls: ToolCall[]): ToolCall[] {
+  const seenKeys = new Set<string>();
+  const out: ToolCall[] = [];
+  for (const call of calls) {
+    const key = `${call.name}\0${stableJsonStringifyForDedupe(call.arguments)}`;
+    if (seenKeys.has(key)) {
+      continue;
+    }
+    seenKeys.add(key);
+    out.push(call);
+  }
+  return out;
+}
+
 let toolCallSequence = 0;
 
 function generateStableToolCallId(name: string, args: Record<string, unknown>) {
@@ -277,17 +306,26 @@ export function parseToolCalls(
 
   let result = parseGemmaFormat(text, tools);
   if (result.toolCalls.length > 0) {
-    return result;
+    return {
+      toolCalls: dedupeSemanticallyIdenticalToolCalls(result.toolCalls),
+      errors: result.errors,
+    };
   }
 
   result = parseQwenFormat(text, tools);
   if (result.toolCalls.length > 0) {
-    return result;
+    return {
+      toolCalls: dedupeSemanticallyIdenticalToolCalls(result.toolCalls),
+      errors: result.errors,
+    };
   }
 
   result = parseLlamacppFormat(text, tools);
   if (result.toolCalls.length > 0) {
-    return result;
+    return {
+      toolCalls: dedupeSemanticallyIdenticalToolCalls(result.toolCalls),
+      errors: result.errors,
+    };
   }
 
   if (text.includes("<tool_call>")) {
@@ -295,7 +333,10 @@ export function parseToolCalls(
   }
 
   result = parseGenericFormat(text, tools);
-  return result;
+  return {
+    toolCalls: dedupeSemanticallyIdenticalToolCalls(result.toolCalls),
+    errors: result.errors,
+  };
 }
 
 export function convertToolsToGrammar(tools: Tool[]): string {

--- a/packages/sdk/test/unit/tool-parser.test.ts
+++ b/packages/sdk/test/unit/tool-parser.test.ts
@@ -1,0 +1,69 @@
+// @ts-expect-error brittle has no type declarations
+import test from "brittle";
+import type { Tool } from "@/schemas";
+import { parseToolCalls } from "@/server/utils/tool-parser";
+
+const weatherTool: Tool = {
+  type: "function",
+  name: "weather",
+  description: "Weather",
+  parameters: {
+    type: "object",
+    properties: {
+      args: { type: "array" },
+      timeoutMs: { type: "integer" },
+    },
+    required: ["args"],
+  },
+};
+
+const tools: Tool[] = [weatherTool];
+
+test("parseToolCalls: duplicate identical tool_call inside and outside thinking → one", (t) => {
+  const assistant = `<redacted_thinking>
+<tool_call>
+{"name": "weather", "arguments": {"args": ["-s", "https://wttr.in/Curitiba"], "timeoutMs": 3000}}
+</tool_call></redacted_thinking>
+
+<tool_call>
+{"name": "weather", "arguments": {"args": ["-s", "https://wttr.in/Curitiba"], "timeoutMs": 3000}}
+</tool_call>`;
+
+  const { toolCalls } = parseToolCalls(assistant, tools);
+  t.is(toolCalls.length, 1);
+  t.is(toolCalls[0]?.name, "weather");
+});
+
+test("parseToolCalls: tool_call only inside redacted_thinking still runs once", (t) => {
+  const assistant = `<redacted_thinking>
+<tool_call>
+{"name": "weather", "arguments": {"args": ["London"]}}
+</tool_call>
+</redacted_thinking>`;
+
+  const { toolCalls } = parseToolCalls(assistant, tools);
+  t.is(toolCalls.length, 1);
+  t.alike(toolCalls[0]?.arguments.args, ["London"]);
+});
+
+test("parseToolCalls: single tool_call without thinking unchanged", (t) => {
+  const assistant = `<tool_call>
+{"name": "weather", "arguments": {"args": ["Paris"]}}
+</tool_call>`;
+
+  const { toolCalls } = parseToolCalls(assistant, tools);
+  t.is(toolCalls.length, 1);
+  t.alike(toolCalls[0]?.arguments.args, ["Paris"]);
+});
+
+test("parseToolCalls: two different weather args are not deduped", (t) => {
+  const assistant = `<tool_call>
+{"name": "weather", "arguments": {"args": ["London"]}}
+</tool_call>
+<tool_call>
+{"name": "weather", "arguments": {"args": ["Paris"]}}
+</tool_call>`;
+
+  const { toolCalls } = parseToolCalls(assistant, tools);
+  t.is(toolCalls.length, 2);
+});


### PR DESCRIPTION
**Note**: Prefer this over stripping `<redacted_thinking>` (see open PR #1316): stripping removes the only tool call when the model wraps it entirely inside thinking, which breaks dev mode and other paths.

## What problem does this PR solve?

- Models sometimes emit the same tool JSON twice in one assistant message (e.g. once inside `<redacted_thinking>` and once in a visible `<tool_call>`), causing duplicate execution.
- Stripping all thinking content fixes duplicates but breaks the common case where the **only** `<tool_call>` lives inside thinking.

## How does it solve it?

- After parsing, collapse tool calls that share the same `name` and semantically equal `arguments` (stable recursive JSON key ordering for the arguments object).
- First occurrence wins (id/raw preserved from the first parse).

## How was it tested?

- `bun run test:unit` in `packages/sdk` (`tool-parser.test.ts`): duplicate inside+outside → 1 call; thinking-only → 1 call; two different arg sets → 2 calls.

## Follow-up

- Close #1316 unmerged if this merges, or merge main and drop the strip-only change from that branch.

Made with [Cursor](https://cursor.com)