### PR TITLE
chore(parakeet): add qvac-lint-cpp dependency to vcpkg.json

### DIFF
--- a/packages/qvac-lib-infer-parakeet/vcpkg.json
+++ b/packages/qvac-lib-infer-parakeet/vcpkg.json
@@ -7,6 +7,10 @@
       "name": "qvac-lib-inference-addon-cpp",
       "version>=": "1.1.5#1"
     },
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.4#2"
+    },
     "nlohmann-json",
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
## Summary
- Add `qvac-lint-cpp` dependency to `qvac-lib-infer-parakeet/vcpkg.json`, matching the version constraint (`1.4.4#2`) used by all other C++ packages
- This was the only C++ package in the monorepo missing the shared linting dependency

## Test plan
- [x] Verify `vcpkg install` resolves `qvac-lint-cpp` correctly during parakeet build
- [ ] Confirm CI passes for `qvac-lib-infer-parakeet`
