### PR TITLE
infra: separate publish jobs from prebuilds workflows (Pattern B)

### DIFF
--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -101,81 +101,120 @@ jobs:
           package-json-path: packages/ocr-onnx/package.json
           changelog-path: packages/ocr-onnx/CHANGELOG.md
 
-  publish-main-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_main == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-ocr-onnx.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-
-  publish-feature-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_feature == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-ocr-onnx.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-
-  publish-tmp-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-ocr-onnx.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-
-  publish-release-npm:
+  build:
     needs: [publish-logic, release-merge-guard]
-    if: |
+    if: >-
       !cancelled() &&
-      needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
+      (
+        needs.publish-logic.outputs.publish_main == 'true' ||
+        needs.publish-logic.outputs.publish_feature == 'true' ||
+        needs.publish-logic.outputs.publish_tmp == 'true' ||
+        (
+          needs.publish-logic.outputs.publish_release == 'true' &&
+          needs.release-merge-guard.result == 'success'
+        )
+      )
     permissions:
       contents: write
       packages: write
       pull-requests: write
     uses: ./.github/workflows/prebuilds-ocr-onnx.yml
     secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"
+
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    continue-on-error: true
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      PKG_DIR: packages/ocr-onnx
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download prebuild artifacts into package dir
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.PKG_DIR }}/prebuilds
+
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
+          workdir: ${{ env.PKG_DIR }}
+          name-suffix: "-mono"
+
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
+      needs.build.result == 'success' &&
+      needs.publish-logic.outputs.publish_release == 'true' &&
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    continue-on-error: false
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      packages: write
+    env:
+      PKG_DIR: packages/ocr-onnx
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Download prebuild artifacts into package dir
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.PKG_DIR }}/prebuilds
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: ${{ env.PKG_DIR }}
+          repo_name: "onnx-ocr"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-release:
-    needs: [publish-release-npm]
+    needs: [publish-npm]
     if: |
       !cancelled() &&
-      needs.publish-release-npm.result == 'success' &&
-      needs.publish-release-npm.outputs.published_version != ''
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
     with:
       repo_name: "ocr-onnx"
       release_name: "QVAC OCR Addon"
-      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
       workdir: "packages/ocr-onnx"
 
-  prebuild:
-    name: Prebuild Gate
+  post-build-gate:
+    name: Post-Build Gate
     runs-on: ubuntu-latest
-    needs: [publish-release-npm, publish-main-gpr, publish-tmp-gpr, publish-feature-gpr]
+    needs: [publish-gpr, publish-npm]
     if: "!cancelled()"
     outputs:
       should_run_tests: ${{ steps.gate.outputs.should_run_tests }}
@@ -186,10 +225,8 @@ jobs:
           set -euo pipefail
           should="false"
 
-          if [ "${{ needs.publish-release-npm.result }}" = "success" ] || \
-             [ "${{ needs.publish-main-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-tmp-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-feature-gpr.result }}" = "success" ]; then
+          if [ "${{ needs.publish-gpr.result }}" = "success" ] || \
+             [ "${{ needs.publish-npm.result }}" = "success" ]; then
             should="true"
           fi
 
@@ -200,8 +237,8 @@ jobs:
       contents: read
       packages: read
     uses: ./.github/workflows/integration-test-ocr-onnx.yml
-    needs: prebuild
-    if: needs.prebuild.outputs.should_run_tests == 'true'
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
     secrets: inherit
     with:
       repository: ${{ github.repository }}

--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -160,6 +160,7 @@ jobs:
   publish-npm:
     needs: [build, publish-logic, release-merge-guard]
     if: >-
+      !cancelled() &&
       needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -32,7 +32,6 @@ permissions:
 jobs:
   publish-logic:
     runs-on: ubuntu-latest
-    environment: release
     outputs:
       publish_main: ${{ steps.logic.outputs.publish_main }}
       publish_release: ${{ steps.logic.outputs.publish_release }}
@@ -107,70 +106,125 @@ jobs:
           package-json-path: packages/qvac-lib-infer-nmtcpp/package.json
           changelog-path: packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
 
-  prebuild-main-gpr:
+  build:
     needs: publish-logic
     permissions:
       contents: write
       packages: write
       pull-requests: write
-    if: needs.publish-logic.outputs.publish_main == 'true'
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_release == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
     secrets: inherit
-    with:
-      tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
 
-  prebuild-feature-gpr:
-    needs: publish-logic
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-24.04
+    continue-on-error: true
     permissions:
-      contents: write
+      contents: read
       packages: write
-      pull-requests: write
-    if: needs.publish-logic.outputs.publish_feature == 'true'
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
-    secrets: inherit
-    with:
-      tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
+    env:
+      PKG_DIR: packages/qvac-lib-infer-nmtcpp
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
-  prebuild-tmp-gpr:
-    needs: publish-logic
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.PKG_DIR }}/prebuilds
+
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          workdir: ${{ env.PKG_DIR }}
+          name-suffix: "-mono"
+
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      needs.publish-logic.outputs.publish_release == 'true' &&
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-24.04
+    environment: release
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+    env:
+      PKG_DIR: packages/qvac-lib-infer-nmtcpp
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.PKG_DIR }}/prebuilds
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: ${{ env.PKG_DIR }}
+          repo_name: "nmtcpp"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+
+  create-github-release:
+    needs: [publish-npm]
+    if: needs.publish-npm.result == 'success' && needs.publish-npm.outputs.published_version != ''
+    permissions:
+      contents: write
+    uses: ./.github/workflows/create-github-release.yml
+    with:
+      repo_name: "nmtcpp"
+      release_name: "QVAC Infer NMTCPP Lib"
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
+      prev_sha: ${{ github.event.before }}
+      workdir: "packages/qvac-lib-infer-nmtcpp"
+
+  run-automated-benchmarks:
+    needs: [publish-npm]
+    if: needs.publish-npm.outputs.published_version != ''
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
     secrets: inherit
     with:
