### PR TITLE
[BCI] QVAC-17058 ci: add empty BCI workflows to enable branch triggering

### DIFF
--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -1,0 +1,17 @@
+# Stub workflow — enables branch-based triggering once this file exists on main.
+# Full implementation will be added in QVAC-17063.
+name: "Integration Mobile Tests (BCI Whispercpp)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      placeholder:
+        description: "Placeholder — full workflow coming in QVAC-17063"
+        required: false
+        type: string
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Stub workflow — see QVAC-17063 for full implementation"

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -1,0 +1,17 @@
+# Stub workflow — enables branch-based triggering once this file exists on main.
+# Full implementation will be added in QVAC-17063.
+name: "Integration Tests (BCI Whispercpp)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      placeholder:
+        description: "Placeholder — full workflow coming in QVAC-17063"
+        required: false
+        type: string
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Stub workflow — see QVAC-17063 for full implementation"

--- a/.github/workflows/prebuilds-bci-whispercpp.yml
+++ b/.github/workflows/prebuilds-bci-whispercpp.yml
@@ -1,0 +1,17 @@
+# Stub workflow — enables branch-based triggering once this file exists on main.
+# Full implementation will be added in QVAC-17063.
+name: "Prebuilds (BCI Whispercpp)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      placeholder:
+        description: "Placeholder — full workflow coming in QVAC-17063"
+        required: false
+        type: string
+
+jobs:
+  placeholder:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Stub workflow — see QVAC-17063 for full implementation"


### PR DESCRIPTION
## Summary

- Add minimal stub workflow files for prebuilds, desktop integration tests, and mobile integration tests
- These must exist on the default branch before `push` / `workflow_call` triggers on feature branches will fire
- Full implementations will replace these stubs in QVAC-17063

## Files

- `.github/workflows/prebuilds-bci-whispercpp.yml` (stub)
- `.github/workflows/integration-test-bci-whispercpp.yml` (stub)
- `.github/workflows/integration-mobile-test-bci-whispercpp.yml` (stub)

## Stacked PR

This is **PR 5 of 6** in the BCI addon stack (based on PR 4: #1586):
1. QVAC-17057 - POC with batch transcription (#1583)
2. QVAC-17071 - Update qvac-ext-lib-whisper.cpp (#1584)
3. QVAC-17072 - Update qvac-registry-vcpkg (#1585)
4. QVAC-17062 - Streaming + integration tests (#1586)
5. **QVAC-17058** - Add empty BCI workflows to main (this PR)
6. QVAC-17063 - Add full CI workflows for all platforms

## Test plan

- [x] Workflow files are valid YAML
- [ ] After merging to main, `workflow_dispatch` triggers show up in the Actions tab

Made with [Cursor](https://cursor.com)