### PR TITLE
QVAC-18674 chore[skiplog]: rag v0.5.0 release, changelog & NOTICE

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0]
+
+### Fixed
+
+- React Native / Expo bundling: routed `bare-crypto` and `bare-fetch` through `package.json#imports` (`#crypto`, `#fetch`) with lazy shims, so non-Bare bundlers no longer corrupt the package output (e.g. `SyntaxError: 'LLMChunkAdapter' not exported`). Missing capabilities now throw `QvacErrorRAG { DEPENDENCY_REQUIRED }` only when invoked.
+- `generateId()` no longer mutates a global `crypto` or depends on `uuid-random`; UUID v4s are generated locally using secure randomness from `globalThis.crypto.getRandomValues` or `#crypto.randomBytes` / `getRandomValues`.
+- `QvacErrorRAG` construction in RAG crypto fallbacks now uses the canonical `{ code, adds }` options object so the documented `DEPENDENCY_REQUIRED` (14015) error code is actually thrown (previously degraded to code `0` / `"Unknown QVAC error"`).
+
+### Changed
+
+- Holepunch singletons (`hyperdb`, `hyperdht`, `hyperschema`, `bare-crypto`, `bare-fetch`, `llm-splitter`) moved from `dependencies` to `peerDependencies` so consumer trees install a single copy aligned with `@qvac/sdk`'s ranges. `hyperdht` is marked optional (reserved for the unwired `replicateWith` path).
+- Examples and integration tests migrated off `@qvac/dl-hyperdrive` to `@qvac/registry-client` (files-based addon construction). `devDependencies` updated accordingly: removed `@qvac/dl-hyperdrive`, added `@qvac/registry-client@^0.4.1`, bumped `@qvac/embed-llamacpp` `^0.7.6 → ^0.14.0` and `@qvac/llm-llamacpp` `^0.5.7 → ^0.16.0`.
+
+### Added
+
+- `crypto-browserify` as an optional peer dependency for browser / React Native consumers that need Node-style `crypto.createHash` (notably for HyperDB document hashing).
+
 ## [0.4.4]
 
 ### Changed

--- a/packages/rag/NOTICE
+++ b/packages/rag/NOTICE
@@ -29,23 +29,23 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-events
   bare-events@2.8.2
     https://github.com/holepunchto/bare-events
-  bare-fs@4.7.1
+  bare-fs@4.5.6
     https://github.com/holepunchto/bare-fs
   bare-inspect@3.1.4
     https://github.com/holepunchto/bare-inspect
   bare-module-resolve@1.12.1
     https://github.com/holepunchto/bare-module-resolve
-  bare-os@3.9.0
+  bare-os@3.8.6
     https://github.com/holepunchto/bare-os
   bare-path@3.0.0
     https://github.com/holepunchto/bare-path
-  bare-semver@1.0.3
+  bare-semver@1.0.2
     https://github.com/holepunchto/bare-semver
-  bare-stream@2.13.0
+  bare-stream@2.11.0
     https://github.com/holepunchto/bare-stream
   bare-type@1.1.0
     https://github.com/holepunchto/bare-type
-  bare-url@2.4.2
+  bare-url@2.4.0
     https://github.com/holepunchto/bare-url
   blind-relay@1.4.0
     https://github.com/holepunchto/blind-relay
@@ -55,8 +55,6 @@ JavaScript Dependencies
     https://github.com/holepunchto/events-universal
   hypercore-id-encoding@1.3.0
     https://github.com/holepunchto/hypercore-id-encoding
-  hyperdht-address@1.0.1
-    https://github.com/holepunchto/hyperdht-address
   hyperschema@1.20.1
     https://github.com/holepunchto/hyperschema
   noise-handshake@4.2.0
@@ -89,8 +87,8 @@ JavaScript Dependencies
 
   bogon@1.2.0
     https://github.com/mafintosh/bogon