-      tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
+      version: ${{ needs.publish-npm.outputs.published_version }}
 
   model-conversion-test:
-    needs: [prebuild-main-gpr]
+    needs: [publish-gpr]
+    if: needs.publish-gpr.result == 'success'
     uses: ./.github/workflows/model-conversion-test-qvac-lib-infer-nmtcpp.yml
     secrets: inherit
 
   run-integration-tests:
-    needs: [prebuild-main-gpr]
+    needs: [publish-gpr]
+    if: needs.publish-gpr.result == 'success'
     uses: ./.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
     secrets: inherit
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
-
-  prebuild-release-npm:
-    needs: [publish-logic, release-merge-guard]
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    if: |
-      !cancelled() &&
-      needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
-    secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
@@ -145,7 +145,7 @@ jobs:
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
           workdir: ${{ env.WORKDIR }}
           path: ${{ env.WORKDIR }}
           name-suffix: "-mono"

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
@@ -98,9 +98,13 @@ jobs:
           package-json-path: packages/qvac-lib-infer-onnx-tts/package.json
           changelog-path: packages/qvac-lib-infer-onnx-tts/CHANGELOG.md
 
-  publish-main-gpr:
+  build:
     needs: publish-logic
-    if: needs.publish-logic.outputs.publish_main == 'true'
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_release == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
     permissions:
       contents: write
       packages: write
@@ -108,83 +112,114 @@ jobs:
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
     secrets: inherit
     with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       workdir: packages/qvac-lib-infer-onnx-tts
 
-  publish-feature-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_feature == 'true'
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-      workdir: packages/qvac-lib-infer-onnx-tts
+    env:
+      WORKDIR: packages/qvac-lib-infer-onnx-tts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
-  publish-tmp-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-      workdir: packages/qvac-lib-infer-onnx-tts
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.WORKDIR }}/prebuilds
 
-  publish-release-npm:
-    needs: [publish-logic, release-merge-guard]
-    if: |
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          workdir: ${{ env.WORKDIR }}
+          path: ${{ env.WORKDIR }}
+          name-suffix: "-mono"
+
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
       !cancelled() &&
