### PR TITLE
[notask] infra: add npm auth to CLI build job

### DIFF
--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -50,6 +50,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -58,10 +59,13 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm install
         working-directory: ${{ env.WORKDIR }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary

- Add `environment: release` and `NODE_AUTH_TOKEN` to CLI workflow build job so `npm install` can resolve the private `@qvac/sdk` package.

## Test plan

- [ ] Merge and trigger `workflow_dispatch` on `release-cli-0.2.3` — build job should pass and CLI 0.2.3 publishes to npm.
