### PR TITLE
infra: separate publish jobs from prebuilds workflows (Pattern A)

### DIFF
--- a/.github/workflows/on-merge-lib-infer-diffusion.yml
+++ b/.github/workflows/on-merge-lib-infer-diffusion.yml
@@ -105,9 +105,14 @@ jobs:
           package-json-path: packages/lib-infer-diffusion/package.json
           changelog-path: packages/lib-infer-diffusion/CHANGELOG.md
 
-  publish-main-gpr:
+  # Build prebuilds (build + merge only, no publishing)
+  build:
     needs: publish-logic
-    if: needs.publish-logic.outputs.publish_main == 'true'
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_release == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
     permissions:
       contents: write
       packages: write
@@ -115,67 +120,119 @@ jobs:
     uses: ./.github/workflows/prebuilds-lib-infer-diffusion.yml
     secrets: inherit
     with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
       workdir: "packages/lib-infer-diffusion"
 
-  publish-feature-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_feature == 'true'
+  # Publish to GitHub Package Registry (GPR) for non-release branches
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-lib-infer-diffusion.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      workdir: "packages/lib-infer-diffusion"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
 
-  publish-tmp-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-lib-infer-diffusion.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      workdir: "packages/lib-infer-diffusion"
+      - name: Setup node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
 
-  publish-release-npm:
-    needs: [publish-logic, release-merge-guard]
-    if: |
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/lib-infer-diffusion/prebuilds
+
+      - name: Scope package as @tetherto for GPR
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const fs=require('fs');const f='packages/lib-infer-diffusion/package.json';const p=JSON.parse(fs.readFileSync(f,'utf8'));const want='@tetherto/diffusion-cpp';if(p.name!==want){p.name=want;fs.writeFileSync(f,JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);} "
+          node -e "console.log('Effective package name (publish-gpr):', JSON.parse(require('fs').readFileSync('packages/lib-infer-diffusion/package.json','utf8')).name)"
+
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          workdir: packages/lib-infer-diffusion
+          name-suffix: "-mono"
+
+  # Publish to NPM for release branches
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
       !cancelled() &&
+      needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-lib-infer-diffusion.yml
-    secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"
-      workdir: "packages/lib-infer-diffusion"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
 
+      - name: Setup node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/lib-infer-diffusion/prebuilds
+
+      - name: Scope package as @qvac for npm
+        working-directory: packages/lib-infer-diffusion
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));const want='@qvac/diffusion-cpp';if(p.name!==want){p.name=want;fs.writeFileSync('package.json',JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);}"
+          node -e "console.log('Effective package name (publish-npm):', JSON.parse(require('fs').readFileSync('package.json','utf8')).name)"
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: packages/lib-infer-diffusion
+          repo_name: "diffusion-cpp"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Create GitHub release only for actual releases (after NPM publish)
   publish-release:
-    needs: [publish-release-npm]
-    if: |
+    needs: [publish-npm]
+    if: >-
       !cancelled() &&
-      needs.publish-release-npm.result == 'success' &&
-      needs.publish-release-npm.outputs.published_version != ''
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
     with:
-      repo_name: "diffusion"
+      repo_name: "diffusion-cpp"
       release_name: "QVAC Stable Diffusion Addon"
-      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
       workdir: "packages/lib-infer-diffusion"

--- a/.github/workflows/on-merge-lib-infer-diffusion.yml
+++ b/.github/workflows/on-merge-lib-infer-diffusion.yml
@@ -166,7 +166,7 @@ jobs:
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
           workdir: packages/lib-infer-diffusion
           name-suffix: "-mono"
 

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
@@ -98,9 +98,14 @@ jobs:
           package-json-path: packages/qvac-lib-infer-llamacpp-embed/package.json
           changelog-path: packages/qvac-lib-infer-llamacpp-embed/CHANGELOG.md
 
-  publish-main-gpr:
+  # Build prebuilds (build + merge only, no publishing)
+  build:
     needs: publish-logic
-    if: needs.publish-logic.outputs.publish_main == 'true'
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_release == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
     permissions:
       contents: write
       packages: write
@@ -108,68 +113,95 @@ jobs:
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
     secrets: inherit
     with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
       workdir: "packages/qvac-lib-infer-llamacpp-embed"
 
-  publish-feature-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_feature == 'true'
+  # Publish to GitHub Package Registry (GPR) for non-release branches
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      workdir: "packages/qvac-lib-infer-llamacpp-embed"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
 
-  publish-tmp-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      workdir: "packages/qvac-lib-infer-llamacpp-embed"
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-llamacpp-embed/prebuilds
 
-  publish-release-npm:
-    needs: [publish-logic, release-merge-guard]
-    if: |
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          name-suffix: "-mono"
+          workdir: packages/qvac-lib-infer-llamacpp-embed
+
+  # Publish to NPM for release branches
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
       !cancelled() &&
+      needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
-    secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"
-      workdir: "packages/qvac-lib-infer-llamacpp-embed"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-llamacpp-embed/prebuilds
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: packages/qvac-lib-infer-llamacpp-embed
+          repo_name: "llamacpp-embed"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+          create-tag: "false"
 
   # Create GitHub release only for actual releases (after NPM publish)
   publish-release:
-    needs: [publish-release-npm]
-    if: |
+    needs: [publish-npm]
+    if: >-
       !cancelled() &&
-      needs.publish-release-npm.result == 'success' &&
-      needs.publish-release-npm.outputs.published_version != ''
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
     with:
       repo_name: "llamacpp-embed"
       release_name: "QVAC Embed Addon"
