### PR TITLE
QVAC-18460 test[skiplog]: skip transcription tests on iOS

### DIFF
--- a/packages/sdk/tests-qvac/tests/mobile/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/mobile/consumer.ts
@@ -366,6 +366,8 @@ export const executor = createExecutor({
         "ocr-multiple-fonts",
       ], "OCR disabled on iOS (ONNX/CoreML OOM)"),
       new SkipExecutor(/^translation-afriquegemma-/, "AfriqueGemma 4B (~2.7 GB) exceeds iOS memory budget"),
+      // TODO(QVAC-18460): re-enable once iOS transcribe() crash is fixed.
+      new SkipExecutor(/^transcription-/, "TODO(QVAC-18460): transcription disabled on iOS — transcribe() hard-crashes consumer after FFmpegDecoder unload"),
     ] : []),
 
     // Real executors


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- iOS smoke is fully blocked: every iOS run dies on `transcription-*` tests because `transcribe()` hard-crashes the consumer process (Mach exception / fatal Corpse 309) right after `FFmpegDecoder unloaded`.
- From the runner's perspective the consumer just goes silent — `transcribe()` never returns, no SDK error is thrown, and the producer marks the consumer dead after the 130 s heartbeat timeout. Net effect: the whole iOS smoke suite fails.
- Reproduces 100% locally on iPhone 16e (cold start, first test) and on CI Device Farm iPhone 16 Pro (after 18-19 prior tests).
- Tracking bug: [QVAC-18460](https://app.asana.com/1/45238840754660/project/1214153063536860/task/1214497808399994) — assigned to the transcription addon team.

## 📝 How does it solve it?

- Add `new SkipExecutor(/^transcription-/, ...)` to the iOS-only handler block in `tests-qvac/tests/mobile/consumer.ts`.
- All `transcription-*` tests (incl. smoke ones: `transcription-short-wav`, `transcription-short-mp3`, `transcription-streaming`) are now skipped only on iOS; Android and desktop are unaffected.
- Skip is marked `TODO(QVAC-18460)` in both the comment and the skip reason so it's easy to grep and revert once the addon team fixes the crash.

## 🧪 How was it tested?

- Local iOS run on iPhone 16e: with the skip applied, smoke no longer hangs on `transcription-short-wav`; runner proceeds to subsequent tests.
- Android and desktop legs are unchanged (no diff outside the iOS-only block).