### PR TITLE
Validate model path before calling common_init_from_params

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-embed/addon/src/patches/qvac-lib-inference-addon-cpp/LlamacppUtils.hpp
+++ b/packages/qvac-lib-infer-llamacpp-embed/addon/src/patches/qvac-lib-inference-addon-cpp/LlamacppUtils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <iostream>
 #include <ranges>
 #include <streambuf>
@@ -150,6 +151,13 @@ inline common_init_result_ptr initFromConfig(
       LOG_INF(
           "%s: load the model from disk file and apply lora adapter, if any.\n",
           __func__);
+      if (!std::filesystem::exists(modelPath)) {
+        throw qvac_errors::StatusError(
+            AddonID,
+            error,
+            string_format(
+                "%s: model file not found: %s\n", __func__, modelPath.c_str()));
+      }
       llamaInit = std::move(common_init_from_params(params));
     } else {
       LOG_INF(

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/patches/qvac-lib-inference-addon-cpp/LlamacppUtils.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/patches/qvac-lib-inference-addon-cpp/LlamacppUtils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <iostream>
 #include <ranges>
 #include <streambuf>
@@ -150,6 +151,13 @@ inline common_init_result_ptr initFromConfig(
       LOG_INF(
           "%s: load the model from disk file and apply lora adapter, if any.\n",
           __func__);
+      if (!std::filesystem::exists(modelPath)) {
+        throw qvac_errors::StatusError(
+            AddonID,
+            error,
+            string_format(
+                "%s: model file not found: %s\n", __func__, modelPath.c_str()));
+      }
       llamaInit = std::move(common_init_from_params(params));
     } else {
       LOG_INF(


### PR DESCRIPTION
The `common_init_from_params` function (in upstream llama.cpp) internally calls `llama_params_fit`, which calls `gguf_init_from_file` on the model path. When the path doesn't exist, this triggers a deep stack unwinding through llama.cpp internals. In the older llama.cpp version, a missing file was handled gracefully. 

The fix adds a `std::filesystem::exists(modelPath)` check before the call, so we throw a clean `StatusError` instead of crashing.