### PR TITLE
QVAC-18121 chore[skiplog]: backmerge release-sdk-0.10.1 — version bump, changelog, NOTICE

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,102 @@
 # Changelog
 
+## [0.10.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.1
+
+This patch release adds a new tool-call dialect for OpenAI's `gpt-oss` (Harmony) models, fixes a regression that caused Bergamot translation models to re-download their vocab files on every `loadModel`, and refreshes the model registry with updated Bergamot translation pairs and the removal of deprecated Marian Opus entries.
+
+## New APIs
+
+### Harmony tool-call dialect for `gpt-oss`
+
+`completion()` now supports a fourth tool-call dialect, `"harmony"`, used by OpenAI's `gpt-oss` family of models. The new dialect is wired into the same streaming/event surface as the existing dialects (`hermes`, `pythonic`, `json`), so tool calls emitted in Harmony frames are parsed and surfaced through the standard `CompletionEvent` stream. `gpt-oss-20b-Q4_K_M` auto-routes to the Harmony dialect; the `toolDialect` parameter is available as an explicit override on any model.
+
+```typescript
+import { completion, type ToolDialect } from "@qvac/sdk";
+
+const run = completion({
+  modelId,                 // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  history,
+  tools,
+  toolDialect: "harmony",  // optional explicit override
+});
+
+const dialect: ToolDialect = "harmony";
+// ToolDialect is now "hermes" | "pythonic" | "json" | "harmony"
+```
+
+This release also picks up `@qvac/llm-llamacpp` 0.17.2, which stops the addon from suppressing the `<|call|>` end-of-generation token — required for Harmony tool-call parsing to work end-to-end.
+
+## Bug Fixes
+
+### Bergamot vocab no longer re-downloaded on every `loadModel`
+
+Bergamot translation pairs that share a vocab blob across two file paths (the same SHA-256 under different names) were being collapsed by registry deduplication, which deleted their standalone vocab entries and forced the plugin to re-download the vocab file every time a model was loaded. This release adjusts the dedup pass to preserve any registry entry that is referenced as a companion file in a companion set, restoring the seven shared-vocab entries (`BERGAMOT_FR_EN_VOCAB`, `BERGAMOT_EN_DE_VOCAB`, `BERGAMOT_EN_CS_VOCAB`, `BERGAMOT_ET_EN_VOCAB`, `BERGAMOT_FI_EN_VOCAB`, `BERGAMOT_PL_EN_VOCAB`, `BERGAMOT_PT_EN_VOCAB`) along with their correct `expectedSize`/`sha` lookups.
+
+For `registry://` Bergamot loads with auto-derived vocabs (both non-pivot and pivot), the plugin now skips the separate per-vocab `resolveModelPath` call entirely — the companion-set download already colocates vocabs under `sets/<setKey>/`, and `createModel` derives those paths via `deriveColocatedBergamotVocabPaths`. This eliminates redundant flat-cache downloads without changing the contract for `pear://` sources or user-supplied vocab overrides, and is locked behind unit tests in `nmtcpp-resolve-vocab.test.ts`.
+
+## Model Changes
+
+### Updated translation pairs
+
+`BERGAMOT_EN_IT` and `BERGAMOT_ES_EN` are bumped to the `base-memory` variant (`bergamot-enit/2026-04-28/`, `bergamot-esen/2026-04-28/`). This fixes leading `"- "` hallucinations on short inputs and an en→it quality regression that affected the previous build.
+
+### Restored shared-vocab Bergamot entries
+
+The vocab fix above restores seven Bergamot vocab constants that had been incorrectly removed by registry dedup:
+
+```
+BERGAMOT_EN_CS_VOCAB
+BERGAMOT_EN_DE_VOCAB
+BERGAMOT_ET_EN_VOCAB
+BERGAMOT_FI_EN_VOCAB
+BERGAMOT_FR_EN_VOCAB
+BERGAMOT_PL_EN_VOCAB
+BERGAMOT_PT_EN_VOCAB
+```
+
+### Removed Marian Opus models
+
+The legacy Marian Opus translation entries are dropped from the registry. They were auto-deprecated upstream and superseded by the Bergamot family.
+
+```
+NMT_Q0F16
+NMT_Q0F16_1
+NMT_Q0F16_2
+NMT_Q0F16_3
+NMT_Q0F16_4
+NMT_Q0F16_5
+NMT_Q0F16_6
+NMT_Q0F16_7
+NMT_Q0F16_8
+NMT_Q0F16_9
+NMT_Q4_0
+NMT_Q4_0_1
+NMT_Q4_0_2
+NMT_Q4_0_3
+NMT_Q4_0_4
+NMT_Q4_0_5
+NMT_Q4_0_6
+NMT_Q4_0_7
+NMT_Q4_0_8
+NMT_Q4_0_9
+NMT_Q4_0_10
+NMT_Q4_0_11
+NMT_Q4_0_12
+NMT_Q4_0_13
+NMT_Q4_0_14
+NMT_Q4_0_15
+NMT_Q4_0_16
+NMT_Q4_0_17
+NMT_Q4_0_18
+NMT_Q4_0_19
+NMT_Q4_0_20
+NMT_Q4_0_21
+```
+
+If you were importing any of these constants, switch to the equivalent `BERGAMOT_*` pair.
+
 ## [0.10.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.0

