### PR TITLE
fix[notask]: remove redundant "using" from lib-infer-parakeet description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Legend:
 | lib-infer-nmtcpp | Native C++ addon for translation using either `qvac-fabric-llm.cpp` or [Bergamot](https://browser.mt) | Addon |
 | lib-infer-onnx | Bare addon for ONNX Runtime session management | Addon |
 | lib-infer-onnx-tts | Text-to-Speech (TTS) library using Chatterbox and Supertonic neural TTS model via ONNX Runtime | Addon |
-| lib-infer-parakeet | High-performance speech-to-text inference addon using via NVIDIA/Parakeet | Addon |
+| lib-infer-parakeet | High-performance speech-to-text inference addon via NVIDIA/Parakeet | Addon |
 | lib-infer-whispercpp | Library for running Whisper transcription model for audio transcription via `qvac-ext-lib-whisper.cpp` | Addon |
 | lib-inference-addon-cpp | Header-only C++ library providing common abstractions and infrastructure for building high-performance inference addons | Addon |
 | lib-langdetect-text | Language detection library providing interface for detecting language of given text | Addon |


### PR DESCRIPTION
## Summary

- Removes the duplicate/redundant word `using` from the `lib-infer-parakeet` row in the repository layout table (`README.md`)
  - Before: `High-performance speech-to-text inference addon using via NVIDIA/Parakeet`
  - After: `High-performance speech-to-text inference addon via NVIDIA/Parakeet`

## Test plan

- [ ] No functional changes — documentation-only fix, no tests required.

Made with [Cursor](https://cursor.com)