### PR TITLE
fix[notask]: Install bare runtime for error package in sdk pod checks

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -258,7 +258,7 @@ jobs:
           fi
 
       - name: Install Bare runtime
-        if: matrix.package == 'rag'
+        if: matrix.package == 'rag' || matrix.package == 'error'
         run: npm install -g bare
 
       # All script steps use npm run --if-present (bun lacks --if-present).


### PR DESCRIPTION
## Summary
- Fix CI failure for check (error) job in `pr-checks-sdk-pod` workflow by installing the Bare runtime for the `error` package
- The `@qvac/error` package runs unit tests via `bare test/unit/all.js`, but the workflow only installed Bare for the `rag` package, `causing sh: 1: bare: not found` (exit 127)