-      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
       workdir: "packages/qvac-lib-infer-llamacpp-embed"

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
@@ -147,7 +147,7 @@ jobs:
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
           name-suffix: "-mono"
           workdir: packages/qvac-lib-infer-llamacpp-embed
 

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
@@ -167,7 +167,7 @@ jobs:
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
           workdir: packages/qvac-lib-infer-llamacpp-llm
           name-suffix: "-mono"
 

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
@@ -106,9 +106,14 @@ jobs:
           package-json-path: packages/qvac-lib-infer-llamacpp-llm/package.json
           changelog-path: packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
 
-  publish-main-gpr:
+  # Build prebuilds (build + merge only, no publishing)
+  build:
     needs: publish-logic
-    if: needs.publish-logic.outputs.publish_main == 'true'
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_release == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
     permissions:
       contents: write
       packages: write
@@ -116,68 +121,120 @@ jobs:
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
     secrets: inherit
     with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
       workdir: "packages/qvac-lib-infer-llamacpp-llm"
 
-  publish-feature-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_feature == 'true'
+  # Publish to GitHub Package Registry (GPR) for non-release branches
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      workdir: "packages/qvac-lib-infer-llamacpp-llm"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
 
-  publish-tmp-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      workdir: "packages/qvac-lib-infer-llamacpp-llm"
+      - name: Setup node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
 
-  publish-release-npm:
-    needs: [publish-logic, release-merge-guard]
-    if: |
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-llamacpp-llm/prebuilds
+
+      - name: Scope package as @tetherto for GPR
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const fs=require('fs');const f='packages/qvac-lib-infer-llamacpp-llm/package.json';const p=JSON.parse(fs.readFileSync(f,'utf8'));const want='@tetherto/llm-llamacpp';if(p.name!==want){p.name=want;fs.writeFileSync(f,JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);} "
+          node -e "console.log('Effective package name (publish-gpr):', JSON.parse(require('fs').readFileSync('packages/qvac-lib-infer-llamacpp-llm/package.json','utf8')).name)"
+
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          workdir: packages/qvac-lib-infer-llamacpp-llm
+          name-suffix: "-mono"
+
+  # Publish to NPM for release branches
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
       !cancelled() &&
+      needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
-    secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"
-      workdir: "packages/qvac-lib-infer-llamacpp-llm"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Setup node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-llamacpp-llm/prebuilds
+
+      - name: Scope package as @qvac for npm
+        working-directory: packages/qvac-lib-infer-llamacpp-llm
+        shell: bash
+        run: |
+          set -euo pipefail
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));const want='@qvac/llm-llamacpp';if(p.name!==want){p.name=want;fs.writeFileSync('package.json',JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);}"
+          node -e "console.log('Effective package name (publish-npm):', JSON.parse(require('fs').readFileSync('package.json','utf8')).name)"
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: packages/qvac-lib-infer-llamacpp-llm
+          repo_name: "llamacpp-llm"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+          create-tag: "false"
 
   # Create GitHub release only for actual releases (after NPM publish)
   publish-release:
-    needs: [publish-release-npm]
-    if: |
+    needs: [publish-npm]
+    if: >-
       !cancelled() &&
-      needs.publish-release-npm.result == 'success' &&
-      needs.publish-release-npm.outputs.published_version != ''
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
     with:
       repo_name: "llamacpp-llm"
       release_name: "QVAC LLM Addon"
-      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
       workdir: "packages/qvac-lib-infer-llamacpp-llm"

--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -98,9 +98,14 @@ jobs:
           package-json-path: packages/qvac-lib-infer-parakeet/package.json
           changelog-path: packages/qvac-lib-infer-parakeet/CHANGELOG.md
 
-  publish-main-gpr:
+  # Build prebuilds (build + merge only, no publishing)
+  build:
     needs: publish-logic
-    if: needs.publish-logic.outputs.publish_main == 'true'
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_release == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
     permissions:
       contents: write
       packages: write
@@ -108,82 +113,139 @@ jobs:
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
     secrets: inherit
     with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
+      workdir: "packages/qvac-lib-infer-parakeet"
 
-  publish-feature-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_feature == 'true'
+  # Publish to GitHub Package Registry (GPR) for non-release branches
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      published_version: ${{ steps.capture_version.outputs.published_version }}
     permissions:
-      contents: write
+      contents: read
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-      workdir: "${{ github.workspace }}/packages/qvac-lib-infer-parakeet"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
-  publish-tmp-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-      workdir: "${{ github.workspace }}/packages/qvac-lib-infer-parakeet"
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-parakeet/prebuilds
 
-  publish-release-npm:
-    needs: [publish-logic, release-merge-guard]
-    if: |
+      - name: Rename prebuild files from qvac_ to tetherto_ prefix
+        working-directory: packages/qvac-lib-infer-parakeet
+        run: |
+          find prebuilds -depth -name 'qvac_*' | while read -r file; do
+            dir=$(dirname "$file")
+            base=$(basename "$file")
+            newbase=$(echo "$base" | sed 's/^qvac_/tetherto_/')
+            mv "$file" "$dir/$newbase"
+          done
+
+          if [ -f binding.js ]; then
+            sed -i 's/qvac_/tetherto_/g' binding.js
+          fi
+
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          workdir: packages/qvac-lib-infer-parakeet
+          name-suffix: "-mono"
+
+      - name: Capture published version
+        id: capture_version
+        if: success()
+        working-directory: packages/qvac-lib-infer-parakeet
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_NAME_GPR=$(echo "$PACKAGE_NAME" | sed 's/@qvac/@tetherto/')
+          if npm view "${PACKAGE_NAME_GPR}@${VERSION}" version --registry=https://npm.pkg.github.com/ >/dev/null 2>&1; then
+            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Publish to NPM for release branches
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
       !cancelled() &&
+      needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      published_version: ${{ steps.capture_version.outputs.published_version }}
     permissions:
