### PR TITLE
chore: update whisper addon package versions to 0.6.8 and qvac-lib-in…

### DIFF
--- a/packages/transcription-whispercpp/CHANGELOG.md
+++ b/packages/transcription-whispercpp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.8]
+
+### Changed
+- Bumped `@qvac/transcription-whispercpp` package version from `0.6.7` to `0.6.8`.
+- Bumped `qvac-lib-inference-addon-cpp` to `1.1.7#1`.
+
 ## [0.6.7]
 
 ### Changed

--- a/packages/transcription-whispercpp/CHANGELOG.md
+++ b/packages/transcription-whispercpp/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.8]
 
 ### Changed
-- Bumped `@qvac/transcription-whispercpp` package version from `0.6.7` to `0.6.8`.
 - Bumped `qvac-lib-inference-addon-cpp` to `1.1.7#1`.
 
 ## [0.6.7]

--- a/packages/transcription-whispercpp/package.json
+++ b/packages/transcription-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Whisper transcription on iOS bare-kit crashed at worklet teardown with `EXC_BAD_ACCESS` (PAC failure) inside `OutputCallBackJs::jsOutputCallback` / `js_delete_reference`. The SDK pod `transcription` integration tests on a physical iPhone went from 15/15 passing on `0.6.6` to 0/15 on `0.6.7` (consumer marked dead, app killed).
- Root cause was in `qvac-lib-inference-addon-cpp 1.1.6` (QVAC-18149, PR #1825), which deferred `js_delete_reference()` cleanup into the libuv `uv_close` callback. On iOS bare-kit the `js_env_t*` is invalidated by `workletInstance.terminate()` before that deferred callback runs, leaving a stale env that crashes on dereference.
- `qvac-lib-inference-addon-cpp 1.1.7#1` (already on `main`) fixes the lifetime; this PR ships it to consumers of `@qvac/transcription-whispercpp`.

## 📝 How does it solve it?

- Pure release bump for the whisper addon — no source changes:
  - `packages/transcription-whispercpp/package.json`: `0.6.7` → `0.6.8`
  - `packages/transcription-whispercpp/CHANGELOG.md`: add `[0.6.8]` entry
- The `vcpkg.json` dependency on `qvac-lib-inference-addon-cpp` is already at `1.1.7#1` on `main`, so this release picks up the iOS callback-lifetime fix without any addon-side edits.

## 🧪 How was it tested?

- Manual bisect on a physical iPhone running the SDK pod transcription integration tests (`qvac-test run:producer --filter transcription`, 15 tests):
  - `whispercpp 0.6.6` (addon-cpp `1.1.5#1`, pre-refactor): **15/15 pass**, ~36 s, peak 418 MB
  - `whispercpp 0.6.7` (addon-cpp `1.1.6`, post-refactor): **0/15** — first test hangs >180 s, consumer dies
  - `whispercpp 0.6.8` (addon-cpp `1.1.7#1`, this PR): expected to pass once `1.1.7#1` propagates through the published xcframework; revalidation on device pending after publish.
- Desktop CI for the whisper addon continues to pass (refactor never broke desktop; the regression is iOS-only).