### PR TITLE
fix: add npm_tag input to nmtcpp on-merge workflow to allow publishin…

### DIFF
--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -23,6 +23,11 @@ on:
           - feature
           - temp
           - latest
+      npm_tag:
+        description: "NPM dist-tag override (default: latest). e.g. latest, next, patch-2.0.1"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -177,6 +182,16 @@ jobs:
     env:
       PKG_DIR: packages/qvac-lib-infer-nmtcpp
     steps:
+      - name: Validate npm_tag input
+        if: inputs.npm_tag != ''
+        shell: bash
+        run: |
+          tag="${{ inputs.npm_tag }}"
+          if ! echo "$tag" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._-]*$'; then
+            echo "::error::Invalid npm dist-tag '$tag'. Must match ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ (e.g. latest, next, patch-2.0.1)"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
@@ -193,7 +208,7 @@ jobs:
         uses: ./.github/actions/publish-library-to-npm
         with:
           secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: "latest"
+          tag: ${{ inputs.npm_tag || 'latest' }}
           workdir: ${{ env.PKG_DIR }}
           repo_name: "translation-nmtcpp"
           git-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -24,7 +24,7 @@ on:
           - temp
           - latest
       npm_tag:
-        description: "NPM dist-tag override (default: latest). e.g. latest, next, patch-2.0.1"
+        description: "NPM dist-tag (default: latest). e.g. release-1.x"
         required: false
         default: ""
         type: string
@@ -188,7 +188,7 @@ jobs:
         run: |
           tag="${{ inputs.npm_tag }}"
           if ! echo "$tag" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._-]*$'; then
-            echo "::error::Invalid npm dist-tag '$tag'. Must match ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ (e.g. latest, next, patch-2.0.1)"
+            echo "::error::Invalid npm dist-tag '$tag'. Must match ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ (e.g. release-1.x)"
             exit 1
           fi
 


### PR DESCRIPTION
…g without latest tag