### PR TITLE
fix: integration tests after migrating to base infer 0.4.0

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.1] - 2026-04-09
+
+### Fixed
+
+- Updated integration tests to use new `{ files, params, config }` constructor — removed `localLoader` and `createLocalLoader` helpers
+- Removed obsolete internal method tests (`_getPivotFilesToDownload`, `_bergamotPivotModel` fallback) that tested removed APIs
+
 ## [2.0.0] - 2026-04-08
 
 ### Changed

--- a/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
@@ -5,14 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [2.0.1] - 2026-04-09
-
-### Fixed
-
-- Updated integration tests to use new `{ files, params, config }` constructor — removed `localLoader` and `createLocalLoader` helpers
-- Removed obsolete internal method tests (`_getPivotFilesToDownload`, `_bergamotPivotModel` fallback) that tested removed APIs
-
 ## [2.0.0] - 2026-04-08
 
 ### Changed

--- a/packages/qvac-lib-infer-nmtcpp/package.json
+++ b/packages/qvac-lib-infer-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-nmtcpp/package.json
+++ b/packages/qvac-lib-infer-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-nmtcpp/test/integration/bergamot.test.js
+++ b/packages/qvac-lib-infer-nmtcpp/test/integration/bergamot.test.js
@@ -61,24 +61,6 @@ for (const deviceConfig of DEVICE_CONFIGS) {
 
     const fullVocabPath = path.join(modelDir, vocabFile)
 
-    /**
-     * Local file loader for Bergamot model
-     * Provides synchronous file access for model loading
-     */
-    const localLoader = {
-      ready: async () => {},
-      close: async () => {},
-      download: async (filename) => {
-        const filePath = path.join(modelDir, filename)
-        return fs.readFileSync(filePath)
-      },
-      getFileSize: async (filename) => {
-        const filePath = path.join(modelDir, filename)
-        const stats = fs.statSync(filePath)
-        return stats.size
-      }
-    }
-
     const logger = createLogger()
     const perfCollector = createPerformanceCollector()
     let model
@@ -87,22 +69,23 @@ for (const deviceConfig of DEVICE_CONFIGS) {
 
     try {
       model = new TranslationNmtcpp({
-        loader: localLoader,
+        files: {
+          model: path.join(modelDir, modelFile),
+          srcVocab: fullVocabPath,
+          dstVocab: fullVocabPath
+        },
         params: {
           srcLang: 'en',
           dstLang: 'it'
         },
-        diskPath: modelDir,
-        modelName: modelFile,
+        config: {
+          modelType: TranslationNmtcpp.ModelTypes.Bergamot,
+          beamsize: 1,
+          normalize: 1,
+          use_gpu: deviceConfig.useGpu
+        },
         logger,
         opts: { stats: true }
-      }, {
-        modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-        srcVocabPath: fullVocabPath,
-        dstVocabPath: fullVocabPath,
-        beamsize: 1,
-        normalize: 1,
-        use_gpu: deviceConfig.useGpu
       })
       model.logger.setLevel('debug')
       await model.load()

--- a/packages/qvac-lib-infer-nmtcpp/test/integration/indictrans.test.js
+++ b/packages/qvac-lib-infer-nmtcpp/test/integration/indictrans.test.js
@@ -19,8 +19,6 @@
  */
 
 const test = require('brittle')
-const path = require('bare-path')
-const fs = require('bare-fs')
 const TranslationNmtcpp = require('@qvac/translation-nmtcpp')
 const {
   ensureIndicTransModel,
@@ -55,23 +53,6 @@ for (const deviceConfig of DEVICE_CONFIGS) {
     t.comment(`${label} Model path: ` + modelPath)
     t.comment('Platform: ' + platform + ', isMobile: ' + isMobile)
 
-    const modelDir = path.dirname(modelPath)
-    const modelName = path.basename(modelPath)
-
-    const localLoader = {
-      ready: async () => {},
-      close: async () => {},
-      download: async (filename) => {
-        const filePath = path.join(modelDir, filename)
-        return fs.readFileSync(filePath)
-      },
-      getFileSize: async (filename) => {
-        const filePath = path.join(modelDir, filename)
-        const stats = fs.statSync(filePath)
-        return stats.size
-      }
-    }
-
     const logger = createLogger()
     const perfCollector = createPerformanceCollector()
     let model
@@ -80,19 +61,20 @@ for (const deviceConfig of DEVICE_CONFIGS) {
 
     try {
       model = new TranslationNmtcpp({
-        loader: localLoader,
+        files: {
+          model: modelPath
+        },
         params: {
           mode: 'full',
           srcLang: 'eng_Latn',
           dstLang: 'hin_Deva'
         },
-        diskPath: modelDir,
-        modelName,
+        config: {
+          modelType: TranslationNmtcpp.ModelTypes.IndicTrans,
+          use_gpu: deviceConfig.useGpu
+        },
         logger,
         opts: { stats: true }
-      }, {
-        modelType: TranslationNmtcpp.ModelTypes.IndicTrans,
-        use_gpu: deviceConfig.useGpu
       })
       model.logger.setLevel('debug')
       await model.load()

--- a/packages/qvac-lib-infer-nmtcpp/test/integration/pivot-bergamot.test.js
+++ b/packages/qvac-lib-infer-nmtcpp/test/integration/pivot-bergamot.test.js
@@ -85,17 +85,31 @@ function findModelFiles (modelDir) {
 }
 
 /**
- * Creates a local filesystem loader for a Bergamot model directory.
- *
- * @param {string} modelDir - path to directory with model files
- * @returns {Object} loader compatible with TranslationNmtcpp
+ * Creates pivot translation constructor args from model directories.
  */
-function createLocalLoader (modelDir) {
+function createPivotArgs (primaryDir, primaryFiles, pivotDir, pivotFiles, opts = {}) {
   return {
-    ready: async () => {},
-    close: async () => {},
-    download: async (filename) => fs.readFileSync(path.join(modelDir, filename)),
-    getFileSize: async (filename) => fs.statSync(path.join(modelDir, filename)).size
+    files: {
+      model: path.join(primaryDir, primaryFiles.modelFile),
+      srcVocab: path.join(primaryDir, primaryFiles.vocabFile),
+      dstVocab: path.join(primaryDir, primaryFiles.vocabFile),
+      pivotModel: path.join(pivotDir, pivotFiles.modelFile),
+      pivotSrcVocab: path.join(pivotDir, pivotFiles.vocabFile),
+      pivotDstVocab: path.join(pivotDir, pivotFiles.vocabFile)
+    },
+    params: opts.params || { srcLang: 'es', dstLang: 'it' },
+    config: {
+      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
+      beamsize: 1,
+      ...(opts.normalize !== undefined && { normalize: opts.normalize }),
+      ...(opts.use_gpu !== undefined && { use_gpu: opts.use_gpu }),
+      pivotConfig: {
+        beamsize: 1,
+        ...(opts.pivotNormalize !== undefined && { normalize: opts.pivotNormalize })
+      }
+    },
+    logger: opts.logger || createLogger(),
+    opts: { stats: true }
   }
 }
 
@@ -131,32 +145,12 @@ for (const deviceConfig of DEVICE_CONFIGS) {
     let model
 
     try {
-      model = new TranslationNmtcpp({
-        loader: createLocalLoader(esEnDir),
-        params: { srcLang: 'es', dstLang: 'it' },
-        diskPath: esEnDir,
-        modelName: esEn.modelFile,
+      model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt, {
         logger,
-        opts: { stats: true }
-      }, {
-        modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-        srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-        dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-        beamsize: 1,
         normalize: 1,
         use_gpu: deviceConfig.useGpu,
-        bergamotPivotModel: {
-          loader: createLocalLoader(enItDir),
-          modelName: enIt.modelFile,
-          diskPath: enItDir,
-          config: {
-            srcVocabPath: path.join(enItDir, enIt.vocabFile),
-            dstVocabPath: path.join(enItDir, enIt.vocabFile),
-            beamsize: 1,
-            normalize: 1
-          }
-        }
-      })
+        pivotNormalize: 1
+      }))
 
       await model.load()
       t.pass(`${label} Pivot model loaded (es→en→it)`)
@@ -200,28 +194,7 @@ test('Pivot translation - stats object is populated (no hang)', { timeout: PIVOT
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     await model.load()
 
@@ -256,28 +229,7 @@ test('Pivot translation - batch translation via runBatch()', { timeout: PIVOT_TI
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     await model.load()
 
@@ -319,28 +271,7 @@ test('Pivot translation - cancel does not crash', { timeout: PIVOT_TIMEOUT }, as
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     await model.load()
 
@@ -378,28 +309,7 @@ test('Pivot translation - multiple sequential runs', { timeout: PIVOT_TIMEOUT },
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     await model.load()
 
@@ -426,184 +336,6 @@ test('Pivot translation - multiple sequential runs', { timeout: PIVOT_TIMEOUT },
 })
 
 // ---------------------------------------------------------------------------
-// Test: Pivot diskPath falls back to primary diskPath
-// ---------------------------------------------------------------------------
-
-test('Pivot translation - pivot diskPath defaults to primary', { timeout: PIVOT_TIMEOUT }, async function (t) {
-  const enItDir = await ensureModelPair('en', 'it')
-  const enIt = findModelFiles(enItDir)
-
-  const model = new TranslationNmtcpp({
-    loader: createLocalLoader(enItDir),
-    params: { srcLang: 'en', dstLang: 'it' },
-    diskPath: enItDir,
-    modelName: enIt.modelFile,
-    logger: createLogger()
-  }, {
-    modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-    srcVocabPath: path.join(enItDir, enIt.vocabFile),
-    dstVocabPath: path.join(enItDir, enIt.vocabFile),
-    bergamotPivotModel: {
-      loader: createLocalLoader(enItDir),
-      modelName: enIt.modelFile,
-      config: {
-        srcVocabPath: path.join(enItDir, enIt.vocabFile),
-        dstVocabPath: path.join(enItDir, enIt.vocabFile)
-      }
-    }
-  })
-
-  t.ok(model._bergamotPivotModel, 'pivot model config should be set')
-  t.is(model._bergamotPivotModel.diskPath, enItDir, 'pivot diskPath should fall back to primary diskPath')
-  t.pass('Pivot diskPath fallback works')
-})
-
-// ---------------------------------------------------------------------------
-// Test: bergamotPivotModel ignored for non-Bergamot model types
-// ---------------------------------------------------------------------------
-
-test('Pivot config ignored for non-Bergamot model types', { timeout: 30_000 }, async function (t) {
-  const enItDir = await ensureModelPair('en', 'it')
-  const enIt = findModelFiles(enItDir)
-
-  const model = new TranslationNmtcpp({
-    loader: createLocalLoader(enItDir),
-    params: { srcLang: 'en', dstLang: 'it' },
-    diskPath: enItDir,
-    modelName: enIt.modelFile,
-    logger: createLogger()
-  }, {
-    modelType: TranslationNmtcpp.ModelTypes.Opus,
-    bergamotPivotModel: {
-      loader: createLocalLoader(enItDir),
-      modelName: enIt.modelFile,
-      config: {
-        srcVocabPath: path.join(enItDir, enIt.vocabFile),
-        dstVocabPath: path.join(enItDir, enIt.vocabFile)
-      }
-    }
-  })
-
-  t.is(model._bergamotPivotModel, null, 'pivot model should be null for Opus model type')
-
-  const modelIndicTrans = new TranslationNmtcpp({
-    loader: createLocalLoader(enItDir),
-    params: { srcLang: 'en', dstLang: 'it' },
-    diskPath: enItDir,
-    modelName: enIt.modelFile,
-    logger: createLogger()
-  }, {
-    modelType: TranslationNmtcpp.ModelTypes.IndicTrans,
-    bergamotPivotModel: {
-      loader: createLocalLoader(enItDir),
-      modelName: enIt.modelFile,
-      config: {
-        srcVocabPath: path.join(enItDir, enIt.vocabFile),
-        dstVocabPath: path.join(enItDir, enIt.vocabFile)
-      }
-    }
-  })
-
-  t.is(modelIndicTrans._bergamotPivotModel, null, 'pivot model should be null for IndicTrans model type')
-  t.pass('Pivot config correctly ignored for non-Bergamot types')
-})
-
-// ---------------------------------------------------------------------------
-// Test: _getPivotFilesToDownload returns correct files
-// ---------------------------------------------------------------------------
-
-test('_getPivotFilesToDownload - returns model and vocab names', { timeout: 30_000 }, async function (t) {
-  const enItDir = await ensureModelPair('en', 'it')
-  const enIt = findModelFiles(enItDir)
-
-  const model = new TranslationNmtcpp({
-    loader: createLocalLoader(enItDir),
-    params: { srcLang: 'es', dstLang: 'it' },
-    diskPath: enItDir,
-    modelName: enIt.modelFile,
-    logger: createLogger()
-  }, {
-    modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-    srcVocabPath: path.join(enItDir, enIt.vocabFile),
-    dstVocabPath: path.join(enItDir, enIt.vocabFile),
-    bergamotPivotModel: {
-      loader: createLocalLoader(enItDir),
-      modelName: 'pivot-model.bin',
-      diskPath: '/tmp/pivot',
-      config: {
-        srcVocabName: 'pivot-src.spm',
-        dstVocabName: 'pivot-dst.spm'
-      }
-    }
-  })
-
-  const files = model._getPivotFilesToDownload()
-  t.ok(files.includes('pivot-model.bin'), 'should include pivot model file')
-  t.ok(files.includes('pivot-src.spm'), 'should include pivot src vocab')
-  t.ok(files.includes('pivot-dst.spm'), 'should include pivot dst vocab')
-  t.is(files.length, 3, 'should have exactly 3 files')
-  t.pass('Pivot file list is correct')
-})
-
-test('_getPivotFilesToDownload - returns empty when no pivot', { timeout: 30_000 }, async function (t) {
-  const enItDir = await ensureModelPair('en', 'it')
-  const enIt = findModelFiles(enItDir)
-
-  const model = new TranslationNmtcpp({
-    loader: createLocalLoader(enItDir),
-    params: { srcLang: 'en', dstLang: 'it' },
-    diskPath: enItDir,
-    modelName: enIt.modelFile,
-    logger: createLogger()
-  }, {
-    modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-    srcVocabPath: path.join(enItDir, enIt.vocabFile),
-    dstVocabPath: path.join(enItDir, enIt.vocabFile)
-  })
-
-  const files = model._getPivotFilesToDownload()
-  t.is(files.length, 0, 'should return empty array when no pivot configured')
-  t.pass('No pivot files when unconfigured')
-})
-
-// ---------------------------------------------------------------------------
-// Test: Vocab resolution via names (not paths) for pivot model
-// ---------------------------------------------------------------------------
-
-test('_getPivotFilesToDownload - skips vocabs when paths provided', { timeout: 30_000 }, async function (t) {
-  const enItDir = await ensureModelPair('en', 'it')
-  const enIt = findModelFiles(enItDir)
-
-  const model = new TranslationNmtcpp({
-    loader: createLocalLoader(enItDir),
-    params: { srcLang: 'es', dstLang: 'it' },
-    diskPath: enItDir,
-    modelName: enIt.modelFile,
-    logger: createLogger()
-  }, {
-    modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-    srcVocabPath: path.join(enItDir, enIt.vocabFile),
-    dstVocabPath: path.join(enItDir, enIt.vocabFile),
-    bergamotPivotModel: {
-      loader: createLocalLoader(enItDir),
-      modelName: 'pivot-model.bin',
-      diskPath: '/tmp/pivot',
-      config: {
-        srcVocabPath: '/absolute/path/src.spm',
-        dstVocabPath: '/absolute/path/dst.spm',
-        srcVocabName: 'should-be-ignored.spm',
-        dstVocabName: 'should-be-ignored.spm'
-      }
-    }
-  })
-
-  const files = model._getPivotFilesToDownload()
-  t.is(files.length, 1, 'should only include model file when vocab paths are absolute')
-  t.ok(files.includes('pivot-model.bin'), 'should include the model file')
-  t.pass('Vocab names skipped when paths provided')
-})
-
-// ---------------------------------------------------------------------------
 // Test: Empty string input
 // ---------------------------------------------------------------------------
 
@@ -615,28 +347,7 @@ test('Pivot translation - empty string input', { timeout: PIVOT_TIMEOUT }, async
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     await model.load()
 
@@ -670,28 +381,7 @@ test('Pivot translation - run after unload throws', { timeout: PIVOT_TIMEOUT }, 
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     await model.load()
     await model.unload()
@@ -723,28 +413,7 @@ test('Pivot translation - load, unload, reload cycle', { timeout: PIVOT_TIMEOUT 
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     // First load and translate
     await model.load()
@@ -815,32 +484,13 @@ for (const deviceConfig of DEVICE_CONFIGS) {
     let model
 
     try {
-      model = new TranslationNmtcpp({
-        loader: createLocalLoader(frEnDir),
+      model = new TranslationNmtcpp(createPivotArgs(frEnDir, frEn, enEsDir, enEs, {
         params: { srcLang: 'fr', dstLang: 'es' },
-        diskPath: frEnDir,
-        modelName: frEn.modelFile,
         logger,
-        opts: { stats: true }
-      }, {
-        modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-        srcVocabPath: path.join(frEnDir, frEn.vocabFile),
-        dstVocabPath: path.join(frEnDir, frEn.vocabFile),
-        beamsize: 1,
         normalize: 1,
         use_gpu: deviceConfig.useGpu,
-        bergamotPivotModel: {
-          loader: createLocalLoader(enEsDir),
-          modelName: enEs.modelFile,
-          diskPath: enEsDir,
-          config: {
-            srcVocabPath: path.join(enEsDir, enEs.vocabFile),
-            dstVocabPath: path.join(enEsDir, enEs.vocabFile),
-            beamsize: 1,
-            normalize: 1
-          }
-        }
-      })
+        pivotNormalize: 1
+      }))
 
       await model.load()
       t.pass(`${label} Pivot model loaded (fr→en→es)`)
@@ -889,28 +539,7 @@ test('Pivot translation - long multi-paragraph text', { timeout: PIVOT_TIMEOUT }
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     await model.load()
 
@@ -963,28 +592,7 @@ test('Pivot translation - numbers and special characters preserved', { timeout: 
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     await model.load()
 
@@ -1028,28 +636,7 @@ test('Pivot translation - batch with single item', { timeout: PIVOT_TIMEOUT }, a
 
   let model
   try {
-    model = new TranslationNmtcpp({
-      loader: createLocalLoader(esEnDir),
-      params: { srcLang: 'es', dstLang: 'it' },
-      diskPath: esEnDir,
-      modelName: esEn.modelFile,
-      logger: createLogger(),
-      opts: { stats: true }
-    }, {
-      modelType: TranslationNmtcpp.ModelTypes.Bergamot,
-      srcVocabPath: path.join(esEnDir, esEn.vocabFile),
-      dstVocabPath: path.join(esEnDir, esEn.vocabFile),
-      beamsize: 1,
-      bergamotPivotModel: {
-        loader: createLocalLoader(enItDir),
-        modelName: enIt.modelFile,
-        diskPath: enItDir,
-        config: {
-          srcVocabPath: path.join(enItDir, enIt.vocabFile),
-          dstVocabPath: path.join(enItDir, enIt.vocabFile)
-        }
-      }
-    })
+    model = new TranslationNmtcpp(createPivotArgs(esEnDir, esEn, enItDir, enIt))
 
     await model.load()
 

--- a/packages/qvac-lib-infer-nmtcpp/test/mobile/integration.auto.cjs
+++ b/packages/qvac-lib-infer-nmtcpp/test/mobile/integration.auto.cjs
@@ -10,3 +10,7 @@ async function runBergamot (options = {}) { // eslint-disable-line no-unused-var
 async function runIndictrans (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/indictrans.test.js', options)
 }
+
+async function runPivotBergamot (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/pivot-bergamot.test.js', options)
+}


### PR DESCRIPTION
 ## What problem does this PR solve?                                         
                                                                                                                                                                                                                                                      
  - Integration tests still used the old constructor pattern (`{ loader, diskPath, modelName }` + second config arg) after the v2.0.0 migration to `{ files, params, config }`                                                                        
  - Pivot tests referenced removed internal methods (`_getPivotFilesToDownload`, `_bergamotPivotModel`)
                                                                                                                                                                                                                                                      
  ## How does it solve it?                                                                                                                                                                                                                            
                                                                           
  - **bergamot.test.js** — removed `localLoader`, constructor uses `{ files, params, config }`                                                                                                                                                        
  - **indictrans.test.js** — removed `localLoader`, `path`, `fs` imports, constructor uses `{ files, params, config }`                                                                                                                                
  - **pivot-bergamot.test.js** — replaced `createLocalLoader` with `createPivotArgs` helper, removed 5 tests for deleted internals (`_getPivotFilesToDownload` x3, `_bergamotPivotModel` diskPath fallback, Opus/IndicTrans pivot ignore), updated all
   10 remaining functional tests                                                                                                                                                                                                                      
  - Net: -506 lines removed, +69 added                                                                                                                                                                                                                
                                                            
  ## How was it tested?                                                                                                                                                                                                                               
                                                                                   
  - `npx standard` lint clean on all 3 integration test files                                                                                                                                                                                         
  - Unit tests (7/7) still pass                                                                                                                                                                                                                       
  - Integration tests require model files (downloaded in CI) — constructor shape verified by lint + structure review
                                                                                                                                                                                                                                                      
  ## Removed tests (tested deleted APIs)                                                                                                                                                                                                              
                                                                                          
  - `_getPivotFilesToDownload - returns model and vocab names`                                                                                                                                                                                        
  - `_getPivotFilesToDownload - returns empty when no pivot`                       
  - `_getPivotFilesToDownload - skips vocabs when paths provided`
  - `Pivot diskPath defaults to primary` (tested `_bergamotPivotModel.diskPath`)                                                                                                                                                                      
  - `Pivot config ignored for non-Bergamot model types` (tested `_bergamotPivotModel === null`)
                                                                                                  