### PR TITLE
fix[notask|skiplog]: add jsonl to metro asset extensions

### DIFF
--- a/packages/sdk/tests-qvac/metro.config.js
+++ b/packages/sdk/tests-qvac/metro.config.js
@@ -7,7 +7,7 @@ const config = getDefaultConfig(__dirname);
 config.resolver = config.resolver || {};
 
 
-const extraAssetExts = ['ogg', 'wma', 'aac', 'm4a', 'wav', 'mp3', 'txt'];
+const extraAssetExts = ['ogg', 'wma', 'aac', 'm4a', 'wav', 'mp3', 'txt', 'jsonl'];
 config.resolver.assetExts = Array.from(
     new Set([...(config.resolver.assetExts || []), ...extraAssetExts])
 );


### PR DESCRIPTION
## What problem does this PR solve?

Android build fails with "Unable to resolve module" error for `.jsonl` files in the assets directory. Metro bundler doesn't recognize `.jsonl` as a valid asset extension.

## How does it solve it?

Add `jsonl` to the `extraAssetExts` array in `metro.config.js`.

## How was it tested?

- CI mobile build (Android) should now pass: GREEN https://github.com/tetherto/qvac/actions/runs/24409001694/job/71300262608