### PR TITLE
chore[skiplog]: add diagnostic smoke scripts for gpt-oss harmony tool-call truncation

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -193,6 +193,7 @@
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@expo/config-plugins": "^54.0.4",
+    "@huggingface/gguf": "^0.4.2",
     "@lancedb/lancedb": "^0.21.3",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@qvac/cli": "^0.2.4",

--- a/packages/sdk/scripts/_eog-suppression-notools.ts
+++ b/packages/sdk/scripts/_eog-suppression-notools.ts
@@ -1,0 +1,34 @@
+/**
+ * Diagnostic-only sibling of `smoke-native-tool-formats.ts`. Loads Qwen3
+ * 1.7B WITHOUT `tools: true`, so we can verify whether the load-time
+ * EOG-suppression (`common_init_from_model_and_params: added <X> logit
+ * bias = -inf`) is gated on `tools: true` (which flips
+ * `params.use_jinja = true`) or happens unconditionally.
+ *
+ * Run from packages/sdk:
+ *   bun run scripts/_eog-suppression-notools.ts
+ */
+
+import { loadModel, unloadModel, QWEN3_1_7B_INST_Q4 } from "@/index";
+
+let modelId: string | undefined;
+try {
+  modelId = await loadModel({
+    modelSrc: QWEN3_1_7B_INST_Q4,
+    modelType: "llm",
+    modelConfig: { ctx_size: 4096, verbosity: 3 },
+  });
+  console.log(`[load] done — modelId=${modelId}\n`);
+} catch (error) {
+  console.error("[smoke] error:", error);
+  process.exitCode = 1;
+} finally {
+  if (modelId) {
+    try {
+      await unloadModel({ modelId, clearStorage: false });
+      console.log(`[unload] done`);
+    } catch (unloadError) {
+      console.error("[unload] failed:", unloadError);
+    }
+  }
+}

