### PR TITLE
QVAC-17939: feat[api]: add responseFormat for structured output

### DIFF
--- a/packages/sdk/client/api/completion-stream.ts
+++ b/packages/sdk/client/api/completion-stream.ts
@@ -54,6 +54,12 @@ type CompletionParams = Omit<CompletionClientParams, "tools"> & {
  * @param params.mcp - Optional array of MCP client inputs for tool integration
  * @param params.captureThinking - Best-effort parsing of `<think>` blocks into `thinkingDelta` events; `final.raw.fullText` always preserves the original output
  * @param params.emitRawDeltas - When true, every raw model token is also emitted as a `rawDelta` event
+ * @param params.responseFormat - Optional structured-output constraint applied to the model's output:
+ *   - `{ type: "text" }` — no constraint (default behavior)
+ *   - `{ type: "json_object" }` — output must be a JSON object
+ *   - `{ type: "json_schema", json_schema: { name, schema } }` — output must validate against `schema`
+ *
+ *   Cannot be combined with `tools` (tools already constrain output via their parameter schema).
  * @param params.kvCache - Optional KV cache configuration. Cache files are organized hierarchically:
  *   - Structure: `{kvCacheKey}/{modelId}/{configHash}.bin`
  *   - The configHash includes model config + system prompt to ensure cache isolation
@@ -207,6 +213,7 @@ export function completion(params: CompletionParams): CompletionRun {
         generationParams: params.generationParams,
         captureThinking: params.captureThinking,
         emitRawDeltas: params.emitRawDeltas,
+        responseFormat: params.responseFormat,
       };
 
       const responses: AsyncGenerator<unknown> = streamRpc(
@@ -237,7 +244,10 @@ export function completion(params: CompletionParams): CompletionRun {
           notifyWaiters();
 
           if (streamResponse.done) {
-            const { final, error } = buildFinalFromEvents(allEvents, allHandlers);
+            const { final, error } = buildFinalFromEvents(
+              allEvents,
+              allHandlers,
+            );
             if (error) {
               const err = new CompletionFailedError(error.message, error);
               finalRejecter(err);

--- a/packages/sdk/examples/llamacpp-structured-output.ts
+++ b/packages/sdk/examples/llamacpp-structured-output.ts
@@ -1,0 +1,133 @@
+import {
+  loadModel,
+  completion,
+  unloadModel,
+  QWEN3_600M_INST_Q4,
+} from "@qvac/sdk";
+
+// Demonstrates per-request structured output via `responseFormat`.
+// Three modes are exercised against the same model so you can eyeball the
+// difference between free-form text, free-form JSON, and a strict JSON Schema.
+//
+// Usage:
+//   bun run examples/llamacpp-structured-output.ts
+
+const PERSON_SCHEMA = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    age: { type: "integer" },
+    occupation: { type: "string" },
+  },
+  required: ["name", "age", "occupation"],
+  additionalProperties: false,
+} as const;
+
+const HISTORY = [
+  {
+    role: "system",
+    content:
+      "You extract structured information about people from short bios. /no_think",
+  },
+  {
+    role: "user",
+    content: "Hi, I'm Alice, I'm 30 years old and I work as a data engineer.",
+  },
+];
+
+// `json_object` mode only enforces that the output is *some* valid JSON object
+// — it doesn't pin the keys. Small models (Qwen3-0.6B in this example) will
+// often emit `{}` because that's the shortest valid completion under the
+// grammar. The same gotcha is documented for OpenAI's `response_format:
+// json_object`. To get useful keys you either need a stronger prompt + a
+// larger model, or — better — switch to `json_schema` (mode 3 below) so the
+// grammar itself forces the keys.
+const JSON_OBJECT_HISTORY = [
+  {
+    role: "system",
+    content:
+      'You extract structured information about people from short bios and reply ONLY with a JSON object containing "name", "age", and "occupation". /no_think',
+  },
+  {
+    role: "user",
+    content: "Hi, I'm Alice, I'm 30 years old and I work as a data engineer.",
+  },
+];
+
+async function streamToString(
+  result: ReturnType<typeof completion>,
+): Promise<string> {
+  const chunks: string[] = [];
+  for await (const token of result.tokenStream) chunks.push(token);
+  return chunks.join("");
+}
+
+try {
+  const modelId = await loadModel({
+    modelSrc: QWEN3_600M_INST_Q4,
+    modelType: "llm",
+    onProgress: (p) =>
+      process.stdout.write(`\rLoading: ${p.percentage.toFixed(1)}%`),
+  });
+  console.log(`\nModel loaded: ${modelId}\n`);
+
+  console.log("--- 1. responseFormat: text (baseline, free-form) ---");
+  const textOut = await streamToString(
+    completion({
+      modelId,
+      history: HISTORY,
+      stream: true,
+      responseFormat: { type: "text" },
+    }),
+  );
+  console.log(textOut.trim(), "\n");
+
+  console.log("--- 2. responseFormat: json_object (any valid JSON) ---");
+  const jsonObjectOut = await streamToString(
+    completion({
+      modelId,
+      history: JSON_OBJECT_HISTORY,
+      stream: true,
+      responseFormat: { type: "json_object" },
+    }),
+  );
+  console.log(jsonObjectOut.trim());
+  console.log("parsed:", JSON.parse(jsonObjectOut.trim()), "\n");
+
+  console.log("--- 3. responseFormat: json_schema (strict shape) ---");
+  const jsonSchemaOut = await streamToString(
+    completion({
+      modelId,
+      history: HISTORY,
+      stream: true,
+      responseFormat: {
+        type: "json_schema",
+        json_schema: {
+          name: "person",
+          schema: PERSON_SCHEMA,
+        },
+      },
+    }),
+  );
+  // Output is guaranteed schema-valid JSON: object with exactly
+  // {name: string, age: integer, occupation: string}, no extras.
+  const parsed = JSON.parse(jsonSchemaOut.trim()) as {
+    name: string;
+    age: number;
+    occupation: string;
+  };
+  console.log(jsonSchemaOut.trim());
+  console.log("parsed:", parsed);
+  console.log(
+    "schema-valid:",
+    typeof parsed.name === "string" &&
+      Number.isInteger(parsed.age) &&
+      typeof parsed.occupation === "string" &&
+      Object.keys(parsed).sort().join(",") === "age,name,occupation",
+  );
+
+  await unloadModel({ modelId });
+} catch (error) {
+  console.error("Error:", error);
+  process.exit(1);
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -177,7 +177,7 @@
     "@qvac/embed-llamacpp": "^0.14.0",
     "@qvac/error": "^0.1.1",
     "@qvac/langdetect-text": "^0.1.2",
-    "@qvac/llm-llamacpp": "^0.17.0",
+    "@qvac/llm-llamacpp": "^0.17.1",
     "@qvac/logging": "^0.1.0",
     "@qvac/ocr-onnx": "^0.4.2",
     "@qvac/rag": "^0.4.4",

--- a/packages/sdk/schemas/completion-stream.ts
+++ b/packages/sdk/schemas/completion-stream.ts
@@ -2,14 +2,13 @@ import { z } from "zod";
 import { toolSchema } from "./tools";
 import { completionEventSchema } from "./completion-event";
 
-export { completionStatsSchema, type CompletionStats } from "./completion-event";
+export {
+  completionStatsSchema,
+  type CompletionStats,
+} from "./completion-event";
 
 export const attachmentSchema = z.object({
-  path: z
-    .string()
-    .describe(
-      "Absolute or SDK-resolvable path to the attachment file (e.g., image for multimodal models).",
-    ),
+  path: z.string(),
 });
 
 const kvCacheSchema = z.union([
@@ -19,104 +18,91 @@ const kvCacheSchema = z.union([
 
 export const generationParamsSchema = z
   .object({
-    temp: z
-      .number()
-      .optional()
-      .describe("Sampling temperature (typically 0–2)."),
-    top_p: z
-      .number()
-      .optional()
-      .describe("Top-p (nucleus) sampling cutoff (0–1)."),
-    top_k: z
-      .number()
-      .optional()
-      .describe("Top-k sampling — keep only the top K tokens."),
-    predict: z
-      .number()
-      .optional()
-      .describe(
-        "Max tokens to predict. `-1` = until stop token, `-2` = until context filled.",
-      ),
-    seed: z
-      .number()
-      .optional()
-      .describe("Random seed for reproducibility."),
-    frequency_penalty: z
-      .number()
-      .optional()
-      .describe("Penalty applied to tokens based on frequency so far."),
-    presence_penalty: z
-      .number()
-      .optional()
-      .describe("Penalty applied to tokens that have already appeared."),
-    repeat_penalty: z
-      .number()
-      .optional()
-      .describe("Penalty applied to repeated tokens."),
+    temp: z.number().optional(),
+    top_p: z.number().optional(),
+    top_k: z.number().optional(),
+    predict: z.number().optional(),
+    seed: z.number().optional(),
+    frequency_penalty: z.number().optional(),
+    presence_penalty: z.number().optional(),
+    repeat_penalty: z.number().optional(),
   })
   .strict();
 
+const jsonSchemaObjectSchema = z.record(z.string(), z.unknown());
+
+export const responseFormatSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("text") }).strict(),
+  z.object({ type: z.literal("json_object") }).strict(),
+  z
+    .object({
+      type: z.literal("json_schema"),
+      json_schema: z
+        .object({
+          name: z.string().min(1),
+          description: z.string().optional(),
+          schema: jsonSchemaObjectSchema,
+          strict: z.boolean().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+
 export const completionParamsSchema = z.object({
-  history: z
-    .array(
-      z.object({
-        role: z
-          .string()
-          .describe(
-            'Message role (e.g., `"user"`, `"assistant"`, `"system"`).',
-          ),
-        content: z.string().describe("Message content."),
-        attachments: z
-          .array(attachmentSchema)
-          .optional()
-          .describe("Optional file attachments for multimodal models."),
-      }),
-    )
-    .describe("Array of conversation messages sent to the model."),
-  modelId: z
-    .string()
-    .describe("The identifier of the model to use for completion."),
-  kvCache: kvCacheSchema
-    .optional()
-    .describe(
-      "KV cache configuration — `true` to auto-generate a cache key from history, a string to use a custom key, or `false`/`undefined` to disable.",
-    ),
-});
-
-export const completionClientParamsSchema = completionParamsSchema.extend({
-  tools: z
-    .array(toolSchema)
-    .optional()
-    .describe(
-      "Optional array of tools (full `Tool` objects or Zod-schema `ToolInput` definitions) the model can call.",
-    ),
-  stream: z
-    .boolean()
-    .describe(
-      "Whether to stream tokens (`true`) or return the complete response once (`false`).",
-    ),
+  history: z.array(
+    z.object({
+      role: z.string(),
+      content: z.string(),
+      attachments: z.array(attachmentSchema).optional(),
+    }),
+  ),
+  modelId: z.string(),
   kvCache: kvCacheSchema.optional(),
-  generationParams: generationParamsSchema
-    .optional()
-    .describe("Optional sampling / generation parameters."),
-  captureThinking: z
-    .boolean()
-    .optional()
-    .describe(
-      "When `true`, capture and emit reasoning/thinking deltas separately from content deltas; requires a model that frames its thinking output.",
-    ),
-  emitRawDeltas: z
-    .boolean()
-    .optional()
-    .describe(
-      "When `true`, also emit raw per-token deltas in the event stream in addition to normalized `contentDelta` events.",
-    ),
 });
 
-export const completionStreamRequestSchema =
-  completionClientParamsSchema.extend({
+const completionClientParamsBaseSchema = completionParamsSchema.extend({
+  tools: z.array(toolSchema).optional(),
+  stream: z.boolean(),
+  kvCache: kvCacheSchema.optional(),
+  generationParams: generationParamsSchema.optional(),
+  captureThinking: z.boolean().optional(),
+  emitRawDeltas: z.boolean().optional(),
+  responseFormat: responseFormatSchema.optional(),
+});
+
+function refineNoToolsWithStructuredOutput(
+  data: {
+    tools?: { type: "function"; name: string }[] | undefined;
+    responseFormat?: z.infer<typeof responseFormatSchema> | undefined;
+  },
+  ctx: z.RefinementCtx,
+): void {
+  if (
+    data.responseFormat &&
+    data.responseFormat.type !== "text" &&
+    data.tools &&
+    data.tools.length > 0
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      message:
+        "responseFormat (json_object/json_schema) cannot be combined with tools; tools already constrain output via their parameter schema.",
+      path: ["responseFormat"],
+    });
+  }
+}
+
+export const completionClientParamsSchema =
+  completionClientParamsBaseSchema.superRefine(
+    refineNoToolsWithStructuredOutput,
+  );
+
+export const completionStreamRequestSchema = completionClientParamsBaseSchema
+  .extend({
     type: z.literal("completionStream"),
-  });
+  })
+  .superRefine(refineNoToolsWithStructuredOutput);
 
 export const completionStreamResponseSchema = z
   .object({
@@ -128,6 +114,7 @@ export const completionStreamResponseSchema = z
 
 export type GenerationParams = z.infer<typeof generationParamsSchema>;
 export type CompletionParams = z.infer<typeof completionParamsSchema>;
+export type ResponseFormat = z.infer<typeof responseFormatSchema>;
 export type CompletionClientParams = z.input<
   typeof completionClientParamsSchema
 >;

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
@@ -3,6 +3,7 @@ import type {
   CompletionParams,
   CompletionStats,
   GenerationParams,
+  ResponseFormat,
   Tool,
   ToolCall,
 } from "@/schemas";
@@ -45,6 +46,7 @@ import {
   prependToolsToHistory,
   setupToolGrammar,
 } from "@/server/utils/tool-integration";
+import { getResponseFormatJsonSchema } from "@/server/utils/response-format";
 import { parseToolCalls } from "@/server/utils/tool-parser";
 import { buildAutoCacheSaveHistory, type CacheMessage } from "@/server/utils";
 import { getServerLogger } from "@/logging";
@@ -92,8 +94,18 @@ interface ChatHistory {
   parameters?: unknown;
 }
 
+// Internal generation-params shape forwarded to the addon. Extends the
+// public `GenerationParams` with `json_schema` (a JSON-Schema string the
+// addon will convert to GBNF) so structured-output requests can constrain
+// sampling per request without mutating the shared `modelConfig`. The
+// addon types in `@qvac/llm-llamacpp@0.17.1`+ already include this field;
+// the explicit `&` here keeps typing correct against `^0.16.0` until the
+// dep bump propagates and is harmless once it has.
+type CompletionGenerationParams = GenerationParams & { json_schema?: string };
+
+
 type CompletionRunOptions = Pick<RunOptions, "cacheKey" | "saveCacheToDisk"> & {
-  generationParams?: GenerationParams;
+  generationParams?: CompletionGenerationParams;
 };
 
 // Re-export so existing callers keep their import surface intact. The pure
@@ -341,23 +353,24 @@ async function* processModelResponse(
   model: AnyModel,
   messagesToSend: ChatHistory[],
   tools?: Tool[],
-  generationParams?: GenerationParams,
+  generationParams?: CompletionGenerationParams,
   cacheOptions?: CacheRunOptions,
 ): AsyncGenerator<
   { token: string; toolCallEvent?: ToolCallEvent },
   ProcessModelResponseResult,
   unknown
 > {
-  const runOptions: CacheRunOptions & { generationParams?: GenerationParams } =
-    {
-      ...(generationParams && { generationParams }),
-      ...(cacheOptions?.cacheKey !== undefined && {
-        cacheKey: cacheOptions.cacheKey,
-      }),
-      ...(cacheOptions?.saveCacheToDisk !== undefined && {
-        saveCacheToDisk: cacheOptions.saveCacheToDisk,
-      }),
-    };
+  const runOptions: CacheRunOptions & {
+    generationParams?: CompletionGenerationParams;
+  } = {
+    ...(generationParams && { generationParams }),
+    ...(cacheOptions?.cacheKey !== undefined && {
+      cacheKey: cacheOptions.cacheKey,
+    }),
+    ...(cacheOptions?.saveCacheToDisk !== undefined && {
+      saveCacheToDisk: cacheOptions.saveCacheToDisk,
+    }),
+  };
   const hasRunOptions = Object.keys(runOptions).length > 0;
 
   const modelStart = nowMs();
@@ -437,13 +450,15 @@ export async function* completion(
   params: CompletionParams & {
     tools?: Tool[];
     generationParams?: GenerationParams;
+    responseFormat?: ResponseFormat;
   },
 ): AsyncGenerator<
   { token: string; toolCallEvent?: ToolCallEvent },
   CompletionResult,
   unknown
 > {
-  const { history, modelId, kvCache, tools, generationParams } = params;
+  const { history, modelId, kvCache, tools, generationParams, responseFormat } =
+    params;
 
   const modelConfig = getModelConfig(modelId);
   const toolsEnabled = (modelConfig as { tools?: boolean }).tools === true;
@@ -453,8 +468,25 @@ export async function* completion(
   const staticTools =
     !!tools?.length && toolsEnabled && !dynamicTools;
 
+  // `responseFormat` is forwarded to the addon as a per-request
+  // `generationParams.json_schema`, which the addon converts to GBNF and
+  // applies for the duration of the request only. This avoids mutating
+  // the shared `modelConfig` and is therefore safe under concurrent
+  // completions on the same model. `tools` still uses the legacy
+  // `setupToolGrammar` modelConfig path (mutually exclusive with a
+  // non-text `responseFormat` at the schema layer).
+  let mergedGenerationParams: CompletionGenerationParams | undefined =
+    generationParams;
   if (tools && tools.length > 0 && toolsEnabled) {
     setupToolGrammar(modelConfig as Record<string, unknown>, tools);
+  } else if (responseFormat) {
+    const jsonSchema = getResponseFormatJsonSchema(responseFormat);
+    if (jsonSchema !== undefined) {
+      mergedGenerationParams = {
+        ...(generationParams ?? {}),
+        json_schema: jsonSchema,
+      };
+    }
   }
 
   const model = getModel(modelId);
@@ -509,7 +541,7 @@ export async function* completion(
         model,
         messagesToSend,
         tools,
-        generationParams,
+        mergedGenerationParams,
         { cacheKey: cachePathToUse, saveCacheToDisk: true },
       );
       const wasCancelled = snapshotCancelCount(modelId) > cancelCountBefore;
@@ -574,7 +606,11 @@ export async function* completion(
           "auto",
           staticTools ? tools : undefined,
         );
-        markCacheInitialized(modelId, configHash, preResponseCacheInfo.cacheKey);
+        markCacheInitialized(
+          modelId,
+          configHash,
+          preResponseCacheInfo.cacheKey,
+        );
         cacheExists = true;
       }
 
@@ -591,7 +627,7 @@ export async function* completion(
         model,
         messagesToSend,
         tools,
-        generationParams,
+        mergedGenerationParams,
         { cacheKey: cachePathToUse, saveCacheToDisk: true },
       );
       const wasCancelled = snapshotCancelCount(modelId) > cancelCountBefore;
@@ -687,7 +723,7 @@ export async function* completion(
       model,
       transformedHistory,
       tools,
-      generationParams,
+      mergedGenerationParams,
     );
   }
 }

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
@@ -163,7 +163,12 @@ export const llmPlugin = definePlugin({
           modelId: request.modelId,
           kvCache: request.kvCache,
           ...(toolsActive && request.tools && { tools: request.tools }),
-          ...(request.generationParams && { generationParams: request.generationParams }),
+          ...(request.generationParams && {
+            generationParams: request.generationParams,
+          }),
+          ...(request.responseFormat && {
+            responseFormat: request.responseFormat,
+          }),
         });
 
         try {
@@ -196,11 +201,14 @@ export const llmPlugin = definePlugin({
 
           const finalEvents = request.stream ? terminalEvents : batchedEvents;
 
-          yield attachModelExecutionMs({
-            type: "completionStream" as const,
-            done: true,
-            events: finalEvents,
-          }, modelExecutionMs);
+          yield attachModelExecutionMs(
+            {
+              type: "completionStream" as const,
+              done: true,
+              events: finalEvents,
+            },
+            modelExecutionMs,
+          );
         } finally {
           await stream.return?.(undefined as never);
         }
@@ -236,12 +244,15 @@ export const llmPlugin = definePlugin({
           }
 
           const { modelExecutionMs, stats } = result.value;
-          yield attachModelExecutionMs({
-            type: "translate" as const,
-            token: "",
-            done: true,
-            ...(stats && { stats }),
-          }, modelExecutionMs);
+          yield attachModelExecutionMs(
+            {
+              type: "translate" as const,
+              token: "",
+              done: true,
+              ...(stats && { stats }),
+            },
+            modelExecutionMs,
+          );
         } finally {
           await stream.return?.(undefined as never);
         }

--- a/packages/sdk/server/utils/response-format.ts
+++ b/packages/sdk/server/utils/response-format.ts
@@ -1,0 +1,24 @@
+import type { ResponseFormat } from "@/schemas";
+
+// Translates the request-level `responseFormat` into the JSON Schema string
+// that the llama.cpp addon's per-request `generationParams.json_schema`
+// expects. Returns `undefined` for `{ type: "text" }` (no constraint).
+//
+// The addon converts the schema to GBNF natively via
+// `json_schema_to_grammar()` and applies it for the duration of the request
+// only, restoring the prior sampling block afterwards — so this surface is
+// safe to use under concurrent completions on the same model. (Tool calling
+// still goes through `setupToolGrammar` / `modelConfig.grammar`; see the
+// mutual-exclusion check in `completionClientParamsSchema`.)
+export function getResponseFormatJsonSchema(
+  responseFormat: ResponseFormat,
+): string | undefined {
+  switch (responseFormat.type) {
+    case "text":
+      return undefined;
+    case "json_object":
+      return JSON.stringify({ type: "object" });
+    case "json_schema":
+      return JSON.stringify(responseFormat.json_schema.schema);
+  }
+}

--- a/packages/sdk/test/unit/response-format.test.ts
+++ b/packages/sdk/test/unit/response-format.test.ts
@@ -1,0 +1,144 @@
+// @ts-expect-error brittle has no type declarations
+import test from "brittle";
+import {
+  responseFormatSchema,
+  completionClientParamsSchema,
+} from "@/schemas/completion-stream";
+import { getResponseFormatJsonSchema } from "@/server/utils/response-format";
+
+test("responseFormatSchema: accepts text", (t) => {
+  t.is(responseFormatSchema.safeParse({ type: "text" }).success, true);
+});
+
+test("responseFormatSchema: accepts json_object", (t) => {
+  t.is(responseFormatSchema.safeParse({ type: "json_object" }).success, true);
+});
+
+test("responseFormatSchema: accepts json_schema with required fields", (t) => {
+  const result = responseFormatSchema.safeParse({
+    type: "json_schema",
+    json_schema: {
+      name: "Person",
+      schema: {
+        type: "object",
+        properties: { name: { type: "string" }, age: { type: "integer" } },
+        required: ["name"],
+      },
+    },
+  });
+  t.is(result.success, true);
+});
+
+test("responseFormatSchema: rejects unknown type", (t) => {
+  const result = responseFormatSchema.safeParse({ type: "yaml" });
+  t.is(result.success, false);
+});
+
+test("responseFormatSchema: rejects json_schema without name", (t) => {
+  const result = responseFormatSchema.safeParse({
+    type: "json_schema",
+    json_schema: { schema: { type: "object" } },
+  });
+  t.is(result.success, false);
+});
+
+test("responseFormatSchema: rejects json_schema with empty name", (t) => {
+  const result = responseFormatSchema.safeParse({
+    type: "json_schema",
+    json_schema: { name: "", schema: { type: "object" } },
+  });
+  t.is(result.success, false);
+});
+
+test("completionClientParamsSchema: rejects responseFormat together with tools", (t) => {
+  const result = completionClientParamsSchema.safeParse({
+    modelId: "test",
+    history: [{ role: "user", content: "hi" }],
+    stream: false,
+    tools: [
+      {
+        type: "function",
+        name: "echo",
+        description: "Echo input",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ],
+    responseFormat: {
+      type: "json_schema",
+      json_schema: { name: "P", schema: { type: "object" } },
+    },
+  });
+  t.is(result.success, false);
+});
+
+test("completionClientParamsSchema: allows responseFormat without tools", (t) => {
+  const result = completionClientParamsSchema.safeParse({
+    modelId: "test",
+    history: [{ role: "user", content: "hi" }],
+    stream: false,
+    responseFormat: {
+      type: "json_schema",
+      json_schema: { name: "P", schema: { type: "object" } },
+    },
+  });
+  t.is(result.success, true);
+});
+
+test("completionClientParamsSchema: allows tools without responseFormat", (t) => {
+  const result = completionClientParamsSchema.safeParse({
+    modelId: "test",
+    history: [{ role: "user", content: "hi" }],
+    stream: false,
+    tools: [
+      {
+        type: "function",
+        name: "echo",
+        description: "Echo input",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ],
+  });
+  t.is(result.success, true);
+});
+
+test("completionClientParamsSchema: text responseFormat is allowed alongside tools", (t) => {
+  const result = completionClientParamsSchema.safeParse({
+    modelId: "test",
+    history: [{ role: "user", content: "hi" }],
+    stream: false,
+    tools: [
+      {
+        type: "function",
+        name: "echo",
+        description: "Echo input",
+        parameters: { type: "object", properties: {}, required: [] },
+      },
+    ],
+    responseFormat: { type: "text" },
+  });
+  t.is(result.success, true);
+});
+
+test("getResponseFormatJsonSchema: text returns undefined", (t) => {
+  t.is(getResponseFormatJsonSchema({ type: "text" }), undefined);
+});
+
+test("getResponseFormatJsonSchema: json_object returns the permissive object schema", (t) => {
+  const result = getResponseFormatJsonSchema({ type: "json_object" });
+  t.is(typeof result, "string");
+  t.alike(JSON.parse(result as string), { type: "object" });
+});
+
+test("getResponseFormatJsonSchema: json_schema returns the schema verbatim", (t) => {
+  const schema = {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+  };
+  const result = getResponseFormatJsonSchema({
+    type: "json_schema",
+    json_schema: { name: "P", schema },
+  });
+  t.is(typeof result, "string");
+  t.alike(JSON.parse(result as string), schema);
+});


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Downstream consumers (e.g. PremAI) need structured-output completions from QVAC-served LLMs
- The SDK had no OpenAI-compatible `responseFormat` knob to constrain llama.cpp output to JSON or to a specific JSON Schema
- Closes QVAC-17939

## 📝 How does it solve it?

- Adds an optional `responseFormat` field to `completion()` / completion-stream requests, mirroring OpenAI's `response_format` shape: `text` | `json_object` | `json_schema`
- New server-side `getResponseFormatJsonSchema()` translates the request-level `responseFormat` into the JSON Schema string the addon expects on `generationParams.json_schema`; the `completion()` op merges that into the per-request params forwarded to `model.run()`
- The llama.cpp addon converts the schema to GBNF natively (`json_schema_to_grammar()`), applies it for the duration of the request, and restores the prior sampling block afterwards → **safe under concurrent completions on the same model**
- `tools` and a non-`text` `responseFormat` are mutually exclusive — rejected at the Zod schema layer (`completionClientParamsSchema` / `completionStreamRequestSchema`) since `tools` already constrains output through its own grammar path (`setupToolGrammar` / `modelConfig.grammar`)
- Bumps `@qvac/llm-llamacpp` peer from `^0.16.0` → `^0.17.1` for the new `generationParams.json_schema` field

> ⚠️ **Merge order**: depends on `@qvac/llm-llamacpp@0.17.1`, published by addon back-port PR #1788 — **merge #1788 first**, then this PR can merge against `^0.17.1`. The mainline-equivalent addon change for `0.19.0` is tracked in #1787.

## 🧪 How was it tested?

- Unit: `responseFormatSchema` accepts `text` / `json_object` / `json_schema` and rejects malformed shapes
- Unit: `completionClientParamsSchema` rejects non-`text` `responseFormat` together with `tools`
- Unit: `getResponseFormatJsonSchema` returns `undefined` for `text`, the permissive object schema for `json_object`, and the verbatim schema for `json_schema`
- Local: typecheck + lint + full SDK unit-test suite green on `qvac-17939-sdk-structured-output`
- Integration (deferred to CI once #1788 publishes `0.17.1`): `responseFormat: { type: "json_schema", ... }` on a real model produces parseable JSON matching the schema

## 🔌 API Changes

```typescript
import { client } from '@qvac/sdk'

const c = client.create({ /* ... */ })

await c.completion({
  modelId,
  history: [{ role: 'user', content: 'Give me a person object.' }],
  stream: false,
  responseFormat: {
    type: 'json_schema',
    json_schema: {
      name: 'Person',
      schema: {
        type: 'object',
        properties: {
          name: { type: 'string' },
          age:  { type: 'integer' }
        },
        required: ['name', 'age']
      }
    }
  }
})
```

Three accepted shapes (mirroring OpenAI):
- `{ type: 'text' }` — no constraint (default)
- `{ type: 'json_object' }` — output must be a JSON object
- `{ type: 'json_schema', json_schema: { name, schema, description?, strict? } }` — output must validate against `schema`

New exports from `@/schemas/completion-stream`:
- `responseFormatSchema` / `ResponseFormat`
- `completionClientParamsSchema.responseFormat`
- `completionStreamRequestSchema.responseFormat`
All existing fields and behavior are unchanged.

## Notes / follow-ups
- This is the SDK-only slice of #1768, with the CLI portion intentionally left out (to be split into a separate PR).
- Migrating tool calling to the same per-request `generationParams.grammar` surface (now available from the addon) is a natural follow-up but out of scope; the `tools` ↔ non-text `responseFormat` mutual exclusion already prevents the two paths from racing on the same request.
- "Reasoning budget / level of thinking" support (the other ask in the same Slack thread) is intentionally not in this PR; it requires the upcoming fabric rebase that exposes a numeric `--reasoning-budget`.