### PR TITLE
test(diffusion): validate ggml Vulkan leak fix via local overlay port

### DIFF
--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/android-vulkan-version.cmake
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/android-vulkan-version.cmake
@@ -1,0 +1,37 @@
+# Detect the Vulkan version shipped with the Android NDK by parsing
+# vulkan_core.h from the NDK sysroot.  Sets `vulkan_version` in the
+# caller's scope (e.g. "1.3.275").
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from ${vulkan_core_h}")
+    endif()
+
+    # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION_COMPLETE from ${vulkan_core_h}")
+    endif()
+endfunction()

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-config-include-dir.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-config-include-dir.patch
@@ -1,0 +1,20 @@
+--- a/cmake/ggml-config.cmake.in
++++ b/cmake/ggml-config.cmake.in
+@@ -112,7 +112,8 @@
+     add_library(ggml::ggml UNKNOWN IMPORTED)
+     set_target_properties(ggml::ggml
+         PROPERTIES
+-            IMPORTED_LOCATION "${GGML_LIBRARY}")
++            IMPORTED_LOCATION "${GGML_LIBRARY}"
++            INTERFACE_INCLUDE_DIRECTORIES "${GGML_INCLUDE_DIR}")
+ 
+     find_library(GGML_BASE_LIBRARY ggml-base
+         REQUIRED
+@@ -120,6 +121,7 @@
+         NO_CMAKE_FIND_ROOT_PATH)
+ 
+     add_library(ggml::ggml-base UNKNOWN IMPORTED)
++    set_property(TARGET ggml::ggml-base PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${GGML_INCLUDE_DIR}")
+     set_target_properties(ggml::ggml-base
+         PROPERTIES
+             IMPORTED_LOCATION "${GGML_BASE_LIBRARY}")

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-cpu-static-hybrid.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-cpu-static-hybrid.patch
@@ -1,0 +1,64 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b0b8e578..576d6a04 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -177,6 +177,7 @@ option(GGML_XTHEADVECTOR     "ggml: enable xtheadvector"     OFF)
+ option(GGML_VXE              "ggml: enable vxe"              ${GGML_NATIVE})
+ 
+ option(GGML_CPU_ALL_VARIANTS "ggml: build all variants of the CPU backend (requires GGML_BACKEND_DL)" OFF)
++option(GGML_CPU_STATIC        "ggml: build CPU backend as static library even with GGML_BACKEND_DL"   OFF)
+ set(GGML_CPU_ARM_ARCH        "" CACHE STRING "ggml: CPU architecture for ARM")
+ set(GGML_CPU_POWERPC_CPUTYPE "" CACHE STRING "ggml: CPU type for PowerPC")
+ 
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index d577f809..ef3a1308 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -187,6 +187,10 @@ endif()
+ 
+ # GGML_BACKEND_DL works with static core when PIC is enabled below.
+ 
++if (GGML_CPU_STATIC AND GGML_CPU_ALL_VARIANTS)
++    message(FATAL_ERROR "GGML_CPU_STATIC is incompatible with GGML_CPU_ALL_VARIANTS")
++endif()
++
+ add_library(ggml-base
+             ../include/ggml.h
+             ../include/ggml-alloc.h
+@@ -243,7 +247,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+ endif()
+ 
+ function(ggml_add_backend_library backend)
+-    if (GGML_BACKEND_DL)
++    if (GGML_BACKEND_DL AND NOT (GGML_CPU_STATIC AND ${backend} MATCHES "^ggml-cpu"))
+         add_library(${backend} MODULE ${ARGN})
+         # write the shared library to the output directory
+         set_target_properties(${backend} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+@@ -299,6 +303,9 @@ function(ggml_add_backend backend)
+             string(TOUPPER "GGML_USE_${backend}" backend_use)
+             target_compile_definitions(ggml PUBLIC ${backend_use})
+         endif()
++        if (GGML_CPU_STATIC AND "${backend}" STREQUAL "CPU")
++            target_compile_definitions(ggml PUBLIC GGML_USE_CPU)
++        endif()
+     endif()
+ endfunction()
+ 
+diff --git a/cmake/ggml-config.cmake.in b/cmake/ggml-config.cmake.in
+index 91c9d5cd..0c7a92c8 100644
+--- a/cmake/ggml-config.cmake.in
++++ b/cmake/ggml-config.cmake.in
+@@ -128,6 +128,12 @@ if(NOT TARGET ggml::ggml)
+     set(_ggml_all_targets "")
+-    if (NOT GGML_BACKEND_DL)
++    # In hybrid mode (GGML_BACKEND_DL + GGML_CPU_STATIC), only the CPU backend
++    # is static and must still be exported to downstream consumers.
++    if (NOT GGML_BACKEND_DL OR GGML_CPU_STATIC)
+         foreach(_ggml_backend ${GGML_AVAILABLE_BACKENDS})
++            string(REGEX MATCH "^ggml-cpu" is_cpu_variant "${_ggml_backend}")
++            if (GGML_BACKEND_DL AND GGML_CPU_STATIC AND NOT is_cpu_variant)
++                continue()
++            endif()
+             string(REPLACE "-" "_" _ggml_backend_pfx "${_ggml_backend}")
+             string(TOUPPER "${_ggml_backend_pfx}" _ggml_backend_pfx)
+ 

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-max-name.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-max-name.patch
@@ -1,0 +1,31 @@
+diff --git a/cmake/ggml-config.cmake.in b/cmake/ggml-config.cmake.in
+index 91c9d5c..b7d8ec2 100644
+--- a/cmake/ggml-config.cmake.in
++++ b/cmake/ggml-config.cmake.in
+@@ -124,6 +124,11 @@ if(NOT TARGET ggml::ggml)
+         PROPERTIES
+             IMPORTED_LOCATION "${GGML_BASE_LIBRARY}")
+ 
++    if(GGML_MAX_NAME)
++        set_property(TARGET ggml::ggml-base APPEND PROPERTY
++            INTERFACE_COMPILE_DEFINITIONS "GGML_MAX_NAME=${GGML_MAX_NAME}")
++    endif()
++
+     set(_ggml_all_targets "")
+     if (NOT GGML_BACKEND_DL)
+         foreach(_ggml_backend ${GGML_AVAILABLE_BACKENDS})
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 2650237..d0987d1 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -221,6 +221,10 @@ if (GGML_SCHED_NO_REALLOC)
+     target_compile_definitions(ggml-base PUBLIC GGML_SCHED_NO_REALLOC)
+ endif()
+ 
++if (DEFINED GGML_MAX_NAME)
++    target_compile_definitions(ggml-base PUBLIC GGML_MAX_NAME=${GGML_MAX_NAME})
++endif()
++
+ add_library(ggml
+             ggml-backend-dl.cpp
+             ggml-backend-reg.cpp)

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-opencl-graceful-no-devices.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-opencl-graceful-no-devices.patch
@@ -1,0 +1,25 @@
+--- a/src/ggml-opencl/ggml-opencl.cpp
++++ b/src/ggml-opencl/ggml-opencl.cpp
+@@ -3467,6 +3467,9 @@
+ 
+ ggml_backend_t ggml_backend_opencl_init(void) {
+     ggml_backend_dev_t dev = ggml_backend_reg_dev_get(ggml_backend_opencl_reg(), 0);
++    if (!dev) {
++        return nullptr;
++    }
+     ggml_backend_opencl_context *backend_ctx = ggml_cl2_init(dev);
+ 
+     ggml_backend_t backend = new ggml_backend {
+@@ -4722,7 +4725,11 @@
+ }
+ 
+ static ggml_backend_dev_t ggml_backend_opencl_reg_device_get(ggml_backend_reg_t reg, size_t index) {
+-    GGML_ASSERT(index < ggml_backend_opencl_reg_device_count(reg));
++    size_t n = ggml_backend_opencl_reg_device_count(reg);
++    if (n == 0) {
++        return nullptr;
++    }
++    GGML_ASSERT(index < n);
+ 
+     return &g_ggml_backend_opencl_devices[index];
+ 

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-opencl-public-header.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-opencl-public-header.patch
@@ -1,0 +1,11 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -319,6 +319,7 @@
+     include/ggml-cpp.h
+     include/ggml-cuda.h
+     include/ggml-opt.h
++    include/ggml-opencl.h
+     include/ggml-metal.h
+     include/ggml-rpc.h
+     include/ggml-virtgpu.h

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-qvac-backend-prefix.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-qvac-backend-prefix.patch
@@ -1,0 +1,45 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4eda64b5..fa379062 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -254,7 +254,9 @@ function(ggml_add_backend_library backend)
+     if (GGML_BACKEND_DL AND NOT (GGML_CPU_STATIC AND ${backend} MATCHES "^ggml-cpu"))
+         add_library(${backend} MODULE ${ARGN})
+         # write the shared library to the output directory
+-        set_target_properties(${backend} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
++        set_target_properties(${backend} PROPERTIES
++            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
++            OUTPUT_NAME "qvac-diffusion-${backend}")
+         target_compile_definitions(${backend} PRIVATE GGML_BACKEND_DL)
+         add_dependencies(ggml ${backend})
+         if (GGML_BACKEND_DIR)
+diff --git a/src/ggml-backend-reg.cpp b/src/ggml-backend-reg.cpp
+index 8a693f84..a514206d 100644
+--- a/src/ggml-backend-reg.cpp
++++ b/src/ggml-backend-reg.cpp
+@@ -437,9 +437,9 @@ static fs::path get_executable_path() {
+ 
+ static fs::path backend_filename_prefix() {
+ #ifdef _WIN32
+-    return fs::u8path("ggml-");
++    return fs::u8path("qvac-diffusion-ggml-");
+ #else
+-    return fs::u8path("libggml-");
++    return fs::u8path("libqvac-diffusion-ggml-");
+ #endif
+ }
+ 
+@@ -526,6 +526,13 @@ static ggml_backend_reg_t ggml_backend_load_best(const char * name, bool silent,
+                 }
+             }
+         }
++        // Android app packaging can flatten native libraries into one directory.
++        // If loading from the requested subdirectory fails, retry by filename only
++        // and leave lookup to dlopen's default search path resolution.
++        fs::path filename = backend_filename_prefix().native() + name_path.native() + backend_filename_extension().native();
++        if (auto reg = get_reg().load_backend(filename, silent)) {
++            return reg;
++        }
+         return nullptr;
+     }
+

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-static-core-dl-backends.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-static-core-dl-backends.patch
@@ -1,0 +1,31 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -185,9 +185,7 @@
+ 
+ # ggml
+ 
+-if (GGML_BACKEND_DL AND NOT BUILD_SHARED_LIBS)
+-    message(FATAL_ERROR "GGML_BACKEND_DL requires BUILD_SHARED_LIBS")
+-endif()
++# GGML_BACKEND_DL works with static core when PIC is enabled below.
+ 
+ add_library(ggml-base
+             ../include/ggml.h
+@@ -269,7 +267,7 @@
+     target_link_libraries(${backend} PRIVATE ggml-base)
+     target_include_directories(${backend} PRIVATE ..)
+ 
+-    if (${BUILD_SHARED_LIBS})
++    if (BUILD_SHARED_LIBS OR GGML_BACKEND_DL)
+         target_compile_definitions(${backend} PRIVATE GGML_BACKEND_BUILD)
+         target_compile_definitions(${backend} PUBLIC  GGML_BACKEND_SHARED)
+     endif()
+@@ -487,7 +485,7 @@
+     target_compile_definitions(ggml-base PUBLIC _DARWIN_C_SOURCE)
+ endif()
+ 
+-if (BUILD_SHARED_LIBS)
++if (BUILD_SHARED_LIBS OR GGML_BACKEND_DL)
+     foreach (target ggml-base ggml)
+         set_target_properties(${target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+         target_compile_definitions(${target} PRIVATE GGML_BUILD)

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-vulkan-device-cache-owned-storage.patch
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/ggml-vulkan-device-cache-owned-storage.patch
@@ -1,0 +1,47 @@
+diff --git a/src/ggml-vulkan/ggml-vulkan.cpp b/src/ggml-vulkan/ggml-vulkan.cpp
+index 3852867..3925e5e 100644
+--- a/src/ggml-vulkan/ggml-vulkan.cpp
++++ b/src/ggml-vulkan/ggml-vulkan.cpp
+@@ -15116,7 +15116,8 @@ static size_t ggml_backend_vk_reg_get_device_count(ggml_backend_reg_t reg) {
+ }
+ 
+ static ggml_backend_dev_t ggml_backend_vk_reg_get_device(ggml_backend_reg_t reg, size_t device) {
+-    static std::vector<ggml_backend_dev_t> devices;
++    static std::vector<std::unique_ptr<ggml_backend_device>> devices;
++    static std::vector<std::unique_ptr<ggml_backend_vk_device_context>> contexts;
+ 
+     static bool initialized = false;
+ 
+@@ -15126,7 +15127,7 @@ static ggml_backend_dev_t ggml_backend_vk_reg_get_device(ggml_backend_reg_t reg,
+         if (!initialized) {
+             const int min_batch_size = getenv("GGML_OP_OFFLOAD_MIN_BATCH") ? atoi(getenv("GGML_OP_OFFLOAD_MIN_BATCH")) : 32;
+             for (int i = 0; i < ggml_backend_vk_get_device_count(); i++) {
+-                ggml_backend_vk_device_context * ctx = new ggml_backend_vk_device_context;
++                auto ctx = std::make_unique<ggml_backend_vk_device_context>();
+                 char desc[256];
+                 ggml_backend_vk_get_device_description(i, desc, sizeof(desc));
+                 ctx->device = i;
+@@ -15135,18 +15136,20 @@ static ggml_backend_dev_t ggml_backend_vk_reg_get_device(ggml_backend_reg_t reg,
+                 ctx->is_integrated_gpu = ggml_backend_vk_get_device_type(i) == vk::PhysicalDeviceType::eIntegratedGpu;
+                 ctx->pci_bus_id = ggml_backend_vk_get_device_pci_id(i);
+                 ctx->op_offload_min_batch_size = min_batch_size;
+-                devices.push_back(new ggml_backend_device {
++                auto dev = std::make_unique<ggml_backend_device>(ggml_backend_device {
+                     /* .iface   = */ ggml_backend_vk_device_i,
+                     /* .reg     = */ reg,
+-                    /* .context = */ ctx,
++                    /* .context = */ ctx.get(),
+                 });
++                contexts.push_back(std::move(ctx));
++                devices.push_back(std::move(dev));
+             }
+             initialized = true;
+         }
+     }
+ 
+     GGML_ASSERT(device < devices.size());
+-    return devices[device];
++    return devices[device].get();
+ }
+ 
+ static const struct ggml_backend_reg_i ggml_backend_vk_reg_i = {

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/portfile.cmake
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/portfile.cmake
@@ -1,0 +1,176 @@
+# ggml vcpkg overlay port
+#
+# Builds the ggml tensor library from ggml-org/ggml.
+# Pinned to the commit used by stable-diffusion.cpp tag master-514-5792c66.
+#
+# Installed artefacts:
+#   include/ggml.h  (+ other ggml public headers)
+#   lib/libggml.a, lib/libggml-base.a, lib/libggml-cpu.a, …
+#   lib/cmake/ggml/  (CMake package config)
+#
+# GPU backend selection via vcpkg features:
+#   metal  -> GGML_METAL=ON  (macOS/iOS, default-feature on Apple platforms)
+#   vulkan -> GGML_VULKAN=ON
+#   cuda   -> GGML_CUDA=ON
+#   opencl -> GGML_OPENCL=ON
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ggml-org/ggml
+    REF a8db410a252c8c8f2d120c6f2e7133ebe032f35d
+    SHA512 bbca42948d994a33f1d6b2a65b254606f8b563d84d2b456db161cf55b6e01ed6b5eae7ad2c878bc4f03afc664c4209c2e87438fd4171a6f7c77dd907706e51bf
+    HEAD_REF master
+    PATCHES
+        ggml-max-name.patch
+        ggml-opencl-public-header.patch
+        ggml-opencl-graceful-no-devices.patch
+        ggml-config-include-dir.patch
+        ggml-vulkan-device-cache-owned-storage.patch
+        ggml-static-core-dl-backends.patch
+        ggml-cpu-static-hybrid.patch
+        ggml-qvac-backend-prefix.patch
+)
+
+# --- GPU feature flags ---
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+
+set(GGML_CUDA_COMPILER_OPTION "")
+
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+    # Locate nvcc explicitly — /usr/local/cuda/bin may not be on the PATH that
+    # vcpkg's isolated cmake process inherits.
+    find_program(NVCC_EXECUTABLE nvcc
+        PATHS /usr/local/cuda/bin /usr/local/cuda-12.8/bin
+        NO_DEFAULT_PATH
+    )
+    if(NOT NVCC_EXECUTABLE)
+        find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+    endif()
+    set(GGML_CUDA_COMPILER_OPTION "-DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}")
+    message(STATUS "CUDA compiler: ${NVCC_EXECUTABLE}")
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+# --- Android: fetch NDK-matched Vulkan C++ headers ---
+# The NDK ships vulkan/vulkan_core.h (C) but not vulkan/vulkan.hpp (C++).
+# Rather than pulling the vcpkg vulkan-headers package (which may be a
+# different version), we detect the NDK's exact Vulkan version and download
+# the matching C++ headers from KhronosGroup/Vulkan-Headers.
+if(VCPKG_TARGET_IS_ANDROID AND "vulkan" IN_LIST FEATURES)
+    include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+    detect_ndk_vulkan_version()
+    message(STATUS "NDK Vulkan version: ${vulkan_version}")
+
+    file(DOWNLOAD
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+        "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        TLS_VERIFY ON
+    )
+    file(ARCHIVE_EXTRACT
+        INPUT "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        DESTINATION "${SOURCE_PATH}"
+        PATTERNS "*.hpp"
+    )
+    # ggml_add_backend_library adds target_include_directories(${backend} PRIVATE ..)
+    # which resolves to src/ for backends under src/ggml-vulkan/.  Placing the
+    # headers at src/vulkan/*.hpp makes #include <vulkan/vulkan.hpp> resolve.
+    file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+         DESTINATION "${SOURCE_PATH}/src/")
+endif()
+
+# --- Platform options ---
+set(PLATFORM_OPTIONS)
+
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+
+# Hybrid backend mode for Android: GPU backends (Vulkan, OpenCL) are MODULE
+# .so files loaded at runtime via dlopen — no libOpenCL.so NEEDED dependency.
+# The CPU backend is statically linked (GGML_CPU_STATIC) so that SD can call
+# ggml_set_f32, ggml_backend_cpu_init, etc. directly at link time.
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_STATIC=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    )
+endif()
+
+# --- Configure & build ---
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_MAX_NAME=128  # stable-diffusion.cpp requires >= 128
+        ${GGML_CUDA_COMPILER_OPTION}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Install DL backend .so files for Android.  ggml builds each backend as a
+# MODULE target but does NOT install them via cmake install().
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-ggml-*.so"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+# Fix up the CMake package config installed by ggml's own build system.
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+# ggml installs a .pc to share/pkgconfig; move it to lib/pkgconfig and fix
+# absolute paths so vcpkg's post-build checks pass.
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# DL backends are only built for release; debug build produces fewer binaries.
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/usage
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/usage
@@ -1,0 +1,10 @@
+The package ggml provides CMake integration:
+
+  find_package(ggml CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ggml::ggml)
+
+Available vcpkg features:
+  metal  - Metal GPU backend (macOS/iOS, auto-enabled on Apple)
+  vulkan - Vulkan GPU backend
+  cuda   - CUDA GPU backend
+  opencl - OpenCL GPU backend

--- a/packages/lib-infer-diffusion/vcpkg/ports/ggml/vcpkg.json
+++ b/packages/lib-infer-diffusion/vcpkg/ports/ggml/vcpkg.json
@@ -1,0 +1,49 @@
+{
+  "name": "ggml",
+  "version-date": "2026-01-30",
+  "port-version": 4,
+  "description": "Tensor library for machine learning (ggml-org fork, pinned to commit used by stable-diffusion.cpp master-514-5792c66)",
+  "homepage": "https://github.com/ggml-org/ggml",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU backend"
+    },
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Uses a local ggml overlay port in `packages/lib-infer-diffusion/vcpkg/ports/ggml` to validate the Vulkan LeakSanitizer fix in qvac CI before the registry PR is merged.

## Scope
- adds the patched ggml overlay port only
- no qvac app code changes
- intended only to validate the fix through the addon workflow

## Validation
- addon build passed locally
- `npm run test:cpp:build` passed
- `packages/lib-infer-diffusion/build/test/unit/addon-test --gtest_filter='*SdModel*'` passed locally