+      needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    outputs:
+      published_version: ${{ steps.capture_version.outputs.published_version }}
+    runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
-    secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"
-      repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-      workdir: packages/qvac-lib-infer-onnx-tts
+    env:
+      WORKDIR: packages/qvac-lib-infer-onnx-tts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.WORKDIR }}/prebuilds
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          path: ${{ env.WORKDIR }}
+          repo_name: "onnx-tts"
+          git-token: ${{ secrets.PAT_TOKEN }}
+          create-tag: "false"
+
+      - name: Capture published version
+        id: capture_version
+        if: success()
+        working-directory: ${{ env.WORKDIR }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
   publish-release:
-    needs: [publish-release-npm]
-    if: |
+    needs: [publish-npm]
+    if: >-
       !cancelled() &&
-      needs.publish-release-npm.result == 'success' &&
-      needs.publish-release-npm.outputs.published_version != ''
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release.yml
     with:
       repo_name: "onnx-tts"
       release_name: "QVAC TTS ONNX Addon"
-      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
       workdir: packages/qvac-lib-infer-onnx-tts
 
-  prebuild:
-    name: Prebuild Gate
+  post-build-gate:
+    name: Post-Build Gate
     runs-on: ubuntu-latest
-    needs: [publish-release-npm, publish-main-gpr, publish-tmp-gpr, publish-feature-gpr]
+    needs: [publish-gpr, publish-npm]
     if: "!cancelled()"
     outputs:
       should_run_tests: ${{ steps.gate.outputs.should_run_tests }}
@@ -195,10 +230,8 @@ jobs:
           set -euo pipefail
           should="false"
 
-          if [ "${{ needs.publish-release-npm.result }}" = "success" ] || \
-             [ "${{ needs.publish-main-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-tmp-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-feature-gpr.result }}" = "success" ]; then
+          if [ "${{ needs.publish-gpr.result }}" = "success" ] || \
+             [ "${{ needs.publish-npm.result }}" = "success" ]; then
             should="true"
           fi
 
@@ -206,8 +239,8 @@ jobs:
 
   integration-tests:
     uses: ./.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
-    needs: prebuild
-    if: needs.prebuild.outputs.should_run_tests == 'true'
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
     secrets: inherit
     with:
       repository: ${{ github.repository }}
@@ -215,8 +248,8 @@ jobs:
 
   mobile-integration-tests:
     uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
-    needs: prebuild
-    if: needs.prebuild.outputs.should_run_tests == 'true'
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
@@ -147,7 +147,7 @@ jobs:
         uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
           workdir: packages/qvac-lib-infer-onnx
           name-suffix: "-mono"
 

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
@@ -101,79 +101,112 @@ jobs:
           package-json-path: packages/qvac-lib-infer-onnx/package.json
           changelog-path: packages/qvac-lib-infer-onnx/CHANGELOG.md
 
-  publish-main-gpr:
+  build:
     needs: publish-logic
-    if: needs.publish-logic.outputs.publish_main == 'true'
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_release == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
     permissions:
       contents: write
       packages: write
       pull-requests: write
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
     secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
 
-  publish-feature-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_feature == 'true'
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    continue-on-error: true
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
+    env:
+      PKG_DIR: packages/qvac-lib-infer-onnx
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  publish-tmp-gpr:
-    needs: publish-logic
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
-    secrets: inherit
-    with:
-      tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
+      - name: Download prebuild artifacts into package dir
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-onnx/prebuilds
 
-  publish-release-npm:
-    needs: [publish-logic, release-merge-guard]
-    if: |
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          workdir: packages/qvac-lib-infer-onnx
+          name-suffix: "-mono"
+
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
       !cancelled() &&
+      needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
-      pull-requests: write
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
-    secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"
+    env:
+      PKG_DIR: packages/qvac-lib-infer-onnx
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Download prebuild artifacts into package dir
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-onnx/prebuilds
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: packages/qvac-lib-infer-onnx
+          repo_name: "onnx"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-release:
-    needs: [publish-release-npm]
-    if: |
+    needs: [publish-npm]
+    if: >-
       !cancelled() &&
-      needs.publish-release-npm.result == 'success' &&
-      needs.publish-release-npm.outputs.published_version != ''
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
     uses: ./.github/workflows/create-github-release-qvac-lib-infer-onnx.yml
     with:
-      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
       workdir: "packages/qvac-lib-infer-onnx"
 
-  prebuild:
-    name: Prebuild Gate
+  post-build-gate:
+    name: Post-Build Gate
     runs-on: ubuntu-latest
-    needs: [publish-release-npm, publish-main-gpr, publish-tmp-gpr, publish-feature-gpr]
+    needs: [publish-gpr, publish-npm]
     if: "!cancelled()"
     outputs:
       should_run_tests: ${{ steps.gate.outputs.should_run_tests }}
@@ -184,10 +217,8 @@ jobs:
           set -euo pipefail
           should="false"
 
-          if [ "${{ needs.publish-release-npm.result }}" = "success" ] || \
-             [ "${{ needs.publish-main-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-tmp-gpr.result }}" = "success" ] || \
-             [ "${{ needs.publish-feature-gpr.result }}" = "success" ]; then
+          if [ "${{ needs.publish-gpr.result }}" = "success" ] || \
+             [ "${{ needs.publish-npm.result }}" = "success" ]; then
             should="true"
           fi
 

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -185,7 +185,6 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       ref: ${{ github.event.pull_request.head.ref || github.ref }}
-      publish_target: "gpr"
 
   run-integration-tests:
     permissions:

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -150,8 +150,6 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
       ref: ${{ github.event.pull_request.head.ref }}
-      tag: "dev"
-      publish_target: "gpr"
 
   run-integration-tests:
     needs: [authorize, changes, sanity-checks, prebuild]

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
@@ -183,7 +183,6 @@ jobs:
     with:
       repository: ${{ needs.context.outputs.repository }}
       ref: ${{ needs.context.outputs.ref }}
-      publish_target: "gpr"
       workdir: ${{ needs.context.outputs.workdir }}
 
   run-integration-tests:

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -183,7 +183,6 @@ jobs:
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       ref: ${{ github.event.pull_request.head.ref || github.ref }}
-      publish_target: "gpr"
 
   merge-guard:
     needs: [authorize, changes, sanity-checks, prebuild]

--- a/.github/workflows/prebuilds-ocr-onnx.yml
+++ b/.github/workflows/prebuilds-ocr-onnx.yml
@@ -1,16 +1,8 @@
+# Build-only workflow. Publishing is handled by on-merge-ocr-onnx.yml
 name: "Prebuilds (OCR)"
 
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: true
-        default: "latest"
-        type: choice
-        options:
-          - latest
-          - dev
 
   workflow_call:
     inputs:
@@ -27,23 +19,6 @@ on:
         type: string
         required: false
         default: "on-onnx-ocr"
-      tag:
-        description: "Tag to publish"
-        type: string
-        required: false
-        default: "dev"
-      publish_target:
-        description: "Target registry to publish to (npm or gpr)"
-        type: string
-        required: false
-        default: ""
-    outputs:
-      published_version:
-        description: "Version that was published"
-        value: ${{ jobs.publish-gpr.outputs.published_version || jobs.publish-npm.outputs.published_version }}
-      publish_target:
-        description: "Target registry to publish to (npm or gpr)"
-        value: ${{ inputs.publish_target }}
 
 env:
   PKG_DIR: packages/ocr-onnx
@@ -124,7 +99,6 @@ jobs:
       - name: Echo workflow inputs
         shell: bash
         env:
-          INPUT_TAG: ${{ inputs.tag || github.event.inputs.tag }}
           INPUT_REF: ${{ inputs.ref || github.ref }}
           INPUT_REPO: ${{ inputs.repository || github.repository }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
@@ -132,7 +106,6 @@ jobs:
           MATRIX_TAGS: ${{ matrix.tags }}
         run: |
           echo "Workflow inputs:"
-          echo "Tag: $INPUT_TAG"
           echo "Ref: $INPUT_REF"
           echo "Repository: $INPUT_REPO"
           echo "Matrix platform: $MATRIX_PLATFORM"
@@ -451,154 +424,3 @@ jobs:
           name: models
           path: models
 
-  publish-logic:
-    runs-on: ubuntu-24.04
-    outputs:
-      publish_gpr: ${{ steps.logic.outputs.publish_gpr }}
-      publish_npm: ${{ steps.logic.outputs.publish_npm }}
-      gpr_tag: ${{ steps.logic.outputs.gpr_tag }}
-    steps:
-      - id: logic
-        shell: bash
-        env:
-          INPUT_PUBLISH_TARGET: ${{ inputs.publish_target }}
-          EVENT_PUBLISH_TARGET: ${{ github.event.inputs.publish_target }}
-          INPUT_TAG: ${{ inputs.tag }}
-          EVENT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          set -euo pipefail
-          ref_name="${GITHUB_REF_NAME}"
-          event_name="${GITHUB_EVENT_NAME}"
-          publish_target="${INPUT_PUBLISH_TARGET}"
-          event_publish_target="${EVENT_PUBLISH_TARGET}"
-
-          publish_gpr="false"
-          publish_npm="false"
-
-          if [ "$publish_target" = "gpr" ] || [ "$event_publish_target" = "gpr" ]; then
-            publish_gpr="true"
-          fi
-
-          if [ "$publish_target" = "npm" ] || [ "$event_publish_target" = "npm" ]; then
-            publish_npm="true"
-          fi
-
-          if [ "$publish_gpr" = "false" ] && [ "$publish_npm" = "false" ]; then
-            if [ "$event_name" = "push" ] || [ "$event_name" = "workflow_dispatch" ]; then
-              if [ "$ref_name" = "main" ] || [[ "$ref_name" == feature-* ]] || [[ "$ref_name" == tmp-* ]]; then
-                publish_gpr="true"
-              elif [[ "$ref_name" == release-* ]]; then
-                publish_npm="true"
-              fi
-            fi
-          fi
-
-          if [[ "$ref_name" == release-* ]]; then
-            publish_gpr="false"
-          fi
-
-          if [ "$publish_npm" = "true" ] && { [ "$event_name" = "pull_request" ] || [ "$event_name" = "pull_request_target" ]; }; then
-            publish_npm="false"
-          fi
-
-          if [ "$publish_gpr" = "true" ] && [ "$publish_npm" = "true" ]; then
-            echo "ERROR: Both GPR and NPM publishing enabled — invalid GitFlow state"
-            exit 1
-          fi
-
-          gpr_tag="${INPUT_TAG:-${EVENT_TAG:-}}"
-          if [ -z "$gpr_tag" ]; then
-            if [ "$ref_name" = "main" ]; then
-              gpr_tag="dev"
-            elif [[ "$ref_name" == feature-* ]]; then
-              gpr_tag="feature"
-            elif [[ "$ref_name" == tmp-* ]]; then
-              gpr_tag="temp"
-            else
-              gpr_tag="dev"
-            fi
-          fi
-
-          echo "publish_gpr=$publish_gpr" >> "$GITHUB_OUTPUT"
-          echo "publish_npm=$publish_npm" >> "$GITHUB_OUTPUT"
-          echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
-
-  publish-gpr:
-    needs: [prebuild, merge, publish-logic]
-    if: ${{ needs.publish-logic.outputs.publish_gpr == 'true' }}
-    continue-on-error: true
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download prebuild artifacts into package dir
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.PKG_DIR }}/prebuilds
-
-      - name: Publish to GitHub Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
-        with:
-          secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: ${{ env.PKG_DIR }}
-          name-suffix: "-mono"
-
-  publish-npm:
-    needs: [prebuild, merge, publish-logic]
-    if: ${{ needs.publish-logic.outputs.publish_npm == 'true' }}
-    continue-on-error: false
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
-
-      - name: Download prebuild artifacts into package dir
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.PKG_DIR }}/prebuilds
-
-      - name: Publish to NPM Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
-        with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: "latest"
-          workdir: ${{ env.PKG_DIR }}
-          repo_name: "onnx-ocr"
-          git-token: ${{ secrets.GITHUB_TOKEN }}
-
-
-  create-github-release:
-    needs: [publish-npm]
-    if: needs.publish-npm.outputs.published_version != '' && startsWith(github.ref_name, 'release-')
-    permissions:
-      contents: write
-    uses: ./.github/workflows/create-github-release-ocr-onnx.yml
-    with:
-      published_version: ${{ needs.publish-npm.outputs.published_version }}
-      prev_sha: ${{ github.event.before }}
-      workdir: packages/ocr-onnx

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -1,3 +1,4 @@
+# Build-only workflow. Publishing is handled by on-merge-qvac-lib-infer-nmtcpp.yml
 name: Prebuilds (NMTCPP)
 
 on:
