### PR TITLE
feat[notask]: add new-addon scaffold skill

### DIFF
--- a/packages/ocr-onnx/.agent/skills/new-addon/SKILL.md
+++ b/packages/ocr-onnx/.agent/skills/new-addon/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: new-addon
+description: Scaffold an empty "hello world" inference addon (package tree + CI workflows) that inherits from qvac-lib-inference-addon-cpp, optionally wired to an inference backend.
+argument-hint: "<package-name> <backend:onnxruntime|qvac-fabric|ggml|none>"
+---
+
+# New Addon — Hello-World Scaffold
+
+Create a new addon package at `packages/<package-name>/` with the same structure used by the existing addons (tests, CMake, vcpkg, JS entry, CI workflows). The C++ side exposes one function `sayHello(name) -> string` and includes at least one `qvac-lib-inference-addon-cpp` header, so it "inherits" from the base addon. An inference backend (ONNX Runtime, qvac-fabric, raw ggml, or none) is wired in based on the second argument.
+
+Arguments in `$ARGUMENTS`:
+1. **package name** (required) — full directory name, e.g. `qvac-lib-infer-hello`
+2. **backend** (required) — one of `onnxruntime`, `qvac-fabric`, `ggml`, `none`
+
+If either is missing, stop and ask the user.
+
+## Step 1 — Parse args and derive names
+
+Let `PKG = $1`, `BACKEND = $2`.
+
+Validate:
+- `PKG` matches `^[a-z][a-z0-9-]+$`
+- `BACKEND` ∈ `{onnxruntime, qvac-fabric, ggml, none}`
+- `packages/$PKG` does **not** already exist (stop if it does)
+
+Derive (use these rules, announce the derived values to the user before proceeding):
+- `SHORT_NAME` = last hyphen-segment of `PKG` (e.g. `qvac-lib-infer-hello` → `hello`)
+- `NPM_NAME` = `@qvac/$SHORT_NAME`
+- `CPP_NAMESPACE` = `PKG` with `-` → `_` (e.g. `qvac_lib_infer_hello`)
+- `DISPLAY_NAME` = `SHORT_NAME` with first letter uppercased (e.g. `Hello`)
+- `EXPORT_FN_NAME` = camelCase of `PKG` + `Exports` (e.g. `qvacLibInferHelloExports`)
+
+## Step 2 — Resolve backend-specific substitutions
+
+Use this table to fill in `BACKEND_VCPKG_DEPS`, `BACKEND_NPM_DEPS_JSON`, `BACKEND_CMAKE_FIND`, `BACKEND_CMAKE_LINK`, `BACKEND_LABEL`.
+
+### `onnxruntime` — via `@qvac/onnx` npm package (not vcpkg)
+- `BACKEND_VCPKG_DEPS` = empty string
+- `BACKEND_NPM_DEPS_JSON` =
+  ```json
+  {
+    "@qvac/onnx": "^0.14.0"
+  }
+  ```
+- `BACKEND_CMAKE_FIND` =
+  ```
+  set(qvac-onnx_DIR "${CMAKE_CURRENT_SOURCE_DIR}/node_modules/@qvac/onnx/prebuilds/share/qvac-onnx/cmake")
+  find_package(qvac-onnx CONFIG REQUIRED)
+  ```
+- `BACKEND_CMAKE_LINK` =
+  ```
+  target_link_libraries(${{{PACKAGE_NAME}}} PRIVATE qvac-onnx::qvac-onnx-static)
+  ```
+- `BACKEND_LABEL` = `ONNX Runtime (@qvac/onnx)`
+
+### `qvac-fabric` — llama.cpp via qvac-fabric vcpkg port
+- `BACKEND_VCPKG_DEPS` =
+  ```json
+  {"name": "qvac-fabric", "version>=": "7248.2.3"},
+  ```
+- `BACKEND_NPM_DEPS_JSON` = `{}`
+- `BACKEND_CMAKE_FIND` = `find_package(llama CONFIG REQUIRED)`
+- `BACKEND_CMAKE_LINK` =
+  ```
+  target_link_libraries(${{{PACKAGE_NAME}}} PRIVATE llama::llama llama::common)
+  ```
+- `BACKEND_LABEL` = `qvac-fabric (llama.cpp)`
+
+### `ggml` — raw ggml via vcpkg
+- `BACKEND_VCPKG_DEPS` =
+  ```json
+  {"name": "ggml", "version>=": "2026-01-30#5"},
+  ```
+- `BACKEND_NPM_DEPS_JSON` = `{}`
+- `BACKEND_CMAKE_FIND` = `find_package(ggml CONFIG REQUIRED)`
+- `BACKEND_CMAKE_LINK` =
+  ```
+  target_link_libraries(${{{PACKAGE_NAME}}} PRIVATE ggml::ggml)
+  ```
+- `BACKEND_LABEL` = `raw ggml`
+
+### `none`
+- `BACKEND_VCPKG_DEPS` = empty string
+- `BACKEND_NPM_DEPS_JSON` = `{}`
+- `BACKEND_CMAKE_FIND` = empty
+- `BACKEND_CMAKE_LINK` = empty
+- `BACKEND_LABEL` = `none (inference-addon-cpp only)`
+
+## Step 3 — Create the package from templates
+
+Directory to create: `packages/$PKG/`. Copy every file from
+`packages/ocr-onnx/.agent/skills/new-addon/templates/` into `packages/$PKG/`,
+performing **string substitution** on file contents. Placeholders:
+
+| placeholder | value |
+|---|---|
+| `{{PACKAGE_NAME}}` | `$PKG` |
+| `{{SHORT_NAME}}` | `$SHORT_NAME` |
+| `{{NPM_NAME}}` | `$NPM_NAME` |
+| `{{CPP_NAMESPACE}}` | `$CPP_NAMESPACE` |
+| `{{DISPLAY_NAME}}` | `$DISPLAY_NAME` |
+| `{{EXPORT_FN_NAME}}` | `$EXPORT_FN_NAME` |
+| `{{BACKEND_VCPKG_DEPS}}` | from table above |
+| `{{BACKEND_NPM_DEPS_JSON}}` | from table above |
+| `{{BACKEND_CMAKE_FIND}}` | from table above |
+| `{{BACKEND_CMAKE_LINK}}` | from table above |
+| `{{BACKEND_LABEL}}` | from table above |
+
+Also copy `LICENSE` and `NOTICE` from `packages/qvac-lib-infer-llamacpp-embed/` verbatim into the new package (they are static Apache 2.0 files).
+
+File listing produced (all substituted):
+- `package.json`, `CMakeLists.txt`, `vcpkg.json`, `vcpkg-configuration.json`
+- `binding.js`, `index.js`, `addon.js`, `index.d.ts`, `tsconfig.dts.json`
+- `README.md`, `CHANGELOG.md`, `PULL_REQUEST_TEMPLATE.md`, `LICENSE`, `NOTICE`
+- `addon/src/js-interface/binding.cpp`
+- `addon/src/addon/AddonJs.hpp`
+- `addon/src/addon/AddonCpp.hpp`
+- `test/unit/CMakeLists.txt`
+- `test/unit/test_hello.cpp`
+- `test/unit/say-hello.test.js`
+- `test/integration/addon.test.js`
+- `vcpkg/triplets/x64-linux.cmake`, `vcpkg/triplets/arm64-linux.cmake`, `vcpkg/toolchains/linux-clang.cmake` — **required** so gtest/other vcpkg deps build with libc++ and match the addon's `-stdlib=libc++` setting. Without these the C++ unit test target will fail to link.
+
+**JS unit test pattern:** `test/unit/*.test.js` must only import from pure-JS helper modules (e.g. `addon.js`), **never** from `index.js` or `binding.js`. CI's `ts-checks` job runs `npm run test:unit --if-present` without building the native addon, so unit tests that load the `.bare` binding will fail with `ADDON_NOT_FOUND`. Mirror the pattern used by `packages/qvac-lib-infer-llamacpp-embed/addon.js` + `test/unit/map-addon-event.test.js`: the scaffold's `addon.js` exports a pure-JS `normalizeName()` helper, `index.js` composes it with `binding.sayHello()`, and the unit test asserts against `normalizeName` only. Integration tests (`test/integration/*.test.js`) are allowed to load the native addon.
+
+## Step 4 — Generate CI workflows
+
+Use `packages/qvac-lib-infer-llamacpp-embed` as the CI reference. For each of the following workflow files in `.github/workflows/`, copy it, rename, and substitute:
+
+Copy **all of these**:
+- `on-pr-qvac-lib-infer-llamacpp-embed.yml`
+- `on-pr-close-qvac-lib-infer-llamacpp-embed.yml`
+- `on-merge-qvac-lib-infer-llamacpp-embed.yml`
+- `prebuilds-qvac-lib-infer-llamacpp-embed.yml`
+- `integration-test-qvac-lib-infer-llamacpp-embed.yml`
+- `integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml`
+- `cpp-tests-embed.yml`
+
+**Skip (do not copy):**
+- `benchmark-qvac-lib-infer-llamacpp-embed.yml`
+
+For each copied workflow:
+1. Rename the file: replace `qvac-lib-infer-llamacpp-embed` with `$PKG`, and replace `embed` (in filenames like `cpp-tests-embed.yml`) with `$SHORT_NAME`. Target name example: `cpp-tests-$SHORT_NAME.yml`, `on-pr-$PKG.yml`.
+2. In file contents, substitute:
+   - `qvac-lib-infer-llamacpp-embed` → `$PKG` (literal, everywhere)
+   - `*embed*` (inside `paths:` triggers) → `*$PKG*`
+   - Display-name references like `(Embed)` in `name:` fields → `($DISPLAY_NAME)`
+   - Job-name references and uses-of-callable-workflows that reference `cpp-tests-embed.yml` → `cpp-tests-$SHORT_NAME.yml`
+   - Remove any benchmark references: drop job blocks that call `./.github/workflows/benchmark-*.yml` and any `needs:` list entries pointing to those jobs.
+3. Within each copied workflow, strip/remove any step or job that does **model-specific work** not applicable to a hello-world addon (e.g. downloading or verifying model checkpoints). When in doubt, preserve the structure — the build + unit + integration test jobs must remain.
+
+Create an additional small file the on-pr workflow consumes if referenced:
+- If `cpp-tests-$SHORT_NAME.yml` references a `.lsan-suppressions.txt` at the package root and you didn't ship one, drop the reference rather than creating the file.
+
+## Step 5 — Verify the scaffold builds and tests pass
+
+Run these sequentially from `packages/$PKG/`:
+
+1. `npm install`
+2. `bare-make generate`
+3. `bare-make build`
+4. `bare-make install`
+5. `npm run test:unit` — must pass (brittle JS test)
+6. `npm run test:integration` — must pass (loads native `.bare` and asserts `sayHello()` output)
+7. `npm run test:cpp` — must pass (GoogleTest C++ unit)
+
+If any step fails:
+- Print the failing step and the last ~30 lines of its output.
+- Do **not** delete the scaffold; report the failure so the user can inspect.
+- Common causes: vcpkg registry token missing (`GH_TOKEN`), backend-specific dep not resolvable, bare-make version too old. Point the user to `CLAUDE.md` prerequisites.
+
+## Step 6 — Final report
+
+Print a short summary:
+- Path to new package
+- Backend wired in
+- Count of CI workflows generated (expect 7)
+- Test results: unit/integration/cpp — pass/fail
+- Next step hint: replace the hello-world stub in `addon/src/addon/AddonCpp.hpp` with real logic; add model-interface files under `addon/src/model-interface/`.
+
+## Notes
+
+- The scaffold intentionally uses the minimal `qvac-lib-inference-addon-cpp` surface (`JsUtils.hpp` / `JsArgsParser` / `JSCATCH`) — enough to demonstrate inheritance. When the addon grows, wire in `JsInterface`, `ModelInterfaces`, `AddonJs`, and the output-handler machinery the way `qvac-lib-infer-llamacpp-embed/addon/src/addon/AddonJs.hpp` does.
+- Do **not** invent vcpkg versions. Use the versions shown in this skill; if they've drifted, copy the current version from `packages/qvac-lib-infer-llamacpp-embed/vcpkg.json` (for `qvac-fabric`) or `packages/lib-infer-diffusion/vcpkg.json` (for `ggml`).
+- Do **not** commit `.npmrc`, `node_modules/`, `build/`, or `prebuilds/` from the new package.

