### PR TITLE
QVAC-18734 feat[api]: add OpenAI-compatible POST /v1/completions (legacy)

### DIFF
--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -12,6 +12,7 @@ This document describes the supported routes and how to configure `serve.models`
 | `GET` | `/v1/models/{id}` | Model metadata |
 | `DELETE` | `/v1/models/{id}` | Unload |
 | `POST` | `/v1/chat/completions` | Chat |
+| `POST` | `/v1/completions` | Legacy text completions (single + multi-prompt; blocking + SSE) |
 | `POST` | `/v1/responses` | Responses API (blocking + SSE streaming); volatile, see below |
 | `GET` | `/v1/responses/{id}` | Retrieve a stored response |
 | `DELETE` | `/v1/responses/{id}` | Delete a stored response |
@@ -27,6 +28,96 @@ This document describes the supported routes and how to configure `serve.models`
 | `GET` | `/v1/files/{id}/content` | Stream the bytes (used by image `response_format=url`) |
 
 Other OpenAI routes may be added over time; this file is updated when they ship.
+
+## `POST /v1/completions`
+
+Legacy (pre-chat) OpenAI text-completions endpoint, kept for compatibility with
+older OpenAI clients and SDKs that have not migrated to `/v1/chat/completions`.
+Backed by the same chat-category models and SDK `completion` capability as
+`/v1/chat/completions` — any alias registered with an endpoint category of
+`chat` in `serve.models` serves both endpoints with no extra configuration.
+
+> **Chat-template caveat.** The prompt is wrapped as a single `{ role: 'user' }`
+> chat turn before being fed to the SDK, so the model's chat template (system
+> prompt, role tags) still runs on every call. Legacy clients that expect raw
+> OpenAI text-completion semantics (no system prompt, no role formatting around
+> the prompt) will see template-shaped output. This is a deliberate
+> compatibility trade-off — QVAC has one chat-category capability, not a
+> raw-completion one. Use `/v1/chat/completions` directly if you need explicit
+> control over the message structure.
+
+### Prompt input
+
+- **String prompt** — blocking JSON or SSE streaming. Response object is
+  `text_completion` with `cmpl-` ids and `choices[0].text`.
+- **Single-element string array** — same as a string prompt.
+- **String array of length ≥ 2** (multi-prompt) — fanned out sequentially as
+  N independent completions and returned in `choices` with matching `index`.
+  Blocking only; combining with `"stream": true` returns
+  `400 unsupported_streaming`. Any single prompt failing aborts the whole
+  request — partial results are not emitted.
+- **Token-id prompts** (`number[]`, `number[][]`) and **empty / missing
+  prompts** — `400 invalid_prompt`.
+
+### Examples
+
+```bash
+# Blocking, single prompt
+curl -sS http://127.0.0.1:11434/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"my-llm","prompt":"Say hello in one word.","max_tokens":16}'
+
+# Streaming (single prompt only)
+curl -sN http://127.0.0.1:11434/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"my-llm","prompt":"Say hello in one word.","stream":true}'
+
+# Multi-prompt fan-out (blocking only; stream:true returns 400)
+curl -sS http://127.0.0.1:11434/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"my-llm","prompt":["Reply with alpha.","Reply with beta."],"max_tokens":8}'
+```
+
+Blocking response shape (single prompt):
+
+```json
+{
+  "id": "cmpl-…",
+  "object": "text_completion",
+  "created": 1718000000,
+  "model": "my-llm",
+  "choices": [
+    { "text": "Hello", "index": 0, "logprobs": null, "finish_reason": "stop" }
+  ],
+  "usage": { "prompt_tokens": 0, "completion_tokens": 1, "total_tokens": 1 }
+}
+```
+
+### Generation parameters
+
+Same as `/v1/chat/completions`: `temperature`, `max_tokens`,
+`max_completion_tokens`, `top_p`, `seed`, `frequency_penalty`,
+`presence_penalty`, `reasoning_budget`.
+
+### Ignored parameters (warning logged)
+
+`logprobs`, `echo`, `best_of`, `suffix`, `stop`, `logit_bias`, `stream_options`,
+`user`, `response_format`, and `n` when greater than `1`. Legacy OpenAI
+semantics for these (logprob distributions, prompt echo, best-of-N sampling,
+suffix insertion, multi-choice `n`) are not implemented.
+
+### Errors
+
+| HTTP | `error.code` | When |
+|------|----------------|------|
+| 400 | `invalid_json` | Body is not valid JSON |
+| 400 | `missing_model` | `model` field is missing |
+| 400 | `invalid_prompt` | Prompt is missing, empty, has empty array entries, or is provided as token ids |
+| 400 | `unsupported_streaming` | Multi-prompt input combined with `"stream": true` |
+| 400 | `invalid_model_type` | Alias is not a `chat` model |
+| 404 | `model_not_found` | Unknown alias |
+| 503 | `model_not_ready` | Model not loaded yet |
+| 500 | `completion_error` | SDK / engine failure |
 
 ## `POST /v1/responses`
 

