### PR TITLE
QVAC-18460 test[skiplog]: re-enable iOS transcription tests

### DIFF
--- a/packages/sdk/tests-qvac/tests/mobile/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/mobile/consumer.ts
@@ -392,13 +392,6 @@ export const executor = createExecutor({
         "addon-logging-ocr",
       ], "OCR disabled on iOS (ONNX/CoreML OOM)"),
       new SkipExecutor(/^translation-afriquegemma-/, "AfriqueGemma 4B (~2.7 GB) exceeds iOS memory budget"),
-      // TODO(QVAC-18460): re-enable once iOS transcribe() crash is fixed.
-      new SkipExecutor(/^(transcription-|addon-logging-whisper$)/, "TODO(QVAC-18460): transcription disabled on iOS — transcribe() hard-crashes consumer after FFmpegDecoder unload"),
-      new SkipExecutor(/^transcribe-stream-events-/, "TODO(QVAC-18460): transcribeStream disabled on iOS — same native crash path as transcription-* (Silero VAD + whisper_full)"),
-      skipTests([
-        "config-reload-then-transcribe",
-        "error-transcription-failed",
-      ], "TODO(QVAC-18460): transcribe() hard-crashes consumer on iOS"),
     ] : []),
 
     // Real executors


### PR DESCRIPTION
<!-- Style: bullets, concise. -->

## 🎯 What problem does this PR solve?

- Follow-up to #1895: iOS transcription tests were skipped while QVAC-18460 was open.
- The native iOS crash (Mach exception / Corpse 309 right after `FFmpegDecoder` unload on the first inference call) was fixed in `@qvac/transcription-whispercpp@0.7.0`, which is now pinned in the SDK via #2015.
- Until the skips are removed, iOS smoke and mobile runs miss coverage of `transcription-*`, `transcribe-stream-events-*`, `addon-logging-whisper`, `config-reload-then-transcribe`, and `error-transcription-failed`.

## 📝 How does it solve it?

- Drops the four iOS-only `SkipExecutor` / `skipTests(...)` entries in `tests/mobile/consumer.ts` that referenced `TODO(QVAC-18460)`.
- No other behavioural change — the executors and test definitions were already in place; only the iOS skip filters are gone.

## 🧪 How was it tested?

- Re-runs the iOS mobile workflow on this PR, which now exercises the full transcription family (previously skipped) on Device Farm.
- Tested locally on iOS (iphone 16e) - all 21 passed
