### PR TITLE
QVAC-18197 fix: avoid blocking flock on contended registry corestore

### DIFF
--- a/packages/sdk/server/bare/registry/registry-client.ts
+++ b/packages/sdk/server/bare/registry/registry-client.ts
@@ -11,8 +11,22 @@ import { DEFAULT_REGISTRY_CORE_KEY } from "@/constants";
 
 const logger = getServerLogger();
 
-const MAX_RETRIES = 3;
-const BASE_DELAY_MS = 500;
+// fd-lock retry budget for the registry corestore.
+//
+// We pass `corestoreOpts: { wait: false }` (tryLock semantics) and provide a
+// JS-bounded retry budget here instead of letting Hypercore's underlying
+// fd-lock issue a blocking flock(LOCK_EX) on a libuv worker thread. The
+// blocking variant cannot be cancelled from JS, so if another SDK process
+// holds the lock indefinitely it leaves a pending native handle that
+// prevents process.exit() from terminating the worker — see QVAC-18197.
+//
+// With tryLock + bounded retries we get the same "tolerate transient locks
+// during another SDK's startup/shutdown" property #1480 wanted, but every
+// retry step is a fresh non-blocking syscall that surfaces failure to JS,
+// so shutdown always remains cancellable.
+const MAX_RETRIES = 8;
+const BASE_DELAY_MS = 250;
+const MAX_TOTAL_WAIT_MS = 10_000;
 
 let registryClient: QVACRegistryClient | null = null;
 let inflightInit: Promise<QVACRegistryClient> | null = null;
