### PR TITLE
infra[notask]: align sdk publish workflow with main

### DIFF
--- a/.github/actions/publish-library-to-npm/action.yaml
+++ b/.github/actions/publish-library-to-npm/action.yaml
@@ -89,16 +89,28 @@ runs:
         if [ -z "$RELEASE" ]; then
           RELEASE="tmp"
         fi
+
+        # Track whether the caller supplied an explicit tag. If not, fall back to
+        # the legacy release-branch heuristic so existing callers without inputs.tag
+        # keep working.
+        EXPLICIT_TAG="true"
         if [ -z "$TAG" ]; then
+          EXPLICIT_TAG="false"
           TAG=$RELEASE
         fi
 
         echo "Base branch: ${GIT_REF}"
         echo "Event name: ${EVENT_NAME}"
 
-        if [[ "${EVENT_NAME}" == "push" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
-          if [[ "${GIT_REF}" == refs/heads/release-* ]]; then
-            TAG="latest"
+        # Only force the legacy "latest" override when the caller did NOT pass an
+        # explicit tag. With the explicit tag, the caller is in control (e.g. an
+        # old release line publishing under a different dist-tag like release-1.x
+        # so it doesn't clobber `latest`).
+        if [ "$EXPLICIT_TAG" = "false" ]; then
+          if [[ "${EVENT_NAME}" == "push" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${GIT_REF}" == refs/heads/release-* ]]; then
+              TAG="latest"
+            fi
           fi
         fi
 

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -30,6 +30,11 @@ on:
         description: "Tag for publishing (optional override for GPR)"
         required: false
         default: "dev"
+      npm_tag:
+        description: "NPM dist-tag (default: latest). e.g. release-1.x"
+        required: false
+        default: ""
+        type: string
 
 env:
   WORKDIR: packages/sdk
@@ -367,6 +372,16 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - name: Validate npm_tag input
+        if: inputs.npm_tag != ''
+        shell: bash
+        run: |
+          tag="${{ inputs.npm_tag }}"
+          if ! echo "$tag" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._-]*$'; then
+            echo "::error::Invalid npm dist-tag '$tag'. Must match ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ (e.g. release-1.x)"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
@@ -380,7 +395,7 @@ jobs:
         id: publish
         uses: ./.github/actions/publish-library-to-npm
         with:
-          tag: "latest"
+          tag: ${{ inputs.npm_tag || 'latest' }}
           workdir: ${{ env.WORKDIR }}
 
   # Create GitHub release only for actual releases (after NPM publish)


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- `release-sdk-0.10.0`'s SDK publish flow lags behind `main`: it does not include #1824 (`fix(ci): allow publishing addons under a custom npm dist-tag via workflow_dispatch input`).
- Without those changes, the workflow can't publish under a non-`latest` dist-tag (e.g. `release-1.x`) and the `publish-library-to-npm` action doesn't honour an explicit caller-provided `tag` over the legacy `release-*` → `latest` heuristic.
- The Node/npm versions and trusted-publishing wiring (#1618 / DEVOPS-2062) are already in place on this branch, so this PR is purely catch-up with `main` for the same two files.

## 📝 How does it solve it?

- Replace `.github/actions/publish-library-to-npm/action.yaml` with the `upstream/main` version (adds `EXPLICIT_TAG` handling).
- Replace `.github/workflows/publish-sdk.yml` with the `upstream/main` version (adds `npm_tag` `workflow_dispatch` input + dist-tag validation step + threads `inputs.npm_tag || 'latest'` into the publish step).
- Net effect on this branch: pure forward-port from `main`. No NPM_TOKEN is passed in the publish step — npm trusted publishing (OIDC, Node 24.14.1 / npm 11.11.0, `id-token: write`) already configured on this branch from #1618 stays intact.
- Dependent local actions (`authorize-pr`, `release-merge-guard`, `publish-library-to-gpr`, `create-github-release.yml`) are byte-identical to `main` on this branch — no further changes needed.

## 🧪 How was it tested?

- Diff verified: `git diff upstream/main HEAD -- .github/actions/publish-library-to-npm/action.yaml .github/workflows/publish-sdk.yml` is empty (files match `main` exactly).
- Reference: PR #1618 (DEVOPS-2062) and PR #1824 already exercise this same workflow shape on `main`; `release-sdk-0.10.0` was missing #1824 only.
