### PR TITLE
chore(error): trigger npm publish for @qvac/error@0.1.2

### DIFF
--- a/packages/error/README.md
+++ b/packages/error/README.md
@@ -122,3 +122,4 @@ After cloning, run `npm install`. If npm lifecycle scripts are disabled, also ru
 4. Use descriptive error names and clear messages
 5. Avoid relying on error messages for logic (use codes instead)
 6. Consider generating documentation from your error codes
+


### PR DESCRIPTION
## Summary

- Add trailing newline to README to trigger the npm publish workflow
