### PR TITLE
Version update bump

### DIFF
--- a/packages/qvac-lib-infer-whispercpp/CHANGELOG.md
+++ b/packages/qvac-lib-infer-whispercpp/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3]
+
 ### Added
-- Enabled Vulkan GPU acceleration in CI prebuilds for Linux, Android, and Windows
-- Added dynamic ggml backend library installation in CMakeLists.txt for Android/Linux (matching the LLM addon pattern)
+- Vulkan GPU acceleration enabled by default in CMakeLists.txt for Linux, Android, and Windows (macOS/iOS use Metal)
+- Dynamic ggml backend library installation in CMakeLists.txt for Android/Linux (matching the LLM addon pattern)
 - Vulkan SDK installation on Windows integration test runner so `vulkan-1.dll` is available at runtime
 - `atexit` cleanup handler in `binding.cpp` that clears streaming sessions before C++ static destructors run
+- Vulkan GPU smoke test in integration test workflow for Linux GPU runners
+- RTF performance benchmark workflow with multi-model/multi-audio matrix support
 
 ### Changed
 - GPU usage is now opt-in: `use_gpu` defaults to `false` in `toWhisperContextParams` instead of inheriting the upstream default (`true`). Callers must explicitly set `use_gpu: true` to enable GPU acceleration.
@@ -19,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed SIGSEGV (exit code 139) at process exit on Linux GPU runners caused by ggml Vulkan backend static destructor ordering (upstream whisper.cpp#2373)
 - Fixed "The specified module could not be found" error on Windows integration tests by installing the Vulkan runtime
+- Fixed `t.skip()` calls in GPU smoke test (brittle does not support `t.skip`, replaced with `t.pass`)
 
 ## [0.6.2]
 

--- a/packages/qvac-lib-infer-whispercpp/package.json
+++ b/packages/qvac-lib-infer-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
🎯 What problem does this PR solve?

qvac-lib-infer-whispercpp was at version 0.6.2, missing changelog entries for the Vulkan enablement work merged via temp_vulkan
📝 How does it solve it?

Bump version to 0.6.3
Document all changes from the Vulkan PR in CHANGELOG: Vulkan enabled by default on Linux/Android/Windows, use_gpu opt-in default, SIGSEGV fix, Windows DLL fix, atexit cleanup, GPU smoke test, RTF benchmark workflow, t.skip fix
🧪 How was it tested?

No code changes — version bump and changelog only