### PR TITLE
doc[notask]: drop FLUX.1 from diffusion addon JSDoc and README

### DIFF
--- a/packages/lib-infer-diffusion/CHANGELOG.md
+++ b/packages/lib-infer-diffusion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.3] - 2026-04-15
+
+### Changed
+
+- README, `index.d.ts`, and `index.js` JSDoc no longer claim FLUX.1 support for `clipLModel` and `t5XxlModel`. The addon exposes SDXL, SD3, and FLUX.2-klein only — FLUX.1 was never wired through the JS layer. The example model name in the constructor JSDoc is also corrected to `flux-2-klein-4b-Q8_0.gguf`.
+
 ## [0.1.2] - 2026-04-03
 
 ### Changed

--- a/packages/lib-infer-diffusion/README.md
+++ b/packages/lib-infer-diffusion/README.md
@@ -184,9 +184,9 @@ const args = {
 | `diskPath` | ✅ | Local directory where model files are already stored |
 | `modelName` | ✅ | Diffusion model file name (all-in-one for SD1.x/2.x; diffusion-only GGUF for FLUX.2) |
 | `logger` | — | Logger instance (e.g. `console`) |
-| `clipLModel` | — | Separate CLIP-L text encoder (FLUX.1 / SD3) |
+| `clipLModel` | — | Separate CLIP-L text encoder (SD3) |
 | `clipGModel` | — | Separate CLIP-G text encoder (SDXL / SD3) |
-| `t5XxlModel` | — | Separate T5-XXL text encoder (FLUX.1 / SD3) |
+| `t5XxlModel` | — | Separate T5-XXL text encoder (SD3) |
 | `llmModel` | — | Qwen3 LLM text encoder (FLUX.2 [klein]) |
 | `vaeModel` | — | Separate VAE file |
 

--- a/packages/lib-infer-diffusion/index.d.ts
+++ b/packages/lib-infer-diffusion/index.d.ts
@@ -203,11 +203,11 @@ export interface ImgStableDiffusionArgs {
   opts?: { stats?: boolean }
   diskPath?: string
   modelName: string
-  /** FLUX.1 / SD3: separate CLIP-L text encoder */
+  /** SD3: separate CLIP-L text encoder */
   clipLModel?: string
   /** SDXL / SD3: separate CLIP-G text encoder */
   clipGModel?: string
-  /** FLUX.1 / SD3: separate T5-XXL text encoder */
+  /** SD3: separate T5-XXL text encoder */
   t5XxlModel?: string
   /** FLUX.2 [klein]: Qwen3 4B text encoder (llm_path) */
   llmModel?: string

--- a/packages/lib-infer-diffusion/index.js
+++ b/packages/lib-infer-diffusion/index.js
@@ -19,10 +19,10 @@ class ImgStableDiffusion extends BaseInference {
    * @param {object} [args.logger] - Structured logger
    * @param {object} [args.opts] - Optional inference options
    * @param {string} [args.diskPath='.'] - Local directory containing model weight files
-   * @param {string} args.modelName - Model file name (e.g. 'flux1-dev-q4_0.gguf')
-   * @param {string} [args.clipLModel] - Optional CLIP-L model file name (FLUX.1 / SD3)
+   * @param {string} args.modelName - Model file name (e.g. 'flux-2-klein-4b-Q8_0.gguf')
+   * @param {string} [args.clipLModel] - Optional CLIP-L model file name (SD3)
    * @param {string} [args.clipGModel] - Optional CLIP-G model file name (SDXL / SD3)
-   * @param {string} [args.t5XxlModel] - Optional T5-XXL text encoder file name (FLUX.1 / SD3)
+   * @param {string} [args.t5XxlModel] - Optional T5-XXL text encoder file name (SD3)
    * @param {string} [args.llmModel] - Optional LLM text encoder file name (FLUX.2 klein → Qwen3 4B)
    * @param {string} [args.vaeModel] - Optional VAE file name
    * @param {object} config - SD context configuration (threads, device, type, etc.)

--- a/packages/lib-infer-diffusion/package.json
+++ b/packages/lib-infer-diffusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/diffusion-cpp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "stable-diffusion.cpp addon for qvac image/video generation",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The diffusion addon JSDoc and README claim FLUX.1 support on `clipLModel` and `t5XxlModel`, but FLUX.1 is not wired through the JS layer. The addon exposes SDXL, SD3, and FLUX.2-klein only.
- The constructor JSDoc example references `flux1-dev-q4_0.gguf` — same problem; suggests a model file the addon has no plumbing for.

## 📝 How does it solve it?

- README args reference: `clipLModel` and `t5XxlModel` rows now read `(SD3)` instead of `(FLUX.1 / SD3)`.
- `index.d.ts` JSDoc on `clipLModel` and `t5XxlModel` updated the same way.
- `index.js` constructor JSDoc updated, and the example model name in `args.modelName` corrected from `'flux1-dev-q4_0.gguf'` to `'flux-2-klein-4b-Q8_0.gguf'` (the model the rest of the docs and examples actually use).
- `docs/architecture.md` line 477 ("FLUX.1-dev/schnell") is left intact: it sits in the engine-selection rationale section listing what the upstream `qvac-ext-stable-diffusion.cpp` library supports, not what the JS addon exposes.

## 🧪 How was it tested?

- `npm run lint` (standard) clean.
- `npm run test:dts` clean.

## 🔌 API Changes

None. Type shape, behavior, and runtime contract are unchanged. Only JSDoc strings and README cell text are edited.

Bumps `@qvac/diffusion-cpp` `0.1.2` → `0.1.3` with a CHANGELOG entry.
