### PR TITLE
QVAC-16920 doc: minor adjustments support and community copy in home

### DIFF
--- a/docs/website/content/docs/(latest)/index.mdx
+++ b/docs/website/content/docs/(latest)/index.mdx
@@ -71,7 +71,7 @@ import { KeetIcon } from '@/components/keet-icon';
 
 <Cards>
   <Card href="https://discord.com/invite/tetherdev" icon={<SiDiscord className="text-[var(--color-fd-primary)]" />} title="Discord">
-    Where you talk directly to us. Report bugs, ask questions, give feedback, request and vote for features, take part in QVAC's evolution.
+    Where we gather. Get real-time help from the team and community, meet peers, join in, discuss QVAC.
   </Card>
 
   <Card
@@ -88,8 +88,7 @@ import { KeetIcon } from '@/components/keet-icon';
 
 ## Support
 
-To get support, use the community channels listed in the previous section:
-- [**Discord:**](https://discord.com/invite/tetherdev) for real-time support from Tether team and other community members.
+[_Use the appropriate channel in our **Discord** to talk directly with us._](https://discord.com/invite/tetherdev) Get real-time help, report bugs, ask questions, share feedback, request and vote for features, take part in QVAC's evolution.
 
 ## Miscellaneous
 

--- a/docs/website/content/docs/(latest)/sdk/examples/utilities/plugin-system.mdx
+++ b/docs/website/content/docs/(latest)/sdk/examples/utilities/plugin-system.mdx
@@ -19,7 +19,7 @@ All the built-in plugins you can select, along with the AI tasks that depend on 
 | --- | --- | --- |
 | LLM | `@qvac/sdk/llamacpp-completion/plugin` | [Completion](/sdk/examples/ai-tasks/completion); [multimodal](/sdk/examples/ai-tasks/multimodal); [RAG](/sdk/examples/ai-tasks/rag) |
 | Embeddings | `@qvac/sdk/llamacpp-embedding/plugin` | [Text embeddings](/sdk/examples/ai-tasks/text-embeddings); [RAG](/sdk/examples/ai-tasks/rag) |
-| ASR with `whisper.cpp` | `@qvac/sdk/whispercpp-transcription/plugin` | [Transcription](/sdk/examples/ai-tasks/transcription) |
+| ASR with `qvac-ext-lib-whisper.cpp` | `@qvac/sdk/whispercpp-transcription/plugin` | [Transcription](/sdk/examples/ai-tasks/transcription) |
 | ASR with Parakeet | `@qvac/sdk/parakeet-transcription/plugin` | [Transcription](/sdk/examples/ai-tasks/transcription) |
 | NMT | `@qvac/sdk/nmtcpp-translation/plugin` | [Translation](/sdk/examples/ai-tasks/translation) |
 | TTS | `@qvac/sdk/onnx-tts/plugin` | [Text-to-Speech](/sdk/examples/ai-tasks/text-to-speech) |


### PR DESCRIPTION
### Scope:

- Minor adjustments support and community copy in home
- Replace Whisper.cpp as inference engine by QVAC's own fork `qvac-ext-lib-whispercpp`. 