-      contents: write
+      contents: read
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
-    secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-      workdir: "${{ github.workspace }}/packages/qvac-lib-infer-parakeet"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-parakeet/prebuilds
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: packages/qvac-lib-infer-parakeet
+          repo_name: "parakeet"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Capture published version
+        id: capture_version
+        if: success()
+        working-directory: packages/qvac-lib-infer-parakeet
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Create GitHub release only for actual releases (after NPM publish)
   publish-release:
-    needs: [publish-release-npm]
-    if: |
+    needs: [publish-npm]
+    if: >-
       !cancelled() &&
-      needs.publish-release-npm.result == 'success' &&
-      needs.publish-release-npm.outputs.published_version != ''
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
     with:
       repo_name: "parakeet"
       release_name: "QVAC Transcription Parakeet Addon"
-      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
-      workdir: "${{ github.workspace }}/packages/qvac-lib-infer-parakeet"
+      workdir: "packages/qvac-lib-infer-parakeet"
 
-  prebuild:
-    name: Prebuild Gate
+  post-build-gate:
+    name: Post-Build Gate
     runs-on: ubuntu-latest
-    needs: [publish-release-npm, publish-main-gpr, publish-tmp-gpr, publish-feature-gpr]
+    needs: [publish-gpr, publish-npm]
     if: "!cancelled()"
     outputs:
       should_run_tests: ${{ steps.gate.outputs.should_run_tests }}
@@ -194,10 +256,8 @@ jobs:
           set -euo pipefail
           should="false"
 
-          if [ "${{ needs.publish-release-npm.result }}" = "success" ] || \
-             [ "${{ needs.publish-main-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-tmp-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-feature-gpr.result }}" = "success" ]; then
+          if [ "${{ needs.publish-npm.result }}" = "success" ] || \
+             [ "${{ needs.publish-gpr.result }}" = "success" ]; then
             should="true"
           fi
 
@@ -205,18 +265,18 @@ jobs:
 
   integration-tests:
     uses: ./.github/workflows/integration-test-qvac-lib-infer-parakeet.yml
-    needs: prebuild
-    if: needs.prebuild.outputs.should_run_tests == 'true'
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
     secrets: inherit
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.sha }}
-      workdir: "${{ github.workspace }}/packages/qvac-lib-infer-parakeet"
+      workdir: "packages/qvac-lib-infer-parakeet"
 
   mobile-integration-tests:
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
-    needs: prebuild
-    if: needs.prebuild.outputs.should_run_tests == 'true'
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -160,7 +160,7 @@ jobs:
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
           workdir: packages/qvac-lib-infer-parakeet
           name-suffix: "-mono"
 

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -96,9 +96,13 @@ jobs:
           package-json-path: packages/qvac-lib-infer-whispercpp/package.json
           changelog-path: packages/qvac-lib-infer-whispercpp/CHANGELOG.md
 
-  publish-main-gpr:
+  build:
     needs: publish-logic
-    if: needs.publish-logic.outputs.publish_main == 'true'
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_release == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
     permissions:
       contents: write
       packages: write
@@ -106,83 +110,155 @@ jobs:
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
     secrets: inherit
     with:
-      tag: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.tag) || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       workdir: "packages/qvac-lib-infer-whispercpp"
 
-  publish-feature-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_feature == 'true'
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    continue-on-error: true
+    outputs:
+      published_version: ${{ steps.capture_version.outputs.published_version }}
+    runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
-    secrets: inherit
-    with:
-      tag: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.tag) || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-      workdir: "packages/qvac-lib-infer-whispercpp"
+    env:
+      WORKDIR: packages/qvac-lib-infer-whispercpp
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
 
-  publish-tmp-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
-    secrets: inherit
-    with:
-      tag: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.tag) || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-      workdir: "packages/qvac-lib-infer-whispercpp"
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.WORKDIR }}/prebuilds
 
-  publish-release-npm:
-    needs: [publish-logic, release-merge-guard]
-    if: |
+      - name: Rename prebuild files from qvac_ to tetherto_ prefix
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "${WORKDIR}"
+
+          find prebuilds -depth -name 'qvac_*' | while read -r file; do
+            dir=$(dirname "$file")
+            base=$(basename "$file")
+            newbase=$(echo "$base" | sed 's/^qvac_/tetherto_/')
+            mv "$file" "$dir/$newbase"
+          done
+
+          if [ -f binding.js ]; then
+            sed -i 's/qvac_/tetherto_/g' binding.js
+          fi
+
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.tag) || needs.publish-logic.outputs.gpr_tag }}
+          workdir: ${{ env.WORKDIR }}
+          name-suffix: "-mono"
+
+      - name: Capture published version
+        id: capture_version
+        if: success()
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "${WORKDIR}"
+          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_NAME_GPR=$(echo "$PACKAGE_NAME" | sed 's/@qvac/@tetherto/')
+
+          if npm view "${PACKAGE_NAME_GPR}@${VERSION}" version --registry=https://npm.pkg.github.com/ >/dev/null 2>&1; then
+            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
       !cancelled() &&
+      needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    outputs:
+      published_version: ${{ steps.capture_version.outputs.published_version }}
+    runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
-    secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-      workdir: "packages/qvac-lib-infer-whispercpp"
+    env:
+      WORKDIR: packages/qvac-lib-infer-whispercpp
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.WORKDIR }}/prebuilds
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: ${{ env.WORKDIR }}
+          repo_name: "whispercpp"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Capture published version
+        id: capture_version
+        working-directory: ${{ env.WORKDIR }}
+        if: success()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+
+          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
   publish-release:
-    needs: [publish-release-npm]
+    needs: [publish-npm]
     if: |
       !cancelled() &&
-      needs.publish-release-npm.result == 'success' &&
-      needs.publish-release-npm.outputs.published_version != ''
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
     with:
       repo_name: "whispercpp"
       release_name: "QVAC Transcription Whisper Addon"
-      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
       workdir: "packages/qvac-lib-infer-whispercpp"
 
