### PR TITLE
fix: use HTTPS instead of SSH for vcpkg registry URLs

### DIFF
--- a/docs/gitflow.md
+++ b/docs/gitflow.md
@@ -86,7 +86,7 @@ This repo assumes a **fork-first** workflow:
 
 ```bash
 # Fork in GitHub UI, then:
-git clone git@github.com:<you>/<repo>.git
+git clone https://github.com/<you>/<repo>.git
 cd <repo>
 
 git remote add upstream https://github.com/tetherto/<repo>.git

--- a/docs/gitflow.md
+++ b/docs/gitflow.md
@@ -89,7 +89,7 @@ This repo assumes a **fork-first** workflow:
 git clone git@github.com:<you>/<repo>.git
 cd <repo>
 
-git remote add upstream git@github.com:tetherto/<repo>.git
+git remote add upstream https://github.com/tetherto/<repo>.git
 
 # Sync your local main to upstream main
 git fetch upstream

--- a/packages/lib-infer-diffusion/vcpkg-configuration.json
+++ b/packages/lib-infer-diffusion/vcpkg-configuration.json
@@ -5,7 +5,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "a9eae49a7c95a63755c0b44ecf9d74b0a00e181b",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/lib-infer-diffusion/vcpkg-configuration.json
+++ b/packages/lib-infer-diffusion/vcpkg-configuration.json
@@ -4,7 +4,7 @@
   ],
   "default-registry": {
     "kind": "git",
-    "baseline": "a9eae49a7c95a63755c0b44ecf9d74b0a00e181b",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/lib-infer-diffusion/vcpkg-configuration.json
+++ b/packages/lib-infer-diffusion/vcpkg-configuration.json
@@ -4,7 +4,7 @@
   ],
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "a9eae49a7c95a63755c0b44ecf9d74b0a00e181b",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/lib-infer-diffusion/vcpkg.json
+++ b/packages/lib-infer-diffusion/vcpkg.json
@@ -7,11 +7,11 @@
     "picojson",
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.1.5"
+      "version>=": "1.1.5#1"
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.4.4#1"
+      "version>=": "1.4.4#2"
     },
     {
       "name": "stable-diffusion-cpp",

--- a/packages/ocr-onnx/.agent/knowledge/vcpkg-management.md
+++ b/packages/ocr-onnx/.agent/knowledge/vcpkg-management.md
@@ -53,7 +53,7 @@ Every addon package uses two registries configured in `vcpkg-configuration.json`
   "default-registry": {
     "kind": "git",
     "baseline": "<commit-sha>",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   }
 }
 ```
@@ -497,7 +497,7 @@ If ONNX Runtime symbols conflict at runtime:
 
 If `bare-make generate` fails with git authentication errors:
 - Verify `GH_TOKEN` is set and has read access to `tetherto/qvac-registry-vcpkg`
-- For local dev with SSH: verify `git@github.com:tetherto/qvac-registry-vcpkg.git` is accessible
+- For local dev with SSH: verify `https://github.com/tetherto/qvac-registry-vcpkg.git` is accessible
 - In CI: check that the `.npmrc` setup step and git credential configuration ran successfully
 - Set `GIT_TERMINAL_PROMPT=0` to prevent hanging on auth prompts
 

--- a/packages/ocr-onnx/.agent/knowledge/vcpkg-management.md
+++ b/packages/ocr-onnx/.agent/knowledge/vcpkg-management.md
@@ -60,7 +60,7 @@ Every addon package uses two registries configured in `vcpkg-configuration.json`
 
 Hosts QVAC-specific packages: `qvac-fabric`, `qvac-lib-inference-addon-cpp`, `qvac-lint-cpp`, `onnxruntime`, `whisper-cpp`, `tokenizers-cpp`, `bergamot-translator`, `sentencepiece`, `ssplit`, and others.
 
-**Authentication**: Requires `GH_TOKEN` (GitHub PAT) with read access to `tetherto/qvac-registry-vcpkg`. In CI, git credentials are configured automatically. Locally, SSH key access to the repo is needed (note the `git@github.com:` URL).
+**Authentication**: Requires `GH_TOKEN` (GitHub PAT) with read access to `tetherto/qvac-registry-vcpkg`. In CI, git credentials are configured automatically. Locally, HTTPS access works with token-based auth or credential helpers.
 
 ### 2. Microsoft Upstream Registry
 

