### PR TITLE
Force gemma4 image test to CPU on macOS and Android

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/gemma4.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/gemma4.test.js
@@ -12,7 +12,11 @@ const platform = os.platform()
 const arch = os.arch()
 const isDarwinX64 = platform === 'darwin' && arch === 'x64'
 const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
+const isDarwin = platform === 'darwin'
+const isMobile = platform === 'ios' || platform === 'android'
 const useCpu = isDarwinX64 || isLinuxArm64
+
+const useCpuForVision = useCpu || isDarwin || isMobile
 
 const GEMMA4_MODEL = {
   llmModel: {
@@ -180,7 +184,7 @@ test('Gemma 4 can describe an image', {
 
   const loader = new FilesystemDL({ dirPath })
   const config = {
-    device: useCpu ? 'cpu' : 'gpu',
+    device: useCpuForVision ? 'cpu' : 'gpu',
     gpu_layers: '98',
     ctx_size: '2048',
     temp: '0',

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/ocr-paddle.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/ocr-paddle.test.js
@@ -28,8 +28,6 @@ const PADDLE_OCR_CONFIG = {
   ctx_size: '4096'
 }
 
-const isIos = platform === 'ios'
-
 const TEST_CONSTANTS = {
   timeout: 1_800_000,
   // Mobile (iOS Metal + Android Mali Vulkan / Adreno OpenCL) runs the


### PR DESCRIPTION
Force gemma4 image test to CPU on macOS and Android, and drop the isIos from ocr-paddle.test.js to make the cpp sanity check happy.