--- a/packages/cli/src/serve/adapters/openai/index.ts
+++ b/packages/cli/src/serve/adapters/openai/index.ts
@@ -50,6 +50,12 @@ export function createOpenAIAdapter (): APIAdapter {
         return true
       }
 
+      if (method === 'POST' && path === '/v1/completions') {
+        const { handleCompletions } = await import('./routes/completions.js')
+        await handleCompletions(req, res, ctx)
+        return true
+      }
+
       if (method === 'POST' && path === '/v1/embeddings') {
         const { handleEmbeddings } = await import('./routes/embeddings.js')
         await handleEmbeddings(req, res, ctx)

--- a/packages/cli/src/serve/adapters/openai/routes/completions.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/completions.ts
@@ -1,0 +1,217 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readBody, sendJson, sendError, initSSE, sendSSE, endSSE } from '../../../http.js'
+import { resolveModelAlias } from '../../../config.js'
+import { sdkCompletion } from '../../../core/sdk.js'
+import type { SDKGenerationParams } from '../../../core/sdk.js'
+import {
+  parseLegacyPrompt,
+  legacyPromptToHistory,
+  extractGenerationParams,
+  logLegacyUnsupportedParams,
+  InvalidPromptError
+} from '../translate.js'
+import type { RouteContext } from '../../types.js'
+
+interface RouteParams {
+  sdkModelId: string
+  modelAlias: string
+  generationParams: SDKGenerationParams | undefined
+  logger: import('../../../../logger.js').Logger
+}
+
+export async function handleCompletions (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<void> {
+  let body: Record<string, unknown>
+  try {
+    body = await readBody(req)
+  } catch {
+    sendError(res, 400, 'invalid_json', 'Request body must be valid JSON.')
+    return
+  }
+
+  if (!body['model']) {
+    sendError(res, 400, 'missing_model', '"model" is required.')
+    return
+  }
+
+  let prompt
+  try {
+    prompt = parseLegacyPrompt(body['prompt'])
+  } catch (err) {
+    if (err instanceof InvalidPromptError) {
+      sendError(res, 400, 'invalid_prompt', err.message)
+      return
+    }
+    throw err
+  }
+
+  const streaming = Boolean(body['stream'])
+
+  if (prompt.kind === 'multi' && streaming) {
+    sendError(
+      res,
+      400,
+      'unsupported_streaming',
+      'Multi-prompt input cannot be streamed. Send a single string prompt or set "stream" to false.'
+    )
+    return
+  }
+
+  const modelName = body['model'] as string
+  const modelEntry = resolveModelAlias(ctx.serveConfig, modelName) ?? ctx.registry.getEntry(modelName)
+
+  if (!modelEntry) {
+    sendError(res, 404, 'model_not_found', `Model "${modelName}" is not available. Check serve.models config.`)
+    return
+  }
+
+  const endpointCategory = 'endpointCategory' in modelEntry ? modelEntry.endpointCategory : undefined
+  if (endpointCategory !== 'chat') {
+    sendError(res, 400, 'invalid_model_type', `Model "${modelName}" does not support completions.`)
+    return
+  }
+
+  const alias = 'alias' in modelEntry ? (modelEntry.alias as string) : modelEntry.id
+  const registryEntry = ctx.registry.getEntry(alias)
+  if (!registryEntry || registryEntry.state !== ctx.registry.STATES.READY) {
+    sendError(res, 503, 'model_not_ready', `Model "${modelName}" is not loaded yet.`)
+    return
+  }
+
+  logLegacyUnsupportedParams(body, ctx.logger)
+
+  const sdkModelId = registryEntry.sdkModelId ?? registryEntry.id
+  const generationParams = extractGenerationParams(body)
+  const params: RouteParams = { sdkModelId, modelAlias: alias, generationParams, logger: ctx.logger }
+
+  const promptCount = prompt.kind === 'single' ? 1 : prompt.values.length
+  ctx.logger.info(`  completions model=${alias} prompts=${promptCount} stream=${streaming}${generationParams ? ` genParams=${JSON.stringify(generationParams)}` : ''}`)
+
+  try {
+    if (prompt.kind === 'single' && streaming) {
+      await handleStreamingCompletion(res, params, prompt.value)
+    } else if (prompt.kind === 'single') {
+      await handleBlockingSingle(res, params, prompt.value)
+    } else {
+      await handleBlockingMulti(res, params, prompt.values)
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.error(`Completion error for "${alias}": ${message}`)
+    sendError(res, 500, 'completion_error', 'An internal error occurred during completion.')
+  }
+}
+
+async function handleBlockingSingle (res: ServerResponse, params: RouteParams, prompt: string): Promise<void> {
+  const choice = await runOne(params, prompt, 0)
+
+  params.logger.info(`  completions done tokens=${choice.tokenCount} finish=${choice.finish_reason}`)
+
+  sendJson(res, 200, {
+    id: `cmpl-${randomId()}`,
+    object: 'text_completion',
+    created: Math.floor(Date.now() / 1000),
+    model: params.modelAlias,
+    choices: [choice.public],
+    usage: {
+      prompt_tokens: 0,
+      completion_tokens: choice.tokenCount,
+      total_tokens: choice.tokenCount
+    }
+  })
+}
+
+async function handleBlockingMulti (res: ServerResponse, params: RouteParams, prompts: string[]): Promise<void> {
+  const choices = []
+  let totalTokens = 0
+
+  for (let i = 0; i < prompts.length; i++) {
+    const result = await runOne(params, prompts[i]!, i)
+    choices.push(result.public)
+    totalTokens += result.tokenCount
+  }
+
+  params.logger.info(`  completions done prompts=${prompts.length} tokens=${totalTokens}`)
+
+  sendJson(res, 200, {
+    id: `cmpl-${randomId()}`,
+    object: 'text_completion',
+    created: Math.floor(Date.now() / 1000),
+    model: params.modelAlias,
+    choices,
+    usage: {
+      prompt_tokens: 0,
+      completion_tokens: totalTokens,
+      total_tokens: totalTokens
+    }
+  })
+}
+
+interface ChoiceResult {
+  public: { text: string; index: number; logprobs: null; finish_reason: 'stop' }
+  tokenCount: number
+  finish_reason: 'stop'
+}
+
+async function runOne (params: RouteParams, prompt: string, index: number): Promise<ChoiceResult> {
+  const result = await sdkCompletion({
+    modelId: params.sdkModelId,
+    history: legacyPromptToHistory(prompt),
+    stream: false,
+    generationParams: params.generationParams
+  })
+
+  const text = await result.text
+  // TODO(QVAC-18522 follow-up): derive `finish_reason` from `result.stats`
+  // ('length' on max_tokens cap, 'stop' otherwise) and unify token accounting
+  // with the chat route's `completionTokensFromStats` helper. Same drift
+  // exists in the streaming path below and in chat.ts.
+  const tokenCount = text ? text.split(/\s+/).filter(Boolean).length : 0
+
+  return {
+    public: { text: text ?? '', index, logprobs: null, finish_reason: 'stop' },
+    tokenCount,
+    finish_reason: 'stop'
+  }
+}
+
+async function handleStreamingCompletion (res: ServerResponse, params: RouteParams, prompt: string): Promise<void> {
+  const result = await sdkCompletion({
+    modelId: params.sdkModelId,
+    history: legacyPromptToHistory(prompt),
+    stream: true,
+    generationParams: params.generationParams
+  })
+
+  initSSE(res)
+
+  const id = `cmpl-${randomId()}`
+  const created = Math.floor(Date.now() / 1000)
+
+  const chunk = (text: string, finishReason: string | null, extra?: Record<string, unknown>) => ({
+    id,
+    object: 'text_completion',
+    created,
+    model: params.modelAlias,
+    choices: [{ text, index: 0, logprobs: null, finish_reason: finishReason }],
+    ...extra
+  })
+
+  let tokenCount = 0
+
+  for await (const token of result.tokenStream) {
+    tokenCount++
+    sendSSE(res, chunk(token, null))
+  }
+
+  params.logger.info(`  completions streaming done tokens=${tokenCount}`)
+
+  sendSSE(res, chunk('', 'stop', {
+    usage: { prompt_tokens: 0, completion_tokens: tokenCount, total_tokens: tokenCount }
+  }))
+
+  endSSE(res)
+}
+
+function randomId (): string {
+  return Math.random().toString(36).slice(2, 12)
+}

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -1019,3 +1019,85 @@ export function logImageEditExtraWarnings (
     logger.warn(`image[] received ${opts.extraImageCount + 1} files; using only the first`)
   }
 }
+
+// ─── /v1/completions (legacy) helpers ───────────────────────────────────────
+
+export class InvalidPromptError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'InvalidPromptError'
+  }
+}
+
+export type LegacyPrompt =
+  | { kind: 'single'; value: string }
+  | { kind: 'multi'; values: string[] }
+
+export function parseLegacyPrompt (raw: unknown): LegacyPrompt {
+  if (raw === undefined || raw === null) {
+    throw new InvalidPromptError('"prompt" is required.')
+  }
+
+  if (typeof raw === 'string') {
+    if (raw.length === 0) {
+      throw new InvalidPromptError('"prompt" must be a non-empty string.')
+    }
+    return { kind: 'single', value: raw }
+  }
+
+  if (typeof raw === 'number') {
+    throw new InvalidPromptError('Token-id prompts are not supported. Pass a string.')
+  }
+
+  if (Array.isArray(raw)) {
+    if (raw.length === 0) {
+      throw new InvalidPromptError('"prompt" array must not be empty.')
+    }
+
+    if (raw.every((p) => typeof p === 'string')) {
+      const values = raw as string[]
+      if (values.some((v) => v.length === 0)) {
+        throw new InvalidPromptError('"prompt" array entries must be non-empty strings.')
+      }
+      if (values.length === 1) {
+        return { kind: 'single', value: values[0]! }
+      }
+      return { kind: 'multi', values }
+    }
+
+    throw new InvalidPromptError('Token-id prompts are not supported. Pass a string or an array of strings.')
+  }
+
+  throw new InvalidPromptError('"prompt" must be a string or an array of strings.')
+}
+
+/**
+ * Wraps a legacy completions prompt as a single `user` turn so it can be fed
+ * to the same SDK `completion` capability that backs `/v1/chat/completions`.
+ *
+ * Caveat: the SDK's chat template (system prompt + role tags) still runs on
+ * every `/v1/completions` call. Legacy OpenAI clients that expect raw
+ * completion semantics (no system prompt, no role formatting around the
+ * prompt) will see template-shaped output. This is a deliberate compatibility
+ * trade-off — we have one chat-category capability, not a raw-completion one.
+ */
+export function legacyPromptToHistory (prompt: string): Array<{ role: string; content: string }> {
+  return [{ role: 'user', content: prompt }]
+}
+
+const LEGACY_UNSUPPORTED_PARAMS = [
+  'logprobs', 'echo', 'best_of', 'suffix',
+  'stop', 'logit_bias', 'stream_options', 'user',
+  'response_format'
+] as const
+
+export function logLegacyUnsupportedParams (body: Record<string, unknown>, logger: Logger): void {
+  for (const param of LEGACY_UNSUPPORTED_PARAMS) {
+    if (body[param] !== undefined) {
+      logger.warn(`Ignoring unsupported OpenAI legacy-completions param: ${param}=${JSON.stringify(body[param])}`)
+    }
+  }
+  if (typeof body['n'] === 'number' && body['n'] !== 1) {
+    logger.warn(`Ignoring unsupported OpenAI legacy-completions param: n=${JSON.stringify(body['n'])}`)
+  }
+}

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -124,7 +124,7 @@ export async function startServer (options: StartServerOptions): Promise<http.Se
 }
 
 const CATEGORY_ENDPOINTS: Record<string, string[]> = {
-  chat: ['POST /v1/chat/completions', 'POST /v1/responses'],
+  chat: ['POST /v1/chat/completions', 'POST /v1/completions', 'POST /v1/responses'],
   embedding: ['POST /v1/embeddings'],
   transcription: ['POST /v1/audio/transcriptions'],
   'audio-translation': ['POST /v1/audio/translations'],

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -522,6 +522,109 @@ TXT
   assert_error "${body}" "invalid_model_type"
 }
 
