### PR TITLE
chore[notask|skiplog]: cherry-pick workflow migration from qvac-devops to oss-actions

### DIFF
--- a/.github/actions/publish-library-to-gpr/action.yaml
+++ b/.github/actions/publish-library-to-gpr/action.yaml
@@ -194,6 +194,7 @@ runs:
         # Check if repo is in always-publish list
         ALWAYS_PUBLISH_REPOS=(
           qvac-devops
+          oss-actions
           qvac-examples
           qvac-ext-lib-mlc
           qvac-ext-lib-tokenizers-cpp

--- a/.github/workflows/approval-worker.yml
+++ b/.github/workflows/approval-worker.yml
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
       statuses: write
       issues: write
-    uses: tetherto/qvac-devops/.github/workflows/approval-check-worker.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/approval-check-worker.yml@v1.1.8
     secrets:
       pat_token: ${{ secrets.PAT_TOKEN }}
     with:

--- a/.github/workflows/approval-worker.yml
+++ b/.github/workflows/approval-worker.yml
@@ -48,7 +48,7 @@ jobs:
       pull-requests: write
       statuses: write
       issues: write
-    uses: tetherto/qvac-devops/.github/workflows/approval-check-worker.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/approval-check-worker.yml@v1.1.0
     secrets:
       pat_token: ${{ secrets.PAT_TOKEN }}
     with:

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -156,7 +156,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -178,13 +178,14 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -156,7 +156,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -185,7 +185,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/on-pr-close-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-close-lib-infer-diffusion.yml
@@ -52,7 +52,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-close-lib-infer-diffusion.yml
@@ -52,7 +52,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-ocr-onnx.yml
+++ b/.github/workflows/on-pr-close-ocr-onnx.yml
@@ -49,7 +49,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-ocr-onnx.yml
+++ b/.github/workflows/on-pr-close-ocr-onnx.yml
@@ -49,7 +49,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-decoder-audio.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-decoder-audio.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-embed.yml
@@ -56,7 +56,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-embed.yml
@@ -56,7 +56,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-llm.yml
@@ -52,7 +52,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-llamacpp-llm.yml
@@ -52,7 +52,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-nmtcpp.yml
@@ -47,7 +47,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-nmtcpp.yml
@@ -47,7 +47,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-onnx-tts.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-onnx-tts.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-onnx.yml
@@ -49,7 +49,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-onnx.yml
@@ -49,7 +49,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-parakeet.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-parakeet.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-whispercpp.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-delete-npm-versions.yml@v1.1.0
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-close-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-close-qvac-lib-infer-whispercpp.yml
@@ -57,7 +57,7 @@ jobs:
   delete-npm-versions-trigger:
     permissions:
       packages: write
-    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-delete-npm-versions.yml@v1.1.8
     with:
       version: ${{ inputs.version }}
       pr-number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || inputs.pr-number }}

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -55,7 +55,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
 
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
     needs: authorize
     secrets: inherit
     with:
@@ -164,7 +164,7 @@ jobs:
         ts-checks,
       ]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/on-pr-lib-infer-diffusion.yml
+++ b/.github/workflows/on-pr-lib-infer-diffusion.yml
@@ -55,7 +55,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
 
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
     needs: authorize
     secrets: inherit
     with:
@@ -164,7 +164,7 @@ jobs:
         ts-checks,
       ]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Verify that yaml files are formatted
         id: yamlfmt
-        uses: tetherto/qvac-devops/.github/actions/yamlfmt@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/yamlfmt@v1.1.0
         continue-on-error: true
 
       - name: Check for disallowed dependencies
@@ -126,7 +126,7 @@ jobs:
       - name: Run JavaScript tests
         id: run_js_tests
         continue-on-error: true
-        uses: tetherto/qvac-devops/.github/actions/run-lint-and-unit-tests@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/run-lint-and-unit-tests@v1.1.0
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
           gpr-token: ${{ secrets.GITHUB_TOKEN }}
