### PR TITLE
chore[notask|skiplog]: release @qvac/infer-base v0.4.1

### DIFF
--- a/packages/qvac-lib-infer-base/CHANGELOG.md
+++ b/packages/qvac-lib-infer-base/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.4.1] - 2026-04-28
+
+This release drops the vestigial `@qvac/dl-hyperdrive` peer dependency from `@qvac/infer-base`'s manifest. Since the `Loader` interface moved into this package and `ready()`/`close()` became optional in `0.4.0`, the peer-dep declaration was no longer required by anything in the runtime — consumers no longer carry an `@qvac/dl-hyperdrive` peer-dep through `@qvac/infer-base` when installing it.
+
+### Changed
+
+- Removed `peerDependencies."@qvac/dl-hyperdrive"` from `package.json`. No runtime behavior change — the `BaseInference` class, public methods, and standalone utilities (`createJobHandler`, `exclusiveRunQueue`, `getApiDefinition`) are all unchanged. Lint and the full `brittle-bare` unit suite (118/118) pass with the declaration removed.
+
+## Pull Requests
+
+- [#1761](https://github.com/tetherto/qvac/pull/1761) - QVAC-14392 chore: drop @qvac/dl-hyperdrive peer-dep chain in infer-base + decoder-audio
+
 ## [0.4.0] - 2026-03-31
 
 ### Added

--- a/packages/qvac-lib-infer-base/package.json
+++ b/packages/qvac-lib-infer-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/infer-base",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Base class for inference clients",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# Description

Release **@qvac/infer-base v0.4.1** (PATCH).

This PR bumps `packages/qvac-lib-infer-base/package.json` to `0.4.1` and adds the matching changelog entry. Merging into `release-qvac-lib-infer-base-0.4.1` triggers the GPR publish; backmerging that branch into `main` triggers the npm publish.

## Included since v0.4.0

### 🧹 Other

- Removed `peerDependencies."@qvac/dl-hyperdrive": "^0.1.0"` from the published manifest. The runtime moved off DataLoaders in #1688 (`Loader` interface lives in this package, `ready()`/`close()` are optional), so this declaration was no longer required by anything. Consumers of `@qvac/infer-base` no longer inherit a `@qvac/dl-hyperdrive` peer-dep through this package. (PR [#1761](https://github.com/tetherto/qvac/pull/1761))

## Why this release matters

This unblocks the SDK-side cleanup tracked in [QVAC-14392](https://app.asana.com/1/45238840754660/project/1212638335655966/task/1213753922140257) / #1754. Once this is on npm and `@qvac/decoder-audio@0.3.8` is on npm (paired release), the SDK's `overrides: { "@qvac/dl-hyperdrive": "^0.2.0" }` block can be dropped and `@qvac/dl-hyperdrive` + `@qvac/dl-base` fall out of `packages/sdk/bun.lock` entirely.

## Verification

- [x] `package.json` bumped: `0.4.0` → `0.4.1`
- [x] `CHANGELOG.md` has `## [0.4.1] - 2026-04-28` block
- [x] `npm run lint` (`standard`) — clean
- [x] `npm run test:unit` (`brittle-bare`) — 118/118 passing, 258/258 asserts

# Checklist

- [x] The **title matches the expected** format `prefix[tags]: subject`
- [x] I have **removed unused sub-sections**
- [x] **I have bumped the version** (PATCH for non-breaking dep-tree cleanup)
- [x] The PR is **focused** on a single feature or fix (release only)
- [x] The PR includes a **clear, structured description**
- [x] I wrote **meaningful commit messages**
- [x] I have **avoided unrelated changes**

# Related PRs

- #1761