-  dht-rpc@6.26.4
-    https://github.com/holepunchto/dht-rpc
+  dht-rpc@6.26.3
+    https://github.com/mafintosh/dht-rpc
   fast-fifo@1.3.2
     https://github.com/mafintosh/fast-fifo
   generate-object-property@2.0.0
@@ -99,7 +97,7 @@ JavaScript Dependencies
     https://github.com/mafintosh/generate-string
   hypercore-crypto@3.6.1
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.30.0
+  hyperdht@6.29.6
     https://github.com/holepunchto/hyperdht
   is-property@1.0.2
     https://github.com/mikolalysenko/is-property
@@ -107,8 +105,8 @@ JavaScript Dependencies
     https://github.com/mafintosh/kademlia-routing-table
   nat-sampler@1.0.1
     https://github.com/mafintosh/nat-sampler
-  protomux@3.10.3
-    https://github.com/holepunchto/protomux
+  protomux@3.10.1
+    https://github.com/mafintosh/protomux
   queue-tick@1.0.1
     https://github.com/mafintosh/queue-tick
   ready-resource@1.2.0
@@ -133,8 +131,6 @@ JavaScript Dependencies
     https://github.com/mafintosh/time-ordered-set
   timeout-refresh@2.0.1
     https://github.com/mafintosh/timeout-refresh
-  uuid-random@1.3.2
-    https://github.com/jchook/uuid-random
   xache@1.2.1
     https://github.com/mafintosh/xache
   z32@1.1.0

