### PR TITLE
fix: close 7 untrusted-checkout CodeQL critical alerts

### DIFF
--- a/.github/workflows/on-pr-decoder-audio.yml
+++ b/.github/workflows/on-pr-decoder-audio.yml
@@ -133,7 +133,12 @@ jobs:
           echo "  workdir=$workdir"
 
   sanity-checks:
-    if: needs.authorize.outputs.allowed == 'true'
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (
+        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        contains(github.event.pull_request.labels.*.name, 'verify')
+      )
     needs: [authorize, context]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr-diffusion-cpp.yml
+++ b/.github/workflows/on-pr-diffusion-cpp.yml
@@ -46,7 +46,12 @@ jobs:
           github-token: ${{ github.token }}
 
   sanity-checks:
-    if: needs.authorize.outputs.allowed == 'true'
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (
+        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        contains(github.event.pull_request.labels.*.name, 'verify')
+      )
     needs: authorize
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -65,7 +65,11 @@ jobs:
     needs: [authorize, changes]
     if: |
       (needs.changes.outputs.pkg == 'true' &&
-       needs.authorize.outputs.allowed == 'true') ||
+       needs.authorize.outputs.allowed == 'true' &&
+       (
+         contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+         contains(github.event.pull_request.labels.*.name, 'verify')
+       )) ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-embed.yml
@@ -56,7 +56,12 @@ jobs:
         run: 'echo "Verified qvac-fabric version: ${{ steps.lockstep.outputs.version }}"'
 
   sanity-checks:
-    if: needs.authorize.outputs.allowed == 'true'
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (
+        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        contains(github.event.pull_request.labels.*.name, 'verify')
+      )
     needs: [authorize, verify-fabric-lockstep]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-llamacpp-llm.yml
@@ -61,7 +61,12 @@ jobs:
         run: 'echo "Verified qvac-fabric version: ${{ steps.lockstep.outputs.version }}"'
 
   sanity-checks:
-    if: needs.authorize.outputs.allowed == 'true'
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (
+        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        contains(github.event.pull_request.labels.*.name, 'verify')
+      )
     needs: [authorize, verify-fabric-lockstep]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-nmtcpp.yml
@@ -74,7 +74,16 @@ jobs:
 
   sanity-checks:
     needs: [authorize, changes, verify-fabric-lockstep]
-    if: always() && ((needs.changes.outputs.pkg == 'true' && needs.authorize.outputs.allowed == 'true') || github.event_name == 'workflow_dispatch')
+    if: |
+      always() && (
+        (needs.changes.outputs.pkg == 'true' &&
+         needs.authorize.outputs.allowed == 'true' &&
+         (
+           contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+           contains(github.event.pull_request.labels.*.name, 'verify')
+         )) ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx-tts.yml
@@ -155,7 +155,12 @@ jobs:
           echo "  tts_integration_profile=$tts_integration_profile"
 
   sanity-checks:
-    if: needs.authorize.outputs.allowed == 'true'
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (
+        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        contains(github.event.pull_request.labels.*.name, 'verify')
+      )
     needs: [authorize, context]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-parakeet.yml
@@ -118,7 +118,12 @@ jobs:
           echo "  run_verify=$run_verify"
 
   sanity-checks:
-    if: needs.authorize.outputs.allowed == 'true'
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (
+        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        contains(github.event.pull_request.labels.*.name, 'verify')
+      )
     needs: [authorize, context]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-whispercpp.yml
@@ -133,7 +133,12 @@ jobs:
           echo "  workdir=$workdir"
 
   sanity-checks:
-    if: needs.authorize.outputs.allowed == 'true'
+    if: |
+      needs.authorize.outputs.allowed == 'true' &&
+      (
+        contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        contains(github.event.pull_request.labels.*.name, 'verify')
+      )
     needs: [authorize, context]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Closes 7/7 `actions/untrusted-checkout/critical` alerts on `main` by mirroring the existing `authorize-pr` composite-action logic inline at the job's `if:`. CodeQL recognizes the inline checks as `LabelIfCheck` + `AssociationCheck`; without an inline `if:` the rule cannot trace through composite actions and flags the steps inside as unprotected.

## What's changed

Same inline guard added to the `sanity-checks` job in 9 workflows:

```yaml
if: |
  needs.authorize.outputs.allowed == 'true' &&
  (
    contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
    contains(github.event.pull_request.labels.*.name, 'verify')
  )
```

Files:
- on-pr-ocr-onnx.yml
- on-pr-diffusion-cpp.yml
- on-pr-decoder-audio.yml
- on-pr-qvac-lib-infer-llamacpp-embed.yml
- on-pr-qvac-lib-infer-llamacpp-llm.yml
- on-pr-qvac-lib-infer-nmtcpp.yml
- on-pr-qvac-lib-infer-onnx-tts.yml
- on-pr-qvac-lib-infer-parakeet.yml
- on-pr-qvac-lib-infer-whispercpp.yml

## Why this approach

- **No env gate** — doesn't add manual approval bottlenecks (per @Proletter's feedback)
- **No new logic** — duplicates the existing `authorize-pr` composite gate (member OR `verify` label) inline so CodeQL can see it. `authorize-pr` is unchanged
- **No flow change** — same PRs that were allowed before are still allowed; same PRs that were gated are still gated
- **Trade-off:** logic is now duplicated (1 composite + 9 inline) — if the gate rule changes, all 10 places need updating

## Verification

Local CodeQL CLI 2.25.2, `codeql/actions-queries@0.6.25`:

| Rule | Main (live) | This PR |
|---|---|---|
| `actions/untrusted-checkout/critical` | 7 | **0** |
| `actions/artifact-poisoning/critical` | 7 | 7 (out of scope) |
| `actions/code-injection/critical` | 0 | 0 |

## Out of scope

7 `artifact-poisoning/critical` alerts remain (2 in `publish-library-to-gpr/npm` chained from `publish-sdk.yml`; 5 in `integration-test-qvac-lib-infer-onnx-tts.yml` from `workflow_dispatch` inputs). Both groups need separate analysis and team alignment before fixing.