### PR TITLE
chore(error): rename package from @qvac/error-base to @qvac/error

### DIFF
--- a/packages/error/CHANGELOG.md
+++ b/packages/error/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [0.1.2] - 2026-04-09
+
+### Changed
+
+#### Package renamed from `@qvac/error-base` to `@qvac/error`
+
+The package has been renamed from `@qvac/error-base` to `@qvac/error` to better reflect its role as the canonical error library for the QVAC ecosystem. All references in the README (title, install command, and require statements) have been updated accordingly.
+
+## [0.1.1]
+
+Initial tracked release.

--- a/packages/error/README.md
+++ b/packages/error/README.md
@@ -1,11 +1,11 @@
-# @qvac/error-base
+# @qvac/error
 
 This library provides standardized error handling capabilities for all QVAC libraries. It ensures consistency in error reporting, serialization, and handling across the entire QVAC ecosystem.
 
 ## Installation
 
 ```bash
-npm i @qvac/error-base
+npm i @qvac/error
 ```
 
 ## Features
@@ -22,7 +22,7 @@ npm i @qvac/error-base
 ### Basic Usage
 
 ```javascript
-const { QvacErrorBase, addCodes } = require('@qvac/error-base')
+const { QvacErrorBase, addCodes } = require('@qvac/error')
 
 // Create your own error class extending the base
 class QvacErrorCustom extends QvacErrorBase {

--- a/packages/error/package.json
+++ b/packages/error/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/error",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Base error handling library for QVAC",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Rename `@qvac/error-base` to `@qvac/error` across README (title, install command, require statement)
- Bump version from 0.1.1 to 0.1.2
- Add `CHANGELOG.md` following the same format used by other QVAC packages

## Test plan

- [x] Verify `npm i @qvac/error` resolves correctly
- [x] Confirm no remaining references to `@qvac/error-base` in the package

