### PR TITLE
feat: registry server hardening per Holepunch team feedback

### DIFF
--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -5449,7 +5449,7 @@
     "description": "Supertone Supertonic 2 tts.json (model layout / sample rate)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5464,7 +5464,7 @@
     "description": "Supertone Supertonic 2 duration predictor (fp32)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5480,7 +5480,7 @@
     "description": "Supertone Supertonic 2 text encoder (fp32)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5496,7 +5496,7 @@
     "description": "Supertone Supertonic 2 vector estimator (fp32)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5512,7 +5512,7 @@
     "description": "Supertone Supertonic 2 vocoder (fp32)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5528,7 +5528,7 @@
     "description": "Supertone Supertonic 2 unicode indexer (fp32)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5544,7 +5544,7 @@
     "description": "Supertone Supertonic 2 voice style F1 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5559,7 +5559,7 @@
     "description": "Supertone Supertonic 2 voice style F2 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5574,7 +5574,7 @@
     "description": "Supertone Supertonic 2 voice style F3 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5589,7 +5589,7 @@
     "description": "Supertone Supertonic 2 voice style F4 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5604,7 +5604,7 @@
     "description": "Supertone Supertonic 2 voice style F5 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5619,7 +5619,7 @@
     "description": "Supertone Supertonic 2 voice style M1 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5634,7 +5634,7 @@
     "description": "Supertone Supertonic 2 voice style M2 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5649,7 +5649,7 @@
     "description": "Supertone Supertonic 2 voice style M3 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5664,7 +5664,7 @@
     "description": "Supertone Supertonic 2 voice style M4 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5679,7 +5679,7 @@
     "description": "Supertone Supertonic 2 voice style M5 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",

--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -5,7 +5,7 @@
     "description": "",
     "quantization": "q8",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -19,7 +19,7 @@
     "description": "",
     "quantization": "q4",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -33,7 +33,7 @@
     "description": "",
     "quantization": "q8",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "small",
@@ -48,7 +48,7 @@
     "description": "",
     "quantization": "",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "large",
@@ -63,7 +63,7 @@
     "description": "",
     "quantization": "",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "tiny-silero",
@@ -77,7 +77,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "tiny",
@@ -91,7 +91,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "tiny",
@@ -106,7 +106,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "tiny",
@@ -121,7 +121,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "base",
@@ -135,7 +135,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "base",
@@ -149,7 +149,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "base",
@@ -164,7 +164,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "base",
@@ -179,7 +179,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "small",
@@ -193,7 +193,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "small",
@@ -207,7 +207,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "small",
@@ -222,7 +222,7 @@
     "description": "VAD model for Whisper",
     "quantization": "",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "tiny-silero",
@@ -237,7 +237,7 @@
     "description": "Multimodal 4B model, good for tool calls",
     "quantization": "q4_K_M",
     "params": "4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -251,7 +251,7 @@
     "description": "Finetuned for medicine 4B model, good for tool calls",
     "quantization": "q4_1",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -265,7 +265,7 @@
     "description": "Finetuned for medicine 4B model, good for tool calls",
     "quantization": "q8_0",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -279,7 +279,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -293,7 +293,7 @@
     "description": "",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "embedding",
       "bert",
@@ -307,7 +307,7 @@
     "description": "",
     "quantization": "q4",
     "params": "1.7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -321,7 +321,7 @@
     "description": "Vision-language model for video understanding",
     "quantization": "q8_0",
     "params": "500M",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "multimodal",
@@ -337,7 +337,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "500M",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "multimodal",
@@ -354,7 +354,7 @@
     "description": "",
     "quantization": "q4_1",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -370,7 +370,7 @@
     "description": "",
     "quantization": "q4_1",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -386,7 +386,7 @@
     "description": "",
     "quantization": "q4_1",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -402,7 +402,7 @@
     "description": "",
     "quantization": "q4_1",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -418,7 +418,7 @@
     "description": "",
     "quantization": "q4_1",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -433,7 +433,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "q4_1",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -449,7 +449,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -465,7 +465,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -481,7 +481,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -497,7 +497,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -513,7 +513,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -528,7 +528,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "q8_0",
     "params": "4B",
