### PR TITLE
feat[notask][mod]: add LFM2-VL-450M and LFM2.5-1.2B-Instruct models

### DIFF
--- a/packages/qvac-lib-registry-server/data/licenses.json
+++ b/packages/qvac-lib-registry-server/data/licenses.json
@@ -43,5 +43,10 @@
     "spdxId": "openrail++",
     "name": "Open RAIL++-M License",
     "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/raw/main/LICENSE.md"
+  },
+  {
+    "spdxId": "lfm1.0",
+    "name": "LFM Open License v1.0",
+    "url": "https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/blob/main/LICENSE"
   }
 ]

--- a/packages/qvac-lib-registry-server/data/licenses/lfm1.0/LICENSE.txt
+++ b/packages/qvac-lib-registry-server/data/licenses/lfm1.0/LICENSE.txt
@@ -1,0 +1,71 @@
+LFM Open License v1.0
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by this document.
+
+"Licensor" shall mean Liquid AI, Inc.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+"Commercial Use" shall mean any use of the Work for direct or indirect commercial advantage or monetary compensation.
+
+"Qualified Non-Profit Organization" shall mean a Legal Entity that is organized and operated exclusively for religious, charitable, scientific, testing for public safety, literary, or educational purposes, and which is exempt from federal income tax under Section 501(c)(3) of the United States Internal Revenue Code of 1986, as amended, or any equivalent non-profit or charitable organization in a foreign jurisdiction.
+
+"Non-Commercial or Research Purposes" shall mean purposes that do not involve any use of the Work or a Derivative Work for Commercial Use.
+
+"Threshold" shall mean annual revenue of 10 million United States dollars ($10,000,000) or more.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, including the Commercial Use limitation set forth in Section 5, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, including the Commercial Use limitation set forth in Section 5, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Commercial Use Limitation.
+
+(a) The rights granted under this License for Commercial Use are conditioned upon You or Your Legal Entity not exceeding the Threshold.
+
+(b) Any Commercial Use of the Work or a Derivative Work by a Legal Entity that exceeds the Threshold is not licensed under this Agreement.
+
+(c) The Threshold shall not apply to a Qualified Non-Profit Organization's use of the Work or a Derivative Work for Non-Commercial or Research Purposes.
+
+6. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+7. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except for the reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+8. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+9. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+10. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+11. Termination. This License will terminate automatically and immediately if You fail to comply with any of its terms and conditions. Upon termination, You must cease all use of the Work and any Derivative Works and delete all copies in Your possession.
+
+END OF TERMS AND CONDITIONS

--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -10711,5 +10711,35 @@
     ],
     "notes": "",
     "link": "https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/vien"
+  },
+  {
+    "source": "https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/dd83d646c705e89a48b1c6e54e03a10adb4ca581/LFM2-VL-450M-Q4_0.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Vision-language model for image understanding",
+    "quantization": "q4_0",
+    "params": "450M",
+    "licenseId": "lfm1.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "lfm2-vl"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF/resolve/dd83d646c705e89a48b1c6e54e03a10adb4ca581/mmproj-LFM2-VL-450M-F16.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "",
+    "quantization": "f16",
+    "params": "450M",
+    "licenseId": "lfm1.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "lfm2-vl"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/LiquidAI/LFM2-VL-450M-GGUF"
   }
 ]


### PR DESCRIPTION
## What problem does this PR solve?

- Registry is missing LiquidAI **LFM2-VL-450M** vision-language GGUFs and **LFM2.5-1.2B-Instruct** text-generation GGUFs
- The LFM2-VL portion was originally proposed in #306 (Feb 2026), closed pending legal review of the LFM Open License v1.0; re-submitting now along with the 1.2B-Instruct quantizations called out in `packages/sdk/changelog/0.6.0/models.md`

## How does it solve it?

- Adds 4 model entries to `packages/qvac-lib-registry-server/data/models.prod.json`, all `engine: @qvac/llm-llamacpp`, `licenseId: lfm1.0`:

  **LFM2-VL-450M (vision-language)** — pinned to HF commit `dd83d646c705e89a48b1c6e54e03a10adb4ca581`
  - `LFM2-VL-450M-Q4_0.gguf` — Q4_0 vision-language model
  - `mmproj-LFM2-VL-450M-F16.gguf` — F16 multimodal projector
  - tags: `generation`, `multimodal`, `lfm2-vl`

  **LFM2.5-1.2B-Instruct (text generation)** — pinned to HF commit `047e06635fbe71469926b35ea414537245218200`
  - `LFM2.5-1.2B-Instruct-Q4_0.gguf` — Q4_0 instruct
  - `LFM2.5-1.2B-Instruct-Q4_K_M.gguf` — Q4_K_M instruct
  - tags: `generation`, `instruct`, `lfm2.5`

- Adds `lfm1.0` entry to `packages/qvac-lib-registry-server/data/licenses.json` (LFM Open License v1.0)
- Adds full license text at `packages/qvac-lib-registry-server/data/licenses/lfm1.0/LICENSE.txt`

## How was it tested?

- `npm run validate:models` → `✓ Valid: 684 model(s) in ./data/models.prod.json`
- All 4 entries parse cleanly, `lfm1.0` license entry resolves, license file present
- License text matches upstream HF (`license_name: lfm1.0`) for both repos
- `npm run verify:licenses` requires `HF_TOKEN`; will run on CI

## Models

### Added models

```
LFM2-VL-450M-Q4_0.gguf
mmproj-LFM2-VL-450M-F16.gguf
LFM2.5-1.2B-Instruct-Q4_0.gguf
LFM2.5-1.2B-Instruct-Q4_K_M.gguf
```

## Notes

- LFM2-VL portion uses the current registry schema (`licenseId` instead of `license`, plus `link` field) — schema differs slightly from the original #306.
- LFM2.5-1.2B-Instruct constants `LFM_2_5_1_2B_INST_Q4_0` and `LFM_2_5_1_2B_INST_Q4_K_M` are referenced in `packages/sdk/changelog/0.6.0/models.md` but were never present in `models.prod.json` — this PR closes that gap.
- Original PR: tetherto/qvac#306 (closed 2026-02-27 — *"will not be added due to license for now"*).