### PR TITLE
QVAC-18267 infra: backport npm trusted publishing to release-sdk-0.9.2

### DIFF
--- a/.github/actions/publish-library-to-npm/action.yaml
+++ b/.github/actions/publish-library-to-npm/action.yaml
@@ -2,10 +2,6 @@ name: Publish NPM
 description: "Publish a package to NPM"
 
 inputs:
-  secret-token:
-    description: "NPM auth token"
-    required: true
-
   release:
     description: "Use tag. Release stream, temporary here for compatibility with old workflows"
     required: false
@@ -22,19 +18,6 @@ inputs:
     description: "Directory containing package.json (preferred for monorepo)"
     required: false
 
-  git-token:
-    description: "PAT with contents:write to create and push git tags"
-    required: false
-
-  create-tag:
-    description: "Set to 'true' to create a git tag after successful npm release"
-    required: false
-    default: "false"
-
-  repo_name:
-    description: "repo suffix name appended to created git tag"
-    required: false
-
 outputs:
   npm_published_version:
     description: "The version that was actually published to npm (empty if skipped)."
@@ -48,7 +31,7 @@ runs:
   steps:
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
       with:
-        node-version: 18
+        node-version: "24.14.1" # installs npm version 11.11.0
         registry-url: https://registry.npmjs.org/
         scope: "@qvac"
 
@@ -56,17 +39,12 @@ runs:
       id: publish
       shell: bash
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.secret-token }}
-        GIT_PUSH_TOKEN: ${{ inputs.git-token }}
-        CREATE_TAG: ${{ inputs.create-tag }}
         INPUT_PATH: ${{ inputs.path }}
         INPUT_WORKDIR: ${{ inputs.workdir }}
         INPUT_TAG: ${{ inputs.tag }}
         INPUT_RELEASE: ${{ inputs.release }}
         EVENT_NAME: ${{ github.event_name }}
         GIT_REF: ${{ github.ref }}
-        GIT_REPO: ${{ github.repository }}
-        REPO_NAME: ${{ inputs.repo_name }}
       run: |
         set -euo pipefail
 
@@ -102,16 +80,6 @@ runs:
         fi
 
         ####################################################################
-        # Write .npmrc
-        ####################################################################
-        echo "Writing .npmrc in $(pwd)"
-        {
-          echo "registry=https://registry.npmjs.org/"
-          echo "@qvac:registry=https://registry.npmjs.org/"
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}"
-        } > .npmrc
-
-        ####################################################################
         # Core logic preserved below
         ####################################################################
 
@@ -121,16 +89,28 @@ runs:
         if [ -z "$RELEASE" ]; then
           RELEASE="tmp"
         fi
+
+        # Track whether the caller supplied an explicit tag. If not, fall back to
+        # the legacy release-branch heuristic so existing callers without inputs.tag
+        # keep working.
+        EXPLICIT_TAG="true"
         if [ -z "$TAG" ]; then
+          EXPLICIT_TAG="false"
           TAG=$RELEASE
         fi
 
         echo "Base branch: ${GIT_REF}"
         echo "Event name: ${EVENT_NAME}"
 
