### PR TITLE
QVAC-16990 fix: remove ubuntu-24.04-arm from nmtcpp integration test matrix

### DIFF
--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -47,9 +47,6 @@ jobs:
           - os: ubuntu-24.04
             platform: linux
             arch: x64
-          - os: ubuntu-24.04-arm
-            platform: linux
-            arch: arm64
           - os: ubuntu-22.04-arm
             platform: linux
             arch: arm64


### PR DESCRIPTION
## Summary

- Remove `ubuntu-24.04-arm` from the nmtcpp integration test matrix
- The runner consistently fails with SIGILL (exit code 132) because prebuilds are compiled on ubuntu-22.04-arm targeting a different ARM microarchitecture
- ARM64 correctness remains validated by ubuntu-22.04-arm and macos-14 (darwin-arm64) runners

## Test plan

- [x] Verify YAML syntax is valid (done locally)
- [ ] Confirm remaining matrix entries are correct (ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, macos-14, windows-2022)
- [ ] CI run on this branch should not trigger the removed runner

Asana: https://app.asana.com/0/0/1213998099341981
