### PR TITLE
QVAC-17939: release(llamacpp-llm): v0.17.1 — back-port per-request grammar / json_schema

### DIFF
--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -253,8 +253,24 @@ jobs:
         if: ${{ matrix.platform != 'win32' }}
         working-directory: ${{ env.WORKDIR }}
         run: |
+          set +e
+          # Stream + capture so we can inspect the TAP summary on non-zero exit.
+          # Some GPU configurations (linux-x64 ai-run-linux-gpu w/ Tesla T4 +
+          # Vulkan) crash with SIGSEGV (exit 139) during ggml-vulkan static
+          # destructor teardown AFTER all tests have passed. Tolerate exit 139
+          # IFF the captured TAP output shows tests passed; surface every other
+          # non-zero exit. Same pattern as commit 1091827ed in
+          # integration-test-qvac-lib-infer-vla.yml.
           npm run test:integration 2>&1 | tee test-output.log
-          exit ${PIPESTATUS[0]}
+          EXIT=${PIPESTATUS[0]}
+          if [ "$EXIT" -eq 0 ]; then
+            exit 0
+          fi
+          if [ "$EXIT" -eq 139 ] && grep -qE '^# ok$' test-output.log && grep -qE '^# tests = [0-9]+/[0-9]+ pass$' test-output.log; then
+            echo "::warning::Tests all passed but process crashed at teardown with SIGSEGV (exit 139). Known ggml/Vulkan static-destructor issue on ai-run-linux-gpu; treating as pass."
+            exit 0
+          fi
+          exit "$EXIT"
         shell: bash
         env:
           QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}

--- a/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-llamacpp-llm.yml
@@ -253,24 +253,8 @@ jobs:
         if: ${{ matrix.platform != 'win32' }}
         working-directory: ${{ env.WORKDIR }}
         run: |
-          set +e
-          # Stream + capture so we can inspect the TAP summary on non-zero exit.
-          # Some GPU configurations (linux-x64 ai-run-linux-gpu w/ Tesla T4 +
-          # Vulkan) crash with SIGSEGV (exit 139) during ggml-vulkan static
-          # destructor teardown AFTER all tests have passed. Tolerate exit 139
-          # IFF the captured TAP output shows tests passed; surface every other
-          # non-zero exit. Same pattern as commit 1091827ed in
-          # integration-test-qvac-lib-infer-vla.yml.
           npm run test:integration 2>&1 | tee test-output.log
-          EXIT=${PIPESTATUS[0]}
-          if [ "$EXIT" -eq 0 ]; then
-            exit 0
-          fi
-          if [ "$EXIT" -eq 139 ] && grep -qE '^# ok$' test-output.log && grep -qE '^# tests = [0-9]+/[0-9]+ pass$' test-output.log; then
-            echo "::warning::Tests all passed but process crashed at teardown with SIGSEGV (exit 139). Known ggml/Vulkan static-destructor issue on ai-run-linux-gpu; treating as pass."
-            exit 0
-          fi
-          exit "$EXIT"
+          exit ${PIPESTATUS[0]}
         shell: bash
         env:
           QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}

--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.17.1] - 2026-04-28
+
+This patch release adds per-request structured-output support to the LLM addon: callers can now constrain a single completion to either a JSON Schema or a raw GBNF grammar without reloading the model. Back-port of the same change being prepared for `main` in [#1787](https://github.com/tetherto/qvac/pull/1787); shipped here on top of `0.17.0` so it can be consumed by SDK lines that have not yet migrated to `0.18.x`.
+
+### Added
+
+#### Per-request `json_schema` and `grammar` in `generationParams`
+
+`RunOptions.generationParams` accepts two new optional fields:
+
+- **`json_schema`** — JSON Schema applied to a single `run()` call. Accepts either a JSON Schema object literal or a pre-stringified JSON Schema. Internally converted to GBNF via llama.cpp's `json_schema_to_grammar()`, the same converter used by the load-time `--json-schema` config key.
+- **`grammar`** — raw GBNF string applied to a single `run()` call. Useful for non-JSON outputs (regex-like DSLs, CSV, custom syntaxes). Mirrors the load-time `--grammar` config key.
+
+The two are mutually exclusive — passing both throws a `TypeError` at the JS boundary. When either is set, the sampler is re-initialized for that request and the prior (typically load-time) grammar is restored automatically afterwards. Both `TextLlmContext` and `MtmdLlmContext` are wired through, so multimodal models get the same per-request hook as text-only ones.
+
+```js
+// JSON Schema (recommended for structured output)
+await model.run(prompt, {
+  generationParams: {
+    json_schema: {
+      type: 'object',
+      properties: { name: { type: 'string' }, age: { type: 'integer' } },
+      required: ['name', 'age']
+    }
+  }
+})
+
+// GBNF (non-JSON outputs)
+await model.run(prompt, {
+  generationParams: {
+    grammar: 'root ::= ("yes" | "no")'
+  }
+})
+```
+
+A new `nlohmann-json` vcpkg dependency is pulled in (header-only) so the addon can call `json_schema_to_grammar()` directly without shipping a JSON-Schema-to-GBNF converter on the JS side. Bad GBNF / unparseable JSON Schema surfaces as `InvalidArgument` with the saved sampler restored, so a malformed per-request schema cannot leave the model in a broken state.
+
+## Pull Requests
+
+- [#1787](https://github.com/tetherto/qvac/pull/1787) - feat[api]: per-request grammar / json_schema in llm-llamacpp generationParams (forward-port to `main`)
+
 ## [0.17.0] - 2026-04-21
 
 ### Changed

--- a/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
@@ -71,6 +71,7 @@ endif()
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/AsyncWeightsLoader.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/CacheManager.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ContextSlider.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/GenerationParamsApply.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaFinetuningHelpers.cpp
@@ -120,6 +121,7 @@ if(BUILD_CLI)
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/AsyncWeightsLoader.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/CacheManager.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ContextSlider.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/GenerationParamsApply.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MtmdLlmContext.cpp
@@ -149,6 +151,7 @@ if(BUILD_CLI)
           llama::llama
           llama::common
           llama::mtmd
+          nlohmann_json::nlohmann_json
   )
   find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS "qvac-lib-inference-addon-cpp/JsInterface.hpp")
   target_include_directories(cli_tool PRIVATE ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS})

--- a/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/CMakeLists.txt
@@ -33,6 +33,12 @@ configure_file(${VCPKG_INSTALLED_PATH}/share/qvac-lint-cpp/.clang-tidy
 find_path(PICOJSON_INCLUDE_DIRS "picojson/picojson.h")
 find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS "qvac-lib-inference-addon-cpp/JsInterface.hpp")
 find_package(llama CONFIG REQUIRED)
+# Required to call llama.cpp's `json_schema_to_grammar()` for per-request
+# JSON-Schema → GBNF conversion. The function signature lives in libcommon
+# (linked via `llama::common`) but takes a `nlohmann::ordered_json`, so we
+# need the full nlohmann headers, not just the forward decl shipped with
+# `llama/common/json-schema-to-grammar.h`.
+find_package(nlohmann_json CONFIG REQUIRED)
 
 if(WIN32)
   add_definitions( -DNOMINMAX -DWIN32_MEAN_AND_LEAN -DNOGDI )
@@ -98,6 +104,7 @@ endif()
       llama::llama
       llama::common
       llama::mtmd
+      nlohmann_json::nlohmann_json
   )
 
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/AddonJs.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/AddonJs.hpp
@@ -339,6 +339,13 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
       readNum("frequency_penalty", ov.frequency_penalty);
       readNum("presence_penalty", ov.presence_penalty);
       readNum("repeat_penalty", ov.repeat_penalty);
