### PR TITLE
QVAC-17807 test[skiplog]: add e2e tests for lingering bare process re…

### DIFF
--- a/packages/sdk/tests-qvac/tests/desktop/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/desktop/consumer.ts
@@ -69,6 +69,7 @@ import { DesktopDiffusionExecutor } from "./executors/diffusion-executor.js";
 import { FinetuneExecutor } from "./executors/finetune-executor.js";
 import { LifecycleExecutor } from "../shared/executors/lifecycle-executor.js";
 import { ConfigExecutor } from "../shared/executors/config-executor.js";
+import { NoLingeringBareExecutor } from "./executors/no-lingering-bare-executor.js";
 
 const resources = new ResourceManager();
 
@@ -369,6 +370,7 @@ export const executor = createExecutor({
     new FinetuneExecutor(resources),
     new LifecycleExecutor(resources),
     new ConfigExecutor(),
+    new NoLingeringBareExecutor(),
   ],
   profiling: {
     init: () => profiler.enable({ mode: "summary", includeServerBreakdown: true }),

--- a/packages/sdk/tests-qvac/tests/desktop/executors/no-lingering-bare-executor.ts
+++ b/packages/sdk/tests-qvac/tests/desktop/executors/no-lingering-bare-executor.ts
@@ -1,0 +1,301 @@
+import { spawn, execFileSync, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import {
+  BaseExecutor,
+  type TestResult,
+} from "@tetherto/qvac-test-suite";
+import {
+  noLingeringBareTests,
+  noLingeringBareSigterm,
+  noLingeringBareClose,
+  noLingeringBareIpcDisconnect,
+} from "../../no-lingering-bare-tests.js";
+
+type ShutdownMode = "sigterm" | "close" | "ipc-disconnect";
+
+const CONSUMER_BOOT_TIMEOUT_MS = 60_000;
+const CONSUMER_EXIT_TIMEOUT_MS = 20_000;
+const BARE_EXIT_GRACE_MS = 15_000;
+const POLL_INTERVAL_MS = 200;
+
+const consumerScriptPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "utils",
+  "no-lingering-bare-consumer.js",
+);
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "ESRCH") return false;
+    if (code === "EPERM") return true;
+    throw error;
+  }
+}
+
+function findBareChildrenPosix(parentPid: number): number[] {
+  let pgrepOutput: string;
+  try {
+    pgrepOutput = execFileSync("pgrep", ["-P", String(parentPid)], {
+      encoding: "utf-8",
+    });
+  } catch (error: unknown) {
+    if ((error as { status?: number })?.status === 1) return [];
+    throw error;
+  }
+
+  const childPids = pgrepOutput
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(Number);
+
+  const bare: number[] = [];
+  for (const pid of childPids) {
+    try {
+      const comm = execFileSync("ps", ["-o", "comm=", "-p", String(pid)], {
+        encoding: "utf-8",
+      }).trim();
+      if (comm.endsWith("bare")) {
+        bare.push(pid);
+      }
+    } catch {
+      // process exited between pgrep and ps — ignore
+    }
+  }
+  return bare;
+}
+
+function findBareChildrenWin32(parentPid: number): number[] {
+  let psOutput: string;
+  try {
+    psOutput = execFileSync("powershell.exe", [
+      "-NoProfile", "-Command",
+      `Get-CimInstance Win32_Process -Filter "ParentProcessId=${parentPid}" ` +
+      `| ForEach-Object { "$($_.ProcessId)|$($_.Name)" }`,
+    ], { encoding: "utf-8" });
+  } catch (error: unknown) {
+    const code = (error as { code?: string })?.code;
+    if (code === "ENOENT") throw new Error("powershell.exe not found in PATH");
+    return [];
+  }
+
+  const bare: number[] = [];
+  for (const line of psOutput.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const sep = trimmed.indexOf("|");
+    if (sep === -1) continue;
+    const pid = Number(trimmed.slice(0, sep));
+    const name = trimmed.slice(sep + 1).toLowerCase();
+    if (isNaN(pid)) continue;
+    if (name === "bare" || name === "bare.exe") {
+      bare.push(pid);
+    }
+  }
+  return bare;
+}
+
+function findBareChildren(parentPid: number): number[] {
+  return process.platform === "win32"
+    ? findBareChildrenWin32(parentPid)
+    : findBareChildrenPosix(parentPid);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return !isAlive(pid);
+}
+
+export class NoLingeringBareExecutor extends BaseExecutor<typeof noLingeringBareTests> {
+  pattern = /^no-lingering-bare-/;
+
+  protected handlers = {
+    [noLingeringBareSigterm.testId]: () => this.runTest("sigterm"),
+    [noLingeringBareClose.testId]: () => this.runTest("close"),
+    [noLingeringBareIpcDisconnect.testId]: () => this.runTest("ipc-disconnect"),
+  };
+
+  private spawnConsumer(mode: ShutdownMode): ChildProcess {
+    return spawn(process.execPath, [consumerScriptPath, mode], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, NODE_ENV: process.env.NODE_ENV ?? "test" },
+    });
+  }
+
+  private waitForReady(child: ChildProcess, stderr: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let buffer = "";
+      let settled = false;
+
+      const fail = (err: Error): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        reject(err);
+      };
+
+      const timeout = setTimeout(() => {
+        fail(new Error(
+          `Consumer did not print READY within ${CONSUMER_BOOT_TIMEOUT_MS}ms. ` +
+          `stderr: ${stderr.join("")}`,
+        ));
+      }, CONSUMER_BOOT_TIMEOUT_MS);
+
+      child.once("error", (err: Error) => {
+        fail(new Error(
+          `Failed to spawn consumer: ${err.message}. stderr: ${stderr.join("")}`,
+        ));
+      });
+
+      child.stdout!.on("data", (chunk: Buffer) => {
+        if (settled) return;
+        buffer += chunk.toString();
+        if (buffer.includes("READY")) {
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+
+      child.once("exit", (code, signal) => {
+        fail(new Error(
+          `Consumer exited before READY (code=${code}, signal=${signal}). ` +
+          `stderr: ${stderr.join("")}`,
+        ));
+      });
+    });
+  }
+
+  private waitForExit(child: ChildProcess, timeoutMs: number): Promise<{ code: number | null; signal: string | null }> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error(`Consumer did not exit within ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      child.once("exit", (code, signal) => {
+        clearTimeout(timeout);
+        resolve({ code, signal });
+      });
+    });
+  }
+
+  private async runTest(mode: ShutdownMode): Promise<TestResult> {
+    const start = Date.now();
+    let consumer: ChildProcess | null = null;
+    let bareChildren: number[] = [];
+    const stderr: string[] = [];
+
+    try {
+      consumer = this.spawnConsumer(mode);
+
+      consumer.stderr!.on("data", (chunk: Buffer) => {
+        stderr.push(chunk.toString());
+      });
+
+      await this.waitForReady(consumer, stderr);
+
+      bareChildren = findBareChildren(consumer.pid!);
+      if (bareChildren.length === 0) {
+        return {
+          passed: false,
+          output:
+            "No bare child process found — SDK did not spawn a worker. " +
+            `stderr: ${stderr.join("")}`,
+        };
+      }
+
+      const exitPromise = this.waitForExit(consumer, CONSUMER_EXIT_TIMEOUT_MS);
+
+      switch (mode) {
+        case "sigterm":
+          consumer.kill("SIGTERM");
+          break;
+        case "close":
+          if (process.platform === "win32") {
+            consumer.stdin!.write("CLOSE\n");
+          } else {
+            consumer.kill("SIGUSR1");
+          }
+          break;
+        case "ipc-disconnect":
+          consumer.kill("SIGKILL");
+          break;
+      }
+
+      try {
+        await exitPromise;
+      } catch {
+        try { consumer.kill("SIGKILL"); } catch {}
+        return {
+          passed: false,
+          output:
+            `Consumer did not exit within ${CONSUMER_EXIT_TIMEOUT_MS}ms after ${mode}. ` +
+            `stderr: ${stderr.join("")}`,
+        };
+      }
+      consumer = null;
+
+      const lingering: number[] = [];
+      await Promise.all(
+        bareChildren.map(async (pid) => {
+          const gone = await pollUntilDead(pid, BARE_EXIT_GRACE_MS);
+          if (!gone) lingering.push(pid);
+        }),
+      );
+
+      const elapsed = Date.now() - start;
+
+      if (lingering.length > 0) {
+        for (const pid of lingering) {
+          try { process.kill(pid, "SIGKILL"); } catch {}
+        }
+        return {
+          passed: false,
+          output:
+            `Bare process(es) still alive ${BARE_EXIT_GRACE_MS}ms after ` +
+            `consumer exit (mode=${mode}): PIDs ${lingering.join(", ")}. ` +
+            `This is the "lingering bare process" regression. ` +
+            `stderr: ${stderr.join("")}`,
+        };
+      }
+
+      return {
+        passed: true,
+        output:
+          `Bare worker(s) exited cleanly after SDK shutdown ` +
+          `(mode=${mode}, PIDs=${bareChildren.join(", ")}, ${elapsed}ms)`,
+      };
+    } catch (error) {
+      return {
+        passed: false,
+        output:
+          `Test error (mode=${mode}): ${error instanceof Error ? error.message : String(error)}. ` +
+          `stderr: ${stderr.join("")}`,
+      };
+    } finally {
+      if (consumer) {
+        try { consumer.kill("SIGKILL"); } catch {}
+      }
+      for (const pid of bareChildren) {
+        try {
+          if (isAlive(pid)) process.kill(pid, "SIGKILL");
+        } catch {}
+      }
+    }
+  }
+}

--- a/packages/sdk/tests-qvac/tests/desktop/executors/no-lingering-bare-executor.ts
+++ b/packages/sdk/tests-qvac/tests/desktop/executors/no-lingering-bare-executor.ts
@@ -17,6 +17,7 @@ type ShutdownMode = "sigterm" | "close" | "ipc-disconnect";
 const CONSUMER_BOOT_TIMEOUT_MS = 60_000;
 const CONSUMER_EXIT_TIMEOUT_MS = 20_000;
 const BARE_EXIT_GRACE_MS = 15_000;
+const BARE_DISCOVERY_TIMEOUT_MS = 5_000;
 const POLL_INTERVAL_MS = 200;
 
 const consumerScriptPath = join(
@@ -83,7 +84,8 @@ function findBareChildrenWin32(parentPid: number): number[] {
   } catch (error: unknown) {
     const code = (error as { code?: string })?.code;
     if (code === "ENOENT") throw new Error("powershell.exe not found in PATH");
-    return [];
+    const msg = (error as { stderr?: string })?.stderr ?? String(error);
+    throw new Error(`PowerShell query failed: ${msg}`);
   }
 
   const bare: number[] = [];
@@ -94,7 +96,7 @@ function findBareChildrenWin32(parentPid: number): number[] {
     if (sep === -1) continue;
     const pid = Number(trimmed.slice(0, sep));
     const name = trimmed.slice(sep + 1).toLowerCase();
-    if (isNaN(pid)) continue;
+    if (Number.isNaN(pid)) continue;
     if (name === "bare" || name === "bare.exe") {
       bare.push(pid);
     }
@@ -119,6 +121,29 @@ async function pollUntilDead(pid: number, timeoutMs: number): Promise<boolean> {
     await sleep(POLL_INTERVAL_MS);
   }
   return !isAlive(pid);
+}
+
+async function waitForBareChildren(parentPid: number): Promise<number[]> {
+  const deadline = Date.now() + BARE_DISCOVERY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const pids = findBareChildren(parentPid);
+    if (pids.length > 0) return pids;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return [];
+}
+
+function assertCleanExit(
+  mode: ShutdownMode,
+  exit: { code: number | null; signal: string | null },
+): string | null {
+  if (mode === "close" && (exit.code !== 0 || exit.signal !== null)) {
+    return `close() exit was not clean: code=${exit.code}, signal=${exit.signal}`;
+  }
+  if (mode === "sigterm" && exit.code !== null && exit.code !== 0) {
+    return `sigterm exit code was non-zero: code=${exit.code}, signal=${exit.signal}`;
+  }
+  return null;
 }
 
 export class NoLingeringBareExecutor extends BaseExecutor<typeof noLingeringBareTests> {
@@ -162,15 +187,17 @@ export class NoLingeringBareExecutor extends BaseExecutor<typeof noLingeringBare
         ));
       });
 
-      child.stdout!.on("data", (chunk: Buffer) => {
+      const onData = (chunk: Buffer) => {
         if (settled) return;
         buffer += chunk.toString();
         if (buffer.includes("READY")) {
           settled = true;
           clearTimeout(timeout);
+          child.stdout!.off("data", onData);
           resolve();
         }
-      });
+      };
+      child.stdout!.on("data", onData);
 
       child.once("exit", (code, signal) => {
         fail(new Error(
@@ -198,6 +225,7 @@ export class NoLingeringBareExecutor extends BaseExecutor<typeof noLingeringBare
     const start = Date.now();
     let consumer: ChildProcess | null = null;
     let bareChildren: number[] = [];
+    const cleanedUp = new Set<number>();
     const stderr: string[] = [];
 
     try {
@@ -209,13 +237,13 @@ export class NoLingeringBareExecutor extends BaseExecutor<typeof noLingeringBare
 
       await this.waitForReady(consumer, stderr);
 
-      bareChildren = findBareChildren(consumer.pid!);
+      bareChildren = await waitForBareChildren(consumer.pid!);
       if (bareChildren.length === 0) {
         return {
           passed: false,
           output:
-            "No bare child process found — SDK did not spawn a worker. " +
-            `stderr: ${stderr.join("")}`,
+            `No bare child process found after ${BARE_DISCOVERY_TIMEOUT_MS}ms — ` +
+            `SDK did not spawn a worker. stderr: ${stderr.join("")}`,
         };
       }
 
@@ -226,19 +254,16 @@ export class NoLingeringBareExecutor extends BaseExecutor<typeof noLingeringBare
           consumer.kill("SIGTERM");
           break;
         case "close":
-          if (process.platform === "win32") {
-            consumer.stdin!.write("CLOSE\n");
-          } else {
-            consumer.kill("SIGUSR1");
-          }
+          consumer.stdin!.write("CLOSE\n");
           break;
         case "ipc-disconnect":
           consumer.kill("SIGKILL");
           break;
       }
 
+      let exit: { code: number | null; signal: string | null };
       try {
-        await exitPromise;
+        exit = await exitPromise;
       } catch {
         try { consumer.kill("SIGKILL"); } catch {}
         return {
@@ -249,6 +274,14 @@ export class NoLingeringBareExecutor extends BaseExecutor<typeof noLingeringBare
         };
       }
       consumer = null;
+
+      const exitError = assertCleanExit(mode, exit);
+      if (exitError) {
+        return {
+          passed: false,
+          output: `${exitError}. stderr: ${stderr.join("")}`,
+        };
+      }
 
       const lingering: number[] = [];
       await Promise.all(
@@ -263,6 +296,7 @@ export class NoLingeringBareExecutor extends BaseExecutor<typeof noLingeringBare
       if (lingering.length > 0) {
         for (const pid of lingering) {
           try { process.kill(pid, "SIGKILL"); } catch {}
+          cleanedUp.add(pid);
         }
         return {
           passed: false,
@@ -292,6 +326,7 @@ export class NoLingeringBareExecutor extends BaseExecutor<typeof noLingeringBare
         try { consumer.kill("SIGKILL"); } catch {}
       }
       for (const pid of bareChildren) {
+        if (cleanedUp.has(pid)) continue;
         try {
           if (isAlive(pid)) process.kill(pid, "SIGKILL");
         } catch {}

--- a/packages/sdk/tests-qvac/tests/no-lingering-bare-tests.ts
+++ b/packages/sdk/tests-qvac/tests/no-lingering-bare-tests.ts
@@ -1,0 +1,39 @@
+import type { TestDefinition } from "@tetherto/qvac-test-suite";
+
+const SKIP_MOBILE = {
+  reason: "Bare worker process lifecycle is desktop-only (mobile uses in-process Worklet)",
+  platforms: ["mobile-ios", "mobile-android"],
+};
+
+const createNoLingeringBareTest = (
+  testId: string,
+  estimatedDurationMs: number = 90000,
+): TestDefinition => ({
+  testId,
+  params: {},
+  expectation: { validation: "type", expectedType: "string" },
+  metadata: {
+    category: "lifecycle",
+    dependency: "none",
+    estimatedDurationMs,
+  },
+  skip: SKIP_MOBILE,
+});
+
+export const noLingeringBareSigterm = createNoLingeringBareTest(
+  "no-lingering-bare-sigterm",
+);
+
+export const noLingeringBareClose = createNoLingeringBareTest(
+  "no-lingering-bare-close",
+);
+
+export const noLingeringBareIpcDisconnect = createNoLingeringBareTest(
+  "no-lingering-bare-ipc-disconnect",
+);
+
+export const noLingeringBareTests = [
+  noLingeringBareSigterm,
+  noLingeringBareClose,
+  noLingeringBareIpcDisconnect,
+] as const;

--- a/packages/sdk/tests-qvac/tests/test-definitions.ts
+++ b/packages/sdk/tests-qvac/tests/test-definitions.ts
@@ -28,6 +28,7 @@ import { diffusionTests } from "./diffusion-tests.js";
 import { finetuneTests } from "./finetune-tests.js";
 import { lifecycleTests } from "./lifecycle-tests.js";
 import { configTests } from "./config-tests.js";
+import { noLingeringBareTests } from "./no-lingering-bare-tests.js";
 import { wrongModelTests } from "./wrong-model-tests.js";
 
 // Model loading tests
@@ -269,6 +270,9 @@ export const tests = [
 
   // Wrong-model error tests
   ...wrongModelTests,
+
+  // No-lingering-bare regression tests
+  ...noLingeringBareTests,
 
   // Additional model tests
   modelSwitchLlm,

--- a/packages/sdk/tests-qvac/tests/utils/no-lingering-bare-consumer.ts
+++ b/packages/sdk/tests-qvac/tests/utils/no-lingering-bare-consumer.ts
@@ -1,0 +1,103 @@
+/**
+ * Child process spawned by NoLingeringBareExecutor.
+ *
+ * Calls modelRegistryList() to initialize the registry client (the source of
+ * the 0.8.3 lingering-process regression), then waits for the harness to
+ * trigger one of three shutdown modes:
+ *
+ *   sigterm        — harness sends SIGTERM; SDK handler cleans up
+ *   close          — harness signals via SIGUSR1 / stdin; we call close()
+ *   ipc-disconnect — harness sends SIGKILL; bare worker detects broken IPC
+ */
+
+import { modelRegistryList, close } from "@qvac/sdk";
+
+type Mode = "sigterm" | "close" | "ipc-disconnect";
+
+const VALID_MODES: Mode[] = ["sigterm", "close", "ipc-disconnect"];
+const REGISTRY_INIT_TIMEOUT_MS = 15_000;
+
+const mode = process.argv[2] as Mode | undefined;
+if (!mode || !VALID_MODES.includes(mode)) {
+  process.stderr.write(
+    `Usage: no-lingering-bare-consumer.js <${VALID_MODES.join("|")}>\n`,
+  );
+  process.exit(1);
+}
+
+function log(message: string) {
+  process.stderr.write(`[consumer] ${message}\n`);
+}
+
+async function triggerRegistryClient(): Promise<void> {
+  // Force the bare worker to open the registry client (corestore + hyperswarm).
+  // Timeout prevents blocking on offline CI.
+  try {
+    await Promise.race([
+      modelRegistryList(),
+      new Promise<never>((_, reject) => {
+        const t: unknown = setTimeout(
+          () => reject(new Error("modelRegistryList timeout")),
+          REGISTRY_INIT_TIMEOUT_MS,
+        );
+        // Don't let the timeout keep the process alive (Bare returns object, not number)
+        if (t && typeof t === "object" && "unref" in t) (t as { unref: () => void }).unref();
+      }),
+    ]);
+    log("modelRegistryList resolved");
+  } catch (error) {
+    log(
+      `modelRegistryList settled with error (expected offline): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  log(`starting (pid=${process.pid}, mode=${mode})`);
+
+  await triggerRegistryClient();
+
+  if (mode === "close") {
+    let closeTriggered = false;
+    const triggerClose = (source: string) => {
+      if (closeTriggered) return;
+      closeTriggered = true;
+      log(`received ${source}, calling close()`);
+      close()
+        .then(() => {
+          log("close() returned, exiting");
+          process.exit(0);
+        })
+        .catch((err: unknown) => {
+          log(`close() failed: ${err instanceof Error ? err.message : String(err)}`);
+          process.exit(2);
+        });
+    };
+
+    process.once("SIGUSR1", () => triggerClose("SIGUSR1"));            // POSIX
+    process.stdin.setEncoding("utf-8");                                 // Windows
+    process.stdin.on("data", (chunk: string) => {
+      if (chunk.trim() === "CLOSE") triggerClose("stdin CLOSE");
+    });
+  }
+
+  process.stdout.write(`READY ${process.pid}\n`);
+  log("READY, waiting for harness signal");
+
+  // Keep the event loop alive until the harness triggers shutdown.
+  process.stdin.resume();
+}
+
+main().catch(async (error) => {
+  log(
+    `fatal: ${error instanceof Error ? error.stack ?? error.message : String(error)}`,
+  );
+  try {
+    await close();
+  } catch {
+    // best-effort
+  }
+  process.exit(2);
+});

