### PR TITLE
fix: bump @qvac/onnx to ^0.15.0 in transcription-parakeet + release 0.4.0 (followup to #1860)

### DIFF
--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0]
+
+### Fixed
+
+- Bumped `@qvac/onnx` to `^0.15.0` to track the renamed `inference-addon-cpp` include path. Earlier `0.14.x` versions ship `Logger.hpp` with `#include <qvac-lib-inference-addon-cpp/JsLogger.hpp>`, which no longer matches the vcpkg port `qvac-lib-inference-addon-cpp@1.1.7#1` (post QVAC-16441 rename, headers now install under `include/inference-addon-cpp/`). Followup to QVAC-16441 / #1860. Released as a minor bump (`0.3.3` → `0.4.0`) instead of a patch to avoid version-range conflicts with the upcoming SDK 0.10 release line.
+
 ## [0.3.3]
 
 This release adds long-form audio support to the Parakeet TDT pipeline. Audio inputs that previously failed against the encoder's static positional-encoding ceilings are now transcribed by streaming the mel-spectrogram through the encoder in overlapping windows.

--- a/packages/transcription-parakeet/package.json
+++ b/packages/transcription-parakeet/package.json
@@ -86,7 +86,7 @@
     "@qvac/error": "^0.1.0",
     "@qvac/infer-base": "^0.4.0",
     "@qvac/logging": "^0.1.0",
-    "@qvac/onnx": "^0.14.0",
+    "@qvac/onnx": "^0.15.0",
     "bare-fs": "^4.5.1",
     "bare-path": "^3.0.0",
     "path": "npm:bare-path",

--- a/packages/transcription-parakeet/package.json
+++ b/packages/transcription-parakeet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-parakeet",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "High-performance speech-to-text inference addon using NVIDIA Parakeet models for Bare runtime",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary

- Bumps `@qvac/onnx` dep in `packages/transcription-parakeet/package.json` from `^0.14.0` → `^0.15.0`
- Bumps `transcription-parakeet` itself `0.3.3` → `0.4.0` (minor, not patch — see below) with a corresponding CHANGELOG entry so the fix gets published
- Unblocks transcription-parakeet CI, which has been failing since the QVAC-16441 rename ([#1860](https://github.com/tetherto/qvac/pull/1860))
- Followup to [#1970](https://github.com/tetherto/qvac/pull/1970) ("Bump version" — published `@qvac/onnx@0.15.0`)
- Sister PRs: [#1979](https://github.com/tetherto/qvac/pull/1979) (tts-onnx → 0.9.0), [#1981](https://github.com/tetherto/qvac/pull/1981) (ocr-onnx → 0.5.0)

## Why

`@qvac/onnx@0.15.0` (published 2026-05-11) is the first version whose `Logger.hpp` uses the renamed include path `#include <inference-addon-cpp/JsLogger.hpp>`. Earlier `0.14.x` versions still reference the old path `<qvac-lib-inference-addon-cpp/JsLogger.hpp>`.

After QVAC-16441 ([#1860](https://github.com/tetherto/qvac/pull/1860)) renamed `packages/qvac-lib-inference-addon-cpp` → `packages/inference-addon-cpp`, the vcpkg port `qvac-lib-inference-addon-cpp@1.1.7#1` started installing headers under `include/inference-addon-cpp/`. Without bumping the npm dep, `npm install` resolves `^0.14.0` to `0.14.0` (semver-zero rules), and the addon build fails. `transcription-parakeet` sets `JS_LOGGER` via [packages/transcription-parakeet/CMakeLists.txt:93](https://github.com/tetherto/qvac/blob/main/packages/transcription-parakeet/CMakeLists.txt#L93), so it hits the same include error as `tts-onnx` and `ocr-onnx`:

```
node_modules/@qvac/onnx/prebuilds/include/qvac-onnx/Logger.hpp:32:10: fatal error:
'qvac-lib-inference-addon-cpp/JsLogger.hpp' file not found
```

Confirmed reproducer: [run 25575833814](https://github.com/tetherto/qvac/actions/runs/25575833814) — `On Merge Trigger (Parakeet)` on `main` after #1860 landed.

## Why a minor bump (`0.3.3` → `0.4.0`) instead of a patch?

Released as a minor bump to avoid version-range conflicts with the upcoming SDK 0.10 release line. A patch (`0.3.4`) would still satisfy `^0.3.3` ranges held by older SDK builds, which we want to avoid pulling the dep bump into.

## Test plan

- [ ] `On PR Trigger (Parakeet)` builds green on this branch (prebuilds + cpp-tests-coverage across all platforms)
- [ ] On merge, `@qvac/transcription-parakeet@0.4.0` publishes successfully and resolves `@qvac/onnx@0.15.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
