### PR TITLE
QVAC-11724 feat[api]: implement cancel embed operation

### DIFF
--- a/packages/sdk/schemas/cancel.ts
+++ b/packages/sdk/schemas/cancel.ts
@@ -25,10 +25,15 @@ const cancelRagParamsSchema = z.object({
   workspace: z.string().optional(),
 });
 
+const cancelEmbeddingsParamsSchema = cancelInferenceBaseSchema.extend({
+  operation: z.literal("embeddings"),
+});
+
 const cancelParamsSchema = z.discriminatedUnion("operation", [
   cancelInferenceParamsSchema,
   cancelDownloadParamsSchema,
   cancelRagParamsSchema,
+  cancelEmbeddingsParamsSchema,
 ]);
 
 export const cancelRequestSchema = z.intersection(

--- a/packages/sdk/server/rpc/handler-registry.ts
+++ b/packages/sdk/server/rpc/handler-registry.ts
@@ -57,7 +57,7 @@ function isModelDelegated(request: Request): boolean {
 function isCancelDelegated(request: Request): boolean {
   if (request.type !== "cancel") return false;
 
-  if (request.operation === "inference") {
+  if (request.operation === "inference" || request.operation === "embeddings") {
     return isModelDelegated(request);
   }
 

--- a/packages/sdk/server/rpc/handlers/cancel-delegated.ts
+++ b/packages/sdk/server/rpc/handlers/cancel-delegated.ts
@@ -16,7 +16,7 @@ type DelegationTarget = {
 function resolveDelegationTarget(
   request: CancelRequest,
 ): DelegationTarget | null {
-  if (request.operation === "inference") {
+  if (request.operation === "inference" || request.operation === "embeddings") {
     const entry = getModelEntry(request.modelId);
     if (!entry?.isDelegated || !entry.delegated) {
       return null;

--- a/packages/sdk/server/rpc/handlers/cancelHandler.ts
+++ b/packages/sdk/server/rpc/handlers/cancelHandler.ts
@@ -15,6 +15,7 @@ export async function cancelHandler(
   try {
     switch (request.operation) {
       case "inference":
+      case "embeddings":
         await cancel({ modelId: request.modelId });
         break;
       case "downloadAsset": {


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- No way to cancel an in-flight `embed()` call — users had to wait for the full embedding to complete even if it was no longer needed.

## 📝 How does it solve it?

- Adds `operation: "embeddings"` as a new variant of the `cancel()` API.
- Routes through the same bare `cancel()` path as `operation: "inference"`, calling `model.addon.cancel()` on the embedding model.
- Delegation support added for cases where the embedding model is served by a remote peer.

## 🔌 API Changes

```typescript
// Cancel an in-flight embed call
void embed({ modelId, text });
await new Promise(resolve => setTimeout(resolve, 1000));
await cancel({ operation: "embeddings", modelId });
```