### PR TITLE
feat[notask]: add Supertonic desktop benchmark reporting

### DIFF
--- a/.github/workflows/benchmark-performance-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/benchmark-performance-qvac-lib-infer-onnx-tts.yml
@@ -1,0 +1,509 @@
+name: Benchmark Performance (Supertonic TTS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Repository to benchmark"
+        required: false
+        type: string
+      ref:
+        description: "Git ref (branch/tag/SHA) to benchmark"
+        required: false
+        type: string
+      max_samples:
+        description: "Maximum samples per language (0 = full dataset)"
+        required: false
+        type: number
+        default: 25
+      round_trip_test:
+        description: "Enable round-trip quality test (TTS -> Whisper -> WER/CER)"
+        required: true
+        type: boolean
+        default: true
+      whisper_model:
+        description: "Whisper model for round-trip quality checks"
+        required: false
+        type: choice
+        default: tiny
+        options:
+          - tiny
+          - base
+          - small
+          - medium
+      num_runs:
+        description: "Number of benchmark runs per device/backend"
+        required: false
+        type: number
+        default: 1
+      run_python:
+        description: "Run the Python baseline on CPU benchmark jobs"
+        required: true
+        type: boolean
+        default: true
+      include_desktop:
+        description: "Run the desktop benchmark matrix"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: read
+  id-token: write
+
+jobs:
+  context:
+    runs-on: ubuntu-latest
+    outputs:
+      repository: ${{ steps.ctx.outputs.repository }}
+      ref: ${{ steps.ctx.outputs.ref }}
+      max_samples: ${{ steps.ctx.outputs.max_samples }}
+      round_trip_test: ${{ steps.ctx.outputs.round_trip_test }}
+      whisper_model: ${{ steps.ctx.outputs.whisper_model }}
+      num_runs: ${{ steps.ctx.outputs.num_runs }}
+      run_python: ${{ steps.ctx.outputs.run_python }}
+      include_desktop: ${{ steps.ctx.outputs.include_desktop }}
+    steps:
+      - id: ctx
+        shell: bash
+        env:
+          INPUT_REPO: ${{ inputs.repository }}
+          INPUT_REF: ${{ inputs.ref }}
+          INPUT_MAX_SAMPLES: ${{ inputs.max_samples }}
+          INPUT_ROUND_TRIP_TEST: ${{ inputs.round_trip_test }}
+          INPUT_WHISPER_MODEL: ${{ inputs.whisper_model }}
+          INPUT_NUM_RUNS: ${{ inputs.num_runs }}
+          INPUT_RUN_PYTHON: ${{ inputs.run_python }}
+          INPUT_INCLUDE_DESKTOP: ${{ inputs.include_desktop }}
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          repo="${INPUT_REPO:-$REPO}"
+          ref="${INPUT_REF:-$REF_NAME}"
+          echo "repository=$repo" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "max_samples=${INPUT_MAX_SAMPLES:-25}" >> "$GITHUB_OUTPUT"
+          echo "round_trip_test=${INPUT_ROUND_TRIP_TEST}" >> "$GITHUB_OUTPUT"
+          echo "whisper_model=${INPUT_WHISPER_MODEL:-tiny}" >> "$GITHUB_OUTPUT"
+          echo "num_runs=${INPUT_NUM_RUNS:-1}" >> "$GITHUB_OUTPUT"
+          echo "run_python=${INPUT_RUN_PYTHON}" >> "$GITHUB_OUTPUT"
+          echo "include_desktop=${INPUT_INCLUDE_DESKTOP}" >> "$GITHUB_OUTPUT"
+
+  prebuild:
+    needs: context
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
+    uses: ./.github/workflows/prebuilds-qvac-lib-infer-onnx-tts.yml
+    secrets: inherit
+    with:
+      repository: ${{ needs.context.outputs.repository }}
+      ref: ${{ needs.context.outputs.ref }}
+
+  desktop-benchmarks:
+    needs: [context, prebuild]
+    if: needs.context.outputs.include_desktop != 'false'
+    runs-on: ${{ matrix.os }}
+    environment: release
+    timeout-minutes: 180
+    name: supertonic-${{ matrix.runner_label }}-${{ matrix.backend }}
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            platform: linux
+            arch: x64
+            runner_label: ubuntu-22.04
+            device_label: ubuntu-22.04-x64
+            backend: cpu
+            use_gpu: false
+            run_python: true
+          - os: ai-run-linux-gpu
+            platform: linux
+            arch: x64
+            runner_label: ai-run-linux-gpu
+            device_label: ai-run-linux-gpu
+            backend: cpu
+            use_gpu: false
+            run_python: true
+          - os: ai-run-linux-gpu
+            platform: linux
+            arch: x64
+            runner_label: ai-run-linux-gpu
+            device_label: ai-run-linux-gpu
+            backend: cuda
+            use_gpu: true
+            run_python: false
+          - os: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
+            runner_label: ubuntu-24.04-arm
+            device_label: ubuntu-24.04-arm64
+            backend: cpu
+            use_gpu: false
+            run_python: true
+          - os: macos-14-xlarge
+            platform: darwin
+            arch: arm64
+            runner_label: macos-14-xlarge
+            device_label: macos-14-xlarge
+            backend: cpu
+            use_gpu: false
+            run_python: true
+          - os: macos-14-xlarge
+            platform: darwin
+            arch: arm64
+            runner_label: macos-14-xlarge
+            device_label: macos-14-xlarge
+            backend: coreml
+            use_gpu: true
+            run_python: false
+          - os: macos-15-large
+            platform: darwin
+            arch: x64
+            runner_label: macos-15-large
+            device_label: macos-15-large
+            backend: cpu
+            use_gpu: false
+            run_python: true
+          - os: macos-15-large
+            platform: darwin
+            arch: x64
+            runner_label: macos-15-large
+            device_label: macos-15-large
+            backend: coreml
+            use_gpu: true
+            run_python: false
+          - os: windows-2022
+            platform: win32
+            arch: x64
+            runner_label: windows-2022
+            device_label: windows-2022-x64
+            backend: cpu
+            use_gpu: false
+            run_python: true
+          - os: windows-2022
+            platform: win32
+            arch: x64
+            runner_label: windows-2022
+            device_label: windows-2022-x64
+            backend: directml
+            use_gpu: true
+            run_python: false
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0
+        with:
+          python-version: '3.14'
+
+      - name: Windows - enable git long paths
+        if: ${{ matrix.platform == 'win32' }}
+        shell: bash
+        run: git config --system core.longpaths true
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          repository: ${{ needs.context.outputs.repository }}
+          ref: ${{ needs.context.outputs.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Configure scoped registry for @tetherto and @qvac packages (Unix)
+        if: ${{ matrix.platform != 'win32' }}
+        working-directory: packages/qvac-lib-infer-onnx-tts
+        env:
+          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_PAT: ${{ secrets.PAT_TOKEN }}
+        shell: bash
+        run: |
+          echo "Configuring scoped registry for @tetherto and @qvac packages..."
+          set -eu
+          cat > .npmrc <<NPMRC
+          always-auth=true
+          registry=https://registry.npmjs.org/
+          @qvac:registry=https://registry.npmjs.org/
+          @tetherto:registry=https://npm.pkg.github.com/
+          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          //npm.pkg.github.com/:_authToken=${GPR_TOKEN}
+          NPMRC
+
+          if [ -n "${GIT_PAT:-}" ]; then
+            git config --global url."https://${GIT_PAT}:@github.com/".insteadOf "https://github.com/"
+          else
+            git config --global url."https://${{ github.token }}:@github.com/".insteadOf "https://github.com/"
+          fi
+
+          cp .npmrc benchmarks/server/.npmrc
+
+      - name: Configure scoped registry for @tetherto and @qvac packages (Windows)
+        if: ${{ matrix.platform == 'win32' }}
+        working-directory: packages/qvac-lib-infer-onnx-tts
+        env:
+          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GIT_PAT: ${{ secrets.PAT_TOKEN }}
+        shell: powershell
+        run: |
+          $npmrc = @"
+          always-auth=true
+          registry=https://registry.npmjs.org/
+          @qvac:registry=https://registry.npmjs.org/
+          @tetherto:registry=https://npm.pkg.github.com/
+          //registry.npmjs.org/:_authToken=$env:NPM_TOKEN
+          //npm.pkg.github.com/:_authToken=$env:GPR_TOKEN
+          "@
+          $npmrc | Out-File -FilePath .npmrc -Encoding utf8
+          if ($env:GIT_PAT) {
+            git config --global url."https://$($env:GIT_PAT):@github.com/".insteadOf "https://github.com/"
+          } else {
+            git config --global url."https://${{ github.token }}:@github.com/".insteadOf "https://github.com/"
+          }
+          Copy-Item -Path .npmrc -Destination benchmarks/server/.npmrc -Force
+
+      - name: Install Bare runtime
+        run: |
+          npm install -g bare bare-make
+
+      - name: Download merged prebuilds
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: prebuilds
+          path: packages/qvac-lib-infer-onnx-tts/prebuilds
+
+      - name: Linux - install runtime dependencies
+        if: ${{ matrix.platform == 'linux' }}
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers
+
+      - name: Install benchmark server dependencies
+        working-directory: packages/qvac-lib-infer-onnx-tts/benchmarks/server
+        run: npm install
+
+      - name: Download Supertonic models
+        working-directory: packages/qvac-lib-infer-onnx-tts/benchmarks/server
+        run: npm run setup:supertonic
+
+      - name: Install Python server dependencies
+        if: ${{ needs.context.outputs.run_python != 'false' && matrix.run_python }}
+        working-directory: packages/qvac-lib-infer-onnx-tts/benchmarks/python-server
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install -r requirements-supertonic.txt
+
+      - name: Install benchmark client dependencies
+        working-directory: packages/qvac-lib-infer-onnx-tts/benchmarks/client
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+
+      - name: Start Python Native server (Unix)
+        if: ${{ matrix.platform != 'win32' && needs.context.outputs.run_python != 'false' && matrix.run_python }}
+        working-directory: packages/qvac-lib-infer-onnx-tts/benchmarks/python-server
+        shell: bash
+        run: |
+          nohup python main.py > server.log 2>&1 &
+          echo $! > server.pid
+          sleep 10
+          if ! kill -0 "$(cat server.pid)" 2>/dev/null; then
+            cat server.log
+            exit 1
+          fi
+
+      - name: Start Python Native server (Windows)
+        if: ${{ matrix.platform == 'win32' && needs.context.outputs.run_python != 'false' && matrix.run_python }}
+        working-directory: packages/qvac-lib-infer-onnx-tts/benchmarks/python-server
+        shell: powershell
+        run: |
+          $logPath = Join-Path $PWD "server.log"
+          $errorPath = Join-Path $PWD "server-error.log"
+          $proc = Start-Process -FilePath python -ArgumentList "main.py" -WorkingDirectory $PWD -RedirectStandardOutput $logPath -RedirectStandardError $errorPath -PassThru
+          $proc.Id | Out-File -FilePath server.pid -Encoding ascii
+          Start-Sleep -Seconds 10
+          if ($proc.HasExited) {
+            if (Test-Path $logPath) { Get-Content $logPath }
+            if (Test-Path $errorPath) { Get-Content $errorPath }
+            exit 1
+          }
+
+      - name: Start TTS Addon server (Unix)
+        if: ${{ matrix.platform != 'win32' }}
+        working-directory: packages/qvac-lib-infer-onnx-tts/benchmarks/server
+        shell: bash
+        run: |
+          nohup npm start > server.log 2>&1 &
+          echo $! > server.pid
+          sleep 5
+          if ! kill -0 "$(cat server.pid)" 2>/dev/null; then
+            cat server.log
+            exit 1
+          fi
+
+      - name: Start TTS Addon server (Windows)
+        if: ${{ matrix.platform == 'win32' }}
+        working-directory: packages/qvac-lib-infer-onnx-tts/benchmarks/server
+        shell: powershell
+        run: |
+          $logPath = Join-Path $PWD "server.log"
+          $errorPath = Join-Path $PWD "server-error.log"
+          $proc = Start-Process -FilePath npm.cmd -ArgumentList "start" -WorkingDirectory $PWD -RedirectStandardOutput $logPath -RedirectStandardError $errorPath -PassThru
+          $proc.Id | Out-File -FilePath server.pid -Encoding ascii
+          Start-Sleep -Seconds 5
+          if ($proc.HasExited) {
+            if (Test-Path $logPath) { Get-Content $logPath }
+            if (Test-Path $errorPath) { Get-Content $errorPath }
+            exit 1
+          }
+
+      - name: Clean old benchmark results
+        working-directory: packages/qvac-lib-infer-onnx-tts
+        shell: bash
+        run: |
+          rm -rf benchmarks/results/*.json
+          rm -rf benchmarks/results/*.md
+
+      - name: Run Supertonic benchmark
+        working-directory: packages/qvac-lib-infer-onnx-tts/benchmarks/client
+        shell: bash
+        env:
+          PYTHONUNBUFFERED: "1"
+          HF_DATASETS_CACHE: /tmp/hf_cache
+          QVAC_SUPERTONIC_BENCHMARK_LABEL: ${{ matrix.runner_label }}-${{ matrix.backend }}
+          QVAC_SUPERTONIC_BENCHMARK_RUNNER: ${{ matrix.runner_label }}
+          QVAC_SUPERTONIC_BENCHMARK_DEVICE: ${{ matrix.device_label }}
+          QVAC_SUPERTONIC_BENCHMARK_BACKEND: ${{ matrix.backend }}
+          QVAC_SUPERTONIC_BENCHMARK_MAX_SAMPLES: ${{ needs.context.outputs.max_samples }}
+          QVAC_SUPERTONIC_BENCHMARK_ROUND_TRIP_TEST: ${{ needs.context.outputs.round_trip_test }}
+          QVAC_SUPERTONIC_BENCHMARK_WHISPER_MODEL: ${{ needs.context.outputs.whisper_model }}
+          QVAC_SUPERTONIC_BENCHMARK_NUM_RUNS: ${{ needs.context.outputs.num_runs }}
+          QVAC_SUPERTONIC_BENCHMARK_USE_GPU: ${{ matrix.use_gpu && 'true' || 'false' }}
+          QVAC_SUPERTONIC_BENCHMARK_RUN_PYTHON: ${{ needs.context.outputs.run_python != 'false' && matrix.run_python && 'true' || 'false' }}
+        run: |
+          python -u -m src.tts.main --config config/config-supertonic.yaml
+          rm -rf /tmp/hf_cache || true
+
+      - name: Stop servers (Unix)
+        if: ${{ always() && matrix.platform != 'win32' }}
+        working-directory: packages/qvac-lib-infer-onnx-tts
+        shell: bash
+        run: |
+          if [ -f benchmarks/python-server/server.pid ]; then
+            kill "$(cat benchmarks/python-server/server.pid)" 2>/dev/null || true
+            rm -f benchmarks/python-server/server.pid
+          fi
+          if [ -f benchmarks/server/server.pid ]; then
+            kill "$(cat benchmarks/server/server.pid)" 2>/dev/null || true
+            rm -f benchmarks/server/server.pid
+          fi
+
+      - name: Stop servers (Windows)
+        if: ${{ always() && matrix.platform == 'win32' }}
+        working-directory: packages/qvac-lib-infer-onnx-tts
+        shell: powershell
+        run: |
+          if (Test-Path benchmarks/python-server/server.pid) {
+            Stop-Process -Id (Get-Content benchmarks/python-server/server.pid) -Force -ErrorAction SilentlyContinue
+            Remove-Item benchmarks/python-server/server.pid -ErrorAction SilentlyContinue
+          }
+          if (Test-Path benchmarks/server/server.pid) {
+            Stop-Process -Id (Get-Content benchmarks/server/server.pid) -Force -ErrorAction SilentlyContinue
+            Remove-Item benchmarks/server/server.pid -ErrorAction SilentlyContinue
+          }
+
+      - name: Display server logs
+        if: always()
+        working-directory: packages/qvac-lib-infer-onnx-tts
+        shell: bash
+        run: |
+          if [ -f benchmarks/server/server.log ]; then
+            echo "=== Addon Server ==="
+            cat benchmarks/server/server.log
+          fi
+          if [ -f benchmarks/server/server-error.log ]; then
+            echo "=== Addon Server Errors ==="
+            cat benchmarks/server/server-error.log
+          fi
+          if [ -f benchmarks/python-server/server.log ]; then
+            echo "=== Python Server ==="
+            cat benchmarks/python-server/server.log
+          fi
+          if [ -f benchmarks/python-server/server-error.log ]; then
+            echo "=== Python Server Errors ==="
+            cat benchmarks/python-server/server-error.log
+          fi
+
+      - name: List structured benchmark results
+        if: always()
+        working-directory: packages/qvac-lib-infer-onnx-tts
+        shell: bash
+        run: |
+          ls -la benchmarks/results || true
+
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: supertonic-rtf-results-${{ matrix.runner_label }}-${{ matrix.backend }}
+          path: packages/qvac-lib-infer-onnx-tts/benchmarks/results/
+          retention-days: 30
+          if-no-files-found: ignore
+
+  summarize:
+    needs: [context, desktop-benchmarks]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          repository: ${{ needs.context.outputs.repository }}
+          ref: ${{ needs.context.outputs.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Download desktop benchmark artifacts
+        if: needs.context.outputs.include_desktop != 'false'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          pattern: supertonic-rtf-results-*
+          path: benchmark-artifacts/desktop
+          merge-multiple: true
+
+      - name: Generate consolidated benchmark report
+        run: |
+          node scripts/perf-report/aggregate-supertonic-rtf.js \
+            --dir benchmark-artifacts/desktop \
+            --manual-dir packages/qvac-lib-infer-onnx-tts/benchmarks/manual-results \
+            --output benchmark-artifacts/supertonic-performance-findings.md \
+            --output-json benchmark-artifacts/supertonic-performance-findings.json \
+            --output-html benchmark-artifacts/supertonic-performance-findings.html
+
+      - name: Add summary
+        run: cat benchmark-artifacts/supertonic-performance-findings.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload consolidated benchmark report
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: supertonic-performance-findings
+          path: |
+            benchmark-artifacts/supertonic-performance-findings.md
+            benchmark-artifacts/supertonic-performance-findings.json
+            benchmark-artifacts/supertonic-performance-findings.html
+          retention-days: 30

--- a/packages/qvac-lib-infer-onnx-tts/benchmarks/client/src/tts/main.py
+++ b/packages/qvac-lib-infer-onnx-tts/benchmarks/client/src/tts/main.py
@@ -7,6 +7,7 @@ and generates comparison reports.
 
 import argparse
 import logging
+import os
 import random
 import sys
 from pathlib import Path
@@ -16,7 +17,13 @@ import numpy as np
 from .config import Config
 from .client import TTSClient
 from .dataset import load_dataset_texts
-from .utils import save_single_result, save_comparison_report, round_trip_quality_test, round_trip_single_implementation
+from .utils import (
+    round_trip_quality_test,
+    round_trip_single_implementation,
+    save_comparison_report,
+    save_single_result,
+    save_supertonic_perf_report,
+)
 from .whisper_transcriber import WhisperTranscriber
 
 # Mapping for TTS language codes to Whisper language codes (where they differ)
@@ -34,6 +41,75 @@ logging.basicConfig(
     datefmt='%Y-%m-%d %H:%M:%S'
 )
 logger = logging.getLogger(__name__)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        logger.warning("Invalid integer for %s: %s", name, value)
+        return default
+
+
+def apply_supertonic_env_overrides(cfg: Config) -> Config:
+    """Apply workflow-driven Supertonic benchmark overrides from env vars."""
+    dataset_updates = {}
+    comparison_updates = {}
+    model_updates = {}
+
+    if "QVAC_SUPERTONIC_BENCHMARK_MAX_SAMPLES" in os.environ:
+        dataset_updates["max_samples"] = _env_int(
+            "QVAC_SUPERTONIC_BENCHMARK_MAX_SAMPLES",
+            cfg.dataset.max_samples,
+        )
+
+    if "QVAC_SUPERTONIC_BENCHMARK_RUN_PYTHON" in os.environ:
+        comparison_updates["run_python"] = _env_bool(
+            "QVAC_SUPERTONIC_BENCHMARK_RUN_PYTHON",
+            cfg.comparison.run_python,
+        )
+
+    if "QVAC_SUPERTONIC_BENCHMARK_ROUND_TRIP_TEST" in os.environ:
+        comparison_updates["round_trip_test"] = _env_bool(
+            "QVAC_SUPERTONIC_BENCHMARK_ROUND_TRIP_TEST",
+            cfg.comparison.round_trip_test,
+        )
+
+    if "QVAC_SUPERTONIC_BENCHMARK_WHISPER_MODEL" in os.environ:
+        comparison_updates["whisper_model"] = os.environ["QVAC_SUPERTONIC_BENCHMARK_WHISPER_MODEL"]
+
+    if "QVAC_SUPERTONIC_BENCHMARK_NUM_RUNS" in os.environ:
+        comparison_updates["num_runs"] = _env_int(
+            "QVAC_SUPERTONIC_BENCHMARK_NUM_RUNS",
+            cfg.comparison.num_runs,
+        )
+
+    if "QVAC_SUPERTONIC_BENCHMARK_USE_GPU" in os.environ:
+        model_updates["useGPU"] = _env_bool(
+            "QVAC_SUPERTONIC_BENCHMARK_USE_GPU",
+            cfg.model.useGPU,
+        )
+
+    if not dataset_updates and not comparison_updates and not model_updates:
+        return cfg
+
+    return cfg.model_copy(
+        update={
+            "dataset": cfg.dataset.model_copy(update=dataset_updates) if dataset_updates else cfg.dataset,
+            "comparison": cfg.comparison.model_copy(update=comparison_updates) if comparison_updates else cfg.comparison,
+            "model": cfg.model.model_copy(update=model_updates) if model_updates else cfg.model,
+        }
+    )
 
 
 def run_supertonic_benchmark_suite(cfg: Config, config_path: str) -> None:
@@ -119,6 +195,13 @@ def run_supertonic_benchmark_suite(cfg: Config, config_path: str) -> None:
                     addon_round_trip,
                     result_language=lang,
                 )
+                save_supertonic_perf_report(
+                    cfg_eff,
+                    addon_runs,
+                    "addon",
+                    addon_round_trip,
+                    result_language=lang,
+                )
             finally:
                 addon_client.close()
 
@@ -142,6 +225,13 @@ def run_supertonic_benchmark_suite(cfg: Config, config_path: str) -> None:
                 save_single_result(
                     cfg_eff,
                     python_runs[0],
+                    "python-native",
+                    python_round_trip,
+                    result_language=lang,
+                )
+                save_supertonic_perf_report(
+                    cfg_eff,
+                    python_runs,
                     "python-native",
                     python_round_trip,
                     result_language=lang,
@@ -176,6 +266,9 @@ def main():
     except Exception as e:
         logger.error(f"Failed to load config: {e}")
         sys.exit(1)
+
+    if "supertonic" in args.config:
+        cfg = apply_supertonic_env_overrides(cfg)
     
     logger.info("Configuration loaded successfully")
 

--- a/packages/qvac-lib-infer-onnx-tts/benchmarks/client/src/tts/utils.py
+++ b/packages/qvac-lib-infer-onnx-tts/benchmarks/client/src/tts/utils.py
@@ -1,8 +1,13 @@
 """Utility functions for TTS benchmarks"""
 
+import json
 import logging
+import os
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
+import platform as pyplatform
+import re
 import statistics
 import numpy as np
 
@@ -38,6 +43,276 @@ def calculate_percentiles(values: List[float]) -> Dict[str, float]:
         "p95": statistics.quantiles(sorted_vals, n=20)[18] if len(sorted_vals) >= 20 else sorted_vals[-1],
         "p99": statistics.quantiles(sorted_vals, n=100)[98] if len(sorted_vals) >= 100 else sorted_vals[-1]
     }
+
+
+def summarize_numeric_values(values: List[float]) -> Optional[Dict[str, float]]:
+    """Summarize numeric values with percentiles."""
+    nums = [float(v) for v in values if v is not None]
+    if not nums:
+        return None
+
+    percentiles = calculate_percentiles(nums)
+    return {
+        "mean": float(statistics.mean(nums)),
+        "min": float(min(nums)),
+        "max": float(max(nums)),
+        "stddev": float(statistics.pstdev(nums)) if len(nums) > 1 else 0.0,
+        "p50": float(percentiles["p50"]),
+        "p90": float(percentiles["p90"]),
+        "p95": float(percentiles["p95"]),
+        "p99": float(percentiles["p99"]),
+        "count": len(nums),
+    }
+
+
+def _sanitize_tag(value: str) -> str:
+    if not value:
+        return ""
+    return re.sub(r"[^a-z0-9]+", "-", str(value).lower()).strip("-")
+
+
+def _normalize_platform_name(raw_name: str) -> str:
+    value = str(raw_name or "").lower()
+    if value.startswith("win"):
+        return "win32"
+    if value == "darwin":
+        return "darwin"
+    if value == "linux":
+        return "linux"
+    return value or "unknown"
+
+
+def _normalize_arch(raw_arch: str) -> str:
+    value = str(raw_arch or "").lower()
+    return {
+        "x86_64": "x64",
+        "amd64": "x64",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }.get(value, value or "unknown")
+
+
+def derive_benchmark_backend(platform_name: str, use_gpu: bool, backend_hint: str = "") -> str:
+    """Infer the backend family for the benchmark record."""
+    hint = str(backend_hint or "").lower()
+    if hint:
+        return hint
+    if not use_gpu:
+        return "cpu"
+    if platform_name == "darwin":
+        return "coreml"
+    if platform_name == "win32":
+        return "directml"
+    if platform_name == "linux":
+        return "cuda"
+    return "gpu"
+
+
+def _get_supertonic_benchmark_labels() -> Dict[str, str]:
+    return {
+        "label": os.environ.get("QVAC_SUPERTONIC_BENCHMARK_LABEL", ""),
+        "runner": os.environ.get("QVAC_SUPERTONIC_BENCHMARK_RUNNER", ""),
+        "device": os.environ.get("QVAC_SUPERTONIC_BENCHMARK_DEVICE", ""),
+        "backend": os.environ.get("QVAC_SUPERTONIC_BENCHMARK_BACKEND", ""),
+    }
+
+
+def _build_supertonic_quality_summary(round_trip_metrics: Optional[Dict]) -> Optional[Dict]:
+    if not round_trip_metrics or not round_trip_metrics.get("runs"):
+        return None
+
+    wer_summary = summarize_numeric_values([
+        run.get("avg_wer") for run in round_trip_metrics["runs"]
+        if run.get("avg_wer") is not None
+    ])
+    cer_summary = summarize_numeric_values([
+        run.get("avg_cer") for run in round_trip_metrics["runs"]
+        if run.get("avg_cer") is not None
+    ])
+
+    return {
+        "wer": wer_summary,
+        "cer": cer_summary,
+        "samplesTested": round_trip_metrics.get("total_tested", 0),
+    }
+
+
+def _build_supertonic_run_reports(
+    runs: List[TTSResults],
+    round_trip_metrics: Optional[Dict],
+) -> List[Dict]:
+    run_reports = []
+    quality_runs = (round_trip_metrics or {}).get("runs", [])
+
+    for run_idx, run in enumerate(runs, 1):
+        run_report = {
+            "iteration": run_idx,
+            "sampleCount": len(run.results),
+            "loadTimeMs": float(run.load_time_ms),
+            "totalGenerationMs": float(run.total_generation_ms),
+            "totalAudioDurationSec": float(run.total_audio_duration),
+            "summary": {
+                "rtf": summarize_numeric_values([result.rtf for result in run.results]),
+                "generationMs": summarize_numeric_values([result.generation_ms for result in run.results]),
+                "durationSec": summarize_numeric_values([result.duration_sec for result in run.results]),
+                "speedRealtime": summarize_numeric_values([
+                    (1 / result.rtf) for result in run.results if result.rtf > 0
+                ]),
+            },
+        }
+
+        if run_idx <= len(quality_runs):
+            quality_run = quality_runs[run_idx - 1]
+            run_report["quality"] = {
+                "avgWer": quality_run.get("avg_wer"),
+                "avgCer": quality_run.get("avg_cer"),
+                "minWer": quality_run.get("min_wer"),
+                "maxWer": quality_run.get("max_wer"),
+                "minCer": quality_run.get("min_cer"),
+                "maxCer": quality_run.get("max_cer"),
+                "perLanguage": quality_run.get("per_language", {}),
+                "perLanguageRtf": quality_run.get("per_language_rtf", {}),
+            }
+
+        run_reports.append(run_report)
+
+    return run_reports
+
+
+def build_supertonic_perf_report(
+    cfg: Config,
+    runs: List[TTSResults],
+    label: str,
+    round_trip_metrics: Optional[Dict] = None,
+    *,
+    result_language: Optional[str] = None,
+) -> Dict:
+    """Build a structured Supertonic benchmark report."""
+    if not runs:
+        raise ValueError("Supertonic benchmark report requires at least one run")
+
+    labels = _get_supertonic_benchmark_labels()
+    platform_name = _normalize_platform_name(pyplatform.system())
+    arch = _normalize_arch(pyplatform.machine())
+    platform_id = f"{platform_name}-{arch}"
+    backend = derive_benchmark_backend(platform_name, cfg.model.useGPU, labels["backend"])
+    language = result_language or cfg.model.language
+    model_dir = getattr(cfg.model, "modelDir", None)
+    all_results = [result for run in runs for result in run.results]
+
+    report = {
+        "schemaVersion": 1,
+        "benchmark": "supertonic-rtf",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "platform": platform_id,
+        "platformName": platform_name,
+        "arch": arch,
+        "labels": {
+            "label": labels["label"],
+            "runner": labels["runner"],
+            "device": labels["device"],
+            "backend": backend,
+        },
+        "requested": {
+            "useGPU": bool(cfg.model.useGPU),
+            "backendHint": labels["backend"],
+            "deviceLabel": labels["device"],
+            "runnerLabel": labels["runner"],
+            "numRuns": cfg.comparison.num_runs,
+            "roundTripTest": cfg.comparison.round_trip_test,
+            "runPython": cfg.comparison.run_python,
+        },
+        "implementation": {
+            "key": label,
+            "name": runs[0].implementation,
+            "version": runs[0].version,
+        },
+        "model": {
+            "name": "supertonic",
+            "variant": Path(model_dir).name if model_dir else "supertonic",
+            "modelDir": model_dir,
+            "language": language,
+            "voiceName": cfg.model.voiceName or "F1",
+            "supertonicMultilingual": bool(getattr(cfg.model, "supertonicMultilingual", False)),
+        },
+        "dataset": {
+            "name": cfg.dataset.name,
+            "split": cfg.dataset.split,
+            "maxSamples": cfg.dataset.max_samples,
+            "language": language,
+        },
+        "config": {
+            "batchSize": cfg.server.batch_size,
+            "numRuns": cfg.comparison.num_runs,
+            "roundTripTest": cfg.comparison.round_trip_test,
+            "whisperModel": cfg.comparison.whisper_model,
+            "speed": getattr(cfg.model, "speed", None),
+            "numInferenceSteps": getattr(cfg.model, "numInferenceSteps", None),
+        },
+        "samples": {
+            "total": len(all_results),
+            "perRun": [len(run.results) for run in runs],
+        },
+        "summary": {
+            "rtf": summarize_numeric_values([result.rtf for result in all_results]),
+            "generationMs": summarize_numeric_values([result.generation_ms for result in all_results]),
+            "durationSec": summarize_numeric_values([result.duration_sec for result in all_results]),
+            "speedRealtime": summarize_numeric_values([
+                (1 / result.rtf) for result in all_results if result.rtf > 0
+            ]),
+            "loadTimeMs": summarize_numeric_values([run.load_time_ms for run in runs]),
+            "totalGenerationMs": summarize_numeric_values([run.total_generation_ms for run in runs]),
+            "totalAudioDurationSec": summarize_numeric_values([run.total_audio_duration for run in runs]),
+        },
+        "quality": _build_supertonic_quality_summary(round_trip_metrics),
+        "runs": _build_supertonic_run_reports(runs, round_trip_metrics),
+    }
+
+    return report
+
+
+def get_supertonic_report_filename(report: Dict) -> str:
+    """Get a stable filename for a structured Supertonic benchmark report."""
+    parts = [
+        "rtf-benchmark",
+        report.get("platform", "unknown"),
+        report.get("implementation", {}).get("key", "unknown"),
+        report.get("dataset", {}).get("language", "unknown"),
+        "gpu" if report.get("requested", {}).get("useGPU") else "cpu",
+    ]
+
+    backend = _sanitize_tag(report.get("labels", {}).get("backend", ""))
+    if backend and backend not in parts:
+        parts.append(backend)
+
+    label = _sanitize_tag(report.get("labels", {}).get("label", ""))
+    if label:
+        parts.append(label)
+
+    return "-".join(filter(None, parts)) + ".json"
+
+
+def save_supertonic_perf_report(
+    cfg: Config,
+    runs: List[TTSResults],
+    label: str,
+    round_trip_metrics: Optional[Dict] = None,
+    *,
+    result_language: Optional[str] = None,
+) -> Path:
+    """Write a structured Supertonic benchmark report to disk."""
+    results_root = _get_results_root()
+    report = build_supertonic_perf_report(
+        cfg,
+        runs,
+        label,
+        round_trip_metrics,
+        result_language=result_language,
+    )
+    report_path = results_root / get_supertonic_report_filename(report)
+    report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    logger.info(f"Saved structured benchmark report to {report_path}")
+    return report_path
 
 
 def save_single_result(
@@ -144,7 +419,7 @@ def save_single_result(
         ""
     ])
     
-    md_path.write_text("\n".join(lines), encoding="utf-8")
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     logger.info(f"Saved results to {md_path}")
 
 
@@ -627,6 +902,6 @@ def save_comparison_report(cfg: Config, addon_runs: List[TTSResults], python_run
         ""
     ])
     
-    md_path.write_text("\n".join(lines), encoding="utf-8")
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     logger.info(f"Saved comparison report to {md_path}")
 

--- a/packages/qvac-lib-infer-onnx-tts/benchmarks/manual-results/README.md
+++ b/packages/qvac-lib-infer-onnx-tts/benchmarks/manual-results/README.md
@@ -1,0 +1,64 @@
+# Manual Performance Results
+
+Drop additional Supertonic desktop benchmark JSON files in this directory when you need
+to include supported GPU backends or devices that are not available on CI.
+
+The preferred input is the same JSON artifact shape emitted by the Supertonic benchmark
+client, for example:
+
+```json
+{
+  "benchmark": "supertonic-rtf",
+  "platform": "linux-x64",
+  "implementation": {
+    "key": "addon",
+    "name": "supertone-onnx-addon"
+  },
+  "labels": {
+    "device": "local-rocm-box",
+    "runner": "manual",
+    "backend": "rocm"
+  },
+  "requested": {
+    "useGPU": true
+  },
+  "dataset": {
+    "language": "en"
+  },
+  "model": {
+    "variant": "supertonic-v1"
+  },
+  "summary": {
+    "rtf": {
+      "mean": 0.42,
+      "p50": 0.41,
+      "p95": 0.46
+    },
+    "generationMs": {
+      "mean": 812
+    },
+    "loadTimeMs": {
+      "mean": 245
+    }
+  },
+  "quality": {
+    "wer": {
+      "mean": 0.031
+    },
+    "cer": {
+      "mean": 0.012
+    }
+  }
+}
+```
+
+These files are picked up automatically by:
+
+- `scripts/perf-report/aggregate-supertonic-rtf.js`
+- `.github/workflows/benchmark-performance-qvac-lib-infer-onnx-tts.yml`
+
+Use this directory for results such as:
+
+- Linux ROCm devices
+- Windows CUDA-specific runs
+- Any other supported backend or desktop device combination that the CI matrix cannot host

--- a/scripts/perf-report/aggregate-supertonic-rtf.js
+++ b/scripts/perf-report/aggregate-supertonic-rtf.js
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const SUPPORTED_GPU_BACKENDS = ['coreml', 'cuda', 'directml', 'rocm', 'nnapi']
+
+function parseArgs (argv) {
+  const args = {
+    input: '',
+    output: '',
+    jsonOutput: '',
+    htmlOutput: '',
+    manualDir: path.resolve('packages/qvac-lib-infer-onnx-tts/benchmarks/manual-results')
+  }
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    const next = argv[i + 1]
+    if ((arg === '--input' || arg === '--dir') && next) {
+      args.input = next
+      i++
+    } else if (arg === '--output' && next) {
+      args.output = next
+      i++
+    } else if ((arg === '--json-output' || arg === '--output-json') && next) {
+      args.jsonOutput = next
+      i++
+    } else if (arg === '--output-html' && next) {
+      args.htmlOutput = next
+      i++
+    } else if (arg === '--manual-dir' && next) {
+      args.manualDir = next
+      i++
+    }
+  }
+
+  if (!args.input) {
+    throw new Error('Missing required --input argument')
+  }
+
+  return args
+}
+
+function walkFiles (dir) {
+  const files = []
+  if (!fs.existsSync(dir)) return files
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath))
+      continue
+    }
+    files.push(fullPath)
+  }
+
+  return files
+}
+
+function ensureParentDir (filePath) {
+  const dirPath = path.dirname(filePath)
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true })
+  }
+}
+
+function formatNumber (value, digits = 4) {
+  if (value === null || value === undefined || Number.isNaN(value)) return 'n/a'
+  return Number(value).toFixed(digits)
+}
+
+function formatMaybeInteger (value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return 'n/a'
+  return String(Math.round(Number(value)))
+}
+
+function formatPercent (value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return 'n/a'
+  return `${(Number(value) * 100).toFixed(2)}%`
+}
+
+function escapeHtml (value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function normalizeBackend (platformName, useGPU, backendHint) {
+  const hint = String(backendHint || '').toLowerCase()
+  if (hint) return hint
+  if (!useGPU) return 'cpu'
+
+  switch (String(platformName || '').toLowerCase()) {
+    case 'darwin':
+      return 'coreml'
+    case 'win32':
+      return 'directml'
+    case 'linux':
+      return 'cuda'
+    default:
+      return 'gpu'
+  }
+}
+
+function isSupertonicArtifact (report) {
+  return Boolean(report && report.benchmark === 'supertonic-rtf' && report.implementation && report.summary)
+}
+
+function humanizeSourceFile (sourceFile) {
+  if (!sourceFile) return 'unknown'
+  return path.basename(sourceFile).replace(/\.[^.]+$/, '').replace(/_/g, ' ')
+}
+
+function normalizeArtifactRecord (report, sourceFile) {
+  const summary = report.summary || {}
+  const quality = report.quality || {}
+  const rtf = summary.rtf || {}
+  const generationMs = summary.generationMs || {}
+  const loadTimeMs = summary.loadTimeMs || {}
+  const platformName = report.platformName || report.platform || ''
+  const useGPU = Boolean(report.requested && report.requested.useGPU)
+  const backend = normalizeBackend(platformName, useGPU, report.labels && report.labels.backend)
+
+  return {
+    source: 'desktop-ci',
+    device: (report.labels && (report.labels.device || report.labels.runner || report.labels.label)) || report.platform || 'unknown',
+    platform: report.platform || 'unknown',
+    platformFamily: platformName || 'unknown',
+    implementation: report.implementation && (report.implementation.key || report.implementation.name) || 'unknown',
+    implementationName: report.implementation && report.implementation.name || 'unknown',
+    language: report.dataset && report.dataset.language || report.model && report.model.language || 'unknown',
+    model: report.model && (report.model.variant || report.model.name) || 'supertonic',
+    gpu: useGPU ? 'gpu' : 'cpu',
+    backend,
+    meanRtf: Number(rtf.mean),
+    p50: Number(rtf.p50),
+    p95: Number(rtf.p95),
+    meanGenerationMs: Number(generationMs.mean),
+    meanLoadMs: Number(loadTimeMs.mean),
+    avgWer: Number(quality.wer && quality.wer.mean),
+    avgCer: Number(quality.cer && quality.cer.mean),
+    notes: sourceFile ? path.basename(sourceFile) : ''
+  }
+}
+
+function normalizeManualRecord (record, sourceFile) {
+  const platformFamily = String(record.platformFamily || record.platform || '').toLowerCase()
+  const useGPU = record.gpu ? record.gpu === 'gpu' : Boolean(record.useGPU)
+
+  return {
+    source: record.source || 'manual',
+    device: record.device || humanizeSourceFile(sourceFile),
+    platform: record.platform || 'unknown',
+    platformFamily: platformFamily || 'unknown',
+    implementation: record.implementation || 'unknown',
+    implementationName: record.implementationName || record.implementation || 'unknown',
+    language: record.language || 'unknown',
+    model: record.model || 'supertonic',
+    gpu: useGPU ? 'gpu' : 'cpu',
+    backend: normalizeBackend(platformFamily, useGPU, record.backend),
+    meanRtf: Number(record.meanRtf),
+    p50: Number(record.p50),
+    p95: Number(record.p95),
+    meanGenerationMs: Number(record.meanGenerationMs),
+    meanLoadMs: Number(record.meanLoadMs),
+    avgWer: Number(record.avgWer),
+    avgCer: Number(record.avgCer),
+    notes: record.notes || ''
+  }
+}
+
+function loadArtifactRecords (inputDir) {
+  const records = []
+  const files = walkFiles(inputDir).filter(file => /^rtf-benchmark-.*\.json$/.test(path.basename(file)))
+
+  for (const file of files) {
+    const report = JSON.parse(fs.readFileSync(file, 'utf8'))
+    if (isSupertonicArtifact(report)) {
+      records.push(normalizeArtifactRecord(report, file))
+    }
+  }
+
+  return records
+}
+
+function loadManualRecords (manualDir) {
+  const records = []
+  if (!fs.existsSync(manualDir)) return records
+
+  const files = walkFiles(manualDir).filter(file => file.endsWith('.json'))
+  for (const file of files) {
+    const payload = JSON.parse(fs.readFileSync(file, 'utf8'))
+    const items = Array.isArray(payload) ? payload : (payload.records || [payload])
+    for (const item of items) {
+      if (isSupertonicArtifact(item)) {
+        records.push(normalizeArtifactRecord(item, file))
+      } else {
+        records.push(normalizeManualRecord(item, file))
+      }
+    }
+  }
+
+  return records
+}
+
+function scoreRecord (record) {
+  let score = 0
+  if (Number.isFinite(record.meanRtf)) score += 8
+  if (Number.isFinite(record.p50)) score += 4
+  if (Number.isFinite(record.p95)) score += 4
+  if (Number.isFinite(record.meanGenerationMs)) score += 2
+  if (Number.isFinite(record.meanLoadMs)) score += 2
+  if (Number.isFinite(record.avgWer)) score += 2
+  if (Number.isFinite(record.avgCer)) score += 2
+  if (record.device && record.device !== 'unknown') score += 1
+  if (record.notes) score += 1
+  return score
+}
+
+function dedupeRecords (records) {
+  const byKey = new Map()
+
+  for (const record of records) {
+    const key = [
+      record.source,
+      record.platform,
+      record.implementation,
+      record.language,
+      record.model,
+      record.gpu,
+      record.backend,
+      record.device
+    ].join('|')
+    const existing = byKey.get(key)
+    if (!existing || scoreRecord(record) > scoreRecord(existing)) {
+      byKey.set(key, record)
+    }
+  }
+
+  return [...byKey.values()]
+}
+
+function sortRecords (records) {
+  return records.sort((left, right) => {
+    return [
+      left.source,
+      left.platform,
+      left.implementation,
+      left.language,
+      left.gpu,
+      left.device
+    ].join('|').localeCompare([
+      right.source,
+      right.platform,
+      right.implementation,
+      right.language,
+      right.gpu,
+      right.device
+    ].join('|'))
+  })
+}
+
+function buildCoverage (records) {
+  const gpuCoverage = new Set(
+    records
+      .filter(record => record.gpu === 'gpu')
+      .map(record => record.backend)
+      .filter(Boolean)
+  )
+
+  return {
+    rowCount: records.length,
+    gpuBackendsCovered: Array.from(gpuCoverage).sort(),
+    missingBackends: SUPPORTED_GPU_BACKENDS.filter(backend => !gpuCoverage.has(backend))
+  }
+}
+
+function renderMarkdown (records) {
+  const coverage = buildCoverage(records)
+  const lines = [
+    '## Supertonic Performance Findings',
+    '',
+    '| Source | Device | Platform | Impl | Lang | Model | GPU | Backend | Mean RTF | P50 | P95 | Mean Gen (ms) | Mean Load (ms) | Avg WER | Avg CER | Notes |',
+    '|--------|--------|----------|------|------|-------|-----|---------|----------|-----|-----|----------------|----------------|---------|---------|-------|'
+  ]
+
+  for (const record of records) {
+    lines.push(
+      `| ${record.source} | ${record.device} | ${record.platform} | ${record.implementation} | ${record.language} | ${record.model} | ${record.gpu} | ${record.backend} | ${formatNumber(record.meanRtf)} | ${formatNumber(record.p50)} | ${formatNumber(record.p95)} | ${formatMaybeInteger(record.meanGenerationMs)} | ${formatMaybeInteger(record.meanLoadMs)} | ${formatPercent(record.avgWer)} | ${formatPercent(record.avgCer)} | ${record.notes || ''} |`
+    )
+  }
+
+  lines.push('')
+  lines.push('### Coverage')
+  lines.push('')
+  lines.push(`- Rows aggregated: ${coverage.rowCount}`)
+  lines.push(`- GPU backends covered: ${coverage.gpuBackendsCovered.join(', ') || 'none'}`)
+  lines.push(`- GPU backends still missing: ${coverage.missingBackends.join(', ') || 'none'}`)
+
+  return lines.join('\n') + '\n'
+}
+
+function renderHtml (records) {
+  const coverage = buildCoverage(records)
+  const rows = records.map(record => {
+    return [
+      record.source,
+      record.device,
+      record.platform,
+      record.implementation,
+      record.language,
+      record.model,
+      record.gpu,
+      record.backend,
+      formatNumber(record.meanRtf),
+      formatNumber(record.p50),
+      formatNumber(record.p95),
+      formatMaybeInteger(record.meanGenerationMs),
+      formatMaybeInteger(record.meanLoadMs),
+      formatPercent(record.avgWer),
+      formatPercent(record.avgCer),
+      record.notes || ''
+    ].map(value => `<td>${escapeHtml(value)}</td>`).join('')
+  }).map(cells => `<tr>${cells}</tr>`).join('\n')
+
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head>',
+    '  <meta charset="utf-8">',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1">',
+    '  <title>Supertonic Performance Findings</title>',
+    '  <style>',
+    '    body { font-family: Arial, sans-serif; margin: 24px; color: #1f2937; }',
+    '    h1, h2 { margin-bottom: 12px; }',
+    '    table { border-collapse: collapse; width: 100%; margin-top: 16px; }',
+    '    th, td { border: 1px solid #d1d5db; padding: 8px 10px; text-align: left; }',
+    '    th { background: #f3f4f6; }',
+    '    tr:nth-child(even) td { background: #f9fafb; }',
+    '    ul { margin-top: 0; }',
+    '    code { font-family: Menlo, Consolas, monospace; }',
+    '  </style>',
+    '</head>',
+    '<body>',
+    '  <h1>Supertonic Performance Findings</h1>',
+    '  <table>',
+    '    <thead>',
+    '      <tr>',
+    '        <th>Source</th>',
+    '        <th>Device</th>',
+    '        <th>Platform</th>',
+    '        <th>Impl</th>',
+    '        <th>Lang</th>',
+    '        <th>Model</th>',
+    '        <th>GPU</th>',
+    '        <th>Backend</th>',
+    '        <th>Mean RTF</th>',
+    '        <th>P50</th>',
+    '        <th>P95</th>',
+    '        <th>Mean Gen (ms)</th>',
+    '        <th>Mean Load (ms)</th>',
+    '        <th>Avg WER</th>',
+    '        <th>Avg CER</th>',
+    '        <th>Notes</th>',
+    '      </tr>',
+    '    </thead>',
+    '    <tbody>',
+    rows,
+    '    </tbody>',
+    '  </table>',
+    '  <h2>Coverage</h2>',
+    '  <ul>',
+    `    <li>Rows aggregated: <code>${escapeHtml(String(coverage.rowCount))}</code></li>`,
+    `    <li>GPU backends covered: <code>${escapeHtml(coverage.gpuBackendsCovered.join(', ') || 'none')}</code></li>`,
+    `    <li>GPU backends still missing: <code>${escapeHtml(coverage.missingBackends.join(', ') || 'none')}</code></li>`,
+    '  </ul>',
+    '</body>',
+    '</html>',
+    ''
+  ].join('\n')
+}
+
+function main () {
+  const args = parseArgs(process.argv.slice(2))
+  const inputDir = path.resolve(args.input)
+  const manualDir = path.resolve(args.manualDir)
+  const records = sortRecords(
+    dedupeRecords(
+      loadArtifactRecords(inputDir).concat(loadManualRecords(manualDir))
+    )
+  )
+  const markdown = renderMarkdown(records)
+  const html = renderHtml(records)
+
+  if (args.output) {
+    const outputPath = path.resolve(args.output)
+    ensureParentDir(outputPath)
+    fs.writeFileSync(outputPath, markdown, 'utf8')
+  }
+
+  if (args.jsonOutput) {
+    const jsonOutputPath = path.resolve(args.jsonOutput)
+    ensureParentDir(jsonOutputPath)
+    fs.writeFileSync(
+      jsonOutputPath,
+      JSON.stringify({ records, coverage: buildCoverage(records) }, null, 2) + '\n',
+      'utf8'
+    )
+  }
+
+  if (args.htmlOutput) {
+    const htmlOutputPath = path.resolve(args.htmlOutput)
+    ensureParentDir(htmlOutputPath)
+    fs.writeFileSync(htmlOutputPath, html, 'utf8')
+  }
+
+  process.stdout.write(markdown)
+}
+
+main()


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Adds a desktop Supertonic benchmark/reporting path that emits structured per-runner artifacts instead of relying on a single-machine markdown-only workflow.
- Produces one aggregated markdown/json/html report across supported desktop backends so addon and baseline findings can be compared from one artifact bundle.

## 📝 How does it solve it?

- Extends the Supertonic benchmark client to honor workflow-provided benchmark settings and to save structured JSON reports for addon and Python runs alongside the existing markdown outputs.
- Adds a Supertonic-specific aggregation script plus manual-results support so CI and manual backend results can be merged into one consolidated report.
- Adds a dedicated desktop benchmark-performance workflow that benchmarks branch prebuilds across CPU, CoreML, CUDA, and DirectML runners and uploads a single summarized report artifact.

## 🧪 How was it tested?

- Ran Python syntax checks for the updated Supertonic benchmark client files.
- Ran node --check for scripts/perf-report/aggregate-supertonic-rtf.js.
- Parsed .github/workflows/benchmark-performance-qvac-lib-infer-onnx-tts.yml with Ruby YAML.load_file.

