### PR TITLE
feat[bc]: replace blob_core_fully_downloaded with length/contiguous_length pair and drop blind-peer metrics

### DIFF
--- a/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
+++ b/packages/qvac-lib-registry-server/docs/DEPLOYMENT_GUIDE.md
@@ -564,7 +564,8 @@ node scripts/bin.js run --storage ./corestore --metrics-port 0
 | `qvac_registry_blob_core_count` | Gauge | Number of blob cores opened locally on this node |
 | `qvac_registry_blob_core_peers` | Gauge | Peers connected to this node's local blob core (may be partial replicas) |
 | `qvac_registry_blob_core_seeders` | Gauge | Peers holding this node's local blob core fully and uploading (full replicas) |
-| `qvac_registry_blob_core_fully_downloaded` | Gauge | Whether this node's local blob core is fully replicated (1/0) |
+| `qvac_registry_blob_core_length` | Gauge | This node's local blob core length in blocks |
+| `qvac_registry_blob_core_contiguous_length` | Gauge | Blob core contiguous length in blocks (gap indicates missing blocks on disk) |
 | `qvac_registry_blob_core_byte_length` | Gauge | Byte length of this node's local blob core |
 | `qvac_registry_view_core_length` | Gauge | View core length (total blocks) |
 | `qvac_registry_view_core_contiguous_length` | Gauge | View core contiguous length (gap indicates replication lag) |
@@ -572,8 +573,6 @@ node scripts/bin.js run --storage ./corestore --metrics-port 0
 | `qvac_registry_rpc_requests_total` | Counter | RPC requests by method |
 | `qvac_registry_rpc_errors_total` | Counter | RPC errors by method |
 | `qvac_registry_is_indexer` | Gauge | Whether this node is an indexer |
-| `qvac_registry_blind_peers_connected` | Gauge | Number of configured blind peers with an active connection |
-| `qvac_registry_blind_peer_connected` | Gauge | Per-blind-peer connection status (labeled by `peer_key`) |
 
 `qvac_registry_total_blob_bytes` is derived from the view, not from the on-disk blob cores, so it reports the logical registry size consistently on every node (indexers that do not store blobs locally still report the same value).
 

--- a/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
+++ b/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
@@ -1153,12 +1153,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "yellow",
-                "value": 0
-              },
-              {
                 "color": "green",
-                "value": 1
+                "value": 0
               }
             ]
           }
@@ -1169,60 +1165,6 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 37
-      },
-      "id": 18,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.0",
-      "targets": [
-        {
-          "expr": "qvac_registry_blind_peers_connected",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Blind Peers",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
         "y": 37
       },
       "id": 19,
@@ -1294,7 +1236,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
+        "x": 12,
         "y": 37
       },
       "id": 20,
@@ -1318,12 +1260,12 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "min(qvac_registry_blob_core_fully_downloaded)",
+          "expr": "min(qvac_registry_blob_core_contiguous_length == bool qvac_registry_blob_core_length) and min(qvac_registry_blob_core_length) > bool 0",
           "legendFormat": "",
           "refId": "A"
         }
       ],
-      "title": "Blobs Synced",
+      "title": "Blob Core Contiguous",
       "type": "stat"
     },
     {
@@ -1349,7 +1291,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 20,
+        "x": 16,
         "y": 37
       },
       "id": 21,

--- a/packages/qvac-lib-registry-server/lib/metrics.js
+++ b/packages/qvac-lib-registry-server/lib/metrics.js
@@ -97,12 +97,18 @@ class QvacMetrics {
     })
 
     registerGauge({
-      name: 'qvac_registry_blob_core_fully_downloaded',
-      help: 'Whether this node\'s local blob core is fully downloaded (1=yes, 0=no)',
+      name: 'qvac_registry_blob_core_length',
+      help: 'This node\'s local blob core length (total blocks)',
       collect () {
-        const core = firstBlobCore(self._service)
-        if (!core || core.length === 0) { this.set(0); return }
-        this.set(core.contiguousLength === core.length ? 1 : 0)
+        this.set(firstBlobCore(self._service)?.length ?? 0)
+      }
+    })
+
+    registerGauge({
+      name: 'qvac_registry_blob_core_contiguous_length',
+      help: 'This node\'s local blob core contiguous length (gap = length - contiguous indicates missing blocks on disk)',
+      collect () {
+        this.set(firstBlobCore(self._service)?.contiguousLength ?? 0)
       }
     })
 