-        if [[ "${EVENT_NAME}" == "push" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
-          if [[ "${GIT_REF}" == refs/heads/release-* ]]; then
-            TAG="latest"
+        # Only force the legacy "latest" override when the caller did NOT pass an
+        # explicit tag. With the explicit tag, the caller is in control (e.g. an
+        # old release line publishing under a different dist-tag like release-1.x
+        # so it doesn't clobber `latest`).
+        if [ "$EXPLICIT_TAG" = "false" ]; then
+          if [[ "${EVENT_NAME}" == "push" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${GIT_REF}" == refs/heads/release-* ]]; then
+              TAG="latest"
+            fi
           fi
         fi
 
@@ -165,7 +145,6 @@ runs:
         if ([ "${EVENT_NAME}" = "push" ] || [ "${EVENT_NAME}" = "workflow_dispatch" ]) && [ "$ACCESS" = "public" ]; then
           echo "Publishing with provenance statements"
           npm publish --tag "$TAG" --access "$ACCESS" --provenance
-          npm access public "$PACKAGE_NAME" || echo "npm access public skipped"
         else
           npm publish --tag "$TAG" --access "$ACCESS"
         fi
@@ -175,41 +154,3 @@ runs:
         # NEW: publish succeeded — set outputs for downstream workflow/release creation
         echo "npm_publish_skipped=false" >> "$GITHUB_OUTPUT"
         echo "npm_published_version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-        ####################################################################
-        # Optional: create and push git tag v<VERSION>
-        ####################################################################
-
-        if [ "${CREATE_TAG}" != "true" ]; then
-          echo "Tag creation disabled (create-tag != 'true'), skipping git tag step"
-          exit 0
-        fi
-
-        if [ -z "${GIT_PUSH_TOKEN:-}" ]; then
-          echo "create-tag is 'true' but no git-token provided, skipping git tag step"
-          exit 0
-        fi
-
-        TAG_NAME="${REPO_NAME}-v${VERSION}"
-
-        echo "Preparing to create git tag: ${TAG_NAME}"
-
-        git -C "$ROOT" config user.name  >/dev/null 2>&1 || git -C "$ROOT" config user.name "github-actions[bot]"
-        git -C "$ROOT" config user.email >/dev/null 2>&1 || git -C "$ROOT" config user.email "github-actions[bot]@users.noreply.github.com"
-
-        if git -C "$ROOT" rev-parse "${TAG_NAME}" >/dev/null 2>&1; then
-          echo "Tag ${TAG_NAME} already exists locally"
-        else
-          FULL_SHA="$(git -C "$ROOT" rev-parse HEAD)"
-          git -C "$ROOT" tag "${TAG_NAME}" "${FULL_SHA}"
-          echo "Created lightweight tag ${TAG_NAME} -> ${FULL_SHA}"
-        fi
-
-        if git -C "$ROOT" ls-remote --tags origin "${TAG_NAME}" | grep -q "${TAG_NAME}"; then
-          echo "Tag ${TAG_NAME} already exists on remote origin, skipping push"
-          exit 0
-        fi
-
-        echo "Pushing tag ${TAG_NAME} to origin"
-        git -C "$ROOT" push "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${GIT_REPO}.git" "refs/tags/${TAG_NAME}"
-        echo "Tag ${TAG_NAME} pushed successfully"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -380,10 +380,7 @@ jobs:
         id: publish
         uses: ./.github/actions/publish-library-to-npm
         with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
           tag: "latest"
-          git-token: ${{ secrets.GITHUB_TOKEN }}
-          repo_name: sdk
           workdir: ${{ env.WORKDIR }}
 
   # Create GitHub release only for actual releases (after NPM publish)


### PR DESCRIPTION
## Summary

Backports the relevant subset of #1618 (DEVOPS-2062, already on `main`) onto `release-sdk-0.9.2` so the SDK publish workflow on this release line stops trying to use `NPM_TOKEN` (which has been removed) and instead uses npm trusted publishing.

Without this, every push to `release-sdk-0.9.2` fails the `Publish to NPM` job — see the failed run on the latest release: https://github.com/tetherto/qvac/actions/runs/25162865044/job/73904295029.

## Changes

- `.github/actions/publish-library-to-npm/action.yaml`:
  - Drop `secret-token`/`NODE_AUTH_TOKEN`/`.npmrc` writing — auth now comes from npm trusted publishing via OIDC.
  - Drop the legacy `git-token`/`create-tag`/`repo_name` inputs and the in-action git tag push (deprecated in #1618; the SDK workflow doesn't rely on this).
  - Drop the post-publish `npm access public` call (not functional / not required with trusted publishing + provenance).
  - Bump `node-version` from `18` to `24.14.1` (npm 11.11.0) — required for trusted publishing.
  - File is now identical to `main`'s version.
- `.github/workflows/publish-sdk.yml`:
  - Stop passing the now-removed `secret-token`, `git-token`, and `repo_name` inputs to the action.
  - The `publish-npm` job already grants `id-token: write`, so OIDC-based trusted publishing works without further changes.

This is the minimal subset of #1618 needed to make the SDK publish workflow on this branch usable; the broader workflow refactors from #1618 (other addons / triggers) are intentionally not backported because this release line only ships the SDK.

## Test plan

- [ ] Trigger / re-run the `Publish SDK` workflow on `release-sdk-0.9.2` and confirm `Publish to NPM` succeeds.
- [ ] Confirm the published package on npmjs shows provenance.