### PR TITLE
fix: replace default CodeQL Actions scanning with advanced setup to suppress false positives

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,12 @@
+# CodeQL configuration for GitHub Actions workflow scanning.
+#
+# Excludes the artifact-poisoning query which produces false positives
+# on workflow_dispatch workflows that only run npm commands.
+# These workflows require write access to trigger and already have:
+#   - Input validation (only @qvac/* packages allowed)
+#   - --ignore-scripts on npm install/pack commands
+#   - No untrusted data flowing into shell commands
+
+query-filters:
+  - exclude:
+      id: actions/artifact-poisoning

--- a/.github/workflows/codeql-actions.yml
+++ b/.github/workflows/codeql-actions.yml
@@ -1,0 +1,47 @@
+name: "CodeQL: GitHub Actions"
+
+# Scans GitHub Actions workflow files using CodeQL with a custom config
+# that excludes false-positive artifact-poisoning alerts.
+#
+# This replaces the "actions" language from the default CodeQL setup.
+# After merging, remove "actions" from the default setup in:
+#   Settings > Code security > Code scanning > CodeQL analysis > Default setup
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/codeql/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/codeql/**"
+  schedule:
+    - cron: "25 14 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze GitHub Actions
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # 3.35.1
+        with:
+          languages: actions
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # 3.35.1
+        with:
+          category: "/language:actions"


### PR DESCRIPTION
## Summary

- Adds a **CodeQL configuration file** (`.github/codeql/codeql-config.yml`) that excludes the `actions/artifact-poisoning` query, which produces false positives on `workflow_dispatch` workflows
- Adds a **CodeQL advanced setup workflow** (`.github/workflows/codeql-actions.yml`) that scans only the `actions` language using the custom config

## Why these alerts are false positives

The `actions/artifact-poisoning/critical` rule flags `npm install`, `npm pack`, and `npm run` commands in `workflow_dispatch`-triggered workflows. However, these are not exploitable because:

1. **`workflow_dispatch` requires write access** — only trusted collaborators can trigger these workflows (unlike `pull_request_target` or `issue_comment`)
2. **Input validation is in place** — the workflows validate that the `package` input matches `^@qvac/` before proceeding
3. **`--ignore-scripts` is used** — `npm install` and `npm pack` commands use `--ignore-scripts` to prevent execution of lifecycle scripts
4. **No untrusted data flows into shell commands** — the flagged steps use hardcoded matrix values, secrets, and workflow-level env vars

This matches the assessment applied when dismissing similar alerts in `integration-test-qvac-lib-infer-nmtcpp.yml` and `integration-mobile-test-qvac-lib-infer-nmtcpp.yml`.

## Post-merge action required

After merging this PR, **remove `actions` from the default CodeQL setup** to avoid duplicate scanning:

> Settings → Code security → Code scanning → CodeQL analysis → Default setup → Edit → uncheck "Actions" → Save

The other three languages (C/C++, JavaScript/TypeScript, Python) should remain on the default setup.

## Test plan

- [ ] Verify the `CodeQL: GitHub Actions` workflow runs successfully on this PR
- [ ] After merge, verify no new artifact-poisoning alerts appear on subsequent scans
- [ ] Remove `actions` from the default setup as described above

Made with [Cursor](https://cursor.com)