### PR TITLE
DEVOPS-2055 ci: remove dead github-token from release-merge-guard callers

### DIFF
--- a/.github/workflows/on-merge-lib-infer-diffusion.yml
+++ b/.github/workflows/on-merge-lib-infer-diffusion.yml
@@ -98,7 +98,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/on-merge-ocr-onnx.yml
+++ b/.github/workflows/on-merge-ocr-onnx.yml
@@ -94,7 +94,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
+++ b/.github/workflows/on-merge-qvac-lib-decoder-audio.yml
@@ -95,7 +95,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-embed.yml
@@ -91,7 +91,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-llamacpp-llm.yml
@@ -99,7 +99,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-nmtcpp.yml
@@ -93,7 +93,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx-tts.yml
@@ -91,7 +91,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-onnx.yml
@@ -94,7 +94,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-parakeet.yml
@@ -91,7 +91,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-merge-qvac-lib-infer-whispercpp.yml
@@ -89,7 +89,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/publish-qvac-lib-registry-server.yml
+++ b/.github/workflows/publish-qvac-lib-registry-server.yml
@@ -57,7 +57,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}
@@ -77,7 +76,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -66,7 +66,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -40,7 +40,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-dl-base.yml
+++ b/.github/workflows/trigger-reusable-lib-dl-base.yml
@@ -39,7 +39,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-dl-filesystem.yml
+++ b/.github/workflows/trigger-reusable-lib-dl-filesystem.yml
@@ -39,7 +39,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-error.yml
+++ b/.github/workflows/trigger-reusable-lib-error.yml
@@ -39,7 +39,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-hyperdrive.yml
+++ b/.github/workflows/trigger-reusable-lib-hyperdrive.yml
@@ -39,7 +39,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-logging.yml
+++ b/.github/workflows/trigger-reusable-lib-logging.yml
@@ -39,7 +39,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-diagnostics.yml
@@ -29,7 +29,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-infer-base.yml
@@ -39,7 +39,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text-cld2.yml
@@ -79,7 +79,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-lib-langdetect-text.yml
@@ -39,7 +39,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}

--- a/.github/workflows/trigger-reusable-lib-rag.yml
+++ b/.github/workflows/trigger-reusable-lib-rag.yml
@@ -39,7 +39,6 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/release-merge-guard
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.ref_name }}
           base-sha: ${{ github.event.before }}
           head-sha: ${{ github.sha }}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- 23 workflows pass `github-token: ${{ secrets.GITHUB_TOKEN }}` to the `release-merge-guard` action, but the action documents that input as **unused**
- Using `secrets.GITHUB_TOKEN` instead of `github.token` is inconsistent with the `on-pr-*` workflows that already use `github.token` for `authorize-pr`

## 📝 How does it solve it?

- Removes the dead `github-token` line from all 23 calling workflows (24 occurrences — `publish-qvac-lib-registry-server.yml` has two guard jobs)
- No functional change: the input was already unused by the action

**Workflows updated:**
- 10× `on-merge-*.yml` (diffusion, ocr-onnx, decoder-audio, llamacpp-embed, llamacpp-llm, nmtcpp, onnx, onnx-tts, parakeet, whispercpp)
- 2× `publish-*.yml` (sdk, registry-server)
- 11× `trigger-reusable-*.yml` (cli, dl-base, dl-filesystem, error, hyperdrive, logging, rag, diagnostics, infer-base, langdetect-text, langdetect-text-cld2)

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214003279179562