--- a/packages/ocr-onnx/.agent/skills/new-addon/SKILL.md
+++ b/packages/ocr-onnx/.agent/skills/new-addon/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<package-name> <backend:onnxruntime|qvac-fabric|ggml|none>"
 
 # New Addon — Hello-World Scaffold
 
-Create a new addon package at `packages/<package-name>/` with the same structure used by the existing addons (tests, CMake, vcpkg, JS entry, CI workflows). The C++ side exposes one function `sayHello(name) -> string` and includes at least one `qvac-lib-inference-addon-cpp` header, so it "inherits" from the base addon. An inference backend (ONNX Runtime, qvac-fabric, raw ggml, or none) is wired in based on the second argument.
+Create a new addon package at `packages/<package-name>/` with the same structure used by the existing addons (tests, CMake, vcpkg, JS entry, CI workflows). The C++ side exposes one function `sayHello(name) -> string` and includes at least one `qvac-lib-inference-addon-cpp` header, so it "inherits" from the base addon. The JS side exposes a class with the **canonical addon shape** (constructor takes `{ files, config, logger, opts }`; `load`/`run`/`unload`/`pause`/`cancel`/`getState` lifecycle; `run()` returns a `QvacResponse` driven through `createJobHandler` + `exclusiveRunQueue` from `@qvac/infer-base`; logging via `@qvac/logging`). An inference backend (ONNX Runtime, qvac-fabric, raw ggml, or none) is wired in based on the second argument.
 
 Arguments in `$ARGUMENTS`:
 1. **package name** (required) — full directory name, e.g. `qvac-lib-infer-hello`
@@ -32,15 +32,16 @@ Derive (use these rules, announce the derived values to the user before proceedi
 
 ## Step 2 — Resolve backend-specific substitutions
 
-Use this table to fill in `BACKEND_VCPKG_DEPS`, `BACKEND_NPM_DEPS_JSON`, `BACKEND_CMAKE_FIND`, `BACKEND_CMAKE_LINK`, `BACKEND_LABEL`.
+Use this table to fill in `BACKEND_VCPKG_DEPS`, `BACKEND_NPM_DEPS`, `BACKEND_CMAKE_FIND`, `BACKEND_CMAKE_LINK`, `BACKEND_LABEL`.
+
+`BACKEND_NPM_DEPS` is appended **inside** the canonical `dependencies` block in `package.json` (`@qvac/infer-base`, `@qvac/logging`, `bare-fs`, `bare-path` are always present). When a backend adds packages, the substitution must include a leading `,` and matching indentation.
 
 ### `onnxruntime` — via `@qvac/onnx` npm package (not vcpkg)
 - `BACKEND_VCPKG_DEPS` = empty string
-- `BACKEND_NPM_DEPS_JSON` =
-  ```json
-  {
+- `BACKEND_NPM_DEPS` =
+  ```
+  ,
     "@qvac/onnx": "^0.14.0"
-  }
   ```
 - `BACKEND_CMAKE_FIND` =
   ```
@@ -58,7 +59,7 @@ Use this table to fill in `BACKEND_VCPKG_DEPS`, `BACKEND_NPM_DEPS_JSON`, `BACKEN
   ```json
   {"name": "qvac-fabric", "version>=": "7248.2.3"},
   ```
-- `BACKEND_NPM_DEPS_JSON` = `{}`
+- `BACKEND_NPM_DEPS` = empty string
 - `BACKEND_CMAKE_FIND` = `find_package(llama CONFIG REQUIRED)`
 - `BACKEND_CMAKE_LINK` =
   ```
@@ -71,7 +72,7 @@ Use this table to fill in `BACKEND_VCPKG_DEPS`, `BACKEND_NPM_DEPS_JSON`, `BACKEN
   ```json
   {"name": "ggml", "version>=": "2026-01-30#5"},
   ```
-- `BACKEND_NPM_DEPS_JSON` = `{}`
+- `BACKEND_NPM_DEPS` = empty string
 - `BACKEND_CMAKE_FIND` = `find_package(ggml CONFIG REQUIRED)`
 - `BACKEND_CMAKE_LINK` =
   ```
