### PR TITLE
chore[notask]: release sdk 0.9.1

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.9.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.9.1
+
+Patch release with a minor documentation fix to the SDK README quickstart example — no API, behavioral, or model changes.
+
+---
+
+## 📘 Docs
+
+- Remove trailing comma in quickstart import example.
+
 ## [0.9.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.9.0

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -39,7 +39,7 @@ npm install @qvac/sdk
 3. Create the quickstart script:
 
 ```js
-import { loadModel, LLAMA_3_2_1B_INST_Q4_0, completion, unloadModel, } from "@qvac/sdk";
+import { loadModel, LLAMA_3_2_1B_INST_Q4_0, completion, unloadModel } from "@qvac/sdk";
 try {
     // Load a model into memory
     const modelId = await loadModel({

--- a/packages/sdk/changelog/0.9.1/CHANGELOG.md
+++ b/packages/sdk/changelog/0.9.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.9.1
+
+Release Date: 2026-04-23
+
+## 📘 Docs
+
+- Remove trailing comma in quickstart import example.

--- a/packages/sdk/changelog/0.9.1/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.9.1/CHANGELOG_LLM.md
@@ -1,0 +1,11 @@
+# QVAC SDK v0.9.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.9.1
+
+Patch release with a minor documentation fix to the SDK README quickstart example — no API, behavioral, or model changes.
+
+---
+
+## 📘 Docs
+
+- Remove trailing comma in quickstart import example.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Patch release of `@qvac/sdk` to `0.9.1` to validate infra workflow changes.
- No user-facing behavioral changes.

## 📝 How does it solve it?

- Minor readme update
- Bump `packages/sdk/package.json` from `0.9.0` → `0.9.1`.
- Add `packages/sdk/changelog/0.9.1/` (`CHANGELOG.md` + `CHANGELOG_LLM.md`) and re-aggregate root `packages/sdk/CHANGELOG.md`.