--- a/packages/sdk/tests-qvac/tests/utils/no-lingering-bare-consumer.ts
+++ b/packages/sdk/tests-qvac/tests/utils/no-lingering-bare-consumer.ts
@@ -6,7 +6,8 @@
  * trigger one of three shutdown modes:
  *
  *   sigterm        — harness sends SIGTERM; SDK handler cleans up
- *   close          — harness signals via SIGUSR1 / stdin; we call close()
+ *   close          — harness writes "CLOSE\n" to stdin; we call close()
+ *                    then let the event loop drain (no process.exit)
  *   ipc-disconnect — harness sends SIGKILL; bare worker detects broken IPC
  */
 
@@ -15,7 +16,7 @@ import { modelRegistryList, close } from "@qvac/sdk";
 type Mode = "sigterm" | "close" | "ipc-disconnect";
 
 const VALID_MODES: Mode[] = ["sigterm", "close", "ipc-disconnect"];
-const REGISTRY_INIT_TIMEOUT_MS = 15_000;
+const REGISTRY_INIT_TIMEOUT_MS = 30_000;
 
 const mode = process.argv[2] as Mode | undefined;
 if (!mode || !VALID_MODES.includes(mode)) {
@@ -61,25 +62,20 @@ async function main(): Promise<void> {
 
   if (mode === "close") {
     let closeTriggered = false;
-    const triggerClose = (source: string) => {
-      if (closeTriggered) return;
+    process.stdin.setEncoding("utf-8");
+    process.stdin.on("data", (chunk: string) => {
+      if (closeTriggered || chunk.trim() !== "CLOSE") return;
       closeTriggered = true;
-      log(`received ${source}, calling close()`);
+      log("received CLOSE, calling close()");
       close()
         .then(() => {
-          log("close() returned, exiting");
-          process.exit(0);
+          log("close() returned, letting event loop drain");
+          process.stdin.destroy();
         })
         .catch((err: unknown) => {
           log(`close() failed: ${err instanceof Error ? err.message : String(err)}`);
           process.exit(2);
         });
-    };
-
-    process.once("SIGUSR1", () => triggerClose("SIGUSR1"));            // POSIX
-    process.stdin.setEncoding("utf-8");                                 // Windows
-    process.stdin.on("data", (chunk: string) => {
-      if (chunk.trim() === "CLOSE") triggerClose("stdin CLOSE");
     });
   }
 


### PR DESCRIPTION
## What problem does this PR solve?

SDK 0.8.3 had a regression where `bare-sidecar` processes lingered after
shutdown — the registry client's hyperswarm + corestore kept the bare
worker's event loop alive. Fixed in #1284 (QVAC-10884) and #1480
(QVAC-12232), but no e2e tests existed to prevent re-introduction.

## How does it solve it?

Adds three e2e tests covering all desktop shutdown paths:

- **sigterm** — harness sends SIGTERM; SDK's built-in handler cleans up
- **close** — harness writes `CLOSE\n` to stdin; consumer calls `close()`,
  then lets the event loop drain naturally (no `process.exit`) — verifies
  `close()` releases all refs
- **ipc-disconnect** — harness sends SIGKILL; bare worker detects broken
  IPC socket and self-terminates

Each test spawns a minimal SDK consumer that initializes the registry
client (the source of the regression), triggers shutdown, then polls to
confirm the bare worker PID has exited.

### Key design decisions

- **Exit code validation:** `close` mode asserts `code=0, signal=null` —
  catches false-positive PASS when `close()` throws but bare process
  still dies
- **Bare child polling:** `waitForBareChildren()` with 5s discovery window
  replaces single-shot lookup, prevents flapping on slow worker startup
- **Unified stdin signaling:** dropped SIGUSR1 (reserved by Node for
  `--inspect`), all platforms use `stdin CLOSE\n`
- **Cleanup safety:** `cleanedUp` set prevents double-kill; finally only
  targets PIDs not already handled in the main flow
- **Cross-platform:** POSIX (`pgrep`/`ps`) and Windows (`Get-CimInstance
  Win32_Process`) with surfaced stderr on PowerShell errors
- **Mobile skip:** `skip.platforms: ["mobile-ios", "mobile-android"]` —
  bare worker runs as in-process Worklet on mobile, no separate PID

## How was it tested?

- All three tests pass locally on macOS desktop consumer
- Mobile consumer skips gracefully (verified via `getTestSkipReason`)
- `npm run typecheck` passes in `packages/sdk/tests-qvac`
- Reviewed against Windows CI runner config (`ai-run-windows11-gpu`)