@@ -81,7 +82,7 @@ Use this table to fill in `BACKEND_VCPKG_DEPS`, `BACKEND_NPM_DEPS_JSON`, `BACKEN
 
 ### `none`
 - `BACKEND_VCPKG_DEPS` = empty string
-- `BACKEND_NPM_DEPS_JSON` = `{}`
+- `BACKEND_NPM_DEPS` = empty string
 - `BACKEND_CMAKE_FIND` = empty
 - `BACKEND_CMAKE_LINK` = empty
 - `BACKEND_LABEL` = `none (inference-addon-cpp only)`
@@ -101,7 +102,7 @@ performing **string substitution** on file contents. Placeholders:
 | `{{DISPLAY_NAME}}` | `$DISPLAY_NAME` |
 | `{{EXPORT_FN_NAME}}` | `$EXPORT_FN_NAME` |
 | `{{BACKEND_VCPKG_DEPS}}` | from table above |
-| `{{BACKEND_NPM_DEPS_JSON}}` | from table above |
+| `{{BACKEND_NPM_DEPS}}` | from table above |
 | `{{BACKEND_CMAKE_FIND}}` | from table above |
 | `{{BACKEND_CMAKE_LINK}}` | from table above |
 | `{{BACKEND_LABEL}}` | from table above |
@@ -126,7 +127,16 @@ File listing produced (all substituted):
 - `scripts/generate-mobile-integration-tests.js`, `scripts/validate-mobile-tests.js` — copied verbatim. Power the `test:mobile:generate` / `test:mobile:validate` npm scripts. Run `npm run test:mobile:generate` whenever you add or rename a `test/integration/*.test.js` file so `integration.auto.cjs` stays in sync.
 - `vcpkg/triplets/x64-linux.cmake`, `vcpkg/triplets/arm64-linux.cmake`, `vcpkg/toolchains/linux-clang.cmake` — **required** so gtest/other vcpkg deps build with libc++ and match the addon's `-stdlib=libc++` setting. Without these the C++ unit test target will fail to link.
 
-**JS unit test pattern:** `test/unit/*.test.js` must only import from pure-JS helper modules (e.g. `addon.js`), **never** from `index.js` or `binding.js`. CI's `ts-checks` job runs `npm run test:unit --if-present` without building the native addon, so unit tests that load the `.bare` binding will fail with `ADDON_NOT_FOUND`. Mirror the pattern used by `packages/qvac-lib-infer-llamacpp-embed/addon.js` + `test/unit/map-addon-event.test.js`: the scaffold's `addon.js` exports a pure-JS `normalizeName()` helper, `index.js` composes it with `binding.sayHello()`, and the unit test asserts against `normalizeName` only. Integration tests (`test/integration/*.test.js`) are allowed to load the native addon.
+**JS unit test pattern:** `test/unit/*.test.js` must only import from pure-JS helper modules (e.g. `addon.js`), **never** from `index.js` or `binding.js`. CI's `ts-checks` job runs `npm run test:unit --if-present` without building the native addon, so unit tests that load the `.bare` binding will fail with `ADDON_NOT_FOUND`. Mirror the pattern used by `packages/qvac-lib-infer-llamacpp-embed/addon.js` + `test/unit/map-addon-event.test.js`: the scaffold's `addon.js` exports a pure-JS `normalizeName()` helper, `index.js` composes it inside the canonical class's `_runInternal()`, and the unit test asserts against `normalizeName` only. Integration tests (`test/integration/*.test.js`) are allowed to load the native addon.
+
+**Canonical JS class shape (template ships with this — do not regress to a synchronous wrapper):**
+
+- `index.js` exports a class named `{{DISPLAY_NAME}}` with constructor `({ files, config = {}, logger = null, opts = {} } = {})`.
+- The constructor validates `files.model` is a non-empty array of absolute path strings (matches `LlmLlamacpp` and every other addon).
+- The class composes `createJobHandler({ cancel: () => /* … */ })` and `exclusiveRunQueue()` from `@qvac/infer-base`, and uses `new QvacLogger(logger)` from `@qvac/logging`. Both are runtime dependencies and are already declared in the template `package.json`.
+- Lifecycle: `async load()`, `async run(input)`, `async unload()`, `async pause()`, `async cancel()`, `getState()`. `run()` resolves to a `QvacResponse` (consumer awaits `response.await()` to receive the final result).
+- Synchronous backends (like the hello-world `binding.sayHello()`) drive the response by calling `this._job.start() → output(result) → end(stats, result)` inline; the wrapper still returns a `QvacResponse` so the public API stays uniform across addons.
+- Replace `_load()` and `_runInternal()` with the real model load + inference. Do **not** change the constructor signature or the lifecycle method names.
 
 ## Step 4 — Generate CI workflows
 
@@ -171,9 +181,10 @@ Run these sequentially from `packages/$PKG/`:
 2. `bare-make generate`
 3. `bare-make build`
 4. `bare-make install`
-5. `npm run test:unit` — must pass (brittle JS test)
-6. `npm run test:integration` — must pass (loads native `.bare` and asserts `sayHello()` output)
+5. `npm run test:unit` — must pass (brittle JS test against the pure-JS helper)
+6. `npm run test:integration` — must pass (instantiates the addon class, awaits `load()` + `run()` + `unload()`, asserts the `sayHello()` output flows through the `QvacResponse`)
 7. `npm run test:cpp` — must pass (GoogleTest C++ unit)
+8. `npm test` — must pass (alias for unit + integration; sanity check that the canonical entry point works)
 
 If any step fails:
 - Print the failing step and the last ~30 lines of its output.
@@ -187,10 +198,9 @@ Print a short summary:
 - Backend wired in
 - Count of CI workflows generated (expect 7)
 - Test results: unit/integration/cpp — pass/fail
-
 Then **offer Step 7** explicitly:
 
-> "The scaffold is in place with a working `sayHello` demo plus a minimal `HelloModel` showing the full AddonJs pattern. Want me to walk through the questions needed to shape `HelloModel` into your real Model (input/output types, interfaces, config, JS wrapper)? Answer 'yes' to start the interview, 'later' to stop here."
+> "The scaffold is in place with a working `sayHello` demo plus a minimal `HelloModel` showing the full AddonJs pattern, and the JS side already exposes the canonical addon class (`load` / `run` / `unload` / `pause` / `cancel` / `getState`). Want me to walk through the questions needed to shape `HelloModel` into your real Model and fill in `_load()` + `_runInternal()` (input/output types, interfaces, config)? Answer 'yes' to start the interview, 'later' to stop here."
 
 Do not start Step 7 unsolicited if the user said "just the scaffold" or similar in the original invocation.
 
@@ -229,8 +239,8 @@ Ask for the shape of the JS-side config object. Default: `{ path, config, backen
 **Q6 — Which output handler?**
 Using Q3's answer, propose one from 7.3 by default (`std::string` → `JsStringOutputHandler`, `std::vector<T>` → `JsTypedArrayOutputHandler<T>`, custom class → subclass `JsBaseOutputHandler`). Ask the user to confirm or override.
 
-**Q7 — JS wrapper class?**
-Three options: (a) none — leave `index.js` exposing the scaffold's `sayHello`, (b) thin — mirror `qvac-lib-infer-llamacpp-embed/index.js`, (c) feature-rich — copy another reference. Default: (b).
+**Q7 — JS wrapper class shape?**
+The scaffold already ships a thin canonical class in `index.js` (constructor `{ files, config, logger, opts }`; `load` / `run` / `unload` / `pause` / `cancel` / `getState`; `createJobHandler` + `exclusiveRunQueue` job composition). Three options: (a) **keep as-is** and just fill in `_load()` + `_runInternal()` — recommended default, (b) **extend** to mirror a feature-rich reference (`qvac-lib-infer-whispercpp/index.js` for streaming, `packages/ocr-onnx/index.js` for validation-heavy), (c) **replace** with a custom class shape (only if the canonical surface genuinely doesn't fit — discourage; consistency across the monorepo matters). Do **not** offer "leave the scaffold's `sayHello`" as an option — synchronous wrappers are not canonical. Default: (a).
 
 **Q8 — C++ test for the new Model?**
 Ask if the user wants a minimal GoogleTest case using `AddonCpp::createInstance()` (see 7.7). Default: yes.
@@ -242,7 +252,7 @@ Once all eight answers are collected, edit the scaffold **incrementally**, one f
 1. Rename `addon/src/model-interface/HelloModel.hpp` → the new class name, update interfaces (Q4), `Input`/`Output` types (Q2/Q3), stub `process()` to match the new signature (don't fake inference — leave a `TODO` body that throws `not implemented`).
 2. Update `AddonJs.hpp` — swap `HelloModel` for the new class, extend `createInstance` arg parsing per Q5, extend `runJob` input branches per Q2, swap the output handler per Q6.
 3. Update `AddonCpp.hpp` — mirror the Model swap + output handler.
-4. Update `index.js` per Q7.
+4. Update `index.js` per Q7 — for option (a) keep the canonical class as-is and only fill in `_load()` + `_runInternal()`; for (b) extend by adding methods (do **not** rewrite the constructor / lifecycle); for (c) replace only if the canonical surface genuinely doesn't fit.
 5. If Q8 is yes, add `test/unit/test_<your-model>.cpp` (GoogleTest, minimal).
 6. Update `package.json` `description` to reflect the real backend.
 7. Leave `sayHello` / `HelloWorld::greet` / `say-hello.test.js` / `addon.test.js` in place. Only remove them when the user says the new Model has replaced them.
@@ -321,15 +331,17 @@ if (type == "text") {
 
 Keep the JS side's `{ type, input }` contract — every real addon uses it.
 
-### 7.6 Add a JS wrapper class
+### 7.6 Adapt the canonical JS wrapper
 
-The scaffold exposes the native bindings directly; real addons wrap them in a class that provides a clean async API. Minimal vs. full examples:
+The scaffold's `index.js` already ships the canonical class shape (constructor `{ files, config, logger, opts }`; `load` / `run` / `unload` / `pause` / `cancel` / `getState`; `createJobHandler` + `exclusiveRunQueue`; `QvacLogger` from `@qvac/logging`). For most addons the right move is to keep the surface and only fill in `_load()` / `_runInternal()` to drive the new Model.
 
-- **Thin** (`qvac-lib-infer-llamacpp-embed/index.js`) — uses `@qvac/infer-base` `createJobHandler` + `exclusiveRunQueue`, maps addon events to `Output` / `JobEnded` / `Error`, streams shards via `loadWeights()`.
-- **Feature-rich** (`qvac-lib-infer-whispercpp/index.js`) — adds streaming audio, VAD, reload.
-- **Validation-heavy** (`packages/ocr-onnx/index.js`) — per-language filtering, file-path normalization, multi-mode selection.
+When the Model needs more, look at these references for shape (do **not** rewrite the constructor / lifecycle):
+- **Streaming output** (`qvac-lib-infer-llamacpp-llm/index.js`) — async addon events arrive via `_handleAddonOutputEvent`, fanned into `_job.output()` / `_job.end()` / `_job.fail()`.
+- **Streamed shard loading** (`qvac-lib-infer-llamacpp-llm/index.js#_streamShards`) — call `addon.loadWeights({ filename, chunk })` per shard before `addon.activate()`.
+- **Streaming audio + VAD** (`qvac-lib-infer-whispercpp/index.js`) — feature-rich extension built on top of the canonical surface.
+- **Validation-heavy input** (`packages/ocr-onnx/index.js`) — per-language filtering, file-path normalization, multi-mode selection.
 
-Copy the thin pattern first; add features only when the Model needs them.
+The synchronous-backend pattern (`binding.sayHello()` driven inline through `_job.start() → output → end`) is what the scaffold ships; switch to the async event-driven pattern only when the C++ side actually emits asynchronously.
 
 ### 7.7 Wire the C++ test harness
 

--- a/packages/ocr-onnx/.agent/skills/new-addon/SKILL.md
+++ b/packages/ocr-onnx/.agent/skills/new-addon/SKILL.md
@@ -106,19 +106,24 @@ performing **string substitution** on file contents. Placeholders:
 | `{{BACKEND_CMAKE_LINK}}` | from table above |
 | `{{BACKEND_LABEL}}` | from table above |
 
-Also copy `LICENSE` and `NOTICE` from `packages/qvac-lib-infer-llamacpp-embed/` verbatim into the new package (they are static Apache 2.0 files).
+Copy `LICENSE` from `packages/qvac-lib-infer-llamacpp-embed/` verbatim into the new package (static Apache 2.0 header).
+
+Do **not** copy `NOTICE` from another package. Instead, after the scaffold is in place, invoke the `notice-generate` skill (see `.cursor/skills/notice-generate/SKILL.md`) for this package so its third-party attributions reflect this addon's actual dependencies (backend choice, vcpkg deps, npm deps). A copied NOTICE would advertise attributions the new addon doesn't use.
 
 File listing produced (all substituted):
 - `package.json`, `CMakeLists.txt`, `vcpkg.json`, `vcpkg-configuration.json`
-- `binding.js`, `index.js`, `addon.js`, `index.d.ts`, `tsconfig.dts.json`
-- `README.md`, `CHANGELOG.md`, `PULL_REQUEST_TEMPLATE.md`, `LICENSE`, `NOTICE`
+- `binding.js`, `index.js`, `addon.js`, `addonLogging.js`, `addonLogging.d.ts`, `index.d.ts`, `tsconfig.dts.json`
+- `README.md`, `CHANGELOG.md`, `PULL_REQUEST_TEMPLATE.md`, `LICENSE` (NOTICE is **not** in templates — generated via the `notice-generate` skill in Step 4.5)
 - `addon/src/js-interface/binding.cpp`
 - `addon/src/addon/AddonJs.hpp`
 - `addon/src/addon/AddonCpp.hpp`
+- `addon/src/model-interface/HelloModel.hpp`
 - `test/unit/CMakeLists.txt`
 - `test/unit/test_hello.cpp`
 - `test/unit/say-hello.test.js`
 - `test/integration/addon.test.js`
+- `test/mobile/integration-runtime.cjs`, `test/mobile/integration.auto.cjs` — **required**. The `integration-mobile-test-$PKG.yml` workflow fails early (step "Verify addon has mobile tests") if `test/mobile/*.cjs` is missing, and the "Validate mobile tests" step runs `npm run test:mobile:validate` which expects `integration.auto.cjs` to cover every file in `test/integration/`. Copy both verbatim — they contain no placeholders.
+- `scripts/generate-mobile-integration-tests.js`, `scripts/validate-mobile-tests.js` — copied verbatim. Power the `test:mobile:generate` / `test:mobile:validate` npm scripts. Run `npm run test:mobile:generate` whenever you add or rename a `test/integration/*.test.js` file so `integration.auto.cjs` stays in sync.
 - `vcpkg/triplets/x64-linux.cmake`, `vcpkg/triplets/arm64-linux.cmake`, `vcpkg/toolchains/linux-clang.cmake` — **required** so gtest/other vcpkg deps build with libc++ and match the addon's `-stdlib=libc++` setting. Without these the C++ unit test target will fail to link.
 
 **JS unit test pattern:** `test/unit/*.test.js` must only import from pure-JS helper modules (e.g. `addon.js`), **never** from `index.js` or `binding.js`. CI's `ts-checks` job runs `npm run test:unit --if-present` without building the native addon, so unit tests that load the `.bare` binding will fail with `ADDON_NOT_FOUND`. Mirror the pattern used by `packages/qvac-lib-infer-llamacpp-embed/addon.js` + `test/unit/map-addon-event.test.js`: the scaffold's `addon.js` exports a pure-JS `normalizeName()` helper, `index.js` composes it with `binding.sayHello()`, and the unit test asserts against `normalizeName` only. Integration tests (`test/integration/*.test.js`) are allowed to load the native addon.
@@ -152,6 +157,12 @@ For each copied workflow:
 Create an additional small file the on-pr workflow consumes if referenced:
 - If `cpp-tests-$SHORT_NAME.yml` references a `.lsan-suppressions.txt` at the package root and you didn't ship one, drop the reference rather than creating the file.
 
+## Step 4.5 — Generate NOTICE via the `notice-generate` skill
+
+Invoke the `notice-generate` skill (`.cursor/skills/notice-generate/SKILL.md`) for the new package. It scans this package's actual dependencies (npm, vcpkg, model files) and writes a correct `NOTICE` at `packages/$PKG/NOTICE`. Do **not** copy a NOTICE from another package — attributions would be wrong for this addon's backend and deps.
+
+If the skill reports missing env (`GH_TOKEN`, `HF_TOKEN`, `NPM_TOKEN`), surface that to the user and stop; do not fabricate a NOTICE file.
+
 ## Step 5 — Verify the scaffold builds and tests pass
 
 Run these sequentially from `packages/$PKG/`:
@@ -176,10 +187,168 @@ Print a short summary:
 - Backend wired in
 - Count of CI workflows generated (expect 7)
 - Test results: unit/integration/cpp — pass/fail
-- Next step hint: replace the hello-world stub in `addon/src/addon/AddonCpp.hpp` with real logic; add model-interface files under `addon/src/model-interface/`.
+
+Then **offer Step 7** explicitly:
+
+> "The scaffold is in place with a working `sayHello` demo plus a minimal `HelloModel` showing the full AddonJs pattern. Want me to walk through the questions needed to shape `HelloModel` into your real Model (input/output types, interfaces, config, JS wrapper)? Answer 'yes' to start the interview, 'later' to stop here."
+
+Do not start Step 7 unsolicited if the user said "just the scaffold" or similar in the original invocation.
+
+## Step 7 — Extending to a real addon (interactive interview)
+
+This step is **agent-driven**: the agent asks the user one question at a time, collects answers, then edits the scaffold files in place to match. The scaffold you produced in Steps 1–6 already builds — if any edit breaks the build, revert that edit and ask the user before proceeding.
+
+The scaffold has **two** layers:
+
+1. `sayHello` — a single synchronous C++ function exported to JS. Exercised by `test/integration/addon.test.js` and the C++ unit test. Keep it until the new Model has its own tests; it's the "proof of life" that the build + bindings are alive.
+2. A full `AddonJs` pattern — `HelloModel` (implements `IModel` + `IModelCancel`) wired through `createInstance` / `runJob` in `addon/src/addon/AddonJs.hpp`, mirrored in `AddonCpp.hpp`, with `JsStringOutputHandler` as the output handler. `binding.cpp` V() already exports every function a real addon needs (`createInstance`, `runJob`, `loadWeights`, `activate`, `cancel`, `destroyInstance`, `setLogger`, `releaseLogger`).
+
+The interview replaces **Layer 2** in place. Layer 1 stays until the user says they're ready to remove it.
+
+### Interview loop
+
+Ask these questions **one at a time**. After each answer, restate the decision in one line so the user can correct it before you edit files. Don't batch — batching hides mistakes.
+
+**Q1 — What model/backend are you wrapping?**
+Goal: free-text description (e.g. "a BERT-style embedder via llama.cpp", "YOLOv8 via ONNX Runtime"). Use it to pick sensible defaults for later questions and to name the new class (e.g. `BertModel`, `YoloModel`). Don't write code yet.
+
+**Q2 — What does `process()` take as input?**
+Offer the options from the table in 7.2 (text / text+array / audio samples / image / custom struct) and ask the user to pick or describe. Capture the C++ type for `using Input`.
+
+**Q3 — What does `process()` produce?**
+Same treatment — pick from the shapes in 7.2 or describe a custom output type. Capture the C++ type for `using Output` / `using OutputType`. If it's a custom class, ask where the data lives (a `std::vector<float>` + shape? a struct of strings + timings?) so you can draft the class definition.
+
+**Q4 — Which optional Model interfaces?**
+For each, ask yes/no with the concrete implication:
+- `IModelCancel` — "Will a single `process()` call ever need to be cancelled mid-run? (yes for LLMs, audio streaming; no for one-shot embedders.)"
+- `IModelAsyncLoad` — "Will weights come from JS as streamed blobs / shards, or loaded by the backend from a file path you pass in? Pick 'streamed' only if your runtime needs the shard-blob handoff."
+
+**Q5 — What config does `createInstance` need to parse?**
+Ask for the shape of the JS-side config object. Default: `{ path, config, backendsDir }` (what embed uses). User may add `{ sessionOptions, languages, … }`. Capture each field and its type (string / number / submap).
+
+**Q6 — Which output handler?**
+Using Q3's answer, propose one from 7.3 by default (`std::string` → `JsStringOutputHandler`, `std::vector<T>` → `JsTypedArrayOutputHandler<T>`, custom class → subclass `JsBaseOutputHandler`). Ask the user to confirm or override.
+
+**Q7 — JS wrapper class?**
+Three options: (a) none — leave `index.js` exposing the scaffold's `sayHello`, (b) thin — mirror `qvac-lib-infer-llamacpp-embed/index.js`, (c) feature-rich — copy another reference. Default: (b).
+
+**Q8 — C++ test for the new Model?**
+Ask if the user wants a minimal GoogleTest case using `AddonCpp::createInstance()` (see 7.7). Default: yes.
+
+### Apply decisions
+
+Once all eight answers are collected, edit the scaffold **incrementally**, one file at a time, in this order. After each file, report the diff summary; after all edits, rerun `npm run test:unit && npm run test:integration && npm run test:cpp` and report results.
+
+1. Rename `addon/src/model-interface/HelloModel.hpp` → the new class name, update interfaces (Q4), `Input`/`Output` types (Q2/Q3), stub `process()` to match the new signature (don't fake inference — leave a `TODO` body that throws `not implemented`).
+2. Update `AddonJs.hpp` — swap `HelloModel` for the new class, extend `createInstance` arg parsing per Q5, extend `runJob` input branches per Q2, swap the output handler per Q6.
+3. Update `AddonCpp.hpp` — mirror the Model swap + output handler.
+4. Update `index.js` per Q7.
+5. If Q8 is yes, add `test/unit/test_<your-model>.cpp` (GoogleTest, minimal).
+6. Update `package.json` `description` to reflect the real backend.
+7. Leave `sayHello` / `HelloWorld::greet` / `say-hello.test.js` / `addon.test.js` in place. Only remove them when the user says the new Model has replaced them.
+
+### Recipes (reference material for the interview)
+
+The subsections below are what the interview *consults* when translating answers into code. They are not meant to be read top-to-bottom by the user.
+
+### 7.1 Pick the right Model interfaces
+
+`HelloModel` extends `IModel` + `IModelCancel`. Add more as the model grows:
+
+- **`IModel`** (required) — `getName()`, `process(std::any) -> std::any`, `runtimeStats()`.
+- **`IModelCancel`** — add if a long-running `process()` must be interruptible. `cancel()` runs on a different thread; the Model is responsible for setting a flag / atomic that `process()` polls.
+- **`IModelAsyncLoad`** — add when weights come from the JS side as streamed blobs (shards). Requires implementing `waitForLoadInitialization()` and `setWeightsForFile(filename, streambuf)`. Reference: `qvac-lib-infer-llamacpp-embed/addon/src/model-interface/BertModel.hpp`.
+
+When you add `IModelAsyncLoad`, the JS side must call `addon.loadWeights(...)` (already bound) for each shard before `addon.activate()`.
+
+### 7.2 Choose Input / Output types
+
+Declare on the Model:
+
+```cpp
+using Input  = /* std::string, std::vector<float>, a custom struct */;
+using Output = /* std::string, std::vector<T>, a custom class */;
+using OutputType = Output;
+```
+
+Reference shapes:
+- **Text in, text out** (LLM, NMT): `Input = std::string`, `Output = std::string`.
+- **Text in, embedding out** (Embed): `Input = std::variant<std::string, std::vector<std::string>>`, `Output = BertEmbeddings` (custom 2D class).
+- **Audio in, transcript out** (Whisper, Parakeet): `Input = std::vector<float>`, `Output = Transcript` (custom struct).
+- **Image in, detections out** (OCR): custom `Input` struct, `Output = std::vector<InferredText>`.
+
+### 7.3 Pick the right output handler(s)
+
+`OutputHandlers` is a *list* — a Model can emit multiple event types through one queue. The scaffold uses a single `JsStringOutputHandler`. Swap or add:
+
+- `JsStringOutputHandler` — one-shot string.
+- `JsStringArrayOutputHandler` — `vector<string>`.
+- `JsTypedArrayOutputHandler<T>` — `vector<T>` as a JS TypedArray.
+- `Js2DArrayOutputHandler<ContainerT, ElementT>` — for structured outputs like `BertEmbeddings`.
+- **Custom handler** — subclass `JsBaseOutputHandler<ModelOutT>` when none of the above match (see `BertEmbeddings` → `Js2DArrayOutputHandler<BertEmbeddings, float>`).
+
+Mirror the same choice in `AddonCpp.hpp` using `CppQueuedOutputHandler<OutputType>` so C++ tests stay in sync.
+
+### 7.4 Grow `createInstance` argument parsing
+
+The scaffold's `createInstance` parses only `jsHandle` and `outputCallback`. Real addons also parse a config object at arg index 1. Pattern:
+
+```cpp
+auto model = std::make_unique<YourModel>(
+    args.getMapEntry(1, "path"),
+    args.getSubmap(1, "config"),
+    args.getMapEntry(1, "backendsDir"));
+```
+
+Add validation close to `JsArgsParser` — throw `StatusError(general_error::InvalidArgument, "...")` for missing/wrong-shape fields; the `JSCATCH` macro converts it into a JS exception.
+
+### 7.5 Grow `runJob` input parsing
+
+The scaffold only handles `type === "text"`. Add branches for other types:
+
+```cpp
+auto [type, jsInput] = JsInterface::getInput(args);
+if (type == "text") {
+  input = js::String(env, jsInput).as<std::string>(env);
+} else if (type == "sequences") {
+  input = parseSequences(js::Object(env, jsInput));   // you define it
+} else if (type == "audio") {
+  input = parseFloatTypedArray(env, jsInput);          // you define it
+} else {
+  throw StatusError(general_error::InvalidArgument, "Unknown input type: " + type);
+}
+```
+
+Keep the JS side's `{ type, input }` contract — every real addon uses it.
+
+### 7.6 Add a JS wrapper class
+
+The scaffold exposes the native bindings directly; real addons wrap them in a class that provides a clean async API. Minimal vs. full examples:
+
+- **Thin** (`qvac-lib-infer-llamacpp-embed/index.js`) — uses `@qvac/infer-base` `createJobHandler` + `exclusiveRunQueue`, maps addon events to `Output` / `JobEnded` / `Error`, streams shards via `loadWeights()`.
+- **Feature-rich** (`qvac-lib-infer-whispercpp/index.js`) — adds streaming audio, VAD, reload.
+- **Validation-heavy** (`packages/ocr-onnx/index.js`) — per-language filtering, file-path normalization, multi-mode selection.
+
+Copy the thin pattern first; add features only when the Model needs them.
+
+### 7.7 Wire the C++ test harness
+
+The scaffold's `AddonCpp::createInstance()` returns an `AddonInstance` with a `CppQueuedOutputHandler<std::string>`. Use it from GoogleTest:
+
+```cpp
+auto instance = {{CPP_NAMESPACE}}::createInstance();
+instance.addon->runJob(std::any(std::string("world")));
+auto out = instance.outputHandler->wait();  // pull from queue
+EXPECT_EQ(std::any_cast<std::string>(out), "hello, world");
+```
+
+This lets C++ tests exercise the full Model pipeline without spinning up a JS env.
+
+### 7.8 Don't copy-paste a real Model file
+
+Do not fork `BertModel.hpp` (or any other real Model) and rename it. Those files carry backend-specific assumptions — BERT pooling, llama.cpp lifecycle, cached tokenizer state — that usually don't apply to a new addon. Instead, read the `IModel` interface, sketch your own `Input` / `Output` / `process()`, and use `BertModel.hpp` only as a reference for shape.
 
 ## Notes
 
-- The scaffold intentionally uses the minimal `qvac-lib-inference-addon-cpp` surface (`JsUtils.hpp` / `JsArgsParser` / `JSCATCH`) — enough to demonstrate inheritance. When the addon grows, wire in `JsInterface`, `ModelInterfaces`, `AddonJs`, and the output-handler machinery the way `qvac-lib-infer-llamacpp-embed/addon/src/addon/AddonJs.hpp` does.
 - Do **not** invent vcpkg versions. Use the versions shown in this skill; if they've drifted, copy the current version from `packages/qvac-lib-infer-llamacpp-embed/vcpkg.json` (for `qvac-fabric`) or `packages/lib-infer-diffusion/vcpkg.json` (for `ggml`).
 - Do **not** commit `.npmrc`, `node_modules/`, `build/`, or `prebuilds/` from the new package.

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/CHANGELOG.md
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial hello-world scaffold for `{{PACKAGE_NAME}}`.

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/CMakeLists.txt
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/CMakeLists.txt
@@ -1,8 +1,15 @@
 cmake_minimum_required(VERSION 3.25)
 
+option(ANDROID_STL "Android STL linkage" c++_shared)
 option(BUILD_TESTING "Build tests" OFF)
+option(ENABLE_COVERAGE "Enable coverage instrumentation for unit tests" OFF)
 if(BUILD_TESTING)
   list(APPEND VCPKG_MANIFEST_FEATURES "tests")
+endif()
+
+option(VK_PROFILING "Force vk performance logging in qvac-fabric" OFF)
+if(VK_PROFILING)
+  list(APPEND VCPKG_MANIFEST_FEATURES "vk-profiling")
 endif()
 
 find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/CMakeLists.txt
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.25)
+
+option(BUILD_TESTING "Build tests" OFF)
+if(BUILD_TESTING)
+  list(APPEND VCPKG_MANIFEST_FEATURES "tests")
+endif()
+
+find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
+find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
+
+set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/triplets;${VCPKG_OVERLAY_TRIPLETS}")
+
+project({{PACKAGE_NAME}} C CXX)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_compile_options(-stdlib=libc++)
+  add_link_options(-stdlib=libc++ -static-libstdc++)
+endif()
+
+find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)
+configure_file(${VCPKG_INSTALLED_PATH}/share/qvac-lint-cpp/.clang-format
+               ${CMAKE_CURRENT_SOURCE_DIR}/.clang-format COPYONLY)
+configure_file(${VCPKG_INSTALLED_PATH}/share/qvac-lint-cpp/.clang-tidy
+               ${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy COPYONLY)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS "qvac-lib-inference-addon-cpp/JsInterface.hpp" REQUIRED)
+
+{{BACKEND_CMAKE_FIND}}
+
+if(WIN32)
+  add_definitions(-DNOMINMAX -DWIN32_LEAN_AND_MEAN -DNOGDI)
+endif()
+
+add_bare_module({{PACKAGE_NAME}})
+
+target_sources(
+  ${{{PACKAGE_NAME}}}
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp
+)
+target_include_directories(
+  ${{{PACKAGE_NAME}}}
+  PRIVATE
+    ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS}
+    ${PROJECT_SOURCE_DIR}/addon/src
+)
+{{BACKEND_CMAKE_LINK}}
+
+if(BUILD_TESTING)
+  find_package(GTest CONFIG REQUIRED)
+  include(GoogleTest)
+  enable_testing()
+
+  add_subdirectory(test/unit)
+endif()
+
+if(WIN32)
+  target_link_libraries(
+    ${{{PACKAGE_NAME}}}
+    PRIVATE
+      msvcrt.lib
+  )
+endif()

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/PULL_REQUEST_TEMPLATE.md
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+
+## Test plan
+
+- [ ] `npm run test:unit`
+- [ ] `npm run test:integration`
+- [ ] `npm run test:cpp`

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/README.md
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/README.md
@@ -1,0 +1,28 @@
+# {{PACKAGE_NAME}}
+
+Hello-world inference addon scaffold built on `qvac-lib-inference-addon-cpp`.
+Inference backend: **{{BACKEND_LABEL}}**.
+
+## Build
+
+```
+npm install
+bare-make generate
+bare-make build
+bare-make install
+```
+
+## Test
+
+```
+npm run test:unit          # JS unit tests (brittle)
+npm run test:integration   # loads the native addon and calls sayHello()
+npm run test:cpp           # GoogleTest C++ unit tests
+```
+
+## Usage
+
+```js
+const { sayHello } = require('{{NPM_NAME}}')
+console.log(sayHello('qvac')) // => "hello, qvac"
+```

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addon.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addon.js
@@ -1,0 +1,17 @@
+'use strict'
+
+/**
+ * Coerce a greeting subject into a non-empty string. Falls back to `'world'`
+ * when the input is `null`/`undefined`/empty. Kept as a pure-JS helper so it
+ * can be unit-tested without loading the native addon.
+ *
+ * @param {*} name
+ * @returns {string}
+ */
+function normalizeName (name) {
+  if (name === null || name === undefined) return 'world'
+  const s = String(name)
+  return s.length === 0 ? 'world' : s
+}
+
+module.exports = { normalizeName }

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/addon/AddonCpp.hpp
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/addon/AddonCpp.hpp
@@ -1,13 +1,53 @@
 #pragma once
+
+#include <memory>
 #include <string>
+
+#include <qvac-lib-inference-addon-cpp/ModelInterfaces.hpp>
+#include <qvac-lib-inference-addon-cpp/addon/AddonCpp.hpp>
+#include <qvac-lib-inference-addon-cpp/handlers/OutputHandler.hpp>
+#include <qvac-lib-inference-addon-cpp/queue/OutputCallbackCpp.hpp>
+#include <qvac-lib-inference-addon-cpp/queue/OutputCallbackInterface.hpp>
+
+#include "../model-interface/HelloModel.hpp"
 
 namespace {{CPP_NAMESPACE}} {
 
+// Pure-synchronous greeter used by the hello-world demo (exercised by
+// test/unit/test_hello.cpp). Not part of the IModel pattern.
 class HelloWorld {
  public:
   static std::string greet(const std::string& name) {
     return "hello, " + name;
   }
 };
+
+// Parallel to AddonJs::createInstance but without any JS dependencies. Use
+// this from CLI tools or pure C++ tests that want to exercise the full Model
+// pipeline without a JS env. Replace HelloModel with your Model when extending.
+struct AddonInstance {
+  std::unique_ptr<qvac_lib_inference_addon_cpp::AddonCpp> addon;
+  std::shared_ptr<qvac_lib_inference_addon_cpp::out_handl::
+                      CppQueuedOutputHandler<std::string>>
+      outputHandler;
+};
+
+inline AddonInstance createInstance() {
+  using namespace qvac_lib_inference_addon_cpp;
+
+  auto model = std::make_unique<HelloModel>();
+
+  auto outHandler =
+      std::make_shared<out_handl::CppQueuedOutputHandler<std::string>>();
+  out_handl::OutputHandlers<out_handl::OutputHandlerInterface<void>>
+      outHandlers;
+  outHandlers.add(outHandler);
+  std::unique_ptr<OutputCallBackInterface> callback =
+      std::make_unique<OutputCallBackCpp>(std::move(outHandlers));
+
+  auto addon = std::make_unique<AddonCpp>(std::move(callback), std::move(model));
+
+  return {.addon = std::move(addon), .outputHandler = std::move(outHandler)};
+}
 
 } // namespace {{CPP_NAMESPACE}}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/addon/AddonCpp.hpp
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/addon/AddonCpp.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <string>
+
+namespace {{CPP_NAMESPACE}} {
+
+class HelloWorld {
+ public:
+  static std::string greet(const std::string& name) {
+    return "hello, " + name;
+  }
+};
+
+} // namespace {{CPP_NAMESPACE}}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/addon/AddonJs.hpp
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/addon/AddonJs.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <string>
+
+#include <qvac-lib-inference-addon-cpp/JsInterface.hpp>
+#include <qvac-lib-inference-addon-cpp/JsUtils.hpp>
+
+#include "AddonCpp.hpp"
+
+namespace {{CPP_NAMESPACE}} {
+
+inline js_value_t* sayHello(js_env_t* env, js_callback_info_t* info) try {
+  using namespace qvac_lib_inference_addon_cpp;
+
+  JsArgsParser args(env, info);
+  std::string name = js::String(env, args.get(0, "name")).as<std::string>(env);
+
+  std::string greeting = HelloWorld::greet(name);
+
+  js_value_t* result = nullptr;
+  js_create_string_utf8(
+      env,
+      reinterpret_cast<const utf8_t*>(greeting.data()),
+      greeting.size(),
+      &result);
+  return result;
+}
+JSCATCH
+
+} // namespace {{CPP_NAMESPACE}}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/addon/AddonJs.hpp
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/addon/AddonJs.hpp
@@ -1,13 +1,24 @@
 #pragma once
+
+#include <any>
+#include <memory>
 #include <string>
 
 #include <qvac-lib-inference-addon-cpp/JsInterface.hpp>
 #include <qvac-lib-inference-addon-cpp/JsUtils.hpp>
+#include <qvac-lib-inference-addon-cpp/ModelInterfaces.hpp>
+#include <qvac-lib-inference-addon-cpp/addon/AddonJs.hpp>
+#include <qvac-lib-inference-addon-cpp/handlers/JsOutputHandlerImplementations.hpp>
+#include <qvac-lib-inference-addon-cpp/handlers/OutputHandler.hpp>
+#include <qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp>
 
 #include "AddonCpp.hpp"
+#include "../model-interface/HelloModel.hpp"
 
 namespace {{CPP_NAMESPACE}} {
 
+// Simple synchronous demo kept from the hello-world scaffold. Useful as a
+// "proof of life" and exercised by test/integration/addon.test.js.
 inline js_value_t* sayHello(js_env_t* env, js_callback_info_t* info) try {
   using namespace qvac_lib_inference_addon_cpp;
 
@@ -23,6 +34,54 @@ inline js_value_t* sayHello(js_env_t* env, js_callback_info_t* info) try {
       greeting.size(),
       &result);
   return result;
+}
+JSCATCH
+
+// Full AddonJs pattern shared by every real addon (embed/llm/nmt/whisper/…):
+// parse args → build Model → register output handler(s) → wrap in
+// OutputCallBackJs → construct AddonJs → register via JsInterface.
+// Extend by swapping HelloModel for your backend-backed Model and choosing the
+// output handler that matches its OutputType.
+inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
+  using namespace qvac_lib_inference_addon_cpp;
+
+  JsArgsParser args(env, info);
+
+  auto model = std::make_unique<HelloModel>();
+
+  out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface> outHandlers;
+  outHandlers.add(std::make_shared<out_handl::JsStringOutputHandler>());
+
+  std::unique_ptr<OutputCallBackInterface> callback =
+      std::make_unique<OutputCallBackJs>(
+          env,
+          args.get(0, "jsHandle"),
+          args.getFunction(2, "outputCallback"),
+          std::move(outHandlers));
+
+  auto addon =
+      std::make_unique<AddonJs>(env, std::move(callback), std::move(model));
+
+  return JsInterface::createInstance(env, std::move(addon));
+}
+JSCATCH
+
+inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
+  using namespace qvac_lib_inference_addon_cpp;
+
+  JsArgsParser args(env, info);
+  std::any input;
+  {
+    auto [type, jsInput] = JsInterface::getInput(args);
+    if (type == "text") {
+      input = js::String(env, jsInput).as<std::string>(env);
+    } else {
+      throw StatusError(
+          general_error::InvalidArgument, "Unknown input type: " + type);
+    }
+  }
+  return JsInterface::getInstance(env, args.get(0, "instance"))
+      .runJob(std::move(input));
 }
 JSCATCH
 

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/js-interface/binding.cpp
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/js-interface/binding.cpp
@@ -18,6 +18,17 @@ js_value_t*
   }
 
   V("sayHello", {{CPP_NAMESPACE}}::sayHello)
