### PR TITLE
fix[notask]: run release-merge-guard on workflow_dispatch so manual sdk publish doesn't auto-skip

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -62,7 +62,7 @@ jobs:
   release-merge-guard:
     name: Release Merge Guard
     if: >-
-      github.event_name == 'push' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
       startsWith(github.ref_name, 'release-')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- A manual `workflow_dispatch` of `publish-sdk.yml` on a `release-sdk-*` branch silently skips `publish-npm` — the publish job never starts (see #1851's manual run on `release-sdk-0.9.2`, where `Publish to NPM` showed `0s` skipped).
- Root cause: `release-merge-guard` is gated `github.event_name == 'push'` only, so on `workflow_dispatch` it's skipped. `publish-npm` lists `release-merge-guard` in `needs:`. GitHub Actions' implicit `success()` check on `needs:` then auto-skips `publish-npm` **before** its own `if:` (which already handles the `result == 'skipped'` branch) is even evaluated.

> [!NOTE]
> Per [GitHub docs](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution): *"If a job is skipped, all jobs that need it are also skipped by default, unless they use a conditional expression that causes the job to run."*

## 📝 How does it solve it?

- Allow `release-merge-guard` to also run on `workflow_dispatch`:

```yaml
  release-merge-guard:
    if: >-
      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
      startsWith(github.ref_name, 'release-')
```

- The guard is safe to run on `workflow_dispatch`:
  - `github.event.before` is empty for `workflow_dispatch`, so `base-sha=""` → the action's `isInitialPush=true` → the changelog-diff check is skipped (intentional for non-merge events; see action's input docstring `"Empty on workflow_dispatch — changelog check is skipped."`).
  - The branch-name pattern check and the `package.json` version vs. branch version check still run. Both are correct invariants to enforce on a manual release publish; if they fail, the publish should be blocked anyway.

- Net effect: manual `publish-sdk` dispatches on release branches now actually reach `publish-npm` instead of silently skipping. `publish-npm`'s existing `if:` (`needs.release-merge-guard.result == 'success' || ... 'skipped'`) keeps working as written.

## 🧪 How was it tested?

- `release-merge-guard` action source inspected (`.github/actions/release-merge-guard/src/index.ts`) — confirmed `isInitialPush` short-circuit on empty base-sha, and that the remaining checks (branch-name regex, version match) only operate on `head-sha`/`base-ref` which are populated for `workflow_dispatch`.
- Reference run that surfaced the bug: manual dispatch on `release-sdk-0.9.2` succeeded for `build` but skipped `Publish to NPM` (0s, never started) — exactly the implicit-success-on-needs symptom this PR fixes.
