### PR TITLE
feat: expand Grafana dashboard with blob-core replication, seeders, and Holepunch P2P panels

### DIFF
--- a/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
+++ b/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
@@ -1697,7 +1697,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 102
       },
       "id": 13,
       "options": {
@@ -1733,7 +1733,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 75
+        "y": 112
       },
       "id": 14,
       "options": {
@@ -1756,6 +1756,1276 @@
       ],
       "title": "Registry Error Logs",
       "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "-1": {
+                  "color": "red",
+                  "text": "never"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 600
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 37
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "max(qvac_registry_totals_refreshed_age_seconds)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Totals Refresh Age",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "qvac_registry_blob_core_length",
+          "legendFormat": "{{instance}} length",
+          "refId": "A"
+        },
+        {
+          "expr": "qvac_registry_blob_core_contiguous_length",
+          "legendFormat": "{{instance}} contiguous",
+          "refId": "B"
+        },
+        {
+          "expr": "qvac_registry_blob_core_length - qvac_registry_blob_core_contiguous_length",
+          "legendFormat": "{{instance}} gap",
+          "refId": "C"
+        }
+      ],
+      "title": "Blob Core Replication",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "qvac_registry_view_core_seeders",
+          "legendFormat": "{{instance}} view",
+          "refId": "A"
+        },
+        {
+          "expr": "qvac_registry_blob_core_seeders",
+          "legendFormat": "{{instance}} blob",
+          "refId": "B"
+        }
+      ],
+      "title": "Core Seeders (full replicas)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "qvac_registry_blob_core_byte_length",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Blob Core Bytes",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 30,
+      "panels": [],
+      "title": "Holepunch P2P Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 74
+      },
+      "id": 31,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "sum(hyperswarm_nr_peers)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Swarm Peers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 74
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "sum(dht_is_firewalled)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Firewalled Nodes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 74
+      },
+      "id": 33,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "sum(hypercore_invalid_data)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Hypercore Invalid Data",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 74
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "sum(hypercore_invalid_requests)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Hypercore Invalid Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 74
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "sum(udx_packets_dropped_total)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "UDX Packet Drops",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 74
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "avg(hyperswarm_avg_congestion_window)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Congestion Window",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 78
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "hyperswarm_nr_peers",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Swarm Peers Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 78
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "hypercore_round_trip_time_avg_seconds",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replication RTT",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 86
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(hyperswarm_client_connections_opened[5m])",
+          "legendFormat": "{{instance}} client-opened",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(hyperswarm_server_connections_opened[5m])",
+          "legendFormat": "{{instance}} server-opened",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(hyperswarm_client_connections_closed[5m])",
+          "legendFormat": "{{instance}} client-closed",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(hyperswarm_server_connections_closed[5m])",
+          "legendFormat": "{{instance}} server-closed",
+          "refId": "D"
+        }
+      ],
+      "title": "Swarm Connection Churn (per-second)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 86
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(hypercore_total_wire_data_transmitted[5m])",
+          "legendFormat": "{{instance}} tx",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(hypercore_total_wire_data_received[5m])",
+          "legendFormat": "{{instance}} rx",
+          "refId": "B"
+        }
+      ],
+      "title": "Hypercore Wire Data Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 94
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(udx_total_bytes_transmitted[5m])",
+          "legendFormat": "{{instance}} tx",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(udx_total_bytes_received[5m])",
+          "legendFormat": "{{instance}} rx",
+          "refId": "B"
+        }
+      ],
+      "title": "UDX Bytes (DHT transport)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 94
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rate(dht_total_queries[5m])",
+          "legendFormat": "{{instance}} queries",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(dht_total_requests[5m])",
+          "legendFormat": "{{instance}} requests",
+          "refId": "B"
+        }
+      ],
+      "title": "DHT Query & Request Rate",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
+++ b/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
@@ -1403,17 +1403,17 @@
       "targets": [
         {
           "expr": "qvac_registry_view_core_length",
-          "legendFormat": "{{instance}} length",
+          "legendFormat": "{{ vm_name }} length",
           "refId": "A"
         },
         {
           "expr": "qvac_registry_view_core_contiguous_length",
-          "legendFormat": "{{instance}} contiguous",
+          "legendFormat": "{{ vm_name }} contiguous",
           "refId": "B"
         },
         {
           "expr": "qvac_registry_view_core_length - qvac_registry_view_core_contiguous_length",
-          "legendFormat": "{{instance}} gap",
+          "legendFormat": "{{ vm_name }} gap",
           "refId": "C"
         }
       ],