+
+  V("createInstance", {{CPP_NAMESPACE}}::createInstance)
+  V("runJob", {{CPP_NAMESPACE}}::runJob)
+
+  V("loadWeights", qvac_lib_inference_addon_cpp::JsInterface::loadWeights)
+  V("activate", qvac_lib_inference_addon_cpp::JsInterface::activate)
+  V("cancel", qvac_lib_inference_addon_cpp::JsInterface::cancel)
+  V("destroyInstance",
+    qvac_lib_inference_addon_cpp::JsInterface::destroyInstance)
+  V("setLogger", qvac_lib_inference_addon_cpp::JsInterface::setLogger)
+  V("releaseLogger", qvac_lib_inference_addon_cpp::JsInterface::releaseLogger)
 #undef V
 // NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/js-interface/binding.cpp
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/js-interface/binding.cpp
@@ -1,0 +1,27 @@
+#include <bare.h>
+
+#include "../addon/AddonJs.hpp"
+
+js_value_t*
+{{EXPORT_FN_NAME}}(js_env_t* env, js_value_t* exports) {
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+#define V(name, fn)                                                            \
+  {                                                                            \
+    js_value_t* val;                                                           \
+    if (js_create_function(env, name, -1, fn, nullptr, &val) != 0) {           \
+      return nullptr;                                                          \
+    }                                                                          \
+    if (js_set_named_property(env, exports, name, val) != 0) {                 \
+      return nullptr;                                                          \
+    }                                                                          \
+  }
+
+  V("sayHello", {{CPP_NAMESPACE}}::sayHello)
+#undef V
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+  return exports;
+}
+
+BARE_MODULE("{{PACKAGE_NAME}}", {{EXPORT_FN_NAME}})

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/model-interface/HelloModel.hpp
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addon/src/model-interface/HelloModel.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <any>
+#include <string>
+
+#include <qvac-lib-inference-addon-cpp/ModelInterfaces.hpp>
+#include <qvac-lib-inference-addon-cpp/RuntimeStats.hpp>
+
+namespace {{CPP_NAMESPACE}} {
+
+// Minimal IModel implementation paired with createInstance/runJob in
+// AddonJs.hpp. Real addons replace this with a backend-backed model (see
+// qvac-lib-infer-llamacpp-embed/addon/src/model-interface/BertModel.hpp for a
+// full example) and mix in IModelAsyncLoad when weight streaming is needed.
+class HelloModel : public qvac_lib_inference_addon_cpp::model::IModel,
+                   public qvac_lib_inference_addon_cpp::model::IModelCancel {
+ public:
+  using Input = std::string;
+  using Output = std::string;
+  using OutputType = Output;
+
+  [[nodiscard]] std::string getName() const final { return "HelloModel"; }
+
+  std::any process(const std::any& input) final {
+    const auto& text = std::any_cast<const std::string&>(input);
+    return std::any(std::string("hello, ") + text);
+  }
+
+  [[nodiscard]] qvac_lib_inference_addon_cpp::RuntimeStats
+  runtimeStats() const final {
+    return {};
+  }
+
+  void cancel() const final {}
+};
+
+} // namespace {{CPP_NAMESPACE}}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addonLogging.d.ts
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addonLogging.d.ts
@@ -1,0 +1,7 @@
+export interface AddonLogging {
+  setLogger(callback: (priority: number, message: string) => void): void
+  releaseLogger(): void
+}
+
+declare const addonLogging: AddonLogging
+export default addonLogging

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/addonLogging.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/addonLogging.js
@@ -1,0 +1,6 @@
+const binding = require('./binding')
+
+module.exports = {
+  setLogger: binding.setLogger,
+  releaseLogger: binding.releaseLogger
+}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/binding.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/binding.js
@@ -1,0 +1,1 @@
+module.exports = require.addon()

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/index.d.ts
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/index.d.ts
@@ -1,1 +1,35 @@
-export function sayHello(name?: string): string
+export interface {{DISPLAY_NAME}}Options {
+  files: { model: string[] }
+  config?: Record<string, unknown>
+  logger?: unknown
+  opts?: { stats?: boolean }
+}
+
+export interface {{DISPLAY_NAME}}RunInput {
+  name?: string | null
+}
+
+export interface {{DISPLAY_NAME}}RunResult {
+  text: string
+}
+
+export interface QvacResponse {
+  await(): Promise<{{DISPLAY_NAME}}RunResult>
+  cancel(): Promise<void>
+  on(event: string, listener: (...args: unknown[]) => void): this
+}
+
+export class {{DISPLAY_NAME}} {
+  constructor (options: {{DISPLAY_NAME}}Options)
+  load (): Promise<void>
+  run (input?: {{DISPLAY_NAME}}RunInput): Promise<QvacResponse>
+  pause (): Promise<void>
+  cancel (): Promise<void>
+  unload (): Promise<void>
+  getState (): { configLoaded: boolean }
+}
+
+export function normalizeName (name: unknown): string
+
+declare const _default: typeof {{DISPLAY_NAME}}
+export default _default

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/index.d.ts
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/index.d.ts
@@ -1,0 +1,1 @@
+export function sayHello(name?: string): string

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/index.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/index.js
@@ -1,10 +1,121 @@
 'use strict'
 
