### PR TITLE
 QVAC-17343 feat: add openclCacheDir config for fast Android GPU startup

### DIFF
--- a/packages/lib-infer-diffusion/CHANGELOG.md
+++ b/packages/lib-infer-diffusion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.3] - 2026-04-13
+
+### Added
+
+- Add `openclCacheDir` config option for OpenCL kernel binary caching on Android. Sets `GGML_OPENCL_CACHE_DIR` before backend init so compiled kernels are cached to disk, reducing GPU load time from ~9.8s to ~2.0s on Adreno devices after the first run
+
 ## [0.1.2] - 2026-04-03
 
 ### Changed

--- a/packages/lib-infer-diffusion/addon/src/handlers/SdCtxHandlers.cpp
+++ b/packages/lib-infer-diffusion/addon/src/handlers/SdCtxHandlers.cpp
@@ -248,6 +248,9 @@ const SdCtxHandlersMap SD_CTX_HANDLERS = {
     {"backendsDir",
      [](SdCtxConfig& c, const std::string& v) { c.backendsDir = v; }},
 
+    {"openclCacheDir",
+     [](SdCtxConfig& c, const std::string& v) { c.openclCacheDir = v; }},
+
     // ── Logging
     // ────────────────────────────────────────────────────────────────
 

--- a/packages/lib-infer-diffusion/addon/src/handlers/SdCtxHandlers.hpp
+++ b/packages/lib-infer-diffusion/addon/src/handlers/SdCtxHandlers.hpp
@@ -101,6 +101,7 @@ struct SdCtxConfig {
 
   // ── Backend loading ────────────────────────────────────────────────────────
   std::string backendsDir; // directory containing DL backend .so modules
+  std::string openclCacheDir; // writable dir for OpenCL kernel binary cache (Android)
 
   // ── Internal ──────────────────────────────────────────────────────────────
   // Upstream defaults to true, which frees model weight buffers after each

--- a/packages/lib-infer-diffusion/addon/src/model-interface/SdModel.cpp
+++ b/packages/lib-infer-diffusion/addon/src/model-interface/SdModel.cpp
@@ -302,6 +302,15 @@ void SdModel::load() {
   params.flash_attn = config_.flashAttn;
   params.diffusion_flash_attn = config_.diffusionFlashAttn;
 
+#ifdef __ANDROID__
+  if (!config_.openclCacheDir.empty()) {
+    std::string oclCachePath =
+        (std::filesystem::path(config_.openclCacheDir) / "opencl-cache")
+            .string();
+    setenv("GGML_OPENCL_CACHE_DIR", oclCachePath.c_str(), /*overwrite=*/1);
+  }
+#endif
+
   // Load DL GPU backend modules before probing devices / creating the SD
   // context. In GGML_BACKEND_DL mode, device enumeration is empty until these
   // backend modules are loaded.

--- a/packages/lib-infer-diffusion/index.d.ts
+++ b/packages/lib-infer-diffusion/index.d.ts
@@ -108,6 +108,8 @@ export interface SdConfig {
   force_sdxl_vae_conv_scale?: boolean
   /** Custom backends directory path (defaults to prebuilds/) */
   backendsDir?: string
+  /** Writable directory for OpenCL kernel binary cache. Required on Android for fast GPU startup. */
+  openclCacheDir?: string
   /** Custom tensor type rules string */
   tensor_type_rules?: string
   /** LoRA application mode */

--- a/packages/lib-infer-diffusion/package.json
+++ b/packages/lib-infer-diffusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/diffusion-cpp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "stable-diffusion.cpp addon for qvac image/video generation",
   "addon": true,
   "scripts": {

--- a/packages/lib-infer-diffusion/test/integration/generate-image.test.js
+++ b/packages/lib-infer-diffusion/test/integration/generate-image.test.js
@@ -54,7 +54,8 @@ test('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000, skip },
     {
       threads: 4,
       device: useCpu ? 'cpu' : 'gpu',
-      prediction: 'v' // SD2.1 uses v-prediction
+      prediction: 'v', // SD2.1 uses v-prediction
+      openclCacheDir: modelDir
     }
   )
 

--- a/packages/lib-infer-diffusion/test/integration/model-loading.test.js
+++ b/packages/lib-infer-diffusion/test/integration/model-loading.test.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const test = require('brittle')
+const fs = require('bare-fs')
+const path = require('bare-path')
 const os = require('bare-os')
 const proc = require('bare-process')
 
@@ -28,8 +30,7 @@ test('model loading - load and unload', { timeout: 600_000 }, async t => {
   const config = {
     threads: '4',
     device: useCpu ? 'cpu' : 'gpu',
-    prediction: 'v',
-    openclCacheDir: modelDir
+    prediction: 'v'
   }
 
   const addon = new ImgStableDiffusion({
@@ -38,10 +39,7 @@ test('model loading - load and unload', { timeout: 600_000 }, async t => {
     logger: console
   }, config)
 
-  const t0 = Date.now()
   await addon.load()
-  const loadMs = Date.now() - t0
-  console.log(`model.load() took ${loadMs} ms`)
   t.pass('model loaded successfully')
 
   await addon.unload()
@@ -49,6 +47,54 @@ test('model loading - load and unload', { timeout: 600_000 }, async t => {
 
   await addon.unload().catch(() => {})
   t.pass('second unload is idempotent')
+})
+
+const isAndroid = platform === 'android'
+
+test('opencl cache - second load is faster than first', { timeout: 600_000, skip: !isAndroid }, async t => {
+  const [downloadedModelName, modelDir] = await ensureModel({
+    modelName: DEFAULT_MODEL.name,
+    downloadUrl: DEFAULT_MODEL.url
+  })
+
+  const cacheDir = path.join(modelDir, 'opencl-cache')
+  if (fs.existsSync(cacheDir)) {
+    fs.rmSync(cacheDir, { recursive: true })
+  }
+
+  const config = {
+    threads: '4',
+    device: 'gpu',
+    prediction: 'v',
+    openclCacheDir: modelDir
+  }
+
+  const args = {
+    modelName: downloadedModelName,
+    diskPath: modelDir,
+    logger: console
+  }
+
+  const first = new ImgStableDiffusion(args, config)
+  const t0 = Date.now()
+  await first.load()
+  const coldLoadMs = Date.now() - t0
+  console.log(`Cold load (no cache): ${coldLoadMs} ms`)
+  await first.unload()
+
+  t.ok(fs.existsSync(cacheDir), 'opencl-cache directory was created')
+  const cachedFiles = fs.readdirSync(cacheDir).filter(f => f.endsWith('.oclbin'))
+  t.ok(cachedFiles.length > 0, `Cache contains ${cachedFiles.length} .oclbin files`)
+
+  const second = new ImgStableDiffusion(args, config)
+  const t1 = Date.now()
+  await second.load()
+  const warmLoadMs = Date.now() - t1
+  console.log(`Warm load (cached): ${warmLoadMs} ms`)
+  await second.unload()
+
+  console.log(`Speedup: ${(coldLoadMs / warmLoadMs).toFixed(1)}x`)
+  t.ok(warmLoadMs < coldLoadMs, `Warm load (${warmLoadMs} ms) faster than cold load (${coldLoadMs} ms)`)
 })
 
 // Keep event loop alive briefly to let pending async operations complete

--- a/packages/lib-infer-diffusion/test/integration/model-loading.test.js
+++ b/packages/lib-infer-diffusion/test/integration/model-loading.test.js
@@ -28,7 +28,8 @@ test('model loading - load and unload', { timeout: 600_000 }, async t => {
   const config = {
     threads: '4',
     device: useCpu ? 'cpu' : 'gpu',
-    prediction: 'v'
+    prediction: 'v',
+    openclCacheDir: modelDir
   }
 
   const addon = new ImgStableDiffusion({
@@ -37,7 +38,10 @@ test('model loading - load and unload', { timeout: 600_000 }, async t => {
     logger: console
   }, config)
 
+  const t0 = Date.now()
   await addon.load()
+  const loadMs = Date.now() - t0
+  console.log(`model.load() took ${loadMs} ms`)
   t.pass('model loaded successfully')
 
   await addon.unload()

--- a/packages/lib-infer-diffusion/test/unit/test_sd_ctx_handlers.cpp
+++ b/packages/lib-infer-diffusion/test/unit/test_sd_ctx_handlers.cpp
@@ -172,6 +172,7 @@ TEST(
       applyOne("tensor_type_rules", "^vae.=f16").tensorTypeRules,
       "^vae.=f16");
   EXPECT_EQ(applyOne("backendsDir", "/tmp/backends").backendsDir, "/tmp/backends");
+  EXPECT_EQ(applyOne("openclCacheDir", "/data/local/tmp").openclCacheDir, "/data/local/tmp");
   EXPECT_FLOAT_EQ(applyOne("flow_shift", "1.25").flowShift, 1.25f);
 
   SdCtxConfig cfg;


### PR DESCRIPTION
## What problem does this PR solve?

On Android with OpenCL (Adreno GPUs), ggml recompiles all OpenCL kernels from source on every model load. This takes ~6.5 seconds and is the dominant bottleneck in model loading for the diffusion addon. There was no way to tell ggml where to cache compiled kernel binaries.

## How does it solve it?

Adds an `openclCacheDir` config option plumbed through the full JS-to-C++ path. On Android, `SdModel::load()` calls `setenv("GGML_OPENCL_CACHE_DIR", "<dir>/opencl-cache")` before backend initialization so the OpenCL backend can cache compiled kernel binaries to disk as `.oclbin` files. On subsequent runs, ggml loads pre-compiled binaries instead of recompiling (~48x faster kernel init, ~4x faster total model load).

Changes:
- `index.d.ts` — add `openclCacheDir?: string` to `SdConfig`
- `SdCtxHandlers.hpp` — add `openclCacheDir` field to `SdCtxConfig`
- `SdCtxHandlers.cpp` — add passthrough handler in `SD_CTX_HANDLERS`
- `SdModel.cpp` — `setenv("GGML_OPENCL_CACHE_DIR")` before `ggml_backend_load_all*` (Android only)
- `test_sd_ctx_handlers.cpp` — unit test for handler
- `model-loading.test.js` — wire config + load timing (runs on Android)
- `generate-image.test.js` — wire config (desktop plumbing check)


## How it was tested

- C++ unit test verifies handler maps `"openclCacheDir"` to `SdCtxConfig.openclCacheDir`
- Desktop integration test (`generate-image.test.js`) validates config flows through JS → C++ without errors
- `model-loading.test.js` — basic load/unload lifecycle unchanged, confirms `openclCacheDir` doesn't break non-Android paths
- `model-loading.test.js` — new `opencl cache - second load is faster than first` test (Android only):
  - Clears any existing `opencl-cache/` directory before test
  - Cold load: loads model with no cached kernels, records time
  - Asserts `opencl-cache/` directory was created with `.oclbin` files
  - Warm load: loads model again with cached kernels, records time
  - Asserts warm load is faster than cold load
  - Logs cold/warm times and speedup factor for CI visibility

## Dependencies

- [tetherto/qvac-registry-vcpkg#121](https://github.com/tetherto/qvac-registry-vcpkg/pull/121) must be merged first — it adds the OpenCL kernel binary cache patch to the standalone `ggml` port. Without it, the `GGML_OPENCL_CACHE_DIR` env var set by this PR is inert (ggml has no code to read it).

## Task link
https://app.asana.com/1/45238840754660/project/1212638335655939/task/1214095118660244?focus=true