### PR TITLE
Case-insensitive reverse prompt matching and disable flash_attn by default

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/test/unit/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/unit/CMakeLists.txt
@@ -37,9 +37,11 @@ endif()
 
 target_include_directories(
   addon-test
+  BEFORE PRIVATE
+    ${CMAKE_SOURCE_DIR}/addon/src/patches
   PRIVATE
-  ${CMAKE_SOURCE_DIR}/addon/src
-  ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/addon/src
+    ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS}
 )
 
 target_compile_features(addon-test PRIVATE cxx_std_20)

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -131,12 +131,14 @@ void LlamaModel::tuneConfigMap(
         (finetuneOverrides.flashAttn
              ? "[LlamaModel] Finetuning: enabling flash attention\n"
              : "[LlamaModel] Finetuning: disabling flash attention\n"));
-  } else if (isBitnet && notUserSet("flash-attn", "flash_attn")) {
+  } else if (notUserSet("flash-attn", "flash_attn")) {
     configFilemap.erase("flash_attn");
     configFilemap["flash-attn"] = "off";
     QLOG_IF(
         Priority::INFO,
-        "[LlamaModel] BitNet model detected: disabling flash attention\n");
+        (isBitnet
+             ? "[LlamaModel] BitNet model detected: disabling flash attention\n"
+             : "[LlamaModel] Disabling flash attention (not supported on Vulkan/Metal)\n"));
   }
 
   constexpr int kAdrenoUbatchThreshold = 800;
@@ -737,7 +739,12 @@ void LlamaModel::commonParamsParse(
       auto listString = iter->second;
       std::vector<std::string> list = split(listString, ',');
       for (const auto& item : list) {
-        params.antiprompt.push_back(item);
+        std::string trimmed = item;
+        trimmed.erase(0, trimmed.find_first_not_of(" \t"));
+        trimmed.erase(trimmed.find_last_not_of(" \t") + 1);
+        if (!trimmed.empty()) {
+          params.antiprompt.push_back(trimmed);
+        }
       }
       if (list.empty() && !listString.empty()) {
         params.antiprompt.push_back(listString);

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -130,7 +130,11 @@ bool MtmdLlmContext::checkAntiprompt() {
     // can decode to many characters, and a short antiprompt like "\n" may
     // appear at the start of such a token, far from the string's tail.
     for (const std::string& antiprompt : params_.antiprompt) {
-      if (lastOutput.find(antiprompt) != std::string::npos) {
+      std::string lowerOutput = lastOutput;
+      std::string lowerAntiprompt = antiprompt;
+      std::transform(lowerOutput.begin(), lowerOutput.end(), lowerOutput.begin(), ::tolower);
+      std::transform(lowerAntiprompt.begin(), lowerAntiprompt.end(), lowerAntiprompt.begin(), ::tolower);
+      if (lowerOutput.find(lowerAntiprompt) != std::string::npos) {
         return true;
       }
     }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -166,7 +166,11 @@ bool TextLlmContext::checkAntiprompt() {
     // can decode to many characters, and a short antiprompt like "\n" may
     // appear at the start of such a token, far from the string's tail.
     for (const std::string& antiprompt : params_.antiprompt) {
-      if (lastOutput.find(antiprompt) != std::string::npos) {
+      std::string lowerOutput = lastOutput;
+      std::string lowerAntiprompt = antiprompt;
+      std::transform(lowerOutput.begin(), lowerOutput.end(), lowerOutput.begin(), ::tolower);
+      std::transform(lowerAntiprompt.begin(), lowerAntiprompt.end(), lowerAntiprompt.begin(), ::tolower);
+      if (lowerOutput.find(lowerAntiprompt) != std::string::npos) {
         return true;
       }
     }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/config-parameters.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/config-parameters.test.js
@@ -254,8 +254,8 @@ const scenarios = [
     ],
     expectSuccess: true,
     assertOutput: (t, output, stats) => {
-      t.ok(output.includes('pizza'), 'reverse prompt output contains keyword')
-      t.ok(output.split('').slice(-5).join('') === 'pizza', 'reverse prompt output ends with keyword')
+      t.ok(output.toLowerCase().includes('pizza'), 'reverse prompt output contains keyword')
+      t.ok(output.toLowerCase().split('').slice(-5).join('') === 'pizza', 'reverse prompt output ends with keyword')
     }
   }
 ]

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
@@ -66,10 +66,12 @@ endif()
 
 target_include_directories(
   addon-test
+  BEFORE PRIVATE
+    ${CMAKE_SOURCE_DIR}/addon/src/patches
   PRIVATE
-  ${CMAKE_SOURCE_DIR}/addon/src
-  ${PICOJSON_INCLUDE_DIRS}
-  ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/addon/src
+    ${PICOJSON_INCLUDE_DIRS}
+    ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS}
 )
 
 # Set C++20 standard for std::views support (required by qvac-lib-inference-addon-cpp)


### PR DESCRIPTION
Fix reverse prompt matching to be case-insensitive and trim whitespace from comma-separated antiprompt entries. Disable flash attention by default for non-finetuning cases, as it is unsupported on Vulkan and Metal backends.