### PR TITLE
QVAC-18608 fix(label-gate): preserve hyphens in input env-var names

### DIFF
--- a/.github/actions/label-gate/src/index.mjs
+++ b/.github/actions/label-gate/src/index.mjs
@@ -8,6 +8,7 @@
 //     exit 0 with `authorised=false`. Downstream jobs gate on the output.
 
 import { appendFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { GitHubClient, GitHubApiError } from './github-client.mjs';
 import { gate, parseList, loadEventPayload } from './gate.mjs';
 
@@ -18,11 +19,19 @@ const notice = (m) => annotate('notice', m);
 const warning = (m) => annotate('warning', m);
 const error = (m) => annotate('error', m);
 
-function getInput(name, { required = false } = {}) {
-  // Composite/JS actions both expose inputs as INPUT_<NAME_UPPERCASED>
-  // with hyphens replaced by underscores.
-  const key = `INPUT_${name.toUpperCase().replace(/-/g, '_')}`;
-  const raw = process.env[key];
+// Exported for unit tests; index.mjs is the only production caller.
+export function getInput(name, { required = false, env = process.env } = {}) {
+  // Match the GitHub Actions runner / @actions/core convention exactly:
+  // INPUT_<NAME> where <NAME> uppercases the input and replaces spaces
+  // (NOT hyphens) with underscores. Hyphens are preserved verbatim, so
+  // `github-token` becomes `INPUT_GITHUB-TOKEN`. Hyphens in env-var
+  // names are technically non-POSIX but Node.js exposes them via
+  // process.env regardless. An earlier impl replaced hyphens with
+  // underscores too, which silently lost any hyphenated input — caught
+  // by the QVAC-18612 canary; the regression test below pins this for
+  // good.
+  const key = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
+  const raw = env[key];
   const value = raw == null ? '' : raw.trim();
   if (required && !value) {
     throw new Error(`required input '${name}' is missing`);
@@ -83,13 +92,20 @@ async function main() {
   await setOutput('authorised', decision.authorised ? 'true' : 'false');
 }
 
-main().catch((e) => {
-  if (e instanceof GitHubApiError) {
-    error(
-      `GitHub API error: ${e.message} (status=${e.status} method=${e.method} path=${e.path})`
-    );
-  } else {
-    error(`unexpected failure: ${e.message ?? e}`);
-  }
-  process.exitCode = 1;
-});
+// Only execute when invoked as the action entrypoint (`node src/index.mjs`).
+// When imported by the test suite the top-level main() must not run.
+const invokedDirectly =
+  process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  main().catch((e) => {
+    if (e instanceof GitHubApiError) {
+      error(
+        `GitHub API error: ${e.message} (status=${e.status} method=${e.method} path=${e.path})`
+      );
+    } else {
+      error(`unexpected failure: ${e.message ?? e}`);
+    }
+    process.exitCode = 1;
+  });
+}

--- a/.github/actions/label-gate/test/index.test.mjs
+++ b/.github/actions/label-gate/test/index.test.mjs
@@ -1,0 +1,74 @@
+// Tests for the entrypoint's input plumbing. Pins the env-var-name
+// resolution against the GitHub Actions runner's actual contract,
+// which is what failed live in the QVAC-18612 canary on 2026-05-11
+// (run id 25672483584): the runner exposes `github-token` as
+// INPUT_GITHUB-TOKEN (hyphen preserved); an earlier impl looked up
+// INPUT_GITHUB_TOKEN (hyphen-to-underscore) and silently lost the
+// token, hard-failing every PR-event run.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getInput } from '../src/index.mjs';
+
+test('getInput: simple uppercase name (no transform)', () => {
+  const env = { INPUT_LABEL: 'verified' };
+  assert.equal(getInput('label', { env }), 'verified');
+});
+
+test('getInput: hyphenated input -> hyphen PRESERVED in env-var name', () => {
+  // This is the QVAC-18612 regression: runner sets INPUT_GITHUB-TOKEN,
+  // not INPUT_GITHUB_TOKEN. getInput must match what the runner sets.
+  const env = { 'INPUT_GITHUB-TOKEN': 'pat_xyz' };
+  assert.equal(getInput('github-token', { env }), 'pat_xyz');
+});
+
+test('getInput: hyphen-replaced lookup must NOT find the value (lock the contract)', () => {
+  // Belt-and-braces: assert the OPPOSITE form is silently empty so we
+  // notice if anyone "helpfully" reintroduces the hyphen-to-underscore
+  // substitution.
+  const env = { INPUT_GITHUB_TOKEN: 'wrong-key' };
+  assert.equal(getInput('github-token', { env }), '');
+});
+
+test('getInput: spaces are replaced with underscores (per @actions/core)', () => {
+  const env = { INPUT_MY_INPUT: 'value' };
+  assert.equal(getInput('my input', { env }), 'value');
+});
+
+test('getInput: missing optional input -> empty string', () => {
+  assert.equal(getInput('label', { env: {} }), '');
+});
+
+test('getInput: missing required input -> throws with the original name', () => {
+  assert.throws(
+    () => getInput('github-token', { required: true, env: {} }),
+    /required input 'github-token' is missing/
+  );
+});
+
+test('getInput: empty/whitespace value treated as missing for required', () => {
+  assert.throws(
+    () => getInput('github-token', {
+      required: true,
+      env: { 'INPUT_GITHUB-TOKEN': '   ' },
+    }),
+    /required input 'github-token' is missing/
+  );
+});
+
+test('getInput: trims surrounding whitespace from supplied value', () => {
+  const env = { 'INPUT_GITHUB-TOKEN': '  pat_xyz  ' };
+  assert.equal(getInput('github-token', { env }), 'pat_xyz');
+});
+
+test('getInput: defaults env to process.env when not supplied', () => {
+  const original = process.env.INPUT_LABEL;
+  process.env.INPUT_LABEL = 'from-process-env';
+  try {
+    assert.equal(getInput('label'), 'from-process-env');
+  } finally {
+    if (original === undefined) delete process.env.INPUT_LABEL;
+    else process.env.INPUT_LABEL = original;
+  }
+});


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The `label-gate` action shipped in #1968 hard-fails on **every PR-event invocation** with `unexpected failure: required input 'github-token' is missing`, even when the workflow correctly passes `github-token: ${{ secrets.GITHUB_TOKEN }}`. Caught live by the QVAC-18612 canary in #1971 (run id 25672483584) before any production workflow could be migrated. Without this fix, the QVAC-18612 fan-out would red-X every PR across 75 workflows on the first run after merge.

## 📝 How does it solve it?

- **Root cause**: `getInput()` in `src/index.mjs` was doing `name.toUpperCase().replace(/-/g, '_')`, looking up `INPUT_GITHUB_TOKEN`. The GitHub Actions runner — and `@actions/core` — only replace **spaces** with underscores, not hyphens. The runner sets `INPUT_GITHUB-TOKEN` (hyphen preserved, technically non-POSIX but Node exposes it via `process.env` regardless). My implementation never found the value and threw the misleading "missing input" error.

- **Why local smoke tests didn't catch it**: my pre-merge smoke set `INPUT_GITHUB_TOKEN=...` (matching the buggy lookup). Both sides were wrong in the same direction, so the smoke "passed". Real-CI exposes this immediately — exactly the failure the canary was designed to find.

- **Fix**: `getInput()` now uses `name.replace(/ /g, '_').toUpperCase()` — matching the runner / `@actions/core` convention exactly.

- **Testability**: `getInput()` is now exported (with an injectable `env` arg) so the env-var-name resolution can be unit-tested. Top-level `main()` is gated on `import.meta.url === argv[1]` so importing `index.mjs` from tests no longer triggers a real run.

## 🧪 How was it tested?

- **9 new regression tests** in `test/index.test.mjs` pin the env-var resolution against the runner contract:
  - `INPUT_GITHUB-TOKEN` (hyphen preserved) → resolves correctly
  - `INPUT_GITHUB_TOKEN` (hyphen-replaced, the old bug) → does **not** resolve (locks the contract against any accidental "helpful" reintroduction of the substitution)
  - Spaces still replaced with underscores (per `@actions/core`)
  - Trim, missing-required, defaults-to-`process.env` paths
- **Full suite**: `node --test .github/actions/label-gate/test/*.test.mjs` → **53/53 pass** (was 44 before, +9 new).
- **End-to-end smoke** against the runner-correct env-var name:
  ```
  env "INPUT_GITHUB-TOKEN=fake-token" INPUT_LABEL=verified INPUT_USERS=Proletter \
      GITHUB_EVENT_NAME=pull_request GITHUB_EVENT_PATH=... \
      GITHUB_OUTPUT=... GITHUB_REPOSITORY=tetherto/qvac \
      node .github/actions/label-gate/src/index.mjs
  ```
  → exit 0, `authorised=false`, notice `"'verified' label is not currently applied to PR #1971"`.
- **Live verification**: once this merges I'll trigger a fresh CI run on #1971 and confirm scenario 1 of its test plan now produces `authorised=false` (gate-job green, downstream skipped) instead of a red gate-job.
