### PR TITLE
chore[notask]: backmerge release qvac-lib-decoder-audio 0.3.8

### DIFF
--- a/packages/decoder-audio/CHANGELOG.md
+++ b/packages/decoder-audio/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2026-04-28
+
+This release bumps `@qvac/infer-base` from `^0.1.0` to `^0.4.0`. Together with `@qvac/infer-base@0.4.1` (which drops the legacy `@qvac/dl-hyperdrive` peer-dep), this stops `@qvac/dl-*` packages from being pulled into consumers' install trees through `@qvac/decoder-audio`. Public behavior of `FFmpegDecoder` is unchanged.
+
+### Changed
+
+- Bumped `@qvac/infer-base` direct dependency from `^0.1.0` to `^0.4.0`. Consumers using `decoder-audio` no longer carry the legacy `@qvac/infer-base@0.1.x` line — and therefore no longer inherit its `@qvac/dl-hyperdrive` peer-dep — in their dependency tree.
+
+### Notes
+
+The `BaseInference` public surface (constructor signature, lifecycle methods) is identical between `@qvac/infer-base` 0.1.1 and 0.4.x, so `class FFmpegDecoder extends BaseInference` continues to work unchanged. Lint clean + 9/9 brittle-bare unit tests pass against the new range.
+
+## Pull Requests
+
+- [#1761](https://github.com/tetherto/qvac/pull/1761) - QVAC-14392 chore: drop @qvac/dl-hyperdrive peer-dep chain in infer-base + decoder-audio
+
 ## [0.3.6]
 
 ### Changed

--- a/packages/decoder-audio/package.json
+++ b/packages/decoder-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/decoder-audio",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "",
   "license": "Apache-2.0",
   "author": "Tether",


### PR DESCRIPTION
# Description

Backmerge of `release-qvac-lib-decoder-audio-0.3.8` into `main`.

Carries the version bump (`0.3.7` → `0.3.8`) and `CHANGELOG.md` entry into `main` so the trunk reflects the published `@qvac/decoder-audio@0.3.8`.

> ⚠️ **npm publish is currently waiting on integration tests.** The On-Merge workflow on `release-qvac-lib-decoder-audio-0.3.8` has every integration test job (`run-integration-tests / test-{linux,darwin,win32}-{x64,arm64}` and `mobile-integration-tests / Build {Android,iOS} and Run E2E Tests`) in `waiting` state — they need environment approval in the GitHub Actions UI before publish-release-npm fires. This backmerge PR is independent of that and can be reviewed/merged in parallel; the actual `0.3.8` artifact has to publish to npm before SDK PR #1754 can drop the `overrides` block.

## Files

- `packages/qvac-lib-decoder-audio/package.json` — version bump
- `packages/qvac-lib-decoder-audio/CHANGELOG.md` — `## [0.3.8] - 2026-04-28` block

## Related PRs

- #1761 — original change (bumps `@qvac/infer-base` direct dep `^0.1.0` → `^0.4.0`)
- #1778 — release PR (GPR merged; npm publish gated on integration tests)

# Checklist

- [x] **No code changes** beyond the version bump and changelog entry
- [x] Title format: `prefix[tags]: subject`