@@ -1500,7 +1500,7 @@
       "targets": [
         {
           "expr": "qvac_registry_blob_core_peers",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{ vm_name }}",
           "refId": "A"
         }
       ],
@@ -1910,17 +1910,17 @@
       "targets": [
         {
           "expr": "qvac_registry_blob_core_length",
-          "legendFormat": "{{instance}} length",
+          "legendFormat": "{{ vm_name }} length",
           "refId": "A"
         },
         {
           "expr": "qvac_registry_blob_core_contiguous_length",
-          "legendFormat": "{{instance}} contiguous",
+          "legendFormat": "{{ vm_name }} contiguous",
           "refId": "B"
         },
         {
           "expr": "qvac_registry_blob_core_length - qvac_registry_blob_core_contiguous_length",
-          "legendFormat": "{{instance}} gap",
+          "legendFormat": "{{ vm_name }} gap",
           "refId": "C"
         }
       ],
@@ -2007,12 +2007,12 @@
       "targets": [
         {
           "expr": "qvac_registry_view_core_seeders",
-          "legendFormat": "{{instance}} view",
+          "legendFormat": "{{ vm_name }} view",
           "refId": "A"
         },
         {
           "expr": "qvac_registry_blob_core_seeders",
-          "legendFormat": "{{instance}} blob",
+          "legendFormat": "{{ vm_name }} blob",
           "refId": "B"
         }
       ],
@@ -2100,7 +2100,7 @@
       "targets": [
         {
           "expr": "qvac_registry_blob_core_byte_length",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{ vm_name }}",
           "refId": "A"
         }
       ],
@@ -2552,7 +2552,7 @@
       "targets": [
         {
           "expr": "hyperswarm_nr_peers",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{ vm_name }}",
           "refId": "A"
         }
       ],
@@ -2640,7 +2640,7 @@
       "targets": [
         {
           "expr": "hypercore_round_trip_time_avg_seconds",
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{ vm_name }}",
           "refId": "A"
         }
       ],
@@ -2727,22 +2727,22 @@
       "targets": [
         {
           "expr": "rate(hyperswarm_client_connections_opened[5m])",
-          "legendFormat": "{{instance}} client-opened",
+          "legendFormat": "{{ vm_name }} client-opened",
           "refId": "A"
         },
         {
           "expr": "rate(hyperswarm_server_connections_opened[5m])",
-          "legendFormat": "{{instance}} server-opened",
+          "legendFormat": "{{ vm_name }} server-opened",
           "refId": "B"
         },
         {
           "expr": "rate(hyperswarm_client_connections_closed[5m])",
-          "legendFormat": "{{instance}} client-closed",
+          "legendFormat": "{{ vm_name }} client-closed",
           "refId": "C"
         },
         {
           "expr": "rate(hyperswarm_server_connections_closed[5m])",
-          "legendFormat": "{{instance}} server-closed",
+          "legendFormat": "{{ vm_name }} server-closed",
           "refId": "D"
         }
       ],
@@ -2830,12 +2830,12 @@
       "targets": [
         {
           "expr": "rate(hypercore_total_wire_data_transmitted[5m])",
-          "legendFormat": "{{instance}} tx",
+          "legendFormat": "{{ vm_name }} tx",
           "refId": "A"
         },
         {
           "expr": "rate(hypercore_total_wire_data_received[5m])",
-          "legendFormat": "{{instance}} rx",
+          "legendFormat": "{{ vm_name }} rx",
           "refId": "B"
         }
       ],
@@ -2923,12 +2923,12 @@
       "targets": [
         {
           "expr": "rate(udx_total_bytes_transmitted[5m])",
-          "legendFormat": "{{instance}} tx",
+          "legendFormat": "{{ vm_name }} tx",
           "refId": "A"
         },
         {
           "expr": "rate(udx_total_bytes_received[5m])",
-          "legendFormat": "{{instance}} rx",
+          "legendFormat": "{{ vm_name }} rx",
           "refId": "B"
         }
       ],
@@ -3015,12 +3015,12 @@
       "targets": [
         {
           "expr": "rate(dht_total_queries[5m])",
-          "legendFormat": "{{instance}} queries",
+          "legendFormat": "{{ vm_name }} queries",
           "refId": "A"
         },
         {
           "expr": "rate(dht_total_requests[5m])",
-          "legendFormat": "{{instance}} requests",
+          "legendFormat": "{{ vm_name }} requests",
           "refId": "B"
         }
       ],

