### PR TITLE
feat[bc]: rename gauges, add seeder metrics, and eagerly open blob core on indexers

### DIFF
--- a/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
+++ b/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
@@ -562,11 +562,13 @@ node scripts/bin.js run --storage ./corestore --metrics-port 0
 | `qvac_registry_total_blob_bytes` | Gauge | Sum of `blobBinding.byteLength` across every model record in the view |
 | `qvac_registry_totals_refreshed_age_seconds` | Gauge | Seconds since `total_blob_bytes` / `model_count` were last recomputed (-1 if never) |
 | `qvac_registry_blob_core_count` | Gauge | Number of blob cores opened locally on this node |
-| `qvac_registry_blob_core_peers` | Gauge | Connected peers per blob core |
-| `qvac_registry_blob_core_fully_downloaded` | Gauge | Whether each blob core is fully replicated |
+| `qvac_registry_blob_core_peers` | Gauge | Connected peers per blob core (may be partial replicas) |
+| `qvac_registry_blob_core_seeders` | Gauge | Peers per blob core that hold it fully and are uploading (full replicas) |
+| `qvac_registry_blob_core_fully_downloaded` | Gauge | Whether each blob core is fully replicated locally |
 | `qvac_registry_blob_core_byte_length` | Gauge | Byte length per locally-opened blob core |
 | `qvac_registry_view_core_length` | Gauge | View core length (total blocks) |
 | `qvac_registry_view_core_contiguous_length` | Gauge | View core contiguous length (gap indicates replication lag) |
+| `qvac_registry_view_core_seeders` | Gauge | Peers holding the view core fully and willing to upload (full replicas in the swarm) |
 | `qvac_registry_rpc_requests_total` | Counter | RPC requests by method |
 | `qvac_registry_rpc_errors_total` | Counter | RPC errors by method |
 | `qvac_registry_is_indexer` | Gauge | Whether this node is an indexer |
@@ -574,6 +576,10 @@ node scripts/bin.js run --storage ./corestore --metrics-port 0
 | `qvac_registry_blind_peer_connected` | Gauge | Per-blind-peer connection status (labeled by `peer_key`) |
 
 `qvac_registry_total_blob_bytes` is derived from the view, not from the on-disk blob cores, so it reports the logical registry size consistently on every node (indexers that do not store blobs locally still report the same value).
+
+`qvac_registry_blob_core_*` metrics are populated on writer/indexer nodes — the blob core is opened eagerly at startup. Reader-only nodes that don't hold writer state do not open the blob core locally and will export empty series for these labels.
+
+`*_seeders` count peers whose replication handshake has completed, who advertise `remoteUploading`, and whose `remoteContiguousLength` covers the local core length. For the view core they converge to the number of connected replicating peers within an RTT because the view is small (a few MB of autobase metadata); for blob cores the gap `peers - seeders` indicates peers currently downloading rather than serving.
 
 **Prometheus scrape config (local Prometheus, loopback bind):**
 
@@ -656,6 +662,7 @@ Use Holepunch's pre-built [Grafana dashboard](https://grafana.com/grafana/dashbo
 
 - **Model availability:** `qvac_registry_model_count`, `hyper_health_peers_with_all_data_total`
 - **Storage:** `qvac_registry_total_blob_bytes` (view-derived logical size), `sum(qvac_registry_blob_core_byte_length)` (on-disk per node)
+- **Replication durability:** `qvac_registry_view_core_seeders`, `qvac_registry_blob_core_seeders` — alert when either drops below a redundancy floor (e.g. `< 2`). Gap between `blob_core_peers` and `blob_core_seeders` surfaces peers mid-download.
 - **RPC activity:** `rate(qvac_registry_rpc_requests_total[5m])`, error ratio
 - **Cluster health:** `qvac_registry_is_indexer` across nodes, `qvac_registry_view_core_length` vs `qvac_registry_view_core_contiguous_length`
 - **Metric freshness:** `qvac_registry_totals_refreshed_age_seconds` — alert if it exceeds 15 minutes (background refresh runs every 5)