@@ -165,7 +165,7 @@ jobs:
   cpp-lint:
     needs: [authorize, changes]
     if: needs.authorize.outputs.allowed == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -229,7 +229,7 @@ jobs:
   merge-guard:
     needs: [authorize, changes, sanity-checks, prebuild, run-integration-tests, run-mobile-integration-tests]
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Verify that yaml files are formatted
         id: yamlfmt
-        uses: tetherto/qvac-devops/.github/actions/yamlfmt@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/yamlfmt@v1.1.8
         continue-on-error: true
 
       - name: Check for disallowed dependencies
@@ -126,7 +126,7 @@ jobs:
       - name: Run JavaScript tests
         id: run_js_tests
         continue-on-error: true
-        uses: tetherto/qvac-devops/.github/actions/run-lint-and-unit-tests@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/run-lint-and-unit-tests@v1.1.8
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
           gpr-token: ${{ secrets.GITHUB_TOKEN }}
@@ -165,7 +165,7 @@ jobs:
   cpp-lint:
     needs: [authorize, changes]
     if: needs.authorize.outputs.allowed == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -229,7 +229,7 @@ jobs:
   merge-guard:
     needs: [authorize, changes, sanity-checks, prebuild, run-integration-tests, run-mobile-integration-tests]
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
@@ -142,7 +142,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -177,7 +177,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, run-integration-tests, run-mobile-integration-tests]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-pr-qvac-lib-decoder-audio.yml
@@ -142,7 +142,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -177,7 +177,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, run-integration-tests, run-mobile-integration-tests]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.run-integration-tests.result == 'success' || needs.run-integration-tests.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -50,7 +50,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha }}
@@ -152,7 +152,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, cpp-lint, cpp-tests, prebuild, integration-tests, run-mobile-integration-tests, ts-checks]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -50,7 +50,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -61,7 +61,7 @@ jobs:
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha }}
@@ -152,7 +152,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, cpp-lint, cpp-tests, prebuild, integration-tests, run-mobile-integration-tests, ts-checks]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -55,7 +55,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
 
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
     needs: authorize
     secrets: inherit
     with:
@@ -164,7 +164,7 @@ jobs:
         ts-checks,
       ]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success'}}

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -55,7 +55,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
 
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
     needs: authorize
     secrets: inherit
     with:
@@ -164,7 +164,7 @@ jobs:
         ts-checks,
       ]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success'}}

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -68,7 +68,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
       always() &&
        needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}
@@ -199,7 +199,7 @@ jobs:
         run-mobile-integration-tests,
       ]
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.cpp-tests.result == 'success' && needs.ts-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -68,7 +68,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -116,7 +116,7 @@ jobs:
       always() &&
        needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}
@@ -199,7 +199,7 @@ jobs:
         run-mobile-integration-tests,
       ]
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && needs.cpp-tests.result == 'success' && needs.ts-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
@@ -142,7 +142,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -153,7 +153,7 @@ jobs:
   cpp-lint:
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -226,7 +226,7 @@ jobs:
         run-mobile-integration-tests,
       ]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
@@ -142,7 +142,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -153,7 +153,7 @@ jobs:
   cpp-lint:
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -226,7 +226,7 @@ jobs:
         run-mobile-integration-tests,
       ]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Verify that yaml files are formatted
         id: yamlfmt
-        uses: tetherto/qvac-devops/.github/actions/yamlfmt@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/yamlfmt@v1.1.8
         continue-on-error: true
 
       - name: Check for disallowed dependencies
@@ -124,7 +124,7 @@ jobs:
       - name: Run JavaScript tests
         id: run_js_tests
         continue-on-error: true
