### PR TITLE
chore: migrate workflows to oss-action v1.2.0

### DIFF
--- a/.github/workflows/approval-worker.yml
+++ b/.github/workflows/approval-worker.yml
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
       statuses: write
       issues: write
-    uses: tetherto/oss-actions/.github/workflows/approval-check-worker.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/approval-check-worker.yml@v1.2.0
     secrets:
       pat_token: ${{ secrets.PAT_TOKEN }}
     with:

--- a/.github/workflows/on-merge-lib-infer-diffusion.yml
+++ b/.github/workflows/on-merge-lib-infer-diffusion.yml
@@ -217,6 +217,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: packages/lib-infer-diffusion

--- a/.github/workflows/on-merge-lib-infer-diffusion.yml
+++ b/.github/workflows/on-merge-lib-infer-diffusion.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -193,6 +193,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: ${{ env.PKG_DIR }}

--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
@@ -191,7 +191,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -154,7 +154,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -185,6 +185,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           repo_name: "decoder-audio"

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
@@ -185,6 +185,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: packages/qvac-lib-infer-llamacpp-embed

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
@@ -183,7 +183,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
@@ -218,6 +218,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: packages/qvac-lib-infer-llamacpp-llm

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
@@ -190,7 +190,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -192,6 +192,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: ${{ env.PKG_DIR }}

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
@@ -183,6 +183,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           path: ${{ env.WORKDIR }}

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
@@ -181,7 +181,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
@@ -184,7 +184,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
@@ -186,6 +186,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: packages/qvac-lib-infer-onnx

--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -211,6 +211,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: packages/qvac-lib-infer-parakeet

--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || needs.publish-logic.outputs.gpr_tag }}
@@ -209,7 +209,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -221,6 +221,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: ${{ env.WORKDIR }}

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.tag) || needs.publish-logic.outputs.gpr_tag }}
@@ -219,7 +219,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-pr-close-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-close-lib-infer-diffusion.yml
@@ -52,7 +52,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-ocr-onnx.yml
+++ b/.github/workflows/on-pr-close-ocr-onnx.yml
@@ -49,7 +49,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-decoder-audio.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-embed.yml
@@ -56,7 +56,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-llm.yml
@@ -52,7 +52,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-nmtcpp.yml
@@ -47,7 +47,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-onnx-tts.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-onnx.yml
@@ -49,7 +49,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-parakeet.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-whispercpp.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.2.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -52,7 +52,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
 
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.2.0
     needs: authorize
     secrets: inherit
     with:
@@ -165,7 +165,7 @@ jobs:
         ts-checks,
       ]
     if: always()
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Verify that yaml files are formatted
         id: yamlfmt
-        uses: tetherto/oss-actions/.github/actions/yamlfmt@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/yamlfmt@v1.2.0
         continue-on-error: true
 
       - name: Check for disallowed dependencies
@@ -123,7 +123,7 @@ jobs:
       - name: Run JavaScript tests
         id: run_js_tests
         continue-on-error: true
-        uses: tetherto/oss-actions/.github/actions/run-lint-and-unit-tests@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/run-lint-and-unit-tests@v1.2.0
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
           gpr-token: ${{ secrets.GITHUB_TOKEN }}
@@ -162,7 +162,7 @@ jobs:
   cpp-lint:
     needs: [authorize, changes]
     if: needs.authorize.outputs.allowed == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.2.0
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -228,7 +228,7 @@ jobs:
   merge-guard:
     needs: [authorize, changes, sanity-checks, prebuild, run-integration-tests, run-mobile-integration-tests]
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
@@ -139,7 +139,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -179,7 +179,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, run-integration-tests, run-mobile-integration-tests]
     if: always()
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -47,7 +47,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
-    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.2.0
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha }}
@@ -153,7 +153,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, cpp-lint, cpp-tests, prebuild, integration-tests, run-mobile-integration-tests, ts-checks]
     if: always()
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -52,7 +52,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -72,7 +72,7 @@ jobs:
 
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.2.0
     needs: authorize
     secrets: inherit
     with:
@@ -165,7 +165,7 @@ jobs:
         ts-checks,
       ]
     if: always()
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success'}}

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -65,7 +65,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -113,7 +113,7 @@ jobs:
       always() &&
        needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.2.0
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}
@@ -201,7 +201,7 @@ jobs:
         run-mobile-integration-tests,
       ]
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.cpp-tests.result == 'success' && needs.ts-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
@@ -139,7 +139,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
   cpp-lint:
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.2.0
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -229,7 +229,7 @@ jobs:
         run-mobile-integration-tests,
       ]
     if: always()
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Verify that yaml files are formatted
         id: yamlfmt
-        uses: tetherto/oss-actions/.github/actions/yamlfmt@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/yamlfmt@v1.2.0
         continue-on-error: true
 
       - name: Check for disallowed dependencies
@@ -121,7 +121,7 @@ jobs:
       - name: Run JavaScript tests
         id: run_js_tests
         continue-on-error: true
-        uses: tetherto/oss-actions/.github/actions/run-lint-and-unit-tests@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/run-lint-and-unit-tests@v1.2.0
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
           gpr-token: ${{ secrets.GITHUB_TOKEN }}
