### PR TITLE
QVAC-18730 feat[api]: add POST /v1/images/generations to qvac serve OpenAI adapter

### DIFF
--- a/packages/cli/src/serve/adapters/openai/index.ts
+++ b/packages/cli/src/serve/adapters/openai/index.ts
@@ -50,6 +50,12 @@ export function createOpenAIAdapter (): APIAdapter {
         return true
       }
 
+      if (method === 'POST' && path === '/v1/images/generations') {
+        const { handleImagesGenerations } = await import('./routes/images.js')
+        await handleImagesGenerations(req, res, ctx)
+        return true
+      }
+
       sendError(res, 404, 'not_found', `Unknown endpoint: ${method} ${path}`)
       return true
     }

--- a/packages/cli/src/serve/adapters/openai/routes/images.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/images.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import { readBody, sendJson, sendError } from '../../../http.js'
+import { readBody, sendJson, sendError, initSSE, sendSSE, endSSE } from '../../../http.js'
 import { resolveModelAlias } from '../../../config.js'
 import { sdkDiffusion } from '../../../core/sdk.js'
 import {
@@ -7,11 +7,13 @@ import {
   encodeImageDataUrl,
   logImageUnsupportedParams,
   InvalidImagePromptError,
-  InvalidImageSizeError
+  InvalidImageSizeError,
+  InvalidImageBatchCountError
 } from '../translate.js'
 import type { RouteContext } from '../../types.js'
 
 const SUPPORTED_RESPONSE_FORMATS = new Set(['b64_json', 'url'])
+const RESPONSE_OUTPUT_FORMAT = 'png' as const
 
 export async function handleImagesGenerations (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<void> {
   let body: Record<string, unknown>
@@ -68,13 +70,18 @@ export async function handleImagesGenerations (req: IncomingMessage, res: Server
       sendError(res, 400, 'invalid_size', err.message)
       return
     }
+    if (err instanceof InvalidImageBatchCountError) {
+      sendError(res, 400, 'invalid_n', err.message)
+      return
+    }
     throw err
   }
 
   logImageUnsupportedParams(body, ctx.logger)
 
+  const wantsStream = body['stream'] === true
   const dims = params.width && params.height ? `${params.width}x${params.height}` : 'default'
-  ctx.logger.info(`  image_generate model=${alias} prompt_chars=${params.prompt.length} size=${dims} n=${params.batch_count ?? 1} response_format=${responseFormat}`)
+  ctx.logger.info(`  image_generate model=${alias} prompt_chars=${params.prompt.length} size=${dims} n=${params.batch_count ?? 1} response_format=${responseFormat} stream=${wantsStream}`)
 
   try {
     const { buffers, stats } = await sdkDiffusion({
@@ -90,6 +97,13 @@ export async function handleImagesGenerations (req: IncomingMessage, res: Server
       ctx.logger.info(`  image_generate done images=${buffers.length} ms=${stats?.totalGenerationMs ?? stats?.totalWallMs ?? 0}`)
     }
 
+    const sizeStr = buildSizeString(params.width, params.height, stats?.width, stats?.height)
+
+    if (wantsStream) {
+      sendStreamingResponse(res, buffers, sizeStr)
+      return
+    }
+
     const data = buffers.map((buf) => {
       if (responseFormat === 'url') {
         return { url: encodeImageDataUrl(buf) }
@@ -99,6 +113,8 @@ export async function handleImagesGenerations (req: IncomingMessage, res: Server
 
     sendJson(res, 200, {
       created: Math.floor(Date.now() / 1000),
+      output_format: RESPONSE_OUTPUT_FORMAT,
+      ...(sizeStr ? { size: sizeStr } : {}),
       data
     })
   } catch (err) {
@@ -106,4 +122,43 @@ export async function handleImagesGenerations (req: IncomingMessage, res: Server
     ctx.logger.error(`Image generation error for "${alias}": ${message}`)
     sendError(res, 500, 'image_generation_error', 'An internal error occurred during image generation.')
   }
+}
+
+/**
+ * Stream the generated images as Server-Sent Events.
+ *
+ * The diffusion addon does not emit intermediate image bytes (only step ticks via
+ * `progressStream`), so we cannot produce `image_generation.partial_image` events
+ * faithfully. Instead we emit one `image_generation.completed` event per generated
+ * image, which matches OpenAI's documented behaviour for `partial_images=0` ("a
+ * single image sent in one streaming event"). Multiple images (`n > 1`) are
+ * emitted as multiple `completed` events on the same stream, then `[DONE]`.
+ */
+function sendStreamingResponse (res: ServerResponse, buffers: Uint8Array[], sizeStr: string | null): void {
+  initSSE(res)
+  const createdAt = Math.floor(Date.now() / 1000)
+  for (const buf of buffers) {
+    sendSSE(res, {
+      type: 'image_generation.completed',
+      created_at: createdAt,
+      output_format: RESPONSE_OUTPUT_FORMAT,
+      ...(sizeStr ? { size: sizeStr } : {}),
+      b64_json: Buffer.from(buf).toString('base64')
+    })
+  }
+  endSSE(res)
+}
+
+function buildSizeString (
+  paramW: number | undefined,
+  paramH: number | undefined,
+  statsW: number | undefined,
+  statsH: number | undefined
+): string | null {
+  const w = statsW ?? paramW
+  const h = statsH ?? paramH
+  if (typeof w === 'number' && typeof h === 'number' && w > 0 && h > 0) {
+    return `${w}x${h}`
+  }
+  return null
 }

--- a/packages/cli/src/serve/adapters/openai/routes/images.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/images.ts
@@ -1,0 +1,109 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readBody, sendJson, sendError } from '../../../http.js'
+import { resolveModelAlias } from '../../../config.js'
+import { sdkDiffusion } from '../../../core/sdk.js'
+import {
+  extractImageGenerationParams,
+  encodeImageDataUrl,
+  logImageUnsupportedParams,
+  InvalidImagePromptError,
+  InvalidImageSizeError
+} from '../translate.js'
+import type { RouteContext } from '../../types.js'
+
+const SUPPORTED_RESPONSE_FORMATS = new Set(['b64_json', 'url'])
+
+export async function handleImagesGenerations (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<void> {
+  let body: Record<string, unknown>
+  try {
+    body = await readBody(req)
+  } catch {
+    sendError(res, 400, 'invalid_json', 'Request body must be valid JSON.')
+    return
+  }
+
+  if (!body['model']) {
+    sendError(res, 400, 'missing_model', '"model" is required.')
+    return
+  }
+
+  const responseFormat = (body['response_format'] as string | undefined) ?? 'b64_json'
+  if (!SUPPORTED_RESPONSE_FORMATS.has(responseFormat)) {
+    sendError(res, 400, 'invalid_response_format', `Unknown response_format "${responseFormat}". Use "b64_json" or "url".`)
+    return
+  }
+
+  const modelName = body['model'] as string
+  const modelEntry = resolveModelAlias(ctx.serveConfig, modelName) ?? ctx.registry.getEntry(modelName)
+
+  if (!modelEntry) {
+    sendError(res, 404, 'model_not_found', `Model "${modelName}" is not available. Check serve.models config.`)
+    return
+  }
+
+  const endpointCategory = 'endpointCategory' in modelEntry ? modelEntry.endpointCategory : undefined
+  if (endpointCategory !== 'image') {
+    sendError(res, 400, 'invalid_model_type', `Model "${modelName}" does not support image generation.`)
+    return
+  }
+
+  const alias = 'alias' in modelEntry ? (modelEntry.alias as string) : modelEntry.id
+  const registryEntry = ctx.registry.getEntry(alias)
+  if (!registryEntry || registryEntry.state !== ctx.registry.STATES.READY) {
+    sendError(res, 503, 'model_not_ready', `Model "${modelName}" is not loaded yet.`)
+    return
+  }
+
+  const sdkModelId = registryEntry.sdkModelId ?? registryEntry.id
+
+  let params
+  try {
+    params = extractImageGenerationParams(body, sdkModelId)
+  } catch (err) {
+    if (err instanceof InvalidImagePromptError) {
+      sendError(res, 400, 'missing_prompt', err.message)
+      return
+    }
+    if (err instanceof InvalidImageSizeError) {
+      sendError(res, 400, 'invalid_size', err.message)
+      return
+    }
+    throw err
+  }
+
+  logImageUnsupportedParams(body, ctx.logger)
+
+  const dims = params.width && params.height ? `${params.width}x${params.height}` : 'default'
+  ctx.logger.info(`  image_generate model=${alias} prompt_chars=${params.prompt.length} size=${dims} n=${params.batch_count ?? 1} response_format=${responseFormat}`)
+
+  try {
+    const { buffers, stats } = await sdkDiffusion({
+      params,
+      onProgress: (tick) => {
+        ctx.logger.debug?.(`    diffusion step=${tick.step}/${tick.totalSteps} elapsed=${tick.elapsedMs}ms`)
+      }
+    })
+
+    if (stats?.seed != null) {
+      ctx.logger.info(`  image_generate done images=${buffers.length} seed=${stats.seed} ms=${stats.totalGenerationMs ?? stats.totalWallMs ?? 0}`)
+    } else {
+      ctx.logger.info(`  image_generate done images=${buffers.length} ms=${stats?.totalGenerationMs ?? stats?.totalWallMs ?? 0}`)
+    }
+
+    const data = buffers.map((buf) => {
+      if (responseFormat === 'url') {
+        return { url: encodeImageDataUrl(buf) }
+      }
+      return { b64_json: Buffer.from(buf).toString('base64') }
+    })
+
+    sendJson(res, 200, {
+      created: Math.floor(Date.now() / 1000),
+      data
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.error(`Image generation error for "${alias}": ${message}`)
+    sendError(res, 500, 'image_generation_error', 'An internal error occurred during image generation.')
+  }
+}

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -236,6 +236,13 @@ export class InvalidImagePromptError extends Error {
   }
 }
 
+export class InvalidImageBatchCountError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'InvalidImageBatchCountError'
+  }
+}
+
 export type ParsedImageSize =
   | { width: number; height: number }
   | { auto: true }
@@ -274,11 +281,13 @@ export function parseImageSize (size: unknown): ParsedImageSize {
   return { width, height }
 }
 
-const MAX_BATCH_COUNT = 4
-
 /**
  * Build the SDK diffusion call parameters from an OpenAI /v1/images/generations body.
- * Throws InvalidImagePromptError / InvalidImageSizeError on bad input.
+ * Throws InvalidImagePromptError / InvalidImageSizeError / InvalidImageBatchCountError on bad input.
+ *
+ * `n` is forwarded as `batch_count` with no upper bound — the SDK / underlying
+ * diffusion addon governs how large a batch is feasible. Only `n < 1` or
+ * non-integer values are rejected here.
  */
 export function extractImageGenerationParams (
   body: Record<string, unknown>,
@@ -301,8 +310,12 @@ export function extractImageGenerationParams (
     params.seed = body['seed']
   }
 
-  if (typeof body['n'] === 'number' && Number.isInteger(body['n']) && body['n'] > 0) {
-    params.batch_count = Math.min(body['n'], MAX_BATCH_COUNT)
+  if (body['n'] !== undefined) {
+    const n = body['n']
+    if (typeof n !== 'number' || !Number.isInteger(n) || n < 1) {
+      throw new InvalidImageBatchCountError(`"n" must be a positive integer (got ${JSON.stringify(n)}).`)
+    }
+    params.batch_count = n
   }
 
   return params
@@ -316,8 +329,9 @@ const IMAGE_UNSUPPORTED_PARAMS = [
 /**
  * Log warnings for OpenAI image-generation params we accept but do not forward to the SDK.
  *
- * `output_format` and `stream` are warned with extra context because they are commonly
- * sent by clients but Tier-1 always returns blocking PNG responses.
+ * `output_format` is warned with extra context because the response body is always PNG
+ * (the response object echoes `output_format: "png"` so clients can detect mismatch).
+ * `stream` is handled by the route itself (single-event SSE), so it is not warned here.
  */
 export function logImageUnsupportedParams (body: Record<string, unknown>, logger: Logger): void {
   for (const param of IMAGE_UNSUPPORTED_PARAMS) {
@@ -329,14 +343,6 @@ export function logImageUnsupportedParams (body: Record<string, unknown>, logger
   const outputFormat = body['output_format']
   if (typeof outputFormat === 'string' && outputFormat !== 'png') {
     logger.warn(`output_format=${outputFormat} is not supported; returning PNG.`)
-  }
-
-  if (body['stream'] === true) {
-    logger.warn('stream=true is not supported for /v1/images/generations; returning the blocking response.')
-  }
-
-  if (typeof body['n'] === 'number' && body['n'] > MAX_BATCH_COUNT) {
-    logger.warn(`n=${body['n']} exceeds maximum of ${MAX_BATCH_COUNT}; clamping.`)
   }
 }
 

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '../../../logger.js'
-import type { SDKTool, SDKToolCall, SDKGenerationParams, SDKResponseFormat } from '../../core/sdk.js'
+import type { SDKTool, SDKToolCall, SDKGenerationParams, SDKResponseFormat, SDKDiffusionParams } from '../../core/sdk.js'
 
 interface OpenAIMessage {
   role: string
@@ -218,4 +218,133 @@ export function logUnsupportedParams (body: Record<string, unknown>, logger: Log
       logger.warn(`Ignoring unsupported OpenAI param: ${param}=${JSON.stringify(body[param])}`)
     }
   }
+}
+
+// ─── /v1/images/generations helpers ────────────────────────────────────────
+
+export class InvalidImageSizeError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'InvalidImageSizeError'
+  }
+}
+
+export class InvalidImagePromptError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'InvalidImagePromptError'
+  }
+}
+
+export type ParsedImageSize =
+  | { width: number; height: number }
+  | { auto: true }
+  | null
+
+const SIZE_PATTERN = /^(\d+)x(\d+)$/
+
+/**
+ * Parse OpenAI `size` request field.
+ * - undefined / missing → null (caller uses SDK defaults)
+ * - "auto" → { auto: true }
+ * - "WIDTHxHEIGHT" → { width, height } (both must be positive multiples of 8)
+ * - anything else → throws InvalidImageSizeError
+ */
+export function parseImageSize (size: unknown): ParsedImageSize {
+  if (size === undefined || size === null || size === '') return null
+  if (typeof size !== 'string') {
+    throw new InvalidImageSizeError('"size" must be a string like "1024x1024" or "auto".')
+  }
+  if (size === 'auto') return { auto: true }
+
+  const match = SIZE_PATTERN.exec(size)
+  if (!match) {
+    throw new InvalidImageSizeError(`"size" must be "WIDTHxHEIGHT" or "auto" (got ${JSON.stringify(size)}).`)
+  }
+
+  const width = Number(match[1])
+  const height = Number(match[2])
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+    throw new InvalidImageSizeError(`"size" dimensions must be positive integers (got ${JSON.stringify(size)}).`)
+  }
+  if (width % 8 !== 0 || height % 8 !== 0) {
+    throw new InvalidImageSizeError(`"size" dimensions must be multiples of 8 (got ${width}x${height}).`)
+  }
+
+  return { width, height }
+}
+
+const MAX_BATCH_COUNT = 4
+
+/**
+ * Build the SDK diffusion call parameters from an OpenAI /v1/images/generations body.
+ * Throws InvalidImagePromptError / InvalidImageSizeError on bad input.
+ */
+export function extractImageGenerationParams (
+  body: Record<string, unknown>,
+  modelId: string
+): SDKDiffusionParams {
+  const prompt = body['prompt']
+  if (typeof prompt !== 'string' || prompt.length === 0) {
+    throw new InvalidImagePromptError('"prompt" is required and must be a non-empty string.')
+  }
+
+  const params: SDKDiffusionParams = { modelId, prompt }
+
+  const parsedSize = parseImageSize(body['size'])
+  if (parsedSize && 'width' in parsedSize) {
+    params.width = parsedSize.width
+    params.height = parsedSize.height
+  }
+
+  if (typeof body['seed'] === 'number' && Number.isInteger(body['seed'])) {
+    params.seed = body['seed']
+  }
+
+  if (typeof body['n'] === 'number' && Number.isInteger(body['n']) && body['n'] > 0) {
+    params.batch_count = Math.min(body['n'], MAX_BATCH_COUNT)
+  }
+
+  return params
+}
+
+const IMAGE_UNSUPPORTED_PARAMS = [
+  'quality', 'style', 'background', 'moderation',
+  'output_compression', 'partial_images', 'user'
+] as const
+
+/**
+ * Log warnings for OpenAI image-generation params we accept but do not forward to the SDK.
+ *
+ * `output_format` and `stream` are warned with extra context because they are commonly
+ * sent by clients but Tier-1 always returns blocking PNG responses.
+ */
+export function logImageUnsupportedParams (body: Record<string, unknown>, logger: Logger): void {
+  for (const param of IMAGE_UNSUPPORTED_PARAMS) {
+    if (body[param] !== undefined) {
+      logger.warn(`Ignoring unsupported OpenAI image param: ${param}=${JSON.stringify(body[param])}`)
+    }
+  }
+
+  const outputFormat = body['output_format']
+  if (typeof outputFormat === 'string' && outputFormat !== 'png') {
+    logger.warn(`output_format=${outputFormat} is not supported; returning PNG.`)
+  }
+
+  if (body['stream'] === true) {
+    logger.warn('stream=true is not supported for /v1/images/generations; returning the blocking response.')
+  }
+
+  if (typeof body['n'] === 'number' && body['n'] > MAX_BATCH_COUNT) {
+    logger.warn(`n=${body['n']} exceeds maximum of ${MAX_BATCH_COUNT}; clamping.`)
+  }
+}
+
+/**
+ * Encode raw image bytes as a `data:` URL for `response_format: "url"` requests.
+ * Defaults to PNG since the SDK diffusion addon emits PNG.
+ */
+export function encodeImageDataUrl (buf: Uint8Array, mime: string = 'image/png'): string {
+  const base64 = Buffer.from(buf).toString('base64')
+  return `data:${mime};base64,${base64}`
 }

--- a/packages/cli/src/serve/config.ts
+++ b/packages/cli/src/serve/config.ts
@@ -16,7 +16,9 @@ const ENDPOINT_CATEGORY: Record<string, string> = {
   tts: 'speech',
   'onnx-tts': 'speech',
   ocr: 'ocr',
-  'onnx-ocr': 'ocr'
+  'onnx-ocr': 'ocr',
+  diffusion: 'image',
+  'sdcpp-generation': 'image'
 }
 
 interface RawServeConfig {

--- a/packages/cli/src/serve/core/sdk.ts
+++ b/packages/cli/src/serve/core/sdk.ts
@@ -40,8 +40,47 @@ interface SDKModule {
   }) => Promise<CompletionResult>
   embed: (opts: { modelId: string; text: string | string[] }) => Promise<{ embedding: number[] | number[][]; stats?: Record<string, unknown> }>
   transcribe: (opts: { modelId: string; audioChunk: string | Buffer; prompt?: string }) => Promise<string>
+  diffusion: (opts: SDKDiffusionParams) => SDKDiffusionResult
   close: () => Promise<void>
   [key: string]: unknown
+}
+
+export interface SDKDiffusionParams {
+  modelId: string
+  prompt: string
+  negative_prompt?: string
+  width?: number
+  height?: number
+  steps?: number
+  seed?: number
+  batch_count?: number
+  cfg_scale?: number
+  guidance?: number
+  sampling_method?: string
+  scheduler?: string
+}
+
+export interface SDKDiffusionStats {
+  width?: number
+  height?: number
+  seed?: number
+  totalSteps?: number
+  totalImages?: number
+  generationMs?: number
+  totalGenerationMs?: number
+  totalWallMs?: number
+}
+
+export interface SDKDiffusionProgressTick {
+  step: number
+  totalSteps: number
+  elapsedMs: number
+}
+
+export interface SDKDiffusionResult {
+  progressStream: AsyncIterable<SDKDiffusionProgressTick>
+  outputs: Promise<Uint8Array[]>
+  stats: Promise<SDKDiffusionStats | undefined>
 }
 
 export interface SDKTool {
@@ -210,6 +249,37 @@ export async function sdkTranscribe (opts: {
   } finally {
     try { fs.unlinkSync(tmpFile) } catch {}
   }
+}
+
+export interface SDKDiffusionRunResult {
+  buffers: Uint8Array[]
+  stats: SDKDiffusionStats | undefined
+}
+
+export async function sdkDiffusion (opts: {
+  params: SDKDiffusionParams
+  onProgress?: (tick: SDKDiffusionProgressTick) => void
+}): Promise<SDKDiffusionRunResult> {
+  const { diffusion } = await getSDK()
+  const result = diffusion(opts.params)
+
+  const drainProgress = async (): Promise<void> => {
+    try {
+      for await (const tick of result.progressStream) {
+        if (opts.onProgress) opts.onProgress(tick)
+      }
+    } catch {
+      // Progress drain errors are reported via outputs/stats below.
+    }
+  }
+
+  const [buffers, stats] = await Promise.all([
+    result.outputs,
+    result.stats,
+    drainProgress()
+  ])
+
+  return { buffers, stats }
 }
 
 export async function sdkClose (): Promise<void> {

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -112,7 +112,8 @@ export async function startServer (options: StartServerOptions): Promise<http.Se
 const CATEGORY_ENDPOINTS: Record<string, string[]> = {
   chat: ['POST /v1/chat/completions'],
   embedding: ['POST /v1/embeddings'],
-  transcription: ['POST /v1/audio/transcriptions']
+  transcription: ['POST /v1/audio/transcriptions'],
+  image: ['POST /v1/images/generations']
 }
 
 const MANAGEMENT_ENDPOINTS = [
@@ -127,7 +128,8 @@ const CATEGORY_LABELS: Record<string, string> = {
   transcription: 'transcription',
   translation: 'translation',
   speech: 'speech',
-  ocr: 'ocr'
+  ocr: 'ocr',
+  image: 'image'
 }
 
 function logStartupSummary (serveConfig: ServeConfig, logger: Logger): void {

--- a/packages/cli/test/images.test.ts
+++ b/packages/cli/test/images.test.ts
@@ -6,7 +6,8 @@ import {
   logImageUnsupportedParams,
   encodeImageDataUrl,
   InvalidImagePromptError,
-  InvalidImageSizeError
+  InvalidImageSizeError,
+  InvalidImageBatchCountError
 } from '../src/serve/adapters/openai/translate.js'
 
 describe('parseImageSize', () => {
@@ -87,15 +88,18 @@ describe('extractImageGenerationParams', () => {
     assert.equal(params.seed, undefined)
   })
 
-  it('clamps n to MAX_BATCH_COUNT (4)', () => {
+  it('forwards positive integer n unchanged (no upper clamp)', () => {
     assert.equal(extractImageGenerationParams({ prompt: 'p', n: 1 }, 'm').batch_count, 1)
     assert.equal(extractImageGenerationParams({ prompt: 'p', n: 4 }, 'm').batch_count, 4)
-    assert.equal(extractImageGenerationParams({ prompt: 'p', n: 10 }, 'm').batch_count, 4)
+    assert.equal(extractImageGenerationParams({ prompt: 'p', n: 10 }, 'm').batch_count, 10)
+    assert.equal(extractImageGenerationParams({ prompt: 'p', n: 64 }, 'm').batch_count, 64)
   })
 
-  it('ignores non-positive n', () => {
-    assert.equal(extractImageGenerationParams({ prompt: 'p', n: 0 }, 'm').batch_count, undefined)
-    assert.equal(extractImageGenerationParams({ prompt: 'p', n: -3 }, 'm').batch_count, undefined)
+  it('throws InvalidImageBatchCountError on n < 1, non-integer, or non-number', () => {
+    assert.throws(() => extractImageGenerationParams({ prompt: 'p', n: 0 }, 'm'), InvalidImageBatchCountError)
+    assert.throws(() => extractImageGenerationParams({ prompt: 'p', n: -3 }, 'm'), InvalidImageBatchCountError)
+    assert.throws(() => extractImageGenerationParams({ prompt: 'p', n: 1.5 }, 'm'), InvalidImageBatchCountError)
+    assert.throws(() => extractImageGenerationParams({ prompt: 'p', n: '4' }, 'm'), InvalidImageBatchCountError)
   })
 
   it('propagates parseImageSize errors', () => {
@@ -154,29 +158,18 @@ describe('logImageUnsupportedParams', () => {
     assert.equal(warnings.length, 0)
   })
 
-  it('warns when stream=true', () => {
+  it('does not warn on stream (handled by route, not the warning helper)', () => {
     const { warnings, logger } = makeLogger()
     logImageUnsupportedParams({ stream: true }, logger)
-    assert.equal(warnings.length, 1)
-    assert.ok(warnings[0]!.includes('stream=true'))
-  })
-
-  it('does not warn when stream=false', () => {
-    const { warnings, logger } = makeLogger()
+    assert.equal(warnings.length, 0)
     logImageUnsupportedParams({ stream: false }, logger)
     assert.equal(warnings.length, 0)
   })
 
-  it('warns when n exceeds MAX_BATCH_COUNT', () => {
+  it('does not warn on n (forwarded as-is by extractImageGenerationParams)', () => {
     const { warnings, logger } = makeLogger()
     logImageUnsupportedParams({ n: 10 }, logger)
-    assert.equal(warnings.length, 1)
-    assert.ok(warnings[0]!.includes('n=10'))
-    assert.ok(warnings[0]!.includes('clamping'))
-  })
-
-  it('does not warn when n is at or below MAX_BATCH_COUNT', () => {
-    const { warnings, logger } = makeLogger()
+    assert.equal(warnings.length, 0)
     logImageUnsupportedParams({ n: 4 }, logger)
     assert.equal(warnings.length, 0)
   })

--- a/packages/cli/test/images.test.ts
+++ b/packages/cli/test/images.test.ts
@@ -1,0 +1,203 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  parseImageSize,
+  extractImageGenerationParams,
+  logImageUnsupportedParams,
+  encodeImageDataUrl,
+  InvalidImagePromptError,
+  InvalidImageSizeError
+} from '../src/serve/adapters/openai/translate.js'
+
+describe('parseImageSize', () => {
+  it('returns null for undefined / null / empty', () => {
+    assert.equal(parseImageSize(undefined), null)
+    assert.equal(parseImageSize(null), null)
+    assert.equal(parseImageSize(''), null)
+  })
+
+  it('returns { auto: true } for "auto"', () => {
+    assert.deepEqual(parseImageSize('auto'), { auto: true })
+  })
+
+  it('parses "WIDTHxHEIGHT" multiples of 8', () => {
+    assert.deepEqual(parseImageSize('1024x1024'), { width: 1024, height: 1024 })
+    assert.deepEqual(parseImageSize('1536x1024'), { width: 1536, height: 1024 })
+    assert.deepEqual(parseImageSize('1024x1536'), { width: 1024, height: 1536 })
+  })
+
+  it('throws on non-multiple-of-8 dimensions', () => {
+    assert.throws(() => parseImageSize('1023x1024'), InvalidImageSizeError)
+    assert.throws(() => parseImageSize('1024x1023'), InvalidImageSizeError)
+  })
+
+  it('throws on malformed strings', () => {
+    assert.throws(() => parseImageSize('1024'), InvalidImageSizeError)
+    assert.throws(() => parseImageSize('big'), InvalidImageSizeError)
+    assert.throws(() => parseImageSize('1024X1024'), InvalidImageSizeError)
+    assert.throws(() => parseImageSize('1024x'), InvalidImageSizeError)
+  })
+
+  it('throws on zero or negative dimensions', () => {
+    assert.throws(() => parseImageSize('0x1024'), InvalidImageSizeError)
+  })
+
+  it('throws on non-string values', () => {
+    assert.throws(() => parseImageSize(1024 as unknown as string), InvalidImageSizeError)
+    assert.throws(() => parseImageSize({} as unknown as string), InvalidImageSizeError)
+  })
+})
+
+describe('extractImageGenerationParams', () => {
+  it('requires prompt', () => {
+    assert.throws(() => extractImageGenerationParams({}, 'm'), InvalidImagePromptError)
+    assert.throws(() => extractImageGenerationParams({ prompt: '' }, 'm'), InvalidImagePromptError)
+    assert.throws(() => extractImageGenerationParams({ prompt: 123 }, 'm'), InvalidImagePromptError)
+  })
+
+  it('returns minimal params for prompt + model', () => {
+    const params = extractImageGenerationParams({ prompt: 'a cat' }, 'sdk-model-1')
+    assert.equal(params.modelId, 'sdk-model-1')
+    assert.equal(params.prompt, 'a cat')
+    assert.equal(params.width, undefined)
+    assert.equal(params.height, undefined)
+    assert.equal(params.batch_count, undefined)
+    assert.equal(params.seed, undefined)
+  })
+
+  it('passes width/height when size is "WxH"', () => {
+    const params = extractImageGenerationParams({ prompt: 'p', size: '1024x1536' }, 'm')
+    assert.equal(params.width, 1024)
+    assert.equal(params.height, 1536)
+  })
+
+  it('omits width/height when size is "auto"', () => {
+    const params = extractImageGenerationParams({ prompt: 'p', size: 'auto' }, 'm')
+    assert.equal(params.width, undefined)
+    assert.equal(params.height, undefined)
+  })
+
+  it('forwards integer seed', () => {
+    const params = extractImageGenerationParams({ prompt: 'p', seed: 42 }, 'm')
+    assert.equal(params.seed, 42)
+  })
+
+  it('ignores non-integer seed', () => {
+    const params = extractImageGenerationParams({ prompt: 'p', seed: 1.5 }, 'm')
+    assert.equal(params.seed, undefined)
+  })
+
+  it('clamps n to MAX_BATCH_COUNT (4)', () => {
+    assert.equal(extractImageGenerationParams({ prompt: 'p', n: 1 }, 'm').batch_count, 1)
+    assert.equal(extractImageGenerationParams({ prompt: 'p', n: 4 }, 'm').batch_count, 4)
+    assert.equal(extractImageGenerationParams({ prompt: 'p', n: 10 }, 'm').batch_count, 4)
+  })
+
+  it('ignores non-positive n', () => {
+    assert.equal(extractImageGenerationParams({ prompt: 'p', n: 0 }, 'm').batch_count, undefined)
+    assert.equal(extractImageGenerationParams({ prompt: 'p', n: -3 }, 'm').batch_count, undefined)
+  })
+
+  it('propagates parseImageSize errors', () => {
+    assert.throws(
+      () => extractImageGenerationParams({ prompt: 'p', size: '999x999' }, 'm'),
+      InvalidImageSizeError
+    )
+  })
+})
+
+describe('logImageUnsupportedParams', () => {
+  function makeLogger (): { warnings: string[]; logger: Parameters<typeof logImageUnsupportedParams>[1] } {
+    const warnings: string[] = []
+    const logger = { warn: (msg: string) => warnings.push(msg) } as Parameters<typeof logImageUnsupportedParams>[1]
+    return { warnings, logger }
+  }
+
+  it('does not warn on empty body', () => {
+    const { warnings, logger } = makeLogger()
+    logImageUnsupportedParams({}, logger)
+    assert.equal(warnings.length, 0)
+  })
+
+  it('warns for each unsupported image param', () => {
+    const { warnings, logger } = makeLogger()
+    logImageUnsupportedParams({
+      quality: 'high',
+      style: 'vivid',
+      background: 'transparent',
+      moderation: 'low',
+      output_compression: 60,
+      partial_images: 2,
+      user: 'end-user-42'
+    }, logger)
+    assert.equal(warnings.length, 7)
+    assert.ok(warnings.some(w => w.includes('quality')))
+    assert.ok(warnings.some(w => w.includes('style')))
+    assert.ok(warnings.some(w => w.includes('background')))
+    assert.ok(warnings.some(w => w.includes('moderation')))
+    assert.ok(warnings.some(w => w.includes('output_compression')))
+    assert.ok(warnings.some(w => w.includes('partial_images')))
+    assert.ok(warnings.some(w => w.includes('user')))
+  })
+
+  it('warns when output_format is not png', () => {
+    const { warnings, logger } = makeLogger()
+    logImageUnsupportedParams({ output_format: 'jpeg' }, logger)
+    assert.equal(warnings.length, 1)
+    assert.ok(warnings[0]!.includes('output_format=jpeg'))
+    assert.ok(warnings[0]!.includes('PNG'))
+  })
+
+  it('does not warn when output_format is png', () => {
+    const { warnings, logger } = makeLogger()
+    logImageUnsupportedParams({ output_format: 'png' }, logger)
+    assert.equal(warnings.length, 0)
+  })
+
+  it('warns when stream=true', () => {
+    const { warnings, logger } = makeLogger()
+    logImageUnsupportedParams({ stream: true }, logger)
+    assert.equal(warnings.length, 1)
+    assert.ok(warnings[0]!.includes('stream=true'))
+  })
+
+  it('does not warn when stream=false', () => {
+    const { warnings, logger } = makeLogger()
+    logImageUnsupportedParams({ stream: false }, logger)
+    assert.equal(warnings.length, 0)
+  })
+
+  it('warns when n exceeds MAX_BATCH_COUNT', () => {
+    const { warnings, logger } = makeLogger()
+    logImageUnsupportedParams({ n: 10 }, logger)
+    assert.equal(warnings.length, 1)
+    assert.ok(warnings[0]!.includes('n=10'))
+    assert.ok(warnings[0]!.includes('clamping'))
+  })
+
+  it('does not warn when n is at or below MAX_BATCH_COUNT', () => {
+    const { warnings, logger } = makeLogger()
+    logImageUnsupportedParams({ n: 4 }, logger)
+    assert.equal(warnings.length, 0)
+  })
+})
+
+describe('encodeImageDataUrl', () => {
+  it('encodes raw bytes as a base64 data URL with the default png mime', () => {
+    const url = encodeImageDataUrl(new Uint8Array([0xff, 0xd8, 0xff]))
+    assert.ok(url.startsWith('data:image/png;base64,'))
+    const base64 = url.slice('data:image/png;base64,'.length)
+    assert.deepEqual(Array.from(Buffer.from(base64, 'base64')), [0xff, 0xd8, 0xff])
+  })
+
+  it('honors a custom mime type', () => {
+    const url = encodeImageDataUrl(new Uint8Array([1, 2, 3]), 'image/webp')
+    assert.ok(url.startsWith('data:image/webp;base64,'))
+  })
+
+  it('produces a valid base64 payload', () => {
+    const url = encodeImageDataUrl(new Uint8Array([0, 0, 0, 0]))
+    const base64 = url.split(',')[1]!
+    assert.match(base64, /^[A-Za-z0-9+/]+={0,2}$/)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `POST /v1/images/generations` to `qvac serve openai`, backed by the SDK `diffusion()` primitive. Tier-1 stateless route adapter — request → SDK → response, no storage, no re-encoding. Supports both blocking JSON and a single-event SSE stream.

Three commits on top of latest `main`:

1. `feat[api]`: the route + helpers + tests
2. `fix(cli)`: startup banner now lists `POST /v1/images/generations` when an `image` category model is configured
3. `fix[api]`: review fix-ups — `stream:true` now returns SSE, response echoes `output_format`/`size`, `n` clamp removed (forwarded as-is, only `n < 1` is rejected)

User-facing docs are intentionally **not** in this branch — handed off to the docs team to land against the new `docs/website/content/docs/cli/http-server.mdx` location.

## Behavior decisions

| OpenAI param | Handling |
| --- | --- |
| `prompt` (required) | → SDK `prompt` |
| `model` (required) | model alias → loaded diffusion model (`endpointCategory: 'image'`). To make OpenAI clients (e.g. OpenClaw default `gpt-image-2`) work as drop-ins, alias the client's model name to a configured diffusion model. |
| `size = "WxH"` or `"auto"` | parsed to `width`/`height`; multiples of 8 enforced; `"auto"` / absent → SDK defaults |
| `n` | positive integer, forwarded as-is to SDK `batch_count` (no upper clamp). `n < 1`, non-integer, or non-number → `400 invalid_n`. |
| `seed` | forwarded; reflected in SDK `stats.seed` (logged) |
| `response_format` | default `b64_json`; `"url"` returns `data:image/png;base64,...`. Ignored when `stream: true`. |
| `output_format` | accepted, warned for non-`png`, body always PNG. **Response echoes `output_format: "png"` so clients can detect the mismatch.** |
| `stream: true` | response is `text/event-stream`; one `image_generation.completed` event per image, then `[DONE]`. Matches OpenAI's documented `partial_images: 0` behaviour. |
| `quality`, `style`, `background`, `moderation`, `output_compression`, `partial_images`, `user` | accepted + warned |

## Response shape

Blocking (non-streaming):

```json
{
  "created": 1718000000,
  "output_format": "png",
  "size": "1024x1024",
  "data": [
    { "b64_json": "iVBORw0KGgoAAAANSUhEUgAA..." }
  ]
}
```

Streaming (`stream: true`) — one event per image:

```
event: image_generation.completed
data: {"type":"image_generation.completed","created_at":1718000000,"output_format":"png","size":"1024x1024","b64_json":"iVBORw0KGgoAAAANSUhEUgAA..."}

data: [DONE]

```

## Caveat (follow-up)

`output_format=jpeg|webp` is accepted but the body is still PNG. The response echoes `output_format: "png"` so a client can detect the mismatch and decide whether to fall back. Honoring other encodings server-side likely needs an encoder dependency (e.g. `sharp`) in `@qvac/cli` — tracked separately on Asana.

## Test plan

- [x] `npm run lint` / `npm run test:unit` in `packages/cli` (157/157 pass).
- [x] Manual: all scenarios in **Attachments** below passed against a live server (`sd21` → `SD_V2_1_1B_Q4_0`).

## Out of scope

- `POST /v1/images/edits`, file hosting, `image_generation.partial_image` SSE events (SDK does not expose intermediate image bytes), JPEG/WebP re-encode in CLI, public docs (handed to docs team).

---

## Attachments (manual smoke — **not committed**)

Save the three files below **side by side in the same directory** (recommended layout: `<qvac-clone>/tmp/serve-images/` so `run-server.sh` resolves the repo root with `../..`).

```bash
mkdir -p tmp/serve-images
# paste each attachment into tmp/serve-images/<filename>
chmod +x tmp/serve-images/run-server.sh tmp/serve-images/test-scenarios.sh
cd packages/cli && npm install && npm run build
cd ../../tmp/serve-images
./run-server.sh
# second terminal, same cwd:
./test-scenarios.sh
```

<details>
<summary><strong>Attachment 1:</strong> <code>qvac.config.json</code></summary>

```json
{
  "serve": {
    "models": {
      "sd21": {
        "model": "SD_V2_1_1B_Q4_0",
        "default": true,
        "preload": true,
        "config": { "prediction": "v" }
      }
    }
  }
}
```

</details>

<details>
<summary><strong>Attachment 2:</strong> <code>run-server.sh</code></summary>

```bash
#!/usr/bin/env bash
# Start the qvac OpenAI-compatible server pointed at this dir's qvac.config.json.
# First boot will download SD_V2_1_1B_Q4_0 (~2.18 GB).
# Expects this directory to live at <repo>/tmp/serve-images (repo root = HERE/../..).
set -euo pipefail

HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
REPO="$(cd "$HERE/../.." && pwd)"
CLI="$REPO/packages/cli/dist/index.js"

if [[ ! -f "$CLI" ]]; then
  echo "CLI build missing at $CLI"
  echo "Run: (cd $REPO/packages/cli && npm install && npm run build)"
  exit 1
fi

cd "$HERE"
exec node "$CLI" serve openai -v --config "$HERE/qvac.config.json" "$@"
```

</details>

<details>
<summary><strong>Attachment 3:</strong> <code>test-scenarios.sh</code></summary>

```bash
#!/usr/bin/env bash
# End-to-end test scenarios for POST /v1/images/generations.
# Assumes `./run-server.sh` is up in another terminal and `sd21` is loaded.
#
# Usage:
#   ./test-scenarios.sh                # run all
#   ./test-scenarios.sh happy_b64      # run a single named scenario
#   BASE_URL=http://1.2.3.4:11434 ./test-scenarios.sh
set -euo pipefail

BASE="${BASE_URL:-http://127.0.0.1:11434}"
HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
OUT="$HERE/out"
mkdir -p "$OUT"

PASS=0
FAIL=0
FAILED_NAMES=()

# ── helpers ────────────────────────────────────────────────────────────────
post_json() {
  # post_json <name> <body-json>
  local name=$1
  local body=$2
  curl -sS -o "$OUT/$name.body.json" -w "%{http_code}" \
    -H "Content-Type: application/json" \
    -X POST "$BASE/v1/images/generations" \
    -d "$body"
}

post_sse() {
  # post_sse <name> <body-json>
  # captures the raw SSE body to <name>.sse and the HTTP status code in stdout.
  local name=$1
  local body=$2
  curl -sS -N -o "$OUT/$name.sse" -w "%{http_code}" \
    -H "Content-Type: application/json" \
    -H "Accept: text/event-stream" \
    -X POST "$BASE/v1/images/generations" \
    -d "$body"
}

assert_status() {
  # assert_status <name> <expected> <actual>
  local name=$1 expected=$2 actual=$3
  if [[ "$actual" == "$expected" ]]; then
    echo "  ✓ status $actual"
  else
    echo "  ✗ status $actual (expected $expected)"
    echo "  body:"; sed -e 's/^/    /' < "$OUT/$name.body.json" | head -20
    FAIL=$((FAIL+1)); FAILED_NAMES+=("$name"); return 1
  fi
}

assert_body() {
  # assert_body <name> <jq-expr> <expected-substring|"non-empty">
  local name=$1 expr=$2 expected=$3
  local got
  got=$(jq -r "$expr" < "$OUT/$name.body.json" 2>/dev/null || echo "")
  if [[ "$expected" == "non-empty" ]]; then
    if [[ -n "$got" && "$got" != "null" ]]; then
      echo "  ✓ $expr is non-empty (${#got} chars)"
    else
      echo "  ✗ $expr is empty/null"
      FAIL=$((FAIL+1)); FAILED_NAMES+=("$name"); return 1
    fi
  else
    if [[ "$got" == *"$expected"* ]]; then
      echo "  ✓ $expr matched ($got)"
    else
      echo "  ✗ $expr was '$got' (expected substring '$expected')"
      FAIL=$((FAIL+1)); FAILED_NAMES+=("$name"); return 1
    fi
  fi
}

decode_b64_png() {
  # decode_b64_png <name> <jq-expr>
  local name=$1 expr=$2
  jq -r "$expr" < "$OUT/$name.body.json" | base64 -d > "$OUT/$name.png"
  local magic
  magic=$(head -c 8 "$OUT/$name.png" | xxd -p)
  if [[ "$magic" == "89504e470d0a1a0a" ]]; then
    echo "  ✓ wrote $OUT/$name.png ($(wc -c < "$OUT/$name.png") bytes, PNG magic OK)"
  else
    echo "  ✗ $OUT/$name.png does not start with PNG magic (got $magic)"
    FAIL=$((FAIL+1)); FAILED_NAMES+=("$name"); return 1
  fi
}

run() {
  # run <name> <fn>
  local name=$1 fn=$2
  if [[ $# -ge 3 && "$3" != "$name" ]]; then
    return 0
  fi
  echo
  echo "── $name ──────────────────────────────────────────────"
  if "$fn" "$name"; then
    PASS=$((PASS+1))
    echo "  PASS"
  fi
}

# ── scenarios ──────────────────────────────────────────────────────────────

# 1. Happy path: defaults (b64_json), single image; response echoes output_format and size.
happy_b64() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"a tiny watercolor robot, studio lighting, sharp focus","steps":8}')
  assert_status "$name" 200 "$code" || return 1
  assert_body "$name" '.created' "non-empty" || return 1
  assert_body "$name" '.output_format' "png" || return 1
  assert_body "$name" '.data | length' "1" || return 1
  decode_b64_png "$name" '.data[0].b64_json' || return 1
}

# 2. Happy path: response_format=url returns data:image/png;base64,...
happy_url() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"a teal cube on a black background","response_format":"url","steps":8}')
  assert_status "$name" 200 "$code" || return 1
  assert_body "$name" '.output_format' "png" || return 1
  assert_body "$name" '.data[0].url' "data:image/png;base64," || return 1
}

# 3. Happy path: explicit size (multiple of 8) is honored and echoed in response.
happy_size_512() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"a tiny pixel-art mountain","size":"512x512","steps":8}')
  assert_status "$name" 200 "$code" || return 1
  assert_body "$name" '.size' "512x512" || return 1
  decode_b64_png "$name" '.data[0].b64_json' || return 1
  local sz; sz=$(wc -c < "$OUT/$name.png")
  if (( sz > 1000 )); then echo "  ✓ png is $sz bytes"; else echo "  ✗ png too small: $sz"; FAIL=$((FAIL+1)); FAILED_NAMES+=("$name"); return 1; fi
}

# 4. Happy path: deterministic seed ⇒ same bytes across runs.
deterministic_seed() {
  local name=$1
  local body='{"model":"sd21","prompt":"a single red apple","seed":12345,"size":"256x256","steps":8}'
  local c1; c1=$(post_json "$name" "$body"); assert_status "$name" 200 "$c1" || return 1
  decode_b64_png "$name" '.data[0].b64_json' || return 1
  cp "$OUT/$name.png" "$OUT/$name.first.png"
  local c2; c2=$(post_json "$name" "$body"); assert_status "$name" 200 "$c2" || return 1
  decode_b64_png "$name" '.data[0].b64_json' || return 1
  if cmp -s "$OUT/$name.first.png" "$OUT/$name.png"; then
    echo "  ✓ identical bytes between two seeded runs"
  else
    echo "  ✗ seeded runs produced different bytes (sd.cpp may be nondeterministic on your GPU; not necessarily a regression)"
    # don't FAIL — flag only
  fi
}

# 5. Happy path: n is forwarded as-is (no clamp). Use n=2 to keep VRAM modest.
batch_unbounded() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"a small green ball","n":2,"size":"256x256","steps":4}')
  assert_status "$name" 200 "$code" || return 1
  assert_body "$name" '.data | length' "2" || return 1
}

# 6. Happy path: stream=true returns SSE with one image_generation.completed event.
stream_sse() {
  local name=$1
  local code; code=$(post_sse "$name" '{"model":"sd21","prompt":"a single olive","stream":true,"size":"256x256","steps":4}')
  if [[ "$code" != "200" ]]; then
    echo "  ✗ status $code (expected 200)"
    sed -e 's/^/    /' < "$OUT/$name.sse" | head -20
    FAIL=$((FAIL+1)); FAILED_NAMES+=("$name"); return 1
  fi
  echo "  ✓ status 200"
  if grep -q '^data: {"type":"image_generation\.completed"' "$OUT/$name.sse"; then
    echo "  ✓ SSE contains image_generation.completed event"
  else
    echo "  ✗ SSE missing image_generation.completed event"
    sed -e 's/^/    /' < "$OUT/$name.sse" | head -20
    FAIL=$((FAIL+1)); FAILED_NAMES+=("$name"); return 1
  fi
  if grep -q '^data: \[DONE\]' "$OUT/$name.sse"; then
    echo "  ✓ SSE terminates with [DONE]"
  else
    echo "  ✗ SSE missing [DONE] terminator"
    FAIL=$((FAIL+1)); FAILED_NAMES+=("$name"); return 1
  fi
  # Decode the b64 payload of the first completed event and check PNG magic.
  local b64
  b64=$(grep -m1 '^data: {"type":"image_generation\.completed"' "$OUT/$name.sse" \
        | sed -e 's/^data: //' \
        | jq -r '.b64_json')
  echo -n "$b64" | base64 -d > "$OUT/$name.png"
  local magic; magic=$(head -c 8 "$OUT/$name.png" | xxd -p)
  if [[ "$magic" == "89504e470d0a1a0a" ]]; then
    echo "  ✓ event payload decodes to valid PNG ($(wc -c < "$OUT/$name.png") bytes)"
  else
    echo "  ✗ event payload is not a PNG (magic $magic)"
    FAIL=$((FAIL+1)); FAILED_NAMES+=("$name"); return 1
  fi
}

# 7. Sad path: missing prompt ⇒ 400 missing_prompt.
sad_missing_prompt() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21"}')
  assert_status "$name" 400 "$code" || return 1
  assert_body "$name" '.error.code' "missing_prompt" || return 1
}

# 8. Sad path: missing model ⇒ 400 missing_model.
sad_missing_model() {
  local name=$1
  local code; code=$(post_json "$name" '{"prompt":"hi"}')
  assert_status "$name" 400 "$code" || return 1
  assert_body "$name" '.error.code' "missing_model" || return 1
}

# 9. Sad path: unknown model ⇒ 404 model_not_found.
sad_unknown_model() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"does-not-exist","prompt":"hi"}')
  assert_status "$name" 404 "$code" || return 1
  assert_body "$name" '.error.code' "model_not_found" || return 1
}

# 10. Sad path: size dimensions not multiples of 8 ⇒ 400 invalid_size.
sad_bad_size_multiple() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"x","size":"1023x1024"}')
  assert_status "$name" 400 "$code" || return 1
  assert_body "$name" '.error.code' "invalid_size" || return 1
  assert_body "$name" '.error.message' "multiples of 8" || return 1
}

# 11. Sad path: malformed size string ⇒ 400 invalid_size.
sad_bad_size_format() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"x","size":"big"}')
  assert_status "$name" 400 "$code" || return 1
  assert_body "$name" '.error.code' "invalid_size" || return 1
}

# 12. Sad path: invalid response_format ⇒ 400 invalid_response_format.
sad_bad_response_format() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"x","response_format":"jpeg"}')
  assert_status "$name" 400 "$code" || return 1
  assert_body "$name" '.error.code' "invalid_response_format" || return 1
}

# 13. Sad path: n=0 ⇒ 400 invalid_n (n must be a positive integer; no upper bound).
sad_invalid_n_zero() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"x","n":0}')
  assert_status "$name" 400 "$code" || return 1
  assert_body "$name" '.error.code' "invalid_n" || return 1
}

# 14. Sad path: non-integer n ⇒ 400 invalid_n.
sad_invalid_n_float() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"x","n":1.5}')
  assert_status "$name" 400 "$code" || return 1
  assert_body "$name" '.error.code' "invalid_n" || return 1
}

# 15. Sad path: malformed JSON body ⇒ 400 invalid_json.
sad_bad_json() {
  local name=$1
  local code
  code=$(curl -sS -o "$OUT/$name.body.json" -w "%{http_code}" \
    -H "Content-Type: application/json" \
    -X POST "$BASE/v1/images/generations" \
    --data-raw '{not-json')
  assert_status "$name" 400 "$code" || return 1
  assert_body "$name" '.error.code' "invalid_json" || return 1
}

# 16. Caveat path: output_format=jpeg is accepted; body is still PNG and the
#     response echoes output_format: "png" so the client can detect mismatch.
caveat_output_format_jpeg() {
  local name=$1
  local code; code=$(post_json "$name" '{"model":"sd21","prompt":"a single olive","output_format":"jpeg","size":"256x256","steps":4}')
  assert_status "$name" 200 "$code" || return 1
  assert_body "$name" '.output_format' "png" || return 1
  decode_b64_png "$name" '.data[0].b64_json' || return 1
  echo "  ℹ check server log for: 'output_format=jpeg is not supported; returning PNG.'"
}

# 17. Sanity: model is loaded and reports as image category.
sanity_models_list() {
  local name=$1
  local code; code=$(curl -sS -o "$OUT/$name.body.json" -w "%{http_code}" "$BASE/v1/models")
  assert_status "$name" 200 "$code" || return 1
  assert_body "$name" '[.data[].id] | tostring' "sd21" || return 1
}

# ── runner ─────────────────────────────────────────────────────────────────
ALL=(
  sanity_models_list
  happy_b64
  happy_url
  happy_size_512
  deterministic_seed
  batch_unbounded
  stream_sse
  sad_missing_prompt
  sad_missing_model
  sad_unknown_model
  sad_bad_size_multiple
  sad_bad_size_format
  sad_bad_response_format
  sad_invalid_n_zero
  sad_invalid_n_float
  sad_bad_json
  caveat_output_format_jpeg
)

FILTER="${1:-}"
for name in "${ALL[@]}"; do
  if [[ -n "$FILTER" && "$FILTER" != "$name" ]]; then
    continue
  fi
  run "$name" "$name"
done

echo
echo "════════════════════════════════════════"
echo "  passed: $PASS"
echo "  failed: $FAIL"
if (( FAIL > 0 )); then
  echo "  failed names: ${FAILED_NAMES[*]}"
  exit 1
fi
```

</details>
