### PR TITLE
fix: increase OIDC session duration to 2hrs for all mobile device far…

### DIFF
--- a/.github/workflows/integration-mobile-test-lib-infer-diffusion.yml
+++ b/.github/workflows/integration-mobile-test-lib-infer-diffusion.yml
@@ -737,6 +737,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Upload App to Device Farm
         id: upload_app

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -325,6 +325,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: eu-central-1
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Generate presigned URLs for OCR models
         working-directory: ./addon/${{ inputs.workdir || env.PKG_DIR }}
@@ -781,6 +782,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Upload App to Device Farm
         id: upload_app

--- a/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-decoder-audio.yml
@@ -649,6 +649,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Upload App to Device Farm
         id: upload_app

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -705,6 +705,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Upload App to Device Farm
         id: upload_app

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -741,6 +741,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Upload App to Device Farm
         id: upload_app

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -366,6 +366,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Generate IndicTrans Model URLs
         working-directory: ./monorepo/${{ inputs.workdir || env.PKG_DIR }}

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -786,6 +786,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Upload App to Device Farm
         id: upload_app

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -728,6 +728,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Upload App to Device Farm
         id: upload_app

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -740,6 +740,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-west-2
+          role-duration-seconds: 7200 # 2hrs for device farm tests
 
       - name: Upload App to Device Farm
         id: upload_app


### PR DESCRIPTION
  **Description:**                                                                                                           
  
  Adds role-duration-seconds: 7200 to OIDC credential steps in all 9 mobile integration test workflows (10 occurrences). 
  Prevents ExpiredTokenException when Device Farm runs exceed the default 1hr session.
                                                                                                                         
  **Workflows updated:**                                                                                                     
  - integration-mobile-test-qvac-lib-infer-llamacpp-llm
  - integration-mobile-test-lib-infer-diffusion                                                                          
  - integration-mobile-test-ocr-onnx (2 occurrences — eu-central-1 + us-west-2)
  - integration-mobile-test-qvac-lib-decoder-audio                                                                       
  - integration-mobile-test-qvac-lib-infer-llamacpp-embed                                                                
  - integration-mobile-test-qvac-lib-infer-nmtcpp        
  - integration-mobile-test-qvac-lib-infer-onnx-tts                                                                      
  - integration-mobile-test-qvac-lib-infer-parakeet                                                                      
  - integration-mobile-test-qvac-lib-infer-whispercpp
                                                                                                                         
  **Pre-requisite:** IAM role GitHub-OIDC-connector must have MaxSessionDuration set to at least 7200 on AWS side, otherwise workflows will fail with DurationSeconds exceeds MaxSessionDuration.   