-        uses: tetherto/qvac-devops/.github/actions/run-lint-and-unit-tests@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/run-lint-and-unit-tests@v1.1.8
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
           gpr-token: ${{ secrets.GITHUB_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
   cpp-lint:
     needs: [authorize, changes]
     if: needs.authorize.outputs.allowed == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -192,7 +192,7 @@ jobs:
   merge-guard:
     needs: [authorize, changes, sanity-checks, prebuild]
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Verify that yaml files are formatted
         id: yamlfmt
-        uses: tetherto/qvac-devops/.github/actions/yamlfmt@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/yamlfmt@v1.1.0
         continue-on-error: true
 
       - name: Check for disallowed dependencies
@@ -124,7 +124,7 @@ jobs:
       - name: Run JavaScript tests
         id: run_js_tests
         continue-on-error: true
-        uses: tetherto/qvac-devops/.github/actions/run-lint-and-unit-tests@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/run-lint-and-unit-tests@v1.1.0
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
           gpr-token: ${{ secrets.GITHUB_TOKEN }}
@@ -163,7 +163,7 @@ jobs:
   cpp-lint:
     needs: [authorize, changes]
     if: needs.authorize.outputs.allowed == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -192,7 +192,7 @@ jobs:
   merge-guard:
     needs: [authorize, changes, sanity-checks, prebuild]
     if: always() && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' }}
       build-status: ${{ needs.prebuild.result == 'success' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -142,7 +142,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -153,7 +153,7 @@ jobs:
   cpp-lint:
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -215,7 +215,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -142,7 +142,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -153,7 +153,7 @@ jobs:
   cpp-lint:
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -215,7 +215,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -142,7 +142,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -153,7 +153,7 @@ jobs:
   cpp-lint:
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -215,7 +215,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -142,7 +142,7 @@ jobs:
     environment: release
     steps:
       - name: Run Sanity checks
-        uses: tetherto/qvac-devops/.github/actions/sanity-checks@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/sanity-checks@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
@@ -153,7 +153,7 @@ jobs:
   cpp-lint:
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/cpp-lint.yaml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/cpp-lint.yaml@v1.1.0
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -215,7 +215,7 @@ jobs:
   merge-guard:
     needs: [authorize, sanity-checks, cpp-lint, cpp-tests-coverage, prebuild, run-integration-tests, run-mobile-integration-tests]
     if: always()
-    uses: tetherto/qvac-devops/.github/workflows/public-pr.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-pr.yml@v1.1.0
     with:
       sanity-checks-status: ${{ needs.sanity-checks.result == 'success' && (needs.cpp-lint.result == 'success' || needs.cpp-lint.result == 'skipped') && (needs.cpp-tests-coverage.result == 'success' || needs.cpp-tests-coverage.result == 'skipped') }}
       build-status: ${{ needs.prebuild.result == 'success' || needs.prebuild.result == 'skipped' }}

--- a/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
@@ -78,7 +78,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: yamlfmt
-        uses: tetherto/qvac-devops/.github/actions/yamlfmt@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/yamlfmt@v1.1.0
         with:
           workdir: ${{ env.PKG_DIR }}
         

--- a/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-qvac-lib-inference-addon-cpp.yml
@@ -78,7 +78,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: yamlfmt
-        uses: tetherto/qvac-devops/.github/actions/yamlfmt@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/yamlfmt@v1.1.8
         with:
           workdir: ${{ env.PKG_DIR }}
         

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -234,7 +234,7 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
 
       - name: Publish to GitHub Package Registry
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           workdir: ${{ env.PKG_DIR }}/shared
@@ -275,7 +275,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
@@ -408,7 +408,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
 
       - name: Publish to GitHub Package Registry
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           workdir: ${{ env.PKG_DIR }}/client
@@ -451,7 +451,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -234,7 +234,7 @@ jobs:
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
 
       - name: Publish to GitHub Package Registry
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           workdir: ${{ env.PKG_DIR }}/shared
@@ -256,6 +256,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -274,7 +275,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
@@ -407,7 +408,7 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
 
       - name: Publish to GitHub Package Registry
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           workdir: ${{ env.PKG_DIR }}/client
@@ -429,6 +430,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -449,7 +451,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -349,7 +349,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || needs.publish-logic.outputs.gpr_tag || 'dev'}}
@@ -369,6 +369,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -381,7 +382,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -349,7 +349,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || needs.publish-logic.outputs.gpr_tag || 'dev'}}
@@ -382,7 +382,7 @@ jobs:
 
       - name: Publish to NPM Package Registry
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -148,7 +148,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: Publish to NPM
         id: publish
