### PR TITLE
fix: bump @qvac/onnx to ^0.15.0 in tts-onnx + release 0.9.0 (followup to #1860)

### DIFF
--- a/packages/tts-onnx/CHANGELOG.md
+++ b/packages/tts-onnx/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0]
+
+### Fixed
+
+- Bumped `@qvac/onnx` to `^0.15.0` to track the renamed `inference-addon-cpp` include path. Earlier `0.14.x` versions ship `Logger.hpp` with `#include <qvac-lib-inference-addon-cpp/JsLogger.hpp>`, which no longer matches the vcpkg port `qvac-lib-inference-addon-cpp@1.1.7#1` (post QVAC-16441 rename, headers now install under `include/inference-addon-cpp/`). Followup to QVAC-16441 / #1860. Released as a minor bump (`0.8.6` → `0.9.0`) instead of a patch to avoid version-range conflicts with the upcoming SDK 0.10 release line.
+
 ## [0.8.6]
 
 ### Changed

--- a/packages/tts-onnx/package.json
+++ b/packages/tts-onnx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-onnx",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "description": "Text to Speech (TTS) addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/tts-onnx/package.json
+++ b/packages/tts-onnx/package.json
@@ -98,7 +98,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/onnx": "^0.14.0",
+    "@qvac/onnx": "^0.15.0",
     "@qvac/infer-base": "^0.4.0",
     "bare-fs": "^4.5.6",
     "bare-os": "^3.8.0",


### PR DESCRIPTION
## Summary

- Bumps `@qvac/onnx` dep in `packages/tts-onnx/package.json` from `^0.14.0` → `^0.15.0`
- Bumps `tts-onnx` itself `0.8.6` → `0.9.0` (minor, not patch — see below) with a corresponding CHANGELOG entry so the fix gets published
- Unblocks tts-onnx CI, which has been failing since the QVAC-16441 rename ([#1860](https://github.com/tetherto/qvac/pull/1860))
- Followup to [#1970](https://github.com/tetherto/qvac/pull/1970) ("Bump version" — published `@qvac/onnx@0.15.0`)
- Sister PRs: [#1981](https://github.com/tetherto/qvac/pull/1981) (ocr-onnx → 0.5.0), [#1982](https://github.com/tetherto/qvac/pull/1982) (transcription-parakeet → 0.4.0)

## Why

`@qvac/onnx@0.15.0` (published 2026-05-11) is the first version whose `Logger.hpp` uses the renamed include path `#include <inference-addon-cpp/JsLogger.hpp>`. Earlier `0.14.x` versions still reference the old path `<qvac-lib-inference-addon-cpp/JsLogger.hpp>`.

After QVAC-16441 ([#1860](https://github.com/tetherto/qvac/pull/1860)) renamed `packages/qvac-lib-inference-addon-cpp` → `packages/inference-addon-cpp`, the vcpkg port `qvac-lib-inference-addon-cpp@1.1.7#1` started installing headers under `include/inference-addon-cpp/`. Without bumping the npm dep, `npm install` resolves `^0.14.0` to `0.14.0` (semver-zero rules), and the addon build fails:

```
node_modules/@qvac/onnx/prebuilds/include/qvac-onnx/Logger.hpp:32:10: fatal error:
'qvac-lib-inference-addon-cpp/JsLogger.hpp' file not found
```

Reproduced on:
- [run 25575833805](https://github.com/tetherto/qvac/actions/runs/25575833805) — `main` after #1860 merged
- [run 25662719696](https://github.com/tetherto/qvac/actions/runs/25662719696) — `On PR Trigger (TTS)` dispatched on `qvac-17801-supertonic-mobile-shared-perf` (PR [#1941](https://github.com/tetherto/qvac/pull/1941))

## Why a minor bump (`0.8.6` → `0.9.0`) instead of a patch?

Released as a minor bump to avoid version-range conflicts with the upcoming SDK 0.10 release line. A patch (`0.8.7`) would still satisfy `^0.8.6` ranges held by older SDK builds, which we want to avoid pulling the dep bump into.

## Test plan

- [ ] `On PR Trigger (TTS)` builds green on this branch (prebuilds + cpp-tests-coverage across all platforms)
- [ ] On merge, `@qvac/tts-onnx@0.9.0` publishes successfully and resolves `@qvac/onnx@0.15.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
