### PR TITLE
Added github action to that checks qvac-fabric version across LLM, Embed and Tanslation addons.

### DIFF
--- a/.github/actions/verify-qvac-fabric-lockstep/action.yml
+++ b/.github/actions/verify-qvac-fabric-lockstep/action.yml
@@ -1,0 +1,59 @@
+name: Verify qvac-fabric lockstep
+description: Ensures qvac-fabric dependency version is identical across selected vcpkg manifests.
+
+outputs:
+  version:
+    description: The shared qvac-fabric version when lockstep check passes.
+    value: ${{ steps.verify.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: verify
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        files=(
+          "packages/qvac-lib-infer-llamacpp-llm/vcpkg.json"
+          "packages/qvac-lib-infer-llamacpp-embed/vcpkg.json"
+          "packages/qvac-lib-infer-nmtcpp/vcpkg.json"
+        )
+
+        versions=()
+        for file in "${files[@]}"; do
+          if [ ! -f "${file}" ]; then
+            echo "Missing file: ${file}"
+            exit 1
+          fi
+
+          version="$(jq -r '
+            [
+              .dependencies[]
+              | objects
+              | select(.name == "qvac-fabric")
+              | .["version>="]
+            ] | first // empty
+          ' "${file}")"
+
+          if [ -z "${version}" ] || [ "${version}" = "null" ]; then
+            echo "qvac-fabric dependency with version>= not found in ${file}"
+            exit 1
+          fi
+
+          echo "${file}: qvac-fabric version>=${version}"
+          versions+=("${version}")
+        done
+
+        baseline="${versions[0]}"
+        for version in "${versions[@]}"; do
+          if [ "${version}" != "${baseline}" ]; then
+            echo "qvac-fabric versions are not in lockstep."
+            echo "Expected all to match: ${baseline}"
+            printf 'Observed versions: %s\n' "${versions[@]}"
+            exit 1
+          fi
+        done
+
+        echo "qvac-fabric lockstep verified: ${baseline}"
+        echo "version=${baseline}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -40,9 +40,24 @@ jobs:
         with:
           github-token: ${{ github.token }}
 
-  sanity-checks:
+  verify-fabric-lockstep:
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Verify qvac-fabric versions are lockstep
+        id: lockstep
+        uses: ./.github/actions/verify-qvac-fabric-lockstep
+
+      - name: Report verified version
+        run: echo "Verified qvac-fabric version: ${{ steps.lockstep.outputs.version }}"
+
+  sanity-checks:
+    if: needs.authorize.outputs.allowed == 'true'
+    needs: [authorize, verify-fabric-lockstep]
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -151,9 +166,9 @@ jobs:
       ref: ${{ github.event.pull_request.head.ref }}
 
   merge-guard:
-    needs: [authorize, sanity-checks, cpp-lint, cpp-tests, prebuild, integration-tests, run-mobile-integration-tests, ts-checks]
+    needs: [authorize, verify-fabric-lockstep, sanity-checks, cpp-lint, cpp-tests, prebuild, integration-tests, run-mobile-integration-tests, ts-checks]
     if: always()
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
-      sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
+      sanity-checks-status: ${{ needs.verify-fabric-lockstep.result == 'success' && needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -45,9 +45,24 @@ jobs:
         with:
           github-token: ${{ github.token }}
 
-  sanity-checks:
+  verify-fabric-lockstep:
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Verify qvac-fabric versions are lockstep
+        id: lockstep
+        uses: ./.github/actions/verify-qvac-fabric-lockstep
+
+      - name: Report verified version
+        run: echo "Verified qvac-fabric version: ${{ steps.lockstep.outputs.version }}"
+
+  sanity-checks:
+    if: needs.authorize.outputs.allowed == 'true'
+    needs: [authorize, verify-fabric-lockstep]
     runs-on: ubuntu-latest
     environment: release
     steps:
@@ -156,6 +171,7 @@ jobs:
     needs:
       [
         authorize,
+        verify-fabric-lockstep,
         run-integration-tests,
         run-mobile-integration-tests,
         sanity-checks,
@@ -167,5 +183,5 @@ jobs:
     if: always()
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
-      sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
+      sanity-checks-status: ${{ needs.verify-fabric-lockstep.result == 'success' && needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success'}}

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -57,9 +57,23 @@ jobs:
             pkg:
               - "packages/qvac-lib-infer-nmtcpp/**"
               - ".github/workflows/*nmtcpp*.yml"
+  verify-fabric-lockstep:
+    needs: [authorize, changes]
+    if: always() && needs.authorize.outputs.allowed == 'true' && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Verify qvac-fabric versions are lockstep
+        id: lockstep
+        uses: ./.github/actions/verify-qvac-fabric-lockstep
+
+      - name: Report verified version
+        run: echo "Verified qvac-fabric version: ${{ steps.lockstep.outputs.version }}"
 
   sanity-checks:
-    needs: [authorize, changes]
+    needs: [authorize, changes, verify-fabric-lockstep]
     if: always() && ((needs.changes.outputs.pkg == 'true' && needs.authorize.outputs.allowed == 'true') || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment: release
@@ -192,6 +206,7 @@ jobs:
       [
         authorize,
         changes,
+        verify-fabric-lockstep,
         sanity-checks,
         ts-checks,
         cpp-lint,
@@ -203,6 +218,6 @@ jobs:
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
     uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
-      sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.cpp-tests.result == 'success' && needs.ts-checks.result == 'success' }}
+      sanity-checks-status: ${{ needs.verify-fabric-lockstep.result == 'success' && needs.sanity-checks.result == 'success' && needs.cpp-tests.result == 'success' && needs.ts-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}
       integration-tests-status: ${{ needs.run-integration-tests.result == 'success' }}


### PR DESCRIPTION
- What problem does this PR solve?

Prevents dependency drift against the intended Fabric version line.

-  How does it solve it?

Adds a version checking across LLM, Embed and NMTCPP addons.