### PR TITLE
QVAC-16777 chore[skiplog]: release sdk 0.10.0

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,449 @@
 # Changelog
 
+## [0.10.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.0
+
+This release lands a redesigned completion API built on a unified event stream, a generic
+companion-set system that handles multi-file models in parallel, and a much stronger model
+type/capability system that catches mis-routed calls at compile time. It also rewires
+delegated inference to direct DHT connections, expands the addon surface (img2img,
+structured output, dynamic tools, tool dialects, per-segment whisper metadata,
+sentence-streaming TTS), and reshapes the model registry around companion sets.
+
+## Breaking Changes
+
+### Unified `CompletionEvent` stream
+
+`completion()` now returns a `CompletionRun` with a single canonical `events` stream that
+carries content, thinking, tool calls, stats, and completion in one ordered, sequenced
+sequence. The legacy `tokenStream`/`stats` fields still work as derived views, but the
+event stream is the authoritative API going forward and is what enables features like
+captured thinking and structured tool framing.
+
+**Before:**
+
+```typescript
+const result = completion({ modelId, history, stream: true });
+for await (const token of result.tokenStream) { /* ... */ }
+const stats = await result.stats;
+```
+
+**After:**
+
+```typescript
+const run = completion({ modelId, history, stream: true, captureThinking: true });
+for await (const event of run.events) {
+  if (event.type === "contentDelta") process.stdout.write(event.text);
+  if (event.type === "toolCall") console.log(event.call.name);
+}
+const result = await run.final;
+// result.contentText, result.thinkingText, result.toolCalls, result.stats, result.raw.fullText
+```
+
+### Model type & capability system overhaul
+
+`LoadModelOptions` is no longer a single catch-all. Custom plugins must use the new
+`LoadCustomPluginModelOptions<"plugin-name">` generic so the literal plugin string is
+pinned at the type level. Built-in model types continue to pick the right overload
+automatically when the annotation is dropped.
+
+At runtime, built-in SDK operations now throw `MODEL_OPERATION_NOT_SUPPORTED` when called
+against the wrong model type — with a message that lists the requested operation, the
+loaded model's type, and the supported operations on it. The lower-level `pluginInvoke`
+and `pluginInvokeStream` paths still surface `PLUGIN_HANDLER_NOT_FOUND` as before.
+
+`translate(...)` now routes by the loaded model's registered type. Passing a mismatched
+`modelType` throws `ModelTypeMismatchError` instead of silently mis-routing the call.
+
+**Before:**
+
+```typescript
+import type { LoadModelOptions } from "@qvac/sdk";
+
+const opts: LoadModelOptions = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
+```
+
+**After:**
+
+```typescript
+import type { LoadCustomPluginModelOptions } from "@qvac/sdk";
+
+const opts: LoadCustomPluginModelOptions<"my-custom-plugin"> = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
+// Or just drop the annotation — TS picks the right overload.
+```
+
+```typescript
+import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
+
+try {
+  await transcribe({ modelId: llmModelId /* ... */ });
+} catch (e) {
+  if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.MODEL_OPERATION_NOT_SUPPORTED) {
+    // Includes requested operation, loaded model type, supported operations,
+    // and suggested model types.
+  }
+}
+```
+
+### Companion-set download progress field
+
+Multi-file model downloads (ONNX, future formats) now report progress through a generic
+`fileSetInfo` field instead of the ONNX-specific `onnxInfo`. The shape is identical, only
+the field name changed.
+
+**Before:**
+
+```typescript
+onProgress: (progress) => {
+  if (progress.onnxInfo) {
+    console.log(`[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`);
+  }
+}
+```
+
+**After:**
+
+```typescript
+onProgress: (progress) => {
+  if (progress.fileSetInfo) {
+    console.log(`[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`);
+  }
+}
+```
+
+### Delegated inference uses direct DHT connect
+
+Delegation no longer rendezvous over a shared topic. Consumers connect directly to a
+provider's public key via `swarm.dht.connect(publicKey)`, and providers bind the DHT
+server with `swarm.listen()` instead of announcing a topic. This removes a class of
+discovery-flake failures and shortens connect time. Callers using the high-level
+delegation API see no surface change; integrators driving Hyperswarm directly should
+update their join/listen logic.
+
+### Plugin constructor migration
+
+SDK plugins (`definePlugin`) now use the new addon constructor shape. Plugin authors
+need to migrate their `createModel` implementation to match — the SDK in this release
+ships with all first-party plugins already migrated.
+
+## New APIs and Capabilities
+
+### `getLoadedModelInfo` for runtime introspection
+
+A new `getLoadedModelInfo` API returns metadata for a loaded `modelId`, discriminated on
+`isDelegated`. Local models expose their authoritative handler list and `modelType`;
+delegated models defer to the provider. Useful for preflighting a built-in SDK call
+before issuing the RPC.
+
+```typescript
+import { getLoadedModelInfo, transcribe } from "@qvac/sdk";
+
+const info = await getLoadedModelInfo({ modelId });
+
+if (info.isDelegated || info.handlers.includes("transcribeStream")) {
+  await transcribe({ modelId /* ... */ });
+}
+```
+
+### Structured output (`responseFormat`)
+
+`completion()` now accepts a `responseFormat` option that constrains the model to emit
+schema-valid JSON. The output is guaranteed to parse against the supplied JSON Schema.
+
+```typescript
+const run = completion({
+  modelId,
+  history: [{ role: "user", content: "Extract: I'm Alice, 30, data engineer." }],
+  stream: true,
+  responseFormat: {
+    type: "json_schema",
+    json_schema: {
+      name: "Person",
+      schema: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "integer" },
+          occupation: { type: "string" },
+        },
+        required: ["name", "age", "occupation"],
+        additionalProperties: false,
+      },
+    },
+  },
+});
+
+for await (const event of run.events) {
+  if (event.type === "contentDelta") process.stdout.write(event.text);
+}
+const final = await run.final;
+JSON.parse(final.contentText); // schema-valid
+```
+
+### Dynamic tools mode
+
+LLM models can now opt into a `dynamic` tools mode at load time. Subsequent
+`completion()` calls can pass an entirely different `tools` array on each turn, and the
+addon trims the previous tool block from the KV cache so rotation is free — no need to
+invalidate the cache or pin the tool set per-session.
+
+```typescript
+import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
+
+const modelId = await loadModel({
+  modelSrc: QWEN3_1_7B_INST_Q4,
+  modelType: "llm",
+  modelConfig: {
+    ctx_size: 4096,
+    tools: true,
+    toolsMode: TOOLS_MODE.dynamic,
+  },
+});
+
+// Turn 1 — weather tools.
+const turn1 = completion({
+  modelId, history, kvCache, stream: true,
+  tools: [{ name: "get_weather", description: "...", parameters: weatherSchema }],
+});
+
+// Turn 2 — same kvCache, different tools. Free rotation.
+const turn2 = completion({
+  modelId, history, kvCache, stream: true,
+  tools: [{ name: "get_horoscope", description: "...", parameters: horoscopeSchema }],
+});
+```
+
+### Tool-call dialect routing
+
+Tool-call parsing is now dialect-aware. The SDK auto-detects between `hermes`,
+`pythonic`, and `json` framings, and a new `toolDialect` parameter lets you force a
+specific parser when auto-detection picks the wrong path — common for Llama 3.x
+fine-tunes that emit native pythonic headers, which the auto-router defaults to `hermes`
+for empirical reasons.
+
+```typescript
+import { completion, type ToolDialect } from "@qvac/sdk";
+
+const result = completion({
+  modelId, history, tools, stream: true,
+  toolDialect: "pythonic", // "hermes" | "pythonic" | "json"
+});
+```
+
+### img2img for diffusion models
+
+The diffusion API now accepts an `init_image` for SDEdit-style image-to-image on
+SD/SDXL, and in-context conditioning on FLUX.2. `strength` controls how much of the
+source is preserved on SD/SDXL; FLUX.2 ignores it (the path is purely conditional).
+
+```typescript
+const initImage = new Uint8Array(fs.readFileSync("input.png"));
+const { outputs } = diffusion({
+  modelId,
+  prompt: "oil painting style, vibrant colors",
+  init_image: initImage,
+  strength: 0.5, // 0 = keep source, 1 = ignore source
+});
+```
+
+### Sentence-level TTS streaming
+
+Onnx text-to-speech can now stream output one sentence at a time, either as a
+self-contained `textToSpeech({ stream: true, sentenceStream: true })` call or via a
+duplex `textToSpeechStream` session that you can pipe a streaming LLM into. Each chunk
+exposes the int16 PCM samples plus the source sentence and chunk index.
+
+```typescript
+const session = await textToSpeechStream({
+  modelId: ttsModelId,
+  inputType: "text",
+  accumulateSentences: true,
+  sentenceDelimiterPreset: "latin", // "latin" | "cjk" | "multilingual"
+  flushAfterMs: 400,
+});
+
+(async () => {
+  for await (const delta of completion({ modelId: llmModelId /* ... */ }).tokenStream) {
+    session.write(delta);
+  }
+  session.end();
+})();
+
+for await (const chunk of session) {
+  // chunk.buffer / chunk.chunkIndex / chunk.sentenceChunk
+  if (chunk.done) break;
+}
+```
+
+### Per-segment whisper metadata
+
+Both `transcribe` (batch) and `transcribeStream` (duplex) now return structured
+`TranscribeSegment` objects with start/end timestamps, segment IDs, and an `append`
+flag — enabling proper subtitle generation and timeline alignment instead of raw text
+concatenation.
+
+```typescript
+const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true });
+for (const s of segments) {
+  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`);
+}
+```
+
+### Suspend lifecycle gate and `state()`
+
+`suspend()` is now serialized through a lifecycle gate that prevents overlapping
+suspend/resume races. A new `state()` API reports the current lifecycle phase:
+`active`, `suspending`, `suspended`, or `resuming`.
+
+```typescript
+import { state, suspend, resume, type LifecycleState } from "@qvac/sdk";
+
+await suspend();
+const current: LifecycleState = await state();
+if (current !== "active") {
+  await resume();
+}
+```
+
+### Registry download retries and configurable stream timeout
+
+Two new SDK config knobs cover slow/unstable links: `registryDownloadMaxRetries` retries
+`REQUEST_TIMEOUT` failures (set to `0` to disable), and `registryStreamTimeoutMs`
+extends the per-block stream timeout beyond the default 60s.
+
+```typescript
+import { setSDKConfig } from "@qvac/sdk";
+
+setSDKConfig({
+  registryDownloadMaxRetries: 5,
+  registryStreamTimeoutMs: 180_000,
+});
+```
+
+### Auto KV-cache: replay the canonical assistant turn
+
+When auto KV-cache is enabled, the completion result now exposes
+`final.cacheableAssistantContent` — the exact assistant string the SDK persisted to the
+cache key on this turn. Push it back into `history` verbatim on the next turn to
+guarantee a cache hit. Tool-call turns aren't auto-cached today and omit the field;
+fall back to `final.contentText` in that case.
+
+```typescript
+const run = completion({ modelId, history, kvCache: true });
+for await (const _ of run.tokenStream) { /* stream */ }
+const final = await run.final;
+const nextHistory = [
+  ...history,
+  { role: "assistant", content: final.cacheableAssistantContent ?? final.contentText },
+  { role: "user", content: "follow-up question" },
+];
+```
+
+### LLM-addon cache API plumbed through SDK
+
+The SDK now wires through the LLM addon's first-class cache API — including explicit
+`deleteCache({ kvCacheKey })` for evicting a named cache key — so consumers can manage
+KV-cache lifetimes alongside `loadModel`/`unloadModel`.
+
+### NMTcpp 2.0.1 surface
+
+The SDK NMT plugin now targets `@qvac/translation-nmtcpp 2.0.1` with a structured
+constructor that distinguishes primary and pivot model files, vocab files, and pivot
+config (beam size, top-k). Bergamot models are also picked up via path-based vocab
+resolution and grouped into companion sets, which lets the cache and download paths
+treat them like any other multi-file model.
+
+## Features
+
+### Parallel orchestration and download dedupe
+
+Model loading is now genuinely parallel where it can be: the primary model and any
+companion files (vision projection, vocab, etc.) download concurrently, and concurrent
+requests for the same asset are deduplicated to a single transfer. Cancellation cleans
+up all active transfers atomically with no leaked state. Profiling fields
+(`sourceType`, `cacheHit`, `sharedTransfer`, `totalLoadTime`,
+`modelInitializationTime`, `checksumValidationTime`) are populated correctly across
+both primary and companion downloads, with aggregate stats merged at the run level.
+
+The companion pipeline is also generic: `companions.ts` is the only format-aware piece,
+and adding a new multi-file format is a matter of dropping in a detection function and
+registering it with `groupCompanionSets`. Everything downstream — codegen, resolver,
+cache probing, storage cleanup — handles it automatically.
+
+### Real-time voice assistant example
+
+A new end-to-end example demonstrates a real-time voice assistant pipeline (whisper →
+LLM → TTS) wired together using the SDK's streaming primitives.
+
+## Bug Fixes
+
+- RPC initialization in the Node runtime now has an explicit timeout, so a wedged
+  transport can no longer hang `loadModel`/`unloadModel` indefinitely.
+- The registry client now opens its corestore with `wait: true`, eliminating a startup
+  race where downloads could begin before replication was ready.
+- KV-cache `savedCount` is no longer incremented on cancelled or zero-token turns,
+  preventing inflated cache stats.
+- `delete-cache` RPC now scopes invalidation to the deleted key only instead of wiping
+  unrelated entries.
+- Delegated transports strip the `__profiling` envelope before zod validation, fixing a
+  spurious validation error when profiling is enabled on the consumer side.
+- Replaced `z.xor` with `z.union` and bumped the zod floor to `^4.3.0` to track upstream
+  breaking changes.
+- LLM-based translation now uses deterministic decoding so the same input produces the
+  same output across runs.
+- Inflight delegation requests that get rejected now run their cleanup chain to
+  completion instead of leaking pending promises.
+
+## Model Registry Changes
+
+The model registry was regenerated around companion-set metadata. The user-facing surface
+is leaner: families that used to live as separate `*_DATA`, `*_LEX`, `*_VOCAB`, and
+`METADATA_*` constants are now companion-only — they're still downloaded, but they're
+not addressable as standalone model sources. Marian Opus models were renamed under the
+`NMT_*` namespace to match the rest of the NMT family.
+
+### Added
+
+```
+NMT_Q0F16 through NMT_Q0F16_9 (10 entries)
+NMT_Q4_0 through NMT_Q4_0_12+ (22 entries)
+```
+
+### Removed (now companion-only or renamed)
+
+```
+*_DATA (32 entries — companion-only, e.g. PARAKEET_TDT_ENCODER_DATA_FP32, TTS_*_DATA)
+BERGAMOT_*_LEX (93 entries — companion-only)
+BERGAMOT_*_VOCAB (93 entries — companion-only)
+BERGAMOT_METADATA_* (87 entries — companion-only)
+MARIAN_OPUS_* (32 entries — renamed to NMT_*)
+```
+
+## Documentation, Tests, and Infrastructure
+
+- Diffusion documentation was extended to cover the new img2img flows (SDEdit on
+  SD/SDXL, in-context conditioning on FLUX.2).
+- Android sharded-model-resume tests no longer trip Scudo OOM — the test harness now
+  bounds memory more conservatively on long-running resume scenarios.
+- The tests-qvac docs, tooling, and CI workflow job names were refreshed for the new
+  suite filtering and PR-triggered e2e workflows. Suite filtering plus PR-trigger labels
+  let CI run targeted SDK e2e subsets on demand instead of always running the full grid.
+- A pre-terminate cleanup hook stabilises mobile smoke: the mobile auto-close path now
+  awaits worker cleanup acknowledgement before terminating the worklet.
+- `DataLoader` cleanup logic was scoped down to `packages/rag` so the SDK no longer
+  carries that surface.
+
 ## [0.9.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.9.1

--- a/packages/sdk/NOTICE
+++ b/packages/sdk/NOTICE
@@ -328,7 +328,7 @@ Third-Party Model Licenses
   model.enis.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enis
   model.enit.intgemm.alphas
-    https://github.com/mozilla/firefox-translations-models/tree/main/models/tiny/enit
+    https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enit
   model.enja.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enja
   model.enkn.intgemm.alphas
@@ -372,7 +372,7 @@ Third-Party Model Licenses
   model.enzh.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enzh
   model.esen.intgemm.alphas
-    https://github.com/mozilla/firefox-translations-models/tree/main/models/tiny/esen
+    https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/esen
   model.eten.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/eten
   model.faen.intgemm.alphas
@@ -489,19 +489,26 @@ JavaScript Dependencies
 
   @hyperswarm/secret-stream@6.9.1
     https://github.com/holepunchto/hyperswarm-secret-stream
-  @qvac/decoder-audio@0.3.8
+  @qvac/decoder-audio@0.3.6
+    https://github.com/tetherto/qvac
+  @qvac/decoder-audio@0.3.7
     https://github.com/tetherto/qvac
   @qvac/diagnostics@0.1.1
   @qvac/diffusion-cpp@0.3.0
     https://github.com/tetherto/qvac
+  @qvac/dl-base@0.1.1
+  @qvac/dl-hyperdrive@0.1.1
   @qvac/embed-llamacpp@0.14.0
     https://github.com/tetherto/qvac
   @qvac/error@0.1.1
+  @qvac/infer-base@0.1.1
+  @qvac/infer-base@0.4.0
+    https://github.com/tetherto/qvac
   @qvac/infer-base@0.4.1
     https://github.com/tetherto/qvac
   @qvac/langdetect-text@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/llm-llamacpp@0.16.0
+  @qvac/llm-llamacpp@0.17.3
     https://github.com/tetherto/qvac
   @qvac/logging@0.1.0
   @qvac/ocr-onnx@0.4.2
@@ -514,9 +521,9 @@ JavaScript Dependencies
     https://github.com/tetherto/qvac
   @qvac/registry-schema@0.1.2
   @qvac/response@0.1.2
-  @qvac/transcription-parakeet@0.3.2
+  @qvac/transcription-parakeet@0.3.1
     https://github.com/tetherto/qvac
-  @qvac/transcription-whispercpp@0.6.4
+  @qvac/transcription-whispercpp@0.6.1
     https://github.com/tetherto/qvac
   @qvac/translation-nmtcpp@2.1.0
     https://github.com/tetherto/qvac
@@ -552,19 +559,19 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-events
   bare-events@2.8.2
     https://github.com/holepunchto/bare-events
-  bare-fetch@2.9.0
+  bare-fetch@2.8.1
     https://github.com/holepunchto/bare-fetch
   bare-ffmpeg@1.2.2
     https://github.com/holepunchto/bare-ffmpeg
   bare-form-data@1.2.1
     https://github.com/holepunchto/bare-form-data
-  bare-fs@4.7.1
+  bare-fs@4.6.0
     https://github.com/holepunchto/bare-fs
   bare-hrtime@2.1.1
     https://github.com/holepunchto/bare-hrtime
   bare-http-parser@1.1.3
     https://github.com/holepunchto/bare-http-parser
-  bare-http1@4.5.6
+  bare-http1@4.5.5
     https://github.com/holepunchto/bare-http1
   bare-https@2.1.3
     https://github.com/holepunchto/bare-https
@@ -574,9 +581,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-lief
   bare-link@3.2.1
     https://github.com/holepunchto/bare-link
-  bare-mime@1.0.0
-    https://github.com/holepunchto/bare-mime
-  bare-module@6.2.0
+  bare-module@6.1.3
     https://github.com/holepunchto/bare-module
   bare-module-lexer@1.4.7
     https://github.com/holepunchto/bare-module-lexer
@@ -590,7 +595,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-node
   bare-node-worker-threads@1.0.0
     https://github.com/holepunchto/bare-node
-  bare-os@3.9.0
+  bare-os@3.8.7
     https://github.com/holepunchto/bare-os
   bare-path@3.0.0
     https://github.com/holepunchto/bare-path
@@ -600,39 +605,39 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-process
   bare-rpc@1.2.0
     https://github.com/holepunchto/bare-rpc
-  bare-runtime@1.28.4
+  bare-runtime@1.28.1
     https://github.com/holepunchto/bare-runtime
-  bare-runtime-darwin-arm64@1.28.4
+  bare-runtime-darwin-arm64@1.28.1
     https://github.com/holepunchto/bare-runtime
-  bare-semver@1.0.3
+  bare-semver@1.0.2
     https://github.com/holepunchto/bare-semver
   bare-signals@4.2.0
     https://github.com/holepunchto/bare-signals
   bare-stdio@1.0.2
     https://github.com/holepunchto/bare-stdio
-  bare-stream@2.13.1
+  bare-stream@2.12.0
     https://github.com/holepunchto/bare-stream
-  bare-structured-clone@1.5.4
+  bare-structured-clone@1.5.3
     https://github.com/holepunchto/bare-structured-clone
   bare-subprocess@5.2.3
     https://github.com/holepunchto/bare-subprocess
-  bare-tcp@2.2.12
+  bare-tcp@2.2.7
     https://github.com/holepunchto/bare-tcp
   bare-thread@1.2.0
     https://github.com/holepunchto/bare-thread
-  bare-tls@2.2.3
+  bare-tls@2.2.1
     https://github.com/holepunchto/bare-tls
   bare-tty@5.1.0
     https://github.com/holepunchto/bare-tty
   bare-type@1.1.0
     https://github.com/holepunchto/bare-type
-  bare-url@2.4.2
+  bare-url@2.4.0
     https://github.com/holepunchto/bare-url
   bare-worker@4.1.6
     https://github.com/holepunchto/bare-worker
-  bare-zlib@1.3.3
+  bare-zlib@1.3.1
     https://github.com/holepunchto/bare-zlib
-  blind-relay@1.5.0
+  blind-relay@1.4.0
     https://github.com/holepunchto/blind-relay
   compact-encoding@2.19.2
     https://github.com/holepunchto/compact-encoding
@@ -642,7 +647,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/events-universal
   fd-lock@2.1.1
     https://github.com/holepunchto/fd-lock
-  fs-native-extensions@1.5.0
+  fs-native-extensions@1.4.5
     https://github.com/holepunchto/fs-native-extensions
   hyperblobs@2.11.1
     https://github.com/holepunchto/hyperblobs
@@ -656,8 +661,6 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore-storage
   hyperdb@4.22.3
     https://github.com/holepunchto/hyperdb
-  hyperdht-address@1.0.1
-    https://github.com/holepunchto/hyperdht-address
   hyperdht-stats@1.10.0
     https://github.com/holepunchto/hyperdht-stats
   hyperdispatch@1.5.1
@@ -670,7 +673,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperswarm-stats
   index-encoder@3.5.0
     https://github.com/holepunchto/index-encoder
-  mirror-drive@1.14.2
+  mirror-drive@1.14.1
     https://github.com/holepunchto/mirror-drive
   noise-handshake@4.2.0
     https://github.com/holepunchto/noise-handshake
@@ -742,8 +745,8 @@ JavaScript Dependencies
     https://github.com/holepunchto/corestore
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
-  dht-rpc@6.26.4
-    https://github.com/holepunchto/dht-rpc
+  dht-rpc@6.26.3
+    https://github.com/mafintosh/dht-rpc
   events@3.3.0
     https://github.com/Gozala/events
   fast-fifo@1.3.2
@@ -762,7 +765,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.6.1
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.30.0
+  hyperdht@6.29.6
     https://github.com/holepunchto/hyperdht
   hyperswarm@4.17.0
     https://github.com/holepunchto/hyperswarm
@@ -780,8 +783,8 @@ JavaScript Dependencies
     https://github.com/mafintosh/nat-sampler
   protocol-buffers-encodings@1.2.0
     https://github.com/mafintosh/protocol-buffers-encodings
-  protomux@3.10.3
-    https://github.com/holepunchto/protomux
+  protomux@3.10.1
+    https://github.com/mafintosh/protomux
   queue-tick@1.0.1
     https://github.com/mafintosh/queue-tick
   random-array-iterator@1.0.0
@@ -816,6 +819,8 @@ JavaScript Dependencies
     https://github.com/mafintosh/tar-stream
   teex@1.0.1
     https://github.com/mafintosh/teex
+  test-tmp@1.4.0
+    https://github.com/mafintosh/test-tmp
   time-ordered-set@2.0.1
     https://github.com/mafintosh/time-ordered-set
   timeout-refresh@2.0.1

--- a/packages/sdk/changelog/0.10.0/CHANGELOG.md
+++ b/packages/sdk/changelog/0.10.0/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog v0.10.0
+
+Release Date: 2026-05-01
+
+## ✨ Features
+
+- Add real-time voice assistant example. (see PR [#1631](https://github.com/tetherto/qvac/pull/1631))
+- Add parallel orchestration, download dedupe, and generic companion-set support. (see PR [#1636](https://github.com/tetherto/qvac/pull/1636)) - See [breaking changes](./breaking.md)
+- Unified CompletionEvent stream as canonical completion API. (see PR [#1673](https://github.com/tetherto/qvac/pull/1673)) - See [breaking changes](./breaking.md)
+- Add Bergamot NMT companion-set grouping and path-based vocab resolution. (see PR [#1707](https://github.com/tetherto/qvac/pull/1707))
+- Switch delegation to direct DHT connect, drop topic end-to-end. (see PR [#1729](https://github.com/tetherto/qvac/pull/1729)) - See [breaking changes](./breaking.md)
+
+## 🔌 API
+
+- Update SDK nmtcpp plugin for @qvac/translation-nmtcpp 2.0.1. (see PR [#1563](https://github.com/tetherto/qvac/pull/1563)) - See [API changes](./api.md)
+- Add sentence-level streaming for onnx text-to-speech. (see PR [#1590](https://github.com/tetherto/qvac/pull/1590)) - See [API changes](./api.md)
+- Support the new llm addon cache api in sdk. (see PR [#1633](https://github.com/tetherto/qvac/pull/1633)) - See [API changes](./api.md)
+- Add img2img support to SDK diffusion API. (see PR [#1662](https://github.com/tetherto/qvac/pull/1662)) - See [API changes](./api.md)
+- Harden suspend with lifecycle gate and add state() api. (see PR [#1691](https://github.com/tetherto/qvac/pull/1691)) - See [API changes](./api.md)
+- Propagate whisper per-segment metadata to SDK users. (see PR [#1701](https://github.com/tetherto/qvac/pull/1701)) - See [API changes](./api.md)
+- Make auto KV-cache reuse completed turn history. (see PR [#1705](https://github.com/tetherto/qvac/pull/1705)) - See [API changes](./api.md)
+- Propagate registry download retries and expose stream timeout. (see PR [#1743](https://github.com/tetherto/qvac/pull/1743)) - See [API changes](./api.md)
+- Improve model type & capability system. (see PR [#1748](https://github.com/tetherto/qvac/pull/1748)) - See [breaking changes](./breaking.md), [API changes](./api.md)
+- Add responseFormat for structured output. (see PR [#1768](https://github.com/tetherto/qvac/pull/1768)) - See [API changes](./api.md)
+- Sdk "dynamic" tools mode. (see PR [#1779](https://github.com/tetherto/qvac/pull/1779)) - See [API changes](./api.md)
+- Pre-terminate cleanup hook + stabilise mobile smoke. (see PR [#1797](https://github.com/tetherto/qvac/pull/1797)) - See [API changes](./api.md)
+- Add native tool-call dialect routing (hermes, pythonic, json) with override. (see PR [#1802](https://github.com/tetherto/qvac/pull/1802)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Add timeout to RPC initialization in Node runtime. (see PR [#1550](https://github.com/tetherto/qvac/pull/1550))
+- Enable corestoreOpts: { wait: true } for registry client. (see PR [#1699](https://github.com/tetherto/qvac/pull/1699))
+- Skip kv-cache savedCount on cancelled or zero-token turns. (see PR [#1737](https://github.com/tetherto/qvac/pull/1737))
+- Scope kv-cache invalidation to deleted key on RPC delete-cache. (see PR [#1740](https://github.com/tetherto/qvac/pull/1740))
+- Strip __profiling envelope in delegate transport before zod validation. (see PR [#1767](https://github.com/tetherto/qvac/pull/1767))
+- Replace z.xor with z.union, bump zod floor to ^4.3.0. (see PR [#1790](https://github.com/tetherto/qvac/pull/1790))
+- Deterministic decoding for LLM translate. (see PR [#1808](https://github.com/tetherto/qvac/pull/1808))
+- Handle inflight delegation rejection cleanup chain. (see PR [#1811](https://github.com/tetherto/qvac/pull/1811))
+
+## 📦 Models
+
+- Regenerate model registry with companion-set metadata. (see PR [#1700](https://github.com/tetherto/qvac/pull/1700)) - See [model changes](./models.md)
+  Added: NMT_Q0F16 through NMT_Q0F16_9, NMT_Q4_0 through NMT_Q4_0_12+
+  Removed: MARIAN_OPUS_*
+
+## 📘 Docs
+
+- Content update - SDK - diffusion - add img2img gen. (see PR [#1796](https://github.com/tetherto/qvac/pull/1796))
+
+## 🧪 Tests
+
+- Fix android sharded-model-resume scudo oom. (see PR [#1831](https://github.com/tetherto/qvac/pull/1831))
+
+## 🧹 Chores
+
+- Migrate SDK plugins to new addon constructor shape. (see PR [#1688](https://github.com/tetherto/qvac/pull/1688)) - See [breaking changes](./breaking.md)
+- Refresh tests-qvac docs, tooling, and workflow job names. (see PR [#1712](https://github.com/tetherto/qvac/pull/1712))
+- Scope down DataLoader cleanup to packages/rag. (see PR [#1754](https://github.com/tetherto/qvac/pull/1754))
+
+## ⚙️ Infrastructure
+
+- Add suite filtering and PR-triggered e2e test workflows for SDK. (see PR [#1653](https://github.com/tetherto/qvac/pull/1653))
+

--- a/packages/sdk/changelog/0.10.0/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.10.0/CHANGELOG_LLM.md
@@ -1,0 +1,443 @@
+# QVAC SDK v0.10.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.0
+
+This release lands a redesigned completion API built on a unified event stream, a generic
+companion-set system that handles multi-file models in parallel, and a much stronger model
+type/capability system that catches mis-routed calls at compile time. It also rewires
+delegated inference to direct DHT connections, expands the addon surface (img2img,
+structured output, dynamic tools, tool dialects, per-segment whisper metadata,
+sentence-streaming TTS), and reshapes the model registry around companion sets.
+
+## Breaking Changes
+
+### Unified `CompletionEvent` stream
+
+`completion()` now returns a `CompletionRun` with a single canonical `events` stream that
+carries content, thinking, tool calls, stats, and completion in one ordered, sequenced
+sequence. The legacy `tokenStream`/`stats` fields still work as derived views, but the
+event stream is the authoritative API going forward and is what enables features like
+captured thinking and structured tool framing.
+
+**Before:**
+
+```typescript
+const result = completion({ modelId, history, stream: true });
+for await (const token of result.tokenStream) { /* ... */ }
+const stats = await result.stats;
+```
+
+**After:**
+
+```typescript
+const run = completion({ modelId, history, stream: true, captureThinking: true });
+for await (const event of run.events) {
+  if (event.type === "contentDelta") process.stdout.write(event.text);
+  if (event.type === "toolCall") console.log(event.call.name);
+}
+const result = await run.final;
+// result.contentText, result.thinkingText, result.toolCalls, result.stats, result.raw.fullText
+```
+
+### Model type & capability system overhaul
+
+`LoadModelOptions` is no longer a single catch-all. Custom plugins must use the new
+`LoadCustomPluginModelOptions<"plugin-name">` generic so the literal plugin string is
+pinned at the type level. Built-in model types continue to pick the right overload
+automatically when the annotation is dropped.
+
+At runtime, built-in SDK operations now throw `MODEL_OPERATION_NOT_SUPPORTED` when called
+against the wrong model type — with a message that lists the requested operation, the
+loaded model's type, and the supported operations on it. The lower-level `pluginInvoke`
+and `pluginInvokeStream` paths still surface `PLUGIN_HANDLER_NOT_FOUND` as before.
+
+`translate(...)` now routes by the loaded model's registered type. Passing a mismatched
+`modelType` throws `ModelTypeMismatchError` instead of silently mis-routing the call.
+
+**Before:**
+
+```typescript
+import type { LoadModelOptions } from "@qvac/sdk";
+
+const opts: LoadModelOptions = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
+```
+
+**After:**
+
+```typescript
+import type { LoadCustomPluginModelOptions } from "@qvac/sdk";
+
+const opts: LoadCustomPluginModelOptions<"my-custom-plugin"> = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
+// Or just drop the annotation — TS picks the right overload.
+```
+
+```typescript
+import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
+
+try {
+  await transcribe({ modelId: llmModelId /* ... */ });
+} catch (e) {
+  if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.MODEL_OPERATION_NOT_SUPPORTED) {
+    // Includes requested operation, loaded model type, supported operations,
+    // and suggested model types.
+  }
+}
+```
+
+### Companion-set download progress field
+
+Multi-file model downloads (ONNX, future formats) now report progress through a generic
+`fileSetInfo` field instead of the ONNX-specific `onnxInfo`. The shape is identical, only
+the field name changed.
+
+**Before:**
+
+```typescript
+onProgress: (progress) => {
+  if (progress.onnxInfo) {
+    console.log(`[${progress.onnxInfo.currentFile}] ${progress.onnxInfo.overallPercentage.toFixed(1)}%`);
+  }
+}
+```
+
+**After:**
+
+```typescript
+onProgress: (progress) => {
+  if (progress.fileSetInfo) {
+    console.log(`[${progress.fileSetInfo.currentFile}] ${progress.fileSetInfo.overallPercentage.toFixed(1)}%`);
+  }
+}
+```
+
+### Delegated inference uses direct DHT connect
+
+Delegation no longer rendezvous over a shared topic. Consumers connect directly to a
+provider's public key via `swarm.dht.connect(publicKey)`, and providers bind the DHT
+server with `swarm.listen()` instead of announcing a topic. This removes a class of
+discovery-flake failures and shortens connect time. Callers using the high-level
+delegation API see no surface change; integrators driving Hyperswarm directly should
+update their join/listen logic.
+
+### Plugin constructor migration
+
+SDK plugins (`definePlugin`) now use the new addon constructor shape. Plugin authors
+need to migrate their `createModel` implementation to match — the SDK in this release
+ships with all first-party plugins already migrated.
+
+## New APIs and Capabilities
+
+### `getLoadedModelInfo` for runtime introspection
+
+A new `getLoadedModelInfo` API returns metadata for a loaded `modelId`, discriminated on
+`isDelegated`. Local models expose their authoritative handler list and `modelType`;
+delegated models defer to the provider. Useful for preflighting a built-in SDK call
+before issuing the RPC.
+
+```typescript
+import { getLoadedModelInfo, transcribe } from "@qvac/sdk";
+
+const info = await getLoadedModelInfo({ modelId });
+
+if (info.isDelegated || info.handlers.includes("transcribeStream")) {
+  await transcribe({ modelId /* ... */ });
+}
+```
+
+### Structured output (`responseFormat`)
+
+`completion()` now accepts a `responseFormat` option that constrains the model to emit
+schema-valid JSON. The output is guaranteed to parse against the supplied JSON Schema.
+
+```typescript
+const run = completion({
+  modelId,
+  history: [{ role: "user", content: "Extract: I'm Alice, 30, data engineer." }],
+  stream: true,
+  responseFormat: {
+    type: "json_schema",
+    json_schema: {
+      name: "Person",
+      schema: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "integer" },
+          occupation: { type: "string" },
+        },
+        required: ["name", "age", "occupation"],
+        additionalProperties: false,
+      },
+    },
+  },
+});
+
+for await (const event of run.events) {
+  if (event.type === "contentDelta") process.stdout.write(event.text);
+}
+const final = await run.final;
+JSON.parse(final.contentText); // schema-valid
+```
+
+### Dynamic tools mode
+
+LLM models can now opt into a `dynamic` tools mode at load time. Subsequent
+`completion()` calls can pass an entirely different `tools` array on each turn, and the
+addon trims the previous tool block from the KV cache so rotation is free — no need to
+invalidate the cache or pin the tool set per-session.
+
+```typescript
+import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
+
+const modelId = await loadModel({
+  modelSrc: QWEN3_1_7B_INST_Q4,
+  modelType: "llm",
+  modelConfig: {
+    ctx_size: 4096,
+    tools: true,
+    toolsMode: TOOLS_MODE.dynamic,
+  },
+});
+
+// Turn 1 — weather tools.
+const turn1 = completion({
+  modelId, history, kvCache, stream: true,
+  tools: [{ name: "get_weather", description: "...", parameters: weatherSchema }],
+});
+
+// Turn 2 — same kvCache, different tools. Free rotation.
+const turn2 = completion({
+  modelId, history, kvCache, stream: true,
+  tools: [{ name: "get_horoscope", description: "...", parameters: horoscopeSchema }],
+});
+```
+
+### Tool-call dialect routing
+
+Tool-call parsing is now dialect-aware. The SDK auto-detects between `hermes`,
+`pythonic`, and `json` framings, and a new `toolDialect` parameter lets you force a
+specific parser when auto-detection picks the wrong path — common for Llama 3.x
+fine-tunes that emit native pythonic headers, which the auto-router defaults to `hermes`
+for empirical reasons.
+
+```typescript
+import { completion, type ToolDialect } from "@qvac/sdk";
+
+const result = completion({
+  modelId, history, tools, stream: true,
+  toolDialect: "pythonic", // "hermes" | "pythonic" | "json"
+});
+```
+
+### img2img for diffusion models
+
+The diffusion API now accepts an `init_image` for SDEdit-style image-to-image on
+SD/SDXL, and in-context conditioning on FLUX.2. `strength` controls how much of the
+source is preserved on SD/SDXL; FLUX.2 ignores it (the path is purely conditional).
+
+```typescript
+const initImage = new Uint8Array(fs.readFileSync("input.png"));
+const { outputs } = diffusion({
+  modelId,
+  prompt: "oil painting style, vibrant colors",
+  init_image: initImage,
+  strength: 0.5, // 0 = keep source, 1 = ignore source
+});
+```
+
+### Sentence-level TTS streaming
+
+Onnx text-to-speech can now stream output one sentence at a time, either as a
+self-contained `textToSpeech({ stream: true, sentenceStream: true })` call or via a
+duplex `textToSpeechStream` session that you can pipe a streaming LLM into. Each chunk
+exposes the int16 PCM samples plus the source sentence and chunk index.
+
+```typescript
+const session = await textToSpeechStream({
+  modelId: ttsModelId,
+  inputType: "text",
+  accumulateSentences: true,
+  sentenceDelimiterPreset: "latin", // "latin" | "cjk" | "multilingual"
+  flushAfterMs: 400,
+});
+
+(async () => {
+  for await (const delta of completion({ modelId: llmModelId /* ... */ }).tokenStream) {
+    session.write(delta);
+  }
+  session.end();
+})();
+
+for await (const chunk of session) {
+  // chunk.buffer / chunk.chunkIndex / chunk.sentenceChunk
+  if (chunk.done) break;
+}
+```
+
+### Per-segment whisper metadata
+
+Both `transcribe` (batch) and `transcribeStream` (duplex) now return structured
+`TranscribeSegment` objects with start/end timestamps, segment IDs, and an `append`
+flag — enabling proper subtitle generation and timeline alignment instead of raw text
+concatenation.
+
+```typescript
+const segments = await transcribe({ modelId, audioChunk: audioFilePath, metadata: true });
+for (const s of segments) {
+  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`);
+}
+```
+
+### Suspend lifecycle gate and `state()`
+
+`suspend()` is now serialized through a lifecycle gate that prevents overlapping
+suspend/resume races. A new `state()` API reports the current lifecycle phase:
+`active`, `suspending`, `suspended`, or `resuming`.
+
+```typescript
+import { state, suspend, resume, type LifecycleState } from "@qvac/sdk";
+
+await suspend();
+const current: LifecycleState = await state();
+if (current !== "active") {
+  await resume();
+}
+```
+
+### Registry download retries and configurable stream timeout
+
+Two new SDK config knobs cover slow/unstable links: `registryDownloadMaxRetries` retries
+`REQUEST_TIMEOUT` failures (set to `0` to disable), and `registryStreamTimeoutMs`
+extends the per-block stream timeout beyond the default 60s.
+
+```typescript
+import { setSDKConfig } from "@qvac/sdk";
+
+setSDKConfig({
+  registryDownloadMaxRetries: 5,
+  registryStreamTimeoutMs: 180_000,
+});
+```
+
+### Auto KV-cache: replay the canonical assistant turn
+
+When auto KV-cache is enabled, the completion result now exposes
+`final.cacheableAssistantContent` — the exact assistant string the SDK persisted to the
+cache key on this turn. Push it back into `history` verbatim on the next turn to
+guarantee a cache hit. Tool-call turns aren't auto-cached today and omit the field;
+fall back to `final.contentText` in that case.
+
+```typescript
+const run = completion({ modelId, history, kvCache: true });
+for await (const _ of run.tokenStream) { /* stream */ }
+const final = await run.final;
+const nextHistory = [
+  ...history,
+  { role: "assistant", content: final.cacheableAssistantContent ?? final.contentText },
+  { role: "user", content: "follow-up question" },
+];
+```
+
+### LLM-addon cache API plumbed through SDK
+
+The SDK now wires through the LLM addon's first-class cache API — including explicit
+`deleteCache({ kvCacheKey })` for evicting a named cache key — so consumers can manage
+KV-cache lifetimes alongside `loadModel`/`unloadModel`.
+
+### NMTcpp 2.0.1 surface
+
+The SDK NMT plugin now targets `@qvac/translation-nmtcpp 2.0.1` with a structured
+constructor that distinguishes primary and pivot model files, vocab files, and pivot
+config (beam size, top-k). Bergamot models are also picked up via path-based vocab
+resolution and grouped into companion sets, which lets the cache and download paths
+treat them like any other multi-file model.
+
+## Features
+
+### Parallel orchestration and download dedupe
+
+Model loading is now genuinely parallel where it can be: the primary model and any
+companion files (vision projection, vocab, etc.) download concurrently, and concurrent
+requests for the same asset are deduplicated to a single transfer. Cancellation cleans
+up all active transfers atomically with no leaked state. Profiling fields
+(`sourceType`, `cacheHit`, `sharedTransfer`, `totalLoadTime`,
+`modelInitializationTime`, `checksumValidationTime`) are populated correctly across
+both primary and companion downloads, with aggregate stats merged at the run level.
+
+The companion pipeline is also generic: `companions.ts` is the only format-aware piece,
+and adding a new multi-file format is a matter of dropping in a detection function and
+registering it with `groupCompanionSets`. Everything downstream — codegen, resolver,
+cache probing, storage cleanup — handles it automatically.
+
+### Real-time voice assistant example
+
+A new end-to-end example demonstrates a real-time voice assistant pipeline (whisper →
+LLM → TTS) wired together using the SDK's streaming primitives.
+
+## Bug Fixes
+
+- RPC initialization in the Node runtime now has an explicit timeout, so a wedged
+  transport can no longer hang `loadModel`/`unloadModel` indefinitely.
+- The registry client now opens its corestore with `wait: true`, eliminating a startup
+  race where downloads could begin before replication was ready.
+- KV-cache `savedCount` is no longer incremented on cancelled or zero-token turns,
+  preventing inflated cache stats.
+- `delete-cache` RPC now scopes invalidation to the deleted key only instead of wiping
+  unrelated entries.
+- Delegated transports strip the `__profiling` envelope before zod validation, fixing a
+  spurious validation error when profiling is enabled on the consumer side.
+- Replaced `z.xor` with `z.union` and bumped the zod floor to `^4.3.0` to track upstream
+  breaking changes.
+- LLM-based translation now uses deterministic decoding so the same input produces the
+  same output across runs.
+- Inflight delegation requests that get rejected now run their cleanup chain to
+  completion instead of leaking pending promises.
+
+## Model Registry Changes
+
+The model registry was regenerated around companion-set metadata. The user-facing surface
+is leaner: families that used to live as separate `*_DATA`, `*_LEX`, `*_VOCAB`, and
+`METADATA_*` constants are now companion-only — they're still downloaded, but they're
+not addressable as standalone model sources. Marian Opus models were renamed under the
+`NMT_*` namespace to match the rest of the NMT family.
+
+### Added
+
+```
+NMT_Q0F16 through NMT_Q0F16_9 (10 entries)
+NMT_Q4_0 through NMT_Q4_0_12+ (22 entries)
+```
+
+### Removed (now companion-only or renamed)
+
+```
+*_DATA (32 entries — companion-only, e.g. PARAKEET_TDT_ENCODER_DATA_FP32, TTS_*_DATA)
+BERGAMOT_*_LEX (93 entries — companion-only)
+BERGAMOT_*_VOCAB (93 entries — companion-only)
+BERGAMOT_METADATA_* (87 entries — companion-only)
+MARIAN_OPUS_* (32 entries — renamed to NMT_*)
+```
+
+## Documentation, Tests, and Infrastructure
+
+- Diffusion documentation was extended to cover the new img2img flows (SDEdit on
+  SD/SDXL, in-context conditioning on FLUX.2).
+- Android sharded-model-resume tests no longer trip Scudo OOM — the test harness now
+  bounds memory more conservatively on long-running resume scenarios.
+- The tests-qvac docs, tooling, and CI workflow job names were refreshed for the new
+  suite filtering and PR-triggered e2e workflows. Suite filtering plus PR-trigger labels
+  let CI run targeted SDK e2e subsets on demand instead of always running the full grid.
+- A pre-terminate cleanup hook stabilises mobile smoke: the mobile auto-close path now
+  awaits worker cleanup acknowledgement before terminating the worklet.
+- `DataLoader` cleanup logic was scoped down to `packages/rag` so the SDK no longer
+  carries that surface.

--- a/packages/sdk/changelog/0.10.0/api.md
+++ b/packages/sdk/changelog/0.10.0/api.md
@@ -1,0 +1,501 @@
+# 🔌 API Changes v0.10.0
+
+## Update SDK nmtcpp plugin for @qvac/translation-nmtcpp 2.0.1
+
+PR: [#1563](https://github.com/tetherto/qvac/pull/1563)
+
+```typescript
+// NMT addon constructor (2.0.1) — called by SDK plugin
+new TranslationNmtcpp({
+  files: {
+    model: '/path/to/model.bin',
+    srcVocab: '/path/to/vocab.spm',
+    dstVocab: '/path/to/vocab.spm',
+    pivotModel: '/path/to/pivot.bin',       // optional
+    pivotSrcVocab: '/path/to/pivot-vocab.spm', // optional
+    pivotDstVocab: '/path/to/pivot-vocab.spm', // optional
+  },
+  params: { srcLang: 'en', dstLang: 'fr' },
+  config: {
+    modelType: TranslationNmtcpp.ModelTypes.Bergamot,
+    beamsize: 4,
+    pivotConfig: { beamsize: 4, topk: 100 }, // optional
+  },
+  logger,
+  opts: { stats: true },
+})
+```
+
+---
+
+## Add sentence-level streaming for onnx text-to-speech
+
+PR: [#1590](https://github.com/tetherto/qvac/pull/1590)
+
+```typescript
+import { loadModel, textToSpeech, unloadModel } from "@qvac/sdk";
+
+const modelId = await loadModel({ /* ...Supertonic ONNX TTS config... */ });
+
+const result = textToSpeech({
+  modelId,
+  text: "Your long passage here.",
+  inputType: "text",
+  stream: true,
+  sentenceStream: true,
+  sentenceStreamLocale: "en",
+});
+
+for await (const chunk of result.chunkUpdates!) {
+  // chunk.buffer      -> int16 PCM samples for this sentence
+  // chunk.chunkIndex  -> 0-based sentence index
+  // chunk.sentenceChunk -> source text for this chunk
+}
+
+await result.done;
+await unloadModel({ modelId });
+```
+
+```typescript
+import { completion, textToSpeechStream } from "@qvac/sdk";
+
+const session = await textToSpeechStream({
+  modelId: ttsModelId,
+  inputType: "text",
+  accumulateSentences: true,
+  sentenceDelimiterPreset: "latin", // "latin" | "cjk" | "multilingual"
+  flushAfterMs: 400,
+});
+
+(async () => {
+  for await (const delta of completion({ modelId: llmModelId, /* ... */ }).tokenStream) {
+    session.write(delta);
+  }
+  session.end();
+})();
+
+for await (const chunk of session) {
+  // chunk.buffer       -> int16 PCM for this sentence / flush window
+  // chunk.chunkIndex   -> optional sentence index
+  // chunk.sentenceChunk-> optional source text
+  if (chunk.done) break;
+}
+```
+
+---
+
+## Support the new llm addon cache api in sdk
+
+PR: [#1633](https://github.com/tetherto/qvac/pull/1633)
+
+```ts
+import {
+  completion,
+  deleteCache,
+  LLAMA_3_2_1B_INST_Q4_0,
+  loadModel,
+  unloadModel,
+  VERBOSITY,
+} from "@qvac/sdk";
+
+type ChatMessage = {
+  role: string;
+  content: string;
+};
+
+const cacheKey = "trip-planner";
+
+const modelId = await loadModel({
+  modelSrc: LLAMA_3_2_1B_INST_Q4_0,
+  modelType: "llm",
+  modelConfig: {
+    ctx_size: 4096,
+    verbosity: VERBOSITY.ERROR,
+  },
+});
+
+async function run(history: ChatMessage[]) {
+  const result = completion({
+    modelId,
+    history,
+    stream: true,
+    kvCache: cacheKey,
+  });
+
+  let text = "";
+  for await (const token of result.tokenStream) {
+    text += token;
+  }
+
+  return text.trim();
+}
+
+const firstReply = await run([
+  { role: "system", content: "You are a concise travel assistant." },
+  { role: "user", content: "I like museums and seafood. Plan a day in Lisbon." },
+]);
+
+const followUpReply = await run([
+  { role: "system", content: "You are a concise travel assistant." },
+  { role: "user", content: "I like museums and seafood. Plan a day in Lisbon." },
+  { role: "assistant", content: firstReply },
+  { role: "user", content: "Now make it a rainy-day itinerary." },
+]);
+
+console.log(followUpReply);
+
+await deleteCache({ kvCacheKey: cacheKey });
+await unloadModel({ modelId, clearStorage: false });
+```
+
+---
+
+## Add img2img support to SDK diffusion API
+
+PR: [#1662](https://github.com/tetherto/qvac/pull/1662)
+
+```typescript
+import { loadModel, diffusion, SD_V2_1_1B_Q8_0 } from "@qvac/sdk";
+import fs from "fs";
+
+const modelId = await loadModel({ modelSrc: SD_V2_1_1B_Q8_0, modelType: "diffusion" });
+
+// SD / SDXL — SDEdit
+const initImage = new Uint8Array(fs.readFileSync("input.png"));
+const { outputs } = diffusion({
+  modelId,
+  prompt: "oil painting style, vibrant colors",
+  init_image: initImage,
+  strength: 0.5, // 0 = keep source, 1 = ignore source
+});
+
+// FLUX.2 — in-context conditioning
+// NOTE: requires `prediction: "flux2_flow"` set on the model config at loadModel time.
+// `strength` is ignored on this path.
+const { outputs: fluxOutputs } = diffusion({
+  modelId,
+  prompt: "turn into watercolor",
+  init_image: initImage,
+});
+
+const buffers = await outputs;
+fs.writeFileSync("out.png", buffers[0]!);
+```
+
+---
+
+## Harden suspend with lifecycle gate and add state() api
+
+PR: [#1691](https://github.com/tetherto/qvac/pull/1691)
+
+```typescript
+import { state, suspend, resume, type LifecycleState } from "@qvac/sdk";
+
+await suspend();
+
+const current: LifecycleState = await state();
+// "active" | "suspending" | "suspended" | "resuming"
+
+if (current !== "active") {
+  await resume();
+}
+```
+
+---
+
+## Propagate whisper per-segment metadata to SDK users
+
+PR: [#1701](https://github.com/tetherto/qvac/pull/1701)
+
+```typescript
+// Batch — returns TranscribeSegment[] instead of string
+const segments = await transcribe({
+  modelId,
+  audioChunk: audioFilePath,
+  metadata: true,
+});
+for (const s of segments) {
+  console.log(`[${s.startMs}ms → ${s.endMs}ms] id=${s.id} append=${s.append} ${s.text}`);
+}
+
+// Duplex streaming — session iterator yields TranscribeSegment
+const session = await transcribeStream({ modelId, metadata: true });
+session.write(audioChunk);
+for await (const segment of session) {
+  console.log(segment.startMs, segment.endMs, segment.text);
+}
+session.end();
+```
+
+```typescript
+type TranscribeSegment = {
+  text: string;
+  startMs: number;
+  endMs: number;
+  append: boolean;
+  id: number;
+};
+```
+
+---
+
+## Make auto KV-cache reuse completed turn history
+
+PR: [#1705](https://github.com/tetherto/qvac/pull/1705)
+
+```typescript
+// New: `final.cacheableAssistantContent` — the canonical assistant
+// string the SDK persisted to the auto-cache key on this turn.
+// Push it back into `history` verbatim to guarantee a next-turn hit.
+const run = completion({ modelId, history, kvCache: true });
+for await (const _ of run.tokenStream) { /* stream */ }
+const final = await run.final;
+const nextHistory = [
+  ...history,
+  {
+    role: "assistant",
+    // Falls back to contentText for tool-call turns, which can't
+    // be auto-cached today and therefore omit the field.
+    content: final.cacheableAssistantContent ?? final.contentText,
+  },
+  { role: "user", content: "follow-up question" },
+];
+```
+
+---
+
+## Propagate registry download retries and expose stream timeout
+
+PR: [#1743](https://github.com/tetherto/qvac/pull/1743)
+
+```ts
+import { setSDKConfig } from "@qvac/sdk";
+
+setSDKConfig({
+  // Retry REQUEST_TIMEOUT failures up to N times before giving up.
+  // Set to 0 to disable retries entirely.
+  registryDownloadMaxRetries: 5,
+
+  // Raise the per-block stream timeout for slow/high-latency links
+  // (default: 60_000 ms).
+  registryStreamTimeoutMs: 180_000,
+});
+```
+
+---
+
+## Improve model type & capability system
+
+PR: [#1748](https://github.com/tetherto/qvac/pull/1748)
+
+```typescript
+import type { LoadModelOptions } from "@qvac/sdk";
+
+const opts: LoadModelOptions = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
+```
+
+```typescript
+import type { LoadCustomPluginModelOptions } from "@qvac/sdk";
+
+// Generic must be supplied; it pins the literal plugin string.
+const opts: LoadCustomPluginModelOptions<"my-custom-plugin"> = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
+
+// Or just drop the annotation — TS picks the right overload.
+```
+
+```typescript
+import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
+
+try {
+  await transcribe({ modelId: llmModelId /* ... */ });
+} catch (e) {
+  if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.PLUGIN_HANDLER_NOT_FOUND) {
+    /* ... */
+  }
+}
+```
+
+```typescript
+import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
+
+try {
+  await transcribe({ modelId: llmModelId /* ... */ });
+} catch (e) {
+  if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.MODEL_OPERATION_NOT_SUPPORTED) {
+    // Message includes the requested operation, the loaded model type,
+    // supported operations on the loaded model, and suggested model types.
+  }
+}
+```
+
+```typescript
+// Loaded an NMT model, but called translate with modelType: "llm".
+// Worker routed to the NMT plugin (modelId-based) but treated the input as LLM-style. Confusing failures.
+await translate({ modelId: nmtModelId, modelType: "llm", text: "..." });
+```
+
+```typescript
+// Drop modelType; the registered type drives behavior.
+await translate({ modelId: nmtModelId, text: "..." });
+
+// Or keep it — but it must match the loaded type, otherwise:
+//   ModelTypeMismatchError: expected "nmtcpp-translation", got "llamacpp-completion"
+await translate({ modelId: nmtModelId, modelType: "nmt", text: "..." });
+```
+
+```typescript
+import { getLoadedModelInfo, transcribe } from "@qvac/sdk";
+
+// Introspect a loaded modelId (local or delegated). Discriminated on `isDelegated`.
+const info = await getLoadedModelInfo({ modelId });
+
+// Preflight a built-in SDK call before sending the RPC.
+// Local: handlers + modelType are authoritative.
+// Delegated: handlers is [] and preflight defers to the provider.
+if (info.isDelegated || info.handlers.includes("transcribeStream")) {
+  await transcribe({ modelId /* ... */ });
+}
+
+if (!info.isDelegated) {
+  // info.modelType, info.loadedAt
+  // info.displayName?, info.addonPackage?  (from the plugin)
+  // info.name?, info.path?                 (from the model file)
+}
+
+// Throws ModelNotFoundError if modelId isn't loaded.
+```
+
+---
+
+## Add responseFormat for structured output
+
+PR: [#1768](https://github.com/tetherto/qvac/pull/1768)
+
+```typescript
+import { completion } from "@qvac/sdk";
+
+const run = completion({
+  modelId,
+  history: [{ role: "user", content: "Extract person info: I'm Alice, 30, data engineer." }],
+  stream: true,
+  responseFormat: {
+    type: "json_schema",
+    json_schema: {
+      name: "Person",
+      schema: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "integer" },
+          occupation: { type: "string" },
+        },
+        required: ["name", "age", "occupation"],
+        additionalProperties: false,
+      },
+    },
+  },
+});
+
+for await (const event of run.events) {
+  if (event.type === "contentDelta") process.stdout.write(event.text);
+}
+const final = await run.final;
+JSON.parse(final.contentText); // guaranteed schema-valid
+```
+
+---
+
+## Sdk "dynamic" tools mode
+
+PR: [#1779](https://github.com/tetherto/qvac/pull/1779)
+
+```typescript              
+  import { loadModel, completion, TOOLS_MODE, QWEN3_1_7B_INST_Q4 } from "@qvac/sdk";
+                                                                                                                                                                                                                                                      
+  // Opt into dynamic tools by setting `toolsMode` on the model config.
+  const modelId = await loadModel({                                                                                                                                                                                                                   
+    modelSrc: QWEN3_1_7B_INST_Q4,
+    modelType: "llm",                                                                                                                                                                                                                                 
+    modelConfig: {
+      ctx_size: 4096,                                                                                                                                                                                                                                 
+      tools: true,           
+      toolsMode: TOOLS_MODE.dynamic, // or the literal string "dynamic"
+    },                                                                                                                                                                                                                                                
+  });
+                                                                                                                                                                                                                                                      
+  const kvCache = `dynamic-tools-${Date.now()}`;
+  const history = [
+    { role: "system", content: "You are a helpful assistant." },
+    { role: "user", content: "What's the weather in Tokyo?" },                                                                                                                                                                                        
+  ];
+                                                                                                                                                                                                                                                      
+  // Turn 1 — weather tools available.
+  const turn1 = completion({
+    modelId,                                                                                                                                                                                                                                          
+    history,
+    kvCache,                                                                                                                                                                                                                                          
+    stream: true,            
+    tools: [{ name: "get_weather", description: "...", parameters: weatherSchema }],
+  });                                                                                                                                                                                                                                                 
+   
+  // Turn 2 — same kvCache, completely different tools. The addon trims the                                                                                                                                                                           
+  // previous tool block from the cache, so this rotation is free.
+  history.push({ role: "user", content: "Now check my horoscope for Aquarius." });
+  const turn2 = completion({                                                                                                                                                                                                                          
+    modelId,
+    history,                                                                                                                                                                                                                                          
+    kvCache,                 
+    stream: true,
+    tools: [{ name: "get_horoscope", description: "...", parameters: horoscopeSchema }],
+  });                                                                                                                                                                                                                                                 
+  ```
+
+---
+
+## Pre-terminate cleanup hook + stabilise mobile smoke
+
+PR: [#1797](https://github.com/tetherto/qvac/pull/1797)
+
+```typescript
+// Mobile auto-close path (unchanged from caller perspective):
+await close(); // now awaits worker cleanup ack before terminating worklet
+```
+
+---
+
+## Add native tool-call dialect routing (hermes, pythonic, json) with override
+
+PR: [#1802](https://github.com/tetherto/qvac/pull/1802)
+
+```typescript
+// New optional `toolDialect` parameter on completion() — force a specific
+// parser chain when the SDK can't auto-detect from the model name.
+import { completion } from "@qvac/sdk";
+
+const result = completion({
+  modelId,
+  history,
+  tools,
+  stream: true,
+  toolDialect: "pythonic", // "hermes" | "pythonic" | "json"
+});
+
+Common override case: Llama 3.x tool-calling fine-tunes that emit the native pythonic header (`<|start_header_id|>tool_call<|end_header_id|>...<|eot_id|>`). Auto-routing keeps these on `hermes` because most observed Llama 3.x tool-calling tunes empirically emit JSON, not pythonic — pass `toolDialect: "pythonic"` for tunes that do emit the native framing
+```
+
+```typescript
+import type { ToolDialect } from "@qvac/sdk";
+```
+
+---
+

--- a/packages/sdk/changelog/0.10.0/breaking.md
+++ b/packages/sdk/changelog/0.10.0/breaking.md
@@ -1,0 +1,278 @@
+# 💥 Breaking Changes v0.10.0
+
+## Add parallel orchestration, download dedupe, and generic companion-set support
+
+PR: [#1636](https://github.com/tetherto/qvac/pull/1636)
+
+**BEFORE:**
+**
+
+```typescript
+onProgress: (progress) => {
+  if (progress.onnxInfo) {
+    console.log(
+      `[${progress.onnxInfo.currentFile}] ` +
+      `file ${progress.onnxInfo.fileIndex}/${progress.onnxInfo.totalFiles} — ` +
+      `${progress.onnxInfo.overallPercentage.toFixed(1)}% overall`
+    );
+  }
+}
+```
+
+**
+
+**AFTER:**
+**
+
+```typescript
+onProgress: (progress) => {
+  if (progress.fileSetInfo) {
+    console.log(
+      `[${progress.fileSetInfo.currentFile}] ` +
+      `file ${progress.fileSetInfo.fileIndex}/${progress.fileSetInfo.totalFiles} — ` +
+      `${progress.fileSetInfo.overallPercentage.toFixed(1)}% overall`
+    );
+  }
+}
+```
+
+## 🔌 Extensibility: adding a new companion format
+
+The companion pipeline is generic. Only `companions.ts` contains format-specific detection (currently ONNX). To add a new format:
+
+1. Add a detection function in `companions.ts`
+2. Call it from `groupCompanionSets`
+
+Everything downstream (codegen, resolver, cache probing, storage cleanup) handles it automatically.
+
+## 🧪 How was it tested?
+
+- Unit tests for `resolveClearStorageTarget` — companion set paths, legacy ONNX paths, flat cache, outside-cache paths, trailing slashes, Windows backslash paths
+- Unit tests for `groupCompanionSets` — ONNX + `_data`/`.data` patterns, non-ONNX models, deterministic `setKey` generation
+- **Companion set smoke test** — ran Parakeet CTC and TDT end-to-end, validated all 4 cache paths (legacy `_data` probe, legacy `.data` probe, canonical fresh download, canonical cache hit) with correct transcription output on each
+- **Parallel orchestration**: ran `examples/llamacpp-multimodal.ts` with labeled progress — confirmed primary and projection models download concurrently via interleaved output
+- **Profiling**: ran `examples/profiling/basic.ts` — confirmed `sourceType`, `cacheHit`, `sharedTransfer`, `totalLoadTime`, `modelInitializationTime`, `checksumValidationTime` populate correctly through `buildDownloadProfilingFields()`. Ran `examples/llamacpp-multimodal.ts` with profiling enabled — confirmed aggregate stats merge correctly across primary and projection downloads
+- **Cancellation**: `^C` during multimodal download cleanly aborts both active transfers with no leaked state
+- Build, lint, and typecheck pass
+
+---
+
+## Unified CompletionEvent stream as canonical completion API
+
+PR: [#1673](https://github.com/tetherto/qvac/pull/1673)
+
+**BEFORE:**
+**
+
+```typescript
+// Wire response
+{ type: "completionStream", token: "Hello", toolCallEvent: {...} }
+{ type: "completionStream", token: "", done: true, stats: {...}, toolCalls: [...] }
+```
+
+**
+
+**AFTER:**
+**
+
+```typescript
+// Wire response
+{ type: "completionStream", events: [{ type: "contentDelta", seq: 0, text: "Hello" }] }
+{ type: "completionStream", done: true, events: [
+  { type: "completionStats", seq: 5, stats: {...} },
+  { type: "completionDone", seq: 6, raw: { fullText: "..." } }
+]}
+```
+
+**Client API**: `completion()` return type is now `CompletionRun` (was anonymous object). Legacy fields still work but are derived views.
+
+**BEFORE:**
+
+```typescript
+const result = completion({ modelId, history, stream: true });
+for await (const token of result.tokenStream) { ... }
+const stats = await result.stats;
+```
+
+**AFTER:**
+
+```typescript
+const run = completion({ modelId, history, stream: true, captureThinking: true });
+for await (const event of run.events) {
+  if (event.type === "contentDelta") process.stdout.write(event.text);
+  if (event.type === "toolCall") console.log(event.call.name);
+}
+const result = await run.final;
+// result.contentText, result.thinkingText, result.toolCalls, result.stats, result.raw.fullText
+```
+
+## 🧪 How was it tested?
+
+- **Unit tests**: event schema validation and wire strictness, normalizer state machine (content, thinking, tool framing, fail-open, error-finish, scoped dedupe), and client-side event aggregation with error-done rejection
+- **Manual**: ran `examples/completion-events.ts` (new event-driven API) and existing legacy examples — both produce correct output
+- Build and typecheck passes
+
+---
+
+## Migrate SDK plugins to new addon constructor shape
+
+PR: [#1688](https://github.com/tetherto/qvac/pull/1688)
+
+**BEFORE:**
+**
+
+```typescript
+export const myPlugin = definePlugin({
+  // ...
+  createModel(params: CreateModelParams): PluginModelResult {
+    return { model, loader: null };
+  },
+});
+```
+
+**
+
+**AFTER:**
+**
+
+---
+
+## Switch delegation to direct DHT connect, drop topic end-to-end
+
+PR: [#1729](https://github.com/tetherto/qvac/pull/1729)
+
+**BEFORE:**
+**
+- Consumer: `swarm.join(topic)` → `swarm.flush()` → wait for `connection` event matching `peerPublicKey` → filter out everyone else.
+- Provider: `swarm.join(topic, { server: true })` → `discovery.flushed()` → `swarm.flush()` (full topic announce on the DHT).
+
+**
+
+**AFTER:**
+**
+- Consumer: `swarm.dht.connect(publicKey)` — direct connection, no discovery, no filtering.
+- Provider: `swarm.listen()` — binds the DHT server on the keyPair so consumers can reach it via `dht.connect(publicKey)`. No topic announce.
+
+---
+
+## Improve model type & capability system
+
+PR: [#1748](https://github.com/tetherto/qvac/pull/1748)
+
+**BEFORE:**
+**
+
+```typescript
+import type { LoadModelOptions } from "@qvac/sdk";
+
+const opts: LoadModelOptions = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
+```
+
+**
+
+**AFTER:**
+**
+
+```typescript
+import type { LoadCustomPluginModelOptions } from "@qvac/sdk";
+
+// Generic must be supplied; it pins the literal plugin string.
+const opts: LoadCustomPluginModelOptions<"my-custom-plugin"> = {
+  modelSrc: "/path/foo",
+  modelType: "my-custom-plugin",
+  modelConfig: { whatever: 1 },
+};
+await loadModel(opts);
+
+// Or just drop the annotation — TS picks the right overload.
+```
+
+### Wrong-model error code/message change (runtime)
+
+Built-in SDK operations now surface `MODEL_OPERATION_NOT_SUPPORTED` instead of `PLUGIN_HANDLER_NOT_FOUND`. Low-level `pluginInvoke` / `pluginInvokeStream` still use `PLUGIN_HANDLER_NOT_FOUND`.
+
+**BEFORE:**
+
+```typescript
+import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
+
+try {
+  await transcribe({ modelId: llmModelId /* ... */ });
+} catch (e) {
+  if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.PLUGIN_HANDLER_NOT_FOUND) {
+    /* ... */
+  }
+}
+```
+
+**AFTER:**
+
+```typescript
+import { SDK_SERVER_ERROR_CODES } from "@qvac/sdk";
+
+try {
+  await transcribe({ modelId: llmModelId /* ... */ });
+} catch (e) {
+  if ((e as { code?: number })?.code === SDK_SERVER_ERROR_CODES.MODEL_OPERATION_NOT_SUPPORTED) {
+    // Message includes the requested operation, the loaded model type,
+    // supported operations on the loaded model, and suggested model types.
+  }
+}
+```
+
+`PLUGIN_HANDLER_NOT_FOUND` is still the low-level path for `pluginInvoke` / `pluginInvokeStream`.
+
+### `translate(...)` validates caller-supplied `modelType` against loaded type (runtime)
+
+`translate(...)` now routes by the loaded model's registered type. A mismatched caller-supplied `modelType` throws `ModelTypeMismatchError` instead of being silently mis-routed.
+
+**BEFORE:**
+
+```typescript
+// Loaded an NMT model, but called translate with modelType: "llm".
+// Worker routed to the NMT plugin (modelId-based) but treated the input as LLM-style. Confusing failures.
+await translate({ modelId: nmtModelId, modelType: "llm", text: "..." });
+```
+
+**AFTER:**
+
+```typescript
+// Drop modelType; the registered type drives behavior.
+await translate({ modelId: nmtModelId, text: "..." });
+
+// Or keep it — but it must match the loaded type, otherwise:
+//   ModelTypeMismatchError: expected "nmtcpp-translation", got "llamacpp-completion"
+await translate({ modelId: nmtModelId, modelType: "nmt", text: "..." });
+```
+
+## 🔌 API Changes
+
+```typescript
+import { getLoadedModelInfo, transcribe } from "@qvac/sdk";
+
+// Introspect a loaded modelId (local or delegated). Discriminated on `isDelegated`.
+const info = await getLoadedModelInfo({ modelId });
+
+// Preflight a built-in SDK call before sending the RPC.
+// Local: handlers + modelType are authoritative.
+// Delegated: handlers is [] and preflight defers to the provider.
+if (info.isDelegated || info.handlers.includes("transcribeStream")) {
+  await transcribe({ modelId /* ... */ });
+}
+
+if (!info.isDelegated) {
+  // info.modelType, info.loadedAt
+  // info.displayName?, info.addonPackage?  (from the plugin)
+  // info.name?, info.path?                 (from the model file)
+}
+
+// Throws ModelNotFoundError if modelId isn't loaded.
+```
+
+---
+

--- a/packages/sdk/changelog/0.10.0/models.md
+++ b/packages/sdk/changelog/0.10.0/models.md
@@ -1,0 +1,20 @@
+# 📦 Model Changes v0.10.0
+
+## Added Models
+
+```
+NMT_Q0F16 through NMT_Q0F16_9
+NMT_Q4_0 through NMT_Q4_0_12+
+```
+
+## Removed Models
+
+```
+MARIAN_OPUS_*
+```
+
+---
+
+### Related PRs
+
+- [#1700](https://github.com/tetherto/qvac/pull/1700) - Regenerate model registry with companion-set metadata

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

Cuts the v0.10.0 release of `@qvac/sdk` on the `release-sdk-0.10.0` branch.

## 🔧 How does it solve it?

- Bumps `packages/sdk/package.json`: `0.9.1` → `0.10.0`.
- Adds `packages/sdk/changelog/0.10.0/{CHANGELOG.md, breaking.md, api.md, models.md, CHANGELOG_LLM.md}` generated by the refreshed `sdk-changelog` tooling.
- Rebuilds the root `packages/sdk/CHANGELOG.md` aggregate with v0.10.0 at top.
- Refreshes `packages/sdk/NOTICE` (191 models, 179 JS dependencies).

Companion PR against `main` lands the same release artifacts plus the changelog tooling improvements (`scripts/sdk/generate-changelog-sdk-pod.cjs`, `.cursor/skills/sdk-changelog/SKILL.md`, `.gitignore`), so the eventual backmerge `release-sdk-0.10.0 → main` is a no-op for these files: tetherto/qvac#1865.

## ✅ How was it tested?

- `release-merge-guard` requirements satisfied:
  - `package.json` version `0.10.0` matches branch `release-sdk-0.10.0`.
  - `packages/sdk/CHANGELOG.md` modified in this push.
- Files produced by `node scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk` against the synced `upstream/release-sdk-0.10.0` tip (33 valid PRs, no validation errors except #1753 which has an invalid title).
- `notice-generate` ran clean: 191 unique models, 179 JS dependencies, 0 NOTICE_LOG.txt entries.

## 📝 Notes for reviewers

- Depends on the `main`-targeted PR landing first (#1865) so the changelog tooling improvements are present in `main` history before this release closes.
- `[skiplog]` — release PRs don't appear in their own changelog.
- PR #1753 (invalid title format) was excluded from v0.10.0 release notes — flag for the author.
