### PR TITLE
QVAC-16804 fix: replace Buffer with cross-platform base64 decode in d…

### DIFF
--- a/packages/sdk/client/api/diffusion.ts
+++ b/packages/sdk/client/api/diffusion.ts
@@ -6,6 +6,18 @@ import {
 } from "@/schemas";
 import { stream as streamRpc } from "@/client/rpc/rpc-client";
 
+function decodeBase64(data: string): Uint8Array {
+  if (typeof globalThis.Buffer !== "undefined") {
+    return globalThis.Buffer.from(data, "base64");
+  }
+  const binaryString = atob(data);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}
+
 export interface DiffusionProgressTick {
   step: number;
   totalSteps: number;
@@ -14,7 +26,7 @@ export interface DiffusionProgressTick {
 
 interface DiffusionResult {
   progressStream: AsyncGenerator<DiffusionProgressTick>;
-  outputs: Promise<Buffer[]>;
+  outputs: Promise<Uint8Array[]>;
   stats: Promise<DiffusionStats | undefined>;
 }
 
@@ -53,14 +65,14 @@ export function diffusion(params: DiffusionClientParams): DiffusionResult {
   statsPromise.catch(() => {});
 
   const progressQueue: DiffusionProgressTick[] = [];
-  const collectedBuffers: Buffer[] = [];
+  const collectedBuffers: Uint8Array[] = [];
   let progressDone = false;
   let progressResolve: (() => void) | null = null;
   let streamError: Error | null = null;
 
-  let outputsResolver: (value: Buffer[]) => void = () => {};
+  let outputsResolver: (value: Uint8Array[]) => void = () => {};
   let outputsRejecter: (error: unknown) => void = () => {};
-  const outputsPromise = new Promise<Buffer[]>((resolve, reject) => {
+  const outputsPromise = new Promise<Uint8Array[]>((resolve, reject) => {
     outputsResolver = resolve;
     outputsRejecter = reject;
   });
@@ -86,7 +98,7 @@ export function diffusion(params: DiffusionClientParams): DiffusionResult {
           }
 
           if (parsed.data) {
-            collectedBuffers.push(Buffer.from(parsed.data, "base64"));
+            collectedBuffers.push(decodeBase64(parsed.data));
           }
 
           if (parsed.done) {


### PR DESCRIPTION
…iffusion client

## What problem does this PR solve?

The `diffusion()` client API uses `Buffer.from(data, "base64")` to decode image data from the RPC stream. `Buffer` is a Node.js/Bare global that does not exist in React Native. This causes all diffusion tests (13/13) to fail on iOS and Android with `Property 'Buffer' doesn't exist`.

Desktop (Bare runtime) is unaffected — tests pass 13/13.

## How does it solve it?

- Adds a `decodeBase64()` helper that uses `globalThis.Buffer` when available (Bare/Node) and falls back to `atob()` + `Uint8Array` on runtimes without Buffer (React Native)
- Changes output type from `Buffer[]` to `Uint8Array[]` — backward compatible since `Buffer extends Uint8Array`

## How was it tested?

- Desktop (macOS): 13/13 diffusion tests still pass (Buffer path used)
[diffusion-desktop-test.html](https://github.com/user-attachments/files/26509975/diffusion-desktop-test.html)
- iOS (iPhone 16e): 13/13 passed after rebuild
[diffusion-ios-test.html](https://github.com/user-attachments/files/26509973/diffusion-ios-test.html)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213937342815223