@@ -137,29 +143,6 @@ class QvacMetrics {
       help: 'Whether this node is an indexer (1=yes, 0=no)',
       collect () {
         this.set(self._service.base?.isIndexer ? 1 : 0)
-      }
-    })
-
-    registerGauge({
-      name: 'qvac_registry_blind_peers_connected',
-      help: 'Number of configured blind peers with an active connection',
-      collect () {
-        this.set(self._service.getConnectedBlindPeerKeys().length)
-      }
-    })
-
-    registerGauge({
-      name: 'qvac_registry_blind_peer_connected',
-      help: 'Whether each configured blind peer currently has an active connection (1=yes, 0=no)',
-      labelNames: ['peer_key'],
-      collect () {
-        this.reset()
-        for (const peerKey of self._service.getConfiguredBlindPeerKeys()) {
-          this.set(
-            { peer_key: peerKey },
-            self._service.isBlindPeerConnected(peerKey) ? 1 : 0
-          )
-        }
       }
     })
 

--- a/packages/qvac-lib-registry-server/tests/integration/metrics.integration.test.js
+++ b/packages/qvac-lib-registry-server/tests/integration/metrics.integration.test.js
@@ -4,7 +4,6 @@ const test = require('brittle')
 const Corestore = require('corestore')
 const Hyperswarm = require('hyperswarm')
 const http = require('http')
-const IdEnc = require('hypercore-id-encoding')
 const promClient = require('prom-client')
 
 const RegistryService = require('../../lib/registry-service')