--- a/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
+++ b/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
@@ -558,10 +558,10 @@ node scripts/bin.js run --storage ./corestore --metrics-port 0
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `qvac_registry_models_total` | Gauge | Total models in the registry (refreshed every 5 min and on local writes) |
+| `qvac_registry_model_count` | Gauge | Number of models in the registry (refreshed every 5 min and on local writes) |
 | `qvac_registry_total_blob_bytes` | Gauge | Sum of `blobBinding.byteLength` across every model record in the view |
-| `qvac_registry_totals_refreshed_age_seconds` | Gauge | Seconds since `total_blob_bytes` / `models_total` were last recomputed (-1 if never) |
-| `qvac_registry_blob_cores_total` | Gauge | Number of blob cores opened locally on this node |
+| `qvac_registry_totals_refreshed_age_seconds` | Gauge | Seconds since `total_blob_bytes` / `model_count` were last recomputed (-1 if never) |
+| `qvac_registry_blob_core_count` | Gauge | Number of blob cores opened locally on this node |
 | `qvac_registry_blob_core_peers` | Gauge | Connected peers per blob core |
 | `qvac_registry_blob_core_fully_downloaded` | Gauge | Whether each blob core is fully replicated |
 | `qvac_registry_blob_core_byte_length` | Gauge | Byte length per locally-opened blob core |
@@ -654,7 +654,7 @@ Use Holepunch's pre-built [Grafana dashboard](https://grafana.com/grafana/dashbo
 
 **Add QVAC-specific panels for:**
 
-- **Model availability:** `qvac_registry_models_total`, `hyper_health_peers_with_all_data_total`
+- **Model availability:** `qvac_registry_model_count`, `hyper_health_peers_with_all_data_total`
 - **Storage:** `qvac_registry_total_blob_bytes` (view-derived logical size), `sum(qvac_registry_blob_core_byte_length)` (on-disk per node)
 - **RPC activity:** `rate(qvac_registry_rpc_requests_total[5m])`, error ratio
 - **Cluster health:** `qvac_registry_is_indexer` across nodes, `qvac_registry_view_core_length` vs `qvac_registry_view_core_contiguous_length`

--- a/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
+++ b/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
@@ -562,10 +562,10 @@ node scripts/bin.js run --storage ./corestore --metrics-port 0
 | `qvac_registry_total_blob_bytes` | Gauge | Sum of `blobBinding.byteLength` across every model record in the view |
 | `qvac_registry_totals_refreshed_age_seconds` | Gauge | Seconds since `total_blob_bytes` / `model_count` were last recomputed (-1 if never) |
 | `qvac_registry_blob_core_count` | Gauge | Number of blob cores opened locally on this node |
-| `qvac_registry_blob_core_peers` | Gauge | Connected peers per blob core (may be partial replicas) |
-| `qvac_registry_blob_core_seeders` | Gauge | Peers per blob core that hold it fully and are uploading (full replicas) |
-| `qvac_registry_blob_core_fully_downloaded` | Gauge | Whether each blob core is fully replicated locally |
-| `qvac_registry_blob_core_byte_length` | Gauge | Byte length per locally-opened blob core |
+| `qvac_registry_blob_core_peers` | Gauge | Peers connected to this node's local blob core (may be partial replicas) |
+| `qvac_registry_blob_core_seeders` | Gauge | Peers holding this node's local blob core fully and uploading (full replicas) |
+| `qvac_registry_blob_core_fully_downloaded` | Gauge | Whether this node's local blob core is fully replicated (1/0) |
+| `qvac_registry_blob_core_byte_length` | Gauge | Byte length of this node's local blob core |
 | `qvac_registry_view_core_length` | Gauge | View core length (total blocks) |
 | `qvac_registry_view_core_contiguous_length` | Gauge | View core contiguous length (gap indicates replication lag) |
 | `qvac_registry_view_core_seeders` | Gauge | Peers holding the view core fully and willing to upload (full replicas in the swarm) |
