### PR TITLE
chore(nmtcpp): bump qvac-fabric to 7248.2.3

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-04-13
+
+### Changed
+
+- Bumped `qvac-fabric` dependency from 7248.2.2 to 7248.2.3
+
 ## [2.0.0] - 2026-04-08
 
 ### Changed

--- a/packages/qvac-lib-infer-nmtcpp/package.json
+++ b/packages/qvac-lib-infer-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/qvac-lib-infer-nmtcpp/vcpkg.json
+++ b/packages/qvac-lib-infer-nmtcpp/vcpkg.json
@@ -13,7 +13,7 @@
     "ssplit",
     {
       "name" : "qvac-fabric",
-      "version>=": "7248.2.2",
+      "version>=": "7248.2.3",
       "default-features" : false
     }
   ],


### PR DESCRIPTION
## Summary

- Bump `qvac-fabric` dependency from 7248.2.2 to 7248.2.3 in the NMT addon
- Bump package version to 2.0.1

## Test plan

- [ ] Verify desktop builds are unaffected
- [ ] Run NMT integration tests