### PR TITLE
QVAC-17408: remove ccache from prebuild workflows

### DIFF
--- a/.github/workflows/prebuilds-lib-infer-diffusion.yml
+++ b/.github/workflows/prebuilds-lib-infer-diffusion.yml
@@ -224,26 +224,6 @@ jobs:
         name: Update apt sources
         run: sudo apt-get update
 
-      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
-        name: Install ccache on Linux
-        run: sudo apt-get install -y ccache
-
-      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
-        name: Configure ccache
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
-      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
-        name: Get ccache cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}
-          path: ~/.cache/ccache-arm
-
       - if: ${{ matrix.platform == 'linux' }}
         name: Install required packages linux
         run: sudo apt-get install libxi-dev libxtst-dev libxrandr-dev

--- a/.github/workflows/prebuilds-ocr-onnx.yml
+++ b/.github/workflows/prebuilds-ocr-onnx.yml
@@ -143,70 +143,11 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19 all
 
-      - if: ${{ matrix.variant == 'ubuntu' }}
-        name: Install ccache on Linux
-        run: sudo apt-get install -y ccache
-
-      - if: ${{ startsWith(matrix.os, 'macos') }}
-        name: Install ccache on macOS
-        run: brew install ccache
-
-      - if: ${{ matrix.os != 'windows-2022' }}
-        name: Configure ccache
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-
-      - if: ${{ matrix.os != 'windows-2022' }}
-        name: Restore ccache cache
-        id: cache-ccache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ github.sha }}
-          restore-keys: |
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}-
-
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure windows runner
         run: |
           git config --system core.longpaths true
           choco upgrade llvm -y --no-progress
-
-      - if: ${{ matrix.os == 'windows-2022' }}
-        name: Install and configure ccache on Windows
-        shell: pwsh
-        run: |
-          # Download ccache directly from GitHub releases
-          $ccacheVersion = "4.10.2"
-          $ccacheUrl = "https://github.com/ccache/ccache/releases/download/v$ccacheVersion/ccache-$ccacheVersion-windows-x86_64.zip"
-          $ccacheZip = "$env:TEMP\ccache.zip"
-          $ccacheDir = "C:\ccache"
-
-          Invoke-WebRequest -Uri $ccacheUrl -OutFile $ccacheZip
-          Expand-Archive -Path $ccacheZip -DestinationPath $env:TEMP -Force
-          New-Item -ItemType Directory -Path $ccacheDir -Force | Out-Null
-          Move-Item -Path "$env:TEMP\ccache-$ccacheVersion-windows-x86_64\*" -Destination $ccacheDir -Force
-
-          # Add to PATH for subsequent steps
-          echo "C:\ccache" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-          # Configure ccache
-          & "C:\ccache\ccache.exe" --set-config=max_size=2G
-          & "C:\ccache\ccache.exe" --set-config=compression=true
-          & "C:\ccache\ccache.exe" -z
-
-      - if: ${{ matrix.os == 'windows-2022' }}
-        name: Restore ccache cache (Windows)
-        id: cache-ccache-win
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          path: ~\AppData\Local\ccache
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.sha }}
-          restore-keys: |
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -311,7 +252,7 @@ jobs:
 
       - name: Generate
         working-directory: ${{ env.PKG_DIR }}
-        run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }} -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
+        run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }}
 
       - name: Run bare-make build
         working-directory: ${{ env.PKG_DIR }}
@@ -331,23 +272,6 @@ jobs:
           else
             find prebuilds -name "*.bare" -exec strip {} \;
           fi
-
-      - name: Show ccache stats
-        run: ccache -s
-
-      - if: ${{ matrix.os != 'windows-2022' && steps.cache-ccache.outputs.cache-hit != 'true' }}
-        name: Save ccache cache
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ github.sha }}
-
-      - if: ${{ matrix.os == 'windows-2022' && steps.cache-ccache-win.outputs.cache-hit != 'true' }}
-        name: Save ccache cache (Windows)
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          path: ~\AppData\Local\ccache
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.sha }}
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -225,27 +225,6 @@ jobs:
         name: Update apt sources
         run: sudo apt-get update
 
-      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
-        name: Install ccache on Linux
-        run: |
-          sudo apt-get install -y ccache
-
-      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
-        name: Configure ccache
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
-      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
-        name: Get ccache cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}
-          path: ~/.cache/ccache-arm
-
       - if: ${{ matrix.platform == 'linux' }}
         name: Install required packages linux
         run: sudo apt-get install libxi-dev libxtst-dev libxrandr-dev

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -232,26 +232,6 @@ jobs:
         name: Update apt sources
         run: sudo apt-get update
 