+# ── Legacy completions (blocking) ────────────────────────────────────
+
+@test "legacy completions: blocking returns text_completion shape" {
+  local body
+  body=$(json_post "/v1/completions" \
+    "{\"model\":\"${LLM_ALIAS}\",\"prompt\":\"Say hello and nothing else.\",\"max_tokens\":16}")
+
+  echo "${body}" | jq -e '.id | startswith("cmpl-")' >/dev/null
+  echo "${body}" | jq -e '.object == "text_completion"' >/dev/null
+  echo "${body}" | jq -e ".model == \"${LLM_ALIAS}\"" >/dev/null
+  echo "${body}" | jq -e '.choices | length == 1' >/dev/null
+  echo "${body}" | jq -e '.choices[0].index == 0' >/dev/null
+  echo "${body}" | jq -e '.choices[0].text | type == "string"' >/dev/null
+  echo "${body}" | jq -e '.choices[0].text | length > 0' >/dev/null
+  echo "${body}" | jq -e '.choices[0].logprobs == null' >/dev/null
+  echo "${body}" | jq -e '.choices[0].finish_reason == "stop"' >/dev/null
+  echo "${body}" | jq -e '.usage.completion_tokens | type == "number"' >/dev/null
+}
+
+@test "legacy completions: respects max_tokens" {
+  local body
+  body=$(json_post "/v1/completions" \
+    "{\"model\":\"${LLM_ALIAS}\",\"prompt\":\"Write a very long story about a cat.\",\"max_tokens\":8}")
+
+  echo "${body}" | jq -e '.choices[0].text | length > 0' >/dev/null
+}
+
+# ── Legacy completions (multi-prompt fan-out) ────────────────────────
+
+@test "legacy completions: multi-prompt blocking returns N choices with matching indices" {
+  local body
+  body=$(json_post "/v1/completions" \
+    "{\"model\":\"${LLM_ALIAS}\",\"prompt\":[\"Reply with the word \\\"alpha\\\".\",\"Reply with the word \\\"beta\\\".\"],\"max_tokens\":8}")
+
+  echo "${body}" | jq -e '.object == "text_completion"' >/dev/null
+  echo "${body}" | jq -e '.choices | length == 2' >/dev/null
+  echo "${body}" | jq -e '.choices[0].index == 0' >/dev/null
+  echo "${body}" | jq -e '.choices[1].index == 1' >/dev/null
+  echo "${body}" | jq -e '.choices[0].text | length > 0' >/dev/null
+  echo "${body}" | jq -e '.choices[1].text | length > 0' >/dev/null
+  echo "${body}" | jq -e '.choices[0].finish_reason == "stop"' >/dev/null
+  echo "${body}" | jq -e '.choices[1].finish_reason == "stop"' >/dev/null
+}
+
+@test "legacy completions: multi-prompt with stream:true returns 400 unsupported_streaming" {
+  local body
+  body=$(json_post "/v1/completions" \
+    "{\"model\":\"${LLM_ALIAS}\",\"prompt\":[\"a\",\"b\"],\"stream\":true,\"max_tokens\":4}")
+  assert_error "${body}" "unsupported_streaming"
+}
+
+@test "legacy completions: rejects token-id prompts" {
+  local body
+  body=$(json_post "/v1/completions" \
+    "{\"model\":\"${LLM_ALIAS}\",\"prompt\":[15496,11,995],\"max_tokens\":4}")
+  assert_error "${body}" "invalid_prompt"
+}
+
+@test "legacy completions: rejects missing prompt" {
+  local body
+  body=$(json_post "/v1/completions" \
+    "{\"model\":\"${LLM_ALIAS}\",\"max_tokens\":4}")
+  assert_error "${body}" "invalid_prompt"
+}
+
+# ── Legacy completions (streaming / SSE) ─────────────────────────────
+
+@test "legacy completions: SSE stream returns valid text_completion chunks" {
+  local raw
+  raw=$(curl -sN "${BASE}/v1/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"${LLM_ALIAS}\",\"prompt\":\"Say hi.\",\"stream\":true,\"max_tokens\":16}")
+
+  echo "${raw}" | grep -q "data: \[DONE\]"
+
+  local first_chunk
+  first_chunk=$(echo "${raw}" | grep "^data: {" | head -1 | sed 's/^data: //')
+  echo "${first_chunk}" | jq -e '.id | startswith("cmpl-")' >/dev/null
+  echo "${first_chunk}" | jq -e '.object == "text_completion"' >/dev/null
+  echo "${first_chunk}" | jq -e ".model == \"${LLM_ALIAS}\"" >/dev/null
+  echo "${first_chunk}" | jq -e '.choices[0].text | type == "string"' >/dev/null
+  echo "${first_chunk}" | jq -e '.choices[0].logprobs == null' >/dev/null
+
+  local last_chunk
+  last_chunk=$(echo "${raw}" | grep "^data: {" | tail -1 | sed 's/^data: //')
+  echo "${last_chunk}" | jq -e '.choices[0].finish_reason == "stop"' >/dev/null
+  echo "${last_chunk}" | jq -e '.usage.completion_tokens | type == "number"' >/dev/null
+
+  local content_count
+  content_count=$(echo "${raw}" | grep "^data: {" | sed 's/^data: //' | \
+    jq -r 'select(.choices[0].text != null and .choices[0].text != "") | .choices[0].text' 2>/dev/null | wc -l)
+  [[ "${content_count}" -gt 0 ]]
+}
+
+# ── Legacy completions: cross-type rejection ─────────────────────────
+
+@test "cross-type: legacy completions endpoint rejects embedding model" {
+  local body
+  body=$(json_post "/v1/completions" \
+    "{\"model\":\"${EMBED_ALIAS}\",\"prompt\":\"hi\"}")
+  assert_error "${body}" "invalid_model_type"
+}
+
 @test "cross-type: embedding endpoint rejects chat model" {
   local body
   body=$(json_post "/v1/embeddings" \

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -25,7 +25,11 @@ import {
   logResponsesUnsupportedParams,
   UnsupportedToolTypeError,
   InvalidResponsesConversationError,
-  InvalidResponsesBackgroundError
+  InvalidResponsesBackgroundError,
+  parseLegacyPrompt,
+  legacyPromptToHistory,
+  logLegacyUnsupportedParams,
+  InvalidPromptError
 } from '../src/serve/adapters/openai/translate.js'
 import type { VectorStoreMeta } from '../src/serve/adapters/openai/vector-stores-store.js'
 
@@ -904,5 +908,115 @@ describe('historyPrefixFromStoredResponse', () => {
       { role: 'user', content: 'bIn' }, { role: 'assistant', content: 'bOut' },
       { role: 'user', content: 'cIn' }, { role: 'assistant', content: 'cOut' }
     ])
+  })
+})
+
+describe('parseLegacyPrompt', () => {
+  it('returns a single prompt for a non-empty string', () => {
+    assert.deepEqual(parseLegacyPrompt('hello'), { kind: 'single', value: 'hello' })
+  })
+
+  it('unwraps a single-element string array to a single prompt', () => {
+    assert.deepEqual(parseLegacyPrompt(['hello']), { kind: 'single', value: 'hello' })
+  })
+
+  it('returns a multi prompt for arrays with two or more strings', () => {
+    assert.deepEqual(parseLegacyPrompt(['a', 'b']), { kind: 'multi', values: ['a', 'b'] })
+    assert.deepEqual(parseLegacyPrompt(['a', 'b', 'c']), { kind: 'multi', values: ['a', 'b', 'c'] })
+  })
+
+  it('throws on missing prompt', () => {
+    assert.throws(() => parseLegacyPrompt(undefined), InvalidPromptError)
+    assert.throws(() => parseLegacyPrompt(null), InvalidPromptError)
+  })
+
+  it('throws on empty string', () => {
+    assert.throws(() => parseLegacyPrompt(''), InvalidPromptError)
+  })
+
+  it('throws on empty array', () => {
+    assert.throws(() => parseLegacyPrompt([]), InvalidPromptError)
+  })
+
+  it('throws on array entries that are not strings (token IDs)', () => {
+    assert.throws(() => parseLegacyPrompt([1, 2, 3]), InvalidPromptError)
+    assert.throws(() => parseLegacyPrompt([[1, 2], [3, 4]]), InvalidPromptError)
+    assert.throws(() => parseLegacyPrompt(['ok', 7]), InvalidPromptError)
+  })
+
+  it('throws on numeric prompt (single token id)', () => {
+    assert.throws(() => parseLegacyPrompt(42), InvalidPromptError)
+  })
+
+  it('throws on array entry that is an empty string', () => {
+    assert.throws(() => parseLegacyPrompt(['ok', '']), InvalidPromptError)
+  })
+
+  it('throws on non-string, non-array, non-numeric prompt', () => {
+    assert.throws(() => parseLegacyPrompt({ text: 'oops' }), InvalidPromptError)
+    assert.throws(() => parseLegacyPrompt(true), InvalidPromptError)
+  })
+})
+
+describe('legacyPromptToHistory', () => {
+  it('wraps a string in a single-turn user history', () => {
+    assert.deepEqual(legacyPromptToHistory('hello'), [{ role: 'user', content: 'hello' }])
+  })
+})
+
+describe('logLegacyUnsupportedParams', () => {
+  function captureWarnings (body: Record<string, unknown>): string[] {
+    const warnings: string[] = []
+    const logger = {
+      info: () => {},
+      warn: (msg: string) => { warnings.push(msg) },
+      error: () => {},
+      debug: () => {}
+    } as unknown as Parameters<typeof logLegacyUnsupportedParams>[1]
+    logLegacyUnsupportedParams(body, logger)
+    return warnings
+  }
+
+  it('warns for legacy-only unsupported params', () => {
+    const warnings = captureWarnings({ echo: true, best_of: 3, suffix: 'end', user: 'u1' })
+    assert.equal(warnings.length, 4)
+    assert.ok(warnings.some((w) => w.includes('echo')))
+    assert.ok(warnings.some((w) => w.includes('best_of')))
+    assert.ok(warnings.some((w) => w.includes('suffix')))
+    assert.ok(warnings.some((w) => w.includes('user')))
+  })
+
+  it('warns for shared unsupported params (logprobs, stop, logit_bias, stream_options)', () => {
+    const warnings = captureWarnings({
+      logprobs: 5,
+      stop: ['\n'],
+      logit_bias: { '50256': -100 },
+      stream_options: { include_usage: true }
+    })
+    assert.ok(warnings.some((w) => w.includes('logprobs')))
+    assert.ok(warnings.some((w) => w.includes('stop')))
+    assert.ok(warnings.some((w) => w.includes('logit_bias')))
+    assert.ok(warnings.some((w) => w.includes('stream_options')))
+  })
+
+  it('warns when response_format is sent (legacy clients should not use it)', () => {
+    const warnings = captureWarnings({ response_format: { type: 'json_object' } })
+    assert.equal(warnings.length, 1)
+    assert.ok(warnings[0]!.includes('response_format'))
+  })
+
+  it('does not warn when n is 1 (default)', () => {
+    const warnings = captureWarnings({ n: 1 })
+    assert.equal(warnings.length, 0)
+  })
+
+  it('warns when n is greater than 1', () => {
+    const warnings = captureWarnings({ n: 4 })
+    assert.equal(warnings.length, 1)
+    assert.ok(warnings[0]!.includes('n=4'))
+  })
+
+  it('is silent for an empty body', () => {
+    assert.deepEqual(captureWarnings({}), [])
   })
 })


