### PR TITLE
fix: remove failing Parakeet INT8 registry model entries

### DIFF
--- a/packages/qvac-lib-registry-server/data/models.prod.json
+++ b/packages/qvac-lib-registry-server/data/models.prod.json
@@ -5279,42 +5279,6 @@
     "notes": ""
   },
   {
-    "source": "s3:///qvac_models_compiled/parakeet/parakeet-eou-onnx-int8/2026-03-17/encoder_int8.onnx",
-    "engine": "@qvac/transcription-parakeet",
-    "link": "https://huggingface.co/nasedkinpv/parakeet-tdt-0.6b-v3-onnx-int8",
-    "description": "Parakeet EOU 120M INT8 Encoder",
-    "quantization": "int8",
-    "params": "120M",
-    "licenseId": "CC-BY-4.0",
-    "tags": [
-      "transcription",
-      "parakeet",
-      "eou",
-      "int8",
-      "encoder"
-    ],
-    "deprecated": false,
-    "notes": ""
-  },
-  {
-    "source": "s3:///qvac_models_compiled/parakeet/parakeet-eou-onnx-int8/2026-03-17/decoder_joint_int8.onnx",
-    "engine": "@qvac/transcription-parakeet",
-    "link": "https://huggingface.co/nasedkinpv/parakeet-tdt-0.6b-v3-onnx-int8",
-    "description": "Parakeet EOU 120M INT8 Decoder",
-    "quantization": "int8",
-    "params": "120M",
-    "licenseId": "CC-BY-4.0",
-    "tags": [
-      "transcription",
-      "parakeet",
-      "eou",
-      "int8",
-      "decoder"
-    ],
-    "deprecated": false,
-    "notes": ""
-  },
-  {
     "source": "https://huggingface.co/cgus/diar_streaming_sortformer_4spk-v2-onnx/resolve/a3e0e6c8485b963cfdee82e4e961af1a9daca99d/diar_streaming_sortformer_4spk-v2.onnx",
     "engine": "@qvac/transcription-parakeet",
     "link": "https://huggingface.co/altunenes/parakeet-rs",
@@ -5328,24 +5292,6 @@
       "sortformer",
       "4spk",
       "en"
-    ],
-    "deprecated": false,
-    "notes": ""
-  },
-  {
-    "source": "s3:///qvac_models_compiled/parakeet/parakeet-sortformer-onnx-int8/2026-03-20/sortformer_int8.onnx",
-    "engine": "@qvac/transcription-parakeet",
-    "link": "https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2",
-    "description": "Parakeet Sortformer 4SPK v2 INT8",
-    "quantization": "int8",
-    "params": "123M",
-    "licenseId": "CC-BY-4.0",
-    "tags": [
-      "transcription",
-      "parakeet",
-      "sortformer",
-      "4spk",
-      "int8"
     ],
     "deprecated": false,
     "notes": ""


### PR DESCRIPTION
## What problem does this PR solve?
Removes failing Parakeet INT8 registry entries that return REQUEST_ERROR during model fetch.
Prevents registry consumers from attempting to download unavailable S3 artifacts.
## How does it solve it?
Deletes the Parakeet EOU INT8 encoder/decoder model entries from models.prod.json.
Deletes the Parakeet Sortformer INT8 model entry from models.prod.json.
## How was it tested?
Validated packages/qvac-lib-registry-server/data/models.prod.json parses as valid JSON after removal.
Confirmed the removed model source paths no longer appear in the registry JSON.