### PR TITLE
fix: release-merge-guard fails on workflow_dispatch (missing base-sha)

### DIFF
--- a/.github/actions/release-merge-guard/action.yml
+++ b/.github/actions/release-merge-guard/action.yml
@@ -7,7 +7,9 @@ inputs:
   base-ref:
     required: true
   base-sha:
-    required: true
+    required: false
+    default: ""
+    description: "Base SHA for diff. Empty on workflow_dispatch — changelog check is skipped."
   head-sha:
     required: true
   package-slug:

--- a/.github/actions/release-merge-guard/dist/index.js
+++ b/.github/actions/release-merge-guard/dist/index.js
@@ -25687,7 +25687,7 @@ const child_process_1 = __nccwpck_require__(5317);
 const ZERO_SHA = '0000000000000000000000000000000000000000';
 try {
     const baseRef = core.getInput('base-ref', { required: true });
-    const baseSha = core.getInput('base-sha', { required: true });
+    const baseSha = core.getInput('base-sha', { required: false });
     const headSha = core.getInput('head-sha', { required: true });
     const pkgSlug = core.getInput('package-slug', { required: true });
     const pkgJsonPath = core.getInput('package-json-path', { required: true });

--- a/.github/actions/release-merge-guard/src/index.ts
+++ b/.github/actions/release-merge-guard/src/index.ts
@@ -5,7 +5,7 @@ const ZERO_SHA = '0000000000000000000000000000000000000000'
 
 try {
   const baseRef = core.getInput('base-ref', { required: true })
-  const baseSha = core.getInput('base-sha', { required: true })
+  const baseSha = core.getInput('base-sha', { required: false })
   const headSha = core.getInput('head-sha', { required: true })
   const pkgSlug = core.getInput('package-slug', { required: true })
   const pkgJsonPath = core.getInput('package-json-path', { required: true })


### PR DESCRIPTION
## Summary

- Make `base-sha` input optional in the `release-merge-guard` composite action
- Fixes `Error: Input required and not supplied: base-sha` when manually dispatching on release branches

## Root Cause

`github.event.before` is only populated on `push` events. On `workflow_dispatch`, it's empty. The action declared `base-sha` as `required: true`, so GitHub Actions rejects the input before the action code even runs.

The action code already handles the empty case gracefully (line 14: `const isInitialPush = !baseSha || baseSha === ZERO_SHA`), skipping the changelog diff check. The fix is simply removing the `required` constraint so the code can run.

## Behavior after fix

On `workflow_dispatch` to a release branch, the guard:
- Still validates branch name matches package slug
- Still validates package.json version matches branch version  
- Skips changelog check (no base SHA to diff against)

## Test plan

- [x] `workflow_dispatch` on a `release-*` branch → guard passes (no base-sha error)
- [x] `push` to a `release-*` branch → guard works as before (changelog check runs)