### PR TITLE
fix[notask]: destructure embedding from new embed() return shape in sdk-tests

### DIFF
--- a/packages/sdk/tests-qvac/tests/shared/executors/embedding-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/embedding-executor.ts
@@ -24,7 +24,7 @@ export class EmbeddingExecutor extends AbstractModelExecutor<
       if (p.texts) {
         const embeddings = [];
         for (const text of p.texts) {
-          const embedding = await embed({ modelId: embeddingModelId, text });
+          const { embedding } = await embed({ modelId: embeddingModelId, text });
           embeddings.push(embedding);
         }
         return ValidationHelpers.validate(
@@ -34,7 +34,7 @@ export class EmbeddingExecutor extends AbstractModelExecutor<
       }
 
       const text = p.text || "";
-      const embedding = await embed({ modelId: embeddingModelId, text });
+      const { embedding } = await embed({ modelId: embeddingModelId, text });
       return ValidationHelpers.validate(embedding, expectation as Expectation);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);

--- a/packages/sdk/tests-qvac/tests/shared/executors/error-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/error-executor.ts
@@ -168,7 +168,7 @@ export class ErrorExecutor extends AbstractModelExecutor<typeof errorTests> {
     const p = params as { text: string };
     const embeddingModelId = await this.resources.ensureLoaded("embeddings");
     try {
-      const result = await embed({ modelId: embeddingModelId, text: p.text });
+      const { embedding: result } = await embed({ modelId: embeddingModelId, text: p.text });
       return ValidationHelpers.validate(result, expectation as Expectation);
     } catch (error) {
       return { passed: true, output: `SDK correctly rejected empty input: ${error}` };

--- a/packages/sdk/tests-qvac/tests/shared/executors/http-embedding-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/http-embedding-executor.ts
@@ -72,7 +72,7 @@ export class HttpEmbeddingExecutor extends AbstractModelExecutor<typeof httpEmbe
         modelType: p.modelType as "embeddings",
       });
       this.resources.register("embeddings", modelId);
-      const embeddings = await embed({ modelId, text: p.text });
+      const { embedding: embeddings } = await embed({ modelId, text: p.text });
       return ValidationHelpers.validate(embeddings, expectation as Expectation);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);

--- a/packages/sdk/tests-qvac/tests/shared/executors/sharded-model-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/sharded-model-executor.ts
@@ -49,7 +49,7 @@ export class ShardedModelExecutor extends AbstractModelExecutor<typeof shardedMo
     const modelId = await this.resources.ensureLoaded("sharded-embeddings");
 
     try {
-      const embeddings = await embed({ modelId, text: p.text });
+      const { embedding: embeddings } = await embed({ modelId, text: p.text });
       return ValidationHelpers.validate(embeddings, expectation as Expectation);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
@@ -64,7 +64,7 @@ export class ShardedModelExecutor extends AbstractModelExecutor<typeof shardedMo
     try {
       const embeddings = [];
       for (const text of p.texts) {
-        const embedding = await embed({ modelId, text });
+        const { embedding } = await embed({ modelId, text });
         embeddings.push(embedding);
       }
       return ValidationHelpers.validate(embeddings, expectation as Expectation);


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- PR #1495 changed `@qvac/sdk`'s `embed()` to return `{ embedding, stats? }` instead of raw `number[] | number[][]`.
- The `sdk-tests` package (under `packages/sdk/tests-qvac`) still treats the return value as raw vectors, so every embedding test executor would fail at runtime once the SDK types propagate through the build.

## 📝 How does it solve it?

Destructure `embedding` from the new return shape in every call site that binds the result to a variable:

- `embedding-executor.ts` — 2 sites (batch loop + single)
- `sharded-model-executor.ts` — 2 sites (batch + per-text)
- `http-embedding-executor.ts` — 1 site
- `error-executor.ts` — 1 site (rename `result` → destructure `embedding: result`)

The 2 call sites that discard the return (`error-executor.ts` invalid-modelId test at line 44, `logging-executor.ts` fire-and-forget at line 56) are intentionally left as `await embed(...)` — they don't bind the result and just exercise the error/logging path.

## 🧪 How was it tested?

- `npm run typecheck` — the embed-shape errors that existed pre-change are now resolved. Remaining typecheck errors (in `delegated-inference-tests.ts` and `download-tests.ts` about `"function"` literal type) are pre-existing and unrelated to this change; they also fail on `main` without this PR applied.

## 🔌 API Changes

None — this is a pure consumer migration to match the SDK's already-shipped embed return shape.

## 📋 Depends on

- tetherto/qvac#1495 (merged) — introduced the new `embed()` return shape in the SDK.
