### PR TITLE
fix: bump @qvac/onnx to ^0.15.0 in ocr-onnx + release 0.5.0 (followup to #1860)

### DIFF
--- a/packages/ocr-onnx/CHANGELOG.md
+++ b/packages/ocr-onnx/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-11
+
+### Fixed
+
+- Bumped `@qvac/onnx` to `^0.15.0` to track the renamed `inference-addon-cpp` include path. Earlier `0.14.x` versions ship `Logger.hpp` with `#include <qvac-lib-inference-addon-cpp/JsLogger.hpp>`, which no longer matches the vcpkg port `qvac-lib-inference-addon-cpp@1.1.7#1` (post QVAC-16441 rename, headers now install under `include/inference-addon-cpp/`). Followup to QVAC-16441 / #1860. Released as a minor bump (`0.4.5` → `0.5.0`) instead of a patch to avoid version-range conflicts with the upcoming SDK 0.10 release line.
+
 ## [0.4.5] - 2026-05-08
 
 ### Added

--- a/packages/ocr-onnx/package.json
+++ b/packages/ocr-onnx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-onnx",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "OCR addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/ocr-onnx/package.json
+++ b/packages/ocr-onnx/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@qvac/error": "^0.1.0",
     "@qvac/infer-base": "^0.4.0",
-    "@qvac/onnx": "^0.14.0",
+    "@qvac/onnx": "^0.15.0",
     "@qvac/response": "^0.1.2",
     "bare-fetch": "^2.5.1",
     "bare-fs": "^4.5.1",


### PR DESCRIPTION
## Summary

- Bumps `@qvac/onnx` dep in `packages/ocr-onnx/package.json` from `^0.14.0` → `^0.15.0`
- Bumps `ocr-onnx` itself `0.4.5` → `0.5.0` (minor, not patch — see below) with a corresponding CHANGELOG entry so the fix gets published
- Unblocks ocr-onnx CI, which has been failing since the QVAC-16441 rename ([#1860](https://github.com/tetherto/qvac/pull/1860))
- Followup to [#1970](https://github.com/tetherto/qvac/pull/1970) ("Bump version" — published `@qvac/onnx@0.15.0`)
- Sister PRs: [#1979](https://github.com/tetherto/qvac/pull/1979) (tts-onnx → 0.9.0), [#1982](https://github.com/tetherto/qvac/pull/1982) (transcription-parakeet → 0.4.0)

## Why

`@qvac/onnx@0.15.0` (published 2026-05-11) is the first version whose `Logger.hpp` uses the renamed include path `#include <inference-addon-cpp/JsLogger.hpp>`. Earlier `0.14.x` versions still reference the old path `<qvac-lib-inference-addon-cpp/JsLogger.hpp>`.

After QVAC-16441 ([#1860](https://github.com/tetherto/qvac/pull/1860)) renamed `packages/qvac-lib-inference-addon-cpp` → `packages/inference-addon-cpp`, the vcpkg port `qvac-lib-inference-addon-cpp@1.1.7#1` started installing headers under `include/inference-addon-cpp/`. Without bumping the npm dep, `npm install` resolves `^0.14.0` to `0.14.0` (semver-zero rules), and the addon build fails. `ocr-onnx` sets `JS_LOGGER` in [packages/ocr-onnx/CMakeLists.txt:167](https://github.com/tetherto/qvac/blob/main/packages/ocr-onnx/CMakeLists.txt#L167), so it hits the same include error as `tts-onnx`:

```
node_modules/@qvac/onnx/prebuilds/include/qvac-onnx/Logger.hpp:32:10: fatal error:
'qvac-lib-inference-addon-cpp/JsLogger.hpp' file not found
```

## Why a minor bump (`0.4.5` → `0.5.0`) instead of a patch?

Released as a minor bump to avoid version-range conflicts with the upcoming SDK 0.10 release line. A patch (`0.4.6`) would still satisfy `^0.4.5` ranges held by older SDK builds, which we want to avoid pulling the dep bump into.

## Test plan

- [x] `On PR Trigger (OCR)` builds green on this branch (prebuilds + cpp-tests-coverage across all platforms)
- [x] On merge, `@qvac/ocr-onnx@0.5.0` publishes successfully and resolves `@qvac/onnx@0.15.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
