### PR TITLE
bumping TTS and Parakeet to apply addpn-cpp v1.1.7#1

### DIFF
--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4]
+
+### Changed
+- Bumped `qvac-lib-inference-addon-cpp` to `1.1.7#1`.
+
 ## [0.3.3]
 
 This release adds long-form audio support to the Parakeet TDT pipeline. Audio inputs that previously failed against the encoder's static positional-encoding ceilings are now transcribed by streaming the mel-spectrogram through the encoder in overlapping windows.

--- a/packages/transcription-parakeet/package.json
+++ b/packages/transcription-parakeet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-parakeet",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "High-performance speech-to-text inference addon using NVIDIA Parakeet models for Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/tts-onnx/CHANGELOG.md
+++ b/packages/tts-onnx/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.7]
+
+### Changed
+- Bumped `qvac-lib-inference-addon-cpp` to `1.1.7#1`.
+
 ## [0.8.6]
 
 ### Changed

--- a/packages/tts-onnx/package.json
+++ b/packages/tts-onnx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-onnx",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Text to Speech (TTS) addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Force a re-publish of `@qvac/transcription-parakeet` and `@qvac/tts-onnx` to npm so that the published artifacts pick up `qvac-lib-inference-addon-cpp@1.1.7#1`.
- Both addons' `vcpkg.json` files on `main` already reference `addon-cpp 1.1.7#1`, but their JS package versions were never bumped. As a result, the currently published `@qvac/transcription-parakeet@0.3.3` and `@qvac/tts-onnx@0.8.6` still ship prebuilds linked against the older `addon-cpp` shipped at the time of their last publish.

## 📝 How does it solve it?

- Cosmetic version bump for `@qvac/transcription-parakeet`: `0.3.3 -> 0.3.4`.
- Cosmetic version bump for `@qvac/tts-onnx`: `0.8.6 -> 0.8.7`.
- `CHANGELOG.md` entries added in both packages noting the `qvac-lib-inference-addon-cpp -> 1.1.7#1` bump.
- No source-code changes in either addon. `vcpkg.json` files are already on `1.1.7#1` on `main` and are not touched here.