### PR TITLE
chore[bc]: LLM addon interface refactor - remove BaseInference and WeightsProvider

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/examples/benchToolsPlacement.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/benchToolsPlacement.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const LlmLlamacpp = require('../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const path = require('bare-path')
 const fs = require('bare-fs')
 const process = require('bare-process')
@@ -213,16 +212,15 @@ function makeBaseConfig (toolsAtEnd) {
 }
 
 async function loadModel (dirPath, modelName, config) {
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const model = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
   await model.load()
-  return { model, loader }
+  return { model }
 }
 
 async function runAndCollect (model, prompt) {
@@ -255,7 +253,7 @@ async function runScenario (dirPath, modelName, opts) {
   console.log('='.repeat(70))
 
   const config = makeBaseConfig(toolsAtEnd)
-  const { model, loader } = await loadModel(dirPath, modelName, config)
+  const { model } = await loadModel(dirPath, modelName, config)
   const cachePath = path.join(dirPath, cacheName)
   cleanCache(cachePath)
 
@@ -341,7 +339,6 @@ async function runScenario (dirPath, modelName, opts) {
     }
   } finally {
     await model.unload()
-    await loader.close()
     cleanCache(cachePath)
   }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/showcase/smart-home-finetune.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/showcase/smart-home-finetune.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const LlamaClient = require('../../../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const process = require('bare-process')
 const { downloadModel, formatProgress, createFilteredLogger } = require('../../utils')
 
@@ -20,7 +20,6 @@ const OUTPUT_DIR = './smart-home-lora'
 
 async function main () {
   let client
-  let loader
 
   const { logger: filteredLogger, restore: restoreConsole } = createFilteredLogger()
 
@@ -33,15 +32,7 @@ async function main () {
 
     const [modelName, modelDir] = await downloadModel(MODEL.url, MODEL.name)
 
-    loader = new FilesystemDL({ dirPath: modelDir })
-
-    const args = {
-      loader,
-      opts: { stats: true },
-      logger: filteredLogger,
-      diskPath: modelDir,
-      modelName
-    }
+    const modelPath = path.join(modelDir, modelName)
 
     const config = {
       gpu_layers: '999',
@@ -50,7 +41,12 @@ async function main () {
       flash_attn: 'off'
     }
 
-    client = new LlamaClient(args, config)
+    client = new LlamaClient({
+      files: { model: [modelPath] },
+      config,
+      logger: filteredLogger,
+      opts: { stats: true }
+    })
     await client.load()
     console.log('Model loaded.\n')
 
@@ -117,13 +113,6 @@ async function main () {
         await client.unload()
       } catch (unloadErr) {
         console.error('Failed to unload model during cleanup:', unloadErr)
-      }
-    }
-    if (loader) {
-      try {
-        await loader.close()
-      } catch (closeErr) {
-        console.error('Failed to close loader during cleanup:', closeErr)
       }
     }
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/showcase/smart-home-finetuned-test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/showcase/smart-home-finetuned-test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const LlamaClient = require('../../../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const process = require('bare-process')
 const path = require('bare-path')
 const fs = require('bare-fs')
@@ -143,15 +142,7 @@ async function runScenario (client, messages) {
 async function main () {
   const [modelName, modelDir] = await downloadModel(MODEL.url, MODEL.name)
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
-
-  const args = {
-    loader,
-    opts: { stats: true },
-    logger: console,
-    diskPath: modelDir,
-    modelName
-  }
+  const modelPath = path.join(modelDir, modelName)
 
   const sharedConfig = {
     device: 'gpu',
@@ -184,7 +175,12 @@ async function main () {
       console.log('  Model: ' + MODEL.name)
       console.log(separator('='))
 
-      baselineClient = new LlamaClient(args, baselineConfig)
+      baselineClient = new LlamaClient({
+        files: { model: [modelPath] },
+        config: baselineConfig,
+        logger: console,
+        opts: { stats: true }
+      })
       await baselineClient.load()
       console.log('Base model loaded (no LoRA).\n')
 
@@ -263,7 +259,12 @@ async function main () {
       console.log('  Adapter: ' + LORA_ADAPTER)
       console.log(separator('='))
 
-      client = new LlamaClient(args, config)
+      client = new LlamaClient({
+        files: { model: [modelPath] },
+        config,
+        logger: console,
+        opts: { stats: true }
+      })
       await client.load()
       console.log('Model + LoRA adapter loaded.\n')
 
@@ -408,8 +409,6 @@ async function main () {
     console.error('\nTest failed:', error.message)
     console.error('Stack:', error.stack)
     process.exit(1)
-  } finally {
-    try { await loader.close() } catch (e) { console.error('Failed to close loader:', e) }
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/simple-lora-finetune-multiple-pause-resume.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/simple-lora-finetune-multiple-pause-resume.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const LlamaClient = require('../../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const process = require('bare-process')
 const path = require('bare-path')
 const fs = require('bare-fs')
@@ -52,17 +51,9 @@ async function main () {
   const trainDatasetPath = './examples/input/small_train_HF.jsonl'
   const evalDatasetPath = './examples/input/small_eval_HF.jsonl'
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
+  const modelPath = path.join(modelDir, modelName)
 
   const { logger: filteredLogger, restore: restoreConsole } = createFilteredLogger()
-
-  const args = {
-    loader,
-    opts: { stats: true },
-    logger: filteredLogger,
-    diskPath: modelDir,
-    modelName
-  }
 
   const config = {
     device: 'gpu',
@@ -76,7 +67,12 @@ async function main () {
   try {
     console.log('=== Multiple Pause/Resume Finetuning Test ===\n')
     console.log('Loading model...')
-    client = new LlamaClient(args, config)
+    client = new LlamaClient({
+      files: { model: [modelPath] },
+      config,
+      logger: filteredLogger,
+      opts: { stats: true }
+    })
 
     await client.load()
     console.log('Model loaded successfully\n')

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/simple-lora-finetune-pause-inference-resume.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/simple-lora-finetune-pause-inference-resume.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const LlamaClient = require('../../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const process = require('bare-process')
 const path = require('bare-path')
 const fs = require('bare-fs')
@@ -76,17 +75,9 @@ async function main () {
   const trainDatasetPath = './examples/input/small_train_HF.jsonl'
   const evalDatasetPath = './examples/input/small_eval_HF.jsonl'
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
+  const modelPath = path.join(modelDir, modelName)
 
   const { logger: filteredLogger, restore: restoreConsole } = createFilteredLogger()
-
-  const args = {
-    loader,
-    opts: { stats: true },
-    logger: filteredLogger,
-    diskPath: modelDir,
-    modelName
-  }
 
   const config = {
     device: 'gpu',
@@ -100,7 +91,12 @@ async function main () {
   try {
     console.log('=== Pause Finetuning, Inference, and Resume Test ===\n')
     console.log('Loading model...')
-    client = new LlamaClient(args, config)
+    client = new LlamaClient({
+      files: { model: [modelPath] },
+      config,
+      logger: filteredLogger,
+      opts: { stats: true }
+    })
 
     await client.load()
     console.log('Model loaded successfully\n')
@@ -219,7 +215,12 @@ async function main () {
       }
 
       console.log('🔮 Preparing inference 1: Loading model with LoRA adapter...')
-      inferenceClientWithLora = new LlamaClient(args, inferenceConfigWithLora)
+      inferenceClientWithLora = new LlamaClient({
+        files: { model: [modelPath] },
+        config: inferenceConfigWithLora,
+        logger: filteredLogger,
+        opts: { stats: true }
+      })
       await inferenceClientWithLora.load()
       console.log('✅ Model with LoRA adapter loaded successfully\n')
 
@@ -246,7 +247,12 @@ async function main () {
       }
 
       console.log('🔮 Preparing inference 2: Loading base model (no LoRA adapters)...')
-      inferenceClientBase = new LlamaClient(args, inferenceConfigBase)
+      inferenceClientBase = new LlamaClient({
+        files: { model: [modelPath] },
+        config: inferenceConfigBase,
+        logger: filteredLogger,
+        opts: { stats: true }
+      })
       await inferenceClientBase.load()
       console.log('✅ Base model loaded successfully\n')
 

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/simple-lora-finetune-pause-resume.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/simple-lora-finetune-pause-resume.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const LlamaClient = require('../../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const process = require('bare-process')
 const path = require('bare-path')
 const fs = require('bare-fs')
@@ -58,17 +57,9 @@ async function main () {
   const trainDatasetPath = './examples/input/small_train_HF.jsonl'
   const evalDatasetPath = './examples/input/small_eval_HF.jsonl'
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
+  const modelPath = path.join(modelDir, modelName)
 
   const { logger: filteredLogger, restore: restoreConsole } = createFilteredLogger()
-
-  const args = {
-    loader,
-    opts: { stats: true },
-    logger: filteredLogger,
-    diskPath: modelDir,
-    modelName
-  }
 
   const config = {
     device: 'gpu',
@@ -82,7 +73,12 @@ async function main () {
   try {
     console.log('=== Pause/Resume Finetuning Test ===\n')
     console.log('Loading model...')
-    client = new LlamaClient(args, config)
+    client = new LlamaClient({
+      files: { model: [modelPath] },
+      config,
+      logger: filteredLogger,
+      opts: { stats: true }
+    })
     await client.load()
     console.log('Model loaded successfully\n')
 

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/simple-lora-finetune.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/finetune/simple-lora-finetune.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const LlmLlamacpp = require('../../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const { downloadModel, formatProgress, createFilteredLogger } = require('../utils')
 
 const MODEL = {
@@ -11,22 +11,13 @@ const MODEL = {
 
 async function runFinetuningTests () {
   let model
-  let loader
 
   const { logger: filteredLogger, restore: restoreConsole } = createFilteredLogger()
 
   try {
     const [modelName, modelDir] = await downloadModel(MODEL.url, MODEL.name)
 
-    loader = new FilesystemDL({ dirPath: modelDir })
-
-    const args = {
-      loader,
-      opts: { stats: true },
-      logger: filteredLogger,
-      diskPath: modelDir,
-      modelName
-    }
+    const modelPath = path.join(modelDir, modelName)
 
     const config = {
       gpu_layers: '999',
@@ -35,7 +26,12 @@ async function runFinetuningTests () {
       flash_attn: 'off'
     }
 
-    model = new LlmLlamacpp(args, config)
+    model = new LlmLlamacpp({
+      files: { model: [modelPath] },
+      config,
+      logger: filteredLogger,
+      opts: { stats: true }
+    })
     await model.load()
 
     const finetuneOptions = {
@@ -57,12 +53,10 @@ async function runFinetuningTests () {
     })
     const finetuneResult = await handle.await()
     console.log('Finetune completed:', finetuneResult)
-    if (args.opts?.stats) {
-      if (finetuneResult && typeof finetuneResult.stats === 'object' && finetuneResult.stats !== null) {
-        console.log('✅ Finetune terminal stats:', finetuneResult.stats)
-      } else {
-        console.warn('⚠️  opts.stats is enabled, but no finetune terminal stats were returned')
-      }
+    if (finetuneResult && typeof finetuneResult.stats === 'object' && finetuneResult.stats !== null) {
+      console.log('✅ Finetune terminal stats:', finetuneResult.stats)
+    } else {
+      console.warn('⚠️  opts.stats is enabled, but no finetune terminal stats were returned')
     }
   } catch (error) {
     console.error('Test failed:', error.message)
@@ -75,13 +69,6 @@ async function runFinetuningTests () {
         await model.unload()
       } catch (unloadErr) {
         console.error('Failed to unload model during cleanup:', unloadErr)
-      }
-    }
-    if (loader) {
-      try {
-        await loader.close()
-      } catch (closeErr) {
-        console.error('Failed to close loader during cleanup:', closeErr)
       }
     }
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/multiCache.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/multiCache.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const LlmLlamacpp = require('../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const process = require('bare-process')
 const { downloadModel } = require('./utils')
 
@@ -15,17 +15,8 @@ async function main () {
     'Llama-3.2-1B-Instruct-Q4_0.gguf'
   )
 
-  // 2. Initializing data loader
-  const fsDL = new FilesystemDL({ dirPath })
-
-  // 3. Configuring model settings
-  const args = {
-    loader: fsDL,
-    opts: { stats: true },
-    logger: console,
-    diskPath: dirPath,
-    modelName
-  }
+  // 2. Configuring model settings
+  const modelPath = path.join(dirPath, modelName)
 
   const config = {
     device: 'gpu',
@@ -33,12 +24,17 @@ async function main () {
     ctx_size: '10000'
   }
 
-  // 4. Loading model
-  const model = new LlmLlamacpp(args, config)
+  // 3. Loading model
+  const model = new LlmLlamacpp({
+    files: { model: [modelPath] },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
   await model.load()
 
   try {
-    // 5. First conversation - no cache will be used. One shot inference
+    // 4. First conversation - no cache will be used. One shot inference
     const messages = [
       {
         role: 'system',
@@ -73,7 +69,7 @@ async function main () {
     console.log(`Inference stats: ${JSON.stringify(response1.stats)}`)
     console.log('\n')
 
-    // 6. Switching to a new session with cache1.bin file
+    // 5. Switching to a new session with cache1.bin file
     const messages2 = [
       {
         role: 'session',
@@ -100,7 +96,7 @@ async function main () {
     console.log(`Inference stats: ${JSON.stringify(response2.stats)}`)
     console.log('\n')
 
-    // 7. Continuing conversation with cache1.bin
+    // 6. Continuing conversation with cache1.bin
     const messages3 = [
       {
         role: 'session',
@@ -131,9 +127,8 @@ async function main () {
     console.error('Error occurred:', errorMessage)
     console.error('Error details:', error)
   } finally {
-    // 8. Cleaning up resources
+    // 7. Cleaning up resources
     await model.unload()
-    await fsDL.close()
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/multiModal.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/multiModal.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const LlmLlamacpp = require('../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const fs = require('bare-fs')
 const process = require('bare-process')
 const { downloadModel } = require('./utils')
@@ -16,23 +16,13 @@ async function main () {
     'SmolVLM2-500M-Video-Instruct-Q8_0.gguf'
   )
 
-  const [projectionModel] = await downloadModel(
+  const [projModelName] = await downloadModel(
     'https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf',
     'mmproj-SmolVLM2-500M-Video-Instruct-Q8_0.gguf'
   )
 
-  // 2. Initializing data loader
-  const fsDL = new FilesystemDL({ dirPath })
-
-  // 3. Configuring model settings
-  const args = {
-    loader: fsDL,
-    opts: { stats: true },
-    logger: console,
-    diskPath: dirPath,
-    modelName,
-    projectionModel
-  }
+  // 2. Configuring model settings
+  const modelPath = path.join(dirPath, modelName)
 
   const config = {
     device: 'gpu',
@@ -40,16 +30,21 @@ async function main () {
     ctx_size: '2048'
   }
 
-  // 4. Loading model
-  const model = new LlmLlamacpp(args, config)
+  // 3. Loading model
+  const model = new LlmLlamacpp({
+    files: { model: [modelPath], projectionModel: path.join(dirPath, projModelName) },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
   await model.load()
 
-  // 5. Preparing media. We will use both the path and the buffer in different inferences
+  // 4. Preparing media. We will use both the path and the buffer in different inferences
   const imageFilePath = 'media/news-paper.jpg'
   const imageBuffer = new Uint8Array(fs.readFileSync(imageFilePath))
 
   try {
-    // 6. First inference with image buffer
+    // 5. First inference with image buffer
     const messages1 = [
       {
         role: 'system',
@@ -81,7 +76,7 @@ async function main () {
     console.log(`Inference stats: ${JSON.stringify(response1.stats)}`)
     console.log('\n')
 
-    // 7. Second inference with image file path
+    // 6. Second inference with image file path
     const messages2 = [
       {
         role: 'system',
@@ -117,9 +112,8 @@ async function main () {
     console.error('Error occurred:', errorMessage)
     console.error('Error details:', error)
   } finally {
-    // 8. Cleaning up resources
+    // 7. Cleaning up resources
     await model.unload()
-    await fsDL.close()
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/nativelog.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/nativelog.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const LlmLlamacpp = require('../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const { setLogger, releaseLogger } = require('../addonLogging')
+const path = require('bare-path')
 const process = require('bare-process')
 const { downloadModel } = require('./utils')
 
@@ -36,17 +36,8 @@ async function main () {
     'Llama-3.2-1B-Instruct-Q4_0.gguf'
   )
 
-  // 3. Initializing data loader
-  const fsDL = new FilesystemDL({ dirPath })
-
-  // 4. Configuring model settings
-  const args = {
-    loader: fsDL,
-    opts: { stats: true },
-    logger: console,
-    diskPath: dirPath,
-    modelName
-  }
+  // 3. Configuring model settings
+  const modelPath = path.join(dirPath, modelName)
 
   const config = {
     device: 'gpu',
@@ -55,12 +46,17 @@ async function main () {
     verbosity: '2'
   }
 
-  // 5. Loading model
-  const model = new LlmLlamacpp(args, config)
+  // 4. Loading model
+  const model = new LlmLlamacpp({
+    files: { model: [modelPath] },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
   await model.load()
 
   try {
-    // 6. Running inference with conversation prompt
+    // 5. Running inference with conversation prompt
     const prompt = [
       {
         role: 'system',
@@ -98,9 +94,8 @@ async function main () {
     console.error('Error occurred:', errorMessage)
     console.error('Error details:', error)
   } finally {
-    // 7. Cleaning up resources
+    // 6. Cleaning up resources
     await model.unload()
-    await fsDL.close()
     releaseLogger()
   }
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/quickstart.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/quickstart.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const LlmLlamacpp = require('../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const process = require('bare-process')
 const { downloadModel } = require('./utils')
 
@@ -15,17 +15,8 @@ async function main () {
     'Llama-3.2-1B-Instruct-Q4_0.gguf'
   )
 
-  // 2. Initializing data loader
-  const fsDL = new FilesystemDL({ dirPath })
-
-  // 3. Configuring model settings
-  const args = {
-    loader: fsDL,
-    opts: { stats: true },
-    logger: console,
-    diskPath: dirPath,
-    modelName
-  }
+  // 2. Configuring model settings
+  const modelPath = path.join(dirPath, modelName)
 
   const config = {
     device: 'gpu',
@@ -33,12 +24,17 @@ async function main () {
     ctx_size: '1024'
   }
 
-  // 4. Loading model
-  const model = new LlmLlamacpp(args, config)
+  // 3. Loading model
+  const model = new LlmLlamacpp({
+    files: { model: [modelPath] },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
   await model.load()
 
   try {
-    // 5. Running inference with conversation prompt
+    // 4. Running inference with conversation prompt
     const prompt = [
       {
         role: 'system',
@@ -76,9 +72,8 @@ async function main () {
     console.error('Error occurred:', errorMessage)
     console.error('Error details:', error)
   } finally {
-    // 6. Cleaning up resources
+    // 5. Cleaning up resources
     await model.unload()
-    await fsDL.close()
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/salamandraTA.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/salamandraTA.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const LlmLlamacpp = require('../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const process = require('bare-process')
 const { downloadModel } = require('./utils')
 
@@ -15,17 +15,8 @@ async function main () {
     'salamandrata_2b_inst_q4.gguf'
   )
 
-  // 2. Initializing data loader
-  const fsDL = new FilesystemDL({ dirPath })
-
-  // 3. Configuring model settings
-  const args = {
-    loader: fsDL,
-    opts: { stats: true },
-    logger: console,
-    diskPath: dirPath,
-    modelName
-  }
+  // 2. Configuring model settings
+  const modelPath = path.join(dirPath, modelName)
 
   const config = {
     device: 'gpu',
@@ -33,12 +24,17 @@ async function main () {
     ctx_size: '1024'
   }
 
-  // 4. Loading model
-  const model = new LlmLlamacpp(args, config)
+  // 3. Loading model
+  const model = new LlmLlamacpp({
+    files: { model: [modelPath] },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
   await model.load()
 
   try {
-    // 5. Running translation inference
+    // 4. Running translation inference
     const messages = [
       {
         role: 'system',
@@ -64,9 +60,8 @@ async function main () {
     console.error('Error occurred:', errorMessage)
     console.error('Error details:', error)
   } finally {
-    // 6. Cleaning up resources
+    // 5. Cleaning up resources
     await model.unload()
-    await fsDL.close()
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/simple-lora-inference.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/simple-lora-inference.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const LlamaClient = require('../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const process = require('bare-process')
 const path = require('bare-path')
 const fs = require('bare-fs')
@@ -112,15 +111,7 @@ async function main () {
 
   const loraAdapterPath = './lora_checkpoints/checkpoint_step_00000006/model.gguf'
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
-
-  const args = {
-    loader,
-    opts: { stats: true },
-    logger: console,
-    diskPath: modelDir,
-    modelName
-  }
+  const modelPath = path.join(modelDir, modelName)
 
   const config = {
     device: 'gpu',
@@ -133,7 +124,12 @@ async function main () {
 
   let client
   try {
-    client = new LlamaClient(args, config)
+    client = new LlamaClient({
+      files: { model: [modelPath] },
+      config,
+      logger: console,
+      opts: { stats: true }
+    })
     await client.load()
 
     const messages = [

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/testToolRemoval.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/testToolRemoval.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const LlmLlamacpp = require('../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const path = require('bare-path')
 const fs = require('bare-fs')
 const process = require('bare-process')
@@ -65,16 +64,15 @@ function extractToolCalls (response) {
 }
 
 async function loadModel (dirPath, modelName, config) {
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const model = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
   await model.load()
-  return { model, loader }
+  return { model }
 }
 
 async function runAndCollect (model, prompt) {
@@ -102,7 +100,7 @@ async function main () {
     tools_at_end: 'true'
   }
 
-  const { model, loader } = await loadModel(dirPath, modelName, config)
+  const { model } = await loadModel(dirPath, modelName, config)
   const cachePath = path.join(dirPath, 'test-tool-removal.bin')
   try { fs.unlinkSync(cachePath) } catch (_) {}
 
@@ -197,7 +195,6 @@ async function main () {
       : '  FAILURES DETECTED — removed tools leaked through the cache')
   } finally {
     await model.unload()
-    await loader.close()
     try { fs.unlinkSync(cachePath) } catch (_) {}
   }
 }
@@ -223,7 +220,7 @@ async function mainInSystem () {
     tools_at_end: 'false'
   }
 
-  const { model, loader } = await loadModel(dirPath, modelName, config)
+  const { model } = await loadModel(dirPath, modelName, config)
   const cachePath = path.join(dirPath, 'test-tool-removal-insystem.bin')
   try { fs.unlinkSync(cachePath) } catch (_) {}
 
@@ -327,7 +324,6 @@ async function mainInSystem () {
       : '  FAILURES DETECTED — removed tools leaked from conversation history')
   } finally {
     await model.unload()
-    await loader.close()
     try { fs.unlinkSync(cachePath) } catch (_) {}
   }
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/toolCalling.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/toolCalling.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const LlmLlamacpp = require('../index')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const process = require('bare-process')
 const { downloadModel } = require('./utils')
 
@@ -80,17 +80,8 @@ async function main () {
     'Qwen3-1.7B-Q4_0.gguf'
   )
 
-  // 2. Initializing data loader
-  const fsDL = new FilesystemDL({ dirPath })
-
-  // 3. Configuring model settings
-  const args = {
-    loader: fsDL,
-    opts: { stats: true },
-    logger: console,
-    diskPath: dirPath,
-    modelName
-  }
+  // 2. Configuring model settings
+  const modelPath = path.join(dirPath, modelName)
 
   const config = {
     device: 'gpu',
@@ -99,12 +90,17 @@ async function main () {
     tools: 'true'
   }
 
-  // 4. Loading model
-  const model = new LlmLlamacpp(args, config)
+  // 3. Loading model
+  const model = new LlmLlamacpp({
+    files: { model: [modelPath] },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
   await model.load()
 
   try {
-    // 5. Defining tool queries with function schemas
+    // 4. Defining tool queries with function schemas
     const systemMessageAmbiguous = {
       role: 'system',
       content: 'You are a helpful assistant with access to various tools. If request is ambiguous,skip tool calls.'
@@ -276,7 +272,7 @@ async function main () {
       }
     ]
 
-    // 6. Running tool calling queries
+    // 5. Running tool calling queries
     const queries = [
       { name: 'Query 1: Complex tool calling with multiple parameters', prompt: toolQuery1 },
       { name: 'Query 2: Math calculation and ambiguous query', prompt: toolQuery2 },
@@ -296,9 +292,8 @@ async function main () {
     console.error('Error occurred:', errorMessage)
     console.error('Error details:', error)
   } finally {
-    // 7. Cleaning up resources
+    // 6. Cleaning up resources
     await model.unload()
-    await fsDL.close()
   }
 }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
@@ -1,21 +1,7 @@
-import BaseInference, {
-  ReportProgressCallback
-} from '@qvac/infer-base/WeightsProvider/BaseInference'
 import type { QvacResponse } from '@qvac/infer-base'
 import type QvacLogger from '@qvac/logging'
 
 export type NumericLike = number | `${number}`
-
-export interface Loader {
-  ready(): Promise<void>
-  close(): Promise<void>
-  getStream(path: string): Promise<AsyncIterable<Uint8Array>>
-  download(
-    path: string,
-    opts: { diskPath: string; progressReporter?: unknown }
-  ): Promise<{ await(): Promise<void> }>
-  getFileSize?(path: string): Promise<number>
-}
 
 export interface AddonMessage {
   type: 'text'
@@ -27,7 +13,6 @@ export interface AddonMediaMessage {
   content: Uint8Array
 }
 export type AddonRunJobMessage = AddonMessage | AddonMediaMessage
-
 
 export interface Addon {
   loadWeights(data: { filename: string; chunk: Uint8Array | null; completed: boolean }, logger?: QvacLogger): Promise<void>
@@ -62,14 +47,10 @@ export interface LlamaConfig {
 }
 
 export interface LlmLlamacppArgs {
-  loader: Loader
+  files: { model: string[]; projectionModel?: string }
+  config: LlamaConfig
   logger?: QvacLogger | Console | null
   opts?: { stats?: boolean }
-  diskPath?: string
-  modelName: string
-  projectionModel?: string
-  modelPath?: string
-  modelConfig?: Record<string, string>
 }
 
 export interface UserTextMessage {
@@ -113,10 +94,6 @@ export interface RunOptions {
   generationParams?: GenerationParams
 }
 
-export interface DownloadWeightsOptions {
-  closeLoader?: boolean
-}
-
 export interface RuntimeStats {
   TTFT: number
   TPS: number
@@ -127,25 +104,17 @@ export interface RuntimeStats {
   backendDevice: 'cpu' | 'gpu'
 }
 
-export interface DownloadResult {
-  filePath: string | null
-  error: boolean
-  completed: boolean
-}
-
 export interface FinetuneValidationNone {
   type: 'none'
 }
 
 export interface FinetuneValidationSplit {
   type: 'split'
-  /** Fraction of training data to hold out for validation (0–1). Default 0.05. */
   fraction?: number
 }
 
 export interface FinetuneValidationDataset {
   type: 'dataset'
-  /** Path to a separate eval dataset file. Must differ from trainDatasetDir. */
   path: string
 }
 
@@ -155,53 +124,29 @@ export type FinetuneValidation =
   | FinetuneValidationDataset
 
 export interface FinetuneOptions {
-  /** Path to training dataset file (.jsonl for SFT, .txt for causal). */
   trainDatasetDir: string
-  /** How to run validation. */
   validation: FinetuneValidation
-  /** Directory (or file path ending in .gguf) for the final LoRA adapter. */
   outputParametersDir: string
-  /** Number of training epochs. Default 1. */
   numberOfEpochs?: number
-  /** Initial learning rate. Default 1e-4. */
   learningRate?: number
-  /** Training sequence length. Default 128. */
   contextLength?: number
-  /** Backend n_batch (tokens per batch). Must be >= microBatchSize and divisible by it. Default 128. */
   batchSize?: number
-  /** Backend n_ubatch (micro-batch size). Must be <= batchSize. Default 128. */
   microBatchSize?: number
-  /** Use SFT (chat) mode when true; causal (next-token) when false. Default false. */
   assistantLossOnly?: boolean
-  /** Comma-separated LoRA target modules (e.g. 'attn_q,attn_k,attn_v,attn_o'). Default: attention Q/K/V/O. */
   loraModules?: string
-  /** LoRA rank. Default 8. */
   loraRank?: number
-  /** LoRA alpha (scaling factor). Default 16.0. */
   loraAlpha?: number
-  /** LoRA init standard deviation. Default 0.02. */
   loraInitStd?: number
-  /** Seed for LoRA weight initialization (0 = non-deterministic). Default 42. */
   loraSeed?: number
-  /** Directory for checkpoints. Default './checkpoints'. */
   checkpointSaveDir?: string
-  /** Save a checkpoint every N optimizer steps (0 = only on pause). Default 0. */
   checkpointSaveSteps?: number
-  /** Path to a custom chat template file (for SFT). */
   chatTemplatePath?: string
-  /** Learning rate scheduler: 'constant', 'cosine', or 'linear'. Default 'cosine'. */
   lrScheduler?: 'constant' | 'cosine' | 'linear'
-  /** Minimum learning rate (for cosine/linear schedulers). Default 0. */
   lrMin?: number
-  /** Warmup ratio (0–1). Requires warmupRatioSet: true. Default 0.1. */
   warmupRatio?: number
-  /** When true, compute warmup steps from warmupRatio. */
   warmupRatioSet?: boolean
-  /** Explicit warmup steps (used when warmupStepsSet is true). Default 0. */
   warmupSteps?: number
-  /** When true, use warmupSteps directly instead of ratio. */
   warmupStepsSet?: boolean
-  /** Weight decay. Default 0.01. */
   weightDecay?: number
 }
 
@@ -245,43 +190,21 @@ export interface FinetuneResult {
   stats?: FinetuneStats
 }
 
-export default class LlmLlamacpp extends BaseInference {
-  protected addon: Addon
+export default class LlmLlamacpp {
+  protected addon: Addon | null
+  opts: { stats?: boolean }
+  logger: QvacLogger
+  state: { configLoaded: boolean }
 
-  constructor(
-    args: LlmLlamacppArgs,
-    config: LlamaConfig
-  )
-  _load(
-    closeLoader?: boolean,
-    onDownloadProgress?: ReportProgressCallback | ((bytes: number) => void)
-  ): Promise<void>
+  constructor(args: LlmLlamacppArgs)
 
-  load(
-    closeLoader?: boolean,
-    onDownloadProgress?: ReportProgressCallback | ((bytes: number) => void)
-  ): Promise<void>
-
-  downloadWeights(
-    onDownloadProgress?: (progress: Record<string, any>, opts: DownloadWeightsOptions) => any,
-    opts?: DownloadWeightsOptions
-  ): Promise<Record<string, DownloadResult>>
-
-  _downloadWeights(
-    onDownloadProgress?: (progress: Record<string, any>, opts: DownloadWeightsOptions) => any,
-    opts?: DownloadWeightsOptions
-  ): Promise<Record<string, DownloadResult>>
-
-  _runInternal(prompt: Message[], runOptions?: RunOptions): Promise<QvacResponse>
-
+  load(): Promise<void>
   run(prompt: Message[], runOptions?: RunOptions): Promise<QvacResponse>
-
   finetune(finetuningOptions: FinetuneOptions): Promise<FinetuneHandle>
-
   cancel(): Promise<void>
-
+  pause(): Promise<void>
   unload(): Promise<void>
-
+  getState(): { configLoaded: boolean }
 }
 
-export { ReportProgressCallback, QvacResponse, FinetuneHandle, FinetuneProgressStats, FinetuneOptions, FinetuneValidation }
+export { QvacResponse, FinetuneHandle, FinetuneProgressStats, FinetuneOptions, FinetuneValidation }

--- a/packages/qvac-lib-infer-llamacpp-llm/index.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.js
@@ -299,11 +299,18 @@ class LlmLlamacpp {
       this._job.fail(error)
     } else if (eventType === 'Output') {
       this._job.output(data)
+    } else if (eventType === 'FinetuneProgress') {
+      if (this.opts.stats && data && data.stats) {
+        this._job.active?.updateStats(data.stats)
+      }
     } else if (eventType === 'JobEnded') {
       this.logger.info('Job completed')
-      this._job.end(this.opts.stats ? data : null)
-    } else if (eventType === 'FinetuneProgress') {
-      this._job.output(data)
+      const isFinetuneTerminal = data && typeof data === 'object' && data.op === 'finetune' && typeof data.status === 'string'
+      if (isFinetuneTerminal) {
+        this._job.end(null, data)
+      } else {
+        this._job.end(this.opts.stats ? data : null)
+      }
     }
   }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/index.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.js
@@ -2,12 +2,9 @@
 
 const fs = require('bare-fs')
 const path = require('bare-path')
-
-const BaseInference = require('@qvac/infer-base/WeightsProvider/BaseInference')
-const WeightsProvider = require('@qvac/infer-base/WeightsProvider/WeightsProvider')
+const QvacLogger = require('@qvac/logging')
+const { createJobHandler, exclusiveRunQueue } = require('@qvac/infer-base')
 const { LlamaInterface } = require('./addon')
-
-const noop = () => { }
 
 const RUN_BUSY_ERROR_MESSAGE = 'Cannot set new job: a job is already set or being processed'
 
@@ -88,100 +85,166 @@ function normalizeFinetuneParams (opts) {
   return out
 }
 
-/**
- * GGML client implementation for Llama LLM model
- */
-class LlmLlamacpp extends BaseInference {
-  /**
-   * Creates an instance of LlmLlamacpp.
-   * @constructor
-   * @param {Object} args - Setup parameters including loader, logger, disk path, and model name
-   * @param {Loader} args.loader - External loader instance
-   * @param {Logger} [args.logger] - Optional structured logger
-   * @param {Object} [args.opts] - Optional inference options
-   * @param {string} args.diskPath - Disk directory where model files are stored
-   * @param {string} args.modelName - Name of the model directory or file. The usage of a sharded
-   * filename (e.g. "llama-00001-of-00004.gguf") will trigger asynchronous loading of the weights for
-   * all remaining files.
-   * @param {string} args.projectionModel - Name of the projection model directory or file
-   * @param {Object} config - Model-specific configuration settings
-   */
-  constructor (
-    { opts = {}, loader, logger = null, diskPath = '.', modelName, projectionModel },
-    config
-  ) {
-    super({ logger, opts })
+class LlmLlamacpp {
+  constructor ({ files, config, logger = null, opts = {} }) {
+    this._files = files.model
+    this._projectionModelPath = files.projectionModel || ''
     this._config = config
-    this._diskPath = diskPath
-    this._modelName = modelName
-    this._projectionModel = projectionModel
-    this._shards = WeightsProvider.expandGGUFIntoShards(this._modelName)
-    this.weightsProvider = new WeightsProvider(loader, this.logger)
+    this.logger = new QvacLogger(logger)
+    this.opts = opts
+    this._job = createJobHandler({ cancel: () => this.addon.cancel() })
+    this._run = exclusiveRunQueue()
+    this.addon = null
     this._checkpointSaveDir = null
     this._hasActiveResponse = false
     this._skipNextRuntimeStats = false
     this._originalLogger = this.logger
-    this._baseOutputCallback = this._outputCallback.bind(this)
+    this.state = { configLoaded: false }
   }
 
-  /**
-   * Load model weights, initialize the native addon, and activate the model.
-   * @param {boolean} [closeLoader=true] - Whether to close the loader when complete
-   * @param {ProgressReportCallback} [onDownloadProgress] - Optional byte-level progress callback
-   * @returns {Promise<void>}
-   */
-  async _load (closeLoader = true, onDownloadProgress = noop) {
+  async load () {
+    if (this.state.configLoaded) {
+      this.logger.info('Reload requested - unloading existing model first')
+      await this.unload()
+    }
+    await this._load()
+    this.state.configLoaded = true
+  }
+
+  async _load () {
     this.logger.info('Starting model load')
+    const configurationParams = {
+      path: this._files[this._files.length - 1],
+      projectionPath: this._projectionModelPath,
+      config: { ...this._config }
+    }
+    this.addon = this._createAddon(configurationParams)
 
-    try {
-      const configForLoad = { ...this._config }
+    if (this._files.length > 1) {
+      await this._streamShards()
+    }
 
-      const configurationParams = {
-        path: path.join(this._diskPath, this._modelName),
-        projectionPath: this._projectionModel ? path.join(this._diskPath, this._projectionModel) : '',
-        config: configForLoad
+    await this.addon.activate()
+    this.logger.info('Model load completed successfully')
+  }
+
+  async _streamShards () {
+    for (const filePath of this._files) {
+      const filename = path.basename(filePath)
+      const stream = fs.createReadStream(filePath)
+      for await (const chunk of stream) {
+        await this.addon.loadWeights({ filename, chunk, completed: false })
       }
+      await this.addon.loadWeights({ filename, chunk: null, completed: true })
+      this.logger.info(`Streamed weights for ${filename}`)
+    }
+  }
 
-      this.logger.info('Creating addon with configuration:', configurationParams)
-      this.addon = this._createAddon(configurationParams)
+  async run (prompt, runOptions = {}) {
+    return this._run(() => this._runInternal(prompt, runOptions))
+  }
 
-      if (this._shards !== null) {
-        await this._loadWeights(onDownloadProgress)
+  async _runInternal (prompt, runOptions = {}) {
+    if (this._hasActiveResponse) {
+      throw new Error(RUN_BUSY_ERROR_MESSAGE)
+    }
+
+    if (!Array.isArray(prompt)) {
+      throw new TypeError('Prompt input must be Message[]')
+    }
+    const { prefill, generationParams } = normalizeRunOptions(runOptions)
+
+    this.logger.info('Starting inference with prompt:', prompt)
+
+    const textMessages = []
+    const mediaItems = []
+
+    for (const message of prompt) {
+      if (message.role === 'user' &&
+          message.type === 'media' &&
+          message.content instanceof Uint8Array) {
+        mediaItems.push(message.content)
+        textMessages.push({ ...message, content: '' })
       } else {
-        await this.downloadWeights(onDownloadProgress, { closeLoader })
+        textMessages.push(message)
       }
+    }
 
-      this.logger.info('Activating addon')
-      await this.addon.activate()
+    const promptMessages = []
 
-      this.logger.info('Model load completed successfully')
+    for (const mediaData of mediaItems) {
+      promptMessages.push({ type: 'media', content: mediaData })
+    }
+
+    promptMessages.push({
+      type: 'text',
+      input: JSON.stringify(textMessages),
+      prefill,
+      generationParams
+    })
+
+    const response = this._job.start()
+
+    let accepted
+    try {
+      accepted = await this.addon.runJob(promptMessages)
     } catch (error) {
-      this.logger.error('Error during model load:', error)
+      this._job.fail(error)
       throw error
     }
-  }
-
-  /**
-   * Download the model weight files and return the local path to the primary file.
-   * @param {ProgressReportCallback} [onDownloadProgress] - Callback invoked with bytes downloaded
-   * @returns {Promise<{filePath: string, completed: boolean, error: boolean}[]>} Local file path for the model weights
-   */
-  async _downloadWeights (onDownloadProgress, opts) {
-    return await this.weightsProvider.downloadFiles(
-      this._projectionModel ? [this._modelName, this._projectionModel] : [this._modelName],
-      this._diskPath,
-      {
-        closeLoader: opts.closeLoader,
-        onDownloadProgress
-      }
-    )
-  }
-
-  async _loadWeights (reportProgressCallback) {
-    const onChunk = async (chunkedWeightsData) => {
-      this.addon.loadWeights(chunkedWeightsData, this.logger)
+    if (!accepted) {
+      this._job.fail(new Error(RUN_BUSY_ERROR_MESSAGE))
+      throw new Error(RUN_BUSY_ERROR_MESSAGE)
     }
-    await this.weightsProvider.streamFiles(this._shards, onChunk, reportProgressCallback)
+
+    this._hasActiveResponse = true
+    const finalized = response.await().finally(() => { this._hasActiveResponse = false })
+    finalized.catch(() => {})
+    response.await = () => finalized
+
+    this.logger.info('Inference job started successfully')
+    return response
+  }
+
+  async finetune (finetuningOptions = undefined) {
+    if (!this.addon) {
+      throw new Error('Addon not initialized. Call load() first.')
+    }
+    if (!finetuningOptions) {
+      throw new Error('Finetuning parameters are required.')
+    }
+    if (finetuningOptions.checkpointSaveDir) {
+      this._checkpointSaveDir = finetuningOptions.checkpointSaveDir
+    }
+    const paramsToSend = normalizeFinetuneParams(finetuningOptions)
+    this.logger.info('finetune() called')
+    this.logger.info('Finetuning parameters:', finetuningOptions)
+
+    return this._run(async () => {
+      if (this._hasActiveResponse) {
+        throw new Error(RUN_BUSY_ERROR_MESSAGE)
+      }
+
+      const response = this._job.start()
+      let accepted
+      try {
+        accepted = await this.addon.finetune(paramsToSend)
+      } catch (err) {
+        this._job.fail(err)
+        throw err
+      }
+
+      if (!accepted) {
+        this._job.fail(new Error(RUN_BUSY_ERROR_MESSAGE))
+        throw new Error(RUN_BUSY_ERROR_MESSAGE)
+      }
+
+      this._hasActiveResponse = true
+      const finalized = response.await().finally(() => { this._hasActiveResponse = false })
+      finalized.catch(() => {})
+      response.await = () => finalized
+      return response
+    })
   }
 
   _isSuppressedNoResponseLog (args) {
@@ -220,61 +283,28 @@ class LlmLlamacpp extends BaseInference {
     return filteredLogger
   }
 
-  _handleAddonOutputEvent (originalOutputCb, originalLoggerRef, instance, eventType, jobId, data, extra) {
+  _handleAddonOutputEvent (eventType, data, error) {
     if (eventType === 'JobEnded' || eventType === 'Error') {
       this._hasActiveResponse = false
     }
 
     if (eventType === 'LogMsg') {
       const logMsg = typeof data === 'string' ? data : (data?.message || JSON.stringify(data))
-      originalLoggerRef?.info?.(logMsg)
+      this._originalLogger?.info?.(logMsg)
       return
     }
 
-    if (originalOutputCb) {
-      return originalOutputCb(instance, eventType, jobId, data, extra)
+    if (eventType === 'Error') {
+      this.logger.error(`Job failed with error: ${error}`)
+      this._job.fail(error)
+    } else if (eventType === 'Output') {
+      this._job.output(data)
+    } else if (eventType === 'JobEnded') {
+      this.logger.info('Job completed')
+      this._job.end(this.opts.stats ? data : null)
+    } else if (eventType === 'FinetuneProgress') {
+      this._job.output(data)
     }
-  }
-
-  /**
-   * Public API entrypoint for inference.
-   * @param {Message[]} prompt - Input prompt array of messages
-   * @param {{prefill?: boolean}} [runOptions] - Optional run settings
-   * @returns {Promise<QvacResponse>}
-   */
-  async run (prompt, runOptions = {}) {
-    return await this._runInternal(prompt, runOptions)
-  }
-
-  /**
-   * Instantiate the native addon with the given parameters.
-   * @param {Object} configurationParams - Configuration parameters for the addon
-   * @param {string} configurationParams.path - Local file or directory path
-   * @param {Object} configurationParams.settings - LLM-specific settings
-   * @returns {Addon} The instantiated addon interface
-   */
-  _createAddon (configurationParams) {
-    const binding = require('./binding')
-
-    this.logger = this._createFilteredLogger(this._originalLogger)
-
-    this._outputCallback = (instance, eventType, jobId, data, extra) => {
-      return this._handleAddonOutputEvent(
-        this._baseOutputCallback,
-        this._originalLogger,
-        instance,
-        eventType,
-        jobId,
-        data,
-        extra
-      )
-    }
-
-    return new LlamaInterface(
-      binding,
-      configurationParams,
-      this._addonOutputCallback.bind(this)
-    )
   }
 
   _addonOutputCallback (addon, event, data, error) {
@@ -289,7 +319,7 @@ class LlmLlamacpp extends BaseInference {
       } else if (runtimeStats.backendDevice === 1) {
         runtimeStats.backendDevice = 'gpu'
       }
-      return this._outputCallback(addon, 'JobEnded', 'OnlyOneJob', runtimeStats, null)
+      return this._handleAddonOutputEvent('JobEnded', runtimeStats, null)
     }
     if (
       typeof data === 'object' &&
@@ -298,14 +328,14 @@ class LlmLlamacpp extends BaseInference {
       typeof data.status === 'string'
     ) {
       this._skipNextRuntimeStats = true
-      return this._outputCallback(addon, 'JobEnded', 'OnlyOneJob', data, null)
+      return this._handleAddonOutputEvent('JobEnded', data, null)
     }
     if (
       typeof data === 'object' &&
       data !== null &&
       data.type === 'finetune_progress'
     ) {
-      return this._outputCallback(addon, 'FinetuneProgress', 'OnlyOneJob', data, null)
+      return this._handleAddonOutputEvent('FinetuneProgress', data, null)
     }
 
     let mappedEvent = event
@@ -315,26 +345,27 @@ class LlmLlamacpp extends BaseInference {
       mappedEvent = 'Output'
     }
 
-    return this._outputCallback(addon, mappedEvent, 'OnlyOneJob', data, error)
+    return this._handleAddonOutputEvent(mappedEvent, data, error)
   }
 
-  /**
-   * Pause finetuning, saving a checkpoint so training can resume later.
-   * cancel inference job if it is running
-   */
+  _createAddon (configurationParams) {
+    const binding = require('./binding')
+    this.logger = this._createFilteredLogger(this._originalLogger)
+    return new LlamaInterface(
+      binding,
+      configurationParams,
+      this._addonOutputCallback.bind(this)
+    )
+  }
+
   async pause () {
-    if (this.addon?.cancel) {
+    if (this.addon) {
       await this.addon.cancel()
     }
   }
 
-  /**
-   * Cancel finetuning and remove the pause checkpoint so the next
-   * finetune() call starts fresh instead of resuming.
-   * cancel inference job if it is running
-   */
   async cancel () {
-    if (this.addon?.cancel) {
+    if (this.addon) {
       await this.addon.cancel()
     }
     this._clearPauseCheckpoints()
@@ -355,159 +386,23 @@ class LlmLlamacpp extends BaseInference {
     }
   }
 
-  /**
-   * Unload model safely by cancelling and clearing pending jobs.
-   * @returns {Promise<void>}
-   */
   async unload () {
-    return await this._withExclusiveRun(async () => {
+    return this._run(async () => {
       try {
         await this.pause()
       } catch (_) {}
-      const currentJobResponse = this._jobToResponse.get('OnlyOneJob')
-      if (currentJobResponse) {
-        currentJobResponse.failed(new Error('Model was unloaded'))
-        this._deleteJobMapping('OnlyOneJob')
+      if (this._job.active) {
+        this._job.fail(new Error('Model was unloaded'))
       }
       this._hasActiveResponse = false
-      await super.unload()
+      if (this.addon) {
+        await this.addon.unload()
+      }
+      this.state.configLoaded = false
     })
   }
 
-  /**
-   * Internal method to start inference with a text prompt.
-   * @param {Message[]} prompt - Input prompt array of messages
-   * @param {{prefill?: boolean}} [runOptions] - Optional run settings
-   * @returns {Promise<QvacResponse>} A QvacResponse representing the inference job
-   */
-  async _runInternal (prompt, runOptions = {}) {
-    return this._withExclusiveRun(async () => {
-      if (this._hasActiveResponse) {
-        throw new Error(RUN_BUSY_ERROR_MESSAGE)
-      }
-
-      if (!Array.isArray(prompt)) {
-        throw new TypeError('Prompt input must be Message[]')
-      }
-      const { prefill, generationParams } = normalizeRunOptions(runOptions)
-
-      this.logger.info('Starting inference with prompt:', prompt)
-
-      // Separate media messages from text messages
-      const textMessages = []
-      const mediaItems = []
-
-      for (const message of prompt) {
-        if (message.role === 'user' &&
-            message.type === 'media' &&
-            message.content instanceof Uint8Array) {
-          mediaItems.push(message.content)
-          // Keep the message as a placeholder marker (with empty content) for tokenization
-          textMessages.push({ ...message, content: '' })
-        } else {
-          textMessages.push(message)
-        }
-      }
-
-      const promptMessages = []
-
-      // Send media first (in order) if present
-      for (const mediaData of mediaItems) {
-        promptMessages.push({ type: 'media', content: mediaData })
-      }
-
-      // Send text messages
-      promptMessages.push({
-        type: 'text',
-        input: JSON.stringify(textMessages),
-        prefill,
-        generationParams
-      })
-
-      const response = this._createResponse('OnlyOneJob')
-
-      // addon-cpp C++ guarantees no events will be generated
-      // until job is fully accepted. This means even if trying
-      // to queue a job fails right now as not accepted,
-      // it will not generate events.
-      //
-      // If any unexpected exception is thrown (e.g. in the C++ code)
-      // it will unwind here and the job will not be accepted.
-      let accepted
-      try {
-        accepted = await this.addon.runJob(promptMessages)
-      } catch (error) {
-        this._deleteJobMapping('OnlyOneJob')
-        response.failed(error)
-        throw error
-      }
-      if (!accepted) {
-        this._deleteJobMapping('OnlyOneJob')
-        const msg = RUN_BUSY_ERROR_MESSAGE
-        response.failed(new Error(msg))
-        throw new Error(msg)
-      }
-
-      this._hasActiveResponse = true
-      const finalized = response.await().finally(() => { this._hasActiveResponse = false })
-      finalized.catch(() => {})
-      response.await = () => finalized
-
-      this.logger.info('Inference job started successfully')
-
-      return response
-    })
-  }
-
-  async finetune (finetuningOptions = undefined) {
-    if (!this.addon) {
-      throw new Error(
-        'Addon not initialized. Call load() first.'
-      )
-    }
-
-    if (!finetuningOptions) {
-      throw new Error(
-        'Finetuning parameters are required.'
-      )
-    }
-    if (finetuningOptions.checkpointSaveDir) {
-      this._checkpointSaveDir = finetuningOptions.checkpointSaveDir
-    }
-    const paramsToSend = normalizeFinetuneParams(finetuningOptions)
-    this.logger?.info?.('finetune() called')
-    this.logger?.info?.('Finetuning parameters:', finetuningOptions)
-
-    return this._withExclusiveRun(async () => {
-      if (this._hasActiveResponse) {
-        throw new Error(RUN_BUSY_ERROR_MESSAGE)
-      }
-
-      const response = this._createResponse('OnlyOneJob')
-      let accepted
-      try {
-        accepted = await this.addon.finetune(paramsToSend)
-      } catch (err) {
-        this._deleteJobMapping('OnlyOneJob')
-        response.failed(err)
-        throw err
-      }
-
-      if (!accepted) {
-        this._deleteJobMapping('OnlyOneJob')
-        const msg = RUN_BUSY_ERROR_MESSAGE
-        response.failed(new Error(msg))
-        throw new Error(msg)
-      }
-
-      this._hasActiveResponse = true
-      const finalized = response.await().finally(() => { this._hasActiveResponse = false })
-      finalized.catch(() => {})
-      response.await = () => finalized
-
-      return response
-    })
-  }
+  getState () { return this.state }
 }
 
 module.exports = LlmLlamacpp

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -57,8 +57,6 @@
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://github.com/tetherto/qvac/tree/main/packages/qvac-lib-infer-llamacpp-llm#readme",
   "devDependencies": {
-    "@qvac/dl-base": "^0.1.0",
-    "@qvac/dl-filesystem": "^0.1.2",
     "@qvac/logging": "^0.1.0",
     "@types/node": "^24.2.1",
     "bare-url": "^2.1.6",
@@ -73,7 +71,7 @@
     "util": "npm:bare-utils@^1.5.1"
   },
   "dependencies": {
-    "@qvac/infer-base": "^0.3.0",
+    "@qvac/infer-base": "^0.4.0",
     "bare-fs": "^4.5.1",
     "bare-path": "^3.0.0",
     "bare-process": "^4.2.2"

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/afriquegemma-translation.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/afriquegemma-translation.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const os = require('bare-os')
@@ -108,15 +107,14 @@ const skipReason = isMobile
 // ---------------------------------------------------------------------------
 test('AfriqueGemma: end-to-end African language translation', { timeout: 1_800_000, skip: skipReason }, async t => {
   const [modelName, dirPath] = await resolveModel()
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
 
   const addon = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config: AFRIQUEGEMMA_CONFIG,
     logger: console,
     opts: { stats: true }
-  }, AFRIQUEGEMMA_CONFIG)
+  })
 
   try {
     // --- Model loading ---
@@ -161,7 +159,6 @@ test('AfriqueGemma: end-to-end African language translation', { timeout: 1_800_0
     t.is(out1, out2, `deterministic: "${out1}"`)
   } finally {
     await addon.unload().catch(() => {})
-    await loader.close().catch(() => {})
   }
 })
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/api-behavior.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/api-behavior.test.js
@@ -3,7 +3,7 @@
 // Tests must match the behavior described in README section "API behavior by state".
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -35,7 +35,7 @@ async function setupModel (t, configOverrides = {}) {
     downloadUrl: MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const config = {
     device: useCpu ? 'cpu' : 'gpu',
     gpu_layers: '999',
@@ -47,18 +47,16 @@ async function setupModel (t, configOverrides = {}) {
 
   const specLogger = attachSpecLogger({ forwardToConsole: true })
   const model = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
 
   await model.load()
 
   t.teardown(async () => {
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     specLogger.release()
   })
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/bitnet.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/bitnet.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -32,7 +32,7 @@ test('bitnet model can run simple inference', { timeout: 600_000, skip: !isAndro
     downloadUrl: BITNET_MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const specLogger = attachSpecLogger({ forwardToConsole: true })
 
   const config = {
@@ -44,12 +44,11 @@ test('bitnet model can run simple inference', { timeout: 600_000, skip: !isAndro
   }
 
   const addon = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
 
   try {
     await addon.load()
@@ -60,7 +59,6 @@ test('bitnet model can run simple inference', { timeout: 600_000, skip: !isAndro
     t.comment(`BitNet output: "${output}"`)
   } finally {
     await addon.unload().catch(() => { })
-    await loader.close().catch(() => { })
     specLogger.release()
   }
 })

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/cache-state-machine.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/cache-state-machine.test.js
@@ -2,7 +2,6 @@
 
 const test = require('brittle')
 const path = require('bare-path')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -87,7 +86,7 @@ async function setupModel (t, overrides = {}) {
     downloadUrl: DEFAULT_MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const config = { ...BASE_CONFIG, ...overrides }
   const specLogger = attachSpecLogger({ forwardToConsole: true })
   let loggerReleased = false
@@ -98,24 +97,21 @@ async function setupModel (t, overrides = {}) {
   }
 
   const model = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
 
   try {
     await model.load()
   } catch (err) {
     releaseLogger()
-    await loader.close().catch(() => { })
     throw err
   }
 
   t.teardown(async () => {
     await model.unload().catch(() => { })
-    await loader.close().catch(() => { })
     releaseLogger()
   })
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/config-parameters.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/config-parameters.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -343,7 +343,7 @@ async function executeScenario (t, scenario) {
     downloadUrl: 'https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_0.gguf'
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
 
   const baseConfig = {
     device: useCpu ? 'cpu' : 'gpu',
@@ -362,12 +362,11 @@ async function executeScenario (t, scenario) {
   const logs = specLogger.logs
 
   const addon = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config: { ...baseConfig, ...scenario.overrides },
     logger: createTestLogger(),
     opts: { stats: true }
-  }, { ...baseConfig, ...scenario.overrides })
+  })
 
   let loadSucceeded = false
 
@@ -410,7 +409,6 @@ async function executeScenario (t, scenario) {
     if (loadSucceeded) {
       await addon.unload().catch(() => {})
     }
-    await loader.close().catch(() => {})
     specLogger.release()
   }
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/dynamic-tools.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/dynamic-tools.test.js
@@ -2,7 +2,6 @@
 
 const test = require('brittle')
 const path = require('bare-path')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -83,7 +82,7 @@ async function setupModel (t, overrides = {}) {
     downloadUrl: QWEN3_MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const config = { ...BASE_CONFIG, ...overrides }
   const specLogger = attachSpecLogger({ forwardToConsole: true })
   let loggerReleased = false
@@ -94,24 +93,21 @@ async function setupModel (t, overrides = {}) {
   }
 
   const model = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
 
   try {
     await model.load()
   } catch (err) {
     releaseLogger()
-    await loader.close().catch(() => {})
     throw err
   }
 
   t.teardown(async () => {
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     releaseLogger()
   })
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/finetuning-pause-resume.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/finetuning-pause-resume.test.js
@@ -2,7 +2,6 @@
 
 const test = require('brittle')
 const path = require('bare-path')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const {
   ensureModel,
@@ -89,7 +88,7 @@ function assertLossAndAccuracyAreFinite (t, result, modelId) {
 async function runLoraInference (t, modelVariant, modelName, modelDir, loraAdapterPath) {
   t.comment(`[${modelVariant.id}] Running inference with LoRA adapter: ${loraAdapterPath}`)
 
-  const inferLoader = new FilesystemDL({ dirPath: modelDir })
+  const inferModelPath = path.join(modelDir, modelName)
   const inferConfig = {
     gpu_layers: '999',
     ctx_size: '512',
@@ -98,16 +97,12 @@ async function runLoraInference (t, modelVariant, modelName, modelDir, loraAdapt
     lora: loraAdapterPath
   }
 
-  const inferModel = new LlmLlamacpp(
-    {
-      loader: inferLoader,
-      modelName,
-      diskPath: modelDir,
-      logger: console,
-      opts: { stats: true }
-    },
-    inferConfig
-  )
+  const inferModel = new LlmLlamacpp({
+    files: { model: [inferModelPath] },
+    config: inferConfig,
+    logger: console,
+    opts: { stats: true }
+  })
 
   try {
     await inferModel.load()
@@ -122,7 +117,6 @@ async function runLoraInference (t, modelVariant, modelName, modelDir, loraAdapt
     t.comment(`[${modelVariant.id}] LoRA inference stats: ${JSON.stringify(response.stats)}`)
   } finally {
     await inferModel.unload().catch(() => {})
-    await inferLoader.close().catch(() => {})
   }
 }
 
@@ -143,7 +137,7 @@ test('finetuning pause and resume', { timeout: PAUSE_RESUME_TIMEOUT_MS, skip: sk
     })
     const checkpointDir = finetuneConfig.checkpointSaveDir
 
-    const loader = new FilesystemDL({ dirPath: modelDir })
+    const finetuneModelPath = path.join(modelDir, modelName)
     const loggerHandle = attachSpecLogger({ forwardToConsole: true })
 
     const config = {
@@ -153,16 +147,12 @@ test('finetuning pause and resume', { timeout: PAUSE_RESUME_TIMEOUT_MS, skip: sk
       verbosity: '2'
     }
 
-    const model = new LlmLlamacpp(
-      {
-        loader,
-        modelName,
-        diskPath: modelDir,
-        logger: console,
-        opts: { stats: true }
-      },
-      config
-    )
+    const model = new LlmLlamacpp({
+      files: { model: [finetuneModelPath] },
+      config,
+      logger: console,
+      opts: { stats: true }
+    })
 
     try {
       await model.load()
@@ -211,7 +201,6 @@ test('finetuning pause and resume', { timeout: PAUSE_RESUME_TIMEOUT_MS, skip: sk
         )
 
         await model.unload().catch(() => {})
-        await loader.close().catch(() => {})
 
         const loraAdapterPath = path.join(finetuneConfig.outputParametersDir, 'trained-lora-adapter.gguf')
         await runLoraInference(t, modelVariant, modelName, modelDir, loraAdapterPath)
@@ -275,7 +264,6 @@ test('finetuning pause and resume', { timeout: PAUSE_RESUME_TIMEOUT_MS, skip: sk
       t.pass(`[${modelVariant.id}] finetuning pause and resume completed`)
 
       await model.unload().catch(() => {})
-      await loader.close().catch(() => {})
 
       const loraAdapterPath = path.join(finetuneConfig.outputParametersDir, 'trained-lora-adapter.gguf')
       await runLoraInference(t, modelVariant, modelName, modelDir, loraAdapterPath)
@@ -283,7 +271,6 @@ test('finetuning pause and resume', { timeout: PAUSE_RESUME_TIMEOUT_MS, skip: sk
     } finally {
       loggerHandle.release()
       await model.unload().catch(() => {})
-      await loader.close().catch(() => {})
       cleanupCheckpoints(checkpointDir)
     }
   }
@@ -299,24 +286,20 @@ test('cancel() stops finetuning and removes pause checkpoint', { timeout: PAUSE_
   const finetuneConfig = setupParams(modelDir, { checkpointSaveSteps: 5, datasetSize: isMobile ? 8 : 16, testId: 'cancel-test' })
   const checkpointDir = finetuneConfig.checkpointSaveDir
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
+  const cancelModelPath = path.join(modelDir, modelName)
   const loggerHandle = attachSpecLogger({ forwardToConsole: true })
 
-  const model = new LlmLlamacpp(
-    {
-      loader,
-      modelName,
-      diskPath: modelDir,
-      logger: console,
-      opts: { stats: true }
-    },
-    {
+  const model = new LlmLlamacpp({
+    files: { model: [cancelModelPath] },
+    config: {
       gpu_layers: '999',
       ctx_size: '512',
       device: forceCpuDevice ? 'cpu' : 'gpu',
       verbosity: '2'
-    }
-  )
+    },
+    logger: console,
+    opts: { stats: true }
+  })
 
   const fs = require('bare-fs')
 
@@ -352,7 +335,6 @@ test('cancel() stops finetuning and removes pause checkpoint', { timeout: PAUSE_
   } finally {
     loggerHandle.release()
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     cleanupCheckpoints(checkpointDir)
   }
 })
@@ -368,7 +350,7 @@ test('inference with session cache works after finetuning', { timeout: PAUSE_RES
   const checkpointDir = finetuneConfig.checkpointSaveDir
   const sessionFile = path.join(modelDir, 'test-session-finetune.bin')
 
-  const loader = new FilesystemDL({ dirPath: modelDir })
+  const sessionModelPath = path.join(modelDir, modelName)
   const loggerHandle = attachSpecLogger({ forwardToConsole: true })
 
   const config = {
@@ -380,16 +362,12 @@ test('inference with session cache works after finetuning', { timeout: PAUSE_RES
     seed: '42'
   }
 
-  const model = new LlmLlamacpp(
-    {
-      loader,
-      modelName,
-      diskPath: modelDir,
-      logger: console,
-      opts: { stats: true }
-    },
-    config
-  )
+  const model = new LlmLlamacpp({
+    files: { model: [sessionModelPath] },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
 
   const fs = require('bare-fs')
 
@@ -432,7 +410,6 @@ test('inference with session cache works after finetuning', { timeout: PAUSE_RES
   } finally {
     loggerHandle.release()
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     cleanupCheckpoints(checkpointDir)
     try { fs.unlinkSync(sessionFile) } catch (_) {}
   }
@@ -447,11 +424,13 @@ test('microBatchSize override changes backend batch geometry', { timeout: PAUSE_
 
   async function getTotalBatches (batchSize, microBatchSize, testId) {
     const config = setupParams(modelDir, { batchSize, microBatchSize, checkpointSaveSteps: 0, testId })
-    const loader = new FilesystemDL({ dirPath: modelDir })
-    const model = new LlmLlamacpp(
-      { loader, modelName, diskPath: modelDir, logger: console, opts: { stats: true } },
-      { gpu_layers: '999', ctx_size: '512', device: forceCpuDevice ? 'cpu' : 'gpu', verbosity: '0' }
-    )
+    const batchModelPath = path.join(modelDir, modelName)
+    const model = new LlmLlamacpp({
+      files: { model: [batchModelPath] },
+      config: { gpu_layers: '999', ctx_size: '512', device: forceCpuDevice ? 'cpu' : 'gpu', verbosity: '0' },
+      logger: console,
+      opts: { stats: true }
+    })
     try {
       await model.load()
       const handle = await model.finetune(config)
@@ -461,7 +440,6 @@ test('microBatchSize override changes backend batch geometry', { timeout: PAUSE_
       return totalBatches
     } finally {
       await model.unload().catch(() => {})
-      await loader.close().catch(() => {})
       cleanupCheckpoints(config.checkpointSaveDir)
     }
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/generation-params.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/generation-params.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -27,7 +27,7 @@ async function setupModel (t, configOverrides = {}) {
     downloadUrl: MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const config = {
     device: useCpu ? 'cpu' : 'gpu',
     gpu_layers: '999',
@@ -40,18 +40,16 @@ async function setupModel (t, configOverrides = {}) {
 
   const specLogger = attachSpecLogger({ forwardToConsole: true })
   const model = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
 
   await model.load()
 
   t.teardown(async () => {
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     specLogger.release()
   })
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/image.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/image.test.js
@@ -4,7 +4,6 @@ const test = require('brittle')
 const fs = require('bare-fs')
 const path = require('bare-path')
 const { ensureModel, getMediaPath } = require('./utils')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const os = require('bare-os')
 
@@ -84,7 +83,7 @@ function getConfig (device, modelConfig) {
  * Sets up a multimodal LlmLlamacpp instance with LLM and projection models
  * @param {Object} t - Test instance
  * @param {string} device - Device to use ('cpu' or 'gpu')
- * @returns {Promise<{inference: LlmLlamacpp, loader: FilesystemDL}>}
+ * @returns {Promise<{inference: LlmLlamacpp}>}
  */
 async function setupMultimodalInference (t, device = 'gpu', modelConfig = MULTIMODAL_MODEL_CONFIG) {
   const [modelName, dirPath] = await ensureModel(modelConfig.llmModel)
@@ -93,23 +92,20 @@ async function setupMultimodalInference (t, device = 'gpu', modelConfig = MULTIM
   const [projModelName] = await ensureModel(modelConfig.projModel)
   t.ok(fs.existsSync(path.join(dirPath, projModelName)), 'Projection model file should exist')
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const inference = new LlmLlamacpp({
-    modelName,
-    loader,
-    logger: console,
-    diskPath: dirPath,
-    projectionModel: projModelName
-  }, getConfig(device, modelConfig))
+    files: { model: [modelPath], projectionModel: path.join(dirPath, projModelName) },
+    config: getConfig(device, modelConfig),
+    logger: console
+  })
 
   t.teardown(async () => {
-    await loader.close()
     await inference.unload()
   })
 
   await inference.load()
 
-  return { inference, loader }
+  return { inference }
 }
 
 /**

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
@@ -126,10 +126,43 @@ const SHARDED_MODEL = {
 // This test can take longer to download and execute. To avoid blowing up testing time on all
 // platforms, just use Linux for now. C++ tests already have faster coverage for each type
 // of load.
-test('network loader can run inference end-to-end with sharded model', { timeout: 4 * 60 * 1000, skip: !isLinuxX64 }, async t => {
+test('sharded model can run inference end-to-end', { timeout: 4 * 60 * 1000, skip: !isLinuxX64 }, async t => {
+  const fs = require('bare-fs')
   const modelDir = path.resolve(__dirname, '../model')
+  fs.mkdirSync(modelDir, { recursive: true })
+
+  const shardPattern = /^(.+)-(\d+)-of-(\d+)\.gguf$/
+  const match = shardPattern.exec(SHARDED_MODEL.name)
+  if (!match) {
+    t.fail('Test model name does not match shard pattern')
+    return
+  }
+
+  const [, basename, , totalShards] = match
+  const totalShardsNum = parseInt(totalShards, 10)
+  const shardFiles = []
+  shardFiles.push(`${basename}.tensors.txt`)
+  for (let i = 1; i <= totalShardsNum; i++) {
+    const num = i.toString().padStart(5, '0')
+    shardFiles.push(`${basename}-${num}-of-${totalShards}.gguf`)
+  }
 
   const loader = new HttpDL({ baseUrl: SHARDED_MODEL.baseUrl })
+  for (const filename of shardFiles) {
+    const dest = path.join(modelDir, filename)
+    if (fs.existsSync(dest)) continue
+    console.log(`  Downloading shard: ${filename}`)
+    const stream = await loader.getStream(filename)
+    const ws = fs.createWriteStream(dest)
+    for await (const chunk of stream) {
+      ws.write(chunk)
+    }
+    ws.end()
+    await new Promise(resolve => ws.on('close', resolve))
+  }
+  await loader.close().catch(() => {})
+
+  const shardPaths = shardFiles.map(f => path.join(modelDir, f))
   const config = {
     gpu_layers: '999',
     ctx_size: '1024',
@@ -139,40 +172,19 @@ test('network loader can run inference end-to-end with sharded model', { timeout
   }
 
   const addon = new LlmLlamacpp({
-    loader,
-    modelName: SHARDED_MODEL.name,
-    diskPath: modelDir,
+    files: { model: shardPaths },
     config,
     logger: console,
     opts: { stats: true }
   })
 
-  let progressMade = 0
-  let lastLogTime = 0
-  const LOG_INTERVAL_MS = 3000
-  const onProgress = (data) => {
-    if (typeof data !== 'object' || data === null) return
-    const now = Date.now()
-    const shard = data.currentFile.replace(/^.*\//, '')
-    progressMade = Math.max(progressMade, data.overallProgress)
-    if (data.action === 'loadingFile' && now - lastLogTime >= LOG_INTERVAL_MS) {
-      console.log(`\r  Loading ${shard}: ${data.currentFileProgress}%  (overall ${data.overallProgress}%)   `)
-      lastLogTime = now
-    } else if (data.action === 'completeFile') {
-      console.log(`\r  Loaded  ${shard}: 100.00% (overall ${data.overallProgress}%) [${data.filesProcessed}/${data.totalFiles}]\n`)
-      lastLogTime = now
-    }
-  }
-
   try {
-    await addon.load(true, onProgress)
+    await addon.load()
     const response = await addon.run(BASE_PROMPT)
     const output = await collectResponse(response)
-    t.ok(output.length > 0, 'network-loaded sharded model should generate output')
-    t.ok(progressMade > 0, 'network-loaded sharded model should make progress')
+    t.ok(output.length > 0, 'sharded model should generate output')
   } finally {
     await addon.unload().catch(() => {})
-    await loader.close().catch(() => {})
   }
 })
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
 
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
@@ -48,7 +47,7 @@ test('filesystem loader can run inference end-to-end', { timeout: 600_000, skip:
     downloadUrl: DEFAULT_MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const config = {
     gpu_layers: '999',
     ctx_size: '1024',
@@ -58,12 +57,11 @@ test('filesystem loader can run inference end-to-end', { timeout: 600_000, skip:
   }
 
   const addon = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
 
   try {
     await addon.load()
@@ -76,7 +74,6 @@ test('filesystem loader can run inference end-to-end', { timeout: 600_000, skip:
     t.fail('filesystem-loaded model should generate output', error)
   } finally {
     await addon.unload().catch(() => {})
-    await loader.close().catch(() => {})
   }
 })
 
@@ -86,7 +83,7 @@ test('model unload is clean and idempotent', { timeout: 600_000 }, async t => {
     downloadUrl: DEFAULT_MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const config = {
     gpu_layers: '512',
     ctx_size: '1024',
@@ -96,34 +93,29 @@ test('model unload is clean and idempotent', { timeout: 600_000 }, async t => {
   }
 
   const addon = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
 
-  try {
-    await addon.load()
-    const firstResponse = await addon.run(BASE_PROMPT)
-    await collectResponse(firstResponse)
+  await addon.load()
+  const firstResponse = await addon.run(BASE_PROMPT)
+  await collectResponse(firstResponse)
 
-    await addon.unload()
-    t.pass('first unload succeeded')
+  await addon.unload()
+  t.pass('first unload succeeded')
 
-    await addon.load()
-    const secondResponse = await addon.run(BASE_PROMPT)
-    await collectResponse(secondResponse)
+  await addon.load()
+  const secondResponse = await addon.run(BASE_PROMPT)
+  await collectResponse(secondResponse)
 
-    await addon.unload()
-    t.pass('second unload succeeded')
+  await addon.unload()
+  t.pass('second unload succeeded')
 
-    await addon.unload().catch(err => {
-      if (err) t.fail('unload should be idempotent', err)
-    })
-  } finally {
-    await loader.close().catch(() => {})
-  }
+  await addon.unload().catch(err => {
+    if (err) t.fail('unload should be idempotent', err)
+  })
 })
 
 const SHARDED_MODEL = {
@@ -150,9 +142,10 @@ test('network loader can run inference end-to-end with sharded model', { timeout
     loader,
     modelName: SHARDED_MODEL.name,
     diskPath: modelDir,
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
 
   let progressMade = 0
   let lastLogTime = 0

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/moe.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/moe.test.js
@@ -2,7 +2,7 @@
 
 const test = require('brittle')
 const os = require('bare-os')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -40,15 +40,14 @@ test('llm addon can run MoE models [dolphin-mixtral-2x7b]', {
 }, async t => {
   const [modelName, dirPath] = await ensureModel({ modelName: MODEL.name, downloadUrl: MODEL.url })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const specLogger = attachSpecLogger({ forwardToConsole: true })
   const inference = new LlmLlamacpp({
-    modelName,
-    loader,
+    files: { model: [modelPath] },
+    config: CONFIG,
     logger: console,
-    diskPath: dirPath,
     opts: { stats: true }
-  }, CONFIG)
+  })
 
   try {
     await inference.load()
@@ -60,6 +59,5 @@ test('llm addon can run MoE models [dolphin-mixtral-2x7b]', {
   } finally {
     specLogger.release()
     await inference.unload().catch(() => {})
-    await loader.close().catch(() => {})
   }
 })

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const os = require('bare-os')
@@ -38,7 +38,7 @@ function createLogger () {
 }
 
 async function createInstance (modelName, dirPath, overrides = {}) {
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const config = {
     device: useCpu ? 'cpu' : 'gpu',
     gpu_layers: '999',
@@ -49,14 +49,13 @@ async function createInstance (modelName, dirPath, overrides = {}) {
   }
 
   const addon = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: createLogger(),
     opts: { stats: true }
-  }, config)
+  })
 
-  return { addon, loader }
+  return { addon }
 }
 
 async function collectResponse (response) {
@@ -74,14 +73,12 @@ test('Two instances can run inference simultaneously', {
     downloadUrl: DEFAULT_MODEL.url
   })
 
-  const { addon: addon1, loader: loader1 } = await createInstance(modelName, dirPath)
-  const { addon: addon2, loader: loader2 } = await createInstance(modelName, dirPath)
+  const { addon: addon1 } = await createInstance(modelName, dirPath)
+  const { addon: addon2 } = await createInstance(modelName, dirPath)
 
   t.teardown(async () => {
     await addon1.unload().catch(() => {})
     await addon2.unload().catch(() => {})
-    await loader1.close().catch(() => {})
-    await loader2.close().catch(() => {})
   })
 
   await addon1.load()
@@ -111,7 +108,7 @@ test('Repeated load/unload cycles should remain stable', {
   const NUM_CYCLES = 6
 
   for (let i = 0; i < NUM_CYCLES; i++) {
-    const { addon, loader } = await createInstance(modelName, dirPath)
+    const { addon } = await createInstance(modelName, dirPath)
 
     await addon.load()
     const response = await addon.run(BASE_PROMPT)
@@ -120,7 +117,6 @@ test('Repeated load/unload cycles should remain stable', {
     t.ok(output.length > 0, `cycle ${i + 1}: produced output`)
 
     await addon.unload()
-    await loader.close()
 
     t.pass(`cycle ${i + 1}: load/unload completed`)
   }
@@ -137,16 +133,14 @@ test('Unloading one instance does not affect another generating instance', {
     downloadUrl: DEFAULT_MODEL.url
   })
 
-  const { addon: addon1, loader: loader1 } = await createInstance(modelName, dirPath, {
+  const { addon: addon1 } = await createInstance(modelName, dirPath, {
     n_predict: '256'
   })
-  const { addon: addon2, loader: loader2 } = await createInstance(modelName, dirPath)
+  const { addon: addon2 } = await createInstance(modelName, dirPath)
 
   t.teardown(async () => {
     await addon1.unload().catch(() => {})
     await addon2.unload().catch(() => {})
-    await loader1.close().catch(() => {})
-    await loader2.close().catch(() => {})
   })
 
   await addon1.load()
@@ -181,7 +175,6 @@ test('Unloading one instance does not affect another generating instance', {
   if (!unloadedInstance2) {
     unloadedInstance2 = true
     await addon2.unload()
-    await loader2.close()
     t.pass('unloaded instance 2 while instance 1 is generating')
   }
 
@@ -201,13 +194,12 @@ test('Multiple load/unload cycles on one instance while another generates', {
     downloadUrl: DEFAULT_MODEL.url
   })
 
-  const { addon: addon1, loader: loader1 } = await createInstance(modelName, dirPath, {
+  const { addon: addon1 } = await createInstance(modelName, dirPath, {
     n_predict: '512'
   })
 
   t.teardown(async () => {
     await addon1.unload().catch(() => {})
-    await loader1.close().catch(() => {})
   })
 
   await addon1.load()
@@ -254,10 +246,9 @@ test('Multiple load/unload cycles on one instance while another generates', {
     }
     cyclesCompleted++
     const cycleNum = cyclesCompleted
-    const { addon: addon2, loader: loader2 } = await createInstance(modelName, dirPath)
+    const { addon: addon2 } = await createInstance(modelName, dirPath)
     await addon2.load()
     await addon2.unload()
-    await loader2.close()
     t.pass(`load/unload cycle ${cycleNum} completed while instance 1 generates`)
   }
 

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/ocr-lighton.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/ocr-lighton.test.js
@@ -4,7 +4,6 @@ const test = require('brittle')
 const fs = require('bare-fs')
 const path = require('bare-path')
 const { ensureModel, getMediaPath } = require('./utils')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const os = require('bare-os')
 
@@ -55,23 +54,20 @@ async function setupLightOnInference (t, device = 'gpu') {
   const [projModelName] = await ensureModel(LIGHTON_OCR_CONFIG.projModel)
   t.ok(fs.existsSync(path.join(dirPath, projModelName)), 'Projection model file should exist')
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const inference = new LlmLlamacpp({
-    modelName,
-    loader,
-    logger: console,
-    diskPath: dirPath,
-    projectionModel: projModelName
-  }, getConfig(device))
+    files: { model: [modelPath], projectionModel: path.join(dirPath, projModelName) },
+    config: getConfig(device),
+    logger: console
+  })
 
   t.teardown(async () => {
-    await loader.close()
     await inference.unload()
   })
 
   await inference.load()
 
-  return { inference, loader }
+  return { inference }
 }
 
 async function runOcr (inference, imageFilePath) {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/reasoning.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/reasoning.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const test = require('brittle')
+const path = require('bare-path')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
 const os = require('bare-os')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
@@ -23,7 +23,7 @@ async function setupReasoningModel (t, toolsEnabled) {
     downloadUrl: MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const specLogger = attachSpecLogger({ forwardToConsole: true })
 
   const config = {
@@ -38,27 +38,24 @@ async function setupReasoningModel (t, toolsEnabled) {
   }
 
   const inference = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
-    projectionPath: '',
     opts: { stats: true }
-  }, config)
+  })
 
   await inference.load()
 
   t.teardown(async () => {
     try {
       specLogger.release()
-      if (loader) await loader.close()
       if (inference) await inference.unload()
     } catch (err) {
       // Ignore cleanup errors
     }
   })
 
-  return { inference, loader }
+  return { inference }
 }
 
 // Shared helper: Run a completion and collect response

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/sliding-context.test.js
@@ -2,7 +2,6 @@
 
 const test = require('brittle')
 const path = require('bare-path')
-const FilesystemDL = require('@qvac/dl-filesystem')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const os = require('bare-os')
@@ -55,7 +54,7 @@ async function setupModel (t, overrides = {}) {
     downloadUrl: DEFAULT_MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
 
   const baseConfig = {
     device: useCpu ? 'cpu' : 'gpu',
@@ -69,19 +68,13 @@ async function setupModel (t, overrides = {}) {
   }
 
   const model = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config: { ...baseConfig, ...overrides },
     logger: createTestLogger(),
     opts: { stats: true }
-  }, { ...baseConfig, ...overrides })
+  })
 
-  try {
-    await model.load()
-  } catch (err) {
-    await loader.close().catch(() => {})
-    throw err
-  }
+  await model.load()
 
   t.teardown(async () => {
     // Guard against model.unload() hanging after context overflow (seen on darwin-arm64 CI).
@@ -89,7 +82,6 @@ async function setupModel (t, overrides = {}) {
     const unloadDone = model.unload().catch(() => {})
     const unloadTimeout = new Promise(resolve => setTimeout(resolve, 30_000))
     await Promise.race([unloadDone, unloadTimeout])
-    await loader.close().catch(() => {})
   })
 
   return { model, dirPath }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/tool-calling.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/tool-calling.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -141,7 +141,7 @@ async function createToolModel (modelVariant) {
     downloadUrl: modelVariant.downloadUrl
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const specLogger = attachSpecLogger({ forwardToConsole: true })
   let loggerReleased = false
   const releaseLogger = () => {
@@ -151,18 +151,16 @@ async function createToolModel (modelVariant) {
   }
 
   const model = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config: BASE_CONFIG,
     logger: console,
     opts: { stats: true }
-  }, BASE_CONFIG)
+  })
 
   try {
     await model.load()
   } catch (err) {
     releaseLogger()
-    await loader.close().catch(() => {})
     throw err
   }
 
@@ -170,7 +168,6 @@ async function createToolModel (modelVariant) {
     model,
     async release () {
       await model.unload().catch(() => {})
-      await loader.close().catch(() => {})
       releaseLogger()
     }
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/utf8-output.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/utf8-output.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('brittle')
-const FilesystemDL = require('@qvac/dl-filesystem')
+const path = require('bare-path')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -39,7 +39,7 @@ test('model returns UTF-8 emoji without truncation', { timeout: 600_000 }, async
     downloadUrl: MODEL.url
   })
 
-  const loader = new FilesystemDL({ dirPath })
+  const modelPath = path.join(dirPath, modelName)
   const specLogger = attachSpecLogger({ forwardToConsole: true })
   let loggerReleased = false
   const releaseLogger = () => {
@@ -61,12 +61,11 @@ test('model returns UTF-8 emoji without truncation', { timeout: 600_000 }, async
   }
 
   const model = new LlmLlamacpp({
-    loader,
-    modelName,
-    diskPath: dirPath,
+    files: { model: [modelPath] },
+    config,
     logger: console,
     opts: { stats: true }
-  }, config)
+  })
 
   let output = ''
   try {
@@ -86,7 +85,6 @@ test('model returns UTF-8 emoji without truncation', { timeout: 600_000 }, async
     t.ok(response.stats.generatedTokens > 0, 'token stats recorded')
   } finally {
     await model.unload().catch(() => {})
-    await loader.close().catch(() => {})
     releaseLogger()
   }
 })


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- LLM addon tightly coupled to BaseInference class and WeightsProvider download layer
- Constructor requires a Loader object even when model files are already on disk
- Job management uses inherited _jobToResponse Map boilerplate

## 📝 How does it solve it?

- Remove BaseInference class inheritance, use composable utilities from @qvac/infer-base@0.4.0
- createJobHandler() replaces _jobToResponse Map, _createResponse, _outputCallback routing
- exclusiveRunQueue() replaces _withExclusiveRun
- Constructor takes { files: { model: string[], projectionModel?: string }, config, logger, opts }
- Shard streaming via bare-fs.createReadStream directly (no WeightsProvider)
- All finetune, media message, and filtered logger functionality preserved

## 🧪 How was it tested?

- Lint passes (standard) across all 20 changed files
- All 17 integration test files updated to new constructor shape

## 💥 Breaking Changes

**BEFORE:**

```javascript
const model = new LlmLlamacpp({
  loader, modelName, diskPath, logger, opts, projectionModel
}, config)
```

**AFTER:**

```javascript
const model = new LlmLlamacpp({
  files: {
    model: ['/absolute/path/to/model.gguf'],
    projectionModel: '/absolute/path/to/proj.gguf'
  },
  config: { device: 'gpu', gpu_layers: '99', ctx_size: '2048' },
  logger,
  opts: { stats: true }
})
```

## 🔌 API Changes

```javascript
// Constructor: single object with files.model (string array) and optional files.projectionModel
// Removed: downloadWeights(), weightsProvider, Loader interface, @qvac/dl-filesystem, @qvac/dl-base
// Kept: load(), run(), finetune(), unload(), cancel(), pause(), getState()
```
