### PR TITLE
feat: replace per-model size gauge with view-derived total blob bytes

### DIFF
--- a/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
+++ b/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
@@ -558,10 +558,13 @@ node scripts/bin.js run --storage ./corestore --metrics-port 0
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `qvac_registry_models_total` | Gauge | Total models in the registry |
-| `qvac_registry_blob_cores_total` | Gauge | Number of blob cores |
+| `qvac_registry_models_total` | Gauge | Total models in the registry (refreshed every 5 min and on local writes) |
+| `qvac_registry_total_blob_bytes` | Gauge | Sum of `blobBinding.byteLength` across every model record in the view |
+| `qvac_registry_totals_refreshed_age_seconds` | Gauge | Seconds since `total_blob_bytes` / `models_total` were last recomputed (-1 if never) |
+| `qvac_registry_blob_cores_total` | Gauge | Number of blob cores opened locally on this node |
 | `qvac_registry_blob_core_peers` | Gauge | Connected peers per blob core |
 | `qvac_registry_blob_core_fully_downloaded` | Gauge | Whether each blob core is fully replicated |
+| `qvac_registry_blob_core_byte_length` | Gauge | Byte length per locally-opened blob core |
 | `qvac_registry_view_core_length` | Gauge | View core length (total blocks) |
 | `qvac_registry_view_core_contiguous_length` | Gauge | View core contiguous length (gap indicates replication lag) |
 | `qvac_registry_rpc_requests_total` | Counter | RPC requests by method |
@@ -569,8 +572,8 @@ node scripts/bin.js run --storage ./corestore --metrics-port 0
 | `qvac_registry_is_indexer` | Gauge | Whether this node is an indexer |
 | `qvac_registry_blind_peers_connected` | Gauge | Number of configured blind peers with an active connection |
 | `qvac_registry_blind_peer_connected` | Gauge | Per-blind-peer connection status (labeled by `peer_key`) |
-| `qvac_registry_blob_core_byte_length` | Gauge | Byte length per blob core |
-| `qvac_registry_model_size_bytes` | Gauge | Size of each model blob (labeled by path, engine, quantization) |
+
+`qvac_registry_total_blob_bytes` is derived from the view, not from the on-disk blob cores, so it reports the logical registry size consistently on every node (indexers that do not store blobs locally still report the same value).
 
 **Prometheus scrape config (local Prometheus, loopback bind):**
 
@@ -652,9 +655,10 @@ Use Holepunch's pre-built [Grafana dashboard](https://grafana.com/grafana/dashbo
 **Add QVAC-specific panels for:**
 
 - **Model availability:** `qvac_registry_models_total`, `hyper_health_peers_with_all_data_total`
-- **Storage breakdown:** `qvac_registry_model_size_bytes` by engine/quantization, `sum(qvac_registry_blob_core_byte_length)`
+- **Storage:** `qvac_registry_total_blob_bytes` (view-derived logical size), `sum(qvac_registry_blob_core_byte_length)` (on-disk per node)
 - **RPC activity:** `rate(qvac_registry_rpc_requests_total[5m])`, error ratio
 - **Cluster health:** `qvac_registry_is_indexer` across nodes, `qvac_registry_view_core_length` vs `qvac_registry_view_core_contiguous_length`
+- **Metric freshness:** `qvac_registry_totals_refreshed_age_seconds` — alert if it exceeds 15 minutes (background refresh runs every 5)
 
 **Import the baseline dashboard:**
 

--- a/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
+++ b/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
@@ -1373,7 +1373,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "sum(qvac_registry_blob_core_byte_length)",
+          "expr": "qvac_registry_total_blob_bytes",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1742,65 +1742,6 @@
       ],
       "title": "RPC Error Rate",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 57
