### PR TITLE
QVAC-18580 chore[skiplog]: release sdk 0.10.2

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.10.2]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.2
+
+This is a hotfix release that restores delegated-inference connection performance to the level it was at in v0.9.0. No API or model changes — drop-in replacement for v0.10.1.
+
+## Bug Fixes
+
+### Delegated connect no longer waits for full DHT bootstrap
+
+Consumers using `loadModel({ delegate: true, ... })` against a remote provider were spending ~2.5–3s longer per connection in v0.10.0/0.10.1 than in v0.9.0. Profiler traces from the Workbench team showed `loadModel.delegation.connection` regressing from ~2.5s (v0.9.0) to ~8.3s (v0.10.0) on the same machine and network.
+
+The cause was a serial `await swarm.dht.fullyBootstrapped()` call that was added to the consumer's connect path in the v0.10.0 redesign. `dht.fullyBootstrapped()` only resolves once Hyperdht has populated its full routing table, which is a slow process from a cold swarm — and on a hot swarm `dht.connect(publicKey)` already drives the lookups it needs internally, so the explicit wait is redundant. Removing it lets the connection use the DHT in whatever state it's in at call time, exactly the way it did in v0.9.0.
+
+The DHT routing table is still populated lazily as `dht.connect()` issues lookups, so cold-swarm correctness is unchanged — `PEER_NOT_FOUND` for non-existent peers and connection timeouts for unreachable ones both still fire on the same code path. The fallback-to-local behaviour for `loadModel` is unaffected; only the hot-path latency improves.
+
+Local benchmarks (10 consumer↔provider runs each, against the published v0.10.1 baseline):
+
+| Build              | Mean connection time | p50    | p95    |
+| ------------------ | -------------------- | ------ | ------ |
+| v0.10.1 (baseline) | 3.82s                | 3.71s  | 4.94s  |
+| v0.10.2 (this fix) | 1.18s                | 1.12s  | 1.49s  |
+
+That's ~3.2× faster on average and brings cold delegated `loadModel` back below the v0.9.0 numbers.
+
+If you were on v0.10.0 or v0.10.1 and had pinned around the regression (custom timeouts, retry shims, falling back to local inference earlier than necessary), you can drop those workarounds.
+
 ## [0.10.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.1

