### PR TITLE
QVAC-17117 chore: backmerge release ocr-onnx v0.4.1

### DIFF
--- a/packages/ocr-onnx/CHANGELOG.md
+++ b/packages/ocr-onnx/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-04-14
+
+### Fixed
+
+- SIGABRT crash on process exit in OCR addon
+- Use HTTPS instead of SSH for vcpkg registry URLs
+
+### Changed
+
+- Updated OCR integration tests for `createJobHandler` migration
+- Removed hyperdrive references and dependencies
+- Renamed `dl-hyperdrive` and `dl-filesystem` package references
+- Migrated qvac-devops to oss-action
+
 ## [0.4.0] - 2026-04-08
 
 ### Changed

--- a/packages/ocr-onnx/package.json
+++ b/packages/ocr-onnx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-onnx",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OCR addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary

- Backmerge `release-ocr-onnx-0.4.1` into `main`
- Bumps `@qvac/ocr-onnx` version to 0.4.1 in package.json
- Adds 0.4.1 changelog entry (SIGABRT fix, HTTPS vcpkg URLs, hyperdrive cleanup, test updates)

## Test plan

- [ ] CI passes on main after merge