### PR TITLE
feat: dummy release to test npm trusted publishing

### DIFF
--- a/packages/qvac-lib-langdetect-text-cld2/package.json
+++ b/packages/qvac-lib-langdetect-text-cld2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/langdetect-text-cld2",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Language detection using CLD2 with same API as @qvac/langdetect-text",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary

This PR performs a dummy release to test npm trusted publishing by bumping the version of `@qvac/langdetect-text-cld2`.

> PR for npm trust publishing: https://github.com/tetherto/qvac/pull/1618

---

## Changes

- The `version` in `packages/qvac-lib-langdetect-text-cld2/package.json` has been updated from `0.3.1` to `0.3.2`.

---

## Impact

This change will trigger a new publication of the `@qvac/langdetect-text-cld2` package to npm.

---

## Test plan

- [ ] Verify that the new package version `0.3.2` for `@qvac/langdetect-text-cld2` is successfully published to npm.

---

> Generated with AI via [OpenCode](https://opencode.ai)