### PR TITLE
QVAC-17009 test[skiplog]: add finetune progress zero-drop E2E test

### DIFF
--- a/packages/sdk/tests-qvac/tests/desktop/executors/finetune-executor.ts
+++ b/packages/sdk/tests-qvac/tests/desktop/executors/finetune-executor.ts
@@ -52,6 +52,7 @@ export class FinetuneExecutor extends AbstractModelExecutor<typeof finetuneTests
     "finetune-pause-resume": this.pauseResume.bind(this),
     "finetune-progress-streaming": this.progressStreaming.bind(this),
     "finetune-error-cases": this.errorCases.bind(this),
+    "finetune-progress-zero-drop": this.progressZeroDrop.bind(this),
   } as never;
 
   async teardown(testId: string, context: unknown) {
@@ -293,6 +294,73 @@ export class FinetuneExecutor extends AbstractModelExecutor<typeof finetuneTests
       );
     } catch (error) {
       return this.failWithError("finetune error cases", error);
+    }
+  }
+
+  async progressZeroDrop(params: BaseParams, expectation: Expectation): Promise<TestResult> {
+    const modelId = await this.resources.ensureLoaded(FINETUNE_DEPENDENCY);
+    const paths = await this.createDatasets();
+
+    try {
+      const handle = finetune({
+        modelId,
+        options: this.buildOptions(paths, params.numberOfEpochs ?? 2),
+      });
+      const progress = await this.collectProgress(handle.progressStream);
+      const result = await handle.result;
+
+      if (result.status !== "COMPLETED") {
+        return {
+          passed: false,
+          output: `Expected COMPLETED status, got ${result.status}`,
+        };
+      }
+
+      if (progress.length === 0) {
+        return { passed: false, output: "No progress events received" };
+      }
+
+      const groups = new Map<string, { batches: Set<number>; totalBatches: number }>();
+
+      for (const ev of progress) {
+        const key = `${ev.is_train ? "train" : "val"}:epoch${ev.current_epoch}`;
+        let group = groups.get(key);
+        if (!group) {
+          group = { batches: new Set(), totalBatches: ev.total_batches };
+          groups.set(key, group);
+        }
+        group.batches.add(ev.current_batch);
+        if (ev.total_batches > group.totalBatches) {
+          group.totalBatches = ev.total_batches;
+        }
+      }
+
+      const drops: string[] = [];
+      for (const [key, group] of groups) {
+        if (group.batches.size < group.totalBatches) {
+          const received = [...group.batches].sort((a, b) => a - b);
+          drops.push(
+            `${key}: ${received.length}/${group.totalBatches} unique batches` +
+            ` (received=[${received.join(",")}])`,
+          );
+        }
+      }
+
+      if (drops.length > 0) {
+        return {
+          passed: false,
+          output:
+            `Progress events dropped: ${drops.join("; ")}. ` +
+            `Total received: ${progress.length}`,
+        };
+      }
+
+      return ValidationHelpers.validate(
+        `Zero-drop verified: ${progress.length} progress events across ${groups.size} phases, no batch gaps`,
+        expectation,
+      );
+    } catch (error) {
+      return this.failWithError("finetune progress zero-drop", error);
     }
   }
 

--- a/packages/sdk/tests-qvac/tests/finetune-tests.ts
+++ b/packages/sdk/tests-qvac/tests/finetune-tests.ts
@@ -51,9 +51,18 @@ export const finetuneErrorCases = createFinetuneTest(
   30000,
 );
 
+export const finetuneProgressZeroDrop = createFinetuneTest(
+  "finetune-progress-zero-drop",
+  {
+    numberOfEpochs: 2,
+  },
+  120000,
+);
+
 export const finetuneTests = [
   finetuneStartComplete,
   finetunePauseResume,
   finetuneProgressStreaming,
   finetuneErrorCases,
+  finetuneProgressZeroDrop,
 ];


### PR DESCRIPTION
**🎯 What problem does this PR solve?**
No E2E coverage for the progress throttle buffering fix (QVAC-16950). Without this test, a regression in executeProgressHandler that silently drops progress events during sub-150ms bursts would go undetected.

**📝 How does it solve it?**
Adds finetune-progress-zero-drop desktop E2E test that:
- Runs a 2-epoch finetune job over IPC (Node → Bare subprocess) using the tiny dataset
- Groups all received progress events by (is_train, current_epoch)
- Asserts that for every phase, the number of unique current_batch values equals total_batches — zero drops

**🧪 How was it tested?**
Desktop consumer run on macOS (M4 Pro, 48GB), 5/5 finetune tests passed:

```
▶️  [5/5] finetune-progress-zero-drop
✅ finetune-progress-zero-drop (52370ms)
🎉 Batch complete!
📊 Total: 5
✅ Passed: 5
❌ Failed: 0
⏱️  Duration: 162.01s
```
Runtime confirmed as node → Bare IPC (the code path where the original bug manifested).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213999853469224