### PR TITLE
chore: bump nmtcpp to 2.1.0

### DIFF
--- a/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-nmtcpp/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-04-22
+
+### Added
+
+- Dynamic GGML backend loading for GPU acceleration. The NMT addon now discovers GGML backend plugins (OpenCL, Vulkan) at runtime via a new `NmtLazyInitializeBackend` singleton, mirroring the LLM addon's `LlamaLazyInitializeBackend` pattern.
+- New `backendsDir` config param — points at the directory containing GGML backend `.so` plugins (e.g. the Android APK's native-lib path), unblocking GPU-backed inference on Android.
+- New `openclCacheDir` config param — caches compiled OpenCL kernels for faster startup on subsequent loads.
+- GPU backend `.so` plugins are installed into prebuilds via the `GGML_AVAILABLE_BACKENDS` CMake loop.
+
 ## [2.0.3] - 2026-04-15
 
 ### Added

--- a/packages/qvac-lib-infer-nmtcpp/package.json
+++ b/packages/qvac-lib-infer-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary

- Bumps `@qvac/translation-nmtcpp` from `2.0.3` → `2.1.0`
- Cuts a release for the dynamic GGML backend loading feature shipped in #1617 (merged 2026-04-22)
- Minor bump because #1617 adds new public config params (`backendsDir`, `openclCacheDir`) and unblocks Android GPU inference

## CHANGELOG entry

```
## [2.1.0] - 2026-04-22

### Added

- Dynamic GGML backend loading for GPU acceleration. The NMT addon now discovers GGML backend plugins (OpenCL, Vulkan) at runtime via a new `NmtLazyInitializeBackend` singleton, mirroring the LLM addon's `LlamaLazyInitializeBackend` pattern.
- New `backendsDir` config param — points at the directory containing GGML backend `.so` plugins (e.g. the Android APK's native-lib path), unblocking GPU-backed inference on Android.
- New `openclCacheDir` config param — caches compiled OpenCL kernels for faster startup on subsequent loads.
- GPU backend `.so` plugins are installed into prebuilds via the `GGML_AVAILABLE_BACKENDS` CMake loop.
```

## Test plan

- [ ] CI (`On PR Trigger (NMTCPP)`) is green — in particular `run-mobile-integration-tests / Build Android and Run E2E Tests` (this is the regression we're cutting the release to fix)
- [ ] Linux / macOS / Windows integration tests still green
- [ ] iOS mobile still green
- [ ] After merge: cut `release-qvac-lib-infer-nmtcpp-2.1.0` branch and verify npm publish succeeds