--- a/packages/sdk/changelog/0.10.2/CHANGELOG.md
+++ b/packages/sdk/changelog/0.10.2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.10.2
+
+Release Date: 2026-05-07
+
+## 🐞 Fixes
+
+- Drop blocking dht.fullyBootstrapped() wait from delegated connect. (see PR [#1934](https://github.com/tetherto/qvac/pull/1934))
+

--- a/packages/sdk/changelog/0.10.2/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.10.2/CHANGELOG_LLM.md
@@ -1,0 +1,26 @@
+# QVAC SDK v0.10.2 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.2
+
+This is a hotfix release that restores delegated-inference connection performance to the level it was at in v0.9.0. No API or model changes — drop-in replacement for v0.10.1.
+
+## Bug Fixes
+
+### Delegated connect no longer waits for full DHT bootstrap
+
+Consumers using `loadModel({ delegate: true, ... })` against a remote provider were spending ~2.5–3s longer per connection in v0.10.0/0.10.1 than in v0.9.0. Profiler traces from the Workbench team showed `loadModel.delegation.connection` regressing from ~2.5s (v0.9.0) to ~8.3s (v0.10.0) on the same machine and network.
+
+The cause was a serial `await swarm.dht.fullyBootstrapped()` call that was added to the consumer's connect path in the v0.10.0 redesign. `dht.fullyBootstrapped()` only resolves once Hyperdht has populated its full routing table, which is a slow process from a cold swarm — and on a hot swarm `dht.connect(publicKey)` already drives the lookups it needs internally, so the explicit wait is redundant. Removing it lets the connection use the DHT in whatever state it's in at call time, exactly the way it did in v0.9.0.
+
+The DHT routing table is still populated lazily as `dht.connect()` issues lookups, so cold-swarm correctness is unchanged — `PEER_NOT_FOUND` for non-existent peers and connection timeouts for unreachable ones both still fire on the same code path. The fallback-to-local behaviour for `loadModel` is unaffected; only the hot-path latency improves.
+
+Local benchmarks (10 consumer↔provider runs each, against the published v0.10.1 baseline):
+
+| Build              | Mean connection time | p50    | p95    |
+| ------------------ | -------------------- | ------ | ------ |
+| v0.10.1 (baseline) | 3.82s                | 3.71s  | 4.94s  |
+| v0.10.2 (this fix) | 1.18s                | 1.12s  | 1.49s  |
+
+That's ~3.2× faster on average and brings cold delegated `loadModel` back below the v0.9.0 numbers.
+
+If you were on v0.10.0 or v0.10.1 and had pinned around the regression (custom timeouts, retry shims, falling back to local inference earlier than necessary), you can drop those workarounds.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/sdk/server/bare/delegate-rpc-client.ts
+++ b/packages/sdk/server/bare/delegate-rpc-client.ts
@@ -183,16 +183,16 @@ async function ensureRPCConnection(
       `🔗 Establishing direct DHT connection to peer: ${publicKey}${timeout ? `, timeout: ${timeout}ms` : ""}`,
     );
 
-    // Ensure the DHT routing table is populated before attempting to look up
-    // the peer. On a cold swarm the table is nearly empty and findPeer can
-    // return PEER_NOT_FOUND immediately even when the provider is reachable.
-    const bootstrapStart = nowMs();
-    const swarm = getSwarm();
-    logger.info(`⏳ Waiting for DHT to fully bootstrap before connect...`);
-    await withTimeout(swarm.dht.fullyBootstrapped(), getRemainingTimeout());
-    logger.info(
-      `✅ DHT bootstrapped in ${(nowMs() - bootstrapStart).toFixed(0)}ms`,
-    );
+    // We deliberately do NOT `await swarm.dht.fullyBootstrapped()` here. The
+    // earlier guard (added with #1729 to side-step a theoretical PEER_NOT_FOUND
+    // on a fully-cold swarm) added a serial 1-3s wait on every first delegated
+    // call — measurably regressing `loadModel.delegation.connection` vs 0.9.0
+    // (≈3.2× slower in local benches). `getSwarm()` is invoked early during
+    // SDK init (registry/runtime), so by the time the consumer reaches this
+    // path the routing table is already warm enough; `dht.connect()` also
+    // bootstraps on demand if it isn't, so we lose nothing by skipping the
+    // explicit await.
+    getSwarm();
 
     conn = openDhtConnection(publicKey);
     await waitForOpen(conn, getRemainingTimeout());


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

Cuts the **v0.10.2 hotfix** of `@qvac/sdk` on the `release-sdk-0.10.2` branch. Brings a single high-priority fix from `main` to the 0.10.x line — the delegated-inference connection regression that was blocking the Workbench 0.7.0 release.

- [#1934](https://github.com/tetherto/qvac/pull/1934) — fix: drop blocking `dht.fullyBootstrapped()` wait from delegated connect (`loadModel.delegation.connection` ~3.2× faster: 3.82s → 1.18s mean, restoring v0.9.0-class latency).

## 📝 How does it solve it?

- Cherry-picks `#1934` (`fix`, QVAC-18580) from `upstream/main` onto `release-sdk-0.10.1` (`5eb6b52e5`).
- Bumps `packages/sdk/package.json`: `0.10.1` → `0.10.2`.
- Adds `packages/sdk/changelog/0.10.2/{CHANGELOG.md, CHANGELOG_LLM.md}`.
- Rebuilds the root `packages/sdk/CHANGELOG.md` aggregate with v0.10.2 at the top.
- `packages/sdk/NOTICE` is **unchanged** — no dependency changes since v0.10.1, so the existing attribution list is byte-identical and stays accurate.

## 🧪 How was it tested?

The underlying fix (#1934) was benchmarked locally before merge (10 consumer↔provider runs each, against the published v0.10.1 build):

| Build              | Mean conn. time | p50    | p95    |
| ------------------ | --------------- | ------ | ------ |
| v0.10.1 (baseline) | 3.82s           | 3.71s  | 4.94s  |
| v0.10.2 (this fix) | 1.18s           | 1.12s  | 1.49s  |

Failure-path tests (`delegated-connection-failure`, `delegated-provider-not-found`, `delegated-load-model-fallback-local`) were re-run against the patched SDK and pass — `PEER_NOT_FOUND` for non-existent peers and connection timeouts for unreachable ones still fire on the same code path. Full verification notes are on PR #1934.

This release branch carries only the cherry-pick + release metadata (4 files: package.json, root CHANGELOG.md, two changelog/0.10.2/ files). No other functional changes from main are included.

Once merged → triggers GPR publish for `@tetherto/sdk@0.10.2`. A backmerge PR (release-sdk-0.10.2 → main) will follow to publish to npm and keep main aligned.