### PR TITLE
chore[notask]: revert Opus registry removal (premature — SDK still references them)

### DIFF
--- a/packages/qvac-lib-registry-server/NOTICE
+++ b/packages/qvac-lib-registry-server/NOTICE
@@ -44,6 +44,7 @@ one of these identifiers.
   Compiled / quantized derivatives (see Modification Notice below):
     Qwen3-1.7B, Qwen3-4B
     dolphin-mixtral-2x7b-dpo
+    Marian translation models (various language pairs)
     salamandrata-2b-instruct (q4, q8)
     Whisper fine-tuned (English, French, German, Italian, Japanese,
       Norwegian, Portuguese, Russian)
@@ -71,6 +72,14 @@ one of these identifiers.
 
   Original model weights are publicly available from Mozilla's
   firefox-translations-models repository.
+
+--- CC-BY-4.0 (Creative Commons Attribution 4.0 International) ---
+
+  Compiled / quantized derivatives (see Modification Notice below):
+    Marian/Opus-MT translation models (en-de, en-pt, ru-en, zh-en)
+
+  Attribution: Helsinki-NLP / OPUS-MT project
+  (https://github.com/Helsinki-NLP/Opus-MT)
 
 --- llama3.2 (Llama 3.2 Community License) ---
 

--- a/packages/qvac-lib-registry-server/client/NOTICE
+++ b/packages/qvac-lib-registry-server/client/NOTICE
@@ -51,6 +51,42 @@ Third-Party Model Licenses
     https://huggingface.co/personalizedrefrigerator/whisper-base-fr
   fr-tiny-ggml-model-f16
     https://huggingface.co/JaepaX/whisper-tiny-fr
+  ggml-opus-ar-en
+    https://huggingface.co/Helsinki-NLP/opus-mt-ar-en
+  ggml-opus-de-en
+    https://huggingface.co/Helsinki-NLP/opus-mt-de-en
+  ggml-opus-de-fr
+    https://huggingface.co/Helsinki-NLP/opus-mt-de-fr
+  ggml-opus-en-ar
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-ar
+  ggml-opus-en-es
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-es
+  ggml-opus-en-fr
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-fr
+  ggml-opus-en-it
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-it
+  ggml-opus-en-ru
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-ru
+  ggml-opus-en-zh
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-zh
+  ggml-opus-es-en
+    https://huggingface.co/Helsinki-NLP/opus-mt-es-en
+  ggml-opus-es-fr
+    https://huggingface.co/Helsinki-NLP/opus-mt-es-fr
+  ggml-opus-fr-de
+    https://huggingface.co/Helsinki-NLP/opus-mt-fr-de
+  ggml-opus-fr-en
+    https://huggingface.co/Helsinki-NLP/opus-mt-fr-en
+  ggml-opus-fr-es
+    https://huggingface.co/Helsinki-NLP/opus-mt-fr-es
+  ggml-opus-it-en
+    https://huggingface.co/Helsinki-NLP/opus-mt-it-en
+  ggml-opus-ja-en
+    https://huggingface.co/Helsinki-NLP/opus-mt-ja-en
+  ggml-opus-mt-en-roa-f16
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-roa
+  ggml-opus-mt-roa-en-f16
+    https://huggingface.co/Helsinki-NLP/opus-mt-roa-en
   gpt-oss-20b-GGUF
     https://huggingface.co/unsloth/gpt-oss-20b-GGUF
   it-base-ggml-model-f16
@@ -91,6 +127,17 @@ Third-Party Model Licenses
     https://huggingface.co/BSC-LT/salamandraTA-2B-instruct-GGUF
   SmolVLM2-500M-Video-Instruct-GGUF
     https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF
+
+--- cc-by-4.0 (Creative Commons Attribution 4.0 International) ---
+
+  ggml-opus-en-de
+    https://huggingface.co/Helsinki-NLP/opus-mt-en-de
+  ggml-opus-en-pt
+    https://huggingface.co/Helsinki-NLP/opus-mt-tc-big-en-pt
+  ggml-opus-ru-en
+    https://huggingface.co/Helsinki-NLP/opus-mt-ru-en
+  ggml-opus-zh-en
+    https://huggingface.co/Helsinki-NLP/opus-mt-zh-en
 
 --- gemma (Gemma Terms of Use) ---
 

--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -1466,6 +1466,70 @@
     "notes": "tensors config"
   },
   {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-en-ru/2025-11-09/ggml-opus-en-ru.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "en-ru"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-ru"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-ru-en/2025-11-09/ggml-opus-ru-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "CC-BY-4.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "ru-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-ru-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-en-ru/2025-09-23/ggml-opus-en-ru.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "en-ru"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-ru"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-ru-en/2025-09-23/ggml-opus-ru-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "CC-BY-4.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "ru-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-ru-en"
+  },
+  {
     "source": "https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF/resolve/ccd7aae53bcb1997355c2f094959e72b3642ce17/SmolVLM2-500M-Video-Instruct-f16.gguf",
     "engine": "@qvac/llm-llamacpp",
     "description": "",
@@ -1556,6 +1620,214 @@
     "notes": ""
   },
   {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-en-pt/2025-11-07/ggml-opus-mt-en-roa-f16.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "en-pt"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-roa"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-pt-en/2025-11-07/ggml-opus-mt-roa-en-f16.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "pt-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-roa-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-en-fr/2025-11-09/ggml-opus-en-fr.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "en-fr"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-fr"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-de-fr/2025-11-09/ggml-opus-de-fr.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "de-fr"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-de-fr"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-de-fr/2025-11-04/ggml-opus-de-fr.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "de-fr"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-de-fr"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-es-fr/2025-11-09/ggml-opus-es-fr.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "es-fr"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-es-fr"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-es-fr/2025-11-04/ggml-opus-es-fr.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "es-fr"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-es-fr"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-fr-es/2025-11-09/ggml-opus-fr-es.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "fr-es"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-fr-es"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-fr-es/2025-11-04/ggml-opus-fr-es.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "fr-es"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-fr-es"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-fr-de/2025-11-09/ggml-opus-fr-de.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "fr-de"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-fr-de"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-fr-de/2025-11-04/ggml-opus-fr-de.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "fr-de"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-fr-de"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q0f16/ggml-opus-fr-en/2025-11-09/ggml-opus-fr-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q0f16",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "fr-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-fr-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-en-pt/2025-11-04/ggml-opus-en-pt.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "CC-BY-4.0",
+    "tags": [
+      "translation",
+      "opus-ggml",
+      "marian",
+      "en-pt"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-tc-big-en-pt"
+  },
+  {
     "source": "s3:///qvac_models_compiled/ocr/2026-02-12/rec_512/recognizer_latin.onnx",
     "engine": "@qvac/ocr-onnx",
     "description": "Text recognizer - Latin (fixed-width 512px)",
@@ -1584,6 +1856,246 @@
     ],
     "notes": "",
     "link": "https://www.jaided.ai/easyocr/modelhub/"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-en-it/2025-09-10/ggml-opus-en-it.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "en-it"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-it"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-it-en/2025-09-10/ggml-opus-it-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "it-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-it-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-en-de/2025-09-10/ggml-opus-en-de.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "CC-BY-4.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "en-de"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-de"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-de-en/2025-09-10/ggml-opus-de-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "de-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-de-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-en-es/2025-09-10/ggml-opus-en-es.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "en-es"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-es"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-es-en/2025-09-10/ggml-opus-es-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "es-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-es-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-en-fr/2025-11-04/ggml-opus-en-fr.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "en-fr"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-fr"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-fr-en/2025-11-04/ggml-opus-fr-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "fr-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-fr-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-en-ar/2025-11-20/ggml-opus-en-ar.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "en-ar"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-ar"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-ar-en/2025-11-20/ggml-opus-ar-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "ar-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-ar-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-en-zh/2025-11-19/ggml-opus-en-zh.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "en-zh"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-zh"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-zh-en/2025-11-19/ggml-opus-zh-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "CC-BY-4.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "zh-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-zh-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-ja-en/2025-11-19/ggml-opus-ja-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "ja-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-ja-en"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-en-roa/2025-11-20/ggml-opus-en-roa.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "en-roa"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-en-roa"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/marian/q4_0/ggml-opus-roa-en/2025-11-19/ggml-opus-roa-en.bin",
+    "engine": "@qvac/translation-nmtcpp",
+    "description": "",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "translation",
+      "opus",
+      "marian",
+      "roa-en"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/Helsinki-NLP/opus-mt-roa-en"
   },
   {
     "source": "s3:///qvac_models_compiled/ggml/whisper-french/2026-03-05/fr-tiny-ggml-model-f16.bin",
@@ -5011,7 +5523,7 @@
     "notes": ""
   },
   {
-    "source": "https://huggingface.co/Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/onnx/unicode_indexer.json",
+   "source": "https://huggingface.co/Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/onnx/unicode_indexer.json",
     "engine": "@qvac/tts",
     "description": "Supertone Supertonic 2 unicode indexer (fp32)",
     "quantization": "fp32",
@@ -5024,7 +5536,7 @@
       "unicode-indexer",
       "fp32"
     ],