-      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
-        name: Install ccache on Linux
-        run: sudo apt-get install -y ccache
-
-      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
-        name: Configure ccache
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
-      - if: ${{ matrix.os == 'ubuntu-22.04-arm' }}
-        name: Get ccache cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}
-          path: ~/.cache/ccache-arm
-
       - if: ${{ matrix.platform == 'linux' }}
         name: Install required packages linux
         run: sudo apt-get install libxi-dev libxtst-dev libxrandr-dev

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
@@ -157,69 +157,16 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19 all
 
-      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        name: Install ccache on Linux
-        run: sudo apt-get install -y ccache
-
       - if: ${{ startsWith(matrix.os, 'macos') }}
-        name: Install ccache on macOS
-        run: |
-          brew install ccache
-          # Unlink Homebrew fmt to prevent header conflicts with vcpkg's fmt
-          # (Homebrew fmt 12.x headers conflict with vcpkg fmt 11.x on Intel Macs)
-          brew unlink fmt || true
-
-      - if: ${{ matrix.platform != 'win32' }}
-        name: Configure ccache
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
-      - if: ${{ matrix.platform != 'win32' }}
-        name: Get ccache cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles('packages/qvac-lib-infer-onnx-tts/vcpkg.json') }}
-          path: ~/.cache/ccache
-          restore-keys: |
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}-
+        name: Unlink Homebrew fmt
+        # Unlink Homebrew fmt to prevent header conflicts with vcpkg's fmt
+        # (Homebrew fmt 12.x headers conflict with vcpkg fmt 11.x on Intel Macs)
+        run: brew unlink fmt || true
 
       - if: ${{ matrix.platform == 'win32' }}
         name: Configure windows runner
         run: |
           git config --system core.longpaths true
-          $ccacheVersion = "4.10.2"
-          $ccacheUrl = "https://github.com/ccache/ccache/releases/download/v$ccacheVersion/ccache-$ccacheVersion-windows-x86_64.zip"
-          $ccacheZip = "$env:TEMP\ccache.zip"
-          $ccacheDir = "C:\ccache"
-          Invoke-WebRequest -Uri $ccacheUrl -OutFile $ccacheZip
-          Expand-Archive -Path $ccacheZip -DestinationPath $ccacheDir -Force
-          $ccacheBin = Get-ChildItem -Path $ccacheDir -Recurse -Filter "ccache.exe" | Select-Object -First 1
-          $ccachePath = $ccacheBin.DirectoryName
-          echo "$ccachePath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - if: ${{ matrix.platform == 'win32' }}
-        name: Configure ccache on Windows
-        shell: bash
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
-      - if: ${{ matrix.platform == 'win32' }}
-        name: Get ccache cache (Windows)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles('packages/qvac-lib-infer-onnx-tts/vcpkg.json') }}
-          path: ~\AppData\Local\ccache
-          restore-keys: |
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -420,9 +367,6 @@ jobs:
         if: ${{ matrix.platform != 'win32' && matrix.platform != 'android' }}
         shell: bash
         run: find ${{ env.WORKDIR }}/prebuilds -name "*.bare" -exec strip {} \;
-
-      - name: Show ccache stats
-        run: ccache -s
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:

--- a/.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-onnx.yml
@@ -143,70 +143,11 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19 all
 
-      - if: ${{ matrix.variant == 'ubuntu' }}
-        name: Install ccache on Linux
-        run: sudo apt-get install -y ccache
-
-      - if: ${{ startsWith(matrix.os, 'macos') }}
-        name: Install ccache on macOS
-        run: brew install ccache
-
-      - if: ${{ matrix.os != 'windows-2022' }}
-        name: Configure ccache
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-
-      - if: ${{ matrix.os != 'windows-2022' }}
-        name: Restore ccache cache
-        id: cache-ccache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ github.sha }}
-          restore-keys: |
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}-
-
       - if: ${{ matrix.os == 'windows-2022' }}
         name: Configure windows runner
         run: |
           git config --system core.longpaths true
           choco upgrade llvm -y --no-progress