+
+      auto grammarStr =
+          configObj->getOptionalPropertyAs<js::String, std::string>(
+              env, "grammar");
+      if (grammarStr.has_value() && !grammarStr->empty()) {
+        ov.grammar = std::move(*grammarStr);
+      }
     }
 
     prompt.cacheKey =

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/AddonJs.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/addon/AddonJs.hpp
@@ -346,6 +346,20 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
       if (grammarStr.has_value() && !grammarStr->empty()) {
         ov.grammar = std::move(*grammarStr);
       }
+
+      auto jsonSchemaStr =
+          configObj->getOptionalPropertyAs<js::String, std::string>(
+              env, "json_schema");
+      if (jsonSchemaStr.has_value() && !jsonSchemaStr->empty()) {
+        ov.json_schema = std::move(*jsonSchemaStr);
+      }
+
+      if (ov.grammar && ov.json_schema) {
+        throw StatusError(
+            general_error::InvalidArgument,
+            "generationParams.grammar and generationParams.json_schema are "
+            "mutually exclusive");
+      }
     }
 
     prompt.cacheKey =

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.cpp
@@ -1,0 +1,47 @@
+#include "GenerationParamsApply.hpp"
+
+#include <exception>
+#include <string>
+
+#include <nlohmann/json.hpp>
+#include <qvac-lib-inference-addon-cpp/Errors.hpp>
+
+#include "addon/LlmErrors.hpp"
+#include "common/json-schema-to-grammar.h"
+
+void applyGenerationOverridesToSampling(
+    common_params& params, const GenerationParams& overrides) {
+  auto setIf = [](const auto& src, auto& dst) {
+    if (src) {
+      dst = *src;
+    }
+  };
+
+  setIf(overrides.temp, params.sampling.temp);
+  setIf(overrides.top_p, params.sampling.top_p);
+  setIf(overrides.top_k, params.sampling.top_k);
+  setIf(overrides.n_predict, params.n_predict);
+  setIf(overrides.seed, params.sampling.seed);
+  setIf(overrides.frequency_penalty, params.sampling.penalty_freq);
+  setIf(overrides.presence_penalty, params.sampling.penalty_present);
+  setIf(overrides.repeat_penalty, params.sampling.penalty_repeat);
+
+  // `json_schema` and `grammar` are mutually exclusive at the JS boundary
+  // and in `AddonJs::runJob::parseText`. Defensive precedence here just in
+  // case a future caller bypasses both checks: schema wins, since it is
+  // the higher-level surface.
+  if (overrides.json_schema) {
+    try {
+      auto parsed = nlohmann::ordered_json::parse(*overrides.json_schema);
+      params.sampling.grammar = json_schema_to_grammar(parsed);
+    } catch (const std::exception& ex) {
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          qvac_errors::general_error::toString(
+              qvac_errors::general_error::InvalidArgument),
+          std::string("invalid generationParams.json_schema: ") + ex.what());
+    }
+  } else if (overrides.grammar) {
+    params.sampling.grammar = *overrides.grammar;
+  }
+}

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.cpp
@@ -2,12 +2,14 @@
 
 #include <exception>
 #include <string>
+#include <utility>
 
 #include <nlohmann/json.hpp>
 #include <qvac-lib-inference-addon-cpp/Errors.hpp>
 
 #include "addon/LlmErrors.hpp"
 #include "common/json-schema-to-grammar.h"
