### PR TITLE
chore[notask]: add memory leak probe and addon-team findings

### DIFF
--- a/packages/sdk/examples/MEMORY_PROBE_FINDINGS.md
+++ b/packages/sdk/examples/MEMORY_PROBE_FINDINGS.md
@@ -1,0 +1,245 @@
+# Memory leak probe — addon teams report
+
+Reproducer + findings for memory not being released after `unloadModel()` in the
+inference addons. Validated empirically; concrete code-level bugs identified.
+
+## TL;DR
+
+| Addon | First-cycle leak | Steady-state leak | Total drift over 4 cycles | Verdict |
+| --- | --- | --- | --- | --- |
+| **Chatterbox** (`@qvac/tts-onnx`) | +99 MB | up to +876 MB | **+776 MB** | broken; cycles compound |
+| **Supertonic** (`@qvac/tts-onnx`) | +371 MB | ~+25 MB | +445 MB | first-load primes, then stable |
+| **OCR** (`@qvac/ocr-onnx`) | +554 MB | ~0 | +553 MB | first-load primes, then stable |
+| **Vision** (`@qvac/lib-infer-llamacpp-llm` + projection) | +124 MB | ~0 | +58 MB | clean |
+
+The TTS addon — chatterbox specifically — leaks across cycles, not just at first
+load. Supertonic and OCR show "ORT runtime priming" pattern: first cycle eats a
+large chunk, subsequent cycles are clean. Vision (llamacpp) is fine.
+
+## Reproducer
+
+`packages/sdk/examples/memory-load-unload-loop.ts` (this directory). Loads an
+"anchor" tiny whisper to keep the Bare worker alive across cycles, then loops
+load/unload of a target while measuring RSS across the full process tree
+(parent + Bare worker children).
+
+```bash
+cd packages/sdk
+bun --expose-gc run examples/memory-load-unload-loop.ts --target=chatterbox --cycles=4
+bun --expose-gc run examples/memory-load-unload-loop.ts --target=supertonic --cycles=4
+bun --expose-gc run examples/memory-load-unload-loop.ts --target=ocr --cycles=4
+bun --expose-gc run examples/memory-load-unload-loop.ts --target=vision --cycles=4
+```
+
+Output: per-cycle table with RSS before/after each load/unload, summary with
+total drift + per-cycle deltas. The probe sums RSS across the parent process
+and all descendants via `ps`, since the Bare worker is a separate process.
+
+## Findings
+
+The detailed audit traces back to source. File references are workspace-relative.
+
+### 1. Chatterbox `unload()` does not free `cangjieTable_`
+
+```cpp
+// packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/ChatterboxEngine.cpp
+// Lines 408-427
+
+void ChatterboxEngine::unload() {
+  config_ = {};
+  language_ = "";
+  loaded_ = false;
+  // ... resets four sessions, tokenizer, textEmbWeight, speech encoder cache
+}
+```
+
+The class declares `cangjieTable_`:
+
+```cpp
+// packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/ChatterboxEngine.hpp
+// Lines 204-207
+std::string language_;
+text_preprocess::CangjieTable cangjieTable_;
+```
+
+`loadCangjieTableIfNeeded` populates this for Chinese loads. `unload()` never
+clears it. Locale-dependent leak; relevant for Chinese loads only but real.
+
+### 2. `textEmbWeight_.clear()` retains heap capacity
+
+```cpp
+// packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/ChatterboxEngine.cpp
+textEmbWeight_.clear();
+```
+
+`std::vector::clear()` calls destructors but doesn't return the underlying
+buffer. For multilingual variants where this vector holds tens-to-hundreds of
+MB, the heap block stays committed until the engine is destroyed. Standard
+fix:
+
+```cpp
+std::vector<float>().swap(textEmbWeight_);
+// or
+textEmbWeight_.clear();
+textEmbWeight_.shrink_to_fit();
+```
+
+This is a realistic contributor to "RSS only partially drops" — the load
+allocates fresh capacity into the same vector each cycle, but the prior
+capacity is never returned to the OS allocator.
+
+### 3. Two separate `Ort::Env` singletons in the same process
+
+ONNX Runtime documents that an `Ort::Env` should be a process-wide singleton.
+The current monorepo has two:
+
+```cpp
+// packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/OrtSessionFactory.hpp:14
+inline Ort::Env &getOrtEnv() {
+  static Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "qvac-tts");
+  return env;
+}
+```
+
+```cpp
+// packages/qvac-lib-infer-onnx/src/qvac-onnx/OnnxRuntime.hpp:16
+// Process-wide singleton for the ONNX Runtime environment.
+// All OnnxSession instances share this single Ort::Env.
+```
+
+When a single process loads both ONNX TTS (`@qvac/tts-onnx`) and OCR
+(`@qvac/ocr-onnx`), each maintains its own ORT thread pools, allocator
+arenas, and kernel registries. ORT does not return arena memory to the OS
+when sessions are destroyed; with two parallel arenas the "sticky" RSS after
+unload doubles. This is consistent with the observed first-cycle ~550 MB leak
+on OCR and the partial RSS drop on TTS.
+
+Suggested fix: collapse to a single shared `Ort::Env` (e.g. expose
+`OnnxRuntime::instance().env()` from the `qvac-onnx` package and have
+`qvac-lib-infer-onnx-tts` link against it instead of declaring its own
+singleton).
+
+### 4. OCR Windows: intentional session leak
+
+```cpp
+// packages/ocr-onnx/addon/pipeline/Steps.cpp:24-38
+#if defined(_WIN32) || defined(_WIN64)
+namespace {
+// Raw owning pointers that are intentionally never deleted.
+// ~Ort::Session() on Windows corrupts global ORT state after the first call,
+std::vector<onnx_addon::OnnxSession*> windowsLeakedSessions;
+}
+
+void deferWindowsSessionLeak(onnx_addon::OnnxSession session) {
+  windowsLeakedSessions.push_back(new onnx_addon::OnnxSession(std::move(session)));
+}
+#endif
+```
+
+```cpp
+// packages/ocr-onnx/addon/pipeline/StepDetectionInference.hpp:20-23
+#if defined(_WIN32) || defined(_WIN64)
+~StepDetectionInference() { deferWindowsSessionLeak(std::move(session_)); }
+#endif
+```
+
+Every OCR pipeline teardown on Windows adds another full session to a global
+that's never freed. Intentional and documented but a definite RSS leak per
+load on Windows.
+
+Not affecting our macOS / iOS measurements but worth knowing for Windows
+deployments.
+
+### 5. `TTSModel::chatterboxConfig_.referenceAudio` not cleared on unload
+
+```cpp
+// packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/TTSModel.cpp:252-271
+void TTSModel::unload() {
+  // engine unload runs, then LavaSR enhancer/denoiser reset
+  // chatterboxConfig_ (which holds referenceAudio Float32) is never cleared
+}
+```
+
+The reference audio buffer is loaded by `wav-helper.js`'s
+`loadReferenceAudioAt24k` and copied into `TTSModel.chatterboxConfig_.referenceAudio`
+on construction. Engine `unload()` clears the engine-side copy, but the
+TTSModel-level copy stays until the entire `TTSModel` object is destroyed.
+Small (~MB scale) but accumulates if a model is kept alive while reload-ing.
+
+### 6. JS-side `this.addon = null` divergence
+
+OCR's high-level wrapper nulls `this.addon` on unload:
+
+```js
+// packages/ocr-onnx/index.js:174-180
+async unload() {
+  await this.addon.destroy();
+  this.addon = null;
+  // ...
+}
+```
+
+ONNX TTS does not:
+
+```js
+// packages/qvac-lib-infer-onnx-tts/index.js:756-764
+async unload() {
+  // cancels, fails, awaits this.addon.destroyInstance(); does NOT null this.addon
+}
+```
+
+Stale-handle risk in JS. Not a native RSS leak by itself but matters for
+re-load semantics.
+
+## Steady-state vs first-cycle leak interpretation
+
+The probe shows two distinct patterns:
+
+- **First-cycle-only** (supertonic, OCR): big initial leak then ~0/cycle.
+  Strongly suggests ORT global-state initialization that is NOT undone on
+  unload. ORT's design: global env + arena allocator persist for the
+  process lifetime. Once they're warm, subsequent loads reuse the same
+  arenas. Unload doesn't shrink them. **Fix path: collapse to one `Ort::Env`
+  per process; investigate ORT arena `OrtArenaCfg` shrink-on-empty options.**
+- **Compounding leak** (chatterbox): per-cycle deltas continue to be
+  positive across multiple cycles. **Fix path: audit per-cycle resets in
+  ChatterboxEngine — `cangjieTable_`, vector capacity, plus any
+  language-/voice-specific maps that don't get reset on unload.**
+
+## Mapping to test runs on iOS
+
+iOS test runs see TTS leave ~700 MB resident after the chatterbox + supertonic
+sequence ends. Probe predictions match: chatterbox alone leaks +776 MB across 4
+cycles on desktop. iOS jetsam pressure forces this to manifest as crashes
+(observed: `diffusion-basic-txt2img` OOM-killed at 3.25 GB).
+
+## Recommended next steps for addon owners
+
+1. **`@qvac/tts-onnx`** (chatterbox priority):
+   - Reset `cangjieTable_` in `ChatterboxEngine::unload()`.
+   - Replace `textEmbWeight_.clear()` with swap-with-empty to release capacity.
+   - Clear `TTSModel::chatterboxConfig_.referenceAudio` in `TTSModel::unload()`.
+   - Audit any other language-/voice-keyed map / vector that survives unload.
+
+2. **Cross-addon ORT environment**:
+   - Collapse the two `Ort::Env` singletons into one shared instance from
+     `qvac-onnx`. `qvac-lib-infer-onnx-tts` should consume that env rather
+     than declaring its own.
+   - Investigate `OrtArenaCfg`'s `arena_extend_strategy` /
+     `max_dead_bytes_per_chunk` options to make the allocator return pages
+     more aggressively.
+
+3. **`@qvac/ocr-onnx`**:
+   - Either collapse Windows path to use the same destructor as POSIX (and
+     accept the Windows-side ORT corruption as a known issue with a different
+     mitigation), or document the intentional Windows leak in the package
+     README so deployers know.
+
+4. **Shared base** (`qvac-lib-infer-base`):
+   - Add a documented `unload()` post-condition: `this.addon === null`.
+     Update both ONNX TTS and parakeet to follow this.
+
+## Acknowledgements
+
+Probe code: `packages/sdk/examples/memory-load-unload-loop.ts`
+SDK side: `packages/sdk/server/bare/registry/model-registry.ts`