--- a/packages/sdk/NOTICE
+++ b/packages/sdk/NOTICE
@@ -489,8 +489,6 @@ JavaScript Dependencies
 
   @hyperswarm/secret-stream@6.9.1
     https://github.com/holepunchto/hyperswarm-secret-stream
-  @qvac/decoder-audio@0.3.6
-    https://github.com/tetherto/qvac
   @qvac/decoder-audio@0.3.7
     https://github.com/tetherto/qvac
   @qvac/diagnostics@0.1.1
@@ -502,8 +500,6 @@ JavaScript Dependencies
     https://github.com/tetherto/qvac
   @qvac/error@0.1.1
   @qvac/infer-base@0.1.1
-  @qvac/infer-base@0.4.0
-    https://github.com/tetherto/qvac
   @qvac/infer-base@0.4.1
     https://github.com/tetherto/qvac
   @qvac/langdetect-text@0.1.2
@@ -521,9 +517,9 @@ JavaScript Dependencies
     https://github.com/tetherto/qvac
   @qvac/registry-schema@0.1.2
   @qvac/response@0.1.2
-  @qvac/transcription-parakeet@0.3.1
+  @qvac/transcription-parakeet@0.3.2
     https://github.com/tetherto/qvac
-  @qvac/transcription-whispercpp@0.6.1
+  @qvac/transcription-whispercpp@0.6.7
     https://github.com/tetherto/qvac
   @qvac/translation-nmtcpp@2.1.0
     https://github.com/tetherto/qvac
@@ -559,19 +555,19 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-events
   bare-events@2.8.2
     https://github.com/holepunchto/bare-events
-  bare-fetch@2.8.1
+  bare-fetch@2.9.0
     https://github.com/holepunchto/bare-fetch
   bare-ffmpeg@1.2.2
     https://github.com/holepunchto/bare-ffmpeg
   bare-form-data@1.2.1
     https://github.com/holepunchto/bare-form-data
-  bare-fs@4.6.0
+  bare-fs@4.7.1
     https://github.com/holepunchto/bare-fs
   bare-hrtime@2.1.1
     https://github.com/holepunchto/bare-hrtime
   bare-http-parser@1.1.3
     https://github.com/holepunchto/bare-http-parser
-  bare-http1@4.5.5
+  bare-http1@4.5.6
     https://github.com/holepunchto/bare-http1
   bare-https@2.1.3
     https://github.com/holepunchto/bare-https
@@ -581,7 +577,9 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-lief
   bare-link@3.2.1
     https://github.com/holepunchto/bare-link
-  bare-module@6.1.3
+  bare-mime@1.0.0
+    https://github.com/holepunchto/bare-mime
+  bare-module@6.2.0
     https://github.com/holepunchto/bare-module
   bare-module-lexer@1.4.7
     https://github.com/holepunchto/bare-module-lexer
@@ -595,7 +593,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-node
   bare-node-worker-threads@1.0.0
     https://github.com/holepunchto/bare-node
-  bare-os@3.8.7
+  bare-os@3.9.0
     https://github.com/holepunchto/bare-os
   bare-path@3.0.0
     https://github.com/holepunchto/bare-path
@@ -605,39 +603,39 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-process
   bare-rpc@1.2.0
     https://github.com/holepunchto/bare-rpc
-  bare-runtime@1.28.1
+  bare-runtime@1.28.4
     https://github.com/holepunchto/bare-runtime
-  bare-runtime-darwin-arm64@1.28.1
+  bare-runtime-darwin-arm64@1.28.4
     https://github.com/holepunchto/bare-runtime
-  bare-semver@1.0.2
+  bare-semver@1.0.3
     https://github.com/holepunchto/bare-semver
   bare-signals@4.2.0
     https://github.com/holepunchto/bare-signals
   bare-stdio@1.0.2
     https://github.com/holepunchto/bare-stdio