--- a/packages/ocr-onnx/BUILD.md
+++ b/packages/ocr-onnx/BUILD.md
@@ -38,7 +38,7 @@ npm install -g bare bare-make
 
 Clone the repository, install dependencies, and build.
 ```
-git clone git@github.com:tetherto/qvac-lib-inference-addon-onnx-ocr-fasttext.git
+git clone https://github.com/tetherto/qvac-lib-inference-addon-onnx-ocr-fasttext.git
 cd qvac-lib-inference-addon-onnx-ocr-fasttext
 npm install
 bare-make generate && bare-make build && bare-make install

--- a/packages/ocr-onnx/README.md
+++ b/packages/ocr-onnx/README.md
@@ -88,7 +88,7 @@ Before building, ensure you have the following installed:
 
 1. **Clone the repository**:
    ```bash
-   git clone git@github.com:tetherto/qvac-lib-inference-addon-onnx-ocr-fasttext.git
+   git clone https://github.com/tetherto/qvac-lib-inference-addon-onnx-ocr-fasttext.git
    cd qvac-lib-inference-addon-onnx-ocr-fasttext
    ```
 

--- a/packages/ocr-onnx/ci/integration-test.sh
+++ b/packages/ocr-onnx/ci/integration-test.sh
@@ -31,7 +31,7 @@ export VCPKG_ROOT="$PWD"
 cd ..
 
 # Setup OCR addon
-git clone git@github.com:tetherto/qvac-lib-inference-addon-onnx-ocr-fasttext.git
+git clone https://github.com/tetherto/qvac-lib-inference-addon-onnx-ocr-fasttext.git
 cd qvac-lib-inference-addon-onnx-ocr-fasttext/
 npm install -g bare bare-make
 npm install

--- a/packages/ocr-onnx/vcpkg-configuration.json
+++ b/packages/ocr-onnx/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "9503ea89fa282691596d0ab9cf74a6c5a178f5ae",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/ocr-onnx/vcpkg-configuration.json
+++ b/packages/ocr-onnx/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "9503ea89fa282691596d0ab9cf74a6c5a178f5ae",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/ocr-onnx/vcpkg-configuration.json
+++ b/packages/ocr-onnx/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "9503ea89fa282691596d0ab9cf74a6c5a178f5ae",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/ocr-onnx/vcpkg.json
+++ b/packages/ocr-onnx/vcpkg.json
@@ -15,11 +15,11 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.1.5"
+      "version>=": "1.1.5#1"
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.4.4"
+      "version>=": "1.4.4#2"
     }
   ],
   "features": {

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg-configuration.json
@@ -5,7 +5,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg-configuration.json
@@ -4,7 +4,7 @@
   ],
   "default-registry": {
     "kind": "git",
-    "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg-configuration.json
@@ -4,7 +4,7 @@
   ],
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/vcpkg.json
@@ -10,11 +10,11 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.1.5"
+      "version>=": "1.1.5#1"
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.4.4"
+      "version>=": "1.4.4#2"
     }
   ],
   "features": {

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
@@ -11,11 +11,11 @@
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.1.5"
+      "version>=": "1.1.5#1"
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.4.4"
+      "version>=": "1.4.4#2"
     }
   ],
   "features": {

--- a/packages/qvac-lib-infer-nmtcpp/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-nmtcpp/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "c5955445a221df255d2204be964647c08c82c28f",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/qvac-lib-infer-nmtcpp/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-nmtcpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "c5955445a221df255d2204be964647c08c82c28f",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-nmtcpp/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-nmtcpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "c5955445a221df255d2204be964647c08c82c28f",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-nmtcpp/vcpkg.json
+++ b/packages/qvac-lib-infer-nmtcpp/vcpkg.json
@@ -3,11 +3,11 @@
     "bergamot-translator",
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.1.5"
+      "version>=": "1.1.5#1"
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.4.4"
+      "version>=": "1.4.4#2"
     },
     "sentencepiece",
     "ssplit",

--- a/packages/qvac-lib-infer-onnx-tts/README.md
+++ b/packages/qvac-lib-infer-onnx-tts/README.md
@@ -128,7 +128,7 @@ Before building, ensure you have the following installed:
 
 1. **Clone the repository**:
    ```bash
