### PR TITLE
QVAC-17007 fix: pivot translation hang — stats key detection mismatch

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/index.js
+++ b/packages/qvac-lib-infer-nmtcpp/index.js
@@ -373,11 +373,7 @@ class TranslationNmtcpp {
 
   _addonOutputCallback (addon, event, data, error) {
     const isStatsObject = typeof data === 'object' && data !== null && !Array.isArray(data) &&
-                         (('TPS' in data) ||
-                          ('BERGAMOT : ->TPS' in data) ||
-                          ('firstModel_TPS' in data) ||
-                          ('totalTime' in data) ||
-                          ('decodeTime' in data))
+                         Object.keys(data).some(k => k.endsWith('TPS'))
 
     if (isStatsObject) {
       return this._job.end(this.opts?.stats ? data : null)


### PR DESCRIPTION
## Summary

- Fix pivot translation (e.g. ES → IT via EN) hanging indefinitely after C++ translation completes
- Root cause: `PivotTranslationModel::runtimeStats()` prefixes every stats key with the model name (e.g. `"BERGAMOT : es->enTPS"`), but `_addonOutputCallback` checked for exact key names to detect job completion — none matched, so `JobEnded` never fired and `.await()` hung until timeout

## Why the previous patterns failed

The old code checked for five hardcoded keys:

| Pattern | When it works | When it fails |
|---------|--------------|---------------|
| `'TPS' in data` | Non-pivot (single model) | Pivot — key is prefixed |
| `'BERGAMOT : ->TPS' in data` | Pivot with empty lang codes | Pivot with lang codes set (e.g. iOS): key is `"BERGAMOT : es->enTPS"` |
| `'firstModel_TPS' in data` | Never — doesn't exist in C++ | Always |
| `'totalTime' in data` | Non-pivot | Pivot — key is `"BERGAMOT : ->totalTime"` |
| `'decodeTime' in data` | Non-pivot | Pivot — key is `"BERGAMOT : ->decodeTime"` |

## Fix

Replace all hardcoded checks with:
```js
Object.keys(data).some(k => k.endsWith('TPS'))
```

This matches every key format the C++ addon has ever emitted: `TPS`, `BergamotTPS`, `BERGAMOT : ->TPS`, `BERGAMOT : es->enTPS`.

## Test plan

- [x] Verified fix locally against `@qvac/translation-nmtcpp@0.6.8` prebuilds — all 17 pivot tests pass (previously hung indefinitely)
- [ ] CI integration tests (desktop)
- [ ] Mobile integration tests (iOS/Android)

Also released as patch `0.6.9` on branch `release-nmtcpp-0.6.9`.