### PR DESCRIPTION
<!-- Ticket: https://app.asana.com/1/45238840754660/task/1214717221316471 -->
<!-- Parent: https://app.asana.com/1/45238840754660/task/1214569070727346 -->

## 🎯 What problem does this PR solve?

- Older OpenAI clients and SDKs still call `POST /v1/completions` (legacy text-completion API) and currently hit a 404 against `qvac serve openai`.
- Per the OpenAI API coverage audit, this is a cheap compatibility win — the SDK already exposes the underlying `completion` capability; only the OpenAI-shaped HTTP request/response mapping was missing.

## 📝 How does it solve it?

- Adds `POST /v1/completions` to the OpenAI adapter, backed by the same SDK `completion` capability and chat-category models as `POST /v1/chat/completions`. Any chat alias in `serve.models` serves both endpoints with no extra configuration.
- Single string prompt: blocking JSON or SSE streaming, response shape `object: "text_completion"` with `cmpl-` IDs and `choices[0].text`.
- String-array prompt (multi-prompt): blocking only — fanned out sequentially as N independent completions, returned in `choices` with matching `index`. Any single prompt failure aborts the whole request (no partial body emitted).
- Multi-prompt combined with `stream: true` returns 400 `unsupported_streaming`.
- Token-id prompts (`number[]`, `number[][]`), missing prompt, and empty prompt return 400 `invalid_prompt`.
- `logprobs`, `echo`, `best_of`, `suffix`, `response_format`, `stop`, `logit_bias`, `stream_options`, `user`, and `n > 1` are accepted but ignored with a warning (matches the audit's caveat — legacy logprobs/echo/best-of semantics are not available).
- Startup log lists the new endpoint under the `chat` category.

### Trade-off worth documenting

`parseLegacyPrompt` wraps the incoming prompt as a single `{ role: 'user' }` chat turn, so the SDK's chat template (system prompt, role tags) still runs on every `/v1/completions` call. This is deliberate — we have one chat-category capability, not a raw-completion one — but legacy clients that expect raw OpenAI text-completion semantics (no system prompt, no role formatting around the prompt) will see template-shaped output. Documented inline on `legacyPromptToHistory`; the public docs follow-up will surface it to users.

## 🧪 How was it tested?

- **Unit tests** (`packages/cli/test/translate.test.ts`, +21 cases, **105/105** pass after rebase): `parseLegacyPrompt` covers single string, single-element array unwrap, multi-string array, missing/empty/whitespace, token-id rejection (`number`, `number[]`, `number[][]`), and non-string-non-array rejection. `legacyPromptToHistory` covers the 1-turn user history mapping. `logLegacyUnsupportedParams` covers legacy-only params (`echo`, `best_of`, `suffix`, `user`), shared params (`logprobs`, `stop`, `logit_bias`, `stream_options`), `response_format` warning, and `n=1` silence vs `n>1` warning.
- **bats e2e** (`packages/cli/test/e2e.bats`, +8 cases): blocking text_completion shape, `max_tokens` cap, multi-prompt N-choices with matching indices, multi-prompt + `stream: true` returns 400 `unsupported_streaming`, token-id prompts return 400 `invalid_prompt`, missing prompt returns 400 `invalid_prompt`, SSE stream chunks valid + `[DONE]` terminator, cross-type rejection (embedding model on `/v1/completions` returns `invalid_model_type`). Reuses the existing preloaded `test-llm` LLM model — no extra model boot.
- **Local validation:** `npm run typecheck` ✓, `npm run build` ✓, `npm run test` ✓ (105/105 unit), `npm run test:bats` ✓ (74/74 smoke), `npm run test:e2e` ✓ (**117/117** total including the 8 new legacy-completions cases).

## 🔌 API Changes

New HTTP endpoint:

```bash
# blocking
curl http://localhost:11434/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "my-llm",
    "prompt": "Say hello in one word.",
    "max_tokens": 16
  }'

# streaming (single prompt only)
curl -N http://localhost:11434/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "my-llm",
    "prompt": "Say hello in one word.",
    "stream": true
  }'

# multi-prompt (blocking only; stream:true returns 400)
curl http://localhost:11434/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "my-llm",
    "prompt": ["Reply with alpha.", "Reply with beta."],
    "max_tokens": 8
  }'
```

Response shape (blocking, single prompt):

```json
{
  "id": "cmpl-…",
  "object": "text_completion",
  "created": 1718000000,
  "model": "my-llm",
  "choices": [
    { "text": "…", "index": 0, "logprobs": null, "finish_reason": "stop" }
  ],
  "usage": { "prompt_tokens": 0, "completion_tokens": 1, "total_tokens": 1 }
}
```

New internal exports from `packages/cli/src/serve/adapters/openai/translate.ts` for tests/consumers: `parseLegacyPrompt`, `legacyPromptToHistory`, `logLegacyUnsupportedParams`, `InvalidPromptError`.

## Follow-ups (tracked under parent QVAC-18522, not in scope for this PR)

These are all known limitations Simon flagged in review. Captured here so they don't get lost; the parent task is the single tracking point.

1. **Marketing-site docs.** In-repo serve docs (`packages/cli/docs/serve-openai.md`) are updated by this PR — endpoints table + a full `POST /v1/completions` section with the chat-template caveat, multi-prompt semantics, parameter list, and error table. The marketing-site copy (`docs/website/content/docs/cli/http-server.mdx`) is not touched here and will land in a separate docs PR alongside the other new OpenAI endpoints (`/v1/images/generations`, `/v1/images/edits`, `/v1/responses`, `/v1/audio/translations`, `/v1/vector_stores/*`).
2. **`finish_reason` + token accounting drift across chat-category routes.** `finish_reason` is hardcoded to `'stop'` even when generation is truncated by `max_tokens` (should be `'length'`); the streaming path counts SSE events, the blocking path uses whitespace word counts, while `chat.ts` already has a `completionTokensFromStats` helper that prefers `result.stats.generatedTokens`. TODO comment in `completions.ts` references this; the fix should unify all chat-category routes in one go.
3. **Streaming cancellation on client disconnect.** No `req.on('close')` propagation on the streaming path — long generations keep consuming inference cycles after a client disconnects. Per Simon, follow-up once the QVAC-18181 lifecycle primitives are wired through.
4. **DRY the chat-category route preamble.** Five routes (`chat`, `completions`, `responses`, `embeddings`, `transcriptions`, `translations`) duplicate the same ~30-line `resolveModelAlias` + `endpointCategory` + `state === READY` preamble. Plan is a `resolveServedModel(res, ctx, modelName, opts)` helper as a follow-up refactor PR.

## Rebase note

Rebased from `8f25f3e1e` onto `upstream/main` HEAD. Conflicts in `translate.ts`, `test/translate.test.ts`, `serve/index.ts` resolved by keeping both the newly-landed `main` endpoints (responses, audio/translations, images/edits, vector_stores, files) and the legacy completions endpoint. `serve/index.ts` `CATEGORY_ENDPOINTS.chat` now lists all three: `/v1/chat/completions`, `/v1/completions`, `/v1/responses`.

`CHANGELOG.md` is intentionally untouched and will be regenerated by the `addon-changelog` skill on the next CLI release.
