### PR TITLE
Switch publish action to push npm packages public instead of restricted

### DIFF
--- a/.github/actions/publish-library-to-npm/action.yaml
+++ b/.github/actions/publish-library-to-npm/action.yaml
@@ -152,7 +152,7 @@ runs:
         echo "Publishing version: $VERSION"
         echo "Commit: $SHORT_SHA"
 
-        ACCESS="restricted"
+        ACCESS="public"
 
         if npm view "$PACKAGE_NAME@$VERSION" version >/dev/null 2>&1; then
           echo "Version $VERSION already exists for $PACKAGE_NAME on npm, skipping publish"


### PR DESCRIPTION
**Summary**
Update the publish-library-to-npm composite action to publish scoped npm packages with --access public instead of --access restricted.

This aligns the workflow with our intended package visibility so published @qvac/* packages are public on npm.
No functional change was made to the actions/setup-node step; the diff there is only a line-ending change.

**Test Plan**

-  Confirm the workflow now runs npm publish --access public
-  Trigger or inspect a release publish and verify the package is public on npm