### PR TITLE
infra[notask]: align sdk publish workflow with main

### DIFF
--- a/.github/actions/publish-library-to-npm/action.yaml
+++ b/.github/actions/publish-library-to-npm/action.yaml
@@ -2,10 +2,6 @@ name: Publish NPM
 description: "Publish a package to NPM"
 
 inputs:
-  secret-token:
-    description: "NPM auth token"
-    required: true
-
   release:
     description: "Use tag. Release stream, temporary here for compatibility with old workflows"
     required: false
@@ -22,19 +18,6 @@ inputs:
     description: "Directory containing package.json (preferred for monorepo)"
     required: false
 
-  git-token:
-    description: "PAT with contents:write to create and push git tags"
-    required: false
-
-  create-tag:
-    description: "Set to 'true' to create a git tag after successful npm release"
-    required: false
-    default: "false"
-
-  repo_name:
-    description: "repo suffix name appended to created git tag"
-    required: false
-
 outputs:
   npm_published_version:
     description: "The version that was actually published to npm (empty if skipped)."
@@ -48,7 +31,7 @@ runs:
   steps:
     - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
       with:
-        node-version: 18
+        node-version: "24.14.1" # installs npm version 11.11.0
         registry-url: https://registry.npmjs.org/
         scope: "@qvac"
 
@@ -56,17 +39,12 @@ runs:
       id: publish
       shell: bash
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.secret-token }}
-        GIT_PUSH_TOKEN: ${{ inputs.git-token }}
-        CREATE_TAG: ${{ inputs.create-tag }}
         INPUT_PATH: ${{ inputs.path }}
         INPUT_WORKDIR: ${{ inputs.workdir }}
         INPUT_TAG: ${{ inputs.tag }}
         INPUT_RELEASE: ${{ inputs.release }}
         EVENT_NAME: ${{ github.event_name }}
         GIT_REF: ${{ github.ref }}
-        GIT_REPO: ${{ github.repository }}
-        REPO_NAME: ${{ inputs.repo_name }}
       run: |
         set -euo pipefail
 
@@ -102,16 +80,6 @@ runs:
         fi
 
         ####################################################################
-        # Write .npmrc
-        ####################################################################
-        echo "Writing .npmrc in $(pwd)"
-        {
-          echo "registry=https://registry.npmjs.org/"
-          echo "@qvac:registry=https://registry.npmjs.org/"
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}"
-        } > .npmrc
-
-        ####################################################################
         # Core logic preserved below
         ####################################################################
 
@@ -121,16 +89,28 @@ runs:
         if [ -z "$RELEASE" ]; then
           RELEASE="tmp"
         fi
+
+        # Track whether the caller supplied an explicit tag. If not, fall back to
+        # the legacy release-branch heuristic so existing callers without inputs.tag
+        # keep working.
+        EXPLICIT_TAG="true"
         if [ -z "$TAG" ]; then
+          EXPLICIT_TAG="false"
           TAG=$RELEASE
         fi
 
         echo "Base branch: ${GIT_REF}"
         echo "Event name: ${EVENT_NAME}"
 