-  prebuild:
-    name: Prebuild Gate
+  post-build-gate:
+    name: Post-Build Gate
     runs-on: ubuntu-latest
-    needs: [publish-release-npm, publish-main-gpr, publish-tmp-gpr, publish-feature-gpr]
+    needs: [publish-gpr, publish-npm]
     if: "!cancelled()"
     outputs:
       should_run_tests: ${{ steps.gate.outputs.should_run_tests }}
@@ -193,10 +269,8 @@ jobs:
           set -euo pipefail
           should="false"
 
-          if [ "${{ needs.publish-release-npm.result }}" = "success" ] || \
-             [ "${{ needs.publish-main-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-tmp-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-feature-gpr.result }}" = "success" ]; then
+          if [ "${{ needs.publish-gpr.result }}" = "success" ] || \
+             [ "${{ needs.publish-npm.result }}" = "success" ]; then
             should="true"
           fi
 
@@ -204,8 +278,8 @@ jobs:
 
   integration-tests:
     uses: ./.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
-    needs: prebuild
-    if: needs.prebuild.outputs.should_run_tests == 'true'
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
     secrets: inherit
     with:
       repository: ${{ github.repository }}
@@ -214,8 +288,8 @@ jobs:
 
   mobile-integration-tests:
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
-    needs: prebuild
-    if: needs.prebuild.outputs.should_run_tests == 'true'
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
     permissions:
       contents: read
       packages: read
@@ -229,8 +303,8 @@ jobs:
     name: Trigger Benchmark (Whispercpp)
     runs-on: ubuntu-latest
     environment: release
-    needs: prebuild
-    if: "!cancelled() && needs.prebuild.outputs.should_run_tests == 'true'"
+    needs: post-build-gate
+    if: "!cancelled() && needs.post-build-gate.outputs.should_run_tests == 'true'"
     steps:
       - name: Trigger benchmark workflow
         env:

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -122,8 +122,6 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
       ref: ${{ github.event.pull_request.head.ref }}
-      publish_target: "gpr"
-      tag: pr-${{ github.event.pull_request.number }}
 
   run-integration-tests:
     if: needs.authorize.outputs.allowed == 'true'

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -120,8 +120,6 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
       ref: ${{ github.event.pull_request.head.ref }}
-      tag: "dev"
-      publish_target: 'gpr'
 
   integration-tests:
     needs: [authorize, prebuild]

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -122,8 +122,6 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
       ref: ${{ github.event.pull_request.head.ref }}
-      publish_target: "gpr"
-      tag: pr-${{ github.event.pull_request.number }}
 
   run-integration-tests:
     if: needs.authorize.outputs.allowed == 'true'

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -167,8 +167,6 @@ jobs:
     with:
       repository: ${{ needs.context.outputs.repository }}
       ref: ${{ needs.context.outputs.ref }}
-      tag: "dev"
-      publish_target: 'gpr'
 
   run-integration-tests:
     needs: [context, prebuild]

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -182,8 +182,6 @@ jobs:
     with:
       repository: ${{ needs.context.outputs.repository }}
       ref: ${{ needs.context.outputs.ref }}
-      tag: "dev"
-      publish_target: 'gpr'
 
   run-integration-tests:
     needs: [authorize, context, prebuild]

--- a/.github/workflows/prebuilds-lib-infer-diffusion.yml
+++ b/.github/workflows/prebuilds-lib-infer-diffusion.yml
@@ -1,16 +1,9 @@
+# Build-only workflow. Publishing is handled by on-merge-lib-infer-diffusion.yml
 name: Prebuilds (Stable Diffusion)
 
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: true
-        default: "latest"
-        type: choice
-        options:
-          - latest
-          - dev
       workdir:
         description: "Working directory (optional)"
         required: false
@@ -27,25 +20,11 @@ on:
         type: string
         required: false
         default: "tetherto/qvac"
-      tag:
-        description: "Tag to publish"
-        type: string
-        required: false
-        default: "dev"
-      publish_target:
-        description: "Where to publish: 'npm', 'gpr' or 'both'"
-        type: string
-        required: false
-        default: ""
       workdir:
         description: "Working directory (optional)"
         required: false
         type: string
         default: "packages/lib-infer-diffusion"
-    outputs:
-      published_version:
-        description: "The version that was published"
-        value: ${{ jobs.publish-npm.outputs.published_version || jobs.publish-gpr.outputs.published_version }}
 
 env:
   WORKDIR: ${{ inputs.workdir }}
@@ -124,7 +103,6 @@ jobs:
       - name: Echo workflow inputs
         shell: bash
         env:
-          INPUT_TAG: ${{ inputs.tag || github.event.inputs.tag }}
           INPUT_REF: ${{ inputs.ref || github.ref }}
           INPUT_REPO: ${{ inputs.repository || github.repository }}
           INPUT_WORKDIR: ${{ env.WORKDIR }}
@@ -133,7 +111,6 @@ jobs:
           MATRIX_TAGS: ${{ matrix.tags }}
         run: |
           echo "Workflow inputs:"
-          echo "Tag: $INPUT_TAG"
           echo "Ref: $INPUT_REF"
           echo "Repository: $INPUT_REPO"
           echo "Workdir: $INPUT_WORKDIR"
@@ -452,120 +429,3 @@ jobs:
           name: prebuilds
           path: prebuilds
 