@@ -30,14 +44,13 @@ async function delay(ms: number): Promise<void> {
 
 async function initRegistryClient(): Promise<QVACRegistryClient> {
   let lastError: unknown;
+  const deadline = Date.now() + MAX_TOTAL_WAIT_MS;
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       const client = new QVACRegistryClient({
         registryCoreKey: DEFAULT_REGISTRY_CORE_KEY,
-        storage: getCacheDir(
-          `registry-corestore/${DEFAULT_REGISTRY_CORE_KEY}`,
-        ),
-        corestoreOpts: { wait: true },
+        storage: getCacheDir(`registry-corestore/${DEFAULT_REGISTRY_CORE_KEY}`),
+        corestoreOpts: { wait: false },
       });
 
       await client.ready();
@@ -61,7 +74,17 @@ async function initRegistryClient(): Promise<QVACRegistryClient> {
     } catch (error) {
       lastError = error;
       if (isFdLockError(error) && attempt < MAX_RETRIES) {
-        const backoff = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+          logger.warn(
+            `Registry client fd-lock failed after ${MAX_TOTAL_WAIT_MS}ms wait budget exhausted (attempt ${attempt}/${MAX_RETRIES})`,
+          );
+          throw error;
+        }
+        const backoff = Math.min(
+          BASE_DELAY_MS * Math.pow(2, attempt - 1),
+          remaining,
+        );
         logger.warn(
           `Registry client fd-lock failed (attempt ${attempt}/${MAX_RETRIES}), retrying in ${backoff}ms...`,
         );

--- a/packages/sdk/server/worker-core.ts
+++ b/packages/sdk/server/worker-core.ts
@@ -34,6 +34,33 @@ let isShuttingDown = false;
 
 const logger = getServerLogger();
 
+// Defense-in-depth grace period for the SIGKILL safety net armed before
+// process.exit() in shutdownBareDirectWorker. If process.exit cannot
+// terminate the worker within this window — typically because some path
+// holds a non-cancellable native handle (e.g. a libuv worker thread
+// blocked on flock; see QVAC-18197) — we force-kill the OS process to
+// guarantee bounded shutdown time.
+const FORCE_EXIT_GRACE_MS = 3_000;
+
+function scheduleForceExit(): void {
+  const timer: unknown = setTimeout(() => {
+    logger.error(
+      `process.exit did not terminate the worker within ${FORCE_EXIT_GRACE_MS}ms — ` +
+        `force-killing self (likely blocked native handle)`,
+    );
+    try {
+      process.kill(process.pid, "SIGKILL");
+    } catch {
+      // best-effort — if SIGKILL itself fails, there's nothing more to do
+    }
+  }, FORCE_EXIT_GRACE_MS);
+  // Don't let the safety-net timer keep the process alive on the happy
+  // path. Bare returns an object (not a number) from setTimeout.
+  if (timer && typeof timer === "object" && "unref" in timer) {
+    (timer as { unref: () => void }).unref();
+  }
+}
+
 export function initializeWorkerCore(): { hasRPCConfig: boolean } {
   if (coreInitialized) {
     const validatedEnv = getValidatedEnv();
@@ -183,6 +210,8 @@ export async function shutdownBareDirectWorker(
   }
 
   releaseWorkerLock();
+
+  scheduleForceExit();
 
   const isGraceful = reason === "signal" || reason === "rpc-close";
   process.exit(isGraceful ? 0 : 1);


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The SDK bare worker leaks indefinitely as an orphaned OS process when started while another SDK process on the same host holds the registry corestore lock at `~/.qvac/registry-corestore/<key>/`. Surfaces three ways:

- CI: `no-lingering-bare-{sigterm,close,ipc-disconnect}` (`packages/sdk/tests-qvac`) fail in mixed-suite runs while passing in isolation — eroding signal value of the lifecycle tests.
- Production: Workbench Desktop + a CLI session, two Electron windows, dev server + smoke harness — anything running two SDKs against the same `~/.qvac/` accumulates orphaned bare processes silently. Each leak holds a full inference runtime in memory.
- The user/app sees `Cleanup completed successfully` and has no programmatic way to detect or recover.

Asana: [QVAC-18197](https://app.asana.com/1/45238840754660/project/1212638335655966/task/1214429765846687) (severity: medium).

### Root cause

`packages/sdk/server/bare/registry/registry-client.ts:40` passes `corestoreOpts: { wait: true }` to `QVACRegistryClient`. That flag is forwarded to the underlying `Corestore` and ultimately makes `fd-lock` issue a **blocking `flock(LOCK_EX)`** on a libuv worker thread. There is no JS-cancellable handle for that thread.

Failure chain when contended:

1. `await client.ready()` never resolves → `registryClient` stays `null`.
2. SIGTERM (or RPC close, or IPC disconnect) fires `shutdownBareDirectWorker`.
3. `runCleanup` calls `closeRegistryClient`, which early-returns because `registryClient === null` — logs `Cleanup completed successfully`.
4. `process.exit(0)` is called, but Bare cannot terminate while the libuv thread is blocked in `flock(2)` keeping a native handle open.
5. OS process wedges indefinitely.

The same wedge breaks `close()`-mode tests via a secondary effect: the parent's `net.Server.close(callback)` only fires when all IPC connections drain, and the wedged child never closes its IPC socket.

### Why we can't just revert `wait: true`

It was deliberately introduced by #1480 (QVAC-12232) to tolerate `tryLock` collisions during another SDK's startup/shutdown — the inverse bug that produced instant `ModelLoadFailedError` on launch. We need to keep the contention tolerance.

## 📝 How does it solve it?

**A. `registry-client.ts` — switch to `tryLock` with a JS-bounded retry budget**

- `corestoreOpts: { wait: false }` so each attempt is a non-blocking `flock(LOCK_EX | LOCK_NB)` that surfaces `EBUSY` immediately as `"File descriptor could not be locked"`.
- The existing retry loop already handles that error; widened the budget so the contention-tolerance #1480 wanted is preserved:
  - `MAX_RETRIES = 8`, `BASE_DELAY_MS = 250`, capped by a `MAX_TOTAL_WAIT_MS = 10_000` deadline (was `3 × 500/1000/2000`).
  - Every retry step is a fresh, cancellable JS operation — shutdown remains instantaneous at every point.
- When the budget is exhausted, the underlying error propagates to the caller. `closeRegistryClient` then takes its existing `registryClient === null` early-return path, and `process.exit()` terminates the worker cleanly.

**B. `worker-core.ts` — SIGKILL safety net (defense in depth)**

- Before `process.exit()` in `shutdownBareDirectWorker`, arm a 3-second unrefed `setTimeout` that calls `process.kill(process.pid, 'SIGKILL')` if `process.exit` hasn't terminated us by then.
- Unrefed so it doesn't keep the loop alive on the happy path; uses the same Bare-friendly `unref()` pattern as `tests-qvac/tests/utils/no-lingering-bare-consumer.ts`.
- Anti-fix to **avoid**: `Promise.race` on the in-flight `client.ready()` does not work — the libuv thread blocked on flock isn't cancellable from JS, the native handle stays open, `process.exit` still wedges. The fix has to live at the flock layer.

## 🧪 How was it tested?

- `bun run lint` (eslint + tsc) green in `packages/sdk`.
- `prettier --check` green on the two modified files.
- `no-lingering-bare-{sigterm,close,ipc-disconnect}` (`packages/sdk/tests-qvac/tests/no-lingering-bare-tests.ts`) directly exercise the regression — they fail before this change in mixed-suite runs and pass after. CI on this PR will confirm.

### Manual repro (per Asana ticket)

1. `node -e "import('@qvac/sdk').then(m => m.modelRegistryList()).then(()=>setTimeout(()=>{},300_000))"` — note bare child PID from `~/.qvac/.worker.lock`.
2. In a second terminal, run the same command; note the new bare child PID.
3. `kill -TERM <second host PID>`.
4. **Before**: second bare child stays alive indefinitely (>60 s), requires SIGKILL from outside.
5. **After**: second bare child exits within ~1 s; the JS-bounded retry budget surfaces the contention as a normal init error, cleanup runs to completion, `process.exit(0)` terminates the worker.

## Files changed

| File | Change |
|------|--------|
| `packages/sdk/server/bare/registry/registry-client.ts` | `corestoreOpts: { wait: false }`; widened retry to 8 attempts / 10 s deadline; expanded comment with the rationale and link to QVAC-18197 |
| `packages/sdk/server/worker-core.ts` | New `scheduleForceExit()` helper armed before `process.exit` in `shutdownBareDirectWorker` (3 s unrefed SIGKILL safety net) |