### PR TITLE
chore[qvac-lib-inference-addon-cpp]: drop unused project VERSION

### DIFF
--- a/packages/qvac-lib-inference-addon-cpp/CMakeLists.txt
+++ b/packages/qvac-lib-inference-addon-cpp/CMakeLists.txt
@@ -6,7 +6,6 @@ if(BUILD_TESTING)
 endif()
 
 project(qvac-lib-inference-addon-cpp
-  VERSION 1.1.4
   LANGUAGES CXX)
 
 find_path(VCPKG_INSTALLED_PATH share/qvac-lint-cpp/.clang-format REQUIRED)
@@ -39,9 +38,6 @@ install(TARGETS qvac-lib-inference-addon-cpp
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 include(CMakePackageConfigHelpers)
-write_basic_package_version_file("qvac-lib-inference-addon-cppConfigVersion.cmake"
-                                 VERSION ${PROJECT_VERSION}
-                                 COMPATIBILITY SameMajorVersion)
 
 configure_package_config_file(
   "${PROJECT_SOURCE_DIR}/cmake/qvac-lib-inference-addon-cppConfig.cmake.in"
@@ -55,7 +51,6 @@ install(EXPORT qvac-lib-inference-addon-cpp_Targets
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/qvac-lib-inference-addon-cpp/cmake)
 
 install(FILES "${PROJECT_BINARY_DIR}/qvac-lib-inference-addon-cppConfig.cmake"
-              "${PROJECT_BINARY_DIR}/qvac-lib-inference-addon-cppConfigVersion.cmake"
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/qvac-lib-inference-addon-cpp/cmake)
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/src/qvac-lib-inference-addon-cpp DESTINATION include)

--- a/packages/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qvac-lib-inference-addon-cpp",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "dependencies": [
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The `VERSION` in `CMakeLists.txt` (`project(... VERSION 1.1.4 ...)`) keeps drifting from the version in `vcpkg.json` (currently `1.1.5`), creating two sources of truth for the package version.
- The CMake-side version is effectively dead code: it only feeds `write_basic_package_version_file()` to generate `qvac-lib-inference-addon-cppConfigVersion.cmake`, which is never consumed — no downstream package calls `find_package(qvac-lib-inference-addon-cpp <version> ...)`. All consumers (`qvac-lib-infer-llamacpp-llm`, `-embed`, `-whispercpp`, `-nmtcpp`, `-parakeet`, `-onnx-tts`, `diffusion-cpp`, `bci-whispercpp`, `ocr-onnx`) locate headers via `find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS "qvac-lib-inference-addon-cpp/...hpp")`.

## 📝 How does it solve it?

- Drop `VERSION 1.1.4` from the `project()` call in `CMakeLists.txt`.
- Drop the `write_basic_package_version_file()` call and the install of the generated `qvac-lib-inference-addon-cppConfigVersion.cmake`. The `Config.cmake` (without version) is still generated and installed for any future `find_package` consumers.
- Bump `vcpkg.json` version `1.1.5 → 1.1.6` so the cleanup ships as a new port version. `vcpkg.json` remains the single source of truth for the package version.

## 🧪 How was it tested?

- Verified via repo-wide grep that no `find_package(qvac-lib-inference-addon-cpp ...)` call exists; all consumers use `find_path` for header discovery.
- All version constraints in dependent packages (`"version>=": "1.1.x"` in their `vcpkg.json`s and `≥1.1.x` mentions in CHANGELOGs/READMEs) target the `vcpkg.json` version, which remains intact.