-    "notes": ""
+    "notes": "" 
   },
   {
     "source": "https://huggingface.co/Supertone/supertonic-2/resolve/75e6727618a02f323c720cba9478152d4bc16ca4/voice_styles/F1.json",
@@ -5475,11 +5987,11 @@
     ],
     "deprecated": false,
     "notes": ""
-  },
+  },  
   {
     "source": "s3:///qvac_models_compiled/parakeet/parakeet-sortformer-onnx-int8/2026-03-20/sortformer_int8.onnx",
     "engine": "@qvac/transcription-parakeet",
-    "link": "https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2",
+    "link":"https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2",
     "description": "Parakeet Sortformer 4SPK v2 INT8",
     "quantization": "int8",
     "params": "123M",


### PR DESCRIPTION
## Summary

Reverts commit 436e29c (PR #1602) which removed 32 Opus model entries from the registry server.

## Why

The registry entries were removed before the SDK stopped referencing them. The published SDK (`@qvac/sdk@0.8.3`) still exports `MARIAN_OPUS_*` constants. Users on that version get broken model resolution because the registry no longer has the Opus entries.

Correct order:
1. First: SDK removes Opus constants (PR #1622)
2. Publish new SDK version
3. Then: remove Opus from registry

## What's restored
- 32 Opus/Marian entries in `data/models.prod.json` (680 → 712)
- Marian attribution in `NOTICE` (Apache-2.0 + CC-BY-4.0 sections)
- 22 `ggml-opus-*` entries in `client/NOTICE`
