### PR TITLE
chore[docs]: tighten registry Grafana dashboard panels based on staging review

### DIFF
--- a/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
+++ b/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
@@ -1067,7 +1067,7 @@
           "refId": "A"
         }
       ],
-      "title": "Models",
+      "title": "Model Files",
       "type": "stat"
     },
     {
@@ -1118,7 +1118,7 @@
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
@@ -1128,14 +1128,14 @@
           "values": false
         },
         "showPercentChange": false,
-        "textMode": "auto",
+        "textMode": "value_and_name",
         "wideLayout": true
       },
       "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "qvac_registry_is_indexer{vm_name=~\"$vm\"}",
-          "legendFormat": "",
+          "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],
@@ -1172,7 +1172,7 @@
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
@@ -1182,14 +1182,14 @@
           "values": false
         },
         "showPercentChange": false,
-        "textMode": "auto",
+        "textMode": "value_and_name",
         "wideLayout": true
       },
       "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "qvac_registry_blob_core_count{vm_name=~\"$vm\"}",
-          "legendFormat": "",
+          "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],
@@ -1202,34 +1202,17 @@
       },
       "fieldConfig": {
         "defaults": {
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "text": "No"
-                },
-                "1": {
-                  "color": "green",
-                  "text": "Yes"
-                }
-              },
-              "type": "value"
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": 0
-              },
-              {
                 "color": "green",
-                "value": 1
+                "value": 0
               }
             ]
-          }
+          },
+          "unit": "short"
         },
         "overrides": []
       },
@@ -1241,10 +1224,10 @@
       },
       "id": 20,
       "options": {
-        "colorMode": "background",
+        "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "vertical",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
@@ -1254,14 +1237,14 @@
           "values": false
         },
         "showPercentChange": false,
-        "textMode": "auto",
+        "textMode": "value_and_name",
         "wideLayout": true
       },
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "min(qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"} == bool qvac_registry_blob_core_length{vm_name=~\"$vm\"}) and min(qvac_registry_blob_core_length{vm_name=~\"$vm\"}) > bool 0",
-          "legendFormat": "",
+          "expr": "qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"}",
+          "legendFormat": "{{vm_name}}",
           "refId": "A"
         }
       ],
@@ -1888,7 +1871,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
         "y": 57
       },
@@ -1910,21 +1893,196 @@
       "targets": [
         {
           "expr": "qvac_registry_blob_core_length{vm_name=~\"$vm\"}",
-          "legendFormat": "{{ vm_name }} length",
+          "legendFormat": "{{ vm_name }}",
           "refId": "A"
-        },
-        {
-          "expr": "qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"}",
-          "legendFormat": "{{ vm_name }} contiguous",
-          "refId": "B"
-        },
-        {
-          "expr": "qvac_registry_blob_core_length{vm_name=~\"$vm\"} - qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"}",
-          "legendFormat": "{{ vm_name }} gap",
-          "refId": "C"
         }
       ],
-      "title": "Blob Core Replication",
+      "title": "Blob Core Length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 57
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"}",
+          "legendFormat": "{{ vm_name }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Blob Core Contiguous Length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 1000000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 57
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "qvac_registry_blob_core_length{vm_name=~\"$vm\"} - qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"}",
+          "legendFormat": "{{ vm_name }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Blob Core Gap (length - contiguous)",
       "type": "timeseries"
     },
     {
@@ -1986,8 +2144,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 57
+        "x": 0,
+        "y": 65
       },
       "id": 28,
       "options": {
@@ -2006,17 +2164,12 @@
       "pluginVersion": "12.4.0",
       "targets": [
         {
-          "expr": "qvac_registry_view_core_seeders{vm_name=~\"$vm\"}",
-          "legendFormat": "{{ vm_name }} view",
-          "refId": "A"
-        },
-        {
           "expr": "qvac_registry_blob_core_seeders{vm_name=~\"$vm\"}",
-          "legendFormat": "{{ vm_name }} blob",
-          "refId": "B"
+          "legendFormat": "{{ vm_name }}",
+          "refId": "A"
         }
       ],
-      "title": "Core Seeders (full replicas)",
+      "title": "Blob Core Seeders (full replicas)",
       "type": "timeseries"
     },
     {
@@ -2078,8 +2231,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
+        "w": 12,
+        "x": 12,
         "y": 65
       },
       "id": 29,
@@ -2211,64 +2364,6 @@
         "x": 4,
         "y": 74
       },
