### PR TITLE
QVAC-12232 fix: handle unhandled worker process termination in Bare runtime

### DIFF
--- a/packages/qvac-lib-registry-server/client/index.d.ts
+++ b/packages/qvac-lib-registry-server/client/index.d.ts
@@ -66,6 +66,7 @@ export interface QVACRegistryClientOptions {
   storage?: string
   registryCoreKey?: string
   logger?: any
+  corestoreOpts?: { wait?: boolean }
 }
 
 export interface QVACModelQuery {

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -24,14 +24,13 @@ class QVACRegistryClient extends ReadyResource {
     this.registryConfig = new RegistryConfig({ logger: this.logger })
 
     this.db = null
-    this.corestore = null
     this.hyperswarm = null
     this._connectionHandler = null
     this._metadataReady = null
 
     this.storage = this.registryConfig.getRegistryStorage(opts.storage)
     this.registryCoreKey = this.registryConfig.getRegistryCoreKey(opts.registryCoreKey)
-    this._corestoreOpts = opts.corestoreOpts || {}
+    this.corestore = new Corestore(this.storage, opts.corestoreOpts || {})
 
     this.logger.debug('Initializing QVAC Registry Client', {
       mode: 'read',
@@ -44,8 +43,7 @@ class QVACRegistryClient extends ReadyResource {
   async _open () {
     this.logger.debug('_open called')
 
-    this.logger.debug('Creating corestore for open')
-    this.corestore = new Corestore(this.storage, this._corestoreOpts)
+    this.logger.debug('Opening corestore')
     await this.corestore.ready()
 
     this.logger.debug('Creating Hyperswarm for open')

--- a/packages/qvac-lib-registry-server/client/lib/client.js
+++ b/packages/qvac-lib-registry-server/client/lib/client.js
@@ -31,6 +31,7 @@ class QVACRegistryClient extends ReadyResource {
 
     this.storage = this.registryConfig.getRegistryStorage(opts.storage)
     this.registryCoreKey = this.registryConfig.getRegistryCoreKey(opts.registryCoreKey)
+    this._corestoreOpts = opts.corestoreOpts || {}
 
     this.logger.debug('Initializing QVAC Registry Client', {
       mode: 'read',
@@ -44,7 +45,7 @@ class QVACRegistryClient extends ReadyResource {
     this.logger.debug('_open called')
 
     this.logger.debug('Creating corestore for open')
-    this.corestore = new Corestore(this.storage)
+    this.corestore = new Corestore(this.storage, this._corestoreOpts)
     await this.corestore.ready()
 
     this.logger.debug('Creating Hyperswarm for open')

--- a/packages/sdk/server/bare/registry/config-registry.ts
+++ b/packages/sdk/server/bare/registry/config-registry.ts
@@ -1,6 +1,6 @@
 import fs from "bare-fs";
 import path from "bare-path";
-import { getEnv } from "@/server/env";
+import { getQvacPath } from "@/server/utils/qvac-paths";
 import {
   CacheDirNotAbsoluteError,
   CacheDirNotWritableError,
@@ -125,8 +125,7 @@ export function getSDKConfig(): QvacConfig {
 }
 
 function getDefaultCacheDir() {
-  const homeDir = getEnv().HOME_DIR;
-  return path.join(homeDir, ".qvac", "models");
+  return getQvacPath("models");
 }
 
 export function getConfiguredCacheDir(): string {

--- a/packages/sdk/server/bare/registry/model-registry.ts
+++ b/packages/sdk/server/bare/registry/model-registry.ts
@@ -213,21 +213,19 @@ export async function unloadAllModels(): Promise<void> {
 
   for (const modelId of modelIds) {
     const entry = modelRegistry.get(modelId);
-    if (entry?.local) {
-      try {
-        if (entry.local.loader) {
-          await entry.local.loader.close();
-        }
-        if (entry.local.model && entry.local.model.unload) {
-          await entry.local.model.unload();
-        }
-        logger.debug(`Model unloaded: ${modelId}`);
-      } catch (error) {
-        logger.error(
-          `Error unloading model ${modelId}:`,
-          error instanceof Error ? error.message : String(error),
-        );
+    try {
+      if (entry?.local?.loader) {
+        await entry.local.loader.close();
       }
+      if (entry?.local?.model?.unload) {
+        await entry.local.model.unload();
+      }
+      if (entry?.local) logger.debug(`Model unloaded: ${modelId}`);
+    } catch (error) {
+      logger.error(
+        `Error unloading model ${modelId}:`,
+        error instanceof Error ? error.message : String(error),
+      );
     }
     modelRegistry.delete(modelId);
   }

--- a/packages/sdk/server/bare/registry/model-registry.ts
+++ b/packages/sdk/server/bare/registry/model-registry.ts
@@ -58,7 +58,12 @@ export function registerModel(
         loader?: FilesystemDL;
         name?: string | undefined;
       }
-    | { topic: string; providerPublicKey: string; timeout?: number; healthCheckTimeout?: number },
+    | {
+        topic: string;
+        providerPublicKey: string;
+        timeout?: number;
+        healthCheckTimeout?: number;
+      },
 ): void {
   if (modelRegistry.has(id)) {
     throw new ModelAlreadyRegisteredError(id);
@@ -208,9 +213,21 @@ export async function unloadAllModels(): Promise<void> {
 
   for (const modelId of modelIds) {
     const entry = modelRegistry.get(modelId);
-    if (entry?.local?.model && entry.local.model.unload) {
-      await entry.local.model.unload();
-      logger.debug(`Model unloaded: ${modelId}`);
+    if (entry?.local) {
+      try {
+        if (entry.local.loader) {
+          await entry.local.loader.close();
+        }
+        if (entry.local.model && entry.local.model.unload) {
+          await entry.local.model.unload();
+        }
+        logger.debug(`Model unloaded: ${modelId}`);
+      } catch (error) {
+        logger.error(
+          `Error unloading model ${modelId}:`,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
     }
     modelRegistry.delete(modelId);
   }

--- a/packages/sdk/server/bare/registry/registry-client.ts
+++ b/packages/sdk/server/bare/registry/registry-client.ts
@@ -15,6 +15,7 @@ const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 500;
 
 let registryClient: QVACRegistryClient | null = null;
+let inflightInit: Promise<QVACRegistryClient> | null = null;
 
 function isFdLockError(error: unknown): boolean {
   if (error instanceof Error) {
@@ -27,14 +28,7 @@ async function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function getRegistryClient(): Promise<QVACRegistryClient> {
-  if (registryClient) {
-    logger.debug("Registry client reused");
-    return registryClient;
-  }
-
-  logger.info("🔗 Creating new registry client...");
-
+async function initRegistryClient(): Promise<QVACRegistryClient> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
@@ -63,7 +57,7 @@ export async function getRegistryClient(): Promise<QVACRegistryClient> {
       }
 
       logger.info("✅ Registry client ready");
-      return registryClient;
+      return client;
     } catch (error) {
       lastError = error;
       if (isFdLockError(error) && attempt < MAX_RETRIES) {
@@ -79,6 +73,26 @@ export async function getRegistryClient(): Promise<QVACRegistryClient> {
   }
 
   throw lastError;
+}
+
+export async function getRegistryClient(): Promise<QVACRegistryClient> {
+  if (registryClient) {
+    logger.debug("Registry client reused");
+    return registryClient;
+  }
+
+  if (inflightInit) {
+    logger.debug("Registry client init already in progress, waiting...");
+    return inflightInit;
+  }
+
+  logger.info("🔗 Creating new registry client...");
+
+  inflightInit = initRegistryClient().finally(() => {
+    inflightInit = null;
+  });
+
+  return inflightInit;
 }
 
 export async function closeRegistryClient(): Promise<void> {

--- a/packages/sdk/server/bare/registry/registry-client.ts
+++ b/packages/sdk/server/bare/registry/registry-client.ts
@@ -11,7 +11,21 @@ import { DEFAULT_REGISTRY_CORE_KEY } from "@/constants";
 
 const logger = getServerLogger();
 
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 500;
+
 let registryClient: QVACRegistryClient | null = null;
+
+function isFdLockError(error: unknown): boolean {
+  if (error instanceof Error) {
+    return error.message.includes("File descriptor could not be locked");
+  }
+  return false;
+}
+
+async function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export async function getRegistryClient(): Promise<QVACRegistryClient> {
   if (registryClient) {
@@ -21,29 +35,50 @@ export async function getRegistryClient(): Promise<QVACRegistryClient> {
 
   logger.info("🔗 Creating new registry client...");
 
-  registryClient = new QVACRegistryClient({
-    registryCoreKey: DEFAULT_REGISTRY_CORE_KEY,
-    storage: getCacheDir(`registry-corestore/${DEFAULT_REGISTRY_CORE_KEY}`),
-  });
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      // TODO(QVAC-12232): pass corestoreOpts: { wait: true } once @qvac/registry-client is bumped
+      const client = new QVACRegistryClient({
+        registryCoreKey: DEFAULT_REGISTRY_CORE_KEY,
+        storage: getCacheDir(
+          `registry-corestore/${DEFAULT_REGISTRY_CORE_KEY}`,
+        ),
+      });
 
-  await registryClient.ready();
+      await client.ready();
+      registryClient = client;
 
-  if (registryClient.corestore) {
-    registerCorestore(registryClient.corestore, {
-      label: "registry-client",
-      createdAt: Date.now(),
-    });
+      if (registryClient.corestore) {
+        registerCorestore(registryClient.corestore, {
+          label: "registry-client",
+          createdAt: Date.now(),
+        });
+      }
+      if (registryClient.hyperswarm) {
+        registerSwarm(registryClient.hyperswarm, {
+          label: "registry-client",
+          createdAt: Date.now(),
+        });
+      }
+
+      logger.info("✅ Registry client ready");
+      return registryClient;
+    } catch (error) {
+      lastError = error;
+      if (isFdLockError(error) && attempt < MAX_RETRIES) {
+        const backoff = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        logger.warn(
+          `Registry client fd-lock failed (attempt ${attempt}/${MAX_RETRIES}), retrying in ${backoff}ms...`,
+        );
+        await delay(backoff);
+        continue;
+      }
+      throw error;
+    }
   }
-  if (registryClient.hyperswarm) {
-    registerSwarm(registryClient.hyperswarm, {
-      label: "registry-client",
-      createdAt: Date.now(),
-    });
-  }
 
-  logger.info("✅ Registry client ready");
-
-  return registryClient;
+  throw lastError;
 }
 
 export async function closeRegistryClient(): Promise<void> {

--- a/packages/sdk/server/rpc/create-server.ts
+++ b/packages/sdk/server/rpc/create-server.ts
@@ -12,7 +12,14 @@ export function createBareKitRPCServer() {
   return new RPC(IPC, handleRequest);
 }
 
-export function createIPCClient(socketPath: string) {
+export interface IPCClientOptions {
+  onDisconnect?: () => void;
+}
+
+export function createIPCClient(
+  socketPath: string,
+  options?: IPCClientOptions,
+) {
   logger.info(`Connecting to IPC socket at ${socketPath}`);
   const socket = connect(socketPath);
 
@@ -22,6 +29,11 @@ export function createIPCClient(socketPath: string) {
 
   socket.on("error", (err: Error) => {
     logger.error("IPC client connection error:", err);
+  });
+
+  socket.on("close", () => {
+    logger.warn("IPC socket closed — parent process likely terminated");
+    options?.onDisconnect?.();
   });
 
   return new RPC(socket as unknown as Duplex<DuplexEvents>, handleRequest);

--- a/packages/sdk/server/rpc/handlers/load-model/hyperdrive.ts
+++ b/packages/sdk/server/rpc/handlers/load-model/hyperdrive.ts
@@ -11,7 +11,7 @@ import Hyperdrive from "hyperdrive";
 import type { Entry } from "hyperdrive";
 import { type Readable, type Writable } from "bare-stream";
 import { AbortController, type AbortSignal } from "bare-abort-controller";
-import { getEnv } from "@/server/env";
+import { getQvacPath } from "@/server/utils/qvac-paths";
 import {
   getModelsCacheDir,
   generateShortHash,
@@ -72,7 +72,7 @@ interface ProgressContext {
 }
 
 function getCorestoreDir(hyperdriveKey: string): string {
-  return path.join(getEnv().HOME_DIR, ".qvac", "corestore", hyperdriveKey);
+  return getQvacPath("corestore", hyperdriveKey);
 }
 
 async function setupHyperdrive(

--- a/packages/sdk/server/utils/cache.ts
+++ b/packages/sdk/server/utils/cache.ts
@@ -1,7 +1,7 @@
 import fs, { promises as fsPromises } from "bare-fs";
 import path from "bare-path";
-import { getEnv } from "@/server/env";
 import { getConfiguredCacheDir } from "@/server/bare/registry/config-registry";
+import { getQvacPath } from "@/server/utils/qvac-paths";
 import type { ShardFileMetadata } from "@/schemas";
 import { calculateFileChecksum } from "@/server/utils/checksum";
 import { validateAndJoinPath } from "@/server/utils/path-security";
@@ -11,8 +11,7 @@ import { nowMs } from "@/profiling";
 const logger = getServerLogger();
 
 export function getCacheDir(subDir: string): string {
-  const homeDir = getEnv().HOME_DIR;
-  const cacheDir = path.join(homeDir, ".qvac", subDir);
+  const cacheDir = getQvacPath(subDir);
   try {
     fs.mkdirSync(cacheDir, { recursive: true });
   } catch (error) {

--- a/packages/sdk/server/utils/qvac-paths.ts
+++ b/packages/sdk/server/utils/qvac-paths.ts
@@ -1,0 +1,6 @@
+import path from "bare-path";
+import { getEnv } from "@/server/env";
+
+export function getQvacPath(...subPaths: string[]): string {
+  return path.join(getEnv().HOME_DIR, ".qvac", ...subPaths);
+}

--- a/packages/sdk/server/utils/worker-lock.ts
+++ b/packages/sdk/server/utils/worker-lock.ts
@@ -81,10 +81,3 @@ export function releaseWorkerLock(homeDir: string): void {
     // Best-effort — may already be gone
   }
 }
-
-export function isStaleWorkerLock(homeDir: string): boolean {
-  const lockPath = getLockFilePath(homeDir);
-  const existing = readLockFile(lockPath);
-  if (!existing) return false;
-  return !isProcessAlive(existing.pid);
-}

--- a/packages/sdk/server/utils/worker-lock.ts
+++ b/packages/sdk/server/utils/worker-lock.ts
@@ -2,6 +2,7 @@ import fs from "bare-fs";
 import path from "bare-path";
 import process from "bare-process";
 import { getServerLogger } from "@/logging";
+import { getEnv } from "@/server/env";
 
 const logger = getServerLogger();
 
@@ -12,8 +13,8 @@ interface LockFileContent {
   startedAt: string;
 }
 
-function getLockFilePath(homeDir: string): string {
-  return path.join(homeDir, ".qvac", LOCK_FILENAME);
+function getLockFilePath(): string {
+  return path.join(getEnv().HOME_DIR, ".qvac", LOCK_FILENAME);
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -35,8 +36,8 @@ function readLockFile(lockPath: string): LockFileContent | null {
   }
 }
 
-export function acquireWorkerLock(homeDir: string): void {
-  const lockPath = getLockFilePath(homeDir);
+export function acquireWorkerLock(): void {
+  const lockPath = getLockFilePath();
   const existing = readLockFile(lockPath);
 
   if (existing) {
@@ -68,8 +69,8 @@ export function acquireWorkerLock(homeDir: string): void {
   }
 }
 
-export function releaseWorkerLock(homeDir: string): void {
-  const lockPath = getLockFilePath(homeDir);
+export function releaseWorkerLock(): void {
+  const lockPath = getLockFilePath();
 
   try {
     const existing = readLockFile(lockPath);

--- a/packages/sdk/server/utils/worker-lock.ts
+++ b/packages/sdk/server/utils/worker-lock.ts
@@ -1,0 +1,90 @@
+import fs from "bare-fs";
+import path from "bare-path";
+import process from "bare-process";
+import { getServerLogger } from "@/logging";
+
+const logger = getServerLogger();
+
+const LOCK_FILENAME = ".worker.lock";
+
+interface LockFileContent {
+  pid: number;
+  startedAt: string;
+}
+
+function getLockFilePath(homeDir: string): string {
+  return path.join(homeDir, ".qvac", LOCK_FILENAME);
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readLockFile(lockPath: string): LockFileContent | null {
+  try {
+    if (!fs.existsSync(lockPath)) return null;
+    const raw = fs.readFileSync(lockPath, "utf-8") as string;
+    return JSON.parse(raw) as LockFileContent;
+  } catch {
+    return null;
+  }
+}
+
+export function acquireWorkerLock(homeDir: string): void {
+  const lockPath = getLockFilePath(homeDir);
+  const existing = readLockFile(lockPath);
+
+  if (existing) {
+    if (isProcessAlive(existing.pid)) {
+      logger.warn(
+        `Another worker (PID ${existing.pid}) is still running — lock file exists at ${lockPath}`,
+      );
+    } else {
+      logger.warn(
+        `Stale lock file detected (PID ${existing.pid} is dead, started ${existing.startedAt}). Removing.`,
+      );
+    }
+  }
+
+  const content: LockFileContent = {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+  };
+
+  try {
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, JSON.stringify(content));
+    logger.debug(`Worker lock acquired (PID ${process.pid})`);
+  } catch (error) {
+    logger.error(
+      "Failed to write worker lock file:",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+export function releaseWorkerLock(homeDir: string): void {
+  const lockPath = getLockFilePath(homeDir);
+
+  try {
+    const existing = readLockFile(lockPath);
+    if (existing && existing.pid === process.pid) {
+      fs.unlinkSync(lockPath);
+      logger.debug("Worker lock released");
+    }
+  } catch {
+    // Best-effort — may already be gone
+  }
+}
+
+export function isStaleWorkerLock(homeDir: string): boolean {
+  const lockPath = getLockFilePath(homeDir);
+  const existing = readLockFile(lockPath);
+  if (!existing) return false;
+  return !isProcessAlive(existing.pid);
+}

--- a/packages/sdk/server/utils/worker-lock.ts
+++ b/packages/sdk/server/utils/worker-lock.ts
@@ -2,7 +2,7 @@ import fs from "bare-fs";
 import path from "bare-path";
 import process from "bare-process";
 import { getServerLogger } from "@/logging";
-import { getEnv } from "@/server/env";
+import { getQvacPath } from "@/server/utils/qvac-paths";
 
 const logger = getServerLogger();
 
@@ -14,7 +14,7 @@ interface LockFileContent {
 }
 
 function getLockFilePath(): string {
-  return path.join(getEnv().HOME_DIR, ".qvac", LOCK_FILENAME);
+  return getQvacPath(LOCK_FILENAME);
 }
 
 function isProcessAlive(pid: number): boolean {

--- a/packages/sdk/server/worker-core.ts
+++ b/packages/sdk/server/worker-core.ts
@@ -4,7 +4,7 @@ import {
   createIPCClient,
 } from "@/server/rpc/create-server";
 import { destroySwarm } from "@/server/bare/hyperswarm";
-import { initEnv, getEnv, getValidatedEnv } from "@/server/env";
+import { initEnv, getValidatedEnv } from "@/server/env";
 import { closeAllRagInstances } from "@/server/bare/rag-hyperdb";
 import { cleanupDownloads } from "@/server/rpc/handlers/load-model/download-manager";
 import { unloadAllModels } from "@/server/bare/registry/model-registry";
@@ -36,7 +36,7 @@ export function initializeWorkerCore(): { hasRPCConfig: boolean } {
 
   const { hasRPCConfig } = initEnv();
 
-  acquireWorkerLock(getEnv().HOME_DIR);
+  acquireWorkerLock();
   setupShutdownHandlers();
 
   coreInitialized = true;
@@ -125,7 +125,7 @@ export async function shutdownBareDirectWorker(
     logger.error("❌ Error during shutdown cleanup:", error);
   }
 
-  releaseWorkerLock(getEnv().HOME_DIR);
+  releaseWorkerLock();
 
   const isGraceful = reason === "signal" || reason === "rpc-close";
   process.exit(isGraceful ? 0 : 1);

--- a/packages/sdk/server/worker-core.ts
+++ b/packages/sdk/server/worker-core.ts
@@ -4,7 +4,7 @@ import {
   createIPCClient,
 } from "@/server/rpc/create-server";
 import { destroySwarm } from "@/server/bare/hyperswarm";
-import { initEnv, getValidatedEnv } from "@/server/env";
+import { initEnv, getEnv, getValidatedEnv } from "@/server/env";
 import { closeAllRagInstances } from "@/server/bare/rag-hyperdb";
 import { cleanupDownloads } from "@/server/rpc/handlers/load-model/download-manager";
 import { unloadAllModels } from "@/server/bare/registry/model-registry";
@@ -15,6 +15,10 @@ import {
 } from "@/server/bare/registry/logging-stream-registry";
 import { clearAllAddonLoggers, getServerLogger, SDK_LOG_ID } from "@/logging";
 import { clearPlugins } from "@/server/plugins";
+import {
+  acquireWorkerLock,
+  releaseWorkerLock,
+} from "@/server/utils/worker-lock";
 
 let coreInitialized = false;
 let rpcInitialized = false;
@@ -32,6 +36,7 @@ export function initializeWorkerCore(): { hasRPCConfig: boolean } {
 
   const { hasRPCConfig } = initEnv();
 
+  acquireWorkerLock(getEnv().HOME_DIR);
   setupShutdownHandlers();
 
   coreInitialized = true;
@@ -57,7 +62,9 @@ export function ensureRPCSetup() {
       logger.info(
         `Running in desktop mode, connecting to IPC socket: ${ipcSocketPath}`,
       );
-      const rpc = createIPCClient(ipcSocketPath);
+      const rpc = createIPCClient(ipcSocketPath, {
+        onDisconnect: () => void shutdownBareDirectWorker("ipc-disconnect"),
+      });
       logger.debug("Desktop IPC client created?", !!rpc);
     } else {
       logger.info("Running in BareKit IPC mode");
@@ -82,7 +89,12 @@ function clearRegistries() {
   clearPlugins();
 }
 
-export type BareDirectShutdownReason = "signal" | "rpc-close";
+export type BareDirectShutdownReason =
+  | "signal"
+  | "rpc-close"
+  | "uncaught-exception"
+  | "unhandled-rejection"
+  | "ipc-disconnect";
 
 export async function shutdownBareDirectWorker(
   reason: BareDirectShutdownReason,
@@ -90,11 +102,14 @@ export async function shutdownBareDirectWorker(
   if (isShuttingDown) return;
   isShuttingDown = true;
 
-  const message =
-    reason === "signal"
-      ? "🐻 Bare worker shutdown signal received, cleaning up..."
-      : "🧹 Bare direct mode RPC closed, cleaning up...";
-  logger.info(message);
+  const messages: Record<BareDirectShutdownReason, string> = {
+    signal: "🐻 Bare worker shutdown signal received, cleaning up...",
+    "rpc-close": "🧹 Bare direct mode RPC closed, cleaning up...",
+    "uncaught-exception": "💥 Uncaught exception, cleaning up...",
+    "unhandled-rejection": "💥 Unhandled rejection, cleaning up...",
+    "ipc-disconnect": "🔌 Parent IPC disconnected, cleaning up...",
+  };
+  logger.info(messages[reason]);
 
   try {
     clearRegistries();
@@ -110,12 +125,23 @@ export async function shutdownBareDirectWorker(
     logger.error("❌ Error during shutdown cleanup:", error);
   }
 
-  process.exit(0);
+  releaseWorkerLock(getEnv().HOME_DIR);
+
+  const isGraceful = reason === "signal" || reason === "rpc-close";
+  process.exit(isGraceful ? 0 : 1);
 }
 
 function setupShutdownHandlers() {
-  process.once("SIGTERM", () =>
-    void shutdownBareDirectWorker("signal"),
-  );
+  process.once("SIGTERM", () => void shutdownBareDirectWorker("signal"));
   process.once("SIGINT", () => void shutdownBareDirectWorker("signal"));
+
+  process.on("uncaughtException", (err) => {
+    logger.error("Uncaught exception in worker:", err);
+    void shutdownBareDirectWorker("uncaught-exception");
+  });
+
+  process.on("unhandledRejection", (reason) => {
+    logger.error("Unhandled rejection in worker:", reason);
+    void shutdownBareDirectWorker("unhandled-rejection");
+  });
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Worker process only handles `SIGTERM`/`SIGINT` for cleanup — uncaught exceptions, unhandled rejections, parent crashes, and `SIGKILL` all leave resources locked
- Corestore directories and RAG instances remain locked after ungraceful termination, causing "resource busy" / "File descriptor could not be locked" errors on restart
- `unloadAllModels` skips `FilesystemDL.close()` that the single-model `unloadModel` path performs, leaking file handles during shutdown
- Registry client's `getRegistryClient()` fails instantly on fd-lock contention with no retry — any transient lock (e.g., previous process still releasing) causes immediate `ModelLoadFailedError`
- `QVACRegistryClient` creates Corestore with `wait: false` (default), using `tryLock` instead of `waitForLock` — concurrent SDK instances on the same machine collide on `~/.qvac/registry-corestore/<key>`

Related: [Slack thread from Zbigniew](https://tether-to.slack.com/archives/C09MQ34GCH5/p1775633055013659?thread_ts=1775579394.728379&cid=C09MQ34GCH5) documenting the fd-lock error chain in production

## 📝 How does it solve it?

**A. Crash handlers** (`worker-core.ts`)
- Register `uncaughtException` and `unhandledRejection` handlers on `bare-process` to trigger full cleanup on unexpected crashes
- Non-graceful shutdowns exit with code 1

**B. IPC disconnect detection** (`create-server.ts`, `worker-core.ts`)
- Listen for IPC socket `close` event in desktop mode — fires when parent process (Electron) crashes or is killed
- Triggers cleanup via callback (avoids circular imports)

**C. Stale lock file** (`server/utils/worker-lock.ts`)
- New PID-based lock file at `~/.qvac/.worker.lock` written on startup, removed on graceful shutdown
- On startup, detects stale locks from dead PIDs (handles `SIGKILL`, OOM, power loss)
- Uses `process.kill(pid, 0)` for cross-platform liveness check

**D. Fix `unloadAllModels`** (`model-registry.ts`)
- Now calls `loader.close()` before `model.unload()`, matching `unloadModel` behavior
- Per-model try/catch so one failing unload doesn't block others

**E. Registry client fd-lock retry** (`registry-client.ts`)
- Retry `getRegistryClient()` up to 3 times with exponential backoff (500ms, 1000ms, 2000ms) on "File descriptor could not be locked" errors
- Only fd-lock errors trigger retry; other errors propagate immediately

**F. Corestore `wait` option plumbing** (`qvac-lib-registry-server/client`)
- `QVACRegistryClient` now accepts `corestoreOpts` and passes them to the `Corestore` constructor
- Type definition updated with `corestoreOpts?: { wait?: boolean }`
- SDK will pass `corestoreOpts: { wait: true }` once `@qvac/registry-client` dependency is bumped (TODO in code)

## 🧪 How was it tested?

Manual verification — no existing test infrastructure covers worker lifecycle. Suggested e2e tests as follow-up:

1. **Stale lock recovery**: create fake lock with dead PID → start worker → verify stale detection log and clean startup
2. **Uncaught exception cleanup**: inject `setTimeout(() => { throw ... }, 3000)` in worker → verify cleanup runs and lock file removed
3. **SIGKILL recovery**: start worker → `kill -9` → verify lock file persists → restart → verify stale detection and no "resource busy"
4. **IPC disconnect**: start desktop worker → kill parent → verify worker exits cleanly
5. **fd-lock retry**: simulate contention → verify retry logs and eventual success

### Files changed

| File | Change |
|------|--------|
| `packages/sdk/server/utils/worker-lock.ts` | **New** — PID lock file: acquire, release, stale detection |
| `packages/sdk/server/worker-core.ts` | Add crash/rejection handlers, lock lifecycle, IPC disconnect callback, expanded shutdown reasons |
| `packages/sdk/server/rpc/create-server.ts` | Add `onDisconnect` callback option to `createIPCClient`, socket close listener |
| `packages/sdk/server/bare/registry/model-registry.ts` | Fix `unloadAllModels` to close loaders, add per-model error handling |
| `packages/sdk/server/bare/registry/registry-client.ts` | Add retry with exponential backoff on fd-lock errors |
| `packages/qvac-lib-registry-server/client/lib/client.js` | Plumb `corestoreOpts` through to `new Corestore()` |
| `packages/qvac-lib-registry-server/client/index.d.ts` | Add `corestoreOpts` to `QVACRegistryClientOptions` type |

### Follow-up needed

- Bump `@qvac/registry-client` → release with `corestoreOpts` support
- Bump SDK's `@qvac/registry-client` dep → enable `corestoreOpts: { wait: true }`

