### PR TITLE
QVAC-18062: handle fork pull_request_review in approval-worker

### DIFF
--- a/.github/workflows/approval-worker.yml
+++ b/.github/workflows/approval-worker.yml
@@ -41,8 +41,21 @@ jobs:
             core.setOutput('number', String(prNumber));
             core.setOutput('sha', pr.head.sha);
 
-  check-approvals:
+  check-prerequisites:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
     needs: run-when-command
+    steps:
+      - name: Fail workflow if triggered by a fork and pull_request_review
+        if: github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.fork == true
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # 8.0.0
+        with:
+          script: |
+            core.setFailed('This action is triggered by a fork repo PR and pull_request_review event - which is why the approval check worker fails. Please add a review comment on the PR to trigger this action properly');
+
+  check-approvals:
+    needs: [run-when-command, check-prerequisites]
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
### 🎯 What problem does this PR solve?

`approval-worker` can be triggered by `pull_request_review`, but for forked PRs that event runs with restricted context and causes the approval check worker path to fail. This creates noisy failures for a valid review flow on fork-based contributions.

### 📝 How does it solve it?

The workflow adds a new `check-prerequisites` job (after `run-when-command`) that explicitly detects `pull_request_review` events from forked PRs and fails early with a clear message to use a PR review comment trigger instead. The `check-approvals` job now depends on both `run-when-command` and `check-prerequisites`, so the workflow exits in a controlled and explainable way before attempting approval actions that are not viable in that forked event context.

### 🧪 How was it tested?
- `Actionlint` isn’t reporting any issues with the workflow during static analysis.
- Validated the workflow run with the same workflow as main repo on one my own repo:
    - Expected Failure Run: case `pull_request_reivew` github event + `fork PR` 
        - https://github.com/sidj-thr-org/workflows/actions/runs/25451243167
    - Successful Run: case `review comment` github event: 
        - https://github.com/sidj-thr-org/workflows/actions/runs/25450954299


Asana Ticket: [Update "Approval Check Worker" to work with forked repos](https://app.asana.com/1/45238840754660/project/1214153063536860/task/1214079748940922)