### PR TITLE
 QVAC-16464 feat: update SDK OCR plugin to work with @qvac/ocr-onnx@0.4.0

### DIFF
--- a/packages/sdk/bun.lock
+++ b/packages/sdk/bun.lock
@@ -12,7 +12,7 @@
         "@qvac/langdetect-text": "^0.1.0",
         "@qvac/llm-llamacpp": "^0.12.1",
         "@qvac/logging": "^0.1.0",
-        "@qvac/ocr-onnx": "^0.2.0",
+        "@qvac/ocr-onnx": "^0.4.0",
         "@qvac/rag": "^0.4.4",
         "@qvac/registry-client": "^0.2.1",
         "@qvac/transcription-parakeet": "^0.2.7",
@@ -506,6 +506,8 @@
 
     "@qvac/decoder-audio": ["@qvac/decoder-audio@0.3.6", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.1.0", "@qvac/logging": "^0.1.0", "@qvac/response": "^0.1.0", "bare-assert": "^1.1.0", "bare-channel": "^5.2.2", "bare-ffmpeg": "^1.0.0-32", "bare-fs": "^4.5.1", "bare-path": "^3.0.0", "bare-process": "^4.2.2", "process": "npm:bare-process@^4.2.2" } }, "sha512-k0ePtP1HSLX5H0Og9cER8QHVSPcWwkiSHb58IpbhqSF41qYwUVhKtFI16hHjA2da+chqyu68c6I1tTWqnFWMDA=="],
 
+    "@qvac/diagnostics": ["@qvac/diagnostics@0.1.1", "", {}, "sha512-KUWpnNjtsNM2h2yIJXyQ6E5S53GDdRf2LXxp0E5dH7qLD5hToBrP4wjvdmahwmBobL7nJU9rum6uT3JgLVKm3w=="],
+
     "@qvac/diffusion-cpp": ["@qvac/diffusion-cpp@0.1.1", "", { "dependencies": { "@qvac/infer-base": "^0.2.2", "bare-path": "^3.0.0", "bare-process": "^4.2.2" } }, "sha512-ecUSbeqz5+WHb7V0lnyruBBFrlDwUZYws0wiUckbdj8xzIkhyxnkCDK6W2UcsCl+Gc+NSXCtIRF6pCiRG5fG/g=="],
 
     "@qvac/dl-base": ["@qvac/dl-base@0.2.1", "", { "dependencies": { "@qvac/logging": "^0.1.0", "ready-resource": "^1.1.1" } }, "sha512-Wd1/oOFsGb4O0kTKWw8OuQXhdr5EGBGn99zEdDYj4h1c+jUtAkpb39W5rf7D0A/XWwyVgsxL7vi7YHv6Xe7n/Q=="],
@@ -526,7 +528,7 @@
 
     "@qvac/logging": ["@qvac/logging@0.1.0", "", {}, "sha512-B9JayZKJGzSsM/9JmMdO7wiOOZ2mY5aWTbXl2aIKzy+l2Uqzkoby0IxMjKSVtYo6uMDs2zcrZqLtjI2dDSaYog=="],
 
-    "@qvac/ocr-onnx": ["@qvac/ocr-onnx@0.2.1", "", { "dependencies": { "@qvac/dl-hyperdrive": "^0.1.0", "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.1.0", "@qvac/response": "^0.1.2", "bare-fetch": "^2.5.1", "bare-fs": "^4.5.1", "bare-path": "^3.0.0", "bare-process": "^4.2.1" } }, "sha512-4njvOvovO4z9I00l2pPYcFm6MOPto7ZbnaWHJeOdn2jAkrpD+7ugttW0jJAapLTeF8hXIbcpX+uRFsXC3Razog=="],
+    "@qvac/ocr-onnx": ["@qvac/ocr-onnx@0.4.0", "", { "dependencies": { "@qvac/dl-hyperdrive": "^0.1.0", "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.4.0", "@qvac/onnx": "^0.14.0", "@qvac/response": "^0.1.2", "bare-fetch": "^2.5.1", "bare-fs": "^4.5.1", "bare-path": "^3.0.0", "bare-process": "^4.2.1" }, "optionalDependencies": { "@qvac/diagnostics": "^0.1.0" } }, "sha512-Yuj1fNO2D2EfWW0vi3p8tyn5t+uBH1dEHQdrheMuLt1hcfVhOCyKyGaIq9JaDd57dtTvHw+5gDWwdPI//TcsiQ=="],
 
     "@qvac/onnx": ["@qvac/onnx@0.14.0", "", {}, "sha512-P2RlpHcAdOs53aMfdMNBk3e8S6SFzroT5ShlZVM4Kag83nTpATJKIsxWyq64sHwSVtJjRtdxOF8lksbVnwzIvQ=="],
 
@@ -2538,6 +2540,8 @@
 
     "@qvac/llm-llamacpp/@qvac/infer-base": ["@qvac/infer-base@0.2.2", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/logging": "^0.1.0", "bare-events": "2.4.2", "bare-os": "^3.2.0", "bare-path": "^3.0.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-8D/5PRIy/A+Uhg1ZSoJMu5FSPDHdrMKZoPnAzTZMceikTj+BWwTV//j8pXbRABsjrFbqBegvr/LujirC9I2cRQ=="],
 
+    "@qvac/ocr-onnx/@qvac/infer-base": ["@qvac/infer-base@0.4.0", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/logging": "^0.1.0", "bare-events": "2.4.2", "bare-os": "^3.2.0", "bare-path": "^3.0.0" }, "optionalDependencies": { "@qvac/diagnostics": "^0.1.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-KoD4PrNzcScFjuLdGSTwtN/i10tMuwpRUW9g5lIiIaoR4s36NHwkfcxjyQDlHFlXkYjf3p3IpWXJgKOSo3jAqg=="],
+
     "@qvac/response/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
 
     "@qvac/transcription-parakeet/@qvac/infer-base": ["@qvac/infer-base@0.2.2", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/logging": "^0.1.0", "bare-events": "2.4.2", "bare-os": "^3.2.0", "bare-path": "^3.0.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-8D/5PRIy/A+Uhg1ZSoJMu5FSPDHdrMKZoPnAzTZMceikTj+BWwTV//j8pXbRABsjrFbqBegvr/LujirC9I2cRQ=="],
@@ -2791,6 +2795,8 @@
     "@qvac/embed-llamacpp/@qvac/infer-base/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
 
     "@qvac/llm-llamacpp/@qvac/infer-base/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
+
+    "@qvac/ocr-onnx/@qvac/infer-base/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
 
     "@qvac/transcription-parakeet/@qvac/infer-base/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -135,7 +135,7 @@
     "@qvac/langdetect-text": "^0.1.0",
     "@qvac/llm-llamacpp": "^0.12.1",
     "@qvac/logging": "^0.1.0",
-    "@qvac/ocr-onnx": "^0.2.0",
+    "@qvac/ocr-onnx": "^0.4.0",
     "@qvac/rag": "^0.4.4",
     "@qvac/registry-client": "^0.2.1",
     "@qvac/transcription-parakeet": "^0.2.7",

--- a/packages/sdk/server/bare/plugins/onnx-ocr/plugin.ts
+++ b/packages/sdk/server/bare/plugins/onnx-ocr/plugin.ts
@@ -15,8 +15,6 @@ import {
 import { ModelLoadFailedError } from "@/utils/errors-server";
 import { hyperdriveUrlSchema } from "@/schemas/load-model";
 import { createStreamLogger, registerAddonLogger } from "@/logging";
-import { parseModelPath } from "@/server/utils";
-import FilesystemDL from "@qvac/dl-filesystem";
 import { ONNXOcr } from "@qvac/ocr-onnx";
 import { ocr } from "@/server/bare/plugins/onnx-ocr/ops/ocr-stream";
 import { attachModelExecutionMs } from "@/profiling/model-execution";
@@ -36,13 +34,11 @@ function deriveDetectorSource(modelSrc: string): string | undefined {
 }
 
 function createOCRModel(
-  modelId: string,
-  detectorPath: string,
-  recognizerPath: string,
-  ocrConfig: OCRConfig,
+    modelId: string,
+    detectorPath: string,
+    recognizerPath: string,
+    ocrConfig: OCRConfig,
 ) {
-  const { dirPath } = parseModelPath(detectorPath);
-  const loader = new FilesystemDL({ dirPath });
   const logger = createStreamLogger(modelId, ModelType.onnxOcr);
   registerAddonLogger(modelId, ModelType.onnxOcr, logger);
 
@@ -77,7 +73,6 @@ function createOCRModel(
   };
 
   const args = {
-    loader: loader,
     logger,
     params,
     opts: { stats: true },
@@ -86,7 +81,7 @@ function createOCRModel(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
   const model = new ONNXOcr(args as any);
 
-  return { model, loader };
+  return model;
 }
 
 export const ocrPlugin = definePlugin({
@@ -96,15 +91,15 @@ export const ocrPlugin = definePlugin({
   loadConfigSchema: ocrConfigSchema,
 
   async resolveConfig(
-    cfg: OCRConfig,
-    ctx: ResolveContext,
+      cfg: OCRConfig,
+      ctx: ResolveContext,
   ): Promise<ResolveResult<Record<string, unknown>, "detectorModelPath">> {
     const { detectorModelSrc, ...ocrConfig } = cfg;
 
     const detectorSrc = detectorModelSrc ?? deriveDetectorSource(ctx.modelSrc);
     if (!detectorSrc) {
       throw new ModelLoadFailedError(
-        "Detector model required for OCR. Use a hyperdrive source or provide detectorModelSrc",
+          "Detector model required for OCR. Use a hyperdrive source or provide detectorModelSrc",
       );
     }
 
@@ -121,18 +116,18 @@ export const ocrPlugin = definePlugin({
 
     if (!detectorModelPath) {
       throw new ModelLoadFailedError(
-        "Detector model path missing. Ensure detectorModelSrc is provided in modelConfig.",
+          "Detector model path missing. Ensure detectorModelSrc is provided in modelConfig.",
       );
     }
 
-    const { model, loader } = createOCRModel(
-      params.modelId,
-      detectorModelPath,
-      params.modelPath, // recognizerPath
-      ocrConfig,
+    const model = createOCRModel(
+        params.modelId,
+        detectorModelPath,
+        params.modelPath, // recognizerPath
+        ocrConfig,
     );
 
-    return { model, loader };
+    return { model, loader: null };
   },
 
   handlers: {


### PR DESCRIPTION
 ## Summary                                                   
                                                                                                                                                                                                                                                      
  Update SDK OCR plugin to work with `@qvac/ocr-onnx@0.4.0` — the addon no longer needs a loader since it was never used (`noAdditionalDownload: true`).                                                                                              
                                                                            
  ## What changed                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                      
  - **Removed `FilesystemDL` loader creation** from OCR plugin — the addon never read from it
  - **Removed imports**: `FilesystemDL`, `parseModelPath`                                                                                                                                                                                             
  - **Simplified `createOCRModel()`** — passes `{ params, logger, opts }` directly instead of wrapping in a loader                                                                                                                                    
  - **`createModel` returns `loader: null`** — SDK's unload guard (`if (entry.local?.loader)`) handles this safely
  - **Bumped `@qvac/ocr-onnx`** from `^0.2.0` to `^0.4.0`                                                                                                                                                                                             
                                                                                          
  ## How was it tested                                                                                                                                                                                                                                
                                                                                          
  - `bun run build` — lint + typecheck + compile all pass                                                                                                                                                                                             
  - `bun run bare:example dist/examples/ocr-fasttext.js` && n`node dist/examples/ocr-fasttext.js` — full end-to-end OCR: model download from registry, load, inference ("tilted", "normal", "vertical" detected), unload
  - No consumer-facing API change — SDK's `loadModel`/`ocr`/`unloadModel` interface is identical                                                                                                                                                      
                                                                                        