### PR TITLE
QVAC-18732 feat[api]: add POST /v1/audio/speech to qvac serve OpenAI adapter

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -306,7 +306,7 @@ Run an **OpenAI-compatible HTTP server** backed by locally configured QVAC model
 qvac serve openai [options]
 ```
 
-See **[docs/serve-openai.md](./docs/serve-openai.md)** for supported `/v1/...` routes, multipart request shapes, and how to register models — including **`whispercpp-audio-translation`** for `POST /v1/audio/translations` (Whisper translate-to-English), the volatile **`POST /v1/responses`** Responses API with `previous_response_id` chaining, and the diffusion-backed **`POST /v1/images/generations`** / **`POST /v1/images/edits`** routes (use `--public-base-url <origin>` to enable `response_format=url` responses backed by `GET /v1/files/{id}/content`).
+See **[docs/serve-openai.md](./docs/serve-openai.md)** for supported `/v1/...` routes, multipart request shapes, and how to register models — including **`whispercpp-audio-translation`** for `POST /v1/audio/translations` (Whisper translate-to-English), the volatile **`POST /v1/responses`** Responses API with `previous_response_id` chaining, the diffusion-backed **`POST /v1/images/generations`** / **`POST /v1/images/edits`** routes (use `--public-base-url <origin>` to enable `response_format=url` responses backed by `GET /v1/files/{id}/content`), and **`POST /v1/audio/speech`** (Chatterbox / Supertonic TTS, `wav` + `pcm` only, with a `serve.openai.audio.speech.voices` map from OpenAI voice → model alias).
 
 ## Configuration
 

--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -20,6 +20,7 @@ This document describes the supported routes and how to configure `serve.models`
 | `POST` | `/v1/embeddings` | Embeddings |
 | `POST` | `/v1/audio/transcriptions` | Speech-to-text (source language) |
 | `POST` | `/v1/audio/translations` | Speech-to-text **into English** (Whisper translate task) |
+| `POST` | `/v1/audio/speech` | Text-to-speech (Chatterbox / Supertonic, `wav` + `pcm` only) |
 | `POST` | `/v1/images/generations` | Diffusion txt2img (blocking + SSE) |
 | `POST` | `/v1/images/edits` | Diffusion img2img (multipart; blocking + SSE) |
 | `POST` | `/v1/files` | Upload a file into the in-memory store (used by image URL responses + vector stores) |
@@ -388,3 +389,146 @@ You normally use the **same** underlying weights for both transcription and tran
 | 404 | `model_not_found` | Unknown alias |
 | 503 | `model_not_ready` | Model not loaded yet |
 | 500 | `translation_error` | SDK / engine failure |
+
+## `POST /v1/audio/speech`
+
+OpenAI-compatible text-to-speech, backed by the SDK's `textToSpeech` capability (`@qvac/sdk` ONNX TTS — Chatterbox or Supertonic). Body is JSON, response body is binary audio.
+
+### Loaded model
+
+The route requires an alias whose **endpoint category** is `speech`. Built-in SDK addons that resolve to this category are `tts` and `onnx-tts`. Register a TTS model in `serve.models` with `preload: true` so the first request does not pay the cold-start tax.
+
+```json
+{
+  "serve": {
+    "models": {
+      "my-tts": {
+        "src": "registry://hf/ResembleAI/chatterbox-turbo-ONNX/resolve/<sha>/tokenizer.json",
+        "type": "tts",
+        "preload": true,
+        "config": {
+          "ttsEngine": "chatterbox",
+          "language": "en",
+          "ttsTokenizerSrc": "registry://hf/ResembleAI/chatterbox-turbo-ONNX/resolve/<sha>/tokenizer.json",
+          "ttsSpeechEncoderSrc": "registry://hf/ResembleAI/chatterbox-turbo-ONNX/resolve/<sha>/onnx/speech_encoder.onnx",
+          "ttsEmbedTokensSrc": "registry://hf/ResembleAI/chatterbox-turbo-ONNX/resolve/<sha>/onnx/embed_tokens.onnx",
+          "ttsConditionalDecoderSrc": "registry://hf/ResembleAI/chatterbox-turbo-ONNX/resolve/<sha>/onnx/conditional_decoder.onnx",
+          "ttsLanguageModelSrc": "registry://hf/ResembleAI/chatterbox-turbo-ONNX/resolve/<sha>/onnx/language_model.onnx",
+          "referenceAudioSrc": "./voices/alloy-ref.wav"
+        }
+      }
+    }
+  }
+}
+```
+
+> **Drop-in for OpenAI clients:** alias an OpenAI TTS model name (`tts-1`, `gpt-4o-mini-tts`, …) to your loaded TTS model so SDKs that hard-code the OpenAI name work without code change.
+
+### Voice → model alias
+
+OpenAI clients select a voice via the request `voice` field. QVAC TTS engines bind voice character to **load-time** config — Chatterbox uses **`referenceAudioSrc`** (a WAV path on disk); Supertonic uses **`ttsVoiceStyleSrc`** (and friends). There is no separate `voiceSrc` field on the wire — map each OpenAI voice to a model alias whose `config` carries the right paths.
+
+The route resolves the backing model alias in this order:
+
+1. **`serve.openai.audio.speech.voices[voice]`** — explicit map from an OpenAI voice string to a `serve.models` alias. Keys are matched **case-insensitively**. When this resolves to a loaded speech model, the request's `model` field is not used for routing (clients can still send a placeholder like `gpt-4o-mini-tts`).
+2. **`serve.models[model + "-" + voice]`** — hyphen alias (e.g. `my-tts-alloy`).
+3. **`serve.models[model]`** — bare model alias.
+4. None of the above — `404 model_not_found`.
+
+When `voice` is omitted, the configured **`serve.openai.audio.speech.defaultVoice`** is used (defaults to `"alloy"`). Set it to `null` to make `voice` strictly required (otherwise `400 missing_voice`).
+
+### Example: voice map + multiple aliases
+
+```json
+{
+  "serve": {
+    "models": {
+      "tts-chatter-alloy": {
+        "src": "registry://hf/ResembleAI/chatterbox-turbo-ONNX/resolve/<sha>/tokenizer.json",
+        "type": "tts",
+        "preload": true,
+        "config": { "ttsEngine": "chatterbox", "language": "en", "referenceAudioSrc": "./voices/alloy-ref.wav" }
+      },
+      "tts-chatter-echo": {
+        "src": "registry://hf/ResembleAI/chatterbox-turbo-ONNX/resolve/<sha>/tokenizer.json",
+        "type": "tts",
+        "config": { "ttsEngine": "chatterbox", "language": "en", "referenceAudioSrc": "./voices/echo-ref.wav" }
+      }
+    },
+    "openai": {
+      "audio": {
+        "speech": {
+          "defaultVoice": "alloy",
+          "voices": {
+            "alloy": "tts-chatter-alloy",
+            "echo": "tts-chatter-echo"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Request
+
+- **Content-Type:** `application/json`
+- **Fields:**
+  - `model` (required) — alias, resolved as described above
+  - `input` (required) — non-empty string, capped at **`serve.openai.audio.speech.maxInputChars`** (default **4096**, OpenAI's documented limit; set to `null` to disable)
+  - `voice` (optional, defaults to `defaultVoice`)
+  - `response_format` (optional) — `wav` (default) or `pcm` (raw 16-bit signed little-endian PCM, mono). `mp3`, `opus`, `aac`, `flac` return `400 unsupported_response_format` (no audio encoder bundled).
+- **Accepted but ignored:** `speed`, `instructions`, `stream_format` (a warning is logged; ignored keys are echoed in the success response via the `X-QVAC-Ignored-Params` header).
+
+### Response
+
+Binary audio body. Headers always include:
+
+| Header | Description |
+|--------|-------------|
+| `Content-Type` | `audio/wav` for `wav`; **`audio/L16; rate=<sr>; channels=1`** (RFC 2586) for `pcm`. |
+| `Content-Length` | Total bytes. |
+| `X-Audio-Sample-Rate` | Native sample rate of the model output. **24000** Hz for Chatterbox, **44100** Hz for Supertonic. Override by setting `sampleRate` on the alias's `config`. |
+| `X-Audio-Channels` | Always `1` (mono). |
+| `X-Audio-Bits-Per-Sample` | Always `16`. |
+| `X-QVAC-Ignored-Params` | Comma-separated list of accepted-but-dropped OpenAI fields (only present when at least one was sent). |
+
+The route always **buffers the full audio** before responding (chunked HTTP streaming is tracked as a follow-up).
+
+### Examples
+
+**WAV (default), drop-in alias for OpenAI `tts-1`:**
+
+```bash
+curl -sS http://127.0.0.1:11434/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model":"tts-1","voice":"alloy","input":"Hello from QVAC."}' \
+  --output speech.wav
+```
+
+**Raw PCM (RFC 2586 `audio/L16`) — easier for in-process playback:**
+
+```bash
+curl -sS http://127.0.0.1:11434/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model":"my-tts","voice":"echo","input":"PCM body.","response_format":"pcm"}' \
+  --output speech.pcm
+ffplay -f s16le -ar 24000 -ac 1 speech.pcm  # rate/channels come from the response headers
+```
+
+### Errors
+
+| HTTP | `error.code` | When |
+|------|--------------|------|
+| 400 | `invalid_json` | Body is not valid JSON |
+| 400 | `missing_model` | `model` field is missing |
+| 400 | `missing_input` | `input` is missing or empty/whitespace |
+| 400 | `input_too_long` | `input.length` exceeds `maxInputChars` (default 4096) |
+| 400 | `missing_voice` | `voice` not sent and `defaultVoice` is `null` |
+| 400 | `unsupported_response_format` | `mp3` / `opus` / `aac` / `flac` (no encoder bundled) |
+| 400 | `invalid_response_format` | Anything other than `wav` / `pcm` / the unsupported set above |
+| 400 | `invalid_model_type` | Alias is not a `speech` model |
+| 404 | `model_not_found` | No `voices` mapping, no hyphen alias, no bare alias matches |
+| 502 | `speech_empty` | The SDK returned zero samples — surfaced loudly so callers can distinguish "no audio" from "audio body" |
+| 503 | `model_not_ready` | Model not loaded yet |
+| 500 | `speech_error` | SDK / engine failure (message goes to server logs only) |

--- a/packages/cli/src/serve/adapters/openai/index.ts
+++ b/packages/cli/src/serve/adapters/openai/index.ts
@@ -74,6 +74,12 @@ export function createOpenAIAdapter (): APIAdapter {
         return true
       }
 
+      if (method === 'POST' && path === '/v1/audio/speech') {
+        const { handleAudioSpeech } = await import('./routes/speech.js')
+        await handleAudioSpeech(req, res, ctx)
+        return true
+      }
+
       if (method === 'POST' && path === '/v1/images/generations') {
         const { handleImagesGenerations } = await import('./routes/images.js')
         await handleImagesGenerations(req, res, ctx)

--- a/packages/cli/src/serve/adapters/openai/routes/speech.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/speech.ts
@@ -1,0 +1,143 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readBody, sendError } from '../../../http.js'
+import { resolveModelAlias } from '../../../config.js'
+import { sdkTextToSpeech } from '../../../core/sdk.js'
+import {
+  buildWavBuffer,
+  int16SamplesToBuffer,
+  mapResponseFormat,
+  resolveSampleRate,
+  speechAliasKey
+} from '../../../audio.js'
+import type { ModelEntry, ResolvedModelEntry } from '../../../core/model-registry.js'
+import type { RouteContext } from '../../types.js'
+
+const IGNORED_PARAMS = new Set([
+  'speed',
+  'instructions',
+  'stream_format'
+])
+
+export async function handleAudioSpeech (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<void> {
+  let body: Record<string, unknown>
+  try {
+    body = await readBody(req)
+  } catch {
+    sendError(res, 400, 'invalid_json', 'Request body must be valid JSON.')
+    return
+  }
+
+  const modelName = typeof body['model'] === 'string' ? body['model'].trim() : ''
+  if (!modelName) {
+    sendError(res, 400, 'missing_model', '"model" is required.')
+    return
+  }
+
+  const input = typeof body['input'] === 'string' ? body['input'] : ''
+  if (!input.trim()) {
+    sendError(res, 400, 'missing_input', '"input" is required and must be a non-empty string.')
+    return
+  }
+
+  const voice = resolveVoice(body['voice'], ctx.serveConfig.openai.audio.speech.defaultVoice)
+  if (voice === null) {
+    sendError(res, 400, 'missing_voice', '"voice" is required (no default voice configured).')
+    return
+  }
+
+  const formatMapping = mapResponseFormat(body['response_format'])
+  if (formatMapping.kind === 'unsupported') {
+    sendError(res, 400, 'unsupported_response_format', formatMapping.message)
+    return
+  }
+  if (formatMapping.kind === 'invalid') {
+    sendError(res, 400, 'invalid_response_format', formatMapping.message)
+    return
+  }
+
+  for (const key of IGNORED_PARAMS) {
+    if (body[key] !== undefined) {
+      ctx.logger.warn(`Ignoring unsupported param: ${key}=${stringifyForLog(body[key])}`)
+    }
+  }
+
+  const aliasKey = speechAliasKey(modelName, voice)
+  let modelEntry: ResolvedModelEntry | ModelEntry | null = resolveModelAlias(ctx.serveConfig, aliasKey)
+  let resolvedAlias = aliasKey
+  if (!modelEntry) {
+    modelEntry = resolveModelAlias(ctx.serveConfig, modelName) ?? ctx.registry.getEntry(modelName)
+    resolvedAlias = modelName
+  }
+
+  if (!modelEntry) {
+    sendError(
+      res,
+      404,
+      'model_not_found',
+      `Model "${modelName}" with voice "${voice}" is not available. Add either a "${modelName}" alias or a "${aliasKey}" alias under serve.models.`
+    )
+    return
+  }
+
+  const endpointCategory = 'endpointCategory' in modelEntry ? modelEntry.endpointCategory : undefined
+  if (endpointCategory !== 'speech') {
+    sendError(res, 400, 'invalid_model_type', `Model "${modelName}" does not support speech synthesis.`)
+    return
+  }
+
+  const alias = 'alias' in modelEntry ? (modelEntry.alias as string) : modelEntry.id
+  const registryEntry = ctx.registry.getEntry(alias)
+  if (!registryEntry || registryEntry.state !== ctx.registry.STATES.READY) {
+    sendError(res, 503, 'model_not_ready', `Model "${modelName}" is not loaded yet.`)
+    return
+  }
+
+  const sdkModelId = registryEntry.sdkModelId ?? registryEntry.id
+  const sampleRate = resolveSampleRate(registryEntry.config)
+  const charCount = input.length
+
+  ctx.logger.info(
+    `  speech model=${alias} voice=${voice} format=${formatMapping.format} chars=${charCount} alias_match=${resolvedAlias === aliasKey ? 'voice' : 'model'}`
+  )
+
+  try {
+    const { samples } = await sdkTextToSpeech({ modelId: sdkModelId, text: input })
+
+    const audioBytes = formatMapping.format === 'wav'
+      ? buildWavBuffer(samples, sampleRate)
+      : int16SamplesToBuffer(samples)
+
+    ctx.logger.info(`  speech done samples=${samples.length} bytes=${audioBytes.length} sample_rate=${sampleRate}`)
+
+    if (res.headersSent) return
+    res.writeHead(200, {
+      'Content-Type': formatMapping.contentType,
+      'Content-Length': audioBytes.length,
+      'X-Audio-Sample-Rate': String(sampleRate),
+      'X-Audio-Channels': '1',
+      'X-Audio-Bits-Per-Sample': '16'
+    })
+    res.end(audioBytes)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.error(`Speech synthesis error for "${alias}": ${message}`)
+    sendError(res, 500, 'speech_error', 'An internal error occurred during speech synthesis.')
+  }
+}
+
+function resolveVoice (raw: unknown, fallback: string | null): string | null {
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim()
+    if (trimmed.length > 0) return trimmed
+  }
+  return fallback
+}
+
+function stringifyForLog (value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}

--- a/packages/cli/src/serve/adapters/openai/routes/speech.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/speech.ts
@@ -6,6 +6,7 @@ import {
   buildWavBuffer,
   int16SamplesToBuffer,
   mapResponseFormat,
+  pcmContentType,
   resolveSampleRate,
   speechAliasKey
 } from '../../../audio.js'
@@ -39,6 +40,18 @@ export async function handleAudioSpeech (req: IncomingMessage, res: ServerRespon
     return
   }
 
+  const maxInputChars = ctx.serveConfig.openai.audio.speech.maxInputChars
+  if (maxInputChars !== null && input.length > maxInputChars) {
+    sendError(
+      res,
+      400,
+      'input_too_long',
+      `"input" exceeds the configured limit of ${maxInputChars} characters (got ${input.length}). ` +
+      'Raise serve.openai.audio.speech.maxInputChars or split the request.'
+    )
+    return
+  }
+
   const voice = resolveVoice(body['voice'], ctx.serveConfig.openai.audio.speech.defaultVoice)
   if (voice === null) {
     sendError(res, 400, 'missing_voice', '"voice" is required (no default voice configured).')
@@ -55,18 +68,45 @@ export async function handleAudioSpeech (req: IncomingMessage, res: ServerRespon
     return
   }
 
+  const ignoredParams: string[] = []
   for (const key of IGNORED_PARAMS) {
     if (body[key] !== undefined) {
+      ignoredParams.push(key)
       ctx.logger.warn(`Ignoring unsupported param: ${key}=${stringifyForLog(body[key])}`)
     }
   }
 
   const aliasKey = speechAliasKey(modelName, voice)
-  let modelEntry: ResolvedModelEntry | ModelEntry | null = resolveModelAlias(ctx.serveConfig, aliasKey)
-  let resolvedAlias = aliasKey
+  const voiceKey = voice.toLowerCase()
+  const voiceMapAlias = ctx.serveConfig.openai.audio.speech.voices?.[voiceKey] ?? null
+
+  let modelEntry: ResolvedModelEntry | ModelEntry | null = null
+  let resolvedAlias = ''
+  let matchMode: 'voice_map' | 'hyphen' | 'model' = 'model'
+
+  if (typeof voiceMapAlias === 'string' && voiceMapAlias.trim().length > 0) {
+    const mapped = voiceMapAlias.trim()
+    modelEntry = resolveModelAlias(ctx.serveConfig, mapped)
+    if (modelEntry) {
+      resolvedAlias = mapped
+      matchMode = 'voice_map'
+    }
+  }
+
+  if (!modelEntry) {
+    modelEntry = resolveModelAlias(ctx.serveConfig, aliasKey)
+    if (modelEntry) {
+      resolvedAlias = aliasKey
+      matchMode = 'hyphen'
+    }
+  }
+
   if (!modelEntry) {
     modelEntry = resolveModelAlias(ctx.serveConfig, modelName) ?? ctx.registry.getEntry(modelName)
-    resolvedAlias = modelName
+    if (modelEntry) {
+      resolvedAlias = modelName
+      matchMode = 'model'
+    }
   }
 
   if (!modelEntry) {
@@ -74,7 +114,7 @@ export async function handleAudioSpeech (req: IncomingMessage, res: ServerRespon
       res,
       404,
       'model_not_found',
-      `Model "${modelName}" with voice "${voice}" is not available. Add either a "${modelName}" alias or a "${aliasKey}" alias under serve.models.`
+      `Model "${modelName}" with voice "${voice}" is not available. Add a "${aliasKey}" alias, a "${modelName}" alias, or map this voice under serve.openai.audio.speech.voices to a model alias.`
     )
     return
   }
@@ -97,26 +137,42 @@ export async function handleAudioSpeech (req: IncomingMessage, res: ServerRespon
   const charCount = input.length
 
   ctx.logger.info(
-    `  speech model=${alias} voice=${voice} format=${formatMapping.format} chars=${charCount} alias_match=${resolvedAlias === aliasKey ? 'voice' : 'model'}`
+    `  speech model=${alias} voice=${voice} format=${formatMapping.format} chars=${charCount} route=${matchMode} resolved_alias=${resolvedAlias}`
   )
 
   try {
+    // TODO(QVAC-18181): wire client disconnect → cancel SDK call. Currently
+    // this awaits to completion even if the HTTP client closed the socket.
     const { samples } = await sdkTextToSpeech({ modelId: sdkModelId, text: input })
+
+    if (samples.length === 0) {
+      ctx.logger.warn(`  speech empty model=${alias} voice=${voice} chars=${charCount}`)
+      sendError(res, 502, 'speech_empty', 'Speech synthesis returned no audio samples.')
+      return
+    }
 
     const audioBytes = formatMapping.format === 'wav'
       ? buildWavBuffer(samples, sampleRate)
       : int16SamplesToBuffer(samples)
+    const contentType = formatMapping.format === 'pcm'
+      ? pcmContentType(sampleRate)
+      : formatMapping.contentType
 
     ctx.logger.info(`  speech done samples=${samples.length} bytes=${audioBytes.length} sample_rate=${sampleRate}`)
 
     if (res.headersSent) return
-    res.writeHead(200, {
-      'Content-Type': formatMapping.contentType,
+    const headers: Record<string, string | number> = {
+      'Content-Type': contentType,
       'Content-Length': audioBytes.length,
       'X-Audio-Sample-Rate': String(sampleRate),
       'X-Audio-Channels': '1',
       'X-Audio-Bits-Per-Sample': '16'
-    })
+    }
+    if (ignoredParams.length > 0) {
+      // Surface dropped OpenAI params to clients without making them grep logs.
+      headers['X-QVAC-Ignored-Params'] = ignoredParams.join(',')
+    }
+    res.writeHead(200, headers)
     res.end(audioBytes)
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)

--- a/packages/cli/src/serve/audio.ts
+++ b/packages/cli/src/serve/audio.ts
@@ -1,0 +1,173 @@
+// OpenAI's documented voice catalog. These are accepted as input on
+// /v1/audio/speech for client compatibility, but voice routing in QVAC is
+// resolved through the model alias suffix (see resolveSpeechAlias).
+export const OPENAI_VOICES = [
+  'alloy',
+  'ash',
+  'ballad',
+  'coral',
+  'echo',
+  'fable',
+  'nova',
+  'onyx',
+  'sage',
+  'shimmer',
+  'verse'
+] as const
+
+export type OpenAIVoice = typeof OPENAI_VOICES[number]
+
+const NATIVE_FORMATS = new Set(['wav', 'pcm'])
+const TRANSCODED_FORMATS = new Set(['mp3', 'opus', 'aac', 'flac'])
+
+export type SpeechResponseFormat = 'wav' | 'pcm'
+
+export interface SpeechFormatNative {
+  kind: 'native'
+  format: SpeechResponseFormat
+  contentType: string
+}
+
+export interface SpeechFormatUnsupported {
+  kind: 'unsupported'
+  format: string
+  message: string
+}
+
+export interface SpeechFormatInvalid {
+  kind: 'invalid'
+  format: string
+  message: string
+}
+
+export type MappedSpeechFormat =
+  | SpeechFormatNative
+  | SpeechFormatUnsupported
+  | SpeechFormatInvalid
+
+// Default to wav (the simplest container we can produce without a transcoder).
+// OpenAI's documented default is mp3, which we cannot encode natively yet —
+// see docs/openai-api-coverage.md for the gap and follow-up plan.
+export const DEFAULT_SPEECH_FORMAT: SpeechResponseFormat = 'wav'
+
+export function mapResponseFormat (input: unknown): MappedSpeechFormat {
+  if (input === undefined || input === null || input === '') {
+    return formatNative(DEFAULT_SPEECH_FORMAT)
+  }
+
+  if (typeof input !== 'string') {
+    return {
+      kind: 'invalid',
+      format: String(input),
+      message: 'response_format must be a string.'
+    }
+  }
+
+  const normalized = input.toLowerCase()
+
+  if (NATIVE_FORMATS.has(normalized)) {
+    return formatNative(normalized as SpeechResponseFormat)
+  }
+
+  if (TRANSCODED_FORMATS.has(normalized)) {
+    return {
+      kind: 'unsupported',
+      format: normalized,
+      message: `response_format "${normalized}" requires an audio transcoder which is not bundled with this CLI yet. Use "wav" or "pcm".`
+    }
+  }
+
+  return {
+    kind: 'invalid',
+    format: normalized,
+    message: `Unknown response_format "${normalized}". Use "wav" or "pcm".`
+  }
+}
+
+function formatNative (format: SpeechResponseFormat): SpeechFormatNative {
+  return {
+    kind: 'native',
+    format,
+    contentType: format === 'wav' ? 'audio/wav' : 'audio/pcm'
+  }
+}
+
+// Engine → native sample rate. Mirrors the constants used in the SDK
+// examples (packages/sdk/examples/tts/{chatterbox,supertonic}.ts).
+const ENGINE_SAMPLE_RATE: Record<string, number> = {
+  chatterbox: 24000,
+  supertonic: 44100
+}
+
+// 24 kHz matches OpenAI's documented pcm output (mono, 16-bit signed LE)
+// and is the right default when the engine is unknown.
+export const DEFAULT_SAMPLE_RATE = 24000
+
+export function resolveSampleRate (config: Record<string, unknown> | undefined): number {
+  if (!config) return DEFAULT_SAMPLE_RATE
+
+  const explicit = config['sampleRate']
+  if (typeof explicit === 'number' && Number.isFinite(explicit) && explicit > 0) {
+    return Math.floor(explicit)
+  }
+
+  const engine = config['ttsEngine']
+  if (typeof engine === 'string') {
+    const fromEngine = ENGINE_SAMPLE_RATE[engine.toLowerCase()]
+    if (fromEngine) return fromEngine
+  }
+
+  return DEFAULT_SAMPLE_RATE
+}
+
+// Convert Int16 PCM samples (number[] from the SDK) into a tightly packed
+// little-endian Buffer. Out-of-range values are clamped to the Int16 domain
+// to match the SDK example utility (packages/sdk/examples/tts/utils.ts).
+export function int16SamplesToBuffer (samples: number[]): Buffer {
+  const buffer = Buffer.alloc(samples.length * 2)
+  for (let i = 0; i < samples.length; i++) {
+    const raw = samples[i] ?? 0
+    const clamped = Math.max(-32768, Math.min(32767, Math.round(raw)))
+    buffer.writeInt16LE(clamped, i * 2)
+  }
+  return buffer
+}
+
+// Build a 44-byte RIFF/WAVE header for 16-bit signed PCM, mono, at the given
+// sample rate, followed by `dataLength` data bytes. Layout matches the
+// canonical PCM WAV format used by the SDK example helpers.
+export function buildWavHeader (dataLength: number, sampleRate: number): Buffer {
+  const header = Buffer.alloc(44)
+
+  header.write('RIFF', 0)
+  header.writeUInt32LE(36 + dataLength, 4)
+  header.write('WAVE', 8)
+
+  header.write('fmt ', 12)
+  header.writeUInt32LE(16, 16)
+  header.writeUInt16LE(1, 20)
+  header.writeUInt16LE(1, 22)
+  header.writeUInt32LE(sampleRate, 24)
+  header.writeUInt32LE(sampleRate * 2, 28)
+  header.writeUInt16LE(2, 32)
+  header.writeUInt16LE(16, 34)
+
+  header.write('data', 36)
+  header.writeUInt32LE(dataLength, 40)
+
+  return header
+}
+
+export function buildWavBuffer (samples: number[], sampleRate: number): Buffer {
+  const data = int16SamplesToBuffer(samples)
+  const header = buildWavHeader(data.length, sampleRate)
+  return Buffer.concat([header, data])
+}
+
+// Voice + model → alias lookup key. The route tries this first and falls
+// back to the bare model name when no <model>-<voice> alias exists, so
+// existing single-alias TTS configs continue to work even when callers omit
+// or randomly pick a voice.
+export function speechAliasKey (model: string, voice: string): string {
+  return `${model}-${voice}`
+}

--- a/packages/cli/src/serve/audio.ts
+++ b/packages/cli/src/serve/audio.ts
@@ -1,21 +1,8 @@
-// OpenAI's documented voice catalog. These are accepted as input on
-// /v1/audio/speech for client compatibility, but voice routing in QVAC is
-// resolved through the model alias suffix (see resolveSpeechAlias).
-export const OPENAI_VOICES = [
-  'alloy',
-  'ash',
-  'ballad',
-  'coral',
-  'echo',
-  'fable',
-  'nova',
-  'onyx',
-  'sage',
-  'shimmer',
-  'verse'
-] as const
-
-export type OpenAIVoice = typeof OPENAI_VOICES[number]
+// Voice routing on /v1/audio/speech (no enforced catalog — clients can use
+// any string; the route resolves it via, in order):
+//   1) serve.openai.audio.speech.voices[voice] -> serve.models alias
+//   2) serve.models["${model}-${voice}"]
+//   3) serve.models[model]
 
 const NATIVE_FORMATS = new Set(['wav', 'pcm'])
 const TRANSCODED_FORMATS = new Set(['mp3', 'opus', 'aac', 'flac'])
@@ -85,15 +72,28 @@ export function mapResponseFormat (input: unknown): MappedSpeechFormat {
 }
 
 function formatNative (format: SpeechResponseFormat): SpeechFormatNative {
+  // PCM uses a placeholder here; the route rebuilds it via pcmContentType()
+  // once it knows the model's sample rate (RFC 2586 audio/L16 needs `rate`).
   return {
     kind: 'native',
     format,
-    contentType: format === 'wav' ? 'audio/wav' : 'audio/pcm'
+    contentType: format === 'wav' ? 'audio/wav' : 'audio/L16'
   }
+}
+
+// RFC 2586 audio/L16: linear PCM, 16-bit, signed, big-endian by default —
+// we emit little-endian, so consumers must read the `rate`/`channels` params.
+// We document the sample rate inline so HTTP clients can pick it up without
+// reaching for the `X-Audio-Sample-Rate` header.
+export function pcmContentType (sampleRate: number): string {
+  return `audio/L16; rate=${sampleRate}; channels=1`
 }
 
 // Engine → native sample rate. Mirrors the constants used in the SDK
 // examples (packages/sdk/examples/tts/{chatterbox,supertonic}.ts).
+// TODO(QVAC-18522): add the GGML engine key here when the TTS-GGML migration
+// lands, otherwise the engine falls through to DEFAULT_SAMPLE_RATE and audio
+// plays back at the wrong speed.
 const ENGINE_SAMPLE_RATE: Record<string, number> = {
   chatterbox: 24000,
   supertonic: 44100

--- a/packages/cli/src/serve/config.ts
+++ b/packages/cli/src/serve/config.ts
@@ -34,6 +34,10 @@ interface RawOpenAIOptions {
   audio?: {
     speech?: {
       defaultVoice?: unknown
+      /** Map OpenAI `voice` -> `serve.models` alias (see ServeConfig.openai.audio.speech.voices). */
+      voices?: unknown
+      /** Cap on `input` length; `null` disables. See ServeConfig.openai.audio.speech.maxInputChars. */
+      maxInputChars?: unknown
     }
   }
 }
@@ -116,9 +120,18 @@ function normalizePublicBaseUrl (raw: string | undefined): string | null {
 }
 
 const DEFAULT_SPEECH_VOICE = 'alloy'
+// OpenAI's documented limit for /v1/audio/speech `input`. Keeps memory
+// pressure bounded since we buffer the full WAV before responding.
+const DEFAULT_MAX_INPUT_CHARS = 4096
 
 function parseOpenAIOptions (raw: RawOpenAIOptions | undefined): {
-  audio: { speech: { defaultVoice: string | null } }
+  audio: {
+    speech: {
+      defaultVoice: string | null
+      voices: Record<string, string> | null
+      maxInputChars: number | null
+    }
+  }
 } {
   const rawDefaultVoice = raw?.audio?.speech?.defaultVoice
   let defaultVoice: string | null = DEFAULT_SPEECH_VOICE
@@ -133,7 +146,36 @@ function parseOpenAIOptions (raw: RawOpenAIOptions | undefined): {
     throw new Error('serve.openai.audio.speech.defaultVoice must be a string or null')
   }
 
-  return { audio: { speech: { defaultVoice } } }
+  const rawVoices = raw?.audio?.speech?.voices
+  let voices: Record<string, string> | null = null
+  if (rawVoices !== undefined && rawVoices !== null) {
+    if (typeof rawVoices !== 'object' || Array.isArray(rawVoices)) {
+      throw new Error('serve.openai.audio.speech.voices must be a JSON object (voice -> model alias)')
+    }
+    const out: Record<string, string> = {}
+    for (const [key, val] of Object.entries(rawVoices as Record<string, unknown>)) {
+      if (typeof val !== 'string' || !val.trim()) {
+        throw new Error(`serve.openai.audio.speech.voices["${key}"] must be a non-empty string (model alias)`)
+      }
+      const k = key.trim().toLowerCase()
+      if (!k) continue
+      out[k] = val.trim()
+    }
+    voices = Object.keys(out).length > 0 ? out : null
+  }
+
+  const rawMaxInput = raw?.audio?.speech?.maxInputChars
+  let maxInputChars: number | null = DEFAULT_MAX_INPUT_CHARS
+  if (rawMaxInput === null) {
+    maxInputChars = null
+  } else if (rawMaxInput !== undefined) {
+    if (typeof rawMaxInput !== 'number' || !Number.isInteger(rawMaxInput) || rawMaxInput < 1) {
+      throw new Error('serve.openai.audio.speech.maxInputChars must be a positive integer or null')
+    }
+    maxInputChars = rawMaxInput
+  }
+
+  return { audio: { speech: { defaultVoice, voices, maxInputChars } } }
 }
 
 export function normalizeEndpointCategory (sdkType: string): string {

--- a/packages/cli/src/serve/config.ts
+++ b/packages/cli/src/serve/config.ts
@@ -26,6 +26,15 @@ interface RawServeConfig {
   serve?: {
     models?: Record<string, string | ConstantModelEntry | ExplicitModelEntry>
     publicBaseUrl?: string
+    openai?: RawOpenAIOptions
+  }
+}
+
+interface RawOpenAIOptions {
+  audio?: {
+    speech?: {
+      defaultVoice?: unknown
+    }
   }
 }
 
@@ -91,7 +100,8 @@ export async function parseServeConfig (rawConfig: RawServeConfig, cliOptions: C
   return {
     models,
     defaults: resolveDefaults(models),
-    publicBaseUrl
+    publicBaseUrl,
+    openai: parseOpenAIOptions(serve.openai)
   }
 }
 
@@ -103,6 +113,27 @@ function normalizePublicBaseUrl (raw: string | undefined): string | null {
     throw new Error(`serve.publicBaseUrl must start with http:// or https:// (got "${trimmed}").`)
   }
   return trimmed.replace(/\/+$/, '')
+}
+
+const DEFAULT_SPEECH_VOICE = 'alloy'
+
+function parseOpenAIOptions (raw: RawOpenAIOptions | undefined): {
+  audio: { speech: { defaultVoice: string | null } }
+} {
+  const rawDefaultVoice = raw?.audio?.speech?.defaultVoice
+  let defaultVoice: string | null = DEFAULT_SPEECH_VOICE
+
+  if (rawDefaultVoice === null) {
+    // Explicit null disables the fallback so callers must always send `voice`.
+    defaultVoice = null
+  } else if (typeof rawDefaultVoice === 'string') {
+    const trimmed = rawDefaultVoice.trim()
+    defaultVoice = trimmed.length > 0 ? trimmed : null
+  } else if (rawDefaultVoice !== undefined) {
+    throw new Error('serve.openai.audio.speech.defaultVoice must be a string or null')
+  }
+
+  return { audio: { speech: { defaultVoice } } }
 }
 
 export function normalizeEndpointCategory (sdkType: string): string {

--- a/packages/cli/src/serve/core/model-registry.ts
+++ b/packages/cli/src/serve/core/model-registry.ts
@@ -36,6 +36,20 @@ export interface OpenAIServeOptions {
   audio: {
     speech: {
       defaultVoice: string | null
+      /**
+       * Maps an OpenAI `voice` string to a `serve.models` alias. Each alias can
+       * carry its own TTS `config` (e.g. Chatterbox `referenceAudioSrc`, Supertonic
+       * `ttsVoiceStyleSrc`). When set, this is tried before `${model}-${voice}` and
+       * before the bare `model` alias. Keys are normalized to lowercase when parsed.
+       */
+      voices: Record<string, string> | null
+      /**
+       * Maximum allowed character length of `input`. Requests above this are
+       * rejected with `400 input_too_long` before any synthesis runs (the
+       * route otherwise buffers the full WAV in memory — DoS vector).
+       * `null` disables the cap. Defaults to OpenAI's documented 4096.
+       */
+      maxInputChars: number | null
     }
   }
 }

--- a/packages/cli/src/serve/core/model-registry.ts
+++ b/packages/cli/src/serve/core/model-registry.ts
@@ -29,6 +29,15 @@ export interface ServeConfig {
    * `response_format=url`. Trailing slash is stripped on parse.
    */
   publicBaseUrl: string | null
+  openai: OpenAIServeOptions
+}
+
+export interface OpenAIServeOptions {
+  audio: {
+    speech: {
+      defaultVoice: string | null
+    }
+  }
 }
 
 export interface ResolvedModelEntry {

--- a/packages/cli/src/serve/core/sdk.ts
+++ b/packages/cli/src/serve/core/sdk.ts
@@ -51,6 +51,7 @@ interface SDKModule {
   }) => CompletionResult
   embed: (opts: { modelId: string; text: string | string[] }) => Promise<{ embedding: number[] | number[][]; stats?: Record<string, unknown> }> & { requestId: string }
   transcribe: (opts: { modelId: string; audioChunk: string | Buffer; prompt?: string }) => Promise<string> & { requestId: string }
+  textToSpeech: (opts: { modelId: string; text: string; inputType?: string; stream?: boolean }) => TtsResult
   cancel: (opts: { requestId: string } | { operation: "request"; requestId: string } | { operation: "broad"; modelId: string; kind?: string }) => Promise<void>
   diffusion: (opts: SDKDiffusionParams) => SDKDiffusionResult
   ragListWorkspaces: () => Promise<RagWorkspaceInfo[]>
@@ -144,6 +145,12 @@ export interface CompletionResult {
   toolCalls: Promise<SDKToolCall[] | null>
   tokenStream: AsyncIterable<string>
   toolCallStream: AsyncIterable<SDKToolEvent>
+}
+
+export interface TtsResult {
+  bufferStream: AsyncIterable<number>
+  buffer: Promise<number[]>
+  done: Promise<boolean>
 }
 
 export interface SDKToolCallEvent {
@@ -411,6 +418,34 @@ export async function sdkRagIngest (opts: {
   }
   if (opts.workspace !== undefined) params.workspace = opts.workspace
   return ragIngest(params)
+}
+
+export async function sdkTextToSpeech (opts: {
+  modelId: string
+  text: string
+}): Promise<{ samples: number[] }> {
+  const { textToSpeech } = await getSDK()
+  // Stream from the SDK so synthesis can start producing samples while we
+  // accumulate them into a single buffer for the HTTP response. The CLI
+  // currently buffers the full audio payload (WAV needs a header with the
+  // total length); chunked HTTP streaming is tracked as a follow-up.
+  const result = textToSpeech({
+    modelId: opts.modelId,
+    text: opts.text,
+    inputType: 'text',
+    stream: true
+  })
+
+  const samples: number[] = []
+  for await (const sample of result.bufferStream) {
+    samples.push(sample)
+  }
+  // Surface any pipeline error that the bufferStream may have settled
+  // through .done rather than the iterator (the SDK may resolve done after
+  // the iterator returns cleanly).
+  await result.done
+
+  return { samples }
 }
 
 export async function sdkClose (): Promise<void> {

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -128,6 +128,7 @@ const CATEGORY_ENDPOINTS: Record<string, string[]> = {
   embedding: ['POST /v1/embeddings'],
   transcription: ['POST /v1/audio/transcriptions'],
   'audio-translation': ['POST /v1/audio/translations'],
+  speech: ['POST /v1/audio/speech'],
   image: ['POST /v1/images/generations', 'POST /v1/images/edits']
 }
 

--- a/packages/cli/test/audio.test.ts
+++ b/packages/cli/test/audio.test.ts
@@ -1,16 +1,17 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  OPENAI_VOICES,
   DEFAULT_SPEECH_FORMAT,
   DEFAULT_SAMPLE_RATE,
   mapResponseFormat,
+  pcmContentType,
   resolveSampleRate,
   int16SamplesToBuffer,
   buildWavHeader,
   buildWavBuffer,
   speechAliasKey
 } from '../src/serve/audio.js'
+import { parseServeConfig } from '../src/serve/config.js'
 
 describe('mapResponseFormat', () => {
   it('returns the documented default for missing input', () => {
@@ -27,13 +28,20 @@ describe('mapResponseFormat', () => {
     assert.equal(result.kind, 'native')
   })
 
-  it('accepts wav and pcm with correct content types', () => {
+  it('accepts wav and pcm as native formats', () => {
     const wav = mapResponseFormat('wav')
     const pcm = mapResponseFormat('pcm')
     assert.equal(wav.kind, 'native')
     assert.equal(pcm.kind, 'native')
-    if (wav.kind === 'native') assert.equal(wav.contentType, 'audio/wav')
-    if (pcm.kind === 'native') assert.equal(pcm.contentType, 'audio/pcm')
+    if (wav.kind === 'native') {
+      assert.equal(wav.format, 'wav')
+      assert.equal(wav.contentType, 'audio/wav')
+    }
+    // PCM content-type is rebuilt with the sample rate at the call site
+    // (RFC 2586 audio/L16 requires it). The mapping only exposes the kind.
+    if (pcm.kind === 'native') {
+      assert.equal(pcm.format, 'pcm')
+    }
   })
 
   it('is case-insensitive for native formats', () => {
@@ -188,10 +196,89 @@ describe('speechAliasKey', () => {
   })
 })
 
-describe('OPENAI_VOICES', () => {
-  it('includes the documented OpenAI voice catalog', () => {
-    for (const v of ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer', 'ash', 'ballad', 'coral', 'sage', 'verse']) {
-      assert.ok(OPENAI_VOICES.includes(v as typeof OPENAI_VOICES[number]), `expected ${v} in OPENAI_VOICES`)
+describe('pcmContentType', () => {
+  it('emits an RFC 2586 audio/L16 type with rate and channels', () => {
+    assert.equal(pcmContentType(24000), 'audio/L16; rate=24000; channels=1')
+    assert.equal(pcmContentType(44100), 'audio/L16; rate=44100; channels=1')
+  })
+})
+
+describe('parseServeConfig — openai.audio.speech.voices', () => {
+  it('normalizes voice keys to lowercase', async () => {
+    const cfg = await parseServeConfig(
+      {
+        serve: {
+          models: {},
+          openai: {
+            audio: {
+              speech: {
+                voices: { Alloy: 'tts-a', ECHO: 'tts-b' }
+              }
+            }
+          }
+        }
+      },
+      {}
+    )
+    assert.equal(cfg.openai.audio.speech.voices?.alloy, 'tts-a')
+    assert.equal(cfg.openai.audio.speech.voices?.echo, 'tts-b')
+  })
+
+  it('rejects a non-object voices value', async () => {
+    await assert.rejects(
+      () =>
+        parseServeConfig(
+          {
+            serve: {
+              models: {},
+              openai: { audio: { speech: { voices: ['alloy'] } } }
+            }
+          },
+          {}
+        ),
+      /serve\.openai\.audio\.speech\.voices must be a JSON object/
+    )
+  })
+})
+
+describe('parseServeConfig — openai.audio.speech.maxInputChars', () => {
+  it('defaults to 4096 when unset', async () => {
+    const cfg = await parseServeConfig({ serve: { models: {} } }, {})
+    assert.equal(cfg.openai.audio.speech.maxInputChars, 4096)
+  })
+
+  it('accepts an explicit positive integer', async () => {
+    const cfg = await parseServeConfig(
+      { serve: { models: {}, openai: { audio: { speech: { maxInputChars: 1024 } } } } },
+      {}
+    )
+    assert.equal(cfg.openai.audio.speech.maxInputChars, 1024)
+  })
+
+  it('treats null as "no cap"', async () => {
+    const cfg = await parseServeConfig(
+      { serve: { models: {}, openai: { audio: { speech: { maxInputChars: null } } } } },
+      {}
+    )
+    assert.equal(cfg.openai.audio.speech.maxInputChars, null)
+  })
+
+  it('rejects non-integer or non-positive values', async () => {
+    for (const bad of [0, -1, 1.5, '4096', true]) {
+      await assert.rejects(
+        () =>
+          parseServeConfig(
+            {
+              serve: {
+                models: {},
+                openai: { audio: { speech: { maxInputChars: bad as unknown as number } } }
+              }
+            },
+            {}
+          ),
+        /serve\.openai\.audio\.speech\.maxInputChars must be a positive integer or null/
+      )
     }
   })
 })
+

--- a/packages/cli/test/audio.test.ts
+++ b/packages/cli/test/audio.test.ts
@@ -1,0 +1,197 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  OPENAI_VOICES,
+  DEFAULT_SPEECH_FORMAT,
+  DEFAULT_SAMPLE_RATE,
+  mapResponseFormat,
+  resolveSampleRate,
+  int16SamplesToBuffer,
+  buildWavHeader,
+  buildWavBuffer,
+  speechAliasKey
+} from '../src/serve/audio.js'
+
+describe('mapResponseFormat', () => {
+  it('returns the documented default for missing input', () => {
+    const result = mapResponseFormat(undefined)
+    assert.equal(result.kind, 'native')
+    if (result.kind === 'native') {
+      assert.equal(result.format, DEFAULT_SPEECH_FORMAT)
+      assert.equal(result.contentType, 'audio/wav')
+    }
+  })
+
+  it('returns the documented default for empty string', () => {
+    const result = mapResponseFormat('')
+    assert.equal(result.kind, 'native')
+  })
+
+  it('accepts wav and pcm with correct content types', () => {
+    const wav = mapResponseFormat('wav')
+    const pcm = mapResponseFormat('pcm')
+    assert.equal(wav.kind, 'native')
+    assert.equal(pcm.kind, 'native')
+    if (wav.kind === 'native') assert.equal(wav.contentType, 'audio/wav')
+    if (pcm.kind === 'native') assert.equal(pcm.contentType, 'audio/pcm')
+  })
+
+  it('is case-insensitive for native formats', () => {
+    const result = mapResponseFormat('WAV')
+    assert.equal(result.kind, 'native')
+    if (result.kind === 'native') assert.equal(result.format, 'wav')
+  })
+
+  it('flags mp3/opus/aac/flac as unsupported (not invalid)', () => {
+    for (const format of ['mp3', 'opus', 'aac', 'flac']) {
+      const result = mapResponseFormat(format)
+      assert.equal(result.kind, 'unsupported', `expected ${format} to be unsupported`)
+      if (result.kind === 'unsupported') {
+        assert.equal(result.format, format)
+        assert.ok(result.message.includes(format))
+      }
+    }
+  })
+
+  it('rejects unknown formats as invalid', () => {
+    const result = mapResponseFormat('mp4')
+    assert.equal(result.kind, 'invalid')
+  })
+
+  it('rejects non-string input', () => {
+    const result = mapResponseFormat(42)
+    assert.equal(result.kind, 'invalid')
+  })
+})
+
+describe('resolveSampleRate', () => {
+  it('returns the default when config is missing', () => {
+    assert.equal(resolveSampleRate(undefined), DEFAULT_SAMPLE_RATE)
+  })
+
+  it('returns the default for empty config', () => {
+    assert.equal(resolveSampleRate({}), DEFAULT_SAMPLE_RATE)
+  })
+
+  it('honors an explicit sampleRate override', () => {
+    assert.equal(resolveSampleRate({ sampleRate: 16000 }), 16000)
+  })
+
+  it('floors a non-integer override to keep WAV header math sane', () => {
+    assert.equal(resolveSampleRate({ sampleRate: 22050.7 }), 22050)
+  })
+
+  it('ignores zero/negative/non-finite overrides', () => {
+    assert.equal(resolveSampleRate({ sampleRate: 0 }), DEFAULT_SAMPLE_RATE)
+    assert.equal(resolveSampleRate({ sampleRate: -1 }), DEFAULT_SAMPLE_RATE)
+    assert.equal(resolveSampleRate({ sampleRate: Number.NaN }), DEFAULT_SAMPLE_RATE)
+  })
+
+  it('maps Chatterbox to 24000 Hz', () => {
+    assert.equal(resolveSampleRate({ ttsEngine: 'chatterbox' }), 24000)
+  })
+
+  it('maps Supertonic to 44100 Hz', () => {
+    assert.equal(resolveSampleRate({ ttsEngine: 'supertonic' }), 44100)
+  })
+
+  it('is case-insensitive on engine name', () => {
+    assert.equal(resolveSampleRate({ ttsEngine: 'CHATTERBOX' }), 24000)
+  })
+
+  it('falls back to the default for unknown engines', () => {
+    assert.equal(resolveSampleRate({ ttsEngine: 'mysteryvoice' }), DEFAULT_SAMPLE_RATE)
+  })
+
+  it('prefers explicit sampleRate over engine inference', () => {
+    assert.equal(resolveSampleRate({ ttsEngine: 'chatterbox', sampleRate: 16000 }), 16000)
+  })
+})
+
+describe('int16SamplesToBuffer', () => {
+  it('encodes samples as little-endian Int16', () => {
+    const buf = int16SamplesToBuffer([0, 1, -1, 32767, -32768])
+    assert.equal(buf.length, 10)
+    assert.equal(buf.readInt16LE(0), 0)
+    assert.equal(buf.readInt16LE(2), 1)
+    assert.equal(buf.readInt16LE(4), -1)
+    assert.equal(buf.readInt16LE(6), 32767)
+    assert.equal(buf.readInt16LE(8), -32768)
+  })
+
+  it('clamps out-of-range values', () => {
+    const buf = int16SamplesToBuffer([40000, -40000])
+    assert.equal(buf.readInt16LE(0), 32767)
+    assert.equal(buf.readInt16LE(2), -32768)
+  })
+
+  it('rounds fractional samples', () => {
+    const buf = int16SamplesToBuffer([1.4, 1.6, -1.5])
+    assert.equal(buf.readInt16LE(0), 1)
+    assert.equal(buf.readInt16LE(2), 2)
+    assert.equal(buf.readInt16LE(4), -1)
+  })
+
+  it('returns an empty buffer for empty input', () => {
+    assert.equal(int16SamplesToBuffer([]).length, 0)
+  })
+})
+
+describe('buildWavHeader', () => {
+  it('writes a 44-byte RIFF/WAVE header for mono 16-bit PCM', () => {
+    const header = buildWavHeader(0, 24000)
+    assert.equal(header.length, 44)
+    assert.equal(header.toString('ascii', 0, 4), 'RIFF')
+    assert.equal(header.toString('ascii', 8, 12), 'WAVE')
+    assert.equal(header.toString('ascii', 12, 16), 'fmt ')
+    assert.equal(header.toString('ascii', 36, 40), 'data')
+
+    assert.equal(header.readUInt32LE(16), 16) // fmt chunk size
+    assert.equal(header.readUInt16LE(20), 1)  // PCM format
+    assert.equal(header.readUInt16LE(22), 1)  // mono
+    assert.equal(header.readUInt32LE(24), 24000)
+    assert.equal(header.readUInt32LE(28), 24000 * 2)
+    assert.equal(header.readUInt16LE(32), 2)  // block align
+    assert.equal(header.readUInt16LE(34), 16) // bits per sample
+  })
+
+  it('records data length and computes RIFF size correctly', () => {
+    const header = buildWavHeader(1000, 44100)
+    assert.equal(header.readUInt32LE(40), 1000)
+    assert.equal(header.readUInt32LE(4), 36 + 1000)
+    assert.equal(header.readUInt32LE(28), 44100 * 2)
+  })
+})
+
+describe('buildWavBuffer', () => {
+  it('concatenates header and PCM data', () => {
+    const samples = [0, 1, 2, 3]
+    const wav = buildWavBuffer(samples, 24000)
+    assert.equal(wav.length, 44 + samples.length * 2)
+    assert.equal(wav.toString('ascii', 0, 4), 'RIFF')
+    assert.equal(wav.readInt16LE(44), 0)
+    assert.equal(wav.readInt16LE(46), 1)
+    assert.equal(wav.readInt16LE(48), 2)
+    assert.equal(wav.readInt16LE(50), 3)
+  })
+
+  it('records the actual PCM byte length in the header', () => {
+    const samples = new Array(100).fill(123)
+    const wav = buildWavBuffer(samples, 24000)
+    assert.equal(wav.readUInt32LE(40), 200)
+  })
+})
+
+describe('speechAliasKey', () => {
+  it('joins model and voice with a hyphen', () => {
+    assert.equal(speechAliasKey('tts-supertonic', 'alloy'), 'tts-supertonic-alloy')
+  })
+})
+
+describe('OPENAI_VOICES', () => {
+  it('includes the documented OpenAI voice catalog', () => {
+    for (const v of ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer', 'ash', 'ballad', 'coral', 'sage', 'verse']) {
+      assert.ok(OPENAI_VOICES.includes(v as typeof OPENAI_VOICES[number]), `expected ${v} in OPENAI_VOICES`)
+    }
+  })
+})

--- a/packages/cli/test/cli.bats
+++ b/packages/cli/test/cli.bats
@@ -683,6 +683,16 @@ http_status() {
   assert_error "${body}" "invalid_response_format"
 }
 
+@test "speech: input over default 4096-char cap returns 400 input_too_long" {
+  # default server inherits the documented default cap (4096).
+  local big body
+  big=$(printf 'a%.0s' $(seq 1 4097))
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"test\",\"voice\":\"alloy\",\"input\":\"${big}\"}")
+  assert_error "${body}" "input_too_long"
+}
+
 @test "speech: unknown model returns 404" {
   local body
   body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \

--- a/packages/cli/test/cli.bats
+++ b/packages/cli/test/cli.bats
@@ -610,6 +610,105 @@ http_status() {
   [[ "${max_age}" -le 3600 ]]
 }
 
+# ── Serve: speech (text-to-speech) validation ─────────────────────────
+
+@test "speech: invalid JSON returns 400" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" -d '{not valid json}')
+  assert_error "${body}" "invalid_json"
+}
+
+@test "speech: missing model returns 400" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"input":"hello","voice":"alloy"}')
+  assert_error "${body}" "missing_model"
+}
+
+@test "speech: missing input returns 400" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"test","voice":"alloy"}')
+  assert_error "${body}" "missing_input"
+}
+
+@test "speech: empty input returns 400" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"test","voice":"alloy","input":"   "}')
+  assert_error "${body}" "missing_input"
+}
+
+@test "speech: mp3 response_format returns 400 unsupported_response_format" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"test","voice":"alloy","input":"hi","response_format":"mp3"}')
+  assert_error "${body}" "unsupported_response_format"
+}
+
+@test "speech: opus response_format returns 400 unsupported_response_format" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"test","voice":"alloy","input":"hi","response_format":"opus"}')
+  assert_error "${body}" "unsupported_response_format"
+}
+
+@test "speech: aac response_format returns 400 unsupported_response_format" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"test","voice":"alloy","input":"hi","response_format":"aac"}')
+  assert_error "${body}" "unsupported_response_format"
+}
+
+@test "speech: flac response_format returns 400 unsupported_response_format" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"test","voice":"alloy","input":"hi","response_format":"flac"}')
+  assert_error "${body}" "unsupported_response_format"
+}
+
+@test "speech: unknown response_format returns 400 invalid_response_format" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"test","voice":"alloy","input":"hi","response_format":"mp4"}')
+  assert_error "${body}" "invalid_response_format"
+}
+
+@test "speech: unknown model returns 404" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"nonexistent","voice":"alloy","input":"hi"}')
+  assert_error "${body}" "model_not_found"
+}
+
+@test "speech: defaults voice to alloy when omitted (still 404 model_not_found)" {
+  # The default voice is "alloy"; with no models loaded the route must reach
+  # alias resolution and return model_not_found, not missing_voice.
+  local body
+  body=$(curl -s "http://127.0.0.1:19920/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"nonexistent","input":"hi"}')
+  assert_error "${body}" "model_not_found"
+}
+
+@test "speech: auth required when api-key set" {
+  local body
+  body=$(curl -s "http://127.0.0.1:19921/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"test","voice":"alloy","input":"hi"}')
+  assert_error "${body}" "invalid_api_key"
+}
+
 # ── Serve: routing ────────────────────────────────────────────────────
 
 @test "GET /unknown returns 404" {

--- a/packages/cli/test/cli.bats
+++ b/packages/cli/test/cli.bats
@@ -43,7 +43,7 @@ setup_file() {
 
   for _ in $(seq 1 20); do
     local code
-    code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:19921/v1/models" 2>/dev/null)
+    code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:19921/v1/models" 2>/dev/null || echo "000")
     [[ "${code}" == "401" ]] && break
     sleep 0.25
   done


### PR DESCRIPTION
## Summary

Adds `POST /v1/audio/speech` to the `qvac serve openai` adapter so OpenAI clients (continue.dev, langchain, openai SDKs, …) can drive QVAC's TTS engines (Chatterbox, Supertonic) through their existing speech codepaths.

- Asana subtask: [QVAC-18732 — New endpoint POST /v1/audio/speech](https://app.asana.com/1/45238840754660/project/1214153063536860/task/1214717221316467) (parent QVAC-18522). Note: this subtask was originally drafted as QVAC-18733; the QVAC ticket numbers were re-shuffled and this work is now QVAC-18732.
- Plan: locked-in scope mirrors the existing `/v1/audio/transcriptions` shape.

### What's in scope

- `response_format`: `wav` (default) and raw `pcm` only.
- `voice`: combined with the requested model into a `<model>-<voice>` alias lookup; falls back to the bare `<model>` alias. `serve.openai.audio.speech.defaultVoice` (default `alloy`) applies when omitted; setting it to `null` makes `voice` strictly required.
- Standard error envelope (`{error: {message, type, code}}`): `missing_input`, `missing_model`, `missing_voice`, `invalid_response_format`, `unsupported_response_format`, `invalid_model_type`, `model_not_found`, `model_not_ready`, `speech_error`.
- Buffered single-shot HTTP body (synthesis runs `textToSpeech({ stream: true })` so first samples flow as soon as the engine produces them, but the full payload is concatenated before the WAV/PCM body is written — the WAV header needs total length).
- Sample rate is derived from registry config (chatterbox=24 kHz, supertonic=44.1 kHz; explicit `config.sampleRate` overrides; 24 kHz default fallback). Surfaced on the response via `X-Audio-Sample-Rate` plus `X-Audio-Channels=1` and `X-Audio-Bits-Per-Sample=16`.

### What's deliberately deferred (tracked, will be filed as a sub-subtask under QVAC-18522)

- `mp3 | opus | aac | flac` — would route through `packages/decoder-audio` / ffmpeg. They return `400 unsupported_response_format` today and the user-facing doc explains the gap.
- Streamed chunked WAV/PCM responses.
- `speed` / `instructions` / `stream_format` runtime parameters (currently logged & ignored).
- Voice-cloning controls (Chatterbox reference audio) via the route — voice selection is purely through the alias suffix.

### Files touched

- **New** `packages/cli/src/serve/audio.ts` — pure helpers: `int16SamplesToBuffer`, `buildWavHeader`, `buildWavBuffer`, `mapResponseFormat`, `resolveSampleRate`, `speechAliasKey`, `OPENAI_VOICES`.
- **New** `packages/cli/src/serve/adapters/openai/routes/speech.ts` — the route.
- **New** `packages/cli/test/audio.test.ts` — `node:test` coverage of the helpers.
- **Edit** `packages/cli/src/serve/core/sdk.ts` — adds `sdkTextToSpeech`.
- **Edit** `packages/cli/src/serve/core/model-registry.ts` — extends `ServeConfig` with `openai.audio.speech.defaultVoice`.
- **Edit** `packages/cli/src/serve/config.ts` — parses `serve.openai.audio.speech`.
- **Edit** `packages/cli/src/serve/adapters/openai/index.ts` — wires the route.
- **Edit** `packages/cli/src/serve/index.ts` — adds the speech endpoint to `CATEGORY_ENDPOINTS` for startup logging.
- **Edit** `packages/cli/test/cli.bats` — 12 new BATS smoke cases.
- **Edit** `docs/website/content/docs/http-server.mdx` — documents the new endpoint, the voice→alias mapping, the response headers, and the wav/pcm caveat.

## Test plan

- [x] `npm run lint` (typecheck) — clean.
- [x] `npm run build` — clean (`tsc` build succeeds).
- [x] `npm run test` — all 156 unit tests pass (28 new audio cases plus the existing CLI/translate/doctor/verify-deps suites).
- [x] `npm run test:bats` — all 51 cases pass (12 new under `Serve: speech (text-to-speech) validation`).
- [ ] Real synthesis happy-path against a loaded Chatterbox/Supertonic model — left as a follow-up integration test because the BATS harness intentionally runs with empty `serve.models`.

```bash
cd packages/cli
npm install
npm run lint
npm run build
npm run test
npm run test:bats
```

### Manual smoke (with a real model)

```bash
# Start the server with a TTS model loaded
qvac serve openai

# Synthesize wav (default)
curl http://localhost:11434/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{"model":"my-tts","voice":"alloy","input":"QVAC SDK is the canonical entry point to QVAC."}' \
  --output speech.wav

# Synthesize raw pcm
curl http://localhost:11434/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{"model":"my-tts","voice":"alloy","input":"hello","response_format":"pcm"}' \
  --output speech.pcm
```
