### PR TITLE
chore[notask|skiplog]: release @qvac/decoder-audio v0.3.8

### DIFF
--- a/packages/qvac-lib-decoder-audio/CHANGELOG.md
+++ b/packages/qvac-lib-decoder-audio/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2026-04-28
+
+This release bumps `@qvac/infer-base` from `^0.1.0` to `^0.4.0`. Together with `@qvac/infer-base@0.4.1` (which drops the legacy `@qvac/dl-hyperdrive` peer-dep), this stops `@qvac/dl-*` packages from being pulled into consumers' install trees through `@qvac/decoder-audio`. Public behavior of `FFmpegDecoder` is unchanged.
+
+### Changed
+
+- Bumped `@qvac/infer-base` direct dependency from `^0.1.0` to `^0.4.0`. Consumers using `decoder-audio` no longer carry the legacy `@qvac/infer-base@0.1.x` line — and therefore no longer inherit its `@qvac/dl-hyperdrive` peer-dep — in their dependency tree.
+
+### Notes
+
+The `BaseInference` public surface (constructor signature, lifecycle methods) is identical between `@qvac/infer-base` 0.1.1 and 0.4.x, so `class FFmpegDecoder extends BaseInference` continues to work unchanged. Lint clean + 9/9 brittle-bare unit tests pass against the new range.
+
+## Pull Requests
+
+- [#1761](https://github.com/tetherto/qvac/pull/1761) - QVAC-14392 chore: drop @qvac/dl-hyperdrive peer-dep chain in infer-base + decoder-audio
+
 ## [0.3.6]
 
 ### Changed

--- a/packages/qvac-lib-decoder-audio/package.json
+++ b/packages/qvac-lib-decoder-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/decoder-audio",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "",
   "license": "Apache-2.0",
   "author": "Tether",


### PR DESCRIPTION
# Description

Release **@qvac/decoder-audio v0.3.8** (PATCH).

This PR bumps `packages/qvac-lib-decoder-audio/package.json` to `0.3.8` and adds the matching changelog entry. Merging into `release-qvac-lib-decoder-audio-0.3.8` triggers the GPR publish; backmerging that branch into `main` triggers the npm publish.

## Included since v0.3.7

### 🧹 Other

- Bumped `@qvac/infer-base` direct dependency from `^0.1.0` to `^0.4.0`. Stops `@qvac/decoder-audio` from dragging the legacy `@qvac/infer-base@0.1.x` line (and its `@qvac/dl-hyperdrive` peer-dep) into consumers' install trees. (PR [#1761](https://github.com/tetherto/qvac/pull/1761))

## Why this release matters

Pairs with `@qvac/infer-base@0.4.1` (#1777) to unblock the SDK cleanup tracked in [QVAC-14392](https://app.asana.com/1/45238840754660/project/1212638335655966/task/1213753922140257) / #1754. Both packages must be on npm before the SDK's `overrides` block can be dropped — `@qvac/decoder-audio@0.3.7` is the last consumer in the SDK install that pins `@qvac/infer-base: ^0.1.0`, and that's exactly what this release fixes.

## Compatibility

The `BaseInference` public surface (constructor signature, lifecycle methods: `load`, `unload`, `pause`, `unpause`, `stop`, `cancel`, `run`, …) is **identical line-for-line** between published `@qvac/infer-base@0.1.1` and `@qvac/infer-base@0.4.0`. The 47-line internal diff is limited to `_handleEvent` (added `FinetuneProgress` dispatch + `RangeError` guard on Output debug logs), neither of which touches `decoder-audio`'s overridden `run()` flow. `class FFmpegDecoder extends BaseInference` continues to work unchanged.

## Verification

- [x] `package.json` bumped: `0.3.7` → `0.3.8`
- [x] `CHANGELOG.md` has `## [0.3.8] - 2026-04-28` block
- [x] `npm install` resolves `@qvac/infer-base@0.4.0` cleanly
- [x] `npm run lint` (`standard`) — clean
- [x] `npm run test:unit` (`brittle-bare`) — 9/9 passing, 34/34 asserts
- [ ] CI integration tests (`ffmpeg-decoder.test.js`) on this PR

# Checklist

- [x] The **title matches the expected** format `prefix[tags]: subject`
- [x] I have **removed unused sub-sections**
- [x] **I have bumped the version** (PATCH for non-breaking dep-tree cleanup)
- [x] The PR is **focused** on a single feature or fix (release only)
- [x] The PR includes a **clear, structured description**
- [x] I wrote **meaningful commit messages**
- [x] I have **avoided unrelated changes**

# Related PRs

- #1761
- #1777