### PR TITLE
feat[llm]: add use_model_chat_template flag to opt out of bundled fixed Qwen3 template

### DIFF
--- a/packages/qvac-lib-infer-llamacpp-llm/README.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/README.md
@@ -174,6 +174,7 @@ const config = {
 | frequency_penalty | float                                       | 0                            | Frequency penalty for sampling                        |
 | tools             | `"true"` or `"false"`                       | `"false"`                    | Enable tool calling with jinja templating             |
 | tools_compact      | `"true"` or `"false"`                       | `"false"`                    | Compact tool tokens from KV cache between turns ([details](./docs/tools-compact.md)) |
+| use_model_chat_template | `"true"` or `"false"`                  | `"false"`                    | Bypass the bundled fixed Qwen3 chat template and use the GGUF embedded `tokenizer.chat_template` instead. No effect on non-Qwen3 models. An explicit `chat_template` string still wins over both. |
 | verbosity         | 0 – 3 (0=ERROR, 1=WARNING, 2=INFO, 3=DEBUG) | 0                            | Logging verbosity level                               |
 | n_discarded       | integer                                     | 0                            | Tokens to discard in sliding window context           |
 | main-gpu          | integer, `"integrated"`, or `"dedicated"`   | —                            | GPU selection for multi-GPU systems                   |

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.cpp
@@ -327,8 +327,14 @@ void LlamaModel::init(bool acquireLock) {
   common_params params;
   std::optional<int> adrenoVersion;
   ResolvedToolsCompactConfig toolsCompactConfig;
+  bool useModelChatTemplate = false;
   commonParamsParse(
-      modelPath, configFilemap, params, adrenoVersion, toolsCompactConfig);
+      modelPath,
+      configFilemap,
+      params,
+      adrenoVersion,
+      toolsCompactConfig,
+      useModelChatTemplate);
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
   auto streamedFiles =
@@ -359,7 +365,8 @@ void LlamaModel::init(bool acquireLock) {
       std::string(constructionArgs_.projectionPath),
       params,
       std::move(llamaInit),
-      *snap->toolsCompact_);
+      *snap->toolsCompact_,
+      useModelChatTemplate);
 
   if (snap->configuredNDiscarded_ > 0 && snap->llmContext_) {
     snap->llmContext_->setNDiscarded(snap->configuredNDiscarded_);
@@ -711,10 +718,12 @@ void LlamaModel::commonParamsParse(
     const std::string& modelPath,
     std::unordered_map<std::string, std::string>& configFilemap,
     common_params& params, std::optional<int>& outAdrenoVersion,
-    ResolvedToolsCompactConfig& outToolsCompactConfig) {
+    ResolvedToolsCompactConfig& outToolsCompactConfig,
+    bool& outUseModelChatTemplate) {
 
   std::vector<std::string> configVector;
   outToolsCompactConfig = ResolvedToolsCompactConfig{};
+  outUseModelChatTemplate = false;
 
   // Check if tools are enabled and exclude it with jinja from the config file
   if (auto iter = configFilemap.find("tools"); iter != configFilemap.end()) {
@@ -772,6 +781,22 @@ void LlamaModel::commonParamsParse(
         Priority::WARNING,
         "[LlamaModel] tools_compact is not supported for this model "
         "architecture, ignoring\n");
+  }
+
+  // parse use_model_chat_template flag from config: when true, the addon does
+  // NOT swap in the bundled fixed Qwen3 template and instead lets llama.cpp
+  // use the chat template embedded in the GGUF (or whatever the user passed
+  // explicitly via chat_template). Accept both snake_case and kebab-case to
+  // match the conventions used by other config keys.
+  for (const std::string& key :
+       {"use_model_chat_template", "use-model-chat-template"}) {
+    if (auto iter = configFilemap.find(key); iter != configFilemap.end()) {
+      std::string val = iter->second;
+      std::transform(val.begin(), val.end(), val.begin(), ::tolower);
+      outUseModelChatTemplate =
+          outUseModelChatTemplate || (val == "true" || val == "1");
+      configFilemap.erase(iter);
+    }
   }
 
   llama_split_mode splitMode = LLAMA_SPLIT_MODE_NONE;
@@ -1193,13 +1218,15 @@ void LlamaModel::resetState(bool resetStats) {
 
 std::unique_ptr<LlmContext> LlamaModel::createContext(
     std::string&& projectionPath, common_params& params,
-    common_init_result&& llamaInit, ToolsCompactController& tools) {
+    common_init_result&& llamaInit, ToolsCompactController& tools,
+    bool useModelChatTemplate) {
   if (!projectionPath.empty()) {
     params.mmproj.path = std::move(projectionPath);
     return std::make_unique<MtmdLlmContext>(
-        params, std::move(llamaInit), tools);
+        params, std::move(llamaInit), tools, useModelChatTemplate);
   }
-  return std::make_unique<TextLlmContext>(params, std::move(llamaInit), tools);
+  return std::make_unique<TextLlmContext>(
+      params, std::move(llamaInit), tools, useModelChatTemplate);
 }
 
 bool LlamaModel::loadMedia(const std::vector<uint8_t>& input) {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/LlamaModel.hpp
@@ -267,7 +267,8 @@ private:
       const std::string& modelPath,
       std::unordered_map<std::string, std::string>& configFilemap,
       common_params& params, std::optional<int>& outAdrenoVersion,
-      ResolvedToolsCompactConfig& outToolsCompactConfig);
+      ResolvedToolsCompactConfig& outToolsCompactConfig,
+      bool& outUseModelChatTemplate);
 
   /**
    * The Format prompt method. It formats the prompt json to chat messages.
@@ -279,7 +280,8 @@ private:
   void resetState(bool resetStats = true);
   std::unique_ptr<LlmContext> createContext(
       std::string&& projectionPath, common_params& params,
-      common_init_result&& llamaInit, ToolsCompactController& tools);
+      common_init_result&& llamaInit, ToolsCompactController& tools,
+      bool useModelChatTemplate);
 
   bool loadMedia(const std::vector<uint8_t>& input);
 

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.cpp
@@ -24,9 +24,10 @@ using namespace qvac_lib_inference_addon_llama::utils;
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 MtmdLlmContext::MtmdLlmContext(
     common_params& commonParams, common_init_result&& llamaInit,
-    ToolsCompactController& tools)
+    ToolsCompactController& tools, bool useModelChatTemplate)
     : tools_(tools), llamaInit_(std::move(llamaInit)), params_(commonParams),
-      model_(llamaInit_.model.get()), lctx_(llamaInit_.context.get()) {
+      model_(llamaInit_.model.get()), lctx_(llamaInit_.context.get()),
+      useModelChatTemplate_(useModelChatTemplate) {
 
   if (model_ == nullptr) {
     throw qvac_errors::StatusError(
@@ -44,7 +45,8 @@ MtmdLlmContext::MtmdLlmContext(
 
   vocab_ = llama_model_get_vocab(model_);
 
-  std::string chatTemplate = getChatTemplate(model_, params_, tools_.enabled());
+  std::string chatTemplate = getChatTemplate(
+      model_, params_, tools_.enabled(), useModelChatTemplate_);
   tmpls_ = common_chat_templates_init(model_, chatTemplate);
 
   smpl_.reset(common_sampler_init(model_, params_.sampling));

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/MtmdLlmContext.hpp
@@ -22,7 +22,7 @@ public:
    */
   MtmdLlmContext(
       common_params& commonParams, common_init_result&& llamaInit,
-      ToolsCompactController& tools);
+      ToolsCompactController& tools, bool useModelChatTemplate = false);
 
   /**
    * The destructor.
@@ -220,6 +220,10 @@ private:
 
   // UTF-8 token buffer for handling incomplete emoji sequences
   qvac_lib_inference_addon_llama::UTF8TokenBuffer utf8Buffer_;
+
+  // When true, do not swap in the bundled fixed Qwen3 template; honour the
+  // user's manual override (or the GGUF embedded template if no override).
+  bool useModelChatTemplate_ = false;
 
   // GPT-OSS Harmony: <|call|> is a frame delimiter, not a stop signal
   bool isHarmonyModel_ = false;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.cpp
@@ -27,8 +27,9 @@ using namespace qvac_lib_inference_addon_llama::utils;
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TextLlmContext::TextLlmContext(
     common_params& commonParams, common_init_result&& llamaInit,
-    ToolsCompactController& tools)
-    : tools_(tools), llamaInit_(std::move(llamaInit)), params_(commonParams) {
+    ToolsCompactController& tools, bool useModelChatTemplate)
+    : tools_(tools), llamaInit_(std::move(llamaInit)), params_(commonParams),
+      useModelChatTemplate_(useModelChatTemplate) {
   {
 
     model_ = llamaInit_.model.get();
@@ -71,8 +72,8 @@ TextLlmContext::TextLlmContext(
             harmonyCallToken_,
             params_.use_jinja));
 
-    std::string chatTemplate =
-        getChatTemplate(model_, params_, tools_.enabled());
+    std::string chatTemplate = getChatTemplate(
+        model_, params_, tools_.enabled(), useModelChatTemplate_);
     tmpls_ = common_chat_templates_init(model_, chatTemplate);
 
     smpl_.reset(common_sampler_init(model_, params_.sampling));

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/model-interface/TextLlmContext.hpp
@@ -21,7 +21,7 @@ public:
   // Constructor
   TextLlmContext(
       common_params& commonParams, common_init_result&& llamaInit,
-      ToolsCompactController& tools);
+      ToolsCompactController& tools, bool useModelChatTemplate = false);
 
   // Destructor
   ~TextLlmContext() override = default;
@@ -197,6 +197,10 @@ private:
 
   // Cache whether this is a Qwen3 model (checked once at load time)
   bool isQwen3Model_ = false;
+
+  // When true, do not swap in the bundled fixed Qwen3 template; honour the
+  // user's manual override (or the GGUF embedded template if no override).
+  bool useModelChatTemplate_ = false;
 
   // GPT-OSS Harmony: <|call|> is a frame delimiter, not a stop signal
   bool isHarmonyModel_ = false;

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/ChatTemplateUtils.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/ChatTemplateUtils.cpp
@@ -154,8 +154,20 @@ std::string getChatTemplateForModel(
 }
 
 std::string getChatTemplate(
-    const ::llama_model* model, const common_params& params,
-    bool toolsCompact) {
+    const ::llama_model* model, const common_params& params, bool toolsCompact,
+    bool useModelChatTemplate) {
+  // Opt-out of the Qwen3 fixed-template override: return the manual override
+  // verbatim (empty string lets llama.cpp pick up the GGUF embedded template).
+  if (useModelChatTemplate) {
+    if (isQwen3Model(model)) {
+      QLOG_IF(
+          Priority::INFO,
+          "[ChatTemplateUtils] use_model_chat_template=true: bypassing fixed "
+          "Qwen3 template and using the model's embedded chat template\n");
+    }
+    return params.chat_template;
+  }
+
   // Use fixed Qwen3 template if model is Qwen3 and Jinja is enabled
   std::string chatTemplate = params.chat_template;
   if (params.use_jinja) {

--- a/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/ChatTemplateUtils.hpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/addon/src/utils/ChatTemplateUtils.hpp
@@ -40,10 +40,22 @@ std::string getChatTemplateForModel(
 
 /**
  * @brief Gets the chat template for a model, applying Qwen3 fixes if Jinja is
- * enabled
+ * enabled.
+ *
+ * When @p useModelChatTemplate is true, the Qwen3 forced-template path is
+ * bypassed and the user's manual override (`params.chat_template`) is returned
+ * verbatim — including the empty string, in which case llama.cpp falls back
+ * to the template embedded in the GGUF (`tokenizer.chat_template`).
+ *
+ * Note: the bundled fixed Qwen3 template patches around minja
+ * incompatibilities in the upstream Qwen3 Jinja template (Python-only filters
+ * such as `.strip()` etc.). Opting into the model's embedded template can
+ * therefore produce broken prompts if that template relies on those
+ * unsupported features.
  */
 std::string getChatTemplate(
-    const ::llama_model* model, const common_params& params, bool toolsCompact);
+    const ::llama_model* model, const common_params& params, bool toolsCompact,
+    bool useModelChatTemplate = false);
 
 /**
  * @brief Applies chat templates to generate a prompt, with fallback handling

--- a/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
@@ -49,6 +49,20 @@ export interface LlamaConfig {
   presence_penalty?: NumericLike
   frequency_penalty?: NumericLike
   tools?: boolean | string
+  /**
+   * When true, bypass the bundled fixed Qwen3 chat template and use the
+   * template embedded in the GGUF (`tokenizer.chat_template`). Has no effect
+   * on non-Qwen3 models, and is ignored if you also pass an explicit
+   * `chat_template` string (the explicit string always wins).
+   *
+   * Note: the bundled fixed template patches around minja Jinja-runtime
+   * incompatibilities in the upstream Qwen3 template. Opting into the
+   * embedded template can produce broken prompts if it relies on those
+   * unsupported features.
+   */
+  use_model_chat_template?: boolean | string
+  /** Kebab-case alias for `use_model_chat_template`. */
+  'use-model-chat-template'?: boolean | string
   verbosity?: NumericLike
   n_discarded?: NumericLike
   'main-gpu'?: NumericLike | string

