### PR TITLE
chore[notask|skiplog]: release @qvac/cli v0.3.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.0]
+
+Release Date: 2026-04-30
+
+## 🔌 API
+
+- Wire OpenAI's standard `response_format` field through `qvac serve` (POST `/v1/chat/completions`). The body field is parsed, validated, and forwarded to the SDK as `responseFormat`, enabling structured-output requests (`text` / `json_object` / `json_schema`) over the OpenAI-compatible HTTP surface. Requires `@qvac/sdk` `^0.10.0`. (see PR [#1810](https://github.com/tetherto/qvac/pull/1810)) - See [API changes](./changelog/0.3.0/api.md)
+
 ## [0.2.4]
 
 Release Date: 2026-04-27

--- a/packages/cli/changelog/0.3.0/CHANGELOG.md
+++ b/packages/cli/changelog/0.3.0/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.3.0
+
+Release Date: 2026-04-30
+
+## 🔌 API
+
+- Wire OpenAI's standard `response_format` field through `qvac serve` (POST `/v1/chat/completions`). The body field is parsed, validated, and forwarded to the SDK as `responseFormat`, enabling structured-output requests (`text` / `json_object` / `json_schema`) over the OpenAI-compatible HTTP surface. Requires `@qvac/sdk` `^0.10.0`. (see PR [#1810](https://github.com/tetherto/qvac/pull/1810)) - See [API changes](./api.md)
+

--- a/packages/cli/changelog/0.3.0/api.md
+++ b/packages/cli/changelog/0.3.0/api.md
@@ -1,0 +1,29 @@
+# 🔌 API Changes v0.3.0
+
+## `response_format` support in OpenAI-compat `/v1/chat/completions`
+
+PR: [#1810](https://github.com/tetherto/qvac/pull/1810)
+
+```bash
+curl http://localhost:8080/v1/chat/completions -d '{
+  "model": "qwen-3-0.6b",
+  "messages": [{ "role": "user", "content": "Give me a person object." }],
+  "response_format": {
+    "type": "json_schema",
+    "json_schema": {
+      "name": "Person",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "age":  { "type": "integer" }
+        },
+        "required": ["name", "age"]
+      }
+    }
+  }
+}'
+```
+
+---
+

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Cuts **`@qvac/cli` v0.3.0** so the new OpenAI-compatible `response_format` support in `qvac serve` (PR [#1810](https://github.com/tetherto/qvac/pull/1810), API change) reaches downstream consumers.
- Bumps from `0.2.4` → `0.3.0` (MINOR — `[api]` change).

## 📝 How does it solve it?

- `packages/cli/package.json`: version `0.2.4` → `0.3.0`; `devDependencies."@qvac/sdk"` `^0.9.0` → `^0.10.0`.
- `packages/cli/src/serve/core/sdk.ts`: runtime guard `MIN_SDK_VERSION` `0.9.0` → `0.10.0`.
- Adds the per-version changelog folder `packages/cli/changelog/0.3.0/` (`CHANGELOG.md` + `api.md`) and prepends the `[0.3.0]` entry to the aggregated `packages/cli/CHANGELOG.md`.
- Merging this PR into `release-cli-0.3.0` triggers the **GPR** publish; the follow-up backmerge into `main` will trigger the **npm** publish.

## 🧪 How was it tested?

- `bun lint`, `bun run build`, and `bun test` from `packages/cli/` are clean.
- Changelog was generated via the SDK-pod release scripts (`generate-changelog-sdk-pod.cjs`); the `0.3.0` folder and aggregated entry match the format used by previous CLI releases (e.g. #1752).
- The `response_format` flow itself was already exercised end-to-end in the source PR ([#1810](https://github.com/tetherto/qvac/pull/1810)).

## 🔌 API Changes

`response_format` is now wired through `qvac serve`'s OpenAI-compatible `POST /v1/chat/completions`. The body field is parsed, validated, and forwarded to the SDK as `responseFormat`, enabling structured-output requests (`text` / `json_object` / `json_schema`).

```bash
curl http://localhost:8080/v1/chat/completions -d '{
  "model": "qwen-3-0.6b",
  "messages": [{ "role": "user", "content": "Give me a person object." }],
  "response_format": {
    "type": "json_schema",
    "json_schema": {
      "name": "Person",
      "schema": {
        "type": "object",
        "properties": {
          "name": { "type": "string" },
          "age":  { "type": "integer" }
        },
        "required": ["name", "age"]
      }
    }
  }
}'
```

> ⚠️ Requires `@qvac/sdk@^0.10.0` (which adds `responseFormat` on `completion()`). `@qvac/sdk@0.10.0` is **not yet published to npm** (latest is `0.9.1`), and the `release-sdk-0.10.0` PR has not been cut yet. The CLI publish itself is independent (`@qvac/sdk` is a dev-only dep, not bundled), but consumers upgrading to `@qvac/cli@0.3.0` will need `@qvac/sdk@0.10.0` present in their project for the new feature to work end-to-end.

Full per-version changelog: [`packages/cli/changelog/0.3.0/CHANGELOG.md`](../blob/release-cli-0.3.0/packages/cli/changelog/0.3.0/CHANGELOG.md) · API details: [`api.md`](../blob/release-cli-0.3.0/packages/cli/changelog/0.3.0/api.md)

## Related PRs

- #1810 — source feature PR for `response_format` support
