### PR TITLE
QVAC-17265 feat: auto-download Bergamot models in pivot.example.js

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/examples/pivot.example.js
+++ b/packages/qvac-lib-infer-nmtcpp/examples/pivot.example.js
@@ -8,7 +8,7 @@
  * - Second model: English -> Italian (en-it)
  * - Result: Spanish -> Italian translation via English pivot
  *
- * Requires local Bergamot model files for both language pairs.
+ * Model files are downloaded automatically from the Firefox CDN if not found locally.
  *
  * Usage:
  *   bare examples/pivot.example.js
@@ -19,9 +19,13 @@
  */
 
 const TranslationNmtcpp = require('../index')
-const fs = require('bare-fs')
 const path = require('bare-path')
 const process = require('bare-process')
+
+const {
+  ensureBergamotModelFiles,
+  getBergamotFileNames
+} = require('../lib/bergamot-model-fetcher')
 
 // ============================================================
 // LOGGING CONFIGURATION
@@ -54,30 +58,25 @@ async function main () {
   console.log(spanishText)
   console.log('-----------------------------------------------------------\n')
 
-  const esenPath = process.env.BERGAMOT_ESEN_PATH || './models/es-en'
-  const enitPath = process.env.BERGAMOT_ENIT_PATH || './models/en-it'
+  // Use local model paths if provided, otherwise auto-download from Firefox CDN
+  const esenPath = process.env.BERGAMOT_ESEN_PATH || './model/bergamot/esen'
+  const enitPath = process.env.BERGAMOT_ENIT_PATH || './model/bergamot/enit'
 
-  const primaryModel = path.join(esenPath, 'model.esen.intgemm.alphas.bin')
-  const primaryVocab = path.join(esenPath, 'vocab.esen.spm')
-  const pivotModel = path.join(enitPath, 'model.enit.intgemm.alphas.bin')
-  const pivotVocab = path.join(enitPath, 'vocab.enit.spm')
+  // Ensure model files are present (downloads from Firefox CDN if not)
+  const esenDir = await ensureBergamotModelFiles('es', 'en', esenPath)
+  const enitDir = await ensureBergamotModelFiles('en', 'it', enitPath)
 
-  for (const f of [primaryModel, primaryVocab, pivotModel, pivotVocab]) {
-    if (!fs.existsSync(f)) {
-      console.log('Missing model file:', f)
-      console.log('\nSet BERGAMOT_ESEN_PATH and BERGAMOT_ENIT_PATH env vars or place models in ./models/es-en and ./models/en-it')
-      return
-    }
-  }
+  const esenFiles = getBergamotFileNames('es', 'en')
+  const enitFiles = getBergamotFileNames('en', 'it')
 
   const model = new TranslationNmtcpp({
     files: {
-      model: primaryModel,
-      srcVocab: primaryVocab,
-      dstVocab: primaryVocab,
-      pivotModel,
-      pivotSrcVocab: pivotVocab,
-      pivotDstVocab: pivotVocab
+      model: path.join(esenDir, esenFiles.modelName),
+      srcVocab: path.join(esenDir, esenFiles.srcVocabName),
+      dstVocab: path.join(esenDir, esenFiles.dstVocabName),
+      pivotModel: path.join(enitDir, enitFiles.modelName),
+      pivotSrcVocab: path.join(enitDir, enitFiles.srcVocabName),
+      pivotDstVocab: path.join(enitDir, enitFiles.dstVocabName)
     },
     params: {
       srcLang: 'es',


### PR DESCRIPTION
## Summary

- Update `pivot.example.js` to auto-download Bergamot model files from the Firefox CDN when not found locally, using `ensureBergamotModelFiles()` and `getBergamotFileNames()` from `bergamot-model-fetcher`
- Follows the same pattern already used by `quickstart.js` and `batch.example.js`
- Removes manual `fs.existsSync` checks and hardcoded filenames in favor of the fetcher utilities
- Env var overrides (`BERGAMOT_ESEN_PATH`, `BERGAMOT_ENIT_PATH`) still supported for custom local paths

## Test plan

- [x] `npx standard examples/pivot.example.js` — lint passes
- [x] `bare examples/pivot.example.js` — models auto-downloaded from Firefox CDN, pivot translation (Spanish → English → Italian) completed successfully
- [x] Verified cached models are reused on subsequent runs (skips download)