### PR TITLE
fix: add id-token write permission to workflows calling OIDC-enabled …

### DIFF
--- a/.github/workflows/on-merge-lib-infer-diffusion.yml
+++ b/.github/workflows/on-merge-lib-infer-diffusion.yml
@@ -33,6 +33,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   publish-logic:

--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -29,6 +29,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   publish-logic:

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -25,6 +25,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   publish-logic:

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
@@ -26,6 +26,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   publish-logic:

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
@@ -33,6 +33,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 
 jobs:

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -28,6 +28,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   publish-logic:

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
@@ -26,6 +26,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   publish-logic:

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
@@ -29,6 +29,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   publish-logic:

--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -26,6 +26,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   publish-logic:

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -26,6 +26,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   publish-logic:

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -23,6 +23,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 env:
   PKG_DIR: packages/lib-infer-diffusion

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -22,6 +22,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   authorize:

--- a/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
@@ -51,6 +51,7 @@ permissions:
   pull-requests: read
   packages: read
   checks: read
+  id-token: write
 
 jobs:
   authorize:

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -21,6 +21,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   authorize:

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -23,6 +23,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 env:
   PKG_DIR: packages/qvac-lib-infer-llamacpp-llm

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -21,6 +21,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 env:
   PKG_DIR: packages/qvac-lib-infer-nmtcpp

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
@@ -51,6 +51,7 @@ permissions:
   pull-requests: read
   packages: read
   checks: read
+  id-token: write
 
 jobs:
   authorize:

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -22,6 +22,7 @@ permissions:
   contents: read
   pull-requests: read
   packages: read
+  id-token: write
 
 jobs:
   authorize:

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -42,6 +42,7 @@ permissions:
   pull-requests: read
   packages: read
   checks: read
+  id-token: write
 
 jobs:
   authorize:

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -51,6 +51,7 @@ permissions:
   pull-requests: read
   packages: read
   checks: read
+  id-token: write
 
 jobs:
   authorize:

--- a/.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
@@ -22,6 +22,7 @@ env:
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 jobs:
   prepare:


### PR DESCRIPTION
Problem: Workflows calling reusable workflows with id-token: write (for OIDC) were missing the permission at the top
level, causing the error:
The nested job 'prebuild' is requesting 'id-token: write', but is only allowed 'id-token: none'.

Solution: Added id-token: write to the top-level permissions block in 21 workflows: