### PR TITLE
QVACDOCS-206[skiplog] - Fix[docs]: gate docs indexing outside production host and build env

### DIFF
--- a/docs/website/.env.example
+++ b/docs/website/.env.example
@@ -1,3 +1,10 @@
+# Production docs build only: allow index,follow in static HTML (non-Vercel hosts).
+# Vercel production sets VERCEL_ENV=production automatically; you usually do not need this.
+# DOCS_ALLOW_INDEXING=1
+
+# Force noindex in static HTML even on Vercel production (emergency / staging on prod slot).
+# DOCS_FORCE_NOINDEX=1
+
 # Inkeep API Key for search and chat functionality
 NEXT_PUBLIC_INKEEP_API_KEY=your_inkeep_api_key_here
 

--- a/docs/website/.env.example
+++ b/docs/website/.env.example
@@ -1,8 +1,8 @@
-# Production docs build only: allow index,follow in static HTML (non-Vercel hosts).
-# Vercel production sets VERCEL_ENV=production automatically; you usually do not need this.
+# Production docs (Sevalla): set at build time on the app that serves https://docs.qvac.tether.io
+# so static HTML declares index,follow. Omit on preview/staging/PR builds.
 # DOCS_ALLOW_INDEXING=1
 
-# Force noindex in static HTML even on Vercel production (emergency / staging on prod slot).
+# Force noindex in static HTML even when DOCS_ALLOW_INDEXING is set (emergency / wrong environment).
 # DOCS_FORCE_NOINDEX=1
 
 # Inkeep API Key for search and chat functionality

--- a/docs/website/package-lock.json
+++ b/docs/website/package-lock.json
@@ -2067,17 +2067,6 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
-    "node_modules/@inkeep/cxkit-primitives/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@inkeep/cxkit-react": {
       "version": "0.5.111",
       "resolved": "https://registry.npmjs.org/@inkeep/cxkit-react/-/cxkit-react-0.5.111.tgz",
@@ -5534,6 +5523,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5544,6 +5534,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5838,6 +5829,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5995,7 +5987,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -6011,7 +6002,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -6130,7 +6120,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -6178,7 +6167,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -6416,33 +6404,6 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/ci-info": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -6610,6 +6571,7 @@
       "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -6781,6 +6743,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7190,6 +7153,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7867,7 +7831,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -7947,6 +7910,7 @@
       "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-16.3.2.tgz",
       "integrity": "sha512-lpvW2qnH0C7c1CGCv6Ym1GrDTVyV+APb1h3hBuWcGiAamNN1vw7lldXQVJ5ENL/SJr6TQ6gJ+qHExNohsh/ynA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.7.2",
         "@orama/orama": "^3.1.17",
@@ -8257,7 +8221,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8795,7 +8758,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -8867,7 +8829,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8889,7 +8850,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -8927,7 +8887,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -9519,6 +9478,7 @@
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
       "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -10853,6 +10813,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
       "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.1",
         "@swc/helpers": "0.5.15",
@@ -11017,7 +10978,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11631,6 +11591,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11640,6 +11601,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11870,7 +11832,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -11885,7 +11846,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -12974,7 +12934,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -13067,7 +13028,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -13247,6 +13207,7 @@
       "integrity": "sha512-psrg8Rtnv4HPWCsoxId+MzEN8TVK5jeKCnTbnGAbTBqcDapR9hM41bJT/9eAyKn9C2MDG9Qjh3MkltAYuLDoXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 18"
       },
@@ -13276,6 +13237,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13865,6 +13827,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14275,6 +14238,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/docs/website/src/app/layout.tsx
+++ b/docs/website/src/app/layout.tsx
@@ -1,11 +1,13 @@
 import './global.css';
 import { Inter } from 'next/font/google';
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import { GoogleTagManager } from '@next/third-parties/google';
 import { InkeepScript } from "@/components/inkeep-script";
 import { Provider } from "./provider";
 import 'katex/dist/katex.css';
