### PR TITLE
QVAC-18580 chore[skiplog]: backmerge release-sdk-0.10.2 — version bump, changelog

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [0.10.2]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.2
+
+This is a hotfix release that restores delegated-inference connection performance to the level it was at in v0.9.0. No API or model changes — drop-in replacement for v0.10.1.
+
+## Bug Fixes
+
+### Delegated connect no longer waits for full DHT bootstrap
+
+Consumers using `loadModel({ delegate: true, ... })` against a remote provider were spending ~2.5–3s longer per connection in v0.10.0/0.10.1 than in v0.9.0. Profiler traces from the Workbench team showed `loadModel.delegation.connection` regressing from ~2.5s (v0.9.0) to ~8.3s (v0.10.0) on the same machine and network.
+
+The cause was a serial `await swarm.dht.fullyBootstrapped()` call that was added to the consumer's connect path in the v0.10.0 redesign. `dht.fullyBootstrapped()` only resolves once Hyperdht has populated its full routing table, which is a slow process from a cold swarm — and on a hot swarm `dht.connect(publicKey)` already drives the lookups it needs internally, so the explicit wait is redundant. Removing it lets the connection use the DHT in whatever state it's in at call time, exactly the way it did in v0.9.0.
+
+The DHT routing table is still populated lazily as `dht.connect()` issues lookups, so cold-swarm correctness is unchanged — `PEER_NOT_FOUND` for non-existent peers and connection timeouts for unreachable ones both still fire on the same code path. The fallback-to-local behaviour for `loadModel` is unaffected; only the hot-path latency improves.
+
+Local benchmarks (10 consumer↔provider runs each, against the published v0.10.1 baseline):
+
+| Build              | Mean connection time | p50    | p95    |
+| ------------------ | -------------------- | ------ | ------ |
+| v0.10.1 (baseline) | 3.82s                | 3.71s  | 4.94s  |
+| v0.10.2 (this fix) | 1.18s                | 1.12s  | 1.49s  |
+
+That's ~3.2× faster on average and brings cold delegated `loadModel` back below the v0.9.0 numbers.
+
+If you were on v0.10.0 or v0.10.1 and had pinned around the regression (custom timeouts, retry shims, falling back to local inference earlier than necessary), you can drop those workarounds.
+
 ## [0.10.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.1

