### PR TITLE
fix[notask]: prevent exit-time SIGSEGV in inference addon teardown

### DIFF
--- a/packages/diffusion-cpp/package.json
+++ b/packages/diffusion-cpp/package.json
@@ -18,7 +18,7 @@
     "lint": "standard --ignore \"addon/**\"",
     "lint:fix": "standard --ignore \"addon/**\" --fix",
     "lint-cpp": "clang-tidy -p build $(find addon -name '*.cpp')",
-    "test:integration": "npm run test:integration:generate && bare test/integration/all.js --exit",
+    "test:integration": "npm run test:integration:generate && bare test/integration/all.js",
     "test:integration:generate": "brittle -r test/integration/all.js test/integration/*.test.js && npm run test:mobile:generate",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js",
     "test:unit": "npm run test:unit:generate && bare test/unit/all.js --exit",

--- a/packages/diffusion-cpp/test/integration/api-behavior.test.js
+++ b/packages/diffusion-cpp/test/integration/api-behavior.test.js
@@ -221,9 +221,3 @@ test('run() before load() throws clear initialization error', { timeout: 60000 }
   t.ok(caught, 'run() before load() throws')
   t.ok(/load\(\) first/i.test(caught?.message || ''), 'error message instructs to call load() first')
 })
-
-// Keep event loop alive briefly to let pending async operations complete.
-// Prevents C++ destructors from running while async cleanup is still happening.
-setImmediate(() => {
-  setTimeout(() => {}, 500)
-})

--- a/packages/diffusion-cpp/test/integration/model-loading.test.js
+++ b/packages/diffusion-cpp/test/integration/model-loading.test.js
@@ -54,10 +54,3 @@ test('model loading - load and unload', { timeout: testTimeout }, async t => {
   await addon.unload().catch(() => {})
   t.pass('second unload is idempotent')
 })
-
-// Keep event loop alive briefly to let pending async operations complete
-// This prevents C++ destructors from running while async cleanup is still happening
-// which can cause segfaults (exit code 139)
-setImmediate(() => {
-  setTimeout(() => {}, 500)
-})

--- a/packages/qvac-lib-infer-llamacpp-embed/package.json
+++ b/packages/qvac-lib-infer-llamacpp-embed/package.json
@@ -14,7 +14,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "lint-cpp": "clang-tidy -p build $(find addon -name '*.cpp')",
-    "test:integration": "npm run test:integration:generate && bare test/integration/all.js --exit",
+    "test:integration": "npm run test:integration:generate && bare test/integration/all.js",
     "test:integration:generate": "brittle -r test/integration/all.js test/integration/*.test.js && npm run test:mobile:generate",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js",
     "test:unit": "npm run test:unit:generate && bare test/unit/all.js --exit",

--- a/packages/qvac-lib-infer-llamacpp-embed/test/integration/multi-instance.test.js
+++ b/packages/qvac-lib-infer-llamacpp-embed/test/integration/multi-instance.test.js
@@ -166,7 +166,3 @@ test('Multiple embed load/unload cycles on one instance while another processes'
 
   t.ok(cyclesCompleted === NUM_CYCLES, `completed ${cyclesCompleted} load/unload cycles during processing`)
 })
-
-setImmediate(() => {
-  setTimeout(() => {}, 500)
-})

--- a/packages/qvac-lib-infer-llamacpp-llm/package.json
+++ b/packages/qvac-lib-infer-llamacpp-llm/package.json
@@ -12,7 +12,7 @@
     "lint-cpp": "clang-tidy -p build $(find addon -name '*.cpp')",
     "quickstart": "node -e \"const fs=require('fs');const path=require('path');const {execSync}=require('child_process');const prebuilds=path.join(process.cwd(),'prebuilds');const source=path.join(process.cwd(),'node_modules','@qvac','llm-llamacpp','prebuilds');if(!fs.existsSync(prebuilds)){if(!fs.existsSync(source)){execSync('npm install @qvac/llm-llamacpp@latest',{stdio:'inherit'});}if(!fs.existsSync(source)){throw new Error('Prebuilds not found after install.');}fs.cpSync(source,prebuilds,{recursive:true});}execSync('bare examples/quickstart.js',{stdio:'inherit'});\"",
     "update:quickstart-section": "node ./scripts/quickstart-testing/update_readme.js",
