### PR TITLE
fix[notask]: update CLI + sdk-tests for new embed() return shape

### DIFF
--- a/packages/cli/src/serve/core/sdk.ts
+++ b/packages/cli/src/serve/core/sdk.ts
@@ -23,7 +23,7 @@ interface SDKModule {
     tools?: SDKTool[]
     generationParams?: SDKGenerationParams
   }) => Promise<CompletionResult>
-  embed: (opts: { modelId: string; text: string | string[] }) => Promise<number[] | number[][]>
+  embed: (opts: { modelId: string; text: string | string[] }) => Promise<{ embedding: number[] | number[][]; stats?: Record<string, unknown> }>
   transcribe: (opts: { modelId: string; audioChunk: string | Buffer; prompt?: string }) => Promise<string>
   close: () => Promise<void>
   [key: string]: unknown
@@ -157,7 +157,8 @@ export async function sdkEmbed (opts: {
   text: string | string[]
 }): Promise<number[] | number[][]> {
   const { embed } = await getSDK()
-  return embed({ modelId: opts.modelId, text: opts.text })
+  const { embedding } = await embed({ modelId: opts.modelId, text: opts.text })
+  return embedding
 }
 
 export async function sdkTranscribe (opts: {

--- a/packages/sdk/tests-qvac/tests/shared/executors/embedding-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/embedding-executor.ts
@@ -24,7 +24,7 @@ export class EmbeddingExecutor extends AbstractModelExecutor<
       if (p.texts) {
         const embeddings = [];
         for (const text of p.texts) {
-          const embedding = await embed({ modelId: embeddingModelId, text });
+          const { embedding } = await embed({ modelId: embeddingModelId, text });
           embeddings.push(embedding);
         }
         return ValidationHelpers.validate(
@@ -34,7 +34,7 @@ export class EmbeddingExecutor extends AbstractModelExecutor<
       }
 
       const text = p.text || "";
-      const embedding = await embed({ modelId: embeddingModelId, text });
+      const { embedding } = await embed({ modelId: embeddingModelId, text });
       return ValidationHelpers.validate(embedding, expectation as Expectation);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);

--- a/packages/sdk/tests-qvac/tests/shared/executors/error-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/error-executor.ts
@@ -168,7 +168,7 @@ export class ErrorExecutor extends AbstractModelExecutor<typeof errorTests> {
     const p = params as { text: string };
     const embeddingModelId = await this.resources.ensureLoaded("embeddings");
     try {
-      const result = await embed({ modelId: embeddingModelId, text: p.text });
+      const { embedding: result } = await embed({ modelId: embeddingModelId, text: p.text });
       return ValidationHelpers.validate(result, expectation as Expectation);
     } catch (error) {
       return { passed: true, output: `SDK correctly rejected empty input: ${error}` };

--- a/packages/sdk/tests-qvac/tests/shared/executors/http-embedding-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/http-embedding-executor.ts
@@ -72,7 +72,7 @@ export class HttpEmbeddingExecutor extends AbstractModelExecutor<typeof httpEmbe
         modelType: p.modelType as "embeddings",
       });
       this.resources.register("embeddings", modelId);
-      const embeddings = await embed({ modelId, text: p.text });
+      const { embedding: embeddings } = await embed({ modelId, text: p.text });
       return ValidationHelpers.validate(embeddings, expectation as Expectation);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);

--- a/packages/sdk/tests-qvac/tests/shared/executors/sharded-model-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/sharded-model-executor.ts
@@ -49,7 +49,7 @@ export class ShardedModelExecutor extends AbstractModelExecutor<typeof shardedMo
     const modelId = await this.resources.ensureLoaded("sharded-embeddings");
 
     try {
-      const embeddings = await embed({ modelId, text: p.text });
+      const { embedding: embeddings } = await embed({ modelId, text: p.text });
       return ValidationHelpers.validate(embeddings, expectation as Expectation);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -64,7 +64,7 @@ export class ShardedModelExecutor extends AbstractModelExecutor<typeof shardedMo
     try {
       const embeddings = [];
       for (const text of p.texts) {
-        const embedding = await embed({ modelId, text });
+        const { embedding } = await embed({ modelId, text });
         embeddings.push(embedding);
       }
       return ValidationHelpers.validate(embeddings, expectation as Expectation);


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

PR #1495 changed `@qvac/sdk`'s `embed()` to return `{ embedding, stats? }` instead of raw `number[] | number[][]`. Two downstream consumers inside this repo still expected the old shape and would break at type-check / runtime:

1. **`packages/cli`** — `SDKModule.embed` type in `src/serve/core/sdk.ts` declared the old return.
2. **`packages/sdk/tests-qvac`** — 6 `await embed(...)` call sites across 4 executor files bound the result to a variable as if it were raw vectors.

## 📝 How does it solve it?

### CLI (`packages/cli/src/serve/core/sdk.ts`)

- Update `SDKModule.embed` to `Promise<{ embedding: number[] | number[][]; stats?: Record<string, unknown> }>`.
- Inside `sdkEmbed()`, destructure `embedding` from the awaited result and return just the vectors. The exported `sdkEmbed()` keeps its outer `Promise<number[] | number[][]>` signature, so the OpenAI embeddings route consumer (`src/serve/adapters/openai/routes/embeddings.ts`) needs no changes.

### sdk-tests (`packages/sdk/tests-qvac`)

Destructure `embedding` from the new return shape in the executors that bind the result to a variable:

- `embedding-executor.ts` — 2 sites (batch loop + single)
- `sharded-model-executor.ts` — 2 sites (batch + per-text)
- `http-embedding-executor.ts` — 1 site
- `error-executor.ts` — 1 site (destructure into `result` via `embedding: result`)

The 2 call sites that discard the return (`error-executor.ts:44` invalid-modelId test and `logging-executor.ts:56` fire-and-forget log) stay as `await embed(...)` — no binding, nothing to destructure.

## 🧪 How was it tested?

- `packages/cli`: `npm run typecheck` (tsc --noEmit) clean.
- `packages/sdk/tests-qvac`: `npm run typecheck` — the 6 embed-shape errors that existed before this change are resolved. Remaining errors in `delegated-inference-tests.ts` and `download-tests.ts` (about the `"function"` literal type) are **pre-existing on `main`** and unrelated to this PR.
- Audited full repo for other stale consumers of the old `embed()` shape — none found beyond CLI and tests-qvac.

## 🔌 API Changes

CLI's internal `SDKModule` type updated — no public API change:

```typescript
// BEFORE
interface SDKModule {
  embed: (opts: { modelId: string; text: string | string[] }) => Promise<number[] | number[][]>
}

// AFTER
interface SDKModule {
  embed: (opts: { modelId: string; text: string | string[] }) => Promise<{ embedding: number[] | number[][]; stats?: Record<string, unknown> }>
}
```

sdk-tests changes are pure consumer migrations, no API surface.

## 📋 Depends on

- tetherto/qvac#1495 (merged) — introduced the new `embed()` return shape in the SDK.
