### PR TITLE
QVAC-17303 test[skiplog]: add suspend/resume lifecycle integration tests

### DIFF
--- a/packages/sdk/tests-qvac/tests/desktop/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/desktop/consumer.ts
@@ -69,6 +69,7 @@ import { DownloadExecutor } from "../shared/executors/download-executor.js";
 import { DelegatedInferenceExecutor } from "./executors/delegated-inference-executor.js";
 import { DiffusionExecutor } from "../shared/executors/diffusion-executor.js";
 import { FinetuneExecutor } from "./executors/finetune-executor.js";
+import { LifecycleExecutor } from "../shared/executors/lifecycle-executor.js";
 
 const resources = new ResourceManager();
 
@@ -400,6 +401,7 @@ export const executor = createExecutor({
     new DelegatedInferenceExecutor(),
     new DiffusionExecutor(resources),
     new FinetuneExecutor(resources),
+    new LifecycleExecutor(resources),
   ],
   profiling: {
     init: () => profiler.enable({ mode: "summary", includeServerBreakdown: true }),

--- a/packages/sdk/tests-qvac/tests/lifecycle-tests.ts
+++ b/packages/sdk/tests-qvac/tests/lifecycle-tests.ts
@@ -1,0 +1,26 @@
+import type { TestDefinition } from "@tetherto/qvac-test-suite";
+
+const createLifecycleTest = (
+  testId: string,
+  dependency: string = "none",
+  estimatedDurationMs: number = 30000,
+): TestDefinition => ({
+  testId,
+  params: {},
+  expectation: { validation: "type", expectedType: "string" },
+  metadata: { category: "lifecycle", dependency, estimatedDurationMs },
+});
+
+export const lifecycleSuspendResumeBasic = createLifecycleTest("lifecycle-suspend-resume-basic");
+export const lifecycleSuspendIdempotent = createLifecycleTest("lifecycle-suspend-idempotent");
+export const lifecycleResumeIdempotent = createLifecycleTest("lifecycle-resume-idempotent");
+export const lifecycleSuspendResumeInference = createLifecycleTest("lifecycle-suspend-resume-inference", "llm", 60000);
+export const lifecycleRapidToggle = createLifecycleTest("lifecycle-rapid-toggle");
+
+export const lifecycleTests = [
+  lifecycleSuspendResumeBasic,
+  lifecycleSuspendIdempotent,
+  lifecycleResumeIdempotent,
+  lifecycleSuspendResumeInference,
+  lifecycleRapidToggle,
+] as const;

--- a/packages/sdk/tests-qvac/tests/lifecycle-tests.ts
+++ b/packages/sdk/tests-qvac/tests/lifecycle-tests.ts
@@ -1,4 +1,4 @@
-import type { TestDefinition } from "@tetherto/qvac-test-suite";
+import type { TestDefinition,  } from "@tetherto/qvac-test-suite";
 
 const createLifecycleTest = (
   testId: string,
@@ -16,6 +16,7 @@ export const lifecycleSuspendIdempotent = createLifecycleTest("lifecycle-suspend
 export const lifecycleResumeIdempotent = createLifecycleTest("lifecycle-resume-idempotent");
 export const lifecycleSuspendResumeInference = createLifecycleTest("lifecycle-suspend-resume-inference", "llm", 60000);
 export const lifecycleRapidToggle = createLifecycleTest("lifecycle-rapid-toggle");
+export const lifecycleSuspendDuringInference = createLifecycleTest("lifecycle-suspend-during-inference", "llm", 60000);
 
 export const lifecycleTests = [
   lifecycleSuspendResumeBasic,
@@ -23,4 +24,5 @@ export const lifecycleTests = [
   lifecycleResumeIdempotent,
   lifecycleSuspendResumeInference,
   lifecycleRapidToggle,
+  lifecycleSuspendDuringInference,
 ] as const;

--- a/packages/sdk/tests-qvac/tests/mobile/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/mobile/consumer.ts
@@ -66,6 +66,7 @@ import { MobileTtsExecutor } from "./executors/tts-executor.js";
 import { DownloadExecutor } from "../shared/executors/download-executor.js";
 import { DelegatedInferenceExecutor } from "../shared/executors/delegated-inference-executor.js";
 import { DiffusionExecutor } from "../shared/executors/diffusion-executor.js";
+import { LifecycleExecutor } from "../shared/executors/lifecycle-executor.js";
 
 const resources = new ResourceManager();
 
@@ -410,6 +411,7 @@ export const executor = createExecutor({
     new DownloadExecutor(),
     new DelegatedInferenceExecutor(),
     new DiffusionExecutor(resources),
+    new LifecycleExecutor(resources),
   ],
   profiling: {
     init: () => profiler.enable({ mode: "summary", includeServerBreakdown: true }),

--- a/packages/sdk/tests-qvac/tests/shared/executors/lifecycle-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/lifecycle-executor.ts
@@ -12,6 +12,7 @@ import {
   lifecycleResumeIdempotent,
   lifecycleSuspendResumeInference,
   lifecycleRapidToggle,
+  lifecycleSuspendDuringInference,
 } from "../../lifecycle-tests.js";
 
 const formatError = (error: unknown): string => error instanceof Error ? error.message : String(error)
@@ -42,11 +43,11 @@ export class LifecycleExecutor extends AbstractModelExecutor<typeof lifecycleTes
       await this.warmRegistry();
       const output = await this.runStrategy(testId);
       const elapsed = Date.now() - start;
+      await this.ensureActive();
       return ValidationHelpers.validate(`${output} (${elapsed}ms)`, exp);
     } catch (error) {
-      return { passed: false, output: `lifecycle [${testId}] failed: ${formatError(error)}` };
-    } finally {
       await this.ensureActive();
+      return { passed: false, output: `lifecycle [${testId}] failed: ${formatError(error)}` };
     }
   };
 
@@ -66,6 +67,9 @@ export class LifecycleExecutor extends AbstractModelExecutor<typeof lifecycleTes
 
       case lifecycleRapidToggle.testId:
         return await this.runRapidToggle();
+
+      case lifecycleSuspendDuringInference.testId:
+        return await this.runSuspendDuringInference();
 
       default:
         throw new Error(`Unknown lifecycle test: ${testId}`);
@@ -120,6 +124,29 @@ export class LifecycleExecutor extends AbstractModelExecutor<typeof lifecycleTes
 
     const models = await modelRegistryList();
     return `Inference preserved, registry OK (${models.length} models). Before: "${textBefore.trim()}", After: "${textAfter.trim()}"`;
+  }
+
+  private async runSuspendDuringInference(): Promise<string> {
+    const modelId = await this.resources.ensureLoaded("llm");
+
+    const completionPromise = completion({
+      modelId,
+      history: [{ role: "user", content: "Count from 1 to 20, one number per line." }],
+      stream: false,
+    }).text;
+
+    await suspend();
+
+    const text = await completionPromise;
+
+    await resume();
+
+    if (!text?.trim()) {
+      throw new Error("Completion during suspend returned empty text");
+    }
+
+    const models = await modelRegistryList();
+    return `Suspend during inference OK, got ${text.trim().length} chars, registry accessible (${models.length} models)`;
   }
 
   private async runRapidToggle(): Promise<string> {

--- a/packages/sdk/tests-qvac/tests/shared/executors/lifecycle-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/lifecycle-executor.ts
@@ -1,0 +1,141 @@
+import { suspend, resume, completion, modelRegistryList } from "@qvac/sdk";
+import {
+  ValidationHelpers,
+  type TestResult,
+  type Expectation,
+} from "@tetherto/qvac-test-suite";
+import { AbstractModelExecutor } from "./abstract-model-executor.js";
+import {
+  lifecycleTests,
+  lifecycleSuspendResumeBasic,
+  lifecycleSuspendIdempotent,
+  lifecycleResumeIdempotent,
+  lifecycleSuspendResumeInference,
+  lifecycleRapidToggle,
+} from "../../lifecycle-tests.js";
+
+const formatError = (error: unknown): string => error instanceof Error ? error.message : String(error)
+
+export class LifecycleExecutor extends AbstractModelExecutor<typeof lifecycleTests> {
+  pattern = /^lifecycle-/;
+
+  protected handlers = {} as never;
+
+  private registryWarmed = false;
+
+  /**
+   * Ensures the registry client is initialized so that its swarm and corestore
+   * are registered with the lifecycle coordinator. Without this, suspend/resume
+   * would operate on zero resources -- a no-op state flip.
+   */
+  private async warmRegistry(): Promise<void> {
+    if (this.registryWarmed) return;
+    await modelRegistryList();
+    this.registryWarmed = true;
+  }
+
+  protected defaultHandler = async (testId: string, _params: unknown, expectation: unknown): Promise<TestResult> => {
+    const exp = expectation as Expectation;
+    const start = Date.now();
+
+    try {
+      await this.warmRegistry();
+      const output = await this.runStrategy(testId);
+      const elapsed = Date.now() - start;
+      return ValidationHelpers.validate(`${output} (${elapsed}ms)`, exp);
+    } catch (error) {
+      return { passed: false, output: `lifecycle [${testId}] failed: ${formatError(error)}` };
+    } finally {
+      await this.ensureActive();
+    }
+  };
+
+  private async runStrategy(testId: string): Promise<string> {
+    switch (testId) {
+      case lifecycleSuspendResumeBasic.testId:
+        return await this.runSuspendResume();
+
+      case lifecycleSuspendIdempotent.testId:
+        return await this.runIdempotentSuspend();
+
+      case lifecycleResumeIdempotent.testId:
+        return await this.runIdempotentResume();
+
+      case lifecycleSuspendResumeInference.testId:
+        return await this.runInference();
+
+      case lifecycleRapidToggle.testId:
+        return await this.runRapidToggle();
+
+      default:
+        throw new Error(`Unknown lifecycle test: ${testId}`);
+    }
+  }
+
+  private async runSuspendResume(): Promise<string> {
+    await suspend();
+    await resume();
+
+    const models = await modelRegistryList();
+    return `suspend/resume round-trip OK, registry accessible after resume (${models.length} models)`;
+  }
+
+  private async runIdempotentSuspend(): Promise<string> {
+    await suspend();
+    await suspend();
+    return "Double suspend() OK";
+  }
+
+  private async runIdempotentResume(): Promise<string> {
+    await resume();
+    await resume();
+    return "Double resume() while active OK";
+  }
+
+  private async runInference(): Promise<string> {
+    const modelId = await this.resources.ensureLoaded("llm");
+
+    const textBefore = await completion({
+      modelId,
+      history: [{ role: "user", content: "What is 2+2? Answer with only the number." }],
+      stream: false,
+    }).text;
+
+    if (!textBefore?.trim()) {
+      throw new Error("Pre-suspend completion returned empty text");
+    }
+
+    await suspend();
+    await resume();
+
+    const textAfter = await completion({
+      modelId,
+      history: [{ role: "user", content: "What is 3+3? Answer with only the number." }],
+      stream: false,
+    }).text;
+
+    if (!textAfter?.trim()) {
+      throw new Error("Post-resume completion returned empty text");
+    }
+
+    const models = await modelRegistryList();
+    return `Inference preserved, registry OK (${models.length} models). Before: "${textBefore.trim()}", After: "${textAfter.trim()}"`;
+  }
+
+  private async runRapidToggle(): Promise<string> {
+    const results = await Promise.allSettled([suspend(), resume()]);
+    const failures = results
+      .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+      .map((r) => formatError(r.reason));
+
+    if (failures.length > 0) throw new Error(failures.join("; "));
+
+    await resume();
+    const models = await modelRegistryList();
+    return `Rapid suspend+resume resolved OK, registry accessible (${models.length} models)`;
+  }
+
+  private async ensureActive(): Promise<void> {
+    try { await resume(); } catch { /* best-effort restore for subsequent tests */ }
+  }
+}

--- a/packages/sdk/tests-qvac/tests/shared/executors/lifecycle-executor.ts
+++ b/packages/sdk/tests-qvac/tests/shared/executors/lifecycle-executor.ts
@@ -35,8 +35,7 @@ export class LifecycleExecutor extends AbstractModelExecutor<typeof lifecycleTes
     this.registryWarmed = true;
   }
 
-  protected defaultHandler = async (testId: string, _params: unknown, expectation: unknown): Promise<TestResult> => {
-    const exp = expectation as Expectation;
+  protected defaultHandler = (async (testId: string, _params: {}, expectation: Expectation): Promise<TestResult> => {
     const start = Date.now();
 
     try {
@@ -44,12 +43,12 @@ export class LifecycleExecutor extends AbstractModelExecutor<typeof lifecycleTes
       const output = await this.runStrategy(testId);
       const elapsed = Date.now() - start;
       await this.ensureActive();
-      return ValidationHelpers.validate(`${output} (${elapsed}ms)`, exp);
+      return ValidationHelpers.validate(`${output} (${elapsed}ms)`, expectation);
     } catch (error) {
       await this.ensureActive();
       return { passed: false, output: `lifecycle [${testId}] failed: ${formatError(error)}` };
     }
-  };
+  }) as never;
 
   private async runStrategy(testId: string): Promise<string> {
     switch (testId) {

--- a/packages/sdk/tests-qvac/tests/test-definitions.ts
+++ b/packages/sdk/tests-qvac/tests/test-definitions.ts
@@ -27,6 +27,7 @@ import { downloadTests } from "./download-tests.js";
 import { delegatedInferenceTests } from "./delegated-inference-tests.js";
 import { diffusionTests } from "./diffusion-tests.js";
 import { finetuneTests } from "./finetune-tests.js";
+import { lifecycleTests } from "./lifecycle-tests.js";
 
 // Model loading tests
 export const modelLoadLlm: TestDefinition = {
@@ -228,6 +229,9 @@ export const tests = [
 
   // Finetuning tests
   ...finetuneTests,
+
+  // Lifecycle tests (suspend/resume)
+  ...lifecycleTests,
 
   // Additional model tests
   modelSwitchLlm,


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

PR #1511 added `suspend()` / `resume()` lifecycle APIs with unit test coverage, but there were no integration tests validating the full RPC path with real Hyperswarm and Corestore resources.

## 🛠 How does it solve it?

Adds 6 integration tests in the `lifecycle` category:

- **suspend-resume-basic** — full round-trip with registry access verification after resume
- **suspend-idempotent** — double `suspend()` on already-suspended runtime (no-op validation)
- **resume-idempotent** — double `resume()` on already-active runtime (no-op validation)
- **suspend-resume-inference** — LLM completion before suspend and after resume, confirms inference continuity
- **rapid-toggle** — concurrent `suspend()` + `resume()` via `Promise.allSettled`, validates transition serialization
- **suspend-during-inference** — calls `suspend()` while a completion is in-flight, verifies no crash and result integrity


Each test warms the registry client before execution to ensure `suspend`/`resume` operates on real swarm and corestore resources (not a zero-resource no-op). Post-resume registry access is verified via `modelRegistryList()`.

## 🧪 How was it tested?

- `bun run lint && bun run typecheck` — pass
- Desktop test run on macOS: 6/6 passed, 100% success rate
[lifecycle-local-desktop.html](https://github.com/user-attachments/files/26777327/lifecycle-local-desktop.html)
- iOS test run: 6/6 passed, 100% success rate
[lifecycle-local-ios.html](https://github.com/user-attachments/files/26777343/lifecycle-local-ios.html)
- Server logs confirmed real resource management: `(1 swarms, 1 stores)` suspended/resumed per cycle

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214077360084022