### PR TITLE
chore[notask|skiplog]: trigger error publish workflow

### DIFF
--- a/packages/error/CHANGELOG.md
+++ b/packages/error/CHANGELOG.md
@@ -11,4 +11,3 @@ The package has been renamed from `@qvac/error-base` to `@qvac/error` to better 
 ## [0.1.1]
 
 Initial tracked release.
-


### PR DESCRIPTION
## Summary

- Minor changelog touch to trigger the `@qvac/error` publish workflow via push event on the release branch