### PR TITLE
chore[notask]: trigger release for @qvac/error 0.1.2

### DIFF
--- a/packages/error/CHANGELOG.md
+++ b/packages/error/CHANGELOG.md
@@ -11,3 +11,4 @@ The package has been renamed from `@qvac/error-base` to `@qvac/error` to better 
 ## [0.1.1]
 
 Initial tracked release.
+


### PR DESCRIPTION
## Summary
Trigger npm publish for qvac/error v0.1.2