-      "id": 32,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.0",
-      "targets": [
-        {
-          "expr": "sum(dht_is_firewalled{vm_name=~\"$vm\"})",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Firewalled Nodes",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 8,
-        "y": 74
-      },
       "id": 33,
       "options": {
         "colorMode": "background",
@@ -2324,7 +2419,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 12,
+        "x": 8,
         "y": 74
       },
       "id": 34,
@@ -2386,7 +2481,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
+        "x": 12,
         "y": 74
       },
       "id": 35,
@@ -2440,7 +2535,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 20,
+        "x": 16,
         "y": 74
       },
       "id": 36,

--- a/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
+++ b/packages/qvac-lib-registry-server/docs/grafana/REGISTRY_DASHBOARD.json
@@ -1212,61 +1212,6 @@
               }
             ]
           },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 12,
-        "y": 37
-      },
-      "id": 20,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "vertical",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value_and_name",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.0",
-      "targets": [
-        {
-          "expr": "qvac_registry_blob_core_contiguous_length{vm_name=~\"$vm\"}",
-          "legendFormat": "{{vm_name}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Blob Core Contiguous",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
           "unit": "bytes"
         },
         "overrides": []
@@ -1274,7 +1219,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
+        "x": 12,
         "y": 37
       },
       "id": 21,
@@ -1365,8 +1310,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 41
+        "x": 12,
+        "y": 57
       },
       "id": 22,
       "options": {
@@ -1462,8 +1407,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 41
+        "x": 0,
+        "y": 49
       },
       "id": 23,
       "options": {
@@ -1550,7 +1495,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 49
+        "y": 65
       },
       "id": 24,
       "options": {
@@ -1641,7 +1586,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 65
       },
       "id": 25,
       "options": {
@@ -1781,7 +1726,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 20,
+        "x": 16,
         "y": 37
       },
       "id": 26,
@@ -1873,7 +1818,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 57
+        "y": 41
       },
       "id": 27,
       "options": {
@@ -1960,7 +1905,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 57
+        "y": 41
       },
       "id": 43,
       "options": {
@@ -2055,7 +2000,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 57
+        "y": 41
       },
       "id": 44,
       "options": {
@@ -2144,8 +2089,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 65
+        "x": 12,
+        "y": 49
       },
       "id": 28,
       "options": {
@@ -2232,8 +2177,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 65
+        "x": 0,
+        "y": 57
       },
       "id": 29,
       "options": {


### PR DESCRIPTION
## What problem does this PR solve?

First pass of dashboard review on staging surfaced several panels that were noisy, hard to read, or conveyed no useful signal:

- `Models` stat was miscounting — the metric tracks individual model files, not logical models.
- `Indexer` and `Blob Cores` stat tiles rendered per-VM series with an empty `legendFormat`, so Grafana fell back to the full metric string as the series name. The big value dominated the tile and the label was illegible.
- `Blob Core Contiguous` was a boolean tile. Since operators intentionally clear blobs from time to time, the tile sat at "No" indefinitely and carried no information.
- `Blob Core Replication` stacked three different metrics (length, contiguous, gap) at three different scales in one timeseries panel. The gap signal (the operationally interesting one) was compressed to near-invisibility by length.
- `Core Seeders (full replicas)` plotted both view-core and blob-core seeders. Only blob-core seeders are of interest.
- `Firewalled Nodes` showed `sum(dht_is_firewalled)` with no per-node breakdown. For indexers running on cloud VMs behind NAT this metric is always the same and does not convey anything actionable.

## How does it solve it?

- Rename `Models` → `Model Files`.
- `Indexer`, `Blob Cores`, `Blob Core Contiguous`: add `legendFormat: "{{vm_name}}"`, switch `textMode` to `value_and_name`, and vertical orientation so per-VM labels render with their values.
- `Blob Core Contiguous`: drop the boolean value mappings and show the actual `qvac_registry_blob_core_contiguous_length` value per VM.
- Split `Blob Core Replication` into three timeseries panels — `Blob Core Length`, `Blob Core Contiguous Length`, `Blob Core Gap (length - contiguous)` — each with its own y-axis. Gap panel uses color thresholds (green/yellow/red) and table legend with last/max calcs for quicker triage.
- `Core Seeders` panel: remove view-core series, keep blob-core only, rename to `Blob Core Seeders (full replicas)`.
- Remove `Firewalled Nodes` panel; reflow the Holepunch row to close the gap.
- Move `Blob Core Seeders` and `Blob Core Bytes` down one row to accommodate the three split blob-core panels without overflowing the grid.

## Breaking changes

None. This is a dashboard-only change in `docs/grafana/REGISTRY_DASHBOARD.json`.