-   git clone git@github.com:tetherto/qvac-lib-infer-onnx-tts.git
+   git clone https://github.com/tetherto/qvac-lib-infer-onnx-tts.git
    cd qvac-lib-infer-onnx-tts
    ```
 

--- a/packages/qvac-lib-infer-onnx-tts/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-onnx-tts/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "4e4c52f549cb5912f66d202f360282cdcf992047",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/qvac-lib-infer-onnx-tts/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-onnx-tts/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "4e4c52f549cb5912f66d202f360282cdcf992047",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-onnx-tts/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-onnx-tts/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "4e4c52f549cb5912f66d202f360282cdcf992047",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-onnx-tts/vcpkg.json
+++ b/packages/qvac-lib-infer-onnx-tts/vcpkg.json
@@ -5,11 +5,11 @@
     "fmt",
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.1.5"
+      "version>=": "1.1.5#1"
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.3.0"
+      "version>=": "1.4.4#2"
     },
     "spdlog",
     {

--- a/packages/qvac-lib-infer-onnx/INTEGRATION.md
+++ b/packages/qvac-lib-infer-onnx/INTEGRATION.md
@@ -87,7 +87,7 @@ Ensure the consumer's `vcpkg-configuration.json` includes the Tether registry as
   "default-registry": {
     "kind": "git",
     "baseline": "<current-baseline>",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/qvac-lib-infer-onnx/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-onnx/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "0318b1c531f630be579f971400379cd73bc5f01e",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/qvac-lib-infer-onnx/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-onnx/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "0318b1c531f630be579f971400379cd73bc5f01e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-onnx/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-onnx/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "0318b1c531f630be579f971400379cd73bc5f01e",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-onnx/vcpkg.json
+++ b/packages/qvac-lib-infer-onnx/vcpkg.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.4.1"
+      "version>=": "1.4.4#2"
     }
   ],
   "overrides": [

--- a/packages/qvac-lib-infer-parakeet/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-parakeet/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "cd26df3b3f4d3ba46efacdf8625f2a8fb5b4420b",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/qvac-lib-infer-parakeet/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-parakeet/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "cd26df3b3f4d3ba46efacdf8625f2a8fb5b4420b",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-parakeet/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-parakeet/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "cd26df3b3f4d3ba46efacdf8625f2a8fb5b4420b",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-parakeet/vcpkg.json
+++ b/packages/qvac-lib-infer-parakeet/vcpkg.json
@@ -5,7 +5,7 @@
     "eigen3",
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.1.5"
+      "version>=": "1.1.5#1"
     },
     "nlohmann-json",
     {

--- a/packages/qvac-lib-infer-whispercpp/README.md
+++ b/packages/qvac-lib-infer-whispercpp/README.md
@@ -479,7 +479,7 @@ try {
 
 ### 1. Clone the repo & Install the dependencies
 ```bash