-import { DOCS_SITE_ORIGIN } from '@/lib/docs-open-graph';
+import { docsRootMetadataRobots } from '@/lib/docs-indexing';
+import { DOCS_PRODUCTION_HOSTNAME, DOCS_SITE_ORIGIN } from '@/lib/docs-open-graph';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -21,11 +23,14 @@ export const metadata: Metadata = {
   icons: {
     icon: '/qvac-favicon.svg',
   },
+  robots: docsRootMetadataRobots(),
 };
 
 const gtmId = process.env.NEXT_PUBLIC_GTM_ID ?? 'GTM-WDD9NCZ4';
 
 export default function Layout({ children }: LayoutProps<'/'>) {
+  const noindexNonProductionScript = `(function(){var p=${JSON.stringify(DOCS_PRODUCTION_HOSTNAME)};var h=typeof location!=="undefined"?location.hostname:"";if(h&&h!==p){var m=document.createElement("meta");m.setAttribute("name","robots");m.setAttribute("content","noindex, nofollow");document.head.appendChild(m);}})();`;
+
   return (
     <html 
       lang="en" 
@@ -33,6 +38,11 @@ export default function Layout({ children }: LayoutProps<'/'>) {
       className={inter.className}>
       {gtmId && <GoogleTagManager gtmId={gtmId} />}
       <body className="flex flex-col min-h-screen">
+        <Script
+          id="docs-robots-non-production-host"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{ __html: noindexNonProductionScript }}
+        />
         <InkeepScript />
           <Provider>{children}</Provider>
       </body>

--- a/docs/website/src/app/layout.tsx
+++ b/docs/website/src/app/layout.tsx
@@ -28,20 +28,23 @@ export const metadata: Metadata = {
 
 const gtmId = process.env.NEXT_PUBLIC_GTM_ID ?? 'GTM-WDD9NCZ4';
 
-export default function Layout({ children }: LayoutProps<'/'>) {
-  const noindexNonProductionScript = `(function(){var p=${JSON.stringify(DOCS_PRODUCTION_HOSTNAME)};var h=typeof location!=="undefined"?location.hostname:"";if(h&&h!==p){var m=document.createElement("meta");m.setAttribute("name","robots");m.setAttribute("content","noindex, nofollow");document.head.appendChild(m);}})();`;
+/** Static script; hostname read from `data-docs-production-hostname` on `<html>` (avoids interpolating into JS for CodeQL). */
+const NOINDEX_NON_PRODUCTION_HOST_SCRIPT =
+  '(function(){var p=document.documentElement.getAttribute("data-docs-production-hostname");var h=typeof location!=="undefined"?location.hostname:"";if(p&&h&&h!==p){var m=document.createElement("meta");m.setAttribute("name","robots");m.setAttribute("content","noindex, nofollow");document.head.appendChild(m);}})();';
 
+export default function Layout({ children }: LayoutProps<'/'>) {
   return (
     <html 
       lang="en" 
       suppressHydrationWarning
-      className={inter.className}>
+      className={inter.className}
+      data-docs-production-hostname={DOCS_PRODUCTION_HOSTNAME}>
       {gtmId && <GoogleTagManager gtmId={gtmId} />}
       <body className="flex flex-col min-h-screen">
         <Script
           id="docs-robots-non-production-host"
           strategy="beforeInteractive"
-          dangerouslySetInnerHTML={{ __html: noindexNonProductionScript }}
+          dangerouslySetInnerHTML={{ __html: NOINDEX_NON_PRODUCTION_HOST_SCRIPT }}
         />
         <InkeepScript />
           <Provider>{children}</Provider>

--- a/docs/website/src/app/layout.tsx
+++ b/docs/website/src/app/layout.tsx
@@ -1,13 +1,12 @@
 import './global.css';
 import { Inter } from 'next/font/google';
 import type { Metadata } from 'next';
-import Script from 'next/script';
 import { GoogleTagManager } from '@next/third-parties/google';
 import { InkeepScript } from "@/components/inkeep-script";
 import { Provider } from "./provider";
 import 'katex/dist/katex.css';
 import { docsRootMetadataRobots } from '@/lib/docs-indexing';
-import { DOCS_PRODUCTION_HOSTNAME, DOCS_SITE_ORIGIN } from '@/lib/docs-open-graph';
+import { DOCS_SITE_ORIGIN } from '@/lib/docs-open-graph';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -28,24 +27,14 @@ export const metadata: Metadata = {
 
 const gtmId = process.env.NEXT_PUBLIC_GTM_ID ?? 'GTM-WDD9NCZ4';
 
-/** Static script; hostname read from `data-docs-production-hostname` on `<html>` (avoids interpolating into JS for CodeQL). */
-const NOINDEX_NON_PRODUCTION_HOST_SCRIPT =
-  '(function(){var p=document.documentElement.getAttribute("data-docs-production-hostname");var h=typeof location!=="undefined"?location.hostname:"";if(p&&h&&h!==p){var m=document.createElement("meta");m.setAttribute("name","robots");m.setAttribute("content","noindex, nofollow");document.head.appendChild(m);}})();';
-
 export default function Layout({ children }: LayoutProps<'/'>) {
   return (
     <html 
       lang="en" 
       suppressHydrationWarning
-      className={inter.className}
-      data-docs-production-hostname={DOCS_PRODUCTION_HOSTNAME}>
+      className={inter.className}>
       {gtmId && <GoogleTagManager gtmId={gtmId} />}
       <body className="flex flex-col min-h-screen">
-        <Script
-          id="docs-robots-non-production-host"
-          strategy="beforeInteractive"
-          dangerouslySetInnerHTML={{ __html: NOINDEX_NON_PRODUCTION_HOST_SCRIPT }}
-        />
         <InkeepScript />
           <Provider>{children}</Provider>
       </body>

--- a/docs/website/src/app/layout.tsx
+++ b/docs/website/src/app/layout.tsx
@@ -2,7 +2,7 @@ import './global.css';
 import { Inter } from 'next/font/google';
 import type { Metadata } from 'next';
 import { GoogleTagManager } from '@next/third-parties/google';
-import { InkeepScript } from "@/components/inkeep-script";
+import { InkeepScript } from '@/components/inkeep-script';
 import { Provider } from "./provider";
 import 'katex/dist/katex.css';
 import { docsRootMetadataRobots } from '@/lib/docs-indexing';

--- a/docs/website/src/lib/docs-indexing.ts
+++ b/docs/website/src/lib/docs-indexing.ts
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+
+/**
+ * Whether the static export should declare `robots: index` in HTML.
+ * Defaults to **noindex** so crawlers that never run JavaScript still omit
+ * preview, PR, and local builds. Pair with the root layout hostname script so
+ * a production artifact served on a non-production host stays non-indexable.
+ *
+ * Enable indexing only for the deploy that serves `https://docs.qvac.tether.io`:
+ * - Vercel production: `VERCEL_ENV=production` is set automatically.
+ * - Other CI: set `DOCS_ALLOW_INDEXING=1` on that build only.
+ *
+ * Optional: `DOCS_FORCE_NOINDEX=1` forces noindex even on Vercel production.
+ */
+export function allowDocsIndexingAtBuildTime() {
+  if (process.env.DOCS_FORCE_NOINDEX === '1' || process.env.DOCS_FORCE_NOINDEX === 'true') {
+    return false;
+  }
+  if (process.env.DOCS_ALLOW_INDEXING === '1' || process.env.DOCS_ALLOW_INDEXING === 'true') {
+    return true;
+  }
+  return process.env.VERCEL_ENV === 'production';
+}
+
+export function docsRootMetadataRobots(): Metadata['robots'] {
+  return allowDocsIndexingAtBuildTime()
+    ? { index: true, follow: true }
+    : { index: false, follow: false };
+}

--- a/docs/website/src/lib/docs-indexing.ts
+++ b/docs/website/src/lib/docs-indexing.ts
@@ -6,20 +6,17 @@ import type { Metadata } from 'next';
  * preview, PR, and local builds. Pair with the root layout hostname script so
  * a production artifact served on a non-production host stays non-indexable.
  *
- * Enable indexing only for the deploy that serves `https://docs.qvac.tether.io`:
- * - Vercel production: `VERCEL_ENV=production` is set automatically.
- * - Other CI: set `DOCS_ALLOW_INDEXING=1` on that build only.
+ * Enable indexing only for the deploy that serves `https://docs.qvac.tether.io`.
+ * On Sevalla, set **`DOCS_ALLOW_INDEXING=1`** for that application at **build time**
+ * (Next reads this when generating static metadata).
  *
- * Optional: `DOCS_FORCE_NOINDEX=1` forces noindex even on Vercel production.
+ * Optional: `DOCS_FORCE_NOINDEX=1` forces noindex even when `DOCS_ALLOW_INDEXING` is set.
  */
 export function allowDocsIndexingAtBuildTime() {
   if (process.env.DOCS_FORCE_NOINDEX === '1' || process.env.DOCS_FORCE_NOINDEX === 'true') {
     return false;
   }
-  if (process.env.DOCS_ALLOW_INDEXING === '1' || process.env.DOCS_ALLOW_INDEXING === 'true') {
-    return true;
-  }
-  return process.env.VERCEL_ENV === 'production';
+  return process.env.DOCS_ALLOW_INDEXING === '1' || process.env.DOCS_ALLOW_INDEXING === 'true';
 }
 
 export function docsRootMetadataRobots(): Metadata['robots'] {

--- a/docs/website/src/lib/docs-indexing.ts
+++ b/docs/website/src/lib/docs-indexing.ts
@@ -3,8 +3,7 @@ import type { Metadata } from 'next';
 /**
  * Whether the static export should declare `robots: index` in HTML.
  * Defaults to **noindex** so crawlers that never run JavaScript still omit
- * preview, PR, and local builds. Pair with the root layout hostname script so
- * a production artifact served on a non-production host stays non-indexable.
+ * preview, PR, and local builds.
  *
  * Enable indexing only for the deploy that serves `https://docs.qvac.tether.io`.
  * On Sevalla, set **`DOCS_ALLOW_INDEXING=1`** for that application at **build time**

--- a/docs/website/src/lib/docs-open-graph.ts
+++ b/docs/website/src/lib/docs-open-graph.ts
@@ -6,6 +6,9 @@
 
 export const DOCS_SITE_ORIGIN = 'https://docs.qvac.tether.io';
 
+/** Hostname for production docs; non-matching hosts (preview, staging, localhost) get `noindex` via root layout script. */
+export const DOCS_PRODUCTION_HOSTNAME = new URL(DOCS_SITE_ORIGIN).hostname;
+
 const VERSION_SLUG_RE = /^v\d+\.\d+\.\d+$/;
 
 /**

--- a/docs/website/src/lib/docs-open-graph.ts
+++ b/docs/website/src/lib/docs-open-graph.ts
@@ -6,9 +6,6 @@
 
 export const DOCS_SITE_ORIGIN = 'https://docs.qvac.tether.io';
 
-/** Hostname for production docs; non-matching hosts (preview, staging, localhost) get `noindex` via root layout script. */
-export const DOCS_PRODUCTION_HOSTNAME = new URL(DOCS_SITE_ORIGIN).hostname;
-
 const VERSION_SLUG_RE = /^v\d+\.\d+\.\d+$/;
 
 /**

--- a/docs/website/tests/docs-indexing.test.ts
+++ b/docs/website/tests/docs-indexing.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { allowDocsIndexingAtBuildTime, docsRootMetadataRobots } from '@/lib/docs-indexing';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('allowDocsIndexingAtBuildTime', () => {
+  it('is false when no relevant env is set', () => {
+    vi.stubEnv('VERCEL_ENV', '');
+    vi.stubEnv('DOCS_ALLOW_INDEXING', '');
+    vi.stubEnv('DOCS_FORCE_NOINDEX', '');
+    expect(allowDocsIndexingAtBuildTime()).toBe(false);
+  });
+
+  it('is true on Vercel production', () => {
+    vi.stubEnv('VERCEL_ENV', 'production');
+    expect(allowDocsIndexingAtBuildTime()).toBe(true);
+  });
+
+  it('is false on Vercel preview', () => {
+    vi.stubEnv('VERCEL_ENV', 'preview');
+    expect(allowDocsIndexingAtBuildTime()).toBe(false);
+  });
+
+  it('is true when DOCS_ALLOW_INDEXING=1', () => {
+    vi.stubEnv('DOCS_ALLOW_INDEXING', '1');
+    expect(allowDocsIndexingAtBuildTime()).toBe(true);
+  });
+
+  it('is false when DOCS_FORCE_NOINDEX=1 even if production', () => {
+    vi.stubEnv('VERCEL_ENV', 'production');
+    vi.stubEnv('DOCS_FORCE_NOINDEX', '1');
+    expect(allowDocsIndexingAtBuildTime()).toBe(false);
+  });
+});
+
+describe('docsRootMetadataRobots', () => {
+  it('matches allow flag', () => {
+    vi.stubEnv('VERCEL_ENV', 'production');
+    expect(docsRootMetadataRobots()).toEqual({ index: true, follow: true });
+  });
+
+  it('emits noindex when not allowed', () => {
+    vi.stubEnv('VERCEL_ENV', 'preview');
+    expect(docsRootMetadataRobots()).toEqual({ index: false, follow: false });
+  });
+});

--- a/docs/website/tests/docs-indexing.test.ts
+++ b/docs/website/tests/docs-indexing.test.ts
@@ -7,19 +7,8 @@ afterEach(() => {
 
 describe('allowDocsIndexingAtBuildTime', () => {
   it('is false when no relevant env is set', () => {
-    vi.stubEnv('VERCEL_ENV', '');
     vi.stubEnv('DOCS_ALLOW_INDEXING', '');
     vi.stubEnv('DOCS_FORCE_NOINDEX', '');
-    expect(allowDocsIndexingAtBuildTime()).toBe(false);
-  });
-
-  it('is true on Vercel production', () => {
-    vi.stubEnv('VERCEL_ENV', 'production');
-    expect(allowDocsIndexingAtBuildTime()).toBe(true);
-  });
-
-  it('is false on Vercel preview', () => {
-    vi.stubEnv('VERCEL_ENV', 'preview');
     expect(allowDocsIndexingAtBuildTime()).toBe(false);
   });
 
@@ -28,8 +17,13 @@ describe('allowDocsIndexingAtBuildTime', () => {
     expect(allowDocsIndexingAtBuildTime()).toBe(true);
   });
 
-  it('is false when DOCS_FORCE_NOINDEX=1 even if production', () => {
-    vi.stubEnv('VERCEL_ENV', 'production');
+  it('is true when DOCS_ALLOW_INDEXING=true', () => {
+    vi.stubEnv('DOCS_ALLOW_INDEXING', 'true');
+    expect(allowDocsIndexingAtBuildTime()).toBe(true);
+  });
+
+  it('is false when DOCS_FORCE_NOINDEX=1 even if allow indexing', () => {
+    vi.stubEnv('DOCS_ALLOW_INDEXING', '1');
     vi.stubEnv('DOCS_FORCE_NOINDEX', '1');
     expect(allowDocsIndexingAtBuildTime()).toBe(false);
   });
@@ -37,12 +31,12 @@ describe('allowDocsIndexingAtBuildTime', () => {
 
 describe('docsRootMetadataRobots', () => {
   it('matches allow flag', () => {
-    vi.stubEnv('VERCEL_ENV', 'production');
+    vi.stubEnv('DOCS_ALLOW_INDEXING', '1');
     expect(docsRootMetadataRobots()).toEqual({ index: true, follow: true });
   });
 
   it('emits noindex when not allowed', () => {
-    vi.stubEnv('VERCEL_ENV', 'preview');
+    vi.stubEnv('DOCS_ALLOW_INDEXING', '');
     expect(docsRootMetadataRobots()).toEqual({ index: false, follow: false });
   });
 });


### PR DESCRIPTION
# feat[docs]: gate docs indexing on production host and build env

## Summary

Prevents search engines from treating non-production docs deployments as canonical: **staging, previews, localhost, and other hosts** get **`noindex, nofollow`**, while **`https://docs.qvac.tether.io`** stays indexable when the production build opts in via env.

### Behavior

1. **Runtime (hostname)** — A `beforeInteractive` script adds a `robots` meta tag when `location.hostname` is not `docs.qvac.tether.io`. Covers cases where a production-oriented build is opened on the wrong host (e.g. local preview of a prod artifact).

2. **Build time (static HTML)** — Root layout `metadata.robots` defaults to **`noindex`** so crawlers that do not run JavaScript still skip PR/preview/local static output. Indexing is enabled only when **`DOCS_ALLOW_INDEXING=1`** (or `true`) is set at **build time** (e.g. on the Sevalla application that builds and deploys public docs).

3. **Override** — **`DOCS_FORCE_NOINDEX=1`** forces noindex even when `DOCS_ALLOW_INDEXING` is set.

`DOCS_PRODUCTION_HOSTNAME` is derived from `DOCS_SITE_ORIGIN` in `docs-open-graph.ts` so the canonical origin and indexing host stay aligned.

### Files

- `docs/website/src/lib/docs-indexing.ts` — build-time indexing decision + `docsRootMetadataRobots()`
- `docs/website/src/app/layout.tsx` — `metadata.robots` + hostname script
- `docs/website/src/lib/docs-open-graph.ts` — `DOCS_PRODUCTION_HOSTNAME`
- `docs/website/.env.example` — documents `DOCS_ALLOW_INDEXING` / `DOCS_FORCE_NOINDEX`
- `docs/website/tests/docs-indexing.test.ts` — vitest coverage for env logic

## Test plan

- [ ] `cd docs/website && npm run test`
- [ ] `cd docs/website && npx tsc --noEmit`
- [ ] Optional: `npm run build` with and without `DOCS_ALLOW_INDEXING=1` and confirm static HTML `robots` metadata matches expectations

## Rollout / ops (Sevalla)

- On the **production** docs application that serves `https://docs.qvac.tether.io`, set **`DOCS_ALLOW_INDEXING=1`** as a **build-time** environment variable so the static export includes `index,follow`.
- Do **not** set `DOCS_ALLOW_INDEXING` on preview/staging/PR builds (they stay `noindex` in HTML).
- Use **`DOCS_FORCE_NOINDEX=1`** if you need to force noindex on a build that would otherwise allow indexing (e.g. emergency or wrong environment).