### PR TITLE
fix(diffusion-cpp): rename qvac-lib-inference-addon-cpp/ #include to inference-addon-cpp/

### DIFF
--- a/packages/diffusion-cpp/addon/src/model-interface/EsrganUpscalerModel.cpp
+++ b/packages/diffusion-cpp/addon/src/model-interface/EsrganUpscalerModel.cpp
@@ -5,7 +5,7 @@
 #include <stdexcept>
 #include <utility>
 
-#include <qvac-lib-inference-addon-cpp/Errors.hpp>
+#include <inference-addon-cpp/Errors.hpp>
 
 #include "utils/BackendLoader.hpp"
 #include "utils/ImageCodec.hpp"

--- a/packages/diffusion-cpp/addon/src/model-interface/EsrganUpscalerModel.hpp
+++ b/packages/diffusion-cpp/addon/src/model-interface/EsrganUpscalerModel.hpp
@@ -7,8 +7,8 @@
 #include <string>
 #include <vector>
 
-#include <qvac-lib-inference-addon-cpp/ModelInterfaces.hpp>
-#include <qvac-lib-inference-addon-cpp/RuntimeStats.hpp>
+#include <inference-addon-cpp/ModelInterfaces.hpp>
+#include <inference-addon-cpp/RuntimeStats.hpp>
 #include <stable-diffusion.h>
 
 #include "handlers/SdCtxHandlers.hpp"


### PR DESCRIPTION
## Summary

Followup to [#1860](https://github.com/tetherto/qvac/pull/1860) and [#1959](https://github.com/tetherto/qvac/pull/1959). Three \`#include\` directives in \`packages/diffusion-cpp/addon/src/model-interface/EsrganUpscalerModel.{cpp,hpp}\` were missed in the namespace rewrite and still pull the legacy \`qvac-lib-inference-addon-cpp/\` namespace. Now that the registry advertises \`qvac-lib-inference-addon-cpp@1.1.7#1\` (REF \`ce2ea933\`) — which installs headers under \`include/inference-addon-cpp/\` — the diffusion-cpp prebuilds fail to compile:

\`\`\`
.../diffusion-cpp/addon/src/model-interface/EsrganUpscalerModel.hpp:10:10:
  fatal error: 'qvac-lib-inference-addon-cpp/ModelInterfaces.hpp' file not found
\`\`\`

Reproducible on the most recent darwin-arm64 prebuild run: <https://github.com/tetherto/qvac/actions/runs/25585162082/job/75112260310>.

## What this PR does

Renames the three `#include` directives in:

- \`packages/diffusion-cpp/addon/src/model-interface/EsrganUpscalerModel.cpp\`: \`<qvac-lib-inference-addon-cpp/Errors.hpp>\` → \`<inference-addon-cpp/Errors.hpp>\`
- \`packages/diffusion-cpp/addon/src/model-interface/EsrganUpscalerModel.hpp\`: \`<qvac-lib-inference-addon-cpp/{ModelInterfaces,RuntimeStats}.hpp>\` → \`<inference-addon-cpp/{ModelInterfaces,RuntimeStats}.hpp>\`

No behaviour change — same headers, just the post-rename short namespace. \`packages/diffusion-cpp/vcpkg.json\` already pins \`qvac-lib-inference-addon-cpp >= 1.1.7#1\` and \`qvac-lint-cpp >= 1.4.4#3\` (set by #1959).

Made with [Cursor](https://cursor.com)