-
-      - if: ${{ matrix.os == 'windows-2022' }}
-        name: Install and configure ccache on Windows
-        shell: pwsh
-        run: |
-          # Download ccache directly from GitHub releases
-          $ccacheVersion = "4.10.2"
-          $ccacheUrl = "https://github.com/ccache/ccache/releases/download/v$ccacheVersion/ccache-$ccacheVersion-windows-x86_64.zip"
-          $ccacheZip = "$env:TEMP\ccache.zip"
-          $ccacheDir = "C:\ccache"
-
-          Invoke-WebRequest -Uri $ccacheUrl -OutFile $ccacheZip
-          Expand-Archive -Path $ccacheZip -DestinationPath $env:TEMP -Force
-          New-Item -ItemType Directory -Path $ccacheDir -Force | Out-Null
-          Move-Item -Path "$env:TEMP\ccache-$ccacheVersion-windows-x86_64\*" -Destination $ccacheDir -Force
-
-          # Add to PATH for subsequent steps
-          echo "C:\ccache" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-          # Configure ccache
-          & "C:\ccache\ccache.exe" --set-config=max_size=2G
-          & "C:\ccache\ccache.exe" --set-config=compression=true
-          & "C:\ccache\ccache.exe" -z
-
-      - if: ${{ matrix.os == 'windows-2022' }}
-        name: Restore ccache cache (Windows)
-        id: cache-ccache-win
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          path: ~\AppData\Local\ccache
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.sha }}
-          restore-keys: |
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -315,7 +256,7 @@ jobs:
 
       - name: Generate
         working-directory: ${{ env.PKG_DIR }}
-        run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }} -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
+        run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} ${{ matrix.flags }}
 
       - name: Run bare-make build
         working-directory: ${{ env.PKG_DIR }}
@@ -335,23 +276,6 @@ jobs:
           else
             find prebuilds -name "*.bare" -exec strip {} \;
           fi
-
-      - name: Show ccache stats
-        run: ccache -s
-
-      - if: ${{ matrix.os != 'windows-2022' && steps.cache-ccache.outputs.cache-hit != 'true' }}
-        name: Save ccache cache
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ github.sha }}
-
-      - if: ${{ matrix.os == 'windows-2022' && steps.cache-ccache-win.outputs.cache-hit != 'true' }}
-        name: Save ccache cache (Windows)
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          path: ~\AppData\Local\ccache
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.sha }}
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:

--- a/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-parakeet.yml
@@ -122,34 +122,6 @@ jobs:
         name: Configure windows runner
         run: |
           git config --system core.longpaths true
-          $ccacheVersion = "4.10.2"
-          $ccacheUrl = "https://github.com/ccache/ccache/releases/download/v$ccacheVersion/ccache-$ccacheVersion-windows-x86_64.zip"
-          $ccacheZip = "$env:TEMP\ccache.zip"
-          $ccacheDir = "C:\ccache"
-          Invoke-WebRequest -Uri $ccacheUrl -OutFile $ccacheZip
-          Expand-Archive -Path $ccacheZip -DestinationPath $ccacheDir -Force
-          $ccacheBin = Get-ChildItem -Path $ccacheDir -Recurse -Filter "ccache.exe" | Select-Object -First 1
-          $ccachePath = $ccacheBin.DirectoryName
-          echo "$ccachePath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - if: ${{ matrix.platform == 'win32' }}
-        name: Configure ccache on Windows
-        shell: bash
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
-      - if: ${{ matrix.platform == 'win32' }}
-        name: Get ccache cache (Windows)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          key: ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-${{ hashFiles(format('{0}/vcpkg.json', env.WORKDIR)) }}
-          path: ~\AppData\Local\ccache
-          restore-keys: |
-            ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -249,33 +221,6 @@ jobs:
           sudo ./llvm.sh 19 all
 
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        name: Install ccache on Linux
-        run: sudo apt-get install -y ccache
-
-      - if: ${{ startsWith(matrix.os, 'macos') }}
-        name: Install ccache on macOS
-        run: brew install ccache
-
-      - if: ${{ matrix.platform != 'win32' }}
-        name: Configure ccache
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
-      - if: ${{ matrix.platform != 'win32' }}
-        name: Get ccache cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          key: ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles(format('{0}/vcpkg.json', env.WORKDIR)) }}
-          path: ~/.cache/ccache
-          restore-keys: |
-            ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-
-            ccache-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-
-
-      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
         name: Update apt sources
         run: sudo apt-get update
 
@@ -363,9 +308,6 @@ jobs:
           fi
 
           echo "All Android binaries have debug sections removed."
-
-      - name: Show ccache stats
-        run: ccache -s
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -140,35 +140,6 @@ jobs:
         name: Configure windows runner
         run: |
           git config --system core.longpaths true
