### PR TITLE
QVAC-18115 doc: fix - missing redirect for v0.9.1

### DIFF
--- a/docs/website/public/_redirects
+++ b/docs/website/public/_redirects
@@ -9,11 +9,14 @@
 /sdk/api/v0.8.0/   /sdk/api/v0.8.0/index.html   200
 /sdk/api/v0.8.0    /sdk/api/v0.8.0/index.html   200
 
+/sdk/api/v0.9.1/   /sdk/api/v0.9.1/index.html   200
+/sdk/api/v0.9.1    /sdk/api/v0.9.1/index.html   200
+
 /sdk/release-notes/v0.7.0/   /sdk/release-notes/v0.7.0/index.html   200
 /sdk/release-notes/v0.7.0    /sdk/release-notes/v0.7.0/index.html   200
 
 /sdk/release-notes/v0.8.0/   /sdk/release-notes/v0.8.0/index.html   200
 /sdk/release-notes/v0.8.0    /sdk/release-notes/v0.8.0/index.html   200
 
-/sdk/release-notes/v0.9.0/   /sdk/release-notes/v0.9.0/index.html   200
-/sdk/release-notes/v0.9.0    /sdk/release-notes/v0.9.0/index.html   200
+/sdk/release-notes/v0.9.1/   /sdk/release-notes/v0.9.1/index.html   200
+/sdk/release-notes/v0.9.1    /sdk/release-notes/v0.9.1/index.html   200


### PR DESCRIPTION
Minor fix in missing redirect after generating new docs version v0.10.0: missing redirects for archived v0.9.1.
Result: 404:
https://docs.qvac.tether.io/sdk/api/v0.9.1
https://docs.qvac.tether.io/sdk/release-notes/v0.9.1