### PR TITLE
fix(llm): honour saveCacheToDisk on prefill-only runs

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [0.17.3] - 2026-04-30
+
+### Fixed
+
+#### `saveCacheToDisk` is now honoured on prefill-only runs
+
+When `processPromptImpl` ran with `prompt.prefill === true`, it returned early and skipped the post-inference branch that persists the KV cache. As a result, a prefill warm-up call with `saveCacheToDisk: true` and a valid `cacheKey` would build the cache in memory but never write it to disk, defeating the purpose of priming the cache for a follow-up turn.
+
+The save logic has been extracted into a new static helper `maybeSaveCacheToDisk(...)` that preserves the original guard (`saveCacheToDisk && cacheManager has value && hasActiveCache()`). Both the `prompt.prefill` early-return branch and the post-generation path now go through this helper, so prefill and full inference persist the cache identically.
+
+A subsequent normal turn that reuses the same `cacheKey` will now correctly load the prefilled tokens from disk and only tokenize/process the incremental delta.
+
+#### `main_gpu` underscore variant is now accepted
+
+The `main_gpu` configuration key was silently ignored - only `main-gpu` (hyphen) was recognised by `tryMainGpuFromMap`, even though every other config parameter accepts both hyphen and underscore forms. This inconsistency could cause GPU selection to quietly not apply, leaving inference on an unintended device.
+
+`main_gpu` is now treated as an alias for `main-gpu` in `BackendSelection`, matching the behaviour of `split-mode`/`split_mode` and `tensor-split`/`tensor_split`. Providing both forms simultaneously still throws an error, as with the other dual-form parameters.
+
+### Documentation
+
+#### New multi-GPU inference guide
+
+A new document at `docs/multi-gpu.md` explains how to distribute a model across multiple GPUs using the four interacting parameters: `device`, `split-mode`, `tensor-split`, and `main-gpu`. It covers:
+
+- The three `split-mode` values (`'none'`, `'layer'`, `'row'`) and what pipeline vs tensor parallelism means in practice.
+- Backend-specific behaviour for tensor parallelism - only CUDA and SYCL implement true split-buffer tensor parallelism; Vulkan and Metal fall back to layer parallelism even when `'row'` is requested.
+- How `tensor-split` proportions are normalised and applied per GPU.
+- How `main-gpu` behaves differently between integrated and dedicated GPUs and across split modes.
+- Worked examples for common hardware configurations.
+
 ## [0.17.2] - 2026-04-30
 
 ### Fixed