--- a/packages/sdk/scripts/smoke-native-tool-formats.ts
+++ b/packages/sdk/scripts/smoke-native-tool-formats.ts
@@ -1,0 +1,280 @@
+/**
+ * Smoke script for native tool-call format support. Loads a model with
+ * `tools: true`, sends a fixed prompt with two tool definitions, and dumps
+ * the raw assistant stream so we can see literal markers like `<|channel|>`
+ * or `<|tool_call_start|>` if the model emits them.
+ *
+ * Usage (run from packages/sdk):
+ *   bun run scripts/smoke-native-tool-formats.ts llama-tool-calling
+ *   bun run scripts/smoke-native-tool-formats.ts lfm-tool
+ *   bun run scripts/smoke-native-tool-formats.ts gpt-oss-20b
+ *   bun run scripts/smoke-native-tool-formats.ts qwen3-1.7b
+ *   bun run scripts/smoke-native-tool-formats.ts custom \
+ *     --src=https://huggingface.co/<owner>/<repo>/resolve/main/<file>.gguf \
+ *     --dialect=pythonic
+ */
+
+import { z } from "zod";
+import {
+  completion,
+  loadModel,
+  unloadModel,
+  GPT_OSS_20B_INST_Q4_K_M,
+  LLAMA_TOOL_CALLING_1B_INST_Q4_K,
+  QWEN3_1_7B_INST_Q4,
+} from "@/index";
+import type { ModelSrcInput } from "@/schemas";
+
+type Dialect = "harmony" | "pythonic" | "hermes" | "json";
+
+type SmokeTarget = {
+  modelSrc: ModelSrcInput;
+  expectedDialect: Dialect;
+  label: string;
+};
+
+const TARGETS: Record<string, SmokeTarget> = {
+  "llama-tool-calling": {
+    modelSrc: LLAMA_TOOL_CALLING_1B_INST_Q4_K,
+    expectedDialect: "pythonic",
+    label: "Llama 3.2 1B Tool Calling V2 (Q4_K) — registry",
+  },
+  "lfm-tool": {
+    modelSrc:
+      "https://huggingface.co/LiquidAI/LFM2-1.2B-Tool-GGUF/resolve/main/LFM2-1.2B-Tool-Q4_K_M.gguf",
+    expectedDialect: "pythonic",
+    label: "LiquidAI LFM2-1.2B-Tool (Q4_K_M) — direct HF download",
+  },
+  "gpt-oss-20b": {
+    modelSrc: GPT_OSS_20B_INST_Q4_K_M,
+    expectedDialect: "harmony",
+    label: "GPT-OSS 20B (Q4_K_M) — registry",
+  },
+  // Qwen3 baseline for the EOG-suppression comparison. Emits Hermes-style
+  // <tool_call>...</tool_call> blocks.
+  "qwen3-1.7b": {
+    modelSrc: QWEN3_1_7B_INST_Q4,
+    expectedDialect: "hermes",
+    label: "Qwen3 1.7B Instruct (Q4_0) — registry",
+  },
+};
+
+function parseFlag(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find((a) => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : undefined;
+}
+
+function hasFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+const singleTool = hasFlag("single-tool");
+
+const targetKey = process.argv[2];
+let target: SmokeTarget | undefined;
+
+if (targetKey === "custom") {
+  const src = parseFlag("src");
+  const dialectFlag = parseFlag("dialect");
+  if (!src || (dialectFlag !== "harmony" && dialectFlag !== "pythonic")) {
+    console.error(
+      "Usage: bun run scripts/smoke-native-tool-formats.ts custom --src=<url-or-path> --dialect=<harmony|pythonic>",
+    );
+    process.exit(2);
+  }
+  target = {
+    modelSrc: src,
+    expectedDialect: dialectFlag,
+    label: `custom — ${src}`,
+  };
+} else if (targetKey && TARGETS[targetKey]) {
+  target = TARGETS[targetKey];
+}
+
+if (!target) {
+  console.error(
+    `Usage: bun run scripts/smoke-native-tool-formats.ts <${Object.keys(TARGETS).join(" | ")} | custom --src=... --dialect=...> [--single-tool]`,
+  );
+  process.exit(2);
+}
+
+const weatherSchema = z.object({
+  city: z.string().describe("City name"),
+  country: z.string().describe("Country code").optional(),
+});
+
+const horoscopeSchema = z.object({
+  sign: z.string().describe("An astrological sign like Taurus or Aquarius"),
+});
+
+const allTools = [
+  {
+    name: "get_weather",
+    description: "Get current weather for a city",
+    parameters: weatherSchema,
+  },
+  {
+    name: "get_horoscope",
+    description: "Get today's horoscope for an astrological sign",
+    parameters: horoscopeSchema,
+  },
+];
+
+const tools = singleTool ? [allTools[0]!] : allTools;
+
+const history = singleTool
+  ? [
+      {
+        role: "system",
+        content:
+          "You are a helpful assistant that can use the get_weather tool.",
+      },
+      { role: "user", content: "What's the weather in Tokyo?" },
+    ]
+  : [
+      {
+        role: "system",
+        content:
+          "You are a helpful assistant that can use tools to get the weather and horoscope.",
+      },
+      {
+        role: "user",
+        content: "What's the weather in Tokyo and my horoscope for Aquarius?",
+      },
+    ];
+
+const srcDescription =
+  typeof target.modelSrc === "string"
+    ? target.modelSrc
+    : (target.modelSrc.name ?? target.modelSrc.src);
+
+console.log(`\n===== SMOKE TARGET =====`);
+console.log(`label:            ${target.label}`);
+console.log(`expectedDialect:  ${target.expectedDialect}`);
+console.log(`modelSrc:         ${srcDescription}`);
+console.log(`mode:             ${singleTool ? "single-tool" : "multi-tool"}`);
+console.log(`tools:            ${tools.map((t) => t.name).join(", ")}`);
+console.log(`========================\n`);
+
+// Bare worker stdio is inherited from the parent, so addon / llama.cpp lines
+// bypass JS-level process.stdout.write hooks. To see load-time
+// `... logit bias = -inf` lines, tee the run output and grep that file.
+const capturedLogLines: string[] = [];
+
+let modelId: string | undefined;
+try {
+  modelId = await loadModel({
+    modelSrc: target.modelSrc,
+    modelType: "llm",
+    modelConfig: {
+      ctx_size: 4096,
+      tools: true,
+      verbosity: 3,
+    },
+    onProgress: (progress) =>
+      console.log(`[load] ${progress.percentage.toFixed(1)}%`),
+  });
+  console.log(`[load] done — modelId=${modelId}\n`);
+
+  const logitBiasHits = capturedLogLines.filter((line) =>
+    line.includes("logit bias"),
+  );
+  console.log(`===== LOAD-TIME LOGIT-BIAS LINES (JS-captured) =====`);
+  console.log(`count: ${logitBiasHits.length}`);
+  console.log(
+    "  (Note: addon stderr is inherited at the OS level; lines emitted",
+  );
+  console.log(
+    "   directly by llama.cpp bypass JS hooks. Grep the run log file",
+  );
+  console.log("   for `logit bias` to see them.)");
+  for (const line of logitBiasHits) console.log(`  ${line}`);
+  console.log(`===== END LOAD-TIME LOGIT-BIAS LINES =====\n`);
+
+  const result = completion({ modelId, history, stream: true, tools });
+
+  let rawAccumulated = "";
+
+  console.log(`===== EVENT STREAM SUMMARY =====`);
+  let stopReason: string | undefined;
+  let eventCount = 0;
+  let contentLen = 0;
+  let rawLen = 0;
+  for await (const event of result.events) {
+    eventCount += 1;
+    switch (event.type) {
+      case "contentDelta":
+        contentLen += event.text.length;
+        rawAccumulated += event.text;
+        break;
+      case "rawDelta":
+        rawLen += event.text.length;
+        break;
+      case "thinkingDelta":
+        break;
+      case "toolCall":
+        console.log(
+          `  [event toolCall] ${event.call.name}(${JSON.stringify(event.call.arguments)})`,
+        );
+        break;
+      case "toolError":
+        console.log(`  [event toolError] ${JSON.stringify(event.error)}`);
+        break;
+      case "completionStats":
+        break;
+      case "completionDone":
+        stopReason = event.stopReason;
+        if (event.stopReason === "error") {
+          console.log(`  [event done error] ${event.error.message}`);
+        }
+        break;
+    }
+  }
+  console.log(`  events: ${eventCount}`);
+  console.log(`  contentDelta total chars: ${contentLen}`);
+  console.log(`  rawDelta total chars:     ${rawLen}`);
+  console.log(`  stopReason:               ${stopReason ?? "<unknown>"}`);
+  console.log(`===== END EVENT STREAM SUMMARY =====\n`);
+
+  console.log(`===== RAW ACCUMULATED TEXT =====`);
+  console.log(rawAccumulated);
+  console.log(`===== END RAW ACCUMULATED TEXT =====\n`);
+
+  console.log(`===== RAW ACCUMULATED TAIL (last 200 chars) =====`);
+  console.log(JSON.stringify(rawAccumulated.slice(-200)));
+  console.log(`===== END RAW ACCUMULATED TAIL =====\n`);
+
+  const final = await result.final;
+  const toolCalls = final.toolCalls;
+  console.log(`===== SDK-PARSED TOOL CALLS =====`);
+  console.log(`length: ${toolCalls.length}`);
+  for (const call of toolCalls) {
+    console.log(`  - ${call.name}(${JSON.stringify(call.arguments)})`);
+  }
+  console.log(`===== END SDK-PARSED TOOL CALLS =====\n`);
+
+  console.log(`[raw.fullText.length] ${final.raw.fullText.length}`);
+  console.log(`[raw.toolDialect]     ${final.raw.toolDialect ?? "<none>"}`);
+  console.log(`===== RAW FULL TEXT (model output, post-detokenize) =====`);
+  console.log(final.raw.fullText);
+  console.log(`===== END RAW FULL TEXT =====\n`);
+
+  console.log(`===== RAW FULL TEXT TAIL (last 200 chars) =====`);
+  console.log(JSON.stringify(final.raw.fullText.slice(-200)));
+  console.log(`===== END RAW FULL TEXT TAIL =====\n`);
+
+  console.log(`[stats] ${JSON.stringify(final.stats)}`);
+} catch (error) {
+  console.error("[smoke] error:", error);
+  process.exitCode = 1;
+} finally {
+  if (modelId) {
+    try {
+      await unloadModel({ modelId, clearStorage: false });
+      console.log(`[unload] done`);
+    } catch (unloadError) {
+      console.error("[unload] failed:", unloadError);
+    }
+  }
+}


### PR DESCRIPTION
## What problem does this PR solve?

GPT-OSS 20B (Q4_K_M) Harmony tool-call frames get truncated downstream of the sampler — generation continues for hundreds of tokens past what reaches the SDK. 

## Diagnosis

- **`smoke-native-tool-formats.ts`** — main repro driver. Loads a model with `tools: true`, sends a fixed prompt with two tool definitions, and dumps the SDK-parsed tool calls, the raw `final.raw.fullText`, a last-200-char tail, and stats. Targets: `gpt-oss-20b`, `qwen3-1.7b` (control, works), `llama-tool-calling`, `lfm-tool`, plus a `custom --src=... --dialect=...` escape hatch. `--single-tool` switches to a one-tool prompt for the partial-frame variant.
- **`_eog-suppression-notools.ts`** — diagnostic-only sibling that loads Qwen3 with `tools: false`. Proves the addon's `common_init_from_model_and_params: added <X> logit bias = -inf` line fires regardless of `tools: true`, so the EOG-suppression log can be ruled out as the cause.

Also adds `@huggingface/gguf` as a devDependency (used for ad-hoc GGUF tokenizer metadata inspection during this debug pass).

## How was it tested?

Ran all targets locally on macOS Apple silicon against `@qvac/llm-llamacpp@0.16.0` (qvac-fabric v7248.2.3):

- `bun run scripts/smoke-native-tool-formats.ts gpt-oss-20b` — model's `<|channel|>analysis` plans both tool calls; only the first `commentary to=functions.get_weather` frame surfaces. `final.toolCalls.length = 1`, `raw.fullText.length = 282`, stats imply ~1000 generated tokens of which ~920 never reach the SDK.
- `bun run scripts/smoke-native-tool-formats.ts gpt-oss-20b --single-tool` — same termination point (frame ends at JSON close brace, no `<|call|>`); SDK fallback recovers the one call.
- `bun run scripts/smoke-native-tool-formats.ts qwen3-1.7b` — 2-of-2 tool calls reach the SDK; closes naturally with `<|im_end|>` after both `</tool_call>` blocks. Same SDK code path, same prompt, same `tools: true`.
- `bun run scripts/_eog-suppression-notools.ts` — same five `... logit bias = -inf` lines as the tools-true Qwen3 run, confirming the log is unconditional.