### PR TITLE
Expose no_mmap config flag to disable weight mmap

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -681,6 +681,17 @@ void LlamaModel::commonParamsParse(
     configFilemap.erase(iter);
   }
 
+  // parse no_mmap flag, disables mmap of model weights when true
+  if (auto iter = configFilemap.find("no_mmap");
+      iter != configFilemap.end()) {
+    std::string val = iter->second;
+    std::transform(val.begin(), val.end(), val.begin(), ::tolower);
+    if (val == "true") {
+      params.use_mmap = false;
+    }
+    configFilemap.erase(iter);
+  }
+
   if (outToolsAtEnd) {
     auto arch = metadata_.tryGetString("general.architecture");
     if (!arch.has_value() || arch.value() != "qwen3") {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/cache-state-machine.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/cache-state-machine.test.js
@@ -32,7 +32,8 @@ const BASE_CONFIG = {
   n_predict: '256',
   temp: '0.7',
   seed: '1',
-  verbosity: '2'
+  verbosity: '2',
+  no_mmap: 'true'
 }
 
 const FOLLOW_UP_MESSAGE = { role: 'user', content: 'Reference the cached conversation and confirm the color again.' }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/dynamic-tools.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/dynamic-tools.test.js
@@ -28,7 +28,8 @@ const BASE_CONFIG = {
   seed: '1',
   verbosity: '2',
   tools: 'true',
-  tools_at_end: 'true'
+  tools_at_end: 'true',
+  no_mmap: 'true'
 }
 
 const TOOL_A = {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/multi-instance.test.js
@@ -45,6 +45,7 @@ async function createInstance (modelName, dirPath, overrides = {}) {
     ctx_size: '1024',
     n_predict: '64',
     verbosity: '2',
+    no_mmap: 'true',
     ...(platform === 'android' ? { openclCacheDir: dirPath } : {}),
     ...overrides
   }

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/tool-calling.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/tool-calling.test.js
@@ -39,7 +39,8 @@ const BASE_CONFIG = {
   temp: '0.1',
   n_predict: '1024',
   verbosity: '2',
-  tools: 'true'
+  tools: 'true',
+  no_mmap: 'true'
 }
 
 const prompt1Base = [


### PR DESCRIPTION
Expose no_mmap config flag to disable weight mmap. This should prevent an OOM issue that we see on the S25, when loading/unloading multiple models in a row. The issue is, that the cache is not cleaned early enough for the next model loading.