### PR TITLE
[tetherto/qvac]: set version to 1.0.0 for first npm release

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
@@ -5,48 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.1] - 2026-04-13
-
-### Changed
-
-- Bumped `qvac-fabric` dependency from 7248.2.2 to 7248.2.3
-
-## [2.0.0] - 2026-04-08
-
-### Changed
-
-- **Breaking**: Constructor now accepts `{ files, params, config }` instead of `{ loader, diskPath, modelName, params }, config`. Addons receive resolved file paths directly — no loader abstraction.
-- **Breaking**: No longer extends `BaseInference`. `TranslationNmtcpp` is now a standalone class owning its own lifecycle, logger, and run serialization via `exclusiveRunQueue()` from `@qvac/infer-base`.
-- Replaced internal `_jobToResponse` Map boilerplate with `createJobHandler()` from `@qvac/infer-base@0.4.0`
-- Switched `QvacResponse` import from `@qvac/response` to `@qvac/infer-base`
-- Removed `pauseHandler`/`continueHandler` from response construction (deprecated in single-job model)
-- Added `@qvac/logging` as direct dependency (previously transitive via BaseInference)
-
-### Removed
-
-- `BaseInference` inheritance — addon owns its own `load()`, `run()`, `unload()`, `destroy()`, `getState()`
-- `WeightsProvider` dependency — addon no longer downloads weights; SDK resolves all file paths before creating the addon
-- `@qvac/dl-hyperdrive` and `bare-path` dependencies
-- `_downloadWeights()`, `_downloadPivotWeights()`, `_getFilesToDownload()`, `_getPivotFilesToDownload()`, `_getVocabularyPaths()` methods
-- `loader`, `diskPath`, `modelName` constructor parameters
-- Bergamot pivot model `bergamotPivotModel.loader` / `bergamotPivotModel.weightsProvider` — pivot file paths now passed via `files.pivotModel`, `files.pivotSrcVocab`, `files.pivotDstVocab`
-
-### Updated
-
-- Examples updated for new constructor — use local file paths or `bergamot-model-fetcher` for auto-download
-- Removed `example.hd.js` and `pause.example.js` (redundant — `quickstart.js` covers basic translation, NMT has no pause support)
-- Removed HyperdriveDL from all examples — `indictrans.js` and `pivot.example.js` now accept local paths via env vars
-- SDK NMT plugin passes resolved file paths via `files` shape instead of creating `FilesystemDL` loader
-
-## [1.0.1] - 2026-04-08
-
-### Changed
-
-- Bumped `qvac-lib-inference-addon-cpp` vcpkg dependency to >=1.1.5
-- Removed legacy model download script (`scripts/download_model_from_s3.sh`)
-- Cleaned up documentation and comments
-
-## [1.0.0] - 2026-03-31
+## [1.0.0] - 2026-04-13
 
 ### Breaking Changes
 
@@ -61,14 +20,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Marian C++ unit tests (`nmt_model_wrapper_test_marian.cpp`)
 - Opus benchmark results, released-models list, and model-conversion-test CI workflow
 - `qvac` (GGML/Opus) translator option and `is_quantized_model` input from benchmark workflow
+- `BaseInference` inheritance — addon owns its own `load()`, `run()`, `unload()`, `destroy()`, `getState()`
+- `WeightsProvider` dependency — addon no longer downloads weights; SDK resolves all file paths before creating the addon
+- `@qvac/dl-hyperdrive` and `bare-path` dependencies
+- `_downloadWeights()`, `_downloadPivotWeights()`, `_getFilesToDownload()`, `_getPivotFilesToDownload()`, `_getVocabularyPaths()` methods
+- `loader`, `diskPath`, `modelName` constructor parameters
+- Bergamot pivot model `bergamotPivotModel.loader` / `bergamotPivotModel.weightsProvider` — pivot file paths now passed via `files.pivotModel`, `files.pivotSrcVocab`, `files.pivotDstVocab`
+- Legacy model download script (`scripts/download_model_from_s3.sh`)
+- `example.hd.js` and `pause.example.js` (redundant — `quickstart.js` covers basic translation, NMT has no pause support)
+- HyperdriveDL from all examples — `indictrans.js` and `pivot.example.js` now accept local paths via env vars
 
 ### Fixed
 
 - Restored `TEST_P` parameterized test definitions for `NmtCppModelWrapperTest` (were lost when Marian test file was deleted)
-- Pinned `bare-process` to `>=4.2.2 <4.4.0` to work around upstream stdin regression in v4.4.0
 
 ### Changed
 
+- Constructor now accepts `{ files, params, config }` instead of `{ loader, diskPath, modelName, params }, config`. Addons receive resolved file paths directly — no loader abstraction.
+- No longer extends `BaseInference`. `TranslationNmtcpp` is now a standalone class owning its own lifecycle, logger, and run serialization via `exclusiveRunQueue()` from `@qvac/infer-base`.
+- Replaced internal `_jobToResponse` Map boilerplate with `createJobHandler()` from `@qvac/infer-base@0.4.0`
+- Switched `QvacResponse` import from `@qvac/response` to `@qvac/infer-base`
+- Removed `pauseHandler`/`continueHandler` from response construction (deprecated in single-job model)
+- Added `@qvac/logging` as direct dependency (previously transitive via BaseInference)
+- Bumped `qvac-lib-inference-addon-cpp` vcpkg dependency to >=1.1.5
+- Bumped `qvac-fabric` dependency from 7248.2.2 to 7248.2.3
 - Renamed internal `marian_ctx` variable to `nmt_ctx` in loader
 - Benchmark workflow default translator changed from `qvac` to `qvac_bergamot`
 - CI cpp-tests workflow only downloads IndicTrans model (Opus model downloads removed)

--- a/packages/qvac-lib-infer-nmtcpp/package.json
+++ b/packages/qvac-lib-infer-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "2.0.1",
+  "version": "1.0.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary
- Sets `@qvac/translation-nmtcpp` version to `1.0.0` for the first npm publish
- Consolidates unreleased internal version entries (`2.0.1`, `2.0.0`, `1.0.1`, `1.0.0`) into a single `[1.0.0]` changelog section
- The package was never published to npm — all prior version bumps were internal

## Why
Starting at `2.0.1` for a first public release is confusing for consumers. Since no version was ever published, we can reset to a clean `1.0.0`.

## Changes
- `package.json`: version `2.0.1` → `1.0.0`
- `CHANGELOG.md`: merged 4 internal version sections into one `[1.0.0] - 2026-04-13`

## Next steps
After merge, create release branch `release-qvac-lib-infer-nmtcpp-1.0.0` to trigger the npm publish pipeline.

## Test plan
- [x] No code changes — version and changelog only
- [ ] Verify CI passes (YAML unchanged, JS unchanged)
