### PR TITLE
infra[notask]: fix sdk e2e prior-comment minimize and missing ios/android report summary

### DIFF
--- a/.github/actions/sdk-e2e-report-finalize/action.yml
+++ b/.github/actions/sdk-e2e-report-finalize/action.yml
@@ -120,26 +120,43 @@ runs:
             `**Config:** suite=${fmt(suite)} · filter=${fmt(filter)} · exclude=${fmt(excludeSuite)}`;
           const linksLine = `[View run](${runUrl}) · [Artifacts](${artifactsUrl})`;
 
+          // actions/download-artifact@v8 extracts a single matched artifact directly
+          // into `path` instead of `path/<artifact-name>/` (the per-artifact subdir is
+          // only created when the pattern matches >=2 artifacts). For families with one
+          // platform (android, ios) we therefore probe both layouts. Desktop always has
+          // multiple platforms so the per-artifact subdir is created and is preferred.
           function findResultsJson(platform) {
-            const dir = path.join(resultsRoot, artifactDir(platform));
-            if (!fs.existsSync(dir)) return null;
-            const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
-            if (files.length === 0) return null;
-            // Pick the first results-*.json; there is normally only one per platform per run.
-            const target = files.find((f) => f.startsWith('results-')) || files[0];
-            return path.join(dir, target);
+            const candidates = [
+              path.join(resultsRoot, artifactDir(platform)),
+              resultsRoot,
+            ];
+            for (const dir of candidates) {
+              if (!fs.existsSync(dir)) continue;
+              const files = fs.readdirSync(dir)
+                .filter((f) => f.endsWith('.json') && f.startsWith('results-'));
+              if (files.length === 0) continue;
+              return path.join(dir, files[0]);
+            }
+            return null;
           }
 
           function findSectionFiles(platform) {
-            const dir = path.join(sectionsRoot, sectionArtifactDir(platform));
-            if (!fs.existsSync(dir)) return { md: null, comparison: null };
-            const entries = fs.readdirSync(dir);
-            const md = entries.find((f) => f.endsWith('.md'));
-            const comparison = entries.find((f) => f.startsWith('comparison-') && f.endsWith('.json'));
-            return {
-              md: md ? path.join(dir, md) : null,
-              comparison: comparison ? path.join(dir, comparison) : null,
-            };
+            const candidates = [
+              path.join(sectionsRoot, sectionArtifactDir(platform)),
+              sectionsRoot,
+            ];
+            for (const dir of candidates) {
+              if (!fs.existsSync(dir)) continue;
+              const entries = fs.readdirSync(dir);
+              const md = entries.find((f) => f.endsWith('.md'));
+              const comparison = entries.find((f) => f.startsWith('comparison-') && f.endsWith('.json'));
+              if (!md && !comparison) continue;
+              return {
+                md: md ? path.join(dir, md) : null,
+                comparison: comparison ? path.join(dir, comparison) : null,
+              };
+            }
+            return { md: null, comparison: null };
           }
 
           function truncate(s, n) {

--- a/.github/actions/sdk-e2e-report-start/action.yml
+++ b/.github/actions/sdk-e2e-report-start/action.yml
@@ -71,16 +71,35 @@ runs:
 
           const marker = (p) => `<!-- sdk-e2e-report:pr=${pr}:family=${family}:platform=${p} -->`;
 
-          const existing = await github.paginate(
-            github.rest.issues.listComments,
-            { owner: context.repo.owner, repo: context.repo.repo, issue_number: pr, per_page: 100 }
-          );
+          // Fetch all issue comments with their minimized state via GraphQL,
+          // since REST listComments does not return isMinimized.
+          const existing = [];
+          let cursor = null;
+          for (;;) {
+            const page = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                 repository(owner: $owner, name: $repo) {
+                   pullRequest(number: $number) {
+                     comments(first: 100, after: $cursor) {
+                       pageInfo { hasNextPage endCursor }
+                       nodes { id databaseId isMinimized body }
+                     }
+                   }
+                 }
+               }`,
+              { owner: context.repo.owner, repo: context.repo.repo, number: pr, cursor }
+            );
+            const conn = page.repository.pullRequest.comments;
+            existing.push(...conn.nodes);
+            if (!conn.pageInfo.hasNextPage) break;
+            cursor = conn.pageInfo.endCursor;
+          }
 
           const commentIds = {};
           for (const platform of platforms) {
             const mark = marker(platform);
-            const prior = existing.find((c) => (c.body || '').includes(mark));
-            if (prior) {
+            const priors = existing.filter((c) => (c.body || '').includes(mark) && !c.isMinimized);
+            for (const prior of priors) {
               try {
                 await github.graphql(
                   `mutation($id: ID!) {
@@ -88,11 +107,11 @@ runs:
                        minimizedComment { isMinimized }
                      }
                    }`,
-                  { id: prior.node_id }
+                  { id: prior.id }
                 );
-                core.info(`Minimized prior comment for ${platform} (id=${prior.id}).`);
+                core.info(`Minimized prior comment for ${platform} (id=${prior.databaseId}).`);
               } catch (err) {
-                core.warning(`Failed to minimize prior comment for ${platform}: ${err.message}`);
+                core.warning(`Failed to minimize prior comment for ${platform} (id=${prior.databaseId}): ${err.message}`);
               }
             }
 


### PR DESCRIPTION
## What problem does this PR solve?

Two unrelated regressions in the SDK e2e PR-comment / step-summary flow on `main` (introduced in #1744 / on the v8 download-artifact bump), observed against PR #745 and recent runs:

- ios and android always rendered `⚠️ no results` in the GitHub Actions step summary (and in the PR comment, in PR context) even when the producer had uploaded a valid `results-ios` / `results-android` artifact. Desktop was unaffected.
- Across multiple runs on the same PR, only the oldest "running" comment was being marked outdated. Subsequent runs left previous comments expanded, accumulating non-minimized comments.

## How does it solve it?

- `sdk-e2e-report-start`: replace `Array.prototype.find` with a paginated GraphQL `comments` query that exposes `isMinimized`, then minimize **every** prior matching comment that is not already minimized. The previous `find` call always returned the oldest matching comment, which was already minimized after the first pass, so the new mutation was a no-op for runs 2+.
- `sdk-e2e-report-finalize`: tolerate the path layout change in `actions/download-artifact@v8`. v8 added an `artifacts.length === 1` shortcut that bypasses the per-artifact subdirectory and extracts straight into `path` (visible in the [v8.0.1 source](https://github.com/actions/download-artifact/blob/v8.0.1/src/download-artifact.ts#L189-L194)). The ios and android families always match exactly one artifact via `pattern:`, so the files landed in `.sdk-e2e-report/current-results/` instead of `.sdk-e2e-report/current-results/results-<family>/`, which is what `findResultsJson` was probing. `findResultsJson` and `findSectionFiles` now check the per-artifact subdirectory first and fall back to the download root.

## How was it tested?

- Pulled the actual `results-ios` / `results-android` artifacts from a recent run (25005085622) and replayed `findResultsJson` locally against both layouts (per-artifact subdir from v4 / multi-artifact pattern matches, and the flat layout from v8 single-artifact pattern matches). All four cases resolve to the right `results-*.json`; missing-artifact still returns `null`.
- Verified the marker enumeration on PR #745 against the live state: 10 stale comments that `find` skipped were minimized one-off; the 5 latest per `(family, platform)` remain expanded. Confirms the plurality fix matches the actual PR comment graph.
- No `actions/download-artifact` or `actions/github-script` SHA changes; only the inline scripts.

## Stale comment cleanup

PR #745 was the only PR with multiple non-minimized comments per marker; those were minimized via a one-off `gh api graphql` pass and do not need a backfill workflow run.
