### PR TITLE
QVAC-17112 chore[skiplog]: registry-client v0.4.0 release

### DIFF
--- a/packages/qvac-lib-registry-server/client/CHANGELOG.md
+++ b/packages/qvac-lib-registry-server/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.4.0]
+
+Release Date: 2026-04-12
+
+### ✨ Features
+
+- Add `suspend()` and `resume()` lifecycle methods to `QVACRegistryClient` — coordinates `Hyperswarm` and `Corestore` shutdown/restart in the correct order with idempotency guards for safe repeated calls (#1469)
+- Expose `corestore` and `hyperswarm` as readonly typed lifecycle handles (`LifecycleStoreHandle`, `LifecycleSwarmHandle`) for orchestrators that coordinate resources directly (#1469)
+- `QVACRegistryClient` type definition now extends `ReadyResource`, with new `LifecycleLogOptions` interface exported for downstream consumers (#1469)
+
+### 🔧 Changed
+
+- Bumped `@qvac/registry-schema` from `^0.1.1` to `^0.1.2` (#1106)
+
 ## [0.3.1]
 
 Release Date: 2026-03-30

--- a/packages/qvac-lib-registry-server/client/package.json
+++ b/packages/qvac-lib-registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
🎯 What problem does this PR solve?

- Prepare the `@qvac/registry-client` `v0.4.0` release with changelog and version bump.

📝 How does it solve it?

- Bump `@qvac/registry-client` version from 0.3.1 to 0.4.0
- Add `v0.4.0` changelog entry covering the suspend/resume lifecycle API and `@qvac/registry-schema` bump 