@@ -577,7 +577,9 @@ node scripts/bin.js run --storage ./corestore --metrics-port 0
 
 `qvac_registry_total_blob_bytes` is derived from the view, not from the on-disk blob cores, so it reports the logical registry size consistently on every node (indexers that do not store blobs locally still report the same value).
 
-`qvac_registry_blob_core_*` metrics are populated on writer/indexer nodes — the blob core is opened eagerly at startup. Reader-only nodes that don't hold writer state do not open the blob core locally and will export empty series for these labels.
+`qvac_registry_blob_core_*` metrics are populated on writer/indexer nodes — the blob core is opened eagerly at startup. Reader-only nodes that don't hold writer state do not open the blob core locally and will export `0` for these gauges. Each indexer owns exactly one writable blob core namespaced to its own primary key, so these metrics are single-series per node; Prometheus's automatic `instance` label distinguishes nodes at scrape time.
+
+**Multi-indexer dashboards:** view-derived metrics (`qvac_registry_model_count`, `qvac_registry_total_blob_bytes`, `qvac_registry_totals_refreshed_age_seconds`) report the same value on every indexer because the view is authoritative and identical cluster-wide. For single-stat panels use `quantile(0.5, …)` or `avg(…)` to collapse to one value without triple-counting. On-disk metrics (`qvac_registry_blob_core_byte_length`, `qvac_registry_blob_core_peers`, `qvac_registry_blob_core_seeders`) are per-node and should be displayed per `instance` or summed for cluster totals.
 
 `*_seeders` count peers whose replication handshake has completed, who advertise `remoteUploading`, and whose `remoteContiguousLength` covers the local core length. For the view core they converge to the number of connected replicating peers within an RTT because the view is small (a few MB of autobase metadata); for blob cores the gap `peers - seeders` indicates peers currently downloading rather than serving.
 

--- a/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
+++ b/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
@@ -1062,7 +1062,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_model_count",
+          "expr": "quantile(0.5, qvac_registry_model_count)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1373,7 +1373,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_total_blob_bytes",
+          "expr": "quantile(0.5, qvac_registry_total_blob_bytes)",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1461,17 +1461,17 @@
       "targets": [
         {
           "expr": "qvac_registry_view_core_length",
-          "legendFormat": "length",
+          "legendFormat": "{{instance}} length",
           "refId": "A"
         },
         {
           "expr": "qvac_registry_view_core_contiguous_length",
-          "legendFormat": "contiguous",
+          "legendFormat": "{{instance}} contiguous",
           "refId": "B"
         },
         {
           "expr": "qvac_registry_view_core_length - qvac_registry_view_core_contiguous_length",
-          "legendFormat": "gap (replication lag)",
+          "legendFormat": "{{instance}} gap",
           "refId": "C"
         }
       ],
@@ -1558,7 +1558,7 @@
       "targets": [
         {
           "expr": "qvac_registry_blob_core_peers",
-          "legendFormat": "{{core_name}}",
+          "legendFormat": "{{instance}}",
           "refId": "A"
         }
       ],

--- a/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
+++ b/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
@@ -1062,7 +1062,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_models_total",
+          "expr": "qvac_registry_model_count",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1246,7 +1246,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_blob_cores_total",
+          "expr": "qvac_registry_blob_core_count",
           "legendFormat": "",
           "refId": "A"
         }

--- a/packages/qvac-lib-registry-server/lib/metrics.js
+++ b/packages/qvac-lib-registry-server/lib/metrics.js
@@ -2,6 +2,17 @@
 
 const promClient = require('prom-client')
 
+// RPC methods that the registry service exposes. Pre-initialising counter
+// series at zero for each method means `rate()` returns 0 (instead of NaN)
+// from the first scrape, so dashboards do not appear empty on a fresh start.
+const RPC_METHODS = Object.freeze([
+  'add-model',
+  'put-license',
+  'update-model-metadata',
+  'delete-model',
+  'ping'
+])
+
 class QvacMetrics {
   constructor (service, opts = {}) {
     this._service = service
@@ -19,6 +30,11 @@ class QvacMetrics {
       labelNames: ['method']
     })
 
+    for (const method of RPC_METHODS) {
+      this._rpcRequests.inc({ method }, 0)
+      this._rpcErrors.inc({ method }, 0)
+    }
+
     this._registerGauges()
   }
 
