### PR TITLE
QVAC-14533 refactor[bc][api]: update TranscriptionWhispercpp to use files map and drop BaseInference

### DIFF
--- a/packages/qvac-lib-infer-whispercpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-whispercpp/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0]
+
+This release is a significant interface modernisation. The constructor switches to a local-files map, model download is removed from the load path, concurrent inference runs are serialised instead of rejected, and the class no longer extends `BaseInference`.
+
+## Breaking Changes
+
+### Constructor now takes a `files` map instead of loader + model name
+
+The old API accepted a `loader`, `modelName`, `vadModelName`, and `diskPath`. Those are all removed. Pass local file paths directly:
+
+```typescript
+// Before
+new TranscriptionWhispercpp({ loader, modelName: 'ggml-tiny.bin', diskPath: '/models' }, config)
+
+// After
+new TranscriptionWhispercpp({ files: { model: '/models/ggml-tiny.bin', vadModel: '/models/silero-vad.bin' } }, config)
+```
+
+`files.model` is required; `files.vadModel` is optional. No download step occurs — files must already exist on disk before calling `load()`.
+
+### `TranscriptionWhispercpp` no longer extends `BaseInference`
+
+The class is now standalone. `instanceof BaseInference` checks and any BaseInference-only APIs (`getApiDefinition`, `downloadWeights`, loader helpers) are no longer available on this class.
+
+### Weight download removed from `_load`
+
+`_load` previously triggered a `WeightsProvider` download when a loader was supplied. That path is gone. Load preparation is now the caller's responsibility.
+
+## New APIs
+
+### `runStreaming(audioStream)` is now part of the public API
+
+The VAD-based live streaming path was previously internal. It is now a documented public method with its own TypeScript declaration, accepting the same audio stream types as `run()`.
+
+```typescript
+const response = await model.runStreaming(audioStream)
+for await (const segment of response) { /* ... */ }
+```
+
+### Concurrent runs serialise instead of throwing
+
+When `exclusiveRun` is enabled (the default), a second call to `run()` or `runStreaming()` while a transcription is in progress will **wait** for the first to complete rather than throwing a `JOB_ALREADY_RUNNING` error. This makes it safe to call `run()` from concurrent contexts.
+
+### New typed exports
+
+`TranscriptionWhispercppFiles` and `InferenceClientState` are now exported from the `TranscriptionWhispercpp` namespace. Lifecycle methods (`load`, `unload`, `destroy`, `cancel`, `pause`, `unpause`, `stop`, `status`, `getState`) are now explicitly declared in `index.d.ts`.
+
 ## [0.5.5]
 
 ### Changed

--- a/packages/qvac-lib-infer-whispercpp/benchmarks/server/src/services/runAddon.js
+++ b/packages/qvac-lib-infer-whispercpp/benchmarks/server/src/services/runAddon.js
@@ -42,31 +42,6 @@ const getPackageVersion = (lib) => {
   }
 }
 