@@ -116,12 +115,12 @@ test('/metrics includes QVAC custom gauges', async (t) => {
     t.ok(body.includes('qvac_registry_totals_refreshed_age_seconds'), 'has totals_refreshed_age_seconds')
     t.ok(body.includes('qvac_registry_blob_core_count'), 'has blob_core_count')
     t.ok(body.includes('qvac_registry_blob_core_seeders'), 'has blob_core_seeders')
+    t.ok(body.includes('qvac_registry_blob_core_length'), 'has blob_core_length')
+    t.ok(body.includes('qvac_registry_blob_core_contiguous_length'), 'has blob_core_contiguous_length')
     t.ok(body.includes('qvac_registry_view_core_length'), 'has view_core_length')
     t.ok(body.includes('qvac_registry_view_core_contiguous_length'), 'has view_core_contiguous_length')
     t.ok(body.includes('qvac_registry_view_core_seeders'), 'has view_core_seeders')
     t.ok(body.includes('qvac_registry_is_indexer'), 'has is_indexer')
-    t.ok(body.includes('qvac_registry_blind_peers_connected'), 'has blind_peers_connected')
-    t.ok(body.includes('qvac_registry_blind_peer_connected'), 'has blind_peer_connected')
     t.ok(body.includes('qvac_registry_rpc_requests_total'), 'has rpc_requests_total')
     t.ok(body.includes('qvac_registry_rpc_errors_total'), 'has rpc_errors_total')
 
@@ -134,10 +133,6 @@ test('/metrics includes QVAC custom gauges', async (t) => {
       .find(line => line.startsWith('qvac_registry_model_count '))
     t.ok(modelCountLine, 'exports model_count as a single series')
     t.ok(modelCountLine.endsWith(' 0'), 'model_count is 0 on an empty registry')
-
-    t.absent(body.includes('qvac_registry_models_total'), 'legacy models_total name is removed')
-    t.absent(body.includes('qvac_registry_blob_cores_total'), 'legacy blob_cores_total name is removed')
-    t.absent(body.includes('qvac_registry_model_size_bytes'), 'per-path model_size_bytes metric is removed')
 
     const viewSeedersLine = body.split('\n')
       .find(line => line.startsWith('qvac_registry_view_core_seeders '))
@@ -177,50 +172,6 @@ test('RPC metrics counters increment', async (t) => {
     const errorLine = body.split('\n').find(l => l.includes('qvac_registry_rpc_errors_total') && l.includes('add-model'))
     t.ok(errorLine, 'has add-model error counter line')
     t.ok(errorLine.includes('1'), 'error counter is 1')
-  } finally {
-    await cleanup(ctx)
-  }
-})
-
-test('blind peer metrics track configured peers with active connections', async (t) => {
-  const blindPeerKeys = [
-    IdEnc.normalize(Buffer.alloc(32, 1)),
-    IdEnc.normalize(Buffer.alloc(32, 2))
-  ]
-  const ctx = await createServiceWithMetrics(t)
-
-  try {
-    ctx.service.blindPeerKeys = blindPeerKeys
-    ctx.service._trackPeerConnection(blindPeerKeys[0])
-    ctx.service._trackPeerConnection(blindPeerKeys[0])
-    ctx.service._trackPeerConnection('writer-peer')
-
-    let res = await httpGet(ctx.port, '/metrics')
-    let body = res.body
-
-    const connectedPeerLine = body.split('\n')
-      .find(line => line.startsWith(`qvac_registry_blind_peer_connected{peer_key="${blindPeerKeys[0]}"}`))
-    t.ok(connectedPeerLine, 'has connected blind peer series')
-    t.ok(connectedPeerLine.endsWith(' 1'), 'connected blind peer is reported as 1')
-
-    const disconnectedPeerLine = body.split('\n')
-      .find(line => line.startsWith(`qvac_registry_blind_peer_connected{peer_key="${blindPeerKeys[1]}"}`))
-    t.ok(disconnectedPeerLine, 'has disconnected blind peer series')
-    t.ok(disconnectedPeerLine.endsWith(' 0'), 'disconnected blind peer is reported as 0')
-
-    ctx.service._untrackPeerConnection(blindPeerKeys[0])
-    ctx.service._untrackPeerConnection(blindPeerKeys[0])
-
-    res = await httpGet(ctx.port, '/metrics')
-    body = res.body
-
-    const afterCloseCountLine = body.split('\n')
-      .find(line => line.startsWith('qvac_registry_blind_peers_connected '))
-    t.ok(afterCloseCountLine.endsWith(' 0'), 'blind peer count drops after connection closes')
-
-    const afterClosePeerLine = body.split('\n')
-      .find(line => line.startsWith(`qvac_registry_blind_peer_connected{peer_key="${blindPeerKeys[0]}"}`))
-    t.ok(afterClosePeerLine.endsWith(' 0'), 'blind peer status drops after connection closes')
   } finally {
     await cleanup(ctx)
   }


### PR DESCRIPTION
## What problem does this PR solve?

`qvac_registry_blob_core_fully_downloaded` is a misnomer: the node exporting it is the writer of its own blob core, not a downloader, so a 1/0 "fully downloaded" boolean conveys less operational detail than the raw replication numbers the view core already exports. The blind-peer metrics (`qvac_registry_blind_peers_connected`, `qvac_registry_blind_peer_connected`) are also dropped: we don't consume them anywhere and they clutter the scrape output.

## How does it solve it?

- Removes `qvac_registry_blob_core_fully_downloaded` and replaces it with `qvac_registry_blob_core_length` + `qvac_registry_blob_core_contiguous_length`, mirroring the existing view-core pattern. The gap (`length - contiguous_length`) now exposes the absolute on-disk magnitude instead of collapsing to a boolean.
- Removes the two blind-peer gauges from `lib/metrics.js`, their `DEPLOYMENT_GUIDE.md` rows, the "Blind Peers" stat panel from the Grafana dashboard, and the associated integration test.
- Updates the Grafana "Blobs Synced" stat panel to "Blob Core Contiguous" using `min(qvac_registry_blob_core_contiguous_length == bool qvac_registry_blob_core_length) and min(qvac_registry_blob_core_length) > bool 0`, preserving the 1/0 color mapping without depending on a dedicated boolean metric. Adjacent panel gridPos shifted left by 4 to close the gap left by the removed "Blind Peers" panel.
- Adds integration assertions for the two new metric names.

## Breaking changes

Yes. The following metric series are removed from `/metrics`:
- `qvac_registry_blob_core_fully_downloaded`
- `qvac_registry_blind_peers_connected`
- `qvac_registry_blind_peer_connected`

Dashboards and alerts that referenced these must migrate to the length/contiguous-length pair or drop the blind-peer panels. No migration path is provided; the feature branch has not been deployed yet.