-  bare-stream@2.12.0
+  bare-stream@2.13.1
     https://github.com/holepunchto/bare-stream
-  bare-structured-clone@1.5.3
+  bare-structured-clone@1.5.4
     https://github.com/holepunchto/bare-structured-clone
   bare-subprocess@5.2.3
     https://github.com/holepunchto/bare-subprocess
-  bare-tcp@2.2.7
+  bare-tcp@2.2.12
     https://github.com/holepunchto/bare-tcp
   bare-thread@1.2.0
     https://github.com/holepunchto/bare-thread
-  bare-tls@2.2.1
+  bare-tls@2.2.3
     https://github.com/holepunchto/bare-tls
   bare-tty@5.1.0
     https://github.com/holepunchto/bare-tty
   bare-type@1.1.0
     https://github.com/holepunchto/bare-type
-  bare-url@2.4.0
+  bare-url@2.4.2
     https://github.com/holepunchto/bare-url
   bare-worker@4.1.6
     https://github.com/holepunchto/bare-worker
-  bare-zlib@1.3.1
+  bare-zlib@1.3.3
     https://github.com/holepunchto/bare-zlib
-  blind-relay@1.4.0
+  blind-relay@1.5.0
     https://github.com/holepunchto/blind-relay
   compact-encoding@2.19.2
     https://github.com/holepunchto/compact-encoding
@@ -647,7 +645,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/events-universal
   fd-lock@2.1.1
     https://github.com/holepunchto/fd-lock
-  fs-native-extensions@1.4.5
+  fs-native-extensions@1.5.0
     https://github.com/holepunchto/fs-native-extensions
   hyperblobs@2.11.1
     https://github.com/holepunchto/hyperblobs
@@ -661,6 +659,8 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore-storage
   hyperdb@4.22.3
     https://github.com/holepunchto/hyperdb
+  hyperdht-address@1.0.1
+    https://github.com/holepunchto/hyperdht-address
   hyperdht-stats@1.10.0
     https://github.com/holepunchto/hyperdht-stats
   hyperdispatch@1.5.1
@@ -673,7 +673,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperswarm-stats
   index-encoder@3.5.0
     https://github.com/holepunchto/index-encoder
-  mirror-drive@1.14.1
+  mirror-drive@1.14.2
     https://github.com/holepunchto/mirror-drive
   noise-handshake@4.2.0
     https://github.com/holepunchto/noise-handshake
@@ -745,8 +745,8 @@ JavaScript Dependencies
     https://github.com/holepunchto/corestore
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
-  dht-rpc@6.26.3
-    https://github.com/mafintosh/dht-rpc
+  dht-rpc@6.26.4
+    https://github.com/holepunchto/dht-rpc
   events@3.3.0
     https://github.com/Gozala/events
   fast-fifo@1.3.2
@@ -765,7 +765,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.6.1
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.29.6
+  hyperdht@6.30.0
     https://github.com/holepunchto/hyperdht
   hyperswarm@4.17.0
     https://github.com/holepunchto/hyperswarm
@@ -783,8 +783,8 @@ JavaScript Dependencies
     https://github.com/mafintosh/nat-sampler
   protocol-buffers-encodings@1.2.0
     https://github.com/mafintosh/protocol-buffers-encodings
-  protomux@3.10.1
-    https://github.com/mafintosh/protomux
+  protomux@3.10.3
+    https://github.com/holepunchto/protomux
   queue-tick@1.0.1
     https://github.com/mafintosh/queue-tick
   random-array-iterator@1.0.0