-class FakeLoader {
-  async start () {}
-  async stop () {}
-  async ready () {
-    return true
-  }
-
-  async getStream () {
-    throw new Error('FakeLoader.getStream should not be called when using diskPath')
-  }
-
-  async download (filepath, destPath) {
-    return {
-      await: async () => ({
-        success: false,
-        message: 'FakeLoader does not support downloading. Model files must exist on disk at the specified path.'
-      })
-    }
-  }
-
-  async list () {
-    return []
-  }
-}
-
 const runAddon = async (payload) => {
   const { inputs, whisper, config } =
     InferenceArgsSchema.parse(payload)
@@ -98,16 +73,16 @@ const runAddon = async (payload) => {
     if (!config.path) {
       throw new Error('Model path is required in config')
     }
-    validateFilePath(config.path)
+    const resolvedModelPath = validateFilePath(config.path)
 
     const constructorArgs = {
-      loader: new FakeLoader(),
-      modelName: path.basename(config.path),
-      diskPath: path.dirname(config.path)
+      files: {
+        model: resolvedModelPath
+      }
     }
 
     if (vadModelPath) {
-      constructorArgs.vadModelName = path.basename(vadModelPath)
+      constructorArgs.files.vadModel = validateFilePath(vadModelPath)
     }
 
     const unsupportedParams = ['mode', 'output_format', 'min_seconds', 'max_seconds']

--- a/packages/qvac-lib-infer-whispercpp/benchmarks/server/src/services/runLiveAudio.js
+++ b/packages/qvac-lib-infer-whispercpp/benchmarks/server/src/services/runLiveAudio.js
@@ -8,31 +8,6 @@ const path = require('bare-path')
 
 const loadedModels = new Map()
 
-class FakeLoader {
-  async start () {}
-  async stop () {}
-  async ready () {
-    return true
-  }
-
-  async getStream () {
-    throw new Error('FakeLoader.getStream should not be called when using diskPath')
-  }
-
-  async download (filepath, destPath) {
-    return {
-      await: async () => ({
-        success: false,
-        message: 'FakeLoader does not support downloading. Model files must exist on disk at the specified path.'
-      })
-    }
-  }
-
-  async list () {
-    return []
-  }
-}
-
 const runLiveAudio = async (payload) => {
   const { audio, config } = payload
 
@@ -69,14 +44,15 @@ const runLiveAudio = async (payload) => {
 
     const TranscriptionWhispercpp = require('@qvac/transcription-whispercpp')
 
+    const resolvedModelPath = path.resolve(modelPath)
     const constructorArgs = {
-      loader: new FakeLoader(),
-      modelName: path.basename(modelPath),
-      diskPath: path.dirname(modelPath)
+      files: {
+        model: resolvedModelPath
+      }
     }
 
     if (vadModelPath) {
-      constructorArgs.vadModelName = path.basename(vadModelPath)
+      constructorArgs.files.vadModel = path.resolve(vadModelPath)
     }
 
     const modelConfig = {

--- a/packages/qvac-lib-infer-whispercpp/examples/example.audio-ctx-chunking.js
+++ b/packages/qvac-lib-infer-whispercpp/examples/example.audio-ctx-chunking.js
@@ -4,7 +4,6 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const process = require('bare-process')
 const TranscriptionWhispercpp = require('../index.js')
-const FakeDL = require('../test/mocks/loader.fake.js')
 
 /**
  * Example: Testing audio_ctx with duration_ms
@@ -113,12 +112,13 @@ async function main () {
   }
 
   const constructorArgs = {
-    modelName: 'ggml-tiny.bin',
-    loader: new FakeDL({}),
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    }
   }
 
   const config = {
+    path: modelPath,
     whisperConfig: {
       language: 'en',
       audio_format: 's16le',

--- a/packages/qvac-lib-infer-whispercpp/examples/example.live-transcription.js
+++ b/packages/qvac-lib-infer-whispercpp/examples/example.live-transcription.js
@@ -5,7 +5,6 @@ const path = require('bare-path')
 const process = require('bare-process')
 const { Readable } = require('streamx')
 const TranscriptionWhispercpp = require('../index.js')
-const FakeDL = require('../test/mocks/loader.fake.js')
 
 /**
  * Example: Simulating live transcription with small audio chunks
@@ -166,12 +165,13 @@ async function main () {
   }
 
   const constructorArgs = {
-    modelName: 'ggml-tiny.bin',
-    loader: new FakeDL({}),
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    }
   }
 
   const config = {
+    path: modelPath,
     whisperConfig: {
       language: 'en',
       audio_format: 's16le',

--- a/packages/qvac-lib-infer-whispercpp/examples/example.reload.js
+++ b/packages/qvac-lib-infer-whispercpp/examples/example.reload.js
@@ -4,7 +4,6 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const process = require('bare-process')
 const TranscriptionWhispercpp = require('../index.js')
-const FakeDL = require('../test/mocks/loader.fake.js')
 
 // Usage: node examples/example.reload.js [audioPath] [modelPath]
 // Demonstrates reloading the model with different configurations
@@ -35,14 +34,14 @@ async function main () {
 
   // Constructor arguments for TranscriptionWhispercpp
   const constructorArgs = {
-    modelName: modelPathArg || 'ggml-tiny.bin',
-    loader: new FakeDL({}),
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    },
+    opts: { stats: true }
   }
 
   // Initial configuration with English language
   const config = {
-    opts: { stats: true },
     whisperConfig: {
       audio_format: 's16le',
       vad_model_path: path.join(modelsDir, 'ggml-silero-v5.1.2.bin'),

--- a/packages/qvac-lib-infer-whispercpp/examples/example.streaming-vad.js
+++ b/packages/qvac-lib-infer-whispercpp/examples/example.streaming-vad.js
@@ -4,7 +4,6 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const process = require('bare-process')
 const TranscriptionWhispercpp = require('../index.js')
-const FakeDL = require('../test/mocks/loader.fake.js')
 const binding = require('../binding.js')
 
 const LOG_PRIORITIES = ['ERROR', 'WARNING', 'INFO', 'DEBUG']
@@ -55,26 +54,27 @@ async function main () {
 
   const model = new TranscriptionWhispercpp(
     {
-      modelName: 'ggml-tiny.bin',
-      loader: new FakeDL({}),
-      diskPath: modelsDir
+      files: {
+        model: modelPath,
+        vadModel: vadModelPath
+      }
     },
     {
       whisperConfig: {
         language: 'en',
         audio_format: 's16le',
         temperature: 0.0,
-        suppress_nst: true
+        suppress_nst: true,
+        vad_params: {
+          threshold: 0.5,
+          min_silence_duration_ms: 500,
+          min_speech_duration_ms: 250,
+          max_speech_duration_s: 30,
+          speech_pad_ms: 30,
+          samples_overlap: 0.1
+        }
       },
-      vadModelPath,
-      vad_params: {
-        threshold: 0.5,
-        min_silence_duration_ms: 500,
-        min_speech_duration_ms: 250,
-        max_speech_duration_s: 30,
-        speech_pad_ms: 30,
-        samples_overlap: 0.1
-      }
+      vadModelPath
     }
   )
 

--- a/packages/qvac-lib-infer-whispercpp/examples/quickstart.js
+++ b/packages/qvac-lib-infer-whispercpp/examples/quickstart.js
@@ -4,7 +4,6 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const process = require('bare-process')
 const TranscriptionWhispercpp = require('../index.js')
-const FakeDL = require('../test/mocks/loader.fake.js')
 const binding = require('../binding.js')
 
 // Configure C++ logger to see logs
@@ -40,11 +39,14 @@ async function main () {
     modelName: modelPathArg || 'ggml-tiny.bin',
     loader: new FakeDL({}),
     diskPath: modelsDir
+    files: {
+      model: modelPath
+    },
+    opts: { stats: true }
   }
 
   // Configuration object
   const config = {
-    opts: { stats: true },
     whisperConfig: {
       audio_format: 's16le',
       // VAD tuning to avoid trimming the beginning

--- a/packages/qvac-lib-infer-whispercpp/examples/quickstart.js
+++ b/packages/qvac-lib-infer-whispercpp/examples/quickstart.js
@@ -18,7 +18,7 @@ binding.setLogger((priority, message) => {
 
 async function main () {
   const args = process.argv.slice(2)
-  const [, modelPathArg, vadModelPathArg, audioPathArg] = args
+  const [,, vadModelPathArg, audioPathArg] = args
 
   const modelsDir = path.join(__dirname, '..', 'models')
   const audioFilePath = audioPathArg || path.join(__dirname, 'samples', 'sample.raw')

--- a/packages/qvac-lib-infer-whispercpp/examples/quickstart.js
+++ b/packages/qvac-lib-infer-whispercpp/examples/quickstart.js
@@ -36,9 +36,6 @@ async function main () {
 
   // Constructor arguments for TranscriptionWhispercpp
   const constructorArgs = {
-    modelName: modelPathArg || 'ggml-tiny.bin',
-    loader: new FakeDL({}),
-    diskPath: modelsDir,
     files: {
       model: modelPath
     },

--- a/packages/qvac-lib-infer-whispercpp/examples/quickstart.js
+++ b/packages/qvac-lib-infer-whispercpp/examples/quickstart.js
@@ -38,7 +38,7 @@ async function main () {
   const constructorArgs = {
     modelName: modelPathArg || 'ggml-tiny.bin',
     loader: new FakeDL({}),
-    diskPath: modelsDir
+    diskPath: modelsDir,
     files: {
       model: modelPath
     },

--- a/packages/qvac-lib-infer-whispercpp/index.d.ts
+++ b/packages/qvac-lib-infer-whispercpp/index.d.ts
@@ -32,16 +32,6 @@ declare interface TranscriptionWhispercppArgs {
   [args: string]: unknown;
 }
 
-declare interface ProgressData {
-  action: string;
-  totalSize: number;
-  totalFiles: number;
-  filesProcessed: number;
-  currentFile: string;
-  currentFileProgress: string;
-  overallProgress: string;
-}
-
 declare interface TranscriptionWhispercppConfig {
   path?: string;
   enableStats?: boolean;
@@ -49,8 +39,6 @@ declare interface TranscriptionWhispercppConfig {
   whisperConfig: WhisperConfig;
   [args: string]: unknown;
 }
-
-declare type ReportProgressCallback = (progressData: ProgressData) => void;
 
 declare interface InferenceClientState {
   configLoaded: boolean;
@@ -103,10 +91,7 @@ declare class TranscriptionWhispercpp {
    * Load model and activate addon. Files must already exist at `files.model` / optional `files.vadModel`.
    * Optional parameters are accepted for `load(...args)` compatibility but are ignored.
    */
-  _load(
-    closeLoader?: boolean,
-    reportProgressCallback?: ReportProgressCallback
-  ): Promise<void>;
+  _load(closeLoader?: boolean): Promise<void>;
 
   /**
    * Reload the model with new configuration parameters.
@@ -169,8 +154,6 @@ declare namespace TranscriptionWhispercpp {
     TranscriptionWhispercppArgs,
     TranscriptionWhispercppFiles,
     TranscriptionWhispercppConfig,
-    ProgressData,
-    ReportProgressCallback,
     WhisperTranscriptionSegment,
     InferenceClientState,
   };

--- a/packages/qvac-lib-infer-whispercpp/index.d.ts
+++ b/packages/qvac-lib-infer-whispercpp/index.d.ts
@@ -102,6 +102,10 @@ declare class TranscriptionWhispercpp extends BaseInference {
   run(
     audioStream: Readable
   ): Promise<QvacResponse<TranscriptionWhispercpp.WhisperRunOutput>>;
+
+  runStreaming(
+    audioStream: Readable
+  ): Promise<QvacResponse<TranscriptionWhispercpp.WhisperRunOutput>>;
 }
 
 declare namespace TranscriptionWhispercpp {

--- a/packages/qvac-lib-infer-whispercpp/index.d.ts
+++ b/packages/qvac-lib-infer-whispercpp/index.d.ts
@@ -1,4 +1,4 @@
-import BaseInference, { Loader, QvacResponse } from "@qvac/infer-base";
+import BaseInference, { QvacResponse } from "@qvac/infer-base";
 import type { LoggerInterface } from "@qvac/logging";
 import { Readable } from "stream";
 
@@ -19,12 +19,16 @@ declare interface WhisperConfig {
   [key: string]: unknown;
 }
 
+declare interface TranscriptionWhispercppFiles {
+  model: string;
+  vadModel?: string;
+}
+
 declare interface TranscriptionWhispercppArgs {
-  loader: Loader;
+  files: TranscriptionWhispercppFiles;
   logger?: LoggerInterface;
-  modelName: string;
-  vadModelName?: string;
-  diskPath?: string;
+  exclusiveRun?: boolean;
+  opts?: { stats?: boolean };
   [args: string]: unknown;
 }
 
@@ -137,6 +141,7 @@ declare namespace TranscriptionWhispercpp {
     VadParams,
     WhisperConfig,
     TranscriptionWhispercppArgs,
+    TranscriptionWhispercppFiles,
     TranscriptionWhispercppConfig,
     ProgressData,
     ReportProgressCallback,

--- a/packages/qvac-lib-infer-whispercpp/index.d.ts
+++ b/packages/qvac-lib-infer-whispercpp/index.d.ts
@@ -76,10 +76,8 @@ declare class TranscriptionWhispercpp extends BaseInference {
   );
 
   /**
-   * Load model, weights, and activate addon.
-   * @param {boolean} [closeLoader=false] - Close loader when done.
-   * @param {ReportProgressCallback} [reportProgressCallback] - Hook for progress updates.
-   * @returns {Promise<void>} - A promise that resolves when the model is fully loaded.
+   * Load model and activate addon. Files must already exist at `files.model` / optional `files.vadModel`.
+   * Optional parameters are accepted for `load(...args)` compatibility but are ignored.
    */
   _load(
     closeLoader?: boolean,

--- a/packages/qvac-lib-infer-whispercpp/index.d.ts
+++ b/packages/qvac-lib-infer-whispercpp/index.d.ts
@@ -1,4 +1,4 @@
-import BaseInference, { QvacResponse } from "@qvac/infer-base";
+import QvacResponse from "@qvac/infer-base/src/QvacResponse";
 import type { LoggerInterface } from "@qvac/logging";
 import { Readable } from "stream";
 
@@ -52,6 +52,12 @@ declare interface TranscriptionWhispercppConfig {
 
 declare type ReportProgressCallback = (progressData: ProgressData) => void;
 
+declare interface InferenceClientState {
+  configLoaded: boolean;
+  weightsLoaded: boolean;
+  destroyed: boolean;
+}
+
 /**
  * A single transcription segment emitted by the Whisper addon in an output update.
  */
@@ -63,7 +69,7 @@ declare interface WhisperTranscriptionSegment {
 /**
  * GGML client implementation for the Whisper transcription model
  */
-declare class TranscriptionWhispercpp extends BaseInference {
+declare class TranscriptionWhispercpp {
   /**
    * Creates an instance of WhisperClient.
    * @constructor
@@ -74,6 +80,24 @@ declare class TranscriptionWhispercpp extends BaseInference {
     args: TranscriptionWhispercppArgs,
     config: TranscriptionWhispercppConfig
   );
+
+  getState(): InferenceClientState;
+
+  load(...args: unknown[]): Promise<void>;
+
+  unload(): Promise<void>;
+
+  destroy(): Promise<void>;
+
+  pause(): Promise<void>;
+
+  unpause(): Promise<void>;
+
+  stop(): Promise<void>;
+
+  status(): Promise<string>;
+
+  cancel(): Promise<void>;
 
   /**
    * Load model and activate addon. Files must already exist at `files.model` / optional `files.vadModel`.
@@ -148,6 +172,7 @@ declare namespace TranscriptionWhispercpp {
     ProgressData,
     ReportProgressCallback,
     WhisperTranscriptionSegment,
+    InferenceClientState,
   };
 }
 

--- a/packages/qvac-lib-infer-whispercpp/index.d.ts
+++ b/packages/qvac-lib-infer-whispercpp/index.d.ts
@@ -88,12 +88,6 @@ declare class TranscriptionWhispercpp {
   cancel(): Promise<void>;
 
   /**
-   * Load model and activate addon. Files must already exist at `files.model` / optional `files.vadModel`.
-   * Optional parameters are accepted for `load(...args)` compatibility but are ignored.
-   */
-  _load(closeLoader?: boolean): Promise<void>;
-
-  /**
    * Reload the model with new configuration parameters.
    * Useful for changing settings like language without destroying the instance.
    * @param {Object} newConfig - New configuration parameters

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -2,8 +2,7 @@
 
 const fs = require('bare-fs')
 const QvacLogger = require('@qvac/logging')
-const createJobHandler = require('@qvac/infer-base/src/utils/createJobHandler')
-const { QvacInferenceBaseError, ERR_CODES: BASE_ERR_CODES } = require('@qvac/infer-base/src/error')
+const { createJobHandler } = require('@qvac/infer-base')
 
 const { WhisperInterface } = require('./whisper')
 const { checkConfig } = require('./configChecker')
@@ -101,40 +100,28 @@ class TranscriptionWhispercpp {
 
   async pause () {
     if (!this.addon?.pause) {
-      throw new QvacInferenceBaseError({
-        code: BASE_ERR_CODES.ADDON_METHOD_NOT_IMPLEMENTED,
-        adds: 'pause'
-      })
+      throw new QvacErrorAddonWhisper({ code: ERR_CODES.FAILED_TO_PAUSE, adds: 'pause not supported' })
     }
     await this.addon.pause()
   }
 
   async unpause () {
     if (!this.addon?.activate) {
-      throw new QvacInferenceBaseError({
-        code: BASE_ERR_CODES.ADDON_METHOD_NOT_IMPLEMENTED,
-        adds: 'activate'
-      })
+      throw new QvacErrorAddonWhisper({ code: ERR_CODES.FAILED_TO_ACTIVATE, adds: 'activate not supported' })
     }
     await this.addon.activate()
   }
 
   async stop () {
     if (!this.addon?.stop) {
-      throw new QvacInferenceBaseError({
-        code: BASE_ERR_CODES.ADDON_METHOD_NOT_IMPLEMENTED,
-        adds: 'stop'
-      })
+      throw new Error('stop is not supported by this addon')
     }
     await this.addon.stop()
   }
 
   async status () {
     if (!this.addon?.status) {
-      throw new QvacInferenceBaseError({
-        code: BASE_ERR_CODES.ADDON_METHOD_NOT_IMPLEMENTED,
-        adds: 'status'
-      })
+      throw new QvacErrorAddonWhisper({ code: ERR_CODES.FAILED_TO_GET_STATUS, adds: 'status not supported' })
     }
     return await this.addon.status()
   }
@@ -230,12 +217,6 @@ class TranscriptionWhispercpp {
   }
 
   async run (input) {
-    if (!this._runInternal) {
-      throw new QvacInferenceBaseError({
-        code: BASE_ERR_CODES.NOT_IMPLEMENTED,
-        adds: '_runInternal'
-      })
-    }
     if (this.exclusiveRun) {
       return await this._enqueueExclusiveRunResponse(() => this._runInternal(input))
     }

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('bare-fs')
 const BaseInference = require('@qvac/infer-base/WeightsProvider/BaseInference')
+const { QvacInferenceBaseError, ERR_CODES: BASE_ERR_CODES } = require('@qvac/infer-base/src/error')
 
 const { WhisperInterface } = require('./whisper')
 const { checkConfig } = require('./configChecker')
@@ -42,7 +43,8 @@ class TranscriptionWhispercpp extends BaseInference {
     this._config = config
 
     this.params = config.whisperConfig
-    this._hasActiveResponse = false
+    /** Serializes inference runs; separate from {@link BaseInference#_runQueueWaiter} (reload/destroy). */
+    this._inferenceQueueWaiter = Promise.resolve()
 
     this.logger.debug('TranscriptionWhispercpp constructor called', {
       params: this.params,
@@ -124,13 +126,49 @@ class TranscriptionWhispercpp extends BaseInference {
     return this._files.model
   }
 
-  async _runInternal (audioStream, opts = {}) {
-    if (this.exclusiveRun && this._hasActiveResponse) {
-      throw new QvacErrorAddonWhisper({
-        code: ERR_CODES.JOB_ALREADY_RUNNING
+  /**
+   * Serialize inference until the returned response settles (replaces `_hasActiveResponse`).
+   * Uses a dedicated waiter so `destroy` / `reload` (`_runQueueWaiter`) can still preempt.
+   */
+  async _enqueueExclusiveRunResponse (runFn) {
+    const prev = this._inferenceQueueWaiter || Promise.resolve()
+    let releaseSlot
+    this._inferenceQueueWaiter = new Promise(resolve => { releaseSlot = resolve })
+    await prev
+    let response
+    try {
+      response = await runFn()
+    } catch (err) {
+      releaseSlot()
+      throw err
+    }
+    response.await().finally(() => { releaseSlot() }).catch(() => {})
+    return response
+  }
+
+  async run (input) {
+    if (!this._runInternal) {
+      throw new QvacInferenceBaseError({
+        code: BASE_ERR_CODES.NOT_IMPLEMENTED,
+        adds: '_runInternal'
       })
     }
+    if (this.exclusiveRun) {
+      return await this._enqueueExclusiveRunResponse(() => this._runInternal(input))
+    }
+    return await this._runInternal(input)
+  }
 
+  async runStreaming (audioStream) {
+    if (this.exclusiveRun) {
+      return await this._enqueueExclusiveRunResponse(() =>
+        this._runInternal(audioStream, { streaming: true })
+      )
+    }
+    return await this._runInternal(audioStream, { streaming: true })
+  }
+
+  async _runInternal (audioStream, opts = {}) {
     const normalizedAudioStream = this._normalizeAudioStream(audioStream)
 
     if (opts.streaming) {
@@ -143,8 +181,7 @@ class TranscriptionWhispercpp extends BaseInference {
     })
 
     const response = this._createResponse(jobId)
-    this._hasActiveResponse = true
-    const finalized = response.await().finally(() => { this._hasActiveResponse = false })
+    const finalized = response.await()
     finalized.catch(() => {})
     response.await = () => finalized
 
@@ -177,9 +214,7 @@ class TranscriptionWhispercpp extends BaseInference {
 
     const jobId = this.addon._activeJobId
     const response = this._createResponse(jobId)
-    this._hasActiveResponse = true
     const finalized = response.await().finally(() => {
-      this._hasActiveResponse = false
       this.addon._activeJobId = null
       this.addon._setState('listening')
     })
@@ -345,15 +380,6 @@ class TranscriptionWhispercpp extends BaseInference {
     })
   }
 
-  async runStreaming (audioStream) {
-    if (this.exclusiveRun) {
-      return await this._withExclusiveRun(() =>
-        this._runInternal(audioStream, { streaming: true })
-      )
-    }
-    return await this._runInternal(audioStream, { streaming: true })
-  }
-
   async cancel () {
     if (this.addon?.cancel) {
       await this.addon.cancel()
@@ -378,7 +404,6 @@ class TranscriptionWhispercpp extends BaseInference {
       response.failed(new Error(reason))
       this._deleteJobMapping(jobId)
     }
-    this._hasActiveResponse = false
   }
 
   validateModelFiles () {

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -121,7 +121,7 @@ class TranscriptionWhispercpp {
 
   async stop () {
     if (!this.addon?.stop) {
-      throw new Error('stop is not supported by this addon')
+      throw new QvacErrorAddonWhisper({ code: ERR_CODES.FAILED_TO_STOP, adds: 'stop not supported' })
     }
     await this.addon.stop()
   }

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -345,7 +345,10 @@ class TranscriptionWhispercpp extends BaseInference {
 
       _checkParamsExists(configurationParams)
       await this.cancel()
-      this._failAndClearActiveResponse('Model was reloaded')
+      this._pendingWhisperJobId = null
+      if (this._job.active) {
+        this._job.fail(new Error('Model was reloaded'))
+      }
       await this.addon.reload(configurationParams)
       await this.addon.activate()
       this.logger.debug('Addon reloaded and activated successfully')
@@ -410,7 +413,10 @@ class TranscriptionWhispercpp extends BaseInference {
   async unload () {
     return await this._withExclusiveRun(async () => {
       await this.cancel()
-      this._failAndClearActiveResponse('Model was unloaded')
+      this._pendingWhisperJobId = null
+      if (this._job.active) {
+        this._job.fail(new Error('Model was unloaded'))
+      }
       if (this.addon) {
         await this.addon.destroyInstance()
       }
@@ -428,7 +434,10 @@ class TranscriptionWhispercpp extends BaseInference {
   async destroy () {
     return await this._withExclusiveRun(async () => {
       await this.cancel()
-      this._failAndClearActiveResponse('Model was destroyed')
+      this._pendingWhisperJobId = null
+      if (this._job.active) {
+        this._job.fail(new Error('Model was destroyed'))
+      }
       if (this.addon) {
         await this.addon.destroyInstance()
       }
@@ -436,13 +445,6 @@ class TranscriptionWhispercpp extends BaseInference {
       this.state.weightsLoaded = false
       this.state.destroyed = true
     })
-  }
-
-  _failAndClearActiveResponse (reason) {
-    this._pendingWhisperJobId = null
-    if (this._job.active) {
-      this._job.fail(new Error(reason))
-    }
   }
 
   validateModelFiles () {

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('bare-fs')
 const BaseInference = require('@qvac/infer-base/WeightsProvider/BaseInference')
+const createJobHandler = require('@qvac/infer-base/src/utils/createJobHandler')
 const { QvacInferenceBaseError, ERR_CODES: BASE_ERR_CODES } = require('@qvac/infer-base/src/error')
 
 const { WhisperInterface } = require('./whisper')
@@ -45,6 +46,14 @@ class TranscriptionWhispercpp extends BaseInference {
     this.params = config.whisperConfig
     /** Serializes inference runs; separate from {@link BaseInference#_runQueueWaiter} (reload/destroy). */
     this._inferenceQueueWaiter = Promise.resolve()
+    /** Batch append returns this id before `_activeJobId` is set; needed for `cancel(jobId)` during buffering. */
+    this._pendingWhisperJobId = null
+    this._job = createJobHandler({
+      cancel: () => {
+        const jobId = this._pendingWhisperJobId ?? this.addon?._activeJobId
+        return this.addon?.cancel?.(jobId)
+      }
+    })
 
     this.logger.debug('TranscriptionWhispercpp constructor called', {
       params: this.params,
@@ -175,19 +184,19 @@ class TranscriptionWhispercpp extends BaseInference {
       return this._runStreaming(normalizedAudioStream)
     }
 
-    const jobId = await this.addon.append({
+    this._pendingWhisperJobId = await this.addon.append({
       type: 'audio',
       input: new Uint8Array()
     })
 
-    const response = this._createResponse(jobId)
+    const response = this._job.start()
     const finalized = response.await()
     finalized.catch(() => {})
     response.await = () => finalized
 
     this._handleAudioStream(normalizedAudioStream).catch((error) => {
-      response.failed(error)
-      this._deleteJobMapping(jobId)
+      this._pendingWhisperJobId = null
+      this._job.fail(error)
     })
     return response
   }
@@ -212,8 +221,8 @@ class TranscriptionWhispercpp extends BaseInference {
       samplesOverlap: vadParams.samples_overlap || 0.1
     })
 
-    const jobId = this.addon._activeJobId
-    const response = this._createResponse(jobId)
+    this._pendingWhisperJobId = null
+    const response = this._job.start()
     const finalized = response.await().finally(() => {
       this.addon._activeJobId = null
       this.addon._setState('listening')
@@ -222,8 +231,8 @@ class TranscriptionWhispercpp extends BaseInference {
     response.await = () => finalized
 
     this._handleStreamingAudio(audioStream).catch((error) => {
-      response.failed(error)
-      this._deleteJobMapping(jobId)
+      this._pendingWhisperJobId = null
+      this._job.fail(error)
     })
     return response
   }
@@ -364,6 +373,36 @@ class TranscriptionWhispercpp extends BaseInference {
     )
   }
 
+  _outputCallback (addon, event, jobId, data, error) {
+    if (event === 'Error') {
+      this.logger.error(`Job failed with error: ${error}`)
+      this._pendingWhisperJobId = null
+      this._job.fail(error)
+      return
+    }
+    if (event === 'Output') {
+      try {
+        this.logger.debug(`Job produced output: ${dataAsStringWhisper(data)}`)
+      } catch (err) {
+        this.logger.error(`Failed to serialize output for logging: ${err.message}`)
+        this.logger.debug('Job produced output: [non-serializable data]')
+      }
+      this._job.output(data)
+      return
+    }
+    if (event === 'JobEnded') {
+      this.logger.info(`Job ${jobId} completed. Stats: ${JSON.stringify(data)}`)
+      this._pendingWhisperJobId = null
+      if (this.opts?.stats) {
+        this._job.end(data)
+      } else {
+        this._job.end()
+      }
+      return
+    }
+    this.logger.debug(`Received event for job ${jobId}: ${event}`)
+  }
+
   /**
    * Override unload to also call destroyInstance for proper cleanup
    * This ensures the process can exit cleanly by closing the uv_async handle
@@ -400,9 +439,9 @@ class TranscriptionWhispercpp extends BaseInference {
   }
 
   _failAndClearActiveResponse (reason) {
-    for (const [jobId, response] of this._jobToResponse.entries()) {
-      response.failed(new Error(reason))
-      this._deleteJobMapping(jobId)
+    this._pendingWhisperJobId = null
+    if (this._job.active) {
+      this._job.fail(new Error(reason))
     }
   }
 
@@ -423,6 +462,14 @@ class TranscriptionWhispercpp extends BaseInference {
       throw new Error(`VAD model file doesn't exist: ${vadModelPath}`)
     }
   }
+}
+
+function dataAsStringWhisper (data) {
+  if (!data) return ''
+  if (typeof data === 'object') {
+    return JSON.stringify(data)
+  }
+  return data.toString()
 }
 
 function _checkParamsExists (params) {

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -2,7 +2,7 @@
 
 const fs = require('bare-fs')
 const QvacLogger = require('@qvac/logging')
-const { createJobHandler } = require('@qvac/infer-base')
+const { createJobHandler, exclusiveRunQueue } = require('@qvac/infer-base')
 
 const { WhisperInterface } = require('./whisper')
 const { checkConfig } = require('./configChecker')
@@ -35,7 +35,7 @@ class TranscriptionWhispercpp {
     this.opts = opts
     this.logger = new QvacLogger(passThrough.logger)
     this.exclusiveRun = !!passThrough.exclusiveRun
-    this._runQueueWaiter = Promise.resolve()
+    this._withExclusiveRun = exclusiveRunQueue()
     this.state = {
       configLoaded: false,
       weightsLoaded: false,
@@ -51,7 +51,7 @@ class TranscriptionWhispercpp {
     this._config = config
 
     this.params = config.whisperConfig
-    /** Serializes inference runs; separate from `_runQueueWaiter` (reload / destroy / unload). */
+    /** Serializes inference runs; separate from `_withExclusiveRun` queue (reload / destroy / unload). */
     this._inferenceQueueWaiter = Promise.resolve()
     /** Batch append returns this id before `_activeJobId` is set; needed for `cancel(jobId)` during buffering. */
     this._pendingWhisperJobId = null
@@ -91,18 +91,6 @@ class TranscriptionWhispercpp {
     await this._load(...loadArgs)
     this.state.configLoaded = true
     this.state.weightsLoaded = true
-  }
-
-  async _withExclusiveRun (fn) {
-    const prev = this._runQueueWaiter || Promise.resolve()
-    let release
-    this._runQueueWaiter = new Promise(resolve => { release = resolve })
-    await prev
-    try {
-      return await fn()
-    } finally {
-      release()
-    }
   }
 
   async pause () {

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -77,6 +77,12 @@ class TranscriptionWhispercpp {
   }
 
   async load (...loadArgs) {
+    if (this.state.destroyed) {
+      throw new QvacErrorAddonWhisper({
+        code: ERR_CODES.FAILED_TO_LOAD_WEIGHTS,
+        adds: 'instance was destroyed'
+      })
+    }
     if (this.state.configLoaded || this.state.weightsLoaded) {
       this.logger.info('Reload requested - unloading existing model first')
       await this.unload()
@@ -84,6 +90,7 @@ class TranscriptionWhispercpp {
 
     await this._load(...loadArgs)
     this.state.configLoaded = true
+    this.state.weightsLoaded = true
   }
 
   async _withExclusiveRun (fn) {

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -28,7 +28,7 @@ class TranscriptionWhispercpp {
     config
   ) {
     if (!files || typeof files.model !== 'string' || files.model.length === 0) {
-      throw new Error('TranscriptionWhispercpp: files.model is required')
+      throw new QvacErrorAddonWhisper({ code: ERR_CODES.MODEL_REQUIRED, adds: 'files.model is required' })
     }
 
     const { opts = {}, ...passThrough } = { logger, exclusiveRun, ...args }
@@ -535,7 +535,7 @@ class TranscriptionWhispercpp {
     const vadModelPath = this._resolveVadModelPath()
     if (vadModelPath && !fs.existsSync(vadModelPath)) {
       this.logger.error('VAD model file not found', { path: vadModelPath })
-      throw new Error(`VAD model file doesn't exist: ${vadModelPath}`)
+      throw new QvacErrorAddonWhisper({ code: ERR_CODES.VAD_MODEL_NOT_FOUND, adds: vadModelPath })
     }
   }
 }

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -426,11 +426,11 @@ class TranscriptionWhispercpp {
       }
 
       _checkParamsExists(configurationParams)
-      await this.cancel()
       this._pendingWhisperJobId = null
       if (this._job.active) {
         this._job.fail(new Error('Model was reloaded'))
       }
+      await this.cancel()
       await this.addon.reload(configurationParams)
       await this.addon.activate()
       this.logger.debug('Addon reloaded and activated successfully')
@@ -494,11 +494,11 @@ class TranscriptionWhispercpp {
    */
   async unload () {
     return await this._withExclusiveRun(async () => {
-      await this.cancel()
       this._pendingWhisperJobId = null
       if (this._job.active) {
         this._job.fail(new Error('Model was unloaded'))
       }
+      await this.cancel()
       if (this.addon) {
         await this.addon.destroyInstance()
       }
@@ -511,15 +511,19 @@ class TranscriptionWhispercpp {
     if (this.addon?.cancel) {
       await this.addon.cancel()
     }
+    this._pendingWhisperJobId = null
+    if (this._job.active) {
+      this._job.fail(new Error('Job cancelled'))
+    }
   }
 
   async destroy () {
     return await this._withExclusiveRun(async () => {
-      await this.cancel()
       this._pendingWhisperJobId = null
       if (this._job.active) {
         this._job.fail(new Error('Model was destroyed'))
       }
+      await this.cancel()
       if (this.addon) {
         await this.addon.destroyInstance()
       }

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fs = require('bare-fs')
-const BaseInference = require('@qvac/infer-base/WeightsProvider/BaseInference')
+const QvacLogger = require('@qvac/logging')
 const createJobHandler = require('@qvac/infer-base/src/utils/createJobHandler')
 const { QvacInferenceBaseError, ERR_CODES: BASE_ERR_CODES } = require('@qvac/infer-base/src/error')
 
@@ -14,7 +14,7 @@ const END_OF_INPUT = 'end of job'
 /**
  * GGML client implementation for the Whisper transcription model
  */
-class TranscriptionWhispercpp extends BaseInference {
+class TranscriptionWhispercpp {
   /**
    * Creates an instance of WhisperClient.
    * @constructor
@@ -32,8 +32,16 @@ class TranscriptionWhispercpp extends BaseInference {
       throw new Error('TranscriptionWhispercpp: files.model is required')
     }
 
-    // Forward extra args (notably `opts`) to BaseInference so features like stats can be enabled.
-    super({ logger, exclusiveRun, ...args })
+    const { opts = {}, ...passThrough } = { logger, exclusiveRun, ...args }
+    this.opts = opts
+    this.logger = new QvacLogger(passThrough.logger)
+    this.exclusiveRun = !!passThrough.exclusiveRun
+    this._runQueueWaiter = Promise.resolve()
+    this.state = {
+      configLoaded: false,
+      weightsLoaded: false,
+      destroyed: false
+    }
 
     const vadModel =
       typeof files.vadModel === 'string' && files.vadModel.length > 0
@@ -44,7 +52,7 @@ class TranscriptionWhispercpp extends BaseInference {
     this._config = config
 
     this.params = config.whisperConfig
-    /** Serializes inference runs; separate from {@link BaseInference#_runQueueWaiter} (reload/destroy). */
+    /** Serializes inference runs; separate from `_runQueueWaiter` (reload / destroy / unload). */
     this._inferenceQueueWaiter = Promise.resolve()
     /** Batch append returns this id before `_activeJobId` is set; needed for `cancel(jobId)` during buffering. */
     this._pendingWhisperJobId = null
@@ -63,6 +71,72 @@ class TranscriptionWhispercpp extends BaseInference {
     })
 
     this.validateModelFiles()
+  }
+
+  getState () {
+    return this.state
+  }
+
+  async load (...loadArgs) {
+    if (this.state.configLoaded || this.state.weightsLoaded) {
+      this.logger.info('Reload requested - unloading existing model first')
+      await this.unload()
+    }
+
+    await this._load(...loadArgs)
+    this.state.configLoaded = true
+  }
+
+  async _withExclusiveRun (fn) {
+    const prev = this._runQueueWaiter || Promise.resolve()
+    let release
+    this._runQueueWaiter = new Promise(resolve => { release = resolve })
+    await prev
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+
+  async pause () {
+    if (!this.addon?.pause) {
+      throw new QvacInferenceBaseError({
+        code: BASE_ERR_CODES.ADDON_METHOD_NOT_IMPLEMENTED,
+        adds: 'pause'
+      })
+    }
+    await this.addon.pause()
+  }
+
+  async unpause () {
+    if (!this.addon?.activate) {
+      throw new QvacInferenceBaseError({
+        code: BASE_ERR_CODES.ADDON_METHOD_NOT_IMPLEMENTED,
+        adds: 'activate'
+      })
+    }
+    await this.addon.activate()
+  }
+
+  async stop () {
+    if (!this.addon?.stop) {
+      throw new QvacInferenceBaseError({
+        code: BASE_ERR_CODES.ADDON_METHOD_NOT_IMPLEMENTED,
+        adds: 'stop'
+      })
+    }
+    await this.addon.stop()
+  }
+
+  async status () {
+    if (!this.addon?.status) {
+      throw new QvacInferenceBaseError({
+        code: BASE_ERR_CODES.ADDON_METHOD_NOT_IMPLEMENTED,
+        adds: 'status'
+      })
+    }
+    return await this.addon.status()
   }
 
   _resolveVadModelPath () {

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -68,14 +68,12 @@ class TranscriptionWhispercpp extends BaseInference {
   }
 
   /**
-   * Load model, weights, and activate addon.
-   * @param {boolean} [closeLoader=false] - Close loader when done.
-   * @param {Function} [reportProgressCallback] - Hook for progress updates.
+   * Load model and activate addon. Model files must already exist at `files.model` / optional `files.vadModel`.
+   * @param {boolean} [_closeLoader=false] - Unused; kept for `load(...args)` forwarding compatibility.
+   * @param {Function} [_reportProgressCallback] - Unused; kept for `load(...args)` forwarding compatibility.
    */
-  async _load (closeLoader = false, reportProgressCallback) {
+  async _load (_closeLoader = false, _reportProgressCallback) {
     this.logger.debug('TranscriptionWhispercpp _load (local model files)')
-
-    await this.downloadWeights(reportProgressCallback, { closeLoader })
 
     const whisperConfig = {
       ...this.params,
@@ -118,7 +116,6 @@ class TranscriptionWhispercpp extends BaseInference {
     _checkParamsExists(configurationParams)
     this.addon = this._createAddon(configurationParams)
 
-    // For whisper.cpp, the model file contains everything - no separate weight loading needed
     await this.addon.activate()
     this.logger.debug('Addon activated')
   }
@@ -309,13 +306,6 @@ class TranscriptionWhispercpp extends BaseInference {
       await this.addon.activate()
       this.logger.debug('Addon reloaded and activated successfully')
     })
-  }
-
-  async _downloadWeights (reportProgressCallback, opts) {
-    this.logger.debug(
-      'TranscriptionWhispercpp: skipping remote weight download (local files.model / files.vadModel)',
-      { closeLoader: opts?.closeLoader, hasProgressCallback: typeof reportProgressCallback === 'function' }
-    )
   }
 
   /**

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -184,6 +184,11 @@ class TranscriptionWhispercpp extends BaseInference {
       return this._runStreaming(normalizedAudioStream)
     }
 
+    return this._runBatchTranscription(normalizedAudioStream)
+  }
+
+  /** Batch runJob path: `_job` / response setup; audio via {@link #_handleAudioStream}. */
+  async _runBatchTranscription (normalizedAudioStream) {
     this._pendingWhisperJobId = await this.addon.append({
       type: 'audio',
       input: new Uint8Array()
@@ -237,8 +242,11 @@ class TranscriptionWhispercpp extends BaseInference {
     return response
   }
 
+  /** Append-only path to the native addon; job lifecycle lives in callers / `_outputCallback`. */
   async _handleAudioStream (audioStream) {
-    this.logger.debug('Start handling audio stream', { file: this.file })
+    this.logger.debug('Start handling audio stream', {
+      modelPath: this._getModelFilePath()
+    })
     for await (const chunk of audioStream) {
       this.logger.debug('Appending audio chunk', { chunkLength: chunk.length })
       await this.addon.append({

--- a/packages/qvac-lib-infer-whispercpp/index.js
+++ b/packages/qvac-lib-infer-whispercpp/index.js
@@ -1,9 +1,7 @@
 'use strict'
 
-const path = require('bare-path')
 const fs = require('bare-fs')
 const BaseInference = require('@qvac/infer-base/WeightsProvider/BaseInference')
-const WeightsProvider = require('@qvac/infer-base/WeightsProvider/WeightsProvider')
 
 const { WhisperInterface } = require('./whisper')
 const { checkConfig } = require('./configChecker')
@@ -18,21 +16,30 @@ class TranscriptionWhispercpp extends BaseInference {
   /**
    * Creates an instance of WhisperClient.
    * @constructor
-   * @param {Object} args - arguments for inference setup
+   * @param {Object} args - arguments for inference setup (`files`, `logger`, `exclusiveRun`, `opts`, …)
+   * @param {Object} args.files - local model file paths
+   * @param {string} args.files.model - path to the Whisper GGML model file
+   * @param {string} [args.files.vadModel] - optional path to the Silero VAD model
    * @param {Object} config - environment-specific inference setup configuration
    */
   constructor (
-    { loader, logger = null, modelName, vadModelName, diskPath, exclusiveRun = true, ...args },
+    { files, logger = null, exclusiveRun = true, ...args },
     config
   ) {
-    // Forward extra args (notably `opts`) to BaseInference so features like stats can be enabled.
-    super({ logger, loader, exclusiveRun, ...args })
+    if (!files || typeof files.model !== 'string' || files.model.length === 0) {
+      throw new Error('TranscriptionWhispercpp: files.model is required')
+    }
 
-    this._diskPath = diskPath || ''
-    this._modelName = modelName
-    this._vadModelName = vadModelName || config.vad_model_path
+    // Forward extra args (notably `opts`) to BaseInference so features like stats can be enabled.
+    super({ logger, exclusiveRun, ...args })
+
+    const vadModel =
+      typeof files.vadModel === 'string' && files.vadModel.length > 0
+        ? files.vadModel
+        : null
+
+    this._files = { model: files.model, vadModel }
     this._config = config
-    this.weightsProvider = new WeightsProvider(loader, this.logger)
 
     this.params = config.whisperConfig
     this._hasActiveResponse = false
@@ -40,10 +47,24 @@ class TranscriptionWhispercpp extends BaseInference {
     this.logger.debug('TranscriptionWhispercpp constructor called', {
       params: this.params,
       config: this._config,
-      diskPath: this._diskPath
+      modelPath: this._files.model,
+      vadModelPath: this._files.vadModel
     })
 
     this.validateModelFiles()
+  }
+
+  _resolveVadModelPath () {
+    if (this._config.vadModelPath) {
+      return this._config.vadModelPath
+    }
+    if (this._files.vadModel) {
+      return this._files.vadModel
+    }
+    if (this.params?.vad_model_path) {
+      return this.params.vad_model_path
+    }
+    return null
   }
 
   /**
@@ -52,7 +73,7 @@ class TranscriptionWhispercpp extends BaseInference {
    * @param {Function} [reportProgressCallback] - Hook for progress updates.
    */
   async _load (closeLoader = false, reportProgressCallback) {
-    this.logger.debug('Loader ready')
+    this.logger.debug('TranscriptionWhispercpp _load (local model files)')
 
     await this.downloadWeights(reportProgressCallback, { closeLoader })
 
@@ -73,7 +94,7 @@ class TranscriptionWhispercpp extends BaseInference {
     delete whisperConfig.vad_params
 
     // VAD model is required for whisper transcription
-    const vadModelPath = this._config.vadModelPath || this._getVadModelFilePath()
+    const vadModelPath = this._resolveVadModelPath()
     if (vadModelPath) {
       whisperConfig.vad_model_path = vadModelPath
       whisperConfig.vadParams = this.params.vad_params || { threshold: 0.6 }
@@ -103,14 +124,7 @@ class TranscriptionWhispercpp extends BaseInference {
   }
 
   _getModelFilePath () {
-    if (!this._modelName) {
-      return ''
-    }
-    return path.join(this._diskPath, this._modelName)
-  }
-
-  _getVadModelFilePath () {
-    return this._vadModelName ? path.join(this._diskPath, this._vadModelName) : null
+    return this._files.model
   }
 
   async _runInternal (audioStream, opts = {}) {
@@ -145,7 +159,7 @@ class TranscriptionWhispercpp extends BaseInference {
   }
 
   async _runStreaming (audioStream) {
-    const vadModelPath = this._config.vadModelPath || this._getVadModelFilePath()
+    const vadModelPath = this._resolveVadModelPath()
     if (!vadModelPath) {
       throw new QvacErrorAddonWhisper({
         code: ERR_CODES.VAD_MODEL_REQUIRED
@@ -271,7 +285,7 @@ class TranscriptionWhispercpp extends BaseInference {
       delete whisperConfig.vad_params
 
       // VAD model configuration
-      const vadModelPath = this._config.vadModelPath || this._getVadModelFilePath()
+      const vadModelPath = this._resolveVadModelPath()
       if (vadModelPath) {
         whisperConfig.vad_model_path = vadModelPath
         whisperConfig.vadParams = newConfig.whisperConfig?.vad_params || this.params.vad_params || { threshold: 0.6 }
@@ -298,23 +312,10 @@ class TranscriptionWhispercpp extends BaseInference {
   }
 
   async _downloadWeights (reportProgressCallback, opts) {
-    const models = [this._modelName]
-    if (this._vadModelName) {
-      models.push(this._vadModelName)
-    }
-
-    this.logger.info('Loading weight files:', models)
-
-    const result = await this.weightsProvider.downloadFiles(
-      models,
-      this._diskPath,
-      {
-        closeLoader: opts.closeLoader,
-        onDownloadProgress: reportProgressCallback
-      }
+    this.logger.debug(
+      'TranscriptionWhispercpp: skipping remote weight download (local files.model / files.vadModel)',
+      { closeLoader: opts?.closeLoader, hasProgressCallback: typeof reportProgressCallback === 'function' }
     )
-    this.logger.info('Weight files downloaded successfully', { models })
-    return result
   }
 
   /**
@@ -401,16 +402,10 @@ class TranscriptionWhispercpp extends BaseInference {
       )
     }
 
-    if (this._config.whisperConfig && this._config.whisperConfig.vad_model_path) {
-      const vadModelPath = this._config.whisperConfig.vad_model_path
-      if (!vadModelPath || !fs.existsSync(vadModelPath)) {
-        this.logger.error('VAD model file not found', { path: vadModelPath })
-        throw new Error(
-          vadModelPath
-            ? `VAD model file doesn't exist: ${vadModelPath}`
-            : "VAD model file doesn't exist"
-        )
-      }
+    const vadModelPath = this._resolveVadModelPath()
+    if (vadModelPath && !fs.existsSync(vadModelPath)) {
+      this.logger.error('VAD model file not found', { path: vadModelPath })
+      throw new Error(`VAD model file doesn't exist: ${vadModelPath}`)
     }
   }
 }

--- a/packages/qvac-lib-infer-whispercpp/lib/error.js
+++ b/packages/qvac-lib-infer-whispercpp/lib/error.js
@@ -22,7 +22,8 @@ const ERR_CODES = Object.freeze({
   FAILED_TO_START_STREAMING: 6012,
   FAILED_TO_APPEND_STREAMING: 6013,
   FAILED_TO_END_STREAMING: 6014,
-  BUFFER_LIMIT_EXCEEDED: 6015
+  BUFFER_LIMIT_EXCEEDED: 6015,
+  FAILED_TO_STOP: 6016
 })
 
 addCodes({
@@ -85,6 +86,10 @@ addCodes({
   [ERR_CODES.BUFFER_LIMIT_EXCEEDED]: {
     name: 'BUFFER_LIMIT_EXCEEDED',
     message: (message) => `Audio buffer size limit exceeded: ${message}`
+  },
+  [ERR_CODES.FAILED_TO_STOP]: {
+    name: 'FAILED_TO_STOP',
+    message: (message) => `Failed to stop addon, error: ${message}`
   }
 }, {
   name,

--- a/packages/qvac-lib-infer-whispercpp/lib/error.js
+++ b/packages/qvac-lib-infer-whispercpp/lib/error.js
@@ -23,7 +23,9 @@ const ERR_CODES = Object.freeze({
   FAILED_TO_APPEND_STREAMING: 6013,
   FAILED_TO_END_STREAMING: 6014,
   BUFFER_LIMIT_EXCEEDED: 6015,
-  FAILED_TO_STOP: 6016
+  FAILED_TO_STOP: 6016,
+  MODEL_REQUIRED: 6017,
+  VAD_MODEL_NOT_FOUND: 6018
 })
 
 addCodes({
@@ -90,6 +92,14 @@ addCodes({
   [ERR_CODES.FAILED_TO_STOP]: {
     name: 'FAILED_TO_STOP',
     message: (message) => `Failed to stop addon, error: ${message}`
+  },
+  [ERR_CODES.MODEL_REQUIRED]: {
+    name: 'MODEL_REQUIRED',
+    message: (message) => `Model is required: ${message}`
+  },
+  [ERR_CODES.VAD_MODEL_NOT_FOUND]: {
+    name: 'VAD_MODEL_NOT_FOUND',
+    message: (message) => `VAD model file not found: ${message}`
   }
 }, {
   name,

--- a/packages/qvac-lib-infer-whispercpp/package.json
+++ b/packages/qvac-lib-infer-whispercpp/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "@qvac/decoder-audio": "^0.3.3",
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.2.0",
+    "@qvac/infer-base": "file:../qvac-lib-infer-base",
     "@qvac/logging": "^0.1.0",
     "bare-channel": "^5.2.2",
     "bare-ffmpeg": "^1.0.0-32",

--- a/packages/qvac-lib-infer-whispercpp/package.json
+++ b/packages/qvac-lib-infer-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {
@@ -85,7 +85,7 @@
   "dependencies": {
     "@qvac/decoder-audio": "^0.3.3",
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "file:../qvac-lib-infer-base",
+    "@qvac/infer-base": "^0.4.0",
     "@qvac/logging": "^0.1.0",
     "bare-channel": "^5.2.2",
     "bare-ffmpeg": "^1.0.0-32",

--- a/packages/qvac-lib-infer-whispercpp/test/integration/accuracy-multilang.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/accuracy-multilang.test.js
@@ -102,9 +102,6 @@ async function runLanguageAccuracyTest (t, langConfig) {
     return { skipped: true, reason: 'model_not_available' }
   }
 
-  const FakeDL = require('../mocks/loader.fake.js')
-  const loader = new FakeDL({})
-
   try {
     console.log(`\n📊 Running ${langConfig.name} accuracy test...`)
     console.log(`   File: ${langConfig.sampleFile}`)
@@ -114,7 +111,6 @@ async function runLanguageAccuracyTest (t, langConfig) {
     const result = await runTranscription({
       audioInput: samplePath,
       modelPath: actualModelPath,
-      loader,
       whisperConfig: {
         language: langConfig.code,
         temperature: 0.0,

--- a/packages/qvac-lib-infer-whispercpp/test/integration/addon.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/addon.test.js
@@ -291,9 +291,9 @@ test('Runtime stats are populated when opts.stats=true', { timeout: 120000 }, as
   }
 
   const constructorArgs = {
-    modelName: path.basename(modelPath),
-    diskPath: path.dirname(modelPath),
-    loader: new (require('../mocks/loader.fake.js'))({}),
+    files: {
+      model: modelPath
+    },
     opts: { stats: true }
   }
 

--- a/packages/qvac-lib-infer-whispercpp/test/integration/audio-ctx-chunking.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/audio-ctx-chunking.test.js
@@ -29,7 +29,7 @@ async function transcribeChunk (model, audioStream, offsetMs, durationMs, audioC
   return results
 }
 
-const { modelsDir, modelPath } = getTestPaths()
+const { modelPath } = getTestPaths()
 
 // Skip on mobile - requires 10min audio file (~19MB) which is too large to bundle
 test('Audio context chunking - 10 minute audio file with 30s chunks', { skip: isMobile }, async (t) => {

--- a/packages/qvac-lib-infer-whispercpp/test/integration/audio-ctx-chunking.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/audio-ctx-chunking.test.js
@@ -3,12 +3,7 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const test = require('brittle')
 const TranscriptionWhispercpp = require('../../index.js')
-const FakeDL = require('../mocks/loader.fake.js')
 const { ensureWhisperModel, getTestPaths, createAudioStream, isMobile } = require('./helpers.js')
-
-function createLoader () {
-  return new FakeDL({})
-}
 
 async function transcribeChunk (model, audioStream, offsetMs, durationMs, audioCtx) {
   await model.reload({
@@ -77,12 +72,13 @@ test('Audio context chunking - 10 minute audio file with 30s chunks', { skip: is
   const totalChunks = Math.ceil(totalDurationSeconds / CHUNK_SIZE_SECONDS)
 
   const constructorArgs = {
-    modelName: path.basename(modelPath),
-    loader: createLoader(),
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    }
   }
 
   const config = {
+    path: modelPath,
     whisperConfig: {
       language: 'en',
       audio_format: 's16le',

--- a/packages/qvac-lib-infer-whispercpp/test/integration/cold-start-timing.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/cold-start-timing.test.js
@@ -18,12 +18,7 @@ const path = require('bare-path')
 const os = require('bare-os')
 const process = require('bare-process')
 const TranscriptionWhispercpp = require('../../index.js')
-const FakeDL = require('../mocks/loader.fake.js')
 const { ensureWhisperModel, ensureVADModel, getAssetPath, isMobile } = require('./helpers.js')
-
-function createLoader () {
-  return new FakeDL({})
-}
 
 async function getModelPaths () {
   // Use writable directory for models
@@ -125,9 +120,6 @@ test('Cold start timing: measure first vs subsequent transcription times', { tim
     return
   }
 
-  const loader = createLoader()
-  const modelName = path.basename(paths.modelPath)
-
   const config = {
     path: paths.modelPath,
     vadModelPath: paths.vadModelPath,
@@ -154,10 +146,12 @@ test('Cold start timing: measure first vs subsequent transcription times', { tim
     console.log('📦 Creating model instance...')
     const loadStartTime = getTimeMs()
 
+    const ctorFiles = { model: paths.modelPath }
+    if (paths.vadModelPath) {
+      ctorFiles.vadModel = paths.vadModelPath
+    }
     model = new TranscriptionWhispercpp({
-      modelName,
-      loader,
-      diskPath: paths.modelsDir
+      files: ctorFiles
     }, config)
 
     // Load model (this should trigger warmup)
@@ -253,9 +247,6 @@ test('Cold start: fresh model instance per transcription', { timeout: 300000 }, 
   for (let i = 0; i < NUM_RUNS; i++) {
     console.log(`--- Instance ${i + 1}/${NUM_RUNS} ---`)
 
-    const loader = createLoader()
-    const modelName = path.basename(paths.modelPath)
-
     const config = {
       path: paths.modelPath,
       vadModelPath: paths.vadModelPath,
@@ -274,10 +265,12 @@ test('Cold start: fresh model instance per transcription', { timeout: 300000 }, 
       // Time includes model creation and loading
       const instanceStartTime = getTimeMs()
 
+      const ctorFiles = { model: paths.modelPath }
+      if (paths.vadModelPath) {
+        ctorFiles.vadModel = paths.vadModelPath
+      }
       model = new TranscriptionWhispercpp({
-        modelName,
-        loader,
-        diskPath: paths.modelsDir
+        files: ctorFiles
       }, config)
 
       await model._load()

--- a/packages/qvac-lib-infer-whispercpp/test/integration/corrupted-model.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/corrupted-model.test.js
@@ -6,12 +6,7 @@ const fs = require('bare-fs')
 const os = require('bare-os')
 const { Readable } = require('bare-stream')
 const TranscriptionWhispercpp = require('../../index.js')
-const FakeDL = require('../mocks/loader.fake.js')
 const { setupJsLogger, ensureWhisperModel, isMobile } = require('./helpers.js')
-
-function createLoader () {
-  return new FakeDL({})
-}
 
 /**
  * Helper function to test that corrupted model files throw exceptions
@@ -97,9 +92,9 @@ test('Corrupted model file should throw exception to JavaScript', { timeout: 300
   await testCorruptedModelFile(t, {
     corruptedFilePath: corruptedModelPath,
     constructorArgs: {
-      modelName: path.basename(corruptedModelPath),
-      diskPath: testDir,
-      loader: createLoader()
+      files: {
+        model: corruptedModelPath
+      }
     },
     config: {
       whisperConfig: { language: 'en' },
@@ -141,16 +136,15 @@ test('Corrupted VAD model file should throw exception to JavaScript', { timeout:
   await testCorruptedModelFile(t, {
     corruptedFilePath: corruptedVadPath,
     constructorArgs: {
-      modelName: path.basename(validModelPath),
-      diskPath: path.dirname(validModelPath),
-      loader: createLoader()
+      files: {
+        model: validModelPath
+      }
     },
     config: {
       whisperConfig: {
         language: 'en',
         vad_model_path: corruptedVadPath
       },
-      vad_model_path: corruptedVadPath,
       contextParams: { model: validModelPath },
       miscConfig: { caption_enabled: false }
     }

--- a/packages/qvac-lib-infer-whispercpp/test/integration/helpers.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/helpers.js
@@ -12,13 +12,6 @@ const isMobile = platform === 'ios' || platform === 'android'
 const HF_WHISPER_BASE = 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main'
 const HF_VAD_BASE = 'https://huggingface.co/ggml-org/whisper-vad/resolve/main'
 
-let FakeDL = null
-if (!isMobile) {
-  try {
-    FakeDL = require('../mocks/loader.fake.js')
-  } catch (e) {}
-}
-
 function detectPlatform () {
   return `${platform}-${arch}`
 }
@@ -452,11 +445,7 @@ function getTestPaths (modelsDir = null) {
  * @param {string|Buffer|Uint8Array|Array|Readable} [params.audioInput] - Audio input (optional - if omitted, only tests config validation)
  * @param {string} [params.modelPath] - Path to whisper model file
  * @param {string} [params.vadModelPath] - Path to VAD model file
- * @param {string} [params.diskPath] - Directory for model files
  * @param {Object} [params.whisperConfig] - Whisper configuration object
- * @param {Object} [params.loader] - Model loader instance
- * @param {string} [params.modelName] - Model filename
- * @param {string} [params.vadModelName] - VAD model filename
  * @param {Object} [expectation={}] - Expectations for validation
  * @param {number} [expectation.minSegments] - Minimum number of segments
  * @param {number} [expectation.maxSegments] - Maximum number of segments
@@ -485,12 +474,6 @@ async function runTranscription (params, expectation = {}) {
   const modelPath = params.modelPath || defaultModelPath
   const vadModelPath = params.vadModelPath // VAD model is optional, no default
 
-  const modelDir = path.dirname(modelPath)
-  const modelName = params.modelName || path.basename(modelPath)
-  const diskPath = params.diskPath || modelDir
-
-  const vadModelName = params.vadModelName || (vadModelPath ? path.basename(vadModelPath) : undefined)
-  const loader = params.loader || new FakeDL({})
   const whisperConfig = params.whisperConfig || {}
 
   const config = {
@@ -508,10 +491,10 @@ async function runTranscription (params, expectation = {}) {
   }
 
   const constructorArgs = {
-    modelName,
-    vadModelName,
-    diskPath,
-    loader
+    files: {
+      model: modelPath,
+      ...(vadModelPath ? { vadModel: vadModelPath } : {})
+    }
   }
 
   if (typeof modelPath === 'string' && !fs.existsSync(modelPath)) {

--- a/packages/qvac-lib-infer-whispercpp/test/integration/live-stream-simulation.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/live-stream-simulation.test.js
@@ -6,12 +6,7 @@ const test = require('brittle')
 const { Readable } = require('streamx')
 
 const TranscriptionWhispercpp = require('../../index.js')
-const FakeDL = require('../mocks/loader.fake.js')
 const { ensureWhisperModel, getTestPaths, createAudioStream, isMobile } = require('./helpers.js')
-
-function createLoader () {
-  return new FakeDL({})
-}
 
 // Create a pushable Readable to simulate a live input source.
 function createLiveReadable () {
@@ -57,12 +52,13 @@ test('Live stream simulation using pushable Readable with model.run()', { timeou
   }
 
   const constructorArgs = {
-    modelName: path.basename(modelPath),
-    loader: createLoader(),
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    }
   }
 
   const config = {
+    path: modelPath,
     whisperConfig: {
       language: 'en',
       audio_format: 's16le',
@@ -155,12 +151,13 @@ test('Live segmented loop: repeated model.run per 3s chunk (no model teardown un
   }
 
   const constructorArgs = {
-    modelName: path.basename(modelPath),
-    loader: createLoader(),
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    }
   }
 
   const config = {
+    path: modelPath,
     whisperConfig: {
       language: 'en',
       audio_format: 's16le',

--- a/packages/qvac-lib-infer-whispercpp/test/integration/live-stream-simulation.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/live-stream-simulation.test.js
@@ -38,7 +38,7 @@ async function feedStreamLive ({ readable, filePath, chunkBytes, bytesPerSecond 
 // Skip on mobile - requires 10min audio file (~19MB) which is too large to bundle
 test('Live stream simulation using pushable Readable with model.run()', { timeout: 180000, skip: isMobile }, async (t) => {
   // Use standardized test paths from helpers
-  const { modelsDir, modelPath } = getTestPaths()
+  const { modelPath } = getTestPaths()
   // Use the 10-minute s16le sample from examples (provided by repo)
   const audioPath = path.resolve(__dirname, '../../examples/samples/10min-16k-s16le.raw')
 
@@ -139,7 +139,7 @@ test('Live stream simulation using pushable Readable with model.run()', { timeou
 // Skip on mobile - requires 10min audio file (~19MB) which is too large to bundle
 test('Live segmented loop: repeated model.run per 3s chunk (no model teardown until end)', { timeout: 180000, skip: isMobile }, async (t) => {
   // Use standardized test paths from helpers
-  const { modelsDir, modelPath } = getTestPaths()
+  const { modelPath } = getTestPaths()
   const audioPath = path.resolve(__dirname, '../../examples/samples/10min-16k-s16le.raw')
 
   const whisperResult = await ensureWhisperModel(modelPath)

--- a/packages/qvac-lib-infer-whispercpp/test/integration/model-file-validation.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/model-file-validation.test.js
@@ -4,7 +4,6 @@ const test = require('brittle')
 const TranscriptionWhispercpp = require('../../index.js')
 const path = require('bare-path')
 const os = require('bare-os')
-const FakeDL = require('../mocks/loader.fake.js')
 const { ensureWhisperModel, ensureVADModel, isMobile } = require('./helpers.js')
 
 const tmpDir = isMobile ? (global.testDir || os.tmpdir()) : os.tmpdir()
@@ -21,28 +20,21 @@ async function ensureModelsDownloaded () {
   modelsReady = true
 }
 
-function createLoader () {
-  return new FakeDL({})
-}
-
 /**
- * Test 1: If the model path is not provided, an exception should be thrown
+ * Test 1: If files.model is not provided, an exception should be thrown
  * Works on both mobile and desktop - just tests constructor validation
  */
-test('Should throw error when model path is not provided', { timeout: 60000 }, async (t) => {
+test('Should throw error when files.model is not provided', { timeout: 60000 }, async (t) => {
   // Restore any stubs from other tests
   TranscriptionWhispercpp.prototype.validateModelFiles?.restore?.()
 
-  const args = {
-    modelName: '', // Empty model name
-    loader: createLoader()
-  }
+  const args = {}
   const config = {
     whisperConfig: {
       language: 'en'
     },
     contextParams: {
-      model: '' // Empty model path
+      model: ''
     },
     miscConfig: {
       caption_enabled: false
@@ -51,9 +43,9 @@ test('Should throw error when model path is not provided', { timeout: 60000 }, a
 
   try {
     new TranscriptionWhispercpp(args, config) // eslint-disable-line no-new
-    t.fail('Should have thrown an error for missing model path')
+    t.fail('Should have thrown an error for missing files.model')
   } catch (error) {
-    t.ok(error.message.includes('Model file doesn\'t exist'), 'Error message should mention model file doesn\'t exist')
+    t.ok(error.message.includes('files.model'), 'Error message should mention files.model')
   }
 })
 
@@ -65,16 +57,18 @@ test('Should throw error when model file does not exist', { timeout: 60000 }, as
   // Restore any stubs from other tests
   TranscriptionWhispercpp.prototype.validateModelFiles?.restore?.()
 
+  const nonexistent = path.join(tmpDir, 'qvac-test-models', 'non-existent-model.bin')
   const args = {
-    modelName: 'non-existent-model.bin',
-    loader: createLoader()
+    files: {
+      model: nonexistent
+    }
   }
   const config = {
     whisperConfig: {
       language: 'en'
     },
     contextParams: {
-      model: 'non-existent-model.bin'
+      model: nonexistent
     },
     miscConfig: {
       caption_enabled: false
@@ -102,8 +96,9 @@ test('Should throw error when VAD model file does not exist', { timeout: 180000 
   await ensureModelsDownloaded()
 
   const args = {
-    modelName: testModelPath,
-    loader: createLoader()
+    files: {
+      model: testModelPath
+    }
   }
   const config = {
     whisperConfig: {
@@ -139,8 +134,9 @@ test('Should not throw error when model file exists and VAD is not specified', {
   await ensureModelsDownloaded()
 
   const args = {
-    modelName: testModelPath,
-    loader: createLoader()
+    files: {
+      model: testModelPath
+    }
   }
   const config = {
     whisperConfig: {
@@ -176,9 +172,10 @@ test('Should not throw error when both model and VAD model files exist', { timeo
   await ensureModelsDownloaded()
 
   const args = {
-    modelName: testModelPath,
-    vadModelName: testVadPath,
-    loader: createLoader()
+    files: {
+      model: testModelPath,
+      vadModel: testVadPath
+    }
   }
   const config = {
     whisperConfig: {

--- a/packages/qvac-lib-infer-whispercpp/test/integration/model-file-validation.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/model-file-validation.test.js
@@ -117,7 +117,7 @@ test('Should throw error when VAD model file does not exist', { timeout: 180000 
     new TranscriptionWhispercpp(args, config) // eslint-disable-line no-new
     t.fail('Should have thrown an error for non-existent VAD model file')
   } catch (error) {
-    t.ok(error.message.includes("VAD model file not found"), 'Error message should mention VAD model file doesn\'t exist')
+    t.ok(error.message.includes('VAD model file not found'), 'Error message should mention VAD model file doesn\'t exist')
     t.ok(error.message.includes('non-existent-vad-model.bin'), 'Error message should include the VAD model filename')
   }
 })

--- a/packages/qvac-lib-infer-whispercpp/test/integration/model-file-validation.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/model-file-validation.test.js
@@ -117,7 +117,7 @@ test('Should throw error when VAD model file does not exist', { timeout: 180000 
     new TranscriptionWhispercpp(args, config) // eslint-disable-line no-new
     t.fail('Should have thrown an error for non-existent VAD model file')
   } catch (error) {
-    t.ok(error.message.includes("VAD model file doesn't exist"), 'Error message should mention VAD model file doesn\'t exist')
+    t.ok(error.message.includes("VAD model file not found"), 'Error message should mention VAD model file doesn\'t exist')
     t.ok(error.message.includes('non-existent-vad-model.bin'), 'Error message should include the VAD model filename')
   }
 })

--- a/packages/qvac-lib-infer-whispercpp/test/integration/multiple-transcriptions.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/integration/multiple-transcriptions.test.js
@@ -5,7 +5,6 @@ const path = require('bare-path')
 const fs = require('bare-fs')
 const os = require('bare-os')
 const TranscriptionWhispercpp = require('../../index')
-const FakeDL = require('../mocks/loader.fake.js')
 const { ensureWhisperModel, getAssetPath, createAudioStream, isMobile } = require('./helpers.js')
 
 // On mobile, runs fewer transcriptions to avoid memory pressure
@@ -46,13 +45,11 @@ test('Multiple consecutive transcriptions should work without errors', { timeout
   t.ok(fs.existsSync(modelPath), 'Model file should exist')
   t.ok(fs.existsSync(audioPath), 'Audio file should exist')
 
-  const loader = new FakeDL({})
-
   const args = {
-    loader,
-    logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
-    modelName: 'ggml-tiny.bin',
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    },
+    logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
   }
 
   const config = {

--- a/packages/qvac-lib-infer-whispercpp/test/stand-alone/seed-vulkan-gpu-speed.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/stand-alone/seed-vulkan-gpu-speed.test.js
@@ -3,7 +3,6 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const test = require('brittle')
 const TranscriptionWhispercpp = require('../../index')
-const FakeDL = require('../mocks/loader.fake.js')
 const { spawnSync, spawn } = require('bare-subprocess')
 
 const modelsDir = path.resolve(__dirname, '../../models')
@@ -39,9 +38,9 @@ async function ensureModel () {
 async function checkVulkanAvailable () {
   try {
     const args = {
-      modelName: 'ggml-small.bin',
-      loader: new FakeDL({}),
-      diskPath: modelsDir
+      files: {
+        model: modelPath
+      }
     }
     const testConfig = {
       path: modelPath,
@@ -265,9 +264,9 @@ test('GPU performance test with Spanish audio (LastQuestion_long_ES.raw)', { tim
   await ensureModel()
 
   const args = {
-    modelName: 'ggml-small.bin',
-    loader: new FakeDL({}),
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    }
   }
 
   const baseConfig = {
@@ -378,9 +377,9 @@ test('Multiple GPU runs with seed for consistency check', { timeout: 120000 }, a
   await ensureModel()
 
   const args = {
-    modelName: 'ggml-small.bin',
-    loader: new FakeDL({}),
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    }
   }
 
   const seed = 9999
@@ -443,9 +442,9 @@ test('CPU vs GPU speed comparison with SHORT audio (30s sample)', { timeout: 300
   await ensureModel()
 
   const args = {
-    modelName: 'ggml-small.bin',
-    loader: new FakeDL({}),
-    diskPath: modelsDir
+    files: {
+      model: modelPath
+    }
   }
 
   const baseConfig = {

--- a/packages/qvac-lib-infer-whispercpp/test/unit/addon.inference.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/unit/addon.inference.test.js
@@ -18,13 +18,9 @@ function createMockedModel ({ onOutput = () => { }, binding = undefined } = {}) 
   const validateStub = sinon.stub(TranscriptionWhispercpp.prototype, 'validateModelFiles').returns(undefined)
 
   const args = {
-    modelName: 'ggml-tiny.bin',
-    vadModelName: 'ggml-silero-v5.1.2.bin',
-    loader: new FakeDL({}),
-    params: {
-      language: 'en',
-      max_seconds: 29,
-      temperature: 0.0
+    files: {
+      model: 'ggml-tiny.bin',
+      vadModel: 'ggml-silero-v5.1.2.bin'
     }
   }
   const config = {

--- a/packages/qvac-lib-infer-whispercpp/test/unit/addon.inference.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/unit/addon.inference.test.js
@@ -313,7 +313,7 @@ test('Destroy fails active response and clears job mapping', async (t) => {
     )
   }
 
-  t.is(model._jobToResponse.size, 0, 'Destroy should clear job-to-response mapping')
+  t.is(model._job.active, null, 'Destroy should clear the single active job handler')
 })
 
 test('Orphan native callbacks are ignored when no active job exists', async (t) => {

--- a/packages/qvac-lib-infer-whispercpp/test/unit/addon.reload.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/unit/addon.reload.test.js
@@ -2,7 +2,6 @@
 
 const test = require('brittle')
 const TranscriptionWhispercpp = require('../../index.js')
-const FakeDL = require('../mocks/loader.fake.js')
 const MockedBinding = require('../mocks/MockedBinding.js')
 const { wait, transitionCb } = require('../mocks/utils.js')
 const { WhisperInterface } = require('../../whisper')
@@ -18,11 +17,8 @@ function createTestModel ({ onOutput = () => { }, binding = undefined } = {}) {
   // Restore any existing stub first
   TranscriptionWhispercpp.prototype.validateModelFiles?.restore?.()
   const args = {
-    modelName: 'ggml-tiny.bin',
-    loader: new FakeDL({}),
-    params: {
-      language: 'en',
-      temperature: 0.0
+    files: {
+      model: 'ggml-tiny.bin'
     }
   }
   const config = {

--- a/packages/qvac-lib-infer-whispercpp/test/unit/streaming.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/unit/streaming.test.js
@@ -2,7 +2,6 @@
 
 const test = require('brittle')
 const TranscriptionWhispercpp = require('../../index.js')
-const FakeDL = require('../mocks/loader.fake.js')
 const MockedBinding = require('../mocks/MockedBinding.js')
 const { transitionCb, wait } = require('../mocks/utils.js')
 const { WhisperInterface } = require('../../whisper')
@@ -16,13 +15,9 @@ function createMockedModel ({ onOutput = () => { }, binding = undefined } = {}) 
   const validateStub = sinon.stub(TranscriptionWhispercpp.prototype, 'validateModelFiles').returns(undefined)
 
   const args = {
-    modelName: 'ggml-tiny.bin',
-    vadModelName: 'ggml-silero-v5.1.2.bin',
-    loader: new FakeDL({}),
-    params: {
-      language: 'en',
-      max_seconds: 29,
-      temperature: 0.0
+    files: {
+      model: 'ggml-tiny.bin',
+      vadModel: 'ggml-silero-v5.1.2.bin'
     }
   }
   const config = {

--- a/packages/qvac-lib-infer-whispercpp/test/unit/streaming.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/unit/streaming.test.js
@@ -217,7 +217,7 @@ test('Streaming error propagation surfaces to response', async (t) => {
   t.ok(errorEvents.length > 0, 'Error event should be emitted for failed processing')
 })
 
-test('Starting a second streaming session throws while one is active', async (t) => {
+test('Second streaming session waits on exclusive queue until first completes', async (t) => {
   const binding = new MockedBinding()
   const model = createMockedModel({ binding })
   await model.load()
@@ -230,18 +230,20 @@ test('Starting a second streaming session throws while one is active', async (t)
     }
   }
 
-  await model.runStreaming(slowStream)
-  await wait(10)
+  const r1 = await model.runStreaming(slowStream)
+  let secondEntered = false
+  const p2 = model.runStreaming([new Uint8Array([9, 9])]).then(async (r) => {
+    secondEntered = true
+    await r.await()
+    return r
+  })
 
-  try {
-    await model.runStreaming([new Uint8Array([9, 9])])
-    t.fail('Should not allow a second streaming session')
-  } catch (error) {
-    t.ok(
-      error.message.includes('already') || error.message.includes('running') || error.message.includes('active'),
-      'Second streaming session should be rejected'
-    )
-  }
+  await wait(20)
+  t.ok(!secondEntered, 'Second run should not start while first job is still active')
+
+  await r1.await()
+  await p2
+  t.ok(secondEntered, 'Second run should start after the first job completes')
 
   await model.cancel()
 })

--- a/packages/qvac-lib-infer-whispercpp/test/unit/vad.test.js
+++ b/packages/qvac-lib-infer-whispercpp/test/unit/vad.test.js
@@ -2,7 +2,6 @@
 
 const test = require('brittle')
 const TranscriptionWhispercpp = require('../../index.js')
-const FakeDL = require('../mocks/loader.fake.js')
 const MockedBinding = require('../mocks/MockedBinding.js')
 const { wait, transitionCb } = require('../mocks/utils.js')
 const { WhisperInterface } = require('../../whisper')
@@ -21,10 +20,10 @@ function createTestModel ({ onOutput = () => { }, vadModelPath = 'ggml-silero-v5
   sinon.stub(TranscriptionWhispercpp.prototype, 'validateModelFiles').returns(undefined)
 
   const args = {
-    modelName: 'ggml-tiny.bin',
-    vadModelName: vadModelPath,
-    loader: new FakeDL({}),
-    params: {}
+    files: {
+      model: 'ggml-tiny.bin',
+      vadModel: vadModelPath
+    }
   }
   const config = {
     vadModelPath,


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- `TranscriptionWhispercpp` previously extended `BaseInference` and relied on `WeightsProvider` for weight downloads, tightly coupling model loading to inference setup.
- The constructor accepted abstract `loader`, `modelName`, `diskPath` params — unclear that model files must already exist on disk before instantiation.
- The bespoke `_hasActiveResponse` flag was fragile and could cause inference queue deadlocks when a job was cancelled mid-queue.

## 📝 How does it solve it?

- Replaces `loader`/`modelName`/`diskPath` constructor params with a `files: { model, vadModel? }` map — callers provide pre-resolved file paths directly.
- Removes `BaseInference` inheritance; state is now self-managed via `configLoaded`, `weightsLoaded`, `destroyed` flags, exposed via `getState()`.
- Adopts `createJobHandler` from `@qvac/infer-base` for centralized job lifecycle, replacing the bespoke `_hasActiveResponse` / `_jobToResponse` pattern.
- Adds `_enqueueExclusiveRunResponse` to serialize inference runs without blocking the exclusive-run lifecycle queue, preventing deadlocks on cancel.

## 🧪 How was it tested?

- Existing integration and unit tests updated to use the new `files`-based constructor interface.
- Tests covering reload, cancel, VAD streaming, and model file validation updated accordingly.

## 💥 Breaking Changes

**BEFORE:**

```typescript
new TranscriptionWhispercpp(
  {
    loader,
    modelName: 'whisper-large.bin',
    vadModelName: 'vad.bin',
    diskPath: '/models'
  },
  config
)
```

**AFTER:**

```typescript
new TranscriptionWhispercpp(
  {
    files: {
      model: '/models/whisper-large.bin',
      vadModel: '/models/vad.bin'  // optional
    }
  },
  config
)
```

Also removed:
- `ProgressData` and `ReportProgressCallback` types
- `_load(closeLoader, reportProgressCallback)` as a public-facing method
