### PR TITLE
fix: handle Harmony <|call|> EOG token for GPT-OSS tool calling

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.17.2] - 2026-04-30
+
+### Fixed
+
+#### GPT-OSS Harmony tool calling: `<|call|>` frame delimiter now surfaces to the SDK
+
+The `<|call|>` token (Harmony frame terminator) is in the model's EOG set. When sampled, it rendered as 0 bytes and silently stopped generation — tool call output was truncated with no visible frame boundary, resulting in the SDK parsing 0 tool calls.
+
+The generation loop now detects Harmony models and intercepts `<|call|>` before the generic EOG break: it renders the token as visible text (`special=true`) so the SDK can identify frame boundaries, then stops generation cleanly. GPT-OSS uses a turn-based tool protocol — one tool call per generation pass — and the SDK is expected to execute the tool, append results, and re-prompt for subsequent calls.
+
 ## [0.17.1] - 2026-04-28
 
 This patch release adds per-request structured-output support to the LLM addon: callers can now constrain a single completion to either a JSON Schema or a raw GBNF grammar without reloading the model. Back-port of the same change being prepared for `main` in [#1787](https://github.com/tetherto/qvac/pull/1787); shipped here on top of `0.17.0` so it can be consumed by SDK lines that have not yet migrated to `0.18.x`.

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -100,6 +100,22 @@ MtmdLlmContext::MtmdLlmContext(
     antipromptTokens_.insert(
         antipromptTokens_.end(), tempTokens.begin(), tempTokens.end());
   }
+
+  isHarmonyModel_ =
+      qvac_lib_inference_addon_llama::utils::isHarmonyModel(model_);
+  if (isHarmonyModel_) {
+    harmonyCallToken_ =
+        qvac_lib_inference_addon_llama::utils::getHarmonyCallToken(lctx_);
+    if (harmonyCallToken_ == LLAMA_TOKEN_NULL) {
+      isHarmonyModel_ = false;
+    }
+  }
+  QLOG_IF(
+      Priority::DEBUG,
+      string_format(
+          "[MtmdLlm] Harmony detection: isHarmony=%d callToken=%d\n",
+          isHarmonyModel_,
+          harmonyCallToken_));
 }
 
 void MtmdLlmContext::initVisionContext() {
@@ -453,7 +469,26 @@ bool MtmdLlmContext::generateResponse(
       }
     }
 
-    if (llama_vocab_is_eog(vocab_, tokenId) || checkAntiprompt()) {
+    bool isEos = llama_vocab_is_eog(vocab_, tokenId);
+
+    if (isEos && isHarmonyModel_ && params_.use_jinja &&
+        tokenId == harmonyCallToken_) {
+      QLOG_IF(
+          Priority::DEBUG,
+          string_format(
+              "[MtmdLlm] Harmony <|call|> stop: tokenId=%d\n", tokenId));
+      if (outputCallback) {
+        std::string callMarker =
+            common_token_to_piece(lctx_, tokenId, true);
+        if (!callMarker.empty()) {
+          outputCallback(callMarker);
+        }
+      }
+      flushPendingUtf8ToCallback(outputCallback);
+      break;
+    }
+
+    if (isEos || checkAntiprompt()) {
       flushPendingUtf8ToCallback(outputCallback);
       break;
     }

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
@@ -220,5 +220,10 @@ private:
 
   // UTF-8 token buffer for handling incomplete emoji sequences
   qvac_lib_inference_addon_llama::UTF8TokenBuffer utf8Buffer_;
+
+  // GPT-OSS Harmony: <|call|> is a frame delimiter, not a stop signal
+  bool isHarmonyModel_ = false;
+  llama_token harmonyCallToken_ = LLAMA_TOKEN_NULL;
+
   std::atomic<bool> stopGeneration_ = false;
 };

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -53,6 +53,23 @@ TextLlmContext::TextLlmContext(
           lctx_, reasoningState_);
     }
 
