### PR TITLE
QVAC-18280 [Decoder] v0.3.9

### DIFF
--- a/packages/decoder-audio/CHANGELOG.md
+++ b/packages/decoder-audio/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.9]
+
+### Changed
+- Bumped `@qvac/decoder-audio` package version from `0.3.8` to `0.3.9`.
+
+### Removed
+- Removed redundant `process` (`npm:bare-process@^4.2.2`) entry from `dependencies` in `package.json`. The `bare-process` package is already declared directly as `bare-process: "^4.2.2"`, and the `process` alias was unused.
+
 ## [0.3.8] - 2026-04-28
 
 This release bumps `@qvac/infer-base` from `^0.1.0` to `^0.4.0`. Together with `@qvac/infer-base@0.4.1` (which drops the legacy `@qvac/dl-hyperdrive` peer-dep), this stops `@qvac/dl-*` packages from being pulled into consumers' install trees through `@qvac/decoder-audio`. Public behavior of `FFmpegDecoder` is unchanged.

--- a/packages/decoder-audio/package.json
+++ b/packages/decoder-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/decoder-audio",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "",
   "license": "Apache-2.0",
   "author": "Tether",
@@ -54,8 +54,7 @@
     "bare-ffmpeg": "^1.0.0-32",
     "bare-fs": "^4.5.1",
     "bare-path": "^3.0.0",
-    "bare-process": "^4.2.2",
-    "process": "npm:bare-process@^4.2.2"
+    "bare-process": "^4.2.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two notes on the deviation from whisper v0.6.6
No "path": "npm:bare-path" line existed in decoder's package.json to begin with — only bare-path: "^3.0.0" was declared (already direct), so there was nothing to remove on the path side. The changelog therefore mentions only the process alias.
Decoder keeps "bare-process": "^4.2.2" as a direct dep (whisper never had it). It's actually used by the example scripts (example/ffmpeg-example.js, example/example.fs.js, example/decode-mp3.js) via require('bare-process'). Only the alias process is unused (no require('process') anywhere in the package), which matches the whisper rationale exactly.