### PR TITLE
QVAC-16950 fix: buffer throttled progress events instead of dropping them

### DIFF
--- a/packages/sdk/server/rpc/handler-utils.ts
+++ b/packages/sdk/server/rpc/handler-utils.ts
@@ -134,11 +134,14 @@ async function executeProgressHandler(
   const stream = req.createResponseStream();
   profiler.startHandler();
 
-  const writeProgress = (update: Response) => {
-    stream.write(profiler.serialize(update, false) + "\n", "utf-8");
+  const writeBatch = (updates: Response[]) => {
+    const payload = updates
+      .map((u) => profiler.serialize(u, false))
+      .join("\n");
+    stream.write(payload + "\n", "utf-8");
   };
 
-  const throttle = createProgressThrottle<Response>(writeProgress);
+  const throttle = createProgressThrottle<Response>(writeBatch);
 
   try {
     let response: Response;

--- a/packages/sdk/server/rpc/handler-utils.ts
+++ b/packages/sdk/server/rpc/handler-utils.ts
@@ -15,8 +15,8 @@ import { PluginHandlerTypeMismatchError } from "@/utils/errors-server";
 import { setSDKConfig } from "@/server/bare/registry/config-registry";
 import { setRuntimeContext } from "@/server/bare/registry/runtime-context-registry";
 import { type ServerProfiler } from "./profiling";
-import { nowMs } from "@/profiling/clock";
 import { isTerminalChunk } from "./rpc-utils";
+import { createProgressThrottle } from "./progress-throttle";
 
 function getProfilingMetaFromRequest(
   request: Request,
@@ -124,8 +124,6 @@ async function executeStreamHandler(
   }
 }
 
-const PROGRESS_THROTTLE_MS = 150;
-
 async function executeProgressHandler(
   req: RPC.IncomingRequest,
   request: Request,
@@ -136,71 +134,33 @@ async function executeProgressHandler(
   const stream = req.createResponseStream();
   profiler.startHandler();
 
-  let lastProgressWrite = 0;
-  let pendingUpdates: Response[] = [];
-  let flushTimer: ReturnType<typeof setTimeout> | null = null;
-
   const writeProgress = (update: Response) => {
     stream.write(profiler.serialize(update, false) + "\n", "utf-8");
   };
 
-  const flushPending = () => {
-    if (pendingUpdates.length === 0) return;
-    lastProgressWrite = nowMs();
-    for (const update of pendingUpdates) {
-      writeProgress(update);
-    }
-    pendingUpdates = [];
-  };
-
-  const progressCallback = (update: Response) => {
-    const now = nowMs();
-    if (now - lastProgressWrite >= PROGRESS_THROTTLE_MS) {
-      lastProgressWrite = now;
-      writeProgress(update);
-    } else {
-      pendingUpdates.push(update);
-      if (!flushTimer) {
-        flushTimer = setTimeout(
-          () => {
-            flushTimer = null;
-            flushPending();
-          },
-          PROGRESS_THROTTLE_MS - (now - lastProgressWrite),
-        );
-      }
-    }
-  };
+  const throttle = createProgressThrottle<Response>(writeProgress);
 
   try {
     let response: Response;
     if (isDelegated) {
       const profilingMeta = getProfilingMetaFromRequest(request);
       const options: {
-        progressCallback: typeof progressCallback;
+        progressCallback: typeof throttle.push;
         profilingMeta?: ProfilingRequestMeta;
-      } = { progressCallback };
+      } = { progressCallback: throttle.push };
       if (profilingMeta) {
         options.profilingMeta = profilingMeta;
       }
       response = await handler(request, options);
     } else {
-      response = await handler(request, progressCallback);
+      response = await handler(request, throttle.push);
     }
-    if (flushTimer) {
-      clearTimeout(flushTimer);
-      flushTimer = null;
-    }
-    flushPending();
+    throttle.flush();
     profiler.endHandler();
     stream.write(profiler.serialize(response, true) + "\n", "utf-8");
     stream.end();
   } catch (error) {
-    if (flushTimer) {
-      clearTimeout(flushTimer);
-      flushTimer = null;
-    }
-    flushPending();
+    throttle.flush();
     profiler.endHandler();
     sendStreamErrorResponse(stream, error, profiler);
   }

--- a/packages/sdk/server/rpc/handler-utils.ts
+++ b/packages/sdk/server/rpc/handler-utils.ts
@@ -137,30 +137,34 @@ async function executeProgressHandler(
   profiler.startHandler();
 
   let lastProgressWrite = 0;
-  let pendingUpdate: Response | null = null;
+  let pendingUpdates: Response[] = [];
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
   const writeProgress = (update: Response) => {
     stream.write(profiler.serialize(update, false) + "\n", "utf-8");
   };
 
+  const flushPending = () => {
+    if (pendingUpdates.length === 0) return;
+    lastProgressWrite = nowMs();
+    for (const update of pendingUpdates) {
+      writeProgress(update);
+    }
+    pendingUpdates = [];
+  };
+
   const progressCallback = (update: Response) => {
     const now = nowMs();
     if (now - lastProgressWrite >= PROGRESS_THROTTLE_MS) {
       lastProgressWrite = now;
-      pendingUpdate = null;
       writeProgress(update);
     } else {
-      pendingUpdate = update;
+      pendingUpdates.push(update);
       if (!flushTimer) {
         flushTimer = setTimeout(
           () => {
             flushTimer = null;
-            if (pendingUpdate) {
-              lastProgressWrite = nowMs();
-              writeProgress(pendingUpdate);
-              pendingUpdate = null;
-            }
+            flushPending();
           },
           PROGRESS_THROTTLE_MS - (now - lastProgressWrite),
         );
@@ -187,10 +191,7 @@ async function executeProgressHandler(
       clearTimeout(flushTimer);
       flushTimer = null;
     }
-    if (pendingUpdate) {
-      writeProgress(pendingUpdate);
-      pendingUpdate = null;
-    }
+    flushPending();
     profiler.endHandler();
     stream.write(profiler.serialize(response, true) + "\n", "utf-8");
     stream.end();
@@ -199,10 +200,7 @@ async function executeProgressHandler(
       clearTimeout(flushTimer);
       flushTimer = null;
     }
-    if (pendingUpdate) {
-      writeProgress(pendingUpdate);
-      pendingUpdate = null;
-    }
+    flushPending();
     profiler.endHandler();
     sendStreamErrorResponse(stream, error, profiler);
   }

--- a/packages/sdk/server/rpc/progress-throttle.ts
+++ b/packages/sdk/server/rpc/progress-throttle.ts
@@ -1,4 +1,5 @@
 export const PROGRESS_THROTTLE_MS = 150;
+export const PROGRESS_MAX_PENDING = 100;
 
 export type ProgressThrottle<T> = {
   push: (update: T) => void;
@@ -9,6 +10,7 @@ export function createProgressThrottle<T>(
   writeBatch: (updates: T[]) => void,
   clock: () => number = Date.now,
   throttleMs: number = PROGRESS_THROTTLE_MS,
+  maxPending: number = PROGRESS_MAX_PENDING,
 ): ProgressThrottle<T> {
   let lastWrite = 0;
   let pending: T[] = [];
@@ -29,6 +31,14 @@ export function createProgressThrottle<T>(
       writeBatch([update]);
     } else {
       pending.push(update);
+      if (pending.length >= maxPending) {
+        if (flushTimer) {
+          clearTimeout(flushTimer);
+          flushTimer = null;
+        }
+        flushPending();
+        return;
+      }
       if (!flushTimer) {
         flushTimer = setTimeout(
           () => {

--- a/packages/sdk/server/rpc/progress-throttle.ts
+++ b/packages/sdk/server/rpc/progress-throttle.ts
@@ -6,7 +6,7 @@ export type ProgressThrottle<T> = {
 };
 
 export function createProgressThrottle<T>(
-  write: (update: T) => void,
+  writeBatch: (updates: T[]) => void,
   clock: () => number = Date.now,
   throttleMs: number = PROGRESS_THROTTLE_MS,
 ): ProgressThrottle<T> {
@@ -17,17 +17,16 @@ export function createProgressThrottle<T>(
   function flushPending() {
     if (pending.length === 0) return;
     lastWrite = clock();
-    for (const update of pending) {
-      write(update);
-    }
+    const batch = pending;
     pending = [];
+    writeBatch(batch);
   }
 
   function push(update: T) {
     const now = clock();
     if (now - lastWrite >= throttleMs) {
       lastWrite = now;
-      write(update);
+      writeBatch([update]);
     } else {
       pending.push(update);
       if (!flushTimer) {

--- a/packages/sdk/server/rpc/progress-throttle.ts
+++ b/packages/sdk/server/rpc/progress-throttle.ts
@@ -1,0 +1,54 @@
+export const PROGRESS_THROTTLE_MS = 150;
+
+export type ProgressThrottle<T> = {
+  push: (update: T) => void;
+  flush: () => void;
+};
+
+export function createProgressThrottle<T>(
+  write: (update: T) => void,
+  clock: () => number = Date.now,
+  throttleMs: number = PROGRESS_THROTTLE_MS,
+): ProgressThrottle<T> {
+  let lastWrite = 0;
+  let pending: T[] = [];
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function flushPending() {
+    if (pending.length === 0) return;
+    lastWrite = clock();
+    for (const update of pending) {
+      write(update);
+    }
+    pending = [];
+  }
+
+  function push(update: T) {
+    const now = clock();
+    if (now - lastWrite >= throttleMs) {
+      lastWrite = now;
+      write(update);
+    } else {
+      pending.push(update);
+      if (!flushTimer) {
+        flushTimer = setTimeout(
+          () => {
+            flushTimer = null;
+            flushPending();
+          },
+          throttleMs - (now - lastWrite),
+        );
+      }
+    }
+  }
+
+  function flush() {
+    if (flushTimer) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    flushPending();
+  }
+
+  return { push, flush };
+}

--- a/packages/sdk/test/unit/progress-throttle.test.ts
+++ b/packages/sdk/test/unit/progress-throttle.test.ts
@@ -13,31 +13,39 @@ type BrittleT = {
 
 const T0 = 1_000_000;
 
-test("immediate write when throttle window has elapsed", (t: BrittleT) => {
+function createTestThrottle(clock: () => number, throttleMs?: number) {
   const written: number[] = [];
-  let time = T0;
+  const batchSizes: number[] = [];
   const throttle = createProgressThrottle<number>(
-    (v) => written.push(v),
-    () => time,
+    (batch) => {
+      batchSizes.push(batch.length);
+      for (const v of batch) written.push(v);
+    },
+    clock,
+    throttleMs,
   );
+  return { written, batchSizes, throttle };
+}
+
+test("immediate write when throttle window has elapsed", (t: BrittleT) => {
+  let time = T0;
+  const { written, batchSizes, throttle } = createTestThrottle(() => time);
 
   throttle.push(1);
   t.alike(written, [1], "first event writes immediately");
+  t.alike(batchSizes, [1], "single batch call");
 
   time += PROGRESS_THROTTLE_MS;
   throttle.push(2);
   t.alike(written, [1, 2], "event after full window writes immediately");
+  t.alike(batchSizes, [1, 1], "two single-item batch calls");
 
   throttle.flush();
 });
 
 test("events within the same window are buffered, not dropped", (t: BrittleT) => {
-  const written: number[] = [];
   let time = T0;
-  const throttle = createProgressThrottle<number>(
-    (v) => written.push(v),
-    () => time,
-  );
+  const { written, batchSizes, throttle } = createTestThrottle(() => time);
 
   throttle.push(1);
   t.alike(written, [1], "first event writes immediately");
@@ -50,18 +58,16 @@ test("events within the same window are buffered, not dropped", (t: BrittleT) =>
 
   throttle.flush();
   t.alike(written, [1, 2, 3, 4], "flush writes all buffered events");
+  t.alike(batchSizes, [1, 3], "buffered events flushed as single batch");
 });
 
 test("flush is a no-op when buffer is empty", (t: BrittleT) => {
-  const written: number[] = [];
   let time = T0;
-  const throttle = createProgressThrottle<number>(
-    (v) => written.push(v),
-    () => time,
-  );
+  const { written, batchSizes, throttle } = createTestThrottle(() => time);
 
   throttle.flush();
   t.alike(written, [], "nothing written on empty flush");
+  t.alike(batchSizes, [], "no batch calls");
 
   throttle.push(1);
   throttle.flush();
@@ -71,15 +77,10 @@ test("flush is a no-op when buffer is empty", (t: BrittleT) => {
   t.alike(written, [1], "second flush is safe");
 });
 
-test("timer flush writes all buffered events", async (t: BrittleT) => {
-  const written: number[] = [];
+test("timer flush writes all buffered events as single batch", async (t: BrittleT) => {
   let time = T0;
   const throttleMs = 50;
-  const throttle = createProgressThrottle<number>(
-    (v) => written.push(v),
-    () => time,
-    throttleMs,
-  );
+  const { written, batchSizes, throttle } = createTestThrottle(() => time, throttleMs);
 
   throttle.push(1);
   time += 10;
@@ -92,16 +93,13 @@ test("timer flush writes all buffered events", async (t: BrittleT) => {
   await new Promise((r) => setTimeout(r, throttleMs + 10));
 
   t.alike(written, [1, 2, 3], "timer flushed all buffered events");
+  t.alike(batchSizes, [1, 2], "timer flush was a single batch call");
   throttle.flush();
 });
 
 test("simulates rapid finetune-like progress: no events lost", (t: BrittleT) => {
-  const written: number[] = [];
   let time = T0;
-  const throttle = createProgressThrottle<number>(
-    (v) => written.push(v),
-    () => time,
-  );
+  const { written, batchSizes, throttle } = createTestThrottle(() => time);
 
   for (let batch = 1; batch <= 8; batch++) {
     throttle.push(batch);
@@ -111,18 +109,51 @@ test("simulates rapid finetune-like progress: no events lost", (t: BrittleT) => 
   throttle.flush();
 
   t.is(written.length, 8, "all 8 batches delivered");
-
   const sorted = [...written].sort((a, b) => a - b);
   t.alike(sorted, [1, 2, 3, 4, 5, 6, 7, 8], "no events lost");
+
+  const totalBatchCalls = batchSizes.length;
+  t.ok(totalBatchCalls < 8, "fewer batch calls than events (throttled)");
 });
 
-test("mixed fast and slow events: all delivered", (t: BrittleT) => {
-  const written: number[] = [];
+test("high-volume download-like burst: all events in few batch calls", (t: BrittleT) => {
   let time = T0;
-  const throttle = createProgressThrottle<number>(
-    (v) => written.push(v),
-    () => time,
-  );
+  const { written, batchSizes, throttle } = createTestThrottle(() => time);
+
+  for (let i = 0; i < 1000; i++) {
+    throttle.push(i);
+    time += 0.01;
+  }
+
+  throttle.flush();
+
+  t.is(written.length, 1000, "all 1000 events delivered");
+  t.is(written[0], 0, "first event present");
+  t.is(written[written.length - 1], 999, "last event present");
+
+  const totalBatchCalls = batchSizes.length;
+  t.ok(totalBatchCalls <= 3, `only ${totalBatchCalls} batch writes for 1000 events`);
+});
+
+test("flush on error path delivers pending events", (t: BrittleT) => {
+  let time = T0;
+  const { written, throttle } = createTestThrottle(() => time);
+
+  throttle.push(1);
+  time += 10;
+  throttle.push(2);
+  throttle.push(3);
+
+  throttle.flush();
+  t.alike(written, [1, 2, 3], "all events flushed even on error path");
+
+  throttle.flush();
+  t.alike(written, [1, 2, 3], "double flush is safe");
+});
+
+test("mixed fast and slow events: all delivered, batch calls minimized", (t: BrittleT) => {
+  let time = T0;
+  const { written, batchSizes, throttle } = createTestThrottle(() => time);
 
   throttle.push(1);
   time += PROGRESS_THROTTLE_MS;
@@ -141,47 +172,7 @@ test("mixed fast and slow events: all delivered", (t: BrittleT) => {
   throttle.flush();
 
   t.is(written.length, 6, "all 6 events delivered");
-
   const sorted = [...written].sort((a, b) => a - b);
   t.alike(sorted, [1, 2, 3, 4, 5, 6], "no events lost");
-});
-
-test("flush on error path delivers pending events", (t: BrittleT) => {
-  const written: number[] = [];
-  let time = T0;
-  const throttle = createProgressThrottle<number>(
-    (v) => written.push(v),
-    () => time,
-  );
-
-  throttle.push(1);
-  time += 10;
-  throttle.push(2);
-  throttle.push(3);
-
-  throttle.flush();
-  t.alike(written, [1, 2, 3], "all events flushed even on error path");
-
-  throttle.flush();
-  t.alike(written, [1, 2, 3], "double flush is safe");
-});
-
-test("high-volume download-like burst: all events preserved", (t: BrittleT) => {
-  const written: number[] = [];
-  let time = T0;
-  const throttle = createProgressThrottle<number>(
-    (v) => written.push(v),
-    () => time,
-  );
-
-  for (let i = 0; i < 100; i++) {
-    throttle.push(i);
-    time += 1;
-  }
-
-  throttle.flush();
-
-  t.is(written.length, 100, "all 100 events delivered");
-  t.is(written[0], 0, "first event present");
-  t.is(written[written.length - 1], 99, "last event present");
+  t.ok(batchSizes.length <= 6, "batch calls <= total events");
 });

--- a/packages/sdk/test/unit/progress-throttle.test.ts
+++ b/packages/sdk/test/unit/progress-throttle.test.ts
@@ -3,6 +3,7 @@ import test from "brittle";
 import {
   createProgressThrottle,
   PROGRESS_THROTTLE_MS,
+  PROGRESS_MAX_PENDING,
 } from "@/server/rpc/progress-throttle";
 
 type BrittleT = {
@@ -13,7 +14,11 @@ type BrittleT = {
 
 const T0 = 1_000_000;
 
-function createTestThrottle(clock: () => number, throttleMs?: number) {
+function createTestThrottle(
+  clock: () => number,
+  throttleMs?: number,
+  maxPending?: number,
+) {
   const written: number[] = [];
   const batchSizes: number[] = [];
   const throttle = createProgressThrottle<number>(
@@ -23,6 +28,7 @@ function createTestThrottle(clock: () => number, throttleMs?: number) {
     },
     clock,
     throttleMs,
+    maxPending,
   );
   return { written, batchSizes, throttle };
 }
@@ -116,7 +122,7 @@ test("simulates rapid finetune-like progress: no events lost", (t: BrittleT) => 
   t.ok(totalBatchCalls < 8, "fewer batch calls than events (throttled)");
 });
 
-test("high-volume download-like burst: all events in few batch calls", (t: BrittleT) => {
+test("high-volume download-like burst: all events in bounded batch calls", (t: BrittleT) => {
   let time = T0;
   const { written, batchSizes, throttle } = createTestThrottle(() => time);
 
@@ -131,8 +137,31 @@ test("high-volume download-like burst: all events in few batch calls", (t: Britt
   t.is(written[0], 0, "first event present");
   t.is(written[written.length - 1], 999, "last event present");
 
-  const totalBatchCalls = batchSizes.length;
-  t.ok(totalBatchCalls <= 3, `only ${totalBatchCalls} batch writes for 1000 events`);
+  for (const size of batchSizes) {
+    t.ok(size <= PROGRESS_MAX_PENDING, `batch size ${size} <= maxPending ${PROGRESS_MAX_PENDING}`);
+  }
+});
+
+test("maxPending cap triggers early flush", (t: BrittleT) => {
+  let time = T0;
+  const maxPending = 5;
+  const { written, batchSizes, throttle } = createTestThrottle(() => time, undefined, maxPending);
+
+  throttle.push(0);
+  time += 1;
+
+  for (let i = 1; i <= 12; i++) {
+    throttle.push(i);
+    time += 1;
+  }
+
+  throttle.flush();
+
+  t.is(written.length, 13, "all 13 events delivered");
+
+  for (const size of batchSizes) {
+    t.ok(size <= maxPending, `batch size ${size} <= maxPending ${maxPending}`);
+  }
 });
 
 test("flush on error path delivers pending events", (t: BrittleT) => {

--- a/packages/sdk/test/unit/progress-throttle.test.ts
+++ b/packages/sdk/test/unit/progress-throttle.test.ts
@@ -1,0 +1,187 @@
+// @ts-ignore brittle has no type declarations
+import test from "brittle";
+import {
+  createProgressThrottle,
+  PROGRESS_THROTTLE_MS,
+} from "@/server/rpc/progress-throttle";
+
+type BrittleT = {
+  is: (a: unknown, b: unknown, msg?: string) => void;
+  ok: (v: unknown, msg?: string) => void;
+  alike: (a: unknown, b: unknown, msg?: string) => void;
+};
+
+const T0 = 1_000_000;
+
+test("immediate write when throttle window has elapsed", (t: BrittleT) => {
+  const written: number[] = [];
+  let time = T0;
+  const throttle = createProgressThrottle<number>(
+    (v) => written.push(v),
+    () => time,
+  );
+
+  throttle.push(1);
+  t.alike(written, [1], "first event writes immediately");
+
+  time += PROGRESS_THROTTLE_MS;
+  throttle.push(2);
+  t.alike(written, [1, 2], "event after full window writes immediately");
+
+  throttle.flush();
+});
+
+test("events within the same window are buffered, not dropped", (t: BrittleT) => {
+  const written: number[] = [];
+  let time = T0;
+  const throttle = createProgressThrottle<number>(
+    (v) => written.push(v),
+    () => time,
+  );
+
+  throttle.push(1);
+  t.alike(written, [1], "first event writes immediately");
+
+  time += 10;
+  throttle.push(2);
+  throttle.push(3);
+  throttle.push(4);
+  t.alike(written, [1], "buffered events not yet written");
+
+  throttle.flush();
+  t.alike(written, [1, 2, 3, 4], "flush writes all buffered events");
+});
+
+test("flush is a no-op when buffer is empty", (t: BrittleT) => {
+  const written: number[] = [];
+  let time = T0;
+  const throttle = createProgressThrottle<number>(
+    (v) => written.push(v),
+    () => time,
+  );
+
+  throttle.flush();
+  t.alike(written, [], "nothing written on empty flush");
+
+  throttle.push(1);
+  throttle.flush();
+  t.alike(written, [1], "only the immediate write");
+
+  throttle.flush();
+  t.alike(written, [1], "second flush is safe");
+});
+
+test("timer flush writes all buffered events", async (t: BrittleT) => {
+  const written: number[] = [];
+  let time = T0;
+  const throttleMs = 50;
+  const throttle = createProgressThrottle<number>(
+    (v) => written.push(v),
+    () => time,
+    throttleMs,
+  );
+
+  throttle.push(1);
+  time += 10;
+  throttle.push(2);
+  throttle.push(3);
+
+  t.alike(written, [1], "only immediate write before timer");
+
+  time += throttleMs;
+  await new Promise((r) => setTimeout(r, throttleMs + 10));
+
+  t.alike(written, [1, 2, 3], "timer flushed all buffered events");
+  throttle.flush();
+});
+
+test("simulates rapid finetune-like progress: no events lost", (t: BrittleT) => {
+  const written: number[] = [];
+  let time = T0;
+  const throttle = createProgressThrottle<number>(
+    (v) => written.push(v),
+    () => time,
+  );
+
+  for (let batch = 1; batch <= 8; batch++) {
+    throttle.push(batch);
+    time += 30;
+  }
+
+  throttle.flush();
+
+  t.is(written.length, 8, "all 8 batches delivered");
+
+  const sorted = [...written].sort((a, b) => a - b);
+  t.alike(sorted, [1, 2, 3, 4, 5, 6, 7, 8], "no events lost");
+});
+
+test("mixed fast and slow events: all delivered", (t: BrittleT) => {
+  const written: number[] = [];
+  let time = T0;
+  const throttle = createProgressThrottle<number>(
+    (v) => written.push(v),
+    () => time,
+  );
+
+  throttle.push(1);
+  time += PROGRESS_THROTTLE_MS;
+  throttle.push(2);
+
+  time += 10;
+  throttle.push(3);
+  throttle.push(4);
+
+  time += PROGRESS_THROTTLE_MS;
+  throttle.push(5);
+
+  time += 5;
+  throttle.push(6);
+
+  throttle.flush();
+
+  t.is(written.length, 6, "all 6 events delivered");
+
+  const sorted = [...written].sort((a, b) => a - b);
+  t.alike(sorted, [1, 2, 3, 4, 5, 6], "no events lost");
+});
+
+test("flush on error path delivers pending events", (t: BrittleT) => {
+  const written: number[] = [];
+  let time = T0;
+  const throttle = createProgressThrottle<number>(
+    (v) => written.push(v),
+    () => time,
+  );
+
+  throttle.push(1);
+  time += 10;
+  throttle.push(2);
+  throttle.push(3);
+
+  throttle.flush();
+  t.alike(written, [1, 2, 3], "all events flushed even on error path");
+
+  throttle.flush();
+  t.alike(written, [1, 2, 3], "double flush is safe");
+});
+
+test("high-volume download-like burst: all events preserved", (t: BrittleT) => {
+  const written: number[] = [];
+  let time = T0;
+  const throttle = createProgressThrottle<number>(
+    (v) => written.push(v),
+    () => time,
+  );
+
+  for (let i = 0; i < 100; i++) {
+    throttle.push(i);
+    time += 1;
+  }
+
+  throttle.flush();
+
+  t.is(written.length, 100, "all 100 events delivered");
+  t.is(written[0], 0, "first event present");
+  t.is(written[written.length - 1], 99, "last event present");
+});


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The RPC progress throttle (added in #1134 to prevent call-stack overflow on mobile) uses a single `pendingUpdate` variable. When multiple progress events fire within the same 150ms window, each new event **overwrites** the previous one — only the last event survives. This causes ~2-3% of finetuning validation-batch progress ticks to be silently dropped when running over IPC (Node/Hermes runtimes).

## 📝 How does it solve it?

- Extracts the throttle logic into a standalone `progress-throttle.ts` module with a `createProgressThrottle<T>(writeBatch)` factory
- Uses a **batch API**: buffered events are collected in an array and flushed as a single `stream.write()` call with newline-delimited JSON — **one RPC frame per flush**, regardless of how many events accumulated
- **`maxPending` cap** (default 100) triggers an early flush when the buffer reaches the limit, bounding per-frame IPC payload to ~50KB — prevents `streamx` backpressure issues and large single-frame allocations on memory-constrained mobile devices
- Write frequency is still capped at 1 flush per 150ms (mobile call-stack protection preserved)
- No events are dropped — the consumer receives all progress updates
- No stack overflow risk — batched writes produce bounded RPC frames
- No memory leak risk — buffer drains on every flush and is capped by `maxPending`

### Why a batch API with a cap

The original single-variable approach dropped events. A naive buffer-and-flush approach (writing each buffered event individually) would produce N separate `bare-rpc` frames per flush — `bare-rpc` processes queued frames via mutual recursion (`_onafterframe` → `_onmessage` → `_onbeforeframe`), so a burst of frames could still overflow the call stack. The batch API coalesces events into a single frame per flush, and the `maxPending` cap ensures that frame stays bounded even during high-frequency bursts (e.g. ~26K download chunks on a fast link).

## 🧪 How was it tested?

- SDK builds and lints clean (`bun run build` in `packages/sdk/`)
- 9 unit tests (42 assertions) covering:
  - Immediate writes when throttle window has elapsed
  - Buffered events preserved (not dropped) within window
  - Buffered events flushed as single batch call
  - Flush no-op when empty
  - Timer-based flush delivers all buffered events as single batch
  - Rapid finetune-like bursts (8 events at 30ms intervals): zero events lost
  - High-volume download-like burst (1000 events): all delivered, every batch ≤ `maxPending`
  - `maxPending` cap triggers early flush (verified with custom cap of 5)
  - Error-path flush safety
  - Mixed fast/slow cadence: all delivered, batch calls minimized

## 📎 Notes

- Surfaced during finetuning integration (PR #1332) — validation batches fire sub-150ms, exposing the overwrite behavior
- Affects all `supportsProgress` handlers (`loadModel`, `downloadAsset`, `rag`, `finetune`) but only observable when progress events fire faster than 150ms
- The client already parses `\n`-delimited JSON from stream chunks, so multi-event payloads in a single frame are handled correctly
- Asana: QVAC-16950
- Replaces #1419 (orphaned when fork was re-created to fix GitHub fork network)
