### PR TITLE
[tetherto/qvac]: add ensure-npm-public job to nmtcpp and ocr-onnx on-merge workflows

### DIFF
--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -81,6 +81,22 @@ jobs:
           echo "publish_tmp=$publish_tmp" >> "$GITHUB_OUTPUT"
           echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
 
+  ensure-npm-public:
+    name: Ensure NPM package is public
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - name: Set package access to public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm access set status=public @qvac/ocr-onnx
+
   release-merge-guard:
     name: Release Merge Guard
     if: >-

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -80,6 +80,22 @@ jobs:
           echo "publish_tmp=$publish_tmp" >> "$GITHUB_OUTPUT"
           echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
 
+  ensure-npm-public:
+    name: Ensure NPM package is public
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - name: Set package access to public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm access set status=public @qvac/translation-nmtcpp
+
   release-merge-guard:
     name: Release Merge Guard
     if: >-

--- a/packages/ocr-onnx/test/integration/full-coverage.test.js
+++ b/packages/ocr-onnx/test/integration/full-coverage.test.js
@@ -198,13 +198,13 @@ test('load() accepts defaultRotationAngles and contrastRetry', { timeout: TEST_T
     })
 
     await response
-        .onUpdate(function (output) {
-          t.ok(Array.isArray(output), 'Output should be an array')
-        })
-        .onError(function (error) {
-          t.fail('Unexpected error: ' + JSON.stringify(error))
-        })
-        .await()
+      .onUpdate(function (output) {
+        t.ok(Array.isArray(output), 'Output should be an array')
+      })
+      .onError(function (error) {
+        t.fail('Unexpected error: ' + JSON.stringify(error))
+      })
+      .await()
 
     t.pass('Inference completed with extra params')
   } finally {


### PR DESCRIPTION
## Summary
- Adds `ensure-npm-public` job to `on-merge-qvac-lib-infer-nmtcpp.yml` and `on-merge-ocr-onnx.yml`
- Runs `npm access set status=public` on every workflow trigger to ensure `@qvac/translation-nmtcpp` and `@qvac/ocr-onnx` remain publicly accessible on npm
- Matches the same pattern added to whispercpp (`@qvac/transcription-whispercpp`) in commit 757ed4a

## Why
The `publish-library-to-npm` action now publishes with `--access public` and runs `npm access public` post-publish (PRs #1509, #1527), but packages that were previously published as **restricted** before those fixes need an explicit `npm access set status=public` to correct their visibility. This standalone job handles that.

## Test plan
- [ ] Verify YAML is valid (no duplicate keys, correct indentation)
- [ ] Confirm `ensure-npm-public` job runs successfully on merge to main
- [ ] Verify `@qvac/translation-nmtcpp` is publicly accessible on npmjs.com
- [ ] Verify `@qvac/ocr-onnx` is publicly accessible on npmjs.com


Made with [Cursor](https://cursor.com)