+const QvacLogger = require('@qvac/logging')
+const { createJobHandler, exclusiveRunQueue } = require('@qvac/infer-base')
+const path = require('bare-path')
 const binding = require('./binding')
 const { normalizeName } = require('./addon.js')
 
-function sayHello (name) {
-  return binding.sayHello(normalizeName(name))
+const RUN_BUSY_ERROR_MESSAGE = 'Cannot set new job: a job is already set or being processed'
+
+/**
+ * Hello-world inference addon, scaffolded with the canonical addon shape.
+ *
+ *   const addon = new {{DISPLAY_NAME}}({ files: { model: ['/abs/path/to/model'] } })
+ *   await addon.load()
+ *   const response = await addon.run({ name: 'world' })
+ *   const { text } = await response.await()
+ *   await addon.unload()
+ *
+ * Replace `_load()` and `_runInternal()` with real model loading + inference.
+ * The shape (constructor signature, lifecycle methods, job composition) is
+ * shared by every addon in the monorepo — keep it consistent.
+ */
+class {{DISPLAY_NAME}} {
+  constructor ({ files, config = {}, logger = null, opts = {} } = {}) {
+    if (!files || !Array.isArray(files.model) || files.model.length === 0) {
+      throw new TypeError('files.model must be a non-empty array of absolute paths')
+    }
+    for (const [i, entry] of files.model.entries()) {
+      if (typeof entry !== 'string' || entry.length === 0) {
+        throw new TypeError(`files.model[${i}] must be an absolute path string`)
+      }
+      if (!path.isAbsolute(entry)) {
+        throw new TypeError(`files.model[${i}] must be an absolute path (got: ${entry})`)
+      }
+    }
+    this._files = files.model
+    this._config = config
+    this.logger = new QvacLogger(logger)
+    this.opts = opts
+    this._job = createJobHandler({ cancel: () => {} })
+    this._run = exclusiveRunQueue()
+    this._hasActiveResponse = false
+    this.state = { configLoaded: false }
+  }
+
+  async load () {
+    return this._run(async () => {
+      if (this.state.configLoaded) return
+      await this._load()
+      this.state.configLoaded = true
+    })
+  }
+
+  async _load () {
+    // Hello-world stub: no real model is opened. Replace with the actual model
+    // load when wiring a real backend (see qvac-lib-infer-llamacpp-llm for a
+    // reference implementation).
+    this.logger.info('Hello-world addon loaded (stub).')
+  }
+
+  async run (input) {
+    return this._run(() => this._runInternal(input))
+  }
+
+  async _runInternal (input) {
+    if (!this.state.configLoaded) {
+      throw new Error('Addon not initialized. Call load() first.')
+    }
+    if (this._hasActiveResponse) {
+      throw new Error(RUN_BUSY_ERROR_MESSAGE)
+    }
+
+    const name = normalizeName(input?.name)
+
+    this.logger.info('Starting hello-world inference')
+
+    const response = this._job.start()
+    this._hasActiveResponse = true
+
+    let text
+    try {
+      text = binding.sayHello(name)
+    } catch (err) {
+      this._job.fail(err)
+      throw err
+    }
+
+    const result = { text }
+    this._job.output(result)
+    this._job.end(this.opts.stats ? { runs: 1 } : null, result)
+
+    const finalized = response.await().finally(() => { this._hasActiveResponse = false })
+    finalized.catch((err) => {
+      this.logger?.warn?.('Inference response rejected:', err?.message || err)
+    })
+    response.await = () => finalized
+
+    return response
+  }
+
+  async pause () { /* no-op: synchronous backend has no in-flight cancel point */ }
+
+  async cancel () { /* no-op: see pause() */ }
+
+  async unload () {
+    return this._run(async () => {
+      if (this._job.active) {
+        this._job.fail(new Error('Model was unloaded'))
+      }
+      this._hasActiveResponse = false
+      this.state.configLoaded = false
+    })
+  }
+
+  getState () { return this.state }
 }
 
-module.exports = { sayHello, normalizeName }
+module.exports = {{DISPLAY_NAME}}
+module.exports.{{DISPLAY_NAME}} = {{DISPLAY_NAME}}
+module.exports.normalizeName = normalizeName

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/index.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/index.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const binding = require('./binding')
+const { normalizeName } = require('./addon.js')
+
+function sayHello (name) {
+  return binding.sayHello(normalizeName(name))
+}
+
+module.exports = { sayHello, normalizeName }

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/package.json
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/package.json
@@ -12,6 +12,8 @@
     "lint:fix": "standard --fix",
     "lint-cpp": "clang-tidy -p build $(find addon -name '*.cpp')",
     "test:integration": "bare test/integration/addon.test.js",
+    "test:mobile:generate": "bare ./scripts/generate-mobile-integration-tests.js",
+    "test:mobile:validate": "node scripts/validate-mobile-tests.js",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js",
     "test:unit": "npm run test:unit:generate && bare test/unit/all.js --exit",
     "test:cpp:build": "bare-make generate -D BUILD_TESTING=ON && bare-make build --target addon-test",
@@ -22,6 +24,8 @@
   },
   "files": [
     "addon.js",
+    "addonLogging.js",
+    "addonLogging.d.ts",
     "binding.js",
     "index.js",
     "index.d.ts",
@@ -52,7 +56,12 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
-    }
+    },
+    "./addonLogging": {
+      "types": "./addonLogging.d.ts",
+      "default": "./addonLogging.js"
+    },
+    "./addonLogging.js": "./addonLogging.js"
   },
   "main": "index.js",
   "types": "index.d.ts"

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/package.json
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "{{NPM_NAME}}",
+  "version": "0.1.0",
+  "description": "Hello-world inference addon scaffold ({{PACKAGE_NAME}})",
+  "addon": true,
+  "engines": {
+    "bare": ">=1.24.0"
+  },
+  "scripts": {
+    "build": "bare-make generate && bare-make build && bare-make install",
+    "lint": "standard",
+    "lint:fix": "standard --fix",
+    "lint-cpp": "clang-tidy -p build $(find addon -name '*.cpp')",
+    "test:integration": "bare test/integration/addon.test.js",
+    "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js",
+    "test:unit": "npm run test:unit:generate && bare test/unit/all.js --exit",
+    "test:cpp:build": "bare-make generate -D BUILD_TESTING=ON && bare-make build --target addon-test",
+    "test:cpp:run": "cd build/test/unit/ && ./addon-test --gtest_output=xml:cpp-test-results.xml",
+    "test:cpp": "npm run test:cpp:build && npm run test:cpp:run",
+    "test:all": "npm run test:unit && npm run test:integration && npm run test:cpp",
+    "test:dts": "tsc -p tsconfig.dts.json"
+  },
+  "files": [
+    "addon.js",
+    "binding.js",
+    "index.js",
+    "index.d.ts",
+    "prebuilds",
+    "LICENSE",
+    "NOTICE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tetherto/qvac.git",
+    "directory": "packages/{{PACKAGE_NAME}}"
+  },
+  "author": "Tether",
+  "license": "Apache-2.0",
+  "bugs": "https://github.com/tetherto/qvac/issues",
+  "homepage": "https://github.com/tetherto/qvac/tree/main/packages/{{PACKAGE_NAME}}#readme",
+  "devDependencies": {
+    "@types/node": "^24.2.1",
+    "brittle": "^3.4.0",
+    "cmake-bare": "^1.7.1",
+    "cmake-vcpkg": "^1.1.0",
+    "standard": "^17.0.0",
+    "typescript": "^5.9.2"
+  },
+  "dependencies": {{BACKEND_NPM_DEPS_JSON}},
+  "exports": {
+    "./package": "./package.json",
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "main": "index.js",
+  "types": "index.d.ts"
+}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/package.json
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/package.json
@@ -11,15 +11,22 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "lint-cpp": "clang-tidy -p build $(find addon -name '*.cpp')",
-    "test:integration": "bare test/integration/addon.test.js",
-    "test:mobile:generate": "bare ./scripts/generate-mobile-integration-tests.js",
-    "test:mobile:validate": "node scripts/validate-mobile-tests.js",
+    "test": "npm run test:unit && npm run test:integration",
+    "test:integration": "npm run test:integration:generate && bare test/integration/all.js --exit",
+    "test:integration:generate": "brittle -r test/integration/all.js test/integration/*.test.js && npm run test:mobile:generate",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js",
     "test:unit": "npm run test:unit:generate && bare test/unit/all.js --exit",
     "test:cpp:build": "bare-make generate -D BUILD_TESTING=ON && bare-make build --target addon-test",
     "test:cpp:run": "cd build/test/unit/ && ./addon-test --gtest_output=xml:cpp-test-results.xml",
     "test:cpp": "npm run test:cpp:build && npm run test:cpp:run",
