### PR TITLE
Revert "fix: prevent code injection and untrusted checkout in CI workflows (#1728)"

### DIFF
--- a/.github/actions/publish-library-to-gpr/action.yaml
+++ b/.github/actions/publish-library-to-gpr/action.yaml
@@ -120,11 +120,9 @@ runs:
       shell: bash
       working-directory: ${{ steps.resolve_dir.outputs.dir }}
       if: steps.determine_version.outputs.version != steps.determine_version.outputs.package_version
-      env:
-        PKG_VERSION: ${{ steps.determine_version.outputs.version }}
       run: |
-        echo "Updating version to ${PKG_VERSION}"
-        npm version "${PKG_VERSION}" --no-git-tag-version --allow-same-version
+        echo "Updating version to ${{ steps.determine_version.outputs.version }}"
+        npm version ${{ steps.determine_version.outputs.version }} --no-git-tag-version --allow-same-version
 
     - name: Check version exists in GitHub Packages
       continue-on-error: true

--- a/.github/actions/sanity-checks/action.yaml
+++ b/.github/actions/sanity-checks/action.yaml
@@ -39,13 +39,15 @@ runs:
         github.event_name == 'pull_request_target' ||
         github.event_name == 'pull_request'
       continue-on-error: true
+      env:
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        PR_FORK_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
         git remote set-url origin https://github.com/${{ github.repository }}.git
         git fetch origin +refs/heads/*:refs/remotes/origin/*
-        git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-        PR_FORK_URL=${{ github.event.pull_request.head.repo.clone_url }}
-        PR_HEAD_REF=${{ github.event.pull_request.head.ref }}
-        git fetch origin $PR_HEAD_REF:refs/pr/head || git fetch $PR_FORK_URL $PR_HEAD_REF:refs/pr/head
+        git fetch origin "$PR_BASE_REF:refs/remotes/origin/$PR_BASE_REF"
+        git fetch origin "$PR_HEAD_REF:refs/pr/head" || git fetch "$PR_FORK_URL" "$PR_HEAD_REF:refs/pr/head"
 
     - name: Check PR status vs. target branch
       shell: bash

--- a/.github/actions/sanity-checks/action.yaml
+++ b/.github/actions/sanity-checks/action.yaml
@@ -39,16 +39,13 @@ runs:
         github.event_name == 'pull_request_target' ||
         github.event_name == 'pull_request'
       continue-on-error: true
-      env:
-        GH_REPOSITORY: ${{ github.repository }}
-        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        PR_FORK_URL: ${{ github.event.pull_request.head.repo.clone_url }}
       run: |
-        git remote set-url origin "https://github.com/${GH_REPOSITORY}.git"
+        git remote set-url origin https://github.com/${{ github.repository }}.git
         git fetch origin +refs/heads/*:refs/remotes/origin/*
-        git fetch origin "${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
-        git fetch origin "${PR_HEAD_REF}:refs/pr/head" || git fetch "${PR_FORK_URL}" "${PR_HEAD_REF}:refs/pr/head"
+        git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+        PR_FORK_URL=${{ github.event.pull_request.head.repo.clone_url }}
+        PR_HEAD_REF=${{ github.event.pull_request.head.ref }}
+        git fetch origin $PR_HEAD_REF:refs/pr/head || git fetch $PR_FORK_URL $PR_HEAD_REF:refs/pr/head
 
     - name: Check PR status vs. target branch
       shell: bash
@@ -57,10 +54,9 @@ runs:
         github.event_name == 'pull_request_target' ||
         github.event_name == 'pull_request'
       continue-on-error: true
-      env:
-        TARGET_SHA: ${{ github.event.pull_request.base.sha }}
-        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
+        TARGET_SHA=${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}
         if ! git merge-base --is-ancestor "$TARGET_SHA" "$PR_HEAD_SHA"; then
           echo "::error title=PR is not up to date::This PR is not up to date with target branch"
           echo "ℹ️  Suggestion: Consider rebasing or merging the latest changes from the target branch"

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -110,32 +110,18 @@ jobs:
         if: matrix.platform == 'Android' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-android-staging
+          path: ${{ env.ADDON_WORKDIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
-
-      - name: Move Android prebuilds from staging
-        if: matrix.platform == 'Android' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_WORKDIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-android-staging/* ${{ env.ADDON_WORKDIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-ios-staging
+          path: ${{ env.ADDON_WORKDIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
-
-      - name: Move iOS prebuilds from staging
-        if: matrix.platform == 'iOS' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_WORKDIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-ios-staging/* ${{ env.ADDON_WORKDIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download prebuilds from package

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -113,32 +113,18 @@ jobs:
         if: matrix.platform == 'Android' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-android-staging
+          path: addon/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
-
-      - name: Move Android prebuilds from staging
-        if: matrix.platform == 'Android' && !inputs.package
-        run: |
-          mkdir -p addon/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-android-staging/* addon/${{ inputs.workdir || env.PKG_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-ios-staging
+          path: addon/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
-
-      - name: Move iOS prebuilds from staging
-        if: matrix.platform == 'iOS' && !inputs.package
-        run: |
-          mkdir -p addon/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-ios-staging/* addon/${{ inputs.workdir || env.PKG_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download prebuilds from package

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-embed.yml
@@ -123,32 +123,18 @@ jobs:
         if: matrix.platform == 'Android' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-android-staging
+          path: ${{ env.ADDON_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
-
-      - name: Move Android prebuilds from staging
-        if: matrix.platform == 'Android' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-android-staging/* ${{ env.ADDON_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-ios-staging
+          path: ${{ env.ADDON_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
-
-      - name: Move iOS prebuilds from staging
-        if: matrix.platform == 'iOS' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-ios-staging/* ${{ env.ADDON_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download prebuilds from package

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-llamacpp-llm.yml
@@ -119,32 +119,18 @@ jobs:
         if: matrix.platform == 'Android' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-android-staging
+          path: ${{ env.ADDON_WORKDIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
-
-      - name: Move Android prebuilds from staging
-        if: matrix.platform == 'Android' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_WORKDIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-android-staging/* ${{ env.ADDON_WORKDIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-ios-staging
+          path: ${{ env.ADDON_WORKDIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
-
-      - name: Move iOS prebuilds from staging
-        if: matrix.platform == 'iOS' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_WORKDIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-ios-staging/* ${{ env.ADDON_WORKDIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download prebuilds from package

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-nmtcpp.yml
@@ -116,32 +116,18 @@ jobs:
         if: matrix.platform == 'Android' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-android-staging
+          path: monorepo/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
-
-      - name: Move Android prebuilds from staging
-        if: matrix.platform == 'Android' && !inputs.package
-        run: |
-          mkdir -p monorepo/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-android-staging/* monorepo/${{ inputs.workdir || env.PKG_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && !inputs.package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-ios-staging
+          path: monorepo/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
-
-      - name: Move iOS prebuilds from staging
-        if: matrix.platform == 'iOS' && !inputs.package
-        run: |
-          mkdir -p monorepo/${{ inputs.workdir || env.PKG_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-ios-staging/* monorepo/${{ inputs.workdir || env.PKG_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download prebuilds from package

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-onnx-tts.yml
@@ -124,32 +124,18 @@ jobs:
         if: matrix.platform == 'Android' && github.event_name != 'workflow_dispatch'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-android-staging
+          path: ${{ env.ADDON_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
-
-      - name: Move Android prebuilds from staging
-        if: matrix.platform == 'Android' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-android-staging/* ${{ env.ADDON_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && github.event_name != 'workflow_dispatch'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-ios-staging
+          path: ${{ env.ADDON_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
-
-      - name: Move iOS prebuilds from staging
-        if: matrix.platform == 'iOS' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-ios-staging/* ${{ env.ADDON_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download prebuilds (from npm - workflow_dispatch)

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-parakeet.yml
@@ -131,16 +131,9 @@ jobs:
         id: artifact_android
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-android-staging
+          path: ${{ env.ADDON_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
-
-      - name: Move Android prebuilds from staging
-        if: matrix.platform == 'Android' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-android-staging/* ${{ env.ADDON_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
@@ -148,16 +141,9 @@ jobs:
         id: artifact_ios
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-ios-staging
+          path: ${{ env.ADDON_DIR }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
-
-      - name: Move iOS prebuilds from staging
-        if: matrix.platform == 'iOS' && !inputs.package
-        run: |
-          mkdir -p ${{ env.ADDON_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-ios-staging/* ${{ env.ADDON_DIR }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download prebuilds (from npm - workflow_dispatch)

--- a/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-qvac-lib-infer-whispercpp.yml
@@ -117,32 +117,18 @@ jobs:
         if: matrix.platform == 'Android' && github.event_name != 'workflow_dispatch'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-android-staging
+          path: addon/${{ inputs.workdir }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}android-*
           merge-multiple: true
-
-      - name: Move Android prebuilds from staging
-        if: matrix.platform == 'Android' && !inputs.package
-        run: |
-          mkdir -p addon/${{ inputs.workdir }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-android-staging/* addon/${{ inputs.workdir }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download iOS prebuilds (from artifacts)
         if: matrix.platform == 'iOS' && github.event_name != 'workflow_dispatch'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-ios-staging
+          path: addon/${{ inputs.workdir }}/prebuilds
           pattern: ${{ env.PREBUILD_ARTIFACT_PREFIX }}ios-*
           merge-multiple: true
-
-      - name: Move iOS prebuilds from staging
-        if: matrix.platform == 'iOS' && !inputs.package
-        run: |
-          mkdir -p addon/${{ inputs.workdir }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-ios-staging/* addon/${{ inputs.workdir }}/prebuilds/ 2>/dev/null || true
-        shell: bash
         continue-on-error: true
 
       - name: Download prebuilds (from npm - workflow_dispatch)

--- a/.github/workflows/integration-test-ocr-onnx.yml
+++ b/.github/workflows/integration-test-ocr-onnx.yml
@@ -93,16 +93,8 @@ jobs:
         if: ${{ !inputs.prebuild_package }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-staging
+          path: ${{ inputs.workdir || env.PKG_DIR }}/prebuilds
           merge-multiple: true
-
-      - name: Move prebuilds from staging to workspace
-        if: ${{ !inputs.prebuild_package }}
-        run: |
-          mkdir -p ${{ inputs.workdir || env.PKG_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-staging/* ${{ inputs.workdir || env.PKG_DIR }}/prebuilds/ 2>/dev/null || true
-          echo "Prebuilds moved from staging area"
-        shell: bash
 
       - name: Download prebuilds from package
         if: ${{ inputs.prebuild_package }}

--- a/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-nmtcpp.yml
@@ -88,16 +88,8 @@ jobs:
         if: ${{ !inputs.prebuild_package }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-staging
+          path: ${{ inputs.workdir || env.PKG_DIR }}/prebuilds
           merge-multiple: true
-
-      - name: Move prebuilds from staging to workspace
-        if: ${{ !inputs.prebuild_package }}
-        shell: bash
-        run: |
-          mkdir -p ${{ inputs.workdir || env.PKG_DIR }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-staging/* ${{ inputs.workdir || env.PKG_DIR }}/prebuilds/ 2>/dev/null || true
-          echo "Prebuilds moved from staging area"
 
       - name: Download prebuilds from package
         if: ${{ inputs.prebuild_package }}

--- a/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-onnx-tts.yml
@@ -187,16 +187,8 @@ jobs:
         if: ${{ !inputs.prebuild_package }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-staging
+          path: ${{ inputs.workdir }}/prebuilds
           merge-multiple: true
-
-      - name: Move prebuilds from staging to workspace
-        if: ${{ !inputs.prebuild_package }}
-        run: |
-          mkdir -p ${{ inputs.workdir }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-staging/* ${{ inputs.workdir }}/prebuilds/ 2>/dev/null || true
-          echo "Prebuilds moved from staging area"
-        shell: bash
 
       - name: Download prebuilds from package
         if: ${{ inputs.prebuild_package }}

--- a/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
+++ b/.github/workflows/integration-test-qvac-lib-infer-whispercpp.yml
@@ -131,16 +131,8 @@ jobs:
         if: ${{ !inputs.prebuild_package }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
         with:
-          path: ${{ runner.temp }}/prebuilds-staging
+          path: ${{ inputs.workdir }}/prebuilds
           merge-multiple: true
-
-      - name: Move prebuilds from staging to workspace
-        if: ${{ !inputs.prebuild_package }}
-        run: |
-          mkdir -p ${{ inputs.workdir }}/prebuilds
-          cp -r ${{ runner.temp }}/prebuilds-staging/* ${{ inputs.workdir }}/prebuilds/ 2>/dev/null || true
-          echo "Prebuilds moved from staging area"
-        shell: bash
 
       - name: Download prebuilds from package (Unix)
         if: ${{ inputs.prebuild_package && matrix.platform != 'win32' }}

--- a/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
+++ b/.github/workflows/on-pr-qvac-lib-infer-onnx.yml
@@ -85,21 +85,17 @@ jobs:
         id: fetch_pr
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
         continue-on-error: true
-        env:
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git fetch origin "${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}"
-          git fetch origin "${PR_HEAD_SHA}:refs/pr/head"
+          git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+          git fetch origin ${{ github.event.pull_request.head.sha }}:refs/pr/head
 
       - name: Check PR Status with Target Branch
         continue-on-error: true
         id: target_branch_checks
         if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request'
-        env:
-          TARGET_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          TARGET_SHA=${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA=${{ github.event.pull_request.head.sha }}
           if ! git merge-base --is-ancestor "$TARGET_SHA" "$PR_HEAD_SHA"; then
             echo "::error title=PR is not up to date::This PR is not up to date with target branch"
           fi


### PR DESCRIPTION
Reverts commit a79602fe399011e30cdb9ea37618da76df5d7b44, with two intentional exclusions noted below.

Excluded from this revert:
- .github/actions/run-lint-and-unit-tests/action.yaml: kept at its current state on main; the env-var indirection #1728 introduced for npm-token/pat-token in the .npmrc-configuration step is preserved.
- .github/workflows/cpp-lint.yaml: net effect on this file is zero. PR #1829 (commit 65bd7460) later rewrote the same `cpp-lint` job and added `id-token: write` to the `permissions` block originally introduced by #1728. The `permissions` block is preserved as-is (contents: read + id-token: write) because #1829's AWS OIDC integration depends on it.

All other changes from #1728 are reverted.