-        if [[ "${EVENT_NAME}" == "push" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
-          if [[ "${GIT_REF}" == refs/heads/release-* ]]; then
-            TAG="latest"
+        # Only force the legacy "latest" override when the caller did NOT pass an
+        # explicit tag. With the explicit tag, the caller is in control (e.g. an
+        # old release line publishing under a different dist-tag like release-1.x
+        # so it doesn't clobber `latest`).
+        if [ "$EXPLICIT_TAG" = "false" ]; then
+          if [[ "${EVENT_NAME}" == "push" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${GIT_REF}" == refs/heads/release-* ]]; then
+              TAG="latest"
+            fi
           fi
         fi
 
@@ -165,7 +145,6 @@ runs:
         if ([ "${EVENT_NAME}" = "push" ] || [ "${EVENT_NAME}" = "workflow_dispatch" ]) && [ "$ACCESS" = "public" ]; then
           echo "Publishing with provenance statements"
           npm publish --tag "$TAG" --access "$ACCESS" --provenance
-          npm access public "$PACKAGE_NAME" || echo "npm access public skipped"
         else
           npm publish --tag "$TAG" --access "$ACCESS"
         fi
@@ -175,41 +154,3 @@ runs:
         # NEW: publish succeeded — set outputs for downstream workflow/release creation
         echo "npm_publish_skipped=false" >> "$GITHUB_OUTPUT"
         echo "npm_published_version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-        ####################################################################
-        # Optional: create and push git tag v<VERSION>
-        ####################################################################
-
-        if [ "${CREATE_TAG}" != "true" ]; then
-          echo "Tag creation disabled (create-tag != 'true'), skipping git tag step"
-          exit 0
-        fi
-
-        if [ -z "${GIT_PUSH_TOKEN:-}" ]; then
-          echo "create-tag is 'true' but no git-token provided, skipping git tag step"
-          exit 0
-        fi
-
-        TAG_NAME="${REPO_NAME}-v${VERSION}"
-
-        echo "Preparing to create git tag: ${TAG_NAME}"
-
-        git -C "$ROOT" config user.name  >/dev/null 2>&1 || git -C "$ROOT" config user.name "github-actions[bot]"
-        git -C "$ROOT" config user.email >/dev/null 2>&1 || git -C "$ROOT" config user.email "github-actions[bot]@users.noreply.github.com"
-
-        if git -C "$ROOT" rev-parse "${TAG_NAME}" >/dev/null 2>&1; then
-          echo "Tag ${TAG_NAME} already exists locally"
-        else
-          FULL_SHA="$(git -C "$ROOT" rev-parse HEAD)"
-          git -C "$ROOT" tag "${TAG_NAME}" "${FULL_SHA}"
-          echo "Created lightweight tag ${TAG_NAME} -> ${FULL_SHA}"
-        fi
-
-        if git -C "$ROOT" ls-remote --tags origin "${TAG_NAME}" | grep -q "${TAG_NAME}"; then
-          echo "Tag ${TAG_NAME} already exists on remote origin, skipping push"
-          exit 0
-        fi
-
-        echo "Pushing tag ${TAG_NAME} to origin"
-        git -C "$ROOT" push "https://x-access-token:${GIT_PUSH_TOKEN}@github.com/${GIT_REPO}.git" "refs/tags/${TAG_NAME}"
-        echo "Tag ${TAG_NAME} pushed successfully"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -30,6 +30,11 @@ on:
         description: "Tag for publishing (optional override for GPR)"
         required: false
         default: "dev"
+      npm_tag:
+        description: "NPM dist-tag (default: latest). e.g. release-1.x"
+        required: false
+        default: ""
+        type: string
 
 env:
   WORKDIR: packages/sdk
@@ -143,7 +148,7 @@ jobs:
           EOF
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install
         working-directory: ${{ env.WORKDIR }}
 
       - name: Modify package name for branch-based builds
@@ -345,7 +350,7 @@ jobs:
 
       - name: Publish to GitHub Package Registry
         id: publish
-        uses: tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0
+        uses: ./.github/actions/publish-library-to-gpr
         with:
           secret-token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.tag || github.event.inputs.tag || needs.publish-logic.outputs.gpr_tag || 'dev'}}
@@ -367,6 +372,16 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - name: Validate npm_tag input
+        if: inputs.npm_tag != ''
+        shell: bash
+        run: |
+          tag="${{ inputs.npm_tag }}"
+          if ! echo "$tag" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9._-]*$'; then
+            echo "::error::Invalid npm dist-tag '$tag'. Must match ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ (e.g. release-1.x)"
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
@@ -380,10 +395,7 @@ jobs:
         id: publish
         uses: ./.github/actions/publish-library-to-npm
         with:
-          secret-token: ${{ secrets.NPM_TOKEN }}
-          tag: "latest"
-          git-token: ${{ secrets.GITHUB_TOKEN }}
-          repo_name: sdk
+          tag: ${{ inputs.npm_tag || 'latest' }}
           workdir: ${{ env.WORKDIR }}
 
   # Create GitHub release only for actual releases (after NPM publish)


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- `release-sdk-0.9.2` was cut before #1618 (DEVOPS-2062 — npm trusted publishing) and #1824 (custom npm dist-tag input) landed on `main`, so the SDK publish on this branch is broken / out of step:
  - `publish-library-to-npm` still uses Node 18, which is below the npm trusted-publishing minimum (Node ≥ 22.14 / npm ≥ 11.5.1).
  - It still wires `NPM_TOKEN` / `NODE_AUTH_TOKEN` into a generated `.npmrc` and runs the deprecated `npm access public` step.
  - `publish-sdk.yml` still passes `secret-token`, `git-token`, `repo_name` to the action and lacks the `workflow_dispatch` `npm_tag` override.
- Net effect: a publish attempt from this release line will fail the same way as the recent failed run that prompted this fix.

## 📝 How does it solve it?

- Replace `.github/actions/publish-library-to-npm/action.yaml` with the `upstream/main` version (pulls in #1618 + #1824 — Node 24.14.1 / npm 11.11.0, no `NPM_TOKEN` / `NODE_AUTH_TOKEN`, no `.npmrc` write, no `npm access public`, no in-action git-tag block, `EXPLICIT_TAG` handling).
- Replace `.github/workflows/publish-sdk.yml` with the `upstream/main` version (drops `secret-token` / `git-token` / `repo_name` from the publish step, adds `id-token: write` for OIDC trusted publishing, adds `npm_tag` `workflow_dispatch` input + dist-tag validation, switches the GPR step from the external `tetherto/oss-actions/.github/actions/publish-library-to-gpr@v1.1.0` to the local `./.github/actions/publish-library-to-gpr`).
- Local actions referenced by the new `publish-sdk.yml` already exist on this branch with compatible inputs (verified against `authorize-pr`, `release-merge-guard`, `publish-library-to-gpr`, and `create-github-release.yml`) — no further file changes needed.

## 🧪 How was it tested?

- Diff verified: `git diff upstream/main HEAD -- .github/actions/publish-library-to-npm/action.yaml .github/workflows/publish-sdk.yml` is empty (files match `main` exactly).
- Action input compatibility verified by inspection: every `with:` key used by the new `publish-sdk.yml` is declared on the corresponding action on this branch (`secret-token`, `tag`, `workdir`, `name-suffix` for GPR; `github-token` for `authorize-pr`; `github-token`, `base-ref`, `base-sha`, `head-sha`, `package-slug`, `package-json-path`, `changelog-path` for `release-merge-guard`).
- Reference: `diffusion-cpp` is publishing successfully through this same workflow shape on `main` (Node 24.14.1 / npm 11.11.0 / OIDC).