@@ -9,31 +10,7 @@ on:
       repository:
         type: string
         default: "tetherto/qvac"
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: false
-        default: "dev"
-        type: string
-      publish_target:
-        description: "Where to publish: 'npm' or 'gpr'"
-        required: false
-        default: ""
-        type: string
-    outputs:
-      published_version:
-        description: "The version that was published"
-        value: ${{ jobs.publish-npm.outputs.published_version || jobs.publish-gpr.outputs.published_version }}
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: true
-        default: "dev"
-        type: choice
-        options:
-          - latest
-          - dev
-          - canary
 
 env:
   PKG_DIR: packages/qvac-lib-infer-nmtcpp
@@ -98,7 +75,6 @@ jobs:
       - name: Echo workflow inputs
         shell: bash
         env:
-          INPUT_TAG: ${{ inputs.tag || github.event.inputs.tag }}
           INPUT_REF: ${{ inputs.ref || github.ref }}
           INPUT_REPO: ${{ inputs.repository || github.repository }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
@@ -107,7 +83,6 @@ jobs:
           PKG_DIR_VAR: ${{ env.PKG_DIR }}
         run: |
           echo "Workflow inputs:"
-          echo "Tag: $INPUT_TAG"
           echo "Ref: $INPUT_REF"
           echo "Repository: $INPUT_REPO"
           echo "Matrix platform: $MATRIX_PLATFORM"
@@ -738,156 +713,3 @@ jobs:
           name: prebuilds
           path: prebuilds
 
-  publish-logic:
-    runs-on: ubuntu-latest
-    outputs:
-      publish_gpr: ${{ steps.logic.outputs.publish_gpr }}
-      publish_npm: ${{ steps.logic.outputs.publish_npm }}
-      gpr_tag: ${{ steps.logic.outputs.gpr_tag }}
-    steps:
-      - id: logic
-        shell: bash
-        env:
-          INPUT_PUBLISH_TARGET: ${{ inputs.publish_target }}
-          EVENT_PUBLISH_TARGET: ${{ github.event.inputs.publish_target }}
-          INPUT_TAG: ${{ inputs.tag }}
-          EVENT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          set -euo pipefail
-          ref_name="${GITHUB_REF_NAME}"
-          event_name="${GITHUB_EVENT_NAME}"
-          publish_target="${INPUT_PUBLISH_TARGET}"
-          event_publish_target="${EVENT_PUBLISH_TARGET}"
-
-          publish_gpr="false"
-          publish_npm="false"
-
-          if [ "$publish_target" = "gpr" ] || [ "$event_publish_target" = "gpr" ]; then
-            publish_gpr="true"
-          fi
-
-          if [ "$publish_target" = "npm" ] || [ "$event_publish_target" = "npm" ]; then
-            publish_npm="true"
-          fi
-
-          if [ "$publish_gpr" = "false" ] && [ "$publish_npm" = "false" ]; then
-            if [ "$event_name" = "push" ] || [ "$event_name" = "workflow_dispatch" ]; then
-              if [ "$ref_name" = "main" ] || [[ "$ref_name" == feature-* ]] || [[ "$ref_name" == tmp-* ]]; then
-                publish_gpr="true"
-              elif [[ "$ref_name" == release-* ]]; then
-                publish_npm="true"
-              fi
-            fi
-          fi
-
-          if [[ "$ref_name" == release-* ]]; then
-            publish_gpr="false"
-          fi
-
-          if [ "$publish_npm" = "true" ] && { [ "$event_name" = "pull_request" ] || [ "$event_name" = "pull_request_target" ]; }; then
-            publish_npm="false"
-          fi
-
-          if [ "$publish_gpr" = "true" ] && [ "$publish_npm" = "true" ]; then
-            echo "ERROR: Both GPR and NPM publishing enabled — invalid GitFlow state"
-            exit 1
-          fi
-
-          gpr_tag="${INPUT_TAG:-${EVENT_TAG:-}}"
-          if [ -z "$gpr_tag" ]; then
-            if [ "$ref_name" = "main" ]; then
-              gpr_tag="dev"
-            elif [[ "$ref_name" == feature-* ]]; then
-              gpr_tag="feature"
-            elif [[ "$ref_name" == tmp-* ]]; then
-              gpr_tag="temp"
-            else
-              gpr_tag="dev"
-            fi
-          fi
-
-          echo "publish_gpr=$publish_gpr" >> "$GITHUB_OUTPUT"
-          echo "publish_npm=$publish_npm" >> "$GITHUB_OUTPUT"
-          echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
-
-  publish-gpr:
-    needs: [prebuild, merge, publish-logic]
-    if: ${{ needs.publish-logic.outputs.publish_gpr == 'true' }}
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.PKG_DIR }}/prebuilds
-
-      - name: Publish to GitHub Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
-        with:
-          secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: ${{ env.PKG_DIR }}
-          name-suffix: "-mono"
-
-  publish-npm:
-    needs: [prebuild, merge, publish-logic]
-    if: ${{ needs.publish-logic.outputs.publish_npm == 'true' }}
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-24.04
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.PKG_DIR }}/prebuilds
-
-      - name: Publish to NPM Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
-        with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: "latest"
-          workdir: ${{ env.PKG_DIR }}
-          repo_name: "nmtcpp"
-          git-token: ${{ secrets.GITHUB_TOKEN }}
-
-  create-github-release:
-    needs: [publish-npm]
-    if: needs.publish-npm.result == 'success' && needs.publish-npm.outputs.published_version != ''
-    permissions:
-      contents: write
-    uses: ./.github/workflows/create-github-release.yml
-    with:
-      repo_name: "nmtcpp"
-      release_name: "QVAC Infer NMTCPP Lib"
-      published_version: ${{ needs.publish-npm.outputs.published_version }}
-      prev_sha: ${{ github.event.before }}
-      workdir: "packages/qvac-lib-infer-nmtcpp"
-
-  run-automated-benchmarks:
-    needs: [publish-npm]
-    if: needs.publish-npm.result == 'success' && needs.publish-npm.outputs.published_version != ''
-    permissions:
-      contents: read
-      packages: read
-    uses: ./.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
-    secrets: inherit
-    with:
-      version: ${{ needs.publish-npm.outputs.published_version }}

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
@@ -1,25 +1,9 @@
+# Build-only workflow. Publishing is handled by on-merge-qvac-lib-infer-onnx-tts.yml
 name: Prebuilds (TTS)
 
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: true
-        default: "latest"
-        type: choice
-        options:
-          - latest
-          - dev
-      publish_target:
-        description: "Target registry to publish to"
-        required: false
-        default: ""
-        type: choice
-        options:
-          - ""
-          - npm
-          - gpr
       workdir:
         description: "Working directory inside the repo (monorepo package path)"
         required: false
