### PR TITLE
doc: autogen pipeline - fix release branch prefix

### DIFF
--- a/.github/workflows/docs-generate-api.yml
+++ b/.github/workflows/docs-generate-api.yml
@@ -73,7 +73,7 @@ jobs:
             echo "❌ SDK_REPOSITORY is not set. Add repository variable SDK_REPOSITORY (e.g. owner/qvac)."
             exit 1
           fi
-          git clone --depth 1 --branch "release-qvac-sdk-${VERSION}" \
+          git clone --depth 1 --branch "release-sdk-${VERSION}" \
             "https://x-access-token:${GH_TOKEN}@github.com/${SDK_REPO}.git" sdk-source \
             || git clone --depth 1 --branch "v${VERSION}" \
             "https://x-access-token:${GH_TOKEN}@github.com/${SDK_REPO}.git" sdk-source \

--- a/.github/workflows/docs-release-pipeline.yml
+++ b/.github/workflows/docs-release-pipeline.yml
@@ -8,7 +8,7 @@ name: Docs Release Pipeline
 on:
   push:
     branches:
-      - 'release-qvac-sdk-*'
+      - 'release-sdk-*'
   release:
     types: [published]
   workflow_dispatch:
@@ -87,11 +87,10 @@ jobs:
             VERSION="$INPUT_VERSION"
           elif [ "$EVENT_NAME" = "release" ]; then
             TAG="$RELEASE_TAG"
-            VERSION="${TAG#v}"
-            VERSION="${VERSION#release-qvac-sdk-}"
+            VERSION="${TAG#sdk-v}"
           else
             BRANCH="$REF_NAME"
-            VERSION="${BRANCH#release-qvac-sdk-}"
+            VERSION="${BRANCH#release-sdk-}"
           fi
           if [ -z "$VERSION" ]; then
             echo "::error::Could not extract version"


### PR DESCRIPTION
### Context

Docs has a GH workflow that automatically generates an API summary and release notes whenever a new SDK version is released.

The workflow triggers the push of a release branch of the SDK.

### Issue

The hardcoded prefix in the workflow for branches is: `release-qvac-sdk-v`, but the current prefix is ​​`release-sdk-v`.

### Scope

Modify 2 GH workflows in Docs, correcting the branch prefix value that triggers the workflow.