### PR TITLE
chore[bc]: embed addon interface refactor - remove BaseInference and WeightsProvider

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/examples/batchInference.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/examples/batchInference.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const GGMLBert = require('../index')
 const { downloadModel } = require('./utils')
 
@@ -14,25 +14,19 @@ async function main () {
     'gte-large_fp16.gguf'
   )
 
-  // 2. Initializing data loader
-  const fsDL = new FilesystemDL({ dirPath })
-
-  // 3. Configuring model settings
-  const args = {
-    loader: fsDL,
+  // 2. Configuring model settings
+  const model = new GGMLBert({
+    files: { model: [path.join(dirPath, modelName)] },
+    config: { device: 'gpu', gpu_layers: '25', batch_size: '128' },
     logger: console,
-    opts: { stats: true },
-    diskPath: dirPath,
-    modelName
-  }
-  const config = { device: 'gpu', gpu_layers: '25', batch_size: '128' } // large enough batch size to run all test prompts in one pass
+    opts: { stats: true }
+  })
 
-  // 4. Loading model
-  const model = new GGMLBert(args, config)
+  // 3. Loading model
   await model.load()
 
   try {
-    // 5. Generating embeddings (all prompts in one batch)
+    // 4. Generating embeddings (all prompts in one batch)
     const prompts = [
       'Hello, can you suggest a game I can play with my 1 year old daughter?',
       'What is the capital of Great Britain?',
@@ -53,9 +47,8 @@ async function main () {
     console.error('Error occurred:', errorMessage)
     console.error('Error details:', error)
   } finally {
-    // 6. Cleaning up resources
+    // 5. Cleaning up resources
     await model.unload()
-    await fsDL.close()
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-embed/examples/nativelog.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/examples/nativelog.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const GGMLBert = require('../index.js')
 const { setLogger, releaseLogger } = require('../addonLogging.js')
 const { downloadModel } = require('./utils')
@@ -36,25 +36,19 @@ async function main () {
     'gte-large_fp16.gguf'
   )
 
-  // 3. Initializing data loader
-  const fsDL = new FilesystemDL({ dirPath })
-
-  // 4. Configuring model settings
-  const args = {
-    loader: fsDL,
+  // 3. Configuring model settings
+  const model = new GGMLBert({
+    files: { model: [path.join(dirPath, modelName)] },
+    config: { device: 'gpu', gpu_layers: '25', verbosity: '2' },
     logger: console,
-    opts: { stats: true },
-    diskPath: dirPath,
-    modelName
-  }
-  const config = { device: 'gpu', gpu_layers: '25', verbosity: '2' }
+    opts: { stats: true }
+  })
 
-  // 5. Loading model
-  const model = new GGMLBert(args, config)
+  // 4. Loading model
   await model.load()
 
   try {
-    // 6. Generating embeddings
+    // 5. Generating embeddings
     const query = 'Hello, can you suggest a game I can play with my 1 year old daughter?'
     const response = await model.run(query)
     const embeddings = await response.await()
@@ -67,9 +61,8 @@ async function main () {
     console.error('Error occurred:', errorMessage)
     console.error('Error details:', error)
   } finally {
-    // 7. Cleaning up resources
+    // 6. Cleaning up resources
     await model.unload()
-    await fsDL.close()
     releaseLogger()
   }
 }

--- a/packages/qvac-lib-infer-llamacpp-embed/examples/quickstart.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/examples/quickstart.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const GGMLBert = require('../index')
 const { downloadModel } = require('./utils')
 
@@ -14,25 +14,19 @@ async function main () {
     'gte-large_fp16.gguf'
   )
 
-  // 2. Initializing data loader
-  const fsDL = new FilesystemDL({ dirPath })
-
-  // 3. Configuring model settings
-  const args = {
-    loader: fsDL,
+  // 2. Configuring model settings
+  const model = new GGMLBert({
+    files: { model: [path.join(dirPath, modelName)] },
+    config: { device: 'gpu', gpu_layers: '25' },
     logger: console,
-    opts: { stats: true },
-    diskPath: dirPath,
-    modelName
-  }
-  const config = { device: 'gpu', gpu_layers: '25' }
+    opts: { stats: true }
+  })
 
-  // 4. Loading model
-  const model = new GGMLBert(args, config)
+  // 3. Loading model
   await model.load()
 
   try {
-    // 5. Generating embeddings
+    // 4. Generating embeddings
     const query = 'Hello, can you suggest a game I can play with my 1 year old daughter?'
     const response = await model.run(query)
     const embeddings = await response.await()
@@ -45,9 +39,8 @@ async function main () {
     console.error('Error occurred:', errorMessage)
     console.error('Error details:', error)
   } finally {
-    // 6. Cleaning up resources
+    // 5. Cleaning up resources
     await model.unload()
-    await fsDL.close()
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-embed/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-embed/index.d.ts
@@ -1,22 +1,7 @@
-import BaseInference, {
-  ReportProgressCallback
-} from '@qvac/infer-base/WeightsProvider/BaseInference'
 import type { QvacResponse } from '@qvac/infer-base'
-
-export { ReportProgressCallback, QvacResponse }
-import type WeightsProvider from '@qvac/infer-base/WeightsProvider/WeightsProvider'
 import type QvacLogger from '@qvac/logging'
 
-export interface Loader {
-  ready(): Promise<void>
-  close(): Promise<void>
-  getStream(path: string): Promise<AsyncIterable<Uint8Array>>
-  download(
-    path: string,
-    opts: { diskPath: string; progressReporter?: unknown }
-  ): Promise<{ await(): Promise<void> }>
-  getFileSize?(path: string): Promise<number>
-}
+export { QvacResponse }
 
 export interface Addon {
   loadWeights(data: { filename: string; chunk: Uint8Array | null; completed: boolean }): Promise<void>
@@ -24,26 +9,6 @@ export interface Addon {
   runJob(input: { type: 'text' | 'sequences'; input?: string | string[] }): Promise<boolean>
   cancel(): Promise<void>
   unload(): Promise<void>
-}
-
-export interface GGMLArgs {
-  loader: Loader
-  logger?: QvacLogger | Console | null
-  opts?: { stats?: boolean }
-  diskPath?: string
-  modelName: string
-  modelPath?: string
-  exclusiveRun?: boolean
-}
-
-export interface DownloadWeightsOptions {
-  closeLoader?: boolean
-}
-
-export interface DownloadResult {
-  filePath: string | null
-  error: boolean
-  completed: boolean
 }
 
 export type NumericLike = `${number}`
@@ -61,6 +26,13 @@ export interface GGMLConfig {
   [key: string]: string | number | boolean | string[] | undefined
 }
 
+export interface GGMLBertArgs {
+  files: { model: string[] }
+  config?: GGMLConfig
+  logger?: QvacLogger | Console | null
+  opts?: { stats?: boolean }
+}
+
 export interface AddonConfigurationParams {
   path: string
   config: GGMLConfig
@@ -76,47 +48,23 @@ export interface RuntimeStats {
   backendDevice: 'cpu' | 'gpu'
 }
 
-export default class GGMLBert extends BaseInference {
-  protected addon: Addon
-  
-  weightsProvider: WeightsProvider
+export default class GGMLBert {
+  protected addon: Addon | null
+  opts: { stats?: boolean }
+  logger: QvacLogger
+  state: { configLoaded: boolean }
 
-  constructor(args: GGMLArgs, config: GGMLConfig)
+  constructor(args: GGMLBertArgs)
 
-  _load(
-    closeLoader?: boolean,
-    reportProgressCallback?: ReportProgressCallback | ((bytes: number) => void)
-  ): Promise<void>
-
-  load(
-    closeLoader?: boolean,
-    reportProgressCallback?: ReportProgressCallback | ((bytes: number) => void)
-  ): Promise<void>
-
-  downloadWeights(
-    onDownloadProgress?: (progress: Record<string, any>, opts: DownloadWeightsOptions) => any,
-    opts?: DownloadWeightsOptions
-  ): Promise<Record<string, DownloadResult>>
-
-  _downloadWeights(
-    onDownloadProgress?: (progress: Record<string, any>, opts: DownloadWeightsOptions) => any,
-    opts?: DownloadWeightsOptions
-  ): Promise<Record<string, DownloadResult>>
-
-  protected _loadWeights(
-    reportProgressCallback?: ReportProgressCallback | ((bytes: number) => void)
-  ): Promise<void>
-
-  protected _createAddon(configurationParams: AddonConfigurationParams): Addon
-
-  _runInternal(text: string | string[]): Promise<QvacResponse>
-
+  load(): Promise<void>
   run(text: string | string[]): Promise<QvacResponse>
-
+  unload(): Promise<void>
   cancel(): Promise<void>
+  getState(): { configLoaded: boolean }
 }
 
 export { GGMLBert }
+
 export interface AddonLogging {
   setLogger(callback: (priority: number, message: string) => void): void
   releaseLogger(): void
@@ -127,12 +75,12 @@ export class BertInterface implements Addon {
   constructor(
     binding: unknown,
     configurationParams: AddonConfigurationParams,
-    outputCb: (addon: unknown, event: string, jobId: number, data: unknown, error?: Error) => void
+    outputCb: (addon: unknown, event: string, data: unknown, error?: Error) => void
   )
-  
+
   loadWeights(data: { filename: string; chunk: Uint8Array | null; completed: boolean }): Promise<void>
   activate(): Promise<void>
-  runJob(input: { type: 'text' | 'sequences'; input?: string | string[] }): Promise<void>
+  runJob(input: { type: 'text' | 'sequences'; input?: string | string[] }): Promise<boolean>
   cancel(): Promise<void>
   unload(): Promise<void>
 }

--- a/packages/qvac-lib-infer-llamacpp-embed/index.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/index.js
@@ -1,178 +1,99 @@
 'use strict'
 
+const fs = require('bare-fs')
 const path = require('bare-path')
-const BaseInference = require('@qvac/infer-base/WeightsProvider/BaseInference')
-const WeightsProvider = require('@qvac/infer-base/WeightsProvider/WeightsProvider')
+const QvacLogger = require('@qvac/logging')
+const { createJobHandler, exclusiveRunQueue } = require('@qvac/infer-base')
 const { BertInterface } = require('./addon')
 
 const RUN_BUSY_ERROR_MESSAGE = 'Cannot set new job: a job is already set or being processed'
 
-/**
- * GGML client implementation for BERT GTE model
- */
-class GGMLBert extends BaseInference {
-  /**
-   * Creates an instance of GGMLBert.
-   * @constructor
-   * @param {Object} params - arguments for model setup
-   * @param {Object} args arguments for inference setup
-   * @param {Object} config - environment specific inference setup configuration
-   */
-  constructor (
-    { opts = {}, loader, logger = null, diskPath = '.', modelName },
-    config = {}
-  ) {
-    super({ logger, opts })
+class GGMLBert {
+  constructor ({ files, config = {}, logger = null, opts = {} }) {
+    this._files = files.model
     this._config = config
-    this._diskPath = diskPath
-    this._modelName = modelName
-    // _shards will be null if the modelName is not a sharded file.
-    this._shards = WeightsProvider.expandGGUFIntoShards(this._modelName)
-    this.weightsProvider = new WeightsProvider(loader, this.logger)
+    this.logger = new QvacLogger(logger)
+    this.opts = opts
+    this._job = createJobHandler({ cancel: () => this.addon.cancel() })
+    this._run = exclusiveRunQueue()
+    this.addon = null
     this._hasActiveResponse = false
+    this.state = { configLoaded: false }
   }
 
-  async _load (closeLoader = false, reportProgressCallback) {
-    this.logger.info('Starting model load')
+  async load () {
+    if (this.state.configLoaded) {
+      this.logger.info('Reload requested - unloading existing model first')
+      await this.unload()
+    }
+    await this._load()
+    this.state.configLoaded = true
+  }
 
+  async _load () {
+    this.logger.info('Starting model load')
     const configurationParams = {
-      path: path.join(this._diskPath, this._modelName),
+      path: this._files[this._files.length - 1],
       config: this._config
     }
-
-    this.logger.info('Creating addon with configuration:', configurationParams)
     this.addon = this._createAddon(configurationParams)
 
-    if (this._shards !== null) {
-      await this._loadWeights(reportProgressCallback)
-    } else {
-      await this.downloadWeights(reportProgressCallback, { closeLoader })
+    if (this._files.length > 1) {
+      await this._streamShards()
     }
 
-    this.logger.info('Activating addon')
     await this.addon.activate()
-
     this.logger.info('Model load completed successfully')
   }
 
-  /**
-   * Download the model weight files and return the local path to the primary file.
-   * @param {ProgressReportCallback} [onDownloadProgress] - Callback invoked with bytes downloaded
-   * @param {Object} opts - Options for the download
-   * @param {boolean} opts.closeLoader - Whether to close the loader when done
-   * @returns {Promise<{filePath: string, completed: boolean, error: boolean}[]>} Local file path for the model weights
-   */
-  async _downloadWeights (onDownloadProgress, opts) {
-    return await this.weightsProvider.downloadFiles(
-      [this._modelName],
-      this._diskPath,
-      {
-        closeLoader: opts.closeLoader,
-        onDownloadProgress
+  async _streamShards () {
+    for (const filePath of this._files) {
+      const filename = path.basename(filePath)
+      const stream = fs.createReadStream(filePath)
+      for await (const chunk of stream) {
+        await this.addon.loadWeights({ filename, chunk, completed: false })
       }
-    )
-  }
-
-  async _loadWeights (reportProgressCallback) {
-    const onChunk = async (chunkedWeightsData) => {
-      this.addon.loadWeights(chunkedWeightsData, this.logger)
-    }
-    await this.weightsProvider.streamFiles(this._shards, onChunk, reportProgressCallback)
-  }
-
-  /**
-   * Cancel the current task.
-   */
-  async cancel () {
-    if (this.addon?.cancel) {
-      await this.addon.cancel()
+      await this.addon.loadWeights({ filename, chunk: null, completed: true })
+      this.logger.info(`Streamed weights for ${filename}`)
     }
   }
 
-  /**
-   * Unload the model and clear resources. Ensures any in-flight job is resolved as failed.
-   * @returns {Promise<void>}
-   */
-  async unload () {
-    return await this._withExclusiveRun(async () => {
-      await this.cancel()
-      const currentJobResponse = this._jobToResponse.get('OnlyOneJob')
-      if (currentJobResponse) {
-        // Make sure not to leak jobs to avoid "job already exists" errors after
-        // loading the model again.
-        currentJobResponse.failed(new Error('Model was unloaded'))
-        this._deleteJobMapping('OnlyOneJob')
-      }
-      this._hasActiveResponse = false
-      await super.unload()
-    })
+  async run (input) {
+    return this._run(() => this._runInternal(input))
   }
 
   async _runInternal (text) {
-    return this._withExclusiveRun(async () => {
-      if (this._hasActiveResponse) {
-        throw new Error(RUN_BUSY_ERROR_MESSAGE)
-      }
+    if (this._hasActiveResponse) {
+      throw new Error(RUN_BUSY_ERROR_MESSAGE)
+    }
 
-      this.logger.info('Starting inference embeddings for text:', text)
+    this.logger.info('Starting inference embeddings for text:', text)
+    const inputData = Array.isArray(text)
+      ? { type: 'sequences', input: text }
+      : { type: 'text', input: text }
 
-      // Detect arrays and set type: 'sequences' for direct vector passing
-      // Otherwise use type: 'text' for string input
-      const inputData = Array.isArray(text)
-        ? { type: 'sequences', input: text }
-        : { type: 'text', input: text }
+    const response = this._job.start()
 
-      const response = this._createResponse('OnlyOneJob')
+    let accepted
+    try {
+      accepted = await this.addon.runJob(inputData)
+    } catch (error) {
+      this._job.fail(error)
+      throw error
+    }
+    if (!accepted) {
+      this._job.fail(new Error(RUN_BUSY_ERROR_MESSAGE))
+      throw new Error(RUN_BUSY_ERROR_MESSAGE)
+    }
 
-      // addon-cpp C++ guarantees no events will be generated until job is
-      // fully accepted. If runJob throws or returns false, no events will be
-      // generated for this job.
-      let accepted
-      try {
-        accepted = await this.addon.runJob(inputData)
-      } catch (error) {
-        this._deleteJobMapping('OnlyOneJob')
-        response.failed(error)
-        throw error
-      }
-      if (!accepted) {
-        this._deleteJobMapping('OnlyOneJob')
-        response.failed(new Error(RUN_BUSY_ERROR_MESSAGE))
-        throw new Error(RUN_BUSY_ERROR_MESSAGE)
-      }
-
-      this._hasActiveResponse = true
-      const finalized = response.await().finally(() => { this._hasActiveResponse = false })
-      finalized.catch(() => {})
-      response.await = () => finalized
-
-      return response
-    })
-  }
-
-  /**
-   * Instantiate the native addon with the given parameters.
-   * @param {Object} configurationParams - Configuration parameters for the addon
-   * @param {string} configurationParams.path - Local file or directory path
-   * @param {Object} configurationParams.settings - Bert-specific settings
-   * @returns {Addon} The instantiated addon interface
-   */
-  _createAddon (configurationParams) {
-    this.logger.info(
-      'Creating Bert interface with configuration:',
-      configurationParams
-    )
-    const binding = require('./binding')
-    return new BertInterface(
-      binding,
-      configurationParams,
-      this._addonOutputCallback.bind(this)
-    )
+    this._hasActiveResponse = true
+    const finalized = response.await().finally(() => { this._hasActiveResponse = false })
+    finalized.catch(() => {})
+    response.await = () => finalized
+    return response
   }
 
   _addonOutputCallback (addon, event, data, error) {
-    // Map C++ mangled type names to expected event names
-    // Stats / job-ended: LLM uses tokens_per_second; embed uses total_tokens, total_time_ms, etc. (RuntimeStats)
     const isStatsData = typeof data === 'object' && data !== null && (
       'tokens_per_second' in data ||
       ('total_tokens' in data || 'total_time_ms' in data || 'batch_size' in data || 'context_size' in data)
@@ -184,17 +105,50 @@ class GGMLBert extends BaseInference {
       } else if (runtimeStats.backendDevice === 1) {
         runtimeStats.backendDevice = 'gpu'
       }
-      return this._outputCallback(addon, 'JobEnded', 'OnlyOneJob', runtimeStats, null)
+      this._job.end(this.opts.stats ? runtimeStats : null)
+      return
     }
 
-    let mappedEvent = event
     if (event.includes('Error')) {
-      mappedEvent = 'Error'
+      this.logger.error(`Job failed with error: ${error}`)
+      this._job.fail(error)
     } else if (event.includes('Embeddings')) {
-      mappedEvent = 'Output'
+      this._job.output(data)
+    } else {
+      this._job.output(data)
     }
-    return this._outputCallback(addon, mappedEvent, 'OnlyOneJob', data, error)
   }
+
+  _createAddon (configurationParams) {
+    const binding = require('./binding')
+    return new BertInterface(
+      binding,
+      configurationParams,
+      this._addonOutputCallback.bind(this)
+    )
+  }
+
+  async unload () {
+    return this._run(async () => {
+      await this.cancel()
+      if (this._job.active) {
+        this._job.fail(new Error('Model was unloaded'))
+      }
+      this._hasActiveResponse = false
+      if (this.addon) {
+        await this.addon.unload()
+      }
+      this.state.configLoaded = false
+    })
+  }
+
+  async cancel () {
+    if (this.addon) {
+      await this.addon.cancel()
+    }
+  }
+
+  getState () { return this.state }
 }
 
 module.exports = GGMLBert

--- a/packages/qvac-lib-infer-llamacpp-embed/package.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/package.json
@@ -59,9 +59,7 @@
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://github.com/tetherto/qvac/tree/main/packages/qvac-lib-infer-llamacpp-embed#readme",
   "devDependencies": {
-    "@qvac/dl-filesystem": "^0.1.2",
     "@types/node": "^24.2.1",
-    "bare-fs": "^4.5.1",
     "brittle": "^3.4.0",
     "cmake-bare": "^1.7.1",
     "cmake-vcpkg": "^1.1.0",
@@ -69,12 +67,10 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@qvac/infer-base": "^0.2.2",
+    "@qvac/infer-base": "^0.4.0",
     "@qvac/logging": "^0.1.0",
+    "bare-fs": "^4.5.1",
     "bare-path": "^3.0.0"
-  },
-  "peerDependencies": {
-    "@qvac/dl-hyperdrive": "^0.1.0"
   },
   "exports": {
     "./package": "./package.json",

--- a/packages/qvac-lib-infer-llamacpp-embed/test/integration/addon.test.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/integration/addon.test.js
@@ -77,7 +77,7 @@ createDeviceModelTest('Model inference works correctly', async (t, modelName, mo
   const embeddingDimension = modelConfig.embeddingDimension
 
   console.log(`Creating new GGMLBert instance for ${modelName} on ${device.toUpperCase()}`)
-  const { inference, loader } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
+  const { inference } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
 
   const sentence = 'That is a happy person'
   const response = await inference.run(sentence)
@@ -87,7 +87,7 @@ createDeviceModelTest('Model inference works correctly', async (t, modelName, mo
   console.log('Generated embeddings:', embeddings[0][0])
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
@@ -95,7 +95,7 @@ createDeviceModelTest('Model inference works correctly with array input', async 
   const embeddingDimension = modelConfig.embeddingDimension
 
   console.log(`Creating new GGMLBert instance for array input test [${modelName}] on ${device.toUpperCase()}`)
-  const { inference, loader } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
+  const { inference } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
 
   const sentences = ['That is a happy person', 'This is a sad person', 'I am feeling neutral']
   const response = await inference.run(sentences)
@@ -121,14 +121,14 @@ createDeviceModelTest('Model inference works correctly with array input', async 
   }
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
 createDeviceModelTest('Model inference works correctly with long string exceeding context size', async (t, modelName, modelConfig, device) => {
   const maxContextSize = modelConfig.maxContextSize
 
-  const { inference, loader } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
+  const { inference } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
 
   // Create a string that exceeds maxContextSize tokens
   // "Hello world " is approximately 2-3 tokens, repeating enough times to exceed context size
@@ -183,14 +183,14 @@ createDeviceModelTest('Model inference works correctly with long string exceedin
   await inference.cancel()
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
 createDeviceModelTest('Model inference works correctly with array input where one sequence exceeds context size', async (t, modelName, modelConfig, device) => {
   const maxContextSize = modelConfig.maxContextSize
 
-  const { inference, loader } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
+  const { inference } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
 
   // Create an array with 3 sequences where the second sequence exceeds context size
   // "Hello world " is approximately 2-3 tokens, repeating enough times to exceed context size
@@ -251,7 +251,7 @@ createDeviceModelTest('Model inference works correctly with array input where on
   await inference.cancel()
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
@@ -260,7 +260,7 @@ createDeviceModelTest('Model inference works correctly with batching - 5 sequenc
   const maxContextSize = modelConfig.maxContextSize
 
   console.log(`Creating new GGMLBert instance for batching test [${modelName}] on ${device.toUpperCase()}`)
-  const { inference, loader } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
+  const { inference } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
 
   // Create 5 sequences of roughly similar length.
   // The goal is to have enough total tokens so that:
@@ -305,12 +305,12 @@ createDeviceModelTest('Model inference works correctly with batching - 5 sequenc
   }
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
 createDeviceModelTest('Embeddings: empty string input', async (t, modelName, modelConfig, device) => {
-  const { inference, loader } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
+  const { inference } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
 
   const sentence = ''
   const response = await inference.run(sentence)
@@ -326,14 +326,14 @@ createDeviceModelTest('Embeddings: empty string input', async (t, modelName, mod
   }
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
 createDeviceModelTest('Embeddings: whitespace-only string input', async (t, modelName, modelConfig, device) => {
   const embeddingDimension = modelConfig.embeddingDimension
 
-  const { inference, loader } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
+  const { inference } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
 
   const sentence = ' \t  \n  '
   const response = await inference.run(sentence)
@@ -345,14 +345,14 @@ createDeviceModelTest('Embeddings: whitespace-only string input', async (t, mode
   )
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
 createDeviceModelTest('Embeddings: unicode / multilingual input with emojis', async (t, modelName, modelConfig, device) => {
   const embeddingDimension = modelConfig.embeddingDimension
 
-  const { inference, loader } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
+  const { inference } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
 
   const sentences = ['Привет, как дела? 😊', '你好，世界 🌏', 'Hola, ¿cómo estás? ❤️', 'Hello, world! 🚀']
   const response = await inference.run(sentences)
@@ -365,14 +365,14 @@ createDeviceModelTest('Embeddings: unicode / multilingual input with emojis', as
   }
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
 createDeviceModelTest('Embeddings: deterministic output for same input', async (t, modelName, modelConfig, device) => {
   const embeddingDimension = modelConfig.embeddingDimension
 
-  const { inference, loader } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
+  const { inference } = await createEmbeddingsTestInstance(t, modelName, device, null, DEFAULT_BATCH_SIZE)
 
   const sentence = 'This sentence should always map to the same embedding.'
 
@@ -422,7 +422,7 @@ createDeviceModelTest('Embeddings: deterministic output for same input', async (
   t.ok(similarity > 0.999, `Same input should produce identical embeddings (cosine similarity: ${similarity.toFixed(6)})`)
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
@@ -434,7 +434,7 @@ createDeviceModelTest(`Stress: inference with large batch size ${STRESS_BATCH_SI
     `(batch_size=${STRESS_BATCH_SIZE})`
   )
 
-  const { inference, loader } = await createEmbeddingsTestInstance(
+  const { inference } = await createEmbeddingsTestInstance(
     t,
     modelName,
     device,
@@ -464,7 +464,7 @@ createDeviceModelTest(`Stress: inference with large batch size ${STRESS_BATCH_SI
   }
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
@@ -476,7 +476,7 @@ createDeviceModelTest(`Stress: inference with many sequences (~${STRESS_NUM_SEQU
     `(num_sequences=${STRESS_NUM_SEQUENCES})`
   )
 
-  const { inference, loader } = await createEmbeddingsTestInstance(
+  const { inference } = await createEmbeddingsTestInstance(
     t,
     modelName,
     device,
@@ -515,14 +515,14 @@ createDeviceModelTest(`Stress: inference with many sequences (~${STRESS_NUM_SEQU
   }
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
 createDeviceModelTest('Cancel: immediate cancel returns fewer embeddings than full run', async (t, modelName, modelConfig, device) => {
   console.log(`Creating GGMLBert instance for cancel comparison test [${modelName}] on ${device.toUpperCase()}`)
 
-  const { inference, loader } = await createEmbeddingsTestInstance(
+  const { inference } = await createEmbeddingsTestInstance(
     t,
     modelName,
     device,
@@ -570,7 +570,7 @@ createDeviceModelTest('Cancel: immediate cancel returns fewer embeddings than fu
   )
 
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
 })
 
@@ -580,7 +580,7 @@ const MODEL_NAME_API = getModelConfigs()[0]?.modelName ?? 'embeddinggemma-300M-Q
 
 async function setupModelApiBehavior (t) {
   await ensureModel(MODEL_NAME_API)
-  const { inference, loader } = await createEmbeddingsTestInstance(
+  const { inference } = await createEmbeddingsTestInstance(
     t,
     MODEL_NAME_API,
     DEVICE_API,
@@ -588,7 +588,7 @@ async function setupModelApiBehavior (t) {
     '1024'
   )
   t.teardown(async () => {
-    await cleanupResources(loader, inference)
+    await cleanupResources(inference)
   })
   return { inference }
 }

--- a/packages/qvac-lib-infer-llamacpp-embed/test/integration/utils.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/integration/utils.js
@@ -5,7 +5,6 @@ const path = require('bare-path')
 const https = require('bare-https')
 const os = require('bare-os')
 const GGMLBert = require('../../index.js')
-const FilesystemDL = require('@qvac/dl-filesystem')
 
 /**
  * Downloads a file from a URL to a destination path
@@ -162,15 +161,14 @@ class TestLogger {
  * @param {string} device - Device to use: 'cpu' or 'gpu' (default: 'gpu')
  * @param {string} gpuLayers - Number of GPU layers (default: '999' for GPU, '0' for CPU)
  * @param {string} batchSize - Batch size (default: '1024')
- * @returns {Promise<{inference: GGMLBert, loader: FilesystemDL}>}
+ * @returns {Promise<{inference: GGMLBert}>}
  */
 async function createEmbeddingsTestInstance (t, modelName, device = 'gpu', gpuLayers = null, batchSize = '1024') {
   const [, modelDir] = await ensureModel(modelName)
-  const diskPath = modelDir
+  const modelPath = path.join(modelDir, modelName)
 
-  t.ok(fs.existsSync(path.join(diskPath, modelName)), 'Model file should exist')
+  t.ok(fs.existsSync(modelPath), 'Model file should exist')
 
-  const loader = new FilesystemDL({ dirPath: diskPath })
   const logger = new TestLogger()
 
   // Force CPU on darwin-x64
@@ -180,31 +178,32 @@ async function createEmbeddingsTestInstance (t, modelName, device = 'gpu', gpuLa
     console.log('Platform detected: darwin-x64, forcing device to CPU')
   }
 
-  // Determine gpu_layers based on device if not explicitly provided
   const actualGpuLayers = gpuLayers !== null ? gpuLayers : (device === 'cpu' ? '0' : '999')
 
-  // Build config object with device and gpu_layers parameters
   const config = {
     gpu_layers: actualGpuLayers,
     batch_size: batchSize
   }
 
-  // Add device preference if specified
   if (device === 'cpu' || device === 'gpu') {
     config.device = device
   }
 
-  // Disable flash attention on Android
   if (os.platform() === 'android') {
     config.flash_attn = 'off'
     console.log('Platform detected: Android, setting flash_attn to off')
   }
 
-  const inference = new GGMLBert({ modelName, loader, logger, diskPath, opts: { stats: true } }, config)
+  const inference = new GGMLBert({
+    files: { model: [modelPath] },
+    config,
+    logger,
+    opts: { stats: true }
+  })
 
   await inference.load()
 
-  return { inference, loader }
+  return { inference }
 }
 
 /**
@@ -256,12 +255,10 @@ function removeErrorHandlers (response) {
 
 /**
  * Cleans up test resources
- * @param {Object} loader - The loader instance
  * @param {Object} inference - The inference instance
  * @returns {Promise<void>}
  */
-async function cleanupResources (loader, inference) {
-  await loader.close()
+async function cleanupResources (inference) {
   await inference.unload()
 }
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Embed addon is tightly coupled to BaseInference class and WeightsProvider download layer
- Constructor requires a Loader object even when model files are already on disk
- Job management uses inherited _jobToResponse Map boilerplate

## 📝 How does it solve it?

- Remove BaseInference class inheritance, use composable utilities from @qvac/infer-base@0.4.0
- createJobHandler() replaces _jobToResponse Map, _createResponse, _outputCallback routing
- exclusiveRunQueue() replaces _withExclusiveRun
- Constructor takes { files: { model: string[] }, config, logger, opts } with pre-resolved absolute paths
- Shard streaming via bare-fs.createReadStream directly (no WeightsProvider)
- Remove @qvac/dl-filesystem and @qvac/dl-hyperdrive dependencies

## 🧪 How was it tested?

- Lint passes (standard)
- Integration tests updated to use new constructor shape

## 💥 Breaking Changes

**BEFORE:**

```javascript
const model = new GGMLBert({ modelName, loader, diskPath, logger }, config)
```

**AFTER:**

```javascript
const model = new GGMLBert({
  files: { model: ['/absolute/path/to/model.gguf'] },
  config: { device: 'gpu', gpu_layers: '25' },
  logger,
  opts: { stats: true }
})
```

## 🔌 API Changes

```javascript
// Constructor: single object with files.model (string array of absolute paths)
// Removed: downloadWeights(), weightsProvider, Loader interface
// Removed: destroy(), pause(), unpause(), stop(), status(), reset()
// Kept: load(), run(), unload(), cancel(), getState()
```
