### PR TITLE
chore[bc]: diffusion addon interface refactor - remove BaseInference

### DIFF
--- a/packages/lib-infer-diffusion/examples/generate-image-sd2.js
+++ b/packages/lib-infer-diffusion/examples/generate-image-sd2.js
@@ -49,21 +49,20 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: MODELS_DIR,
-      modelName: MODEL_NAME
-      // No llmModel — SD2.1 uses the CLIP text encoder baked into the checkpoint.
-      // No vaeModel — the VAE is baked into the checkpoint.
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(MODELS_DIR, MODEL_NAME)
+      // No llm — SD2.1 uses the CLIP text encoder baked into the checkpoint.
+      // No vae — the VAE is baked into the checkpoint.
     },
-    {
+    config: {
       threads: 8,
       // SD2.1 uses v-prediction. This safetensors file has no GGUF metadata so
       // auto-detection cannot determine the prediction type; set it explicitly.
       prediction: 'v'
-    }
-  )
+    },
+    logger: console
+  })
 
   try {
     // ── 1. Load weights ───────────────────────────────────────────────────────

--- a/packages/lib-infer-diffusion/examples/generate-image-sd3.js
+++ b/packages/lib-infer-diffusion/examples/generate-image-sd3.js
@@ -54,24 +54,23 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: MODELS_DIR,
-      modelName: MODEL_NAME
-      // All-in-one safetensors: no clipLModel, clipGModel, t5XxlModel, or vaeModel.
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(MODELS_DIR, MODEL_NAME)
+      // All-in-one safetensors: no clipL, clipG, t5Xxl, or vae.
       //
       // To add T5-XXL (better text following) without redownloading the main file:
-      //   t5XxlModel: 't5xxl_fp8_e4m3fn.safetensors'   // download via download-model-sd3.sh
+      //   t5Xxl: path.join(MODELS_DIR, 't5xxl_fp8_e4m3fn.safetensors')   // download via download-model-sd3.sh
     },
-    {
+    config: {
       threads: 4,
       // SD3 uses flow-matching. The safetensors metadata allows auto-detection,
       // but we set these explicitly as safety overrides.
       prediction: 'flow', // FLOW_PRED — SD3 flow-matching
       flow_shift: '3.0' // SD3 Medium default; overrides INFINITY sentinel
-    }
-  )
+    },
+    logger: console
+  })
 
   try {
     // ── 1. Load weights ───────────────────────────────────────────────────────

--- a/packages/lib-infer-diffusion/examples/generate-image-sdxl.js
+++ b/packages/lib-infer-diffusion/examples/generate-image-sdxl.js
@@ -51,20 +51,19 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: MODELS_DIR,
-      modelName: MODEL_NAME
-      // No llmModel — SDXL uses CLIP-L + CLIP-G baked into the checkpoint.
-      // No vaeModel — the VAE is baked into the checkpoint.
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(MODELS_DIR, MODEL_NAME)
+      // No llm — SDXL uses CLIP-L + CLIP-G baked into the checkpoint.
+      // No vae — the VAE is baked into the checkpoint.
     },
-    {
+    config: {
       threads: 4
       // No prediction override — SDXL uses eps-prediction and the GGUF
       // has the correct metadata for auto-detection.
-    }
-  )
+    },
+    logger: console
+  })
 
   try {
     // ── 1. Load weights ───────────────────────────────────────────────────────

--- a/packages/lib-infer-diffusion/examples/generate-image.js
+++ b/packages/lib-infer-diffusion/examples/generate-image.js
@@ -41,18 +41,17 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: MODELS_DIR,
-      modelName: MODEL_NAME,
-      llmModel: LLM_MODEL,
-      vaeModel: VAE_MODEL
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(MODELS_DIR, MODEL_NAME),
+      llm: path.join(MODELS_DIR, LLM_MODEL),
+      vae: path.join(MODELS_DIR, VAE_MODEL)
     },