@@ -37,29 +21,11 @@ on:
         type: string
         required: false
         default: "tetherto/qvac"
-      tag:
-        description: "Tag to publish"
-        type: string
-        required: false
-        default: "dev"
-      publish_target:
-        description: "Target registry to publish to (npm or gpr)"
-        type: string
-        required: false
-        default: ""
       workdir:
         description: "Working directory inside the repo (monorepo package path)"
         type: string
         required: false
         default: "packages/qvac-lib-infer-onnx-tts"
-
-    outputs:
-      published_version:
-        description: "Version that was published"
-        value: ${{ jobs.publish-gpr.outputs.published_version || jobs.publish-npm.outputs.published_version }}
-      publish_target:
-        description: "Target registry to publish to (npm or gpr)"
-        value: ${{ inputs.publish_target }}
 
 permissions:
   contents: read
@@ -166,7 +132,6 @@ jobs:
       - name: Echo workflow inputs
         shell: bash
         env:
-          INPUT_TAG: ${{ inputs.tag || github.event.inputs.tag }}
           INPUT_REF: ${{ inputs.ref || github.ref }}
           INPUT_REPO: ${{ inputs.repository || github.repository }}
           INPUT_WORKDIR: ${{ inputs.workdir || github.event.inputs.workdir || 'packages/qvac-lib-infer-onnx-tts' }}
