### PR TITLE
QVAC-18736 feat[api]: add /v1/vector_stores OpenAI endpoints to qvac serve

### DIFF
--- a/packages/cli/src/serve/adapters/openai/chunk-attribution-store.ts
+++ b/packages/cli/src/serve/adapters/openai/chunk-attribution-store.ts
@@ -1,0 +1,41 @@
+export interface ChunkAttribution {
+  fileId: string
+  fileName: string
+}
+
+export interface ChunkAttributionStore {
+  /**
+   * Record attribution for a chunk under a specific vector store. Later
+   * `lookup(vectorStoreId, chunkId)` calls will return this attribution so
+   * `searchResultsToOpenAI` can map RAG chunks back to the original upload's
+   * `file_id` and `filename`.
+   */
+  record: (vectorStoreId: string, chunkId: string, attribution: ChunkAttribution) => void
+  /** Look up attribution. Returns null when the chunk has no recorded source (eg. ingested before the current process). */
+  lookup: (vectorStoreId: string, chunkId: string) => ChunkAttribution | null
+  /** Drop all attributions for a vector store; called on DELETE so the map cannot leak across the store's lifetime. */
+  evict: (vectorStoreId: string) => void
+}
+
+export function createChunkAttributionStore (): ChunkAttributionStore {
+  const map = new Map<string, Map<string, ChunkAttribution>>()
+
+  return {
+    record (vectorStoreId, chunkId, attribution) {
+      let inner = map.get(vectorStoreId)
+      if (!inner) {
+        inner = new Map()
+        map.set(vectorStoreId, inner)
+      }
+      inner.set(chunkId, { fileId: attribution.fileId, fileName: attribution.fileName })
+    },
+    lookup (vectorStoreId, chunkId) {
+      const inner = map.get(vectorStoreId)
+      const found = inner?.get(chunkId)
+      return found ? { fileId: found.fileId, fileName: found.fileName } : null
+    },
+    evict (vectorStoreId) {
+      map.delete(vectorStoreId)
+    }
+  }
+}

--- a/packages/cli/src/serve/adapters/openai/ephemeral-files-store.ts
+++ b/packages/cli/src/serve/adapters/openai/ephemeral-files-store.ts
@@ -1,0 +1,47 @@
+import { randomBytes } from 'node:crypto'
+
+export interface EphemeralFileRecord {
+  data: Buffer
+  fileName: string
+  purpose: string
+  createdAtMs: number
+}
+
+export interface EphemeralFilesStore {
+  /** Store bytes and return an OpenAI-shaped `file-…` id. */
+  put: (record: Omit<EphemeralFileRecord, 'createdAtMs'>) => string
+  /** Return the record if present; does not remove. */
+  get: (id: string) => EphemeralFileRecord | null
+  /** Return all current records (newest first), without their bytes. */
+  list: () => Array<{ id: string; record: EphemeralFileRecord }>
+  /** Remove a file by id if present. */
+  remove: (id: string) => void
+}
+
+export function createEphemeralFilesStore (nowMs: () => number = () => Date.now()): EphemeralFilesStore {
+  const map = new Map<string, EphemeralFileRecord>()
+
+  return {
+    put (record) {
+      const id = `file-${randomBytes(12).toString('hex')}`
+      map.set(id, {
+        data: record.data,
+        fileName: record.fileName,
+        purpose: record.purpose,
+        createdAtMs: nowMs()
+      })
+      return id
+    },
+    get (id) {
+      return map.get(id) ?? null
+    },
+    list () {
+      return Array.from(map.entries())
+        .map(([id, record]) => ({ id, record }))
+        .sort((a, b) => b.record.createdAtMs - a.record.createdAtMs)
+    },
+    remove (id) {
+      map.delete(id)
+    }
+  }
+}

--- a/packages/cli/src/serve/adapters/openai/index.ts
+++ b/packages/cli/src/serve/adapters/openai/index.ts
@@ -62,6 +62,47 @@ export function createOpenAIAdapter (): APIAdapter {
         return true
       }
 
+      if (method === 'GET' && path === '/v1/vector_stores') {
+        const { handleListVectorStores } = await import('./routes/vector-stores.js')
+        await handleListVectorStores(req, res, ctx)
+        return true
+      }
+
+      if (method === 'POST' && path === '/v1/vector_stores') {
+        const { handleCreateVectorStore } = await import('./routes/vector-stores.js')
+        await handleCreateVectorStore(req, res, ctx)
+        return true
+      }
+
+      const vectorStoreMatch = path.match(/^\/v1\/vector_stores\/([^/]+)(?:\/(search))?$/)
+      if (vectorStoreMatch) {
+        const id = vectorStoreMatch[1] ?? ''
+        const sub = vectorStoreMatch[2]
+        if (sub === 'search') {
+          if (method === 'POST') {
+            const { handleSearchVectorStore } = await import('./routes/vector-stores.js')
+            await handleSearchVectorStore(req, res, ctx, id)
+            return true
+          }
+        } else {
+          if (method === 'GET') {
+            const { handleGetVectorStore } = await import('./routes/vector-stores.js')
+            await handleGetVectorStore(req, res, ctx, id)
+            return true
+          }
+          if (method === 'POST') {
+            const { handleUpdateVectorStore } = await import('./routes/vector-stores.js')
+            await handleUpdateVectorStore(req, res, ctx, id)
+            return true
+          }
+          if (method === 'DELETE') {
+            const { handleDeleteVectorStore } = await import('./routes/vector-stores.js')
+            await handleDeleteVectorStore(req, res, ctx, id)
+            return true
+          }
+        }
+      }
+
       sendError(res, 404, 'not_found', `Unknown endpoint: ${method} ${path}`)
       return true
     }

--- a/packages/cli/src/serve/adapters/openai/index.ts
+++ b/packages/cli/src/serve/adapters/openai/index.ts
@@ -62,6 +62,25 @@ export function createOpenAIAdapter (): APIAdapter {
         return true
       }
 
