### PR TITLE
fix[test]: gemma4 + qwen3.5 multi-turn tests use the canonical KV cache API

### DIFF
--- a/packages/llm-llamacpp/test/integration/gemma4.test.js
+++ b/packages/llm-llamacpp/test/integration/gemma4.test.js
@@ -169,30 +169,33 @@ test('Gemma 4 supports multi-turn conversation with KV cache', {
     const systemMsg = { role: 'system', content: 'You are a helpful assistant. Answer concisely with just the city name.' }
     const userTurn1 = { role: 'user', content: 'What is the capital of France?' }
 
-    const prompt1 = [
-      { role: 'session', content: sessionName },
-      systemMsg,
-      userTurn1
-    ]
-    const response1 = await addon.run(prompt1)
+    // Cache control is a runOption (cacheKey), NOT a `{ role: 'session' }`
+    // chat message — the latter was removed in v0.15.0 and is silently dropped
+    // by Jinja chat templates that have no matching elif branch.
+    const prompt1 = [systemMsg, userTurn1]
+    const response1 = await addon.run(prompt1, { cacheKey: sessionName })
     const output1 = await collectResponse(response1)
     t.ok(output1.length > 0, `first turn produced output (${output1.length} chars)`)
     const lowerOutput1 = output1.toLowerCase()
     t.ok(/paris/.test(lowerOutput1), `first turn mentions Paris: "${output1.slice(0, 100)}"`)
+    t.ok(response1.stats?.CacheTokens > 0, `first turn populated KV cache (CacheTokens=${response1.stats?.CacheTokens})`)
 
     const prompt2 = [
-      { role: 'session', content: sessionName },
       systemMsg,
       userTurn1,
       { role: 'assistant', content: output1 },
       { role: 'user', content: 'And what about Germany?' }
     ]
-    const response2 = await addon.run(prompt2)
+    const response2 = await addon.run(prompt2, { cacheKey: sessionName })
     const output2 = await collectResponse(response2)
     t.ok(output2.length > 0, `second turn produced output (${output2.length} chars)`)
     const lowerOutput2 = output2.toLowerCase()
     t.ok(/berlin/.test(lowerOutput2), `second turn mentions Berlin: "${output2.slice(0, 100)}"`)
     t.ok(output2 !== output1, 'second turn produced different output from first')
+    t.ok(
+      response2.stats?.CacheTokens > response1.stats?.CacheTokens,
+      `second turn extended the KV cache from turn 1 (${response1.stats?.CacheTokens} -> ${response2.stats?.CacheTokens})`
+    )
   } finally {
     await addon.unload().catch(() => {})
   }

--- a/packages/llm-llamacpp/test/integration/qwen3-5.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5.test.js
@@ -171,30 +171,33 @@ test('Qwen3.5-0.8B supports multi-turn conversation with KV cache', {
     const systemMsg = { role: 'system', content: 'You are a helpful assistant. Answer concisely with just the city name.' }
     const userTurn1 = { role: 'user', content: 'What is the capital of France?' }
 
-    const prompt1 = [
-      { role: 'session', content: sessionName },
-      systemMsg,
-      userTurn1
-    ]
-    const response1 = await addon.run(prompt1)
+    // Cache control is a runOption (cacheKey), NOT a `{ role: 'session' }`
+    // chat message — the latter was removed in v0.15.0 and is silently dropped
+    // by Jinja chat templates that have no matching elif branch.
+    const prompt1 = [systemMsg, userTurn1]
+    const response1 = await addon.run(prompt1, { cacheKey: sessionName })
     const output1 = await collectResponse(response1)
     t.ok(output1.length > 0, `first turn produced output (${output1.length} chars)`)
     const lowerOutput1 = output1.toLowerCase()
     t.ok(/paris/.test(lowerOutput1), `first turn mentions Paris: "${output1.slice(0, 100)}"`)
+    t.ok(response1.stats?.CacheTokens > 0, `first turn populated KV cache (CacheTokens=${response1.stats?.CacheTokens})`)
 
     const prompt2 = [
-      { role: 'session', content: sessionName },
       systemMsg,
       userTurn1,
       { role: 'assistant', content: output1 },
       { role: 'user', content: 'And what about Germany?' }
     ]
-    const response2 = await addon.run(prompt2)
+    const response2 = await addon.run(prompt2, { cacheKey: sessionName })
     const output2 = await collectResponse(response2)
     t.ok(output2.length > 0, `second turn produced output (${output2.length} chars)`)
     const lowerOutput2 = output2.toLowerCase()
     t.ok(/berlin/.test(lowerOutput2), `second turn mentions Berlin: "${output2.slice(0, 100)}"`)
     t.ok(output2 !== output1, 'second turn produced different output from first')
+    t.ok(
+      response2.stats?.CacheTokens > response1.stats?.CacheTokens,
+      `second turn extended the KV cache from turn 1 (${response1.stats?.CacheTokens} -> ${response2.stats?.CacheTokens})`
+    )
   } finally {
     await addon.unload().catch(() => {})
   }


### PR DESCRIPTION
## Summary

Both \`Gemma 4 supports multi-turn conversation with KV cache\` and \`Qwen3.5-0.8B supports multi-turn conversation with KV cache\` were injecting \`{ role: 'session', content: <path> }\` into the prompt array to try to enable KV caching. That message protocol was **removed in v0.15.0** — see \`CHANGELOG.md\`:

> **[0.15.0] - 2026-04-09 — KV cache API simplified — \`{ role: \"session\" }\` replaced with \`runOptions\`**
> Cache control moved from \`{ role: \"session\" }\` chat messages to explicit \`runOptions\` fields: \`cacheKey\` and \`saveCacheToDisk\`. […]
> **Removed:** \`{ role: \"session\" }\` message protocol […]

What was actually happening on \`main\`:

- The bogus \`{ role: 'session', content: <path> }\` chat message reaches \`LlamaModel::commonProcessPrompt\` (`addon/src/model-interface/LlamaModel.cpp:1175`), which accepts any role string blindly and pushes it into \`chatMsgs\`.
- The Qwen3 / Gemma4 Jinja templates (\`addon/src/utils/QwenTemplate.cpp:32\`, \`addon/src/utils/Qwen3ToolsDynamicTemplate.cpp:17\`) only have \`elif\` branches for \`system\`/\`user\`/\`assistant\`/\`tool\`, so the \`'session'\` message is **silently dropped**.
- \`runOptions.cacheKey\` is never set, so caching is fully disabled on both turns.
- Both tests still pass because the assertions only check that the outputs contain \`/paris/\` and \`/berlin/\` and differ from each other — none of which actually requires cache reuse. The test names \"with KV cache\" are misleading.

## Fix

Mechanical port to the canonical API used everywhere else in the addon (\`cache-state-machine.test.js\`, \`docs/cache-api.md\`, \`index.js\` \`normalizeRunOptions\`):

\`\`\`diff
-    const prompt1 = [
-      { role: 'session', content: sessionName },
-      systemMsg,
-      userTurn1
-    ]
-    const response1 = await addon.run(prompt1)
+    const prompt1 = [systemMsg, userTurn1]
+    const response1 = await addon.run(prompt1, { cacheKey: sessionName })
\`\`\`

…and identically for \`prompt2\` / \`response2\`.

To make the tests actually validate what their names claim, two new assertions are added on \`response.stats.CacheTokens\`:

- turn 1: \`CacheTokens > 0\` proves the first run primed the session,
- turn 2: \`CacheTokens\` strictly grows vs. turn 1, proving the second run reused the cache and only evaluated the delta.

Both tests already construct the addon with \`opts: { stats: true }\`, so no new model load knob is needed.

## Test plan

- [ ] \`cd packages/llm-llamacpp && npm run test:integration -- --grep \"multi-turn conversation with KV cache\"\` — both tests still pass.
- [ ] After the fix, \`response.stats.CacheTokens\` is non-zero on turn 1 and strictly larger on turn 2 (the new assertions).
- [ ] No other test files touch \`{ role: 'session' }\` (\`rg -n \"role:\\s*['\\\"]session['\\\"]\"\` returns only the CHANGELOG historical mention after this PR).


Made with [Cursor](https://cursor.com)