### PR TITLE
infra: refactor nmtcpp on-merge workflow to Pattern B

### DIFF
--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -10,19 +10,17 @@ on:
     paths:
       - "packages/qvac-lib-infer-nmtcpp/**"
       - ".github/workflows/*nmtcpp*.yml"
+
   workflow_dispatch:
     inputs:
       tag:
-        description: "GPR tag override (optional)"
+        description: "Tag to publish with"
         required: false
-        default: ""
+        default: "dev"
         type: choice
         options:
-          - ""
-          - dev
-          - feature
-          - temp
           - latest
+          - dev
 
 permissions:
   contents: read
@@ -108,73 +106,207 @@ jobs:
           package-json-path: packages/qvac-lib-infer-nmtcpp/package.json
           changelog-path: packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
 
-  prebuild-main-gpr:
+  # Build prebuilds (build + merge only, no publishing)
+  build:
     needs: publish-logic
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_release == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
     permissions:
       contents: write
       packages: write
       pull-requests: write
       id-token: write
-    if: needs.publish-logic.outputs.publish_main == 'true'
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
-    secrets: inherit
-    with:
-      tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-
-  prebuild-feature-gpr:
-    needs: publish-logic
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-      id-token: write
-    if: needs.publish-logic.outputs.publish_feature == 'true'
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
-    secrets: inherit
-    with:
-      tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-
-  prebuild-tmp-gpr:
-    needs: publish-logic
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-      id-token: write
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
-    secrets: inherit
-    with:
-      tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
-
-  run-integration-tests:
-    needs: [prebuild-main-gpr]
-    permissions:
-      contents: read
-      packages: read
-      id-token: write
-    uses: ./.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
     secrets: inherit
     with:
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
 
-  prebuild-release-npm:
-    needs: [publish-logic, release-merge-guard]
+  # Publish to GitHub Package Registry (GPR) for non-release branches
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      published_version: ${{ steps.capture_version.outputs.published_version }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-nmtcpp/prebuilds
+
+      - name: Rename prebuild files from qvac_ to tetherto_ prefix
+        working-directory: packages/qvac-lib-infer-nmtcpp
+        run: |
+          find prebuilds -depth -name 'qvac_*' | while read -r file; do
+            dir=$(dirname "$file")
+            base=$(basename "$file")
+            newbase=$(echo "$base" | sed 's/^qvac_/tetherto_/')
+            mv "$file" "$dir/$newbase"
+          done
+
+          if [ -f binding.js ]; then
+            sed -i 's/qvac_/tetherto_/g' binding.js
+          fi
+
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
+          workdir: packages/qvac-lib-infer-nmtcpp
+          name-suffix: "-mono"
+
+      - name: Capture published version
+        id: capture_version
+        if: success()
+        working-directory: packages/qvac-lib-infer-nmtcpp
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_NAME_GPR=$(echo "$PACKAGE_NAME" | sed 's/@qvac/@tetherto/')
+          if npm view "${PACKAGE_NAME_GPR}@${VERSION}" version --registry=https://npm.pkg.github.com/ >/dev/null 2>&1; then
+            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Publish to NPM for release branches
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      needs.publish-logic.outputs.publish_release == 'true' &&
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    runs-on: ubuntu-latest
+    environment: release
+    outputs:
+      published_version: ${{ steps.capture_version.outputs.published_version }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Download prebuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-nmtcpp/prebuilds
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: packages/qvac-lib-infer-nmtcpp
+          repo_name: "nmtcpp"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Capture published version
+        id: capture_version
+        if: success()
+        working-directory: packages/qvac-lib-infer-nmtcpp
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Create GitHub release only for actual releases (after NPM publish)
+  publish-release:
+    needs: [publish-npm]
+    if: >-
+      !cancelled() &&
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
-      packages: write
-      pull-requests: write
-      id-token: write
-    if: |
-      !cancelled() &&
-      needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+    uses: ./.github/workflows/create-github-release.yml
+    with:
+      repo_name: "nmtcpp"
+      release_name: "QVAC Translation NMTCPP Addon"
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
+      prev_sha: ${{ github.event.before }}
+      workdir: "packages/qvac-lib-infer-nmtcpp"
+
+  # Run benchmarks after NPM publish
+  run-automated-benchmarks:
+    needs: [publish-npm]
+    if: needs.publish-npm.outputs.published_version != ''
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
     secrets: inherit
     with:
-      tag: "latest"
-      publish_target: "npm"
+      version: ${{ needs.publish-npm.outputs.published_version }}
+
+  post-build-gate:
+    name: Post-Build Gate
+    runs-on: ubuntu-latest
+    needs: [publish-gpr, publish-npm]
+    if: "!cancelled()"
+    outputs:
+      should_run_tests: ${{ steps.gate.outputs.should_run_tests }}
+    steps:
+      - id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          should="false"
+
+          if [ "${{ needs.publish-npm.result }}" = "success" ] || \
+             [ "${{ needs.publish-gpr.result }}" = "success" ]; then
+            should="true"
+          fi
+
+          echo "should_run_tests=$should" >> "$GITHUB_OUTPUT"
+
+  integration-tests:
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+    uses: ./.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
+    secrets: inherit
+    with:
+      repository: ${{ github.repository }}
+      ref: ${{ github.sha }}
+      workdir: "packages/qvac-lib-infer-nmtcpp"
+
+  mobile-integration-tests:
+    uses: ./.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
+    secrets: inherit
+    with:
+      repository: ${{ github.repository }}
+      ref: ${{ github.sha }}

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -257,6 +257,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
     uses: ./.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
     secrets: inherit
     with:

--- a/.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-publish-benchmark-qvac-lib-infer-nmtcpp.yml
@@ -71,7 +71,6 @@ jobs:
       metric_chrfpp: true
       metric_comet: true
       use_pivot: false
-      is_quantized_model: false
       use_batch: false
       hyperparams: 'fast'
 


### PR DESCRIPTION
## What problem does this PR solve?

The `on-merge-qvac-lib-infer-nmtcpp.yml` workflow passes `tag` and `publish_target` inputs to the `prebuilds` workflow, but PR #1348 refactored prebuilds to be build-only (removed those inputs). This blocks all nmtcpp workflow dispatches including the v1.0.0 release.

Also fixes: `is_quantized_model` input passed by `on-publish-benchmark` was removed from the benchmark workflow in PR #1260.

## How does it solve it?

Applies the same "Pattern B" refactor used by parakeet, onnx-tts, and whispercpp:

- Single `build` job calls prebuilds with only `repository` and `ref`
- Separate `publish-gpr` job for GitHub Packages
- Separate `publish-npm` job for NPM
- `publish-release` creates GitHub release after NPM publish
- `post-build-gate` gates integration tests on successful publish
- Adds `id-token: write` for benchmark job (AWS OIDC)
- Removes stale `is_quantized_model` from on-publish-benchmark

Reference: `on-merge-qvac-lib-infer-parakeet.yml`

## How was it tested?

- Workflow dispatch succeeded (run #136) — no YAML errors, publish-logic ran correctly
- All inputs verified against called workflow interfaces
- All permissions verified against called workflow requirements


Made with [Cursor](https://cursor.com)