### PR TITLE
QVAC-16473 infra: fix startup_failure in on-pr-test-sdk.yml — add missing id-token permission

### DIFF
--- a/.github/workflows/on-pr-test-sdk.yml
+++ b/.github/workflows/on-pr-test-sdk.yml
@@ -19,6 +19,7 @@ on:
       - "packages/sdk/**"
 
 permissions:
+  id-token: write
   contents: read
   pull-requests: write
   packages: read


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `on-pr-test-sdk.yml` fails with `startup_failure` every time it triggers — no jobs run at all
- Error: "The nested job 'android-tests' is requesting 'id-token: write', but is only allowed 'id-token: none'" (same for ios-tests)
- Root cause: caller workflow permissions are the ceiling for all nested reusable workflows. `test-sdk.yml` android/ios jobs need `id-token: write` for AWS OIDC, but `on-pr-test-sdk.yml` didn't grant it.

## 📝 How does it solve it?

- Adds `id-token: write` to the top-level permissions block in `on-pr-test-sdk.yml`
- Verified this is the only missing permission across the full chain: `on-pr-test-sdk.yml` -> `test-sdk.yml` -> `test-{desktop,android,ios}-sdk.yml`

## 🧪 How was it tested?

- Reproduced: https://github.com/tetherto/qvac/actions/runs/24774882344
- After merge, re-apply `test-e2e-smoke` or `test-e2e-full` label on PR #1703 to verify