@@ -175,7 +140,6 @@ jobs:
           MATRIX_TAGS: ${{ matrix.tags }}
         run: |
           echo "Workflow inputs:"
-          echo "Tag: $INPUT_TAG"
           echo "Ref: $INPUT_REF"
           echo "Repository: $INPUT_REPO"
           echo "Workdir: $INPUT_WORKDIR"
@@ -541,152 +505,4 @@ jobs:
           name: prebuilds
           path: prebuilds
 
-  publish-logic:
-    runs-on: ubuntu-latest
-    outputs:
-      publish_gpr: ${{ steps.logic.outputs.publish_gpr }}
-      publish_npm: ${{ steps.logic.outputs.publish_npm }}
-      gpr_tag: ${{ steps.logic.outputs.gpr_tag }}
-    steps:
-      - id: logic
-        shell: bash
-        env:
-          INPUT_PUBLISH_TARGET: ${{ inputs.publish_target }}
-          EVENT_PUBLISH_TARGET: ${{ github.event.inputs.publish_target }}
-          INPUT_TAG: ${{ inputs.tag }}
-          EVENT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          set -euo pipefail
-          ref_name="${GITHUB_REF_NAME}"
-          event_name="${GITHUB_EVENT_NAME}"
-          publish_target="${INPUT_PUBLISH_TARGET}"
-          event_publish_target="${EVENT_PUBLISH_TARGET}"
-
-          publish_gpr="false"
-          publish_npm="false"
-
-          if [ "$publish_target" = "gpr" ] || [ "$event_publish_target" = "gpr" ]; then
-            publish_gpr="true"
-          fi
-
-          if [ "$publish_target" = "npm" ] || [ "$event_publish_target" = "npm" ]; then
-            publish_npm="true"
-          fi
-
-          if [ "$publish_gpr" = "false" ] && [ "$publish_npm" = "false" ]; then
-            if [ "$event_name" = "push" ] || [ "$event_name" = "workflow_dispatch" ]; then
-              if [ "$ref_name" = "main" ] || [[ "$ref_name" == feature-* ]] || [[ "$ref_name" == tmp-* ]]; then
-                publish_gpr="true"
-              elif [[ "$ref_name" == release-* ]]; then
-                publish_npm="true"
-              fi
-            fi
-          fi
-
-          if [[ "$ref_name" == release-* ]]; then
-            publish_gpr="false"
-          fi
-
-          if [ "$publish_npm" = "true" ] && { [ "$event_name" = "pull_request" ] || [ "$event_name" = "pull_request_target" ]; }; then
-            publish_npm="false"
-          fi
-
-          if [ "$publish_gpr" = "true" ] && [ "$publish_npm" = "true" ]; then
-            echo "ERROR: Both GPR and NPM publishing enabled — invalid GitFlow state"
-            exit 1
-          fi
-
-          gpr_tag="${INPUT_TAG:-${EVENT_TAG:-}}"
-          if [ -z "$gpr_tag" ]; then
-            if [ "$ref_name" = "main" ]; then
-              gpr_tag="dev"
-            elif [[ "$ref_name" == feature-* ]]; then
-              gpr_tag="feature"
-            elif [[ "$ref_name" == tmp-* ]]; then
-              gpr_tag="temp"
-            else
-              gpr_tag="dev"
-            fi
-          fi
-
-          echo "publish_gpr=$publish_gpr" >> "$GITHUB_OUTPUT"
-          echo "publish_npm=$publish_npm" >> "$GITHUB_OUTPUT"
-          echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
-
-  publish-gpr:
-    needs: [prebuild, merge, publish-logic]
-    if: ${{ needs.publish-logic.outputs.publish_gpr == 'true' }}
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    env:
-      WORKDIR: ${{ inputs.workdir || github.event.inputs.workdir || 'packages/qvac-lib-infer-onnx-tts' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Publish to GitHub Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
-        with:
-          secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: ${{ env.WORKDIR }}
-          path: ${{ env.WORKDIR }}
-          name-suffix: "-mono"
-
-  publish-npm:
-    needs: [prebuild, merge, publish-logic]
-    if: ${{ needs.publish-logic.outputs.publish_npm == 'true' }}
-    outputs:
-      published_version: ${{ steps.capture_version.outputs.published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    env:
-      WORKDIR: ${{ inputs.workdir || github.event.inputs.workdir || 'packages/qvac-lib-infer-onnx-tts' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-
-      - name: Download prebuild artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.WORKDIR }}/prebuilds
-
-      - name: Publish to NPM Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
-        with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: "latest"
-          path: ${{ env.WORKDIR }}
-          repo_name: "onnx-tts"
-          git-token: ${{ secrets.PAT_TOKEN }}
-          create-tag: "false"
-
-      - name: Capture published version
-        id: capture_version
-        if: success()
-        working-directory: ${{ env.WORKDIR }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          VERSION=$(node -p "require('./package.json').version")
-          PACKAGE_NAME=$(node -p "require('./package.json').name")
-          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
-            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
-          fi
 

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
@@ -1,16 +1,8 @@
+# Build-only workflow. Publishing is handled by on-merge-qvac-lib-infer-onnx.yml
 name: "Prebuilds (ONNX)"
 
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to publish with ('latest' by default)"
-        required: true
-        default: "latest"
-        type: choice
-        options:
-          - latest
-          - dev
 
   workflow_call:
     inputs:
@@ -27,23 +19,6 @@ on:
         type: string
         required: false
         default: "on-onnx"
-      tag:
-        description: "Tag to publish"
-        type: string
-        required: false
-        default: "dev"
-      publish_target:
-        description: "Target registry to publish to (npm or gpr)"
-        type: string
-        required: false
-        default: ""
-    outputs:
-      published_version:
-        description: "Version that was published"
-        value: ${{ jobs.publish-gpr.outputs.published_version || jobs.publish-npm.outputs.published_version }}
-      publish_target:
-        description: "Target registry to publish to (npm or gpr)"
-        value: ${{ inputs.publish_target }}
 
 env:
   PKG_DIR: packages/qvac-lib-infer-onnx
@@ -127,7 +102,6 @@ jobs:
       - name: Echo workflow inputs
         shell: bash
         env:
-          INPUT_TAG: ${{ inputs.tag || github.event.inputs.tag }}
           INPUT_REF: ${{ inputs.ref || github.ref }}
           INPUT_REPO: ${{ inputs.repository || github.repository }}
           MATRIX_PLATFORM: ${{ matrix.platform }}
@@ -135,7 +109,6 @@ jobs:
           MATRIX_TAGS: ${{ matrix.tags }}
         run: |
           echo "Workflow inputs:"
-          echo "Tag: $INPUT_TAG"
           echo "Ref: $INPUT_REF"
           echo "Repository: $INPUT_REPO"
           echo "Matrix platform: $MATRIX_PLATFORM"
@@ -433,154 +406,3 @@ jobs:
           name: prebuilds
           path: prebuilds
 
-  publish-logic:
-    runs-on: ubuntu-24.04
-    outputs:
-      publish_gpr: ${{ steps.logic.outputs.publish_gpr }}
-      publish_npm: ${{ steps.logic.outputs.publish_npm }}
-      gpr_tag: ${{ steps.logic.outputs.gpr_tag }}
-    steps:
-      - id: logic
-        shell: bash
-        env:
-          INPUT_PUBLISH_TARGET: ${{ inputs.publish_target }}
-          EVENT_PUBLISH_TARGET: ${{ github.event.inputs.publish_target }}
-          INPUT_TAG: ${{ inputs.tag }}
-          EVENT_TAG: ${{ github.event.inputs.tag }}
-        run: |
-          set -euo pipefail
-          ref_name="${GITHUB_REF_NAME}"
-          event_name="${GITHUB_EVENT_NAME}"
-          publish_target="${INPUT_PUBLISH_TARGET}"
-          event_publish_target="${EVENT_PUBLISH_TARGET}"
-
-          publish_gpr="false"
-          publish_npm="false"
-
-          if [ "$publish_target" = "gpr" ] || [ "$event_publish_target" = "gpr" ]; then
-            publish_gpr="true"
-          fi
-
-          if [ "$publish_target" = "npm" ] || [ "$event_publish_target" = "npm" ]; then
-            publish_npm="true"
-          fi
-
-          if [ "$publish_gpr" = "false" ] && [ "$publish_npm" = "false" ]; then
-            if [ "$event_name" = "push" ] || [ "$event_name" = "workflow_dispatch" ]; then
-              if [ "$ref_name" = "main" ] || [[ "$ref_name" == feature-* ]] || [[ "$ref_name" == tmp-* ]]; then
-                publish_gpr="true"
-              elif [[ "$ref_name" == release-* ]]; then
-                publish_npm="true"
-              fi
-            fi
-          fi
-
-          if [[ "$ref_name" == release-* ]]; then
-            publish_gpr="false"
-          fi
-
-          if [ "$publish_npm" = "true" ] && { [ "$event_name" = "pull_request" ] || [ "$event_name" = "pull_request_target" ]; }; then
-            publish_npm="false"
-          fi
-
-          if [ "$publish_gpr" = "true" ] && [ "$publish_npm" = "true" ]; then
-            echo "ERROR: Both GPR and NPM publishing enabled — invalid GitFlow state"
-            exit 1
-          fi
-
-          gpr_tag="${INPUT_TAG:-${EVENT_TAG:-}}"
-          if [ -z "$gpr_tag" ]; then
-            if [ "$ref_name" = "main" ]; then
-              gpr_tag="dev"
-            elif [[ "$ref_name" == feature-* ]]; then
-              gpr_tag="feature"
-            elif [[ "$ref_name" == tmp-* ]]; then
-              gpr_tag="temp"
-            else
-              gpr_tag="dev"
-            fi
-          fi
-
-          echo "publish_gpr=$publish_gpr" >> "$GITHUB_OUTPUT"
-          echo "publish_npm=$publish_npm" >> "$GITHUB_OUTPUT"
-          echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
-
-  publish-gpr:
-    needs: [prebuild, merge, publish-logic]
-    if: ${{ needs.publish-logic.outputs.publish_gpr == 'true' }}
-    continue-on-error: true
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download prebuild artifacts into package dir
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.PKG_DIR }}/prebuilds
-
-      - name: Publish to GitHub Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
-        with:
-          secret-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: ${{ env.PKG_DIR }}
-          name-suffix: "-mono"
-
-  publish-npm:
-    needs: [prebuild, merge, publish-logic]
-    if: ${{ needs.publish-logic.outputs.publish_npm == 'true' }}
-    continue-on-error: false
-    outputs:
-      published_version: ${{ steps.publish.outputs.npm_published_version }}
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.ref }}
-          token: ${{ secrets.PAT_TOKEN }}
-
-      - name: Download prebuild artifacts into package dir
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
-        with:
-          name: prebuilds
-          path: ${{ env.PKG_DIR }}/prebuilds
-
-      - name: Publish to NPM Package Registry
-        id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
-        with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: "latest"
-          workdir: ${{ env.PKG_DIR }}
-          repo_name: "onnx"
-          git-token: ${{ secrets.GITHUB_TOKEN }}
-
-
-  create-github-release:
-    needs: [publish-npm]
-    if: needs.publish-npm.outputs.published_version != '' && startsWith(github.ref_name, 'release-')
-    permissions:
-      contents: write
-    uses: ./.github/workflows/create-github-release-qvac-lib-infer-onnx.yml
-    with:
-      published_version: ${{ needs.publish-npm.outputs.published_version }}
-      prev_sha: ${{ github.event.before }}
-      workdir: packages/qvac-lib-infer-onnx


### PR DESCRIPTION
## Summary

- Extract publish-logic, publish-gpr, publish-npm, create-github-release, and run-automated-benchmarks jobs from 4 publish-logic prebuilds workflows into their on-merge callers
- Completes the separation started in #1347 (Pattern A) — all 9 prebuilds are now build-only
- Remove stale `tag`/`publish_target` inputs from 4 on-pr files that call these prebuilds
- Add `needs.build.result == 'success'` guard to all publish-npm conditions

### Depends on
- #1347 (Pattern A) — should merge first, but this PR has no file conflicts with it

### Files modified (12)

**Prebuilds (stripped to build-only):**
- `prebuilds-ocr-onnx.yml`
- `prebuilds-qvac-lib-infer-nmtcpp.yml`
- `prebuilds-qvac-lib-infer-onnx.yml`
- `prebuilds-qvac-lib-infer-onnx-tts.yml`

**On-merge (gained local publish jobs):**
- `on-merge-ocr-onnx.yml`
- `on-merge-qvac-lib-infer-nmtcpp.yml`
- `on-merge-qvac-lib-infer-onnx.yml`
- `on-merge-qvac-lib-infer-onnx-tts.yml`

**On-PR (removed stale inputs):**
- `on-pr-ocr-onnx.yml`
- `on-pr-qvac-lib-infer-nmtcpp.yml`
- `on-pr-qvac-lib-infer-onnx.yml`
- `on-pr-qvac-lib-infer-onnx-tts.yml`

### NMTCPP-specific additions

NMTCPP was the most complex — these jobs moved from prebuilds to on-merge:
- `create-github-release` (with `repo_name: "nmtcpp"`)
- `run-automated-benchmarks` (calls `on-publish-benchmark-qvac-lib-infer-nmtcpp.yml`)
- `model-conversion-test` and `run-integration-tests` now depend on `publish-gpr` (they install the GPR-published package)

### What's next

After both Pattern A (#1347) and Pattern B merge:
- Create tiered GitHub Environments (`ci`, `testing`, `release`)
- Re-tag jobs to correct tier
- OIDC for AWS (DEVOPS-1869) and npm Trusted Publishing (DEVOPS-1868) — parallel workstreams

## Test plan

- [ ] Push to `main` touching any of these 4 packages → build + GPR publish + tests
- [ ] Push to `release-*` → build + NPM publish + create-github-release
- [ ] Push to `feature-*` / `tmp-*` → build + GPR publish
- [ ] Open PR → build-only (no publish)
- [ ] Manual dispatch on prebuilds → build + merge only
- [ ] NMTCPP: verify model-conversion-test and run-integration-tests run after GPR publish
- [ ] NMTCPP: verify create-github-release and benchmarks run after NPM publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)