### PR TITLE
fix: align nmtcpp on-merge workflow with Pattern B

### DIFF
--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -43,13 +43,10 @@ jobs:
     steps:
       - id: logic
         shell: bash
-        env:
-          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
           ref_name="${GITHUB_REF_NAME}"
           event_name="${GITHUB_EVENT_NAME}"
-          input_tag="${INPUT_TAG}"
 
           publish_main="false"
           publish_release="false"
@@ -68,17 +65,13 @@ jobs:
             fi
           fi
 
-          gpr_tag="$input_tag"
-          if [ -z "$gpr_tag" ]; then
-            if [ "$ref_name" = "main" ]; then
-              gpr_tag="dev"
-            elif [[ "$ref_name" == feature-* ]]; then
-              gpr_tag="feature"
-            elif [[ "$ref_name" == tmp-* ]]; then
-              gpr_tag="temp"
-            else
-              gpr_tag="dev"
-            fi
+          gpr_tag="dev"
+          if [ "$ref_name" = "main" ]; then
+            gpr_tag="dev"
+          elif [[ "$ref_name" == feature-* ]]; then
+            gpr_tag="feature"
+          elif [[ "$ref_name" == tmp-* ]]; then
+            gpr_tag="temp"
           fi
 
           echo "publish_main=$publish_main" >> "$GITHUB_OUTPUT"
@@ -108,73 +101,147 @@ jobs:
           package-json-path: packages/qvac-lib-infer-nmtcpp/package.json
           changelog-path: packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
 
-  prebuild-main-gpr:
-    needs: publish-logic
+  build:
+    needs: [publish-logic, release-merge-guard]
+    if: >-
+      !cancelled() &&
+      (
+        needs.publish-logic.outputs.publish_main == 'true' ||
+        needs.publish-logic.outputs.publish_feature == 'true' ||
+        needs.publish-logic.outputs.publish_tmp == 'true' ||
+        (
+          needs.publish-logic.outputs.publish_release == 'true' &&
+          needs.release-merge-guard.result == 'success'
+        )
+      )
     permissions:
       contents: write
       packages: write
       pull-requests: write
       id-token: write
-    if: needs.publish-logic.outputs.publish_main == 'true'
     uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
     secrets: inherit
-    with:
-      tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
 
-  prebuild-feature-gpr:
-    needs: publish-logic
+  publish-gpr:
+    needs: [build, publish-logic]
+    if: >-
+      needs.publish-logic.outputs.publish_main == 'true' ||
+      needs.publish-logic.outputs.publish_feature == 'true' ||
+      needs.publish-logic.outputs.publish_tmp == 'true'
+    continue-on-error: true
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      PKG_DIR: packages/qvac-lib-infer-nmtcpp
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download prebuild artifacts into package dir
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.PKG_DIR }}/prebuilds
+
+      - name: Publish to GitHub Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
+          workdir: ${{ env.PKG_DIR }}
+          name-suffix: "-mono"
+
+  publish-npm:
+    needs: [build, publish-logic, release-merge-guard]
+    if: >-
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      needs.publish-logic.outputs.publish_release == 'true' &&
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+    continue-on-error: false
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       packages: write
-      pull-requests: write
       id-token: write
-    if: needs.publish-logic.outputs.publish_feature == 'true'
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
-    secrets: inherit
-    with:
-      tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
+    env:
+      PKG_DIR: packages/qvac-lib-infer-nmtcpp
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
 
-  prebuild-tmp-gpr:
-    needs: publish-logic
+      - name: Download prebuild artifacts into package dir
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: ${{ env.PKG_DIR }}/prebuilds
+
+      - name: Publish to NPM Package Registry
+        id: publish
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
+        with:
+          secret-token: ${{ secrets.NPM_TOKEN }}
+          tag: "latest"
+          workdir: ${{ env.PKG_DIR }}
+          repo_name: "translation-nmtcpp"
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-release:
+    needs: [publish-npm]
+    if: |
+      !cancelled() &&
+      needs.publish-npm.result == 'success' &&
+      needs.publish-npm.outputs.published_version != ''
     permissions:
       contents: write
-      packages: write
-      pull-requests: write
-      id-token: write
-    if: needs.publish-logic.outputs.publish_tmp == 'true'
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
-    secrets: inherit
+    uses: ./.github/workflows/create-github-release-qvac-lib-infer-nmtcpp.yml
     with:
-      tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-      publish_target: "gpr"
+      published_version: ${{ needs.publish-npm.outputs.published_version }}
+      prev_sha: ${{ github.event.before }}
+      workdir: "packages/qvac-lib-infer-nmtcpp"
 
-  run-integration-tests:
-    needs: [prebuild-main-gpr]
+  post-build-gate:
+    name: Post-Build Gate
+    runs-on: ubuntu-latest
+    needs: [publish-gpr, publish-npm]
+    if: "!cancelled()"
+    outputs:
+      should_run_tests: ${{ steps.gate.outputs.should_run_tests }}
+    steps:
+      - id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          should="false"
+
+          if [ "${{ needs.publish-gpr.result }}" = "success" ] || \
+             [ "${{ needs.publish-npm.result }}" = "success" ]; then
+            should="true"
+          fi
+
+          echo "should_run_tests=$should" >> "$GITHUB_OUTPUT"
+
+  integration-tests:
     permissions:
       contents: read
       packages: read
       id-token: write
     uses: ./.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+    needs: post-build-gate
+    if: needs.post-build-gate.outputs.should_run_tests == 'true'
     secrets: inherit
     with:
       repository: ${{ github.repository }}
-      ref: ${{ github.ref }}
-
-  prebuild-release-npm:
-    needs: [publish-logic, release-merge-guard]
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-      id-token: write
-    if: |
-      !cancelled() &&
-      needs.publish-logic.outputs.publish_release == 'true' &&
-      needs.release-merge-guard.result == 'success'
-    uses: ./.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
-    secrets: inherit
-    with:
-      tag: "latest"
-      publish_target: "npm"
+      ref: ${{ github.sha }}


### PR DESCRIPTION
## Summary
- The prebuilds workflow no longer accepts tag/publish_target inputs after PR #1348 (Pattern B separation), but the on-merge workflow was still passing them
- This caused startup_failure when triggering the release workflow on release-qvac-lib-infer-nmtcpp-1.0.1
- Aligns the on-merge workflow with the same pattern used by ocr-onnx: single build job, separate publish-gpr/publish-npm/publish-release jobs, post-build-gate for integration tests

## Test plan
- [ ] Merge to main, then re-trigger the nmtcpp release workflow on the release branch
- [ ] Verify the workflow starts successfully (no startup_failure)
- [ ] Verify prebuilds complete and npm publish succeeds