-    "test:integration": "npm run test:integration:generate && bare test/integration/all.js --exit",
+    "test:integration": "npm run test:integration:generate && bare test/integration/all.js",
     "test:mobile:generate": "bare ./scripts/generate-mobile-integration-tests.js",
     "test:mobile:validate": "node scripts/validate-mobile-tests.js",
     "test:dts": "tsc -p tsconfig.dts.json",

--- a/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/integration/model-loading.test.js
@@ -178,10 +178,3 @@ test('sharded model can run inference end-to-end', { timeout: 4 * 60 * 1000, ski
     await addon.unload().catch(() => {})
   }
 })
-
-// Keep event loop alive briefly to let pending async operations complete
-// This prevents C++ destructors from running while async cleanup is still happening
-// which can cause segfaults (exit code 139)
-setImmediate(() => {
-  setTimeout(() => {}, 500)
-})

--- a/packages/qvac-lib-inference-addon-cpp/CMakeLists.txt
+++ b/packages/qvac-lib-inference-addon-cpp/CMakeLists.txt
@@ -72,6 +72,7 @@ if(BUILD_TESTING)
         tests/batched_addon_test.cpp
         tests/job_runner_test.cpp
         tests/addon_js_test.cpp
+        tests/exit_lifecycle_test.cpp
     )
     target_include_directories(unit_tests PRIVATE src tests/helpers_header)
     target_link_libraries(unit_tests PRIVATE GTest::gmock_main)

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsInterface.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/JsInterface.hpp
@@ -157,20 +157,65 @@ public:
   JSCATCH
 
 private:
