### PR TITLE
chore: hide PR template style note in HTML comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/addon.md
+++ b/.github/PULL_REQUEST_TEMPLATE/addon.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## 🎯 What problem does this PR solve?
 

--- a/.github/PULL_REQUEST_TEMPLATE/sdk-pod.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sdk-pod.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## 🎯 What problem does this PR solve?
 

--- a/packages/bci-whispercpp/PULL_REQUEST_TEMPLATE.md
+++ b/packages/bci-whispercpp/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## 🎯 What problem does this PR solve?
 

--- a/packages/decoder-audio/PULL_REQUEST_TEMPLATE.md
+++ b/packages/decoder-audio/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## 🎯 What problem does this PR solve?
 

--- a/packages/qvac-lib-infer-llamacpp-embed/PULL_REQUEST_TEMPLATE.md
+++ b/packages/qvac-lib-infer-llamacpp-embed/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## 🎯 What problem does this PR solve?
 

--- a/packages/qvac-lib-infer-llamacpp-llm/PULL_REQUEST_TEMPLATE.md
+++ b/packages/qvac-lib-infer-llamacpp-llm/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## 🎯 What problem does this PR solve?
 

--- a/packages/qvac-lib-infer-nmtcpp/PULL_REQUEST_TEMPLATE.md
+++ b/packages/qvac-lib-infer-nmtcpp/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## What problem does this PR solve?
 

--- a/packages/qvac-lib-infer-onnx-tts/PULL_REQUEST_TEMPLATE.md
+++ b/packages/qvac-lib-infer-onnx-tts/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## 🎯 What problem does this PR solve?
 

--- a/packages/qvac-lib-infer-parakeet/PULL_REQUEST_TEMPLATE.md
+++ b/packages/qvac-lib-infer-parakeet/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## 🎯 What problem does this PR solve?
 

--- a/packages/qvac-lib-infer-whispercpp/PULL_REQUEST_TEMPLATE.md
+++ b/packages/qvac-lib-infer-whispercpp/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-**Note**: be concise and prefer bullet points.
+<!--
+Style guide for this PR description:
+- Be concise; prefer bullet points.
+- Delete sections that don't apply.
+- Keep code examples minimal.
+-->
 
 ## 🎯 What problem does this PR solve?
 


### PR DESCRIPTION
<!--
Style guide for this PR description:
- Be concise; prefer bullet points.
- Delete sections that don't apply.
- Keep code examples minimal.
-->

## What problem does this PR solve?

Every PR opened against this repo currently starts with a literal `**Note**: be concise and prefer bullet points.` line, because that meta-instruction sits as visible Markdown at the top of all 10 PR templates. It was authored as guidance for the PR author at fill-in time but ends up rendered into every PR body and copy-pasted forward by agents (Cursor, Claude Code) that read the template verbatim.

## How does it solve it?

- Replace the visible `**Note**:` line in all 10 templates with an HTML comment containing a short style guide (be concise, drop unused sections, keep code examples minimal).
- HTML comments are visible to anyone editing the template (humans and agents) but disappear in rendered Markdown, so generated PRs stay clean.
- Templates touched: `.github/PULL_REQUEST_TEMPLATE/{sdk-pod,addon}.md` and 8 per-package `packages/*/PULL_REQUEST_TEMPLATE.md` files.
- Skill files and per-tool agent configs are intentionally out of scope — fixing the template is the only place that covers every PR-creation path (gh CLI auto-template, Cursor skills, Claude Code, manual edits).

## Breaking changes

None. Templates only; no code, no APIs.