-          $ccacheVersion = "4.10.2"
-          $ccacheUrl = "https://github.com/ccache/ccache/releases/download/v$ccacheVersion/ccache-$ccacheVersion-windows-x86_64.zip"
-          $ccacheZip = "$env:TEMP\ccache.zip"
-          $ccacheDir = "C:\ccache"
-          Invoke-WebRequest -Uri $ccacheUrl -OutFile $ccacheZip
-          Expand-Archive -Path $ccacheZip -DestinationPath $ccacheDir -Force
-          $ccacheBin = Get-ChildItem -Path $ccacheDir -Recurse -Filter "ccache.exe" | Select-Object -First 1
-          $ccachePath = $ccacheBin.DirectoryName
-          echo "$ccachePath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - if: ${{ matrix.platform == 'win32' }}
-        name: Configure ccache on Windows
-        shell: bash
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
-      - if: ${{ matrix.platform == 'win32' }}
-        name: Get ccache cache (Windows)
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.tags }}-${{ hashFiles(format('{0}/vcpkg.json', inputs.workdir)) }}
-          path: ~\AppData\Local\ccache
-          restore-keys: |
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.tags }}-
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -262,33 +233,6 @@ jobs:
           chmod +x llvm.sh
           sudo ./llvm.sh 19 all
 
-      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        name: Install ccache on Linux
-        run: sudo apt-get install -y ccache
-
-      - if: ${{ startsWith(matrix.os, 'macos') }}
-        name: Install ccache on macOS
-        run: brew install ccache
-
-      - if: ${{ matrix.platform != 'win32' }}
-        name: Configure ccache
-        run: |
-          ccache --set-config=max_size=2G
-          ccache --set-config=compression=true
-          ccache -z
-          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
-
-      - if: ${{ matrix.platform != 'win32' }}
-        name: Get ccache cache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
-        with:
-          key: ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-${{ hashFiles(format('{0}/vcpkg.json', inputs.workdir)) }}
-          path: ~/.cache/ccache
-          restore-keys: |
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}-
-            ccache-${{ matrix.platform }}-${{ matrix.arch }}-
-
       - if: ${{ matrix.platform == 'linux' }}
         name: Install required packages linux
         run: |
@@ -349,9 +293,6 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         run: |
           find prebuilds -name "*.bare" -exec strip {} \;
-
-      - name: Show ccache stats
-        run: ccache -s
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:


### PR DESCRIPTION
## What problem does this PR solve?

- ccache setup across the eight prebuild workflows is duplicated and drifted across three incompatible patterns (ARM64-only with broken cache keys, `hashFiles(vcpkg.json)`-keyed combined cache, and `github.sha`-keyed split restore/save), adding maintenance load and review noise.
- Observed hit rates on these prebuild jobs no longer justify the cost of maintaining the ccache install / configure / cache blocks across Linux, macOS, and Windows.

## How does it solve it?

- Removes ccache entirely from every `prebuilds-*.yml` workflow instead of standardizing it.
- Deletes, in each in-scope workflow: `Install ccache on Linux` / `...on macOS` / `...on Windows`, `Configure ccache`, `Get / Restore / Save ccache cache` (both combined `actions/cache` and split `actions/cache/restore` + `actions/cache/save`), `Show ccache stats`, and the `CMAKE_C_COMPILER_LAUNCHER` / `CMAKE_CXX_COMPILER_LAUNCHER` exports to `$GITHUB_ENV`.
- Drops the `-D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache` flags on `bare-make generate` in `prebuilds-qvac-lib-infer-onnx.yml` and `prebuilds-ocr-onnx.yml`.
- Preserves unrelated Windows bootstrap that shared the ccache step (`git config --system core.longpaths true`, `choco upgrade llvm -y --no-progress`) as their own Windows-only step.
- Extracts the onnx-tts `brew unlink fmt || true` fmt header-conflict workaround into its own macOS-only step so it survives the ccache removal.
- In-scope workflows: `prebuilds-qvac-lib-infer-whispercpp.yml`, `prebuilds-qvac-lib-infer-parakeet.yml`, `prebuilds-qvac-lib-infer-onnx-tts.yml`, `prebuilds-qvac-lib-infer-onnx.yml`, `prebuilds-ocr-onnx.yml`, `prebuilds-qvac-lib-infer-llamacpp-llm.yml`, `prebuilds-qvac-lib-infer-llamacpp-embed.yml`, `prebuilds-lib-infer-diffusion.yml`.
- Out of scope: `cpp-test-coverage-qvac-lib-infer-parakeet.yml`, `benchmark-qvac-lib-infer-nmtcpp.yml`, `benchmark-ocr-onnx.yml` — these are not prebuild workflows and still use ccache; they can be revisited separately.

## How was it tested?

- YAML parse-checked locally for all 8 edited workflow files.
- Verified zero residual references to `ccache`, `CMAKE_C_COMPILER_LAUNCHER`, or `CMAKE_CXX_COMPILER_LAUNCHER` in any `prebuilds-*.yml`.
- Ran the prebuilds for each addon, all completed in the expected time.