--- a/packages/rag/changelog/0.5.0/CHANGELOG.md
+++ b/packages/rag/changelog/0.5.0/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog v0.5.0
+
+Release Date: 2026-05-08
+
+## 🐞 Fixes
+
+- Pass options object to QvacErrorRAG in RAG crypto fallbacks. (see PR [#1664](https://github.com/tetherto/qvac/pull/1664))
+- Route bare-crypto and bare-fetch through imports map. (see PR [#1932](https://github.com/tetherto/qvac/pull/1932))
+
+## 🧹 Chores
+
+- Scope down DataLoader cleanup to packages/rag. (see PR [#1754](https://github.com/tetherto/qvac/pull/1754))
+- Move Holepunch libs to peerDependencies. (see PR [#1905](https://github.com/tetherto/qvac/pull/1905))
+

--- a/packages/rag/changelog/0.5.0/CHANGELOG_LLM.md
+++ b/packages/rag/changelog/0.5.0/CHANGELOG_LLM.md
@@ -1,0 +1,48 @@
+# QVAC RAG v0.5.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.5.0
+
+This release makes `@qvac/rag` a first-class citizen in non-Bare runtimes — React Native and Expo bundlers no longer choke on Bare-specific imports — and tightens the package's place in the SDK install graph so Holepunch singletons (DHT, Corestore, HyperDB) are no longer duplicated in consumer trees. It also lands a small but real bug fix in RAG's crypto-fallback error path so consumers can finally catch missing-dependency errors by code.
+
+---
+
+## 🐞 Fixes
+
+### React Native / Expo bundling: `LLMChunkAdapter` is exported again
+
+Previously, importing `@qvac/rag` from a React Native or Expo project failed with `SyntaxError: 'LLMChunkAdapter' not exported` even though the export was present in the source — the bundler was getting corrupted output because RAG's source had hard `bare-crypto` and `bare-fetch` imports that non-Bare bundlers tried (and failed) to resolve.
+
+Bare-specific dependencies are now routed through Node.js `package.json#imports` so the right module is selected per runtime:
+
+- `#crypto` resolves to `bare-crypto` on Bare, `node:crypto` on Node, and a lazy shim on React Native and other targets.
+- `#fetch` resolves to `bare-fetch` on Bare and a lazy shim on Node, React Native, and other targets.
+
+The shims allow bundling to succeed and only throw `QvacErrorRAG { DEPENDENCY_REQUIRED }` if the missing capability is actually invoked at runtime. Consumers on browsers, React Native, or Node who need Node-style `crypto.createHash` (notably for HyperDB document hashing) can install `crypto-browserify`, which is now declared as an **optional peer dependency**.
+
+`generateId()` no longer mutates a global `crypto` or depends on `uuid-random`. It generates UUID v4 IDs locally using secure randomness from `globalThis.crypto.getRandomValues` or `#crypto.randomBytes` / `getRandomValues`, and throws a clear error if neither is available.
+
+### `QvacErrorRAG` in crypto fallbacks now reports the correct error code
+
+Two RAG crypto-fallback call sites were constructing `QvacErrorRAG` with positional arguments `(code, message)` instead of the canonical `{ code, adds }` options object. Because `QvacErrorBase` destructures its single options argument, the thrown error silently degraded to code `0` / `"Unknown QVAC error"` instead of the intended `DEPENDENCY_REQUIRED` (14015) — so consumers catching by code never matched. Both call sites in `helper.js` and `HyperDBAdapter.js` now use the canonical form, and the documented error code is what's actually thrown.
+
+---
+
+## 🧹 Maintenance
+
+### Holepunch singletons moved to `peerDependencies`
+
+`@qvac/rag` previously declared `hyperdb`, `hyperdht`, `hyperschema`, `bare-crypto`, `bare-fetch`, and `llm-splitter` as hard dependencies. When the SDK declared its own (drifting) ranges for these as peers, npm could end up installing duplicate copies of stateful singletons in a consumer's tree — separate DHT nodes, separate Corestores, broken P2P connectivity. These libraries are now `peerDependencies` (mirrored in `devDependencies` so the package still builds and tests in isolation), and `@qvac/sdk` is the single source of truth for the actual installed range. `hyperdht` is marked optional in RAG since it is reserved for the not-yet-wired `replicateWith` path.
+
+Consumers using `@qvac/sdk` or any tooling that auto-installs required peers (npm 7+, pnpm, bun) are unaffected — the peers resolve transparently. Direct standalone consumers of `@qvac/rag` using `yarn` or `legacy-peer-deps=true` may now see missing-peer warnings and should add `hyperdb`, `hyperschema`, and `bare-crypto` (and `bare-fetch` if used in a Bare runtime) to their own dependencies.
+
+### DataLoader cleanup: examples and integration tests off `@qvac/dl-hyperdrive`
+
+The RAG examples and integration test no longer depend on `@qvac/dl-hyperdrive`. Model fetching now goes through `@qvac/registry-client` (mirroring how the SDK and OCR addons consume the QVAC registry), and the addon construction has migrated from the old `HyperDriveDL` + loader-based shape to the current files-based shape (`{ files, config, logger, opts }`).
+
+To support this, `devDependencies` were updated:
+
+- Removed: `@qvac/dl-hyperdrive`
+- Added: `@qvac/registry-client@^0.4.1`
+- Bumped: `@qvac/embed-llamacpp` `^0.7.6 → ^0.14.0`, `@qvac/llm-llamacpp` `^0.5.7 → ^0.16.0` (versions that ship the files-based API).
+
+This is purely a developer-facing change — runtime behavior of `@qvac/rag` is unchanged. The SDK-side `overrides: { @qvac/dl-hyperdrive: ^0.2.0 }` is intentionally retained until the addons-side cleanup of `@qvac/infer-base`'s `dl-hyperdrive` peer dep lands.

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "main": "index.js",
   "scripts": {
     "lint": "standard",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?
- Prepare the qvac-rag v0.5.0 release with changelog, version bump, and NOTICE update

## 📝 How does it solve it?
- Bump `@qvac/rag` version from `0.4.4` to `0.5.0`
- Generate changelog for merged PRs since `rag-v0.4.4`
- Create version-specific changelog files (`changelog/0.5.0/CHANGELOG.md`, `CHANGELOG_LLM.md`)
- Update root `CHANGELOG.md` (Keep a Changelog format) with `[0.5.0]` entry
- Regenerate `NOTICE` file