+    "coverage:cpp:build": "bare-make generate -D BUILD_TESTING=ON -D ENABLE_COVERAGE=ON && bare-make build --target addon-test",
+    "coverage:cpp:run": "cd build/test/unit/ && LLVM_PROFILE_FILE=default.profraw ./addon-test --gtest_output=xml:cpp-test-results.xml",
+    "coverage:cpp:summary": "cd build/test/unit && llvm-cov-19 report ./addon-test --instr-profile=coverage.profdata -ignore-filename-regex='(tests|build|node_modules|gtest|gmock|\\.vcpkg|/usr)/' > coverage-summary.txt",
+    "coverage:cpp:report": "cd build/test/unit/ && ls -lha && llvm-profdata-19 merge -sparse default.profraw -o coverage.profdata && llvm-cov-19 show ./addon-test -instr-profile=coverage.profdata -format=html -output-dir=coverage-html -ignore-filename-regex='(tests|build|node_modules|gtest|gmock|\\.vcpkg|/usr)/' && llvm-cov-19 export ./addon-test -instr-profile=coverage.profdata -format=lcov -ignore-filename-regex='(tests|build|node_modules|gtest|gmock|\\.vcpkg|/usr)/' > lcov.info && npm run coverage:cpp:summary",
+    "coverage:cpp": "npm run coverage:cpp:build && npm run coverage:cpp:run && npm run coverage:cpp:report",
     "test:all": "npm run test:unit && npm run test:integration && npm run test:cpp",
