### PR TITLE
QVAC-17877 feat[mod]: add TTS GGUF models to prod registry

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -4306,6 +4306,75 @@
     "notes": ""
   },
   {
+    "source": "s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-s3gen-mtl.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Chatterbox S3Gen vocoder (GGUF, multilingual)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "MIT",
+    "tags": [
+      "tts",
+      "chatterbox",
+      "gguf",
+      "s3gen",
+      "multilingual"
+    ],
+    "notes": ""
+  },
+  {
+    "source": "s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-t3-turbo.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Chatterbox T3 turbo language model (GGUF)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "MIT",
+    "tags": [
+      "tts",
+      "chatterbox",
+      "gguf",
+      "t3",
+      "turbo",
+      "en"
+    ],
+    "notes": ""
+  },
+  {
+    "source": "s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-s3gen.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Chatterbox S3Gen vocoder (GGUF, English)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "MIT",
+    "tags": [
+      "tts",
+      "chatterbox",
+      "gguf",
+      "s3gen",
+      "en"
+    ],
+    "notes": ""
+  },
+  {
+    "source": "s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-t3-mtl.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Chatterbox T3 language model (GGUF, multilingual)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "MIT",
+    "tags": [
+      "tts",
+      "chatterbox",
+      "gguf",
+      "t3",
+      "multilingual",
+      "en",
+      "es",
+      "it",
+      "pt"
+    ],
+    "notes": ""
+  },
+  {
     "source": "https://huggingface.co/onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/tokenizer.json",
     "engine": "@qvac/tts",
     "description": "Supertonic tokenizer",

--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -4375,6 +4375,35 @@
     "notes": ""
   },
   {
+    "source": "s3:///qvac_models_compiled/supertonic/2026-05-08/supertonic.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Supertonic TTS (GGUF)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "openrail",
+    "tags": [
+      "tts",
+      "supertonic",
+      "gguf"
+    ],
+    "notes": ""
+  },
+  {
+    "source": "s3:///qvac_models_compiled/supertonic/2026-05-08/supertonic2.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Supertonic 2 TTS (GGUF)",
+    "quantization": "",
+    "params": "",
+    "licenseId": "openrail",
+    "tags": [
+      "tts",
+      "supertonic",
+      "supertonic2",
+      "gguf"
+    ],
+    "notes": ""
+  },
+  {
     "source": "https://huggingface.co/onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/tokenizer.json",
     "engine": "@qvac/tts",
     "description": "Supertonic tokenizer",


### PR DESCRIPTION
## What problem does this PR solve?

- Chatterbox and Supertonic GGUF weights were uploaded to S3 under dated prefixes (`2026-05-08`) but were not yet listed in the production model catalog, so they could not be picked up by registry sync and downstream flows that rely on `models.prod.json`.

## How does it solve it?

- Extends `packages/qvac-lib-registry-server/data/models.prod.json` with six new entries, all `engine` `@qvac/tts-ggml` and S3 keys under `qvac_models_compiled/…/2026-05-08/`:
  - **Chatterbox (4):** `chatterbox-s3gen-mtl.gguf`, `chatterbox-t3-turbo.gguf`, `chatterbox-s3gen.gguf`, `chatterbox-t3-mtl.gguf` — `licenseId` MIT (aligned with existing Chatterbox ONNX rows).
  - **Supertonic (2):** `supertonic.gguf`, `supertonic2.gguf` — `licenseId` openrail (aligned with existing Supertonic ONNX rows).

## How was it tested?

- `node scripts/validate-models-json.js data/models.prod.json` from `packages/qvac-lib-registry-server` (675 models).