-    "license": "health-ai-developer-foundations",
+    "licenseId": "health-ai-developer-foundations",
     "tags": [
       "generation",
       "it",
@@ -544,7 +544,7 @@
     "description": "",
     "quantization": "fp16",
     "params": "335M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "embedding",
       "bert",
@@ -560,7 +560,7 @@
     "description": "",
     "quantization": "fp16",
     "params": "335M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "embedding",
       "bert",
@@ -576,7 +576,7 @@
     "description": "",
     "quantization": "fp16",
     "params": "335M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "embedding",
       "bert",
@@ -592,7 +592,7 @@
     "description": "",
     "quantization": "fp16",
     "params": "335M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "embedding",
       "bert",
@@ -608,7 +608,7 @@
     "description": "",
     "quantization": "fp16",
     "params": "335M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "embedding",
       "bert",
@@ -623,7 +623,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "fp16",
     "params": "335M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "embedding",
       "bert",
@@ -639,7 +639,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -655,7 +655,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -671,7 +671,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -687,7 +687,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -703,7 +703,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -719,7 +719,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -735,7 +735,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -751,7 +751,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -766,7 +766,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "llama3.2",
+    "licenseId": "llama3.2",
     "tags": [
       "generation",
       "instruct",
@@ -782,7 +782,7 @@
     "description": "",
     "quantization": "q4",
     "params": "4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -798,7 +798,7 @@
     "description": "",
     "quantization": "q4",
     "params": "4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -814,7 +814,7 @@
     "description": "",
     "quantization": "q4",
     "params": "4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -830,7 +830,7 @@
     "description": "",
     "quantization": "q4",
     "params": "4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -846,7 +846,7 @@
     "description": "",
     "quantization": "q4",
     "params": "4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -861,7 +861,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "q4",
     "params": "4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -877,7 +877,7 @@
     "description": "",
     "quantization": "q4",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -893,7 +893,7 @@
     "description": "",
     "quantization": "q4",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -909,7 +909,7 @@
     "description": "",
     "quantization": "q4",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -924,7 +924,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "q4",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -940,7 +940,7 @@
     "description": "",
     "quantization": "q8",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -956,7 +956,7 @@
     "description": "",
     "quantization": "q8",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -972,7 +972,7 @@
     "description": "",
     "quantization": "q8",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -988,7 +988,7 @@
     "description": "",
     "quantization": "q8",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1003,7 +1003,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "q8",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1019,7 +1019,7 @@
     "description": "",
     "quantization": "q4",
     "params": "1.7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1035,7 +1035,7 @@
     "description": "",
     "quantization": "q4",
     "params": "1.7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1051,7 +1051,7 @@
     "description": "",
     "quantization": "q4",
     "params": "1.7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1067,7 +1067,7 @@
     "description": "",
     "quantization": "q4",
     "params": "1.7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1083,7 +1083,7 @@
     "description": "",
     "quantization": "q4",
     "params": "1.7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1098,7 +1098,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "q4",
     "params": "1.7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1113,7 +1113,7 @@
     "description": "Google multilingual embedding model, 768-dim output, 2048 token context",
     "quantization": "q4_0",
     "params": "300M",
-    "license": "gemma",
+    "licenseId": "gemma",
     "tags": [
       "embedding",
       "embed",
@@ -1127,7 +1127,7 @@
     "description": "Google multilingual embedding model, 768-dim output, 2048 token context",
     "quantization": "q8_0",
     "params": "300M",
-    "license": "gemma",
+    "licenseId": "gemma",
     "tags": [
       "embedding",
       "embed",
@@ -1141,7 +1141,7 @@
     "description": "",
     "quantization": "BF16",
     "params": "300M",
-    "license": "gemma",
+    "licenseId": "gemma",
     "tags": [
       "embedding",
       "embed",
@@ -1155,7 +1155,7 @@
     "description": "",
     "quantization": "F32",
     "params": "300M",
-    "license": "gemma",
+    "licenseId": "gemma",
     "tags": [
       "embedding",
       "embed",
@@ -1169,7 +1169,7 @@
     "description": "MoE model with DPO training",
     "quantization": "Q2_K",
     "params": "2x7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1184,7 +1184,7 @@
     "description": "",
     "quantization": "f16",
     "params": "1B",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1200,7 +1200,7 @@
     "description": "",
     "quantization": "f16",
     "params": "200M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1216,7 +1216,7 @@
     "description": "",
     "quantization": "f16",
     "params": "1B",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1232,7 +1232,7 @@
     "description": "",
     "quantization": "f16",
     "params": "200M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1248,7 +1248,7 @@
     "description": "",
     "quantization": "f16",
     "params": "1B",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1264,7 +1264,7 @@
     "description": "",
     "quantization": "f16",
     "params": "320M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1280,7 +1280,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1296,7 +1296,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "200M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1312,7 +1312,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1328,7 +1328,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "200M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1344,7 +1344,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "1B",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1360,7 +1360,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "320M",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "translation",
       "full",
@@ -1377,7 +1377,7 @@
     "description": "",
     "quantization": "Q2_K",
     "params": "2x7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "moe",
@@ -1393,7 +1393,7 @@
     "description": "",
     "quantization": "Q2_K",
     "params": "2x7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "moe",
@@ -1409,7 +1409,7 @@
     "description": "",
     "quantization": "Q2_K",
     "params": "2x7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "moe",
@@ -1425,7 +1425,7 @@
     "description": "",
     "quantization": "Q2_K",
     "params": "2x7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "moe",
@@ -1441,7 +1441,7 @@
     "description": "",
     "quantization": "Q2_K",
     "params": "2x7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "moe",
@@ -1456,7 +1456,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "Q2_K",
     "params": "2x7B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "moe",
@@ -1471,7 +1471,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -1487,7 +1487,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "translation",
       "opus",
@@ -1503,7 +1503,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -1519,7 +1519,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "translation",
       "opus",
@@ -1535,7 +1535,7 @@
     "description": "",
     "quantization": "f16",
     "params": "500M",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "multimodal",
@@ -1550,7 +1550,7 @@
     "description": "",
     "quantization": "f16",
     "params": "500M",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "multimodal",
@@ -1565,7 +1565,7 @@
     "description": "",
     "quantization": "q4",
     "params": "600M",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -1580,7 +1580,7 @@
     "description": "Fine-tuned for Norwegian",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -1596,7 +1596,7 @@
     "description": "With acoustic fine-tuning",
     "quantization": "",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "ggml",
@@ -1611,7 +1611,7 @@
     "description": "With acoustic fine-tuning",
     "quantization": "",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "ggml",
@@ -1625,7 +1625,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1641,7 +1641,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1657,7 +1657,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1673,7 +1673,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1689,7 +1689,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1705,7 +1705,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1721,7 +1721,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1737,7 +1737,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1753,7 +1753,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1769,7 +1769,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1785,7 +1785,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1801,7 +1801,7 @@
     "description": "",
     "quantization": "q0f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1817,7 +1817,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "translation",
       "opus-ggml",
@@ -1833,7 +1833,7 @@
     "description": "Text recognizer - Latin (fixed-width 512px)",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -1848,7 +1848,7 @@
     "description": "CRAFT text detector",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "detector",
@@ -1863,7 +1863,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -1879,7 +1879,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -1895,7 +1895,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "translation",
       "opus",
@@ -1911,7 +1911,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -1927,7 +1927,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -1943,7 +1943,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -1959,7 +1959,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -1975,7 +1975,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -1991,7 +1991,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -2007,7 +2007,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -2023,7 +2023,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -2039,7 +2039,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "translation",
       "opus",
@@ -2055,7 +2055,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -2071,7 +2071,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -2087,7 +2087,7 @@
     "description": "",
     "quantization": "q4_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "translation",
       "opus",
@@ -2104,7 +2104,7 @@
     "description": "Fine-tuned for French",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2120,7 +2120,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2136,7 +2136,7 @@
     "description": "Fine-tuned for German",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2152,7 +2152,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2168,7 +2168,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2184,7 +2184,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2200,7 +2200,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2216,7 +2216,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2232,7 +2232,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2248,7 +2248,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2264,7 +2264,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2280,7 +2280,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2296,7 +2296,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2312,7 +2312,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2328,7 +2328,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2344,7 +2344,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2360,7 +2360,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2376,7 +2376,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2392,7 +2392,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2408,7 +2408,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2424,7 +2424,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2440,7 +2440,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2456,7 +2456,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2472,7 +2472,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2488,7 +2488,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2504,7 +2504,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "base-ggml",
@@ -2520,7 +2520,7 @@
     "description": "",
     "quantization": "f16",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2536,7 +2536,7 @@
     "description": "",
     "quantization": "q8_0",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "transcription",
       "tiny-ggml",
@@ -2551,7 +2551,7 @@
     "description": "Multimodal 2B model",
     "quantization": "q4_k",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "multimodal",
@@ -2567,7 +2567,7 @@
     "description": "Vision adapter (mmproj)",
     "quantization": "q4_k",
     "params": "2B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "multimodal",
@@ -2583,7 +2583,7 @@
     "description": "Bergamot lexical shortlist ar-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2599,7 +2599,7 @@
     "description": "Bergamot metadata ar-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2615,7 +2615,7 @@
     "description": "Bergamot NMT model ar-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2631,7 +2631,7 @@
     "description": "Bergamot vocabulary ar-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2647,7 +2647,7 @@
     "description": "Bergamot lexical shortlist cs-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2663,7 +2663,7 @@
     "description": "Bergamot metadata cs-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2679,7 +2679,7 @@
     "description": "Bergamot NMT model cs-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2695,7 +2695,7 @@
     "description": "Bergamot vocabulary cs-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2711,7 +2711,7 @@
     "description": "Bergamot lexical shortlist en-ar",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2727,7 +2727,7 @@
     "description": "Bergamot metadata en-ar",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2743,7 +2743,7 @@
     "description": "Bergamot NMT model en-ar",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2759,7 +2759,7 @@
     "description": "Bergamot vocabulary en-ar",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2775,7 +2775,7 @@
     "description": "Bergamot lexical shortlist en-cs",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2791,7 +2791,7 @@
     "description": "Bergamot metadata en-cs",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2807,7 +2807,7 @@
     "description": "Bergamot NMT model en-cs",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2823,7 +2823,7 @@
     "description": "Bergamot vocabulary en-cs",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2839,7 +2839,7 @@
     "description": "Bergamot lexical shortlist en-es",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2855,7 +2855,7 @@
     "description": "Bergamot metadata en-es",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2871,7 +2871,7 @@
     "description": "Bergamot NMT model en-es",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2887,7 +2887,7 @@
     "description": "Bergamot vocabulary en-es",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2903,7 +2903,7 @@
     "description": "Bergamot lexical shortlist en-fr",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2919,7 +2919,7 @@
     "description": "Bergamot metadata en-fr",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2935,7 +2935,7 @@
     "description": "Bergamot NMT model en-fr",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2951,7 +2951,7 @@
     "description": "Bergamot vocabulary en-fr",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2967,7 +2967,7 @@
     "description": "Bergamot lexical shortlist en-it",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2983,7 +2983,7 @@
     "description": "Bergamot metadata en-it",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -2999,7 +2999,7 @@
     "description": "Bergamot NMT model en-it",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3015,7 +3015,7 @@
     "description": "Bergamot vocabulary en-it",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3031,7 +3031,7 @@
     "description": "Bergamot lexical shortlist en-ja",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3047,7 +3047,7 @@
     "description": "Bergamot metadata en-ja",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3063,7 +3063,7 @@
     "description": "Bergamot NMT model en-ja",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3079,7 +3079,7 @@
     "description": "Bergamot vocabulary en-ja",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3095,7 +3095,7 @@
     "description": "Bergamot vocabulary en-ja",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3111,7 +3111,7 @@
     "description": "Bergamot lexical shortlist en-pt",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3127,7 +3127,7 @@
     "description": "Bergamot metadata en-pt",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3143,7 +3143,7 @@
     "description": "Bergamot NMT model en-pt",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3159,7 +3159,7 @@
     "description": "Bergamot vocabulary en-pt",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3175,7 +3175,7 @@
     "description": "Bergamot lexical shortlist en-ru",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3191,7 +3191,7 @@
     "description": "Bergamot metadata en-ru",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3207,7 +3207,7 @@
     "description": "Bergamot NMT model en-ru",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3223,7 +3223,7 @@
     "description": "Bergamot vocabulary en-ru",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3239,7 +3239,7 @@
     "description": "Bergamot lexical shortlist en-zh",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3255,7 +3255,7 @@
     "description": "Bergamot metadata en-zh",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3271,7 +3271,7 @@
     "description": "Bergamot NMT model en-zh",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3287,7 +3287,7 @@
     "description": "Bergamot vocabulary en-zh",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3303,7 +3303,7 @@
     "description": "Bergamot vocabulary en-zh",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3319,7 +3319,7 @@
     "description": "Bergamot lexical shortlist es-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3335,7 +3335,7 @@
     "description": "Bergamot metadata es-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3351,7 +3351,7 @@
     "description": "Bergamot NMT model es-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3367,7 +3367,7 @@
     "description": "Bergamot vocabulary es-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3383,7 +3383,7 @@
     "description": "Bergamot lexical shortlist fr-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3399,7 +3399,7 @@
     "description": "Bergamot metadata fr-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3415,7 +3415,7 @@
     "description": "Bergamot NMT model fr-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3431,7 +3431,7 @@
     "description": "Bergamot vocabulary fr-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3447,7 +3447,7 @@
     "description": "Bergamot lexical shortlist it-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3463,7 +3463,7 @@
     "description": "Bergamot metadata it-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3479,7 +3479,7 @@
     "description": "Bergamot NMT model it-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3495,7 +3495,7 @@
     "description": "Bergamot vocabulary it-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3511,7 +3511,7 @@
     "description": "Bergamot lexical shortlist ja-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3527,7 +3527,7 @@
     "description": "Bergamot metadata ja-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3543,7 +3543,7 @@
     "description": "Bergamot NMT model ja-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3559,7 +3559,7 @@
     "description": "Bergamot vocabulary ja-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3575,7 +3575,7 @@
     "description": "Bergamot lexical shortlist pt-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3591,7 +3591,7 @@
     "description": "Bergamot metadata pt-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3607,7 +3607,7 @@
     "description": "Bergamot NMT model pt-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3623,7 +3623,7 @@
     "description": "Bergamot vocabulary pt-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3639,7 +3639,7 @@
     "description": "Bergamot lexical shortlist ru-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3655,7 +3655,7 @@
     "description": "Bergamot metadata ru-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3671,7 +3671,7 @@
     "description": "Bergamot NMT model ru-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3687,7 +3687,7 @@
     "description": "Bergamot vocabulary ru-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3703,7 +3703,7 @@
     "description": "Bergamot lexical shortlist zh-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3719,7 +3719,7 @@
     "description": "Bergamot metadata zh-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3735,7 +3735,7 @@
     "description": "Bergamot NMT model zh-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3751,7 +3751,7 @@
     "description": "Bergamot vocabulary zh-en",
     "quantization": "",
     "params": "",
-    "license": "MPL-2.0",
+    "licenseId": "MPL-2.0",
     "tags": [
       "translation",
       "nmt",
@@ -3767,7 +3767,7 @@
     "description": "Llama 3.2 1B with tool calling support",
     "quantization": "q4_k",
     "params": "1B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -3782,7 +3782,7 @@
     "description": "GPT-OSS 20B instruct",
     "quantization": "q4_k_m",
     "params": "20B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -3796,7 +3796,7 @@
     "description": "Qwen 3 8B instruct",
     "quantization": "q4_k_m",
     "params": "8B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -3810,7 +3810,7 @@
     "description": "Text recognizer - Arabic",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3825,7 +3825,7 @@
     "description": "Text recognizer - Bengali",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3840,7 +3840,7 @@
     "description": "Text recognizer - Cyrillic",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3855,7 +3855,7 @@
     "description": "Text recognizer - Devanagari",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3870,7 +3870,7 @@
     "description": "Text recognizer - Japanese",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3885,7 +3885,7 @@
     "description": "Text recognizer - Kannada",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3900,7 +3900,7 @@
     "description": "Text recognizer - Korean",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3915,7 +3915,7 @@
     "description": "Text recognizer - Latin",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3930,7 +3930,7 @@
     "description": "Text recognizer - Tamil",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3945,7 +3945,7 @@
     "description": "Text recognizer - Telugu",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3960,7 +3960,7 @@
     "description": "Text recognizer - Thai",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3975,7 +3975,7 @@
     "description": "Text recognizer - Chinese Simplified",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -3990,7 +3990,7 @@
     "description": "Text recognizer - Chinese Traditional",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "recognizer",
@@ -4005,7 +4005,7 @@
     "description": "DocTR text detector - DBNet ResNet50",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "doctr",
@@ -4021,7 +4021,7 @@
     "description": "DocTR text detector - DBNet MobileNetV3 Large",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "doctr",
@@ -4037,7 +4037,7 @@
     "description": "DocTR text recognizer - PARSeq",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "doctr",
@@ -4053,7 +4053,7 @@
     "description": "DocTR text recognizer - CRNN MobileNetV3 Small",
     "quantization": "",
     "params": "",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "ocr",
       "doctr",
@@ -4069,7 +4069,7 @@
     "description": "Chatterbox tokenizer",
     "quantization": "",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4084,7 +4084,7 @@
     "description": "Chatterbox speech encoder (fp32, graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4099,7 +4099,7 @@
     "description": "Chatterbox speech encoder (fp32, weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4114,7 +4114,7 @@
     "description": "Chatterbox token embeddings (fp32, graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4129,7 +4129,7 @@
     "description": "Chatterbox token embeddings (fp32, weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4144,7 +4144,7 @@
     "description": "Chatterbox conditional decoder (fp32, graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4159,7 +4159,7 @@
     "description": "Chatterbox conditional decoder (fp32, weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4174,7 +4174,7 @@
     "description": "Chatterbox language model (fp32, graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4189,7 +4189,7 @@
     "description": "Chatterbox language model (fp32, weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4204,7 +4204,7 @@
     "description": "Chatterbox speech encoder (fp16, graph)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4219,7 +4219,7 @@
     "description": "Chatterbox speech encoder (fp16, weights)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4234,7 +4234,7 @@
     "description": "Chatterbox token embeddings (fp16, graph)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4249,7 +4249,7 @@
     "description": "Chatterbox token embeddings (fp16, weights)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4264,7 +4264,7 @@
     "description": "Chatterbox conditional decoder (fp16, graph)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4279,7 +4279,7 @@
     "description": "Chatterbox conditional decoder (fp16, weights)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4294,7 +4294,7 @@
     "description": "Chatterbox language model (fp16, graph)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4309,7 +4309,7 @@
     "description": "Chatterbox language model (fp16, weights)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4324,7 +4324,7 @@
     "description": "Chatterbox speech encoder (q4, graph)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4339,7 +4339,7 @@
     "description": "Chatterbox speech encoder (q4, weights)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4354,7 +4354,7 @@
     "description": "Chatterbox token embeddings (q4, graph)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4369,7 +4369,7 @@
     "description": "Chatterbox token embeddings (q4, weights)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4384,7 +4384,7 @@
     "description": "Chatterbox conditional decoder (q4, graph)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4399,7 +4399,7 @@
     "description": "Chatterbox conditional decoder (q4, weights)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4414,7 +4414,7 @@
     "description": "Chatterbox language model (q4, graph)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4429,7 +4429,7 @@
     "description": "Chatterbox language model (q4, weights)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4444,7 +4444,7 @@
     "description": "Chatterbox speech encoder (quantized, graph)",
     "quantization": "quantized",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4459,7 +4459,7 @@
     "description": "Chatterbox speech encoder (quantized, weights)",
     "quantization": "quantized",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4474,7 +4474,7 @@
     "description": "Chatterbox token embeddings (quantized, graph)",
     "quantization": "quantized",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4489,7 +4489,7 @@
     "description": "Chatterbox token embeddings (quantized, weights)",
     "quantization": "quantized",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4504,7 +4504,7 @@
     "description": "Chatterbox conditional decoder (quantized, graph)",
     "quantization": "quantized",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4519,7 +4519,7 @@
     "description": "Chatterbox conditional decoder (quantized, weights)",
     "quantization": "quantized",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4534,7 +4534,7 @@
     "description": "Chatterbox language model (quantized, graph)",
     "quantization": "quantized",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4549,7 +4549,7 @@
     "description": "Chatterbox language model (quantized, weights)",
     "quantization": "quantized",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4564,7 +4564,7 @@
     "description": "Chatterbox speech encoder (q4f16, graph)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4579,7 +4579,7 @@
     "description": "Chatterbox speech encoder (q4f16, weights)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4594,7 +4594,7 @@
     "description": "Chatterbox token embeddings (q4f16, graph)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4609,7 +4609,7 @@
     "description": "Chatterbox token embeddings (q4f16, weights)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4624,7 +4624,7 @@
     "description": "Chatterbox conditional decoder (q4f16, graph)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4639,7 +4639,7 @@
     "description": "Chatterbox conditional decoder (q4f16, weights)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4654,7 +4654,7 @@
     "description": "Chatterbox language model (q4f16, graph)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4669,7 +4669,7 @@
     "description": "Chatterbox language model (q4f16, weights)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4684,7 +4684,7 @@
     "description": "Chatterbox multilingual conditional decoder (fp32, graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4703,7 +4703,7 @@
     "description": "Chatterbox multilingual conditional decoder (fp32, weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4722,7 +4722,7 @@
     "description": "Chatterbox multilingual token embeddings (fp32, graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4741,7 +4741,7 @@
     "description": "Chatterbox multilingual token embeddings (fp32, weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4760,7 +4760,7 @@
     "description": "Chatterbox multilingual speech encoder (fp32, graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4779,7 +4779,7 @@
     "description": "Chatterbox multilingual speech encoder (fp32, weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4798,7 +4798,7 @@
     "description": "Chatterbox multilingual language model (fp32, graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4817,7 +4817,7 @@
     "description": "Chatterbox multilingual language model (fp32, weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4836,7 +4836,7 @@
     "description": "Chatterbox multilingual language model (fp16, graph)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4855,7 +4855,7 @@
     "description": "Chatterbox multilingual language model (fp16, weights)",
     "quantization": "fp16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4874,7 +4874,7 @@
     "description": "Chatterbox multilingual language model (q4, graph)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4893,7 +4893,7 @@
     "description": "Chatterbox multilingual language model (q4, weights)",
     "quantization": "q4",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4912,7 +4912,7 @@
     "description": "Chatterbox multilingual language model (q4f16, graph)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4929,7 +4929,7 @@
     "description": "Chatterbox multilingual language model (q4f16, weights)",
     "quantization": "q4f16",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4948,7 +4948,7 @@
     "description": "Chatterbox multilingual tokenizer",
     "quantization": "",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "chatterbox",
@@ -4967,7 +4967,7 @@
     "description": "Supertonic tokenizer",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -4981,7 +4981,7 @@
     "description": "Supertonic text encoder (graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -4995,7 +4995,7 @@
     "description": "Supertonic text encoder (weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5009,7 +5009,7 @@
     "description": "Supertonic latent denoiser (graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5023,7 +5023,7 @@
     "description": "Supertonic latent denoiser (weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5037,7 +5037,7 @@
     "description": "Supertonic voice decoder (graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5051,7 +5051,7 @@
     "description": "Supertonic voice decoder (weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5065,7 +5065,7 @@
     "description": "Supertonic voice style F1 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5079,7 +5079,7 @@
     "description": "Supertonic voice style F2 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5093,7 +5093,7 @@
     "description": "Supertonic voice style F3 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5107,7 +5107,7 @@
     "description": "Supertonic voice style F4 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5121,7 +5121,7 @@
     "description": "Supertonic voice style F5 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5135,7 +5135,7 @@
     "description": "Supertonic voice style M1 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5149,7 +5149,7 @@
     "description": "Supertonic voice style M2 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5163,7 +5163,7 @@
     "description": "Supertonic voice style M3 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5177,7 +5177,7 @@
     "description": "Supertonic voice style M4 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5191,7 +5191,7 @@
     "description": "Supertonic voice style M5 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertonic",
@@ -5205,7 +5205,7 @@
     "description": "Supertone Supertonic tts.json (model layout / sample rate)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5220,7 +5220,7 @@
     "description": "Supertone Supertonic unicode indexer",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5235,7 +5235,7 @@
     "description": "Supertone Supertonic text encoder (fp32)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5251,7 +5251,7 @@
     "description": "Supertone Supertonic duration predictor (fp32)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5267,7 +5267,7 @@
     "description": "Supertone Supertonic vector estimator (fp32)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5283,7 +5283,7 @@
     "description": "Supertone Supertonic vocoder (fp32)",
     "quantization": "fp32",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5299,7 +5299,7 @@
     "description": "Supertone Supertonic voice style F1 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5314,7 +5314,7 @@
     "description": "Supertone Supertonic voice style F2 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5329,7 +5329,7 @@
     "description": "Supertone Supertonic voice style F3 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5344,7 +5344,7 @@
     "description": "Supertone Supertonic voice style F4 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5359,7 +5359,7 @@
     "description": "Supertone Supertonic voice style F5 (female)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5374,7 +5374,7 @@
     "description": "Supertone Supertonic voice style M1 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5389,7 +5389,7 @@
     "description": "Supertone Supertonic voice style M2 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5404,7 +5404,7 @@
     "description": "Supertone Supertonic voice style M3 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5419,7 +5419,7 @@
     "description": "Supertone Supertonic voice style M4 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5434,7 +5434,7 @@
     "description": "Supertone Supertonic voice style M5 (male)",
     "quantization": "",
     "params": "",
-    "license": "openrail",
+    "licenseId": "openrail",
     "tags": [
       "tts",
       "supertone",
@@ -5694,7 +5694,7 @@
     "description": "Parakeet TDT 0.6B v3 encoder (graph)",
     "quantization": "fp32",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5709,7 +5709,7 @@
     "description": "Parakeet TDT 0.6B v3 encoder (weights)",
     "quantization": "fp32",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5724,7 +5724,7 @@
     "description": "Parakeet TDT 0.6B v3 decoder-joint",
     "quantization": "fp32",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5740,7 +5740,7 @@
     "description": "Parakeet TDT 0.6B v3 vocabulary",
     "quantization": "",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5755,7 +5755,7 @@
     "description": "Parakeet TDT 0.6B v3 preprocessor",
     "quantization": "fp32",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5771,7 +5771,7 @@
     "description": "Parakeet TDT 0.6B v3 encoder INT8 (weights embedded)",
     "quantization": "int8",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5787,7 +5787,7 @@
     "description": "Parakeet TDT 0.6B v3 decoder-joint INT8",
     "quantization": "int8",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5803,7 +5803,7 @@
     "description": "Parakeet TDT 0.6B v3 vocabulary",
     "quantization": "",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5819,7 +5819,7 @@
     "description": "Parakeet TDT 0.6B v3 preprocessor INT8",
     "quantization": "int8",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5835,7 +5835,7 @@
     "description": "Parakeet CTC 0.6B onnx-community (graph)",
     "quantization": "fp32",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5852,7 +5852,7 @@
     "description": "Parakeet CTC 0.6B onnx-community (weights)",
     "quantization": "fp32",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5869,7 +5869,7 @@
     "description": "Parakeet CTC 0.6B tokenizer",
     "quantization": "",
     "params": "0.6B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5887,7 +5887,7 @@
     "description": "Parakeet EOU 120M Decoder",
     "quantization": "fp32",
     "params": "120M",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5905,7 +5905,7 @@
     "description": "Parakeet EOU 120M Encoder",
     "quantization": "fp32",
     "params": "120M",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5923,7 +5923,7 @@
     "description": "Parakeet EOU 120M Tokenizer",
     "quantization": "",
     "params": "120M",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5941,7 +5941,7 @@
     "description": "Parakeet EOU 120M INT8 Encoder",
     "quantization": "int8",
     "params": "120M",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5959,7 +5959,7 @@
     "description": "Parakeet EOU 120M INT8 Decoder",
     "quantization": "int8",
     "params": "120M",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5977,7 +5977,7 @@
     "description": "Parakeet Sortformer 4SPK v2",
     "quantization": "fp32",
     "params": "123M",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -5995,7 +5995,7 @@
     "description": "Parakeet Sortformer 4SPK v2 INT8",
     "quantization": "int8",
     "params": "123M",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "transcription",
       "parakeet",
@@ -6012,7 +6012,7 @@
     "description": "OCR-specialized vision-language model for document understanding",
     "quantization": "q4_k_m",
     "params": "0.6B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "multimodal",
@@ -6028,7 +6028,7 @@
     "description": "Vision projector for LightON OCR-2 1B",
     "quantization": "f16",
     "params": "0.6B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "multimodal",
@@ -6044,7 +6044,7 @@
     "description": "AfriqueGemma 4B - African language model (20 languages + EN/FR/PT/AR)",
     "quantization": "Q4_K_M",
     "params": "4B",
-    "license": "CC-BY-4.0",
+    "licenseId": "CC-BY-4.0",
     "tags": [
       "generation",
       "translation",
@@ -6059,7 +6059,7 @@
     "link": "https://huggingface.co/1bitLLM/bitnet_b1_58-3B",
     "description": "Bitnet 3B model",
     "notes": "TQ2_0 quantization of https://huggingface.co/1bitLLM/bitnet_b1_58-3B",
-    "license": "MIT",
+    "licenseId": "MIT",
     "quantization": "TQ2_0",
     "params": "3B",
     "tags": [
@@ -6074,7 +6074,7 @@
     "link": "https://huggingface.co/1bitLLM/bitnet_b1_58-large",
     "description": "Bitnet 0.7B model",
     "notes": "TQ2_0 quantization of https://huggingface.co/1bitLLM/bitnet_b1_58-large",
-    "license": "MIT",
+    "licenseId": "MIT",
     "quantization": "TQ2_0",
     "params": "0.7B",
     "tags": [
@@ -6089,7 +6089,7 @@
     "link": "https://huggingface.co/1bitLLM/bitnet_b1_58-xl",
     "description": "Bitnet 1B model",
     "notes": "TQ2_0 quantization of https://huggingface.co/1bitLLM/bitnet_b1_58-xl",
-    "license": "MIT",
+    "licenseId": "MIT",
     "quantization": "TQ2_0",
     "params": "1B",
     "tags": [
@@ -6103,7 +6103,7 @@
     "engine": "@qvac/diffusion-cpp",
     "description": "FLUX.2 Klein 4B model",
     "notes": "Quantized version of https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "quantization": "Q4_0",
     "params": "4B",
     "tags": [
@@ -6116,7 +6116,7 @@
     "engine": "@qvac/diffusion-cpp",
     "description": "FLUX.2 Klein 4B model",
     "notes": "Quantized version of https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "quantization": "Q8_0",
     "params": "4B",
     "tags": [
@@ -6129,7 +6129,7 @@
     "engine": "@qvac/diffusion-cpp",
     "description": "FLUX.2 Klein 4B model",
     "notes": "Quantized version of https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "quantization": "Q6_K",
     "params": "4B",
     "tags": [
@@ -6142,7 +6142,7 @@
     "engine": "@qvac/diffusion-cpp",
     "description": "FLUX.2 Klein 4B model",
     "notes": "Quantized version of https://huggingface.co/black-forest-labs/FLUX.2-klein-4B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "quantization": "Q4_K_M",
     "params": "4B",
     "tags": [
@@ -6154,7 +6154,7 @@
     "source": "https://huggingface.co/unsloth/Qwen3-4B-GGUF/resolve/9b5c4f3506ac99d74e59ecd9aa9abb05537b7f59/Qwen3-4B-Q4_K_M.gguf",
     "engine": "@qvac/diffusion-cpp",
     "description": "Qwen3 4B model",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "quantization": "Q4_K_M",
     "params": "4B",
     "tags": [
@@ -6166,7 +6166,7 @@
     "source": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B/resolve/5e67da950fce4a097bc150c22958a05716994cea/vae/diffusion_pytorch_model.safetensors",
     "engine": "@qvac/diffusion-cpp",
     "description": "FLUX.2 Klein Variational Autoencoder model",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "vae"
     ]
@@ -6176,7 +6176,7 @@
     "engine": "@qvac/diffusion-cpp",
     "description": "Stable Diffusion 2.1 model",
     "notes": "Quantized version of https://huggingface.co/stabilityai/stable-diffusion-2-1",
-    "license": "openrail++",
+    "licenseId": "openrail++",
     "quantization": "Q8_0",
     "params": "1B",
     "tags": [
@@ -6189,7 +6189,7 @@
     "engine": "@qvac/diffusion-cpp",
     "description": "Stable Diffusion 2.1 model",
     "notes": "Quantized version of https://huggingface.co/stabilityai/stable-diffusion-2-1",
-    "license": "openrail++",
+    "licenseId": "openrail++",
     "quantization": "Q4_0",
     "params": "1B",
     "tags": [
@@ -6202,7 +6202,7 @@
     "engine": "@qvac/diffusion-cpp",
     "description": "Stable Diffusion XL model",
     "notes": "Quantized version of https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
-    "license": "openrail++",
+    "licenseId": "openrail++",
     "quantization": "Q4_0",
     "params": "3B",
     "tags": [
@@ -6215,7 +6215,7 @@
     "engine": "@qvac/diffusion-cpp",
     "description": "Stable Diffusion XL model",
     "notes": "Quantized version of https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0",
-    "license": "openrail++",
+    "licenseId": "openrail++",
     "quantization": "Q8_0",
     "params": "3B",
     "tags": [
@@ -6229,7 +6229,7 @@
     "link": "https://huggingface.co/unsloth/gpt-oss-120b-GGUF/blob/main/Q4_K_M/gpt-oss-120b-Q4_K_M-00001-of-00002.gguf",
     "description": "GPT-OSS 120B model",
     "notes": "shard 1/2",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "quantization": "q4_k_m",
     "params": "120B",
     "tags": [
@@ -6245,7 +6245,7 @@
     "link": "https://huggingface.co/unsloth/gpt-oss-120b-GGUF/blob/main/Q4_K_M/gpt-oss-120b-Q4_K_M-00002-of-00002.gguf",
     "description": "GPT-OSS 120B model",
     "notes": "shard 2/2",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "quantization": "q4_k_m",
     "params": "120B",
     "tags": [
@@ -6261,7 +6261,7 @@
     "description": "Required for Llamacpp to create the model layers before the weights are loaded",
     "quantization": "q4_k_m",
     "params": "120B",
-    "license": "Apache-2.0",
+    "licenseId": "Apache-2.0",
     "tags": [
       "generation",
       "instruct",
@@ -6276,7 +6276,7 @@
     "description": "LavaSR speech enhancer backbone (graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "lavasr",
@@ -6291,7 +6291,7 @@
     "description": "LavaSR speech enhancer backbone (weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "lavasr",
@@ -6306,7 +6306,7 @@
     "description": "LavaSR speech enhancer spectrogram head (graph)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "lavasr",
@@ -6321,7 +6321,7 @@
     "description": "LavaSR speech enhancer spectrogram head (weights)",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "lavasr",
@@ -6336,7 +6336,7 @@
     "description": "LavaSR speech denoiser",
     "quantization": "fp32",
     "params": "",
-    "license": "MIT",
+    "licenseId": "MIT",
     "tags": [
       "tts",
       "lavasr",

--- a/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
+++ b/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
@@ -395,6 +395,22 @@ pm2 restart registry
 pm2 restart registry
 ```
 
+### Authenticated CI RPC Connections
+
+By default, CI RPC clients discover registry servers via a derived topic key. This is unauthenticated -- any peer that derives the same topic can intercept connections.
+
+For production, configure `QVAC_INDEXER_KEYS` so CI clients connect directly to known indexer public keys via `swarm.joinPeer()`. The Noise protocol handshake inherently verifies server identity.
+
+**On each CI runner or RPC writer client**, set the indexer keys:
+
+```bash
+QVAC_INDEXER_KEYS=<indexer1-z32-public-key>,<indexer2-z32-public-key>
+```
+
+The RPC client will round-robin across configured indexer keys and only accept connections from peers whose public key matches the list.
+
+If `QVAC_INDEXER_KEYS` is not set, the client falls back to topic-based discovery (backward compatible).
+
 ### Sync Models from JSON Config
 
 Preview changes:
@@ -526,6 +542,7 @@ node scripts/bin.js run --storage ./new-writer --bootstrap <key> --skip-storage-
 | `QVAC_ADDITIONAL_INDEXERS` | Comma-separated writer local keys to promote to indexers |
 | `QVAC_REMOVE_INDEXERS` | Comma-separated writer local keys to remove from quorum (one-shot, clean up after restart) |
 | `QVAC_ALLOWED_WRITER_KEYS` | Comma-separated hex keys allowed to call add-model RPC |
+| `QVAC_INDEXER_KEYS` | Comma-separated z32 indexer public keys for authenticated CI RPC connections (see below) |
 | `QVAC_BLIND_PEER_KEYS` | Comma-separated blind peer public keys for replication |
 | `QVAC_PRIMARY_KEY` | Optional: Deterministic key generation (testing only) |
 | `QVAC_WRITER_PRIMARY_KEY` | Optional: Deterministic writer key (testing only) |

--- a/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
+++ b/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
@@ -407,7 +407,7 @@ For production, configure `QVAC_INDEXER_KEYS` so CI clients connect directly to 
 QVAC_INDEXER_KEYS=<indexer1-z32-public-key>,<indexer2-z32-public-key>
 ```
 
-The RPC client will round-robin across configured indexer keys and only accept connections from peers whose public key matches the list.
+The RPC client picks a random indexer from the list on each connection attempt and only accepts peers whose public key matches the configured keys.
 
 If `QVAC_INDEXER_KEYS` is not set, the client falls back to topic-based discovery (backward compatible).
 

--- a/packages/qvac-lib-registry-server/docs/MODEL_SUBMISSION_GUIDE.md
+++ b/packages/qvac-lib-registry-server/docs/MODEL_SUBMISSION_GUIDE.md
@@ -7,7 +7,7 @@
    {
      "source": "https://huggingface.co/<org>/<repo>/resolve/<commit>/<file>",
      "engine": "@qvac/<engine-name>",
-     "license": "MIT",
+     "licenseId": "MIT",
      "quantization": "q4_0",
      "params": "1B",
      "tags": ["generation", "instruct"],
@@ -109,7 +109,7 @@ If you remove an entry from `models.prod.json`, the sync script will auto-deprec
 |-------|----------|-------------|
 | `source` | Yes | URL to model file (`https://huggingface.co/...` or `s3:///key`) |
 | `engine` | Yes | Engine identifier (e.g., `@qvac/llm-llamacpp`) |
-| `license` | Yes | License identifier matching an entry in `data/licenses.json` |
+| `licenseId` | Yes | License identifier matching an entry in `data/licenses.json` |
 | `quantization` | No | Quantization format (e.g., `q4_0`, `q8_0`) |
 | `params` | No | Model parameter count (e.g., `1B`, `4B`) |
 | `description` | No | Human-readable description |

--- a/packages/qvac-lib-registry-server/lib/config.js
+++ b/packages/qvac-lib-registry-server/lib/config.js
@@ -257,6 +257,21 @@ class RegistryConfig {
   }
 
   /**
+   * Get known indexer public keys for authenticated RPC connections.
+   * CI clients use these to connect directly via Noise handshake
+   * instead of topic-based discovery.
+   */
+  getIndexerKeys () {
+    const rawKeys = getEnv('QVAC_INDEXER_KEYS', '')
+    if (!rawKeys) return []
+
+    return rawKeys
+      .split(',')
+      .map(key => key.trim())
+      .filter(Boolean)
+  }
+
+  /**
    * Optionally load writer keypair from env (CI use-case)
    */
   getWriterKeyPair () {

--- a/packages/qvac-lib-registry-server/lib/model-schema.js
+++ b/packages/qvac-lib-registry-server/lib/model-schema.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { z } = require('zod')
+
+const baseModelFields = {
+  source: z.string().min(1, 'source is required'),
+  engine: z.string().min(1, 'engine is required'),
+  licenseId: z.string().min(1, 'licenseId is required'),
+  description: z.string().max(512).optional(),
+  quantization: z.string().max(512).optional(),
+  params: z.string().max(64).optional(),
+  notes: z.string().max(512).optional(),
+  tags: z.array(z.string().max(128)).max(50).optional(),
+  deprecated: z.boolean().optional(),
+  deprecatedAt: z.string().optional(),
+  replacedBy: z.string().optional(),
+  deprecationReason: z.string().max(512).optional()
+}
+
+const addModelRequestSchema = z.object({
+  ...baseModelFields,
+  skipExisting: z.boolean().optional()
+}).strict()
+
+module.exports = { baseModelFields, addModelRequestSchema }

--- a/packages/qvac-lib-registry-server/lib/registry-service.js
+++ b/packages/qvac-lib-registry-server/lib/registry-service.js
@@ -35,6 +35,7 @@ const { QVAC_MAIN_REGISTRY } = schema
 const { getFileMetadata } = require('../utils/file-metadata')
 const { parseCanonicalSource, resolveS3Bucket } = require('./source-helpers')
 const { isGGUFSource, isFirstShard, extractGGUFMetadata } = require('./gguf-helpers')
+const { addModelRequestSchema } = require('./model-schema')
 
 const DISPATCH_PUT_MODEL = `@${QVAC_MAIN_REGISTRY}/put-model`
 const DISPATCH_PUT_LICENSE = `@${QVAC_MAIN_REGISTRY}/put-license`
@@ -153,17 +154,7 @@ class RegistryService extends ReadyResource {
 
       this._setupRpc(conn)
 
-      // Create a single replication stream for the store
-      const replicationStream = this.store.replicate(conn)
-
-      // Attach Autobase to the replication stream (writer cores, system core)
-      this.base.replicate(replicationStream)
-
-      // Also attach the view core to ensure read-only clients can sync
-      // Without this, the view core is not included in replication
-      if (this.view?.core) {
-        this.view.core.replicate(replicationStream)
-      }
+      this.store.replicate(conn)
     })
 
     // Log if there's a significant contiguous gap for troubleshooting
@@ -189,12 +180,11 @@ class RegistryService extends ReadyResource {
     this._rpcDiscoveryKey = deriveRpcDiscoveryKey(this.base.key)
     this.swarm.join(this._rpcDiscoveryKey, { server: true, client: false })
 
-    await this.swarm.flush()
     this.logger.info({
       autobaseKey: IdEnc.normalize(this.base.discoveryKey),
       viewKey: IdEnc.normalize(this.view.discoveryKey),
       rpcKey: IdEnc.normalize(this._rpcDiscoveryKey)
-    }, 'Swarm joined')
+    }, 'Swarm topics joined')
 
     if (this.base.isIndexer) {
       const linearizerIndexers = (this.base.linearizer?.indexers || [])
@@ -615,39 +605,16 @@ class RegistryService extends ReadyResource {
   }
 
   _validateAddModelRequest (entry) {
-    if (!entry || typeof entry !== 'object') {
-      throw new TypeError('model entry must be an object')
-    }
-
-    for (const field of ['source', 'engine', 'licenseId']) {
-      if (typeof entry[field] !== 'string' || entry[field].trim().length === 0) {
-        throw new TypeError(`${field} is required`)
+    const { ZodError } = require('zod')
+    try {
+      addModelRequestSchema.parse(entry)
+    } catch (err) {
+      if (err instanceof ZodError) {
+        const issues = err.issues.map(i => `${i.path.join('.')}: ${i.message}`)
+        this.logger.warn({ issues }, 'RPC: add-model payload rejected by schema')
+        throw new TypeError(issues.join('; '))
       }
-    }
-
-    const MAX_FIELD_LENGTH = 512
-    const MAX_TAG_LENGTH = 128
-    const MAX_TAGS = 50
-
-    for (const field of ['description', 'quantization', 'params', 'notes', 'deprecationReason']) {
-      if (entry[field] !== undefined && typeof entry[field] === 'string' && entry[field].length > MAX_FIELD_LENGTH) {
-        throw new TypeError(`${field} exceeds maximum length of ${MAX_FIELD_LENGTH}`)
-      }
-    }
-
-    if (entry.tags) {
-      if (!Array.isArray(entry.tags)) {
-        throw new TypeError('tags must be an array of strings')
-      }
-      if (entry.tags.length > MAX_TAGS) {
-        throw new TypeError(`tags array exceeds maximum of ${MAX_TAGS} items`)
-      }
-      if (entry.tags.some(tag => typeof tag !== 'string')) {
-        throw new TypeError('tags must be an array of strings')
-      }
-      if (entry.tags.some(tag => tag.length > MAX_TAG_LENGTH)) {
-        throw new TypeError(`each tag must be at most ${MAX_TAG_LENGTH} characters`)
-      }
+      throw err
     }
   }
 

--- a/packages/qvac-lib-registry-server/package.json
+++ b/packages/qvac-lib-registry-server/package.json
@@ -82,6 +82,7 @@
     "stream": "npm:bare-node-stream"
   },
   "devDependencies": {
+    "@qvac/error": "^0.1.1",
     "brittle": "^3.4.0",
     "dotenv": "^17.2.3",
     "standard": "^17.1.0",

--- a/packages/qvac-lib-registry-server/scripts/add-all-models.js
+++ b/packages/qvac-lib-registry-server/scripts/add-all-models.js
@@ -85,7 +85,7 @@ async function addAllModels (flags) {
       const payload = {
         source: entry.source,
         engine: entry.engine,
-        licenseId: entry.license,
+        licenseId: entry.licenseId,
         description: entry.description || '',
         quantization: entry.quantization || '',
         params: entry.params || '',

--- a/packages/qvac-lib-registry-server/scripts/add-model.js
+++ b/packages/qvac-lib-registry-server/scripts/add-model.js
@@ -83,7 +83,7 @@ async function addModel () {
   const modelRequest = {
     source: modelEntry.source,
     engine: modelEntry.engine,
-    licenseId: modelEntry.license,
+    licenseId: modelEntry.licenseId,
     description: modelEntry.description || '',
     quantization: modelEntry.quantization || '',
     params: modelEntry.params || '',

--- a/packages/qvac-lib-registry-server/scripts/sync-models.js
+++ b/packages/qvac-lib-registry-server/scripts/sync-models.js
@@ -73,7 +73,7 @@ async function syncModels () {
             const modelRequest = {
               source: entry.source,
               engine: entry.engine,
-              licenseId: entry.license,
+              licenseId: entry.licenseId,
               description: entry.description || '',
               quantization: entry.quantization || '',
               params: entry.params || '',
@@ -108,7 +108,7 @@ async function syncModels () {
               path: sourceInfo.path,
               source: sourceInfo.protocol,
               engine: entry.engine,
-              licenseId: entry.license,
+              licenseId: entry.licenseId,
               description: entry.description || '',
               quantization: entry.quantization || '',
               params: entry.params || '',
@@ -188,7 +188,7 @@ async function syncModels () {
 function needsMetadataUpdate (config, existing, sourceInfo) {
   return (
     config.engine !== existing.engine ||
-    config.license !== existing.licenseId ||
+    config.licenseId !== existing.licenseId ||
     (config.description || '') !== (existing.description || '') ||
     (config.quantization || '') !== (existing.quantization || '') ||
     (config.params || '') !== (existing.params || '') ||
@@ -205,8 +205,8 @@ function needsMetadataUpdate (config, existing, sourceInfo) {
 function getChanges (config, existing) {
   const changes = {}
   if (config.engine !== existing.engine) changes.engine = { from: existing.engine, to: config.engine }
-  if (config.license !== existing.licenseId) {
-    changes.licenseId = { from: existing.licenseId, to: config.license }
+  if (config.licenseId !== existing.licenseId) {
+    changes.licenseId = { from: existing.licenseId, to: config.licenseId }
   }
   if ((config.description || '') !== (existing.description || '')) {
     changes.description = { from: existing.description || '', to: config.description || '' }

--- a/packages/qvac-lib-registry-server/scripts/utils/rpc-client.js
+++ b/packages/qvac-lib-registry-server/scripts/utils/rpc-client.js
@@ -137,9 +137,9 @@ async function connectToRegistry ({ config, logger = console, storage = './temp-
     ;(async () => {
       try {
         if (useDirectConnect) {
-          for (const key of resolvedIndexerKeys) {
-            swarm.joinPeer(IdEnc.decode(key))
-          }
+          const picked = resolvedIndexerKeys[Math.floor(Math.random() * resolvedIndexerKeys.length)]
+          logger.info('RPC Client: Connecting to indexer', { peer: picked })
+          swarm.joinPeer(IdEnc.decode(picked))
         } else {
           const rpcDiscoveryKey = deriveRpcDiscoveryKey(autobaseKey)
           swarm.join(rpcDiscoveryKey, { client: true, server: false })

--- a/packages/qvac-lib-registry-server/scripts/utils/rpc-client.js
+++ b/packages/qvac-lib-registry-server/scripts/utils/rpc-client.js
@@ -19,7 +19,7 @@ function deriveRpcDiscoveryKey (autobaseKey) {
     .digest()
 }
 
-async function connectToRegistry ({ config, logger = console, storage = './temp-client-storage', timeout = 30000, primaryKey = null, targetPeer = null }) {
+async function connectToRegistry ({ config, logger = console, storage = './temp-client-storage', timeout = 30000, primaryKey = null, targetPeer = null, indexerKeys = null }) {
   const autobaseKeyEncoded = config.getAutobaseBootstrapKey()
   if (!autobaseKeyEncoded) {
     throw new Error('QVAC_AUTOBASE_KEY not set. Run "node scripts/bin.js run" once to initialize keys.')
@@ -43,13 +43,26 @@ async function connectToRegistry ({ config, logger = console, storage = './temp-
 
   const autobaseKey = IdEnc.decode(autobaseKeyEncoded)
 
-  // Use dedicated RPC topic - only the server joins this topic, not blind peers
-  const rpcDiscoveryKey = deriveRpcDiscoveryKey(autobaseKey)
+  // Resolve indexer keys: parameter > config > empty
+  const resolvedIndexerKeys = indexerKeys || config.getIndexerKeys()
+  const useDirectConnect = resolvedIndexerKeys.length > 0
 
-  logger.info('RPC Client: Connecting via dedicated RPC topic', {
-    autobaseKey: IdEnc.normalize(autobaseKey),
-    rpcDiscoveryKey: IdEnc.normalize(rpcDiscoveryKey)
-  })
+  // Build a set of allowed peer keys for connection filtering
+  const allowedPeerKeys = useDirectConnect
+    ? new Set(resolvedIndexerKeys.map(k => IdEnc.normalize(IdEnc.decode(k))))
+    : null
+
+  if (useDirectConnect) {
+    logger.info('RPC Client: Connecting via direct indexer keys (Noise-authenticated)', {
+      indexerCount: resolvedIndexerKeys.length
+    })
+  } else {
+    const rpcDiscoveryKey = deriveRpcDiscoveryKey(autobaseKey)
+    logger.info('RPC Client: Connecting via RPC topic (legacy)', {
+      autobaseKey: IdEnc.normalize(autobaseKey),
+      rpcDiscoveryKey: IdEnc.normalize(rpcDiscoveryKey)
+    })
+  }
 
   // Normalize targetPeer if provided
   const targetPeerNormalized = targetPeer ? IdEnc.normalize(IdEnc.decode(targetPeer)) : null
@@ -70,6 +83,12 @@ async function connectToRegistry ({ config, logger = console, storage = './temp-
       // If targeting a specific peer, skip others
       if (targetPeerNormalized && peerKey !== targetPeerNormalized) {
         logger.info('RPC Client: Skipping peer (waiting for target)', { peer: peerKey, target: targetPeerNormalized })
+        return
+      }
+
+      // When using direct connect, only accept known indexer keys
+      if (allowedPeerKeys && !allowedPeerKeys.has(peerKey)) {
+        logger.info('RPC Client: Ignoring unknown peer', { peer: peerKey })
         return
       }
 
@@ -117,7 +136,14 @@ async function connectToRegistry ({ config, logger = console, storage = './temp-
 
     ;(async () => {
       try {
-        swarm.join(rpcDiscoveryKey, { client: true, server: false })
+        if (useDirectConnect) {
+          for (const key of resolvedIndexerKeys) {
+            swarm.joinPeer(IdEnc.decode(key))
+          }
+        } else {
+          const rpcDiscoveryKey = deriveRpcDiscoveryKey(autobaseKey)
+          swarm.join(rpcDiscoveryKey, { client: true, server: false })
+        }
         await swarm.flush()
         logger.debug('RPC Client: Swarm joined and flushed, waiting for connection...')
       } catch (err) {

--- a/packages/qvac-lib-registry-server/scripts/validate-models-json.js
+++ b/packages/qvac-lib-registry-server/scripts/validate-models-json.js
@@ -5,6 +5,7 @@ const path = require('path')
 const { z } = require('zod')
 
 const { parseCanonicalSource } = require('../lib/source-helpers')
+const { baseModelFields } = require('../lib/model-schema')
 
 const ENGINE_PATTERN = /^@qvac\/[a-z][a-z0-9-]*$/
 const S3_DATE_FOLDER_PATTERN = /\/\d{4}-\d{2}-\d{2}\//
@@ -55,27 +56,18 @@ const HF_COMMIT_PIN = (val) => {
   return HF_COMMIT_HASH_PATTERN.test(val)
 }
 
-const baseFields = {
-  source: z.string()
-    .min(1, 'source is required')
+// CI-specific fields: layer refinements on top of shared base
+const ciFields = {
+  ...baseModelFields,
+  source: baseModelFields.source
     .refine(SOURCE_REFINE, { message: 'Invalid source URL (must be s3:// or https://huggingface.co/)' })
     .refine(S3_NO_BUCKET, { message: 'S3 URLs must not contain a bucket name. Use s3:///key format; bucket is resolved from QVAC_S3_BUCKET env var.' })
     .refine(S3_DATE_FOLDER, { message: 'S3 URLs must include a date folder (YYYY-MM-DD) in the path. Upload artifacts to a dated directory to ensure registry consistency when models are updated.' })
     .refine(HF_COMMIT_PIN, { message: 'HuggingFace source URLs must pin to a specific commit hash, not a branch name. Use https://huggingface.co/<org>/<repo>/resolve/<full-commit-sha>/<file>' }),
 
-  engine: z.string()
-    .min(1, 'engine is required')
+  engine: baseModelFields.engine
     .regex(ENGINE_PATTERN, 'Invalid engine format (expected @qvac/<engine-name>)'),
 
-  license: z.string().min(1, 'license is required'),
-
-  description: z.string().max(512).optional(),
-  quantization: z.string().max(512).optional(),
-  params: z.string().max(64).optional(),
-  notes: z.string().max(512).optional(),
-  tags: z.array(z.string().max(128)).max(50).optional(),
-  deprecated: z.boolean().optional(),
-  deprecationReason: z.string().max(512).optional(),
   replacedBy: z.string()
     .refine(SOURCE_REFINE, { message: 'replacedBy must be a valid source URL' })
     .optional()
@@ -83,8 +75,8 @@ const baseFields = {
 
 function createModelSchema (validLicenses) {
   return z.object({
-    ...baseFields,
-    license: baseFields.license.refine(
+    ...ciFields,
+    licenseId: ciFields.licenseId.refine(
       (val) => validLicenses.has(val),
       (val) => ({ message: `Unknown license: "${val}" (not found in licenses.json)` })
     )
@@ -92,7 +84,7 @@ function createModelSchema (validLicenses) {
 }
 
 function createDeprecatedModelSchema () {
-  return z.object(baseFields)
+  return z.object(ciFields)
 }
 
 async function loadValidLicenses () {

--- a/packages/qvac-lib-registry-server/tests/integration/rpc-connect.integration.test.js
+++ b/packages/qvac-lib-registry-server/tests/integration/rpc-connect.integration.test.js
@@ -1,0 +1,136 @@
+'use strict'
+
+const test = require('brittle')
+const Hyperswarm = require('hyperswarm')
+const createTestnet = require('hyperdht/testnet')
+const IdEnc = require('hypercore-id-encoding')
+const crypto = require('crypto')
+
+function deriveRpcDiscoveryKey (autobaseKey) {
+  return crypto.createHash('sha256')
+    .update(autobaseKey)
+    .update('qvac-registry-rpc')
+    .digest()
+}
+
+test('peer filter accepts connection from known indexer key', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const server = new Hyperswarm({ bootstrap })
+  const client = new Hyperswarm({ bootstrap })
+
+  t.teardown(async () => {
+    await client.destroy().catch(() => {})
+    await server.destroy().catch(() => {})
+  })
+
+  const allowedKeys = new Set([IdEnc.normalize(server.keyPair.publicKey)])
+  const topic = crypto.randomBytes(32)
+
+  server.join(topic, { server: true, client: false })
+  await server.flush()
+
+  const accepted = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('no connection within 15s')), 15000)
+
+    client.on('connection', (conn, peerInfo) => {
+      const peerKey = IdEnc.normalize(peerInfo.publicKey)
+
+      if (!allowedKeys.has(peerKey)) {
+        conn.on('error', () => {})
+        conn.destroy()
+        return
+      }
+
+      clearTimeout(timer)
+      resolve(peerKey)
+    })
+  })
+
+  client.join(topic, { client: true, server: false })
+  await client.flush()
+
+  const connectedKey = await accepted
+  t.is(connectedKey, IdEnc.normalize(server.keyPair.publicKey), 'accepted known indexer')
+})
+
+test('peer filter rejects connection when peer key not in allowlist', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const server = new Hyperswarm({ bootstrap })
+  const client = new Hyperswarm({ bootstrap })
+
+  t.teardown(async () => {
+    await client.destroy().catch(() => {})
+    await server.destroy().catch(() => {})
+  })
+
+  // Allowlist contains a random key that doesn't match the server
+  const fakeIndexerKey = crypto.randomBytes(32)
+  const allowedKeys = new Set([IdEnc.normalize(fakeIndexerKey)])
+  const topic = crypto.randomBytes(32)
+
+  server.on('connection', (conn) => { conn.on('error', () => {}) })
+  server.join(topic, { server: true, client: false })
+  await server.flush()
+
+  const rejected = []
+
+  const result = await new Promise((resolve) => {
+    const timer = setTimeout(() => resolve('timeout'), 5000)
+
+    client.on('connection', (conn, peerInfo) => {
+      const peerKey = IdEnc.normalize(peerInfo.publicKey)
+
+      if (!allowedKeys.has(peerKey)) {
+        rejected.push(peerKey)
+        conn.on('error', () => {})
+        conn.destroy()
+        return
+      }
+
+      clearTimeout(timer)
+      resolve('accepted')
+    })
+
+    client.join(topic, { client: true, server: false })
+    client.flush()
+  })
+
+  t.is(result, 'timeout', 'no connection was accepted (all rejected by filter)')
+  t.ok(rejected.length > 0, 'at least one connection was rejected')
+  t.is(rejected[0], IdEnc.normalize(server.keyPair.publicKey), 'rejected peer was the server')
+})
+
+test('topic-based fallback connects without indexer keys', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const server = new Hyperswarm({ bootstrap })
+  const client = new Hyperswarm({ bootstrap })
+
+  t.teardown(async () => {
+    await client.destroy().catch(() => {})
+    await server.destroy().catch(() => {})
+  })
+
+  const autobaseKey = crypto.randomBytes(32)
+  const rpcTopic = deriveRpcDiscoveryKey(autobaseKey)
+
+  server.join(rpcTopic, { server: true, client: false })
+  await server.flush()
+
+  const connected = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('no connection within 15s')), 15000)
+
+    client.on('connection', (conn, peerInfo) => {
+      clearTimeout(timer)
+      resolve(IdEnc.normalize(peerInfo.publicKey))
+    })
+  })
+
+  client.join(rpcTopic, { client: true, server: false })
+  await client.flush()
+
+  const peerKey = await connected
+  t.is(peerKey, IdEnc.normalize(server.keyPair.publicKey), 'topic discovery connected to server')
+})

--- a/packages/qvac-lib-registry-server/tests/integration/rpc-connect.integration.test.js
+++ b/packages/qvac-lib-registry-server/tests/integration/rpc-connect.integration.test.js
@@ -19,6 +19,8 @@ test('peer filter accepts connection from known indexer key', async (t) => {
   const server = new Hyperswarm({ bootstrap })
   const client = new Hyperswarm({ bootstrap })
 
+  server.on('connection', (conn) => { conn.on('error', () => {}) })
+
   t.teardown(async () => {
     await client.destroy().catch(() => {})
     await server.destroy().catch(() => {})
@@ -34,10 +36,10 @@ test('peer filter accepts connection from known indexer key', async (t) => {
     const timer = setTimeout(() => reject(new Error('no connection within 15s')), 15000)
 
     client.on('connection', (conn, peerInfo) => {
+      conn.on('error', () => {})
       const peerKey = IdEnc.normalize(peerInfo.publicKey)
 
       if (!allowedKeys.has(peerKey)) {
-        conn.on('error', () => {})
         conn.destroy()
         return
       }
@@ -108,6 +110,8 @@ test('topic-based fallback connects without indexer keys', async (t) => {
   const server = new Hyperswarm({ bootstrap })
   const client = new Hyperswarm({ bootstrap })
 
+  server.on('connection', (conn) => { conn.on('error', () => {}) })
+
   t.teardown(async () => {
     await client.destroy().catch(() => {})
     await server.destroy().catch(() => {})
@@ -123,6 +127,7 @@ test('topic-based fallback connects without indexer keys', async (t) => {
     const timer = setTimeout(() => reject(new Error('no connection within 15s')), 15000)
 
     client.on('connection', (conn, peerInfo) => {
+      conn.on('error', () => {})
       clearTimeout(timer)
       resolve(IdEnc.normalize(peerInfo.publicKey))
     })

--- a/packages/qvac-lib-registry-server/tests/unit/model-schema.test.js
+++ b/packages/qvac-lib-registry-server/tests/unit/model-schema.test.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const test = require('brittle')
+const { addModelRequestSchema, baseModelFields } = require('../../lib/model-schema')
+
+const VALID_PAYLOAD = {
+  source: 'https://huggingface.co/org/repo/resolve/abc123/model.gguf',
+  engine: '@qvac/llm-llamacpp',
+  licenseId: 'Apache-2.0'
+}
+
+test('addModelRequestSchema accepts minimal valid payload', async t => {
+  const result = addModelRequestSchema.safeParse(VALID_PAYLOAD)
+  t.ok(result.success)
+})
+
+test('addModelRequestSchema accepts full valid payload', async t => {
+  const result = addModelRequestSchema.safeParse({
+    ...VALID_PAYLOAD,
+    description: 'test model',
+    quantization: 'q4_0',
+    params: '1B',
+    notes: 'some notes',
+    tags: ['generation', 'instruct'],
+    deprecated: false,
+    deprecatedAt: '',
+    replacedBy: '',
+    deprecationReason: '',
+    skipExisting: true
+  })
+  t.ok(result.success)
+})
+
+test('addModelRequestSchema rejects unknown fields (.strict)', async t => {
+  const result = addModelRequestSchema.safeParse({
+    ...VALID_PAYLOAD,
+    extraField: 'should fail'
+  })
+  t.absent(result.success)
+  t.ok(result.error.issues.some(i => i.message.includes('extraField') || i.code === 'unrecognized_keys'))
+})
+
+test('addModelRequestSchema rejects missing required fields', async t => {
+  for (const field of ['source', 'engine', 'licenseId']) {
+    const payload = { ...VALID_PAYLOAD }
+    delete payload[field]
+    const result = addModelRequestSchema.safeParse(payload)
+    t.absent(result.success, `should reject when ${field} is missing`)
+  }
+})
+
+test('addModelRequestSchema rejects empty required fields', async t => {
+  for (const field of ['source', 'engine', 'licenseId']) {
+    const result = addModelRequestSchema.safeParse({ ...VALID_PAYLOAD, [field]: '' })
+    t.absent(result.success, `should reject empty ${field}`)
+  }
+})
+
+test('addModelRequestSchema enforces max length on description', async t => {
+  const result = addModelRequestSchema.safeParse({
+    ...VALID_PAYLOAD,
+    description: 'x'.repeat(513)
+  })
+  t.absent(result.success)
+})
+
+test('addModelRequestSchema enforces max length on deprecationReason', async t => {
+  const result = addModelRequestSchema.safeParse({
+    ...VALID_PAYLOAD,
+    deprecationReason: 'x'.repeat(513)
+  })
+  t.absent(result.success)
+})
+
+test('addModelRequestSchema enforces tag limits', async t => {
+  const tooManyTags = addModelRequestSchema.safeParse({
+    ...VALID_PAYLOAD,
+    tags: Array.from({ length: 51 }, (_, i) => `tag-${i}`)
+  })
+  t.absent(tooManyTags.success, 'rejects > 50 tags')
+
+  const tagTooLong = addModelRequestSchema.safeParse({
+    ...VALID_PAYLOAD,
+    tags: ['x'.repeat(129)]
+  })
+  t.absent(tagTooLong.success, 'rejects tag > 128 chars')
+})
+
+test('addModelRequestSchema rejects non-boolean skipExisting', async t => {
+  const result = addModelRequestSchema.safeParse({
+    ...VALID_PAYLOAD,
+    skipExisting: 'yes'
+  })
+  t.absent(result.success)
+})
+
+test('addModelRequestSchema rejects non-object input', async t => {
+  t.absent(addModelRequestSchema.safeParse(null).success)
+  t.absent(addModelRequestSchema.safeParse('string').success)
+  t.absent(addModelRequestSchema.safeParse(42).success)
+})
+
+test('baseModelFields is exported for CI schema reuse', async t => {
+  t.ok(baseModelFields)
+  t.ok(baseModelFields.source)
+  t.ok(baseModelFields.engine)
+  t.ok(baseModelFields.licenseId)
+})

--- a/packages/qvac-lib-registry-server/tests/unit/model-schema.test.js
+++ b/packages/qvac-lib-registry-server/tests/unit/model-schema.test.js
@@ -62,6 +62,7 @@ test('addModelRequestSchema enforces max length on description', async t => {
     description: 'x'.repeat(513)
   })
   t.absent(result.success)
+  t.ok(result.error.issues.some(i => i.path.includes('description')), 'error references description field')
 })
 
 test('addModelRequestSchema enforces max length on deprecationReason', async t => {
@@ -70,6 +71,7 @@ test('addModelRequestSchema enforces max length on deprecationReason', async t =
     deprecationReason: 'x'.repeat(513)
   })
   t.absent(result.success)
+  t.ok(result.error.issues.some(i => i.path.includes('deprecationReason')), 'error references deprecationReason field')
 })
 
 test('addModelRequestSchema enforces tag limits', async t => {
@@ -78,12 +80,14 @@ test('addModelRequestSchema enforces tag limits', async t => {
     tags: Array.from({ length: 51 }, (_, i) => `tag-${i}`)
   })
   t.absent(tooManyTags.success, 'rejects > 50 tags')
+  t.ok(tooManyTags.error.issues.some(i => i.path.includes('tags')), 'error references tags field')
 
   const tagTooLong = addModelRequestSchema.safeParse({
     ...VALID_PAYLOAD,
     tags: ['x'.repeat(129)]
   })
   t.absent(tagTooLong.success, 'rejects tag > 128 chars')
+  t.ok(tagTooLong.error.issues.length > 0, 'error has issues')
 })
 
 test('addModelRequestSchema rejects non-boolean skipExisting', async t => {
@@ -92,6 +96,7 @@ test('addModelRequestSchema rejects non-boolean skipExisting', async t => {
     skipExisting: 'yes'
   })
   t.absent(result.success)
+  t.ok(result.error.issues.some(i => i.path.includes('skipExisting')), 'error references skipExisting field')
 })
 
 test('addModelRequestSchema rejects non-object input', async t => {


### PR DESCRIPTION
## What problem does this PR solve?

Addresses four issues identified during the Holepunch team code review of qvac-lib-registry-server: missing schema validation on the RPC write path, redundant replication calls, unnecessary swarm.flush() blocking server startup, and unauthenticated CI RPC topic discovery.

## How does it solve it?

**1. Server-side Zod schema validation for RPC write path**

- Renamed `license` to `licenseId` in `models.prod.json` (391 entries) and all CI scripts to align with the HyperDB schema, eliminating the field mapping layer
- Extracted shared `baseModelFields` into `lib/model-schema.js`, imported by both server-side RPC validation and CI `validate-models-json.js`
- Replaced manual `_validateAddModelRequest` with `addModelRequestSchema.parse()` using `.strict()` to reject unknown fields
- Added structured logging for rejected payloads (Zod issues array)
- Added 11 unit tests for schema validation

**2. Remove redundant replication calls**

- Removed `base.replicate(replicationStream)` and `view.core.replicate(replicationStream)` from the connection handler -- `store.replicate(conn)` already covers all managed cores via Corestore
- All 20 integration tests pass (multi-writer, indexer quorum, blind peer reseed, download resume)

**3. Remove unnecessary swarm.flush() from server startup**

- Removed `await this.swarm.flush()` from `_open()` -- not needed for a long-running server that accepts connections as they arrive

**4. CI RPC connection hardening**

- Added `getIndexerKeys()` to `RegistryConfig` reading `QVAC_INDEXER_KEYS` env var
- Modified `connectToRegistry()` in `rpc-client.js` to use `swarm.joinPeer()` when indexer keys are configured, with Noise protocol handshake for identity verification
- Falls back to topic-based discovery when no indexer keys are set (backward compatible)
- Connection filter rejects peers whose public key is not in the configured indexer list
- Documented in DEPLOYMENT_GUIDE.md

## Breaking changes

- `models.prod.json` field rename: `license` → `licenseId`. All CI scripts updated. External tooling reading this file directly needs to use `licenseId`.
- RPC `add-model` now rejects payloads with unknown fields (`.strict()` Zod validation). Existing CI clients sending only known fields are unaffected.

Asana: https://app.asana.com/1/45238840754660/project/1212638335655966/task/1213985150771346