--- a/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.d.ts
@@ -298,3 +298,21 @@ export { QvacResponse, FinetuneHandle, FinetuneProgressStats, FinetuneOptions, F
 
 /** Returns the first shard (matching `-NNNNN-of-MMMMM.gguf`) or the sole entry for single-file models. */
 export function pickPrimaryGgufPath(files: string[]): string
+
+/**
+ * Validate and normalize the `use_model_chat_template` config key (and its
+ * `use-model-chat-template` kebab-case alias) into the canonical
+ * `'true'` / `'false'` string the native addon understands.
+ *
+ * - Accepts native booleans and case-insensitive `"true"` / `"false"` /
+ *   `"1"` / `"0"` strings.
+ * - Throws `TypeError` on any other type or unrecognized string.
+ * - Throws `TypeError` when both keys are present with conflicting values.
+ * - Returns the input unchanged if neither key is present (or both are
+ *   `undefined` / `null`); otherwise returns a clone with the kebab-case
+ *   alias removed and `use_model_chat_template` set to the canonical string.
+ *
+ * Called automatically by `LlmLlamacpp.load()`. Exported so callers can
+ * pre-validate user-supplied configs before instantiating the model.
+ */
+export function normalizeChatTemplateConfig<T extends Record<string, any>>(config: T): T

--- a/packages/qvac-lib-infer-llamacpp-llm/index.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/index.js
@@ -149,6 +149,70 @@ function pickPrimaryGgufPath (files) {
   return files.find((p) => SHARD_REGEX.test(p)) || files[0]
 }
 
+const USE_MODEL_CHAT_TEMPLATE_KEYS = ['use_model_chat_template', 'use-model-chat-template']
+
+/**
+ * Validates and normalizes the `use_model_chat_template` config key (or its
+ * kebab-case alias) into a single canonical `'true'` / `'false'` string the
+ * native addon can read. Accepts native booleans and case-insensitive
+ * `"true"` / `"false"` / `"1"` / `"0"` strings; throws TypeError on anything
+ * else so users get an immediate JS-side error instead of the option being
+ * silently dropped or mis-parsed by the C++ side.
+ *
+ * Returns a (possibly cloned) config; never mutates the input.
+ *
+ * @param {Record<string, any>} config - The raw user-supplied config.
+ * @returns {Record<string, any>} The same `config` if neither key is present,
+ *   otherwise a clone with `use_model_chat_template` set to the normalized
+ *   string and the kebab-case alias removed.
+ */
+function normalizeChatTemplateConfig (config) {
+  if (!config || typeof config !== 'object') return config
+
+  let resolved = null
+  let firstKey = null
+  for (const key of USE_MODEL_CHAT_TEMPLATE_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(config, key)) continue
+    const raw = config[key]
+    if (raw === undefined || raw === null) continue
+
+    let asBool
+    if (typeof raw === 'boolean') {
+      asBool = raw
+    } else if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase()
+      if (v === 'true' || v === '1') {
+        asBool = true
+      } else if (v === 'false' || v === '0' || v === '') {
+        asBool = false
+      } else {
+        throw new TypeError(
+          `${key} must be a boolean or one of "true"/"false"/"1"/"0" (got: ${JSON.stringify(raw)})`
+        )
+      }
+    } else {
+      throw new TypeError(
+        `${key} must be a boolean or string (got: ${typeof raw})`
+      )
+    }
+
+    if (resolved !== null && resolved !== asBool) {
+      throw new TypeError(
+        `Conflicting values for ${firstKey}=${resolved} and ${key}=${asBool}; pass only one or use the same value`
+      )
+    }
+    resolved = asBool
+    if (firstKey === null) firstKey = key
+  }
+
+  if (resolved === null) return config
+
+  const out = { ...config }
+  delete out['use-model-chat-template']
+  out.use_model_chat_template = String(resolved)
+  return out
+}
+
 /** LLM client wrapping the native LlamaInterface for inference, finetuning, and pause/resume. */
 class LlmLlamacpp {
   constructor ({ files, config, logger = null, opts = {} }) {
@@ -201,7 +265,7 @@ class LlmLlamacpp {
     const configurationParams = {
       path: primaryGgufPath,
       projectionPath: this._projectionModelPath,
-      config: { ...this._config }
+      config: normalizeChatTemplateConfig({ ...this._config })
     }
 
     this.logger.info('Creating addon with configuration:', configurationParams)
@@ -477,3 +541,4 @@ class LlmLlamacpp {
 
 module.exports = LlmLlamacpp
 module.exports.pickPrimaryGgufPath = pickPrimaryGgufPath
+module.exports.normalizeChatTemplateConfig = normalizeChatTemplateConfig

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/normalize-chat-template-config.test.js
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/normalize-chat-template-config.test.js
@@ -1,0 +1,134 @@
+'use strict'
+
+const test = require('brittle')
+const { normalizeChatTemplateConfig } = require('../../index.js')
+
+// Both keys are absent — config returned as-is (referentially identical).
+test('passthrough when neither key present', function (t) {
+  const cfg = { device: 'gpu', gpu_layers: '999' }
+  t.is(normalizeChatTemplateConfig(cfg), cfg)
+})
+
+test('passthrough when value is undefined', function (t) {
+  const cfg = { device: 'gpu', use_model_chat_template: undefined }
+  t.is(normalizeChatTemplateConfig(cfg), cfg)
+})
+
+test('passthrough when value is null', function (t) {
+  const cfg = { device: 'gpu', use_model_chat_template: null }
+  t.is(normalizeChatTemplateConfig(cfg), cfg)
+})
+
+// Native booleans coerce to canonical "true"/"false" strings.
+test('boolean true -> "true" string', function (t) {
+  const out = normalizeChatTemplateConfig({ use_model_chat_template: true })
+  t.is(out.use_model_chat_template, 'true')
+})
+
+test('boolean false -> "false" string', function (t) {
+  const out = normalizeChatTemplateConfig({ use_model_chat_template: false })
+  t.is(out.use_model_chat_template, 'false')
+})
+
+// String values: case-insensitive, "1"/"0" aliases accepted.
+test('string "true" passthrough', function (t) {
+  const out = normalizeChatTemplateConfig({ use_model_chat_template: 'true' })
+  t.is(out.use_model_chat_template, 'true')
+})
+
+test('string "TRUE" -> "true"', function (t) {
+  const out = normalizeChatTemplateConfig({ use_model_chat_template: 'TRUE' })
+  t.is(out.use_model_chat_template, 'true')
+})
+
+test('string "False" -> "false"', function (t) {
+  const out = normalizeChatTemplateConfig({ use_model_chat_template: 'False' })
+  t.is(out.use_model_chat_template, 'false')
+})
+
+test('string "1" -> "true"', function (t) {
+  const out = normalizeChatTemplateConfig({ use_model_chat_template: '1' })
+  t.is(out.use_model_chat_template, 'true')
+})
+
+test('string "0" -> "false"', function (t) {
+  const out = normalizeChatTemplateConfig({ use_model_chat_template: '0' })
+  t.is(out.use_model_chat_template, 'false')
+})
+
+test('whitespace-only string -> "false"', function (t) {
+  const out = normalizeChatTemplateConfig({ use_model_chat_template: '  ' })
+  t.is(out.use_model_chat_template, 'false')
+})
+
+// Kebab-case alias is accepted and folded into the snake_case canonical form.
+test('kebab-case alias is accepted and folded', function (t) {
+  const out = normalizeChatTemplateConfig({ 'use-model-chat-template': true })
+  t.is(out.use_model_chat_template, 'true')
+  t.is(out['use-model-chat-template'], undefined, 'alias removed from output')
+})
+
+test('both keys with same value (different forms) merge cleanly', function (t) {
+  const out = normalizeChatTemplateConfig({
+    use_model_chat_template: 'TRUE',
+    'use-model-chat-template': true
+  })
+  t.is(out.use_model_chat_template, 'true')
+  t.is(out['use-model-chat-template'], undefined)
+})
+
+// Conflicts and bad values throw a TypeError with a clear message.
+// Note: brittle's plain `t.exception` deliberately re-raises native error
+// subclasses (TypeError / RangeError / etc.) — use `t.exception.all` to catch
+// them like any other throw. Also see grammar.test.js for the same pattern.
+test('conflicting values throw TypeError', async function (t) {
+  await t.exception.all(() => normalizeChatTemplateConfig({
+    use_model_chat_template: true,
+    'use-model-chat-template': false
+  }), /Conflicting values/)
+})
+
+test('non-true/false string throws TypeError', async function (t) {
+  await t.exception.all(() => normalizeChatTemplateConfig({
+    use_model_chat_template: 'yes'
+  }), /must be a boolean or one of/)
+})
+
+test('numeric value throws TypeError', async function (t) {
+  await t.exception.all(() => normalizeChatTemplateConfig({
+    use_model_chat_template: 1
+  }), /must be a boolean or string/)
+})
+
+test('object value throws TypeError', async function (t) {
+  await t.exception.all(() => normalizeChatTemplateConfig({
+    use_model_chat_template: { foo: 'bar' }
+  }), /must be a boolean or string/)
+})
+
+// Hardening: input is not mutated; unrelated keys are preserved.
+test('does not mutate input config', function (t) {
+  const input = { device: 'gpu', use_model_chat_template: true }
+  const snapshot = { ...input }
+  normalizeChatTemplateConfig(input)
+  t.alike(input, snapshot, 'input config must remain unchanged')
+})
+
+test('preserves unrelated keys in output', function (t) {
+  const out = normalizeChatTemplateConfig({
+    device: 'gpu',
+    gpu_layers: '999',
+    use_model_chat_template: true
+  })
+  t.is(out.device, 'gpu')
+  t.is(out.gpu_layers, '999')
+  t.is(out.use_model_chat_template, 'true')
+})
+
+// Defensive: non-object inputs flow through unchanged (matches the helper's
+// "best-effort, never throw on shape" contract for callers).
+test('non-object input passes through', function (t) {
+  t.is(normalizeChatTemplateConfig(null), null)
+  t.is(normalizeChatTemplateConfig(undefined), undefined)
+  t.is(normalizeChatTemplateConfig('not-a-config'), 'not-a-config')
+})

--- a/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_chat_template_utils.cpp
+++ b/packages/qvac-lib-infer-llamacpp-llm/test/unit/test_chat_template_utils.cpp
@@ -217,3 +217,54 @@ TEST_F(
   std::string result = getChatTemplate(nullptr, params, false);
   EXPECT_EQ(result, "my_custom_template");
 }
+
+// useModelChatTemplate=true makes getChatTemplate return params.chat_template
+// verbatim (including empty), bypassing the Qwen3 fixed-template path. The
+// nullptr-model variants exercise just the bypass logic; the integration with
+// real Qwen3 metadata is covered by GetChatTemplateUseModelChatTemplate* tests.
+TEST_F(
+    ChatTemplateUtilsTest, GetChatTemplateUseModelChatTemplateEmptyOverride) {
+  common_params params;
+  params.chat_template = "";
+  params.use_jinja = true;
+
+  std::string result = getChatTemplate(
+      nullptr, params, /*toolsCompact=*/false, /*useModelChatTemplate=*/true);
+  EXPECT_EQ(result, "");
+}
+
+TEST_F(
+    ChatTemplateUtilsTest,
+    GetChatTemplateUseModelChatTemplateRespectsManualOverride) {
+  common_params params;
+  params.chat_template = "user-supplied";
+  params.use_jinja = true;
+
+  std::string result = getChatTemplate(
+      nullptr, params, /*toolsCompact=*/false, /*useModelChatTemplate=*/true);
+  EXPECT_EQ(result, "user-supplied");
+}
+
+TEST_F(
+    ChatTemplateUtilsTest,
+    GetChatTemplateUseModelChatTemplateIgnoresToolsCompact) {
+  common_params params;
+  params.chat_template = "";
+  params.use_jinja = true;
+
+  std::string result = getChatTemplate(
+      nullptr, params, /*toolsCompact=*/true, /*useModelChatTemplate=*/true);
+  EXPECT_EQ(result, "");
+}
+
+TEST_F(
+    ChatTemplateUtilsTest,
+    GetChatTemplateDefaultsToOldBehaviourWhenFlagOmitted) {
+  common_params params;
+  params.chat_template = "explicit";
+  params.use_jinja = false;
+
+  // Default value of useModelChatTemplate (false) preserves prior behaviour.
+  std::string result = getChatTemplate(nullptr, params, false);
+  EXPECT_EQ(result, "explicit");
+}


### PR DESCRIPTION
## Summary

- Add an opt-in `use_model_chat_template` config flag (snake_case + kebab-case alias) on `LlamaConfig`. When true, the addon stops swapping in the bundled fixed Qwen3 chat template and instead lets `common_chat_templates_init` fall back to the GGUF's embedded `tokenizer.chat_template` (or the explicit `chat_template` if the user supplied one).
- The fixed-template path exists because the upstream Qwen3 Jinja template uses Python-only filters (`.lstrip()/.rstrip()/.strip()`) that minja can't render. Some Qwen3-derived GGUFs (e.g. MedPsy with a persona block, in-house finetunes, Qwen3.5 variants) ship cleaned-up templates that users want to apply as-is — this flag is the escape hatch.
- Logs an `INFO` line at load time when the bypass actually replaces the Qwen3 template, so the trade-off is visible at runtime. The TS doc-comment and README config table both call out the minja compatibility caveat.
- Backwards compatible: the new param on `getChatTemplate()` and the context constructors defaults to `false`; behaviour without the flag is unchanged.

## Background / why

The current `getChatTemplate()` forces the bundled `getFixedQwen3Template()` (or `getToolsDynamicQwen3Template()` when `tools_compact` is on) whenever the model is detected as Qwen3 and `use_jinja` is on (i.e. `tools: 'true'`). Today there is no way to say *"use the template the GGUF author put in this file"* short of reading `tokenizer.chat_template` out of the GGUF and feeding it back as a literal `chat_template` string. This PR adds the boolean opt-out.

## Files

- `addon/src/utils/ChatTemplateUtils.{hpp,cpp}` — new `useModelChatTemplate` parameter (default `false`); when true, returns `params.chat_template` verbatim and logs an INFO line for Qwen3 models.
- `addon/src/model-interface/LlamaModel.{hpp,cpp}` — `commonParamsParse()` parses `use_model_chat_template` / `use-model-chat-template` (case-insensitive `"true"`/`"1"`); `createContext()` and the new `outUseModelChatTemplate` plumb it into the context constructors.
- `addon/src/model-interface/{TextLlmContext,MtmdLlmContext}.{hpp,cpp}` — store `useModelChatTemplate_` and forward it to `getChatTemplate(...)`.
- `index.d.ts` — typed `use_model_chat_template` (and the kebab alias) on `LlamaConfig`.
- `README.md` — config-table row.
- `test/unit/test_chat_template_utils.cpp` — 4 new unit tests covering: empty-override → empty (GGUF fallback), manual override still wins, `tools_compact` ignored when bypassing, default-false preserves the old behaviour.

## Usage

```js
const config = {
  device: 'gpu',
  gpu_layers: '999',
  ctx_size: '2048',
  use_model_chat_template: 'true'   // bypass the bundled fixed Qwen3 template
}
```

Precedence: explicit `chat_template` > `use_model_chat_template` > Qwen3 forced template.

## Test plan

- [x] `npm run test:cpp` — all 26 `ChatTemplateUtilsTest` tests pass (22 existing + 4 new).
- [x] Local addon builds clean (`bare-make build`) — only the 3 pre-existing `llama_adapter_lora_free` deprecation warnings.
- [x] End-to-end against a Qwen3 GGUF with a custom embedded template (MedPsy 1.7B):
  - **Without flag** → log line `[ChatTemplateUtils] Using fixed Qwen3 template`; the persona is not injected.
  - **With flag** → log line `[ChatTemplateUtils] use_model_chat_template=true: bypassing fixed Qwen3 template and using the model's embedded chat template`; the persona block from `tokenizer.chat_template` is now applied (model output reflects it).
- [ ] CI green
- [ ] Reviewer: confirm the log INFO line is acceptable as the only runtime indicator of the bypass

## Known caveats (called out in code/docs)

- For *vanilla* upstream Qwen3 templates that use Python-only Jinja filters, opting in can produce broken prompts (the very reason the fixed template was added). The TS doc-comment, README, and runtime INFO log all call this out.
- When combined with `tools: 'true'`, the embedded template is rendered through minja with tools — correctness depends on the GGUF author's template having proper tool-calling Jinja. `getPrompt`'s existing catch block (`use_jinja=false` retry) still applies as a safety net.
- `tools_compact` becomes a no-op for *template selection* when the bypass is on (the dynamic Qwen3 tools template lives behind the bypassed path); the trim/anchor controller still runs but will be looking for `<tool_call>` markers in whatever the embedded template emits.

Made with [Cursor](https://cursor.com)