+    "test:mobile:generate": "bare ./scripts/generate-mobile-integration-tests.js",
+    "test:mobile:validate": "node scripts/validate-mobile-tests.js",
     "test:dts": "tsc -p tsconfig.dts.json"
   },
   "files": [
@@ -42,15 +49,20 @@
   "license": "Apache-2.0",
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://github.com/tetherto/qvac/tree/main/packages/{{PACKAGE_NAME}}#readme",
+  "dependencies": {
+    "@qvac/infer-base": "^0.4.0",
+    "@qvac/logging": "^0.1.0",
+    "bare-fs": "^4.5.1",
+    "bare-path": "^3.0.0"{{BACKEND_NPM_DEPS}}
+  },
   "devDependencies": {
     "@types/node": "^24.2.1",
-    "brittle": "^3.4.0",
-    "cmake-bare": "^1.7.1",
+    "brittle": "^3.16.5",
+    "cmake-bare": "1.7.5",
     "cmake-vcpkg": "^1.1.0",
     "standard": "^17.0.0",
     "typescript": "^5.9.2"
   },
-  "dependencies": {{BACKEND_NPM_DEPS_JSON}},
   "exports": {
     "./package": "./package.json",
     ".": {

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/scripts/generate-mobile-integration-tests.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/scripts/generate-mobile-integration-tests.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const fs = require('bare-fs')
+const path = require('bare-path')
+
+const repoRoot = path.resolve(__dirname, '..')
+const integrationDir = path.join(repoRoot, 'test', 'integration')
+const mobileDir = path.join(repoRoot, 'test', 'mobile')
+const outputFile = path.join(mobileDir, 'integration.auto.cjs')
+
+function getIntegrationFiles () {
+  if (!fs.existsSync(integrationDir)) {
+    throw new Error(`Integration directory not found: ${integrationDir}`)
+  }
+
+  return fs.readdirSync(integrationDir)
+    .filter(entry => entry.endsWith('.test.js'))
+    .sort()
+}
+
+function toFunctionName (fileName) {
+  const base = fileName.replace(/\.js$/, '')
+  const parts = base.split(/[^a-zA-Z0-9]+/).filter(Boolean)
+  const suffix = parts.map(part => part.charAt(0).toUpperCase() + part.slice(1)).join('')
+  return `run${suffix}`
+}
+
+function buildFileContents (files) {
+  const lines = []
+  lines.push("'use strict'")
+  lines.push("require('./integration-runtime.cjs')")
+  lines.push('')
+  lines.push('// AUTO-GENERATED FILE. Run `npm run test:mobile:generate` to update.')
+  lines.push('// Each function mirrors a single file under test/integration/.')
+  lines.push('')
+  lines.push('/* global runIntegrationModule */')
+  lines.push('')
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]
+    const fnName = toFunctionName(file)
+    const relativePath = `../integration/${file}`
+    lines.push(`async function ${fnName} (options = {}) { // eslint-disable-line no-unused-vars`)
+    lines.push(`  return runIntegrationModule('${relativePath}', options)`)
+    lines.push('}')
+    // Only add blank line between functions, not after the last one
+    if (i < files.length - 1) {
+      lines.push('')
+    }
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+function main () {
+  const files = getIntegrationFiles()
+  if (files.length === 0) {
+    throw new Error(`No integration test files found inside ${integrationDir}`)
+  }
+
+  const content = buildFileContents(files)
+  fs.writeFileSync(outputFile, content, 'utf8')
+  console.log(`Generated ${outputFile} with ${files.length} integration runners.`)
+}
+
+if (require.main === module) {
+  main()
+}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/scripts/validate-mobile-tests.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/scripts/validate-mobile-tests.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const repoRoot = path.resolve(__dirname, '..')
+const integrationDir = path.join(repoRoot, 'test', 'integration')
+const mobileAutoFile = path.join(repoRoot, 'test', 'mobile', 'integration.auto.cjs')
+
+function getIntegrationTestFiles () {
+  if (!fs.existsSync(integrationDir)) {
+    throw new Error(`Integration directory not found: ${integrationDir}`)
+  }
+
+  return fs.readdirSync(integrationDir)
+    .filter(f => f.endsWith('.test.js'))
+    .sort()
+}
+
+function getGeneratedIntegrationRefs (content) {
+  const references = new Set()
+  const referencePattern = /runIntegrationModule\('\.\.\/integration\/([^']+)'(?:,\s*options)?\)/g
+  let match = referencePattern.exec(content)
+
+  while (match !== null) {
+    references.add(match[1])
+    match = referencePattern.exec(content)
+  }
+
+  return references
+}
+
+function setDiff (left, right) {
+  return [...left].filter(item => !right.has(item)).sort()
+}
+
+function printMismatchDetails (label, items) {
+  console.error(`   ${label}:`)
+  items.forEach(item => console.error(`     - ${item}`))
+}
+
+try {
+  const integrationFiles = getIntegrationTestFiles()
+  if (!fs.existsSync(mobileAutoFile)) {
+    console.error('❌ Mobile integration tests not generated!')
+    console.error('   Run: npm run test:mobile:generate')
+    process.exit(1)
+  }
+
+  const expectedSet = new Set(integrationFiles)
+  const mobileAutoContent = fs.readFileSync(mobileAutoFile, 'utf8')
+  const generatedSet = getGeneratedIntegrationRefs(mobileAutoContent)
+
+  const missingFromGenerated = setDiff(expectedSet, generatedSet)
+  const staleInGenerated = setDiff(generatedSet, expectedSet)
+
+  if (missingFromGenerated.length > 0 || staleInGenerated.length > 0) {
+    console.error('❌ Mobile integration tests are out of sync with test/integration')
+    if (missingFromGenerated.length > 0) {
+      printMismatchDetails('Missing from integration.auto.cjs', missingFromGenerated)
+    }
+    if (staleInGenerated.length > 0) {
+      printMismatchDetails('Stale references in integration.auto.cjs', staleInGenerated)
+    }
+    console.error('   Run: npm run test:mobile:generate')
+    process.exit(1)
+  }
+
+  if (integrationFiles.length === 0) {
+    console.log('✅ Mobile integration tests are up to date (no integration tests found)')
+    process.exit(0)
+  }
+
+  // Keep timestamp validation as a fast stale-content signal for edited tests.
+  const latestIntegrationTime = Math.max(
+    ...integrationFiles.map(f => fs.statSync(path.join(integrationDir, f)).mtimeMs)
+  )
+  const mobileAutoTime = fs.statSync(mobileAutoFile).mtimeMs
+
+  if (latestIntegrationTime > mobileAutoTime) {
+    console.error('❌ Mobile integration tests are out of date!')
+    console.error('   Integration tests modified after mobile tests were generated.')
+    console.error('   Run: npm run test:mobile:generate')
+    process.exit(1)
+  }
+
+  console.log('✅ Mobile integration tests are up to date')
+  process.exit(0)
+} catch (error) {
+  console.error('Error validating mobile tests:', error.message)
+  process.exit(1)
+}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/test/integration/addon.test.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/test/integration/addon.test.js
@@ -1,14 +1,37 @@
 'use strict'
 
 const test = require('brittle')
-const { sayHello } = require('../..')
+const Addon = require('../..')
 
-test('integration: addon loads and returns greeting', (t) => {
-  const out = sayHello('integration')
-  t.is(typeof out, 'string')
-  t.is(out, 'hello, integration')
+// The hello-world _load() does not actually open a file. Any existing absolute
+// path satisfies the constructor's `files.model` validation; we use the test
+// file itself as a stable, always-present fixture. Replace with a real model
+// path when you wire a real backend.
+const FIXTURE_PATH = __filename
+
+test('integration: addon loads and runs', async (t) => {
+  const addon = new Addon({ files: { model: [FIXTURE_PATH] } })
+  t.teardown(async () => { await addon.unload() })
+  await addon.load()
+
+  const response = await addon.run({ name: 'integration' })
+  const { text } = await response.await()
+  t.is(typeof text, 'string')
+  t.is(text, 'hello, integration')
 })
 
-test('integration: addon handles default argument', (t) => {
-  t.is(sayHello(), 'hello, world')
+test('integration: addon handles default name', async (t) => {
+  const addon = new Addon({ files: { model: [FIXTURE_PATH] } })
+  t.teardown(async () => { await addon.unload() })
+  await addon.load()
+
+  const response = await addon.run()
+  const { text } = await response.await()
+  t.is(text, 'hello, world')
+})
+
+test('integration: constructor rejects missing files.model', (t) => {
+  let err = null
+  try { const a = new Addon(); t.absent(a) } catch (e) { err = e }
+  t.ok(err && /non-empty array/.test(err.message))
 })

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/test/integration/addon.test.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/test/integration/addon.test.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const test = require('brittle')
+const { sayHello } = require('../..')
+
+test('integration: addon loads and returns greeting', (t) => {
+  const out = sayHello('integration')
+  t.is(typeof out, 'string')
+  t.is(out, 'hello, integration')
+})
+
+test('integration: addon handles default argument', (t) => {
+  t.is(sayHello(), 'hello, world')
+})

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/test/mobile/integration-runtime.cjs
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/test/mobile/integration-runtime.cjs
@@ -1,0 +1,20 @@
+'use strict'
+
+const path = require('bare-path')
+const fs = require('bare-fs')
+const { pathToFileURL } = require('bare-url')
+
+async function runIntegrationModule (relativeModulePath, options = {}) {
+  const modulePath = path.join(__dirname, relativeModulePath)
+
+  if (!fs.existsSync(modulePath)) {
+    console.warn(`[integration-runner] Missing module: ${relativeModulePath}`)
+    return 'missing'
+  }
+
+  const moduleUrl = pathToFileURL(modulePath).href
+  await import(moduleUrl)
+  return modulePath
+}
+
+global.runIntegrationModule = runIntegrationModule

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/test/mobile/integration.auto.cjs
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/test/mobile/integration.auto.cjs
@@ -1,0 +1,11 @@
+'use strict'
+require('./integration-runtime.cjs')
+
+// AUTO-GENERATED FILE. Run `npm run test:mobile:generate` to update.
+// Each function mirrors a single file under test/integration/.
+
+/* global runIntegrationModule */
+
+async function runAddonTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/addon.test.js', options)
+}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/test/unit/CMakeLists.txt
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/test/unit/CMakeLists.txt
@@ -1,0 +1,35 @@
+find_package(GTest CONFIG REQUIRED)
+
+add_executable(
+  addon-test
+  test_hello.cpp
+)
+
+target_compile_options(
+  addon-test
+  PRIVATE
+    -Wno-deprecated
+    -Wfatal-errors
+    -g)
+
+target_include_directories(
+  addon-test
+  PRIVATE
+    ${CMAKE_SOURCE_DIR}/addon/src
+    ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS}
+)
+
+target_compile_features(addon-test PRIVATE cxx_std_20)
+
+target_link_libraries(
+  addon-test
+  PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock_main
+)
+
+add_test(NAME HelloUnit COMMAND addon-test)
+set_tests_properties(HelloUnit PROPERTIES
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  TIMEOUT 120)

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/test/unit/say-hello.test.js
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/test/unit/say-hello.test.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const test = require('brittle')
+const { normalizeName } = require('../../addon.js')
+
+test('normalizeName returns "world" for null', (t) => {
+  t.is(normalizeName(null), 'world')
+})
+
+test('normalizeName returns "world" for undefined', (t) => {
+  t.is(normalizeName(undefined), 'world')
+})
+
+test('normalizeName returns "world" for empty string', (t) => {
+  t.is(normalizeName(''), 'world')
+})
+
+test('normalizeName returns the input when non-empty string', (t) => {
+  t.is(normalizeName('qvac'), 'qvac')
+})
+
+test('normalizeName coerces numbers to strings', (t) => {
+  t.is(normalizeName(42), '42')
+})

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/test/unit/test_hello.cpp
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/test/unit/test_hello.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "addon/AddonCpp.hpp"
+
+TEST(HelloWorld, GreetsGivenName) {
+  EXPECT_EQ({{CPP_NAMESPACE}}::HelloWorld::greet("world"), "hello, world");
+  EXPECT_EQ({{CPP_NAMESPACE}}::HelloWorld::greet("qvac"), "hello, qvac");
+}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/tsconfig.dts.json
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/tsconfig.dts.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["index.d.ts"]
+}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg-configuration.json
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg-configuration.json
@@ -1,0 +1,17 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "baseline": "16c71a39e5a0fc0bdb3fad03beef8f38ee00ee3b",
+      "repository": "https://github.com/microsoft/vcpkg",
+      "packages": [
+        "gtest"
+      ]
+    }
+  ]
+}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg.json
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "{{PACKAGE_NAME}}",
+  "version": "0.1.0",
+  "dependencies": [
+    {{BACKEND_VCPKG_DEPS}}
+    {
+      "name": "qvac-lib-inference-addon-cpp",
+      "version>=": "1.1.5#1"
+    },
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.4#2"
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build and run unit tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg/toolchains/linux-clang.cmake
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg/toolchains/linux-clang.cmake
@@ -1,0 +1,4 @@
+set(CMAKE_C_COMPILER "clang-19")
+set(CMAKE_CXX_COMPILER "clang++-19")
+
+include("$ENV{VCPKG_ROOT}/scripts/toolchains/linux.cmake")

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg/triplets/arm64-linux.cmake
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg/triplets/arm64-linux.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/linux-clang.cmake")
+set(VCPKG_C_FLAGS "-fPIC")
+set(VCPKG_CXX_FLAGS "-fPIC -stdlib=libc++")
+set(VCPKG_LINKER_FLAGS "-stdlib=libc++")

--- a/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg/triplets/x64-linux.cmake
+++ b/packages/ocr-onnx/.agent/skills/new-addon/templates/vcpkg/triplets/x64-linux.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/../toolchains/linux-clang.cmake")
+set(VCPKG_C_FLAGS "-fPIC")
+set(VCPKG_CXX_FLAGS "-fPIC -stdlib=libc++")
+set(VCPKG_LINKER_FLAGS "-stdlib=libc++")


### PR DESCRIPTION
## Summary

Adds a `new-addon` skill under `packages/ocr-onnx/.agent/skills/` that scaffolds a hello-world native addon package with the same structure as our existing addons: `CMakeLists.txt` + vcpkg + bare-make, unit/integration/C++ tests, CI workflows (on-pr, on-merge, prebuilds, integration-test, integration-mobile-test, cpp-tests), and a pluggable backend (`onnxruntime`, `qvac-fabric`, `ggml`, or `none`).

Usage (from within the repo):

```
/new-addon qvac-lib-infer-<name> <backend>
```

## What's in the box

- `SKILL.md` — step-by-step invocation: arg parsing, backend substitution table, template copy + placeholder replacement, CI workflow generation, verification (`npm install && bare-make generate && bare-make build && bare-make install` then unit/integration/cpp tests).
- `templates/` — full scaffolded package:
  - `package.json`, `CMakeLists.txt`, `vcpkg.json`, `vcpkg-configuration.json`, linux triplets + toolchain
  - `binding.js`, `index.js`, `addon.js` (pure-JS helper), `index.d.ts`, `tsconfig.dts.json`
  - `addon/src/` — minimal C++ stub using `qvac-lib-inference-addon-cpp` (`JsUtils.hpp`, `JsArgsParser`, `JSCATCH`)
  - `test/unit/` — GoogleTest C++ unit and a JS test against the pure-JS helper
  - `test/integration/` — bare-runtime integration test loading the native `.bare`

## Two patterns baked in (both battle-tested on `qvac-lib-infer-vla`)

1. **Pure-JS helper pattern for unit tests.** Unit tests import from `addon.js` (a pure-JS helper), not `index.js`. This mirrors `qvac-lib-infer-llamacpp-embed/addon.js` and is needed because CI's `ts-checks` job runs `npm run test:unit --if-present` without a native build — loading the `.bare` addon there would fail with `ADDON_NOT_FOUND`.
2. **Windows build fix.** `CMakeLists.txt` adds `NOMINMAX`, `WIN32_LEAN_AND_MEAN`, `NOGDI` as compile definitions on `WIN32` and links `msvcrt.lib`. Without these, Windows SDK macros `ERROR` (wingdi.h) and `min` (minwindef.h) collide with `Priority::ERROR` and `std::min` used inside `qvac-lib-inference-addon-cpp` headers. Mirrors the embed package's `CMakeLists.txt`.

`SKILL.md` documents both so future edits preserve them.

## Test plan

- [ ] `/new-addon qvac-lib-infer-hello-test ggml` produces a buildable package (tested offline via `qvac-lib-infer-vla`).
- [ ] `qvac-lib-infer-vla` (scaffolded from this skill) passed the full on-pr CI matrix on `tmp-vla`: prebuilds on linux-x64/linux-arm64/android-arm64/darwin-x64/darwin-arm64/ios variants/**win32-x64** + cpp-tests on linux-x64/darwin-x64/darwin-arm64/windows-x64 + integration tests. Run: https://github.com/tetherto/qvac/actions/runs/24714332832 (only unrelated failures: `cpp-lint` workflow_dispatch artifact and the repo-wide mobile-checkout PAT issue).
