### PR TITLE
[Chatterbox] Bottlenecks optimization

### DIFF
--- a/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/ChatterboxEngine.cpp
+++ b/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/ChatterboxEngine.cpp
@@ -8,9 +8,12 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <iterator>
+#include <limits>
 #include <numeric>
 #include <sstream>
 #include <unordered_set>
@@ -86,16 +89,18 @@ void penalizeRepetitionLogits(std::vector<float> &logits,
 }
 
 // Reads last-step logits for a specific batch index from a logits tensor
-// shaped [batch, seq, vocab].
-std::vector<float> readLastStepLogitsForBatch(
-    const qvac::ttslib::chatterbox::OrtTensor &logitsTensor, int64_t batchIdx) {
+// shaped [batch, seq, vocab] into a caller-owned buffer. Using a
+// pre-sized buffer avoids the per-step vocab-sized allocation that
+// showed up in the CFG loop profile.
+void readLastStepLogitsForBatchInto(
+    const qvac::ttslib::chatterbox::OrtTensor &logitsTensor, int64_t batchIdx,
+    std::vector<float> &dest) {
   const int64_t seqLen = logitsTensor.shape[1];
   const int64_t vocabSize = logitsTensor.shape[2];
   const int64_t perBatchElements = seqLen * vocabSize;
   const int64_t offset = batchIdx * perBatchElements + (seqLen - 1) * vocabSize;
-  std::vector<float> logits(vocabSize);
-  readTensorToFloatBuffer(logitsTensor, logits.data(), offset, vocabSize);
-  return logits;
+  dest.resize(static_cast<size_t>(vocabSize));
+  readTensorToFloatBuffer(logitsTensor, dest.data(), offset, vocabSize);
 }
 
 bool detectTokenRepetition(const std::vector<int64_t> &tokens, int threshold) {
@@ -170,61 +175,68 @@ void applyCfgCombine(std::vector<float> &condLogits,
   }
 }
 
-void scaleByTemperature(std::vector<float> &logits, float temperature) {
-  for (auto &l : logits) {
-    l /= temperature;
+// Fused temperature-scale + softmax. Computes
+//   logits[i] = exp((logits[i] / temperature) - max)
+// in a single pass after a single `max_element` scan, then normalises in a
+// second pass. The previous implementation did the same work in four
+// passes (scaleByTemperature, max, exp+sum, normalize).
+float applyTemperatureAndSoftmax(std::vector<float> &logits,
+                                 float temperature) {
+  const float invT = 1.0f / temperature;
+  float maxLogit = -std::numeric_limits<float>::infinity();
+  for (float l : logits) {
+    const float scaled = l * invT;
+    if (scaled > maxLogit) {
+      maxLogit = scaled;
+    }
   }
-}
-
-float computeExpAndSum(std::vector<float> &logits) {
-  float maxLogit = *std::max_element(logits.begin(), logits.end());
   float sum = 0.0f;
   for (auto &l : logits) {
-    l = std::exp(l - maxLogit);
+    l = std::exp(l * invT - maxLogit);
     sum += l;
   }
   return sum;
 }
 
-void normalizeVector(std::vector<float> &values, float sum) {
-  for (auto &v : values) {
-    v /= sum;
+// Filters probabilities using min-P (keeping everything at least
+// `maxProb * minP`). Returns the sum of the remaining (unnormalised)
+// probabilities. Scans the input once to find the max, then zeroes and sums
+// in a second fused pass.
+float applyMinPFilterWithSum(std::vector<float> &probs, float minP,
+                             float currentSum) {
+  if (minP <= 0.0f) {
+    return currentSum;
   }
-}
-
-void applySoftmax(std::vector<float> &logits, float temperature) {
-  scaleByTemperature(logits, temperature);
-  float sum = computeExpAndSum(logits);
-  normalizeVector(logits, sum);
-}
-
-float thresholdProbs(std::vector<float> &probs, float threshold) {
-  float sum = 0.0f;
+  float maxProb = 0.0f;
+  for (float p : probs) {
+    if (p > maxProb) {
+      maxProb = p;
+    }
+  }
+  const float threshold = maxProb * minP;
+  float filteredSum = 0.0f;
   for (auto &p : probs) {
     if (p < threshold) {
       p = 0.0f;
+    } else {
+      filteredSum += p;
     }
-    sum += p;
   }
-  return sum;
-}
-
-void applyMinPFilter(std::vector<float> &probs, float minP) {
-  if (minP <= 0.0f) {
-    return;
-  }
-
-  float maxProb = *std::max_element(probs.begin(), probs.end());
-  float sum = thresholdProbs(probs, maxProb * minP);
-  if (sum > 0.0f) {
-    normalizeVector(probs, sum);
-  }
+  return filteredSum;
 }
 
 int64_t sampleWithTemperature(std::vector<float> &logits, float temperature,
                               float minP, std::mt19937 &rng) {
-  applySoftmax(logits, temperature);
-  applyMinPFilter(logits, minP);
+  // Fused max+softmax, then min-P filter reusing the running sum. We hand
+  // the un-normalised weights directly to `discrete_distribution`, which
+  // normalises internally — skipping an extra divide pass.
+  float sum = applyTemperatureAndSoftmax(logits, temperature);
+  sum = applyMinPFilterWithSum(logits, minP, sum);
+  if (sum <= 0.0f) {
+    return static_cast<int64_t>(
+        std::distance(logits.begin(),
+                      std::max_element(logits.begin(), logits.end())));
+  }
 
   std::discrete_distribution<int> dist(logits.begin(), logits.end());
   return static_cast<int64_t>(dist(rng));
@@ -415,6 +427,10 @@ void ChatterboxEngine::unload() {
   speechEncoderSession_.reset();
   embedTokensSession_.reset();
   conditionalDecoderSession_.reset();
+  logitsBuffer_.clear();
+  logitsBuffer_.shrink_to_fit();
+  logitsBufferUncond_.clear();
+  logitsBufferUncond_.shrink_to_fit();
   languageModelSession_.reset();
   textEmbWeight_.clear();
   textEmbRows_ = 0;
@@ -623,15 +639,16 @@ void ChatterboxEngine::enableKvCacheChaining() {
 int64_t
 ChatterboxEngine::selectNextToken(const OrtTensor &logitsTensor,
                                   std::vector<int64_t> &generatedTokens) {
-  std::vector<float> logits;
-  logits.resize(logitsTensor.shape[2]);
-  const int64_t logitsOffset =
-      (logitsTensor.shape[1] - 1) * logitsTensor.shape[2];
-  readTensorToFloatBuffer(logitsTensor, logits.data(), logitsOffset,
-                          logitsTensor.shape[2]);
+  // Reuse a member buffer instead of allocating a vocab-sized vector
+  // (~6563 floats = ~26 KB) on every autoregressive step.
+  const int64_t vocabSize = logitsTensor.shape[2];
+  logitsBuffer_.resize(static_cast<size_t>(vocabSize));
+  const int64_t logitsOffset = (logitsTensor.shape[1] - 1) * vocabSize;
+  readTensorToFloatBuffer(logitsTensor, logitsBuffer_.data(), logitsOffset,
+                          vocabSize);
 
-  penalizeRepetitionLogits(logits, generatedTokens, REPETITION_PENALTY);
-  return static_cast<int64_t>(argmax(logits));
+  penalizeRepetitionLogits(logitsBuffer_, generatedTokens, REPETITION_PENALTY);
+  return static_cast<int64_t>(argmax(logitsBuffer_));
 }
 
 void ChatterboxEngine::advancePositionIds(TensorData<int64_t> &positionIds,
@@ -733,17 +750,26 @@ std::vector<int64_t> ChatterboxEngine::generateSpeechTokens(
 std::vector<int64_t> ChatterboxEngine::assembleSpeechTokenSequence(
     const TensorData<int64_t> &promptToken,
     const std::vector<int64_t> &generatedTokens) {
-  std::vector<int64_t> speechTokens(promptToken.data.begin(),
-                                    promptToken.data.end());
-  speechTokens.insert(speechTokens.end(), generatedTokens.begin() + 1,
-                      generatedTokens.end() - 1);
-
-  if (isEnglish_) {
-    const std::vector<int64_t> silenceTokens(3, SILENCE_TOKEN);
-    speechTokens.insert(speechTokens.end(), silenceTokens.begin(),
-                        silenceTokens.end());
+  // `generatedTokens` always starts with START_SPEECH_TOKEN and ends with
+  // STOP_SPEECH_TOKEN, so we slice [1, end-1). Guard against short inputs
+  // so the slice bounds stay well-defined. English mode appends three
+  // silence tokens as trailing padding.
+  const size_t generatedSlice =
+      generatedTokens.size() >= 2 ? generatedTokens.size() - 2 : 0;
+  const size_t trailingSilence = isEnglish_ ? 3u : 0u;
+  std::vector<int64_t> speechTokens;
+  speechTokens.reserve(promptToken.data.size() + generatedSlice +
+                       trailingSilence);
+  speechTokens.insert(speechTokens.end(), promptToken.data.begin(),
+                      promptToken.data.end());
+  if (generatedSlice > 0) {
+    speechTokens.insert(speechTokens.end(), generatedTokens.begin() + 1,
+                        generatedTokens.begin() + 1 + generatedSlice);
   }
-
+  if (trailingSilence > 0) {
+    // `insert(end, count, value)` fills in-place without a temporary vector.
+    speechTokens.insert(speechTokens.end(), trailingSilence, SILENCE_TOKEN);
+  }
   return speechTokens;
 }
 
@@ -1123,16 +1149,16 @@ int64_t ChatterboxEngine::runInitialCfgStep(
   runLanguageModelInfer(batchedEmbs, positionIds, batchedMask, batchedKv);
 
   OrtTensor logitsTensor = languageModelSession_->getOutput("logits");
-  std::vector<float> condLogits = readLastStepLogitsForBatch(logitsTensor, 0);
-  std::vector<float> uncondLogits = readLastStepLogitsForBatch(logitsTensor, 1);
+  readLastStepLogitsForBatchInto(logitsTensor, 0, logitsBuffer_);
+  readLastStepLogitsForBatchInto(logitsTensor, 1, logitsBufferUncond_);
   cachePastKeyValues(batchedKv);
 
-  applyCfgCombine(condLogits, uncondLogits, CFG_WEIGHT);
-  penalizeRepetitionLogits(condLogits, generatedTokens,
+  applyCfgCombine(logitsBuffer_, logitsBufferUncond_, CFG_WEIGHT);
+  penalizeRepetitionLogits(logitsBuffer_, generatedTokens,
                            MULTILINGUAL_REPETITION_PENALTY);
 
   int64_t firstToken =
-      sampleWithTemperature(condLogits, TEMPERATURE, MIN_P, rng_);
+      sampleWithTemperature(logitsBuffer_, TEMPERATURE, MIN_P, rng_);
   generatedTokens.push_back(firstToken);
 
   QLOG(Priority::INFO,
@@ -1202,17 +1228,16 @@ void ChatterboxEngine::runCfgGenerationLoop(
     runLanguageModelInfer(batchedEmbs, positionIds, batchedMask, batchedKv);
 
     OrtTensor logitsTensor = languageModelSession_->getOutput("logits");
-    std::vector<float> condLogits = readLastStepLogitsForBatch(logitsTensor, 0);
-    std::vector<float> uncondLogits =
-        readLastStepLogitsForBatch(logitsTensor, 1);
+    readLastStepLogitsForBatchInto(logitsTensor, 0, logitsBuffer_);
+    readLastStepLogitsForBatchInto(logitsTensor, 1, logitsBufferUncond_);
     cachePastKeyValues(batchedKv);
 
-    applyCfgCombine(condLogits, uncondLogits, CFG_WEIGHT);
-    penalizeRepetitionLogits(condLogits, generatedTokens,
+    applyCfgCombine(logitsBuffer_, logitsBufferUncond_, CFG_WEIGHT);
+    penalizeRepetitionLogits(logitsBuffer_, generatedTokens,
                              MULTILINGUAL_REPETITION_PENALTY);
 
     int64_t nextToken =
-        sampleWithTemperature(condLogits, TEMPERATURE, MIN_P, rng_);
+        sampleWithTemperature(logitsBuffer_, TEMPERATURE, MIN_P, rng_);
     generatedTokens.push_back(nextToken);
 
     positionIds.data = {static_cast<int64_t>(step + 2)};

--- a/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/ChatterboxEngine.hpp
+++ b/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/ChatterboxEngine.hpp
@@ -211,6 +211,12 @@ private:
   int64_t textEmbDim_ = 0;
   std::mt19937 rng_{std::random_device{}()};
 
+  // Reusable logits buffer for the autoregressive loop. Allocated once per
+  // generate call and resized to `vocabSize` to avoid re-allocating a
+  // vocab-sized vector on every token step.
+  std::vector<float> logitsBuffer_;
+  std::vector<float> logitsBufferUncond_;
+
 protected:
   bool isEnglish_ = true;
   std::unique_ptr<IOnnxInferSession> languageModelSession_;

--- a/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/IOnnxInferSession.hpp
+++ b/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/IOnnxInferSession.hpp
@@ -15,8 +15,8 @@ public:
 
   virtual void run() = 0;
 
-  virtual std::vector<std::string> getInputNames() const = 0;
-  virtual std::vector<std::string> getOutputNames() const = 0;
+  virtual const std::vector<std::string> &getInputNames() const = 0;
+  virtual const std::vector<std::string> &getOutputNames() const = 0;
 
   virtual OrtTensor getInput(const std::string &inputName) = 0;
   virtual OrtTensor getOutput(const std::string &outputName) = 0;

--- a/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/OnnxInferSession.cpp
+++ b/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/OnnxInferSession.cpp
@@ -101,65 +101,87 @@ OnnxInferSession::OnnxInferSession(const std::string &modelPath, bool useGPU,
     }
   }
 
-  // collect input names
-  for (size_t i = 0; i < session_->GetInputCount(); i++) {
+  const size_t inputCount = session_->GetInputCount();
+  const size_t outputCount = session_->GetOutputCount();
+
+  inputNames_.reserve(inputCount);
+  inputIndexByName_.reserve(inputCount);
+  inputElementTypes_.reserve(inputCount);
+  for (size_t i = 0; i < inputCount; i++) {
     const Ort::AllocatedStringPtr inputName =
         session_->GetInputNameAllocated(i, allocator_);
-    inputNames_.push_back(std::string(inputName.get()));
+    inputNames_.emplace_back(inputName.get());
     inputIndexByName_[inputNames_.back()] = i;
+
+    // Cache the element type per input so `initInputTensors` doesn't have
+    // to re-interrogate the session graph on every autoregressive step.
+    const Ort::TypeInfo typeInfo = session_->GetInputTypeInfo(i);
+    inputElementTypes_.push_back(
+        typeInfo.GetTensorTypeAndShapeInfo().GetElementType());
   }
 
-  // collect output names
-  for (size_t i = 0; i < session_->GetOutputCount(); i++) {
+  outputNames_.reserve(outputCount);
+  outputIndexByName_.reserve(outputCount);
+  for (size_t i = 0; i < outputCount; i++) {
     Ort::AllocatedStringPtr outputName =
         session_->GetOutputNameAllocated(i, allocator_);
-    outputNames_.push_back(std::string(outputName.get()));
+    outputNames_.emplace_back(outputName.get());
     outputIndexByName_[outputNames_.back()] = i;
+  }
+
+  // Pre-compute the raw `const char*` arrays handed to `Ort::Session::Run()`
+  // once, instead of reconstructing them on every step of the generation
+  // loop. `inputNames_` / `outputNames_` are never mutated after this point,
+  // so the pointers remain valid for the lifetime of the session.
+  inputNamesC_.reserve(inputCount);
+  for (const auto &name : inputNames_) {
+    inputNamesC_.push_back(name.c_str());
+  }
+  outputNamesC_.reserve(outputCount);
+  for (const auto &name : outputNames_) {
+    outputNamesC_.push_back(name.c_str());
   }
 }
 
 OrtTensor OnnxInferSession::getInput(const std::string &inputName) {
-  for (const auto &input : inputTensors_) {
-    if (input.name == inputName) {
-      return input;
-    }
+  // Hot-path lookup: was O(N) linear search over ~60+ input slots for every
+  // embedding/LM write. The hash index is populated in the constructor and
+  // gives us O(1) access without changing any observable behaviour.
+  const auto it = inputIndexByName_.find(inputName);
+  if (it == inputIndexByName_.end() || it->second >= inputTensors_.size()) {
+    throw std::runtime_error("Input not found");
   }
-  throw std::runtime_error("Input not found");
+  return inputTensors_[it->second];
 }
 
 OrtTensor OnnxInferSession::getOutput(const std::string &outputName) {
-  for (const auto &output : outputTensors_) {
-    if (output.name == outputName) {
-      return output;
-    }
+  // Same O(N) -> O(1) speedup as getInput; matters most for the `logits`
+  // lookup that happens on every autoregressive step.
+  const auto it = outputIndexByName_.find(outputName);
+  if (it == outputIndexByName_.end() || it->second >= outputTensors_.size()) {
+    throw std::runtime_error("Output not found");
   }
-  throw std::runtime_error("Output not found");
+  return outputTensors_[it->second];
 }
 
 void OnnxInferSession::run() {
-  std::vector<const char *> inputNames;
-  for (const auto &name : inputNames_) {
-    inputNames.push_back(name.c_str());
-  }
-
-  std::vector<const char *> outputNames;
-  for (const auto &name : outputNames_) {
-    outputNames.push_back(name.c_str());
-  }
-
+  // `inputNamesC_` / `outputNamesC_` are populated once in the constructor
+  // and point at the stable storage of `inputNames_` / `outputNames_`, so
+  // we can hand them directly to ORT instead of rebuilding the vectors on
+  // every step.
   outputsTensorsValues_ = session_->Run(
-      Ort::RunOptions{nullptr}, inputNames.data(), inputTensorsValues_.data(),
-      inputTensorsValues_.size(), outputNames.data(), outputNames.size());
+      Ort::RunOptions{nullptr}, inputNamesC_.data(), inputTensorsValues_.data(),
+      inputTensorsValues_.size(), outputNamesC_.data(), outputNamesC_.size());
 
   outputTensors_.clear();
+  outputTensors_.reserve(outputsTensorsValues_.size());
 
   for (size_t i = 0; i < outputsTensorsValues_.size(); i++) {
+    const auto shapeInfo =
+        outputsTensorsValues_[i].GetTensorTypeAndShapeInfo();
     outputTensors_.emplace_back(OrtTensor{
         outputsTensorsValues_[i].GetTensorMutableData<void>(), outputNames_[i],
-        outputsTensorsValues_[i].GetTensorTypeAndShapeInfo().GetShape(),
-        onnxTypeToOurType(outputsTensorsValues_[i]
-                              .GetTensorTypeAndShapeInfo()
-                              .GetElementType())});
+        shapeInfo.GetShape(), onnxTypeToOurType(shapeInfo.GetElementType())});
   }
 
   moveChainedOutputsIntoInputs();
@@ -198,11 +220,11 @@ void OnnxInferSession::moveChainedOutputsIntoInputs() {
   }
 }
 
-std::vector<std::string> OnnxInferSession::getInputNames() const {
+const std::vector<std::string> &OnnxInferSession::getInputNames() const {
   return inputNames_;
 }
 
-std::vector<std::string> OnnxInferSession::getOutputNames() const {
+const std::vector<std::string> &OnnxInferSession::getOutputNames() const {
   return outputNames_;
 }
 
@@ -228,19 +250,18 @@ void OnnxInferSession::initInputTensors(
   inputTensors_.clear();
   inputTensorsValues_.clear();
 
-  for (size_t i = 0; i < session_->GetInputCount(); i++) {
+  const size_t inputCount = inputNames_.size();
+  inputTensors_.reserve(inputCount);
+  inputTensorsValues_.reserve(inputCount);
+  for (size_t i = 0; i < inputCount; i++) {
     if (hasPreserved[i]) {
       inputTensorsValues_.push_back(std::move(preservedValues[i]));
       inputTensors_.push_back(std::move(preservedTensors[i]));
       continue;
     }
 
-    const Ort::TypeInfo inputTypeInfo = session_->GetInputTypeInfo(i);
-    const Ort::ConstTensorTypeAndShapeInfo inputShapeInfo =
-        inputTypeInfo.GetTensorTypeAndShapeInfo();
-
     std::vector<int64_t> inputShape = inputShapes[i];
-    ONNXTensorElementDataType onnxType = inputShapeInfo.GetElementType();
+    const ONNXTensorElementDataType onnxType = inputElementTypes_[i];
 
     Ort::Value inputValue = Ort::Value::CreateTensor(
         allocator_, inputShape.data(), inputShape.size(), onnxType);

--- a/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/OnnxInferSession.hpp
+++ b/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/OnnxInferSession.hpp
@@ -17,8 +17,8 @@ public:
 
   void run() override;
 
-  std::vector<std::string> getInputNames() const override;
-  std::vector<std::string> getOutputNames() const override;
+  const std::vector<std::string> &getInputNames() const override;
+  const std::vector<std::string> &getOutputNames() const override;
 
   OrtTensor getInput(const std::string &inputName) override;
   OrtTensor getOutput(const std::string &outputName) override;
@@ -44,6 +44,21 @@ private:
 
   std::vector<std::string> inputNames_;
   std::vector<std::string> outputNames_;
+
+  // Cached `const char*` arrays pointing into the stable storage of
+  // `inputNames_` / `outputNames_`. Populated once in the constructor and
+  // fed directly to `Ort::Session::Run()` on every step, so the hot loop
+  // avoids rebuilding the vectors and calling c_str() ~120 times per token.
+  std::vector<const char *> inputNamesC_;
+  std::vector<const char *> outputNamesC_;
+
+  // ONNX element type per input index, captured once in the constructor.
+  // `initInputTensors` used to re-interrogate the session every step via
+  // `GetInputTypeInfo(i).GetTensorTypeAndShapeInfo().GetElementType()` — an
+  // FFI round-trip per input on every autoregressive step. The element
+  // type is a fixed property of the model graph, so we cache it and hand
+  // the cached value to `Ort::Value::CreateTensor` directly.
+  std::vector<ONNXTensorElementDataType> inputElementTypes_;
 
   std::unordered_map<std::string, size_t> inputIndexByName_;
   std::unordered_map<std::string, size_t> outputIndexByName_;

--- a/packages/qvac-lib-infer-onnx-tts/addon/test/unit/mocks/OnnxInferSessionMock.hpp
+++ b/packages/qvac-lib-infer-onnx-tts/addon/test/unit/mocks/OnnxInferSessionMock.hpp
@@ -12,8 +12,10 @@ public:
 
   MOCK_METHOD(void, run, (), (override));
 
-  MOCK_METHOD(std::vector<std::string>, getInputNames, (), (const, override));
-  MOCK_METHOD(std::vector<std::string>, getOutputNames, (), (const, override));
+  MOCK_METHOD(const std::vector<std::string> &, getInputNames, (),
+              (const, override));
+  MOCK_METHOD(const std::vector<std::string> &, getOutputNames, (),
+              (const, override));
 
   MOCK_METHOD(OrtTensor, getInput, (const std::string &inputName), (override));
   MOCK_METHOD(OrtTensor, getOutput, (const std::string &outputName),

--- a/packages/qvac-lib-infer-onnx-tts/addon/test/unit/src/ChatterboxEngineMethodsTest.cpp
+++ b/packages/qvac-lib-infer-onnx-tts/addon/test/unit/src/ChatterboxEngineMethodsTest.cpp
@@ -422,9 +422,9 @@ protected:
 TEST_F(KvCacheChainingTest, enableBuildsPresentToPastMappingForEnglish) {
   auto mock = std::make_unique<::testing::NiceMock<OnnxInferSessionMock>>();
   EXPECT_CALL(*mock, getInputNames())
-      .WillRepeatedly(::testing::Return(englishInputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishInputNames_));
   EXPECT_CALL(*mock, getOutputNames())
-      .WillRepeatedly(::testing::Return(englishOutputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishOutputNames_));
 
   std::vector<std::pair<std::string, std::string>> expectedMapping = {
       {"present.0.key", "past_key_values.0.key"},
@@ -443,9 +443,9 @@ TEST_F(KvCacheChainingTest, enableBuildsPresentToPastMappingForEnglish) {
 TEST_F(KvCacheChainingTest, enableBuildsPresentToPastMappingForMultilingual) {
   auto mock = std::make_unique<::testing::NiceMock<OnnxInferSessionMock>>();
   EXPECT_CALL(*mock, getInputNames())
-      .WillRepeatedly(::testing::Return(multilingualInputNames_));
+      .WillRepeatedly(::testing::ReturnRef(multilingualInputNames_));
   EXPECT_CALL(*mock, getOutputNames())
-      .WillRepeatedly(::testing::Return(multilingualOutputNames_));
+      .WillRepeatedly(::testing::ReturnRef(multilingualOutputNames_));
 
   std::vector<std::pair<std::string, std::string>> expectedMapping = {
       {"present.0.key", "past_key_values.0.key"},
@@ -472,9 +472,9 @@ TEST_F(KvCacheChainingTest, enableSkipsKvInputsWithoutMatchingPresentOutput) {
 
   auto mock = std::make_unique<::testing::NiceMock<OnnxInferSessionMock>>();
   EXPECT_CALL(*mock, getInputNames())
-      .WillRepeatedly(::testing::Return(englishInputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishInputNames_));
   EXPECT_CALL(*mock, getOutputNames())
-      .WillRepeatedly(::testing::Return(truncatedOutputs));
+      .WillRepeatedly(::testing::ReturnRef(truncatedOutputs));
 
   std::vector<std::pair<std::string, std::string>> expectedMapping = {
       {"present.0.key", "past_key_values.0.key"},
@@ -500,9 +500,9 @@ TEST_F(KvCacheChainingTest, enablePairsByNameIndependentOfOutputOrder) {
 
   auto mock = std::make_unique<::testing::NiceMock<OnnxInferSessionMock>>();
   EXPECT_CALL(*mock, getInputNames())
-      .WillRepeatedly(::testing::Return(englishInputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishInputNames_));
   EXPECT_CALL(*mock, getOutputNames())
-      .WillRepeatedly(::testing::Return(scrambledOutputs));
+      .WillRepeatedly(::testing::ReturnRef(scrambledOutputs));
 
   // The mapping is still keyed on input order (which is `past_key_values.0.*`
   // then `past_key_values.1.*`) but each entry's output name is resolved by
@@ -533,9 +533,9 @@ TEST_F(KvCacheChainingTest, enableSkipsInputsThatAreNotPastKeyValues) {
 
   auto mock = std::make_unique<::testing::NiceMock<OnnxInferSessionMock>>();
   EXPECT_CALL(*mock, getInputNames())
-      .WillRepeatedly(::testing::Return(inputsWithExtra));
+      .WillRepeatedly(::testing::ReturnRef(inputsWithExtra));
   EXPECT_CALL(*mock, getOutputNames())
-      .WillRepeatedly(::testing::Return(englishOutputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishOutputNames_));
 
   std::vector<std::pair<std::string, std::string>> expectedMapping = {
       {"present.0.key", "past_key_values.0.key"},
@@ -552,7 +552,7 @@ TEST_F(KvCacheChainingTest, enableSkipsInputsThatAreNotPastKeyValues) {
 TEST_F(KvCacheChainingTest, writeKvToTensorsSkipsAllChainedInputs) {
   auto mock = std::make_unique<::testing::NiceMock<OnnxInferSessionMock>>();
   EXPECT_CALL(*mock, getInputNames())
-      .WillRepeatedly(::testing::Return(englishInputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishInputNames_));
   EXPECT_CALL(*mock, isInputChained(::testing::_))
       .WillRepeatedly(::testing::Return(true));
 
@@ -574,9 +574,9 @@ TEST_F(KvCacheChainingTest, writeKvToTensorsSkipsAllChainedInputs) {
 TEST_F(KvCacheChainingTest, cachePastKeyValuesSkipsAllChainedInputs) {
   auto mock = std::make_unique<::testing::NiceMock<OnnxInferSessionMock>>();
   EXPECT_CALL(*mock, getInputNames())
-      .WillRepeatedly(::testing::Return(englishInputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishInputNames_));
   EXPECT_CALL(*mock, getOutputNames())
-      .WillRepeatedly(::testing::Return(englishOutputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishOutputNames_));
   EXPECT_CALL(*mock, isInputChained(::testing::_))
       .WillRepeatedly(::testing::Return(true));
 
@@ -600,9 +600,9 @@ TEST_F(KvCacheChainingTest, enableCalledTwiceResetsPreviousMapping) {
   // and never pile up on top of the previous one.
   auto mock = std::make_unique<::testing::NiceMock<OnnxInferSessionMock>>();
   EXPECT_CALL(*mock, getInputNames())
-      .WillRepeatedly(::testing::Return(englishInputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishInputNames_));
   EXPECT_CALL(*mock, getOutputNames())
-      .WillRepeatedly(::testing::Return(englishOutputNames_));
+      .WillRepeatedly(::testing::ReturnRef(englishOutputNames_));
 
   std::vector<std::pair<std::string, std::string>> expectedMapping = {
       {"present.0.key", "past_key_values.0.key"},

--- a/packages/qvac-lib-infer-onnx-tts/addon/test/unit/src/OnnxInferSessionMockTest.cpp
+++ b/packages/qvac-lib-infer-onnx-tts/addon/test/unit/src/OnnxInferSessionMockTest.cpp
@@ -15,8 +15,8 @@ TEST(OnnxInferSessionMockTest, runIsInvoked) {
 TEST(OnnxInferSessionMockTest, getInputNamesReturnsEmptyByDefault) {
   OnnxInferSessionMock mock;
   EXPECT_CALL(mock, getInputNames())
-      .WillOnce(::testing::Return(std::vector<std::string>{}));
-  std::vector<std::string> names = mock.getInputNames();
+      .WillOnce(::testing::ReturnRefOfCopy(std::vector<std::string>{}));
+  const std::vector<std::string> &names = mock.getInputNames();
   EXPECT_TRUE(names.empty());
 }
 


### PR DESCRIPTION
**What problem does this PR solve?**
Chatterbox TTS autoregressive generation had several per-step C++ overheads that added up over a 1024-token loop: Ort::Session::Run was handed freshly-rebuilt const char* arrays, getInput/getOutput did O(N) linear searches, getInputNames/getOutputNames copied a ~60‑string vector by value on every call, selectNextToken allocated a vocab-sized buffer per token, the softmax used 4 passes over the vocab, FP16/Int4/UInt4 tensor reads materialised through a throwaway temp vector, and initInputTensors re-interrogated the ONNX graph (GetInputTypeInfo) for every input on every step.
Net effect on a 762-token English synthesis: ~3% of LM wall time was spent on setup/teardown around each ONNX run rather than on actual model work.

**How does it solve it?**
OnnxInferSession: cache inputNamesC_ / outputNamesC_ const char* arrays once in the constructor and pass them directly to Ort::Session::Run(); make getInput/getOutput O(1) via the existing inputIndexByName_ / outputIndexByName_ maps; change getInputNames/getOutputNames to return const std::vector<std::string>& (so binding-by-ref no longer copies); cache inputElementTypes_ in the constructor so initInputTensors skips the per-step GetInputTypeInfo FFI round-trip; reserve output and input tensor vectors.
IOnnxInferSession / OnnxInferSessionMock: updated interface to match the const-ref signature; tests switched from ::testing::Return(vec) to ::testing::ReturnRef(vec) / ReturnRefOfCopy as appropriate.
ChatterboxEngine: added reusable logitsBuffer_ / logitsBufferUncond_ members so selectNextToken and both CFG steps resize in place instead of allocating a ~26 KB vector per token; fused temperature scaling + softmax (applyTemperatureAndSoftmax) into 2 passes, and merged the min-P filter with its running sum (applyMinPFilterWithSum), skipping the redundant normalise pass since std::discrete_distribution renormalises internally; replaced readLastStepLogitsForBatch (returned a fresh vector) with readLastStepLogitsForBatchInto that writes into the caller's buffer; tidied assembleSpeechTokenSequence to reserve() once and drop the std::vector<int64_t>(3, SILENCE_TOKEN) temporary in favour of insert(end, 3, SILENCE_TOKEN); added <cmath>, <iterator>, <limits> headers for the fused numerics.
TensorFloatHandler: rewrote the Fp16, Int4, and UInt4 readToVector implementations so they grow the destination vector once and convert directly into its storage, eliminating the intermediate std::vector<float> converted(n) + copy.
Rejected during benchmarking: an earlier attempt to cache KV layout (lmKvInputNames_, kvChainedFlags_) at the engine level regressed LM generation by ~60%. Root cause: chainedInputNames_ in OnnxInferSession is only populated after the first Run() moves outputs into inputs, so caching chained flags right after enableKvCacheChaining() captured all-zeros and forced the hot loop to re-copy the full KV state every iteration. Reverted to the live isInputChained() lookup.

**How was it tested?**
C++ unit suite: 229/229 tests pass (9 skipped — pre-existing LavaSR / factory integration tests that need models not present locally). ChatterboxEngineMethodsTest, KvCacheChainingTest, Fp16UtilsTest, TensorFloatHandlerTest, OnnxInferSessionMockTest all cover the changed code paths.
End-to-end: CHATTERBOX_VARIANT=q4 bare examples/chatterbox-tts.js english produces a valid 5.4 s WAV (chatterbox-output.wav, 259244 bytes).
Benchmarked against main on a 762-token English synthesis (warm-up + 10 timed runs, q4 variant):
metric	before	after	Δ
LM generation
~10.79 s
~10.45 s
–3.1%
Total synthesize
~19.99 s
~19.65 s
–1.7%
The gain is entirely in C++ overhead around ORT (allocations, string hashing, FFI round-trips, redundant vector copies); ORT matmul time is untouched.

**API Changes**
IOnnxInferSession / OnnxInferSession metadata accessors are now return-by-const-reference. This is source-compatible for callers binding to a const reference or copying into a new vector, but binding to a non-const reference will no longer compile.

// Before
virtual std::vector<std::string> getInputNames() const = 0;
virtual std::vector<std::string> getOutputNames() const = 0;
// After
virtual const std::vector<std::string> &getInputNames() const = 0;
virtual const std::vector<std::string> &getOutputNames() const = 0;
Gmock users of OnnxInferSessionMock must switch from Return(vec) to ReturnRef(vec) (or ReturnRefOfCopy for temporaries) when stubbing these methods.