-  inline static std::mutex instancesMtx_;
-  inline static std::vector<std::unique_ptr<AddonJs>> instances_;
+  /// @brief Per-env state holding the AddonJs instances bound to that env.
+  ///
+  /// Instances are stored per js_env_t* so that they can be deterministically
+  /// destructed when the env tears down (via js_add_teardown_callback). Using a
+  /// process-global vector with no env hook causes static-destruction-time
+  /// teardown of the addons to race with downstream globals such as ggml /
+  /// Vulkan ICDs, producing a SIGSEGV on shutdown.
+  struct EnvState {
+    std::vector<std::unique_ptr<AddonJs>> instances;
+  };
+
+  inline static std::mutex envsMtx_;
+  inline static std::unordered_map<js_env_t*, std::unique_ptr<EnvState>> envs_;
+
+  /// @brief Bare libjs teardown callback, invoked while the env (and its libuv
+  /// loop) are still alive. Synchronously destructs all AddonJs instances bound
+  /// to this env so model/backend teardown happens before C++ static
+  /// destructors run.
+  static void onEnvTeardown(void* arg) {
+    auto* env = static_cast<js_env_t*>(arg);
+    std::unique_ptr<EnvState> envState;
+    {
+      std::scoped_lock lock{envsMtx_};
+      auto it = envs_.find(env);
+      if (it == envs_.end()) {
+        return;
+      }
+      envState = std::move(it->second);
+      envs_.erase(it);
+    }
+    // Destruct outside the lock so individual AddonJs destructors (which may
+    // join worker threads, etc.) cannot deadlock if they reentered the map.
+  }
+
+  /// @brief Look up the EnvState for an env. Caller must hold envsMtx_.
+  /// Returns nullptr if no state exists for this env.
+  static auto findEnvStateLocked(js_env_t* env) -> EnvState* {
+    auto it = envs_.find(env);
+    if (it == envs_.end()) {
+      return nullptr;
+    }
+    return it->second.get();
+  }
 
 public:
   static auto getInstance(js_env_t* env, js_value_t* val) -> AddonJs& {
     auto handle = js::External(env, val).as<void*>(env);
-    std::scoped_lock lockGuard{instancesMtx_};
+    std::scoped_lock lockGuard{envsMtx_};
+    auto* envState = findEnvStateLocked(env);
+    if (envState == nullptr) {
+      throw StatusError(general_error::InvalidArgument, "Invalid handle");
+    }
     auto found = std::find_if(
-        instances_.begin(),
-        instances_.end(),
+        envState->instances.begin(),
+        envState->instances.end(),
         [handle](auto& instanceUniquePtr) {
           return static_cast<void*>(instanceUniquePtr.get()) == handle;
         });
-    if (found == instances_.end()) {
+    if (found == envState->instances.end()) {
       throw StatusError(general_error::InvalidArgument, "Invalid handle");
     }
     return *static_cast<AddonJs*>(handle);
@@ -178,9 +223,30 @@ public:
 
   static auto createInstance(js_env_t* env, std::unique_ptr<AddonJs>&& addonJs)
       -> js_value_t* try {
-    std::scoped_lock lock{instancesMtx_};
-    auto& handle = instances_.emplace_back(std::move(addonJs));
-    return js::External::create(env, handle.get());
+    AddonJs* rawHandle = nullptr;
+    bool registerHook = false;
+    {
+      std::scoped_lock lock{envsMtx_};
+      auto it = envs_.find(env);
+      if (it == envs_.end()) {
+        it = envs_.emplace(env, std::make_unique<EnvState>()).first;
+        registerHook = true;
+      }
+      auto& slot = it->second->instances.emplace_back(std::move(addonJs));
+      rawHandle = slot.get();
+    }
+    if (registerHook) {
+      // Register on first use of this env. Failure here means we leak the
+      // EnvState until process exit, which is no worse than the legacy
+      // behaviour, so we only log instead of unwinding.
+      if (js_add_teardown_callback(env, &onEnvTeardown, env) != 0) {
+        QLOG(
+            qvac_lib_inference_addon_cpp::logger::Priority::WARNING,
+            "Could not register js teardown callback for env; "
+            "AddonJs instances will be destructed at static destruction time");
+      }
+    }
+    return js::External::create(env, rawHandle);
   }
   JSCATCH
 
@@ -260,17 +326,28 @@ public:
       -> js_value_t* try {
     JsArgsParser argsParser(env, info);
     auto handle = argsParser.getRawPointer(0, "instance");
-    std::scoped_lock lockGuard{instancesMtx_};
-    auto found = std::find_if(
-        instances_.begin(),
-        instances_.end(),
-        [handle](auto& instanceUniquePtr) {
-          return static_cast<void*>(instanceUniquePtr.get()) == handle;
-        });
-    if (found == instances_.end()) {
-      throw StatusError(general_error::InvalidArgument, "Invalid handle");
+    std::unique_ptr<AddonJs> doomed;
+    {
+      std::scoped_lock lockGuard{envsMtx_};
+      auto* envState = findEnvStateLocked(env);
+      if (envState == nullptr) {
+        throw StatusError(general_error::InvalidArgument, "Invalid handle");
+      }
+      auto found = std::find_if(
+          envState->instances.begin(),
+          envState->instances.end(),
+          [handle](auto& instanceUniquePtr) {
+            return static_cast<void*>(instanceUniquePtr.get()) == handle;
+          });
+      if (found == envState->instances.end()) {
+        throw StatusError(general_error::InvalidArgument, "Invalid handle");
+      }
+      // Move the unique_ptr out so the AddonJs destructor runs after the lock
+      // is released (its dtor may join worker threads which could touch the
+      // env state).
+      doomed = std::move(*found);
+      envState->instances.erase(found);
     }
-    instances_.erase(found);
     return nullptr;
   }
   JSCATCH

--- a/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp
+++ b/packages/qvac-lib-inference-addon-cpp/src/qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp
@@ -109,6 +109,13 @@ public:
           qvac_errors::general_error::InternalError,
           "Could not initialize uv async handle");
     }
+    // The async handle must NOT keep the libuv loop alive on its own. Pending
+    // JS work (unresolved promises returned from runJob) is what keeps the
+    // process alive while inference is running. Without uv_unref the handle
+    // would prevent the loop from exiting after all JS work is done, blocking
+    // brittle's `beforeExit` hook and preventing process shutdown until libuv
+    // gives up (~65s observed). uv_async_send still wakes the loop after this.
+    uv_unref(reinterpret_cast<uv_handle_t*>(state_->asyncHandle));
     // jsOutputCallbackAsyncHandle_ has been correctly initialized, so if thread
     // fails it needs to be closed
     auto e3 = utils::onError([this]() {

--- a/packages/qvac-lib-inference-addon-cpp/tests/exit_lifecycle_test.cpp
+++ b/packages/qvac-lib-inference-addon-cpp/tests/exit_lifecycle_test.cpp
@@ -1,0 +1,250 @@
+// Tests for the two exit-time lifecycle fixes:
+//   1. OutputCallBackJs uv_unrefs its async handle so it does not, by itself,
+//      keep the libuv loop alive (else brittle's beforeExit never fires and the
+//      process hangs ~65s before SIGSEGV during static destruction).
+//   2. JsInterface stores AddonJs instances per js_env_t and registers a
+//      teardown callback so the instances are deterministically destructed
+//      while the env is still alive — before llama.cpp / Vulkan globals are
+//      torn down by C++ static destructors.
+
+#include <any>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "helpers_header/js.h"
+#include "qvac-lib-inference-addon-cpp/Errors.hpp"
+#include "qvac-lib-inference-addon-cpp/JsInterface.hpp"
+#include "qvac-lib-inference-addon-cpp/ModelInterfaces.hpp"
+#include "qvac-lib-inference-addon-cpp/addon/AddonJs.hpp"
+#include "qvac-lib-inference-addon-cpp/handlers/JsOutputHandlerImplementations.hpp"
+#include "qvac-lib-inference-addon-cpp/handlers/OutputHandler.hpp"
+#include "qvac-lib-inference-addon-cpp/queue/OutputCallbackInterface.hpp"
+#include "qvac-lib-inference-addon-cpp/queue/OutputCallbackJs.hpp"
+#include "qvac-lib-inference-addon-cpp/queue/OutputQueue.hpp"
+
+namespace qvac_lib_inference_addon_cpp {
+
+namespace {
+
+class NoopModel : public model::IModel {
+public:
+  std::string getName() const override { return "NoopModel"; }
+  RuntimeStats runtimeStats() const override { return {}; }
+  std::any process(const std::any& input) override { return input; }
+};
+
+class NoopOutputCallback : public OutputCallBackInterface {
+public:
+  void initializeProcessingThread(
+      std::shared_ptr<OutputQueue> /*outputQueue*/) override {}
+  void notify() override {}
+  void stop() override {}
+};
+
+std::unique_ptr<AddonJs> makeAddon(js_env_t* env) {
+  return std::make_unique<AddonJs>(
+      env,
+      std::make_unique<NoopOutputCallback>(),
+      std::make_unique<NoopModel>());
+}
+
+class ExitLifecycleTest : public ::testing::Test {
+protected:
+  void SetUp() override { js_test_mocks::resetAll(); }
+  void TearDown() override { js_test_mocks::resetAll(); }
+};
+
+} // namespace
+
+// ============================================================================
+// Phase 1: OutputCallBackJs::initializeProcessingThread must uv_unref the
+// async handle so it doesn't keep the libuv loop alive.
+// ============================================================================
+
+TEST_F(ExitLifecycleTest, OutputCallbackUnrefsAsyncHandleAfterInit) {
+  js_env_t env;
+  js_value_t jsHandle;
+  js_value_t outputCb;
+
+  out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface> handlers;
+  auto callback = std::make_unique<OutputCallBackJs>(
+      &env, &jsHandle, &outputCb, std::move(handlers));
+
+  // Sanity: no handles registered before init.
+  EXPECT_TRUE(js_test_mocks::refdHandles().empty());
+
+  NoopOutputCallback dummyCb;
+  NoopModel dummyModel;
+  auto outputQueue = std::make_shared<OutputQueue>(dummyCb, dummyModel);
+
+  callback->initializeProcessingThread(outputQueue);
+
+  // After init the async handle must NOT keep the loop alive. The mock's
+  // uv_async_init adds the handle to refdHandles; uv_unref removes it.
+  EXPECT_TRUE(js_test_mocks::refdHandles().empty())
+      << "OutputCallBackJs left a ref'd handle on the loop after "
+         "initializeProcessingThread; this prevents the libuv loop from "
+         "exiting and reproduces the 65s post-test hang.";
+
+  // Destructor cleans up the handle (uv_close path).
+  callback.reset();
+  EXPECT_TRUE(js_test_mocks::refdHandles().empty());
+}
+
+TEST_F(ExitLifecycleTest, OutputCallbackHandleClosedOnDestruction) {
+  js_env_t env;
+  js_value_t jsHandle;
+  js_value_t outputCb;
+
+  out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface> handlers;
+  {
+    auto callback = std::make_unique<OutputCallBackJs>(
+        &env, &jsHandle, &outputCb, std::move(handlers));
+    NoopOutputCallback dummyCb;
+    NoopModel dummyModel;
+    auto outputQueue = std::make_shared<OutputQueue>(dummyCb, dummyModel);
+    callback->initializeProcessingThread(outputQueue);
+  }
+  EXPECT_TRUE(js_test_mocks::refdHandles().empty());
+}
+
+// ============================================================================
+// Phase 2: JsInterface must store instances per env, register a teardown
+// callback, and synchronously destruct all instances when the env tears down.
+// ============================================================================
+
+TEST_F(ExitLifecycleTest, CreateInstanceRegistersTeardownCallback) {
+  js_env_t env;
+
+  auto* result = JsInterface::createInstance(&env, makeAddon(&env));
+  ASSERT_NE(result, nullptr);
+
+  auto& callbacks = js_test_mocks::teardownCallbacks();
+  ASSERT_EQ(callbacks.count(&env), 1u)
+      << "createInstance must register exactly one teardown callback per env";
+  EXPECT_EQ(callbacks[&env].size(), 1u);
+  EXPECT_EQ(callbacks[&env][0].data, &env)
+      << "Teardown callback data must be the env pointer so it knows which "
+         "env to clean up";
+}
+
+TEST_F(ExitLifecycleTest, CreateInstanceRegistersHookOnceForMultipleInstances) {
+  js_env_t env;
+
+  JsInterface::createInstance(&env, makeAddon(&env));
+  JsInterface::createInstance(&env, makeAddon(&env));
+  JsInterface::createInstance(&env, makeAddon(&env));
+
+  auto& callbacks = js_test_mocks::teardownCallbacks();
+  EXPECT_EQ(callbacks[&env].size(), 1u)
+      << "Hook must be registered exactly once per env regardless of how "
+         "many AddonJs instances are created";
+}
+
+TEST_F(ExitLifecycleTest, EachEnvGetsItsOwnTeardownCallback) {
+  js_env_t envA;
+  js_env_t envB;
+
+  JsInterface::createInstance(&envA, makeAddon(&envA));
+  JsInterface::createInstance(&envB, makeAddon(&envB));
+
+  auto& callbacks = js_test_mocks::teardownCallbacks();
+  EXPECT_EQ(callbacks[&envA].size(), 1u);
+  EXPECT_EQ(callbacks[&envB].size(), 1u);
+  EXPECT_EQ(callbacks[&envA][0].data, &envA);
+  EXPECT_EQ(callbacks[&envB][0].data, &envB);
+}
+
+TEST_F(ExitLifecycleTest, EnvTeardownDestructsAllInstancesForThatEnv) {
+  js_env_t env;
+
+  // Use a model whose destructor flips a flag so we can prove the dtor ran.
+  struct DestructionTrackingModel : public model::IModel {
+    bool* destructed_;
+    explicit DestructionTrackingModel(bool* d) : destructed_(d) {}
+    ~DestructionTrackingModel() override { *destructed_ = true; }
+    std::string getName() const override { return "DestructionTrackingModel"; }
+    RuntimeStats runtimeStats() const override { return {}; }
+    std::any process(const std::any& input) override { return input; }
+  };
+
+  bool destructedA = false;
+  bool destructedB = false;
+  bool destructedC = false;
+
+  auto makeTrackingAddon = [&](js_env_t* e, bool* flag) {
+    return std::make_unique<AddonJs>(
+        e,
+        std::make_unique<NoopOutputCallback>(),
+        std::make_unique<DestructionTrackingModel>(flag));
+  };
+
+  JsInterface::createInstance(&env, makeTrackingAddon(&env, &destructedA));
+  JsInterface::createInstance(&env, makeTrackingAddon(&env, &destructedB));
+  JsInterface::createInstance(&env, makeTrackingAddon(&env, &destructedC));
+
+  EXPECT_FALSE(destructedA);
+  EXPECT_FALSE(destructedB);
+  EXPECT_FALSE(destructedC);
+
+  js_test_mocks::triggerEnvTeardown(&env);
+
+  EXPECT_TRUE(destructedA)
+      << "AddonJs instance A must be destructed when the env tears down";
+  EXPECT_TRUE(destructedB);
+  EXPECT_TRUE(destructedC);
+}
+
+TEST_F(ExitLifecycleTest, EnvTeardownDoesNotAffectOtherEnvsInstances) {
+  js_env_t envA;
+  js_env_t envB;
+
+  struct DestructionTrackingModel : public model::IModel {
+    bool* destructed_;
+    explicit DestructionTrackingModel(bool* d) : destructed_(d) {}
+    ~DestructionTrackingModel() override { *destructed_ = true; }
+    std::string getName() const override { return "DestructionTrackingModel"; }
+    RuntimeStats runtimeStats() const override { return {}; }
+    std::any process(const std::any& input) override { return input; }
+  };
+
+  bool destructedA = false;
+  bool destructedB = false;
+
+  JsInterface::createInstance(
+      &envA,
+      std::make_unique<AddonJs>(
+          &envA,
+          std::make_unique<NoopOutputCallback>(),
+          std::make_unique<DestructionTrackingModel>(&destructedA)));
+  JsInterface::createInstance(
+      &envB,
+      std::make_unique<AddonJs>(
+          &envB,
+          std::make_unique<NoopOutputCallback>(),
+          std::make_unique<DestructionTrackingModel>(&destructedB)));
+
+  js_test_mocks::triggerEnvTeardown(&envA);
+
+  EXPECT_TRUE(destructedA);
+  EXPECT_FALSE(destructedB)
+      << "Tearing down envA must NOT touch instances bound to envB";
+
+  // Clean up envB so we don't leak across tests.
+  js_test_mocks::triggerEnvTeardown(&envB);
+  EXPECT_TRUE(destructedB);
+}
+
+TEST_F(ExitLifecycleTest, EnvTeardownIsIdempotent) {
+  js_env_t env;
+
+  JsInterface::createInstance(&env, makeAddon(&env));
+
+  EXPECT_NO_THROW(js_test_mocks::triggerEnvTeardown(&env));
+  // Second teardown for the same env (no callbacks registered) is a no-op.
+  EXPECT_NO_THROW(js_test_mocks::triggerEnvTeardown(&env));
+}
+
+} // namespace qvac_lib_inference_addon_cpp

--- a/packages/qvac-lib-inference-addon-cpp/tests/helpers_header/js.h
+++ b/packages/qvac-lib-inference-addon-cpp/tests/helpers_header/js.h
@@ -6,6 +6,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 // Forward declarations for opaque types
 struct js_env_t {};
@@ -14,11 +18,89 @@ struct js_ref_t {};
 struct js_callback_info_t {};
 struct js_handle_scope_t {};
 struct js_deferred_t {};
-struct uv_async_t {
+// uv_async_t MUST contain a `data` field and live at the same offset as it
+// would in a real uv_handle_t cast. The simplest mock is to make uv_handle_t
+// be a base with a `data` pointer, and uv_async_t derive from it. Code in
+// OutputCallbackJs.hpp / JsLogger.hpp reinterpret_casts uv_async_t* to
+// uv_handle_t*, so the layout must allow that.
+struct uv_handle_t {
+  void* data{nullptr};
+};
+struct uv_async_t : uv_handle_t {};
+struct uv_loop_t {};
+
+// ============================================================================
+// Mock libuv refcount + teardown callback registry. These are intentionally
+// minimal — they exist so unit tests can verify that:
+//   * uv_unref was called on the OutputCallBackJs async handle
+//   * js_add_teardown_callback was registered for an env on createInstance
+//   * onEnvTeardown synchronously frees the AddonJs instances bound to an env
+// ============================================================================
+
+namespace js_test_mocks {
+
+// Set of uv handles that are currently considered "ref'd" (live and keeping
+// the loop alive). uv_async_init adds; uv_unref / uv_close removes.
+inline std::unordered_set<uv_handle_t*>& refdHandles() {
+  static std::unordered_set<uv_handle_t*> s;
+  return s;
+}
+
+// Registered teardown callbacks per env, in registration order.
+struct TeardownCallback {
+  void (*cb)(void* data);
   void* data;
 };
-struct uv_handle_t {};
-struct uv_loop_t {};
+
+inline std::unordered_map<js_env_t*, std::vector<TeardownCallback>>&
+teardownCallbacks() {
+  static std::unordered_map<js_env_t*, std::vector<TeardownCallback>> m;
+  return m;
+}
+
+// Test helper: invoke all registered teardown callbacks for an env, then
+// remove them. Mirrors what bare's libjs does at env destruction.
+inline void triggerEnvTeardown(js_env_t* env) {
+  auto it = teardownCallbacks().find(env);
+  if (it == teardownCallbacks().end()) {
+    return;
+  }
+  // Copy then erase first so callbacks that re-register during teardown don't
+  // observe themselves in the list.
+  auto callbacks = std::move(it->second);
+  teardownCallbacks().erase(it);
+  for (auto& tcb : callbacks) {
+    tcb.cb(tcb.data);
+  }
+}
+
+// Test helper: fire ALL registered teardown callbacks across every env, then
+// clear remaining state. Call from a test fixture's TearDown so JsInterface's
+// per-env state (which the mock alone cannot reach) is also cleaned up
+// between tests. Without this, a stack-allocated `js_env_t env;` from a prior
+// test that registered an instance leaves a dangling EnvState in
+// JsInterface::envs_ keyed by that stack address; the next test may reuse the
+// same address and observe stale state.
+inline void triggerAllTeardowns() {
+  while (!teardownCallbacks().empty()) {
+    auto it = teardownCallbacks().begin();
+    auto callbacks = std::move(it->second);
+    teardownCallbacks().erase(it);
+    for (auto& tcb : callbacks) {
+      tcb.cb(tcb.data);
+    }
+  }
+}
+
+// Test helper: clear all mock state between tests. Call from test SetUp /
+// TearDown so leftover handles or callbacks from a previous test don't leak.
+inline void resetAll() {
+  triggerAllTeardowns();
+  refdHandles().clear();
+  teardownCallbacks().clear();
+}
+
+} // namespace js_test_mocks
 
 // js_loop_t is an alias for uv_loop_t in the real implementation
 typedef uv_loop_t js_loop_t;
@@ -220,6 +302,8 @@ inline int js_create_external(
     js_env_t* env, void* data,
     void (*finalize_cb)(js_env_t* env, void* data, void* hint),
     void* finalize_hint, js_value_t** result) {
+  static js_value_t sentinel;
+  *result = &sentinel;
   return 0;
 }
 
@@ -290,6 +374,14 @@ inline int js_get_named_property(
 
 inline int js_get_property(
     js_env_t* env, js_value_t* object, js_value_t* key, js_value_t** result) {
+  return -1;
+}
+
+inline int js_has_property(
+    js_env_t* env, js_value_t* object, js_value_t* key, bool* result) {
+  if (result != nullptr) {
+    *result = false;
+  }
   return -1;
 }
 
@@ -443,13 +535,60 @@ inline int js_create_error(
 // UV/libuv functions (minimal stubs for compilation)
 inline int
 uv_async_init(uv_loop_t* loop, uv_async_t* handle, void (*cb)(uv_async_t*)) {
+  js_test_mocks::refdHandles().insert(reinterpret_cast<uv_handle_t*>(handle));
   return 0;
 }
 
 inline int uv_async_send(uv_async_t* handle) { return 0; }
 
-inline void* uv_handle_get_data(uv_handle_t* handle) { return nullptr; }
+inline void* uv_handle_get_data(uv_handle_t* handle) {
+  return handle != nullptr ? handle->data : nullptr;
+}
 
-inline void uv_handle_set_data(uv_handle_t* handle, void* data) {}
+inline void uv_handle_set_data(uv_handle_t* handle, void* data) {
+  if (handle != nullptr) {
+    handle->data = data;
+  }
+}
 
-inline void uv_close(uv_handle_t* handle, void (*cb)(uv_handle_t*)) {}
+inline void uv_close(uv_handle_t* handle, void (*cb)(uv_handle_t*)) {
+  js_test_mocks::refdHandles().erase(handle);
+  if (cb != nullptr) {
+    cb(handle);
+  }
+}
+
+inline void uv_unref(uv_handle_t* handle) {
+  js_test_mocks::refdHandles().erase(handle);
+}
+
+inline void uv_ref(uv_handle_t* handle) {
+  js_test_mocks::refdHandles().insert(handle);
+}
+
+// Teardown callback API (mirrors libjs's js_add_teardown_callback /
+// js_remove_teardown_callback). Use js_test_mocks::triggerEnvTeardown(env) in
+// tests to simulate env shutdown.
+typedef void (*js_teardown_cb)(void* data);
+
+inline int
+js_add_teardown_callback(js_env_t* env, js_teardown_cb cb, void* data) {
+  js_test_mocks::teardownCallbacks()[env].push_back({cb, data});
+  return 0;
+}
+
+inline int
+js_remove_teardown_callback(js_env_t* env, js_teardown_cb cb, void* data) {
+  auto it = js_test_mocks::teardownCallbacks().find(env);
+  if (it == js_test_mocks::teardownCallbacks().end()) {
+    return 0;
+  }
+  auto& vec = it->second;
+  for (auto vit = vec.begin(); vit != vec.end(); ++vit) {
+    if (vit->cb == cb && vit->data == data) {
+      vec.erase(vit);
+      return 0;
+    }
+  }
+  return 0;
+}

--- a/packages/qvac-lib-inference-addon-cpp/tests/helpers_header/uv.h
+++ b/packages/qvac-lib-inference-addon-cpp/tests/helpers_header/uv.h
@@ -1,0 +1,8 @@
+// Mock <uv.h> for unit tests. The real libuv is not linked into the unit
+// tests, but several headers (`JsLogger.hpp`, `OutputCallbackJs.hpp`) include
+// <uv.h> directly. The opaque uv types and the no-op uv functions we need are
+// already defined in our mock `js.h`, so this header just forwards there.
+
+#pragma once
+
+#include "js.h"


### PR DESCRIPTION
Draft — see commit message for details. Fixes the 65s post-test hang + exit 139 on `ai-run-linux-gpu` integration runs for embed, llm, and diffusion-cpp.