--- a/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
+++ b/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
@@ -1062,7 +1062,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "quantile(0.5, qvac_registry_model_count)",
+          "expr": "quantile(0.5, qvac_registry_model_count{vm_name=~\"$vm\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1134,7 +1134,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_is_indexer",
+          "expr": "qvac_registry_is_indexer{vm_name=~\"$vm\"}",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1188,7 +1188,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_blob_core_count",
+          "expr": "qvac_registry_blob_core_count{vm_name=~\"$vm\"}",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1260,7 +1260,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "min(qvac_registry_blob_core_contiguous_length == bool qvac_registry_blob_core_length) and min(qvac_registry_blob_core_length) > bool 0",
+          "expr": "min(qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"} == bool qvac_registry_blob_core_length{vm_name=~\"$vm\"}) and min(qvac_registry_blob_core_length{vm_name=~\"$vm\"}) > bool 0",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1315,7 +1315,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "quantile(0.5, qvac_registry_total_blob_bytes)",
+          "expr": "quantile(0.5, qvac_registry_total_blob_bytes{vm_name=~\"$vm\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1402,17 +1402,17 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_view_core_length",
+          "expr": "qvac_registry_view_core_length{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }} length",
           "refId": "A"
         },
         {
-          "expr": "qvac_registry_view_core_contiguous_length",
+          "expr": "qvac_registry_view_core_contiguous_length{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }} contiguous",
           "refId": "B"
         },
         {
-          "expr": "qvac_registry_view_core_length - qvac_registry_view_core_contiguous_length",
+          "expr": "qvac_registry_view_core_length{vm_name=~\"$vm\"} - qvac_registry_view_core_contiguous_length{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }} gap",
           "refId": "C"
         }
@@ -1499,7 +1499,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_blob_core_peers",
+          "expr": "qvac_registry_blob_core_peers{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }}",
           "refId": "A"
         }
@@ -1586,7 +1586,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "rate(qvac_registry_rpc_requests_total[5m])",
+          "expr": "rate(qvac_registry_rpc_requests_total{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{method}}",
           "refId": "A"
         }
@@ -1677,7 +1677,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "rate(qvac_registry_rpc_errors_total[5m])",
+          "expr": "rate(qvac_registry_rpc_errors_total{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{method}}",
           "refId": "A"
         }
@@ -1822,7 +1822,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "max(qvac_registry_totals_refreshed_age_seconds)",
+          "expr": "max(qvac_registry_totals_refreshed_age_seconds{vm_name=~\"$vm\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1909,17 +1909,17 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_blob_core_length",
+          "expr": "qvac_registry_blob_core_length{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }} length",
           "refId": "A"
         },
         {
-          "expr": "qvac_registry_blob_core_contiguous_length",
+          "expr": "qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }} contiguous",
           "refId": "B"
         },
         {
-          "expr": "qvac_registry_blob_core_length - qvac_registry_blob_core_contiguous_length",
+          "expr": "qvac_registry_blob_core_length{vm_name=~\"$vm\"} - qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }} gap",
           "refId": "C"
         }
@@ -2006,12 +2006,12 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_view_core_seeders",
+          "expr": "qvac_registry_view_core_seeders{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }} view",
           "refId": "A"
         },
         {
-          "expr": "qvac_registry_blob_core_seeders",
+          "expr": "qvac_registry_blob_core_seeders{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }} blob",
           "refId": "B"
         }
@@ -2099,7 +2099,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_blob_core_byte_length",
+          "expr": "qvac_registry_blob_core_byte_length{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }}",
           "refId": "A"
         }
@@ -2174,7 +2174,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "sum(hyperswarm_nr_peers)",
+          "expr": "sum(hyperswarm_nr_peers{vm_name=~\"$vm\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -2232,7 +2232,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "sum(dht_is_firewalled)",
+          "expr": "sum(dht_is_firewalled{vm_name=~\"$vm\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -2290,7 +2290,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "sum(hypercore_invalid_data)",
+          "expr": "sum(hypercore_invalid_data{vm_name=~\"$vm\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -2348,7 +2348,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "sum(hypercore_invalid_requests)",
+          "expr": "sum(hypercore_invalid_requests{vm_name=~\"$vm\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -2410,7 +2410,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "sum(udx_packets_dropped_total)",
+          "expr": "sum(udx_packets_dropped_total{vm_name=~\"$vm\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -2464,7 +2464,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "avg(hyperswarm_avg_congestion_window)",
+          "expr": "avg(hyperswarm_avg_congestion_window{vm_name=~\"$vm\"})",
           "legendFormat": "",
           "refId": "A"
         }
@@ -2551,7 +2551,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "hyperswarm_nr_peers",
+          "expr": "hyperswarm_nr_peers{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }}",
           "refId": "A"
         }