+    isHarmonyModel_ =
+        qvac_lib_inference_addon_llama::utils::isHarmonyModel(model_);
+    if (isHarmonyModel_) {
+      harmonyCallToken_ =
+          qvac_lib_inference_addon_llama::utils::getHarmonyCallToken(lctx_);
+      if (harmonyCallToken_ == LLAMA_TOKEN_NULL) {
+        isHarmonyModel_ = false;
+      }
+    }
+    QLOG_IF(
+        Priority::DEBUG,
+        string_format(
+            "[TextLlm] Harmony detection: isHarmony=%d callToken=%d useJinja=%d\n",
+            isHarmonyModel_,
+            harmonyCallToken_,
+            params_.use_jinja));
+
     std::string chatTemplate =
         getChatTemplate(model_, params_, tools_.enabled());
     tmpls_ = common_chat_templates_init(model_, chatTemplate);
@@ -508,6 +525,23 @@ bool TextLlmContext::generateResponse(
               tokenId, tokenStr, *batch, nPast_, outputCallback)) {
         continue;
       }
+    }
+
+    if (isEos && isHarmonyModel_ && params_.use_jinja &&
+        tokenId == harmonyCallToken_) {
+      QLOG_IF(
+          Priority::DEBUG,
+          string_format(
+              "[TextLlm] Harmony <|call|> stop: tokenId=%d\n", tokenId));
+      if (outputCallback) {
+        std::string callMarker =
+            common_token_to_piece(lctx_, tokenId, true);
+        if (!callMarker.empty()) {
+          outputCallback(callMarker);
+        }
+      }
+      flushPendingUtf8ToCallback(outputCallback);
+      break;
     }
 
     if (isEos || checkAntiprompt()) {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
@@ -198,5 +198,9 @@ private:
   // Cache whether this is a Qwen3 model (checked once at load time)
   bool isQwen3Model_ = false;
 
+  // GPT-OSS Harmony: <|call|> is a frame delimiter, not a stop signal
+  bool isHarmonyModel_ = false;
+  llama_token harmonyCallToken_ = LLAMA_TOKEN_NULL;
+
   std::atomic<bool> stopGeneration_ = false;
 };

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/ChatTemplateUtils.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/ChatTemplateUtils.cpp
@@ -31,6 +31,11 @@ bool isQwen3Architecture(const std::string& architecture) {
   return archStr == "qwen3";
 }
 
