### PR TITLE
chore[notask|skiplog]: release @qvac/cli v0.2.4

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.4]
+
+Release Date: 2026-04-27
+
+## 🐞 Fixes
+
+- Update `SDKModule.embed` type and `sdkEmbed()` to handle the new `{ embedding, stats? }` return shape introduced in `@qvac/sdk` 0.9+. The CLI's internal `number[] | number[][]` contract is preserved so callers (notably the OpenAI embeddings route) stay unchanged. (see PR [#1596](https://github.com/tetherto/qvac/pull/1596))
+- Extract nested `node_modules` packages when generating the addons manifest in `qvac bundle sdk`, so deeply-hoisted addon dependencies are correctly included in the mobile worker bundle. (see PR [#1731](https://github.com/tetherto/qvac/pull/1731))
+
 ## [0.2.3]
 
 Release Date: 2026-04-06

--- a/packages/cli/changelog/0.2.4/CHANGELOG.md
+++ b/packages/cli/changelog/0.2.4/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.2.4
+
+Release Date: 2026-04-27
+
+## 🐞 Fixes
+
+- Update `SDKModule.embed` type and `sdkEmbed()` to handle the new `{ embedding, stats? }` return shape introduced in `@qvac/sdk` 0.9+. The CLI's internal `number[] | number[][]` contract is preserved so callers (notably the OpenAI embeddings route) stay unchanged. (see PR [#1596](https://github.com/tetherto/qvac/pull/1596))
+- Extract nested `node_modules` packages when generating the addons manifest in `qvac bundle sdk`, so deeply-hoisted addon dependencies are correctly included in the mobile worker bundle. (see PR [#1731](https://github.com/tetherto/qvac/pull/1731))

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Description

Release **@qvac/cli v0.2.4** (PATCH).

This PR bumps `packages/cli/package.json` to `0.2.4` and adds the changelog entry. Merging into `release-cli-0.2.4` triggers GPR publish; backmerging that branch into `main` will trigger the npm publish.

## Included since v0.2.3

### 🐞 Fixes

- Update `SDKModule.embed` type and `sdkEmbed()` to handle the new `{ embedding, stats? }` return shape introduced in `@qvac/sdk` 0.9+. The CLI's internal `number[] | number[][]` contract is preserved so callers (notably the OpenAI embeddings route) stay unchanged. (PR [#1596](https://github.com/tetherto/qvac/pull/1596))
- Extract nested `node_modules` packages when generating the addons manifest in `qvac bundle sdk`, so deeply-hoisted addon dependencies are correctly included in the mobile worker bundle. (PR [#1731](https://github.com/tetherto/qvac/pull/1731))

# Checklist

- [x] The **title matches the expected** format `prefix[tags]: subject`
- [x] I have **removed unused sub-sections**
- [x] **I have bumped the version** (PATCH for bug fixes)
- [x] The PR is **focused** on a single feature or fix (release only)
- [x] The PR includes a **clear, structured description**
- [x] I wrote **meaningful commit messages**
- [x] I have **avoided unrelated changes**

# Related PRs

- #1596
- #1731