### PR TITLE
fix[notask]: remove NPM_TOKEN usage from sdk publish workflow

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -112,8 +112,6 @@ jobs:
 
       - name: Configure scoped registry for @tetherto and @qvac packages
         env:
-          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_PAT: ${{ secrets.PAT_TOKEN }}
         shell: bash
         working-directory: ${{ env.WORKDIR }}
@@ -125,7 +123,6 @@ jobs:
           registry=https://registry.npmjs.org/
           @qvac:registry=https://registry.npmjs.org/
           @tetherto:registry=https://npm.pkg.github.com/
-          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
           //npm.pkg.github.com/:_authToken=${GIT_PAT}
           NPMRC
 
@@ -144,7 +141,6 @@ jobs:
 
           [install.scopes]
           "@tetherto" = { token = "${{ env.READ_NPM_TOKEN }}", url = "https://npm.pkg.github.com" }
-          "@qvac" = { token = "${NPM_TOKEN}", url = "https://registry.npmjs.org" }
           EOF
 
       - name: Install dependencies


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- SDK npm publish on `release-sdk-*` was failing because the workflow still wired `NPM_TOKEN` into `.npmrc` / `bunfig.toml` during build, even though the publish step migrated to npm trusted publishing in #1618 (DEVOPS-2062).
- Trusted publishing requires Node ≥ 22.14 / npm ≥ 11.5.1 and an OIDC `id-token`; the legacy `NPM_TOKEN` is now unnecessary noise that obscures the real auth path.

## 📝 How does it solve it?

- Drop `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` (and the dead `GPR_TOKEN`) from the build job's "Configure scoped registry" step.
- Remove `//registry.npmjs.org/:_authToken=${NPM_TOKEN}` from the generated `.npmrc`.
- Remove the `@qvac` scope override from the generated `bunfig.toml` (default registry already points at `registry.npmjs.org/`, and `@qvac/*` packages are public on npm so no token is needed for reads).
- Keep `@tetherto` / GitHub Packages auth (`GIT_PAT` / `READ_NPM_TOKEN`) intact — those packages are private on GHP.

## 🧪 How was it tested?

- Verified `@qvac/sdk` is publicly readable on `registry.npmjs.org/` without auth (`npm view @qvac/sdk` resolves anonymously), so the SDK's `@qvac/*` deps install fine without a token.
- Reference: #1618 (DEVOPS-2062) successfully publishes other addons (e.g. `diffusion-cpp`) through the same trusted-publishing path with Node 24.14.1 / npm 11.11.0.

> [!NOTE]
> This fix needs to also land on `release-sdk-0.10.0` for Monday's SDK release. Cherry-pick after merge.