-git clone git@github.com:tetherto/qvac-lib-infer-whispercpp.git
+git clone https://github.com/tetherto/qvac-lib-infer-whispercpp.git
 cd qvac-lib-infer-whispercpp
 npm install
 ```

--- a/packages/qvac-lib-infer-whispercpp/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-whispercpp/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "c85a41c9417ade8f307091ad7fc0f3d31cca477e",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/qvac-lib-infer-whispercpp/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-whispercpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "c85a41c9417ade8f307091ad7fc0f3d31cca477e",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-whispercpp/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-whispercpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "c85a41c9417ade8f307091ad7fc0f3d31cca477e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-infer-whispercpp/vcpkg.json
+++ b/packages/qvac-lib-infer-whispercpp/vcpkg.json
@@ -2,11 +2,11 @@
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.1.5"
+      "version>=": "1.1.5#1"
     },
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.4.1"
+      "version>=": "1.4.4#2"
     },
     "whisper-cpp",
     "gtest"

--- a/packages/qvac-lib-inference-addon-cpp/tests/logger/vcpkg-configuration.json
+++ b/packages/qvac-lib-inference-addon-cpp/tests/logger/vcpkg-configuration.json
@@ -2,7 +2,7 @@
     "default-registry": {
       "kind": "git",
       "baseline": "a1fda84c2f1f6c1efdeaed98ac99e3778445f67a",
-      "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+      "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
     },
     "registries": [
       {

--- a/packages/qvac-lib-inference-addon-cpp/tests/logger/vcpkg-configuration.json
+++ b/packages/qvac-lib-inference-addon-cpp/tests/logger/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
     "default-registry": {
       "kind": "git",
-      "baseline": "a1fda84c2f1f6c1efdeaed98ac99e3778445f67a",
+      "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
       "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
     },
     "registries": [

--- a/packages/qvac-lib-inference-addon-cpp/tests/logger/vcpkg-configuration.json
+++ b/packages/qvac-lib-inference-addon-cpp/tests/logger/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
     "default-registry": {
       "kind": "git",
-      "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+      "baseline": "a1fda84c2f1f6c1efdeaed98ac99e3778445f67a",
       "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
     },
     "registries": [

--- a/packages/qvac-lib-inference-addon-cpp/tests/logger/vcpkg.json
+++ b/packages/qvac-lib-inference-addon-cpp/tests/logger/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "test-logger",
   "version": "0.1.0",
   "dependencies": [
-     { "name": "qvac-lint-cpp", "version>=": "1.3.0" }
+     { "name": "qvac-lint-cpp", "version>=": "1.4.4#2" }
   ],
   "overrides": []
 }

--- a/packages/qvac-lib-inference-addon-cpp/vcpkg-configuration.json
+++ b/packages/qvac-lib-inference-addon-cpp/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "default-registry": {
     "kind": "git",
     "baseline": "a1fda84c2f1f6c1efdeaed98ac99e3778445f67a",
-    "repository": "git@github.com:tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/qvac-lib-inference-addon-cpp/vcpkg-configuration.json
+++ b/packages/qvac-lib-inference-addon-cpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
+    "baseline": "a1fda84c2f1f6c1efdeaed98ac99e3778445f67a",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-inference-addon-cpp/vcpkg-configuration.json
+++ b/packages/qvac-lib-inference-addon-cpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "a1fda84c2f1f6c1efdeaed98ac99e3778445f67a",
+    "baseline": "e357bb6656700234bc5c6586cbfe70f0d5dc3c8e",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -4,7 +4,7 @@
   "dependencies": [
     {
       "name": "qvac-lint-cpp",
-      "version>=": "1.4.1"
+      "version>=": "1.4.4#2"
     },
     {
       "name": "vcpkg-cmake",

--- a/packages/qvac-lint-cpp/README.md
+++ b/packages/qvac-lint-cpp/README.md
@@ -13,7 +13,7 @@ follows.
 
 ```cmake
 # vcpkg/ports/qvac-lint-cpp/portfile.cmake
-set(QVAC_LINT_CPP "git@github.com:tetherto/qvac-lint-cpp.git")
+set(QVAC_LINT_CPP "https://github.com/tetherto/qvac-lint-cpp.git")
 
 find_package(Git REQUIRED)
 execute_process(


### PR DESCRIPTION
## Summary

- Replaces all `git@github.com:tetherto/qvac-registry-vcpkg.git` SSH URLs with `https://github.com/tetherto/qvac-registry-vcpkg.git` across all addon packages
- SSH URLs require SSH key configuration which fails silently in vcpkg, causing packages to report as "not found" rather than showing an auth error
- HTTPS URLs work universally with token-based auth (`GH_TOKEN`) and don't require SSH key setup

## Changed files (13)

**vcpkg-configuration.json** (10 packages):
- `lib-infer-diffusion`
- `ocr-onnx`
- `qvac-lib-infer-llamacpp-embed`
- `qvac-lib-infer-llamacpp-llm`
- `qvac-lib-infer-nmtcpp`
- `qvac-lib-infer-onnx`
- `qvac-lib-infer-onnx-tts`
- `qvac-lib-infer-parakeet`
- `qvac-lib-infer-whispercpp`
- `qvac-lib-inference-addon-cpp` (+ `tests/logger/`)

**Documentation** (2 files):
- `ocr-onnx/.agent/knowledge/vcpkg-management.md`
- `qvac-lib-infer-onnx/INTEGRATION.md`

## Test plan

- [x] Verified `npm run build` succeeds with HTTPS URL in `qvac-lib-infer-llamacpp-llm`
- [ ] CI should validate that all packages can resolve dependencies from the registry via HTTPS