-        uses: ./.github/actions/publish-library-to-npm
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
@@ -226,7 +226,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -258,7 +258,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -148,7 +148,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -182,7 +182,7 @@ jobs:
 
       - name: Publish to NPM
         id: publish
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-npm-oidc@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-npm@v1.1.0
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
@@ -226,7 +226,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -258,7 +258,7 @@ jobs:
         uses: ./.github/actions/cli-rewrite-sdk-scope-for-gpr
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-error.yml
+++ b/.github/workflows/trigger-reusable-lib-error.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/error
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-error.yml
+++ b/.github/workflows/trigger-reusable-lib-error.yml
@@ -1,6 +1,6 @@
 name: General CI/CD (error)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
+# This workflow is used to call the reusable workflows in the oss-actions repository
+# https://github.com/tetherto/oss-actions/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 on:
   push:
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
       workdir: packages/error
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-logging.yml
+++ b/.github/workflows/trigger-reusable-lib-logging.yml
@@ -1,6 +1,6 @@
 name: General CI/CD (logging)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
+# This workflow is used to call the reusable workflows in the oss-actions repository
+# https://github.com/tetherto/oss-actions/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 on:
   push:
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
       workdir: packages/logging
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-logging.yml
+++ b/.github/workflows/trigger-reusable-lib-logging.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/logging
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
@@ -1,6 +1,6 @@
 name: General CI/CD (Qvac-lib-diagnostics)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
+# This workflow is used to call the reusable workflows in the oss-actions repository
+# https://github.com/tetherto/oss-actions/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 on:
   push:
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
       packages: write
       id-token: write
     if: needs.publish-logic.outputs.publish_release == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
       workdir: packages/qvac-lib-diagnostics
@@ -153,7 +153,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -176,7 +176,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
       packages: write
       id-token: write
     if: needs.publish-logic.outputs.publish_release == 'true'
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/qvac-lib-diagnostics
@@ -153,7 +153,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -176,7 +176,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/qvac-lib-dl-base
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-base.yml
@@ -1,6 +1,6 @@
-name: General CI/CD (Qvac-lib-dl-base)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
+name: General CI/CD (dl-base)
+# This workflow is used to call the reusable workflows in the oss-actions repository
+# https://github.com/tetherto/oss-actions/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - feature-*
       - tmp-*
     paths:
-      - "packages/qvac-lib-dl-base/**"
+      - "packages/dl-base/**"
   workflow_dispatch:
     inputs:
       custom_input_1:
@@ -25,9 +25,6 @@ on:
 
 permissions:
   contents: read
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   release-merge-guard:
@@ -46,9 +43,9 @@ jobs:
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}
-          package-slug: qvac-lib-dl-base
-          package-json-path: packages/qvac-lib-dl-base/package.json
-          changelog-path: packages/qvac-lib-dl-base/CHANGELOG.md
+          package-slug: dl-base
+          package-json-path: packages/dl-base/package.json
+          changelog-path: packages/dl-base/CHANGELOG.md
 
   publish-logic:
     runs-on: ubuntu-latest
@@ -112,13 +109,13 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: packages/qvac-lib-dl-base
+          workdir: packages/dl-base
           name-suffix: "-mono"
 
   publish-release-npm:
@@ -131,10 +128,10 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
-      workdir: packages/qvac-lib-dl-base
+      workdir: packages/dl-base
       repo_name: "dl-base"
       caller_event_name: ${{ github.event_name }}
 
