### PR TITLE
infra[QVAC-17058]: add empty BCI whispercpp workflow stubs to enable branch dispatch

### DIFF
--- a/.github/workflows/benchmark-bci-whispercpp.yml
+++ b/.github/workflows/benchmark-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: Benchmark (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/benchmark-performance-bci-whispercpp.yml
+++ b/.github/workflows/benchmark-performance-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: Benchmark Performance (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: C++ Test Coverage (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/create-github-release-bci-whispercpp.yml
+++ b/.github/workflows/create-github-release-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: Create GitHub Release (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: Integration Mobile Test (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: Integration Test (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/on-merge-bci-whispercpp.yml
+++ b/.github/workflows/on-merge-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: On Merge (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/on-pr-bci-whispercpp.yml
+++ b/.github/workflows/on-pr-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: On PR Trigger (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/on-pr-close-bci-whispercpp.yml
+++ b/.github/workflows/on-pr-close-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: On PR Close (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/prebuilds-bci-whispercpp.yml
+++ b/.github/workflows/prebuilds-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: Prebuilds (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."

--- a/.github/workflows/repository-dispatch-bci-whispercpp.yml
+++ b/.github/workflows/repository-dispatch-bci-whispercpp.yml
@@ -1,0 +1,14 @@
+name: Repository Dispatch (BCI Whispercpp)
+
+# Stub workflow on main so it can be dispatched from feature branches.
+# The real implementation lives on the bci-whispercpp feature branch.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op stub
+        run: echo "Stub workflow on main; real implementation lives on the bci-whispercpp feature branch."


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- New `packages/bci-whispercpp` addon needs CI workflows, but those workflows are being iterated on a feature branch and cannot be manually dispatched until they are registered on `main`.
- GitHub Actions only allows `workflow_dispatch` against a non-default branch when a workflow file with the same name already exists on the default branch — otherwise the workflow is invisible to the API/UI.

## 📝 How does it solve it?

- Adds 11 no-op stub workflow files under `.github/workflows/` mirroring the `qvac-lib-infer-whispercpp` lineup:
  - `benchmark-bci-whispercpp.yml`
  - `benchmark-performance-bci-whispercpp.yml`
  - `cpp-test-coverage-bci-whispercpp.yml`
  - `create-github-release-bci-whispercpp.yml`
  - `integration-mobile-test-bci-whispercpp.yml`
  - `integration-test-bci-whispercpp.yml`
  - `on-merge-bci-whispercpp.yml`
  - `on-pr-close-bci-whispercpp.yml`
  - `on-pr-bci-whispercpp.yml`
  - `prebuilds-bci-whispercpp.yml`
  - `repository-dispatch-bci-whispercpp.yml`
- Each stub uses `on: workflow_dispatch:` only (no push / pull_request triggers) so it cannot fire on unrelated PRs or merges to `main`.
- The single job is a no-op `echo` clarifying that the real implementation lives on the `bci-whispercpp` feature branch.

## 🧪 How was it tested?

- YAML is valid and intentionally minimal; once merged, dispatch will be verified from the feature branch via `gh workflow run <file>.yml --ref <branch>`.