### PR TITLE
QVAC-18612 test: validate label-gate fan-out across 5 packages

### DIFF
--- a/packages/diffusion-cpp/README.md
+++ b/packages/diffusion-cpp/README.md
@@ -659,3 +659,4 @@ must be released under a compatible CC BY-SA license.
 ## License
 
 Apache-2.0 — see [LICENSE](./LICENSE) for details.
+<!-- test: label-gate fan-out validation (PR will be closed; do not merge) -->

--- a/packages/embed-llamacpp/README.md
+++ b/packages/embed-llamacpp/README.md
@@ -263,3 +263,5 @@ C++ unit tests live under [`addon/test/`](./addon/test/) and exercise the native
 This project is licensed under the Apache-2.0 [License](./LICENSE) – see the LICENSE file for details.
 
 _For questions or issues, please open an issue on the GitHub repository._
+
+<!-- test: label-gate fan-out validation (PR will be closed; do not merge) -->

--- a/packages/llm-llamacpp/README.md
+++ b/packages/llm-llamacpp/README.md
@@ -446,3 +446,5 @@ These tests validate the native implementation and help catch issues early in de
 This project is licensed under the Apache-2.0 [License](./LICENSE) – see the LICENSE file for details.
 
 _For questions or issues, please open an issue on the GitHub repository._
+
+<!-- test: label-gate fan-out validation (PR will be closed; do not merge) -->

--- a/packages/transcription-whispercpp/README.md
+++ b/packages/transcription-whispercpp/README.md
@@ -566,3 +566,5 @@ This project is licensed under the Apache-2.0 License – see the LICENSE file f
 
 For questions or issues, please open an issue on the GitHub repository.
 
+
+<!-- test: label-gate fan-out validation (PR will be closed; do not merge) -->

--- a/packages/translation-nmtcpp/README.md
+++ b/packages/translation-nmtcpp/README.md
@@ -888,3 +888,5 @@ npm run test:cpp    # C++ tests only (requires build first)
 
 This project is licensed under the Apache-2.0 License - see the [LICENSE](LICENSE) file for details.<br>
 For any questions or issues, please open an issue on the GitHub repository.
+
+<!-- test: label-gate fan-out validation (PR will be closed; do not merge) -->


### PR DESCRIPTION
> **⛔ Do not merge.** Throwaway test PR for validating the label-gate fan-out from #1997. Will be closed once the matrix below has been walked through.

## 🎯 Why this PR exists

#1997 fanned `label-gate` out to 108 secret-bearing workflows. We need a live PR that touches enough package paths to actually fire the gated workflows so we can confirm:

1. Without `verified` → label-gate denies, secret-bearing jobs skip.
2. With `verified` applied by a trusted actor → label-gate authorises, secret-bearing jobs run.
3. Synchronize from a non-trusted actor → label is stripped automatically.

## 📝 What changed

One trailing HTML comment per README in 5 packages picked to span different gated workflow shapes (NLP / vision / speech / translation):

- `packages/embed-llamacpp/README.md` → fires `on-pr-embed-llamacpp.yml`
- `packages/llm-llamacpp/README.md` → fires `on-pr-llm-llamacpp.yml`
- `packages/diffusion-cpp/README.md` → fires `on-pr-diffusion-cpp.yml`
- `packages/transcription-whispercpp/README.md` → fires `on-pr-transcription-whispercpp.yml`
- `packages/translation-nmtcpp/README.md` → fires `on-pr-translation-nmtcpp.yml`

The comment is invisible when the README renders. `diffusion-cpp` also got an implicit trailing newline (file previously had no final newline).

## 🧪 Validation matrix

| # | Action | Expected behaviour |
|---|---|---|
| 1 | PR opened with no labels | All 5 `label-gate` jobs run; `authorised=false`; downstream sanity-checks / cpp-lint / prebuild jobs all skip with `if: needs.label-gate.outputs.authorised == 'true'`. |
| 2 | Apply `verified` (as `qvac-internal-*` member) | Re-run all 5 `label-gate` jobs; `authorised=true`; downstream secret-bearing jobs now run. |
| 3 | Push a no-op commit (synchronize as same trusted actor) | All 5 gates re-authorise; downstream jobs run again. |
| 4 | Remove `verified` label | New runs deny; downstream jobs skip. |
| 5 | (Optional) Re-apply `verified`, then synchronize as a non-trusted actor | Gate strips the label automatically; downstream jobs skip; bot leaves a `notice` annotation. |

After matrix is complete:
- Take screenshots / job-link snapshots of each step.
- Close this PR (do not merge).

## 🔗 Related

- Parent: [QVAC-18612 — Add label-gate plus verified gating to every secret-bearing workflow](https://app.asana.com/1/45238840754660/project/1214153063536860/task/1214612672233099)
- Closes the validation gap left open by #1997's merge (which only had unit/static validation).

Made with [Cursor](https://cursor.com)