-      },
-      "id": 26,
-      "options": {
-        "displayMode": "gradient",
-        "maxVizHeight": 300,
-        "minVizHeight": 16,
-        "minVizWidth": 8,
-        "namePlacement": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
-      },
-      "pluginVersion": "12.4.0",
-      "targets": [
-        {
-          "expr": "qvac_registry_model_size_bytes",
-          "legendFormat": "{{path}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Model Size Breakdown",
-      "type": "bargauge"
     },
     {
       "datasource": {

--- a/packages/qvac-lib-registry-server/lib/metrics.js
+++ b/packages/qvac-lib-registry-server/lib/metrics.js
@@ -2,15 +2,10 @@
 
 const promClient = require('prom-client')
 
-const MODEL_CACHE_TTL_MS = 15000
-
 class QvacMetrics {
   constructor (service, opts = {}) {
     this._service = service
     this._logger = opts.logger || console
-
-    this._modelCache = null
-    this._modelCacheExpiry = 0
 
     this._rpcRequests = new promClient.Counter({
       name: 'qvac_registry_rpc_requests_total',
@@ -42,9 +37,29 @@ class QvacMetrics {
     new promClient.Gauge({
       name: 'qvac_registry_models_total',
       help: 'Total number of models in the registry',
-      async collect () {
-        const models = await self._getCachedModels()
-        this.set(models.length)
+      collect () {
+        this.set(self._service.modelCount)
+      }
+    })
+
+    // eslint-disable-next-line no-new
+    new promClient.Gauge({
+      name: 'qvac_registry_total_blob_bytes',
+      help: 'Total bytes across all model blobs (sum of blobBinding.byteLength across view records)',
+      collect () {
+        this.set(self._service.totalModelBytes)
+      }
+    })
+
+    // Derived from totalModelBytes via a background refresh; expose staleness so
+    // operators can alert when the refresh stalls.
+    // eslint-disable-next-line no-new
+    new promClient.Gauge({
+      name: 'qvac_registry_totals_refreshed_age_seconds',
+      help: 'Seconds since qvac_registry_total_blob_bytes and qvac_registry_models_total were last recomputed (-1 if never)',
+      collect () {
+        const ts = self._service.totalsRefreshedAt
+        this.set(ts ? (Date.now() - ts) / 1000 : -1)
       }
     })
 
@@ -141,7 +156,7 @@ class QvacMetrics {
     // eslint-disable-next-line no-new
     new promClient.Gauge({
       name: 'qvac_registry_blob_core_byte_length',
-      help: 'Byte length of each blob core',
+      help: 'Byte length of each blob core (only populated on nodes that opened the blob core locally)',
       labelNames: ['core_name'],
       collect () {
         this.reset()
@@ -150,45 +165,6 @@ class QvacMetrics {
         }
       }
     })
-
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
-      name: 'qvac_registry_model_size_bytes',
-      help: 'Size in bytes of each model blob',
-      labelNames: ['path', 'engine', 'quantization'],
-      async collect () {
-        const models = await self._getCachedModels()
-        this.reset()
-        for (const m of models) {
-          if (m.blobBinding && m.blobBinding.byteLength > 0) {
-            this.set({
-              path: m.path,
-              engine: m.engine || '',
-              quantization: m.quantization || ''
-            }, m.blobBinding.byteLength)
-          }
-        }
-      }
-    })
-  }
-
-  async _getCachedModels () {
-    const now = Date.now()
-    if (this._modelCache && now < this._modelCacheExpiry) {
-      return this._modelCache
-    }
-
-    try {
-      const view = this._service.view
-      if (!view || !view.opened) return this._modelCache || []
-      const models = await view.findModelsByPath({}).toArray()
-      this._modelCache = models
-      this._modelCacheExpiry = now + MODEL_CACHE_TTL_MS
-      return models
-    } catch (err) {
-      this._logger.warn({ err: err.message }, 'QvacMetrics: failed to query models')
-      return this._modelCache || []
-    }
   }
 }
 

--- a/packages/qvac-lib-registry-server/lib/registry-service.js
+++ b/packages/qvac-lib-registry-server/lib/registry-service.js
@@ -46,6 +46,8 @@ const DISPATCH_DELETE_MODEL = `@${QVAC_MAIN_REGISTRY}/delete-model`
 
 const BLOB_CORE_NAME = 'models'
 
+const MODEL_TOTALS_REFRESH_INTERVAL_MS = 5 * 60 * 1000
+
 class RegistryService extends ReadyResource {
   constructor (store, swarm, config, opts = {}) {
     super()
@@ -76,6 +78,11 @@ class RegistryService extends ReadyResource {
     this.blindPeering = null
     this.reseedTracker = null
     this.metrics = null
+
+    this._totalModelBytes = 0
+    this._modelCount = 0
+    this._totalModelBytesRefreshedAt = 0
+    this._totalsRefreshTimer = null
 
     this._registerApplyHandlers()
 
@@ -144,10 +151,6 @@ class RegistryService extends ReadyResource {
 
     this.view = this.base.view
     await this.view.ready()
-
-    this._logAvailableModels().catch(err => {
-      this.logger.error({ err }, 'RegistryService: Failed to log available models')
-    })
 
     this.swarm.on('connection', (conn, peerInfo) => {
       const peerKey = peerInfo?.publicKey ? IdEnc.normalize(peerInfo.publicKey) : null
@@ -259,11 +262,24 @@ class RegistryService extends ReadyResource {
       this._startCompactionInterval()
     }
 
+    await this._refreshTotals()
+    this._totalsRefreshTimer = setInterval(() => {
+      this._refreshTotals().catch(err => {
+        this.logger.warn({ err: err.message }, 'RegistryService: failed to refresh model totals')
+      })
+    }, MODEL_TOTALS_REFRESH_INTERVAL_MS)
+    if (this._totalsRefreshTimer.unref) this._totalsRefreshTimer.unref()
+
     this.logger.info('RegistryService: swarm joined and flushed')
   }
 
   async _close () {
     this.logger.info('RegistryService: closing')
+
+    if (this._totalsRefreshTimer) {
+      clearInterval(this._totalsRefreshTimer)
+      this._totalsRefreshTimer = null
+    }
 
     if (this._compactionInterval) {
       clearInterval(this._compactionInterval)
@@ -704,6 +720,8 @@ class RegistryService extends ReadyResource {
 
       await this._appendOperation(DISPATCH_PUT_MODEL, modelData)
 
+      this._scheduleTotalsRefresh()
+
       if (this.reseedTracker) {
         await this.reseedTracker.waitForComplete()
         this.logger.info({
@@ -1132,6 +1150,8 @@ class RegistryService extends ReadyResource {
 
     await this._appendOperation(DISPATCH_DELETE_MODEL, { path, source })
 
+    this._scheduleTotalsRefresh()
+
     this.logger.info({ path, source }, 'deleteModel: completed')
 
     return { success: true, path, source }
@@ -1212,26 +1232,45 @@ class RegistryService extends ReadyResource {
     }
   }
 
-  async _logAvailableModels () {
-    if (!this.view) return
+  async _refreshTotals () {
+    if (!this.view || !this.view.opened) return
 
-    try {
-      if (!this.view.opened) await this.view.ready()
-      const models = await this.view.findModelsByPath({}).toArray()
+    const startedAt = Date.now()
+    let total = 0
+    let count = 0
 
-      if (models.length === 0) {
-        this.logger.info('RegistryService: No models in registry yet')
-      } else {
-        const modelsToLog = models.length > 5 ? models.slice(-5) : models
-        this.logger.info({
-          count: models.length,
-          showing: modelsToLog.length,
-          models: modelsToLog.map(m => `${m.path} [${m.engine}]`)
-        }, 'RegistryService: models available')
-      }
-    } catch (err) {
-      this.logger.error({ err }, 'RegistryService: Failed to log models')
+    for await (const model of this.view.findModelsByPath({})) {
+      total += model.blobBinding?.byteLength || 0
+      count++
     }
+
+    this._totalModelBytes = total
+    this._modelCount = count
+    this._totalModelBytesRefreshedAt = Date.now()
+
+    this.logger.debug({
+      totalBytes: total,
+      models: count,
+      durationMs: Date.now() - startedAt
+    }, 'RegistryService: refreshed model totals')
+  }
+
+  _scheduleTotalsRefresh () {
+    this._refreshTotals().catch(err => {
+      this.logger.warn({ err: err.message }, 'RegistryService: failed to refresh model totals')
+    })
+  }
+
+  get totalModelBytes () {
+    return this._totalModelBytes
+  }
+
+  get modelCount () {
+    return this._modelCount
+  }
+
+  get totalsRefreshedAt () {
+    return this._totalModelBytesRefreshedAt
   }
 
   _normalizeKey (key) {

--- a/packages/qvac-lib-registry-server/tests/integration/metrics.integration.test.js
+++ b/packages/qvac-lib-registry-server/tests/integration/metrics.integration.test.js
@@ -112,6 +112,8 @@ test('/metrics includes QVAC custom gauges', async (t) => {
     const body = res.body
 
     t.ok(body.includes('qvac_registry_models_total'), 'has models_total')
+    t.ok(body.includes('qvac_registry_total_blob_bytes'), 'has total_blob_bytes')
+    t.ok(body.includes('qvac_registry_totals_refreshed_age_seconds'), 'has totals_refreshed_age_seconds')
     t.ok(body.includes('qvac_registry_blob_cores_total'), 'has blob_cores_total')
     t.ok(body.includes('qvac_registry_view_core_length'), 'has view_core_length')
     t.ok(body.includes('qvac_registry_view_core_contiguous_length'), 'has view_core_contiguous_length')
@@ -120,6 +122,18 @@ test('/metrics includes QVAC custom gauges', async (t) => {
     t.ok(body.includes('qvac_registry_blind_peer_connected'), 'has blind_peer_connected')
     t.ok(body.includes('qvac_registry_rpc_requests_total'), 'has rpc_requests_total')
     t.ok(body.includes('qvac_registry_rpc_errors_total'), 'has rpc_errors_total')
+
+    const totalBytesLine = body.split('\n')
+      .find(line => line.startsWith('qvac_registry_total_blob_bytes '))
+    t.ok(totalBytesLine, 'exports total_blob_bytes as a single series')
+    t.ok(totalBytesLine.endsWith(' 0'), 'total_blob_bytes is 0 on an empty registry')
+
+    const modelsTotalLine = body.split('\n')
+      .find(line => line.startsWith('qvac_registry_models_total '))
+    t.ok(modelsTotalLine, 'exports models_total as a single series')
+    t.ok(modelsTotalLine.endsWith(' 0'), 'models_total is 0 on an empty registry')
+
+    t.absent(body.includes('qvac_registry_model_size_bytes'), 'per-path model_size_bytes metric is removed')
   } finally {
     await cleanup(ctx)
   }


### PR DESCRIPTION
## What problem does this PR solve?

The metrics layer landed in QVAC-17131 emits `qvac_registry_model_size_bytes` as a high-cardinality gauge (one series per `{path, engine, quantization}` — 700+ static series on staging, growing with registry size). The values never change once a model is written, so they produce flat lines in Prometheus while inflating scrape payload, storage, and Grafana query cost. At the same time there is no metric answering the operational question "how many bytes of model data does this registry hold?" — on an indexer node the blob-core gauges report nothing because `blobsCores` is populated lazily and stays empty unless blind peering or `addModel` has run since startup.

## How does it solve it?

- Replaces the per-path gauge with `qvac_registry_total_blob_bytes`, derived from the view (`blobBinding.byteLength` across every model record), so it reports the same logical size on every node regardless of whether blobs are stored locally.
- Moves the model totals (`_totalModelBytes`, `_modelCount`) onto `RegistryService`, seeded at startup and refreshed by a 5-minute background `setInterval` plus fire-and-forget invalidation after `addModel` / `deleteModel`. Scrape cost is now a single integer read.
- Adds `qvac_registry_totals_refreshed_age_seconds` so operators can alert if the background refresh stalls.
- Rewires `qvac_registry_models_total` to read the same counter, eliminating the per-scrape `findModelsByPath({}).toArray()` and dropping the 15-second `_modelCache` / `_getCachedModels` infrastructure in `lib/metrics.js`.
- Drops the now-unused `_logAvailableModels` startup scan — monitoring covers the same observability.
- Updates `DEPLOYMENT_GUIDE.md` metrics table and retargets the Grafana "Blob Storage" stat panel to the new metric; removes the "Model Size Breakdown" bargauge that depended on the deleted series.
- Extends the integration test to assert the new metric is exported as a single series and that the per-path metric is gone.

Verified with `npm run lint`, `npm run test:unit` (37/37), and `npm run test:integration` (30/30).

## Breaking changes

- `qvac_registry_model_size_bytes` is removed. Dashboards or alerts that referenced it must switch to `qvac_registry_total_blob_bytes` (single series) or use `qvac_registry_models_total` for counts. The metric carried no time-series value — all samples were static — so no historical data is lost by dropping it.