+bool isHarmonyArchitecture(const std::string& architecture) {
+  const std::string archStr = normalizeArchitecture(architecture);
+  return archStr == "gpt-oss";
+}
+
 bool modelNameLooksLikeQwen3(const std::string& modelName) {
   std::string normalizedName = modelName;
   std::transform(
@@ -83,6 +88,23 @@ bool isQwen3Model(const ::llama_model* model) {
 
   return supportsToolsCompactForModelMetadata(
       getModelArchitecture(model), getModelName(model));
+}
+
+bool isHarmonyModel(const ::llama_model* model) {
+  if (model == nullptr) {
+    return false;
+  }
+  std::optional<std::string> arch = getModelArchitecture(model);
+  return arch.has_value() && isHarmonyArchitecture(arch.value());
+}
+
+llama_token getHarmonyCallToken(::llama_context* lctx) {
+  std::vector<llama_token> tokens =
+      common_tokenize(lctx, "<|call|>", false, true);
+  if (tokens.size() == 1) {
+    return tokens[0];
+  }
+  return LLAMA_TOKEN_NULL;
 }
 
 bool supportsToolsCompactForModelMetadata(

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/ChatTemplateUtils.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/ChatTemplateUtils.hpp
@@ -14,6 +14,8 @@ namespace qvac_lib_inference_addon_llama {
 namespace utils {
 
 bool isQwen3Model(const ::llama_model* model);
+bool isHarmonyModel(const ::llama_model* model);
+llama_token getHarmonyCallToken(::llama_context* lctx);
 std::optional<std::string> getModelArchitecture(const ::llama_model* model);
 bool supportsToolsCompactForModelMetadata(
     const std::optional<std::string>& architecture,

--- a/packages/qvac-lib-infer-llamacpp-llm/examples/harmonyMultiTurnTools.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/examples/harmonyMultiTurnTools.js
@@ -1,0 +1,223 @@
+'use strict'
+
+const LlmLlamacpp = require('../index')
+const path = require('bare-path')
+const process = require('bare-process')
+const { downloadModel } = require('./utils')
+
+const MAX_TOOL_TURNS = 5
+
+function parseHarmonyToolCall (rawText) {
+  const match = rawText.match(
+    /commentary to=functions\.(\w+)\s+<\|constrain\|>json<\|message\|>(\{[^}]*\})<\|call\|>/
+  )
+  if (!match) return null
+  try {
+    return { name: match[1], arguments: JSON.parse(match[2]) }
+  } catch {
+    return null
+  }
+}
+
+function simulateToolExecution (name, args) {
+  if (name === 'get_weather') {
+    return JSON.stringify({
+      city: args.city,
+      country: args.country || 'unknown',
+      temperature: '22°C',
+      condition: 'Partly cloudy',
+      wind: '12 km/h from the east',
+      humidity: '65%'
+    })
+  }
+  if (name === 'get_horoscope') {
+    return JSON.stringify({
+      sign: args.sign,
+      horoscope: 'Today is a great day for new beginnings. Your curiosity leads to fresh insights.'
+    })
+  }
+  return JSON.stringify({ error: `Unknown tool: ${name}` })
+}
+
+async function main () {
+  console.log('Harmony Multi-Turn Tool Calling Example')
+  console.log('========================================')
+  console.log('GPT-OSS emits one tool call per turn, ending with <|call|>.')
+  console.log('This example demonstrates the full multi-turn loop.\n')
+
+  // 1. Downloading model
+  const [modelName, dirPath] = await downloadModel(
+    'https://huggingface.co/unsloth/gpt-oss-20b-GGUF/resolve/main/gpt-oss-20b-Q4_K_M.gguf',
+    'gpt-oss-20b-Q4_K_M.gguf'
+  )
+
+  // 2. Configuring model settings
+  const modelPath = path.join(dirPath, modelName)
+
+  const config = {
+    device: 'cpu',
+    gpu_layers: '0',
+    ctx_size: '4096',
+    tools: 'true'
+  }
+
+  // 3. Loading model
+  const model = new LlmLlamacpp({
+    files: { model: [modelPath] },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
+  await model.load()
+
+  const toolDefs = [
+    {
+      type: 'function',
+      name: 'get_weather',
+      description: 'Get current weather for a city',
+      parameters: {
+        type: 'object',
+        properties: {
+          city: { type: 'string', description: 'City name' },
+          country: { type: 'string', description: 'Country code' }
+        },
+        required: ['city']
+      }
+    },
+    {
+      type: 'function',
+      name: 'get_horoscope',
+      description: "Get today's horoscope for an astrological sign",
+      parameters: {
+        type: 'object',
+        properties: {
+          sign: { type: 'string', description: 'An astrological sign like Taurus or Aquarius' }
+        },
+        required: ['sign']
+      }
+    }
+  ]
+
+  const history = [
+    { role: 'system', content: 'You are a helpful assistant that can use tools to get the weather and horoscope.' },
+    ...toolDefs,
+    { role: 'user', content: "What's the weather in Tokyo and my horoscope for Aquarius?" }
+  ]
+
+  try {
+    // 4. Running multi-turn tool calling loop
+    let turn = 0
+    while (turn < MAX_TOOL_TURNS) {
+      turn++
+      console.log(`\n--- Turn ${turn} ---`)
+
+      const response = await model.run(history)
+      let fullResponse = ''
+
+      await response
+        .onUpdate(data => { fullResponse += data })
+        .await()
+
+      console.log(`[output length] ${fullResponse.length}`)
+      console.log(`[tail]          ...${fullResponse.slice(-120)}`)
+
+      const hasCall = fullResponse.includes('<|call|>')
+      console.log(`[has <|call|>]  ${hasCall}`)
+
+      if (!hasCall) {
+        console.log('\n[DONE] Model produced final response.\n')
+        const finalMatch = fullResponse.match(/<\|channel\|>final<\|message\|>([\s\S]*?)$/)
+        if (finalMatch) {
+          console.log('=== FINAL RESPONSE ===')
+          console.log(finalMatch[1])
+          console.log('=== END ===')
+        } else {
+          console.log('=== RAW OUTPUT (last 500) ===')
+          console.log(fullResponse.slice(-500))
+          console.log('=== END ===')
+        }
+        break
+      }
+
+      const toolCall = parseHarmonyToolCall(fullResponse)
+      if (!toolCall) {
+        console.log('[ERROR] <|call|> present but could not parse tool call.')
+        console.log(fullResponse)
+        break
+      }
+
+      console.log(`[tool call]    ${toolCall.name}(${JSON.stringify(toolCall.arguments)})`)
+
+      const toolResult = simulateToolExecution(toolCall.name, toolCall.arguments)
+      console.log(`[tool result]  ${toolResult}`)
+
+      history.push({ role: 'assistant', content: fullResponse })
+      history.push({ role: 'tool', content: toolResult })
+    }
+
+    if (turn >= MAX_TOOL_TURNS) {
+      console.log(`\n[WARN] Reached max turns (${MAX_TOOL_TURNS}) without final response.`)
+    }
+
+    console.log(`\n--- Conversation (${history.length} messages) ---`)
+    for (const msg of history) {
+      const preview = msg.content
+        ? msg.content.slice(0, 80).replace(/\n/g, '\\n')
+        : `[${msg.type}: ${msg.name}]`
+      console.log(`  [${msg.role || msg.type}] ${preview}`)
+    }
+
+    // 5. Parallel tool calling test
+    console.log('\n\n========================================')
+    console.log('PARALLEL TOOL CALL TEST')
+    console.log('========================================')
+    console.log('Testing if model can emit multiple tool calls in a single generation...\n')
+
+    const parallelHistory = [
+      { role: 'system', content: 'You are a helpful assistant. Call ALL required tools in a single response.' },
+      ...toolDefs,
+      { role: 'user', content: 'I need both: weather in Tokyo AND horoscope for Aquarius. Call both tools now.' }
+    ]
+
+    const parallelResponse = await model.run(parallelHistory)
+    let parallelOutput = ''
+
+    await parallelResponse
+      .onUpdate(data => { parallelOutput += data })
+      .await()
+
+    const callCount = (parallelOutput.match(/<\|call\|>/g) || []).length
+    const toolFrames = parallelOutput.match(/commentary to=functions\.\w+/g) || []
+
+    console.log(`[output length]     ${parallelOutput.length}`)
+    console.log(`[<|call|> count]    ${callCount}`)
+    console.log(`[tool frames found] ${toolFrames.length} (${toolFrames.join(', ')})`)
+    console.log(`[raw tail]          ...${parallelOutput.slice(-150)}`)
+
+    if (callCount > 1) {
+      console.log('\n[RESULT] PARALLEL SUPPORTED — model emitted multiple tool calls in one pass.')
+    } else if (callCount === 1) {
+      console.log('\n[RESULT] PARALLEL NOT SUPPORTED — model emits exactly one tool call per generation.')
+      console.log('         GPT-OSS uses sequential multi-turn tool calling (one <|call|> per turn).')
+    } else {
+      console.log('\n[RESULT] UNEXPECTED — no <|call|> found in output.')
+      console.log(`[raw output]\n${parallelOutput}`)
+    }
+  } catch (error) {
+    const errorMessage = error?.message || error?.toString() || String(error)
+    console.error('Error occurred:', errorMessage)
+    console.error('Error details:', error)
+  } finally {
+    // 6. Cleaning up resources
+    await model.unload()
+  }
+}
+
+main().catch(error => {
+  console.error('Fatal error in main function:', {
+    error: error.message,
+    stack: error.stack,
+    timestamp: new Date().toISOString()
+  })
+  process.exit(1)
+})

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## Summary
GPT-OSS 20B tool calling was broken — the model emits a Harmony tool call frame but generation stops silently before `<|call|>` reaches the SDK, resulting in 0 parsed tool calls and no visible frame delimiter.


## Root cause
`<|call|>` (token 200012) is in the model's EOG set. When sampled, it renders as 0 bytes (control token with `special=false`) and immediately triggers the generation loop break. The model produces the tool call JSON but the output is truncated with no frame boundary visible to the SDK.

## Fix
- Detect Harmony/GPT-OSS architecture at initialization and resolve the `<|call|>` token ID
- In the generation loop, intercept `<|call|>` before the generic EOG break when `isHarmonyModel_` and `params_.use_jinja` are true
- Render `<|call|>` as visible text using `common_token_to_piece(lctx_, tokenId, true)` so the SDK can parse frame boundaries
- Stop generation cleanly — Harmony is turn-based, one tool call per pass, SDK handles tool execution and re-prompts
- Applied to both `TextLlmContext.cpp` and `MtmdLlmContext.cpp`
- Added multi-turn example (`harmonyMultiTurnTools.js`) demonstrating sequential tool execution across turns
- Confirmed parallel tool calling is not supported — model emits exactly one <|call|> per generation regardless of prompt