### PR TITLE
fix: remove debug step that logs sensitive inputs in publish-library-to-gpr

### DIFF
--- a/.github/actions/publish-library-to-gpr/action.yaml
+++ b/.github/actions/publish-library-to-gpr/action.yaml
@@ -34,16 +34,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Print job context for debugging
-      continue-on-error: true
-      shell: bash
-      env:
-        INPUTS_CONTEXT: ${{ toJSON(inputs) }}
-      run: |
-        echo "Input context: $INPUTS_CONTEXT"
-        ls -l ${{ inputs.path }}
-        tree ${{ inputs.path }}
-
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
       with:
         node-version: lts/*


### PR DESCRIPTION
## Summary

The "Print job context for debugging" step in publish-library-to-gpr uses toJSON(inputs) which dumps all composite action inputs — including secret-token and pat-token — into workflow logs.

Removed the step entirely to prevent sensitive token exposure.

## File changed
- .github/actions/publish-library-to-gpr/action.yaml — removed "Print job context for debugging" step