### PR TITLE
infra: drop llvm-19 install from setup-build-host

### DIFF
--- a/.github/actions/setup-build-host/action.yml
+++ b/.github/actions/setup-build-host/action.yml
@@ -1,12 +1,18 @@
 name: Setup build host
 description: >-
   Install and configure the OS-level prerequisites needed by prebuild
-  workflows. Runs a fixed set of steps per runner/platform/arch: on ubuntu we
-  maximize disk space and install llvm-19; on windows we enable long paths,
-  configure the CMake generator, and (on arm64) rename the Windows 10 SDK; on
-  linux we install the base X11 dev headers plus any caller-supplied extras;
-  on android we export the NDK / toolchain env and install the ubuntu cross
+  workflows. Runs a fixed set of steps per runner/platform/arch: on ubuntu
+  we maximize disk space; on windows we enable long paths, configure the
+  CMake generator, and (on arm64) rename the Windows 10 SDK; on linux we
+  install the base X11 dev headers plus any caller-supplied extras; on
+  android we export the NDK / toolchain env and install the ubuntu cross
   toolchain.
+
+  LLVM/Clang installation has been split out into the dedicated
+  `setup-llvm` composite action. Callers that need a versioned LLVM
+  toolchain (every C++ workflow today) MUST invoke `setup-llvm` themselves
+  on linux/windows runners; it is the single source of truth for the LLVM
+  major used across the monorepo.
 
 inputs:
   platform:
@@ -52,17 +58,6 @@ runs:
         fi
         echo "=== Disk space after cleanup ==="
         df -h /
-
-    - if: ${{ runner.os == 'Linux' }}
-      name: Install llvm-19
-      shell: bash
-      run: |
-        set -euo pipefail
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
-        sudo chmod 644 /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-        wget -q https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 19 all
 
     - if: ${{ runner.os == 'Windows' }}
       name: Configure Windows long paths


### PR DESCRIPTION
## What problem does this PR solve?

- `setup-build-host` is pinned by SHA at every caller (today: `reusable-prebuilds.yml`, `cpp-lint.yaml`), so any change to its inline `sudo ./llvm.sh 19 all` step only takes effect once each caller bumps its `@<sha>` pin.
- The follow-up monorepo-wide LLVM 22 migration (PR #1896) needs every C++ workflow to call the new `setup-llvm` composite action (#1894) **and** bump its `setup-build-host` SHA pin in lockstep — otherwise the same job ends up double-installing LLVM (19 inline here + 22 from `setup-llvm`) for every prebuild and cpp-lint run until both pins are synced.
- Because `main` uses squash-merges, the only way to make those two changes land atomically is to publish the LLVM-removed `setup-build-host` as its own merge commit first, so the follow-up PR can pin to it.

## How does it solve it?

- Removes the Linux-only `Install llvm-19` step from `.github/actions/setup-build-host/action.yml` so the action no longer ships any Clang toolchain on its own.
- Rewords the action `description` to drop the "install llvm-19" claim and add an explicit callout: callers that need a versioned LLVM toolchain (every C++ workflow today) **MUST** invoke `setup-llvm` themselves on linux/windows runners; that action is the single source of truth for the LLVM major used across the monorepo.
- All other steps (`Maximize disk space` on Linux, Windows long-paths / CMake generator / arm64 SDK rename, base X11 dev headers + caller-supplied extras on Linux, Android NDK env + cross toolchain) are unchanged.

## How was it tested?

- Verified the only callers of `setup-build-host` in the repo are `reusable-prebuilds.yml` (line 170) and `cpp-lint.yaml` (line 66), and both currently pin to `setup-build-host@1d9b21658…` — i.e. they keep installing llvm-19 inline until they bump the pin. So no in-tree consumer is broken by this commit on its own.
- The follow-up PR (#1896) covers the full migration: it bumps the `setup-build-host` SHA pin to this commit and adds an explicit `tetherto/qvac/.github/actions/setup-llvm@<sha>` step to every C++ workflow, where end-to-end CI is exercised against LLVM 22.

## Breaking Changes

- **No behavior change** for callers still pinned to the previous `setup-build-host` SHA — they keep installing llvm-19 inline.
- **For callers that bump to this SHA**: `setup-build-host` no longer provides any Clang/LLVM toolchain on Linux. Those callers MUST invoke `tetherto/qvac/.github/actions/setup-llvm@<sha>` themselves on Linux and Windows runners, otherwise `bare-make generate` / `clang-tidy` / `clang-format` / `llvm-cov` will not be available on PATH.

**BEFORE:**

```yaml
- name: Setup build host
  uses: tetherto/qvac/.github/actions/setup-build-host@<old-sha>
  with:
    platform: linux
    arch: x64
# (LLVM/Clang implicitly installed by setup-build-host on Linux)
```

**AFTER:**

```yaml
- name: Setup build host
  uses: tetherto/qvac/.github/actions/setup-build-host@<new-sha>
  with:
    platform: linux
    arch: x64

- name: Setup LLVM
  uses: tetherto/qvac/.github/actions/setup-llvm@<setup-llvm-sha>
  # defaults: version=22, windows-version=22.1.0
```