-  publish-gpr:
-    needs: [prebuild, merge]
-    if: ${{ inputs.publish_target == 'gpr'
-          || inputs.publish_target == 'both'
-          || (
-              (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-              && (inputs.publish_target == '' || inputs.publish_target == null)
-              && (
-                github.ref_name == 'main'
-                || startsWith(github.ref_name, 'feature-')
-                || startsWith(github.ref_name, 'tmp-')
-                || (inputs.ref != '' && (
-                      inputs.ref == 'refs/heads/main'
-                      || startsWith(inputs.ref, 'refs/heads/feature-')
-                      || startsWith(inputs.ref, 'refs/heads/tmp-')
-                   ))
-              )
-            ) }}
-    continue-on-error: true
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
-
-      - name: Setup node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
-        with:
-          node-version: lts/*
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Scope package as @tetherto for GPR
-        shell: bash
-        run: |
-          set -euo pipefail
-          node -e "const fs=require('fs');const f='${{ env.WORKDIR }}/package.json';const p=JSON.parse(fs.readFileSync(f,'utf8'));const want='@tetherto/diffusion-cpp';if(p.name!==want){p.name=want;fs.writeFileSync(f,JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);} "
-          node -e "console.log('Effective package name (publish-gpr):', JSON.parse(require('fs').readFileSync('${{ env.WORKDIR }}/package.json','utf8')).name)"
-
-      - name: Publish to GitHub Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
-        with:
-          secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
-          workdir:  ${{ env.WORKDIR }}
-          name-suffix: "-mono"
-
-  publish-npm:
-    needs: [prebuild, merge]
-    if: ${{ inputs.publish_target == 'npm'
-          || inputs.publish_target == 'both'
-          || (
-              (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-              && (inputs.publish_target == '' || inputs.publish_target == null)
-              && (
-                startsWith(github.ref_name, 'release-')
-                || (inputs.ref != '' && startsWith(inputs.ref, 'refs/heads/release-'))
-              )
-            ) }}
-    continue-on-error: false
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
-
-      - name: Setup node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
-        with:
-          node-version: lts/*
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Scope package as @qvac for npm
-        working-directory: ${{ env.WORKDIR }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));const want='@qvac/diffusion-cpp';if(p.name!==want){p.name=want;fs.writeFileSync('package.json',JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);}"
-          node -e "console.log('Effective package name (publish-npm):', JSON.parse(require('fs').readFileSync('package.json','utf8')).name)"
-
-      - name: Publish to NPM Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
-        with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: 'latest'
-          workdir: ${{ env.WORKDIR }}
-          repo_name: "diffusion-cpp"
-          git-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -1,16 +1,9 @@
+# Build-only workflow. Publishing is handled by on-merge-qvac-lib-infer-llamacpp-embed.yml
 name: Prebuilds (Embed)
 
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: true
-        default: "latest"
-        type: choice
-        options:
-          - latest
-          - dev
       vk-profiling:
         type: boolean
         default: false
@@ -19,34 +12,28 @@ on:
         required: false
         type: string
         default: "packages/qvac-lib-infer-llamacpp-embed"
+
   workflow_call:
     inputs:
       ref:
         description: "ref"
         type: string
+        required: false
       repository:
         type: string
         required: false
         default: "tetherto/qvac"
-      tag:
-        description: "Tag to publish"
-        type: string
+      vk-profiling:
+        description: "Enable Vulkan profiling"
+        type: boolean
         required: false
-        default: "dev"
-      publish_target:
-        description: "Target registry for publishing (npm, gpr, or both)"
-        type: string
-        required: false
-        default: ""
+        default: false
       workdir:
         description: "Working directory (optional)"
         required: false
         type: string
         default: "packages/qvac-lib-infer-llamacpp-embed"
-    outputs:
-      published_version:
-        description: "Version published to registry"
-        value: ${{ jobs.publish-npm.outputs.published_version || jobs.publish-gpr.outputs.published_version }}
+
 env:
   WORKDIR: ${{ inputs.workdir }}
 
@@ -125,7 +112,6 @@ jobs:
       - name: Echo workflow inputs
         shell: bash
         env:
-          INPUT_TAG: ${{ inputs.tag || github.event.inputs.tag }}
           INPUT_REF: ${{ inputs.ref || github.ref }}
           INPUT_REPO: ${{ inputs.repository || github.repository }}
           INPUT_WORKDIR: ${{ inputs.workdir }}
@@ -134,7 +120,6 @@ jobs:
           MATRIX_TAGS: ${{ matrix.tags }}
         run: |
           echo "Workflow inputs:"
-          echo "Tag: $INPUT_TAG"
           echo "Ref: $INPUT_REF"
           echo "Repository: $INPUT_REPO"
           echo "Workdir: $INPUT_WORKDIR"
@@ -443,97 +428,3 @@ jobs:
           name: prebuilds
           path: prebuilds
 
-  publish-gpr:
-    needs: [prebuild, merge]
-    if: ${{ inputs.publish_target == 'gpr'
-      || inputs.publish_target == 'both'
-      || (
-          (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-          && (inputs.publish_target == '' || inputs.publish_target == null)
-          && (
-            github.ref_name == 'main'
-            || startsWith(github.ref_name, 'feature-')
-            || startsWith(github.ref_name, 'tmp-')
-            || (inputs.ref != '' && (
-                  inputs.ref == 'refs/heads/main'
-                  || startsWith(inputs.ref, 'refs/heads/feature-')
-                  || startsWith(inputs.ref, 'refs/heads/tmp-')
-                ))
-          )
-        ) }}
-    continue-on-error: true
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Publish to GitHub Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
-        with:
-          secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
-          name-suffix: "-mono"
-          workdir:  ${{ env.WORKDIR }}
-
-  publish-npm:
-    needs: [prebuild, merge]
-    if: ${{ inputs.publish_target == 'npm'
-        || inputs.publish_target == 'both'
-        || (
-            (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-            && (inputs.publish_target == '' || inputs.publish_target == null)
-            && (
-              startsWith(github.ref_name, 'release-')
-              || (inputs.ref != '' && startsWith(inputs.ref, 'refs/heads/release-'))
-            )
-          ) }}
-    continue-on-error: false
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Publish to NPM Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
-        with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: "latest"
-          workdir: ${{ env.WORKDIR }}
-          repo_name: "llamacpp-embed"
-          git-token: ${{ secrets.GITHUB_TOKEN }}
-          create-tag: "false"
-          

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -1,16 +1,9 @@
+# Build-only workflow. Publishing is handled by on-merge-qvac-lib-infer-llamacpp-llm.yml
 name: Prebuilds (LLM)
 
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: true
-        default: "latest"
-        type: choice
-        options:
-          - latest
-          - dev
       vk-profiling:
         type: boolean
         default: false
@@ -30,16 +23,6 @@ on:
         type: string
         required: false
         default: "tetherto/qvac"
-      tag:
-        description: "Tag to publish"
-        type: string
-        required: false
-        default: "dev"
-      publish_target:
-        description: "Where to publish: 'npm', 'gpr' or 'both'"
-        type: string
-        required: false
-        default: ""
       vk-profiling:
         description: "Enable Vulkan profiling"
         type: boolean
@@ -50,10 +33,6 @@ on:
         required: false
         type: string
         default: "packages/qvac-lib-infer-llamacpp-llm"
-    outputs:
-      published_version:
-        description: "The version that was published"
-        value: ${{ jobs.publish-npm.outputs.published_version || jobs.publish-gpr.outputs.published_version }}
 
 env:
   WORKDIR: ${{ inputs.workdir }}
@@ -133,7 +112,6 @@ jobs:
       - name: Echo workflow inputs
         shell: bash
         env:
-          INPUT_TAG: ${{ inputs.tag || github.event.inputs.tag }}
           INPUT_REF: ${{ inputs.ref || github.ref }}
           INPUT_REPO: ${{ inputs.repository || github.repository }}
           INPUT_WORKDIR: ${{ env.WORKDIR }}
@@ -142,7 +120,6 @@ jobs:
           MATRIX_TAGS: ${{ matrix.tags }}
         run: |
           echo "Workflow inputs:"
-          echo "Tag: $INPUT_TAG"
           echo "Ref: $INPUT_REF"
           echo "Repository: $INPUT_REPO"
           echo "Workdir: $INPUT_WORKDIR"
@@ -465,122 +442,3 @@ jobs:
           name: prebuilds
           path: prebuilds
 
-  publish-gpr:
-    needs: [prebuild, merge]
-    if: ${{ inputs.publish_target == 'gpr'
-          || inputs.publish_target == 'both'
-          || (
-              (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-              && (inputs.publish_target == '' || inputs.publish_target == null)
-              && (
-                github.ref_name == 'main'
-                || startsWith(github.ref_name, 'feature-')
-                || startsWith(github.ref_name, 'tmp-')
-                || (inputs.ref != '' && (
-                      inputs.ref == 'refs/heads/main'
-                      || startsWith(inputs.ref, 'refs/heads/feature-')
-                      || startsWith(inputs.ref, 'refs/heads/tmp-')
-                   ))
-              )
-            ) }}
-    continue-on-error: true
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
-
-      - name: Setup node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
-        with:
-          node-version: lts/*
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Scope package as @tetherto for GPR
-        shell: bash
-        run: |
-          set -euo pipefail
-          node -e "const fs=require('fs');const f='${{ env.WORKDIR }}/package.json';const p=JSON.parse(fs.readFileSync(f,'utf8'));const want='@tetherto/llm-llamacpp';if(p.name!==want){p.name=want;fs.writeFileSync(f,JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);} "
-          node -e "console.log('Effective package name (publish-gpr):', JSON.parse(require('fs').readFileSync('${{ env.WORKDIR }}/package.json','utf8')).name)"
-
-      - name: Publish to GitHub Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
-        with:
-          secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
-          workdir:  ${{ env.WORKDIR }}
-          name-suffix: "-mono"
-
-  publish-npm:
-    needs: [prebuild, merge]
-    if: ${{ inputs.publish_target == 'npm'
-          || inputs.publish_target == 'both'
-          || (
-              (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-              && (inputs.publish_target == '' || inputs.publish_target == null)
-              && (
-                startsWith(github.ref_name, 'release-')
-                || (inputs.ref != '' && startsWith(inputs.ref, 'refs/heads/release-'))
-              )
-            ) }}
-    continue-on-error: false
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
-
-      - name: Setup node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
-        with:
-          node-version: lts/*
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      # Re-assert scope for public npm (fresh checkout)
-      - name: Scope package as @qvac for npm
-        working-directory: ${{ env.WORKDIR }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));const want='@qvac/llm-llamacpp';if(p.name!==want){p.name=want;fs.writeFileSync('package.json',JSON.stringify(p,null,2));console.log('Set name to',p.name);}else{console.log('Already',p.name);}"
-          node -e "console.log('Effective package name (publish-npm):', JSON.parse(require('fs').readFileSync('package.json','utf8')).name)"
-
-      - name: Publish to NPM Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
-        with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: 'latest'
-          workdir: ${{ env.WORKDIR }}
-          repo_name: "llamacpp-llm"
-          git-token: ${{ secrets.GITHUB_TOKEN }}
-          create-tag: "false"

--- a/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
@@ -1,16 +1,14 @@
+# Build-only workflow. Publishing is handled by on-merge-qvac-lib-infer-parakeet.yml
 name: "Prebuilds (Parakeet)"
 
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: true
-        default: "latest"
-        type: choice
-        options:
-          - latest
-          - dev
+      workdir:
+        description: "Working directory for the package"
+        type: string
+        required: false
+        default: "packages/qvac-lib-infer-parakeet"
   workflow_call:
     inputs:
       ref:
@@ -20,25 +18,11 @@ on:
         type: string
         required: false
         default: "tetherto/qvac"
-      tag:
-        description: "Tag to publish"
-        type: string
-        required: false
-        default: "dev"
-      publish_target:
-        description: "Where to publish (npm or gpr)"
-        type: string
-        required: false
-        default: ""
       workdir:
         description: "Working directory for the package"
         type: string
         required: false
         default: "packages/qvac-lib-infer-parakeet"
-    outputs:
-      published_version:
-        description: "The version that was published"
-        value: ${{ jobs.publish-gpr.outputs.published_version || jobs.publish-npm.outputs.published_version }}
 
 permissions:
   contents: read
@@ -424,130 +408,3 @@ jobs:
           name: prebuilds
           path: prebuilds
 
-  publish-gpr:
-    needs: [ prebuild, merge ]
-    if: ${{ inputs.publish_target == 'gpr'
-          || inputs.publish_target == 'both'
-          || (
-              (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-              && (inputs.publish_target == '' || inputs.publish_target == null)
-              && (
-                github.ref_name == 'main'
-                || startsWith(github.ref_name, 'feature-')
-                || startsWith(github.ref_name, 'tmp-')
-                || (inputs.ref != '' && (
-                      inputs.ref == 'refs/heads/main'
-                      || startsWith(inputs.ref, 'refs/heads/feature-')
-                      || startsWith(inputs.ref, 'refs/heads/tmp-')
-                   ))
-              )
-            ) }}
-    continue-on-error: true
-    outputs:
-      published_version: ${{ steps.capture_version.outputs.published_version }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    env:
-      WORKDIR: ${{ inputs.workdir || 'packages/qvac-lib-infer-parakeet' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Rename prebuild files from qvac_ to tetherto_ prefix
-        working-directory: ${{ env.WORKDIR }}
-        run: |
-          find prebuilds -depth -name 'qvac_*' | while read -r file; do
-            dir=$(dirname "$file")
-            base=$(basename "$file")
-            newbase=$(echo "$base" | sed 's/^qvac_/tetherto_/')
-            mv "$file" "$dir/$newbase"
-          done
-
-          if [ -f binding.js ]; then
-            sed -i 's/qvac_/tetherto_/g' binding.js
-          fi
-
-      - name: Publish to GitHub Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
-        with:
-          secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
-          workdir: ${{ env.WORKDIR }}
-          name-suffix: "-mono"
-
-      - name: Capture published version
-        id: capture_version
-        if: success()
-        working-directory: ${{ env.WORKDIR }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-          VERSION=$(node -p "require('./package.json').version")
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-          PACKAGE_NAME_GPR=$(echo "$PACKAGE_NAME" | sed 's/@qvac/@tetherto/')
-          if npm view "${PACKAGE_NAME_GPR}@${VERSION}" version --registry=https://npm.pkg.github.com/ >/dev/null 2>&1; then
-            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
-          fi
-
-  publish-npm:
-    needs: [ prebuild, merge ]
-    if: ${{ inputs.publish_target == 'npm'
-          || inputs.publish_target == 'both'
-          || (
-              (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-              && (inputs.publish_target == '' || inputs.publish_target == null)
-              && (
-                startsWith(github.ref_name, 'release-')
-                || (inputs.ref != '' && startsWith(inputs.ref, 'refs/heads/release-'))
-              )
-            ) }}
-    continue-on-error: false
-    outputs:
-      published_version: ${{ steps.capture_version.outputs.published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: read
-      packages: write
-    env:
-      WORKDIR: ${{ inputs.workdir || 'packages/qvac-lib-infer-parakeet' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Publish to NPM Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
-        with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: 'latest'
-          workdir: ${{ env.WORKDIR }}
-          repo_name: "parakeet"
-          git-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Capture published version
-        id: capture_version
-        if: success()
-        working-directory: ${{ env.WORKDIR }}
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
-            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
-          fi

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -1,16 +1,9 @@
+# Build-only workflow. Publishing is handled by on-merge-qvac-lib-infer-whispercpp.yml
 name: "Prebuilds (Whispercpp)"
 
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: true
-        default: "latest"
-        type: choice
-        options:
-          - latest
-          - dev
       workdir:
         description: "Working directory"
         required: false
@@ -26,25 +19,11 @@ on:
         type: string
         required: false
         default: "tetherto/qvac"
-      tag:
-        description: "Tag to publish"
-        type: string
-        required: false
-        default: "dev"
-      publish_target:
-        description: "Where to publish (npm or gpr)"
-        type: string
-        required: false
-        default: ""
       workdir:
         description: "Working directory"
         type: string
         required: false
         default: "packages/qvac-lib-infer-whispercpp"
-    outputs:
-      published_version:
-        description: "The version that was published"
-        value: ${{ jobs.publish-gpr.outputs.published_version || jobs.publish-npm.outputs.published_version }}
 
 permissions:
   contents: read
@@ -121,7 +100,6 @@ jobs:
         shell: bash
         env:
           INPUT_WORKDIR: ${{ env.WORKDIR }}
-          INPUT_TAG: ${{ inputs.tag || github.event.inputs.tag }}
           INPUT_REF: ${{ inputs.ref || github.ref }}
           INPUT_REPO: ${{ inputs.repository || github.repository }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
@@ -130,7 +108,6 @@ jobs:
         run: |
           echo "Workflow inputs:"
           echo "Workdir: $INPUT_WORKDIR"
-          echo "Tag: $INPUT_TAG"
           echo "Ref: $INPUT_REF"
           echo "Repository: $INPUT_REPO"
           echo "Matrix platform: $MATRIX_PLATFORM"
@@ -464,145 +441,3 @@ jobs:
           name: prebuilds
           path: prebuilds
 
-  publish-gpr:
-    needs: [ prebuild, merge ]
-    if: ${{ inputs.publish_target == 'gpr'
-      || inputs.publish_target == 'both'
-      || (
-          (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-          && (inputs.publish_target == '' || inputs.publish_target == null)
-          && (
-            github.ref_name == 'main'
-            || startsWith(github.ref_name, 'feature-')
-            || startsWith(github.ref_name, 'tmp-')
-            || (inputs.ref != '' && (
-                  inputs.ref == 'refs/heads/main'
-                  || startsWith(inputs.ref, 'refs/heads/feature-')
-                  || startsWith(inputs.ref, 'refs/heads/tmp-')
-                ))
-          )
-        ) }}
-    continue-on-error: true
-    outputs:
-      published_version: ${{ steps.capture_version.outputs.published_version }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    env:
-      WORKDIR: ${{ inputs.workdir || 'packages/qvac-lib-infer-whispercpp' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Rename prebuild files from qvac_ to tetherto_ prefix
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd "${WORKDIR}"
-
-          find prebuilds -depth -name 'qvac_*' | while read -r file; do
-            dir=$(dirname "$file")
-            base=$(basename "$file")
-            newbase=$(echo "$base" | sed 's/^qvac_/tetherto_/')
-            mv "$file" "$dir/$newbase"
-          done
-
-          if [ -f binding.js ]; then
-            sed -i 's/qvac_/tetherto_/g' binding.js
-          fi
-
-      - name: Publish to GitHub Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
-        with:
-          secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ inputs.tag || github.event.inputs.tag || 'dev' }}
-          workdir: ${{ env.WORKDIR }}
-          name-suffix: "-mono"
-
-      - name: Capture published version
-        id: capture_version
-        if: success()
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd "${WORKDIR}"
-          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-
-          VERSION=$(node -p "require('./package.json').version")
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-          PACKAGE_NAME_GPR=$(echo "$PACKAGE_NAME" | sed 's/@qvac/@tetherto/')
-
-          if npm view "${PACKAGE_NAME_GPR}@${VERSION}" version --registry=https://npm.pkg.github.com/ >/dev/null 2>&1; then
-            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
-          fi
-
-  publish-npm:
-    needs: [ prebuild, merge ]
-    if: ${{ inputs.publish_target == 'npm'
-        || inputs.publish_target == 'both'
-        || (
-            (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name == 'push')
-            && (inputs.publish_target == '' || inputs.publish_target == null)
-            && (
-              startsWith(github.ref_name, 'release-')
-              || (inputs.ref != '' && startsWith(inputs.ref, 'refs/heads/release-'))
-            )
-          ) }} 
-    continue-on-error: false
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    env:
-      WORKDIR: ${{ inputs.workdir || 'packages/qvac-lib-infer-whispercpp' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Publish to NPM Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
-        with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: "latest"
-          workdir: ${{ env.WORKDIR }}
-          repo_name: "whispercpp"
-          git-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Capture published version
-        id: capture_version
-        working-directory: ${{ env.WORKDIR }}
-        if: success()
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          VERSION=$(node -p "require('./package.json').version")
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-
-          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
-            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
-          fi


### PR DESCRIPTION
## Summary

- Extract publish-gpr, publish-npm, and create-github-release jobs from 5 direct-conditional prebuilds workflows into their on-merge callers
- Prebuilds become build-only (prebuild matrix + merge artifacts), enabling future security tiering where builds run ungated and only NPM publishes require management approval
- Remove stale `tag`/`publish_target` inputs from 5 on-pr files that call these prebuilds
- Add `needs.build.result == 'success'` guard to all publish-npm conditions (required because `!cancelled()` + `.result` access disables GitHub Actions default `success()` check)

### Files modified (15)

**Prebuilds (stripped to build-only):**
- `prebuilds-lib-infer-diffusion.yml`
- `prebuilds-qvac-lib-infer-llamacpp-embed.yml`
- `prebuilds-qvac-lib-infer-llamacpp-llm.yml`
- `prebuilds-qvac-lib-infer-parakeet.yml`
- `prebuilds-qvac-lib-infer-whispercpp.yml`

**On-merge (gained local publish jobs):**
- `on-merge-lib-infer-diffusion.yml`
- `on-merge-qvac-lib-infer-llamacpp-embed.yml`
- `on-merge-qvac-lib-infer-llamacpp-llm.yml`
- `on-merge-qvac-lib-infer-parakeet.yml`
- `on-merge-qvac-lib-infer-whispercpp.yml`

**On-PR (removed stale inputs):**
- `on-pr-lib-infer-diffusion.yml`
- `on-pr-qvac-lib-infer-llamacpp-embed.yml`
- `on-pr-qvac-lib-infer-llamacpp-llm.yml`
- `on-pr-qvac-lib-infer-parakeet.yml`
- `on-pr-qvac-lib-infer-whispercpp.yml`

### Architecture change

**Before:** on-merge calls prebuilds 4x (one per branch type, only 1 runs) → prebuilds does build + merge + publish + release
**After:** on-merge calls prebuilds 1x (build-only) → on-merge does publish locally using shared artifacts

### Why this matters for security tiering

| Component | Future Environment | Approvals |
|---|---|---|
| `prebuilds-*.yml` (build+merge) | `ci` (Tier 1) | None |
| `publish-gpr` job | `ci` (Tier 1) | None |
| `publish-npm` job | `release` (Tier 3) | 2 management |
| Integration tests | `testing` (Tier 2) | None or 1 |

This PR does **not** change any `environment:` tags — it only moves jobs. Re-tagging is a clean follow-up once GitHub Environments are created.

### No behavioral change

Same jobs run with same conditions, same secrets, same action versions. The only difference is where they live (on-merge instead of prebuilds).

## Test plan

- [ ] Push to `main` touching any of these 5 packages → build + GPR publish + tests (where applicable)
- [ ] Push to `release-*` → build + NPM publish + create-github-release
- [ ] Push to `feature-*` / `tmp-*` → build + GPR publish
- [ ] Open PR touching any package → build-only (no publish)
- [ ] Manual dispatch on prebuilds → build + merge only
- [ ] Verify `published_version` output flows to create-github-release
