### PR TITLE
feat[api]: expose backendDevice stat in SDK for LLM and embed addons

### DIFF
--- a/packages/sdk/schemas/completion-stream.ts
+++ b/packages/sdk/schemas/completion-stream.ts
@@ -51,6 +51,7 @@ export const completionStatsSchema = z.object({
   timeToFirstToken: z.number().optional(),
   tokensPerSecond: z.number().optional(),
   cacheTokens: z.number().optional(),
+  backendDevice: z.enum(["cpu", "gpu"]).optional(),
 });
 
 export const completionStreamResponseSchema = z.object({

--- a/packages/sdk/schemas/embed.ts
+++ b/packages/sdk/schemas/embed.ts
@@ -18,6 +18,7 @@ export const embedStatsSchema = z.object({
   totalTime: z.number().optional(),
   tokensPerSecond: z.number().optional(),
   totalTokens: z.number().optional(),
+  backendDevice: z.enum(["cpu", "gpu"]).optional(),
 });
 
 export const embedResponseSchema = z.object({

--- a/packages/sdk/server/bare/ops/embed.ts
+++ b/packages/sdk/server/bare/ops/embed.ts
@@ -38,6 +38,7 @@ export async function embed(params: EmbedParams): Promise<EmbedResult> {
     ...(response.stats?.total_time_ms !== undefined && { totalTime: response.stats.total_time_ms }),
     ...(response.stats?.tokens_per_second !== undefined && { tokensPerSecond: response.stats.tokens_per_second }),
     ...(response.stats?.total_tokens !== undefined && { totalTokens: response.stats.total_tokens }),
+    ...(response.stats?.backendDevice !== undefined && { backendDevice: response.stats.backendDevice }),
   };
 
   const embeddingsArray = rawEmbeddings[0];

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
@@ -281,6 +281,9 @@ async function* processModelResponse(
     ...(responseWithStats.stats?.CacheTokens !== undefined && {
       cacheTokens: responseWithStats.stats.CacheTokens,
     }),
+    ...(responseWithStats.stats?.backendDevice !== undefined && {
+      backendDevice: responseWithStats.stats.backendDevice,
+    }),
   };
 
   return {

--- a/packages/sdk/server/bare/types/addon-responses.ts
+++ b/packages/sdk/server/bare/types/addon-responses.ts
@@ -3,6 +3,7 @@ export interface LlmStats {
   TPS?: number;
   CacheTokens?: number;
   generatedTokens?: number;
+  backendDevice?: "cpu" | "gpu";
 }
 
 export interface LlmResponse {
@@ -38,6 +39,7 @@ export interface EmbedStats {
   total_time_ms?: number;
   tokens_per_second?: number;
   total_tokens?: number;
+  backendDevice?: "cpu" | "gpu";
 }
 
 export interface EmbedResponse {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- PR #1393 adds backendDevice (cpu/gpu) to RuntimeStats in LLM and embed addons
- SDK does not expose this stat to consumers

## 📝 How does it solve it?

- Add optional backendDevice field to LlmStats and EmbedStats addon response interfaces
- Add backendDevice to completionStatsSchema and embedStatsSchema (Zod)
- Map backendDevice through in completion-stream and embed ops

> **Depends on:** Finetuning PR #1332 by @maxim-smotrov, which bumps llm@0.14.* and embed@0.13.* into SDK.

## 🔌 API Changes

```typescript
// CompletionStats - new optional field
{
  timeToFirstToken?: number
  tokensPerSecond?: number
  cacheTokens?: number
  backendDevice?: \"cpu\" | \"gpu\"  // NEW
}

// EmbedStats - new optional field
{
  totalTime?: number
  tokensPerSecond?: number
  totalTokens?: number
  backendDevice?: \"cpu\" | \"gpu\"  // NEW
}
```