@@ -2639,7 +2639,7 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "hypercore_round_trip_time_avg_seconds",
+          "expr": "hypercore_round_trip_time_avg_seconds{vm_name=~\"$vm\"}",
           "legendFormat": "{{ vm_name }}",
           "refId": "A"
         }
@@ -2726,22 +2726,22 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "rate(hyperswarm_client_connections_opened[5m])",
+          "expr": "rate(hyperswarm_client_connections_opened{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} client-opened",
           "refId": "A"
         },
         {
-          "expr": "rate(hyperswarm_server_connections_opened[5m])",
+          "expr": "rate(hyperswarm_server_connections_opened{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} server-opened",
           "refId": "B"
         },
         {
-          "expr": "rate(hyperswarm_client_connections_closed[5m])",
+          "expr": "rate(hyperswarm_client_connections_closed{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} client-closed",
           "refId": "C"
         },
         {
-          "expr": "rate(hyperswarm_server_connections_closed[5m])",
+          "expr": "rate(hyperswarm_server_connections_closed{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} server-closed",
           "refId": "D"
         }
@@ -2829,12 +2829,12 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "rate(hypercore_total_wire_data_transmitted[5m])",
+          "expr": "rate(hypercore_total_wire_data_transmitted{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} tx",
           "refId": "A"
         },
         {
-          "expr": "rate(hypercore_total_wire_data_received[5m])",
+          "expr": "rate(hypercore_total_wire_data_received{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} rx",
           "refId": "B"
         }
@@ -2922,12 +2922,12 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "rate(udx_total_bytes_transmitted[5m])",
+          "expr": "rate(udx_total_bytes_transmitted{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} tx",
           "refId": "A"
         },
         {
-          "expr": "rate(udx_total_bytes_received[5m])",
+          "expr": "rate(udx_total_bytes_received{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} rx",
           "refId": "B"
         }
@@ -3014,12 +3014,12 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "rate(dht_total_queries[5m])",
+          "expr": "rate(dht_total_queries{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} queries",
           "refId": "A"
         },
         {
-          "expr": "rate(dht_total_requests[5m])",
+          "expr": "rate(dht_total_requests{vm_name=~\"$vm\"}[5m])",
           "legendFormat": "{{ vm_name }} requests",
           "refId": "B"
         }


### PR DESCRIPTION
## What problem does this PR solve?

The Grafana dashboard only visualizes a small subset of what the `/metrics` endpoint exposes. A full scrape includes 12 QVAC metrics, 20 Hypercore metrics, 12 Hyperswarm metrics, and ~25 DHT/UDX metrics, but the existing dashboard covers only 6 QVAC metrics and zero Holepunch P2P layer metrics. Operators have no visibility into swarm connectivity, replication RTT, wire throughput, DHT health, firewall state, or protocol-level anomalies (invalid data/requests, packet drops), and registry-specific gaps remain — the blob core's raw replication numbers are collapsed into a single boolean, per-node on-disk bytes are not plotted over time, and full-replica seeder counts are not displayed.

## How does it solve it?

Adds 17 panels grouped into two blocks.

Registry block (4 panels):
- **Blob Core Replication** timeseries (length / contiguous / gap) — mirrors the existing View Core Replication panel.
- **Core Seeders (full replicas)** timeseries combining `qvac_registry_view_core_seeders` and `qvac_registry_blob_core_seeders` per instance.
- **Blob Core Bytes** full-width timeseries for per-instance on-disk growth.
- **Totals Refresh Age** stat (unit s, red at >600s, `-1` mapped to "never") — catches a stalled background refresh that would silently freeze `model_count` / `total_blob_bytes`.

New "Holepunch P2P Metrics" section:
- Stat row: Swarm Peers, Firewalled Nodes, Hypercore Invalid Data, Hypercore Invalid Requests, UDX Packet Drops, Avg Congestion Window.
- Timeseries row: Swarm Peers Over Time, Replication RTT.
- Timeseries row: Swarm Connection Churn (client/server opened/closed rates), Hypercore Wire Data Throughput (Bps).
- Timeseries row: UDX Bytes (Bps), DHT Query & Request Rate.

The two Loki log panels shift from y=65/75 to y=102/112 to make room; the new `Totals Refresh Age` stat fills the previously-empty x=20 slot in the existing y=37 stat row. Panel IDs allocated from 26 upward to avoid collision. Protocol internals (per-type wire counters, DHT ping/find-node/down-hint, hypercore sessions/hotswaps/cache) are deliberately not shown to keep the dashboard focused on actionable signals.

## Breaking changes

None. Dashboard-only change; no metric additions, removals, or renames.