@@ -150,7 +147,7 @@ jobs:
       release_name: "QVAC dl-base Lib"
       published_version: ${{ needs.publish-release-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
-      workdir: "packages/qvac-lib-dl-base"
+      workdir: "packages/dl-base"
 
   publish-feature-gpr:
     needs: publish-logic
@@ -166,13 +163,13 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: packages/qvac-lib-dl-base
+          workdir: packages/dl-base
           name-suffix: "-mono"
 
   publish-tmp-gpr:
@@ -189,11 +186,11 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: packages/qvac-lib-dl-base
+          workdir: packages/dl-base
           name-suffix: "-mono"

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
@@ -1,6 +1,6 @@
-name: General CI/CD (Qvac-lib-dl-filesystem)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
+name: General CI/CD (dl-filesystem)
+# This workflow is used to call the reusable workflows in the oss-actions repository
+# https://github.com/tetherto/oss-actions/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - feature-*
       - tmp-*
     paths:
-      - "packages/qvac-lib-dl-filesystem/**"
+      - "packages/dl-filesystem/**"
   workflow_dispatch:
     inputs:
       custom_input_1:
@@ -25,9 +25,6 @@ on:
 
 permissions:
   contents: read
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   release-merge-guard:
@@ -46,9 +43,9 @@ jobs:
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}
-          package-slug: qvac-lib-dl-filesystem
-          package-json-path: packages/qvac-lib-dl-filesystem/package.json
-          changelog-path: packages/qvac-lib-dl-filesystem/CHANGELOG.md
+          package-slug: dl-filesystem
+          package-json-path: packages/dl-filesystem/package.json
+          changelog-path: packages/dl-filesystem/CHANGELOG.md
 
   publish-logic:
     runs-on: ubuntu-latest
@@ -112,13 +109,13 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: packages/qvac-lib-dl-filesystem
+          workdir: packages/dl-filesystem
           name-suffix: "-mono"
 
   publish-release-npm:
@@ -131,10 +128,10 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
-      workdir: packages/qvac-lib-dl-filesystem
+      workdir: packages/dl-filesystem
       repo_name: dl-filesystem
       caller_event_name: ${{ github.event_name }}
 
@@ -150,7 +147,7 @@ jobs:
       release_name: "QVAC dl-filesystem Lib"
       published_version: ${{ needs.publish-release-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
-      workdir: "packages/qvac-lib-dl-filesystem"
+      workdir: "packages/dl-filesystem"
 
   publish-feature-gpr:
     needs: publish-logic
@@ -166,13 +163,13 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: packages/qvac-lib-dl-filesystem
+          workdir: packages/dl-filesystem
           name-suffix: "-mono"
 
   publish-tmp-gpr:
@@ -189,11 +186,11 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: packages/qvac-lib-dl-filesystem
+          workdir: packages/dl-filesystem
           name-suffix: "-mono"

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-filesystem.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/qvac-lib-dl-filesystem
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/qvac-lib-dl-hyperdrive
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-dl-hyperdrive.yml
@@ -1,5 +1,5 @@
-name: General CI/CD (Qvac-lib-dl-hyperdrive)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
+name: General CI/CD (dl-hyperdrive)
+# This workflow is used to call the reusable workflows in the oss-actions repository
 # (ported into the monorepo)
 
 on:
@@ -10,7 +10,7 @@ on:
       - feature-*
       - tmp-*
     paths:
-      - "packages/qvac-lib-dl-hyperdrive/**"
+      - "packages/dl-hyperdrive/**"
   workflow_dispatch:
     inputs:
       custom_input_1:
@@ -25,9 +25,6 @@ on:
 
 permissions:
   contents: read
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
 
 jobs:
   release-merge-guard:
@@ -46,9 +43,9 @@ jobs:
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}
-          package-slug: qvac-lib-dl-hyperdrive
-          package-json-path: packages/qvac-lib-dl-hyperdrive/package.json
-          changelog-path: packages/qvac-lib-dl-hyperdrive/CHANGELOG.md
+          package-slug: dl-hyperdrive
+          package-json-path: packages/dl-hyperdrive/package.json
+          changelog-path: packages/dl-hyperdrive/CHANGELOG.md
 
   publish-logic:
     runs-on: ubuntu-latest
@@ -112,13 +109,13 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: packages/qvac-lib-dl-hyperdrive
+          workdir: packages/dl-hyperdrive
           name-suffix: "-mono"
 
   publish-release-npm:
@@ -131,10 +128,10 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
-      workdir: packages/qvac-lib-dl-hyperdrive
+      workdir: packages/dl-hyperdrive
       repo_name: dl-hyperdrive
       caller_event_name: ${{ github.event_name }}
 
@@ -150,7 +147,7 @@ jobs:
       release_name: "QVAC dl-hyperdrive Lib"
       published_version: ${{ needs.publish-release-npm.outputs.published_version }}
       prev_sha: ${{ github.event.before }}
-      workdir: "packages/qvac-lib-dl-hyperdrive"
+      workdir: "packages/dl-hyperdrive"
 
   publish-feature-gpr:
     needs: publish-logic
@@ -166,13 +163,13 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: packages/qvac-lib-dl-hyperdrive
+          workdir: packages/dl-hyperdrive
           name-suffix: "-mono"
 
   publish-tmp-gpr:
@@ -189,11 +186,11 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
           npm-token: ${{ secrets.NPM_TOKEN }}
           tag: ${{ needs.publish-logic.outputs.gpr_tag }}
-          workdir: packages/qvac-lib-dl-hyperdrive
+          workdir: packages/dl-hyperdrive
           name-suffix: "-mono"

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/qvac-lib-infer-base
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
@@ -1,6 +1,6 @@
 name: General CI/CD (Qvac-lib-infer-base)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
+# This workflow is used to call the reusable workflows in the oss-actions repository
+# https://github.com/tetherto/oss-actions/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 on:
   push:
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
       workdir: packages/qvac-lib-infer-base
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -171,7 +171,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/qvac-lib-langdetect-text-cld2
@@ -192,7 +192,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -215,7 +215,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
@@ -1,6 +1,6 @@
 name: General CI/CD (Qvac-lib-langdetect-text-cld2)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
+# This workflow is used to call the reusable workflows in the oss-actions repository
+# https://github.com/tetherto/oss-actions/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 on:
   push:
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -171,7 +171,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
       workdir: packages/qvac-lib-langdetect-text-cld2
@@ -192,7 +192,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -215,7 +215,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
@@ -1,6 +1,6 @@
 name: General CI/CD (Qvac-lib-langdetect-text)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
+# This workflow is used to call the reusable workflows in the oss-actions repository
+# https://github.com/tetherto/oss-actions/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 on:
   push:
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
       workdir: packages/qvac-lib-langdetect-text
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/qvac-lib-langdetect-text
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-rag.yml
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.7
+    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
     secrets: inherit
     with:
       workdir: packages/rag
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.7
+        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/trigger-reusable-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-rag.yml
@@ -1,6 +1,6 @@
 name: General CI/CD (rag)
-# This workflow is used to call the reusable workflows in the qvac-devops repository
-# https://github.com/tetherto/qvac-devops/blob/production-workflows-tag/.github/workflows/public-reusable.yml
+# This workflow is used to call the reusable workflows in the oss-actions repository
+# https://github.com/tetherto/oss-actions/blob/production-workflows-tag/.github/workflows/public-reusable.yml
 
 on:
   push:
@@ -112,7 +112,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (dev)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -131,7 +131,7 @@ jobs:
       always() &&
       needs.publish-logic.outputs.publish_release == 'true' &&
       (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
-    uses: tetherto/qvac-devops/.github/workflows/public-reusable-npm.yml@v1.1.8
+    uses: tetherto/oss-actions/.github/workflows/public-reusable-npm.yml@v1.1.0
     secrets: inherit
     with:
       workdir: packages/rag
@@ -166,7 +166,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (feature)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}
@@ -189,7 +189,7 @@ jobs:
           fetch-depth: 0
 
       - name: Publish to GitHub Packages (tmp)
-        uses: tetherto/qvac-devops/.github/actions/publish-library-to-gpr@v1.1.8
+        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           pat-token: ${{ secrets.PAT_TOKEN }}

--- a/packages/ocr-onnx/.agent/knowledge/ci-validation.md
+++ b/packages/ocr-onnx/.agent/knowledge/ci-validation.md
@@ -60,7 +60,7 @@ Packages: `qvac-lib-dl-filesystem`, `qvac-lib-dl-hyperdrive`, `qvac-lib-dl-base`
 |----------|-------------|---------|
 | Publish | `trigger-reusable-lib-<pkg>.yml` | Publish to GPR/npm on merge (no tests, no builds) |
 
-These delegate to `tetherto/qvac-devops` reusable workflows for publishing.
+These delegate to `tetherto/oss-actions` reusable workflows for publishing.
 
 ## Trigger Mechanisms
 
@@ -186,7 +186,7 @@ These are environment/configuration issues, not code bugs:
 | Disk space error | Runner out of space (common on Ubuntu) | Disk cleanup step may need updating |
 | Xcode version not found | iOS runner missing required Xcode | Update Xcode version selection in mobile workflow |
 | Android SDK / Gradle failure | Build tools version mismatch | Check `setup-android` and JDK version |
-| `merge-guard` failure | External `qvac-devops` workflow issue | Check `tetherto/qvac-devops@monorepo_update` ref |
+| `merge-guard` failure | External `oss-actions` workflow issue | Check `tetherto/oss-actions@monorepo_update` ref |
 | Workflow syntax error | YAML issue in workflow file | Validate YAML; check `gh workflow list` for errors |
 
 ### Code logic failures (implementer must fix)
@@ -304,7 +304,7 @@ Replace `<pkg>` with the package directory name (e.g., `qvac-lib-infer-llamacpp-
 
 ### External dependencies
 
-- **Reusable workflows/actions**: `tetherto/qvac-devops@monorepo_update`
+- **Reusable workflows/actions**: `tetherto/oss-actions@monorepo_update`
 - **Mobile test framework**: `tetherto/qvac-test-addon-mobile`
 - **Merge guard**: `.github/actions/release-merge-guard` (local action)
 - **Release notes script**: `.github/scripts/release-notes-check.js`

--- a/packages/qvac-lib-decoder-audio/CHANGELOG.md
+++ b/packages/qvac-lib-decoder-audio/CHANGELOG.md
@@ -59,7 +59,7 @@ Security hardening release from comprehensive security audit.
 - Windows x64 integration tests (#92)
 
 ### Changed
-- Updated qvac-devops to v1.1.3 and enabled automatic git tag creation on npm publish (#89)
+- Updated oss-actions to v1.1.3 and enabled automatic git tag creation on npm publish (#89)
 
 ### Removed
 - GstDecoder - library now uses FFmpegDecoder only (#94)

--- a/packages/qvac-lib-decoder-audio/package.json
+++ b/packages/qvac-lib-decoder-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/decoder-audio",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "",
   "license": "Apache-2.0",
   "author": "Tether",

--- a/packages/qvac-lib-registry-server/scripts/migrate-hyperbee-server.js
+++ b/packages/qvac-lib-registry-server/scripts/migrate-hyperbee-server.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 // Read the prod.config.json file
-const configPath = path.join(__dirname, '../../qvac-devops/hyperbee-models-server/prod.config.json')
+const configPath = path.join(__dirname, '../../oss-actions/hyperbee-models-server/prod.config.json')
 const config = JSON.parse(fs.readFileSync(configPath, 'utf8'))
 
 // Transform the data


### PR DESCRIPTION
## Summary

- Cherry-picks `b593cf2e` and `78f204be` from `main` to fix broken CI publish workflows on the release branch
- Migrates all workflow action references from the retired `tetherto/qvac-devops` repo to the new `tetherto/oss-actions` repo
- Adds `id-token: write` permission for NPM OIDC publish support

## Context

The SDK publish workflow was failing with:
```
##[error]Unable to resolve action `tetherto/qvac-devops`, not found
```

The `tetherto/qvac-devops` repo was migrated to `tetherto/oss-actions` on `main` via #1362 and #1478, but the release branch didn't have these changes since it was created from cherry-picks.