### PR TITLE
Bump @qvac/onnx package version

### DIFF
--- a/packages/onnx/CHANGELOG.md
+++ b/packages/onnx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.15.0] - 2026-05-11
+
+### Changed
+
+- Updated package's directory structure to be more consistent with the remaning QVAC packages.
+
 ## [0.14.1] - 2026-04-21
 
 ### Fixed

--- a/packages/onnx/package.json
+++ b/packages/onnx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/onnx",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Bare addon for ONNX Runtime session management",
   "addon": true,
   "engines": {


### PR DESCRIPTION
Bumped `@qvac/onnx` package version to 0.15.0 considering the new directory structure change in QVAC packages.