### PR TITLE
QVAC-18184 chore: release sdk 0.9.2 (zod hotfix)

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [0.9.2]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.9.2
+
+Hotfix patch release. Single-fix patch — no API, behavioral, or model changes.
+
+---
+
+## 🐞 Fixes
+
+### Fix `TypeError: z.xor is not a function` for consumers on zod < 4.3
+
+The SDK's finetune schemas used `z.xor([z.number(), z.nan()])` in 8 places, an API only available in zod ≥ 4.3.0. The package declared `"zod": "^4.0.17"`, so consumer projects whose tree resolved zod to a 4.0.x / 4.1.x / 4.2.x version crashed at runtime when finetune schemas loaded.
+
+Two coordinated changes:
+
+- Replaced `z.xor([z.number(), z.nan()])` with `z.union([z.number(), z.nan()])` in `packages/sdk/schemas/finetune.ts`. In zod v4, `z.number()` rejects `NaN` by default, so `z.number()` and `z.nan()` are disjoint — `z.xor` and `z.union` are semantically identical here.
+- Bumped the declared `zod` floor from `^4.0.17` to `^4.3.0` to align the declared range with the version of zod the SDK is actually built and tested against.
+
+Consumers who hit `_zod.z.xor is not a function` on `0.9.1` will be unblocked at runtime after upgrading to `0.9.2`.
+
+See PR [#1790](https://github.com/tetherto/qvac/pull/1790) for full details and reasoning.
+
 ## [0.9.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.9.1

--- a/packages/sdk/changelog/0.9.2/CHANGELOG.md
+++ b/packages/sdk/changelog/0.9.2/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.9.2
+
+Release Date: 2026-04-30
+
+## 🐞 Fixes
+
+- Replace `z.xor` with `z.union` in finetune schemas and bump `zod` floor to `^4.3.0` to fix `TypeError: _zod.z.xor is not a function` for consumers whose tree resolved `zod` to a pre-4.3 version. (see PR [#1790](https://github.com/tetherto/qvac/pull/1790))

--- a/packages/sdk/changelog/0.9.2/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.9.2/CHANGELOG_LLM.md
@@ -1,0 +1,22 @@
+# QVAC SDK v0.9.2 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.9.2
+
+Hotfix patch release. Single-fix patch — no API, behavioral, or model changes.
+
+---
+
+## 🐞 Fixes
+
+### Fix `TypeError: z.xor is not a function` for consumers on zod < 4.3
+
+The SDK's finetune schemas used `z.xor([z.number(), z.nan()])` in 8 places, an API only available in zod ≥ 4.3.0. The package declared `"zod": "^4.0.17"`, so consumer projects whose tree resolved zod to a 4.0.x / 4.1.x / 4.2.x version crashed at runtime when finetune schemas loaded.
+
+Two coordinated changes:
+
+- Replaced `z.xor([z.number(), z.nan()])` with `z.union([z.number(), z.nan()])` in `packages/sdk/schemas/finetune.ts`. In zod v4, `z.number()` rejects `NaN` by default, so `z.number()` and `z.nan()` are disjoint — `z.xor` and `z.union` are semantically identical here.
+- Bumped the declared `zod` floor from `^4.0.17` to `^4.3.0` to align the declared range with the version of zod the SDK is actually built and tested against.
+
+Consumers who hit `_zod.z.xor is not a function` on `0.9.1` will be unblocked at runtime after upgrading to `0.9.2`.
+
+See PR [#1790](https://github.com/tetherto/qvac/pull/1790) for full details and reasoning.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -189,7 +189,7 @@
     "@qvac/tts-onnx": "^0.8.2",
     "fast-safe-stringify": "2.1.1",
     "which-runtime": "^1.3.2",
-    "zod": "^4.0.17"
+    "zod": "^4.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/packages/sdk/schemas/finetune.ts
+++ b/packages/sdk/schemas/finetune.ts
@@ -136,10 +136,10 @@ export const finetuneStatusSchema = z.enum(finetuneStatusValues);
 export const finetuneProgressSchema = z
   .object({
     is_train: z.boolean(),
-    loss: z.xor([z.number(), z.nan()]).nullable(),
-    loss_uncertainty: z.xor([z.number(), z.nan()]).nullable(),
-    accuracy: z.xor([z.number(), z.nan()]).nullable(),
-    accuracy_uncertainty: z.xor([z.number(), z.nan()]).nullable(),
+    loss: z.union([z.number(), z.nan()]).nullable(),
+    loss_uncertainty: z.union([z.number(), z.nan()]).nullable(),
+    accuracy: z.union([z.number(), z.nan()]).nullable(),
+    accuracy_uncertainty: z.union([z.number(), z.nan()]).nullable(),
     global_steps: z.number().int().min(0),
     current_epoch: z.number().int().min(0),
     current_batch: z.number().int().min(0),
@@ -152,13 +152,13 @@ export const finetuneProgressSchema = z
 export const finetuneStatsSchema = z
   .object({
     train_loss: z.number().optional(),
-    train_loss_uncertainty: z.xor([z.number(), z.nan()]).nullable().optional(),
+    train_loss_uncertainty: z.union([z.number(), z.nan()]).nullable().optional(),
     val_loss: z.number().optional(),
-    val_loss_uncertainty: z.xor([z.number(), z.nan()]).nullable().optional(),
+    val_loss_uncertainty: z.union([z.number(), z.nan()]).nullable().optional(),
     train_accuracy: z.number().optional(),
-    train_accuracy_uncertainty: z.xor([z.number(), z.nan()]).nullable().optional(),
+    train_accuracy_uncertainty: z.union([z.number(), z.nan()]).nullable().optional(),
     val_accuracy: z.number().optional(),
-    val_accuracy_uncertainty: z.xor([z.number(), z.nan()]).nullable().optional(),
+    val_accuracy_uncertainty: z.union([z.number(), z.nan()]).nullable().optional(),
     learning_rate: z.number().optional(),
     global_steps: z.number().int().min(0),
     epochs_completed: z.number().int().min(0),


### PR DESCRIPTION
## Summary

Hotfix patch release. Cherry-picks PR #1790 (`replace z.xor with z.union, bump zod floor to ^4.3.0`) onto the `release-sdk-0.9.1` base, plus the standard release commit (version bump + changelog).

This is **not** a release of all SDK PRs that have landed on `main` since `0.9.1` — those will go out as `0.10.0` later. `0.9.2` is intentionally scoped to the single bug fix that consumers are hitting in the wild (`TypeError: _zod.z.xor is not a function`).

**Asana**: [QVAC-18184 — SDK Release 0.9.2](https://app.asana.com/1/45238840754660/project/1212638335655966/task/1214418547641702)

## Commits

1. `fix[notask]: replace z.xor with z.union, bump zod floor to ^4.3.0 (#1790)` — cherry-picked from `main` (squash-merge of [PR #1790](https://github.com/tetherto/qvac/pull/1790)).
2. `chore[notask]: release sdk 0.9.2` — version bump + changelog files.

## Files changed

- `packages/sdk/schemas/finetune.ts` — 8 `z.xor` → `z.union` (from cherry-pick).
- `packages/sdk/package.json` — `version` `0.9.1` → `0.9.2`, `zod` `^4.0.17` → `^4.3.0`.
- `packages/sdk/CHANGELOG.md` — prepend 0.9.2 section.
- `packages/sdk/changelog/0.9.2/CHANGELOG.md` (new).
- `packages/sdk/changelog/0.9.2/CHANGELOG_LLM.md` (new).

## Background

`@qvac/sdk@0.9.1` declared `"zod": "^4.0.17"` but the finetune schemas used `z.xor`, which is only available in `zod >= 4.3.0`. Consumers whose tree resolved `zod` to a 4.0.x / 4.1.x / 4.2.x version (via hard pin, transitive constraint, or stale lockfile) hit a runtime `TypeError: _zod.z.xor is not a function` when finetune schemas loaded.

PR #1790 fixes the bug at two levels:
- **Source**: replaces `z.xor` with `z.union` (semantically identical here since `z.number()` and `z.nan()` are disjoint in zod v4) — fixes the runtime crash for any consumer.
- **Range**: bumps the declared `zod` floor to `^4.3.0` to align declared metadata with what the SDK is actually built and tested against, and to convert any pinned-old-zod consumer's failure mode from a cryptic runtime crash to a clear install-time conflict.

See [PR #1790](https://github.com/tetherto/qvac/pull/1790) for the full reasoning, including the consumer-impact analysis.

## NOTICE

This hotfix is a version-range bump on an existing dependency (`zod`, same author, same license — no new or removed deps), so the package's `NOTICE` file is unchanged. If reviewers prefer it regenerated as belt-and-suspenders, happy to do so in a follow-up.

## Release flow

- This PR (fork → `release-sdk-0.9.2` on `tetherto/qvac`) — merge triggers GPR publish for `@tetherto/sdk`.
- Follow-up PR (`release-sdk-0.9.2` → `main`) — merge triggers npm publish for `@qvac/sdk`.

## Test plan

- [ ] CI green on this PR.
- [ ] After GPR publish, install `@tetherto/sdk@0.9.2` in a tree pinned to `zod@4.0.17` and verify install-time conflict (clean error) — not a runtime `z.xor` crash.
- [ ] After npm publish, install `@qvac/sdk@0.9.2` in a tree without zod pin and verify finetune schemas load without `z.xor` errors.