--- a/packages/sdk/changelog/0.10.1/CHANGELOG.md
+++ b/packages/sdk/changelog/0.10.1/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog v0.10.1
+
+Release Date: 2026-05-05
+
+## 🔌 API
+
+- Add harmony tool-call dialect (gpt-oss). (see PR [#1878](https://github.com/tetherto/qvac/pull/1878)) - See [API changes](./api.md)
+
+## 📦 Models
+
+- Bergamot vocab re-downloaded on every loadModel for shared-vocab pairs. (see PR [#1892](https://github.com/tetherto/qvac/pull/1892)) - See [model changes](./models.md)
+- Sync sdk model registry to bergamot base-memory and drop deprecated marian opus. (see PR [#1903](https://github.com/tetherto/qvac/pull/1903)) - See [model changes](./models.md)
+

--- a/packages/sdk/changelog/0.10.1/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.10.1/CHANGELOG_LLM.md
@@ -1,0 +1,96 @@
+# QVAC SDK v0.10.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.1
+
+This patch release adds a new tool-call dialect for OpenAI's `gpt-oss` (Harmony) models, fixes a regression that caused Bergamot translation models to re-download their vocab files on every `loadModel`, and refreshes the model registry with updated Bergamot translation pairs and the removal of deprecated Marian Opus entries.
+
+## New APIs
+
+### Harmony tool-call dialect for `gpt-oss`
+
+`completion()` now supports a fourth tool-call dialect, `"harmony"`, used by OpenAI's `gpt-oss` family of models. The new dialect is wired into the same streaming/event surface as the existing dialects (`hermes`, `pythonic`, `json`), so tool calls emitted in Harmony frames are parsed and surfaced through the standard `CompletionEvent` stream. `gpt-oss-20b-Q4_K_M` auto-routes to the Harmony dialect; the `toolDialect` parameter is available as an explicit override on any model.
+
+```typescript
+import { completion, type ToolDialect } from "@qvac/sdk";
+
+const run = completion({
+  modelId,                 // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  history,
+  tools,
+  toolDialect: "harmony",  // optional explicit override
+});
+
+const dialect: ToolDialect = "harmony";
+// ToolDialect is now "hermes" | "pythonic" | "json" | "harmony"
+```
+
+This release also picks up `@qvac/llm-llamacpp` 0.17.2, which stops the addon from suppressing the `<|call|>` end-of-generation token — required for Harmony tool-call parsing to work end-to-end.
+
+## Bug Fixes
+
+### Bergamot vocab no longer re-downloaded on every `loadModel`
+
+Bergamot translation pairs that share a vocab blob across two file paths (the same SHA-256 under different names) were being collapsed by registry deduplication, which deleted their standalone vocab entries and forced the plugin to re-download the vocab file every time a model was loaded. This release adjusts the dedup pass to preserve any registry entry that is referenced as a companion file in a companion set, restoring the seven shared-vocab entries (`BERGAMOT_FR_EN_VOCAB`, `BERGAMOT_EN_DE_VOCAB`, `BERGAMOT_EN_CS_VOCAB`, `BERGAMOT_ET_EN_VOCAB`, `BERGAMOT_FI_EN_VOCAB`, `BERGAMOT_PL_EN_VOCAB`, `BERGAMOT_PT_EN_VOCAB`) along with their correct `expectedSize`/`sha` lookups.
+
+For `registry://` Bergamot loads with auto-derived vocabs (both non-pivot and pivot), the plugin now skips the separate per-vocab `resolveModelPath` call entirely — the companion-set download already colocates vocabs under `sets/<setKey>/`, and `createModel` derives those paths via `deriveColocatedBergamotVocabPaths`. This eliminates redundant flat-cache downloads without changing the contract for `pear://` sources or user-supplied vocab overrides, and is locked behind unit tests in `nmtcpp-resolve-vocab.test.ts`.
+
+## Model Changes
+
+### Updated translation pairs
+
+`BERGAMOT_EN_IT` and `BERGAMOT_ES_EN` are bumped to the `base-memory` variant (`bergamot-enit/2026-04-28/`, `bergamot-esen/2026-04-28/`). This fixes leading `"- "` hallucinations on short inputs and an en→it quality regression that affected the previous build.
+
+### Restored shared-vocab Bergamot entries
+
+The vocab fix above restores seven Bergamot vocab constants that had been incorrectly removed by registry dedup:
+
+```
+BERGAMOT_EN_CS_VOCAB
+BERGAMOT_EN_DE_VOCAB
+BERGAMOT_ET_EN_VOCAB
+BERGAMOT_FI_EN_VOCAB
+BERGAMOT_FR_EN_VOCAB
+BERGAMOT_PL_EN_VOCAB
+BERGAMOT_PT_EN_VOCAB
+```
+
+### Removed Marian Opus models
+
+The legacy Marian Opus translation entries are dropped from the registry. They were auto-deprecated upstream and superseded by the Bergamot family.
+
+```
+NMT_Q0F16
+NMT_Q0F16_1
+NMT_Q0F16_2
+NMT_Q0F16_3
+NMT_Q0F16_4
+NMT_Q0F16_5
+NMT_Q0F16_6
+NMT_Q0F16_7
+NMT_Q0F16_8
+NMT_Q0F16_9
+NMT_Q4_0
+NMT_Q4_0_1
+NMT_Q4_0_2
+NMT_Q4_0_3
+NMT_Q4_0_4
+NMT_Q4_0_5
+NMT_Q4_0_6
+NMT_Q4_0_7
+NMT_Q4_0_8
+NMT_Q4_0_9
+NMT_Q4_0_10
+NMT_Q4_0_11
+NMT_Q4_0_12
+NMT_Q4_0_13
+NMT_Q4_0_14
+NMT_Q4_0_15
+NMT_Q4_0_16
+NMT_Q4_0_17
+NMT_Q4_0_18
+NMT_Q4_0_19
+NMT_Q4_0_20
+NMT_Q4_0_21
+```
+
+If you were importing any of these constants, switch to the equivalent `BERGAMOT_*` pair.

--- a/packages/sdk/changelog/0.10.1/api.md
+++ b/packages/sdk/changelog/0.10.1/api.md
@@ -1,0 +1,23 @@
+# 🔌 API Changes v0.10.1
+
+## Add harmony tool-call dialect (gpt-oss)
+
+PR: [#1878](https://github.com/tetherto/qvac/pull/1878)
+
+```typescript
+import { completion, type ToolDialect } from "@qvac/sdk";
+
+// New dialect value (existing override parameter, fourth enum value).
+const result = completion({
+  modelId,         // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  history,
+  tools,
+  toolDialect: "harmony", // optional explicit override
+});
+
+// `ToolDialect` is now "hermes" | "pythonic" | "json" | "harmony".
+const dialect: ToolDialect = "harmony";
+```
+
+---
+

--- a/packages/sdk/changelog/0.10.1/models.md
+++ b/packages/sdk/changelog/0.10.1/models.md
@@ -1,0 +1,57 @@
+# 📦 Model Changes v0.10.1
+
+## Added Models
+
+```
+BERGAMOT_EN_CS_VOCAB
+BERGAMOT_EN_DE_VOCAB
+BERGAMOT_ET_EN_VOCAB
+BERGAMOT_FI_EN_VOCAB
+BERGAMOT_FR_EN_VOCAB
+BERGAMOT_PL_EN_VOCAB
+BERGAMOT_PT_EN_VOCAB
+```
+
+## Removed Models
+
+```
+NMT_Q0F16
+NMT_Q0F16_1
+NMT_Q0F16_2
+NMT_Q0F16_3
+NMT_Q0F16_4
+NMT_Q0F16_5
+NMT_Q0F16_6
+NMT_Q0F16_7
+NMT_Q0F16_8
+NMT_Q0F16_9
+NMT_Q4_0
+NMT_Q4_0_1
+NMT_Q4_0_10
+NMT_Q4_0_11
+NMT_Q4_0_12
+NMT_Q4_0_13
+NMT_Q4_0_14
+NMT_Q4_0_15
+NMT_Q4_0_16
+NMT_Q4_0_17
+NMT_Q4_0_18
+NMT_Q4_0_19
+NMT_Q4_0_2
+NMT_Q4_0_20
+NMT_Q4_0_21
+NMT_Q4_0_3
+NMT_Q4_0_4
+NMT_Q4_0_5
+NMT_Q4_0_6
+NMT_Q4_0_7
+NMT_Q4_0_8
+NMT_Q4_0_9
+```
+
+---
+
+### Related PRs
+
+- [#1892](https://github.com/tetherto/qvac/pull/1892) - Bergamot vocab re-downloaded on every loadModel for shared-vocab pairs
+- [#1903](https://github.com/tetherto/qvac/pull/1903) - Sync sdk model registry to bergamot base-memory and drop deprecated marian opus

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Keeps `main` aligned with the v0.10.1 release of `@qvac/sdk` shipping on `release-sdk-0.10.1` (companion release PR: tetherto/qvac#1909)

## 📝 How does it solve it?

- Cherry-picks (with `-x`) the single release-metadata commit `8dfed8f1d` from `release-sdk-0.10.1` onto `main`.
- Carries only release metadata — no functional code. The three feature/fix PRs that ship in v0.10.1 ([#1892](https://github.com/tetherto/qvac/pull/1892), [#1878](https://github.com/tetherto/qvac/pull/1878), [#1903](https://github.com/tetherto/qvac/pull/1903)) are already on `main` from their original merges.
- Files:
  - `packages/sdk/package.json` — `0.10.0` → `0.10.1`
  - `packages/sdk/changelog/0.10.1/{CHANGELOG.md, api.md, models.md, CHANGELOG_LLM.md}` — generated changelog files
  - `packages/sdk/CHANGELOG.md` — aggregated changelog (v0.10.1 added at top)
  - `packages/sdk/NOTICE` — refreshed dependency attributions