+      if (method === 'POST' && path === '/v1/files') {
+        const { handlePostFile } = await import('./routes/files.js')
+        await handlePostFile(req, res, ctx)
+        return true
+      }
+
+      if (method === 'GET' && path === '/v1/files') {
+        const { handleListFiles } = await import('./routes/files.js')
+        handleListFiles(req, res, ctx)
+        return true
+      }
+
+      const fileIdMatch = path.match(/^\/v1\/files\/([^/]+)$/)
+      if (fileIdMatch && method === 'GET') {
+        const { handleGetFile } = await import('./routes/files.js')
+        handleGetFile(req, res, ctx, fileIdMatch[1] ?? '')
+        return true
+      }
+
       if (method === 'GET' && path === '/v1/vector_stores') {
         const { handleListVectorStores } = await import('./routes/vector-stores.js')
         await handleListVectorStores(req, res, ctx)
@@ -74,32 +93,42 @@ export function createOpenAIAdapter (): APIAdapter {
         return true
       }
 
-      const vectorStoreMatch = path.match(/^\/v1\/vector_stores\/([^/]+)(?:\/(search))?$/)
-      if (vectorStoreMatch) {
-        const id = vectorStoreMatch[1] ?? ''
-        const sub = vectorStoreMatch[2]
+      const vectorStoreSub = path.match(/^\/v1\/vector_stores\/([^/]+)\/(search|files)$/)
+      if (vectorStoreSub) {
+        const id = vectorStoreSub[1] ?? ''
+        const sub = vectorStoreSub[2]
         if (sub === 'search') {
           if (method === 'POST') {
             const { handleSearchVectorStore } = await import('./routes/vector-stores.js')
             await handleSearchVectorStore(req, res, ctx, id)
             return true
           }
-        } else {
-          if (method === 'GET') {
-            const { handleGetVectorStore } = await import('./routes/vector-stores.js')
-            await handleGetVectorStore(req, res, ctx, id)
-            return true
-          }
+        } else if (sub === 'files') {
           if (method === 'POST') {
-            const { handleUpdateVectorStore } = await import('./routes/vector-stores.js')
-            await handleUpdateVectorStore(req, res, ctx, id)
+            const { handleAttachVectorStoreFile } = await import('./routes/vector-stores.js')
+            await handleAttachVectorStoreFile(req, res, ctx, id)
             return true
           }
-          if (method === 'DELETE') {
-            const { handleDeleteVectorStore } = await import('./routes/vector-stores.js')
-            await handleDeleteVectorStore(req, res, ctx, id)
-            return true
-          }
+        }
+      }
+
+      const vectorStoreIdOnly = path.match(/^\/v1\/vector_stores\/([^/]+)$/)
+      if (vectorStoreIdOnly) {
+        const id = vectorStoreIdOnly[1] ?? ''
+        if (method === 'GET') {
+          const { handleGetVectorStore } = await import('./routes/vector-stores.js')
+          await handleGetVectorStore(req, res, ctx, id)
+          return true
+        }
+        if (method === 'POST') {
+          const { handleUpdateVectorStore } = await import('./routes/vector-stores.js')
+          await handleUpdateVectorStore(req, res, ctx, id)
+          return true
+        }
+        if (method === 'DELETE') {
+          const { handleDeleteVectorStore } = await import('./routes/vector-stores.js')
+          await handleDeleteVectorStore(req, res, ctx, id)
+          return true
         }
       }
 

--- a/packages/cli/src/serve/adapters/openai/routes/files.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/files.ts
@@ -1,0 +1,98 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { sendJson, sendError } from '../../../http.js'
+import { readMultipart } from '../../../multipart.js'
+import type { EphemeralFileRecord } from '../ephemeral-files-store.js'
+import type { RouteContext } from '../../types.js'
+
+function toOpenAIFile (id: string, record: EphemeralFileRecord): Record<string, unknown> {
+  return {
+    object: 'file',
+    id,
+    bytes: record.data.length,
+    created_at: Math.floor(record.createdAtMs / 1000),
+    filename: record.fileName,
+    purpose: record.purpose,
+    status: 'uploaded'
+  }
+}
+
+/**
+ * Minimal OpenAI-style `POST /v1/files`: multipart upload, bytes kept in memory only
+ * until attached to a vector store (then removed). No durable metadata across restarts.
+ */
+export async function handlePostFile (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<void> {
+  const contentType = req.headers['content-type'] ?? ''
+  if (!contentType.includes('multipart/form-data')) {
+    sendError(res, 400, 'invalid_content_type', 'Content-Type must be multipart/form-data.')
+    return
+  }
+
+  let fields: Map<string, string>
+  let file: { fieldName: string; fileName: string; contentType: string; data: Buffer } | null
+
+  try {
+    const result = await readMultipart(req)
+    fields = result.fields
+    file = result.file
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.error(`Multipart parse error (files): ${message}`)
+    sendError(res, 400, 'invalid_multipart', 'Failed to parse multipart request.')
+    return
+  }
+
+  if (!file || file.fieldName !== 'file') {
+    sendError(res, 400, 'missing_file', '"file" field is required.')
+    return
+  }
+
+  const purposeRaw = fields.get('purpose')
+  const purpose = purposeRaw !== undefined && purposeRaw.length > 0 ? purposeRaw : 'assistants'
+
+  const id = ctx.ephemeralFiles.put({
+    data: file.data,
+    fileName: file.fileName.length > 0 ? file.fileName : 'upload.bin',
+    purpose
+  })
+
+  ctx.logger.info(`  files upload id=${id} bytes=${file.data.length} purpose=${purpose}`)
+
+  const rec = ctx.ephemeralFiles.get(id)
+  if (rec === null) {
+    sendError(res, 500, 'internal_error', 'File was uploaded but could not be retrieved.')
+    return
+  }
+  sendJson(res, 200, toOpenAIFile(id, rec))
+}
+
+/**
+ * Minimal `GET /v1/files`: lists currently-in-memory uploaded files.
+ * Files are dropped from the store on `POST /v1/vector_stores/{id}/files`,
+ * so this only shows files that have not been attached yet.
+ */
+export function handleListFiles (_req: IncomingMessage, res: ServerResponse, ctx: RouteContext): void {
+  const entries = ctx.ephemeralFiles.list()
+  sendJson(res, 200, {
+    object: 'list',
+    data: entries.map(({ id, record }) => toOpenAIFile(id, record)),
+    has_more: false
+  })
+}
+
+/**
+ * Minimal `GET /v1/files/{file_id}`: retrieves a single in-memory file's metadata.
+ */
+export function handleGetFile (
+  _req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RouteContext,
+  rawId: string
+): void {
+  const id = decodeURIComponent(rawId)
+  const record = ctx.ephemeralFiles.get(id)
+  if (record === null) {
+    sendError(res, 404, 'file_not_found', `File "${id}" not found.`)
+    return
+  }
+  sendJson(res, 200, toOpenAIFile(id, record))
+}

--- a/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
@@ -332,6 +332,20 @@ export async function handleAttachVectorStoreFile (
     return
   }
 
+  // Buffer#toString('utf8') is lossy: invalid bytes become U+FFFD and most
+  // binaries (PDF / PNG / DOCX) survive .trim() non-empty and would silently
+  // ingest garbage. A null-byte sniff catches every common binary format
+  // before we waste an embed pass on it.
+  if (looksBinary(record.data)) {
+    sendError(
+      res,
+      400,
+      'unsupported_file_type',
+      'File appears to be binary. This minimal ingest path expects UTF-8 text content (e.g. .txt, .md, .json).'
+    )
+    return
+  }
+
   const text = record.data.toString('utf8').trim()
   if (text.length === 0) {
     sendError(
@@ -379,6 +393,17 @@ export async function handleAttachVectorStoreFile (
 }
 
 // ---------- internals ----------
+
+/**
+ * Cheap heuristic: any NUL byte in the first 8 KB is a strong binary signal
+ * (every common text encoding avoids U+0000, and every common binary format
+ * — PDF, PNG, JPEG, GZIP, ZIP, DOCX, etc. — has one within the header).
+ * Exported for unit testing.
+ */
+export function looksBinary (data: Buffer): boolean {
+  const window = data.length > 8192 ? data.subarray(0, 8192) : data
+  return window.includes(0)
+}
 
 interface RagInfo {
   workspaces: Array<{ name: string; open: boolean }>

--- a/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
@@ -3,7 +3,9 @@ import { readBody, sendJson, sendError } from '../../../http.js'
 import {
   sdkRagListWorkspaces,
   sdkRagSearch,
-  sdkRagDeleteWorkspace
+  sdkRagDeleteWorkspace,
+  sdkRagCloseWorkspace,
+  sdkRagIngest
 } from '../../../core/sdk.js'
 import {
   vectorStoreToOpenAI,
@@ -64,7 +66,9 @@ export async function handleCreateVectorStore (
   }
 
   if (Array.isArray(body['file_ids']) && body['file_ids'].length > 0) {
-    ctx.logger.warn('Ignoring "file_ids": files endpoints are not yet supported.')
+    ctx.logger.warn(
+      'Ignoring "file_ids" on create: upload with POST /v1/files, then attach with POST /v1/vector_stores/{id}/files.'
+    )
   }
   if (body['chunking_strategy'] !== undefined) {
     ctx.logger.warn('Ignoring "chunking_strategy": chunking is configured via SDK ingest options.')
@@ -261,18 +265,125 @@ export async function handleSearchVectorStore (
       ...(topK !== undefined ? { topK } : {}),
       workspace: id
     })
+    await closeWorkspaceQuiet(ctx, id, 'search')
     sendJson(res, 200, searchResultsToOpenAI(results, query))
   } catch (err) {
+    await closeWorkspaceQuiet(ctx, id, 'search')
     const message = err instanceof Error ? err.message : String(err)
     ctx.logger.error(`Vector store search error for "${id}": ${message}`)
     sendError(res, 500, 'vector_store_search_failed', 'An internal error occurred during vector store search.')
   }
 }
 
+export async function handleAttachVectorStoreFile (
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RouteContext,
+  rawId: string
+): Promise<void> {
+  const id = decodeId(rawId)
+  if (id === null) {
+    sendError(res, 400, 'invalid_vector_store_id', 'Vector store id is invalid.')
+    return
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await readBody(req)
+  } catch {
+    sendError(res, 400, 'invalid_json', 'Request body must be valid JSON.')
+    return
+  }
+
+  const fileId = body['file_id']
+  if (typeof fileId !== 'string' || fileId.length === 0) {
+    sendError(res, 400, 'missing_file_id', '"file_id" must be a non-empty string.')
+    return
+  }
+
+  const ragInfo = await safeListWorkspaces(ctx)
+  const meta = ctx.vectorStores.get(id) ?? syntheticFromWorkspace(id, ragInfo.workspaces)
+  if (!meta) {
+    sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
+    return
+  }
+
+  const embedding = resolveEmbeddingModel(ctx)
+  if (!embedding.ok) {
+    sendError(res, embedding.status, embedding.code, embedding.message)
+    return
+  }
+
+  const record = ctx.ephemeralFiles.get(fileId)
+  if (record === null) {
+    sendError(
+      res,
+      404,
+      'file_not_found',
+      `File "${fileId}" not found. Upload bytes with POST /v1/files (multipart) first; files are kept in memory only until attached.`
+    )
+    return
+  }
+
+  const text = record.data.toString('utf8').trim()
+  if (text.length === 0) {
+    sendError(
+      res,
+      400,
+      'empty_file',
+      'File has no UTF-8 text after trim. This minimal ingest path expects text-like content (e.g. .txt, .md, .json).'
+    )
+    return
+  }
+
+  ctx.vectorStores.touch(id)
+
+  ctx.logger.info(
+    `  vector_store files attach id=${id} file_id=${fileId} bytes=${record.data.length} embed=${embedding.entry.alias}`
+  )
+
+  try {
+    await sdkRagIngest({
+      modelId: embedding.sdkModelId,
+      documents: text,
+      workspace: id,
+      chunk: true
+    })
+  } catch (err) {
+    await closeWorkspaceQuiet(ctx, id, 'ingest')
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.error(`Vector store ingest error for "${id}": ${message}`)
+    sendError(res, 500, 'vector_store_ingest_failed', 'An internal error occurred while ingesting file content into the vector store.')
+    return
+  }
+
+  await closeWorkspaceQuiet(ctx, id, 'ingest')
+  ctx.ephemeralFiles.remove(fileId)
+
+  sendJson(res, 200, {
+    id: fileId,
+    object: 'vector_store.file',
+    created_at: Math.floor(Date.now() / 1000),
+    vector_store_id: meta.id,
+    status: 'completed',
+    last_error: null,
+    usage_bytes: record.data.length
+  })
+}
+
 // ---------- internals ----------
 
 interface RagInfo {
   workspaces: Array<{ name: string; open: boolean }>
+}
+
+async function closeWorkspaceQuiet (ctx: RouteContext, id: string, op: string): Promise<void> {
+  try {
+    await sdkRagCloseWorkspace({ workspace: id })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.warn(`ragCloseWorkspace after ${op} failed for "${id}": ${message}`)
+  }
 }
 
 async function safeListWorkspaces (ctx: RouteContext): Promise<RagInfo> {

--- a/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
@@ -275,6 +275,18 @@ export async function handleSearchVectorStore (
     return
   }
 
+  if (meta.embeddingAlias !== null && meta.embeddingAlias !== embedding.entry.alias) {
+    sendError(
+      res,
+      400,
+      'embedding_model_mismatch',
+      `Vector store "${id}" was previously ingested with embedding "${meta.embeddingAlias}"; ` +
+      `current request resolves to "${embedding.entry.alias}". Mark "${meta.embeddingAlias}" as the default ` +
+      'embedding under serve.models, or create a new vector store.'
+    )
+    return
+  }
+
   ctx.vectorStores.touch(id)
 
   ctx.logger.info(
@@ -325,15 +337,47 @@ export async function handleAttachVectorStoreFile (
   }
 
   const ragInfo = await safeListWorkspaces(ctx)
-  const meta = ctx.vectorStores.get(id) ?? syntheticFromWorkspace(id, ragInfo.workspaces)
+  let meta = ctx.vectorStores.get(id)
   if (!meta) {
-    sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
-    return
+    const synthetic = syntheticFromWorkspace(id, ragInfo.workspaces)
+    if (!synthetic) {
+      sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
+      return
+    }
+    // Materialize a local meta entry for the disk-only workspace so we can
+    // record the embedding alias. Uses the same race-guarded pattern as
+    // handleUpdateVectorStore.
+    try {
+      meta = ctx.vectorStores.create({ id: synthetic.id, name: synthetic.name })
+    } catch (err) {
+      if (err instanceof InvalidVectorStoreIdError && err.kind === 'duplicate') {
+        const existing = ctx.vectorStores.get(id)
+        if (!existing) {
+          sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
+          return
+        }
+        meta = existing
+      } else {
+        throw err
+      }
+    }
   }
 
   const embedding = resolveEmbeddingModel(ctx)
   if (!embedding.ok) {
     sendError(res, embedding.status, embedding.code, embedding.message)
+    return
+  }
+
+  if (meta.embeddingAlias !== null && meta.embeddingAlias !== embedding.entry.alias) {
+    sendError(
+      res,
+      400,
+      'embedding_model_mismatch',
+      `Vector store "${id}" was previously ingested with embedding "${meta.embeddingAlias}"; ` +
+      `current request resolves to "${embedding.entry.alias}". Mark "${meta.embeddingAlias}" as the default ` +
+      'embedding under serve.models, or create a new vector store.'
+    )
     return
   }
 
@@ -395,6 +439,7 @@ export async function handleAttachVectorStoreFile (
     await closeWorkspaceQuiet(ctx, id, 'ingest')
   }
 
+  ctx.vectorStores.setEmbedding(id, embedding.entry.alias)
   ctx.ephemeralFiles.remove(fileId)
 
   sendJson(res, 200, {
@@ -467,7 +512,8 @@ function syntheticFromWorkspace (
     metadata: {},
     expiresAfter: null,
     expiresAt: null,
-    lastActiveAt: now
+    lastActiveAt: now,
+    embeddingAlias: null
   }
 }
 

--- a/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
@@ -79,7 +79,7 @@ export async function handleCreateVectorStore (
     meta = ctx.vectorStores.create(input)
   } catch (err) {
     if (err instanceof InvalidVectorStoreIdError) {
-      sendError(res, 400, 'invalid_vector_store_id', err.message)
+      handleInputError(res, err)
       return
     }
     throw err
@@ -146,7 +146,23 @@ export async function handleUpdateVectorStore (
       sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
       return
     }
-    meta = ctx.vectorStores.create({ id: synthetic.id, name: synthetic.name })
+    try {
+      meta = ctx.vectorStores.create({ id: synthetic.id, name: synthetic.name })
+    } catch (err) {
+      // Race: a concurrent request materialized the same synthetic between
+      // get() and create() above. Reuse whatever the winner produced.
+      if (err instanceof InvalidVectorStoreIdError && err.kind === 'duplicate') {
+        const existing = ctx.vectorStores.get(id)
+        if (!existing) {
+          // Created-then-deleted within the window — vanishingly unlikely.
+          sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
+          return
+        }
+        meta = existing
+      } else {
+        throw err
+      }
+    }
   }
 
   const updated = ctx.vectorStores.update(meta.id, update)
@@ -272,13 +288,13 @@ export async function handleSearchVectorStore (
       ...(topK !== undefined ? { topK } : {}),
       workspace: id
     })
-    await closeWorkspaceQuiet(ctx, id, 'search')
     sendJson(res, 200, searchResultsToOpenAI(results, query))
   } catch (err) {
-    await closeWorkspaceQuiet(ctx, id, 'search')
     const message = err instanceof Error ? err.message : String(err)
     ctx.logger.error(`Vector store search error for "${id}": ${message}`)
     sendError(res, 500, 'vector_store_search_failed', 'An internal error occurred during vector store search.')
+  } finally {
+    await closeWorkspaceQuiet(ctx, id, 'search')
   }
 }
 
@@ -371,14 +387,14 @@ export async function handleAttachVectorStoreFile (
       chunk: true
     })
   } catch (err) {
-    await closeWorkspaceQuiet(ctx, id, 'ingest')
     const message = err instanceof Error ? err.message : String(err)
     ctx.logger.error(`Vector store ingest error for "${id}": ${message}`)
     sendError(res, 500, 'vector_store_ingest_failed', 'An internal error occurred while ingesting file content into the vector store.')
     return
+  } finally {
+    await closeWorkspaceQuiet(ctx, id, 'ingest')
   }
 
-  await closeWorkspaceQuiet(ctx, id, 'ingest')
   ctx.ephemeralFiles.remove(fileId)
 
   sendJson(res, 200, {
@@ -546,7 +562,11 @@ function handleInputError (res: ServerResponse, err: unknown): void {
     return
   }
   if (err instanceof InvalidVectorStoreIdError) {
-    sendError(res, 400, 'invalid_vector_store_id', err.message)
+    if (err.kind === 'duplicate') {
+      sendError(res, 409, 'vector_store_already_exists', err.message)
+    } else {
+      sendError(res, 400, 'invalid_vector_store_id', err.message)
+    }
     return
   }
   throw err
@@ -566,8 +586,8 @@ interface EmbeddingResolutionErr {
 }
 
 function resolveEmbeddingModel (ctx: RouteContext): EmbeddingResolutionOk | EmbeddingResolutionErr {
-  const entry = pickDefaultEmbedding(ctx.serveConfig)
-  if (!entry) {
+  const picked = pickDefaultEmbedding(ctx.serveConfig)
+  if (picked.kind === 'none') {
     return {
       ok: false,
       status: 400,
@@ -575,6 +595,15 @@ function resolveEmbeddingModel (ctx: RouteContext): EmbeddingResolutionOk | Embe
       message: 'No embedding model configured. Add an embedding model under serve.models, optionally with default: true.'
     }
   }
+  if (picked.kind === 'ambiguous') {
+    return {
+      ok: false,
+      status: 400,
+      code: 'ambiguous_embedding_model',
+      message: `Multiple embedding models configured (${picked.aliases.join(', ')}); none flagged as default. Mark exactly one with default: true.`
+    }
+  }
+  const entry = picked.entry
   const registryEntry = ctx.registry.getEntry(entry.alias)
   if (!registryEntry || registryEntry.state !== ctx.registry.STATES.READY) {
     return {
@@ -588,7 +617,12 @@ function resolveEmbeddingModel (ctx: RouteContext): EmbeddingResolutionOk | Embe
   return { ok: true, entry, sdkModelId }
 }
 
-function pickDefaultEmbedding (serveConfig: ServeConfig): ResolvedModelEntry | null {
+type PickEmbeddingResult =
+  | { kind: 'found'; entry: ResolvedModelEntry }
+  | { kind: 'none' }
+  | { kind: 'ambiguous'; aliases: string[] }
+
+function pickDefaultEmbedding (serveConfig: ServeConfig): PickEmbeddingResult {
   const embeddings: ResolvedModelEntry[] = []
   let explicitDefault: ResolvedModelEntry | null = null
   for (const [, entry] of serveConfig.models) {
@@ -596,7 +630,8 @@ function pickDefaultEmbedding (serveConfig: ServeConfig): ResolvedModelEntry | n
     embeddings.push(entry)
     if (entry.isDefault) explicitDefault = entry
   }
-  if (explicitDefault) return explicitDefault
-  if (embeddings.length === 1) return embeddings[0] ?? null
-  return null
+  if (explicitDefault) return { kind: 'found', entry: explicitDefault }
+  if (embeddings.length === 1) return { kind: 'found', entry: embeddings[0]! }
+  if (embeddings.length === 0) return { kind: 'none' }
+  return { kind: 'ambiguous', aliases: embeddings.map((e) => e.alias) }
 }

--- a/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
@@ -498,21 +498,28 @@ function workspaceInfoFor (
   return found ? { exists: true, open: found.open } : { exists: false }
 }
 
-function syntheticFromWorkspace (
+/**
+ * Stable sentinel for disk-only (workspace-but-no-local-meta) synthetics.
+ * Using 0 keeps GET responses deterministic across reads, sorts these
+ * reconstructed-from-disk entries last in list responses (smallest
+ * createdAt), and honestly signals "timestamp unknown" to OpenAI clients.
+ */
+const SYNTHETIC_TIMESTAMP = 0
+
+export function syntheticFromWorkspace (
   id: string,
   workspaces: Array<{ name: string; open: boolean }>
 ): VectorStoreMeta | null {
   const found = workspaces.find((w) => w.name === id)
   if (!found) return null
-  const now = Date.now()
   return {
     id,
-    createdAt: now,
+    createdAt: SYNTHETIC_TIMESTAMP,
     name: id,
     metadata: {},
     expiresAfter: null,
     expiresAt: null,
-    lastActiveAt: now,
+    lastActiveAt: SYNTHETIC_TIMESTAMP,
     embeddingAlias: null
   }
 }

--- a/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
@@ -212,6 +212,7 @@ export async function handleDeleteVectorStore (
   }
 
   ctx.vectorStores.delete(id)
+  ctx.chunkAttributions.evict(id)
 
   ctx.logger.info(`  vector_store delete id=${id} workspace=${workspaceExists ? 'deleted' : 'noop'}`)
   sendJson(res, 200, {
@@ -300,7 +301,7 @@ export async function handleSearchVectorStore (
       ...(topK !== undefined ? { topK } : {}),
       workspace: id
     })
-    sendJson(res, 200, searchResultsToOpenAI(results, query))
+    sendJson(res, 200, searchResultsToOpenAI(results, query, (chunkId) => ctx.chunkAttributions.lookup(id, chunkId)))
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     ctx.logger.error(`Vector store search error for "${id}": ${message}`)
@@ -423,8 +424,9 @@ export async function handleAttachVectorStoreFile (
     `  vector_store files attach id=${id} file_id=${fileId} bytes=${record.data.length} embed=${embedding.entry.alias}`
   )
 
+  let ingestResult: { processed: unknown[]; droppedIndices: number[] }
   try {
-    await sdkRagIngest({
+    ingestResult = await sdkRagIngest({
       modelId: embedding.sdkModelId,
       documents: text,
       workspace: id,
@@ -440,6 +442,7 @@ export async function handleAttachVectorStoreFile (
   }
 
   ctx.vectorStores.setEmbedding(id, embedding.entry.alias)
+  recordChunkAttributions(ctx, id, fileId, record.fileName, ingestResult.processed)
   ctx.ephemeralFiles.remove(fileId)
 
   sendJson(res, 200, {
@@ -464,6 +467,28 @@ export async function handleAttachVectorStoreFile (
 export function looksBinary (data: Buffer): boolean {
   const window = data.length > 8192 ? data.subarray(0, 8192) : data
   return window.includes(0)
+}
+
+/**
+ * Record per-chunk attribution so subsequent search hits can carry the
+ * uploaded file's `file_id` and `filename` instead of an opaque chunk id.
+ * Defensive against the SDK's `processed[i]` shape — we only treat entries
+ * with `status === 'fulfilled'` and a string `id` as recordable.
+ */
+function recordChunkAttributions (
+  ctx: RouteContext,
+  vectorStoreId: string,
+  fileId: string,
+  fileName: string,
+  processed: unknown[]
+): void {
+  for (const entry of processed) {
+    if (typeof entry !== 'object' || entry === null) continue
+    const e = entry as { status?: unknown, id?: unknown }
+    if (e.status !== 'fulfilled') continue
+    if (typeof e.id !== 'string') continue
+    ctx.chunkAttributions.record(vectorStoreId, e.id, { fileId, fileName })
+  }
 }
 
 interface RagInfo {

--- a/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
@@ -171,7 +171,7 @@ export async function handleDeleteVectorStore (
   }
 
   const ragInfo = await safeListWorkspaces(ctx)
-  const hadMeta = ctx.vectorStores.delete(id)
+  const hadMeta = ctx.vectorStores.get(id) !== null
   const workspaceExists = ragInfo.workspaces.some((w) => w.name === id)
 
   if (!hadMeta && !workspaceExists) {
@@ -179,6 +179,11 @@ export async function handleDeleteVectorStore (
     return
   }
 
+  // RAG first: if it throws, both the workspace and the local meta stay
+  // intact so a retry sees the same state. If we deleted the local meta
+  // up-front, a partial failure would lose caller-supplied fields
+  // (name, expires_after, metadata) permanently — the synthetic-from-
+  // workspace fallback in GET only recovers id and an empty record.
   if (workspaceExists) {
     try {
       await sdkRagDeleteWorkspace({ workspace: id })
@@ -189,6 +194,8 @@ export async function handleDeleteVectorStore (
       return
     }
   }
+
+  ctx.vectorStores.delete(id)
 
   ctx.logger.info(`  vector_store delete id=${id} workspace=${workspaceExists ? 'deleted' : 'noop'}`)
   sendJson(res, 200, {

--- a/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/vector-stores.ts
@@ -1,0 +1,459 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readBody, sendJson, sendError } from '../../../http.js'
+import {
+  sdkRagListWorkspaces,
+  sdkRagSearch,
+  sdkRagDeleteWorkspace
+} from '../../../core/sdk.js'
+import {
+  vectorStoreToOpenAI,
+  searchResultsToOpenAI,
+  parseExpiresAfter,
+  parseMetadata,
+  InvalidExpiresAfterError,
+  InvalidMetadataError,
+  type VectorStoreRagInfo
+} from '../translate.js'
+import {
+  idToWorkspace,
+  InvalidVectorStoreIdError,
+  type CreateVectorStoreInput,
+  type UpdateVectorStoreInput,
+  type VectorStoreMeta
+} from '../vector-stores-store.js'
+import type { ResolvedModelEntry, ServeConfig } from '../../../core/model-registry.js'
+import type { RouteContext } from '../../types.js'
+
+export async function handleListVectorStores (
+  _req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RouteContext
+): Promise<void> {
+  const ragInfo = await safeListWorkspaces(ctx)
+  const local = ctx.vectorStores.list()
+  const merged = mergeStoresAndWorkspaces(local, ragInfo.workspaces)
+
+  sendJson(res, 200, {
+    object: 'list',
+    data: merged.map((entry) => vectorStoreToOpenAI(entry.meta, entry.ragInfo)),
+    first_id: merged[0]?.meta.id ?? null,
+    last_id: merged[merged.length - 1]?.meta.id ?? null,
+    has_more: false
+  })
+}
+
+export async function handleCreateVectorStore (
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RouteContext
+): Promise<void> {
+  let body: Record<string, unknown>
+  try {
+    body = await readBody(req)
+  } catch {
+    sendError(res, 400, 'invalid_json', 'Request body must be valid JSON.')
+    return
+  }
+
+  let input: CreateVectorStoreInput
+  try {
+    input = parseCreateInput(body)
+  } catch (err) {
+    handleInputError(res, err)
+    return
+  }
+
+  if (Array.isArray(body['file_ids']) && body['file_ids'].length > 0) {
+    ctx.logger.warn('Ignoring "file_ids": files endpoints are not yet supported.')
+  }
+  if (body['chunking_strategy'] !== undefined) {
+    ctx.logger.warn('Ignoring "chunking_strategy": chunking is configured via SDK ingest options.')
+  }
+
+  let meta: VectorStoreMeta
+  try {
+    meta = ctx.vectorStores.create(input)
+  } catch (err) {
+    if (err instanceof InvalidVectorStoreIdError) {
+      sendError(res, 400, 'invalid_vector_store_id', err.message)
+      return
+    }
+    throw err
+  }
+
+  ctx.logger.info(`  vector_store create id=${meta.id} name=${meta.name ?? '(none)'}`)
+  sendJson(res, 200, vectorStoreToOpenAI(meta, { exists: false }))
+}
+
+export async function handleGetVectorStore (
+  _req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RouteContext,
+  rawId: string
+): Promise<void> {
+  const id = decodeId(rawId)
+  if (id === null) {
+    sendError(res, 400, 'invalid_vector_store_id', 'Vector store id is invalid.')
+    return
+  }
+
+  const ragInfo = await safeListWorkspaces(ctx)
+  const meta = ctx.vectorStores.get(id) ?? syntheticFromWorkspace(id, ragInfo.workspaces)
+  if (!meta) {
+    sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
+    return
+  }
+  sendJson(res, 200, vectorStoreToOpenAI(meta, workspaceInfoFor(id, ragInfo.workspaces)))
+}
+
+export async function handleUpdateVectorStore (
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RouteContext,
+  rawId: string
+): Promise<void> {
+  const id = decodeId(rawId)
+  if (id === null) {
+    sendError(res, 400, 'invalid_vector_store_id', 'Vector store id is invalid.')
+    return
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await readBody(req)
+  } catch {
+    sendError(res, 400, 'invalid_json', 'Request body must be valid JSON.')
+    return
+  }
+
+  let update: UpdateVectorStoreInput
+  try {
+    update = parseUpdateInput(body)
+  } catch (err) {
+    handleInputError(res, err)
+    return
+  }
+
+  const ragInfo = await safeListWorkspaces(ctx)
+  let meta = ctx.vectorStores.get(id)
+  if (!meta) {
+    const synthetic = syntheticFromWorkspace(id, ragInfo.workspaces)
+    if (!synthetic) {
+      sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
+      return
+    }
+    meta = ctx.vectorStores.create({ id: synthetic.id, name: synthetic.name })
+  }
+
+  const updated = ctx.vectorStores.update(meta.id, update)
+  if (!updated) {
+    sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
+    return
+  }
+  ctx.logger.info(`  vector_store update id=${updated.id}`)
+  sendJson(res, 200, vectorStoreToOpenAI(updated, workspaceInfoFor(id, ragInfo.workspaces)))
+}
+
+export async function handleDeleteVectorStore (
+  _req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RouteContext,
+  rawId: string
+): Promise<void> {
+  const id = decodeId(rawId)
+  if (id === null) {
+    sendError(res, 400, 'invalid_vector_store_id', 'Vector store id is invalid.')
+    return
+  }
+
+  const ragInfo = await safeListWorkspaces(ctx)
+  const hadMeta = ctx.vectorStores.delete(id)
+  const workspaceExists = ragInfo.workspaces.some((w) => w.name === id)
+
+  if (!hadMeta && !workspaceExists) {
+    sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
+    return
+  }
+
+  if (workspaceExists) {
+    try {
+      await sdkRagDeleteWorkspace({ workspace: id })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      ctx.logger.error(`Failed to delete RAG workspace "${id}": ${message}`)
+      sendError(res, 500, 'vector_store_delete_failed', 'Failed to delete underlying RAG workspace.')
+      return
+    }
+  }
+
+  ctx.logger.info(`  vector_store delete id=${id} workspace=${workspaceExists ? 'deleted' : 'noop'}`)
+  sendJson(res, 200, {
+    id,
+    object: 'vector_store.deleted',
+    deleted: true
+  })
+}
+
+export async function handleSearchVectorStore (
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RouteContext,
+  rawId: string
+): Promise<void> {
+  const id = decodeId(rawId)
+  if (id === null) {
+    sendError(res, 400, 'invalid_vector_store_id', 'Vector store id is invalid.')
+    return
+  }
+
+  let body: Record<string, unknown>
+  try {
+    body = await readBody(req)
+  } catch {
+    sendError(res, 400, 'invalid_json', 'Request body must be valid JSON.')
+    return
+  }
+
+  const query = body['query']
+  if (typeof query !== 'string' || query.length === 0) {
+    sendError(res, 400, 'missing_query', '"query" must be a non-empty string.')
+    return
+  }
+
+  for (const param of ['filters', 'ranking_options', 'rewrite_query'] as const) {
+    if (body[param] !== undefined) {
+      ctx.logger.warn(`Ignoring unsupported vector_store search param: ${param}`)
+    }
+  }
+
+  const maxNumResults = body['max_num_results']
+  let topK: number | undefined
+  if (typeof maxNumResults === 'number' && Number.isInteger(maxNumResults) && maxNumResults > 0) {
+    topK = maxNumResults
+  } else if (maxNumResults !== undefined) {
+    sendError(res, 400, 'invalid_max_num_results', '"max_num_results" must be a positive integer.')
+    return
+  }
+
+  const ragInfo = await safeListWorkspaces(ctx)
+  const meta = ctx.vectorStores.get(id) ?? syntheticFromWorkspace(id, ragInfo.workspaces)
+  if (!meta) {
+    sendError(res, 404, 'vector_store_not_found', `Vector store "${id}" not found.`)
+    return
+  }
+
+  const embedding = resolveEmbeddingModel(ctx)
+  if (!embedding.ok) {
+    sendError(res, embedding.status, embedding.code, embedding.message)
+    return
+  }
+
+  ctx.vectorStores.touch(id)
+
+  ctx.logger.info(
+    `  vector_store search id=${id} model=${embedding.entry.alias} q.len=${query.length}${topK ? ` topK=${topK}` : ''}`
+  )
+
+  try {
+    const results = await sdkRagSearch({
+      modelId: embedding.sdkModelId,
+      query,
+      ...(topK !== undefined ? { topK } : {}),
+      workspace: id
+    })
+    sendJson(res, 200, searchResultsToOpenAI(results, query))
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.error(`Vector store search error for "${id}": ${message}`)
+    sendError(res, 500, 'vector_store_search_failed', 'An internal error occurred during vector store search.')
+  }
+}
+
+// ---------- internals ----------
+
+interface RagInfo {
+  workspaces: Array<{ name: string; open: boolean }>
+}
+
+async function safeListWorkspaces (ctx: RouteContext): Promise<RagInfo> {
+  try {
+    const workspaces = await sdkRagListWorkspaces()
+    return { workspaces }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.warn(`ragListWorkspaces failed; assuming none: ${message}`)
+    return { workspaces: [] }
+  }
+}
+
+function workspaceInfoFor (
+  id: string,
+  workspaces: Array<{ name: string; open: boolean }>
+): VectorStoreRagInfo {
+  const found = workspaces.find((w) => w.name === id)
+  return found ? { exists: true, open: found.open } : { exists: false }
+}
+
+function syntheticFromWorkspace (
+  id: string,
+  workspaces: Array<{ name: string; open: boolean }>
+): VectorStoreMeta | null {
+  const found = workspaces.find((w) => w.name === id)
+  if (!found) return null
+  const now = Date.now()
+  return {
+    id,
+    createdAt: now,
+    name: id,
+    metadata: {},
+    expiresAfter: null,
+    expiresAt: null,
+    lastActiveAt: now
+  }
+}
+
+interface MergedEntry {
+  meta: VectorStoreMeta
+  ragInfo: VectorStoreRagInfo
+}
+
+function mergeStoresAndWorkspaces (
+  local: VectorStoreMeta[],
+  workspaces: Array<{ name: string; open: boolean }>
+): MergedEntry[] {
+  const seen = new Set<string>()
+  const merged: MergedEntry[] = []
+  for (const meta of local) {
+    seen.add(meta.id)
+    merged.push({ meta, ragInfo: workspaceInfoFor(meta.id, workspaces) })
+  }
+  for (const ws of workspaces) {
+    if (seen.has(ws.name)) continue
+    const synthetic = syntheticFromWorkspace(ws.name, workspaces)
+    if (synthetic) {
+      merged.push({ meta: synthetic, ragInfo: { exists: true, open: ws.open } })
+    }
+  }
+  merged.sort((a, b) => b.meta.createdAt - a.meta.createdAt)
+  return merged
+}
+
+function decodeId (raw: string): string | null {
+  try {
+    const decoded = decodeURIComponent(raw)
+    return idToWorkspace(decoded)
+  } catch {
+    return null
+  }
+}
+
+function parseCreateInput (body: Record<string, unknown>): CreateVectorStoreInput {
+  const input: CreateVectorStoreInput = {}
+  if (body['name'] !== undefined && body['name'] !== null) {
+    if (typeof body['name'] !== 'string') {
+      throw new InvalidMetadataError('"name" must be a string.')
+    }
+    input.name = body['name']
+  } else if (body['name'] === null) {
+    input.name = null
+  }
+
+  const expires = parseExpiresAfter(body['expires_after'])
+  if (expires !== undefined) input.expiresAfter = expires
+
+  const metadata = parseMetadata(body['metadata'])
+  if (metadata !== undefined) input.metadata = metadata ?? {}
+
+  return input
+}
+
+function parseUpdateInput (body: Record<string, unknown>): UpdateVectorStoreInput {
+  const update: UpdateVectorStoreInput = {}
+  if (Object.prototype.hasOwnProperty.call(body, 'name')) {
+    const name = body['name']
+    if (name === null) {
+      update.name = null
+    } else if (typeof name === 'string') {
+      update.name = name
+    } else {
+      throw new InvalidMetadataError('"name" must be a string or null.')
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'expires_after')) {
+    const expires = parseExpiresAfter(body['expires_after'])
+    if (expires !== undefined) update.expiresAfter = expires
+  }
+
+  if (Object.prototype.hasOwnProperty.call(body, 'metadata')) {
+    const metadata = parseMetadata(body['metadata'])
+    if (metadata !== undefined) update.metadata = metadata
+  }
+
+  return update
+}
+
+function handleInputError (res: ServerResponse, err: unknown): void {
+  if (err instanceof InvalidExpiresAfterError) {
+    sendError(res, 400, 'invalid_expires_after', err.message)
+    return
+  }
+  if (err instanceof InvalidMetadataError) {
+    sendError(res, 400, 'invalid_metadata', err.message)
+    return
+  }
+  if (err instanceof InvalidVectorStoreIdError) {
+    sendError(res, 400, 'invalid_vector_store_id', err.message)
+    return
+  }
+  throw err
+}
+
+interface EmbeddingResolutionOk {
+  ok: true
+  entry: ResolvedModelEntry
+  sdkModelId: string
+}
+
+interface EmbeddingResolutionErr {
+  ok: false
+  status: number
+  code: string
+  message: string
+}
+
+function resolveEmbeddingModel (ctx: RouteContext): EmbeddingResolutionOk | EmbeddingResolutionErr {
+  const entry = pickDefaultEmbedding(ctx.serveConfig)
+  if (!entry) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'no_embedding_model_configured',
+      message: 'No embedding model configured. Add an embedding model under serve.models, optionally with default: true.'
+    }
+  }
+  const registryEntry = ctx.registry.getEntry(entry.alias)
+  if (!registryEntry || registryEntry.state !== ctx.registry.STATES.READY) {
+    return {
+      ok: false,
+      status: 503,
+      code: 'model_not_ready',
+      message: `Embedding model "${entry.alias}" is not loaded yet.`
+    }
+  }
+  const sdkModelId = registryEntry.sdkModelId ?? registryEntry.id
+  return { ok: true, entry, sdkModelId }
+}
+
+function pickDefaultEmbedding (serveConfig: ServeConfig): ResolvedModelEntry | null {
+  const embeddings: ResolvedModelEntry[] = []
+  let explicitDefault: ResolvedModelEntry | null = null
+  for (const [, entry] of serveConfig.models) {
+    if (entry.endpointCategory !== 'embedding') continue
+    embeddings.push(entry)
+    if (entry.isDefault) explicitDefault = entry
+  }
+  if (explicitDefault) return explicitDefault
+  if (embeddings.length === 1) return embeddings[0] ?? null
+  return null
+}

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -432,20 +432,31 @@ export interface RagSearchResultLike {
   score: number
 }
 
+/**
+ * Optional lookup from RAG chunk id back to the original upload's identity.
+ * When unknown (eg. pre-restart chunks, disk-only workspaces), the caller
+ * falls back to the chunk id, matching today's behavior.
+ */
+export type ChunkAttributionLookup = (chunkId: string) => { fileId: string; fileName: string } | null
+
 export function searchResultsToOpenAI (
   results: RagSearchResultLike[],
-  query: string
+  query: string,
+  lookup?: ChunkAttributionLookup
 ): OpenAISearchResultsPage {
   return {
     object: 'vector_store.search_results.page',
     search_query: query,
-    data: results.map((r) => ({
-      file_id: r.id,
-      filename: r.id,
-      score: r.score,
-      attributes: {},
-      content: [{ type: 'text', text: r.content }]
-    })),
+    data: results.map((r) => {
+      const attribution = lookup ? lookup(r.id) : null
+      return {
+        file_id: attribution?.fileId ?? r.id,
+        filename: attribution?.fileName ?? r.id,
+        score: r.score,
+        attributes: {},
+        content: [{ type: 'text', text: r.content }]
+      }
+    }),
     has_more: false,
     next_page: null
   }

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '../../../logger.js'
 import type { SDKTool, SDKToolCall, SDKGenerationParams, SDKResponseFormat, SDKDiffusionParams } from '../../core/sdk.js'
+import type { VectorStoreExpiresAfter, VectorStoreMeta } from './vector-stores-store.js'
 
 interface OpenAIMessage {
   role: string
@@ -353,4 +354,163 @@ export function logImageUnsupportedParams (body: Record<string, unknown>, logger
 export function encodeImageDataUrl (buf: Uint8Array, mime: string = 'image/png'): string {
   const base64 = Buffer.from(buf).toString('base64')
   return `data:${mime};base64,${base64}`
+}
+
+// ============== Vector Stores ==============
+
+interface OpenAIVectorStoreObject {
+  id: string
+  object: 'vector_store'
+  created_at: number
+  name: string | null
+  usage_bytes: number
+  file_counts: {
+    in_progress: number
+    completed: number
+    failed: number
+    cancelled: number
+    total: number
+  }
+  status: 'completed' | 'in_progress' | 'expired'
+  expires_after: VectorStoreExpiresAfter | null
+  expires_at: number | null
+  last_active_at: number
+  metadata: Record<string, string>
+}
+
+export interface VectorStoreRagInfo {
+  exists: boolean
+  open?: boolean
+}
+
+export function vectorStoreToOpenAI (
+  meta: VectorStoreMeta,
+  ragInfo?: VectorStoreRagInfo
+): OpenAIVectorStoreObject {
+  const exists = ragInfo?.exists === true
+  const status: 'completed' | 'in_progress' = exists ? 'completed' : 'in_progress'
+  return {
+    id: meta.id,
+    object: 'vector_store',
+    created_at: Math.floor(meta.createdAt / 1000),
+    name: meta.name,
+    usage_bytes: 0,
+    file_counts: {
+      in_progress: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+      total: 0
+    },
+    status,
+    expires_after: meta.expiresAfter,
+    expires_at: meta.expiresAt === null ? null : Math.floor(meta.expiresAt / 1000),
+    last_active_at: Math.floor(meta.lastActiveAt / 1000),
+    metadata: { ...meta.metadata }
+  }
+}
+
+interface OpenAISearchResultItem {
+  file_id: string
+  filename: string
+  score: number
+  attributes: Record<string, string>
+  content: Array<{ type: 'text'; text: string }>
+}
+
+interface OpenAISearchResultsPage {
+  object: 'vector_store.search_results.page'
+  search_query: string
+  data: OpenAISearchResultItem[]
+  has_more: false
+  next_page: null
+}
+
+export interface RagSearchResultLike {
+  id: string
+  content: string
+  score: number
+}
+
+export function searchResultsToOpenAI (
+  results: RagSearchResultLike[],
+  query: string
+): OpenAISearchResultsPage {
+  return {
+    object: 'vector_store.search_results.page',
+    search_query: query,
+    data: results.map((r) => ({
+      file_id: r.id,
+      filename: r.id,
+      score: r.score,
+      attributes: {},
+      content: [{ type: 'text', text: r.content }]
+    })),
+    has_more: false,
+    next_page: null
+  }
+}
+
+export class InvalidExpiresAfterError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'InvalidExpiresAfterError'
+  }
+}
+
+export function parseExpiresAfter (raw: unknown): VectorStoreExpiresAfter | null | undefined {
+  if (raw === undefined) return undefined
+  if (raw === null) return null
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new InvalidExpiresAfterError('"expires_after" must be an object.')
+  }
+  const obj = raw as Record<string, unknown>
+  const anchor = obj['anchor']
+  if (anchor !== 'last_active_at') {
+    throw new InvalidExpiresAfterError('"expires_after.anchor" must be "last_active_at".')
+  }
+  const days = obj['days']
+  if (typeof days !== 'number' || !Number.isFinite(days) || days <= 0 || !Number.isInteger(days)) {
+    throw new InvalidExpiresAfterError('"expires_after.days" must be a positive integer.')
+  }
+  return { anchor: 'last_active_at', days }
+}
+
+export class InvalidMetadataError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'InvalidMetadataError'
+  }
+}
+
+const MAX_METADATA_KEYS = 16
+const MAX_METADATA_KEY_LENGTH = 64
+const MAX_METADATA_VALUE_LENGTH = 512
+
+export function parseMetadata (raw: unknown): Record<string, string> | null | undefined {
+  if (raw === undefined) return undefined
+  if (raw === null) return null
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new InvalidMetadataError('"metadata" must be an object of string values.')
+  }
+  const obj = raw as Record<string, unknown>
+  const keys = Object.keys(obj)
+  if (keys.length > MAX_METADATA_KEYS) {
+    throw new InvalidMetadataError(`"metadata" has more than ${MAX_METADATA_KEYS} keys.`)
+  }
+  const out: Record<string, string> = {}
+  for (const key of keys) {
+    if (key.length > MAX_METADATA_KEY_LENGTH) {
+      throw new InvalidMetadataError(`"metadata" key "${key}" exceeds ${MAX_METADATA_KEY_LENGTH} characters.`)
+    }
+    const value = obj[key]
+    if (typeof value !== 'string') {
+      throw new InvalidMetadataError(`"metadata.${key}" must be a string.`)
+    }
+    if (value.length > MAX_METADATA_VALUE_LENGTH) {
+      throw new InvalidMetadataError(`"metadata.${key}" exceeds ${MAX_METADATA_VALUE_LENGTH} characters.`)
+    }
+    out[key] = value
+  }
+  return out
 }

--- a/packages/cli/src/serve/adapters/openai/vector-stores-store.ts
+++ b/packages/cli/src/serve/adapters/openai/vector-stores-store.ts
@@ -1,0 +1,173 @@
+import { randomBytes } from 'node:crypto'
+
+export interface VectorStoreExpiresAfter {
+  anchor: 'last_active_at'
+  days: number
+}
+
+export interface VectorStoreMeta {
+  id: string
+  createdAt: number
+  name: string | null
+  metadata: Record<string, string>
+  expiresAfter: VectorStoreExpiresAfter | null
+  expiresAt: number | null
+  lastActiveAt: number
+}
+
+export interface CreateVectorStoreInput {
+  id?: string
+  name?: string | null
+  metadata?: Record<string, string>
+  expiresAfter?: VectorStoreExpiresAfter | null
+}
+
+export interface UpdateVectorStoreInput {
+  name?: string | null
+  metadata?: Record<string, string> | null
+  expiresAfter?: VectorStoreExpiresAfter | null
+}
+
+export interface VectorStoresStore {
+  create: (input?: CreateVectorStoreInput) => VectorStoreMeta
+  get: (id: string) => VectorStoreMeta | null
+  update: (id: string, input: UpdateVectorStoreInput) => VectorStoreMeta | null
+  delete: (id: string) => boolean
+  list: () => VectorStoreMeta[]
+  touch: (id: string) => void
+}
+
+const ID_PREFIX = 'vs_'
+const ID_RANDOM_BYTES = 12
+const MAX_ID_LENGTH = 64
+const SAFE_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/
+const TRAVERSAL_PATTERNS = ['..', '/', '\\', '\0']
+
+export class InvalidVectorStoreIdError extends Error {
+  constructor (id: string, reason: string) {
+    super(`Invalid vector store id "${id}": ${reason}`)
+    this.name = 'InvalidVectorStoreIdError'
+  }
+}
+
+export function generateVectorStoreId (): string {
+  return ID_PREFIX + randomBytes(ID_RANDOM_BYTES).toString('hex')
+}
+
+export function idToWorkspace (id: string): string {
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new InvalidVectorStoreIdError(String(id), 'must be a non-empty string')
+  }
+  if (id.length > MAX_ID_LENGTH) {
+    throw new InvalidVectorStoreIdError(id, `must be at most ${MAX_ID_LENGTH} characters`)
+  }
+  for (const bad of TRAVERSAL_PATTERNS) {
+    if (id.includes(bad)) {
+      throw new InvalidVectorStoreIdError(id, `must not contain "${bad}"`)
+    }
+  }
+  if (!SAFE_ID_PATTERN.test(id)) {
+    throw new InvalidVectorStoreIdError(
+      id,
+      'must match [a-zA-Z0-9_-]{1,64}'
+    )
+  }
+  return id
+}
+
+function clone (meta: VectorStoreMeta): VectorStoreMeta {
+  return {
+    id: meta.id,
+    createdAt: meta.createdAt,
+    name: meta.name,
+    metadata: { ...meta.metadata },
+    expiresAfter: meta.expiresAfter ? { ...meta.expiresAfter } : null,
+    expiresAt: meta.expiresAt,
+    lastActiveAt: meta.lastActiveAt
+  }
+}
+
+function computeExpiresAt (
+  baseMs: number,
+  expiresAfter: VectorStoreExpiresAfter | null
+): number | null {
+  if (!expiresAfter) return null
+  const days = expiresAfter.days
+  if (!Number.isFinite(days) || days <= 0) return null
+  return baseMs + Math.floor(days * 24 * 60 * 60 * 1000)
+}
+
+export function createVectorStoresStore (
+  now: () => number = Date.now
+): VectorStoresStore {
+  const stores = new Map<string, VectorStoreMeta>()
+
+  function create (input: CreateVectorStoreInput = {}): VectorStoreMeta {
+    const id = input.id !== undefined ? idToWorkspace(input.id) : generateVectorStoreId()
+    if (stores.has(id)) {
+      throw new InvalidVectorStoreIdError(id, 'already exists')
+    }
+    const created = now()
+    const expiresAfter = input.expiresAfter ?? null
+    const meta: VectorStoreMeta = {
+      id,
+      createdAt: created,
+      name: input.name ?? null,
+      metadata: { ...(input.metadata ?? {}) },
+      expiresAfter,
+      expiresAt: computeExpiresAt(created, expiresAfter),
+      lastActiveAt: created
+    }
+    stores.set(id, meta)
+    return clone(meta)
+  }
+
+  function get (id: string): VectorStoreMeta | null {
+    const meta = stores.get(id)
+    return meta ? clone(meta) : null
+  }
+
+  function update (id: string, input: UpdateVectorStoreInput): VectorStoreMeta | null {
+    const meta = stores.get(id)
+    if (!meta) return null
+    if (input.name !== undefined) {
+      meta.name = input.name
+    }
+    if (input.metadata !== undefined) {
+      meta.metadata = input.metadata === null ? {} : { ...input.metadata }
+    }
+    if (input.expiresAfter !== undefined) {
+      meta.expiresAfter = input.expiresAfter
+      meta.expiresAt = computeExpiresAt(meta.lastActiveAt, input.expiresAfter)
+    }
+    return clone(meta)
+  }
+
+  function deleteStore (id: string): boolean {
+    return stores.delete(id)
+  }
+
+  function list (): VectorStoreMeta[] {
+    return Array.from(stores.values())
+      .map(clone)
+      .sort((a, b) => b.createdAt - a.createdAt)
+  }
+
+  function touch (id: string): void {
+    const meta = stores.get(id)
+    if (!meta) return
+    meta.lastActiveAt = now()
+    if (meta.expiresAfter) {
+      meta.expiresAt = computeExpiresAt(meta.lastActiveAt, meta.expiresAfter)
+    }
+  }
+
+  return {
+    create,
+    get,
+    update,
+    delete: deleteStore,
+    list,
+    touch
+  }
+}

--- a/packages/cli/src/serve/adapters/openai/vector-stores-store.ts
+++ b/packages/cli/src/serve/adapters/openai/vector-stores-store.ts
@@ -13,6 +13,12 @@ export interface VectorStoreMeta {
   expiresAfter: VectorStoreExpiresAfter | null
   expiresAt: number | null
   lastActiveAt: number
+  /**
+   * Embedding alias the store was first ingested with. Null until the first
+   * successful attach records it. Used to reject silent-mismatch searches
+   * if the operator swaps the default embedding mid-flight.
+   */
+  embeddingAlias: string | null
 }
 
 export interface CreateVectorStoreInput {
@@ -35,6 +41,11 @@ export interface VectorStoresStore {
   delete: (id: string) => boolean
   list: () => VectorStoreMeta[]
   touch: (id: string) => void
+  /**
+   * Record the embedding alias used at first attach. No-op if id is unknown
+   * or if an alias is already recorded (idempotent: never overwrites).
+   */
+  setEmbedding: (id: string, alias: string) => void
 }
 
 const ID_PREFIX = 'vs_'
@@ -87,7 +98,8 @@ function clone (meta: VectorStoreMeta): VectorStoreMeta {
     metadata: { ...meta.metadata },
     expiresAfter: meta.expiresAfter ? { ...meta.expiresAfter } : null,
     expiresAt: meta.expiresAt,
-    lastActiveAt: meta.lastActiveAt
+    lastActiveAt: meta.lastActiveAt,
+    embeddingAlias: meta.embeddingAlias
   }
 }
 
@@ -120,7 +132,8 @@ export function createVectorStoresStore (
       metadata: { ...(input.metadata ?? {}) },
       expiresAfter,
       expiresAt: computeExpiresAt(created, expiresAfter),
-      lastActiveAt: created
+      lastActiveAt: created,
+      embeddingAlias: null
     }
     stores.set(id, meta)
     return clone(meta)
@@ -166,12 +179,20 @@ export function createVectorStoresStore (
     }
   }
 
+  function setEmbedding (id: string, alias: string): void {
+    const meta = stores.get(id)
+    if (!meta) return
+    if (meta.embeddingAlias !== null) return
+    meta.embeddingAlias = alias
+  }
+
   return {
     create,
     get,
     update,
     delete: deleteStore,
     list,
-    touch
+    touch,
+    setEmbedding
   }
 }

--- a/packages/cli/src/serve/adapters/openai/vector-stores-store.ts
+++ b/packages/cli/src/serve/adapters/openai/vector-stores-store.ts
@@ -43,10 +43,14 @@ const MAX_ID_LENGTH = 64
 const SAFE_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/
 const TRAVERSAL_PATTERNS = ['..', '/', '\\', '\0']
 
+export type InvalidVectorStoreIdKind = 'invalid' | 'duplicate'
+
 export class InvalidVectorStoreIdError extends Error {
-  constructor (id: string, reason: string) {
+  readonly kind: InvalidVectorStoreIdKind
+  constructor (id: string, reason: string, kind: InvalidVectorStoreIdKind = 'invalid') {
     super(`Invalid vector store id "${id}": ${reason}`)
     this.name = 'InvalidVectorStoreIdError'
+    this.kind = kind
   }
 }
 
@@ -105,7 +109,7 @@ export function createVectorStoresStore (
   function create (input: CreateVectorStoreInput = {}): VectorStoreMeta {
     const id = input.id !== undefined ? idToWorkspace(input.id) : generateVectorStoreId()
     if (stores.has(id)) {
-      throw new InvalidVectorStoreIdError(id, 'already exists')
+      throw new InvalidVectorStoreIdError(id, 'already exists', 'duplicate')
     }
     const created = now()
     const expiresAfter = input.expiresAfter ?? null

--- a/packages/cli/src/serve/adapters/types.ts
+++ b/packages/cli/src/serve/adapters/types.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { ModelRegistry, ServeConfig } from '../core/model-registry.js'
 import type { Logger } from '../../logger.js'
+import type { EphemeralFilesStore } from './openai/ephemeral-files-store.js'
 import type { VectorStoresStore } from './openai/vector-stores-store.js'
 
 export interface RouteContext {
@@ -8,6 +9,7 @@ export interface RouteContext {
   serveConfig: ServeConfig
   logger: Logger
   vectorStores: VectorStoresStore
+  ephemeralFiles: EphemeralFilesStore
   /** @internal Unit tests only — replaces sdkTranscribe when set */
   transcribeOverride?: (opts: {
     modelId: string

--- a/packages/cli/src/serve/adapters/types.ts
+++ b/packages/cli/src/serve/adapters/types.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { ModelRegistry, ServeConfig } from '../core/model-registry.js'
 import type { Logger } from '../../logger.js'
+import type { ChunkAttributionStore } from './openai/chunk-attribution-store.js'
 import type { EphemeralFilesStore } from './openai/ephemeral-files-store.js'
 import type { VectorStoresStore } from './openai/vector-stores-store.js'
 
@@ -10,6 +11,7 @@ export interface RouteContext {
   logger: Logger
   vectorStores: VectorStoresStore
   ephemeralFiles: EphemeralFilesStore
+  chunkAttributions: ChunkAttributionStore
   /** @internal Unit tests only — replaces sdkTranscribe when set */
   transcribeOverride?: (opts: {
     modelId: string

--- a/packages/cli/src/serve/adapters/types.ts
+++ b/packages/cli/src/serve/adapters/types.ts
@@ -1,11 +1,13 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { ModelRegistry, ServeConfig } from '../core/model-registry.js'
 import type { Logger } from '../../logger.js'
+import type { VectorStoresStore } from './openai/vector-stores-store.js'
 
 export interface RouteContext {
   registry: ModelRegistry
   serveConfig: ServeConfig
   logger: Logger
+  vectorStores: VectorStoresStore
   /** @internal Unit tests only — replaces sdkTranscribe when set */
   transcribeOverride?: (opts: {
     modelId: string

--- a/packages/cli/src/serve/core/sdk.ts
+++ b/packages/cli/src/serve/core/sdk.ts
@@ -62,6 +62,12 @@ interface SDKModule {
   }) => Promise<RagSearchResult[]>
   ragDeleteWorkspace: (opts: { workspace: string }) => Promise<void>
   ragCloseWorkspace: (opts: { workspace?: string; deleteOnClose?: boolean }) => Promise<void>
+  ragIngest: (opts: {
+    modelId: string
+    documents: string | string[]
+    workspace?: string
+    chunk?: boolean
+  }) => Promise<{ processed: unknown[]; droppedIndices: number[] }>
   close: () => Promise<void>
   [key: string]: unknown
 }
@@ -340,6 +346,22 @@ export async function sdkRagCloseWorkspace (opts: {
   if (opts.workspace !== undefined) params.workspace = opts.workspace
   if (opts.deleteOnClose !== undefined) params.deleteOnClose = opts.deleteOnClose
   await ragCloseWorkspace(params)
+}
+
+export async function sdkRagIngest (opts: {
+  modelId: string
+  documents: string | string[]
+  workspace?: string | undefined
+  chunk?: boolean | undefined
+}): Promise<{ processed: unknown[]; droppedIndices: number[] }> {
+  const { ragIngest } = await getSDK()
+  const params: Parameters<SDKModule['ragIngest']>[0] = {
+    modelId: opts.modelId,
+    documents: opts.documents,
+    chunk: opts.chunk ?? true
+  }
+  if (opts.workspace !== undefined) params.workspace = opts.workspace
+  return ragIngest(params)
 }
 
 export async function sdkClose (): Promise<void> {

--- a/packages/cli/src/serve/core/sdk.ts
+++ b/packages/cli/src/serve/core/sdk.ts
@@ -27,6 +27,17 @@ export type SDKResponseFormat =
       }
     }
 
+export interface RagWorkspaceInfo {
+  name: string
+  open: boolean
+}
+
+export interface RagSearchResult {
+  id: string
+  content: string
+  score: number
+}
+
 interface SDKModule {
   loadModel: (opts: { modelSrc: string; modelType: string; modelConfig: Record<string, unknown> }) => Promise<string>
   unloadModel: (opts: { modelId: string }) => Promise<void>
@@ -41,6 +52,16 @@ interface SDKModule {
   embed: (opts: { modelId: string; text: string | string[] }) => Promise<{ embedding: number[] | number[][]; stats?: Record<string, unknown> }>
   transcribe: (opts: { modelId: string; audioChunk: string | Buffer; prompt?: string }) => Promise<string>
   diffusion: (opts: SDKDiffusionParams) => SDKDiffusionResult
+  ragListWorkspaces: () => Promise<RagWorkspaceInfo[]>
+  ragSearch: (opts: {
+    modelId: string
+    query: string
+    topK?: number
+    n?: number
+    workspace?: string
+  }) => Promise<RagSearchResult[]>
+  ragDeleteWorkspace: (opts: { workspace: string }) => Promise<void>
+  ragCloseWorkspace: (opts: { workspace?: string; deleteOnClose?: boolean }) => Promise<void>
   close: () => Promise<void>
   [key: string]: unknown
 }
@@ -280,6 +301,45 @@ export async function sdkDiffusion (opts: {
   ])
 
   return { buffers, stats }
+}
+
+export async function sdkRagListWorkspaces (): Promise<RagWorkspaceInfo[]> {
+  const { ragListWorkspaces } = await getSDK()
+  return ragListWorkspaces()
+}
+
+export async function sdkRagSearch (opts: {
+  modelId: string
+  query: string
+  topK?: number | undefined
+  n?: number | undefined
+  workspace?: string | undefined
+}): Promise<RagSearchResult[]> {
+  const { ragSearch } = await getSDK()
+  const params: Parameters<SDKModule['ragSearch']>[0] = {
+    modelId: opts.modelId,
+    query: opts.query
+  }
+  if (opts.topK !== undefined) params.topK = opts.topK
+  if (opts.n !== undefined) params.n = opts.n
+  if (opts.workspace !== undefined) params.workspace = opts.workspace
+  return ragSearch(params)
+}
+
+export async function sdkRagDeleteWorkspace (opts: { workspace: string }): Promise<void> {
+  const { ragDeleteWorkspace } = await getSDK()
+  await ragDeleteWorkspace({ workspace: opts.workspace })
+}
+
+export async function sdkRagCloseWorkspace (opts: {
+  workspace?: string | undefined
+  deleteOnClose?: boolean | undefined
+}): Promise<void> {
+  const { ragCloseWorkspace } = await getSDK()
+  const params: Parameters<SDKModule['ragCloseWorkspace']>[0] = {}
+  if (opts.workspace !== undefined) params.workspace = opts.workspace
+  if (opts.deleteOnClose !== undefined) params.deleteOnClose = opts.deleteOnClose
+  await ragCloseWorkspace(params)
 }
 
 export async function sdkClose (): Promise<void> {

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -8,6 +8,7 @@ import { createModelRegistry } from './core/model-registry.js'
 import { preloadModels, shutdownSDK } from './core/lifecycle.js'
 import { handleCors, sendError } from './http.js'
 import { createOpenAIAdapter } from './adapters/openai/index.js'
+import { createChunkAttributionStore } from './adapters/openai/chunk-attribution-store.js'
 import { createEphemeralFilesStore } from './adapters/openai/ephemeral-files-store.js'
 import { createVectorStoresStore } from './adapters/openai/vector-stores-store.js'
 import type { APIAdapter, RouteContext } from './adapters/types.js'
@@ -42,7 +43,8 @@ export async function startServer (options: StartServerOptions): Promise<http.Se
 
   const vectorStores = createVectorStoresStore()
   const ephemeralFiles = createEphemeralFilesStore()
-  const ctx: RouteContext = { registry, serveConfig, logger, vectorStores, ephemeralFiles }
+  const chunkAttributions = createChunkAttributionStore()
+  const ctx: RouteContext = { registry, serveConfig, logger, vectorStores, ephemeralFiles, chunkAttributions }
 
   const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const start = performance.now()

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -8,6 +8,7 @@ import { createModelRegistry } from './core/model-registry.js'
 import { preloadModels, shutdownSDK } from './core/lifecycle.js'
 import { handleCors, sendError } from './http.js'
 import { createOpenAIAdapter } from './adapters/openai/index.js'
+import { createEphemeralFilesStore } from './adapters/openai/ephemeral-files-store.js'
 import { createVectorStoresStore } from './adapters/openai/vector-stores-store.js'
 import type { APIAdapter, RouteContext } from './adapters/types.js'
 import type { ServeConfig, ResolvedModelEntry } from './core/model-registry.js'
@@ -40,7 +41,8 @@ export async function startServer (options: StartServerOptions): Promise<http.Se
   ]
 
   const vectorStores = createVectorStoresStore()
-  const ctx: RouteContext = { registry, serveConfig, logger, vectorStores }
+  const ephemeralFiles = createEphemeralFilesStore()
+  const ctx: RouteContext = { registry, serveConfig, logger, vectorStores, ephemeralFiles }
 
   const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const start = performance.now()
@@ -120,12 +122,16 @@ const CATEGORY_ENDPOINTS: Record<string, string[]> = {
 }
 
 const VECTOR_STORE_ENDPOINTS = [
+  'POST /v1/files',
+  'GET  /v1/files',
+  'GET  /v1/files/:id',
   'GET  /v1/vector_stores',
   'POST /v1/vector_stores',
   'GET  /v1/vector_stores/:id',
   'POST /v1/vector_stores/:id',
   'DELETE /v1/vector_stores/:id',
-  'POST /v1/vector_stores/:id/search'
+  'POST /v1/vector_stores/:id/search',
+  'POST /v1/vector_stores/:id/files'
 ]
 
 const MANAGEMENT_ENDPOINTS = [

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -8,6 +8,7 @@ import { createModelRegistry } from './core/model-registry.js'
 import { preloadModels, shutdownSDK } from './core/lifecycle.js'
 import { handleCors, sendError } from './http.js'
 import { createOpenAIAdapter } from './adapters/openai/index.js'
+import { createVectorStoresStore } from './adapters/openai/vector-stores-store.js'
 import type { APIAdapter, RouteContext } from './adapters/types.js'
 import type { ServeConfig, ResolvedModelEntry } from './core/model-registry.js'
 
@@ -38,7 +39,8 @@ export async function startServer (options: StartServerOptions): Promise<http.Se
     createOpenAIAdapter()
   ]
 
-  const ctx: RouteContext = { registry, serveConfig, logger }
+  const vectorStores = createVectorStoresStore()
+  const ctx: RouteContext = { registry, serveConfig, logger, vectorStores }
 
   const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const start = performance.now()
@@ -117,6 +119,15 @@ const CATEGORY_ENDPOINTS: Record<string, string[]> = {
   image: ['POST /v1/images/generations']
 }
 
+const VECTOR_STORE_ENDPOINTS = [
+  'GET  /v1/vector_stores',
+  'POST /v1/vector_stores',
+  'GET  /v1/vector_stores/:id',
+  'POST /v1/vector_stores/:id',
+  'DELETE /v1/vector_stores/:id',
+  'POST /v1/vector_stores/:id/search'
+]
+
 const MANAGEMENT_ENDPOINTS = [
   'GET  /v1/models',
   'GET  /v1/models/:id',
@@ -170,6 +181,9 @@ function logStartupSummary (serveConfig: ServeConfig, logger: Logger): void {
     if (endpoints) {
       for (const ep of endpoints) logger.info(`  ${ep}`)
     }
+  }
+  if (categories.has('embedding')) {
+    for (const ep of VECTOR_STORE_ENDPOINTS) logger.info(`  ${ep}`)
   }
   for (const ep of MANAGEMENT_ENDPOINTS) logger.info(`  ${ep}`)
   logger.info('')

--- a/packages/cli/test/chunk-attribution-store.test.ts
+++ b/packages/cli/test/chunk-attribution-store.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createChunkAttributionStore } from '../src/serve/adapters/openai/chunk-attribution-store.js'
+
+describe('createChunkAttributionStore', () => {
+  it('records and looks up attribution under a vector store id', () => {
+    const store = createChunkAttributionStore()
+    store.record('vs_a', 'chunk_1', { fileId: 'file-abc', fileName: 'notes.txt' })
+    const found = store.lookup('vs_a', 'chunk_1')
+    assert.deepEqual(found, { fileId: 'file-abc', fileName: 'notes.txt' })
+  })
+
+  it('returns null for unknown chunk or unknown store', () => {
+    const store = createChunkAttributionStore()
+    assert.equal(store.lookup('vs_a', 'chunk_missing'), null)
+    assert.equal(store.lookup('vs_missing', 'chunk_anything'), null)
+  })
+
+  it('scopes attributions per vector store id (no cross-talk)', () => {
+    const store = createChunkAttributionStore()
+    store.record('vs_a', 'chunk_shared', { fileId: 'file-a', fileName: 'a.txt' })
+    store.record('vs_b', 'chunk_shared', { fileId: 'file-b', fileName: 'b.txt' })
+    assert.deepEqual(store.lookup('vs_a', 'chunk_shared'), { fileId: 'file-a', fileName: 'a.txt' })
+    assert.deepEqual(store.lookup('vs_b', 'chunk_shared'), { fileId: 'file-b', fileName: 'b.txt' })
+  })
+
+  it('latest record wins for the same (vs, chunk) pair', () => {
+    const store = createChunkAttributionStore()
+    store.record('vs_a', 'chunk_1', { fileId: 'file-old', fileName: 'old.txt' })
+    store.record('vs_a', 'chunk_1', { fileId: 'file-new', fileName: 'new.txt' })
+    assert.deepEqual(store.lookup('vs_a', 'chunk_1'), { fileId: 'file-new', fileName: 'new.txt' })
+  })
+
+  it('evict drops every attribution for a vector store', () => {
+    const store = createChunkAttributionStore()
+    store.record('vs_a', 'chunk_1', { fileId: 'file-1', fileName: 'a.txt' })
+    store.record('vs_a', 'chunk_2', { fileId: 'file-2', fileName: 'b.txt' })
+    store.record('vs_b', 'chunk_1', { fileId: 'file-3', fileName: 'c.txt' })
+    store.evict('vs_a')
+    assert.equal(store.lookup('vs_a', 'chunk_1'), null)
+    assert.equal(store.lookup('vs_a', 'chunk_2'), null)
+    // Other vs untouched.
+    assert.deepEqual(store.lookup('vs_b', 'chunk_1'), { fileId: 'file-3', fileName: 'c.txt' })
+  })
+
+  it('lookup returns a defensive clone (callers cannot mutate stored entries)', () => {
+    const store = createChunkAttributionStore()
+    store.record('vs_a', 'chunk_1', { fileId: 'file-abc', fileName: 'notes.txt' })
+    const found = store.lookup('vs_a', 'chunk_1')
+    assert.ok(found)
+    found.fileId = 'tampered'
+    found.fileName = 'tampered'
+    const fresh = store.lookup('vs_a', 'chunk_1')
+    assert.deepEqual(fresh, { fileId: 'file-abc', fileName: 'notes.txt' })
+  })
+})

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -381,6 +381,25 @@ TXT
   curl -s -X DELETE "${BASE}/v1/vector_stores/${vs}" >/dev/null
 }
 
+@test "vector_stores: attach binary upload returns 400 unsupported_file_type" {
+  local vs upload file body
+  vs=$(json_post "/v1/vector_stores" '{"name":"binary-sad"}' | jq -r '.id')
+
+  # PNG magic header — contains NUL bytes so looksBinary catches it.
+  local png_path="${BATS_TEST_TMPDIR}/bin.png"
+  printf '\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR' > "${png_path}"
+
+  upload=$(curl -sf "${BASE}/v1/files" \
+    -F "file=@${png_path};type=image/png" \
+    -F "purpose=assistants")
+  file=$(echo "${upload}" | jq -r '.id')
+
+  body=$(json_post "/v1/vector_stores/${vs}/files" "{\"file_id\":\"${file}\"}")
+  assert_error "${body}" "unsupported_file_type"
+
+  curl -s -X DELETE "${BASE}/v1/vector_stores/${vs}" >/dev/null
+}
+
 @test "vector_stores: invalid id returns 400 invalid_vector_store_id" {
   local body
   body=$(curl -s "${BASE}/v1/vector_stores/bad%2Fid")

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -261,6 +261,132 @@ json_post() {
   assert_error "${body}" "invalid_model_type"
 }
 
+# ── Vector stores ─────────────────────────────────────────────────────
+# Each test is self-contained (creates the store/file it needs and cleans
+# up) so they survive `bats -f <pattern>` filtering and can run in any
+# order. The happy-path "upload → attach → search → delete" lives in a
+# single @test to keep the dependent steps together without leaking state
+# via files.
+
+VS_DOC_FILE="${BATS_FILE_TMPDIR:-/tmp}/vs_doc.txt"
+
+@test "vector_stores: CRUD — create, list, get, update, delete" {
+  local create
+  create=$(json_post "/v1/vector_stores" '{"name":"crud","metadata":{"by":"e2e.bats"}}')
+  echo "${create}" | jq -e '.object == "vector_store"' >/dev/null
+  echo "${create}" | jq -e '.id | startswith("vs_")' >/dev/null
+  echo "${create}" | jq -e '.name == "crud"' >/dev/null
+  local id
+  id=$(echo "${create}" | jq -r '.id')
+
+  local list
+  list=$(curl -sf "${BASE}/v1/vector_stores")
+  echo "${list}" | jq -e '.object == "list"' >/dev/null
+  echo "${list}" | jq -e --arg id "${id}" 'any(.data[]; .id == $id)' >/dev/null
+
+  local get_before
+  get_before=$(curl -sf "${BASE}/v1/vector_stores/${id}")
+  echo "${get_before}" | jq -e --arg id "${id}" '.id == $id' >/dev/null
+  echo "${get_before}" | jq -e '.status == "in_progress"' >/dev/null
+
+  local update
+  update=$(json_post "/v1/vector_stores/${id}" '{"name":"crud-updated"}')
+  echo "${update}" | jq -e '.name == "crud-updated"' >/dev/null
+
+  local del
+  del=$(curl -s -X DELETE "${BASE}/v1/vector_stores/${id}")
+  echo "${del}" | jq -e --arg id "${id}" '.id == $id' >/dev/null
+  echo "${del}" | jq -e '.object == "vector_store.deleted"' >/dev/null
+  echo "${del}" | jq -e '.deleted == true' >/dev/null
+
+  local status_after
+  status_after=$(curl -s -o /dev/null -w "%{http_code}" "${BASE}/v1/vector_stores/${id}")
+  [[ "${status_after}" == "404" ]]
+}
+
+@test "vector_stores: upload → attach → search end-to-end" {
+  cat > "${VS_DOC_FILE}" <<'TXT'
+Local e2e document about planets, moons and the solar system.
+Another note about OpenAI vector stores and RAG.
+TXT
+
+  local vs
+  vs=$(json_post "/v1/vector_stores" '{"name":"flow"}' | jq -r '.id')
+
+  local upload file
+  upload=$(curl -sf "${BASE}/v1/files" \
+    -F "file=@${VS_DOC_FILE};type=text/plain" \
+    -F "purpose=assistants")
+  echo "${upload}" | jq -e '.object == "file"' >/dev/null
+  echo "${upload}" | jq -e '.id | startswith("file-")' >/dev/null
+  echo "${upload}" | jq -e '.status == "uploaded"' >/dev/null
+  echo "${upload}" | jq -e '.purpose == "assistants"' >/dev/null
+  file=$(echo "${upload}" | jq -r '.id')
+
+  curl -sf "${BASE}/v1/files" | jq -e --arg id "${file}" 'any(.data[]; .id == $id)' >/dev/null
+  curl -sf "${BASE}/v1/files/${file}" | jq -e --arg id "${file}" '.id == $id and .object == "file"' >/dev/null
+
+  local attach
+  attach=$(json_post "/v1/vector_stores/${vs}/files" "{\"file_id\":\"${file}\"}")
+  echo "${attach}" | jq -e '.object == "vector_store.file"' >/dev/null
+  echo "${attach}" | jq -e --arg id "${file}" '.id == $id' >/dev/null
+  echo "${attach}" | jq -e --arg vs "${vs}" '.vector_store_id == $vs' >/dev/null
+  echo "${attach}" | jq -e '.status == "completed"' >/dev/null
+  echo "${attach}" | jq -e '.last_error == null' >/dev/null
+  echo "${attach}" | jq -e '.usage_bytes | type == "number"' >/dev/null
+
+  # Bytes are dropped from the in-memory file store after attach.
+  local file_status_after
+  file_status_after=$(curl -s -o /dev/null -w "%{http_code}" "${BASE}/v1/files/${file}")
+  [[ "${file_status_after}" == "404" ]]
+
+  curl -sf "${BASE}/v1/vector_stores/${vs}" | jq -e '.status == "completed"' >/dev/null
+
+  local search
+  search=$(json_post "/v1/vector_stores/${vs}/search" \
+    '{"query":"planets and solar system","max_num_results":5}')
+  echo "${search}" | jq -e '.object == "vector_store.search_results.page"' >/dev/null
+  echo "${search}" | jq -e '.data | type == "array"' >/dev/null
+  echo "${search}" | jq -e '.data | length > 0' >/dev/null
+  echo "${search}" | jq -e '
+    any(.data[];
+      (.content // []) | map(select(.type == "text") | .text // "") | join(" ")
+        | test("planets|moons|OpenAI|vector stores"; "i"))
+  ' >/dev/null
+
+  curl -s -X DELETE "${BASE}/v1/vector_stores/${vs}" >/dev/null
+}
+
+@test "vector_stores: search with missing query returns 400 missing_query" {
+  local vs body
+  vs=$(json_post "/v1/vector_stores" '{}' | jq -r '.id')
+  body=$(json_post "/v1/vector_stores/${vs}/search" '{}')
+  assert_error "${body}" "missing_query"
+  curl -s -X DELETE "${BASE}/v1/vector_stores/${vs}" >/dev/null
+}
+
+@test "vector_stores: attach with unknown file_id returns 404 file_not_found" {
+  local vs body
+  vs=$(json_post "/v1/vector_stores" '{}' | jq -r '.id')
+  body=$(json_post "/v1/vector_stores/${vs}/files" '{"file_id":"file-doesnotexist"}')
+  assert_error "${body}" "file_not_found"
+  curl -s -X DELETE "${BASE}/v1/vector_stores/${vs}" >/dev/null
+}
+
+@test "vector_stores: attach with missing file_id returns 400 missing_file_id" {
+  local vs body
+  vs=$(json_post "/v1/vector_stores" '{}' | jq -r '.id')
+  body=$(json_post "/v1/vector_stores/${vs}/files" '{}')
+  assert_error "${body}" "missing_file_id"
+  curl -s -X DELETE "${BASE}/v1/vector_stores/${vs}" >/dev/null
+}
+
+@test "vector_stores: invalid id returns 400 invalid_vector_store_id" {
+  local body
+  body=$(curl -s "${BASE}/v1/vector_stores/bad%2Fid")
+  assert_error "${body}" "invalid_vector_store_id"
+}
+
 # ── Cross-endpoint model type validation ──────────────────────────────
 
 @test "cross-type: chat endpoint rejects embedding model" {

--- a/packages/cli/test/ephemeral-files-store.test.ts
+++ b/packages/cli/test/ephemeral-files-store.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createEphemeralFilesStore } from '../src/serve/adapters/openai/ephemeral-files-store.js'
+
+describe('createEphemeralFilesStore', () => {
+  it('put returns a file- prefixed id and get returns the same bytes', () => {
+    const clock = () => 1_700_000_000_000
+    const store = createEphemeralFilesStore(clock)
+    const id = store.put({
+      data: Buffer.from('hello', 'utf8'),
+      fileName: 'a.txt',
+      purpose: 'assistants'
+    })
+    assert.match(id, /^file-[0-9a-f]{24}$/)
+    const got = store.get(id)
+    assert.notEqual(got, null)
+    if (got === null) return
+    assert.equal(got.data.toString('utf8'), 'hello')
+    assert.equal(got.fileName, 'a.txt')
+    assert.equal(got.purpose, 'assistants')
+    assert.equal(got.createdAtMs, 1_700_000_000_000)
+  })
+
+  it('remove drops the entry', () => {
+    const store = createEphemeralFilesStore()
+    const id = store.put({
+      data: Buffer.from('x'),
+      fileName: 'b.txt',
+      purpose: 'assistants'
+    })
+    store.remove(id)
+    assert.equal(store.get(id), null)
+  })
+
+  it('list returns entries newest-first', () => {
+    let t = 1_000
+    const store = createEphemeralFilesStore(() => t)
+    t = 1_000; const idOld = store.put({ data: Buffer.from('a'), fileName: 'a.txt', purpose: 'assistants' })
+    t = 2_000; const idNew = store.put({ data: Buffer.from('b'), fileName: 'b.txt', purpose: 'assistants' })
+    const listed = store.list().map((e) => e.id)
+    assert.deepEqual(listed, [idNew, idOld])
+  })
+})

--- a/packages/cli/test/synthetic-workspace.test.ts
+++ b/packages/cli/test/synthetic-workspace.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { syntheticFromWorkspace } from '../src/serve/adapters/openai/routes/vector-stores.js'
+
+describe('syntheticFromWorkspace', () => {
+  const workspaces = [{ name: 'vs_known', open: false }]
+
+  it('returns null when the workspace is not present', () => {
+    assert.equal(syntheticFromWorkspace('vs_missing', workspaces), null)
+  })
+
+  it('uses a stable 0 anchor for createdAt and lastActiveAt (no wall-clock tick)', () => {
+    const a = syntheticFromWorkspace('vs_known', workspaces)
+    const b = syntheticFromWorkspace('vs_known', workspaces)
+    assert.ok(a)
+    assert.ok(b)
+    assert.equal(a.createdAt, 0)
+    assert.equal(a.lastActiveAt, 0)
+    assert.equal(b.createdAt, 0)
+    assert.equal(b.lastActiveAt, 0)
+    // No drift between calls — the previous Date.now() implementation
+    // would have shown different values here.
+    assert.deepEqual(a, b)
+  })
+
+  it('keeps name = id and an empty metadata map', () => {
+    const meta = syntheticFromWorkspace('vs_known', workspaces)
+    assert.ok(meta)
+    assert.equal(meta.id, 'vs_known')
+    assert.equal(meta.name, 'vs_known')
+    assert.deepEqual(meta.metadata, {})
+    assert.equal(meta.expiresAfter, null)
+    assert.equal(meta.expiresAt, null)
+    assert.equal(meta.embeddingAlias, null)
+  })
+})

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -603,6 +603,30 @@ describe('searchResultsToOpenAI', () => {
     assert.deepEqual(first.attributes, {})
     assert.deepEqual(first.content, [{ type: 'text', text: 'first chunk text' }])
   })
+
+  it('uses the attribution lookup for file_id and filename when available', () => {
+    const page = searchResultsToOpenAI(
+      [
+        { id: 'chunk-1', content: 'first chunk', score: 0.9 },
+        { id: 'chunk-2', content: 'second chunk', score: 0.8 }
+      ],
+      'query',
+      (chunkId) => {
+        if (chunkId === 'chunk-1') return { fileId: 'file-abc', fileName: 'notes.txt' }
+        return null
+      }
+    )
+    const first = page.data[0]
+    const second = page.data[1]
+    assert.ok(first)
+    assert.ok(second)
+    // Attributed hit reports the original upload's identity.
+    assert.equal(first.file_id, 'file-abc')
+    assert.equal(first.filename, 'notes.txt')
+    // Unattributed hit falls back to the chunk id (today's behavior).
+    assert.equal(second.file_id, 'chunk-2')
+    assert.equal(second.filename, 'chunk-2')
+  })
 })
 
 describe('parseExpiresAfter', () => {

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -8,8 +8,15 @@ import {
   extractGenerationParams,
   extractResponseFormat,
   InvalidResponseFormatError,
-  logUnsupportedParams
+  logUnsupportedParams,
+  vectorStoreToOpenAI,
+  searchResultsToOpenAI,
+  parseExpiresAfter,
+  parseMetadata,
+  InvalidExpiresAfterError,
+  InvalidMetadataError
 } from '../src/serve/adapters/openai/translate.js'
+import type { VectorStoreMeta } from '../src/serve/adapters/openai/vector-stores-store.js'
 
 describe('openaiMessagesToHistory', () => {
   it('converts simple user/assistant messages', () => {
@@ -502,5 +509,149 @@ describe('extractResponseFormat', () => {
       }),
       InvalidResponseFormatError
     )
+  })
+})
+
+function fixtureMeta (overrides: Partial<VectorStoreMeta> = {}): VectorStoreMeta {
+  return {
+    id: 'vs_abc123',
+    createdAt: 1_700_000_000_000,
+    name: 'docs',
+    metadata: { topic: 'rag' },
+    expiresAfter: null,
+    expiresAt: null,
+    lastActiveAt: 1_700_000_000_000,
+    ...overrides
+  }
+}
+
+describe('vectorStoreToOpenAI', () => {
+  it('produces the OpenAI vector_store shape with second-precision timestamps', () => {
+    const out = vectorStoreToOpenAI(fixtureMeta())
+    assert.equal(out.object, 'vector_store')
+    assert.equal(out.id, 'vs_abc123')
+    assert.equal(out.created_at, 1_700_000_000)
+    assert.equal(out.name, 'docs')
+    assert.equal(out.usage_bytes, 0)
+    assert.deepEqual(out.file_counts, {
+      in_progress: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+      total: 0
+    })
+    assert.equal(out.last_active_at, 1_700_000_000)
+    assert.deepEqual(out.metadata, { topic: 'rag' })
+  })
+
+  it('reports status="in_progress" when no underlying RAG workspace exists', () => {
+    const out = vectorStoreToOpenAI(fixtureMeta())
+    assert.equal(out.status, 'in_progress')
+  })
+
+  it('reports status="completed" once a workspace exists', () => {
+    const out = vectorStoreToOpenAI(fixtureMeta(), { exists: true, open: true })
+    assert.equal(out.status, 'completed')
+  })
+
+  it('preserves expires_after and converts expires_at to seconds', () => {
+    const out = vectorStoreToOpenAI(fixtureMeta({
+      expiresAfter: { anchor: 'last_active_at', days: 7 },
+      expiresAt: 1_700_604_800_000
+    }))
+    assert.deepEqual(out.expires_after, { anchor: 'last_active_at', days: 7 })
+    assert.equal(out.expires_at, 1_700_604_800)
+  })
+
+  it('keeps null name (no synthetic fallback)', () => {
+    const out = vectorStoreToOpenAI(fixtureMeta({ name: null }))
+    assert.equal(out.name, null)
+  })
+
+  it('clones metadata so mutations on the response do not leak', () => {
+    const meta = fixtureMeta()
+    const out = vectorStoreToOpenAI(meta)
+    out.metadata['topic'] = 'mutated'
+    assert.equal(meta.metadata['topic'], 'rag')
+  })
+})
+
+describe('searchResultsToOpenAI', () => {
+  it('returns an empty page on no results', () => {
+    const page = searchResultsToOpenAI([], 'find me')
+    assert.equal(page.object, 'vector_store.search_results.page')
+    assert.equal(page.search_query, 'find me')
+    assert.deepEqual(page.data, [])
+    assert.equal(page.has_more, false)
+    assert.equal(page.next_page, null)
+  })
+
+  it('maps RAG results to OpenAI search items preserving score', () => {
+    const page = searchResultsToOpenAI(
+      [
+        { id: 'doc-1', content: 'first chunk text', score: 0.92 },
+        { id: 'doc-2', content: 'second chunk text', score: 0.81 }
+      ],
+      'embedding query'
+    )
+    assert.equal(page.data.length, 2)
+    const first = page.data[0]
+    assert.ok(first)
+    assert.equal(first.file_id, 'doc-1')
+    assert.equal(first.filename, 'doc-1')
+    assert.equal(first.score, 0.92)
+    assert.deepEqual(first.attributes, {})
+    assert.deepEqual(first.content, [{ type: 'text', text: 'first chunk text' }])
+  })
+})
+
+describe('parseExpiresAfter', () => {
+  it('returns undefined when missing, null when explicit null', () => {
+    assert.equal(parseExpiresAfter(undefined), undefined)
+    assert.equal(parseExpiresAfter(null), null)
+  })
+
+  it('parses a valid expires_after object', () => {
+    assert.deepEqual(
+      parseExpiresAfter({ anchor: 'last_active_at', days: 30 }),
+      { anchor: 'last_active_at', days: 30 }
+    )
+  })
+
+  it('throws on a wrong anchor or non-integer days', () => {
+    assert.throws(() => parseExpiresAfter({ anchor: 'created_at', days: 7 }), InvalidExpiresAfterError)
+    assert.throws(() => parseExpiresAfter({ anchor: 'last_active_at', days: 0 }), InvalidExpiresAfterError)
+    assert.throws(() => parseExpiresAfter({ anchor: 'last_active_at', days: 1.5 }), InvalidExpiresAfterError)
+  })
+
+  it('throws on non-object inputs', () => {
+    assert.throws(() => parseExpiresAfter('soon'), InvalidExpiresAfterError)
+    assert.throws(() => parseExpiresAfter(['anchor', 'last_active_at']), InvalidExpiresAfterError)
+  })
+})
+
+describe('parseMetadata', () => {
+  it('round-trips a small string-valued object', () => {
+    assert.deepEqual(parseMetadata({ a: '1', b: 'two' }), { a: '1', b: 'two' })
+  })
+
+  it('returns undefined when missing, null when explicit null', () => {
+    assert.equal(parseMetadata(undefined), undefined)
+    assert.equal(parseMetadata(null), null)
+  })
+
+  it('rejects non-string values', () => {
+    assert.throws(() => parseMetadata({ count: 5 }), InvalidMetadataError)
+  })
+
+  it('rejects more than 16 keys', () => {
+    const big: Record<string, string> = {}
+    for (let i = 0; i < 17; i++) big[`k${i}`] = 'v'
+    assert.throws(() => parseMetadata(big), InvalidMetadataError)
+  })
+
+  it('rejects oversized keys or values', () => {
+    assert.throws(() => parseMetadata({ ['x'.repeat(65)]: 'v' }), InvalidMetadataError)
+    assert.throws(() => parseMetadata({ k: 'v'.repeat(513) }), InvalidMetadataError)
   })
 })

--- a/packages/cli/test/vector-stores-binary.test.ts
+++ b/packages/cli/test/vector-stores-binary.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { looksBinary } from '../src/serve/adapters/openai/routes/vector-stores.js'
+
+describe('looksBinary', () => {
+  it('returns false for plain UTF-8 text', () => {
+    assert.equal(looksBinary(Buffer.from('Hello, world.\nSecond line.', 'utf8')), false)
+  })
+
+  it('returns false for empty buffers (handled separately by empty_file)', () => {
+    assert.equal(looksBinary(Buffer.alloc(0)), false)
+  })
+
+  it('returns false for multibyte UTF-8 (emoji, CJK)', () => {
+    assert.equal(looksBinary(Buffer.from('café — 中文 — 🎉', 'utf8')), false)
+  })
+
+  it('returns true for a PNG header', () => {
+    // PNG magic: 89 50 4E 47 0D 0A 1A 0A — contains 0x00 in the IHDR length that follows.
+    const png = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52
+    ])
+    assert.equal(looksBinary(png), true)
+  })
+
+  it('returns true for a PDF (NUL inside xref)', () => {
+    // Real PDFs always contain NUL bytes in cross-reference tables.
+    const pdf = Buffer.concat([
+      Buffer.from('%PDF-1.4\n'),
+      Buffer.from([0x00, 0x10, 0x20])
+    ])
+    assert.equal(looksBinary(pdf), true)
+  })
+
+  it('only sniffs the first 8 KB (so a NUL deep in the file is still flagged because it lies inside the window when within 8 KB)', () => {
+    // Sanity-check the windowing: a NUL just past 8 KB is ignored.
+    const padded = Buffer.concat([
+      Buffer.alloc(8192, 0x20),
+      Buffer.from([0x00])
+    ])
+    assert.equal(looksBinary(padded), false)
+  })
+})

--- a/packages/cli/test/vector-stores-store.test.ts
+++ b/packages/cli/test/vector-stores-store.test.ts
@@ -165,4 +165,46 @@ describe('createVectorStoresStore', () => {
     const store = createVectorStoresStore()
     assert.doesNotThrow(() => store.touch('vs_missing'))
   })
+
+  it('create initializes embeddingAlias to null', () => {
+    const store = createVectorStoresStore()
+    const meta = store.create()
+    assert.equal(meta.embeddingAlias, null)
+  })
+
+  it('setEmbedding records the alias on a known id', () => {
+    const store = createVectorStoresStore()
+    const meta = store.create()
+    store.setEmbedding(meta.id, 'gte-large-fp16')
+    const fresh = store.get(meta.id)
+    assert.ok(fresh)
+    assert.equal(fresh.embeddingAlias, 'gte-large-fp16')
+  })
+
+  it('setEmbedding is idempotent (never overwrites an existing alias)', () => {
+    const store = createVectorStoresStore()
+    const meta = store.create()
+    store.setEmbedding(meta.id, 'first-model')
+    store.setEmbedding(meta.id, 'second-model')
+    const fresh = store.get(meta.id)
+    assert.ok(fresh)
+    assert.equal(fresh.embeddingAlias, 'first-model')
+  })
+
+  it('setEmbedding on missing id is a no-op', () => {
+    const store = createVectorStoresStore()
+    assert.doesNotThrow(() => store.setEmbedding('vs_missing', 'whatever'))
+  })
+
+  it('get returns a clone — mutating embeddingAlias on the result does not leak', () => {
+    const store = createVectorStoresStore()
+    const meta = store.create()
+    store.setEmbedding(meta.id, 'a')
+    const fetched = store.get(meta.id)
+    assert.ok(fetched)
+    fetched.embeddingAlias = 'b'
+    const fresh = store.get(meta.id)
+    assert.ok(fresh)
+    assert.equal(fresh.embeddingAlias, 'a')
+  })
 })

--- a/packages/cli/test/vector-stores-store.test.ts
+++ b/packages/cli/test/vector-stores-store.test.ts
@@ -1,0 +1,168 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createVectorStoresStore,
+  generateVectorStoreId,
+  idToWorkspace,
+  InvalidVectorStoreIdError
+} from '../src/serve/adapters/openai/vector-stores-store.js'
+
+describe('generateVectorStoreId', () => {
+  it('returns a vs_-prefixed id of expected length', () => {
+    const id = generateVectorStoreId()
+    assert.match(id, /^vs_[0-9a-f]{24}$/)
+  })
+
+  it('produces unique ids across calls', () => {
+    const a = generateVectorStoreId()
+    const b = generateVectorStoreId()
+    assert.notEqual(a, b)
+  })
+})
+
+describe('idToWorkspace', () => {
+  it('accepts safe alphanumeric ids with - and _', () => {
+    assert.equal(idToWorkspace('vs_abc-123_XYZ'), 'vs_abc-123_XYZ')
+  })
+
+  it('rejects path traversal sequences', () => {
+    assert.throws(() => idToWorkspace('..'), InvalidVectorStoreIdError)
+    assert.throws(() => idToWorkspace('vs/../etc'), InvalidVectorStoreIdError)
+    assert.throws(() => idToWorkspace('vs\\evil'), InvalidVectorStoreIdError)
+    assert.throws(() => idToWorkspace('vs\0name'), InvalidVectorStoreIdError)
+  })
+
+  it('rejects oversized ids', () => {
+    assert.throws(() => idToWorkspace('a'.repeat(65)), InvalidVectorStoreIdError)
+  })
+
+  it('rejects empty and non-string', () => {
+    assert.throws(() => idToWorkspace(''), InvalidVectorStoreIdError)
+    assert.throws(() => idToWorkspace(undefined as unknown as string), InvalidVectorStoreIdError)
+  })
+
+  it('rejects characters outside the safe set', () => {
+    assert.throws(() => idToWorkspace('vs.abc'), InvalidVectorStoreIdError)
+    assert.throws(() => idToWorkspace('vs abc'), InvalidVectorStoreIdError)
+    assert.throws(() => idToWorkspace('vs!abc'), InvalidVectorStoreIdError)
+  })
+})
+
+describe('createVectorStoresStore', () => {
+  it('create returns a meta with a generated id when none is supplied', () => {
+    const store = createVectorStoresStore(() => 1_700_000_000_000)
+    const meta = store.create({ name: 'docs' })
+    assert.match(meta.id, /^vs_[0-9a-f]{24}$/)
+    assert.equal(meta.name, 'docs')
+    assert.equal(meta.createdAt, 1_700_000_000_000)
+    assert.equal(meta.lastActiveAt, 1_700_000_000_000)
+    assert.equal(meta.expiresAfter, null)
+    assert.equal(meta.expiresAt, null)
+    assert.deepEqual(meta.metadata, {})
+  })
+
+  it('create uses the provided id when valid', () => {
+    const store = createVectorStoresStore()
+    const meta = store.create({ id: 'vs_my-store' })
+    assert.equal(meta.id, 'vs_my-store')
+  })
+
+  it('create rejects an invalid id', () => {
+    const store = createVectorStoresStore()
+    assert.throws(() => store.create({ id: 'vs/bad' }), InvalidVectorStoreIdError)
+  })
+
+  it('create with expires_after computes expires_at', () => {
+    const store = createVectorStoresStore(() => 1_000)
+    const meta = store.create({ expiresAfter: { anchor: 'last_active_at', days: 1 } })
+    assert.equal(meta.expiresAt, 1_000 + 86_400_000)
+  })
+
+  it('refuses to overwrite an existing id', () => {
+    const store = createVectorStoresStore()
+    store.create({ id: 'vs_dup' })
+    assert.throws(() => store.create({ id: 'vs_dup' }), InvalidVectorStoreIdError)
+  })
+
+  it('get returns a clone (mutations do not leak)', () => {
+    const store = createVectorStoresStore()
+    const meta = store.create({ name: 'a', metadata: { k: 'v' } })
+    const fetched = store.get(meta.id)
+    assert.ok(fetched)
+    fetched.metadata['k'] = 'mutated'
+    fetched.name = 'changed'
+    const fresh = store.get(meta.id)
+    assert.ok(fresh)
+    assert.equal(fresh.metadata['k'], 'v')
+    assert.equal(fresh.name, 'a')
+  })
+
+  it('get returns null for missing', () => {
+    const store = createVectorStoresStore()
+    assert.equal(store.get('vs_missing'), null)
+  })
+
+  it('update merges name, metadata, and expires_after', () => {
+    let now = 1_000
+    const store = createVectorStoresStore(() => now)
+    const meta = store.create({ name: 'a', metadata: { k: 'v' } })
+    now = 2_000
+    const updated = store.update(meta.id, {
+      name: 'b',
+      metadata: { x: 'y' },
+      expiresAfter: { anchor: 'last_active_at', days: 2 }
+    })
+    assert.ok(updated)
+    assert.equal(updated.name, 'b')
+    assert.deepEqual(updated.metadata, { x: 'y' })
+    assert.deepEqual(updated.expiresAfter, { anchor: 'last_active_at', days: 2 })
+  })
+
+  it('update with metadata=null clears the map', () => {
+    const store = createVectorStoresStore()
+    const meta = store.create({ metadata: { a: '1' } })
+    const updated = store.update(meta.id, { metadata: null })
+    assert.ok(updated)
+    assert.deepEqual(updated.metadata, {})
+  })
+
+  it('update returns null for unknown id', () => {
+    const store = createVectorStoresStore()
+    assert.equal(store.update('vs_missing', { name: 'x' }), null)
+  })
+
+  it('delete returns true when present, false otherwise', () => {
+    const store = createVectorStoresStore()
+    const meta = store.create()
+    assert.equal(store.delete(meta.id), true)
+    assert.equal(store.delete(meta.id), false)
+  })
+
+  it('list returns entries sorted by createdAt descending', () => {
+    let t = 1_000
+    const store = createVectorStoresStore(() => t++)
+    store.create({ id: 'vs_first' })
+    store.create({ id: 'vs_second' })
+    store.create({ id: 'vs_third' })
+    const ids = store.list().map((s) => s.id)
+    assert.deepEqual(ids, ['vs_third', 'vs_second', 'vs_first'])
+  })
+
+  it('touch updates lastActiveAt and recomputes expiresAt', () => {
+    let now = 1_000
+    const store = createVectorStoresStore(() => now)
+    const meta = store.create({ expiresAfter: { anchor: 'last_active_at', days: 1 } })
+    assert.equal(meta.expiresAt, 1_000 + 86_400_000)
+    now = 5_000
+    store.touch(meta.id)
+    const fresh = store.get(meta.id)
+    assert.ok(fresh)
+    assert.equal(fresh.lastActiveAt, 5_000)
+    assert.equal(fresh.expiresAt, 5_000 + 86_400_000)
+  })
+
+  it('touch on missing id is a no-op', () => {
+    const store = createVectorStoresStore()
+    assert.doesNotThrow(() => store.touch('vs_missing'))
+  })
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Drop-in clients that target the OpenAI **vector stores** API (LangChain, LlamaIndex, raw `openai` SDK, etc.) currently can't point at `http://localhost:11434/v1` for their RAG flow — neither **populating** a store nor searching it works.
- Ships subtask [_OpenAI full coverage + benchmarks → New endpoints - /v1/vector_stores_](https://app.asana.com/1/45238840754660/task/1214717221316475) under [QVAC-18522](https://app.asana.com/1/45238840754660/task/1214569070727346), unblocking the RAG slice of OpenAI parity.

## 📝 How does it solve it?

### 1. Vector store CRUD + search (initial commit)

- New module `packages/cli/src/serve/adapters/openai/routes/vector-stores.ts` implements:
  - `GET /v1/vector_stores` — merges in-memory metadata with `ragListWorkspaces()`
  - `POST /v1/vector_stores` — synthetic create (no-op for the workspace; first ingest materializes it)
  - `GET /v1/vector_stores/:id` — synthetic record + workspace existence
  - `POST /v1/vector_stores/:id` — update `name` / `metadata` / `expires_after`
  - `DELETE /v1/vector_stores/:id` — `ragDeleteWorkspace`
  - `POST /v1/vector_stores/:id/search` — maps OpenAI search to `ragSearch`
- Pure in-memory metadata store (`vector-stores-store.ts`) keyed by store id, with `vs_<24-hex>` id generator and a path-traversal-safe `idToWorkspace()` sanitizer (1–64 chars, `[A-Za-z0-9_-]`, rejects `..`, `/`, `\`, `\0`).
- Translators in `translate.ts`: `vectorStoreToOpenAI`, `searchResultsToOpenAI`, `parseExpiresAfter`, `parseMetadata`.
- SDK wrappers in `core/sdk.ts`: `sdkRagListWorkspaces`, `sdkRagSearch`, `sdkRagDeleteWorkspace`, `sdkRagCloseWorkspace` (existing `MIN_SDK_VERSION = 0.10.0` already exposes RAG).
- Embedding model resolution: explicit `serve.models[*].default === true` for category `embedding`, else the sole embedding model if there's exactly one. Otherwise `400 no_embedding_model_configured`.

### 2. Minimal Files API + attach-and-ingest (added in this PR)

Lets clients populate vector stores **entirely over HTTP**, matching the OpenAI mental model (`POST /v1/files` → `POST /v1/vector_stores/{id}/files`) without shipping a real storage engine yet.

- `POST /v1/files` — multipart upload kept in an **in-memory** store (`ephemeral-files-store.ts`); returns an OpenAI-shaped `file-<24-hex>` id and a `vector_store.file`-compatible response (`object: "file"`, `bytes`, `created_at`, `filename`, `purpose`, `status: "uploaded"`).
- `GET /v1/files` — lists currently-in-memory uploads (newest first).
- `GET /v1/files/:id` — returns the file record; `404 file_not_found` once the file has been attached and its bytes dropped.
- `POST /v1/vector_stores/:id/files` — reads the in-memory bytes as UTF-8, runs SDK `ragIngest` into the workspace, removes the bytes from the store, and returns `{ object: "vector_store.file", status: "completed", … }`.
- Workspace hygiene: each `ragIngest` and `ragSearch` is now followed by `ragCloseWorkspace` so the workspace is **quiescent between requests** and `DELETE /v1/vector_stores/:id` works without a close-and-delete fallback.

### Trade-offs / caveats (⚠️ temporary by design)

> **This is a deliberately minimal, in-memory ingestion path — not the durable Files / VectorIndex foundation.** It lines up with the Tier 2 slice in `docs/openai-api-coverage.md`; a real `BlobStore` + `JobStore` + `VectorIndex` story is planned for Tier 3+ (`docs/openai-cli-storage-foundation.md`, Groups 1 & 5).

- **In-process memory only.** Uploaded bytes live in a `Map<string, Buffer>` inside the running server. Bytes are dropped on `POST /v1/vector_stores/{id}/files` (attach) and on process exit. Restart = empty file store.
- **Not suitable for many or large files.** Each upload sits in the Node heap until attached. A handful of small documents (KB–MB) is fine; large PDFs or hundreds of files will blow memory. There is no spill-to-disk, no streaming chunker, no rate limiting.
- **Text-only ingest.** The attach handler treats the upload as UTF-8 (`.txt`, `.md`, `.json`); binary bodies are sniffed via a null-byte check and rejected with `400 unsupported_file_type` before any embed pass, zero-text bodies still return `400 empty_file`. No PDF/HTML/DOCX parser is wired in.
- **No durable Files API.** `GET /v1/files` only sees uploads that haven't been attached yet. Once attached, the `file_id` is no longer retrievable.
- **No async batches.** The attach response is synchronous and always `status: "completed"` (or an error). There is no `in_progress` lifecycle, no `POST .../file_batches`, no per-file status polling.
- **No `usage_bytes` / `file_counts` accounting** on the store object beyond `usage_bytes` returned by attach itself.
- **No `expires_after` enforcement daemon.** The field is parsed and round-tripped but the server never proactively deletes expired stores.
- **Per-store embedding alias is in-memory only.** The first successful attach records the alias on `VectorStoreMeta`; subsequent attach / search reject mismatches with `400 embedding_model_mismatch`. After a restart the alias is lost and the check no-ops for disk-only workspaces — same restart-loss footprint as everything else in this slice.
- **Chunk → file attribution is in-memory only.** Search hits carry the uploaded `file_id` and `filename` while the process is running. After a restart, hits for chunks ingested earlier fall back to the RAG chunk id in `file_id` (today's pre-fix behavior).

When QVAC ships a real storage layer (`BlobStore` + `DocStore` + `JobStore` + `VectorIndex` per the storage-foundation doc), this code becomes the Tier-2 fallback that the new layer replaces, not a layer in the new stack.

### Other plumbing

- `packages/cli/src/serve/adapters/openai/index.ts` — adds `/v1/files` and `/v1/vector_stores/:id/files` routes; switches the vector-store sub-routing to two narrower regex matches so `:id/files` doesn't collide with `:id`.
- `packages/cli/src/serve/index.ts` startup banner lists all eight vector-stores-related routes when an embedding model is configured.

## 🧪 How was it tested?

- `npm run typecheck`, `npm run lint`, `npm run build`, `npm run test` in `packages/cli` — all green.
- Unit suites (no SDK / no models): translators + stores + ephemeral file store + chunk-attribution store + binary sniff + synthetic timestamps. **194 tests / 0 fail** on the head commit.
- New bats e2e coverage in `packages/cli/test/e2e.bats` (gated behind the existing `e2e` workflow, reuses the already-loaded `EMBEDDINGGEMMA_300M_Q4_0`):
  - `vector_stores: CRUD — create, list, get, update, delete`
  - `vector_stores: upload → attach → search end-to-end` (single happy-path test with a keyword hit assertion and an ephemeral-drop check on `GET /v1/files/:id` after attach)
  - 4 sad-path tests: `missing_query`, `file_not_found`, `missing_file_id`, `invalid_vector_store_id`
- Manual smoke against a real local server using **`QWEN3_600M_INST_Q4`** (chat) + **`GTE_LARGE_FP16`** (embed) — scripts attached at the bottom of this PR (mirrors the layout used in #2008).

## 🔌 API Changes

New OpenAI-compatible HTTP API surface (additive only, no existing endpoints changed):

```bash
# 1. Create a vector store (synthetic; no workspace materialized yet)
curl http://localhost:11434/v1/vector_stores \
  -H "Content-Type: application/json" \
  -d '{ "name": "product-docs" }'

# 2. Upload a file (multipart, bytes kept in memory until attached)
curl http://localhost:11434/v1/files \
  -F "file=@./notes.txt;type=text/plain" \
  -F "purpose=assistants"

# 3. Attach the file to the store (runs ragIngest, drops the bytes)
curl http://localhost:11434/v1/vector_stores/vs_abc123/files \
  -H "Content-Type: application/json" \
  -d '{ "file_id": "file-abc..." }'

# 4. Search the store
curl http://localhost:11434/v1/vector_stores/vs_abc123/search \
  -H "Content-Type: application/json" \
  -d '{ "query": "How do I configure preload?", "max_num_results": 5 }'
```

Other endpoints: `GET /v1/vector_stores`, `GET /v1/vector_stores/:id`, `POST /v1/vector_stores/:id` (update), `DELETE /v1/vector_stores/:id`, `GET /v1/files`, `GET /v1/files/:id`.

## Review feedback addressed

Reviewers — see threads on the PR for the inline conversation; each fix below lands as its own commit so it's easy to spot in the diff.

| # | Commit | Change |
| --- | --- | --- |
| 1 | `d0186b0c0` | `fix[api]: order RAG delete before local metadata delete` — partial-failure path no longer permanently loses caller-supplied metadata. (@simon-iribarren) |
| 2 | `56eb8e776` | `fix[api]: reject binary uploads in vector store file attach` — null-byte sniff before UTF-8 decode → `400 unsupported_file_type`. Matches the documented "text-only" contract. (@simon-iribarren) |
| 3 | `da8ff25ed` | `chore[api]: tidy vector_stores edge cases` — 409 for duplicate id, race-guard in update synthesize-then-create, `try/finally` around `closeWorkspaceQuiet`, discriminated `pickDefaultEmbedding` (`no_embedding_model_configured` vs `ambiguous_embedding_model`). (@simon-iribarren nits) |
| 4 | `15e89e7f7` | `fix[api]: pin embedding model per vector store` — `embeddingAlias` on `VectorStoreMeta`, recorded on first attach, mismatch rejected with `400 embedding_model_mismatch`. (@opaninakuffo) |
| 5 | `d628b8e86` | `fix[api]: stabilize synthetic vector store timestamps` — disk-only `syntheticFromWorkspace` returns `createdAt`/`lastActiveAt = 0` so GET responses are deterministic and list order doesn't shuffle on every read. (@opaninakuffo) |
| 6 | `83c8506fe` | `feat[api]: surface file_id and filename in vector_store search hits` — per-(vs, chunk) attribution map populated from `sdkRagIngest.processed`, consumed in `searchResultsToOpenAI`, evicted on `DELETE`. (@opaninakuffo) |

## Out of scope (planned follow-ups)

- Durable Files API (`POST /v1/files` bytes survive restarts, listing across sessions, content retrieval after attach) — needs the `BlobStore` foundation from `docs/openai-cli-storage-foundation.md` Group 1.
- `POST /v1/vector_stores/:id/file_batches` + per-file status polling — needs `JobStore` (Group 4).
- Real `usage_bytes` / `file_counts` accounting on the store object.
- `expires_after` enforcement daemon.
- Per-request embedding-model override.
- PDF / HTML / DOCX parsers for ingest (current code is UTF-8 text only).

---

<details>
<summary><strong>Attachments (manual smoke — not committed)</strong></summary>


Save the four files below side by side in a directory outside the repo (e.g. `~/.qvac-vector-stores-local-test/`). Build the CLI once, run the server in one terminal, run the scenarios in another — same layout as #2008.

```bash
mkdir -p ~/.qvac-vector-stores-local-test
# paste each attachment into ~/.qvac-vector-stores-local-test/<filename>
chmod +x ~/.qvac-vector-stores-local-test/run-server.sh ~/.qvac-vector-stores-local-test/test-scenarios.sh
cd packages/cli && npm install && npm run build
cd ~/.qvac-vector-stores-local-test
./run-server.sh
# second terminal:
./test-scenarios.sh
```

Requires `jq` on `PATH`. First boot downloads `QWEN3_600M_INST_Q4` (chat) and `GTE_LARGE_FP16` (embed).

**Attachment 1: `qvac.config.json`**

```json
{
  "serve": {
    "models": {
      "my-llm": {
        "model": "QWEN3_600M_INST_Q4",
        "default": true,
        "preload": true,
        "config": { "ctx_size": 4096, "tools": false }
      },
      "my-embed": {
        "model": "GTE_LARGE_FP16",
        "default": true,
        "preload": true
      }
    }
  }
}
```

**Attachment 2: `qvac.config.no-embed.json`** — for the `no_embedding_model_configured` sad path

```json
{
  "serve": {
    "models": {
      "my-llm": {
        "model": "QWEN3_600M_INST_Q4",
        "default": true,
        "preload": true,
        "config": { "ctx_size": 4096, "tools": false }
      }
    }
  }
}
```

**Attachment 3: `run-server.sh`**

```bash
#!/usr/bin/env bash
# Start qvac serve openai with this directory's config. Logs stay in this terminal.
# Expects a built CLI at $QVAC_REPO/packages/cli/dist/index.js.
#
# Env: QVAC_REPO, CFG (default ./qvac.config.json), PORT (default 11437).
# No-embed smoke: CFG="$HERE/qvac.config.no-embed.json" PORT=11438 ./run-server.sh
set -euo pipefail

HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
REPO="${QVAC_REPO:-$HOME/qvac}"
CLI="$REPO/packages/cli/dist/index.js"
CFG="${CFG:-$HERE/qvac.config.json}"
PORT="${PORT:-11437}"

if [[ ! -f "$CLI" ]]; then
  echo "CLI build missing at $CLI" >&2
  echo "Run: (cd $REPO/packages/cli && npm install && npm run build)" >&2
  exit 1
fi

cd "$HERE"
exec node "$CLI" serve openai -H 127.0.0.1 -p "$PORT" -v -c "$CFG" "$@"
```

**Attachment 4: `test-scenarios.sh`** — drives the full HTTP flow and asserts ingestion produces real search hits

```bash
#!/usr/bin/env bash
# Vector store API checks against a server you started with ./run-server.sh (other terminal).
#
# Usage:
#   ./test-scenarios.sh                    # full flow incl. POST /v1/files + attach + search hit proof (needs jq)
#   ./test-scenarios.sh no_embed           # sad path; use no-embed server (BASE_URL=http://127.0.0.1:11438)
#
# Env: BASE_URL, SKIP_INGEST=1 (skip file upload + attach + hit proof; API-only pass)
set -euo pipefail

HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
BASE="${BASE_URL:-http://127.0.0.1:11437}"
cd "$HERE"

wait_models() {
  local root=$1
  local i=0
  local code=000
  while [[ $i -lt 45 ]]; do
    i=$((i + 1))
    code=$(curl -sS -o /dev/null -w "%{http_code}" "$root/v1/models" || echo 000)
    if [[ "$code" == "200" ]]; then
      echo "server ready ($i)"
      return 0
    fi
    sleep 1
  done
  echo "server not ready at $root" >&2
  exit 1
}

assert_search_hits() {
  local path=$1
  echo "== assert: search returned at least one text hit =="
  jq -e '
    .object == "vector_store.search_results.page"
    and (.data | type == "array")
    and (.data | length) > 0
    and any(
      .data[];
      (.content // []) | map(select(.type == "text") | .text // "") | join(" ")
        | test("planets|moons|OpenAI|vector stores"; "i")
    )
  ' "$path" >/dev/null
}

if [[ "${1:-}" == "no_embed" ]]; then
  BASE="${BASE_URL:-http://127.0.0.1:11438}"
  wait_models "$BASE"
  echo "== sad: search with no embedding model =="
  curl -sS -o /tmp/qvac-sad3.txt -w "HTTP %{http_code}\n" \
    -X POST "$BASE/v1/vector_stores/vs_dummy/search" \
    -H "Content-Type: application/json" \
    -d '{"query":"x"}'
  cat /tmp/qvac-sad3.txt
  echo ""
  exit 0
fi

wait_models "$BASE"

if [[ "${SKIP_INGEST:-}" != "1" ]] && ! command -v jq >/dev/null 2>&1; then
  echo "jq is required unless SKIP_INGEST=1." >&2
  exit 1
fi

echo "== GET /v1/vector_stores =="
curl -sS "$BASE/v1/vector_stores"; echo ""

echo "== POST /v1/vector_stores =="
curl -sS -o /tmp/qvac-vs-create.json -w "HTTP %{http_code}\n" \
  -X POST "$BASE/v1/vector_stores" \
  -H "Content-Type: application/json" \
  -d '{"name":"smoke","metadata":{"by":"test-scenarios.sh"}}'
VS_ID=$(jq -r .id /tmp/qvac-vs-create.json)
export VS_ID
echo "VS_ID=$VS_ID"

echo "== GET /v1/vector_stores/{id} =="
curl -sS "$BASE/v1/vector_stores/$VS_ID"; echo ""

echo "== POST search before ingest (expect 200, often zero hits) =="
curl -sS -o /tmp/qvac-search-empty.json -w "HTTP %{http_code}\n" \
  -X POST "$BASE/v1/vector_stores/$VS_ID/search" \
  -H "Content-Type: application/json" \
  -d '{"query":"planets","max_num_results":3}'
[[ "${SKIP_INGEST:-}" != "1" ]] && jq '{object, hit_count: (.data | length)}' /tmp/qvac-search-empty.json || cat /tmp/qvac-search-empty.json
echo ""

if [[ "${SKIP_INGEST:-}" != "1" ]]; then
  DOC_PATH=/tmp/qvac-vs-doc.txt
  printf 'Local smoke document about planets, moons and the solar system.\nAnother note about OpenAI vector stores and RAG.\n' > "$DOC_PATH"

  echo "== POST /v1/files =="
  curl -sS -o /tmp/qvac-file-create.json -w "HTTP %{http_code}\n" \
    -X POST "$BASE/v1/files" \
    -F "file=@$DOC_PATH;type=text/plain" \
    -F "purpose=assistants"
  jq '{object, id, bytes, purpose, status}' /tmp/qvac-file-create.json
  FILE_ID=$(jq -r '.id' /tmp/qvac-file-create.json)
  echo "FILE_ID=$FILE_ID"

  echo "== GET /v1/files =="
  curl -sS -o /tmp/qvac-files-list.json "$BASE/v1/files"
  jq -e --arg id "$FILE_ID" '.object == "list" and any(.data[]; .id == $id)' /tmp/qvac-files-list.json >/dev/null
  jq '{object, count: (.data | length)}' /tmp/qvac-files-list.json

  echo "== GET /v1/files/$FILE_ID =="
  curl -sS -o /tmp/qvac-file-get.json -w "HTTP %{http_code}\n" "$BASE/v1/files/$FILE_ID"
  jq '{object, id, bytes, purpose, status}' /tmp/qvac-file-get.json

  echo "== POST /v1/vector_stores/$VS_ID/files (attach + ingest) =="
  curl -sS -o /tmp/qvac-vs-attach.json -w "HTTP %{http_code}\n" \
    -X POST "$BASE/v1/vector_stores/$VS_ID/files" \
    -H "Content-Type: application/json" \
    -d "{\"file_id\":\"$FILE_ID\"}"
  jq -e '
    .object == "vector_store.file"
    and .status == "completed"
    and .vector_store_id == env.VS_ID
    and (.usage_bytes | type == "number")
  ' /tmp/qvac-vs-attach.json >/dev/null
  echo "PASS attach ($(jq -c '{id, vector_store_id, usage_bytes}' /tmp/qvac-vs-attach.json))"

  echo "== GET /v1/files/$FILE_ID after attach (expect 404 file_not_found) =="
  curl -sS -o /tmp/qvac-file-get-after.json -w "HTTP %{http_code}\n" "$BASE/v1/files/$FILE_ID"
  jq -e '.error.code == "file_not_found"' /tmp/qvac-file-get-after.json >/dev/null

  echo "== POST search after ingest =="
  curl -sS -o /tmp/qvac-search-hits.json -w "HTTP %{http_code}\n" \
    -X POST "$BASE/v1/vector_stores/$VS_ID/search" \
    -H "Content-Type: application/json" \
    -d '{"query":"planets and solar system","max_num_results":5}'
  assert_search_hits /tmp/qvac-search-hits.json
  echo "PASS search ($(jq -c '{hit_count: (.data | length), first_preview: (.data[0].content[0].text // "" | .[0:120])}' /tmp/qvac-search-hits.json))"

  echo "== sad: attach unknown file_id =="
  curl -sS -o /tmp/qvac-attach-bad.json -w "HTTP %{http_code}\n" \
    -X POST "$BASE/v1/vector_stores/$VS_ID/files" \
    -H "Content-Type: application/json" \
    -d '{"file_id":"file-doesnotexist"}'
  jq -e '.error.code == "file_not_found"' /tmp/qvac-attach-bad.json >/dev/null

  echo "== sad: attach missing file_id =="
  curl -sS -o /tmp/qvac-attach-empty.json -w "HTTP %{http_code}\n" \
    -X POST "$BASE/v1/vector_stores/$VS_ID/files" \
    -H "Content-Type: application/json" \
    -d '{}'
  jq -e '.error.code == "missing_file_id"' /tmp/qvac-attach-empty.json >/dev/null
fi

echo "== sad: invalid id =="
curl -sS -o /tmp/qvac-sad1.txt -w "HTTP %{http_code}\n" "$BASE/v1/vector_stores/bad%2Fid"
cat /tmp/qvac-sad1.txt; echo ""

echo "== sad: search missing query =="
curl -sS -o /tmp/qvac-sad2.txt -w "HTTP %{http_code}\n" \
  -X POST "$BASE/v1/vector_stores/$VS_ID/search" \
  -H "Content-Type: application/json" \
  -d '{}'
cat /tmp/qvac-sad2.txt; echo ""

echo "== DELETE /v1/vector_stores/{id} =="
curl -sS -X DELETE "$BASE/v1/vector_stores/$VS_ID"; echo ""

echo "Main scenarios finished OK."
echo "No-embed check: CFG=$HERE/qvac.config.no-embed.json PORT=11438 ./run-server.sh"
echo "then: BASE_URL=http://127.0.0.1:11438 ./test-scenarios.sh no_embed"
```

</details>