--- a/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/CHANGELOG.md
@@ -12,24 +12,6 @@ The save logic has been extracted into a new static helper `maybeSaveCacheToDisk
 
 A subsequent normal turn that reuses the same `cacheKey` will now correctly load the prefilled tokens from disk and only tokenize/process the incremental delta.
 
-#### `main_gpu` underscore variant is now accepted
-
-The `main_gpu` configuration key was silently ignored - only `main-gpu` (hyphen) was recognised by `tryMainGpuFromMap`, even though every other config parameter accepts both hyphen and underscore forms. This inconsistency could cause GPU selection to quietly not apply, leaving inference on an unintended device.
-
-`main_gpu` is now treated as an alias for `main-gpu` in `BackendSelection`, matching the behaviour of `split-mode`/`split_mode` and `tensor-split`/`tensor_split`. Providing both forms simultaneously still throws an error, as with the other dual-form parameters.
-
-### Documentation
-
-#### New multi-GPU inference guide
-
-A new document at `docs/multi-gpu.md` explains how to distribute a model across multiple GPUs using the four interacting parameters: `device`, `split-mode`, `tensor-split`, and `main-gpu`. It covers:
-
-- The three `split-mode` values (`'none'`, `'layer'`, `'row'`) and what pipeline vs tensor parallelism means in practice.
-- Backend-specific behaviour for tensor parallelism - only CUDA and SYCL implement true split-buffer tensor parallelism; Vulkan and Metal fall back to layer parallelism even when `'row'` is requested.
-- How `tensor-split` proportions are normalised and applied per GPU.
-- How `main-gpu` behaves differently between integrated and dedicated GPUs and across split modes.
-- Worked examples for common hardware configurations.
-
 ## [0.17.2] - 2026-04-30
 
 ### Fixed

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -571,6 +571,7 @@ std::string LlamaModel::processPromptImpl(const Prompt& prompt) {
   }
 
   if (prompt.prefill) {
+    maybeSaveCacheToDisk(prompt);
     return out;
   }
 
@@ -617,15 +618,19 @@ std::string LlamaModel::processPromptImpl(const Prompt& prompt) {
       state_->llmContext_->setFirstMsgTokens(state_->llmContext_->getNPast());
     }
   }
-  if (prompt.saveCacheToDisk && state_->cacheManager_.has_value() &&
-      state_->cacheManager_->hasActiveCache()) {
-    state_->cacheManager_->saveCache();
-  }
+  maybeSaveCacheToDisk(prompt);
 
   if (resolved.shouldResetAfterInference) {
     resetState(false);
   }
   return out;
+}
+
+void LlamaModel::maybeSaveCacheToDisk(const Prompt& prompt) {
+  if (prompt.saveCacheToDisk && state_->cacheManager_.has_value() &&
+      state_->cacheManager_->hasActiveCache()) {
+    state_->cacheManager_->saveCache();
+  }
 }
 
 qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -46,6 +46,17 @@ using namespace qvac_lib_inference_addon_llama::errors;
 using namespace qvac_lib_inference_addon_cpp::logger;
 using namespace qvac_lib_inference_addon_llama::logging;
 
+/// @brief Persist the active KV cache to disk when the caller opted in via
+/// `saveCacheToDisk`. Shared by the prefill and post-generation paths so
+/// both honour the option identically. No-op when no cache is active.
+static void maybeSaveCacheToDisk(
+    bool saveCacheToDisk, std::optional<CacheManager>& cacheManager) {
+  if (saveCacheToDisk && cacheManager.has_value() &&
+      cacheManager->hasActiveCache()) {
+    cacheManager->saveCache();
+  }
+}
+
 static std::vector<std::string> split(const std::string& str, char delimiter) {
   auto trim = [](const std::string& str) -> std::string {
     auto start =
@@ -571,7 +582,7 @@ std::string LlamaModel::processPromptImpl(const Prompt& prompt) {
   }
 
   if (prompt.prefill) {
-    maybeSaveCacheToDisk(prompt);
+    maybeSaveCacheToDisk(prompt.saveCacheToDisk, state_->cacheManager_);
     return out;
   }
 
@@ -618,19 +629,12 @@ std::string LlamaModel::processPromptImpl(const Prompt& prompt) {
       state_->llmContext_->setFirstMsgTokens(state_->llmContext_->getNPast());
     }
   }
-  maybeSaveCacheToDisk(prompt);
+  maybeSaveCacheToDisk(prompt.saveCacheToDisk, state_->cacheManager_);
 
   if (resolved.shouldResetAfterInference) {
     resetState(false);
   }
   return out;
-}
-
-void LlamaModel::maybeSaveCacheToDisk(const Prompt& prompt) {
-  if (prompt.saveCacheToDisk && state_->cacheManager_.has_value() &&
-      state_->cacheManager_->hasActiveCache()) {
-    state_->cacheManager_->saveCache();
-  }
 }
 
 qvac_lib_inference_addon_cpp::RuntimeStats LlamaModel::runtimeStats() const {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -205,6 +205,11 @@ private:
   std::string processPromptImpl(const Prompt& prompt);
   void cancelImpl() const;
 
+  /// @brief Persist the active KV cache to disk when the prompt opted in via
+  /// `saveCacheToDisk`. Shared by the prefill and post-generation paths so
+  /// both honour the option identically. No-op when no cache is active.
+  void maybeSaveCacheToDisk(const Prompt& prompt);
+
   struct ReloadableState {
     ReloadableState(
         const ConstructionArgs& args, const std::string& loadingContext,

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -205,11 +205,6 @@ private:
   std::string processPromptImpl(const Prompt& prompt);
   void cancelImpl() const;
 
-  /// @brief Persist the active KV cache to disk when the prompt opted in via
-  /// `saveCacheToDisk`. Shared by the prefill and post-generation paths so
-  /// both honour the option identically. No-op when no cache is active.
-  void maybeSaveCacheToDisk(const Prompt& prompt);
-
   struct ReloadableState {
     ReloadableState(
         const ConstructionArgs& args, const std::string& loadingContext,

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/cache-state-machine.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/cache-state-machine.test.js
@@ -474,3 +474,50 @@ test('Options: saveCacheToDisk true with no cacheKey is a no-op', { timeout: 600
   const stats = await runAndCollectStats(model, [...BASE_PROMPT], { saveCacheToDisk: true })
   t.is(stats.CacheTokens, 0, 'no cacheKey means no cache even with saveCacheToDisk: true')
 })
+
+test('Options: prefill with saveCacheToDisk persists cache file', { timeout: 600_000 }, async t => {
+  const { model, dirPath } = await setupModel(t, { n_predict: '256', ctx_size: '4096' })
+  const sessionName = path.join(dirPath, 'opts-prefill-save.bin')
+
+  const stats = await runAndCollectStats(model, [SYSTEM_MESSAGE], {
+    cacheKey: sessionName,
+    saveCacheToDisk: true,
+    prefill: true
+  })
+
+  t.is(stats.generatedTokens, 0, 'prefill reports zero generated tokens')
+  t.ok(stats.CacheTokens > 0, 'prefill ingests prompt into cache')
+  t.ok(fs.existsSync(sessionName), 'prefill + saveCacheToDisk writes cache file to disk')
+  t.ok(fs.statSync(sessionName).size > 0, 'persisted prefill cache file is non-empty')
+})
+
+test('Options: prefilled cache primes a follow-up conversation', { timeout: 600_000 }, async t => {
+  const { model, dirPath } = await setupModel(t, { n_predict: '256', ctx_size: '4096' })
+  const sessionName = path.join(dirPath, 'opts-prefill-followup.bin')
+
+  // Prime the cache once with the system prompt — the typical "warm-up"
+  // performed once per session before any user turns.
+  const primeStats = await runAndCollectStats(model, [SYSTEM_MESSAGE], {
+    cacheKey: sessionName,
+    saveCacheToDisk: true,
+    prefill: true
+  })
+
+  // Real-world turn: send the full conversation, system prompt included.
+  // The addon should prefix-match against the primed cache and only evaluate
+  // the new user message.
+  const turnStats = await runAndCollectStats(model, [...BASE_PROMPT], {
+    cacheKey: sessionName,
+    saveCacheToDisk: true
+  })
+
+  const delta = toNumber(turnStats.CacheTokens) - toNumber(primeStats.CacheTokens)
+  const expectedDelta = turnStats.promptTokens + turnStats.generatedTokens
+
+  t.ok(primeStats.CacheTokens > 0, 'prime stored prefilled tokens in cache')
+  t.ok(turnStats.generatedTokens > 0, 'follow-up turn generated output')
+  t.ok(
+    Math.abs(delta - expectedDelta) <= 1,
+    `cache grew by exactly the new tokens (delta=${delta}, expected=${expectedDelta}); system prompt was reused from cache`
+  )
+})

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/tools-compact.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/tools-compact.test.js
@@ -2,6 +2,7 @@
 
 const test = require('brittle')
 const path = require('bare-path')
+const fs = require('bare-fs')
 const LlmLlamacpp = require('../../index.js')
 const { ensureModel } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
@@ -501,5 +502,63 @@ test('[tools-compact] cache-aware empty-tools contract', { timeout: 600_000 }, a
     ],
     { ...opts, prefill: true },
     invalidReason
+  )
+})
+
+test('[tools-compact] prefill with tools persists cache and loads on fresh model', { timeout: 600_000 }, async t => {
+  if (cachedToolsSupport === false) {
+    t.comment('Skipping tools_compact behavior assertions: model/template runtime does not support tools in this environment')
+    t.pass('tools unsupported in runtime; assertions skipped')
+    return
+  }
+  const { model: probeModel, logs } = await setupModel(t)
+  if (!await ensureToolsSupportOrSkip(t, probeModel, logs)) return
+
+  const { model: warmModel, dirPath } = await setupModel(t)
+  const sessionName = path.join(dirPath, 'tools-compact-prefill-save.bin')
+
+  // Prefill the warmed [system, user, TOOL_A] prefix with persistence.
+  // tools_compact intentionally skips its post-generation trim on prefill,
+  // so the persisted cache must include the tool block.
+  const primeRun = await runAndCollect(
+    warmModel,
+    [
+      SYSTEM_MESSAGE,
+      { role: 'user', content: 'Start session with available tools.' },
+      TOOL_A
+    ],
+    { cacheKey: sessionName, saveCacheToDisk: true, prefill: true }
+  )
+
+  t.is(primeRun.stats.generatedTokens, 0, 'prefill emits no tokens')
+  t.ok(
+    primeRun.stats.CacheTokens > TOOL_A_TOKENS,
+    `prefill keeps the tool block in cache (CacheTokens=${primeRun.stats.CacheTokens} > TOOL_A_TOKENS=${TOOL_A_TOKENS})`
+  )
+  t.ok(fs.existsSync(sessionName), 'prefill + saveCacheToDisk wrote cache file to disk')
+  t.ok(fs.statSync(sessionName).size > 0, 'persisted prefill cache file is non-empty')
+
+  // Tear down the warm model so the only path to a non-zero CacheTokens on
+  // the follow-up turn is loading the persisted cache file from disk.
+  await warmModel.unload()
+
+  const { model: freshModel } = await setupModel(t)
+  const turn = await runAndCollect(
+    freshModel,
+    [
+      { role: 'user', content: 'What is the weather in Tokyo?' },
+      TOOL_A
+    ],
+    { cacheKey: sessionName, saveCacheToDisk: true }
+  )
+
+  t.ok(turn.output.length > 0, 'follow-up turn produces output from prefilled state')
+  t.ok(
+    turn.stats.CacheTokens > 0,
+    `follow-up loads prefilled cache from disk (CacheTokens=${turn.stats.CacheTokens} > 0)`
+  )
+  t.ok(
+    turn.stats.CacheTokens > primeRun.stats.CacheTokens,
+    `follow-up CacheTokens (${turn.stats.CacheTokens}) grew past prefilled prefix (${primeRun.stats.CacheTokens})`
   )
 })


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `processPromptImpl` returned early on `prompt.prefill == true` and skipped the post-inference block that persists the KV cache, so a `prefill` run with `saveCacheToDisk: true` and a valid `cacheKey` would warm up the cache in memory but never write it to disk.

## 📝 How does it solve it?

- Extracted the save logic from `processPromptImpl` into a new static helper `maybeSaveCacheToDisk(...)`, which keeps the same guard (`saveCacheToDisk && cacheManager has value && hasActiveCache()`) so behavior is identical for non-prefill paths.
- Called `maybeSaveCacheToDisk(prompt)` both in the `prompt.prefill` early-return branch and in the post-generation path, so prefill and full inference now persist the cache identically.

## 🧪 How was it tested?

- Added two integration tests in `test/integration/cache-state-machine.test.js`:
  - `Options: prefill with saveCacheToDisk persists cache file` - runs a `prefill: true` turn with `cacheKey` + `saveCacheToDisk: true`, asserts `generatedTokens === 0`, `CacheTokens > 0`, and that the cache file exists on disk and is non-empty.
  - `Options: prefilled cache primes a follow-up conversation` - primes the cache with the system prompt via prefill, then runs a normal turn and verifies the cache grew by exactly `promptTokens + generatedTokens`, proving the prefilled portion was reused from disk.