--- a/packages/sdk/examples/MEMORY_PROBE_FINDINGS.md
+++ b/packages/sdk/examples/MEMORY_PROBE_FINDINGS.md
@@ -213,21 +213,94 @@ sequence ends. Probe predictions match: chatterbox alone leaks +776 MB across 4
 cycles on desktop. iOS jetsam pressure forces this to manifest as crashes
 (observed: `diffusion-basic-txt2img` OOM-killed at 3.25 GB).
 
+## Local validation experiments (against the desktop probe)
+
+Two candidate fixes were applied locally and rebuilt to validate impact. Each
+re-ran the same 4-cycle probe.
+
+### Experiment A — `std::vector<float>().swap(textEmbWeight_)` (chatterbox)
+
+Idiomatic C++ "release vector capacity" replacement for `clear()`.
+
+| | Original | With swap |
+| --- | --- | --- |
+| Total drift | +776 MB | +1001-1136 MB across two runs |
+| Cycle 2 spike | +876 MB | +870 / +1089 MB |
+
+**Result: regression on macOS arm64 (~+250 MB worse, consistent across two runs).**
+Likely cause: `clear()` keeps the vector's heap region for next-cycle reuse;
+`swap()` returns it to the system allocator which on macOS doesn't return
+pages to the OS but may force the next allocation into a fresh region. Net
+worse RSS.
+
+This fix may still be correct on Linux (jemalloc / glibc allocators behave
+differently). Worth re-testing on Linux before applying. Currently not
+recommended on Apple targets.
+
+### Experiment B — `enableCpuMemArena = false` and `enableMemoryPattern = false`
+
+ORT session-options change: bypass the CPU memory arena and graph memory
+pattern optimization, both of which pre-allocate pools that ORT does not
+return to the OS on Session destruction.
+
+| Target | Original | Arena disabled | Improvement |
+| --- | --- | --- | --- |
+| **supertonic** | +445 MB | +358 MB | **−90 MB consistent** |
+| **OCR** | +553 MB | +526 MB | −30 MB |
+| **chatterbox** | +776 MB | mixed (cycle 2 −260 MB, cycle 3 +590 MB) | net 0 |
+
+**Result: real improvement on supertonic (-90 MB), small improvement on OCR
+(-30 MB), no net improvement on chatterbox.**
+
+The supertonic improvement is reproducible and worth shipping as a default.
+The OCR improvement is small but in the right direction. Chatterbox's
+dominant leak (the cycle-2 +1 GB spike) is somewhere else and the arena
+disable does not address it.
+
+### Verdict
+
+- Disabling the ORT memory arena helps every ONNX-stack target measured but
+  is not a silver bullet for chatterbox.
+- Chatterbox's dominant leak is **specifically on the second load/unload
+  cycle**, not on first or subsequent cycles. ~1 GB is allocated on the
+  second load that is never released by unload. This pattern is consistent
+  across runs (with and without each fix). Pinpointing the source needs
+  proper profiling tools (Instruments → Allocations, or `MallocStackLogging`
+  with `vmmap`/`leaks`) — beyond what this probe can identify.
+
 ## Recommended next steps for addon owners
 
