### PR TITLE
chore[ci][notask]: add qvac-internal-merge team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tetherto/qvac-internal-dev
+* @tetherto/qvac-internal-dev @tetherto/qvac-internal-merge


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The new `@tetherto/qvac-internal-merge` team currently has no code-owner authority on the repo, so its members are not auto-requested for review and cannot satisfy CODEOWNERS-based protection rules.
- Without this, merge-side automation/operators routed to that team are blocked from owning approvals on PRs targeting `main`.

## 📝 How does it solve it?

- Append `@tetherto/qvac-internal-merge` to the existing catch-all `*` rule in `.github/CODEOWNERS`, on the same line as `@tetherto/qvac-internal-dev`.
- Both teams are now listed as code owners for every path; either team's review counts toward CODEOWNERS approval.

**Diff:**

```diff
-* @tetherto/qvac-internal-dev
+* @tetherto/qvac-internal-dev @tetherto/qvac-internal-merge
```

## 🧪 How was it tested?

- Verified the file parses as a single `*` rule with two valid `@tetherto/<team>` owners (GitHub CODEOWNERS syntax: space-separated owners on one line).
- No workflow/IaC changes; nothing to dry-run.
- Effective behavior will be visible on the next PR opened against `main` (review request to both teams).

Made with [Cursor](https://cursor.com)