### PR TITLE
chore[notask|skiplog]: trigger sdk publish workflow

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.8.3
 
-This is a patch release that fixes a race condition in the KV cache save path during tool-calling completions, improving stability for multi-turn conversations that use tool integration.
+This release fixes a race condition in the KV cache save path during tool-calling completions, improving stability for multi-turn conversations that use tool integration.
 
 ---
 


### PR DESCRIPTION
## Summary

- Minor changelog touch to trigger the SDK publish workflow via push event on the release branch