-    {
+    config: {
       threads: 4
-    }
-  )
+    },
+    logger: console
+  })
 
   try {
     // ── 1. Load weights ───────────────────────────────────────────────────────

--- a/packages/lib-infer-diffusion/examples/load-model.js
+++ b/packages/lib-infer-diffusion/examples/load-model.js
@@ -24,18 +24,17 @@ async function main () {
   console.log()
 
   // ── 1. Construct — stores config, allocates nothing ────────────────────────
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: MODELS_DIR,
-      modelName: MODEL_NAME,
-      llmModel: LLM_MODEL,
-      vaeModel: VAE_MODEL
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(MODELS_DIR, MODEL_NAME),
+      llm: path.join(MODELS_DIR, LLM_MODEL),
+      vae: path.join(MODELS_DIR, VAE_MODEL)
     },
-    {
+    config: {
       threads: 8 // Metal handles GPU; threads are for CPU fallback ops
-    }
-  )
+    },
+    logger: console
+  })
 
   try {
     // ── 2. Load — reads weights into memory via activate() → new_sd_ctx() ───

--- a/packages/lib-infer-diffusion/examples/quickstart.js
+++ b/packages/lib-infer-diffusion/examples/quickstart.js
@@ -46,19 +46,18 @@ async function main () {
   console.log(`Model : ${MODEL_NAME}`)
   console.log(`Prompt: ${PROMPT}\n`)
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: MODELS_DIR,
-      modelName: MODEL_NAME,
-      opts: { stats: true }
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(MODELS_DIR, MODEL_NAME)
     },
-    {
+    config: {
       threads: 4,
       prediction: 'v',
       verbosity: 2
-    }
-  )
+    },
+    logger: console,
+    opts: { stats: true }
+  })
 
   try {
     // 3. Load model weights

--- a/packages/lib-infer-diffusion/examples/runtime-stats-sd2.js
+++ b/packages/lib-infer-diffusion/examples/runtime-stats-sd2.js
@@ -59,18 +59,17 @@ async function main () {
   console.log('Seed   :', SEED)
   console.log()
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: MODELS_DIR,
-      modelName: MODEL_NAME,
-      opts: { stats: true }
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(MODELS_DIR, MODEL_NAME)
     },
-    {
+    config: {
       threads: 4,
       prediction: 'v'
-    }
-  )
+    },
+    logger: console,
+    opts: { stats: true }
+  })
 
   try {
     // ── 1. Load weights ─────────────────────────────────────────────────────

--- a/packages/lib-infer-diffusion/index.d.ts
+++ b/packages/lib-infer-diffusion/index.d.ts
@@ -1,4 +1,3 @@
-import BaseInference from '@qvac/infer-base/WeightsProvider/BaseInference'
 import type { QvacResponse } from '@qvac/infer-base'
 import type QvacLogger from '@qvac/logging'
 
@@ -11,7 +10,6 @@ export interface Addon {
   unload(): Promise<void>
 }
 
-/** Supported diffusion sampling methods */
 export type SamplerMethod =
   | 'euler'
   | 'euler_a'
@@ -28,7 +26,6 @@ export type SamplerMethod =
   | 'res_multistep'
   | 'res_2s'
 
-/** Supported weight quantization types */
 export type WeightType =
   | 'auto'
   | 'f32'
@@ -45,10 +42,8 @@ export type WeightType =
   | 'q6_k'
   | 'q8_0'
 
-/** Supported RNG types */
 export type RngType = 'cpu' | 'cuda' | 'std_default'
 
-/** Supported sampling schedules */
 export type ScheduleType =
   | 'discrete'
   | 'karras'
@@ -62,59 +57,51 @@ export type ScheduleType =
   | 'kl_optimal'
   | 'bong_tangent'
 
-/** Supported noise prediction types */
 export type PredictionType = 'auto' | 'eps' | 'v' | 'edm_v' | 'flow' | 'flux_flow' | 'flux2_flow'
 
-/** LoRA application mode */
 export type LoraApplyMode = 'auto' | 'immediately' | 'at_runtime'
 
-/** Step-caching algorithm */
 export type CacheMode = 'disabled' | 'easycache' | 'ucache' | 'dbcache' | 'taylorseer' | 'cache-dit'
 
 export interface SdConfig {
-  /** Number of CPU threads (-1 = auto) */
   threads?: NumericLike
-  /** Preferred compute device: 'gpu' (Metal/Vulkan) or 'cpu' */
   device?: 'gpu' | 'cpu'
-  /** Weight quantization type */
   type?: WeightType
-  /** RNG type for reproducible generation */
   rng?: RngType
-  /** RNG type for the sampler (separate from context RNG) */
   sampler_rng?: RngType
-  /** Run CLIP encoder on CPU even when GPU is available */
   clip_on_cpu?: boolean
-  /** Run VAE decoder on CPU even when GPU is available */
   vae_on_cpu?: boolean
-  /** Enable VAE tiling to reduce VRAM usage */
   vae_tiling?: boolean
-  /** Enable flash attention for memory efficiency */
   flash_attn?: boolean
-  /** Enable flash attention for diffusion model specifically */
   diffusion_fa?: boolean
-  /** Use memory-mapped model loading */
   mmap?: boolean
-  /** Offload model weights to CPU when not in use */
   offload_to_cpu?: boolean
-  /** Noise prediction type override (auto-detected from model by default) */
   prediction?: PredictionType
-  /** Flow-matching guidance shift */
   flow_shift?: number
-  /** Use direct convolution in diffusion model */
   diffusion_conv_direct?: boolean
-  /** Use direct convolution in VAE */
   vae_conv_direct?: boolean
-  /** Force SDXL VAE conv scale factor */
   force_sdxl_vae_conv_scale?: boolean
-  /** Custom backends directory path (defaults to prebuilds/) */
   backendsDir?: string
-  /** Custom tensor type rules string */
   tensor_type_rules?: string
-  /** LoRA application mode */
   lora_apply_mode?: LoraApplyMode
-  /** Logging verbosity: 0=error, 1=warn, 2=info, 3=debug */
   verbosity?: NumericLike
   [key: string]: string | number | boolean | undefined
+}
+
+export interface DiffusionFiles {
+  model: string
+  clipL?: string
+  clipG?: string
+  t5Xxl?: string
+  llm?: string
+  vae?: string
+}
+
+export interface ImgStableDiffusionArgs {
+  files: DiffusionFiles
+  config: SdConfig
+  logger?: QvacLogger | Console | null
+  opts?: { stats?: boolean }
 }
 
 export interface GenerationParams {
@@ -123,111 +110,53 @@ export interface GenerationParams {
   width?: number
   height?: number
   steps?: number
-  /** CFG scale (SD1/SD2/SDXL/SD3) */
   cfg_scale?: number
-  /** Distilled guidance (FLUX.2) */
   guidance?: number
-  /** Sampler name (e.g. 'euler', 'dpm++2m') */
   sampling_method?: SamplerMethod
-  /** Alias for sampling_method — accepted by the C++ layer */
   sampler?: SamplerMethod
-  /** Scheduler name */
   scheduler?: ScheduleType
   seed?: number
   batch_count?: number
-  /** Enable VAE tiling (for large images) */
   vae_tiling?: boolean
-  /** VAE tile dimensions — integer or 'WxH' string (e.g. '512x512') */
   vae_tile_size?: number | string
-  /** VAE tile overlap fraction (0.0–1.0) */
   vae_tile_overlap?: number
-  /** Step-caching algorithm */
   cache_mode?: CacheMode
-  /** Cache preset: slow/medium/fast/ultra (shorthand for cache_mode + threshold) */
   cache_preset?: string
-  /** Direct cache reuse threshold override (0 = library default) */
   cache_threshold?: number
-  /** Stochasticity parameter for DDIM/TCD samplers */
   eta?: number
-  /** Image CFG scale for img2img/inpaint (-1 = use cfg_scale) */
   img_cfg_scale?: number
-  /** Skip last N CLIP encoder layers (SD1.x/SD2.x) */
   clip_skip?: number
-  /** Input image as PNG/JPEG bytes for img2img (not yet supported — throws at runtime) */
   init_image?: Uint8Array
-  /** img2img denoising strength (0.0–1.0). 0 = keep source, 1 = ignore source (not yet supported) */
   strength?: number
 }
 
-/**
- * Shape of the stats object emitted on the 'stats' event of a QvacResponse.
- *
- * All time values are in milliseconds. Cumulative fields (totalGenerationMs,
- * totalWallMs, totalSteps, totalGenerations, totalImages, totalPixels) accumulate
- * across the lifetime of the model instance; per-job fields (generationMs, width,
- * height, seed) reflect only the most recent generation.
- *
- * Derivable rates (stepsPerSecond, msPerStep, megapixelsPerSecond) are intentionally
- * omitted — callers can compute them from the primitives provided:
- *   stepsPerSecond    = totalSteps  / (totalWallMs / 1000)
- *   msPerStep         = totalWallMs / totalSteps
- *   megapixelsPerSec  = (totalPixels / 1e6) / (totalWallMs / 1000)
- */
 export interface RuntimeStats {
-  /** Wall time to load the model weights (ms) */
   modelLoadMs: number
-  /** Wall time for the most recent generation job (ms) */
   generationMs: number
-  /** Cumulative generation time across all jobs (ms) */
   totalGenerationMs: number
-  /** Cumulative wall time across all jobs (ms) */
   totalWallMs: number
-  /** Cumulative diffusion steps across all jobs */
   totalSteps: number
-  /** Cumulative number of generation calls */
   totalGenerations: number
-  /** Cumulative number of images produced */
   totalImages: number
-  /** Cumulative number of pixels produced */
   totalPixels: number
-  /** Width of the most recent generated image (px) */
   width: number
-  /** Height of the most recent generated image (px) */
   height: number
-  /** Seed used for the most recent generation */
   seed: number
 }
 
-export interface ImgStableDiffusionArgs {
-  logger?: QvacLogger | Console | null
-  opts?: { stats?: boolean }
-  diskPath?: string
-  modelName: string
-  /** FLUX.1 / SD3: separate CLIP-L text encoder */
-  clipLModel?: string
-  /** SDXL / SD3: separate CLIP-G text encoder */
-  clipGModel?: string
-  /** FLUX.1 / SD3: separate T5-XXL text encoder */
-  t5XxlModel?: string
-  /** FLUX.2 [klein]: Qwen3 4B text encoder (llm_path) */
-  llmModel?: string
-  vaeModel?: string
-}
+export default class ImgStableDiffusion {
+  protected addon: Addon | null
+  opts: { stats?: boolean }
+  logger: QvacLogger
+  state: { configLoaded: boolean }
 
-export default class ImgStableDiffusion extends BaseInference {
-  protected addon: Addon
-
-  constructor(args: ImgStableDiffusionArgs, config: SdConfig)
-
-  _load(): Promise<void>
+  constructor(args: ImgStableDiffusionArgs)
 
   load(): Promise<void>
-
   run(params: GenerationParams): Promise<QvacResponse>
-
   unload(): Promise<void>
-
   cancel(): Promise<void>
+  getState(): { configLoaded: boolean }
 }
 
 export { QvacResponse, RuntimeStats }

--- a/packages/lib-infer-diffusion/index.js
+++ b/packages/lib-infer-diffusion/index.js
@@ -1,106 +1,61 @@
 'use strict'
 
-const path = require('bare-path')
-
-const BaseInference = require('@qvac/infer-base/WeightsProvider/BaseInference')
+const QvacLogger = require('@qvac/logging')
+const { createJobHandler, exclusiveRunQueue } = require('@qvac/infer-base')
 const { SdInterface } = require('./addon')
 
 const LOG_METHODS = ['error', 'warn', 'info', 'debug']
 
 const RUN_BUSY_ERROR_MESSAGE = 'Cannot set new job: a job is already set or being processed'
 
-/**
- * Text-to-image and image-to-image generation using stable-diffusion.cpp.
- * Supports SD1.x, SD2.x, SDXL, SD3, and FLUX.2 [klein].
- */
-class ImgStableDiffusion extends BaseInference {
-  /**
-   * @param {object} args
-   * @param {object} [args.logger] - Structured logger
-   * @param {object} [args.opts] - Optional inference options
-   * @param {string} [args.diskPath='.'] - Local directory containing model weight files
-   * @param {string} args.modelName - Model file name (e.g. 'flux1-dev-q4_0.gguf')
-   * @param {string} [args.clipLModel] - Optional CLIP-L model file name (FLUX.1 / SD3)
-   * @param {string} [args.clipGModel] - Optional CLIP-G model file name (SDXL / SD3)
-   * @param {string} [args.t5XxlModel] - Optional T5-XXL text encoder file name (FLUX.1 / SD3)
-   * @param {string} [args.llmModel] - Optional LLM text encoder file name (FLUX.2 klein → Qwen3 4B)
-   * @param {string} [args.vaeModel] - Optional VAE file name
-   * @param {object} config - SD context configuration (threads, device, type, etc.)
-   */
-  constructor (
-    {
-      opts = {},
-      logger = null,
-      diskPath = '.',
-      modelName,
-      clipLModel,
-      clipGModel,
-      t5XxlModel,
-      llmModel,
-      vaeModel
-    },
-    config
-  ) {
-    super({ logger, opts })
+class ImgStableDiffusion {
+  constructor ({ files, config, logger = null, opts = {} }) {
+    this._files = files
     this._config = config
-    this._diskPath = diskPath
-    this._modelName = modelName
-    this._clipLModel = clipLModel || null
-    this._clipGModel = clipGModel || null
-    this._t5XxlModel = t5XxlModel || null
-    this._llmModel = llmModel || null
-    this._vaeModel = vaeModel || null
+    this.logger = new QvacLogger(logger)
+    this.opts = opts
+    this._job = createJobHandler({ cancel: () => this.addon.cancel() })
+    this._run = exclusiveRunQueue()
+    this.addon = null
     this._hasActiveResponse = false
+    this._binding = null
+    this._nativeLoggerActive = false
+    this.state = { configLoaded: false }
+  }
+
+  async load () {
+    if (this.state.configLoaded) {
+      this.logger.info('Reload requested - unloading existing model first')
+      await this.unload()
+    }
+    await this._load()
+    this.state.configLoaded = true
   }
 
   async _load () {
     this.logger.info('Starting stable-diffusion model load')
 
-    try {
-      // Route the primary model file to the correct stable-diffusion.cpp param:
-      //
-      //   model_path           — all-in-one checkpoints that embed their own text
-      //                          encoders and version metadata (SD1.x, SD2.x, SDXL,
-      //                          SD3 all-in-one GGUF).
-      //
-      //   diffusion_model_path — standalone diffusion-only weights that have no
-      //                          embedded SD metadata and require separate encoders:
-      //                            FLUX.2 [klein] → llmModel (Qwen3)
-      //                            SD3 pure GGUF  → t5XxlModel (T5-XXL) + clipLModel + clipGModel
-      //
-      // Heuristic: if any separate encoder is provided (LLM for FLUX.2, T5-XXL
-      // for SD3 split) the caller is using a pure diffusion GGUF that must be
-      // loaded via diffusion_model_path.
-      const isSplitLayout = !!this._llmModel || !!this._t5XxlModel
-      const resolve = (name) => name ? (path.isAbsolute(name) ? name : path.join(this._diskPath, name)) : ''
-      const configurationParams = {
-        path: isSplitLayout ? '' : resolve(this._modelName),
-        diffusionModelPath: isSplitLayout ? resolve(this._modelName) : '',
-        clipLPath: resolve(this._clipLModel),
-        clipGPath: resolve(this._clipGModel),
-        t5XxlPath: resolve(this._t5XxlModel),
-        llmPath: resolve(this._llmModel),
-        vaePath: resolve(this._vaeModel),
-        config: this._config
-      }
-
-      this.logger.info('Creating stable-diffusion addon with configuration:', configurationParams)
-      this.addon = this._createAddon(configurationParams)
-
-      this.logger.info('Activating stable-diffusion addon')
-      await this.addon.activate()
-
-      this.logger.info('Stable-diffusion model load completed successfully')
-    } catch (error) {
-      this.logger.error('Error during stable-diffusion model load:', error)
-      throw error
+    const isSplitLayout = !!this._files.llm || !!this._files.t5Xxl
+    const configurationParams = {
+      path: isSplitLayout ? '' : (this._files.model || ''),
+      diffusionModelPath: isSplitLayout ? (this._files.model || '') : '',
+      clipLPath: this._files.clipL || '',
+      clipGPath: this._files.clipG || '',
+      t5XxlPath: this._files.t5Xxl || '',
+      llmPath: this._files.llm || '',
+      vaePath: this._files.vae || '',
+      config: this._config
     }
+
+    this.logger.info('Creating stable-diffusion addon with configuration:', configurationParams)
+    this.addon = this._createAddon(configurationParams)
+
+    this.logger.info('Activating stable-diffusion addon')
+    await this.addon.activate()
+
+    this.logger.info('Stable-diffusion model load completed successfully')
   }
 
-  /**
-   * @param {object} configurationParams
-   * @returns {SdInterface}
-   */
   _createAddon (configurationParams) {
     this._binding = require('./binding')
     this._connectNativeLogger()
@@ -136,78 +91,28 @@ class ImgStableDiffusion extends BaseInference {
 
   _addonOutputCallback (addon, event, data, error) {
     if (event.includes('Error')) {
-      return this._outputCallback(addon, 'Error', 'OnlyOneJob', data, error)
+      this.logger.error(`Job failed with error: ${error}`)
+      this._job.fail(error)
+      return
     }
 
     if (data instanceof Uint8Array || typeof data === 'string') {
-      return this._outputCallback(addon, 'Output', 'OnlyOneJob', data, error)
+      this._job.output(data)
+      return
     }
 
-    // RuntimeStats is the only plain-object payload the C++ addon emits.
-    // Matching structurally avoids coupling to specific stats key names.
     if (typeof data === 'object' && data !== null) {
-      return this._outputCallback(addon, 'JobEnded', 'OnlyOneJob', data, null)
+      this._job.end(this.opts.stats ? data : null)
+      return
     }
 
-    return this._outputCallback(addon, event, 'OnlyOneJob', data, error)
+    this._job.output(data)
   }
 
-  /**
-   * Cancel the current generation job.
-   */
-  async cancel () {
-    if (this.addon?.cancel) {
-      await this.addon.cancel()
-    }
+  async run (params) {
+    return this._run(() => this._runInternal(params))
   }
 
-  /**
-   * Unload the model and release all resources.
-   */
-  async unload () {
-    return await this._withExclusiveRun(async () => {
-      await this.cancel()
-      const currentJobResponse = this._jobToResponse.get('OnlyOneJob')
-      if (currentJobResponse) {
-        currentJobResponse.failed(new Error('Model was unloaded'))
-        this._deleteJobMapping('OnlyOneJob')
-      }
-      this._hasActiveResponse = false
-      if (this.addon) {
-        await super.unload()
-      }
-      this._releaseNativeLogger()
-    })
-  }
-
-  /**
-   * Generate an image from a text prompt, or from an input image + text prompt.
-   *
-   * Currently supports txt2img only. img2img is not yet wired in the JS
-   * layer — passing `init_image` will throw.
-   *
-   * Returns a QvacResponse that streams two types of updates:
-   *   - Uint8Array  — PNG-encoded output image (one per batch_count)
-   *   - string      — JSON step-progress tick: {"step":N,"total":M,"elapsed_ms":T}
-   *
-   * @param {object} params
-   * @param {string} params.prompt                  - Text prompt
-   * @param {string} [params.negative_prompt]       - Negative prompt
-   * @param {number} [params.steps=20]              - Denoising step count
-   * @param {number} [params.width=512]             - Output width (multiple of 8)
-   * @param {number} [params.height=512]            - Output height (multiple of 8)
-   * @param {number} [params.guidance=3.5]          - Distilled guidance (FLUX.2)
-   * @param {number} [params.cfg_scale=7.0]         - CFG scale (SD1/SD2)
-   * @param {string} [params.sampling_method]       - Sampler name
-   * @param {string} [params.scheduler]             - Scheduler name
-   * @param {number} [params.seed=-1]               - RNG seed; -1 = random
-   * @param {number} [params.batch_count=1]         - Images per call
-   * @param {boolean} [params.vae_tiling=false]     - Enable VAE tiling (for large images)
-   * @param {string}  [params.cache_preset]         - Cache preset: slow/medium/fast/ultra
-   * @param {Uint8Array} [params.init_image]        - Source image bytes for img2img (PNG/JPEG) — not yet supported
-   * @param {number}    [params.strength=0.75]      - img2img: 0 = keep source, 1 = ignore source — not yet supported
-   * @returns {Promise<QvacResponse>}
-   */
   async _runInternal (params) {
     if (params.init_image) {
       throw new Error('img2img is not yet supported — omit init_image to run txt2img')
@@ -216,39 +121,56 @@ class ImgStableDiffusion extends BaseInference {
     const mode = 'txt2img'
     this.logger.info('Starting generation with mode:', mode)
 
-    return await this._withExclusiveRun(async () => {
-      if (this._hasActiveResponse) {
-        throw new Error(RUN_BUSY_ERROR_MESSAGE)
+    if (this._hasActiveResponse) {
+      throw new Error(RUN_BUSY_ERROR_MESSAGE)
+    }
+
+    const response = this._job.start()
+
+    let accepted
+    try {
+      accepted = await this.addon.runJob({ ...params, mode })
+    } catch (error) {
+      this._job.fail(error)
+      throw error
+    }
+
+    if (!accepted) {
+      this._job.fail(new Error(RUN_BUSY_ERROR_MESSAGE))
+      throw new Error(RUN_BUSY_ERROR_MESSAGE)
+    }
+
+    this._hasActiveResponse = true
+    const finalized = response.await().finally(() => { this._hasActiveResponse = false })
+    finalized.catch(() => {})
+    response.await = () => finalized
+
+    this.logger.info('Generation job started successfully')
+    return response
+  }
+
+  async cancel () {
+    if (this.addon) {
+      await this.addon.cancel()
+    }
+  }
+
+  async unload () {
+    return this._run(async () => {
+      await this.cancel()
+      if (this._job.active) {
+        this._job.fail(new Error('Model was unloaded'))
       }
-
-      const response = this._createResponse('OnlyOneJob')
-
-      let accepted
-      try {
-        accepted = await this.addon.runJob({ ...params, mode })
-      } catch (error) {
-        this._deleteJobMapping('OnlyOneJob')
-        response.failed(error)
-        throw error
+      this._hasActiveResponse = false
+      if (this.addon) {
+        await this.addon.unload()
       }
-
-      if (!accepted) {
-        this._deleteJobMapping('OnlyOneJob')
-        const msg = RUN_BUSY_ERROR_MESSAGE
-        response.failed(new Error(msg))
-        throw new Error(msg)
-      }
-
-      this._hasActiveResponse = true
-      const finalized = response.await().finally(() => { this._hasActiveResponse = false })
-      finalized.catch(() => {})
-      response.await = () => finalized
-
-      this.logger.info('Generation job started successfully')
-
-      return response
+      this._releaseNativeLogger()
+      this.state.configLoaded = false
     })
   }
+
+  getState () { return this.state }
 }
 
 module.exports = ImgStableDiffusion

--- a/packages/lib-infer-diffusion/package.json
+++ b/packages/lib-infer-diffusion/package.json
@@ -73,7 +73,8 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@qvac/infer-base": "^0.2.2",
+    "@qvac/infer-base": "^0.4.0",
+    "@qvac/logging": "^0.1.0",
     "bare-path": "^3.0.0",
     "bare-process": "^4.2.2"
   },

--- a/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
+++ b/packages/lib-infer-diffusion/test/integration/api-behavior.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const test = require('brittle')
+const path = require('bare-path')
 const os = require('bare-os')
 const proc = require('bare-process')
 const binding = require('../../binding')
@@ -49,20 +50,19 @@ async function setupModel (t) {
     downloadUrl: MODEL.url
   })
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: modelDir,
-      modelName
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(modelDir, modelName)
     },
-    {
+    config: {
       device: useCpu ? 'cpu' : 'gpu',
       vae_on_cpu: isAndroid,
       threads: 4,
       prediction: 'v',
       verbosity: '2'
-    }
-  )
+    },
+    logger: console
+  })
 
   await model.load()
 

--- a/packages/lib-infer-diffusion/test/integration/generate-image-flux2.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-flux2.test.js
@@ -68,19 +68,18 @@ test('FLUX.2 klein txt2img — generates a valid PNG image', { timeout: 1800000,
   const modelPath = path.join(modelDir, downloadedModelName)
   t.ok(fs.existsSync(modelPath), 'Model file exists on disk')
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: modelDir,
-      modelName: downloadedModelName,
-      llmModel: LLM_MODEL.name,
-      vaeModel: VAE_MODEL.name
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(modelDir, downloadedModelName),
+      llm: path.join(modelDir, LLM_MODEL.name),
+      vae: path.join(modelDir, VAE_MODEL.name)
     },
-    {
+    config: {
       threads: 4,
       device: useCpu ? 'cpu' : 'gpu'
-    }
-  )
+    },
+    logger: console
+  })
 
   const images = []
   const progressTicks = []

--- a/packages/lib-infer-diffusion/test/integration/generate-image-sd3.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-sd3.test.js
@@ -46,19 +46,18 @@ test('SD3 Medium txt2img — generates a valid PNG image', { timeout: 900000, sk
   const modelPath = path.join(modelDir, downloadedModelName)
   t.ok(fs.existsSync(modelPath), 'Model file exists on disk')
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: modelDir,
-      modelName: downloadedModelName
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(modelDir, downloadedModelName)
     },
-    {
+    config: {
       threads: 4,
       device: useCpu ? 'cpu' : 'gpu',
       prediction: 'flow',
       flow_shift: '3.0'
-    }
-  )
+    },
+    logger: console
+  })
 
   const images = []
   const progressTicks = []

--- a/packages/lib-infer-diffusion/test/integration/generate-image-sdxl.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image-sdxl.test.js
@@ -46,18 +46,16 @@ test('SDXL txt2img — generates a valid PNG image', { timeout: 900000, skip }, 
   const modelPath = path.join(modelDir, downloadedModelName)
   t.ok(fs.existsSync(modelPath), 'Model file exists on disk')
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: modelDir,
-      modelName: downloadedModelName
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(modelDir, downloadedModelName)
     },
-    {
+    config: {
       threads: 4,
       device: useCpu ? 'cpu' : 'gpu'
-
-    }
-  )
+    },
+    logger: console
+  })
 
   const images = []
   const progressTicks = []

--- a/packages/lib-infer-diffusion/test/integration/generate-image.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image.test.js
@@ -45,18 +45,17 @@ test('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000, skip },
   const modelPath = path.join(modelDir, downloadedModelName)
   t.ok(fs.existsSync(modelPath), 'Model file exists on disk')
 
-  const model = new ImgStableDiffusion(
-    {
-      logger: console,
-      diskPath: modelDir,
-      modelName: downloadedModelName
+  const model = new ImgStableDiffusion({
+    files: {
+      model: path.join(modelDir, downloadedModelName)
     },
-    {
+    config: {
       threads: 4,
       device: useCpu ? 'cpu' : 'gpu',
       prediction: 'v' // SD2.1 uses v-prediction
-    }
-  )
+    },
+    logger: console
+  })
 
   const images = []
   const progressTicks = []

--- a/packages/lib-infer-diffusion/test/integration/model-loading.test.js
+++ b/packages/lib-infer-diffusion/test/integration/model-loading.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const test = require('brittle')
+const path = require('bare-path')
 const os = require('bare-os')
 const proc = require('bare-process')
 
@@ -32,10 +33,12 @@ test('model loading - load and unload', { timeout: 600_000 }, async t => {
   }
 
   const addon = new ImgStableDiffusion({
-    modelName: downloadedModelName,
-    diskPath: modelDir,
+    files: {
+      model: path.join(modelDir, downloadedModelName)
+    },
+    config,
     logger: console
-  }, config)
+  })
 
   await addon.load()
   t.pass('model loaded successfully')


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Diffusion addon inherits from BaseInference solely for job management boilerplate
- Constructor uses diskPath + individual model name strings instead of resolved paths

## 📝 How does it solve it?

- Remove BaseInference class inheritance, use composable utilities from @qvac/infer-base@0.4.0
- createJobHandler() replaces _jobToResponse Map, _createResponse, _outputCallback routing
- exclusiveRunQueue() replaces _withExclusiveRun
- Constructor takes { files: { model, clipL?, clipG?, t5Xxl?, llm?, vae? }, config, logger, opts } with absolute paths
- All 6 tests and 7 examples updated to new constructor shape

## 🧪 How was it tested?

- Lint passes (standard)
- TypeScript type check passes
- All tests and examples updated

## 💥 Breaking Changes

**BEFORE:**

```javascript
const model = new ImgStableDiffusion(
  { diskPath, modelName, llmModel, vaeModel, logger, opts },
  config
)
```

**AFTER:**

```javascript
const model = new ImgStableDiffusion({
  files: {
    model: '/abs/path/to/model.gguf',
    llm: '/abs/path/to/qwen3.gguf',
    vae: '/abs/path/to/vae.safetensors'
  },
  config: { device: 'gpu', threads: 4 },
  logger: console,
  opts: { stats: true }
})
```

## 🔌 API Changes

```javascript
// Constructor: single object with files (absolute paths for each model component)
// Removed: diskPath, modelName, clipLModel, clipGModel, t5XxlModel, llmModel, vaeModel as separate params
// Removed: BaseInference inheritance
// Kept: load(), run(), unload(), cancel(), getState()
```
