### PR TITLE
infra[notask]: cache bun and npm globals on windows for sdk desktop e2e

### DIFF
--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -209,9 +209,48 @@ jobs:
             console.log('✅ Client key written');
           }
 
+      - name: Resolve cache dirs (Windows)
+        if: runner.os == 'Windows'
+        working-directory: ${{ inputs.project-directory }}
+        shell: bash
+        run: |
+          BUN_CACHE_DIR="$(bun pm cache)"
+          NPM_CACHE_DIR="$(npm config get cache)"
+          echo "BUN_CACHE_DIR=$BUN_CACHE_DIR" >> "$GITHUB_ENV"
+          echo "NPM_CACHE_DIR=$NPM_CACHE_DIR" >> "$GITHUB_ENV"
+          echo "Resolved bun cache dir: $BUN_CACHE_DIR"
+          echo "Resolved npm cache dir: $NPM_CACHE_DIR"
+
+      - name: Restore bun cache (Windows)
+        id: bun-cache
+        if: runner.os == 'Windows'
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
+        with:
+          path: ${{ env.BUN_CACHE_DIR }}
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('packages/sdk/package.json') }}
+          restore-keys: |
+            bun-cache-${{ runner.os }}-
+
+      - name: Restore npm cache (Windows)
+        id: npm-cache
+        if: runner.os == 'Windows'
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
+        with:
+          path: ${{ env.NPM_CACHE_DIR }}
+          key: npm-cache-${{ runner.os }}-${{ hashFiles('packages/sdk/tests-qvac/package.json') }}
+          restore-keys: |
+            npm-cache-${{ runner.os }}-
+
       - name: Install dependencies (root)
         working-directory: ${{ inputs.project-directory }}
         run: bun install
+
+      - name: Save bun cache (Windows)
+        if: runner.os == 'Windows' && steps.bun-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
+        with:
+          path: ${{ env.BUN_CACHE_DIR }}
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('packages/sdk/package.json') }}
 
       - name: Build project (root)
         working-directory: ${{ inputs.project-directory }}
@@ -245,6 +284,13 @@ jobs:
       - name: Install dependencies (consumer)
         working-directory: ${{ inputs.working-directory }}
         run: npm install --install-links
+
+      - name: Save npm cache (Windows)
+        if: runner.os == 'Windows' && steps.npm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
+        with:
+          path: ${{ env.NPM_CACHE_DIR }}
+          key: npm-cache-${{ runner.os }}-${{ hashFiles('packages/sdk/tests-qvac/package.json') }}
 
       - name: Build project (consumer)
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Windows runners (`ai-run-windows11-gpu`) for desktop SDK e2e tests hit network flakiness on `bun install` (root) and `npm install --install-links` (consumer).
- Step-time data from the four most recent `test-sdk.yml` desktop runs:
  - Windows `bun install`: median ~4m 30s, worst observed **20m 54s** (run 25160292020).
  - Windows `npm install`: median ~4m, worst observed **21m 53s** (run 25061304356).
  - Linux: bun 16-23s, npm 50-59s. macOS: bun 4-6s, npm 35-48s.
- Combined Windows install median is ~8m and worst-case ~27m, eating most of the 45m test budget before tests even start.

## 📝 How does it solve it?

- Adds Windows-only steps to [`.github/workflows/test-desktop-sdk.yml`](.github/workflows/test-desktop-sdk.yml) that cache the bun and npm global cache directories.
- Cache paths are resolved dynamically (`bun pm cache`, `npm config get cache`) rather than hard-coded, so a non-default npm prefix on the self-hosted Windows runner still works.
- Both restores happen up front (single block); each save runs immediately after its respective install so a later test failure does not lose the cache.
- Save steps are guarded by `cache-hit != 'true'` to avoid duplicate-key warnings.
- All five new steps gated on `runner.os == 'Windows'` -> Linux/macOS flow is byte-identical to today.
- `node_modules` is intentionally NOT cached (consumer depends on `@qvac/sdk` via `file:..` and is rebuilt every run).

## 🧪 How was it tested?

- Workflow YAML validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Cache action SHA (`668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4`) matches the rest of the repo.
- 🔁Validation runs: 
   - cache save: https://github.com/tetherto/qvac/actions/runs/25184845325/job/73839351980 (currently pending  ...) ✅ 
<img width="1020" height="406" alt="Screenshot 2026-05-01 at 00 13 58" src="https://github.com/user-attachments/assets/1ce4331b-6316-44f3-b036-9b3757e6b269" />

   - cache restore: ✅  - https://github.com/tetherto/qvac/actions/runs/25186033383
   
<img width="1016" height="403" alt="Screenshot 2026-05-01 at 00 15 16" src="https://github.com/user-attachments/assets/657f220f-c9e1-46a4-9fbf-ef8dd7081344" />

## Conclusion

I'm not sure this will actually improve performance of the pipeline. It may eliminate the 20+minute waits, but it seems to me like the I/O performance is unpredictable and that is the root cause here. That would mean that we would still possibly get those 20+ minute runs, but now also be spending cache space. 

