### PR TITLE
QVAC-17101 chore[bc]: migrate parakeet plugin to updated addon API

### DIFF
--- a/packages/sdk/bun.lock
+++ b/packages/sdk/bun.lock
@@ -15,7 +15,7 @@
         "@qvac/ocr-onnx": "^0.4.0",
         "@qvac/rag": "^0.4.4",
         "@qvac/registry-client": "^0.2.1",
-        "@qvac/transcription-parakeet": "^0.2.7",
+        "@qvac/transcription-parakeet": "0.3.0",
         "@qvac/transcription-whispercpp": "^0.6.0",
         "@qvac/translation-nmtcpp": "^0.6.1",
         "@qvac/tts-onnx": "^0.6.7",
@@ -532,6 +532,8 @@
 
     "@qvac/onnx": ["@qvac/onnx@0.14.0", "", {}, "sha512-P2RlpHcAdOs53aMfdMNBk3e8S6SFzroT5ShlZVM4Kag83nTpATJKIsxWyq64sHwSVtJjRtdxOF8lksbVnwzIvQ=="],
 
+    "@qvac/onnx": ["@qvac/onnx@0.14.0", "", {}, "sha512-P2RlpHcAdOs53aMfdMNBk3e8S6SFzroT5ShlZVM4Kag83nTpATJKIsxWyq64sHwSVtJjRtdxOF8lksbVnwzIvQ=="],
+
     "@qvac/rag": ["@qvac/rag@0.4.4", "", { "dependencies": { "@qvac/error": "^0.1.0", "hyperdht": "^6.23.0", "ready-resource": "^1.1.2", "uuid-random": "^1.3.2", "zod": "^4.1.13" }, "peerDependencies": { "bare-crypto": "^1.13.4", "bare-fetch": "^2.5.0", "hyperdb": "^4.19.0", "hyperschema": "^1.13.0", "llm-splitter": "^0.2.0" }, "optionalPeers": ["bare-crypto", "bare-fetch", "hyperdb", "hyperschema", "llm-splitter"] }, "sha512-3LRLNPzmRwHn7S76QPM/01sX8JDLPFCdTRycL5YgJ8Vm0FfAXhLCqYX7t/7hFgY7SZxqSgZie/ZhOfg5+xL1gA=="],
 
     "@qvac/registry-client": ["@qvac/registry-client@0.2.1", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/registry-schema": "^0.1.1", "b4a": "^1.6.7", "bare-fs": "^4.5.2", "bare-os": "^3.6.2", "bare-path": "^3.0.0", "bare-process": "^4.2.2", "corestore": "^7.4.5", "hyperblobs": "^2.8.0", "hypercore-id-encoding": "^1.3.0", "hyperdb": "^4.16.1", "hyperswarm": "^4.14.0", "paparam": "^1.10.0", "ready-resource": "^1.0.1" }, "bin": { "qvac-registry": "bin/cli.js" } }, "sha512-ekT7MvFbX1MjTusS+Z/kbw1rLI5k9mpw41gNZv3rvL1ZDTfjuJ++iRYDUDZO9wT5ehyqChVwsPjoDuBiZpcC3A=="],
@@ -540,7 +542,7 @@
 
     "@qvac/response": ["@qvac/response@0.1.2", "", { "dependencies": { "bare-events": "2.4.2" } }, "sha512-xWAsUyxOd7kqOayjFwUGOGiWlwQ8z6bzy5lOTUdI3uHGCAbdsqUMivpMymktd3ub+ZvF7F/iCM4dxdDCTISSdA=="],
 
-    "@qvac/transcription-parakeet": ["@qvac/transcription-parakeet@0.2.7", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.2.0", "@qvac/logging": "^0.1.0", "@qvac/onnx": "^0.14.0", "bare-fs": "^4.5.1", "bare-path": "^3.0.0", "path": "npm:bare-path", "process": "npm:bare-process@^4.2.2" } }, "sha512-/Ziz0sgMWuWpEgkjsJLU4OEGu6iT6wTdVAG/BsCxecmhmnbyQRzxkOJE04f4kBUuNxx4lYvrwanMaoijrwWLIQ=="],
+    "@qvac/transcription-parakeet": ["@qvac/transcription-parakeet@0.3.0", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.4.0", "@qvac/logging": "^0.1.0", "@qvac/onnx": "^0.14.0", "bare-fs": "^4.5.1", "bare-path": "^3.0.0", "path": "npm:bare-path", "process": "npm:bare-process@^4.2.2" } }, "sha512-bABff7KzBw6f1UQHJJSLivkP0osG7nXo0MeE8irh1bGyerY+cLPYalOVdLjmSFqmbspKIWEhctrL7eIR51S9EQ=="],
 
     "@qvac/transcription-whispercpp": ["@qvac/transcription-whispercpp@0.6.1", "", { "dependencies": { "@qvac/decoder-audio": "^0.3.3", "@qvac/error": "^0.1.0", "@qvac/infer-base": "^0.4.0", "@qvac/logging": "^0.1.0", "bare-channel": "^5.2.2", "bare-ffmpeg": "^1.0.0-32", "bare-node-worker-threads": "^1.0.0", "bare-path": "^3.0.0", "bare-stream": "^2.7.0", "bare-worker": "^4.1.0", "path": "npm:bare-path", "process": "npm:bare-process@^4.2.2", "stream": "npm:bare-node-stream", "worker_threads": "npm:bare-node-worker-threads@^1.0.0" } }, "sha512-GrOKYjtCAJGVnCssDpoKgMD2S7O6zdOG2rFnR1+Almc5/+924U08peR3eQEuvTiP0+No6X5Aa0CIx0lGsOFBig=="],
 
@@ -2544,7 +2546,7 @@
 
     "@qvac/response/bare-events": ["bare-events@2.4.2", "", {}, "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q=="],
 
-    "@qvac/transcription-parakeet/@qvac/infer-base": ["@qvac/infer-base@0.2.2", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/logging": "^0.1.0", "bare-events": "2.4.2", "bare-os": "^3.2.0", "bare-path": "^3.0.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-8D/5PRIy/A+Uhg1ZSoJMu5FSPDHdrMKZoPnAzTZMceikTj+BWwTV//j8pXbRABsjrFbqBegvr/LujirC9I2cRQ=="],
+    "@qvac/transcription-parakeet/@qvac/infer-base": ["@qvac/infer-base@0.4.0", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/logging": "^0.1.0", "bare-events": "2.4.2", "bare-os": "^3.2.0", "bare-path": "^3.0.0" }, "optionalDependencies": { "@qvac/diagnostics": "^0.1.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-KoD4PrNzcScFjuLdGSTwtN/i10tMuwpRUW9g5lIiIaoR4s36NHwkfcxjyQDlHFlXkYjf3p3IpWXJgKOSo3jAqg=="],
 
     "@qvac/transcription-whispercpp/@qvac/infer-base": ["@qvac/infer-base@0.4.0", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/logging": "^0.1.0", "bare-events": "2.4.2", "bare-os": "^3.2.0", "bare-path": "^3.0.0" }, "optionalDependencies": { "@qvac/diagnostics": "^0.1.0" }, "peerDependencies": { "@qvac/dl-hyperdrive": "^0.1.0" } }, "sha512-KoD4PrNzcScFjuLdGSTwtN/i10tMuwpRUW9g5lIiIaoR4s36NHwkfcxjyQDlHFlXkYjf3p3IpWXJgKOSo3jAqg=="],
 

--- a/packages/sdk/bun.lock
+++ b/packages/sdk/bun.lock
@@ -15,7 +15,7 @@
         "@qvac/ocr-onnx": "^0.4.0",
         "@qvac/rag": "^0.4.4",
         "@qvac/registry-client": "^0.2.1",
-        "@qvac/transcription-parakeet": "0.3.0",
+        "@qvac/transcription-parakeet": "^0.3.0",
         "@qvac/transcription-whispercpp": "^0.6.0",
         "@qvac/translation-nmtcpp": "^0.6.1",
         "@qvac/tts-onnx": "^0.6.7",

--- a/packages/sdk/bun.lock
+++ b/packages/sdk/bun.lock
@@ -532,8 +532,6 @@
 
     "@qvac/onnx": ["@qvac/onnx@0.14.0", "", {}, "sha512-P2RlpHcAdOs53aMfdMNBk3e8S6SFzroT5ShlZVM4Kag83nTpATJKIsxWyq64sHwSVtJjRtdxOF8lksbVnwzIvQ=="],
 
-    "@qvac/onnx": ["@qvac/onnx@0.14.0", "", {}, "sha512-P2RlpHcAdOs53aMfdMNBk3e8S6SFzroT5ShlZVM4Kag83nTpATJKIsxWyq64sHwSVtJjRtdxOF8lksbVnwzIvQ=="],
-
     "@qvac/rag": ["@qvac/rag@0.4.4", "", { "dependencies": { "@qvac/error": "^0.1.0", "hyperdht": "^6.23.0", "ready-resource": "^1.1.2", "uuid-random": "^1.3.2", "zod": "^4.1.13" }, "peerDependencies": { "bare-crypto": "^1.13.4", "bare-fetch": "^2.5.0", "hyperdb": "^4.19.0", "hyperschema": "^1.13.0", "llm-splitter": "^0.2.0" }, "optionalPeers": ["bare-crypto", "bare-fetch", "hyperdb", "hyperschema", "llm-splitter"] }, "sha512-3LRLNPzmRwHn7S76QPM/01sX8JDLPFCdTRycL5YgJ8Vm0FfAXhLCqYX7t/7hFgY7SZxqSgZie/ZhOfg5+xL1gA=="],
 
     "@qvac/registry-client": ["@qvac/registry-client@0.2.1", "", { "dependencies": { "@qvac/error": "^0.1.0", "@qvac/registry-schema": "^0.1.1", "b4a": "^1.6.7", "bare-fs": "^4.5.2", "bare-os": "^3.6.2", "bare-path": "^3.0.0", "bare-process": "^4.2.2", "corestore": "^7.4.5", "hyperblobs": "^2.8.0", "hypercore-id-encoding": "^1.3.0", "hyperdb": "^4.16.1", "hyperswarm": "^4.14.0", "paparam": "^1.10.0", "ready-resource": "^1.0.1" }, "bin": { "qvac-registry": "bin/cli.js" } }, "sha512-ekT7MvFbX1MjTusS+Z/kbw1rLI5k9mpw41gNZv3rvL1ZDTfjuJ++iRYDUDZO9wT5ehyqChVwsPjoDuBiZpcC3A=="],

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -183,7 +183,7 @@
     "@qvac/ocr-onnx": "^0.4.0",
     "@qvac/rag": "^0.4.4",
     "@qvac/registry-client": "^0.2.1",
-    "@qvac/transcription-parakeet": "0.3.0",
+    "@qvac/transcription-parakeet": "^0.3.0",
     "@qvac/transcription-whispercpp": "^0.6.0",
     "@qvac/translation-nmtcpp": "^0.6.1",
     "@qvac/tts-onnx": "^0.6.7",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -183,7 +183,7 @@
     "@qvac/ocr-onnx": "^0.4.0",
     "@qvac/rag": "^0.4.4",
     "@qvac/registry-client": "^0.2.1",
-    "@qvac/transcription-parakeet": "^0.2.7",
+    "@qvac/transcription-parakeet": "0.3.0",
     "@qvac/transcription-whispercpp": "^0.6.0",
     "@qvac/translation-nmtcpp": "^0.6.1",
     "@qvac/tts-onnx": "^0.6.7",

--- a/packages/sdk/server/bare/plugins/parakeet-transcription/plugin.ts
+++ b/packages/sdk/server/bare/plugins/parakeet-transcription/plugin.ts
@@ -1,7 +1,7 @@
 import parakeetAddonLogging from "@qvac/transcription-parakeet/addonLogging";
 import TranscriptionParakeet, {
   type ParakeetConfig,
-  type TranscriptionParakeetArgs,
+  type TranscriptionParakeetFiles,
   type TranscriptionParakeetConfig,
 } from "@qvac/transcription-parakeet";
 import {
@@ -18,6 +18,8 @@ import {
   type ResolveContext,
   type ResolveResult,
 } from "@/schemas";
+import fs from "bare-fs";
+import path from "bare-path";
 import { createStreamLogger, registerAddonLogger } from "@/logging";
 import { parseModelPath } from "@/server/utils";
 import {
@@ -47,6 +49,40 @@ type ParakeetModelConfig = {
   // Sortformer
   parakeetSortformerSrc?: ModelSrcInput;
 };
+
+// ONNX external data files must be co-located with their companion .onnx file.
+// The SDK cache may store them at separate hash-prefixed paths, so we symlink
+// the data file into the .onnx file's directory before the addon opens the session.
+const ONNX_DATA_COMPANIONS = [
+  { onnxKey: "encoder", dataKey: "encoderData", dataFilename: "encoder-model.onnx.data" },
+  { onnxKey: "model", dataKey: "modelData", dataFilename: "model.onnx_data" },
+] as const;
+
+function ensureOnnxDataColocated(
+  artifacts: Record<string, string | undefined>,
+) {
+  for (const { onnxKey, dataKey, dataFilename } of ONNX_DATA_COMPANIONS) {
+    const onnxPath = artifacts[onnxKey];
+    const dataPath = artifacts[dataKey];
+    if (!onnxPath || !dataPath) continue;
+
+    const onnxDir = path.dirname(onnxPath);
+    const colocatedPath = path.join(onnxDir, dataFilename);
+
+    if (dataPath === colocatedPath) continue;
+    if (fs.existsSync(colocatedPath)) {
+      artifacts[dataKey] = colocatedPath;
+      continue;
+    }
+
+    try {
+      fs.symlinkSync(dataPath, colocatedPath);
+      artifacts[dataKey] = colocatedPath;
+    } catch {
+      // Keep original path if symlink creation fails
+    }
+  }
+}
 
 async function resolveTdtConfig(
   cfg: ParakeetModelConfig,
@@ -86,10 +122,11 @@ async function resolveTdtConfig(
   return {
     config: cfg,
     artifacts: {
-      encoderPath,
-      ...(decoderPath !== undefined && { decoderPath }),
-      ...(vocabPath !== undefined && { vocabPath }),
-      ...(preprocessorPath !== undefined && { preprocessorPath }),
+      encoder: encoderPath,
+      ...(encoderDataPath !== undefined && { encoderData: encoderDataPath }),
+      ...(decoderPath !== undefined && { decoder: decoderPath }),
+      ...(vocabPath !== undefined && { vocab: vocabPath }),
+      ...(preprocessorPath !== undefined && { preprocessor: preprocessorPath }),
     },
   };
 }
@@ -115,8 +152,9 @@ async function resolveCtcConfig(
   return {
     config: cfg,
     artifacts: {
-      ctcModelPath,
-      ...(tokenizerPath !== undefined && { tokenizerPath }),
+      model: ctcModelPath,
+      ...(ctcModelDataPath !== undefined && { modelData: ctcModelDataPath }),
+      ...(tokenizerPath !== undefined && { tokenizer: tokenizerPath }),
     },
   };
 }
@@ -139,19 +177,19 @@ async function resolveSortformerConfig(
   return {
     config: cfg,
     artifacts: {
-      ...(sortformerPath !== undefined && { sortformerPath }),
+      ...(sortformerPath !== undefined && { sortformer: sortformerPath }),
     },
   };
 }
 
 function createParakeetModel(
   params: CreateModelParams,
-  addonPathKey: string,
+  primaryFileKey: keyof TranscriptionParakeetFiles,
 ): PluginModelResult {
   const config = (params.modelConfig ?? {}) as ParakeetModelConfig;
-  const artifacts = params.artifacts ?? {};
+  const artifacts = { ...(params.artifacts ?? {}) };
   const modelType = config.modelType ?? "tdt";
-  const primaryPath = artifacts[addonPathKey] ?? params.modelPath;
+  const primaryPath = artifacts[primaryFileKey] ?? params.modelPath;
 
   if (!primaryPath) {
     throw new ModelLoadFailedError(
@@ -159,15 +197,20 @@ function createParakeetModel(
     );
   }
 
+  ensureOnnxDataColocated(artifacts);
+
   const { dirPath } = parseModelPath(primaryPath);
   const loader = new FilesystemDL({ dirPath });
   const logger = createStreamLogger(params.modelId, ModelType.parakeetTranscription);
   registerAddonLogger(params.modelId, ModelType.parakeetTranscription, logger);
 
-  const addonConfig: TranscriptionParakeetConfig = {
-    path: dirPath,
-    [addonPathKey]: primaryPath,
+  const files: TranscriptionParakeetFiles = {
+    [primaryFileKey]: primaryPath,
     ...artifacts,
+  };
+
+  const addonConfig: TranscriptionParakeetConfig = {
+    enableStats: true,
     parakeetConfig: {
       modelType,
       maxThreads: config.maxThreads,
@@ -179,16 +222,11 @@ function createParakeetModel(
     } as ParakeetConfig,
   };
 
-  const model = new TranscriptionParakeet(
-    {
-      loader,
-      logger,
-      modelName: parseModelPath(dirPath).basePath,
-      diskPath: dirPath,
-      opts: { stats: true },
-    } as TranscriptionParakeetArgs,
-    addonConfig,
-  );
+  const model = new TranscriptionParakeet({
+    files,
+    config: addonConfig,
+    logger,
+  });
 
   return { model, loader };
 }
@@ -215,10 +253,10 @@ export const parakeetPlugin = definePlugin({
     const modelType =
       ((params.modelConfig ?? {}) as ParakeetModelConfig).modelType ?? "tdt";
 
-    if (modelType === "ctc") return createParakeetModel(params, "ctcModelPath");
+    if (modelType === "ctc") return createParakeetModel(params, "model");
     if (modelType === "sortformer")
-      return createParakeetModel(params, "sortformerPath");
-    return createParakeetModel(params, "encoderPath");
+      return createParakeetModel(params, "sortformer");
+    return createParakeetModel(params, "encoder");
   },
 
   handlers: {

--- a/packages/sdk/server/bare/plugins/parakeet-transcription/plugin.ts
+++ b/packages/sdk/server/bare/plugins/parakeet-transcription/plugin.ts
@@ -18,8 +18,6 @@ import {
   type ResolveContext,
   type ResolveResult,
 } from "@/schemas";
-import fs from "bare-fs";
-import path from "bare-path";
 import { createStreamLogger, registerAddonLogger } from "@/logging";
 import { parseModelPath } from "@/server/utils";
 import {
@@ -52,39 +50,6 @@ type ParakeetModelConfig = {
   parakeetSortformerSrc?: ModelSrcInput;
 };
 
-// ONNX external data files must be co-located with their companion .onnx file.
-// The SDK cache may store them at separate hash-prefixed paths, so we symlink
-// the data file into the .onnx file's directory before the addon opens the session.
-const ONNX_DATA_COMPANIONS = [
-  { onnxKey: "encoder", dataKey: "encoderData", dataFilename: "encoder-model.onnx.data" },
-  { onnxKey: "model", dataKey: "modelData", dataFilename: "model.onnx_data" },
-] as const;
-
-function ensureOnnxDataColocated(
-  artifacts: Record<string, string | undefined>,
-) {
-  for (const { onnxKey, dataKey, dataFilename } of ONNX_DATA_COMPANIONS) {
-    const onnxPath = artifacts[onnxKey];
-    const dataPath = artifacts[dataKey];
-    if (!onnxPath || !dataPath) continue;
-
-    const onnxDir = path.dirname(onnxPath);
-    const colocatedPath = path.join(onnxDir, dataFilename);
-
-    if (dataPath === colocatedPath) continue;
-    if (fs.existsSync(colocatedPath)) {
-      artifacts[dataKey] = colocatedPath;
-      continue;
-    }
-
-    try {
-      fs.symlinkSync(dataPath, colocatedPath);
-      artifacts[dataKey] = colocatedPath;
-    } catch {
-      // Keep original path if symlink creation fails
-    }
-  }
-}
 
 async function resolveTdtConfig(
   cfg: ParakeetModelConfig,
@@ -203,8 +168,6 @@ function createParakeetModel(
       `Parakeet ${modelType} requires a model source`,
     );
   }
-
-  ensureOnnxDataColocated(artifacts);
 
   const { dirPath } = parseModelPath(primaryPath);
   const loader = new FilesystemDL({ dirPath });

--- a/packages/sdk/server/bare/plugins/parakeet-transcription/plugin.ts
+++ b/packages/sdk/server/bare/plugins/parakeet-transcription/plugin.ts
@@ -40,11 +40,13 @@ type ParakeetModelConfig = {
   timestampsEnabled?: boolean;
   // TDT
   parakeetEncoderSrc?: ModelSrcInput;
+  parakeetEncoderDataSrc?: ModelSrcInput;
   parakeetDecoderSrc?: ModelSrcInput;
   parakeetVocabSrc?: ModelSrcInput;
   parakeetPreprocessorSrc?: ModelSrcInput;
   // CTC
   parakeetCtcModelSrc?: ModelSrcInput;
+  parakeetCtcModelDataSrc?: ModelSrcInput;
   parakeetTokenizerSrc?: ModelSrcInput;
   // Sortformer
   parakeetSortformerSrc?: ModelSrcInput;
@@ -90,6 +92,7 @@ async function resolveTdtConfig(
 ): Promise<ResolveResult<ParakeetModelConfig>> {
   const {
     parakeetEncoderSrc,
+    parakeetEncoderDataSrc,
     parakeetDecoderSrc,
     parakeetVocabSrc,
     parakeetPreprocessorSrc,
@@ -109,11 +112,13 @@ async function resolveTdtConfig(
   const resolve = ctx.resolveModelPath;
   const [
     encoderPath,
+    encoderDataPath,
     decoderPath,
     vocabPath,
     preprocessorPath,
   ] = await Promise.all([
     resolve(parakeetEncoderSrc),
+    parakeetEncoderDataSrc ? resolve(parakeetEncoderDataSrc) : undefined,
     resolve(parakeetDecoderSrc),
     resolve(parakeetVocabSrc),
     resolve(parakeetPreprocessorSrc),
@@ -135,7 +140,8 @@ async function resolveCtcConfig(
   cfg: ParakeetModelConfig,
   ctx: ResolveContext,
 ): Promise<ResolveResult<ParakeetModelConfig>> {
-  const { parakeetCtcModelSrc, parakeetTokenizerSrc } = cfg;
+  const { parakeetCtcModelSrc, parakeetCtcModelDataSrc, parakeetTokenizerSrc } =
+    cfg;
 
   if (!parakeetCtcModelSrc || !parakeetTokenizerSrc) {
     throw new ParakeetArtifactsRequiredError(
@@ -144,8 +150,9 @@ async function resolveCtcConfig(
   }
 
   const resolve = ctx.resolveModelPath;
-  const [ctcModelPath, tokenizerPath] = await Promise.all([
+  const [ctcModelPath, ctcModelDataPath, tokenizerPath] = await Promise.all([
     resolve(parakeetCtcModelSrc),
+    parakeetCtcModelDataSrc ? resolve(parakeetCtcModelDataSrc) : undefined,
     resolve(parakeetTokenizerSrc),
   ]);
 

--- a/packages/sdk/types/bare-fs/index.d.ts
+++ b/packages/sdk/types/bare-fs/index.d.ts
@@ -75,11 +75,6 @@ declare module "bare-fs" {
     options?: { encoding?: BufferEncoding; withFileTypes?: boolean },
   ): string[] | Buffer[];
   export function renameSync(oldPath: string, newPath: string): void;
-  export function symlinkSync(
-    target: string,
-    path: string,
-    type?: "file" | "dir" | "junction",
-  ): void;
   export function createReadStream(
     path: string,
     options?: ReadStreamOptions,

--- a/packages/sdk/types/bare-fs/index.d.ts
+++ b/packages/sdk/types/bare-fs/index.d.ts
@@ -75,6 +75,11 @@ declare module "bare-fs" {
     options?: { encoding?: BufferEncoding; withFileTypes?: boolean },
   ): string[] | Buffer[];
   export function renameSync(oldPath: string, newPath: string): void;
+  export function symlinkSync(
+    target: string,
+    path: string,
+    type?: "file" | "dir" | "junction",
+  ): void;
   export function createReadStream(
     path: string,
     options?: ReadStreamOptions,


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- The `@qvac/transcription-parakeet` package updated its constructor API — the old two-argument form (`TranscriptionParakeetArgs`, `TranscriptionParakeetConfig`) no longer exists
- With the new API, ONNX Runtime fails to load CTC/TDT models because the SDK cache stores `.onnx` and `.onnx_data` files at separate hash-prefixed paths in different directories, while ONNX Runtime requires external data files to be co-located with their companion `.onnx`

## 📝 How does it solve it?

- Migrates `parakeet-transcription/plugin.ts` to the new single-object constructor (`{ files, config, logger }`)
- Renames artifact keys to match the new `TranscriptionParakeetFiles` interface (`encoderPath` → `encoder`, `ctcModelPath` → `model`, etc.)
- Adds `ensureOnnxDataColocated()`: before constructing the addon, symlinks any scattered `.onnx_data` artifact into the companion `.onnx` file's directory so ONNX Runtime can resolve it
- Adds `symlinkSync` to the `bare-fs` type declarations (present at runtime, missing from the SDK's hand-maintained types)

## 🧪 How was it tested?

- Ran parakeet examples end-to-end; model now loads and transcribes successfully after the symlink fix