### PR TITLE
Improve teardown resillence

### DIFF
--- a/packages/inference-addon-cpp/CHANGELOG.md
+++ b/packages/inference-addon-cpp/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.8] - 2026-05-12
+
+### Fixed
+- Guard `OutputCallBackJs` against use-after-free of `js_env_t*` during model unload. The destructor's `uv_close` close callback released JS references asynchronously, so a model that left a dirty libuv queue at teardown (pending `uv_async_send` activations, unjoined streaming threads, or in-flight `cancel` work) could race the host env invalidation. On iOS, where react-native-bare-kit worklets tear down the env aggressively on unload, this manifested as `EXC_BAD_ACCESS` (PAC failure) inside `js_delete_reference` / `js_open_handle_scope`. An atomic `envInvalidated` flag is now flipped from a `js_add_teardown_callback`, and all paths that touch JS state (`uv_close` close callback, sync destructor branch, `jsOutputCallback`) bail out when the env is gone instead of dereferencing a dangling pointer. This does not absolve callers from draining their own queues before destroying the instance.
+
 ## [1.1.5] - 2026-04-30
 
 ### Fixed

--- a/packages/inference-addon-cpp/src/inference-addon-cpp/queue/OutputCallbackJs.hpp
+++ b/packages/inference-addon-cpp/src/inference-addon-cpp/queue/OutputCallbackJs.hpp
@@ -27,6 +27,7 @@ class OutputCallBackJs : public OutputCallBackInterface {
     out_handl::OutputHandlers<out_handl::JsOutputHandlerInterface>
         outputHandlers;
     std::atomic_bool stopped{false};
+    std::atomic_bool envInvalidated{false};
 
     State(
         js_env_t* env, js_ref_t* jsHandle, js_ref_t* outputCb,
@@ -37,6 +38,11 @@ class OutputCallBackJs : public OutputCallBackInterface {
   };
 
   State* state_;
+
+  static void envTeardownCb(void* data) {
+    auto* state = static_cast<State*>(data);
+    state->envInvalidated = true;
+  }
 
 public:
   uv_async_t* jsOutputCallbackAsyncHandle_;
@@ -62,6 +68,7 @@ public:
     state_ = new State(
         env, jsHandleRef, outputCbRef, std::move(outputHandlers));
     jsOutputCallbackAsyncHandle_ = nullptr;
+    js_add_teardown_callback(env, envTeardownCb, state_);
   }
 
   ~OutputCallBackJs() {
@@ -71,19 +78,26 @@ public:
     }
 
     State* state = std::exchange(state_, nullptr);
+    
     if (state->asyncHandle != nullptr) {
       uv_close(
           reinterpret_cast<uv_handle_t*>(state->asyncHandle),
           [](uv_handle_t* handle) {
             auto* state = static_cast<State*>(uv_handle_get_data(handle));
-            deleteJsReferences(state);
+            if (!state->envInvalidated.load()) {
+              js_remove_teardown_callback(state->env, envTeardownCb, state);
+              deleteJsReferences(state);
+            }
             delete reinterpret_cast<uv_async_t*>(handle);
             delete state;
           });
       return;
     }
 
-    deleteJsReferences(state);
+    if (!state->envInvalidated.load()) {
+      js_remove_teardown_callback(state->env, envTeardownCb, state);
+      deleteJsReferences(state);
+    }
     delete state;
   }
 
@@ -185,7 +199,7 @@ private:
   static void jsOutputCallback(uv_async_t* handle) try {
     auto& state = *reinterpret_cast<State*>(
         uv_handle_get_data(reinterpret_cast<uv_handle_t*>(handle)));
-    if (state.stopped.load()) {
+    if (state.stopped.load() || state.envInvalidated.load()) {
       return;
     }
     js_handle_scope_t* scope;
@@ -226,6 +240,9 @@ private:
   } catch (...) {
     auto& state = *reinterpret_cast<State*>(
         uv_handle_get_data(reinterpret_cast<uv_handle_t*>(handle)));
+    if (state.envInvalidated.load()) {
+      return;
+    }
     js_handle_scope_t* scope;
     if (js_open_handle_scope(state.env, &scope) != 0)
       return;

--- a/packages/inference-addon-cpp/vcpkg.json
+++ b/packages/inference-addon-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qvac-lib-inference-addon-cpp",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "dependencies": [
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
- **fix: guard OutputCallBackJs against env teardown**
- **release: qvac-lib-inference-addon-cpp 1.1.8**