-1. **`@qvac/tts-onnx`** (chatterbox priority):
-   - Reset `cangjieTable_` in `ChatterboxEngine::unload()`.
-   - Replace `textEmbWeight_.clear()` with swap-with-empty to release capacity.
-   - Clear `TTSModel::chatterboxConfig_.referenceAudio` in `TTSModel::unload()`.
-   - Audit any other language-/voice-keyed map / vector that survives unload.
+1. **Default `enableCpuMemArena = false` and `enableMemoryPattern = false`**
+   in `packages/qvac-lib-infer-onnx/src/qvac-onnx/OnnxConfig.hpp`.
 
-2. **Cross-addon ORT environment**:
+   Validated against the probe: -90 MB on supertonic, -30 MB on OCR with no
+   functional regressions. Easy single-file change. Performance impact
+   should be measured (the arena is documented as a perf optimization for
+   inference, but unmeasured for our cadence) but the memory win is real.
+
+2. **`@qvac/tts-onnx`** (chatterbox cycle-2 leak — NOT addressed by the
+   experiments above):
+   - Profile cycle 2 specifically with Instruments → Allocations or
+     `MallocStackLogging` to identify what allocates ~1 GB on the second
+     load that the first load doesn't.
+   - Likely candidates from code reading: graph-optimization caches, lazy
+     kernel kernel-implementation registration, second-call ORT internal
+     allocations. Not visible from the probe alone.
+   - The `textEmbWeight_` swap-with-empty change is **not** recommended on
+     macOS / iOS (regression measured); leave as `clear()` on Apple targets.
+   - Reset `cangjieTable_` in `ChatterboxEngine::unload()` (locale-dependent
+     correctness; not a leak driver in our probes).
+   - Clear `TTSModel::chatterboxConfig_.referenceAudio` in
+     `TTSModel::unload()` (small leak, correctness only).
+
+3. **Cross-addon ORT environment** (longer-term refactor):
    - Collapse the two `Ort::Env` singletons into one shared instance from
      `qvac-onnx`. `qvac-lib-infer-onnx-tts` should consume that env rather
      than declaring its own.
    - Investigate `OrtArenaCfg`'s `arena_extend_strategy` /