@@ -160,7 +160,7 @@ jobs:
   cpp-lint:
     needs: [authorize, changes]
     if: needs.authorize.outputs.allowed == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.2.0
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -188,7 +188,7 @@ jobs:
   merge-guard:
     needs: [authorize, changes, sanity-checks, prebuild]
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -124,7 +124,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -135,7 +135,7 @@ jobs:
   cpp-lint:
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.2.0
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -200,7 +200,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
     if: always()
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -139,7 +139,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
   cpp-lint:
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.2.0
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -216,7 +216,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
     if: always()
-    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.2.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}

--- a/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
@@ -74,7 +74,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: yamlfmt
-        uses: tetherto/oss-actions/.github/actions/yamlfmt@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/yamlfmt@v1.2.0
         with:
           workdir: ${{ env.PKG_DIR }}
         

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -230,7 +230,7 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
 
       - name: Publish to GitHub Package Registry
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           workdir: ${{ env.PKG_DIR }}/shared
@@ -271,7 +271,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
@@ -404,7 +404,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
 
       - name: Publish to GitHub Package Registry
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           workdir: ${{ env.PKG_DIR }}/client
@@ -447,7 +447,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -273,6 +273,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: ${{ env.PKG_DIR }}/shared
@@ -449,6 +451,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           workdir: ${{ env.PKG_DIR }}/client

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -345,7 +345,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || needs.publish-logic.outputs.gpr_tag || 'dev'}}
@@ -378,7 +378,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -380,6 +380,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           git-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -181,6 +181,8 @@ jobs:
         id: publish
         uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
+          npm_package_scope: "@qvac"
+          npm_package_access: "public"
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
           git-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -145,7 +145,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -179,7 +179,7 @@ jobs:
 
       - name: Publish to NPM
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm-oidc@v1.2.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
@@ -223,7 +223,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -255,7 +255,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-dl-base.yml
+++ b/.github/workflows/trigger-reusable-lib-dl-base.yml
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/dl-base
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-dl-filesystem.yml
+++ b/.github/workflows/trigger-reusable-lib-dl-filesystem.yml
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/dl-filesystem
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-error.yml
+++ b/.github/workflows/trigger-reusable-lib-error.yml
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/error
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-hyperdrive.yml
+++ b/.github/workflows/trigger-reusable-lib-hyperdrive.yml
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/dl-hyperdrive
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-logging.yml
+++ b/.github/workflows/trigger-reusable-lib-logging.yml
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/logging
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
@@ -99,7 +99,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -115,7 +115,7 @@ jobs:
       packages: write
       id-token: write
     if: needs.publish-logic.outputs.publish_release == 'true'
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/qvac-lib-diagnostics
@@ -150,7 +150,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -173,7 +173,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/qvac-lib-infer-base
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
@@ -149,7 +149,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/qvac-lib-langdetect-text-cld2
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -212,7 +212,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/qvac-lib-langdetect-text
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-rag.yml
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.2.0
     secrets: inherit
     with:
       workdir: packages/rag
@@ -163,7 +163,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.2.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Summary

This PR upgrades the oss-actions reusable workflows and actions from v1.1.0 to v1.2.0 across all 40+ workflow files, incorporating the npm trust publishing feature.

The changes fall into three logical groups:

1. **oss-actions version bump** (v1.1.0 to v1.2.0) across all workflow files using tetherto/oss-actions
2. **NPM publishing migration** from `publish-library-to-npm` to `publish-library-to-npm-oidc` for OIDC-based authentication

---

## Changes

**oss-actions version bump** (40 workflow files): Updated all uses of tetherto/oss-actions actions and workflows from v1.1.0 to v1.2.0. Affected actions include `publish-library-to-gpr`, `publish-library-to-npm-oidc`, `sanity-checks`, `yamlfmt`, `run-lint-and-unit-tests`, `cpp-lint.yaml`, `public-pr.yml`, `public-reusable-npm.yml`, `public-delete-npm-versions.yml`, and `approval-check-worker.yml`.

**NPM publishing action migration** (17 workflows): Replaced `publish-library-to-npm@v1.1.0` with `publish-library-to-npm-oidc@v1.2.0` in all on-merge and trigger workflows. This enables OIDC-based authentication for npm publishing instead of token-based authentication.

---

## Impact

- **NPM publishing**: The migration from token-based (`publish-library-to-npm`) to OIDC-based (`publish-library-to-npm-oidc`) authentication eliminates the need for long-lived npm tokens. This improves security posture by removing secret token dependencies for npm publishing.
- **CI behavior**: No functional changes to workflow execution. All runners, jobs, and steps remain the same with updated action versions.
- **External impact**: npm publishing behavior changes from token-based to OIDC-based authentication. Relies on repository/org OIDC configuration for npm publishing.

---

## Validation

- Zero syntax errors across all 40+ modified workflow files
- All action references updated from v1.1.0 to v1.2.0 consistently
- All NPM publish steps migrated from `publish-library-to-npm` to `publish-library-to-npm-oidc`

---

## Test plan

- [ ] Verify npm publishing works with OIDC authentication after merge
- [ ] Monitor publish workflows in CI after merge to main

---

## Additional notes

### Security considerations

- Removing dependency on long-lived npm tokens improves security by eliminating a secret that could be leaked or misused.
- OIDC authentication is short-lived and automatically rotated, reducing the window of potential abuse.