### PR TITLE
infra[notask]: switch sdk desktop ci macos runner to mac-mini-m4-gpu

### DIFF
--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       platforms:
-        description: 'JSON array of runner labels (e.g., ["ubuntu-latest"] or ["ai-run-linux-gpu", "macos-latest-xlarge"])'
+        description: 'JSON array of runner labels (e.g., ["ubuntu-latest"] or ["ai-run-linux-gpu", "mac-mini-m4-gpu"])'
         required: true
         type: string
       consumer-timeout:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -34,7 +34,7 @@ on:
       desktop-platforms:
         description: "JSON array of runner labels for desktop tests"
         type: string
-        default: '["ai-run-windows11-gpu", "ai-run-linux-gpu", "macos-latest-xlarge"]'
+        default: '["ai-run-windows11-gpu", "ai-run-linux-gpu", "mac-mini-m4-gpu"]'
       test-version:
         description: "Git ref to checkout for the tested project (branch, tag, or SHA). Defaults to current branch HEAD."
         type: string
@@ -70,7 +70,7 @@ jobs:
     with:
       project-directory: "packages/sdk"
       working-directory: "packages/sdk/tests-qvac"
-      platforms: ${{ inputs.desktop-platforms || '["ai-run-windows11-gpu", "ai-run-linux-gpu", "macos-latest-xlarge"]' }}
+      platforms: ${{ inputs.desktop-platforms || '["ai-run-windows11-gpu", "ai-run-linux-gpu", "mac-mini-m4-gpu"]' }}
       consumer-timeout: ${{ fromJSON(inputs.desktop-consumer-timeout || '60') }}
       filter: ${{ inputs.filter }}
       test-version: ${{ inputs.test-version || '' }}


### PR DESCRIPTION
## What problem does this PR solve?

The GitHub-hosted `macos-latest-xlarge` runner was unstable for our desktop SDK CI and did not expose a usable hardware GPU, which caused `@qvac/diffusion-cpp` tests to time out on macOS.

## How does it solve it?

- Switch the default macOS runner for desktop SDK tests to the self-hosted `mac-mini-m4-gpu` (Apple M4 + Metal GPU).
- It is more stable than `macos-latest-xlarge` and lets diffusion tests actually run on macOS (the same runner is already used by addon integration tests).
- Updated defaults and descriptions in `test-sdk.yml` and `test-desktop-sdk.yml`.

## How was it tested?

- Triggered the desktop SDK workflow on this runner: https://github.com/tetherto/qvac/actions/runs/24519752573/job/71673917868.
- Verified diffusion tests complete on macOS instead of timing out.