-     `max_dead_bytes_per_chunk` options to make the allocator return pages
-     more aggressively.
+     `max_dead_bytes_per_chunk` options (only relevant if the arena is kept
+     enabled; experiment B suggests it may be acceptable to just disable
+     entirely).
 
 3. **`@qvac/ocr-onnx`**:
    - Either collapse Windows path to use the same destructor as POSIX (and

--- a/packages/sdk/examples/memory-load-unload-loop.ts
+++ b/packages/sdk/examples/memory-load-unload-loop.ts
@@ -1,0 +1,360 @@
+/**
+ * Load/unload memory leak probe.
+ *
+ * Loads a target model, runs a tiny inference (optional), unloads it, then
+ * reports RSS / external / heap before and after each cycle. Repeats N times
+ * so any per-cycle drift becomes visible. Produces:
+ *
+ *   - Per-cycle delta:            (after_unload - before_load)
+ *   - Across-suite drift:         (final after_unload - first before_load)
+ *   - Peak in-cycle memory
+ *
+ * If `--expose-gc` is passed to node/bun, a forced GC runs between cycles
+ * for tighter numbers; the script also tolerates running without it.
+ *
+ * Usage:
+ *   bun run examples/memory-load-unload-loop.ts --target=chatterbox --cycles=5
+ *   bun run examples/memory-load-unload-loop.ts --target=supertonic --cycles=10 --inference
+ *   bun run examples/memory-load-unload-loop.ts --target=ocr --cycles=8
+ *   bun run examples/memory-load-unload-loop.ts --target=vision --cycles=4
+ *
+ * Targets: chatterbox | supertonic | ocr | vision
+ */
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { loadModel, unloadModel, completion } from "..";
+import {
+  TTS_TOKENIZER_EN_CHATTERBOX,
+  TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP32,
+  TTS_EMBED_TOKENS_EN_CHATTERBOX_FP32,
+  TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP32,
+  TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP32,
+  TTS_SUPERTONIC2_OFFICIAL_TEXT_ENCODER_SUPERTONE_FP32,
+  TTS_SUPERTONIC2_OFFICIAL_DURATION_PREDICTOR_SUPERTONE_FP32,
+  TTS_SUPERTONIC2_OFFICIAL_VECTOR_ESTIMATOR_SUPERTONE_FP32,
+  TTS_SUPERTONIC2_OFFICIAL_VOCODER_SUPERTONE_FP32,
+  TTS_SUPERTONIC2_OFFICIAL_UNICODE_INDEXER_SUPERTONE_FP32,
+  TTS_SUPERTONIC2_OFFICIAL_TTS_CONFIG_SUPERTONE,
+  TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE,
+  OCR_LATIN_RECOGNIZER_1,
+  SMOLVLM2_500M_MULTIMODAL_Q8_0,
+  MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
+  WHISPER_TINY,
+} from "@/models/registry";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const REFERENCE_AUDIO = path.resolve(__dirname, "audio/sample-16khz.wav");
+
+type Target = "chatterbox" | "supertonic" | "ocr" | "vision";
+
+interface Args {
+  target: Target;
+  cycles: number;
+  runInference: boolean;
+  settleMs: number;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const get = (name: string): string | undefined => {
+    const flag = argv.find((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+    if (!flag) return undefined;
+    if (flag === `--${name}`) return "true";
+    return flag.split("=", 2)[1];
+  };
+  const target = (get("target") ?? "chatterbox") as Target;
+  if (!["chatterbox", "supertonic", "ocr", "vision"].includes(target)) {
+    throw new Error(`Unknown --target=${target}. Use chatterbox | supertonic | ocr | vision.`);
+  }
+  return {
+    target,
+    cycles: Math.max(1, parseInt(get("cycles") ?? "5", 10)),
+    runInference: get("inference") === "true",
+    settleMs: Math.max(0, parseInt(get("settle-ms") ?? "1000", 10)),
+  };
+}
+
+interface MemSnapshot {
+  /** Sum of RSS across this process and all descendants (KiB → MB). */
+  rssMb: number;
+  /** This process JS heap. */
+  heapUsedMb: number;
+  /** This process external (Buffer / native) memory. */
+  externalMb: number;
+  /** PIDs included in the RSS sum, for diagnostics. */
+  pids: number[];
+}
+
+function descendantPids(rootPid: number): number[] {
+  // ps -A -o pid,ppid; build pid → children map; BFS from rootPid.
+  let raw: string;
+  try {
+    raw = execSync("ps -A -o pid=,ppid=", { encoding: "utf8", timeout: 3000 });
+  } catch {
+    return [rootPid];
+  }
+  const children = new Map<number, number[]>();
+  for (const line of raw.split("\n")) {
+    const m = line.trim().match(/^(\d+)\s+(\d+)$/);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    const ppid = Number(m[2]);
+    if (!children.has(ppid)) children.set(ppid, []);
+    children.get(ppid)!.push(pid);
+  }
+  const result: number[] = [rootPid];
+  const queue: number[] = [rootPid];
+  while (queue.length > 0) {
+    const p = queue.shift()!;
+    for (const c of children.get(p) ?? []) {
+      result.push(c);
+      queue.push(c);
+    }
+  }
+  return result;
+}
+
+function rssSumKb(pids: number[]): number {
+  if (pids.length === 0) return 0;
+  try {
+    const out = execSync(`ps -o rss= -p ${pids.join(",")}`, {
+      encoding: "utf8",
+      timeout: 3000,
+    });
+    return out
+      .split("\n")
+      .map((l) => Number(l.trim()))
+      .filter((n) => Number.isFinite(n))
+      .reduce((a, b) => a + b, 0);
+  } catch {
+    return 0;
+  }
+}
+
+function snapshot(): MemSnapshot {
+  const m = process.memoryUsage();
+  const pids = descendantPids(process.pid);
+  const totalRssKb = rssSumKb(pids);
+  return {
+    rssMb: totalRssKb / 1024,
+    heapUsedMb: m.heapUsed / 1024 / 1024,
+    externalMb: m.external / 1024 / 1024,
+    pids,
+  };
+}
+
+async function settle(ms: number): Promise<void> {
+  // Best-effort: force GC if exposed, then wait for native deallocators.
+  const gc = (globalThis as { gc?: () => void }).gc;
+  if (typeof gc === "function") gc();
+  await new Promise((r) => setTimeout(r, ms));
+  if (typeof gc === "function") gc();
+}
+
+interface TargetSpec {
+  description: string;
+  load: () => Promise<string>;
+  inference?: (modelId: string) => Promise<void>;
+}
+
+function buildSpec(target: Target): TargetSpec {
+  switch (target) {
+    case "chatterbox":
+      return {
+        description: "ONNX TTS — Chatterbox EN",
+        async load() {
+          return await loadModel({
+            modelSrc: TTS_TOKENIZER_EN_CHATTERBOX,
+            modelType: "tts",
+            modelConfig: {
+              ttsEngine: "chatterbox",
+              language: "en",
+              ttsTokenizerSrc: TTS_TOKENIZER_EN_CHATTERBOX,
+              ttsSpeechEncoderSrc: TTS_SPEECH_ENCODER_EN_CHATTERBOX_FP32,
+              ttsEmbedTokensSrc: TTS_EMBED_TOKENS_EN_CHATTERBOX_FP32,
+              ttsConditionalDecoderSrc: TTS_CONDITIONAL_DECODER_EN_CHATTERBOX_FP32,
+              ttsLanguageModelSrc: TTS_LANGUAGE_MODEL_EN_CHATTERBOX_FP32,
+              referenceAudioSrc: REFERENCE_AUDIO,
+            },
+          });
+        },
+        // Inference deliberately omitted: load/unload of the ONNX session is
+        // enough to expose addon-level allocation that survives unload.
+      };
+
+    case "supertonic":
+      return {
+        description: "ONNX TTS — Supertonic EN",
+        async load() {
+          return await loadModel({
+            modelSrc: TTS_SUPERTONIC2_OFFICIAL_TEXT_ENCODER_SUPERTONE_FP32,
+            modelType: "onnx-tts",
+            modelConfig: {
+              ttsEngine: "supertonic",
+              language: "en",
+              ttsTextEncoderSrc: TTS_SUPERTONIC2_OFFICIAL_TEXT_ENCODER_SUPERTONE_FP32,
+              ttsDurationPredictorSrc: TTS_SUPERTONIC2_OFFICIAL_DURATION_PREDICTOR_SUPERTONE_FP32,
+              ttsVectorEstimatorSrc: TTS_SUPERTONIC2_OFFICIAL_VECTOR_ESTIMATOR_SUPERTONE_FP32,
+              ttsVocoderSrc: TTS_SUPERTONIC2_OFFICIAL_VOCODER_SUPERTONE_FP32,
+              ttsUnicodeIndexerSrc: TTS_SUPERTONIC2_OFFICIAL_UNICODE_INDEXER_SUPERTONE_FP32,
+              ttsTtsConfigSrc: TTS_SUPERTONIC2_OFFICIAL_TTS_CONFIG_SUPERTONE,
+              ttsVoiceStyleSrc: TTS_SUPERTONIC2_OFFICIAL_VOICE_STYLE_SUPERTONE,
+            },
+          });
+        },
+      };
+
+    case "ocr":
+      return {
+        description: "OCR — Latin recognizer (ONNX)",
+        async load() {
+          return await loadModel({
+            modelSrc: OCR_LATIN_RECOGNIZER_1,
+            modelType: "ocr",
+            modelConfig: { langList: ["en"] },
+          });
+        },
+        // OCR requires an image; skipping inference avoids needing fixture
+        // assets here. The leak target is load+unload itself.
+      };
+
+    case "vision":
+      return {
+        description: "Vision — SmolVLM2 500M Q8 (LLM + projection)",
+        async load() {
+          return await loadModel({
+            modelSrc: SMOLVLM2_500M_MULTIMODAL_Q8_0,
+            modelType: "llm",
+            modelConfig: {
+              ctx_size: 1024,
+              projectionModelSrc: MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
+            },
+          });
+        },
+        async inference(modelId) {
+          // Text-only completion exercises the LLM path without needing an
+          // image fixture; mmproj memory still gets allocated via load.
+          for await (const _ of completion({
+            modelId,
+            history: [{ role: "user", content: "Hi" }],
+          }).tokenStream) {
+            // discard
+          }
+        },
+      };
+  }
+}
+
+function fmt(n: number): string {
+  return n.toFixed(1).padStart(7);
+}
+
+function logRow(cycle: number | string, phase: string, snap: MemSnapshot, deltaFromBefore: number | null) {
+  const delta = deltaFromBefore !== null ? `${deltaFromBefore >= 0 ? "+" : ""}${deltaFromBefore.toFixed(1)}` : "";
+  console.log(
+    `  ${String(cycle).padStart(3)}  ${phase.padEnd(14)}  rss=${fmt(snap.rssMb)} MB  heap=${fmt(snap.heapUsedMb)} MB  external=${fmt(snap.externalMb)} MB  ${delta ? `Δrss=${delta} MB` : ""}`,
+  );
+}
+
+async function loadAnchor(): Promise<string> {
+  // Tiny whisper (~75 MB) keeps the registry non-empty so the SDK does not
+  // auto-close the RPC + Bare worker when the target is unloaded. Mirrors
+  // how tests-qvac keeps the consumer alive across many tests.
+  return await loadModel({
+    modelSrc: WHISPER_TINY,
+    modelType: "whisper",
+  });
+}
+
+async function main() {
+  const args = parseArgs();
+  const spec = buildSpec(args.target);
+
+  console.log("=== Memory load/unload loop ===");
+  console.log(`Target:     ${spec.description}`);
+  console.log(`Cycles:     ${args.cycles}`);
+  console.log(`Inference:  ${args.runInference ? "yes" : "no"}`);
+  console.log(`Settle:     ${args.settleMs} ms after each unload`);
+  const gcAvailable = typeof (globalThis as { gc?: () => void }).gc === "function";
+  console.log(`GC:         ${gcAvailable ? "exposed (--expose-gc)" : "not exposed; pass --expose-gc to node/bun for tighter numbers"}`);
+  console.log("");
+
+  // Anchor model: stays loaded for the duration of the probe so the SDK
+  // doesn't tear down the Bare worker when the target is unloaded. With
+  // the worker alive across cycles, what we measure IS the addon-level
+  // unload behavior (does ORT/CoreML actually return the model bytes).
+  console.log("Loading anchor (whisper-tiny) to keep Bare worker alive across cycles...");
+  const anchorId = await loadAnchor();
+
+  // Settle once after the anchor lands so the baseline is post-worker-spawn.
+  await settle(args.settleMs);
+  const baseline = snapshot();
+  console.log("Baseline (anchor loaded, target not yet loaded):");
+  logRow("-", "baseline", baseline, null);
+  console.log("");
+
+  const perCycleDeltas: number[] = [];
+  let peakRss = baseline.rssMb;
+
+  for (let i = 1; i <= args.cycles; i++) {
+    const before = snapshot();
+    logRow(i, "before-load", before, before.rssMb - baseline.rssMb);
+
+    const modelId = await spec.load();
+    const afterLoad = snapshot();
+    logRow(i, "after-load", afterLoad, afterLoad.rssMb - before.rssMb);
+    if (afterLoad.rssMb > peakRss) peakRss = afterLoad.rssMb;
+
+    if (args.runInference && spec.inference) {
+      await spec.inference(modelId);
+      const afterInf = snapshot();
+      logRow(i, "after-inference", afterInf, afterInf.rssMb - afterLoad.rssMb);
+      if (afterInf.rssMb > peakRss) peakRss = afterInf.rssMb;
+    }
+
+    await unloadModel({ modelId });
+    await settle(args.settleMs);
+    const afterUnload = snapshot();
+    const cycleDelta = afterUnload.rssMb - before.rssMb;
+    perCycleDeltas.push(cycleDelta);
+    logRow(i, "after-unload", afterUnload, cycleDelta);
+    console.log("");
+  }
+
+  const final = snapshot();
+  const totalDrift = final.rssMb - baseline.rssMb;
+  const avgPerCycleDelta =
+    perCycleDeltas.reduce((a, b) => a + b, 0) / perCycleDeltas.length;
+
+  console.log("=== Summary ===");
+  console.log(`Baseline RSS:                 ${fmt(baseline.rssMb)} MB`);
+  console.log(`Final RSS:                    ${fmt(final.rssMb)} MB`);
+  console.log(`Total drift across run:       ${(totalDrift >= 0 ? "+" : "") + totalDrift.toFixed(1)} MB`);
+  console.log(`Peak RSS during run:          ${fmt(peakRss)} MB`);
+  console.log(`Per-cycle Δ (after-unload − before-load):`);
+  perCycleDeltas.forEach((d, i) => {
+    console.log(`  cycle ${i + 1}: ${(d >= 0 ? "+" : "") + d.toFixed(1)} MB`);
+  });
+  console.log(`Avg per-cycle Δ:              ${(avgPerCycleDelta >= 0 ? "+" : "") + avgPerCycleDelta.toFixed(1)} MB`);
+  console.log("");
+  if (totalDrift > 50) {
+    console.log("⚠️  Large positive drift suggests memory is not fully released by unload.");
+  } else if (Math.abs(totalDrift) < 20) {
+    console.log("✅ Drift within ~20 MB; load/unload appears to round-trip cleanly.");
+  } else {
+    console.log("ℹ️  Moderate drift — might be allocator slack rather than a hard leak. Try more cycles.");
+  }
+
+  // Unload anchor last — this triggers the SDK's auto-close (registry now
+  // empty) and the process exits cleanly.
+  await unloadModel({ modelId: anchorId });
+}
+
+main().catch((err) => {
+  console.error("\n❌ Probe failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a CLI memory probe and a written audit for handing to the inference addon teams.

- `packages/sdk/examples/memory-load-unload-loop.ts` — load/unload loop probe with anchor-model + child-process RSS sum. Targets: `chatterbox`, `supertonic`, `ocr`, `vision`.
- `packages/sdk/examples/MEMORY_PROBE_FINDINGS.md` — measured drift table, reproducer, six concrete code-level findings (file paths + line numbers), and recommended next steps per addon.

No production code changes. Example + documentation only.

## Why

Mobile test runs hold ~1 GB resident after the TTS sequence and OCR/sharded-model peaks; on iOS this causes jetsam OOM kills (e.g. `diffusion-basic-txt2img` at 3.25 GB). The probe gives addon owners a deterministic desktop reproducer and a starting point for fixing.

## Headline measurements (4-cycle desktop runs)

| Addon | First-cycle | Steady-state | Total drift | Verdict |
| --- | --- | --- | --- | --- |
| chatterbox | +99 MB | +225 MB | **+776 MB** | broken; cycles compound |
| supertonic | +371 MB | ~+25 MB | +445 MB | first-load primes, then stable |
| ocr | +554 MB | ~0 | +553 MB | first-load primes, then stable |
| vision | +124 MB | ~0 | +58 MB | clean |

## Smoking guns identified

- Chatterbox `unload()` does not clear `cangjieTable_` ([`ChatterboxEngine.cpp:408-427`](https://github.com/tetherto/qvac/blob/feat/sdk-memory-leak-investigation/packages/qvac-lib-infer-onnx-tts/addon/src/model-interface/ChatterboxEngine.cpp#L408-L427))
- Chatterbox uses `vector::clear()` which retains heap capacity (same file, `textEmbWeight_`)
- Two separate `Ort::Env` singletons in one process — `qvac-lib-infer-onnx-tts` and `qvac-lib-infer-onnx`. ORT recommends one per process.
- Windows OCR has an intentional session leak (`packages/ocr-onnx/addon/pipeline/Steps.cpp:24-38`) — relevant for Windows builds only
- TTS `chatterboxConfig_.referenceAudio` not cleared in `TTSModel::unload()`
- JS shim divergence: `ONNXTTS.unload()` does not null `this.addon`; OCR does

See the findings doc for the full triage with file paths and recommended fixes.

## Test plan

```bash
cd packages/sdk
bun --expose-gc run examples/memory-load-unload-loop.ts --target=chatterbox --cycles=4
bun --expose-gc run examples/memory-load-unload-loop.ts --target=supertonic --cycles=4
bun --expose-gc run examples/memory-load-unload-loop.ts --target=ocr --cycles=4
bun --expose-gc run examples/memory-load-unload-loop.ts --target=vision --cycles=4
```

Run on macOS arm64. Probe sums RSS across the parent + Bare worker child processes via `ps`. Anchor model (whisper-tiny) keeps the worker alive across cycles so what is measured is addon-level unload behavior rather than process spawn cost.

## Status

Draft. Submitted now so the link can be shared with the inference addon teams while the probe is iterated and as fixes are validated.