### PR TITLE
QVAC-17045 fix: add asset download instructions to examples that use local files

### DIFF
--- a/packages/sdk/examples/ocr-fasttext.ts
+++ b/packages/sdk/examples/ocr-fasttext.ts
@@ -1,3 +1,14 @@
+/**
+ * OCR example using the QVAC SDK.
+ *
+ * Usage:
+ *   bun examples/ocr-fasttext.ts [path-to-image]
+ *
+ * This example requires a test image (default: examples/image/basic_test.bmp).
+ * Sample images are available in the QVAC source repository, but not included in the published npm package.
+ * Pass a custom image path, or download the default image into examples/image/:
+ *   https://github.com/tetherto/qvac/blob/main/packages/sdk/examples/image/basic_test.bmp
+ */
 import {
   close,
   loadModel,

--- a/packages/sdk/examples/transcription/parakeet-sortformer.ts
+++ b/packages/sdk/examples/transcription/parakeet-sortformer.ts
@@ -1,3 +1,14 @@
+/**
+ * Parakeet Sortformer diarization + TDT transcription example.
+ *
+ * Usage:
+ *   bun examples/transcription/parakeet-sortformer.ts [sortformer-src] [path-to-audio]
+ *
+ * This example requires a test audio file (default: examples/audio/diarization-sample-16k.wav).
+ * Sample audio files are available in the QVAC source repository, but not included in the published npm package.
+ * Pass a custom audio path as the second argument, or download the default audio into examples/audio/:
+ *   https://github.com/tetherto/qvac/blob/main/packages/sdk/examples/audio/diarization-sample-16k.wav
+ */
 import {
   loadModel,
   unloadModel,
@@ -18,7 +29,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
 const sortformerSrc = args[0] ?? PARAKEET_SORTFORMER_FP32;
 
-const defaultAudioPath = join(__dirname, "audio", "diarization-sample-16k.wav");
+const defaultAudioPath = join(
+  __dirname,
+  "..",
+  "audio",
+  "diarization-sample-16k.wav",
+);
 const audioFilePath = args[1] ?? defaultAudioPath;
 
 // ── Step 1: Diarize with Sortformer ──

--- a/packages/sdk/examples/transcription/whispercpp-filesystem-streaming.ts
+++ b/packages/sdk/examples/transcription/whispercpp-filesystem-streaming.ts
@@ -6,6 +6,11 @@
  *
  * Uses FFmpeg to convert the WAV to raw f32le and streams chunks
  * through the duplex RPC session to the whisper addon.
+ *
+ * This example requires a test audio file (default: examples/audio/diarization-sample-16k.wav).
+ * Sample audio files are available in the QVAC source repository, but not included in the published npm package.
+ * Set SAMPLE_FILE to a custom WAV, or download the default audio into examples/audio/:
+ *   https://github.com/tetherto/qvac/blob/main/packages/sdk/examples/audio/diarization-sample-16k.wav
  */
 import {
   loadModel,

--- a/packages/sdk/examples/transcription/whispercpp-prompt.ts
+++ b/packages/sdk/examples/transcription/whispercpp-prompt.ts
@@ -1,3 +1,14 @@
+/**
+ * Whisper transcription with prompt example.
+ *
+ * Usage:
+ *   bun examples/transcription/whispercpp-prompt.ts
+ *
+ * This example requires a test audio file (default: examples/audio/sample-16khz.wav).
+ * Sample audio files are available in the QVAC source repository, but not included in the published npm package.
+ * Set audioChunk to a custom WAV, or download the default audio into examples/audio/:
+ *   https://github.com/tetherto/qvac/blob/main/packages/sdk/examples/audio/sample-16khz.wav
+ */
 import { loadModel, unloadModel, transcribe, WHISPER_TINY } from "@qvac/sdk";
 
 try {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Examples that reference local assets (images, audio) have no indication that these files are only available in the repo and not in the published npm package
- Users installing via npm and running examples from `dist/` hit missing file errors with no guidance on how to resolve them
- The parakeet-sortformer example had an incorrect relative audio path (missing `..` for its subdirectory location)

## 📝 How does it solve it?

- Adds JSDoc headers to all 4 examples that depend on local assets, documenting what files are needed and how to obtain them from the repo.
- Fixes the `parakeet-sortformer.ts` default audio path since the file lives in `examples/transcription/`, not `examples/`