### PR TITLE
[DEVOPS-2011]: fixes missing permission block on the workflows

### DIFF
--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-onnx-tts.yml
@@ -223,6 +223,9 @@ jobs:
           fi
 
   coverage-report:
+    permissions:
+      contents: read
+      actions: read
     needs: cpp-tests
     runs-on: ubuntu-latest
     if: ${{ always() }}

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-parakeet.yml
@@ -17,6 +17,10 @@ env:
 
 jobs:
   cpp-tests:
+    permissions:
+      contents: read
+      id-token: write
+      checks: write
     runs-on: ${{ matrix.os }}
     environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}-cpp-tests
@@ -225,6 +229,9 @@ jobs:
           fi
 
   coverage-report:
+    permissions:
+      contents: read
+      actions: read
     needs: cpp-tests
     runs-on: ubuntu-latest
     if: always()

--- a/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-qvac-lib-infer-whispercpp.yml
@@ -28,6 +28,10 @@ env:
 
 jobs:
   cpp-tests:
+    permissions:
+      contents: read
+      id-token: write
+      checks: write
     runs-on: ${{ matrix.os }}
     environment: release
     name: ${{ matrix.platform }}-${{ matrix.arch }}-cpp-tests
@@ -209,6 +213,9 @@ jobs:
           fi
 
   coverage-report:
+    permissions:
+      contents: read
+      actions: read
     needs: cpp-tests
     runs-on: ubuntu-latest
     if: always()


### PR DESCRIPTION
## Summary

Adds missing `permissions:` blocks to jobs in three C++ test coverage workflows. These permissions are required for the jobs to read workflow artifacts and write test results under the least-privilege model now enforced across the repository.

The fix follows the same pattern applied to other workflows in this series: `coverage-report` jobs require `contents: read` and `actions: read` to access test artifacts, while `cpp-tests` jobs require `contents: read`, `id-token: write`, and `checks: write` to authenticate with OIDC and publish test results.

---

## Changes

- `cpp-test-coverage-qvac-lib-infer-onnx-tts.yml`: Added `permissions:` block to `coverage-report` job
- `cpp-test-coverage-qvac-lib-infer-parakeet.yml`: Added `permissions:` block to `cpp-tests` job and `coverage-report` job
- `cpp-test-coverage-qvac-lib-infer-whispercpp.yml`: Added `permissions:` block to `cpp-tests` job and `coverage-report` job

---

## Impact

- Tightens permissions to explicit scopes; no functional change expected beyond resolving permission errors in restricted environments.

---

## Validation

- Zero missing `permissions:` blocks across all 3 modified workflow files.
- All affected jobs now declare explicit read/write scopes.

---

## Test plan

- [ ] Confirm `coverage-report` job downloads artifacts from `cpp-tests`.
- [ ] Confirm `cpp-tests` job publishes results to the GitHub Checks API.

Asana Ticket: https://app.asana.com/1/45238840754660/project/1210033537941987/task/1213980594127686?focus=true