### PR TITLE
chore[ci]: register benchmark-rtf-tts workflow_dispatch entry point

### DIFF
--- a/.github/workflows/benchmark-rtf-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/benchmark-rtf-qvac-lib-infer-onnx-tts.yml
@@ -1,0 +1,32 @@
+name: Benchmark RTF (ONNX TTS)
+
+# Stub workflow registered on `main` so that `workflow_dispatch` shows up in
+# the GitHub Actions UI and `gh workflow run` can target this filename.
+#
+# The full orchestrator (context -> prebuild -> desktop-benchmarks -> summarize)
+# is being added under PR #1677 (QVAC-17092). Once that PR merges, this stub
+# is replaced by the real workflow. Until then, dispatching this workflow
+# with `--ref <branch>` runs the *branch's* version of the YAML, not this
+# stub — that is exactly what we need to validate the orchestrator on a
+# feature branch before it merges into main.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/SHA) to benchmark"
+        required: false
+
+jobs:
+  noop:
+    name: Stub - real orchestrator lives on QVAC-17092 branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain
+        run: |
+          echo "This is a stub on main. The real benchmark orchestrator"
+          echo "is wired in PR #1677 (QVAC-17092)."
+          echo ""
+          echo "To run the real benchmark, dispatch this workflow with"
+          echo "  --ref QVAC-17092-Benchmark-performance-of-chatterbox-model"
+          echo "or pick that branch in the GitHub Actions 'Run workflow' UI."


### PR DESCRIPTION
## Summary
Adds a stub `Benchmark RTF (ONNX TTS)` workflow file on `main` so that GitHub registers its `workflow_dispatch` trigger. Without this, the full orchestrator added in #1677 (QVAC-17092) is unreachable from the Actions UI or `gh workflow run`.
## Why this is needed
GitHub Actions only registers `workflow_dispatch` for workflow files that live on the default branch. The orchestrator workflow file `benchmark-rtf-qvac-lib-infer-onnx-tts.yml` is brand new — it was renamed from `benchmark-performance-...yml` in #1677 to avoid colliding with PR #1732's Supertonic file at the original path. Until it exists on `main`, neither the UI Run workflow button nor `gh workflow run` can find it.
## What this PR does
- Adds `.github/workflows/benchmark-rtf-qvac-lib-infer-onnx-tts.yml` with:
  - `name: Benchmark RTF (ONNX TTS)` and `on: workflow_dispatch` so GitHub registers the dispatch entry
  - An `inputs.ref` so the dispatch UI prompts for a branch ref, matching what #1677's full version expects
  - A single no-op job that just echoes a message explaining where the real orchestrator lives
## What this PR does NOT do
- Does not include any benchmark logic. The actual `context -> prebuild -> desktop-benchmarks -> summarize` pipeline lives in #1677 and will overwrite this stub when that PR merges.
- Does not change any other workflow file. Zero behavioral impact on existing CI.
## How it gets used
After merge, dispatching this workflow with \`--ref QVAC-17092-Benchmark-performance-of-chatterbox-model\` (or any other branch) makes GitHub run the **branch's** version of the file rather than this stub. That's the standard "stub on main" pattern for unblocking \`workflow_dispatch\` validation of new workflows on feature branches.
## Test plan
- [x] YAML parses (\`python3 -c "import yaml; yaml.safe_load(...)"\` clean)
- [ ] After merge, \`gh workflow run benchmark-rtf-qvac-lib-infer-onnx-tts.yml --ref QVAC-17092-...\` resolves and runs PR #1677's orchestrator (validated on PR #1677 itself)