### PR TITLE
fix: use versionless filename for pinned Vulkan SDK download

### DIFF
--- a/.github/actions/setup-vulkan-sdk/action.yml
+++ b/.github/actions/setup-vulkan-sdk/action.yml
@@ -74,7 +74,7 @@ runs:
         if [ "$VULKAN_VERSION" = "latest" ]; then
           VULKAN_URL="https://sdk.lunarg.com/sdk/download/latest/linux/vulkan_sdk.tar.xz"
         else
-          VULKAN_URL="https://sdk.lunarg.com/sdk/download/${VULKAN_VERSION}/linux/vulkansdk-linux-x86_64-${VULKAN_VERSION}.tar.xz"
+          VULKAN_URL="https://sdk.lunarg.com/sdk/download/${VULKAN_VERSION}/linux/vulkan_sdk.tar.xz"
         fi
 
         sudo apt install -y xz-utils

--- a/.github/workflows/prebuilds-lib-infer-diffusion.yml
+++ b/.github/workflows/prebuilds-lib-infer-diffusion.yml
@@ -207,7 +207,7 @@ jobs:
         run: sudo apt-get install libxi-dev libxtst-dev libxrandr-dev
 
       - name: Setup Vulkan SDK
-        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@0bbdca93da303a0b1634ba14a89cec085621078d
+        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@3641e5602eb5fed9635ab3a197aee18b20495f8c
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-embed.yml
@@ -209,7 +209,7 @@ jobs:
         run: sudo apt-get install libxi-dev libxtst-dev libxrandr-dev
 
       - name: Setup Vulkan SDK
-        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@0bbdca93da303a0b1634ba14a89cec085621078d
+        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@3641e5602eb5fed9635ab3a197aee18b20495f8c
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-llamacpp-llm.yml
@@ -215,7 +215,7 @@ jobs:
         run: sudo apt-get install libxi-dev libxtst-dev libxrandr-dev
 
       - name: Setup Vulkan SDK
-        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@0bbdca93da303a0b1634ba14a89cec085621078d
+        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@3641e5602eb5fed9635ab3a197aee18b20495f8c
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-nmtcpp.yml
@@ -235,7 +235,7 @@ jobs:
         run: echo "CMAKE_GENERATOR_PLATFORM=ARM64" >> $env:GITHUB_ENV
 
       - name: Setup Vulkan SDK
-        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@0bbdca93da303a0b1634ba14a89cec085621078d
+        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@3641e5602eb5fed9635ab3a197aee18b20495f8c
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/prebuilds-qvac-lib-infer-whispercpp.yml
@@ -217,7 +217,7 @@ jobs:
           sudo apt-get install -y libopenblas-dev liblapack-dev libfftw3-dev
 
       - name: Setup Vulkan SDK
-        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@0bbdca93da303a0b1634ba14a89cec085621078d
+        uses: tetherto/qvac/.github/actions/setup-vulkan-sdk@3641e5602eb5fed9635ab3a197aee18b20495f8c
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:


### PR DESCRIPTION
## Summary

Prebuild workflows on Linux/Android have started failing with `wget` exit code **8** (HTTP 404) at the `Setup Vulkan SDK` step. LunarG rotated out the versioned filename `vulkansdk-linux-x86_64-${VERSION}.tar.xz` for pinned versions (including the one pinned in `.github/config/vulkan-sdk-version.txt`: `1.4.341.1`). The versionless filename `vulkan_sdk.tar.xz` — the one already used by the `latest` branch of the same action — still returns 200 for every pinned version.

**Commit 1** aligns the pinned URL with the `latest` URL pattern, unblocking new packages that don't yet have a warm SDK cache.

**Commit 2** bumps the five existing prebuild workflows that pin the action by SHA so they pick up the fix. Without this, the repair only takes effect for workflows that repin manually.

**Verified:**

```
$ curl -sIL https://sdk.lunarg.com/sdk/download/1.4.341.1/linux/vulkan_sdk.tar.xz | head -1
HTTP/2 200

$ curl -sIL https://sdk.lunarg.com/sdk/download/1.4.341.1/linux/vulkansdk-linux-x86_64-1.4.341.1.tar.xz | head -1
HTTP/2 404
```

**How it surfaced:** new package `qvac-lib-infer-vla` hits this on its first CI run. Existing packages that had a warm GH runner cache still succeed, but any fresh run (new package, new runner) hits the 404.

## Test plan

- [ ] CI passes on this PR (the action itself is exercised when any prebuild workflow runs against the new commit)
- [ ] Prebuild workflow for `qvac-lib-infer-vla` (Linux/Android) passes the `Setup Vulkan SDK` step once this lands
- [ ] Prebuild workflows for `llamacpp-llm`, `llamacpp-embed`, `whispercpp`, `nmtcpp`, `lib-infer-diffusion` continue to pass (SHA bumped to this PR's fix commit)
