### PR TITLE
chore[notask]: release sdk 0.9.2

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.9.2]
+
+Release Date: 2026-04-27
+
+## 🔌 API
+
+- Add sentence-level streaming for onnx text-to-speech. (see PR [#1590](https://github.com/tetherto/qvac/pull/1590)) - See [API changes](./changelog/0.9.2/api.md)
+- Make auto KV-cache reuse completed turn history. (see PR [#1705](https://github.com/tetherto/qvac/pull/1705)) - See [API changes](./changelog/0.9.2/api.md)
+- Propagate registry download retries and expose stream timeout. (see PR [#1743](https://github.com/tetherto/qvac/pull/1743)) - See [API changes](./changelog/0.9.2/api.md)
+
+## 🐞 Fixes
+
+- Scope kv-cache invalidation to deleted key on RPC delete-cache. (see PR [#1740](https://github.com/tetherto/qvac/pull/1740))
+
+## 🧹 Chores
+
+- Migrate SDK plugins to new addon constructor shape. (see PR [#1688](https://github.com/tetherto/qvac/pull/1688)) - See [breaking changes](./changelog/0.9.2/breaking.md)
+- Refresh tests-qvac docs, tooling, and workflow job names. (see PR [#1712](https://github.com/tetherto/qvac/pull/1712))
+- Backmerge release sdk 0.9.1. (see PR [#1726](https://github.com/tetherto/qvac/pull/1726))
+
 ## [0.9.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.9.1

--- a/packages/sdk/changelog/0.9.2/CHANGELOG.md
+++ b/packages/sdk/changelog/0.9.2/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog v0.9.2
+
+Release Date: 2026-04-27
+
+## 🔌 API
+
+- Add sentence-level streaming for onnx text-to-speech. (see PR [#1590](https://github.com/tetherto/qvac/pull/1590)) - See [API changes](./api.md)
+- Make auto KV-cache reuse completed turn history. (see PR [#1705](https://github.com/tetherto/qvac/pull/1705)) - See [API changes](./api.md)
+- Propagate registry download retries and expose stream timeout. (see PR [#1743](https://github.com/tetherto/qvac/pull/1743)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Scope kv-cache invalidation to deleted key on RPC delete-cache. (see PR [#1740](https://github.com/tetherto/qvac/pull/1740))
+
+## 🧹 Chores
+
+- Migrate SDK plugins to new addon constructor shape. (see PR [#1688](https://github.com/tetherto/qvac/pull/1688)) - See [breaking changes](./breaking.md)
+- Refresh tests-qvac docs, tooling, and workflow job names. (see PR [#1712](https://github.com/tetherto/qvac/pull/1712))
+- Backmerge release sdk 0.9.1. (see PR [#1726](https://github.com/tetherto/qvac/pull/1726))
+

--- a/packages/sdk/changelog/0.9.2/api.md
+++ b/packages/sdk/changelog/0.9.2/api.md
@@ -1,0 +1,103 @@
+# 🔌 API Changes v0.9.2
+
+## Add sentence-level streaming for onnx text-to-speech
+
+PR: [#1590](https://github.com/tetherto/qvac/pull/1590)
+
+```typescript
+import { loadModel, textToSpeech, unloadModel } from "@qvac/sdk";
+
+const modelId = await loadModel({ /* ...Supertonic ONNX TTS config... */ });
+
+const result = textToSpeech({
+  modelId,
+  text: "Your long passage here.",
+  inputType: "text",
+  stream: true,
+  sentenceStream: true,
+  sentenceStreamLocale: "en",
+});
+
+for await (const chunk of result.chunkUpdates!) {
+  // chunk.buffer      -> int16 PCM samples for this sentence
+  // chunk.chunkIndex  -> 0-based sentence index
+  // chunk.sentenceChunk -> source text for this chunk
+}
+
+await result.done;
+await unloadModel({ modelId });
+```
+
+```typescript
+import { completion, textToSpeechStream } from "@qvac/sdk";
+
+const session = await textToSpeechStream({
+  modelId: ttsModelId,
+  inputType: "text",
+  accumulateSentences: true,
+  sentenceDelimiterPreset: "latin", // "latin" | "cjk" | "multilingual"
+  flushAfterMs: 400,
+});
+
+(async () => {
+  for await (const delta of completion({ modelId: llmModelId, /* ... */ }).tokenStream) {
+    session.write(delta);
+  }
+  session.end();
+})();
+
+for await (const chunk of session) {
+  // chunk.buffer       -> int16 PCM for this sentence / flush window
+  // chunk.chunkIndex   -> optional sentence index
+  // chunk.sentenceChunk-> optional source text
+  if (chunk.done) break;
+}
+```
+
+---
+
+## Make auto KV-cache reuse completed turn history
+
+PR: [#1705](https://github.com/tetherto/qvac/pull/1705)
+
+```typescript
+// New: `final.cacheableAssistantContent` — the canonical assistant
+// string the SDK persisted to the auto-cache key on this turn.
+// Push it back into `history` verbatim to guarantee a next-turn hit.
+const run = completion({ modelId, history, kvCache: true });
+for await (const _ of run.tokenStream) { /* stream */ }
+const final = await run.final;
+const nextHistory = [
+  ...history,
+  {
+    role: "assistant",
+    // Falls back to contentText for tool-call turns, which can't
+    // be auto-cached today and therefore omit the field.
+    content: final.cacheableAssistantContent ?? final.contentText,
+  },
+  { role: "user", content: "follow-up question" },
+];
+```
+
+---
+
+## Propagate registry download retries and expose stream timeout
+
+PR: [#1743](https://github.com/tetherto/qvac/pull/1743)
+
+```ts
+import { setSDKConfig } from "@qvac/sdk";
+
+setSDKConfig({
+  // Retry REQUEST_TIMEOUT failures up to N times before giving up.
+  // Set to 0 to disable retries entirely.
+  registryDownloadMaxRetries: 5,
+
+  // Raise the per-block stream timeout for slow/high-latency links
+  // (default: 60_000 ms).
+  registryStreamTimeoutMs: 180_000,
+});
+```
+
+---
+

--- a/packages/sdk/changelog/0.9.2/breaking.md
+++ b/packages/sdk/changelog/0.9.2/breaking.md
@@ -1,0 +1,25 @@
+# 💥 Breaking Changes v0.9.2
+
+## Migrate SDK plugins to new addon constructor shape
+
+PR: [#1688](https://github.com/tetherto/qvac/pull/1688)
+
+**BEFORE:**
+**
+
+```typescript
+export const myPlugin = definePlugin({
+  // ...
+  createModel(params: CreateModelParams): PluginModelResult {
+    return { model, loader: null };
+  },
+});
+```
+
+**
+
+**AFTER:**
+**
+
+---
+

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Ship `@qvac/sdk@0.9.2` to the `release-test-sdk-0.9.2` line.
- Land the generated changelog so consumers see what's in the release.

## 📝 How does it solve it?

- Bump `packages/sdk/package.json` to `0.9.2`.
- Add `packages/sdk/changelog/0.9.2/` (`CHANGELOG.md`, `api.md`, `breaking.md`) generated from PRs landed since the `0.9.1` release commit (`e723f486d`).
- Prepend the `[0.9.2]` section to the aggregated `packages/sdk/CHANGELOG.md`.
- User-facing changes shipped: 3 `[api]` PRs (#1590, #1705, #1743), 1 fix (#1740), 1 `[bc]` chore (#1688), plus tooling/backmerge entries — full list in the changelog.

## 🧪 How was it tested?

- No code changes in this PR — functional changes were validated in their original merged PRs.
- Verified locally that `git diff upstream/release-test-sdk-0.9.2..HEAD` contains only release metadata (5 files, +169/-1).
