### PR TITLE
fix[notask]: remove hardcoded Xcode 16.4 from ocr prebuilds

### DIFF
--- a/.github/workflows/prebuilds-ocr-onnx.yml
+++ b/.github/workflows/prebuilds-ocr-onnx.yml
@@ -257,10 +257,6 @@ jobs:
           echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
           echo "$VCPKG_ROOT" >> $GITHUB_PATH
 
-      - if: ${{ startsWith(matrix.os, 'macos') }}
-        name: Select Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
-
       - if: ${{ startsWith(matrix.os, 'macos') && matrix.platform == 'ios' }}
         name: Verify UIKit Frameworks
         run: |

--- a/.github/workflows/prebuilds-ocr-onnx.yml
+++ b/.github/workflows/prebuilds-ocr-onnx.yml
@@ -63,10 +63,10 @@ jobs:
             arch: x64
             tags: -simulator
             flags: --simulator -D BUILD_TESTING=OFF
-          - os: macos-14
+          - os: macos-15
             platform: darwin
             arch: arm64
-          - os: macos-14
+          - os: macos-15-large
             platform: darwin
             arch: x64
           - os: windows-2022

--- a/.github/workflows/prebuilds-ocr-onnx.yml
+++ b/.github/workflows/prebuilds-ocr-onnx.yml
@@ -63,10 +63,10 @@ jobs:
             arch: x64
             tags: -simulator
             flags: --simulator -D BUILD_TESTING=OFF
-          - os: macos-15
+          - os: macos-14
             platform: darwin
             arch: arm64
-          - os: macos-15-large
+          - os: macos-14
             platform: darwin
             arch: x64
           - os: windows-2022

--- a/.github/workflows/prebuilds-ocr-onnx.yml
+++ b/.github/workflows/prebuilds-ocr-onnx.yml
@@ -49,16 +49,16 @@ jobs:
             arch: arm64
             variant: ubuntu
             flags: -D ANDROID_STL=c++_shared -D BUILD_TESTING=OFF
-          - os: macos-14
+          - os: macos-15
             platform: ios
             arch: arm64
             flags: -D BUILD_TESTING=OFF
-          - os: macos-14
+          - os: macos-15
             platform: ios
             arch: arm64
             tags: -simulator
             flags: --simulator -D BUILD_TESTING=OFF
-          - os: macos-14
+          - os: macos-15
             platform: ios
             arch: x64
             tags: -simulator


### PR DESCRIPTION
## Summary
- Remove explicit `xcode-select -s /Applications/Xcode_16.4.app` step from OCR prebuild workflow
- Xcode 16.4 is not available on `macos-14` runners, causing iOS prebuild failures
- Uses runner default Xcode instead, matching the NMT prebuild workflow approach

## Test plan
- [ ] Verify OCR prebuilds pass on macos-14 (iOS) and macos-15 (darwin)