### PR TITLE
QVAC-16473 test: define smoke suite for SDK test definitions

### DIFF
--- a/packages/sdk/tests-qvac/tests/completion-tests.ts
+++ b/packages/sdk/tests-qvac/tests/completion-tests.ts
@@ -23,10 +23,12 @@ const createCompletionTest = (
         expectedType: "string" | "number" | "array";
       },
   estimatedDurationMs: number = 10000,
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params,
   expectation,
+  ...(suites && { suites }),
   metadata: { category: "completion", dependency: "llm", estimatedDurationMs },
 });
 
@@ -40,6 +42,8 @@ export const completionStreaming = createCompletionTest(
     stream: true,
   },
   { validation: "contains-all", contains: ["4"] },
+  10000,
+  ["smoke"],
 );
 
 export const completionEmptyPrompt = createCompletionTest(
@@ -50,6 +54,7 @@ export const completionEmptyPrompt = createCompletionTest(
   },
   { validation: "type", expectedType: "string" },
   5000,
+  ["smoke"],
 );
 
 export const completionMultiTurn = createCompletionTest(
@@ -67,6 +72,8 @@ export const completionMultiTurn = createCompletionTest(
     stream: false,
   },
   { validation: "contains-all", contains: ["42"] },
+  10000,
+  ["smoke"],
 );
 
 export const completionSpecialChars: TestDefinition = {
@@ -98,6 +105,7 @@ export const completionTemperature00 = createCompletionTest(
   },
   { validation: "contains-all", contains: ["10"] },
   8000,
+  ["smoke"],
 );
 
 export const completionTemperature05 = createCompletionTest(
@@ -169,6 +177,7 @@ export const completionTopP01 = createCompletionTest(
   },
   { validation: "contains-all", contains: ["1", "2", "3", "4", "5"] },
   8000,
+  ["smoke"],
 );
 
 export const completionTopP05 = createCompletionTest(
@@ -418,6 +427,7 @@ export const completionConcurrentRequests = createCompletionTest(
   { history: [{ role: "user", content: "What is 3 + 3?" }], stream: false },
   { validation: "contains-all", contains: ["6"] },
   15000,
+  ["smoke"],
 );
 
 export const completionRepeatedTokens = createCompletionTest(
@@ -456,6 +466,8 @@ export const completionJsonFormat = createCompletionTest(
     stream: false,
   },
   { validation: "contains-all", contains: ["25", "{", "}"] },
+  10000,
+  ["smoke"],
 );
 
 export const completionCodeGeneration = createCompletionTest(
@@ -496,6 +508,8 @@ export const completionQaFromContext = createCompletionTest(
     stream: false,
   },
   { validation: "contains-all", contains: ["blue"] },
+  10000,
+  ["smoke"],
 );
 
 export const completionSimpleYesNo: TestDefinition = {

--- a/packages/sdk/tests-qvac/tests/config-reload-tests.ts
+++ b/packages/sdk/tests-qvac/tests/config-reload-tests.ts
@@ -25,6 +25,7 @@ export const configReloadInvalidModelId: TestDefinition = {
   testId: "config-reload-invalid-model-id",
   params: { invalidModelId: "0000000000000000" },
   expectation: { validation: "throws-error", errorContains: "" },
+  suites: ["smoke"],
   metadata: { category: "config-reload", dependency: "whisper", estimatedDurationMs: 5000 },
 };
 
@@ -39,6 +40,7 @@ export const configReloadThenTranscribe: TestDefinition = {
   testId: "config-reload-then-transcribe",
   params: { audioFileName: "transcription-short-wav.wav", newLanguage: "en" },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "config-reload", dependency: "whisper", estimatedDurationMs: 30000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/delegated-inference-tests.ts
+++ b/packages/sdk/tests-qvac/tests/delegated-inference-tests.ts
@@ -6,20 +6,24 @@ const createDelegatedTest = (
   expectation: TestDefinition["expectation"],
   estimatedDurationMs: number = 15000,
   skip?: TestDefinition["skip"],
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params,
   expectation,
+  ...(suites && { suites }),
   metadata: { category: "delegated-inference", dependency: "none", estimatedDurationMs },
   skip,
 });
 
 export const delegatedProviderStart = createDelegatedTest(
   "delegated-provider-start", {}, { validation: "function", fn: () => true },
+  15000, undefined, ["smoke"],
 );
 
 export const delegatedProviderStop = createDelegatedTest(
   "delegated-provider-stop", {}, { validation: "function", fn: () => true },
+  15000, undefined, ["smoke"],
 );
 
 export const delegatedProviderFirewall = createDelegatedTest(
@@ -36,7 +40,7 @@ export const delegatedLoadModelFallbackLocal = createDelegatedTest(
   "delegated-load-model-fallback-local",
   { fallbackToLocal: true },
   { validation: "type", expectedType: "string" },
-  90000,
+  90000, undefined, ["smoke"],
 );
 
 export const delegatedHeartbeatProvider = createDelegatedTest(
@@ -51,6 +55,7 @@ export const delegatedConnectionFailure = createDelegatedTest(
   "delegated-connection-failure",
   { timeout: 3000 },
   { validation: "throws-error", errorContains: "" },
+  15000, undefined, ["smoke"],
 );
 
 export const delegatedInvalidTopic = createDelegatedTest(

--- a/packages/sdk/tests-qvac/tests/diffusion-tests.ts
+++ b/packages/sdk/tests-qvac/tests/diffusion-tests.ts
@@ -8,10 +8,12 @@ const createDiffusionTest = (
     | { validation: "type"; expectedType: "string" | "number" | "array" }
     | { validation: "throws-error"; errorContains: string },
   estimatedDurationMs: number = 300000,
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params,
   expectation,
+  ...(suites && { suites }),
   metadata: {
     category: "diffusion",
     dependency: "diffusion",
@@ -31,6 +33,8 @@ export const diffusionBasicTxt2img = createDiffusionTest(
     seed: 42,
   },
   { validation: "type", expectedType: "array" },
+  300000,
+  ["smoke"],
 );
 
 export const diffusionDefaultSize = createDiffusionTest(
@@ -161,6 +165,8 @@ export const diffusionStreamingProgress = createDiffusionTest(
     seed: 42,
   },
   { validation: "type", expectedType: "string" },
+  300000,
+  ["smoke"],
 );
 
 // ---- stats ----

--- a/packages/sdk/tests-qvac/tests/download-tests.ts
+++ b/packages/sdk/tests-qvac/tests/download-tests.ts
@@ -5,6 +5,7 @@ export const downloadCancelIsolation: TestDefinition = {
   params: { cancelAtPercent: 1 },
   // expectation is ignored in test executor, it does validation in the executor itself.
   expectation: { validation: "function", fn: () => true },
+  suites: ["smoke"],
   metadata: {
     category: "download",
     dependency: "none",

--- a/packages/sdk/tests-qvac/tests/embedding-tests.ts
+++ b/packages/sdk/tests-qvac/tests/embedding-tests.ts
@@ -5,10 +5,12 @@ const createEmbeddingTest = (
   testId: string,
   params: { text?: string; codeFile?: string },
   minDimensions: number = 128,
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params,
   expectation: { validation: "type", expectedType: "array" },
+  ...(suites && { suites }),
   metadata: {
     category: "embedding",
     dependency: "embeddings",
@@ -20,6 +22,7 @@ export const embedSimpleText = createEmbeddingTest(
   "embed-simple-text",
   { text: "Hello world, this is a test of text embedding." },
   100,
+  ["smoke"],
 );
 
 export const embedLongText = createEmbeddingTest(
@@ -75,6 +78,7 @@ export const embedBatch: TestDefinition = {
     ],
   },
   expectation: { validation: "type", expectedType: "array" },
+  suites: ["smoke"],
   metadata: {
     category: "embedding",
     dependency: "embeddings",

--- a/packages/sdk/tests-qvac/tests/error-tests.ts
+++ b/packages/sdk/tests-qvac/tests/error-tests.ts
@@ -4,6 +4,7 @@ export const errorInvalidModelId: TestDefinition = {
   testId: "error-invalid-model-id",
   params: { modelId: "nonexistent-model-id-12345", operation: "embed" },
   expectation: { validation: "throws-error", errorContains: "" },
+  suites: ["smoke"],
   metadata: { category: "error", dependency: "embeddings", estimatedDurationMs: 5000 },
 };
 
@@ -32,6 +33,7 @@ export const errorStructuredErrorCode: TestDefinition = {
   testId: "error-structured-error-code",
   params: { verifyErrorCodes: true },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "error", dependency: "none", estimatedDurationMs: 2000 },
 };
 
@@ -46,6 +48,7 @@ export const errorRagOperationFailed: TestDefinition = {
   testId: "error-rag-operation-failed",
   params: { modelId: "nonexistent-model", query: "test query" },
   expectation: { validation: "throws-error", errorContains: "" },
+  suites: ["smoke"],
   metadata: { category: "error", dependency: "embeddings", estimatedDurationMs: 5000 },
 };
 
@@ -60,6 +63,7 @@ export const errorCompletionNegativeTemperature: TestDefinition = {
   testId: "error-completion-negative-temperature",
   params: { history: [{ role: "user", content: "Test" }], stream: false, temperature: -0.5 },
   expectation: { validation: "throws-error", errorContains: "" },
+  suites: ["smoke"],
   metadata: { category: "error", dependency: "llm", estimatedDurationMs: 3000 },
 };
 
@@ -95,6 +99,7 @@ export const errorUseUnloadedModel: TestDefinition = {
   testId: "error-use-unloaded-model",
   params: { modelIdOverride: "unloaded-model-id-12345", history: [{ role: "user", content: "Test" }], stream: false },
   expectation: { validation: "throws-error", errorContains: "" },
+  suites: ["smoke"],
   metadata: { category: "error", dependency: "llm", estimatedDurationMs: 3000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/http-embedding-tests.ts
+++ b/packages/sdk/tests-qvac/tests/http-embedding-tests.ts
@@ -9,6 +9,7 @@ export const httpShardedEmbedLoad: TestDefinition = {
   testId: "http-sharded-embed-load",
   params: { modelType: "embeddings", modelUrl: SHARDED_URL },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "http", dependency: "none", estimatedDurationMs: 300000 },
 };
 
@@ -27,6 +28,7 @@ export const httpShardedEmbedInference: TestDefinition = {
     text: "This is a test sentence for embedding generation using an HTTP sharded model.",
   },
   expectation: { validation: "type", expectedType: "array" },
+  suites: ["smoke"],
   metadata: { category: "http", dependency: "none", estimatedDurationMs: 300000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/kv-cache-tests.ts
+++ b/packages/sdk/tests-qvac/tests/kv-cache-tests.ts
@@ -4,6 +4,7 @@ export const kvCacheDeleteAll: TestDefinition = {
   testId: "kv-cache-delete-all",
   params: { deleteAll: true },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "kv-cache", dependency: "none", estimatedDurationMs: 10000 },
 };
 
@@ -48,6 +49,7 @@ export const kvCacheSlidingWindow: TestDefinition = {
     kvCache: "test-sliding-window-session",
   },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "kv-cache", dependency: "llm", estimatedDurationMs: 30000 },
 };
 
@@ -90,6 +92,7 @@ export const kvCacheStreamingSlidingWindow: TestDefinition = {
     kvCache: "streaming-sliding-window-session",
   },
   expectation: { validation: "contains-any", contains: ["14"] },
+  suites: ["smoke"],
   metadata: { category: "kv-cache", dependency: "llm", estimatedDurationMs: 35000 },
 };
 
@@ -185,6 +188,7 @@ export const kvCacheStatsVerification: TestDefinition = {
     stream: false,
   },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "kv-cache", dependency: "llm", estimatedDurationMs: 30000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/logging-tests.ts
+++ b/packages/sdk/tests-qvac/tests/logging-tests.ts
@@ -4,6 +4,7 @@ export const addonLoggingLlm: TestDefinition = {
   testId: "addon-logging-llm",
   params: {},
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "addon-logging", dependency: "llm", estimatedDurationMs: 10000 },
 };
 
@@ -40,6 +41,7 @@ export const addonLoggingDuringInference: TestDefinition = {
   testId: "addon-logging-during-inference",
   params: {},
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "addon-logging", dependency: "llm", estimatedDurationMs: 15000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/model-info-tests.ts
+++ b/packages/sdk/tests-qvac/tests/model-info-tests.ts
@@ -4,6 +4,7 @@ export const modelInfoGet: TestDefinition = {
   testId: "model-info-get",
   params: { modelConstant: "LLAMA_3_2_1B_INST_Q4_0" },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "model-info", dependency: "llm", estimatedDurationMs: 5000 },
 };
 
@@ -25,6 +26,7 @@ export const modelInfoPersistsAfterUnload: TestDefinition = {
   testId: "model-info-persists-after-unload",
   params: { modelConstant: "LLAMA_3_2_1B_INST_Q4_0" },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "model-info", dependency: "llm", estimatedDurationMs: 5000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/ocr-tests.ts
+++ b/packages/sdk/tests-qvac/tests/ocr-tests.ts
@@ -8,10 +8,12 @@ const createOcrTest = (
     | { validation: "type"; expectedType: "array" },
   options?: { streaming?: boolean; paragraph?: boolean },
   estimatedDurationMs: number = 30000,
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: { imageFileName, timeout: 300000, ...options },
   expectation,
+  ...(suites && { suites }),
   metadata: { category: "ocr", dependency: "ocr", estimatedDurationMs },
 });
 
@@ -19,6 +21,7 @@ export const ocrBasicPng = createOcrTest(
   "ocr-basic-png", "ocr-simple-test-png.png",
   { validation: "contains-any", contains: ["OCR", "text", "testing", "implementation", "recognize", "Type", "enter"] },
   undefined, 60000,
+  ["smoke"],
 );
 
 export const ocrBasicJpg = createOcrTest(
@@ -31,6 +34,7 @@ export const ocrStreaming = createOcrTest(
   "ocr-streaming", "ocr-simple-test-png.png",
   { validation: "contains-any", contains: ["OCR", "text", "testing", "Type", "enter"] },
   { streaming: true }, 60000,
+  ["smoke"],
 );
 
 export const ocrParagraphMode = createOcrTest(
@@ -119,6 +123,7 @@ export const ocrStats = createOcrTest(
   "ocr-stats", "ocr-simple-test-png.png",
   { validation: "type", expectedType: "array" },
   undefined, 60000,
+  ["smoke"],
 );
 
 export const ocrStreamingStats = createOcrTest(
@@ -131,6 +136,7 @@ export const ocrBlockStructure = createOcrTest(
   "ocr-block-structure", "ocr-simple-test-png.png",
   { validation: "type", expectedType: "array" },
   undefined, 60000,
+  ["smoke"],
 );
 
 export const ocrStreamingBlockStructure = createOcrTest(

--- a/packages/sdk/tests-qvac/tests/parakeet-tests.ts
+++ b/packages/sdk/tests-qvac/tests/parakeet-tests.ts
@@ -11,10 +11,12 @@ const createParakeetTest = (
     | { validation: "type"; expectedType: "string" | "number" | "array" }
     | { validation: "throws-error"; errorContains: string },
   estimatedDurationMs: number = 60000,
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: { audioFileName },
   expectation,
+  ...(suites && { suites }),
   metadata: {
     category: "parakeet",
     dependency,
@@ -31,6 +33,7 @@ export const parakeetTdtWav = createParakeetTest(
   "transcription-short-wav.wav",
   { validation: "contains-all", contains: ["test", "automation"] },
   300000, // download ~700 MB
+  ["smoke"],
 );
 
 export const parakeetTdtMp3 = createParakeetTest(
@@ -82,6 +85,7 @@ export const parakeetTdtCorruptedWav = createParakeetTest(
   "corrupted-wav.wav",
   { validation: "throws-error", errorContains: "" },
   60000,
+  ["smoke"],
 );
 
 // ── CTC tests ─────────────────────────────────────────────────────────────────
@@ -101,6 +105,7 @@ export const parakeetCtcMp3 = createParakeetTest(
   "transcription-short-mp3.mp3",
   { validation: "contains-all", contains: ["test", "automation"] },
   120000,
+  ["smoke"],
 );
 
 export const parakeetCtcSilence = createParakeetTest(
@@ -129,6 +134,7 @@ export const parakeetSortformerSingle = createParakeetTest(
   "diarization-sample-16k.wav",
   { validation: "contains-any", contains: ["Speaker"] },
   600000, // Sortformer model download
+  ["smoke"],
 );
 
 export const parakeetSortformerTwoSpeakers = createParakeetTest(

--- a/packages/sdk/tests-qvac/tests/rag-tests.ts
+++ b/packages/sdk/tests-qvac/tests/rag-tests.ts
@@ -11,10 +11,12 @@ const createRagTest = (
     chunkOverlap: number;
     chunkStrategy?: string;
   },
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params,
   expectation: { validation: "type", expectedType: "string" }, // Returns success message or result object
+  ...(suites && { suites }),
   metadata: {
     category: "rag",
     dependency: "embeddings",
@@ -29,7 +31,7 @@ export const ragEmbeddingsSmall = createRagTest("rag-embeddings-small-chunks", {
   chunkSize: 50,
   chunkOverlap: 10,
   chunkStrategy: "paragraph",
-});
+}, ["smoke"]);
 
 export const ragEmbeddingsMedium = createRagTest(
   "rag-embeddings-medium-chunks",
@@ -107,6 +109,7 @@ export const ragLargeDocument: TestDefinition = {
     chunkStrategy: "paragraph",
   },
   expectation: { validation: "throws-error", errorContains: "context overflow" },
+  suites: ["smoke"],
   metadata: { category: "rag", dependency: "embeddings", estimatedDurationMs: 120000 },
 };
 
@@ -116,7 +119,7 @@ export const ragMediumDocument = createRagTest("rag-medium-document-10kb", {
   chunkSize: 350,
   chunkOverlap: 70,
   chunkStrategy: "paragraph",
-});
+}, ["smoke"]);
 
 export const ragTests = [
   ragEmbeddingsSmall,

--- a/packages/sdk/tests-qvac/tests/registry-tests.ts
+++ b/packages/sdk/tests-qvac/tests/registry-tests.ts
@@ -11,6 +11,7 @@ export const registryListReturnsModels: TestDefinition = {
   testId: "registry-list-returns-models",
   params: { action: "list" },
   expectation: { validation: "type", expectedType: "array", minLength: 1 },
+  suites: ["smoke"],
   metadata: { category: "registry", dependency: "none", estimatedDurationMs: 5000 },
 };
 
@@ -32,6 +33,7 @@ export const registrySearchByEngineLlm: TestDefinition = {
   testId: "registry-search-by-engine-llm",
   params: { action: "search", engine: "llamacpp-completion" },
   expectation: { validation: "type", expectedType: "array", minLength: 1 },
+  suites: ["smoke"],
   metadata: { category: "registry", dependency: "none", estimatedDurationMs: 5000 },
 };
 
@@ -60,6 +62,7 @@ export const registryGetModelValid: TestDefinition = {
   testId: "registry-get-model-valid",
   params: { action: "getModel", useFirstFromList: true },
   expectation: { validation: "regex", pattern: ".+" },
+  suites: ["smoke"],
   metadata: { category: "registry", dependency: "none", estimatedDurationMs: 5000 },
 };
 
@@ -67,6 +70,7 @@ export const registryGetModelNotFound: TestDefinition = {
   testId: "registry-get-model-not-found",
   params: { action: "getModel", registryPath: "nonexistent/model/path.gguf", registrySource: "nonexistent-source" },
   expectation: { validation: "throws-error", errorContains: "not found" },
+  suites: ["smoke"],
   metadata: { category: "registry", dependency: "none", estimatedDurationMs: 5000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/sharded-model-tests.ts
+++ b/packages/sdk/tests-qvac/tests/sharded-model-tests.ts
@@ -4,6 +4,7 @@ export const shardedModelLoad: TestDefinition = {
   testId: "sharded-model-load",
   params: {},
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "sharded-model", dependency: "none", estimatedDurationMs: 120000 },
 };
 
@@ -11,6 +12,7 @@ export const shardedModelDetection: TestDefinition = {
   testId: "sharded-model-detection",
   params: {},
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "sharded-model", dependency: "none", estimatedDurationMs: 120000 },
 };
 
@@ -53,6 +55,7 @@ export const shardedModelInference: TestDefinition = {
   testId: "sharded-model-inference",
   params: { text: "This is a test sentence for embedding generation using a sharded model." },
   expectation: { validation: "type", expectedType: "array" },
+  suites: ["smoke"],
   metadata: { category: "sharded-model", dependency: "sharded-embeddings", estimatedDurationMs: 45000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/test-definitions.ts
+++ b/packages/sdk/tests-qvac/tests/test-definitions.ts
@@ -33,6 +33,7 @@ export const modelLoadLlm: TestDefinition = {
   testId: "model-load-llm",
   params: {},
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: {
     category: "model",
     dependency: "none",
@@ -44,6 +45,7 @@ export const modelLoadEmbedding: TestDefinition = {
   testId: "model-load-embedding",
   params: {},
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: {
     category: "model",
     dependency: "none",
@@ -55,6 +57,7 @@ export const modelLoadOcr: TestDefinition = {
   testId: "model-load-ocr",
   params: {},
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: {
     category: "model",
     dependency: "none",
@@ -72,6 +75,7 @@ export const modelLoadInvalid: TestDefinition = {
     validation: "throws-error",
     errorContains: "failed to locate",
   },
+  suites: ["smoke"],
   metadata: {
     category: "model",
     dependency: "none",
@@ -83,6 +87,7 @@ export const modelUnload: TestDefinition = {
   testId: "model-unload",
   params: { shouldClearStorage: false },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "model", dependency: "llm", estimatedDurationMs: 5000 },
 };
 
@@ -95,6 +100,7 @@ export const modelLoadConcurrent: TestDefinition = {
     ],
   },
   expectation: { validation: "type", expectedType: "array" },
+  suites: ["smoke"],
   metadata: {
     category: "model",
     dependency: "none",

--- a/packages/sdk/tests-qvac/tests/tools-tests.ts
+++ b/packages/sdk/tests-qvac/tests/tools-tests.ts
@@ -22,6 +22,7 @@ const createToolsTest = (
     validation: "type",
     expectedType: "string",
   },
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: {
@@ -30,6 +31,7 @@ const createToolsTest = (
     stream: false,
   },
   expectation,
+  ...(suites && { suites }),
   metadata: {
     category: "tools",
     dependency: "tools",
@@ -66,6 +68,8 @@ export const toolsSimpleFunction = createToolsTest(
       },
     },
   ],
+  undefined,
+  ["smoke"],
 );
 
 export const toolsMultipleFunctions = createToolsTest(
@@ -98,6 +102,8 @@ export const toolsMultipleFunctions = createToolsTest(
       },
     },
   ],
+  undefined,
+  ["smoke"],
 );
 
 // Add remaining ~40 tools tests as simplified placeholders

--- a/packages/sdk/tests-qvac/tests/transcription-tests.ts
+++ b/packages/sdk/tests-qvac/tests/transcription-tests.ts
@@ -12,10 +12,12 @@ const createTranscriptionTest = (
       }
     | { validation: "regex"; pattern: string },
   estimatedDurationMs: number = 30000,
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: { audioFileName, timeout: 300000 },
   expectation,
+  ...(suites && { suites }),
   metadata: {
     category: "transcription",
     dependency: "whisper",
@@ -30,6 +32,8 @@ export const transcriptionShortWav = createTranscriptionTest(
     validation: "contains-all",
     contains: ["test", "automation"],
   },
+  30000,
+  ["smoke"],
 );
 
 export const transcriptionShortMp3 = createTranscriptionTest(
@@ -39,6 +43,8 @@ export const transcriptionShortMp3 = createTranscriptionTest(
     validation: "contains-all",
     contains: ["test", "automation"],
   },
+  30000,
+  ["smoke"],
 );
 
 export const transcriptionShortAac = createTranscriptionTest(
@@ -79,6 +85,7 @@ export const transcriptionStreaming = createTranscriptionTest(
   "transcription-short-wav.wav",
   { validation: "type", expectedType: "string" },
   10000,
+  ["smoke"],
 );
 
 export const transcriptionVeryShort = createTranscriptionTest(
@@ -92,6 +99,7 @@ export const transcriptionCorruptedMp3: TestDefinition = {
   testId: "transcription-corrupted-mp3",
   params: { audioFileName: "corrupted-mp3.mp3" },
   expectation: { validation: "throws-error", errorContains: "" },
+  suites: ["smoke"],
   metadata: { category: "transcription", dependency: "whisper", estimatedDurationMs: 30000 },
 };
 
@@ -109,6 +117,7 @@ export const transcriptionWithPrompt: TestDefinition = {
     prompt: "This is a test recording about QVAC SDK automation testing.",
   },
   expectation: { validation: "contains-any", contains: ["test", "QVAC"] },
+  suites: ["smoke"],
   metadata: { category: "transcription", dependency: "whisper", estimatedDurationMs: 30000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/translation-afriquegemma-tests.ts
+++ b/packages/sdk/tests-qvac/tests/translation-afriquegemma-tests.ts
@@ -6,6 +6,7 @@ const createAfriquegemmaTest = (
   to: string,
   expectation: Expectation,
   opts: { from?: string; estimatedDurationMs?: number } = {},
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: {
@@ -15,6 +16,7 @@ const createAfriquegemmaTest = (
     ...(opts.from && { from: opts.from }),
   },
   expectation,
+  ...(suites && { suites }),
   metadata: {
     category: "translation-afriquegemma",
     dependency: "afriquegemma",
@@ -36,6 +38,7 @@ export const afriquegemmSwEn = createAfriquegemmaTest(
   "en",
   { validation: "contains-any", contains: ["hello", "how", "are", "you", "today", "news"] },
   { from: "sw" },
+  ["smoke"],
 );
 
 export const afriquegemmaStreaming: TestDefinition = {

--- a/packages/sdk/tests-qvac/tests/translation-bergamot-tests.ts
+++ b/packages/sdk/tests-qvac/tests/translation-bergamot-tests.ts
@@ -6,10 +6,12 @@ const createBergamotTest = (
   resource: string,
   expectation: Expectation,
   estimatedDurationMs: number = 15000,
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: { text, resource },
   expectation,
+  ...(suites && { suites }),
   metadata: { category: "translation-bergamot", dependency: resource, estimatedDurationMs },
 });
 
@@ -20,6 +22,8 @@ export const bergamotEnFrBasic = createBergamotTest(
   "Hello, how are you today?",
   "bergamot-en-fr",
   { validation: "contains-any", contains: ["bonjour", "comment", "vous", "aujourd"] },
+  15000,
+  ["smoke"],
 );
 
 export const bergamotEnFrLongText = createBergamotTest(
@@ -71,6 +75,8 @@ export const bergamotEnFrStreaming = createBergamotTest(
   "Good morning, how are you?",
   "bergamot-en-fr",
   { validation: "contains-any", contains: ["bonjour", "comment", "allez"] },
+  15000,
+  ["smoke"],
 );
 
 export const bergamotEnFrStats = createBergamotTest(
@@ -104,6 +110,8 @@ export const bergamotEnEsBasic = createBergamotTest(
   "Hello, how are you today?",
   "bergamot-en-es",
   { validation: "contains-any", contains: ["hola", "cómo", "estás", "hoy"] },
+  15000,
+  ["smoke"],
 );
 
 export const bergamotEnEsLongText = createBergamotTest(

--- a/packages/sdk/tests-qvac/tests/translation-indictrans-tests.ts
+++ b/packages/sdk/tests-qvac/tests/translation-indictrans-tests.ts
@@ -6,10 +6,12 @@ const createIndicTransTest = (
   resource: string,
   expectation: Expectation,
   estimatedDurationMs: number = 20000,
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: { text, resource },
   expectation,
+  ...(suites && { suites }),
   metadata: { category: "translation-indictrans", dependency: resource, estimatedDurationMs },
 });
 
@@ -21,6 +23,8 @@ export const indictransEnHiBasic = createIndicTransTest(
   "Hello, how are you today?",
   "indictrans-en-hi",
   { validation: "type", expectedType: "string" },
+  20000,
+  ["smoke"],
 );
 
 export const indictransEnHiLongText = createIndicTransTest(
@@ -88,6 +92,8 @@ export const indictransHiEnBasic = createIndicTransTest(
   "नमस्ते, आप कैसे हैं?",
   "indictrans-hi-en",
   { validation: "contains-any", contains: ["hello", "how", "are", "you", "namaste"] },
+  20000,
+  ["smoke"],
 );
 
 export const indictransHiEnLongText = createIndicTransTest(

--- a/packages/sdk/tests-qvac/tests/translation-llm-tests.ts
+++ b/packages/sdk/tests-qvac/tests/translation-llm-tests.ts
@@ -5,6 +5,7 @@ const createLlmTest = (
   text: string,
   to: string,
   opts: { from?: string; context?: string; estimatedDurationMs?: number } = {},
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: {
@@ -15,6 +16,7 @@ const createLlmTest = (
     ...(opts.context && { context: opts.context }),
   },
   expectation: { validation: "type", expectedType: "string" },
+  ...(suites && { suites }),
   metadata: {
     category: "translation-llm",
     dependency: "llm",
@@ -27,6 +29,7 @@ export const llmEnEs = createLlmTest(
   "Hello, how are you today?",
   "es",
   { from: "en" },
+  ["smoke"],
 );
 
 export const llmEnFr = createLlmTest(
@@ -53,6 +56,7 @@ export const llmStreaming: TestDefinition = {
   testId: "translation-llm-streaming",
   params: { text: "Hello, how are you today?", from: "en", to: "es", resource: "llm" },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "translation-llm", dependency: "llm", estimatedDurationMs: 30000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/translation-marian-tests.ts
+++ b/packages/sdk/tests-qvac/tests/translation-marian-tests.ts
@@ -6,10 +6,12 @@ const createMarianTest = (
   resource: string,
   expectation: Expectation,
   estimatedDurationMs: number = 15000,
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: { text, resource },
   expectation,
+  ...(suites && { suites }),
   metadata: { category: "translation-marian", dependency: resource, estimatedDurationMs },
 });
 
@@ -20,6 +22,8 @@ export const marianDeEnBasic = createMarianTest(
   "Hallo, wie geht es dir heute?",
   "marian-de-en",
   { validation: "contains-any", contains: ["hello", "how", "are", "you", "today"] },
+  15000,
+  ["smoke"],
 );
 
 export const marianDeEnLongText = createMarianTest(
@@ -78,6 +82,8 @@ export const marianDeEnStreaming = createMarianTest(
   "Guten Tag, wie geht es Ihnen?",
   "marian-de-en",
   { validation: "contains-any", contains: ["good", "day", "how", "are"] },
+  15000,
+  ["smoke"],
 );
 
 export const marianDeEnStats = createMarianTest(
@@ -91,6 +97,7 @@ export const marianDeEnBatchBasic: TestDefinition = {
   testId: "translation-marian-de-en-batch-basic",
   params: { texts: ["Guten Morgen", "Gute Nacht"], resource: "marian-de-en" },
   expectation: { validation: "contains-any", contains: ["morning", "night", "good"] },
+  suites: ["smoke"],
   metadata: { category: "translation-marian", dependency: "marian-de-en", estimatedDurationMs: 15000 },
 };
 
@@ -111,6 +118,8 @@ export const marianEnEsBasic = createMarianTest(
   "Hello, how are you today?",
   "marian-en-es",
   { validation: "contains-any", contains: ["hola", "cómo", "estás", "hoy"] },
+  15000,
+  ["smoke"],
 );
 
 export const marianEnEsLongText = createMarianTest(

--- a/packages/sdk/tests-qvac/tests/translation-salamandra-tests.ts
+++ b/packages/sdk/tests-qvac/tests/translation-salamandra-tests.ts
@@ -6,6 +6,7 @@ const createSalamandraTest = (
   to: string,
   expectation: Expectation,
   opts: { from?: string; context?: string; estimatedDurationMs?: number } = {},
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: {
@@ -16,6 +17,7 @@ const createSalamandraTest = (
     ...(opts.context && { context: opts.context }),
   },
   expectation,
+  ...(suites && { suites }),
   metadata: {
     category: "translation-salamandra",
     dependency: "salamandra",
@@ -29,6 +31,7 @@ export const salamandraEnEs = createSalamandraTest(
   "es",
   { validation: "contains-any", contains: ["hola", "cómo", "estás", "hoy", "buenos"] },
   { from: "en" },
+  ["smoke"],
 );
 
 export const salamandraEsEn = createSalamandraTest(
@@ -43,6 +46,7 @@ export const salamandraStreaming: TestDefinition = {
   testId: "translation-salamandra-streaming",
   params: { text: "Hello, how are you today?", from: "en", to: "es", resource: "salamandra" },
   expectation: { validation: "contains-any", contains: ["hola", "cómo", "estás", "hoy", "buenos"] },
+  suites: ["smoke"],
   metadata: { category: "translation-salamandra", dependency: "salamandra", estimatedDurationMs: 30000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/tts-tests.ts
+++ b/packages/sdk/tests-qvac/tests/tts-tests.ts
@@ -4,6 +4,7 @@ export const ttsChatterboxShortText: TestDefinition = {
   testId: "tts-chatterbox-short-text",
   params: { text: "Hello, how are you today?", stream: false },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "tts", dependency: "tts-chatterbox", estimatedDurationMs: 30000 },
 };
 
@@ -52,6 +53,7 @@ export const ttsSupertonicStreaming: TestDefinition = {
   testId: "tts-supertonic-streaming",
   params: { text: "This is a streaming test for the Supertonic engine.", stream: true },
   expectation: { validation: "type", expectedType: "string" },
+  suites: ["smoke"],
   metadata: { category: "tts", dependency: "tts-supertonic", estimatedDurationMs: 45000 },
 };
 

--- a/packages/sdk/tests-qvac/tests/vision-tests.ts
+++ b/packages/sdk/tests-qvac/tests/vision-tests.ts
@@ -6,6 +6,7 @@ const createVisionTest = (
   imagePath: string,
   expectation: Expectation,
   opts: { stream?: boolean; estimatedDurationMs?: number } = {},
+  suites?: string[],
 ): TestDefinition => ({
   testId,
   params: {
@@ -19,6 +20,7 @@ const createVisionTest = (
     ...(opts.stream && { stream: true }),
   },
   expectation,
+  ...(suites && { suites }),
   metadata: {
     category: "vision",
     dependency: "vision",
@@ -31,6 +33,8 @@ export const visionBasic = createVisionTest(
   "What animal is in this image?",
   "elephant.jpg",
   { validation: "contains-any", contains: ["elephant"] },
+  {},
+  ["smoke"],
 );
 
 export const visionStreaming = createVisionTest(
@@ -39,6 +43,7 @@ export const visionStreaming = createVisionTest(
   "elephant.jpg",
   { validation: "contains-any", contains: ["elephant"] },
   { stream: true },
+  ["smoke"],
 );
 
 export const visionStats = createVisionTest(
@@ -159,6 +164,7 @@ export const visionErrorMissingImage: TestDefinition = {
     ],
   },
   expectation: { validation: "throws-error", errorContains: "not found" },
+  suites: ["smoke"],
   metadata: {
     category: "vision",
     dependency: "vision",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- No way to run a fast, curated subset of SDK tests -- running all ~388 tests takes 6-39 minutes depending on platform
- Need a `--suite smoke` option that covers the SDK API surface with high-confidence, performant tests

## 📝 How does it solve it?

- Adds `suites: ["smoke"]` to 84 test definitions across 27 files
- Selection based on: API surface coverage (every public function), plugin load tests, validation quality (executor-level analysis, not just definition expectations), and performance data from desktop/mobile batch reports
- Helper functions (`createCompletionTest`, `createTranscriptionTest`, etc.) extended with optional `suites` parameter
- 3 documentation files added: short PR summary, mid-length reference, full selection report with per-test justifications
- Estimated smoke run time: ~88s desktop, ~290s mobile (vs ~350s/2340s full suite)

Coverage: all 8 built-in plugins, vision, delegated inference, registry, config reload, logging, KV cache, error handling, download/cancel, sharded models, HTTP embeddings, model info

## 📄 Selection criteria & additional documentation
I used my knowledge of the test 
suite to define a reasonable criteria, reviewed cursor suggestions and went back and forth to come up with this selection of tests.
More info in these docs if interested: 

Short version:
[SMOKE_SUITE.md](https://github.com/user-attachments/files/26716970/SMOKE_SUITE.md)
Long version:
[SMOKE_SUITE_REPORT.md](https://github.com/user-attachments/files/26716979/SMOKE_SUITE_REPORT.md)



## 🧪 How was it tested?

- [ ] Run `--suite smoke` on desktop, verify all tagged tests execute and pass
- [ ] Run `--suite smoke` on mobile, verify appropriate tests execute (some skipped by existing platform skip rules)
- [ ] Verify non-smoke tests are excluded when `--suite smoke` is active