### PR TITLE
[tetherto/qvac]: prevent E409 npm conflict by sequencing ensure-npm-public before publish-npm

### DIFF
--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -176,12 +176,13 @@ jobs:
           name-suffix: "-mono"
 
   publish-npm:
-    needs: [build, publish-logic, release-merge-guard]
+    needs: [build, publish-logic, release-merge-guard, ensure-npm-public]
     if: >-
       !cancelled() &&
       needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
-      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped') &&
+      (needs.ensure-npm-public.result == 'success' || needs.ensure-npm-public.result == 'skipped')
     continue-on-error: false
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -175,12 +175,13 @@ jobs:
           name-suffix: "-mono"
 
   publish-npm:
-    needs: [build, publish-logic, release-merge-guard]
+    needs: [build, publish-logic, release-merge-guard, ensure-npm-public]
     if: >-
       !cancelled() &&
       needs.build.result == 'success' &&
       needs.publish-logic.outputs.publish_release == 'true' &&
-      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped')
+      (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped') &&
+      (needs.ensure-npm-public.result == 'success' || needs.ensure-npm-public.result == 'skipped')
     continue-on-error: false
     outputs:
       published_version: ${{ steps.publish.outputs.npm_published_version }}


### PR DESCRIPTION
## Summary
- Adds `ensure-npm-public` to the `needs` list of `publish-npm` in both nmtcpp and ocr-onnx on-merge workflows
- Prevents the E409 Conflict error we hit during the nmtcpp v2.0.1 release

## Problem
The `ensure-npm-public` job (added in PR #1541) and `publish-npm` both write to the same npm packument concurrently. npm uses optimistic concurrency control, so the second write gets `E409 Conflict - Failed to save packument`.

This caused the nmtcpp v2.0.1 release to fail twice before we re-ran only the failed `publish-npm` job (which succeeded since `ensure-npm-public` had already completed).

## Fix
Add `ensure-npm-public` to `publish-npm`'s `needs` array so it waits for the access change to complete before attempting to publish. Also added `needs.ensure-npm-public.result == 'success' || needs.ensure-npm-public.result == 'skipped'` to the `if` condition so `publish-npm` still runs even if `ensure-npm-public` is skipped (e.g., on branches where it doesn't apply).

## Test plan
- [x] YAML validated, no duplicate keys
- [ ] Next release publish should not hit E409
