### PR TITLE
QVAC-16997 feat[api]: add suspend/resume lifecycle to registry client

### DIFF
--- a/packages/qvac-lib-registry-server/client/index.d.ts
+++ b/packages/qvac-lib-registry-server/client/index.d.ts
@@ -80,11 +80,27 @@ export interface FindByParams {
   includeDeprecated?: boolean
 }
 
+export interface LifecycleSwarmHandle {
+  readonly suspended: boolean
+  suspend (): Promise<void>
+  resume (): Promise<void>
+}
+
+export interface LifecycleStoreHandle {
+  suspend (): Promise<void>
+  resume (): Promise<void>
+}
+
 export class QVACRegistryClient {
   constructor (opts?: QVACRegistryClientOptions)
 
+  readonly corestore: LifecycleStoreHandle | null
+  readonly hyperswarm: LifecycleSwarmHandle | null
+
   ready (): Promise<void>
   close (): Promise<void>
+  suspend (): Promise<void>
+  resume (): Promise<void>
 
   getModel (path: string, source: string): Promise<QVACModelEntry | null>
   downloadModel (path: string, source: string, options?: QVACDownloadOptions): Promise<QVACDownloadResult>

--- a/packages/qvac-lib-registry-server/client/index.d.ts
+++ b/packages/qvac-lib-registry-server/client/index.d.ts
@@ -1,3 +1,9 @@
+import ReadyResource = require('ready-resource')
+
+export interface LifecycleLogOptions {
+  log?: (msg: string) => Promise<void> | void
+}
+
 export interface QVACBlobBinding {
   coreKey: Buffer | string
   blockOffset: number
@@ -82,25 +88,27 @@ export interface FindByParams {
 
 export interface LifecycleSwarmHandle {
   readonly suspended: boolean
-  suspend (): Promise<void>
-  resume (): Promise<void>
+  suspend (opts?: LifecycleLogOptions): Promise<void>
+  resume (opts?: LifecycleLogOptions): Promise<void>
 }
 
 export interface LifecycleStoreHandle {
-  suspend (): Promise<void>
+  suspend (opts?: LifecycleLogOptions): Promise<void>
   resume (): Promise<void>
 }
 
-export class QVACRegistryClient {
+export class QVACRegistryClient extends ReadyResource {
   constructor (opts?: QVACRegistryClientOptions)
 
+  /** Valid only while the client remains open. Cached handles become stale after close(). */
   readonly corestore: LifecycleStoreHandle | null
+  /** Valid only while the client remains open. Cached handles become stale after close(). */
   readonly hyperswarm: LifecycleSwarmHandle | null
 
   ready (): Promise<void>
   close (): Promise<void>
-  suspend (): Promise<void>
-  resume (): Promise<void>
+  suspend (opts?: LifecycleLogOptions): Promise<void>
+  resume (opts?: LifecycleLogOptions): Promise<void>
 
   getModel (path: string, source: string): Promise<QVACModelEntry | null>
   downloadModel (path: string, source: string, options?: QVACDownloadOptions): Promise<QVACDownloadResult>

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -526,27 +526,37 @@ class QVACRegistryClient extends ReadyResource {
     }
   }
 
-  async suspend () {
+  async suspend (opts = {}) {
     this.logger.debug('suspend called')
 
+    if (!this.opened || this.closing) {
+      this.logger.debug('Skipping suspend while client is not open or is closing')
+      return
+    }
+
     if (this.hyperswarm && !this.hyperswarm.suspended) {
-      await this.hyperswarm.suspend()
+      await this.hyperswarm.suspend(opts)
     }
     if (this.corestore) {
-      await this.corestore.suspend()
+      await this.corestore.suspend(opts)
     }
 
     this.logger.debug('QVACRegistryClient suspended')
   }
 
-  async resume () {
+  async resume (opts = {}) {
     this.logger.debug('resume called')
+
+    if (!this.opened || this.closing) {
+      this.logger.debug('Skipping resume while client is not open or is closing')
+      return
+    }
 
     if (this.corestore) {
       await this.corestore.resume()
     }
     if (this.hyperswarm && this.hyperswarm.suspended) {
-      await this.hyperswarm.resume()
+      await this.hyperswarm.resume(opts)
     }
 
     this.logger.debug('QVACRegistryClient resumed')

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -526,6 +526,32 @@ class QVACRegistryClient extends ReadyResource {
     }
   }
 
+  async suspend () {
+    this.logger.debug('suspend called')
+
+    if (this.hyperswarm && !this.hyperswarm.suspended) {
+      await this.hyperswarm.suspend()
+    }
+    if (this.corestore) {
+      await this.corestore.suspend()
+    }
+
+    this.logger.debug('QVACRegistryClient suspended')
+  }
+
+  async resume () {
+    this.logger.debug('resume called')
+
+    if (this.corestore) {
+      await this.corestore.resume()
+    }
+    if (this.hyperswarm && this.hyperswarm.suspended) {
+      await this.hyperswarm.resume()
+    }
+
+    this.logger.debug('QVACRegistryClient resumed')
+  }
+
   async _close () {
     this.logger.debug('_close called')
 

--- a/packages/qvac-lib-registry-server/client/tests/unit/client.api.test.js
+++ b/packages/qvac-lib-registry-server/client/tests/unit/client.api.test.js
@@ -17,6 +17,8 @@ test('client api surface', async t => {
   t.ok(QVACRegistryClient.prototype.findBy, 'has findBy method')
   t.ok(QVACRegistryClient.prototype.ready, 'has ready method')
   t.ok(QVACRegistryClient.prototype.close, 'has close method')
+  t.ok(QVACRegistryClient.prototype.suspend, 'has suspend method')
+  t.ok(QVACRegistryClient.prototype.resume, 'has resume method')
 })
 
 test('client find methods are async functions', async t => {
@@ -27,4 +29,6 @@ test('client find methods are async functions', async t => {
   t.ok(QVACRegistryClient.prototype.findModelsByName.constructor.name === 'AsyncFunction', 'findModelsByName is async')
   t.ok(QVACRegistryClient.prototype.findModelsByQuantization.constructor.name === 'AsyncFunction', 'findModelsByQuantization is async')
   t.ok(QVACRegistryClient.prototype.findBy.constructor.name === 'AsyncFunction', 'findBy is async')
+  t.ok(QVACRegistryClient.prototype.suspend.constructor.name === 'AsyncFunction', 'suspend is async')
+  t.ok(QVACRegistryClient.prototype.resume.constructor.name === 'AsyncFunction', 'resume is async')
 })


### PR DESCRIPTION
## What problem does this PR solve?

`QVACRegistryClient` manages an internal `Hyperswarm` and `Corestore`, but it does not currently expose a lifecycle API for suspending and resuming them.

That makes standalone lifecycle handling awkward and forces orchestrators such as `@qvac/sdk` to rely on internal details when coordinating app background/foreground transitions.

## How does it solve it?

- Adds `suspend()` and `resume()` convenience methods to `QVACRegistryClient`
- Preserves the required ordering:
  - `suspend()`: swarm first, then store
  - `resume()`: store first, then swarm
- Adds idempotency guards so repeated calls are safe
- Exposes `readonly corestore` and `readonly hyperswarm` as narrow lifecycle handles for orchestrators that need to coordinate these resources directly

## New API

```ts
import { QVACRegistryClient } from '@qvac/registry-client'

const client = new QVACRegistryClient({ registryCoreKey: '...' })
await client.ready()

// Standalone use
await client.suspend()
await client.resume()

// Orchestrator use
if (client.hyperswarm) {
  coordinator.registerSwarm(client.hyperswarm)
}

if (client.corestore) {
  coordinator.registerCorestore(client.corestore)
}
```

## How was it tested?
- Updated registry-client unit tests to cover the new lifecycle API
- Verified `suspend()` and `resume()` exist and are async methods
- Verified lifecycle handles are exposed with the expected types
- Confirmed downstream SDK lint, typecheck, and unit tests still pass against this API shape