--- a/packages/sdk/changelog/0.10.2/CHANGELOG.md
+++ b/packages/sdk/changelog/0.10.2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.10.2
+
+Release Date: 2026-05-07
+
+## 🐞 Fixes
+
+- Drop blocking dht.fullyBootstrapped() wait from delegated connect. (see PR [#1934](https://github.com/tetherto/qvac/pull/1934))
+

--- a/packages/sdk/changelog/0.10.2/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.10.2/CHANGELOG_LLM.md
@@ -1,0 +1,26 @@
+# QVAC SDK v0.10.2 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.2
+
+This is a hotfix release that restores delegated-inference connection performance to the level it was at in v0.9.0. No API or model changes — drop-in replacement for v0.10.1.
+
+## Bug Fixes
+
+### Delegated connect no longer waits for full DHT bootstrap
+
+Consumers using `loadModel({ delegate: true, ... })` against a remote provider were spending ~2.5–3s longer per connection in v0.10.0/0.10.1 than in v0.9.0. Profiler traces from the Workbench team showed `loadModel.delegation.connection` regressing from ~2.5s (v0.9.0) to ~8.3s (v0.10.0) on the same machine and network.
+
+The cause was a serial `await swarm.dht.fullyBootstrapped()` call that was added to the consumer's connect path in the v0.10.0 redesign. `dht.fullyBootstrapped()` only resolves once Hyperdht has populated its full routing table, which is a slow process from a cold swarm — and on a hot swarm `dht.connect(publicKey)` already drives the lookups it needs internally, so the explicit wait is redundant. Removing it lets the connection use the DHT in whatever state it's in at call time, exactly the way it did in v0.9.0.
+
+The DHT routing table is still populated lazily as `dht.connect()` issues lookups, so cold-swarm correctness is unchanged — `PEER_NOT_FOUND` for non-existent peers and connection timeouts for unreachable ones both still fire on the same code path. The fallback-to-local behaviour for `loadModel` is unaffected; only the hot-path latency improves.
+
+Local benchmarks (10 consumer↔provider runs each, against the published v0.10.1 baseline):
+
+| Build              | Mean connection time | p50    | p95    |
+| ------------------ | -------------------- | ------ | ------ |
+| v0.10.1 (baseline) | 3.82s                | 3.71s  | 4.94s  |
+| v0.10.2 (this fix) | 1.18s                | 1.12s  | 1.49s  |
+
+That's ~3.2× faster on average and brings cold delegated `loadModel` back below the v0.9.0 numbers.
+
+If you were on v0.10.0 or v0.10.1 and had pinned around the regression (custom timeouts, retry shims, falling back to local inference earlier than necessary), you can drop those workarounds.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- Keeps `main` aligned with the v0.10.2 hotfix of `@qvac/sdk` shipping on `release-sdk-0.10.2` (companion release PR: tetherto/qvac#1939).
- Without this backmerge, `main` would have a hole in its changelog history (no `changelog/0.10.2/` folder, no v0.10.2 entry in the aggregated `CHANGELOG.md`) and `package.json` would still claim `0.10.1` even though `@qvac/sdk@0.10.2` is on npm.

## 📝 How does it solve it?

- Cherry-picks (with `-x`) the single release-metadata commit `a4f72257a` from `release-sdk-0.10.2` onto `main`.
- Carries only release metadata — no functional code. The delegation fix that ships in v0.10.2 ([#1934](https://github.com/tetherto/qvac/pull/1934)) is already on `main` from its original merge (`318f0c6a3`).
- Files:
  - `packages/sdk/package.json` — `0.10.1` → `0.10.2` (single-line change, dependencies untouched)
  - `packages/sdk/changelog/0.10.2/{CHANGELOG.md, CHANGELOG_LLM.md}` — generated changelog files
  - `packages/sdk/CHANGELOG.md` — aggregated changelog (v0.10.2 added at top)

## 🧪 How was it tested?

This is a **hand-crafted backmerge** rather than a literal `git merge release-sdk-0.10.2 → main` because `main` has advanced past `release-sdk-0.10.1` (the base of `release-sdk-0.10.2`) on multiple SDK dependencies. A literal merge would either bring up conflict markers or quietly regress these versions:

| Dependency                      | release-sdk-0.10.1 | main (current)   |
| ------------------------------- | ------------------ | ---------------- |
| `@qvac/diffusion-cpp`           | `^0.3.0`           | `^0.5.0`         |
| `@qvac/embed-llamacpp`          | `^0.14.0`          | `^0.15.0`        |
| `@qvac/llm-llamacpp`            | `^0.17.1`          | `^0.18.0`        |
| `@qvac/transcription-whispercpp`| `^0.6.1`           | `^0.6.5`         |
| `hyperswarm`                    | `^4.12.1`          | `^4.14.0`        |
| `hyperdht`                      | (absent)           | `^6.23.0`        |
| `hyperblobs`                    | (absent)           | `^2.8.0`         |
| `peerDependencies` block        | (absent)           | present          |

The cherry-pick of `a4f72257a` carries **only** the version-bump line in `package.json` (`0.10.1` → `0.10.2`) plus the new `changelog/0.10.2/` folder and the root `CHANGELOG.md` aggregate update. Verified locally with `git diff --stat upstream/main`:

```
packages/sdk/CHANGELOG.md                      | 27 ++++++++++++++++++++++++++
packages/sdk/changelog/0.10.2/CHANGELOG.md     |  8 ++++++++
packages/sdk/changelog/0.10.2/CHANGELOG_LLM.md | 26 +++++++++++++++++++++++++
packages/sdk/package.json                      |  2 +-
4 files changed, 62 insertions(+), 1 deletion(-)
```

Same shape as the previous backmerge ([#1910](https://github.com/tetherto/qvac/pull/1910) for v0.10.1).