### PR TITLE
feat[mod]: add RealESRGAN x4 upscaler models to registry

### DIFF
--- a/packages/qvac-lib-registry-server/NOTICE
+++ b/packages/qvac-lib-registry-server/NOTICE
@@ -121,6 +121,15 @@ one of these identifiers.
     distribution, and downstream users must be notified of these
     restrictions.
 
+--- BSD-3-Clause (BSD 3-Clause License) ---
+
+  Original repositories:
+    xinntao/Real-ESRGAN
+      Copyright (c) 2021, Xintao Wang. All rights reserved.
+
+  Distributed weights:
+    RealESRGAN_x4plus, RealESRNet_x4plus, RealESRGAN_x4plus_anime_6B
+
 =========================================================================
 Modification Notice
 =========================================================================

--- a/packages/qvac-lib-registry-server/data/licenses.json
+++ b/packages/qvac-lib-registry-server/data/licenses.json
@@ -43,5 +43,10 @@
     "spdxId": "openrail++",
     "name": "Open RAIL++-M License",
     "url": "https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/raw/main/LICENSE.md"
+  },
+  {
+    "spdxId": "BSD-3-Clause",
+    "name": "BSD 3-Clause License",
+    "url": "https://opensource.org/licenses/BSD-3-Clause"
   }
 ]

--- a/packages/qvac-lib-registry-server/data/licenses/BSD-3-Clause/LICENSE.txt
+++ b/packages/qvac-lib-registry-server/data/licenses/BSD-3-Clause/LICENSE.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, Xintao Wang
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -5568,6 +5568,44 @@
     ]
   },
   {
+    "source": "s3:///qvac_models_compiled/esrgan/2026-05-07/RealESRGAN_x4plus.pth",
+    "engine": "@qvac/diffusion-cpp",
+    "link": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth",
+    "description": "Real-ESRGAN x4 upscaler trained on general real-world images",
+    "licenseId": "BSD-3-Clause",
+    "tags": [
+      "upscale",
+      "esrgan",
+      "x4"
+    ]
+  },
+  {
+    "source": "s3:///qvac_models_compiled/esrgan/2026-05-07/RealESRNet_x4plus.pth",
+    "engine": "@qvac/diffusion-cpp",
+    "link": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/RealESRNet_x4plus.pth",
+    "description": "Real-ESRNet x4 upscaler trained on general real-world images (non-GAN variant)",
+    "licenseId": "BSD-3-Clause",
+    "tags": [
+      "upscale",
+      "esrgan",
+      "x4",
+      "non-gan"
+    ]
+  },
+  {
+    "source": "s3:///qvac_models_compiled/esrgan/2026-05-07/RealESRGAN_x4plus_anime_6B.pth",
+    "engine": "@qvac/diffusion-cpp",
+    "link": "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth",
+    "description": "Real-ESRGAN x4 upscaler optimized for anime illustrations (6 RRDB blocks)",
+    "licenseId": "BSD-3-Clause",
+    "tags": [
+      "upscale",
+      "esrgan",
+      "x4",
+      "anime"
+    ]
+  },
+  {
     "source": "s3:///qvac_models_compiled/ggml/gpt-oss120b/2026-03-17/gpt-oss-120b-Q4_K_M-00001-of-00002.gguf",
     "engine": "@qvac/llm-llamacpp",
     "link": "https://huggingface.co/unsloth/gpt-oss-120b-GGUF/blob/main/Q4_K_M/gpt-oss-120b-Q4_K_M-00001-of-00002.gguf",

--- a/packages/qvac-lib-registry-server/docs/MODEL_SUBMISSION_GUIDE.md
+++ b/packages/qvac-lib-registry-server/docs/MODEL_SUBMISSION_GUIDE.md
@@ -129,7 +129,7 @@ Each license used in `models.prod.json` must have:
 1. An entry in `data/licenses.json` with `spdxId`, `name`, and `url`.
 2. A full license text at `data/licenses/<spdxId>/LICENSE.txt`.
 
-Existing licenses: `Apache-2.0`, `MIT`, `llama3.2`, `gemma`, `health-ai-developer-foundations`, `MPL-2.0`, `CC-BY-4.0`, `openrail`.
+Existing licenses: `Apache-2.0`, `MIT`, `llama3.2`, `gemma`, `health-ai-developer-foundations`, `MPL-2.0`, `CC-BY-4.0`, `openrail`, `openrail++`, `BSD-3-Clause`.
 
 When adding a model with a new license, include the license file in the same PR.
 


### PR DESCRIPTION
## What problem does this PR solve?

The `@qvac/diffusion-cpp` engine supports ESRGAN-based post-generation upscaling (see `examples/generate-image-esrgan-upscale.js`), but the registry currently has no ESRGAN weights, so consumers must source them out-of-band.

## How does it solve it?

Adds the three official Real-ESRGAN x4 weights from `xinntao/Real-ESRGAN` to `models.prod.json` under `@qvac/diffusion-cpp`:

- `RealESRGAN_x4plus.pth` — general real-world images (v0.1.0)
- `RealESRNet_x4plus.pth` — non-GAN variant (v0.1.1)
- `RealESRGAN_x4plus_anime_6B.pth` — anime-tuned, 6 RRDB blocks (v0.2.2.4)

Supporting changes:

- Register `BSD-3-Clause` in `data/licenses.json` and add `data/licenses/BSD-3-Clause/LICENSE.txt` (verbatim text from the upstream repo, verified via the GitHub license API).
- Add a `BSD-3-Clause` entry to the registry-server `NOTICE` file with upstream attribution.
- Update `MODEL_SUBMISSION_GUIDE.md` to list the newly-supported license IDs (`openrail++`, `BSD-3-Clause`).

S3 paths follow the standard convention (`s3:///qvac_models_compiled/esrgan/2026-05-07/...`); artifacts will be uploaded by `sync-models.js` on merge.

Validated locally:

```
node scripts/validate-models-json.js --file=./data/models.prod.json
✓ Valid: 670 model(s)
```

## Breaking changes

None. Additive only.