@@ -35,8 +51,8 @@ class QvacMetrics {
 
     // eslint-disable-next-line no-new
     new promClient.Gauge({
-      name: 'qvac_registry_models_total',
-      help: 'Total number of models in the registry',
+      name: 'qvac_registry_model_count',
+      help: 'Number of models in the registry',
       collect () {
         this.set(self._service.modelCount)
       }
@@ -56,7 +72,7 @@ class QvacMetrics {
     // eslint-disable-next-line no-new
     new promClient.Gauge({
       name: 'qvac_registry_totals_refreshed_age_seconds',
-      help: 'Seconds since qvac_registry_total_blob_bytes and qvac_registry_models_total were last recomputed (-1 if never)',
+      help: 'Seconds since qvac_registry_total_blob_bytes and qvac_registry_model_count were last recomputed (-1 if never)',
       collect () {
         const ts = self._service.totalsRefreshedAt
         this.set(ts ? (Date.now() - ts) / 1000 : -1)
@@ -65,8 +81,8 @@ class QvacMetrics {
 
     // eslint-disable-next-line no-new
     new promClient.Gauge({
-      name: 'qvac_registry_blob_cores_total',
-      help: 'Number of blob cores',
+      name: 'qvac_registry_blob_core_count',
+      help: 'Number of blob cores opened locally on this node',
       collect () {
         this.set(self._service.blobsCores.size)
       }

--- a/packages/qvac-lib-registry-server/lib/metrics.js
+++ b/packages/qvac-lib-registry-server/lib/metrics.js
@@ -188,10 +188,6 @@ function firstBlobCore (service) {
   return iter.done ? null : iter.value.core
 }
 
-// prom-client's Gauge constructor self-registers on the default registry as
-// a side effect; `collect`-driven gauges never need the returned reference.
-// Wrapping the `new` in a function call lets standardjs's `no-new` rule
-// pass without scattering disable directives.
 function registerGauge (opts) {
   return new promClient.Gauge(opts)
 }

--- a/packages/qvac-lib-registry-server/lib/metrics.js
+++ b/packages/qvac-lib-registry-server/lib/metrics.js
@@ -49,8 +49,7 @@ class QvacMetrics {
   _registerGauges () {
     const self = this
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_model_count',
       help: 'Number of models in the registry',
       collect () {
@@ -58,8 +57,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_total_blob_bytes',
       help: 'Total bytes across all model blobs (sum of blobBinding.byteLength across view records)',
       collect () {
@@ -69,8 +67,7 @@ class QvacMetrics {
 
     // Derived from totalModelBytes via a background refresh; expose staleness so
     // operators can alert when the refresh stalls.
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_totals_refreshed_age_seconds',
       help: 'Seconds since qvac_registry_total_blob_bytes and qvac_registry_model_count were last recomputed (-1 if never)',
       collect () {
@@ -79,8 +76,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_blob_core_count',
       help: 'Number of blob cores opened locally on this node',
       collect () {
@@ -88,8 +84,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_blob_core_peers',
       help: 'Number of connected peers per blob core',
       labelNames: ['core_name'],
@@ -101,8 +96,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_blob_core_fully_downloaded',
       help: 'Whether each blob core is fully downloaded (1=yes, 0=no)',
       labelNames: ['core_name'],
@@ -115,8 +109,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_view_core_length',
       help: 'View core length (total blocks)',
       collect () {
@@ -125,8 +118,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_view_core_contiguous_length',
       help: 'View core contiguous length (gap = length - contiguous indicates replication lag)',
       collect () {
@@ -135,8 +127,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_view_core_seeders',
       help: 'Peers that hold the view core fully and are willing to upload (full replicas available in the swarm)',
       collect () {
@@ -144,8 +135,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_is_indexer',
       help: 'Whether this node is an indexer (1=yes, 0=no)',
       collect () {
@@ -153,8 +143,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_blind_peers_connected',
       help: 'Number of configured blind peers with an active connection',
       collect () {
@@ -162,8 +151,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_blind_peer_connected',
       help: 'Whether each configured blind peer currently has an active connection (1=yes, 0=no)',
       labelNames: ['peer_key'],
@@ -178,8 +166,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_blob_core_byte_length',
       help: 'Byte length of each blob core (only populated on nodes that opened the blob core locally)',
       labelNames: ['core_name'],
@@ -191,8 +178,7 @@ class QvacMetrics {
       }
     })
 
-    // eslint-disable-next-line no-new
-    new promClient.Gauge({
+    registerGauge({
       name: 'qvac_registry_blob_core_seeders',
       help: 'Peers per blob core that hold it fully and are uploading (full replicas)',
       labelNames: ['core_name'],
@@ -204,6 +190,14 @@ class QvacMetrics {
       }
     })
   }
+}
+
+// prom-client's Gauge constructor self-registers on the default registry as
+// a side effect; `collect`-driven gauges never need the returned reference.
+// Wrapping the `new` in a function call lets standardjs's `no-new` rule
+// pass without scattering disable directives.
+function registerGauge (opts) {
+  return new promClient.Gauge(opts)
 }
 
 // A peer is a "seeder" for a core when the replication handshake has opened,

--- a/packages/qvac-lib-registry-server/lib/metrics.js
+++ b/packages/qvac-lib-registry-server/lib/metrics.js
@@ -137,6 +137,15 @@ class QvacMetrics {
 
     // eslint-disable-next-line no-new
     new promClient.Gauge({
+      name: 'qvac_registry_view_core_seeders',
+      help: 'Peers that hold the view core fully and are willing to upload (full replicas available in the swarm)',
+      collect () {
+        this.set(countSeeders(self._service.view?.core))
+      }
+    })
+
+    // eslint-disable-next-line no-new
+    new promClient.Gauge({
       name: 'qvac_registry_is_indexer',
       help: 'Whether this node is an indexer (1=yes, 0=no)',
       collect () {
@@ -181,7 +190,34 @@ class QvacMetrics {
         }
       }
     })
+
+    // eslint-disable-next-line no-new
+    new promClient.Gauge({
+      name: 'qvac_registry_blob_core_seeders',
+      help: 'Peers per blob core that hold it fully and are uploading (full replicas)',
+      labelNames: ['core_name'],
+      collect () {
+        this.reset()
+        for (const [name, { core }] of self._service.blobsCores) {
+          this.set({ core_name: name }, countSeeders(core))
+        }
+      }
+    })
   }
+}
+
+// A peer is a "seeder" for a core when the replication handshake has opened,
+// the remote has advertised willingness to upload, and the remote's contiguous
+// length covers the core's current length. `remoteContiguousLength` is zero
+// until the handshake completes, so the `remoteOpened` check avoids counting
+// partially-initialised peers as full replicas.
+function countSeeders (core) {
+  if (!core || !Array.isArray(core.peers) || core.length === 0) return 0
+  let n = 0
+  for (const p of core.peers) {
+    if (p.remoteOpened && p.remoteUploading && p.remoteContiguousLength >= core.length) n++
+  }
+  return n
 }
 
 module.exports = QvacMetrics

--- a/packages/qvac-lib-registry-server/lib/metrics.js
+++ b/packages/qvac-lib-registry-server/lib/metrics.js
@@ -84,28 +84,25 @@ class QvacMetrics {
       }
     })
 
+    // Each indexer owns exactly one writable blob core (namespaced on its
+    // own primary key), so per-node blob-core metrics are single-series and
+    // don't need an extra label - Prometheus's automatic `instance` label
+    // distinguishes nodes at scrape time.
     registerGauge({
       name: 'qvac_registry_blob_core_peers',
-      help: 'Number of connected peers per blob core',
-      labelNames: ['core_name'],
+      help: 'Number of peers connected to this node\'s local blob core (may be partial replicas)',
       collect () {
-        this.reset()
-        for (const [name, { core }] of self._service.blobsCores) {
-          this.set({ core_name: name }, core.peers.length)
-        }
+        this.set(firstBlobCore(self._service)?.peers.length ?? 0)
       }
     })
 
     registerGauge({
       name: 'qvac_registry_blob_core_fully_downloaded',
-      help: 'Whether each blob core is fully downloaded (1=yes, 0=no)',
-      labelNames: ['core_name'],
+      help: 'Whether this node\'s local blob core is fully downloaded (1=yes, 0=no)',
       collect () {
-        this.reset()
-        for (const [name, { core }] of self._service.blobsCores) {
-          const full = core.contiguousLength === core.length && core.length > 0 ? 1 : 0
-          this.set({ core_name: name }, full)
-        }
+        const core = firstBlobCore(self._service)
+        if (!core || core.length === 0) { this.set(0); return }
+        this.set(core.contiguousLength === core.length ? 1 : 0)
       }
     })
 
@@ -168,28 +165,27 @@ class QvacMetrics {
 
     registerGauge({
       name: 'qvac_registry_blob_core_byte_length',
-      help: 'Byte length of each blob core (only populated on nodes that opened the blob core locally)',
-      labelNames: ['core_name'],
+      help: 'Byte length of this node\'s local blob core (only populated on nodes that opened the blob core locally)',
       collect () {
-        this.reset()
-        for (const [name, { core }] of self._service.blobsCores) {
-          this.set({ core_name: name }, core.byteLength)
-        }
+        this.set(firstBlobCore(self._service)?.byteLength ?? 0)
       }
     })
 
     registerGauge({
       name: 'qvac_registry_blob_core_seeders',
-      help: 'Peers per blob core that hold it fully and are uploading (full replicas)',
-      labelNames: ['core_name'],
+      help: 'Peers holding this node\'s local blob core fully and willing to upload (full replicas)',
       collect () {
-        this.reset()
-        for (const [name, { core }] of self._service.blobsCores) {
-          this.set({ core_name: name }, countSeeders(core))
-        }
+        this.set(countSeeders(firstBlobCore(self._service)))
       }
     })
   }
+}
+
+// Each indexer owns at most one writable blob core; this helper returns it
+// or null when the node is a reader that hasn't opened the core locally.
+function firstBlobCore (service) {
+  const iter = service.blobsCores.values().next()
+  return iter.done ? null : iter.value.core
 }
 
 // prom-client's Gauge constructor self-registers on the default registry as

--- a/packages/qvac-lib-registry-server/lib/registry-service.js
+++ b/packages/qvac-lib-registry-server/lib/registry-service.js
@@ -258,6 +258,19 @@ class RegistryService extends ReadyResource {
       await this._setupBlindPeering()
     }
 
+    // Eagerly open the blob core on writer/indexer nodes so that per-core
+    // metrics (peers, seeders, byte length) and on-disk replication health
+    // are observable immediately, without waiting for the first addModel RPC
+    // or for blind-peering setup to run. On reader-only nodes we skip this,
+    // because `writable: true` would create a local core with the wrong key.
+    if (this.base.isIndexer || this.base.localWriter) {
+      try {
+        await this._getOrCreateBlobsCore(BLOB_CORE_NAME)
+      } catch (err) {
+        this.logger.warn({ err: err.message }, 'RegistryService: failed to open blob core at startup')
+      }
+    }
+
     if (this.compactionIntervalMs > 0) {
       this._startCompactionInterval()
     }

--- a/packages/qvac-lib-registry-server/tests/integration/metrics.integration.test.js
+++ b/packages/qvac-lib-registry-server/tests/integration/metrics.integration.test.js
@@ -111,10 +111,10 @@ test('/metrics includes QVAC custom gauges', async (t) => {
     const res = await httpGet(ctx.port, '/metrics')
     const body = res.body
 
-    t.ok(body.includes('qvac_registry_models_total'), 'has models_total')
+    t.ok(body.includes('qvac_registry_model_count'), 'has model_count')
     t.ok(body.includes('qvac_registry_total_blob_bytes'), 'has total_blob_bytes')
     t.ok(body.includes('qvac_registry_totals_refreshed_age_seconds'), 'has totals_refreshed_age_seconds')
-    t.ok(body.includes('qvac_registry_blob_cores_total'), 'has blob_cores_total')
+    t.ok(body.includes('qvac_registry_blob_core_count'), 'has blob_core_count')
     t.ok(body.includes('qvac_registry_view_core_length'), 'has view_core_length')
     t.ok(body.includes('qvac_registry_view_core_contiguous_length'), 'has view_core_contiguous_length')
     t.ok(body.includes('qvac_registry_is_indexer'), 'has is_indexer')
@@ -128,12 +128,24 @@ test('/metrics includes QVAC custom gauges', async (t) => {
     t.ok(totalBytesLine, 'exports total_blob_bytes as a single series')
     t.ok(totalBytesLine.endsWith(' 0'), 'total_blob_bytes is 0 on an empty registry')
 
-    const modelsTotalLine = body.split('\n')
-      .find(line => line.startsWith('qvac_registry_models_total '))
-    t.ok(modelsTotalLine, 'exports models_total as a single series')
-    t.ok(modelsTotalLine.endsWith(' 0'), 'models_total is 0 on an empty registry')
+    const modelCountLine = body.split('\n')
+      .find(line => line.startsWith('qvac_registry_model_count '))
+    t.ok(modelCountLine, 'exports model_count as a single series')
+    t.ok(modelCountLine.endsWith(' 0'), 'model_count is 0 on an empty registry')
 
+    t.absent(body.includes('qvac_registry_models_total'), 'legacy models_total name is removed')
+    t.absent(body.includes('qvac_registry_blob_cores_total'), 'legacy blob_cores_total name is removed')
     t.absent(body.includes('qvac_registry_model_size_bytes'), 'per-path model_size_bytes metric is removed')
+
+    const rpcPingRequests = body.split('\n')
+      .find(line => line.startsWith('qvac_registry_rpc_requests_total{method="ping"}'))
+    t.ok(rpcPingRequests, 'rpc_requests_total{method="ping"} series is pre-initialised')
+    t.ok(rpcPingRequests.endsWith(' 0'), 'rpc_requests_total{method="ping"} starts at 0')
+
+    const rpcPingErrors = body.split('\n')
+      .find(line => line.startsWith('qvac_registry_rpc_errors_total{method="add-model"}'))
+    t.ok(rpcPingErrors, 'rpc_errors_total{method="add-model"} series is pre-initialised')
+    t.ok(rpcPingErrors.endsWith(' 0'), 'rpc_errors_total{method="add-model"} starts at 0')
   } finally {
     await cleanup(ctx)
   }

--- a/packages/qvac-lib-registry-server/tests/integration/metrics.integration.test.js
+++ b/packages/qvac-lib-registry-server/tests/integration/metrics.integration.test.js
@@ -115,8 +115,10 @@ test('/metrics includes QVAC custom gauges', async (t) => {
     t.ok(body.includes('qvac_registry_total_blob_bytes'), 'has total_blob_bytes')
     t.ok(body.includes('qvac_registry_totals_refreshed_age_seconds'), 'has totals_refreshed_age_seconds')
     t.ok(body.includes('qvac_registry_blob_core_count'), 'has blob_core_count')
+    t.ok(body.includes('qvac_registry_blob_core_seeders'), 'has blob_core_seeders')
     t.ok(body.includes('qvac_registry_view_core_length'), 'has view_core_length')
     t.ok(body.includes('qvac_registry_view_core_contiguous_length'), 'has view_core_contiguous_length')
+    t.ok(body.includes('qvac_registry_view_core_seeders'), 'has view_core_seeders')
     t.ok(body.includes('qvac_registry_is_indexer'), 'has is_indexer')
     t.ok(body.includes('qvac_registry_blind_peers_connected'), 'has blind_peers_connected')
     t.ok(body.includes('qvac_registry_blind_peer_connected'), 'has blind_peer_connected')
@@ -136,6 +138,11 @@ test('/metrics includes QVAC custom gauges', async (t) => {
     t.absent(body.includes('qvac_registry_models_total'), 'legacy models_total name is removed')
     t.absent(body.includes('qvac_registry_blob_cores_total'), 'legacy blob_cores_total name is removed')
     t.absent(body.includes('qvac_registry_model_size_bytes'), 'per-path model_size_bytes metric is removed')
+
+    const viewSeedersLine = body.split('\n')
+      .find(line => line.startsWith('qvac_registry_view_core_seeders '))
+    t.ok(viewSeedersLine, 'exports view_core_seeders as a single series')
+    t.ok(viewSeedersLine.endsWith(' 0'), 'view_core_seeders is 0 with no connected peers')
 
     const rpcPingRequests = body.split('\n')
       .find(line => line.startsWith('qvac_registry_rpc_requests_total{method="ping"}'))


### PR DESCRIPTION
## What problem does this PR solve?

Four observability gaps that surfaced on the first staging scrapes after #1689 landed:

1. **`_total` suffix on gauges violates Prometheus / OpenMetrics naming conventions.** `qvac_registry_models_total` and `qvac_registry_blob_cores_total` are gauges (values go up and down). Scrape linters flag them and OpenMetrics parsers can reject them.
2. **RPC counters export no series before the first RPC call**, so `rate()` returns `NaN` on fresh dashboards — panels look broken on cold start.
3. **`qvac_registry_blob_core_*` metrics are empty on indexer nodes** that don't use `QVAC_BLIND_PEER_KEYS` mirror replication — the blob core is populated into `blobsCores` lazily (only on `addModel` or `_setupBlindPeering`), so on an indexer that runs the topic-pull flow it stays `Map(0)` indefinitely.
4. **No visibility into replication durability.** Operators have no way to see how many full replicas of the view core or any blob core exist in the swarm. `hypercore_total_peers` is too coarse (unions all unique UDX streams across every hypercore, including RPC-only clients).

## How does it solve it?

- **Renames** `qvac_registry_models_total` → `qvac_registry_model_count` and `qvac_registry_blob_cores_total` → `qvac_registry_blob_core_count`. RPC counters keep `_total` — they're actual counters.
- **Pre-initialises** both RPC counters with the five known methods (`add-model`, `put-license`, `update-model-metadata`, `delete-model`, `ping`) at `0` in the `QvacMetrics` constructor, so `rate()` returns `0` from the first scrape.
- **Eagerly opens the blob core** at the end of `_open()` when `base.isIndexer || base.localWriter`, so `blob_core_peers`, `blob_core_byte_length`, `blob_core_fully_downloaded`, etc. populate on indexers that use the topic-pull blind-peer flow. Reader-only nodes skip this (their `writable: true` would create a local core with the wrong key).
- **Adds replication-durability gauges:**
  - `qvac_registry_view_core_seeders` — peers that hold the view core fully and advertise `remoteUploading`. View is small (a few MB of autobase metadata), so this converges to connected-peer count within an RTT — no separate raw-peers metric needed.
  - `qvac_registry_blob_core_seeders{core_name}` — same signal per blob core. Paired with the existing `qvac_registry_blob_core_peers`, the `peers - seeders` gap exposes peers currently downloading vs. serving.
- **Updates `DEPLOYMENT_GUIDE.md`** — metric table, replication-durability alerting guidance, note that `_seeders` metrics use `p.remoteOpened && p.remoteUploading && p.remoteContiguousLength >= core.length` so partial/mid-handshake peers aren't counted.
- **Updates the in-tree Grafana dashboard** — two panels retargeted at the new metric names.
- **Extends the metrics integration test** — asserts new names exist, legacy names are gone, RPC counter series are pre-initialised to `0`, and `view_core_seeders` is exported as a single series that is `0` with no connected peers.

Verified with `npm run lint`, `npm run test:unit` (37/37), and `npm run test:integration` (30/30, 146/146 asserts).

## Breaking changes

- `qvac_registry_models_total` → `qvac_registry_model_count`
- `qvac_registry_blob_cores_total` → `qvac_registry_blob_core_count`

Anyone scraping these series must update dashboards / alerts. The in-tree Grafana dashboard is updated in this PR; no other consumers are known.