+#include "common/log.h"
 
 void applyGenerationOverridesToSampling(
     common_params_sampling& sampling, int& nPredict,
@@ -28,9 +30,20 @@ void applyGenerationOverridesToSampling(
   setIf(overrides.repeat_penalty, sampling.penalty_repeat);
 
   // `json_schema` and `grammar` are mutually exclusive at the JS boundary
-  // and in `AddonJs::runJob::parseText`. Defensive precedence here just in
-  // case a future caller bypasses both checks: schema wins, since it is
-  // the higher-level surface.
+  // and in `AddonJs::runJob::parseText`, so reaching this branch with both
+  // set means a caller bypassed those checks (most likely the C++ unit
+  // tests or `cli_tool` driving the helper directly). Log a warning so
+  // the issue surfaces in stderr/log output and pick `json_schema`, which
+  // is the higher-level surface.
+  if (overrides.json_schema && overrides.grammar) {
+    LOG_WRN(
+        "%s: both generationParams.grammar and generationParams.json_schema "
+        "were provided; ignoring `grammar` and applying `json_schema` "
+        "(the JS and AddonJs paths reject this combination — this branch "
+        "exists only for direct C++ callers).\n",
+        __func__);
+  }
+
   if (overrides.json_schema) {
     try {
       auto parsed = nlohmann::ordered_json::parse(*overrides.json_schema);
@@ -45,4 +58,64 @@ void applyGenerationOverridesToSampling(
   } else if (overrides.grammar) {
     sampling.grammar = *overrides.grammar;
   }
+}
+
+std::function<void()> applyGenerationParamsToContext(
+    common_params& params, CommonSamplerPtr& smpl, llama_model* model,
+    const GenerationParams& overrides) {
+  if (!overrides.hasOverrides()) {
+    return []() {};
+  }
+
+  // Apply overrides to *local copies* first. Only commit them onto the
+  // live `params` and `smpl` after both the json_schema parse/convert and
+  // `common_sampler_init` have succeeded — otherwise a partially applied
+  // override (e.g. temp/seed already written, then json_schema throws)
+  // would leak into subsequent requests because no restore lambda gets
+  // returned to the caller's `ScopeGuard`.
+  common_params_sampling nextSampling = params.sampling;
+  int nextPredict = params.n_predict;
+
+  // May throw `InvalidArgument` for malformed `json_schema`. `params`
+  // and `smpl` remain untouched in that case.
+  applyGenerationOverridesToSampling(nextSampling, nextPredict, overrides);
+
+  // `common_sampler_init` returns nullptr on bad inputs (most commonly an
+  // invalid GBNF grammar — `json_schema` is converted to GBNF above and
+  // can in principle produce a grammar that the sampler rejects). Build
+  // the new sampler before touching live state so a failure here also
+  // leaves `params` / `smpl` intact.
+  CommonSamplerPtr nextSmpl(common_sampler_init(model, nextSampling));
+  if (!nextSmpl) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InvalidArgument),
+        "failed to initialise sampler with per-request generationParams "
+        "(invalid grammar or json_schema?)");
+  }
+
+  // Snapshot the live values before committing so the restore lambda can
+  // roll the request's mutations back at the end of the call.
+  common_params_sampling savedSampling = params.sampling;
+  int savedPredict = params.n_predict;
+
+  params.sampling = std::move(nextSampling);
+  params.n_predict = nextPredict;
+  smpl = std::move(nextSmpl);
+
+  bool restored = false;
+  return [&params,
+          &smpl,
+          model,
+          savedSampling = std::move(savedSampling),
+          savedPredict,
+          restored]() mutable {
+    if (restored)
+      return;
+    restored = true;
+    params.sampling = savedSampling;
+    params.n_predict = savedPredict;
+    smpl.reset(common_sampler_init(model, params.sampling));
+  };
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.cpp
@@ -10,21 +10,22 @@
 #include "common/json-schema-to-grammar.h"
 
 void applyGenerationOverridesToSampling(
-    common_params& params, const GenerationParams& overrides) {
+    common_params_sampling& sampling, int& nPredict,
+    const GenerationParams& overrides) {
   auto setIf = [](const auto& src, auto& dst) {
     if (src) {
       dst = *src;
     }
   };
 
-  setIf(overrides.temp, params.sampling.temp);
-  setIf(overrides.top_p, params.sampling.top_p);
-  setIf(overrides.top_k, params.sampling.top_k);
-  setIf(overrides.n_predict, params.n_predict);
-  setIf(overrides.seed, params.sampling.seed);
-  setIf(overrides.frequency_penalty, params.sampling.penalty_freq);
-  setIf(overrides.presence_penalty, params.sampling.penalty_present);
-  setIf(overrides.repeat_penalty, params.sampling.penalty_repeat);
+  setIf(overrides.temp, sampling.temp);
+  setIf(overrides.top_p, sampling.top_p);
+  setIf(overrides.top_k, sampling.top_k);
+  setIf(overrides.n_predict, nPredict);
+  setIf(overrides.seed, sampling.seed);
+  setIf(overrides.frequency_penalty, sampling.penalty_freq);
+  setIf(overrides.presence_penalty, sampling.penalty_present);
+  setIf(overrides.repeat_penalty, sampling.penalty_repeat);
 
   // `json_schema` and `grammar` are mutually exclusive at the JS boundary
   // and in `AddonJs::runJob::parseText`. Defensive precedence here just in
@@ -33,7 +34,7 @@ void applyGenerationOverridesToSampling(
   if (overrides.json_schema) {
     try {
       auto parsed = nlohmann::ordered_json::parse(*overrides.json_schema);
-      params.sampling.grammar = json_schema_to_grammar(parsed);
+      sampling.grammar = json_schema_to_grammar(parsed);
     } catch (const std::exception& ex) {
       throw qvac_errors::StatusError(
           ADDON_ID,
@@ -42,6 +43,6 @@ void applyGenerationOverridesToSampling(
           std::string("invalid generationParams.json_schema: ") + ex.what());
     }
   } else if (overrides.grammar) {
-    params.sampling.grammar = *overrides.grammar;
+    sampling.grammar = *overrides.grammar;
   }
 }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "LlmContext.hpp"
+#include "common/common.h"
+
+// Apply per-request `generationParams` overrides onto a `common_params`
+// sampling block in place. Mutates `params.sampling` and `params.n_predict`
+// for fields that are set on `overrides`; leaves the rest untouched.
+//
+// If `overrides.json_schema` is set, parses the JSON Schema and converts
+// it to GBNF via llama.cpp's `json_schema_to_grammar()`, mirroring what
+// the `--json-schema` load-time flag does. If `overrides.grammar` is set,
+// the GBNF is used verbatim. The two are mutually exclusive (validated at
+// the JS boundary and again in `AddonJs::runJob::parseText`); if both are
+// present here only `json_schema` is honoured.
+//
+// Throws `qvac_errors::StatusError(InvalidArgument)` when `json_schema`
+// fails to parse or convert. Caller is responsible for re-initialising
+// the sampler after this call so the new sampling block takes effect.
+void applyGenerationOverridesToSampling(
+    common_params& params, const GenerationParams& overrides);

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.hpp
@@ -3,9 +3,12 @@
 #include "LlmContext.hpp"
 #include "common/common.h"
 
-// Apply per-request `generationParams` overrides onto a `common_params`
-// sampling block in place. Mutates `params.sampling` and `params.n_predict`
-// for fields that are set on `overrides`; leaves the rest untouched.
+// Apply per-request `generationParams` overrides onto a sampling block
+// + `n_predict` value in place. Operates on the two mutable fields the
+// helper actually needs so callers can pass *copies* and only commit
+// them to live state once the whole call (including json_schema parse
+// and `common_sampler_init`) has succeeded — avoiding partial mutation
+// of the live `common_params` if this throws.
 //
 // If `overrides.json_schema` is set, parses the JSON Schema and converts
 // it to GBNF via llama.cpp's `json_schema_to_grammar()`, mirroring what
@@ -18,4 +21,5 @@
 // fails to parse or convert. Caller is responsible for re-initialising
 // the sampler after this call so the new sampling block takes effect.
 void applyGenerationOverridesToSampling(
-    common_params& params, const GenerationParams& overrides);
+    common_params_sampling& sampling, int& nPredict,
+    const GenerationParams& overrides);

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/GenerationParamsApply.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "LlmContext.hpp"
 #include "common/common.h"
 
@@ -15,11 +17,40 @@
 // the `--json-schema` load-time flag does. If `overrides.grammar` is set,
 // the GBNF is used verbatim. The two are mutually exclusive (validated at
 // the JS boundary and again in `AddonJs::runJob::parseText`); if both are
-// present here only `json_schema` is honoured.
+// present here a `LOG_WRN` is emitted and `json_schema` wins — the JS and
+// AddonJs paths reject this combination, so reaching it means a direct
+// C++ caller (unit tests / `cli_tool`) bypassed those checks.
 //
 // Throws `qvac_errors::StatusError(InvalidArgument)` when `json_schema`
 // fails to parse or convert. Caller is responsible for re-initialising
 // the sampler after this call so the new sampling block takes effect.
 void applyGenerationOverridesToSampling(
     common_params_sampling& sampling, int& nPredict,
+    const GenerationParams& overrides);
+
+// Apply per-request `generationParams` overrides onto a context's live
+// `params` + `smpl` and return a restore lambda the caller can install
+// into a `ScopeGuard` to roll the mutation back at end-of-request.
+//
+// Implements the atomic-commit pattern: overrides are applied to local
+// copies of `params.sampling` and `params.n_predict`, the new sampler is
+// built against those copies, and only after both the json_schema parse
+// and `common_sampler_init` have succeeded are the live `params` / `smpl`
+// updated. Any throw or null-sampler failure leaves live state untouched.
+//
+// Returns a no-op lambda when `overrides.hasOverrides()` is false. The
+// returned lambda re-initialises `smpl` from the saved sampling block, so
+// it MUST be invoked before the owning context is destroyed (i.e. via a
+// guard scoped to the request).
+//
+// Throws `qvac_errors::StatusError(InvalidArgument)` for malformed
+// `json_schema` or when the resulting GBNF is rejected by the sampler.
+//
+// `params`, `smpl`, and `model` are captured by reference inside the
+// returned lambda; callers must guarantee they outlive the lambda. Both
+// `TextLlmContext::applyGenerationParams` and
+// `MtmdLlmContext::applyGenerationParams` satisfy this — the context
+// owns the fields and outlives any single request.
+std::function<void()> applyGenerationParamsToContext(
+    common_params& params, CommonSamplerPtr& smpl, llama_model* model,
     const GenerationParams& overrides);

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
@@ -26,10 +26,16 @@ struct GenerationParams {
   // request and the prior grammar is restored afterwards. Mirrors the
   // load-time `--grammar` flag but scoped to a single completion call.
   std::optional<std::string> grammar;
+  // JSON-Schema applied per request. Converted to GBNF via llama.cpp's
+  // `json_schema_to_grammar()` and applied identically to `grammar`.
+  // Mutually exclusive with `grammar` — the JS wrapper rejects requests
+  // that set both. Mirrors the load-time `--json-schema` flag.
+  std::optional<std::string> json_schema;
 
   [[nodiscard]] bool hasOverrides() const {
     return n_predict || temp || top_p || top_k || frequency_penalty ||
-           presence_penalty || repeat_penalty || seed || grammar;
+           presence_penalty || repeat_penalty || seed || grammar ||
+           json_schema;
   }
 };
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
@@ -34,8 +34,7 @@ struct GenerationParams {
 
   [[nodiscard]] bool hasOverrides() const {
     return n_predict || temp || top_p || top_k || frequency_penalty ||
-           presence_penalty || repeat_penalty || seed || grammar ||
-           json_schema;
+           presence_penalty || repeat_penalty || seed || grammar || json_schema;
   }
 };
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlmContext.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <functional>
 #include <optional>
+#include <string>
 
 #include "addon/LlmErrors.hpp"
 #include "common/chat.h"
@@ -20,10 +21,15 @@ struct GenerationParams {
   std::optional<float> presence_penalty;
   std::optional<float> repeat_penalty;
   std::optional<uint32_t> seed;
+  // GBNF grammar applied per request to constrain sampling. When set, the
+  // sampler is re-initialized with this grammar for the duration of the
+  // request and the prior grammar is restored afterwards. Mirrors the
+  // load-time `--grammar` flag but scoped to a single completion call.
+  std::optional<std::string> grammar;
 
   [[nodiscard]] bool hasOverrides() const {
     return n_predict || temp || top_p || top_k || frequency_penalty ||
-           presence_penalty || repeat_penalty || seed;
+           presence_penalty || repeat_penalty || seed || grammar;
   }
 };
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -481,56 +481,7 @@ bool MtmdLlmContext::generateResponse(
 
 std::function<void()>
 MtmdLlmContext::applyGenerationParams(const GenerationParams& overrides) {
-  if (!overrides.hasOverrides()) {
-    return []() {};
-  }
-
-  // Apply overrides to *local copies* first. Only commit them onto the
-  // live `params_` and `smpl_` after both the json_schema parse/convert
-  // and `common_sampler_init` have succeeded — otherwise a partially
-  // applied override (e.g. temp/seed already written, then json_schema
-  // throws) would leak into subsequent requests because no restore
-  // lambda gets returned to the caller's `ScopeGuard`.
-  common_params_sampling nextSampling = params_.sampling;
-  int nextPredict = params_.n_predict;
-
-  // May throw `InvalidArgument` for malformed `json_schema`. `params_`
-  // and `smpl_` remain untouched in that case.
-  applyGenerationOverridesToSampling(nextSampling, nextPredict, overrides);
-
-  // `common_sampler_init` returns nullptr on bad inputs (most commonly an
-  // invalid GBNF grammar — `json_schema` is converted to GBNF above and
-  // can in principle produce a grammar that the sampler rejects). Build
-  // the new sampler before touching live state so a failure here also
-  // leaves `params_` / `smpl_` intact.
-  CommonSamplerPtr nextSmpl(common_sampler_init(model_, nextSampling));
-  if (!nextSmpl) {
-    throw qvac_errors::StatusError(
-        ADDON_ID,
-        qvac_errors::general_error::toString(
-            qvac_errors::general_error::InvalidArgument),
-        "failed to initialise sampler with per-request generationParams "
-        "(invalid grammar or json_schema?)");
-  }
-
-  // Snapshot the live values before committing so the restore lambda
-  // can roll the request's mutations back at the end of the call.
-  common_params_sampling savedSampling = params_.sampling;
-  int savedPredict = params_.n_predict;
-
-  params_.sampling = std::move(nextSampling);
-  params_.n_predict = nextPredict;
-  smpl_ = std::move(nextSmpl);
-
-  bool restored = false;
-  return [this, savedSampling, savedPredict, restored]() mutable {
-    if (restored)
-      return;
-    restored = true;
-    params_.sampling = savedSampling;
-    params_.n_predict = savedPredict;
-    smpl_.reset(common_sampler_init(model_, params_.sampling));
-  };
+  return applyGenerationParamsToContext(params_, smpl_, model_, overrides);
 }
 
 void MtmdLlmContext::stop() { stopGeneration_.store(true); }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -485,26 +485,26 @@ MtmdLlmContext::applyGenerationParams(const GenerationParams& overrides) {
     return []() {};
   }
 
-  common_params_sampling savedSampling = params_.sampling;
-  int savedPredict = params_.n_predict;
+  // Apply overrides to *local copies* first. Only commit them onto the
+  // live `params_` and `smpl_` after both the json_schema parse/convert
+  // and `common_sampler_init` have succeeded — otherwise a partially
+  // applied override (e.g. temp/seed already written, then json_schema
+  // throws) would leak into subsequent requests because no restore
+  // lambda gets returned to the caller's `ScopeGuard`.
+  common_params_sampling nextSampling = params_.sampling;
+  int nextPredict = params_.n_predict;
 
-  // Mutates `params_.sampling` / `params_.n_predict` in place. May throw
-  // `InvalidArgument` if `json_schema` fails to parse or convert; in that
-  // case `params_` is left untouched and the existing sampler stays valid.
-  applyGenerationOverridesToSampling(params_, overrides);
+  // May throw `InvalidArgument` for malformed `json_schema`. `params_`
+  // and `smpl_` remain untouched in that case.
+  applyGenerationOverridesToSampling(nextSampling, nextPredict, overrides);
 
   // `common_sampler_init` returns nullptr on bad inputs (most commonly an
   // invalid GBNF grammar — `json_schema` is converted to GBNF above and
-  // can in principle produce a grammar that the sampler rejects). On
-  // failure restore the saved sampling block, re-init with the
-  // known-good params, and surface a clear `InvalidArgument` to the
-  // caller. Without this guard the addon would carry a null `smpl_` into
-  // the next sample call and crash.
-  smpl_.reset(common_sampler_init(model_, params_.sampling));
-  if (!smpl_) {
-    params_.sampling = savedSampling;
-    params_.n_predict = savedPredict;
-    smpl_.reset(common_sampler_init(model_, params_.sampling));
+  // can in principle produce a grammar that the sampler rejects). Build
+  // the new sampler before touching live state so a failure here also
+  // leaves `params_` / `smpl_` intact.
+  CommonSamplerPtr nextSmpl(common_sampler_init(model_, nextSampling));
+  if (!nextSmpl) {
     throw qvac_errors::StatusError(
         ADDON_ID,
         qvac_errors::general_error::toString(
@@ -512,6 +512,15 @@ MtmdLlmContext::applyGenerationParams(const GenerationParams& overrides) {
         "failed to initialise sampler with per-request generationParams "
         "(invalid grammar or json_schema?)");
   }
+
+  // Snapshot the live values before committing so the restore lambda
+  // can roll the request's mutations back at the end of the call.
+  common_params_sampling savedSampling = params_.sampling;
+  int savedPredict = params_.n_predict;
+
+  params_.sampling = std::move(nextSampling);
+  params_.n_predict = nextPredict;
+  smpl_ = std::move(nextSmpl);
 
   bool restored = false;
   return [this, savedSampling, savedPredict, restored]() mutable {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -9,6 +9,7 @@
 #include <qvac-lib-inference-addon-cpp/Errors.hpp>
 
 #include "ContextSlider.hpp"
+#include "GenerationParamsApply.hpp"
 #include "addon/LlmErrors.hpp"
 #include "qvac-lib-inference-addon-cpp/Logger.hpp"
 #include "utils/ChatTemplateUtils.hpp"
@@ -487,21 +488,30 @@ MtmdLlmContext::applyGenerationParams(const GenerationParams& overrides) {
   common_params_sampling savedSampling = params_.sampling;
   int savedPredict = params_.n_predict;
 
-  auto setIf = [](const auto& src, auto& dst) {
-    if (src) {
-      dst = *src;
-    }
-  };
-  setIf(overrides.temp, params_.sampling.temp);
-  setIf(overrides.top_p, params_.sampling.top_p);
-  setIf(overrides.top_k, params_.sampling.top_k);
-  setIf(overrides.n_predict, params_.n_predict);
-  setIf(overrides.seed, params_.sampling.seed);
-  setIf(overrides.frequency_penalty, params_.sampling.penalty_freq);
-  setIf(overrides.presence_penalty, params_.sampling.penalty_present);
-  setIf(overrides.repeat_penalty, params_.sampling.penalty_repeat);
+  // Mutates `params_.sampling` / `params_.n_predict` in place. May throw
+  // `InvalidArgument` if `json_schema` fails to parse or convert; in that
+  // case `params_` is left untouched and the existing sampler stays valid.
+  applyGenerationOverridesToSampling(params_, overrides);
 
+  // `common_sampler_init` returns nullptr on bad inputs (most commonly an
+  // invalid GBNF grammar — `json_schema` is converted to GBNF above and
+  // can in principle produce a grammar that the sampler rejects). On
+  // failure restore the saved sampling block, re-init with the
+  // known-good params, and surface a clear `InvalidArgument` to the
+  // caller. Without this guard the addon would carry a null `smpl_` into
+  // the next sample call and crash.
   smpl_.reset(common_sampler_init(model_, params_.sampling));
+  if (!smpl_) {
+    params_.sampling = savedSampling;
+    params_.n_predict = savedPredict;
+    smpl_.reset(common_sampler_init(model_, params_.sampling));
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InvalidArgument),
+        "failed to initialise sampler with per-request generationParams "
+        "(invalid grammar or json_schema?)");
+  }
 
   bool restored = false;
   return [this, savedSampling, savedPredict, restored]() mutable {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -6,13 +6,12 @@
 #include <cstddef>
 
 #include <llama.h>
-#include <nlohmann/json.hpp>
 #include <qvac-lib-inference-addon-cpp/Errors.hpp>
 
 #include "ContextSlider.hpp"
+#include "GenerationParamsApply.hpp"
 #include "addon/LlmErrors.hpp"
 #include "common/common.h"
-#include "common/json-schema-to-grammar.h"
 #include "common/log.h"
 #include "qvac-lib-inference-addon-cpp/Logger.hpp"
 #include "utils/ChatTemplateUtils.hpp"
@@ -546,43 +545,30 @@ TextLlmContext::applyGenerationParams(const GenerationParams& overrides) {
   common_params_sampling savedSampling = params_.sampling;
   int savedPredict = params_.n_predict;
 
-  auto setIf = [](const auto& src, auto& dst) {
-    if (src) {
-      dst = *src;
-    }
-  };
-  setIf(overrides.temp, params_.sampling.temp);
-  setIf(overrides.top_p, params_.sampling.top_p);
-  setIf(overrides.top_k, params_.sampling.top_k);
-  setIf(overrides.n_predict, params_.n_predict);
-  setIf(overrides.seed, params_.sampling.seed);
-  setIf(overrides.frequency_penalty, params_.sampling.penalty_freq);
-  setIf(overrides.presence_penalty, params_.sampling.penalty_present);
-  setIf(overrides.repeat_penalty, params_.sampling.penalty_repeat);
-  // Per-request grammar / json_schema override any load-time grammar; the
-  // sampler is re-initialized below so the new grammar takes effect for
-  // this run, and the saved sampling snapshot above ensures the prior
-  // grammar is re-applied when the restore lambda runs. `grammar` and
-  // `json_schema` are mutually exclusive (validated at the JS boundary
-  // and again in `parseText`); when `json_schema` is set we convert it to
-  // GBNF here using llama.cpp's converter, mirroring the load-time
-  // `--json-schema` flag.
-  if (overrides.json_schema) {
-    try {
-      auto parsed = nlohmann::ordered_json::parse(*overrides.json_schema);
-      params_.sampling.grammar = json_schema_to_grammar(parsed);
-    } catch (const std::exception& ex) {
-      throw qvac_errors::StatusError(
-          ADDON_ID,
-          qvac_errors::general_error::toString(
-              qvac_errors::general_error::InvalidArgument),
-          std::string("invalid generationParams.json_schema: ") + ex.what());
-    }
-  } else {
-    setIf(overrides.grammar, params_.sampling.grammar);
-  }
+  // Mutates `params_.sampling` / `params_.n_predict` in place. May throw
+  // `InvalidArgument` if `json_schema` fails to parse or convert; in that
+  // case `params_` is left untouched and the existing sampler stays valid.
+  applyGenerationOverridesToSampling(params_, overrides);
 
+  // `common_sampler_init` returns nullptr on bad inputs (most commonly an
+  // invalid GBNF grammar — `json_schema` is converted to GBNF above and
+  // can in principle produce a grammar that the sampler rejects). On
+  // failure restore the saved sampling block, re-init with the
+  // known-good params, and surface a clear `InvalidArgument` to the
+  // caller. Without this guard the addon would carry a null `smpl_` into
+  // the next sample call and crash.
   smpl_.reset(common_sampler_init(model_, params_.sampling));
+  if (!smpl_) {
+    params_.sampling = savedSampling;
+    params_.n_predict = savedPredict;
+    smpl_.reset(common_sampler_init(model_, params_.sampling));
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InvalidArgument),
+        "failed to initialise sampler with per-request generationParams "
+        "(invalid grammar or json_schema?)");
+  }
 
   bool restored = false;
   return [this, savedSampling, savedPredict, restored]() mutable {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -542,26 +542,26 @@ TextLlmContext::applyGenerationParams(const GenerationParams& overrides) {
     return []() {};
   }
 
-  common_params_sampling savedSampling = params_.sampling;
-  int savedPredict = params_.n_predict;
+  // Apply overrides to *local copies* first. Only commit them onto the
+  // live `params_` and `smpl_` after both the json_schema parse/convert
+  // and `common_sampler_init` have succeeded — otherwise a partially
+  // applied override (e.g. temp/seed already written, then json_schema
+  // throws) would leak into subsequent requests because no restore
+  // lambda gets returned to the caller's `ScopeGuard`.
+  common_params_sampling nextSampling = params_.sampling;
+  int nextPredict = params_.n_predict;
 
-  // Mutates `params_.sampling` / `params_.n_predict` in place. May throw
-  // `InvalidArgument` if `json_schema` fails to parse or convert; in that
-  // case `params_` is left untouched and the existing sampler stays valid.
-  applyGenerationOverridesToSampling(params_, overrides);
+  // May throw `InvalidArgument` for malformed `json_schema`. `params_`
+  // and `smpl_` remain untouched in that case.
+  applyGenerationOverridesToSampling(nextSampling, nextPredict, overrides);
 
   // `common_sampler_init` returns nullptr on bad inputs (most commonly an
   // invalid GBNF grammar — `json_schema` is converted to GBNF above and
-  // can in principle produce a grammar that the sampler rejects). On
-  // failure restore the saved sampling block, re-init with the
-  // known-good params, and surface a clear `InvalidArgument` to the
-  // caller. Without this guard the addon would carry a null `smpl_` into
-  // the next sample call and crash.
-  smpl_.reset(common_sampler_init(model_, params_.sampling));
-  if (!smpl_) {
-    params_.sampling = savedSampling;
-    params_.n_predict = savedPredict;
-    smpl_.reset(common_sampler_init(model_, params_.sampling));
+  // can in principle produce a grammar that the sampler rejects). Build
+  // the new sampler before touching live state so a failure here also
+  // leaves `params_` / `smpl_` intact.
+  CommonSamplerPtr nextSmpl(common_sampler_init(model_, nextSampling));
+  if (!nextSmpl) {
     throw qvac_errors::StatusError(
         ADDON_ID,
         qvac_errors::general_error::toString(
@@ -569,6 +569,15 @@ TextLlmContext::applyGenerationParams(const GenerationParams& overrides) {
         "failed to initialise sampler with per-request generationParams "
         "(invalid grammar or json_schema?)");
   }
+
+  // Snapshot the live values before committing so the restore lambda
+  // can roll the request's mutations back at the end of the call.
+  common_params_sampling savedSampling = params_.sampling;
+  int savedPredict = params_.n_predict;
+
+  params_.sampling = std::move(nextSampling);
+  params_.n_predict = nextPredict;
+  smpl_ = std::move(nextSmpl);
 
   bool restored = false;
   return [this, savedSampling, savedPredict, restored]() mutable {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -538,56 +538,7 @@ bool TextLlmContext::generateResponse(
 
 std::function<void()>
 TextLlmContext::applyGenerationParams(const GenerationParams& overrides) {
-  if (!overrides.hasOverrides()) {
-    return []() {};
-  }
-
-  // Apply overrides to *local copies* first. Only commit them onto the
-  // live `params_` and `smpl_` after both the json_schema parse/convert
-  // and `common_sampler_init` have succeeded — otherwise a partially
-  // applied override (e.g. temp/seed already written, then json_schema
-  // throws) would leak into subsequent requests because no restore
-  // lambda gets returned to the caller's `ScopeGuard`.
-  common_params_sampling nextSampling = params_.sampling;
-  int nextPredict = params_.n_predict;
-
-  // May throw `InvalidArgument` for malformed `json_schema`. `params_`
-  // and `smpl_` remain untouched in that case.
-  applyGenerationOverridesToSampling(nextSampling, nextPredict, overrides);
-
-  // `common_sampler_init` returns nullptr on bad inputs (most commonly an
-  // invalid GBNF grammar — `json_schema` is converted to GBNF above and
-  // can in principle produce a grammar that the sampler rejects). Build
-  // the new sampler before touching live state so a failure here also
-  // leaves `params_` / `smpl_` intact.
-  CommonSamplerPtr nextSmpl(common_sampler_init(model_, nextSampling));
-  if (!nextSmpl) {
-    throw qvac_errors::StatusError(
-        ADDON_ID,
-        qvac_errors::general_error::toString(
-            qvac_errors::general_error::InvalidArgument),
-        "failed to initialise sampler with per-request generationParams "
-        "(invalid grammar or json_schema?)");
-  }
-
-  // Snapshot the live values before committing so the restore lambda
-  // can roll the request's mutations back at the end of the call.
-  common_params_sampling savedSampling = params_.sampling;
-  int savedPredict = params_.n_predict;
-
-  params_.sampling = std::move(nextSampling);
-  params_.n_predict = nextPredict;
-  smpl_ = std::move(nextSmpl);
-
-  bool restored = false;
-  return [this, savedSampling, savedPredict, restored]() mutable {
-    if (restored)
-      return;
-    restored = true;
-    params_.sampling = savedSampling;
-    params_.n_predict = savedPredict;
-    smpl_.reset(common_sampler_init(model_, params_.sampling));
-  };
+  return applyGenerationParamsToContext(params_, smpl_, model_, overrides);
 }
 
 void TextLlmContext::stop() { stopGeneration_.store(true); }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -6,11 +6,13 @@
 #include <cstddef>
 
 #include <llama.h>
+#include <nlohmann/json.hpp>
 #include <qvac-lib-inference-addon-cpp/Errors.hpp>
 
 #include "ContextSlider.hpp"
 #include "addon/LlmErrors.hpp"
 #include "common/common.h"
+#include "common/json-schema-to-grammar.h"
 #include "common/log.h"
 #include "qvac-lib-inference-addon-cpp/Logger.hpp"
 #include "utils/ChatTemplateUtils.hpp"
@@ -557,11 +559,28 @@ TextLlmContext::applyGenerationParams(const GenerationParams& overrides) {
   setIf(overrides.frequency_penalty, params_.sampling.penalty_freq);
   setIf(overrides.presence_penalty, params_.sampling.penalty_present);
   setIf(overrides.repeat_penalty, params_.sampling.penalty_repeat);
-  // Per-request grammar overrides any load-time grammar; the sampler is
-  // re-initialized below so the new grammar takes effect for this run, and
-  // the saved sampling snapshot above ensures the prior grammar is
-  // re-applied when the restore lambda runs.
-  setIf(overrides.grammar, params_.sampling.grammar);
+  // Per-request grammar / json_schema override any load-time grammar; the
+  // sampler is re-initialized below so the new grammar takes effect for
+  // this run, and the saved sampling snapshot above ensures the prior
+  // grammar is re-applied when the restore lambda runs. `grammar` and
+  // `json_schema` are mutually exclusive (validated at the JS boundary
+  // and again in `parseText`); when `json_schema` is set we convert it to
+  // GBNF here using llama.cpp's converter, mirroring the load-time
+  // `--json-schema` flag.
+  if (overrides.json_schema) {
+    try {
+      auto parsed = nlohmann::ordered_json::parse(*overrides.json_schema);
+      params_.sampling.grammar = json_schema_to_grammar(parsed);
+    } catch (const std::exception& ex) {
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          qvac_errors::general_error::toString(
+              qvac_errors::general_error::InvalidArgument),
+          std::string("invalid generationParams.json_schema: ") + ex.what());
+    }
+  } else {
+    setIf(overrides.grammar, params_.sampling.grammar);
+  }
 
   smpl_.reset(common_sampler_init(model_, params_.sampling));
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -557,6 +557,11 @@ TextLlmContext::applyGenerationParams(const GenerationParams& overrides) {
   setIf(overrides.frequency_penalty, params_.sampling.penalty_freq);
   setIf(overrides.presence_penalty, params_.sampling.penalty_present);
   setIf(overrides.repeat_penalty, params_.sampling.penalty_repeat);
+  // Per-request grammar overrides any load-time grammar; the sampler is
+  // re-initialized below so the new grammar takes effect for this run, and
+  // the saved sampling snapshot above ensures the prior grammar is
+  // re-applied when the restore lambda runs.
+  setIf(overrides.grammar, params_.sampling.grammar);
 
   smpl_.reset(common_sampler_init(model_, params_.sampling));
 

--- a/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
@@ -109,7 +109,10 @@ export interface GenerationParams {
    * GBNF grammar applied per request to constrain sampling. Equivalent to
    * the load-time `--grammar` config but scoped to a single `run()` call;
    * the sampler is re-initialized with this grammar for the request and
-   * the prior grammar is restored afterwards. Empty string disables.
+   * the prior grammar is restored afterwards.
+   *
+   * `undefined` or an empty string is treated as "no override" and falls
+   * through to whatever grammar was set at load time (typically none).
    *
    * Mutually exclusive with `json_schema` — passing both throws.
    */

--- a/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
@@ -110,8 +110,21 @@ export interface GenerationParams {
    * the load-time `--grammar` config but scoped to a single `run()` call;
    * the sampler is re-initialized with this grammar for the request and
    * the prior grammar is restored afterwards. Empty string disables.
+   *
+   * Mutually exclusive with `json_schema` — passing both throws.
    */
   grammar?: string
+  /**
+   * JSON Schema applied per request to constrain sampling to valid JSON
+   * matching the schema. Equivalent to the load-time `--json-schema`
+   * config but scoped to a single `run()` call; the schema is converted
+   * to GBNF natively (via llama.cpp's `json_schema_to_grammar()`) and
+   * applied identically to `grammar`.
+   *
+   * Accepts either a JSON Schema object literal or a pre-stringified
+   * JSON Schema. Mutually exclusive with `grammar` — passing both throws.
+   */
+  json_schema?: string | Record<string, unknown>
 }
 
 export interface RunOptions {

--- a/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
@@ -105,6 +105,13 @@ export interface GenerationParams {
   frequency_penalty?: number
   presence_penalty?: number
   repeat_penalty?: number
+  /**
+   * GBNF grammar applied per request to constrain sampling. Equivalent to
+   * the load-time `--grammar` config but scoped to a single `run()` call;
+   * the sampler is re-initialized with this grammar for the request and
+   * the prior grammar is restored afterwards. Empty string disables.
+   */
+  grammar?: string
 }
 
 export interface RunOptions {

--- a/packages/qvac-lib-infer-llamacpp-llm/index.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.js
@@ -37,10 +37,51 @@ function normalizeRunOptions (runOptions) {
 
   return {
     prefill: runOptions.prefill === true,
-    generationParams: runOptions.generationParams,
+    generationParams: normalizeGenerationParams(runOptions.generationParams),
     cacheKey: runOptions.cacheKey,
     saveCacheToDisk: runOptions.saveCacheToDisk === true
   }
+}
+
+// Normalizes the per-request `generationParams.json_schema` field. The
+// addon binding expects a string; callers commonly pass a plain object
+// (a JSON Schema literal) for ergonomics, so we stringify it here. Also
+// validates the mutual exclusion with `grammar`, since enforcing it at
+// the JS boundary gives a clearer error than letting the C++ throw.
+function normalizeGenerationParams (generationParams) {
+  if (generationParams === undefined) return undefined
+
+  const hasGrammar = typeof generationParams.grammar === 'string' &&
+    generationParams.grammar.length > 0
+  const hasJsonSchema = generationParams.json_schema !== undefined &&
+    generationParams.json_schema !== null &&
+    !(typeof generationParams.json_schema === 'string' && generationParams.json_schema.length === 0)
+
+  if (hasGrammar && hasJsonSchema) {
+    throw new TypeError(
+      'generationParams.grammar and generationParams.json_schema are mutually exclusive'
+    )
+  }
+
+  if (!hasJsonSchema) return generationParams
+
+  let jsonSchemaString
+  if (typeof generationParams.json_schema === 'string') {
+    jsonSchemaString = generationParams.json_schema
+  } else if (typeof generationParams.json_schema === 'object' &&
+      !Array.isArray(generationParams.json_schema)) {
+    try {
+      jsonSchemaString = JSON.stringify(generationParams.json_schema)
+    } catch (err) {
+      throw new TypeError('generationParams.json_schema is not JSON-serializable: ' + err.message)
+    }
+  } else {
+    throw new TypeError(
+      'generationParams.json_schema must be a JSON Schema object or a JSON Schema string'
+    )
+  }
+
+  return { ...generationParams, json_schema: jsonSchemaString }
 }
 
 const VALIDATION_TYPES = ['none', 'split', 'dataset']

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/grammar.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/grammar.test.js
@@ -180,10 +180,13 @@ test('generationParams | json_schema (string) is accepted', { timeout: 600_000 }
 test('generationParams | grammar + json_schema together throws', { timeout: 600_000 }, async t => {
   const { model } = await setupModel(t, { seed: '42' })
 
-  // Pass the run() promise directly to t.exception (no async-wrapper IIFE)
-  // so brittle attaches its catch handler before Bare's runtime-level
-  // unhandled-rejection guard sees the rejection and aborts the process.
-  await t.exception(
+  // `normalizeGenerationParams` throws a `TypeError` for the mutually
+  // exclusive case, and brittle's plain `t.exception` deliberately
+  // re-raises native error subclasses (TypeError / RangeError / etc.)
+  // — the rejection bypasses the catch and trips Bare's
+  // unhandled-rejection guard, aborting with exit 134. `t.exception.all`
+  // is the documented escape hatch for native-error rejections.
+  await t.exception.all(
     () => model.run(PERSON_PROMPT, {
       generationParams: {
         grammar: 'root ::= "x"',

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/grammar.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/grammar.test.js
@@ -180,16 +180,17 @@ test('generationParams | json_schema (string) is accepted', { timeout: 600_000 }
 test('generationParams | grammar + json_schema together throws', { timeout: 600_000 }, async t => {
   const { model } = await setupModel(t, { seed: '42' })
 
+  // Pass the run() promise directly to t.exception (no async-wrapper IIFE)
+  // so brittle attaches its catch handler before Bare's runtime-level
+  // unhandled-rejection guard sees the rejection and aborts the process.
   await t.exception(
-    async () => {
-      await model.run(PERSON_PROMPT, {
-        generationParams: {
-          grammar: 'root ::= "x"',
-          json_schema: PERSON_SCHEMA,
-          predict: 4
-        }
-      })
-    },
+    () => model.run(PERSON_PROMPT, {
+      generationParams: {
+        grammar: 'root ::= "x"',
+        json_schema: PERSON_SCHEMA,
+        predict: 4
+      }
+    }),
     /mutually exclusive/i,
     'rejects requests that set both grammar and json_schema'
   )

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/grammar.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/grammar.test.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const test = require('brittle')
+const path = require('bare-path')
+const LlmLlamacpp = require('../../index.js')
+const { ensureModel } = require('./utils')
+const { attachSpecLogger } = require('./spec-logger')
+const os = require('bare-os')
+
+const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
+const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
+const useCpu = isDarwinX64 || isLinuxArm64
+
+const MODEL = {
+  name: 'Qwen3-0.6B-Q8_0.gguf',
+  url: 'https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf'
+}
+
+const PROMPT = [
+  { role: 'system', content: 'You are a binary classifier. Reply only "yes" or "no". /no_think' },
+  { role: 'user', content: 'Is the sky blue on a clear day?' }
+]
+
+async function setupModel (t, configOverrides = {}) {
+  const [modelName, dirPath] = await ensureModel({
+    modelName: MODEL.name,
+    downloadUrl: MODEL.url
+  })
+
+  const modelPath = path.join(dirPath, modelName)
+  const config = {
+    device: useCpu ? 'cpu' : 'gpu',
+    gpu_layers: '999',
+    ctx_size: '1024',
+    n_predict: '64',
+    temp: '1.0',
+    verbosity: '2',
+    ...configOverrides
+  }
+
+  const specLogger = attachSpecLogger({ forwardToConsole: true })
+  const model = new LlmLlamacpp({
+    files: { model: [modelPath] },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
+
+  await model.load()
+
+  t.teardown(async () => {
+    await model.unload().catch(() => {})
+    specLogger.release()
+  })
+
+  return { model }
+}
+
+async function collectResponse (response) {
+  const chunks = []
+  await response.onUpdate(data => { chunks.push(data) }).await()
+  return chunks.join('')
+}
+
+test('generationParams | grammar constrains output to GBNF', { timeout: 600_000 }, async t => {
+  const { model } = await setupModel(t, { seed: '42' })
+
+  const grammar = 'root ::= ("yes" | "no")'
+
+  const response = await model.run(PROMPT, {
+    generationParams: { grammar, predict: 4, seed: 42 }
+  })
+  const output = (await collectResponse(response)).trim()
+
+  t.ok(
+    output === 'yes' || output === 'no',
+    `output "${output}" is constrained to "yes" or "no"`
+  )
+})
+
+test('generationParams | grammar is per-request, restored after run', { timeout: 600_000 }, async t => {
+  const { model } = await setupModel(t, { seed: '42' })
+
+  const grammar = 'root ::= ("yes" | "no")'
+
+  const constrained = await model.run(PROMPT, {
+    generationParams: { grammar, predict: 4, seed: 42 }
+  })
+  const constrainedOutput = (await collectResponse(constrained)).trim()
+  t.ok(
+    constrainedOutput === 'yes' || constrainedOutput === 'no',
+    `constrained output "${constrainedOutput}" respects grammar`
+  )
+
+  const unconstrained = await model.run(
+    [
+      { role: 'system', content: 'You are a helpful assistant. /no_think' },
+      { role: 'user', content: 'List three random animals.' }
+    ],
+    { generationParams: { predict: 48, seed: 42 } }
+  )
+  const unconstrainedOutput = await collectResponse(unconstrained)
+
+  t.ok(
+    unconstrainedOutput.length > constrainedOutput.length,
+    `unconstrained output (${unconstrainedOutput.length} chars) exceeds constrained (${constrainedOutput.length} chars)`
+  )
+  t.ok(
+    !(unconstrainedOutput.trim() === 'yes' || unconstrainedOutput.trim() === 'no'),
+    'second run is not constrained by the previous request grammar'
+  )
+})
+
+test('generationParams | grammar overrides load-time grammar', { timeout: 600_000 }, async t => {
+  const loadTimeGrammar = 'root ::= "loaded"'
+  const { model } = await setupModel(t, {
+    seed: '42',
+    grammar: loadTimeGrammar
+  })
+
+  const requestGrammar = 'root ::= ("yes" | "no")'
+  const response = await model.run(PROMPT, {
+    generationParams: { grammar: requestGrammar, predict: 4, seed: 42 }
+  })
+  const output = (await collectResponse(response)).trim()
+
+  t.ok(
+    output === 'yes' || output === 'no',
+    `per-request grammar wins over load-time grammar (got "${output}")`
+  )
+})

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/grammar.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/grammar.test.js
@@ -129,3 +129,68 @@ test('generationParams | grammar overrides load-time grammar', { timeout: 600_00
     `per-request grammar wins over load-time grammar (got "${output}")`
   )
 })
+
+const PERSON_SCHEMA = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    age: { type: 'integer' }
+  },
+  required: ['name', 'age'],
+  additionalProperties: false
+}
+
+const PERSON_PROMPT = [
+  { role: 'system', content: 'Extract the person info as JSON. /no_think' },
+  { role: 'user', content: "Hi, I'm Alice and I'm 30 years old." }
+]
+
+test('generationParams | json_schema (object) constrains output to schema-valid JSON', { timeout: 600_000 }, async t => {
+  const { model } = await setupModel(t, { seed: '42' })
+
+  const response = await model.run(PERSON_PROMPT, {
+    generationParams: { json_schema: PERSON_SCHEMA, predict: 64, seed: 42 }
+  })
+  const output = (await collectResponse(response)).trim()
+
+  let parsed
+  t.execution(() => { parsed = JSON.parse(output) }, `output "${output}" parses as JSON`)
+  t.ok(parsed && typeof parsed.name === 'string', `name is a string (got ${JSON.stringify(parsed?.name)})`)
+  t.ok(parsed && Number.isInteger(parsed.age), `age is an integer (got ${JSON.stringify(parsed?.age)})`)
+  t.is(Object.keys(parsed || {}).sort().join(','), 'age,name', 'no extra properties beyond schema')
+})
+
+test('generationParams | json_schema (string) is accepted', { timeout: 600_000 }, async t => {
+  const { model } = await setupModel(t, { seed: '42' })
+
+  const response = await model.run(PERSON_PROMPT, {
+    generationParams: {
+      json_schema: JSON.stringify(PERSON_SCHEMA),
+      predict: 64,
+      seed: 42
+    }
+  })
+  const output = (await collectResponse(response)).trim()
+
+  let parsed
+  t.execution(() => { parsed = JSON.parse(output) }, `output "${output}" parses as JSON`)
+  t.ok(parsed && typeof parsed.name === 'string' && Number.isInteger(parsed.age), 'matches schema shape')
+})
+
+test('generationParams | grammar + json_schema together throws', { timeout: 600_000 }, async t => {
+  const { model } = await setupModel(t, { seed: '42' })
+
+  await t.exception(
+    async () => {
+      await model.run(PERSON_PROMPT, {
+        generationParams: {
+          grammar: 'root ::= "x"',
+          json_schema: PERSON_SCHEMA,
+          predict: 4
+        }
+      })
+    },
+    /mutually exclusive/i,
+    'rejects requests that set both grammar and json_schema'
+  )
+})

--- a/packages/qvac-lib-infer-llamacpp-llm/test/mobile/integration.auto.cjs
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/mobile/integration.auto.cjs
@@ -51,6 +51,11 @@ async function runGenerationParamsTest (options = {}) { // eslint-disable-line n
   return runIntegrationModule('../integration/generation-params.test.js', options)
 }
 
+async function runGrammarTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runGrammarTest')) return __FILTERED
+  return runIntegrationModule('../integration/grammar.test.js', options)
+}
+
 async function runImageTest (options = {}) { // eslint-disable-line no-unused-vars
   if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runImageTest')) return __FILTERED
   return runIntegrationModule('../integration/image.test.js', options)

--- a/packages/qvac-lib-infer-llamacpp-llm/test/mobile/test-groups.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/mobile/test-groups.json
@@ -17,6 +17,7 @@
     ],
     "lightB": [
       "runGenerationParamsTest",
+      "runGrammarTest",
       "runModelLoadingTest",
       "runMoeTest",
       "runMultiInstanceTest",
@@ -34,6 +35,7 @@
       "runToolsCompactTest",
       "runFinetuningPauseResumeTest",
       "runGenerationParamsTest",
+      "runGrammarTest",
       "runImageTest"
     ],
     "groupB": [

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/AsyncWeightsLoader.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/CacheManager.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/ContextSlider.cpp
+  ${CMAKE_SOURCE_DIR}/addon/src/model-interface/GenerationParamsApply.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaFinetuningHelpers.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
@@ -112,6 +113,7 @@ target_link_libraries(
     llama::llama
     llama::common
     llama::mtmd
+    nlohmann_json::nlohmann_json
     GTest::gtest
     GTest::gtest_main
     GTest::gmock_main

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg-configuration.json
@@ -11,6 +11,7 @@
       "repository": "https://github.com/microsoft/vcpkg",
       "packages": [
         "gtest",
+        "nlohmann-json",
         "picojson"
       ]
     }

--- a/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/vcpkg.json
@@ -5,6 +5,7 @@
       "platform": "android"
     },
     "picojson",
+    "nlohmann-json",
     {
       "name": "qvac-fabric",
       "version>=": "7248.2.3"


### PR DESCRIPTION
## Why

This is the **0.17.1 back-port** of [#1787](https://github.com/tetherto/qvac/pull/1787) (`feat[api]: per-request grammar / json_schema in llm-llamacpp generationParams`).

`@qvac/llm-llamacpp@0.18.0` is already on `main`, but per Gianfranco it cannot be consumed by SDK 0.10.x yet (other 0.18.0 changes haven't been integrated/tested in the SDK). The SDK structured-output partner work (QVAC-17939) needs this change immediately, so we patch-release it on top of `0.17.0` here while the same change continues to land for `main` as `0.19.0` via #1787.

Targets the `release-llamacpp-llm-0.17.1` branch on `tetherto/qvac` (branched off the `llamacpp-llm-v0.17.0` tag). Merging triggers the GPR publish for `@tetherto/llm-llamacpp@0.17.1` so the SDK can consume it without migrating off the 0.17 line.

## What

Identical source changes to #1787 (after its review fixes), cherry-picked onto `llamacpp-llm-v0.17.0`. Three new optional surfaces:

- **`generationParams.json_schema`** — JSON Schema (object literal or string) applied per request. Converted to GBNF natively via llama.cpp's `json_schema_to_grammar()`. Recommended for structured output.
- **`generationParams.grammar`** — raw GBNF, escape hatch for non-JSON output.
- Mutually exclusive; both `TextLlmContext` and `MtmdLlmContext` are wired.

```ts
// JSON Schema (recommended for structured output)
await model.run(prompt, {
  generationParams: {
    json_schema: {
      type: 'object',
      properties: { name: { type: 'string' }, age: { type: 'integer' } },
      required: ['name', 'age']
    }
  }
})
```

Bad GBNF / unparseable JSON Schema surfaces as `InvalidArgument` with the saved sampler restored, so a malformed per-request schema cannot leave the model in a broken state.

## Commits (cherry-picked from #1787)

1. \`feat[api]: per-request GBNF grammar in llm-llamacpp generationParams\` (\`64f48a0\`)
2. \`feat[api]: per-request json_schema in llm-llamacpp generationParams\` (\`bfab419\`)
3. \`fix[api]: address review feedback on per-request grammar/json_schema\` (\`4b7f46d\`) — wires `MtmdLlmContext`, fixes doc comment, adds `common_sampler_init` null-check + restore-on-failure
4. \`release(llamacpp-llm): v0.17.1 — back-port…\` (\`3f2fb2a\`) — version bump + changelog block

For the full rationale, API surface notes, and design discussion see #1787.

## Test plan

- [x] `bare-make generate && bare-make build && bare-make install` (darwin-arm64, on the 0.17.0 base) — vcpkg pulls `nlohmann-json` 3.12.0 cleanly
- [x] `npm run test:dts`
- [x] `npm run lint`
- [x] `node scripts/validate-mobile-tests.js`
- [ ] CI: unit + integration + cpp + mobile groups
- [ ] After merge: GPR publish of `@tetherto/llm-llamacpp@0.17.1` succeeds and SDK 0.10 can install it

## Linked

- Forward-port to main: tetherto/qvac#1787
- Asana: QVAC-17939 (SDK structured output)
- SDK PR consuming this: tetherto/qvac#1768