### PR TITLE
QVAC-18733 feat[api]: add openai responses routes with in-memory store

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -306,7 +306,7 @@ Run an **OpenAI-compatible HTTP server** backed by locally configured QVAC model
 qvac serve openai [options]
 ```
 
-See **[docs/serve-openai.md](./docs/serve-openai.md)** for supported `/v1/...` routes, multipart request shapes, and how to register models — including **`whispercpp-audio-translation`** for `POST /v1/audio/translations` (Whisper translate-to-English).
+See **[docs/serve-openai.md](./docs/serve-openai.md)** for supported `/v1/...` routes, multipart request shapes, and how to register models — including **`whispercpp-audio-translation`** for `POST /v1/audio/translations` (Whisper translate-to-English) and the volatile **`POST /v1/responses`** Responses API with `previous_response_id` chaining.
 
 ## Configuration
 

--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -12,11 +12,52 @@ This document describes the supported routes and how to configure `serve.models`
 | `GET` | `/v1/models/{id}` | Model metadata |
 | `DELETE` | `/v1/models/{id}` | Unload |
 | `POST` | `/v1/chat/completions` | Chat |
+| `POST` | `/v1/responses` | Responses API (blocking + SSE streaming); volatile, see below |
+| `GET` | `/v1/responses/{id}` | Retrieve a stored response |
+| `DELETE` | `/v1/responses/{id}` | Delete a stored response |
+| `GET` | `/v1/responses/{id}/input_items` | Paginate the original input items |
 | `POST` | `/v1/embeddings` | Embeddings |
 | `POST` | `/v1/audio/transcriptions` | Speech-to-text (source language) |
 | `POST` | `/v1/audio/translations` | Speech-to-text **into English** (Whisper translate task) |
 
 Other OpenAI routes may be added over time; this file is updated when they ship.
+
+## `POST /v1/responses`
+
+OpenAI-compatible Responses API: blocking, SSE streaming, retrieval by id,
+and `previous_response_id` chaining. Backed by the same chat models registered
+under `serve.models` (any alias whose endpoint category is `chat`).
+
+> **Volatile state.** All responses are kept in process memory only — there is
+> no disk or P2P persistence. Stored ids expire on server restart, after the
+> per-entry TTL (1h by default), or once the LRU cap (256 entries) evicts
+> them. Each response is also tagged with `X-QVAC-Stub: responses-volatile`
+> and a one-line warn is logged at startup so operators know the surface is
+> not durable. Pass `store: false` in the request body to skip persistence
+> entirely.
+
+Intentionally rejected with `400`: `conversation`, `background: true`, and
+built-in tools (`web_search`, `file_search`, `code_interpreter`).
+`function`-typed tools work normally.
+
+### Examples
+
+```bash
+# Blocking
+curl -sS http://127.0.0.1:11434/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<alias>","input":"ping","store":true}'
+
+# Streaming (SSE)
+curl -sN http://127.0.0.1:11434/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<alias>","input":"ping","stream":true}'
+
+# Multi-turn via previous_response_id
+curl -sS http://127.0.0.1:11434/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"<alias>","input":"and now?","previous_response_id":"resp_..."}'
+```
 
 ## `POST /v1/audio/translations`
 

--- a/packages/cli/src/serve/adapters/openai/index.ts
+++ b/packages/cli/src/serve/adapters/openai/index.ts
@@ -32,6 +32,18 @@ export function createOpenAIAdapter (): APIAdapter {
         return true
       }
 
+      if (method === 'POST' && path === '/v1/responses') {
+        const { handlePostResponses } = await import('./routes/responses.js')
+        await handlePostResponses(req, res, ctx)
+        return true
+      }
+
+      if (path.startsWith('/v1/responses/')) {
+        const { routeResponsesId } = await import('./routes/responses-id.js')
+        const handled = await routeResponsesId(req, res, ctx)
+        if (handled) return true
+      }
+
       if (method === 'POST' && path === '/v1/chat/completions') {
         const { handleChatCompletions } = await import('./routes/chat.js')
         await handleChatCompletions(req, res, ctx)

--- a/packages/cli/src/serve/adapters/openai/responses-shape.ts
+++ b/packages/cli/src/serve/adapters/openai/responses-shape.ts
@@ -28,7 +28,7 @@ export interface BuildResponseObjectParams {
   temperature: number | undefined
   topP: number | undefined
   maxOutputTokens: number | undefined
-  parallelToolCalls: boolean | undefined
+  parallelToolCalls: boolean
   previousResponseId: string | null | undefined
   store: boolean
   /** When set (e.g. streaming), must match SSE item ids so finalized response matches the stream. */
@@ -95,7 +95,7 @@ export function buildResponseObject (params: BuildResponseObjectParams): Record<
     output,
     output_text: params.text || '',
     usage,
-    parallel_tool_calls: params.parallelToolCalls ?? true,
+    parallel_tool_calls: params.parallelToolCalls,
     store: params.store
   }
 

--- a/packages/cli/src/serve/adapters/openai/responses-shape.ts
+++ b/packages/cli/src/serve/adapters/openai/responses-shape.ts
@@ -1,0 +1,91 @@
+import type { SDKToolCall } from '../../core/sdk.js'
+import { sdkToolCallsToOpenai } from './translate.js'
+
+export function responseId (): string {
+  return `resp_${randomId()}`
+}
+
+export function messageId (): string {
+  return `msg_${randomId()}`
+}
+
+export function functionCallOutputItemId (): string {
+  return `fc_${randomId()}`
+}
+
+function randomId (): string {
+  return Math.random().toString(36).slice(2, 12)
+}
+
+export interface BuildResponseObjectParams {
+  id: string
+  modelAlias: string
+  text: string
+  toolCalls: SDKToolCall[] | null | undefined
+  createdAtSec: number
+  metadata: Record<string, unknown> | null | undefined
+  temperature: number | undefined
+  topP: number | undefined
+  maxOutputTokens: number | undefined
+  parallelToolCalls: boolean | undefined
+  previousResponseId: string | null | undefined
+  store: boolean
+}
+
+export function buildResponseObject (params: BuildResponseObjectParams): Record<string, unknown> {
+  const hasToolCalls = params.toolCalls !== null && params.toolCalls !== undefined && params.toolCalls.length > 0
+  const msgId = messageId()
+  const output: unknown[] = []
+
+  if (hasToolCalls) {
+    const openaiCalls = sdkToolCallsToOpenai(params.toolCalls)
+    for (const tc of openaiCalls ?? []) {
+      output.push({
+        type: 'function_call',
+        id: functionCallOutputItemId(),
+        call_id: tc.id,
+        name: tc.function.name,
+        arguments: tc.function.arguments,
+        status: 'completed'
+      })
+    }
+  } else {
+    output.push({
+      type: 'message',
+      id: msgId,
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: params.text || '', annotations: [] }]
+    })
+  }
+
+  const completionTokens = params.text ? params.text.split(/\s+/).filter(Boolean).length : 0
+  const usage = {
+    input_tokens: 0,
+    output_tokens: completionTokens,
+    total_tokens: completionTokens
+  }
+
+  const base: Record<string, unknown> = {
+    id: params.id,
+    object: 'response',
+    created_at: params.createdAtSec,
+    status: hasToolCalls ? 'requires_action' : 'completed',
+    model: params.modelAlias,
+    output,
+    output_text: hasToolCalls ? '' : (params.text || ''),
+    usage,
+    parallel_tool_calls: params.parallelToolCalls ?? true,
+    store: params.store
+  }
+
+  if (params.metadata !== undefined && params.metadata !== null) {
+    base['metadata'] = params.metadata
+  }
+  if (params.temperature !== undefined) base['temperature'] = params.temperature
+  if (params.topP !== undefined) base['top_p'] = params.topP
+  if (params.maxOutputTokens !== undefined) base['max_output_tokens'] = params.maxOutputTokens
+  if (params.previousResponseId) base['previous_response_id'] = params.previousResponseId
+
+  return base
+}

--- a/packages/cli/src/serve/adapters/openai/responses-shape.ts
+++ b/packages/cli/src/serve/adapters/openai/responses-shape.ts
@@ -1,4 +1,5 @@
-import type { SDKToolCall } from '../../core/sdk.js'
+import crypto from 'node:crypto'
+import type { SDKToolCall, CompletionRunStats } from '../../core/sdk.js'
 import { sdkToolCallsToOpenai } from './translate.js'
 
 export function responseId (): string {
@@ -14,7 +15,7 @@ export function functionCallOutputItemId (): string {
 }
 
 function randomId (): string {
-  return Math.random().toString(36).slice(2, 12)
+  return crypto.randomUUID()
 }
 
 export interface BuildResponseObjectParams {
@@ -30,40 +31,59 @@ export interface BuildResponseObjectParams {
   parallelToolCalls: boolean | undefined
   previousResponseId: string | null | undefined
   store: boolean
+  /** When set (e.g. streaming), must match SSE item ids so finalized response matches the stream. */
+  messageItemId?: string
+  /** When set, must align with `toolCalls` length; same ids as streamed function_call items. */
+  functionCallItemIds?: string[]
+  /** From SDK completion stats; `generatedTokens` maps to `usage.output_tokens`. */
+  stats?: CompletionRunStats
+}
+
+function wordCountFallback (text: string): number {
+  return text ? text.split(/\s+/).filter(Boolean).length : 0
 }
 
 export function buildResponseObject (params: BuildResponseObjectParams): Record<string, unknown> {
   const hasToolCalls = params.toolCalls !== null && params.toolCalls !== undefined && params.toolCalls.length > 0
-  const msgId = messageId()
+  const msgId = params.messageItemId ?? messageId()
   const output: unknown[] = []
 
+  output.push({
+    type: 'message',
+    id: msgId,
+    status: 'completed',
+    role: 'assistant',
+    content: [{ type: 'output_text', text: params.text || '', annotations: [] }]
+  })
+
+  const openaiCalls = sdkToolCallsToOpenai(params.toolCalls)
   if (hasToolCalls) {
-    const openaiCalls = sdkToolCallsToOpenai(params.toolCalls)
+    const ids = params.functionCallItemIds
+    let i = 0
     for (const tc of openaiCalls ?? []) {
+      const fcId = ids !== undefined && ids[i] !== undefined ? ids[i]! : functionCallOutputItemId()
+      i++
       output.push({
         type: 'function_call',
-        id: functionCallOutputItemId(),
+        id: fcId,
         call_id: tc.id,
         name: tc.function.name,
         arguments: tc.function.arguments,
         status: 'completed'
       })
     }
-  } else {
-    output.push({
-      type: 'message',
-      id: msgId,
-      status: 'completed',
-      role: 'assistant',
-      content: [{ type: 'output_text', text: params.text || '', annotations: [] }]
-    })
   }
 
-  const completionTokens = params.text ? params.text.split(/\s+/).filter(Boolean).length : 0
+  const outputTokens =
+    typeof params.stats?.generatedTokens === 'number' && Number.isFinite(params.stats.generatedTokens)
+      ? params.stats.generatedTokens
+      : wordCountFallback(params.text || '')
+  // SDK does not expose prompt token count today; `cacheTokens` is KV-cache hit count, not full prompt size.
+  const inputTokens = 0
   const usage = {
-    input_tokens: 0,
-    output_tokens: completionTokens,
-    total_tokens: completionTokens
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: inputTokens + outputTokens
   }
 
   const base: Record<string, unknown> = {
@@ -73,10 +93,26 @@ export function buildResponseObject (params: BuildResponseObjectParams): Record<
     status: hasToolCalls ? 'requires_action' : 'completed',
     model: params.modelAlias,
     output,
-    output_text: hasToolCalls ? '' : (params.text || ''),
+    output_text: params.text || '',
     usage,
     parallel_tool_calls: params.parallelToolCalls ?? true,
     store: params.store
+  }
+
+  if (hasToolCalls) {
+    base['required_action'] = {
+      type: 'submit_tool_outputs',
+      submit_tool_outputs: {
+        tool_calls: (openaiCalls ?? []).map((tc) => ({
+          id: tc.id,
+          type: 'function',
+          function: {
+            name: tc.function.name,
+            arguments: tc.function.arguments
+          }
+        }))
+      }
+    }
   }
 
   if (params.metadata !== undefined && params.metadata !== null) {

--- a/packages/cli/src/serve/adapters/openai/responses-store.ts
+++ b/packages/cli/src/serve/adapters/openai/responses-store.ts
@@ -1,0 +1,142 @@
+export const RESPONSES_VOLATILE_STUB = 'responses-volatile'
+
+export interface StoredResponse {
+  id: string
+  createdAtSec: number
+  expiresAtSec: number
+  responseObject: Record<string, unknown>
+  inputItems: unknown[]
+  modelAlias: string
+}
+
+export interface ResponsesStoreOptions {
+  maxEntries?: number
+  ttlMs?: number
+  now?: () => number
+}
+
+export interface ListInputItemsOptions {
+  limit?: number
+  after?: string | undefined
+}
+
+export interface ResponsesStore {
+  put: (record: StoredResponse) => void
+  get: (id: string) => StoredResponse | undefined
+  delete: (id: string) => boolean
+  listInputItems: (id: string, opts?: ListInputItemsOptions) => {
+    object: string
+    data: unknown[]
+    first_id: string | null
+    last_id: string | null
+    has_more: boolean
+  } | null
+  size: () => number
+  bannerLine: () => string
+}
+
+const DEFAULT_MAX = 256
+const DEFAULT_TTL_MS = 60 * 60 * 1000
+
+export const RESPONSES_DEFAULT_TTL_SEC = Math.floor(DEFAULT_TTL_MS / 1000)
+
+export function createResponsesStore (options: ResponsesStoreOptions = {}): ResponsesStore {
+  const maxEntries = options.maxEntries ?? DEFAULT_MAX
+  const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS
+  const nowMs = options.now ?? ((): number => Date.now())
+
+  const map = new Map<string, StoredResponse>()
+
+  function pruneExpired (): void {
+    const t = nowMs() / 1000
+    for (const [k, v] of map) {
+      if (v.expiresAtSec <= t) map.delete(k)
+    }
+  }
+
+  function bump (id: string, rec: StoredResponse): void {
+    map.delete(id)
+    map.set(id, rec)
+  }
+
+  return {
+    put (record: StoredResponse): void {
+      pruneExpired()
+      bump(record.id, record)
+      while (map.size > maxEntries) {
+        const first = map.keys().next().value
+        if (first === undefined) break
+        map.delete(first)
+      }
+    },
+
+    get (id: string): StoredResponse | undefined {
+      pruneExpired()
+      const rec = map.get(id)
+      if (!rec) return undefined
+      if (rec.expiresAtSec <= nowMs() / 1000) {
+        map.delete(id)
+        return undefined
+      }
+      bump(id, rec)
+      return rec
+    },
+
+    delete (id: string): boolean {
+      return map.delete(id)
+    },
+
+    listInputItems (id: string, opts?: ListInputItemsOptions): {
+      object: string
+      data: unknown[]
+      first_id: string | null
+      last_id: string | null
+      has_more: boolean
+    } | null {
+      pruneExpired()
+      const rec = map.get(id)
+      if (!rec) return null
+      if (rec.expiresAtSec <= nowMs() / 1000) {
+        map.delete(id)
+        return null
+      }
+      const limit = typeof opts?.limit === 'number' && opts.limit > 0 ? Math.min(opts.limit, 100) : 20
+      const items = rec.inputItems as Array<{ id?: string }>
+      let start = 0
+      if (opts?.after) {
+        const idx = items.findIndex((it) => {
+          if (!it || typeof it !== 'object') return false
+          const ito = it as Record<string, unknown>
+          return ito['id'] === opts.after
+        })
+        start = idx >= 0 ? idx + 1 : items.length
+      }
+      const slice = items.slice(start, start + limit)
+      const hasMore = start + slice.length < items.length
+      const firstId = slice[0] && typeof slice[0] === 'object' && typeof (slice[0] as { id?: string }).id === 'string'
+        ? (slice[0] as { id: string }).id
+        : null
+      const last = slice[slice.length - 1]
+      const lastId = last && typeof last === 'object' && typeof (last as { id?: string }).id === 'string'
+        ? (last as { id: string }).id
+        : null
+      return {
+        object: 'list',
+        data: slice,
+        first_id: firstId,
+        last_id: lastId,
+        has_more: hasMore
+      }
+    },
+
+    size (): number {
+      pruneExpired()
+      return map.size
+    },
+
+    bannerLine (): string {
+      const ttlMin = Math.round(ttlMs / 60000)
+      return `responses: in-memory only — IDs expire on restart, max ${maxEntries} entries, ${ttlMin}m TTL`
+    }
+  }
+}

--- a/packages/cli/src/serve/adapters/openai/routes/chat.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/chat.ts
@@ -117,6 +117,13 @@ interface CompletionParams {
   logger: import('../../../../logger.js').Logger
 }
 
+function completionTokensFromStats (text: string, stats: { generatedTokens?: number } | undefined): number {
+  if (typeof stats?.generatedTokens === 'number' && Number.isFinite(stats.generatedTokens)) {
+    return stats.generatedTokens
+  }
+  return text ? text.split(/\s+/).filter(Boolean).length : 0
+}
+
 async function handleBlockingCompletion (res: ServerResponse, params: CompletionParams): Promise<void> {
   const result = await sdkCompletion({
     modelId: params.sdkModelId,
@@ -129,6 +136,7 @@ async function handleBlockingCompletion (res: ServerResponse, params: Completion
 
   const text = await result.text
   const toolCalls = await result.toolCalls
+  const stats = await result.stats
 
   const hasToolCalls = toolCalls !== null && toolCalls !== undefined && toolCalls.length > 0
   const finishReason = hasToolCalls ? 'tool_calls' : 'stop'
@@ -141,7 +149,7 @@ async function handleBlockingCompletion (res: ServerResponse, params: Completion
     message['tool_calls'] = sdkToolCallsToOpenai(toolCalls)
   }
 
-  const completionTokens = text ? text.split(/\s+/).length : 0
+  const completionTokens = completionTokensFromStats(text || '', stats)
 
   params.logger.info(`  completion done tokens=${completionTokens} finish=${finishReason}`)
 
@@ -189,17 +197,18 @@ async function handleStreamingCompletion (res: ServerResponse, params: Completio
 
   sendSSE(res, chunk({ role: 'assistant', content: '' }, null))
 
-  let tokenCount = 0
-
   for await (const token of result.tokenStream) {
-    tokenCount++
     sendSSE(res, chunk({ content: token }, null))
   }
 
-  params.logger.info(`  streaming done tokens=${tokenCount}`)
-
   const toolCalls = await result.toolCalls
   const hasToolCalls = toolCalls !== null && toolCalls !== undefined && toolCalls.length > 0
+
+  const stats = await result.stats
+  const fullText = await result.text
+  const completionTokens = completionTokensFromStats(fullText || '', stats)
+
+  params.logger.info(`  streaming done tokens=${completionTokens}`)
 
   if (hasToolCalls) {
     const openaiToolCalls = sdkToolCallsToOpenaiDeltas(toolCalls)
@@ -207,7 +216,7 @@ async function handleStreamingCompletion (res: ServerResponse, params: Completio
     sendSSE(res, chunk({}, 'tool_calls'))
   } else {
     sendSSE(res, chunk({}, 'stop', {
-      usage: { prompt_tokens: 0, completion_tokens: tokenCount, total_tokens: tokenCount }
+      usage: { prompt_tokens: 0, completion_tokens: completionTokens, total_tokens: completionTokens }
     }))
   }
 

--- a/packages/cli/src/serve/adapters/openai/routes/responses-id.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/responses-id.ts
@@ -1,0 +1,94 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { sendJson, sendError } from '../../../http.js'
+import { RESPONSES_VOLATILE_STUB } from '../responses-store.js'
+import type { RouteContext } from '../../types.js'
+
+function setVolatileHeader (res: ServerResponse): void {
+  res.setHeader('X-QVAC-Stub', RESPONSES_VOLATILE_STUB)
+}
+
+function parseResponsesSubPath (path: string): { id: string; kind: 'input_items' | 'resource' } | null {
+  const prefix = '/v1/responses/'
+  if (!path.startsWith(prefix)) return null
+  const rest = path.slice(prefix.length)
+  if (rest.length === 0) return null
+  if (rest.endsWith('/input_items')) {
+    const id = rest.slice(0, -'/input_items'.length)
+    if (!id || id.includes('/')) return null
+    return { id, kind: 'input_items' }
+  }
+  if (rest.includes('/')) return null
+  return { id: rest, kind: 'resource' }
+}
+
+export async function routeResponsesId (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<boolean> {
+  const method = req.method ?? ''
+  const path = (req.url ?? '').split('?')[0] ?? ''
+  const parsed = parseResponsesSubPath(path)
+  if (!parsed) return false
+
+  if (parsed.kind === 'input_items') {
+    if (method !== 'GET') return false
+    await handleListInputItems(req, res, ctx, parsed.id)
+    return true
+  }
+
+  if (method === 'GET') {
+    await handleGetResponse(res, ctx, parsed.id)
+    return true
+  }
+  if (method === 'DELETE') {
+    await handleDeleteResponse(res, ctx, parsed.id)
+    return true
+  }
+
+  return false
+}
+
+function parseLimit (req: IncomingMessage): number | undefined {
+  const q = (req.url ?? '').split('?')[1]
+  if (!q) return undefined
+  const params = new URLSearchParams(q)
+  const raw = params.get('limit')
+  if (!raw) return undefined
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : undefined
+}
+
+async function handleListInputItems (
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: RouteContext,
+  id: string
+): Promise<void> {
+  setVolatileHeader(res)
+  const limit = parseLimit(req)
+  const page = limit !== undefined
+    ? ctx.responsesStore.listInputItems(id, { limit })
+    : ctx.responsesStore.listInputItems(id)
+  if (!page) {
+    sendError(res, 404, 'response_not_found', `Response "${id}" not found or expired.`)
+    return
+  }
+  sendJson(res, 200, page)
+}
+
+async function handleGetResponse (res: ServerResponse, ctx: RouteContext, id: string): Promise<void> {
+  setVolatileHeader(res)
+  const rec = ctx.responsesStore.get(id)
+  if (!rec) {
+    sendError(res, 404, 'response_not_found', `Response "${id}" not found or expired.`)
+    return
+  }
+  sendJson(res, 200, rec.responseObject)
+}
+
+async function handleDeleteResponse (res: ServerResponse, ctx: RouteContext, id: string): Promise<void> {
+  setVolatileHeader(res)
+  const ok = ctx.responsesStore.delete(id)
+  if (!ok) {
+    sendError(res, 404, 'response_not_found', `Response "${id}" not found or expired.`)
+    return
+  }
+  sendJson(res, 200, { id, object: 'response.deleted', deleted: true })
+}

--- a/packages/cli/src/serve/adapters/openai/routes/responses-id.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/responses-id.ts
@@ -45,14 +45,19 @@ export async function routeResponsesId (req: IncomingMessage, res: ServerRespons
   return false
 }
 
-function parseLimit (req: IncomingMessage): number | undefined {
+function parseListInputItemsOpts (req: IncomingMessage): { limit?: number; after?: string } {
   const q = (req.url ?? '').split('?')[1]
-  if (!q) return undefined
+  if (!q) return {}
   const params = new URLSearchParams(q)
-  const raw = params.get('limit')
-  if (!raw) return undefined
-  const n = Number(raw)
-  return Number.isFinite(n) ? n : undefined
+  const out: { limit?: number; after?: string } = {}
+  const rawLimit = params.get('limit')
+  if (rawLimit) {
+    const n = Number(rawLimit)
+    if (Number.isFinite(n)) out.limit = n
+  }
+  const after = params.get('after')
+  if (after) out.after = after
+  return out
 }
 
 async function handleListInputItems (
@@ -62,9 +67,9 @@ async function handleListInputItems (
   id: string
 ): Promise<void> {
   setVolatileHeader(res)
-  const limit = parseLimit(req)
-  const page = limit !== undefined
-    ? ctx.responsesStore.listInputItems(id, { limit })
+  const opts = parseListInputItemsOpts(req)
+  const page = (opts.limit !== undefined || opts.after !== undefined)
+    ? ctx.responsesStore.listInputItems(id, opts)
     : ctx.responsesStore.listInputItems(id)
   if (!page) {
     sendError(res, 404, 'response_not_found', `Response "${id}" not found or expired.`)

--- a/packages/cli/src/serve/adapters/openai/routes/responses.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/responses.ts
@@ -130,7 +130,7 @@ export async function handlePostResponses (req: IncomingMessage, res: ServerResp
       sendError(res, 404, 'previous_response_not_found', `No response found for previous_response_id "${previousResponseId}".`)
       return
     }
-    const prefix = historyPrefixFromStoredResponse(prev)
+    const prefix = historyPrefixFromStoredResponse(prev, (id) => ctx.responsesStore.get(id))
     history = [...prefix, ...history]
   }
 

--- a/packages/cli/src/serve/adapters/openai/routes/responses.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/responses.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { readBody, sendJson, sendError, initSSE, sendSSE, endSSE } from '../../../http.js'
 import { resolveModelAlias } from '../../../config.js'
-import { sdkCompletion } from '../../../core/sdk.js'
+import { sdkCompletion, type CompletionResult } from '../../../core/sdk.js'
 import type { SDKGenerationParams, SDKResponseFormat, SDKTool } from '../../../core/sdk.js'
 import {
   extractResponsesGenerationParams,
@@ -84,14 +84,6 @@ export async function handlePostResponses (req: IncomingMessage, res: ServerResp
     return
   }
 
-  if (previousResponseId) {
-    const prev = ctx.responsesStore.get(previousResponseId)
-    if (!prev) {
-      sendError(res, 404, 'previous_response_not_found', `No response found for previous_response_id "${previousResponseId}".`)
-      return
-    }
-  }
-
   logResponsesUnsupportedParams(body, ctx.logger)
 
   let tools: SDKTool[] | undefined
@@ -169,47 +161,47 @@ export async function handlePostResponses (req: IncomingMessage, res: ServerResp
     ? body['max_output_tokens'] as number
     : (typeof body['max_tokens'] === 'number' ? body['max_tokens'] as number : undefined)
 
+  const handlerParams: ResponsesHandlerParams = {
+    ctx,
+    sdkModelId,
+    history,
+    tools,
+    generationParams,
+    responseFormat,
+    modelAlias,
+    rid,
+    createdAtSec,
+    storeEnabled,
+    inputItems,
+    metadata,
+    temperature,
+    topP,
+    maxOutputTokens: maxOut,
+    parallelToolCalls,
+    previousResponseId: previousResponseId ?? null
+  }
+
   try {
     if (streaming) {
-      await handleStreamingResponses(res, {
-        ctx,
-        sdkModelId,
-        history,
-        tools,
-        generationParams,
-        responseFormat,
-        modelAlias,
-        rid,
-        createdAtSec,
-        storeEnabled,
-        inputItems,
-        metadata,
-        temperature,
-        topP,
-        maxOutputTokens: maxOut,
-        parallelToolCalls,
-        previousResponseId: previousResponseId ?? null
+      const result = await sdkCompletion({
+        modelId: handlerParams.sdkModelId,
+        history: handlerParams.history,
+        stream: true,
+        tools: handlerParams.tools,
+        generationParams: handlerParams.generationParams,
+        responseFormat: handlerParams.responseFormat
       })
+      await writeStreamingResponse(res, handlerParams, result)
     } else {
-      await handleBlockingResponses(res, {
-        ctx,
-        sdkModelId,
-        history,
-        tools,
-        generationParams,
-        responseFormat,
-        modelAlias,
-        rid,
-        createdAtSec,
-        storeEnabled,
-        inputItems,
-        metadata,
-        temperature,
-        topP,
-        maxOutputTokens: maxOut,
-        parallelToolCalls,
-        previousResponseId: previousResponseId ?? null
+      const result = await sdkCompletion({
+        modelId: handlerParams.sdkModelId,
+        history: handlerParams.history,
+        stream: false,
+        tools: handlerParams.tools,
+        generationParams: handlerParams.generationParams,
+        responseFormat: handlerParams.responseFormat
       })
+      await writeBlockingResponse(res, handlerParams, result)
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
@@ -218,7 +210,7 @@ export async function handlePostResponses (req: IncomingMessage, res: ServerResp
   }
 }
 
-interface ResponsesHandlerParams {
+export interface ResponsesHandlerParams {
   ctx: RouteContext
   sdkModelId: string
   history: Array<{ role: string; content: string }>
@@ -238,18 +230,14 @@ interface ResponsesHandlerParams {
   previousResponseId: string | null
 }
 
-async function handleBlockingResponses (res: ServerResponse, p: ResponsesHandlerParams): Promise<void> {
-  const result = await sdkCompletion({
-    modelId: p.sdkModelId,
-    history: p.history,
-    stream: false,
-    tools: p.tools,
-    generationParams: p.generationParams,
-    responseFormat: p.responseFormat
-  })
-
+export async function writeBlockingResponse (
+  res: ServerResponse,
+  p: ResponsesHandlerParams,
+  result: CompletionResult
+): Promise<Record<string, unknown>> {
   const text = await result.text
   const toolCalls = await result.toolCalls
+  const stats = await result.stats
 
   const responseObject = buildResponseObject({
     id: p.rid,
@@ -263,7 +251,8 @@ async function handleBlockingResponses (res: ServerResponse, p: ResponsesHandler
     maxOutputTokens: p.maxOutputTokens,
     parallelToolCalls: p.parallelToolCalls,
     previousResponseId: p.previousResponseId,
-    store: p.storeEnabled
+    store: p.storeEnabled,
+    ...(stats !== undefined ? { stats } : {})
   })
 
   if (p.storeEnabled) {
@@ -281,18 +270,14 @@ async function handleBlockingResponses (res: ServerResponse, p: ResponsesHandler
   p.ctx.logger.info(`  responses done id=${p.rid} stored=${p.storeEnabled}`)
 
   sendJson(res, 200, responseObject)
+  return responseObject
 }
 
-async function handleStreamingResponses (res: ServerResponse, p: ResponsesHandlerParams): Promise<void> {
-  const result = await sdkCompletion({
-    modelId: p.sdkModelId,
-    history: p.history,
-    stream: true,
-    tools: p.tools,
-    generationParams: p.generationParams,
-    responseFormat: p.responseFormat
-  })
-
+export async function writeStreamingResponse (
+  res: ServerResponse,
+  p: ResponsesHandlerParams,
+  result: CompletionResult
+): Promise<Record<string, unknown>> {
   initSSE(res)
 
   const msgId = messageId()
@@ -365,14 +350,20 @@ async function handleStreamingResponses (res: ServerResponse, p: ResponsesHandle
     response_id: p.rid
   })
 
+  const openaiCalls = sdkToolCallsToOpenai(toolCalls)
+  const fcItemIds = hasToolCalls
+    ? (openaiCalls ?? []).map(() => functionCallOutputItemId())
+    : []
+
   if (hasToolCalls) {
-    const openaiCalls = sdkToolCallsToOpenai(toolCalls)
+    let i = 0
     for (const tc of openaiCalls ?? []) {
-      const fcItemId = functionCallOutputItemId()
+      const fcItemId = fcItemIds[i]!
+      const outputIndex = i + 1
       const argsStr = tc.function.arguments
       sendSSE(res, {
         type: 'response.output_item.added',
-        output_index: 1,
+        output_index: outputIndex,
         item: {
           type: 'function_call',
           id: fcItemId,
@@ -385,21 +376,21 @@ async function handleStreamingResponses (res: ServerResponse, p: ResponsesHandle
       })
       sendSSE(res, {
         type: 'response.function_call_arguments.delta',
-        item_id: tc.id,
-        output_index: 1,
+        item_id: fcItemId,
+        output_index: outputIndex,
         delta: argsStr,
         response_id: p.rid
       })
       sendSSE(res, {
         type: 'response.function_call_arguments.done',
-        item_id: tc.id,
-        output_index: 1,
+        item_id: fcItemId,
+        output_index: outputIndex,
         arguments: argsStr,
         response_id: p.rid
       })
       sendSSE(res, {
         type: 'response.output_item.done',
-        output_index: 1,
+        output_index: outputIndex,
         item: {
           type: 'function_call',
           id: fcItemId,
@@ -410,8 +401,11 @@ async function handleStreamingResponses (res: ServerResponse, p: ResponsesHandle
         },
         response_id: p.rid
       })
+      i++
     }
   }
+
+  const stats = await result.stats
 
   const responseObject = buildResponseObject({
     id: p.rid,
@@ -425,7 +419,10 @@ async function handleStreamingResponses (res: ServerResponse, p: ResponsesHandle
     maxOutputTokens: p.maxOutputTokens,
     parallelToolCalls: p.parallelToolCalls,
     previousResponseId: p.previousResponseId,
-    store: p.storeEnabled
+    store: p.storeEnabled,
+    messageItemId: msgId,
+    ...(hasToolCalls ? { functionCallItemIds: fcItemIds } : {}),
+    ...(stats !== undefined ? { stats } : {})
   })
 
   if (p.storeEnabled) {
@@ -443,4 +440,5 @@ async function handleStreamingResponses (res: ServerResponse, p: ResponsesHandle
   sendSSE(res, { type: 'response.completed', response: responseObject })
   endSSE(res)
   p.ctx.logger.info(`  responses stream done id=${p.rid} stored=${p.storeEnabled}`)
+  return responseObject
 }

--- a/packages/cli/src/serve/adapters/openai/routes/responses.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/responses.ts
@@ -206,7 +206,7 @@ export async function handlePostResponses (req: IncomingMessage, res: ServerResp
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     ctx.logger.error(`Responses error for "${modelAlias}": ${message}`)
-    sendError(res, 500, 'response_error', 'An internal error occurred during response generation.')
+    sendError(res, 500, 'response_error', 'An internal error occurred during response generation.', { sseSentinel: false })
   }
 }
 

--- a/packages/cli/src/serve/adapters/openai/routes/responses.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/responses.ts
@@ -1,0 +1,446 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readBody, sendJson, sendError, initSSE, sendSSE, endSSE } from '../../../http.js'
+import { resolveModelAlias } from '../../../config.js'
+import { sdkCompletion } from '../../../core/sdk.js'
+import type { SDKGenerationParams, SDKResponseFormat, SDKTool } from '../../../core/sdk.js'
+import {
+  extractResponsesGenerationParams,
+  extractResponsesResponseFormat,
+  historyPrefixFromStoredResponse,
+  InvalidResponseFormatError,
+  InvalidResponsesBackgroundError,
+  InvalidResponsesConversationError,
+  logResponsesUnsupportedParams,
+  normalizeResponsesInputItemsForStorage,
+  openaiResponsesInputToHistory,
+  openaiResponsesToolsToSdk,
+  sdkToolCallsToOpenai,
+  UnsupportedToolTypeError,
+  validateResponsesStatefulOptions
+} from '../translate.js'
+import { buildResponseObject, functionCallOutputItemId, messageId, responseId as allocResponseId } from '../responses-shape.js'
+import { RESPONSES_DEFAULT_TTL_SEC, RESPONSES_VOLATILE_STUB, type StoredResponse } from '../responses-store.js'
+import type { RouteContext } from '../../types.js'
+
+function setVolatileHeader (res: ServerResponse): void {
+  res.setHeader('X-QVAC-Stub', RESPONSES_VOLATILE_STUB)
+}
+
+export async function handlePostResponses (req: IncomingMessage, res: ServerResponse, ctx: RouteContext): Promise<void> {
+  setVolatileHeader(res)
+
+  let body: Record<string, unknown>
+  try {
+    body = await readBody(req)
+  } catch {
+    sendError(res, 400, 'invalid_json', 'Request body must be valid JSON.')
+    return
+  }
+
+  let previousResponseId: string | undefined
+  let storeEnabled: boolean
+  try {
+    ;({ previousResponseId, storeEnabled } = validateResponsesStatefulOptions(body))
+  } catch (err) {
+    if (err instanceof InvalidResponsesConversationError) {
+      sendError(res, 400, 'conversation_not_supported', err.message)
+      return
+    }
+    if (err instanceof InvalidResponsesBackgroundError) {
+      sendError(res, 400, 'background_not_supported', err.message)
+      return
+    }
+    throw err
+  }
+
+  if (!body['model']) {
+    sendError(res, 400, 'missing_model', '"model" is required.')
+    return
+  }
+
+  if (!('input' in body)) {
+    sendError(res, 400, 'missing_input', '"input" is required.')
+    return
+  }
+
+  const modelName = body['model'] as string
+  const modelEntry = resolveModelAlias(ctx.serveConfig, modelName) ?? ctx.registry.getEntry(modelName)
+
+  if (!modelEntry) {
+    sendError(res, 404, 'model_not_found', `Model "${modelName}" is not available. Check serve.models config.`)
+    return
+  }
+
+  const endpointCategory = 'endpointCategory' in modelEntry ? modelEntry.endpointCategory : undefined
+  if (endpointCategory !== 'chat') {
+    sendError(res, 400, 'invalid_model_type', `Model "${modelName}" does not support responses.`)
+    return
+  }
+
+  const alias = 'alias' in modelEntry ? (modelEntry.alias as string) : modelEntry.id
+  const registryEntry = ctx.registry.getEntry(alias)
+  if (!registryEntry || registryEntry.state !== ctx.registry.STATES.READY) {
+    sendError(res, 503, 'model_not_ready', `Model "${modelName}" is not loaded yet.`)
+    return
+  }
+
+  if (previousResponseId) {
+    const prev = ctx.responsesStore.get(previousResponseId)
+    if (!prev) {
+      sendError(res, 404, 'previous_response_not_found', `No response found for previous_response_id "${previousResponseId}".`)
+      return
+    }
+  }
+
+  logResponsesUnsupportedParams(body, ctx.logger)
+
+  let tools: SDKTool[] | undefined
+  try {
+    tools = openaiResponsesToolsToSdk(body['tools'] as Parameters<typeof openaiResponsesToolsToSdk>[0])
+  } catch (err) {
+    if (err instanceof UnsupportedToolTypeError) {
+      sendError(res, 400, 'invalid_tool_type', err.message)
+      return
+    }
+    throw err
+  }
+
+  const generationParams = extractResponsesGenerationParams(body)
+
+  let responseFormat: SDKResponseFormat | undefined
+  try {
+    responseFormat = extractResponsesResponseFormat(body)
+  } catch (err) {
+    if (err instanceof InvalidResponseFormatError) {
+      sendError(res, 400, 'invalid_response_format', err.message)
+      return
+    }
+    throw err
+  }
+
+  if (responseFormat && responseFormat.type !== 'text' && tools && tools.length > 0) {
+    sendError(
+      res,
+      400,
+      'invalid_response_format',
+      'Structured output (json_object/json_schema) cannot be combined with "tools".'
+    )
+    return
+  }
+
+  const instructions = typeof body['instructions'] === 'string' ? body['instructions'] : undefined
+  const inputItems = normalizeResponsesInputItemsForStorage(body['input'])
+
+  let history = openaiResponsesInputToHistory(body['input'], instructions)
+  if (previousResponseId) {
+    const prev = ctx.responsesStore.get(previousResponseId)
+    if (!prev) {
+      sendError(res, 404, 'previous_response_not_found', `No response found for previous_response_id "${previousResponseId}".`)
+      return
+    }
+    const prefix = historyPrefixFromStoredResponse(prev)
+    history = [...prefix, ...history]
+  }
+
+  const sdkModelId = registryEntry.sdkModelId ?? registryEntry.id
+  const modelAlias = alias
+  const streaming = Boolean(body['stream'])
+  const parallel = body['parallel_tool_calls']
+  const parallelToolCalls = typeof parallel === 'boolean' ? parallel : true
+
+  ctx.logger.info(
+    `  responses model=${modelAlias} stream=${streaming}` +
+    `${tools ? ` tools=${tools.length}` : ''}` +
+    `${generationParams ? ` genParams=${JSON.stringify(generationParams)}` : ''}` +
+    `${responseFormat ? ` responseFormat=${responseFormat.type}` : ''}` +
+    `${previousResponseId ? ` prev=${previousResponseId}` : ''}`
+  )
+
+  const createdAtSec = Math.floor(Date.now() / 1000)
+  const rid = allocResponseId()
+  const meta = body['metadata']
+  const metadata = meta !== undefined && meta !== null && typeof meta === 'object' && !Array.isArray(meta)
+    ? meta as Record<string, unknown>
+    : undefined
+
+  const temperature = typeof body['temperature'] === 'number' ? body['temperature'] as number : undefined
+  const topP = typeof body['top_p'] === 'number' ? body['top_p'] as number : undefined
+  const maxOut = typeof body['max_output_tokens'] === 'number'
+    ? body['max_output_tokens'] as number
+    : (typeof body['max_tokens'] === 'number' ? body['max_tokens'] as number : undefined)
+
+  try {
+    if (streaming) {
+      await handleStreamingResponses(res, {
+        ctx,
+        sdkModelId,
+        history,
+        tools,
+        generationParams,
+        responseFormat,
+        modelAlias,
+        rid,
+        createdAtSec,
+        storeEnabled,
+        inputItems,
+        metadata,
+        temperature,
+        topP,
+        maxOutputTokens: maxOut,
+        parallelToolCalls,
+        previousResponseId: previousResponseId ?? null
+      })
+    } else {
+      await handleBlockingResponses(res, {
+        ctx,
+        sdkModelId,
+        history,
+        tools,
+        generationParams,
+        responseFormat,
+        modelAlias,
+        rid,
+        createdAtSec,
+        storeEnabled,
+        inputItems,
+        metadata,
+        temperature,
+        topP,
+        maxOutputTokens: maxOut,
+        parallelToolCalls,
+        previousResponseId: previousResponseId ?? null
+      })
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    ctx.logger.error(`Responses error for "${modelAlias}": ${message}`)
+    sendError(res, 500, 'response_error', 'An internal error occurred during response generation.')
+  }
+}
+
+interface ResponsesHandlerParams {
+  ctx: RouteContext
+  sdkModelId: string
+  history: Array<{ role: string; content: string }>
+  tools?: SDKTool[] | undefined
+  generationParams?: SDKGenerationParams | undefined
+  responseFormat?: SDKResponseFormat | undefined
+  modelAlias: string
+  rid: string
+  createdAtSec: number
+  storeEnabled: boolean
+  inputItems: unknown[]
+  metadata: Record<string, unknown> | undefined
+  temperature: number | undefined
+  topP: number | undefined
+  maxOutputTokens: number | undefined
+  parallelToolCalls: boolean
+  previousResponseId: string | null
+}
+
+async function handleBlockingResponses (res: ServerResponse, p: ResponsesHandlerParams): Promise<void> {
+  const result = await sdkCompletion({
+    modelId: p.sdkModelId,
+    history: p.history,
+    stream: false,
+    tools: p.tools,
+    generationParams: p.generationParams,
+    responseFormat: p.responseFormat
+  })
+
+  const text = await result.text
+  const toolCalls = await result.toolCalls
+
+  const responseObject = buildResponseObject({
+    id: p.rid,
+    modelAlias: p.modelAlias,
+    text,
+    toolCalls,
+    createdAtSec: p.createdAtSec,
+    metadata: p.metadata,
+    temperature: p.temperature,
+    topP: p.topP,
+    maxOutputTokens: p.maxOutputTokens,
+    parallelToolCalls: p.parallelToolCalls,
+    previousResponseId: p.previousResponseId,
+    store: p.storeEnabled
+  })
+
+  if (p.storeEnabled) {
+    const rec: StoredResponse = {
+      id: p.rid,
+      createdAtSec: p.createdAtSec,
+      expiresAtSec: p.createdAtSec + RESPONSES_DEFAULT_TTL_SEC,
+      responseObject,
+      inputItems: p.inputItems,
+      modelAlias: p.modelAlias
+    }
+    p.ctx.responsesStore.put(rec)
+  }
+
+  p.ctx.logger.info(`  responses done id=${p.rid} stored=${p.storeEnabled}`)
+
+  sendJson(res, 200, responseObject)
+}
+
+async function handleStreamingResponses (res: ServerResponse, p: ResponsesHandlerParams): Promise<void> {
+  const result = await sdkCompletion({
+    modelId: p.sdkModelId,
+    history: p.history,
+    stream: true,
+    tools: p.tools,
+    generationParams: p.generationParams,
+    responseFormat: p.responseFormat
+  })
+
+  initSSE(res)
+
+  const msgId = messageId()
+  let fullText = ''
+
+  sendSSE(res, {
+    type: 'response.created',
+    response: { id: p.rid, object: 'response', created_at: p.createdAtSec, status: 'in_progress', model: p.modelAlias }
+  })
+  sendSSE(res, {
+    type: 'response.in_progress',
+    response: { id: p.rid, object: 'response', created_at: p.createdAtSec, status: 'in_progress', model: p.modelAlias }
+  })
+  sendSSE(res, {
+    type: 'response.output_item.added',
+    output_index: 0,
+    item: { type: 'message', id: msgId, status: 'in_progress', role: 'assistant', content: [] },
+    sequence_number: 0,
+    response_id: p.rid
+  })
+  sendSSE(res, {
+    type: 'response.content_part.added',
+    item_id: msgId,
+    output_index: 0,
+    content_index: 0,
+    part: { type: 'output_text', text: '' },
+    response_id: p.rid
+  })
+
+  for await (const token of result.tokenStream) {
+    fullText += token
+    sendSSE(res, {
+      type: 'response.output_text.delta',
+      item_id: msgId,
+      output_index: 0,
+      content_index: 0,
+      delta: token,
+      response_id: p.rid
+    })
+  }
+
+  const toolCalls = await result.toolCalls
+  const hasToolCalls = toolCalls !== null && toolCalls !== undefined && toolCalls.length > 0
+
+  sendSSE(res, {
+    type: 'response.output_text.done',
+    item_id: msgId,
+    output_index: 0,
+    content_index: 0,
+    text: fullText,
+    response_id: p.rid
+  })
+  sendSSE(res, {
+    type: 'response.content_part.done',
+    item_id: msgId,
+    output_index: 0,
+    content_index: 0,
+    response_id: p.rid
+  })
+  sendSSE(res, {
+    type: 'response.output_item.done',
+    output_index: 0,
+    item: {
+      type: 'message',
+      id: msgId,
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: fullText, annotations: [] }]
+    },
+    response_id: p.rid
+  })
+
+  if (hasToolCalls) {
+    const openaiCalls = sdkToolCallsToOpenai(toolCalls)
+    for (const tc of openaiCalls ?? []) {
+      const fcItemId = functionCallOutputItemId()
+      const argsStr = tc.function.arguments
+      sendSSE(res, {
+        type: 'response.output_item.added',
+        output_index: 1,
+        item: {
+          type: 'function_call',
+          id: fcItemId,
+          call_id: tc.id,
+          name: tc.function.name,
+          arguments: '',
+          status: 'in_progress'
+        },
+        response_id: p.rid
+      })
+      sendSSE(res, {
+        type: 'response.function_call_arguments.delta',
+        item_id: tc.id,
+        output_index: 1,
+        delta: argsStr,
+        response_id: p.rid
+      })
+      sendSSE(res, {
+        type: 'response.function_call_arguments.done',
+        item_id: tc.id,
+        output_index: 1,
+        arguments: argsStr,
+        response_id: p.rid
+      })
+      sendSSE(res, {
+        type: 'response.output_item.done',
+        output_index: 1,
+        item: {
+          type: 'function_call',
+          id: fcItemId,
+          call_id: tc.id,
+          name: tc.function.name,
+          arguments: argsStr,
+          status: 'completed'
+        },
+        response_id: p.rid
+      })
+    }
+  }
+
+  const responseObject = buildResponseObject({
+    id: p.rid,
+    modelAlias: p.modelAlias,
+    text: fullText,
+    toolCalls,
+    createdAtSec: p.createdAtSec,
+    metadata: p.metadata,
+    temperature: p.temperature,
+    topP: p.topP,
+    maxOutputTokens: p.maxOutputTokens,
+    parallelToolCalls: p.parallelToolCalls,
+    previousResponseId: p.previousResponseId,
+    store: p.storeEnabled
+  })
+
+  if (p.storeEnabled) {
+    const rec: StoredResponse = {
+      id: p.rid,
+      createdAtSec: p.createdAtSec,
+      expiresAtSec: p.createdAtSec + RESPONSES_DEFAULT_TTL_SEC,
+      responseObject,
+      inputItems: p.inputItems,
+      modelAlias: p.modelAlias
+    }
+    p.ctx.responsesStore.put(rec)
+  }
+
+  sendSSE(res, { type: 'response.completed', response: responseObject })
+  endSSE(res)
+  p.ctx.logger.info(`  responses stream done id=${p.rid} stored=${p.storeEnabled}`)
+}

--- a/packages/cli/src/serve/adapters/openai/routes/responses.ts
+++ b/packages/cli/src/serve/adapters/openai/routes/responses.ts
@@ -287,10 +287,9 @@ export async function writeStreamingResponse (
     type: 'response.created',
     response: { id: p.rid, object: 'response', created_at: p.createdAtSec, status: 'in_progress', model: p.modelAlias }
   })
-  sendSSE(res, {
-    type: 'response.in_progress',
-    response: { id: p.rid, object: 'response', created_at: p.createdAtSec, status: 'in_progress', model: p.modelAlias }
-  })
+  // Note: not emitting a duplicate `response.in_progress` event back-to-back with `response.created`
+  // — the OpenAI stream only sends `response.in_progress` after a real state transition, and
+  // emitting it here with identical payload is just noise for strict parsers.
   sendSSE(res, {
     type: 'response.output_item.added',
     output_index: 0,
@@ -438,7 +437,8 @@ export async function writeStreamingResponse (
   }
 
   sendSSE(res, { type: 'response.completed', response: responseObject })
-  endSSE(res)
+  // OpenAI Responses spec ends on `response.completed`; no `[DONE]` sentinel.
+  endSSE(res, { sentinel: false })
   p.ctx.logger.info(`  responses stream done id=${p.rid} stored=${p.storeEnabled}`)
   return responseObject
 }

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -525,3 +525,310 @@ export function parseMetadata (raw: unknown): Record<string, string> | null | un
   }
   return out
 }
+
+// ── OpenAI Responses API (POST /v1/responses) ─────────────────────────────
+
+export class UnsupportedToolTypeError extends Error {
+  readonly toolType: string
+
+  constructor (toolType: string) {
+    super(`Unsupported tool type "${toolType}" for Responses API.`)
+    this.name = 'UnsupportedToolTypeError'
+    this.toolType = toolType
+  }
+}
+
+export class InvalidResponsesConversationError extends Error {
+  constructor () {
+    super('"conversation" is not supported by this server (no Conversation persistence).')
+    this.name = 'InvalidResponsesConversationError'
+  }
+}
+
+export class InvalidResponsesBackgroundError extends Error {
+  constructor () {
+    super('"background": true is not supported; only synchronous responses are available.')
+    this.name = 'InvalidResponsesBackgroundError'
+  }
+}
+
+const RESPONSES_UNSUPPORTED_PARAMS = [
+  'service_tier',
+  'safety_identifier',
+  'prompt_cache_key',
+  'truncation',
+  'top_logprobs',
+  'include',
+  'reasoning',
+  'modalities',
+  'audio',
+  'tool_choice',
+  'parallel_tool_calls'
+] as const
+
+export function logResponsesUnsupportedParams (body: Record<string, unknown>, logger: Logger): void {
+  for (const param of RESPONSES_UNSUPPORTED_PARAMS) {
+    if (body[param] !== undefined) {
+      logger.info(`Ignoring unsupported Responses param: ${param}=${JSON.stringify(body[param])}`)
+    }
+  }
+  const text = body['text']
+  if (text !== null && text !== undefined && typeof text === 'object' && !Array.isArray(text)) {
+    const verbosity = (text as Record<string, unknown>)['verbosity']
+    if (verbosity !== undefined) {
+      logger.info(`Ignoring unsupported Responses param: text.verbosity=${JSON.stringify(verbosity)}`)
+    }
+  }
+}
+
+export function validateResponsesStatefulOptions (body: Record<string, unknown>): {
+  previousResponseId: string | undefined
+  storeEnabled: boolean
+} {
+  if (body['conversation'] !== undefined && body['conversation'] !== null) {
+    throw new InvalidResponsesConversationError()
+  }
+  if (body['background'] === true) {
+    throw new InvalidResponsesBackgroundError()
+  }
+  const prev = body['previous_response_id']
+  const previousResponseId = typeof prev === 'string' && prev.length > 0 ? prev : undefined
+  const storeEnabled = body['store'] !== false
+  return { previousResponseId, storeEnabled }
+}
+
+export function extractResponsesGenerationParams (body: Record<string, unknown>): SDKGenerationParams | undefined {
+  const params: SDKGenerationParams = {}
+
+  if (typeof body['temperature'] === 'number') params.temp = body['temperature']
+  if (typeof body['top_p'] === 'number') params.top_p = body['top_p']
+  if (typeof body['seed'] === 'number') params.seed = body['seed']
+  if (typeof body['frequency_penalty'] === 'number') params.frequency_penalty = body['frequency_penalty']
+  if (typeof body['presence_penalty'] === 'number') params.presence_penalty = body['presence_penalty']
+
+  if (typeof body['max_tokens'] === 'number') params.predict = body['max_tokens']
+  if (typeof body['max_output_tokens'] === 'number') params.predict = body['max_output_tokens']
+
+  if (typeof body['reasoning_budget'] === 'boolean') params.reasoning_budget = body['reasoning_budget']
+
+  return Object.keys(params).length > 0 ? params : undefined
+}
+
+export function extractResponsesResponseFormat (body: Record<string, unknown>): SDKResponseFormat | undefined {
+  const top = body['response_format']
+  if (top !== undefined && top !== null) {
+    return extractResponseFormat({ response_format: top } as Record<string, unknown>)
+  }
+  const text = body['text']
+  if (text !== null && text !== undefined && typeof text === 'object' && !Array.isArray(text)) {
+    const fmt = (text as Record<string, unknown>)['format']
+    if (fmt !== undefined && fmt !== null) {
+      return extractResponseFormat({ response_format: fmt } as Record<string, unknown>)
+    }
+  }
+  return undefined
+}
+
+interface ResponsesFunctionTool {
+  type: string
+  name?: string
+  description?: string
+  parameters?: Record<string, unknown>
+}
+
+export function openaiResponsesToolsToSdk (tools: ResponsesFunctionTool[] | undefined): SDKTool[] | undefined {
+  if (!tools || tools.length === 0) return undefined
+
+  return tools
+    .map((t): SDKTool | null => {
+      if (t.type === 'function') {
+        const name = typeof t.name === 'string' ? t.name : ''
+        if (!name) return null
+        return {
+          type: 'function',
+          name,
+          description: typeof t.description === 'string' ? t.description : '',
+          parameters: normalizeToolParameters(t.parameters ?? { type: 'object', properties: {} })
+        }
+      }
+      if (t.type === 'web_search' || t.type === 'file_search' || t.type === 'code_interpreter') {
+        throw new UnsupportedToolTypeError(t.type)
+      }
+      throw new UnsupportedToolTypeError(t.type)
+    })
+    .filter((t): t is SDKTool => t !== null)
+}
+
+function inputTextPart (text: string): Record<string, unknown> {
+  return { type: 'input_text', text }
+}
+
+function normalizeInputItemId (item: Record<string, unknown>, index: number): Record<string, unknown> {
+  if (typeof item['id'] === 'string' && item['id'].length > 0) return item
+  return { ...item, id: `item_${index}_${randomHex(8)}` }
+}
+
+function randomHex (len: number): string {
+  let s = ''
+  for (let i = 0; i < len; i++) s += Math.floor(Math.random() * 16).toString(16)
+  return s
+}
+
+export function normalizeResponsesInputItemsForStorage (input: unknown): unknown[] {
+  if (typeof input === 'string') {
+    return [{
+      type: 'message',
+      id: `item_0_${randomHex(8)}`,
+      role: 'user',
+      content: [inputTextPart(input)]
+    }]
+  }
+  if (!Array.isArray(input)) {
+    return [{
+      type: 'message',
+      id: `item_0_${randomHex(8)}`,
+      role: 'user',
+      content: [inputTextPart('')]
+    }]
+  }
+  return input.map((raw, i) => {
+    if (typeof raw === 'string') {
+      return {
+        type: 'message',
+        id: `item_${i}_${randomHex(8)}`,
+        role: 'user',
+        content: [inputTextPart(raw)]
+      }
+    }
+    if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) {
+      return normalizeInputItemId(raw as Record<string, unknown>, i)
+    }
+    return { type: 'message', id: `item_${i}_${randomHex(8)}`, role: 'user', content: [inputTextPart('')] }
+  })
+}
+
+export function openaiResponsesInputToHistory (
+  input: unknown,
+  instructions: string | undefined
+): Array<{ role: string; content: string }> {
+  const history: Array<{ role: string; content: string }> = []
+
+  if (typeof instructions === 'string' && instructions.length > 0) {
+    history.push({ role: 'system', content: instructions })
+  }
+
+  if (typeof input === 'string') {
+    history.push({ role: 'user', content: input })
+    return history
+  }
+
+  if (!Array.isArray(input)) {
+    history.push({ role: 'user', content: '' })
+    return history
+  }
+
+  for (const raw of input) {
+    if (typeof raw === 'string') {
+      history.push({ role: 'user', content: raw })
+      continue
+    }
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) continue
+    const item = raw as Record<string, unknown>
+    const t = item['type']
+    if (t === 'message') {
+      const role = typeof item['role'] === 'string' ? item['role'] : 'user'
+      const content = item['content']
+      history.push({ role, content: flattenResponsesContent(content) })
+      continue
+    }
+    if (t === 'input_text') {
+      const text = typeof item['text'] === 'string' ? item['text'] : ''
+      history.push({ role: 'user', content: text })
+    }
+  }
+
+  return history
+}
+
+function flattenResponsesContent (content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  const parts: string[] = []
+  for (const p of content) {
+    if (typeof p === 'string') {
+      parts.push(p)
+      continue
+    }
+    if (p === null || typeof p !== 'object' || Array.isArray(p)) continue
+    const o = p as Record<string, unknown>
+    if (o['type'] === 'input_text' && typeof o['text'] === 'string') parts.push(o['text'])
+  }
+  return parts.join('\n')
+}
+
+export function historyPrefixFromStoredResponse (stored: {
+  inputItems: unknown[]
+  responseObject: Record<string, unknown>
+}): Array<{ role: string; content: string }> {
+  const prefix: Array<{ role: string; content: string }> = []
+
+  for (const raw of stored.inputItems) {
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) continue
+    const item = raw as Record<string, unknown>
+    if (item['type'] === 'message') {
+      const role = typeof item['role'] === 'string' ? item['role'] : 'user'
+      prefix.push({ role, content: flattenResponsesContent(item['content']) })
+    } else if (item['type'] === 'input_text') {
+      const text = typeof item['text'] === 'string' ? item['text'] : ''
+      prefix.push({ role: 'user', content: text })
+    }
+  }
+
+  const output = stored.responseObject['output']
+  const outputText = stored.responseObject['output_text']
+  if (typeof outputText === 'string' && outputText.length > 0) {
+    prefix.push({ role: 'assistant', content: outputText })
+    return prefix
+  }
+
+  if (Array.isArray(output)) {
+    for (const out of output) {
+      if (out === null || typeof out !== 'object' || Array.isArray(out)) continue
+      const o = out as Record<string, unknown>
+      if (o['type'] === 'message' && o['role'] === 'assistant') {
+        const text = extractOutputTextFromMessage(o)
+        prefix.push({ role: 'assistant', content: text })
+      } else if (o['type'] === 'function_call') {
+        const name = typeof o['name'] === 'string' ? o['name'] : ''
+        const args = typeof o['arguments'] === 'string' ? o['arguments'] : JSON.stringify(o['arguments'] ?? {})
+        prefix.push({
+          role: 'assistant',
+          content: `<tool_call>\n${JSON.stringify({ name, arguments: safeJsonParse(args) })}\n</tool_call>`
+        })
+      }
+    }
+  }
+
+  return prefix
+}
+
+function safeJsonParse (s: string): Record<string, unknown> {
+  try {
+    return JSON.parse(s) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+function extractOutputTextFromMessage (msg: Record<string, unknown>): string {
+  const content = msg['content']
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  const parts: string[] = []
+  for (const p of content) {
+    if (p === null || typeof p !== 'object' || Array.isArray(p)) continue
+    const o = p as Record<string, unknown>
+    if (o['type'] === 'output_text' && typeof o['text'] === 'string') parts.push(o['text'])
+  }
+  return parts.join('')
+}

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -788,11 +788,47 @@ function flattenResponsesContent (content: unknown): string {
   return parts.join('\n')
 }
 
-export function historyPrefixFromStoredResponse (stored: {
+export interface StoredResponseLike {
   inputItems: unknown[]
   responseObject: Record<string, unknown>
-}): Array<{ role: string; content: string }> {
+}
+
+/**
+ * Default cap for `historyPrefixFromStoredResponse` chain walks.
+ * Prevents pathological recursion if a malformed `previous_response_id` cycle is ever stored,
+ * and bounds work for very long chains. 32 mirrors typical chat-app history depth.
+ */
+export const RESPONSES_HISTORY_MAX_DEPTH = 32
+
+/**
+ * Build the chat history that should precede the current request when chaining
+ * via `previous_response_id`.
+ *
+ * If a `resolve` callback is provided, this walks the chain via
+ * `responseObject.previous_response_id` and prepends earlier turns first
+ * (oldest → newest). Without `resolve`, only the immediate stored turn is used
+ * — kept that way so the legacy single-step callers and unit tests still work.
+ *
+ * Each `StoredResponse.inputItems` only carries that turn's NEW input
+ * (`normalizeResponsesInputItemsForStorage(body['input'])`), so without the
+ * walk a chain of depth ≥ 3 would silently lose grandparent history.
+ */
+export function historyPrefixFromStoredResponse (
+  stored: StoredResponseLike,
+  resolve?: (id: string) => StoredResponseLike | undefined,
+  maxDepth: number = RESPONSES_HISTORY_MAX_DEPTH
+): Array<{ role: string; content: string }> {
   const prefix: Array<{ role: string; content: string }> = []
+
+  if (resolve && maxDepth > 0) {
+    const prevId = stored.responseObject['previous_response_id']
+    if (typeof prevId === 'string' && prevId.length > 0) {
+      const prev = resolve(prevId)
+      if (prev) {
+        prefix.push(...historyPrefixFromStoredResponse(prev, resolve, maxDepth - 1))
+      }
+    }
+  }
 
   for (const raw of stored.inputItems) {
     if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) continue

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import type { Logger } from '../../../logger.js'
 import type { SDKTool, SDKToolCall, SDKGenerationParams, SDKResponseFormat, SDKDiffusionParams } from '../../core/sdk.js'
 import type { VectorStoreExpiresAfter, VectorStoreMeta } from './vector-stores-store.js'
@@ -562,8 +563,7 @@ const RESPONSES_UNSUPPORTED_PARAMS = [
   'reasoning',
   'modalities',
   'audio',
-  'tool_choice',
-  'parallel_tool_calls'
+  'tool_choice'
 ] as const
 
 export function logResponsesUnsupportedParams (body: Record<string, unknown>, logger: Logger): void {
@@ -665,20 +665,30 @@ function inputTextPart (text: string): Record<string, unknown> {
 
 function normalizeInputItemId (item: Record<string, unknown>, index: number): Record<string, unknown> {
   if (typeof item['id'] === 'string' && item['id'].length > 0) return item
-  return { ...item, id: `item_${index}_${randomHex(8)}` }
+  return { ...item, id: `item_${index}_${crypto.randomUUID()}` }
 }
 
-function randomHex (len: number): string {
-  let s = ''
-  for (let i = 0; i < len; i++) s += Math.floor(Math.random() * 16).toString(16)
-  return s
+function responsesFunctionCallItemToAssistantContent (item: Record<string, unknown>): string {
+  const name = typeof item['name'] === 'string' ? item['name'] : ''
+  const rawArgs = item['arguments']
+  const argsStr = typeof rawArgs === 'string'
+    ? rawArgs
+    : (rawArgs !== null && rawArgs !== undefined ? JSON.stringify(rawArgs) : '{}')
+  let args: Record<string, unknown>
+  try {
+    args = JSON.parse(argsStr) as Record<string, unknown>
+  } catch {
+    args = {}
+  }
+  const callObj = { name, arguments: args }
+  return `<tool_call>\n${JSON.stringify(callObj)}\n</tool_call>`
 }
 
 export function normalizeResponsesInputItemsForStorage (input: unknown): unknown[] {
   if (typeof input === 'string') {
     return [{
       type: 'message',
-      id: `item_0_${randomHex(8)}`,
+      id: `item_0_${crypto.randomUUID()}`,
       role: 'user',
       content: [inputTextPart(input)]
     }]
@@ -686,7 +696,7 @@ export function normalizeResponsesInputItemsForStorage (input: unknown): unknown
   if (!Array.isArray(input)) {
     return [{
       type: 'message',
-      id: `item_0_${randomHex(8)}`,
+      id: `item_0_${crypto.randomUUID()}`,
       role: 'user',
       content: [inputTextPart('')]
     }]
@@ -695,7 +705,7 @@ export function normalizeResponsesInputItemsForStorage (input: unknown): unknown
     if (typeof raw === 'string') {
       return {
         type: 'message',
-        id: `item_${i}_${randomHex(8)}`,
+        id: `item_${i}_${crypto.randomUUID()}`,
         role: 'user',
         content: [inputTextPart(raw)]
       }
@@ -703,7 +713,7 @@ export function normalizeResponsesInputItemsForStorage (input: unknown): unknown
     if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) {
       return normalizeInputItemId(raw as Record<string, unknown>, i)
     }
-    return { type: 'message', id: `item_${i}_${randomHex(8)}`, role: 'user', content: [inputTextPart('')] }
+    return { type: 'message', id: `item_${i}_${crypto.randomUUID()}`, role: 'user', content: [inputTextPart('')] }
   })
 }
 
@@ -744,6 +754,18 @@ export function openaiResponsesInputToHistory (
     if (t === 'input_text') {
       const text = typeof item['text'] === 'string' ? item['text'] : ''
       history.push({ role: 'user', content: text })
+      continue
+    }
+    if (t === 'function_call_output') {
+      const out = item['output']
+      const text = typeof out === 'string'
+        ? out
+        : (out !== null && out !== undefined ? JSON.stringify(out) : '')
+      history.push({ role: 'tool', content: text })
+      continue
+    }
+    if (t === 'function_call') {
+      history.push({ role: 'assistant', content: responsesFunctionCallItemToAssistantContent(item) })
     }
   }
 
@@ -781,17 +803,21 @@ export function historyPrefixFromStoredResponse (stored: {
     } else if (item['type'] === 'input_text') {
       const text = typeof item['text'] === 'string' ? item['text'] : ''
       prefix.push({ role: 'user', content: text })
+    } else if (item['type'] === 'function_call_output') {
+      const out = item['output']
+      const text = typeof out === 'string'
+        ? out
+        : (out !== null && out !== undefined ? JSON.stringify(out) : '')
+      prefix.push({ role: 'tool', content: text })
+    } else if (item['type'] === 'function_call') {
+      prefix.push({ role: 'assistant', content: responsesFunctionCallItemToAssistantContent(item) })
     }
   }
 
   const output = stored.responseObject['output']
   const outputText = stored.responseObject['output_text']
-  if (typeof outputText === 'string' && outputText.length > 0) {
-    prefix.push({ role: 'assistant', content: outputText })
-    return prefix
-  }
 
-  if (Array.isArray(output)) {
+  if (Array.isArray(output) && output.length > 0) {
     for (const out of output) {
       if (out === null || typeof out !== 'object' || Array.isArray(out)) continue
       const o = out as Record<string, unknown>
@@ -807,6 +833,11 @@ export function historyPrefixFromStoredResponse (stored: {
         })
       }
     }
+    return prefix
+  }
+
+  if (typeof outputText === 'string' && outputText.length > 0) {
+    prefix.push({ role: 'assistant', content: outputText })
   }
 
   return prefix

--- a/packages/cli/src/serve/adapters/openai/translate.ts
+++ b/packages/cli/src/serve/adapters/openai/translate.ts
@@ -579,6 +579,11 @@ export function logResponsesUnsupportedParams (body: Record<string, unknown>, lo
       logger.info(`Ignoring unsupported Responses param: text.verbosity=${JSON.stringify(verbosity)}`)
     }
   }
+  // The Responses spec defines `max_output_tokens`, not `max_tokens`. Accept both for forgiveness
+  // (the route maps `max_tokens` as a fallback) but warn so consumers migrate.
+  if (body['max_tokens'] !== undefined && body['max_output_tokens'] === undefined) {
+    logger.warn('"max_tokens" on /v1/responses is non-spec; use "max_output_tokens".')
+  }
 }
 
 export function validateResponsesStatefulOptions (body: Record<string, unknown>): {

--- a/packages/cli/src/serve/adapters/types.ts
+++ b/packages/cli/src/serve/adapters/types.ts
@@ -4,6 +4,7 @@ import type { Logger } from '../../logger.js'
 import type { ChunkAttributionStore } from './openai/chunk-attribution-store.js'
 import type { EphemeralFilesStore } from './openai/ephemeral-files-store.js'
 import type { VectorStoresStore } from './openai/vector-stores-store.js'
+import type { ResponsesStore } from './openai/responses-store.js'
 
 export interface RouteContext {
   registry: ModelRegistry
@@ -12,6 +13,7 @@ export interface RouteContext {
   vectorStores: VectorStoresStore
   ephemeralFiles: EphemeralFilesStore
   chunkAttributions: ChunkAttributionStore
+  responsesStore: ResponsesStore
   /** @internal Unit tests only — replaces sdkTranscribe when set */
   transcribeOverride?: (opts: {
     modelId: string

--- a/packages/cli/src/serve/core/sdk.ts
+++ b/packages/cli/src/serve/core/sdk.ts
@@ -117,9 +117,24 @@ export interface SDKTool {
   parameters: Record<string, unknown>
 }
 
+export interface SDKToolCall {
+  id: string
+  name: string
+  arguments: string | Record<string, unknown>
+}
+
+/** Subset of SDK completion stats surfaced to OpenAI-compatible usage fields. */
+export interface CompletionRunStats {
+  generatedTokens?: number
+  cacheTokens?: number
+  tokensPerSecond?: number
+  timeToFirstToken?: number
+  backendDevice?: 'cpu' | 'gpu'
+}
+
 export interface CompletionResult {
   text: Promise<string>
-  stats: Promise<Record<string, unknown>>
+  stats: Promise<CompletionRunStats | undefined>
   toolCalls: Promise<SDKToolCall[] | null>
   tokenStream: AsyncIterable<string>
   toolCallStream: AsyncIterable<SDKToolEvent>
@@ -136,12 +151,6 @@ export interface SDKToolCallErrorEvent {
 }
 
 export type SDKToolEvent = SDKToolCallEvent | SDKToolCallErrorEvent
-
-export interface SDKToolCall {
-  id: string
-  name: string
-  arguments: string | Record<string, unknown>
-}
 
 let sdk: SDKModule | null = null
 

--- a/packages/cli/src/serve/http.ts
+++ b/packages/cli/src/serve/http.ts
@@ -46,10 +46,27 @@ export function sendJson (
   res.end(payload)
 }
 
-export function sendError (res: ServerResponse, status: number, code: string, message: string): void {
+export interface SendErrorOptions {
+  /**
+   * When the response has already started streaming, controls whether
+   * `endSSE` writes the trailing `data: [DONE]\n\n` sentinel after the
+   * error event. Pass `false` for streams whose spec does not use the
+   * sentinel (e.g. OpenAI Responses, which terminates on `response.error`).
+   * Defaults to `true` to preserve chat-completions behavior.
+   */
+  sseSentinel?: boolean
+}
+
+export function sendError (
+  res: ServerResponse,
+  status: number,
+  code: string,
+  message: string,
+  opts?: SendErrorOptions
+): void {
   if (res.headersSent) {
     sendSSE(res, { error: { message, type: 'server_error', code } })
-    endSSE(res)
+    endSSE(res, { sentinel: opts?.sseSentinel ?? true })
     return
   }
 

--- a/packages/cli/src/serve/http.ts
+++ b/packages/cli/src/serve/http.ts
@@ -78,8 +78,19 @@ export function sendSSE (res: ServerResponse, data: unknown): void {
   res.write(`data: ${json}\n\n`)
 }
 
-export function endSSE (res: ServerResponse): void {
-  res.write('data: [DONE]\n\n')
+export interface EndSSEOptions {
+  /**
+   * Whether to write a `data: [DONE]\n\n` sentinel before closing.
+   * Chat-completions clients expect it; the OpenAI Responses spec does not.
+   * Defaults to true to preserve existing behavior.
+   */
+  sentinel?: boolean
+}
+
+export function endSSE (res: ServerResponse, opts?: EndSSEOptions): void {
+  if (opts?.sentinel !== false) {
+    res.write('data: [DONE]\n\n')
+  }
   res.end()
 }
 

--- a/packages/cli/src/serve/http.ts
+++ b/packages/cli/src/serve/http.ts
@@ -28,14 +28,21 @@ export function readBody (req: IncomingMessage): Promise<Record<string, unknown>
   })
 }
 
-export function sendJson (res: ServerResponse, status: number, body: unknown): void {
+export function sendJson (
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  extraHeaders?: Record<string, string | number>
+): void {
   if (res.headersSent) return
 
   const payload = JSON.stringify(body)
-  res.writeHead(status, {
+  const headers: Record<string, string | number> = {
     'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(payload)
-  })
+    'Content-Length': Buffer.byteLength(payload),
+    ...extraHeaders
+  }
+  res.writeHead(status, headers)
   res.end(payload)
 }
 
@@ -55,11 +62,12 @@ export function sendError (res: ServerResponse, status: number, code: string, me
   })
 }
 
-export function initSSE (res: ServerResponse): void {
+export function initSSE (res: ServerResponse, extraHeaders?: Record<string, string | number>): void {
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
-    Connection: 'keep-alive'
+    Connection: 'keep-alive',
+    ...extraHeaders
   })
 }
 

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -7,6 +7,7 @@ import { parseServeConfig } from './config.js'
 import { createModelRegistry } from './core/model-registry.js'
 import { preloadModels, shutdownSDK } from './core/lifecycle.js'
 import { handleCors, sendError } from './http.js'
+import { createResponsesStore } from './adapters/openai/responses-store.js'
 import { createOpenAIAdapter } from './adapters/openai/index.js'
 import { createChunkAttributionStore } from './adapters/openai/chunk-attribution-store.js'
 import { createEphemeralFilesStore } from './adapters/openai/ephemeral-files-store.js'
@@ -37,6 +38,7 @@ export async function startServer (options: StartServerOptions): Promise<http.Se
 
   await preloadModels(serveConfig, registry, logger)
 
+  const responsesStore = createResponsesStore()
   const adapters: APIAdapter[] = [
     createOpenAIAdapter()
   ]
@@ -44,7 +46,8 @@ export async function startServer (options: StartServerOptions): Promise<http.Se
   const vectorStores = createVectorStoresStore()
   const ephemeralFiles = createEphemeralFilesStore()
   const chunkAttributions = createChunkAttributionStore()
-  const ctx: RouteContext = { registry, serveConfig, logger, vectorStores, ephemeralFiles, chunkAttributions }
+  const ctx: RouteContext = { registry, serveConfig, logger, vectorStores, ephemeralFiles, chunkAttributions, responsesStore }
+  logger.warn(responsesStore.bannerLine())
 
   const server = http.createServer(async (req: IncomingMessage, res: ServerResponse) => {
     const start = performance.now()
@@ -116,7 +119,7 @@ export async function startServer (options: StartServerOptions): Promise<http.Se
 }
 
 const CATEGORY_ENDPOINTS: Record<string, string[]> = {
-  chat: ['POST /v1/chat/completions'],
+  chat: ['POST /v1/chat/completions', 'POST /v1/responses'],
   embedding: ['POST /v1/embeddings'],
   transcription: ['POST /v1/audio/transcriptions'],
   'audio-translation': ['POST /v1/audio/translations'],
@@ -139,7 +142,10 @@ const VECTOR_STORE_ENDPOINTS = [
 const MANAGEMENT_ENDPOINTS = [
   'GET  /v1/models',
   'GET  /v1/models/:id',
-  'DELETE /v1/models/:id'
+  'DELETE /v1/models/:id',
+  'GET  /v1/responses/:id',
+  'DELETE /v1/responses/:id',
+  'GET  /v1/responses/:id/input_items'
 ]
 
 const CATEGORY_LABELS: Record<string, string> = {

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -63,7 +63,7 @@ CONF
   '
 
   cd "${FILE_TMPDIR}/project"
-  ${QVAC} serve openai -p "${E2E_PORT}" --cors &
+  ${QVAC} serve openai -p "${E2E_PORT}" --cors >"${FILE_TMPDIR}/serve.log" 2>&1 &
   echo "$!" > "${FILE_TMPDIR}/server_pid"
 
   local max_wait=300
@@ -99,6 +99,10 @@ assert_error() {
 
 json_post() {
   curl -s "${BASE}$1" -H "Content-Type: application/json" -d "$2"
+}
+
+json_post_capture() {
+  curl -sS -D "${FILE_TMPDIR}/resp.hdr" -o "${FILE_TMPDIR}/resp.body" "${BASE}$1" -H "Content-Type: application/json" -d "$2"
 }
 
 # ── Models ────────────────────────────────────────────────────────────
@@ -406,6 +410,88 @@ TXT
   assert_error "${body}" "invalid_vector_store_id"
 }
 
+# ── Responses API ─────────────────────────────────────────────────────
+
+@test "responses: startup log documents volatile store" {
+  grep -q 'responses: in-memory only' "${FILE_TMPDIR}/serve.log"
+}
+
+@test "responses: blocking completion returns response shape and stub header" {
+  json_post_capture "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"input\":\"Reply with exactly OK.\"}"
+  grep -qi 'X-QVAC-Stub: responses-volatile' "${FILE_TMPDIR}/resp.hdr"
+  jq -e '.id | startswith("resp_")' "${FILE_TMPDIR}/resp.body" >/dev/null
+  jq -e '.object == "response"' "${FILE_TMPDIR}/resp.body" >/dev/null
+  jq -e '.output_text | length > 0' "${FILE_TMPDIR}/resp.body" >/dev/null
+  jq -e '.usage.output_tokens | type == "number"' "${FILE_TMPDIR}/resp.body" >/dev/null
+}
+
+@test "responses: streaming returns response.completed and stub header" {
+  curl -sN -D "${FILE_TMPDIR}/resp.hdr" -o "${FILE_TMPDIR}/resp.body" "${BASE}/v1/responses" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"${LLM_ALIAS}\",\"input\":\"Say hi.\",\"stream\":true,\"max_output_tokens\":24}"
+  grep -qi 'X-QVAC-Stub: responses-volatile' "${FILE_TMPDIR}/resp.hdr"
+  grep -q 'response.created' "${FILE_TMPDIR}/resp.body"
+  grep -q 'response.completed' "${FILE_TMPDIR}/resp.body"
+  grep -q 'data: \[DONE\]' "${FILE_TMPDIR}/resp.body"
+}
+
+@test "responses: store retrieve delete and input_items" {
+  json_post_capture "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"input\":\"ping\",\"store\":true}"
+  local rid
+  rid=$(jq -r '.id' "${FILE_TMPDIR}/resp.body")
+  [[ "${rid}" == resp_* ]]
+
+  curl -sS -D "${FILE_TMPDIR}/g.hdr" -o "${FILE_TMPDIR}/g.body" "${BASE}/v1/responses/${rid}"
+  grep -qi 'X-QVAC-Stub: responses-volatile' "${FILE_TMPDIR}/g.hdr"
+  jq -e ".id == \"${rid}\"" "${FILE_TMPDIR}/g.body" >/dev/null
+
+  curl -sS -D "${FILE_TMPDIR}/i.hdr" -o "${FILE_TMPDIR}/i.body" "${BASE}/v1/responses/${rid}/input_items"
+  grep -qi 'X-QVAC-Stub: responses-volatile' "${FILE_TMPDIR}/i.hdr"
+  jq -e '.object == "list"' "${FILE_TMPDIR}/i.body" >/dev/null
+  jq -e '.data | length >= 1' "${FILE_TMPDIR}/i.body" >/dev/null
+
+  curl -sS -D "${FILE_TMPDIR}/d.hdr" -o "${FILE_TMPDIR}/d.body" -X DELETE "${BASE}/v1/responses/${rid}"
+  jq -e '.deleted == true' "${FILE_TMPDIR}/d.body" >/dev/null
+
+  local gone
+  gone=$(curl -s "${BASE}/v1/responses/${rid}")
+  assert_error "${gone}" "response_not_found"
+}
+
+@test "responses: previous_response_id chains context" {
+  json_post_capture "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"input\":\"Remember the code word is XYZZY.\",\"store\":true,\"max_output_tokens\":48}"
+  local rid
+  rid=$(jq -r '.id' "${FILE_TMPDIR}/resp.body")
+
+  local body2
+  body2=$(json_post "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"previous_response_id\":\"${rid}\",\"input\":\"What is the code word? Reply with one word only.\",\"max_output_tokens\":32}")
+  echo "${body2}" | jq -e '(.output_text | test("XYZZY"; "i"))' >/dev/null
+}
+
+@test "responses: bogus previous_response_id returns 404" {
+  local body
+  body=$(json_post "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"previous_response_id\":\"resp_nonexistent123\",\"input\":\"hi\"}")
+  assert_error "${body}" "previous_response_not_found"
+}
+
+@test "responses: rejects conversation id" {
+  local body
+  body=$(json_post "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"conversation\":\"conv_1\",\"input\":\"hi\"}")
+  assert_error "${body}" "conversation_not_supported"
+}
+
+@test "responses: rejects background mode" {
+  local body
+  body=$(json_post "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"background\":true,\"input\":\"hi\"}")
+  assert_error "${body}" "background_not_supported"
+}
+
+@test "responses: rejects built-in web_search tool" {
+  local body
+  body=$(json_post "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"input\":\"hi\",\"tools\":[{\"type\":\"web_search\"}]}")
+  assert_error "${body}" "invalid_tool_type"
+}
+
 # ── Cross-endpoint model type validation ──────────────────────────────
 
 @test "cross-type: chat endpoint rejects embedding model" {
@@ -435,6 +521,12 @@ TXT
   body=$(curl -s "${BASE}/v1/audio/translations" \
     -F "model=${LLM_ALIAS}" \
     -F "file=@${BATS_FILE_TMPDIR}/silence.wav;filename=audio.wav")
+  assert_error "${body}" "invalid_model_type"
+}
+
+@test "cross-type: responses endpoint rejects embedding model" {
+  local body
+  body=$(json_post "/v1/responses" "{\"model\":\"${EMBED_ALIAS}\",\"input\":\"hello\"}")
   assert_error "${body}" "invalid_model_type"
 }
 

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -432,7 +432,8 @@ TXT
   grep -qi 'X-QVAC-Stub: responses-volatile' "${FILE_TMPDIR}/resp.hdr"
   grep -q 'response.created' "${FILE_TMPDIR}/resp.body"
   grep -q 'response.completed' "${FILE_TMPDIR}/resp.body"
-  grep -q 'data: \[DONE\]' "${FILE_TMPDIR}/resp.body"
+  # OpenAI Responses spec terminates on response.completed; no [DONE] sentinel.
+  ! grep -q 'data: \[DONE\]' "${FILE_TMPDIR}/resp.body"
 }
 
 @test "responses: store retrieve delete and input_items" {

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -459,12 +459,15 @@ TXT
 }
 
 @test "responses: previous_response_id chains context" {
-  json_post_capture "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"input\":\"Remember the code word is XYZZY.\",\"store\":true,\"max_output_tokens\":48}"
+  # Pin sampling (temperature=0, seed) and give a generous token budget so the tiny reasoning
+  # LLM has room for both its <think> block and an actual answer. Test exercises chain wiring,
+  # not the model's creativity, so XYZZY recall must be deterministic.
+  json_post_capture "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"input\":\"Remember the code word is XYZZY.\",\"store\":true,\"max_output_tokens\":512,\"temperature\":0,\"seed\":1}"
   local rid
   rid=$(jq -r '.id' "${FILE_TMPDIR}/resp.body")
 
   local body2
-  body2=$(json_post "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"previous_response_id\":\"${rid}\",\"input\":\"What is the code word? Reply with one word only.\",\"max_output_tokens\":32}")
+  body2=$(json_post "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"previous_response_id\":\"${rid}\",\"input\":\"What is the code word? Reply with one word only.\",\"max_output_tokens\":512,\"temperature\":0,\"seed\":1}")
   echo "${body2}" | jq -e '(.output_text | test("XYZZY"; "i"))' >/dev/null
 }
 

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -471,6 +471,23 @@ TXT
   echo "${body2}" | jq -e '(.output_text | test("XYZZY"; "i"))' >/dev/null
 }
 
+@test "responses: previous_response_id walks deeper than one step (chain depth 3)" {
+  # Each StoredResponse only carries its own NEW input items, so without a recursive walk
+  # depth-3 chains would silently lose the grandparent turn. This test asserts the resp_1
+  # fact (XYZZY) survives through resp_2 (innocuous) into resp_3.
+  json_post_capture "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"input\":\"Remember the code word is XYZZY.\",\"store\":true,\"max_output_tokens\":512,\"temperature\":0,\"seed\":1}"
+  local rid1
+  rid1=$(jq -r '.id' "${FILE_TMPDIR}/resp.body")
+
+  json_post_capture "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"previous_response_id\":\"${rid1}\",\"input\":\"Got it.\",\"store\":true,\"max_output_tokens\":256,\"temperature\":0,\"seed\":1}"
+  local rid2
+  rid2=$(jq -r '.id' "${FILE_TMPDIR}/resp.body")
+
+  local body3
+  body3=$(json_post "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"previous_response_id\":\"${rid2}\",\"input\":\"What is the code word? Reply with one word only.\",\"max_output_tokens\":512,\"temperature\":0,\"seed\":1}")
+  echo "${body3}" | jq -e '(.output_text | test("XYZZY"; "i"))' >/dev/null
+}
+
 @test "responses: bogus previous_response_id returns 404" {
   local body
   body=$(json_post "/v1/responses" "{\"model\":\"${LLM_ALIAS}\",\"previous_response_id\":\"resp_nonexistent123\",\"input\":\"hi\"}")

--- a/packages/cli/test/responses-store.test.ts
+++ b/packages/cli/test/responses-store.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createResponsesStore } from '../src/serve/adapters/openai/responses-store.js'
+
+describe('createResponsesStore', () => {
+  it('put then get returns record', () => {
+    const store = createResponsesStore({ maxEntries: 10, ttlMs: 60_000 })
+    const rec = {
+      id: 'resp_a',
+      createdAtSec: 100,
+      expiresAtSec: 2_000_000_000,
+      responseObject: { id: 'resp_a', object: 'response' },
+      inputItems: [{ type: 'message', id: '1', role: 'user', content: [] }],
+      modelAlias: 'm'
+    }
+    store.put(rec)
+    const got = store.get('resp_a')
+    assert.ok(got)
+    assert.equal(got!.id, 'resp_a')
+  })
+
+  it('delete removes record', () => {
+    const store = createResponsesStore({ maxEntries: 10, ttlMs: 60_000 })
+    store.put({
+      id: 'resp_b',
+      createdAtSec: 1,
+      expiresAtSec: 2_000_000_000,
+      responseObject: {},
+      inputItems: [],
+      modelAlias: 'm'
+    })
+    assert.equal(store.delete('resp_b'), true)
+    assert.equal(store.get('resp_b'), undefined)
+  })
+
+  it('evicts oldest when over maxEntries', () => {
+    const store = createResponsesStore({ maxEntries: 2, ttlMs: 600_000 })
+    store.put({
+      id: 'resp_1',
+      createdAtSec: 1,
+      expiresAtSec: 2_000_000_000,
+      responseObject: {},
+      inputItems: [],
+      modelAlias: 'm'
+    })
+    store.put({
+      id: 'resp_2',
+      createdAtSec: 2,
+      expiresAtSec: 2_000_000_000,
+      responseObject: {},
+      inputItems: [],
+      modelAlias: 'm'
+    })
+    store.put({
+      id: 'resp_3',
+      createdAtSec: 3,
+      expiresAtSec: 2_000_000_000,
+      responseObject: {},
+      inputItems: [],
+      modelAlias: 'm'
+    })
+    assert.equal(store.get('resp_1'), undefined)
+    assert.ok(store.get('resp_3'))
+  })
+
+  it('expires by ttl', () => {
+    let t = 0
+    const store = createResponsesStore({
+      maxEntries: 10,
+      ttlMs: 1000,
+      now: (): number => { return t }
+    })
+    t = 0
+    store.put({
+      id: 'resp_e',
+      createdAtSec: 0,
+      expiresAtSec: 1,
+      responseObject: {},
+      inputItems: [],
+      modelAlias: 'm'
+    })
+    t = 2000
+    assert.equal(store.get('resp_e'), undefined)
+  })
+
+  it('listInputItems returns list shape', () => {
+    const store = createResponsesStore({ maxEntries: 10, ttlMs: 60_000 })
+    store.put({
+      id: 'resp_l',
+      createdAtSec: 1,
+      expiresAtSec: 2_000_000_000,
+      responseObject: {},
+      inputItems: [
+        { type: 'message', id: 'i1', role: 'user', content: [{ type: 'input_text', text: 'x' }] }
+      ],
+      modelAlias: 'm'
+    })
+    const page = store.listInputItems('resp_l', { limit: 10 })
+    assert.ok(page)
+    assert.equal(page!.object, 'list')
+    assert.equal(page!.data.length, 1)
+  })
+
+  it('bannerLine mentions limits', () => {
+    const store = createResponsesStore({ maxEntries: 128, ttlMs: 120_000 })
+    assert.ok(store.bannerLine().includes('128'))
+    assert.ok(store.bannerLine().includes('2m'))
+  })
+})

--- a/packages/cli/test/responses-store.test.ts
+++ b/packages/cli/test/responses-store.test.ts
@@ -101,6 +101,44 @@ describe('createResponsesStore', () => {
     assert.equal(page!.data.length, 1)
   })
 
+  it('listInputItems paginates with after cursor and reports has_more correctly', () => {
+    const store = createResponsesStore({ maxEntries: 10, ttlMs: 60_000 })
+    const items = Array.from({ length: 5 }, (_, i) => ({
+      type: 'message',
+      id: `i${i + 1}`,
+      role: 'user',
+      content: [{ type: 'input_text', text: `t${i + 1}` }]
+    }))
+    store.put({
+      id: 'resp_p',
+      createdAtSec: 1,
+      expiresAtSec: 2_000_000_000,
+      responseObject: {},
+      inputItems: items,
+      modelAlias: 'm'
+    })
+
+    const page1 = store.listInputItems('resp_p', { limit: 2 })
+    assert.ok(page1)
+    assert.equal(page1!.data.length, 2)
+    assert.equal(page1!.first_id, 'i1')
+    assert.equal(page1!.last_id, 'i2')
+    assert.equal(page1!.has_more, true)
+
+    const page2 = store.listInputItems('resp_p', { limit: 2, after: page1!.last_id! })
+    assert.ok(page2)
+    assert.equal(page2!.data.length, 2)
+    assert.equal(page2!.first_id, 'i3')
+    assert.equal(page2!.last_id, 'i4')
+    assert.equal(page2!.has_more, true)
+
+    const page3 = store.listInputItems('resp_p', { limit: 2, after: page2!.last_id! })
+    assert.ok(page3)
+    assert.equal(page3!.data.length, 1)
+    assert.equal(page3!.first_id, 'i5')
+    assert.equal(page3!.has_more, false)
+  })
+
   it('bannerLine mentions limits', () => {
     const store = createResponsesStore({ maxEntries: 128, ttlMs: 120_000 })
     assert.ok(store.bannerLine().includes('128'))

--- a/packages/cli/test/responses-streaming.test.ts
+++ b/packages/cli/test/responses-streaming.test.ts
@@ -1,0 +1,178 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { ServerResponse } from 'node:http'
+import { writeStreamingResponse } from '../src/serve/adapters/openai/routes/responses.js'
+import type { ResponsesHandlerParams } from '../src/serve/adapters/openai/routes/responses.js'
+import type { CompletionResult, SDKToolCall } from '../src/serve/core/sdk.js'
+import type { RouteContext } from '../src/serve/adapters/types.js'
+
+function minimalRouteContext (): RouteContext {
+  return {
+    registry: {} as RouteContext['registry'],
+    serveConfig: {} as RouteContext['serveConfig'],
+    logger: {
+      info: (): void => {},
+      warn: (): void => {},
+      error: (): void => {},
+      debug: (): void => {}
+    },
+    responsesStore: {
+      put: (): void => {},
+      get: (): undefined => undefined,
+      delete: (): boolean => false,
+      listInputItems: (): null => null,
+      size: (): number => 0,
+      bannerLine: (): string => ''
+    }
+  }
+}
+
+function baseHandlerParams (rid: string): ResponsesHandlerParams {
+  return {
+    ctx: minimalRouteContext(),
+    sdkModelId: 'mid',
+    history: [],
+    modelAlias: 'alias',
+    rid,
+    createdAtSec: 100,
+    storeEnabled: false,
+    inputItems: [],
+    metadata: undefined,
+    temperature: undefined,
+    topP: undefined,
+    maxOutputTokens: undefined,
+    parallelToolCalls: true,
+    previousResponseId: null
+  }
+}
+
+function fakeStreamCompletion (opts: {
+  tokens: string[]
+  toolCalls: SDKToolCall[] | null
+  text: string
+  stats?: import('../src/serve/core/sdk.js').CompletionRunStats
+}): CompletionResult {
+  async function * gen (): AsyncGenerator<string> {
+    for (const t of opts.tokens) yield t
+  }
+  return {
+    text: Promise.resolve(opts.text),
+    toolCalls: Promise.resolve(opts.toolCalls),
+    stats: Promise.resolve(opts.stats),
+    tokenStream: gen(),
+    toolCallStream: (async function * empty (): AsyncGenerator<never> {})()
+  }
+}
+
+function parseSseJsonEvents (raw: string): unknown[] {
+  const out: unknown[] = []
+  for (const block of raw.split('\n\n')) {
+    for (const line of block.split('\n')) {
+      if (!line.startsWith('data: ')) continue
+      const payload = line.slice(6)
+      if (payload === '[DONE]') continue
+      try {
+        out.push(JSON.parse(payload) as unknown)
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return out
+}
+
+function createStreamResponse (): { res: ServerResponse; raw: string } {
+  const parts: string[] = []
+  let sent = false
+  const res = {
+    setHeader: (): void => {},
+    writeHead: (): void => {
+      sent = true
+    },
+    write (chunk: string): boolean {
+      parts.push(chunk)
+      return true
+    },
+    end (chunk?: string | Buffer): void {
+      if (chunk !== undefined && chunk !== null) parts.push(String(chunk))
+    },
+    get headersSent (): boolean {
+      return sent
+    }
+  } as unknown as ServerResponse
+  return {
+    res,
+    get raw (): string {
+      return parts.join('')
+    }
+  }
+}
+
+describe('writeStreamingResponse', () => {
+  it('keeps same message item_id in deltas and in response.completed output', async () => {
+    const holder = createStreamResponse()
+    const p = baseHandlerParams('resp_stream_msg')
+    const result = fakeStreamCompletion({
+      tokens: ['x', 'y'],
+      toolCalls: null,
+      text: 'xy',
+      stats: { generatedTokens: 5 }
+    })
+
+    const completed = await writeStreamingResponse(holder.res, p, result)
+    const events = parseSseJsonEvents(holder.raw) as Array<Record<string, unknown>>
+
+    const deltas = events.filter((e) => e['type'] === 'response.output_text.delta')
+    assert.ok(deltas.length >= 1)
+    const msgIdFromDelta = deltas[0]!['item_id'] as string
+    const out = (completed['output'] as Array<{ type: string; id: string }>)[0]!
+    assert.equal(out.type, 'message')
+    assert.equal(out.id, msgIdFromDelta)
+
+    const completedEvent = events.find((e) => e['type'] === 'response.completed') as {
+      response: { output: Array<{ id: string }>; usage: { output_tokens: number } }
+    }
+    assert.ok(completedEvent)
+    assert.equal(completedEvent.response.output[0]!.id, msgIdFromDelta)
+    assert.equal(completedEvent.response.usage.output_tokens, 5)
+  })
+
+  it('uses fc item ids and distinct output_index per tool call in SSE and final output', async () => {
+    const holder = createStreamResponse()
+    const p = baseHandlerParams('resp_stream_tools')
+    const result = fakeStreamCompletion({
+      tokens: [],
+      toolCalls: [
+        { id: 'call_a', name: 'fn1', arguments: '{}' },
+        { id: 'call_b', name: 'fn2', arguments: '{"k":1}' }
+      ],
+      text: '',
+      stats: { generatedTokens: 3 }
+    })
+
+    const completed = await writeStreamingResponse(holder.res, p, result)
+    const events = parseSseJsonEvents(holder.raw) as Array<Record<string, unknown>>
+
+    const argDeltas = events.filter((e) => e['type'] === 'response.function_call_arguments.delta')
+    assert.equal(argDeltas.length, 2)
+    assert.notEqual((argDeltas[0] as { item_id: string }).item_id, 'call_a')
+    assert.notEqual((argDeltas[1] as { item_id: string }).item_id, 'call_b')
+    assert.equal((argDeltas[0] as { output_index: number }).output_index, 1)
+    assert.equal((argDeltas[1] as { output_index: number }).output_index, 2)
+
+    const out = completed['output'] as Array<{ type: string; id: string; call_id?: string }>
+    assert.equal(out.length, 3)
+    assert.equal(out[0]!.type, 'message')
+    assert.equal(out[1]!.type, 'function_call')
+    assert.equal(out[2]!.type, 'function_call')
+    assert.equal(out[1]!.id, (argDeltas[0] as { item_id: string }).item_id)
+    assert.equal(out[2]!.id, (argDeltas[1] as { item_id: string }).item_id)
+    assert.equal(out[1]!.call_id, 'call_a')
+    assert.equal(out[2]!.call_id, 'call_b')
+
+    const completedEvent = events.find((e) => e['type'] === 'response.completed') as {
+      response: { usage: { output_tokens: number } }
+    }
+    assert.equal(completedEvent.response.usage.output_tokens, 3)
+  })
+})

--- a/packages/cli/test/responses.test.ts
+++ b/packages/cli/test/responses.test.ts
@@ -1,6 +1,13 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import type { ServerResponse } from 'node:http'
 import { buildResponseObject } from '../src/serve/adapters/openai/responses-shape.js'
+import { writeBlockingResponse } from '../src/serve/adapters/openai/routes/responses.js'
+import type { ResponsesHandlerParams } from '../src/serve/adapters/openai/routes/responses.js'
+import type { CompletionResult } from '../src/serve/core/sdk.js'
+import type { RouteContext } from '../src/serve/adapters/types.js'
+
+const uuidSuffix = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 describe('buildResponseObject', () => {
   it('builds text response', () => {
@@ -24,13 +31,16 @@ describe('buildResponseObject', () => {
     assert.equal(o['model'], 'my-model')
     assert.equal(o['output_text'], 'hello world')
     assert.equal((o['usage'] as { output_tokens: number }).output_tokens, 2)
+    const out = o['output'] as Array<{ type: string }>
+    assert.equal(out.length, 1)
+    assert.equal(out[0]!.type, 'message')
   })
 
-  it('requires_action when tool calls present', () => {
+  it('requires_action when tool calls present; message first then function_call (approach b)', () => {
     const o = buildResponseObject({
       id: 'resp_t',
       modelAlias: 'm',
-      text: '',
+      text: 'hi',
       toolCalls: [{ id: 'call_1', name: 'fn', arguments: '{}' }],
       createdAtSec: 1,
       metadata: undefined,
@@ -42,8 +52,208 @@ describe('buildResponseObject', () => {
       store: false
     })
     assert.equal(o['status'], 'requires_action')
-    const out = o['output'] as unknown[]
+    assert.equal(o['output_text'], 'hi')
+    const out = o['output'] as Array<{ type: string; id?: string }>
     assert.ok(Array.isArray(out))
-    assert.equal((out[0] as { type: string }).type, 'function_call')
+    assert.equal(out.length, 2)
+    assert.equal(out[0]!.type, 'message')
+    assert.equal(out[1]!.type, 'function_call')
+    const ra = o['required_action'] as {
+      type: string
+      submit_tool_outputs: { tool_calls: Array<{ id: string; function: { name: string; arguments: string } }> }
+    }
+    assert.equal(ra.type, 'submit_tool_outputs')
+    assert.equal(ra.submit_tool_outputs.tool_calls.length, 1)
+    assert.equal(ra.submit_tool_outputs.tool_calls[0]!.id, 'call_1')
+    assert.equal(ra.submit_tool_outputs.tool_calls[0]!.function.name, 'fn')
+  })
+
+  it('reuses messageItemId and functionCallItemIds when provided', () => {
+    const msgId = 'msg_fixed_1'
+    const fcIds = ['fc_fixed_a', 'fc_fixed_b']
+    const o = buildResponseObject({
+      id: 'resp_x',
+      modelAlias: 'm',
+      text: '',
+      toolCalls: [
+        { id: 'c1', name: 'a', arguments: '{}' },
+        { id: 'c2', name: 'b', arguments: '{}' }
+      ],
+      createdAtSec: 1,
+      metadata: undefined,
+      temperature: undefined,
+      topP: undefined,
+      maxOutputTokens: undefined,
+      parallelToolCalls: true,
+      previousResponseId: null,
+      store: false,
+      messageItemId: msgId,
+      functionCallItemIds: fcIds
+    })
+    const out = o['output'] as Array<{ type: string; id: string }>
+    assert.equal(out[0]!.id, msgId)
+    assert.equal(out[1]!.id, fcIds[0])
+    assert.equal(out[2]!.id, fcIds[1])
+  })
+
+  it('uses stats.generatedTokens for usage.output_tokens when present', () => {
+    const o = buildResponseObject({
+      id: 'resp_u',
+      modelAlias: 'm',
+      text: 'one two three',
+      toolCalls: null,
+      createdAtSec: 1,
+      metadata: undefined,
+      temperature: undefined,
+      topP: undefined,
+      maxOutputTokens: undefined,
+      parallelToolCalls: true,
+      previousResponseId: null,
+      store: true,
+      stats: { generatedTokens: 99 }
+    })
+    const u = o['usage'] as { output_tokens: number; input_tokens: number; total_tokens: number }
+    assert.equal(u.output_tokens, 99)
+    assert.equal(u.total_tokens, 99)
+  })
+
+  it('ids use uuid suffix after prefix', () => {
+    const o = buildResponseObject({
+      id: 'resp_test',
+      modelAlias: 'm',
+      text: 'x',
+      toolCalls: [{ id: 'c1', name: 'f', arguments: '{}' }],
+      createdAtSec: 1,
+      metadata: undefined,
+      temperature: undefined,
+      topP: undefined,
+      maxOutputTokens: undefined,
+      parallelToolCalls: true,
+      previousResponseId: null,
+      store: false
+    })
+    const out = o['output'] as Array<{ id: string }>
+    const msgRest = out[0]!.id.replace(/^msg_/, '')
+    const fcRest = out[1]!.id.replace(/^fc_/, '')
+    assert.match(msgRest, uuidSuffix)
+    assert.match(fcRest, uuidSuffix)
+  })
+})
+
+function minimalRouteContext (): RouteContext {
+  return {
+    registry: {} as RouteContext['registry'],
+    serveConfig: {} as RouteContext['serveConfig'],
+    logger: {
+      info: (): void => {},
+      warn: (): void => {},
+      error: (): void => {},
+      debug: (): void => {}
+    },
+    responsesStore: {
+      put: (): void => {},
+      get: (): undefined => undefined,
+      delete: (): boolean => false,
+      listInputItems: (): null => null,
+      size: (): number => 0,
+      bannerLine: (): string => ''
+    }
+  }
+}
+
+function baseHandlerParams (): ResponsesHandlerParams {
+  return {
+    ctx: minimalRouteContext(),
+    sdkModelId: 'mid',
+    history: [],
+    modelAlias: 'alias',
+    rid: 'resp_block_test',
+    createdAtSec: 100,
+    storeEnabled: false,
+    inputItems: [],
+    metadata: undefined,
+    temperature: undefined,
+    topP: undefined,
+    maxOutputTokens: undefined,
+    parallelToolCalls: true,
+    previousResponseId: null
+  }
+}
+
+function fakeCompletion (opts: {
+  text: string
+  toolCalls: import('../src/serve/core/sdk.js').SDKToolCall[] | null
+  stats?: import('../src/serve/core/sdk.js').CompletionRunStats
+}): CompletionResult {
+  return {
+    text: Promise.resolve(opts.text),
+    toolCalls: Promise.resolve(opts.toolCalls),
+    stats: Promise.resolve(opts.stats),
+    tokenStream: (async function * empty (): AsyncGenerator<string> {})(),
+    toolCallStream: (async function * empty (): AsyncGenerator<never> {})()
+  }
+}
+
+describe('writeBlockingResponse', () => {
+  it('returns JSON with usage from stats.generatedTokens', async () => {
+    let status = 0
+    let bodyStr = ''
+    let sent = false
+    const res = {
+      setHeader: (): void => {},
+      writeHead (s: number): void {
+        status = s
+        sent = true
+      },
+      end (payload?: string | Buffer): void {
+        if (typeof payload === 'string') bodyStr = payload
+      },
+      get headersSent (): boolean {
+        return sent
+      }
+    } as unknown as ServerResponse
+
+    const p = baseHandlerParams()
+    const result = fakeCompletion({
+      text: 'hello',
+      toolCalls: null,
+      stats: { generatedTokens: 42 }
+    })
+
+    const obj = await writeBlockingResponse(res, p, result)
+    assert.equal(status, 200)
+    assert.equal((obj['usage'] as { output_tokens: number }).output_tokens, 42)
+    const parsed = JSON.parse(bodyStr) as { usage: { output_tokens: number } }
+    assert.equal(parsed.usage.output_tokens, 42)
+  })
+
+  it('includes required_action when tool calls present', async () => {
+    let bodyStr = ''
+    let sent = false
+    const res = {
+      setHeader: (): void => {},
+      writeHead: (): void => {
+        sent = true
+      },
+      end (payload?: string | Buffer): void {
+        if (typeof payload === 'string') bodyStr = payload
+      },
+      get headersSent (): boolean {
+        return sent
+      }
+    } as unknown as ServerResponse
+
+    const p = baseHandlerParams()
+    const result = fakeCompletion({
+      text: '',
+      toolCalls: [{ id: 'call_x', name: 'fn', arguments: '{}' }],
+      stats: { generatedTokens: 1 }
+    })
+
+    const obj = await writeBlockingResponse(res, p, result)
+    assert.equal(obj['status'], 'requires_action')
+    assert.ok((obj['required_action'] as { submit_tool_outputs: unknown }).submit_tool_outputs)
+    const parsed = JSON.parse(bodyStr) as { required_action: { submit_tool_outputs: { tool_calls: unknown[] } } }
+    assert.equal(parsed.required_action.submit_tool_outputs.tool_calls.length, 1)
   })
 })

--- a/packages/cli/test/responses.test.ts
+++ b/packages/cli/test/responses.test.ts
@@ -47,7 +47,7 @@ describe('buildResponseObject', () => {
       temperature: undefined,
       topP: undefined,
       maxOutputTokens: undefined,
-      parallelToolCalls: undefined,
+      parallelToolCalls: true,
       previousResponseId: null,
       store: false
     })

--- a/packages/cli/test/responses.test.ts
+++ b/packages/cli/test/responses.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildResponseObject } from '../src/serve/adapters/openai/responses-shape.js'
+
+describe('buildResponseObject', () => {
+  it('builds text response', () => {
+    const o = buildResponseObject({
+      id: 'resp_test',
+      modelAlias: 'my-model',
+      text: 'hello world',
+      toolCalls: null,
+      createdAtSec: 42,
+      metadata: undefined,
+      temperature: 0.1,
+      topP: undefined,
+      maxOutputTokens: 16,
+      parallelToolCalls: true,
+      previousResponseId: null,
+      store: true
+    })
+    assert.equal(o['id'], 'resp_test')
+    assert.equal(o['object'], 'response')
+    assert.equal(o['status'], 'completed')
+    assert.equal(o['model'], 'my-model')
+    assert.equal(o['output_text'], 'hello world')
+    assert.equal((o['usage'] as { output_tokens: number }).output_tokens, 2)
+  })
+
+  it('requires_action when tool calls present', () => {
+    const o = buildResponseObject({
+      id: 'resp_t',
+      modelAlias: 'm',
+      text: '',
+      toolCalls: [{ id: 'call_1', name: 'fn', arguments: '{}' }],
+      createdAtSec: 1,
+      metadata: undefined,
+      temperature: undefined,
+      topP: undefined,
+      maxOutputTokens: undefined,
+      parallelToolCalls: undefined,
+      previousResponseId: null,
+      store: false
+    })
+    assert.equal(o['status'], 'requires_action')
+    const out = o['output'] as unknown[]
+    assert.ok(Array.isArray(out))
+    assert.equal((out[0] as { type: string }).type, 'function_call')
+  })
+})

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -22,6 +22,7 @@ import {
   validateResponsesStatefulOptions,
   normalizeResponsesInputItemsForStorage,
   historyPrefixFromStoredResponse,
+  logResponsesUnsupportedParams,
   UnsupportedToolTypeError,
   InvalidResponsesConversationError,
   InvalidResponsesBackgroundError
@@ -708,6 +709,22 @@ describe('openaiResponsesInputToHistory', () => {
     assert.equal(h[0]!.role, 'user')
     assert.equal(h[0]!.content, 'a')
   })
+
+  it('maps function_call_output to tool role', () => {
+    const h = openaiResponsesInputToHistory([
+      { type: 'function_call_output', output: '{"ok":true}' }
+    ], undefined)
+    assert.deepEqual(h[0], { role: 'tool', content: '{"ok":true}' })
+  })
+
+  it('maps function_call to synthesized assistant tool markup', () => {
+    const h = openaiResponsesInputToHistory([
+      { type: 'function_call', name: 'x', arguments: '{"a":1}' }
+    ], undefined)
+    assert.equal(h[0]!.role, 'assistant')
+    assert.ok(h[0]!.content.includes('<tool_call>'))
+    assert.ok(h[0]!.content.includes('x'))
+  })
 })
 
 describe('openaiResponsesToolsToSdk', () => {
@@ -773,6 +790,20 @@ describe('validateResponsesStatefulOptions', () => {
   })
 })
 
+describe('logResponsesUnsupportedParams', () => {
+  it('does not treat parallel_tool_calls as unsupported', () => {
+    const lines: string[] = []
+    const logger = {
+      info: (msg: string) => lines.push(msg),
+      warn: (): void => {},
+      error: (): void => {},
+      debug: (): void => {}
+    } as Parameters<typeof logResponsesUnsupportedParams>[1]
+    logResponsesUnsupportedParams({ parallel_tool_calls: false, input: '' }, logger)
+    assert.ok(!lines.some((l) => l.includes('parallel_tool_calls')))
+  })
+})
+
 describe('normalizeResponsesInputItemsForStorage', () => {
   it('wraps string input', () => {
     const items = normalizeResponsesInputItemsForStorage('hi')
@@ -782,7 +813,7 @@ describe('normalizeResponsesInputItemsForStorage', () => {
 })
 
 describe('historyPrefixFromStoredResponse', () => {
-  it('uses output_text shortcut when present', () => {
+  it('uses output_text when output array is empty', () => {
     const prefix = historyPrefixFromStoredResponse({
       inputItems: [{ type: 'message', id: '1', role: 'user', content: [{ type: 'input_text', text: 'u' }] }],
       responseObject: { output_text: 'assistant reply', output: [] }
@@ -791,5 +822,33 @@ describe('historyPrefixFromStoredResponse', () => {
       { role: 'user', content: 'u' },
       { role: 'assistant', content: 'assistant reply' }
     ])
+  })
+
+  it('prefers non-empty output array so tool calls are included with assistant text', () => {
+    const prefix = historyPrefixFromStoredResponse({
+      inputItems: [],
+      responseObject: {
+        output_text: 'ignored when structured output present',
+        output: [
+          { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'hello' }] },
+          { type: 'function_call', name: 'f', arguments: '{}', call_id: 'c1' }
+        ]
+      }
+    })
+    const assistantText = prefix.filter((p) => p.role === 'assistant' && !p.content.includes('tool_call'))
+    const toolCalls = prefix.filter((p) => p.role === 'assistant' && p.content.includes('tool_call'))
+    assert.equal(assistantText.length, 1)
+    assert.equal(assistantText[0]!.content, 'hello')
+    assert.equal(toolCalls.length, 1)
+  })
+
+  it('includes function_call_output from stored input items', () => {
+    const prefix = historyPrefixFromStoredResponse({
+      inputItems: [
+        { type: 'function_call_output', output: '{"r":1}' }
+      ],
+      responseObject: { output: [], output_text: '' }
+    })
+    assert.deepEqual(prefix, [{ role: 'tool', content: '{"r":1}' }])
   })
 })

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -851,4 +851,58 @@ describe('historyPrefixFromStoredResponse', () => {
     })
     assert.deepEqual(prefix, [{ role: 'tool', content: '{"r":1}' }])
   })
+
+  it('walks previous_response_id chain so depth-3 carries the grandparent turn', () => {
+    const records: Record<string, { inputItems: unknown[]; responseObject: Record<string, unknown> }> = {
+      resp_1: {
+        inputItems: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'A' }] }
+        ],
+        responseObject: { output: [], output_text: 'X' }
+      },
+      resp_2: {
+        inputItems: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'B' }] }
+        ],
+        responseObject: { output: [], output_text: 'Y', previous_response_id: 'resp_1' }
+      },
+      resp_3: {
+        inputItems: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'C' }] }
+        ],
+        responseObject: { output: [], output_text: 'Z', previous_response_id: 'resp_2' }
+      }
+    }
+    const prefix = historyPrefixFromStoredResponse(
+      records['resp_3']!,
+      (id) => records[id]
+    )
+    assert.deepEqual(prefix, [
+      { role: 'user', content: 'A' }, { role: 'assistant', content: 'X' },
+      { role: 'user', content: 'B' }, { role: 'assistant', content: 'Y' },
+      { role: 'user', content: 'C' }, { role: 'assistant', content: 'Z' }
+    ])
+  })
+
+  it('caps chain walk at maxDepth to bound work on pathological input', () => {
+    const records: Record<string, { inputItems: unknown[]; responseObject: Record<string, unknown> }> = {
+      a: {
+        inputItems: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'aIn' }] }],
+        responseObject: { output: [], output_text: 'aOut' }
+      },
+      b: {
+        inputItems: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'bIn' }] }],
+        responseObject: { output: [], output_text: 'bOut', previous_response_id: 'a' }
+      },
+      c: {
+        inputItems: [{ type: 'message', role: 'user', content: [{ type: 'input_text', text: 'cIn' }] }],
+        responseObject: { output: [], output_text: 'cOut', previous_response_id: 'b' }
+      }
+    }
+    const prefix = historyPrefixFromStoredResponse(records['c']!, (id) => records[id], 1)
+    assert.deepEqual(prefix, [
+      { role: 'user', content: 'bIn' }, { role: 'assistant', content: 'bOut' },
+      { role: 'user', content: 'cIn' }, { role: 'assistant', content: 'cOut' }
+    ])
+  })
 })

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -14,7 +14,17 @@ import {
   parseExpiresAfter,
   parseMetadata,
   InvalidExpiresAfterError,
-  InvalidMetadataError
+  InvalidMetadataError,
+  openaiResponsesInputToHistory,
+  openaiResponsesToolsToSdk,
+  extractResponsesGenerationParams,
+  extractResponsesResponseFormat,
+  validateResponsesStatefulOptions,
+  normalizeResponsesInputItemsForStorage,
+  historyPrefixFromStoredResponse,
+  UnsupportedToolTypeError,
+  InvalidResponsesConversationError,
+  InvalidResponsesBackgroundError
 } from '../src/serve/adapters/openai/translate.js'
 import type { VectorStoreMeta } from '../src/serve/adapters/openai/vector-stores-store.js'
 
@@ -677,5 +687,109 @@ describe('parseMetadata', () => {
   it('rejects oversized keys or values', () => {
     assert.throws(() => parseMetadata({ ['x'.repeat(65)]: 'v' }), InvalidMetadataError)
     assert.throws(() => parseMetadata({ k: 'v'.repeat(513) }), InvalidMetadataError)
+  })
+})
+
+describe('openaiResponsesInputToHistory', () => {
+  it('maps string input to user message', () => {
+    const h = openaiResponsesInputToHistory('hello', undefined)
+    assert.deepEqual(h, [{ role: 'user', content: 'hello' }])
+  })
+
+  it('prepends instructions as system', () => {
+    const h = openaiResponsesInputToHistory('x', 'sys')
+    assert.deepEqual(h, [{ role: 'system', content: 'sys' }, { role: 'user', content: 'x' }])
+  })
+
+  it('maps message items', () => {
+    const h = openaiResponsesInputToHistory([
+      { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'a' }] }
+    ], undefined)
+    assert.equal(h[0]!.role, 'user')
+    assert.equal(h[0]!.content, 'a')
+  })
+})
+
+describe('openaiResponsesToolsToSdk', () => {
+  it('maps Responses-style function tools', () => {
+    const t = openaiResponsesToolsToSdk([{
+      type: 'function',
+      name: 'fn',
+      description: 'd',
+      parameters: { type: 'object', properties: {} }
+    }])
+    assert.ok(t && t.length === 1)
+    assert.equal(t[0]!.name, 'fn')
+  })
+
+  it('throws on web_search', () => {
+    assert.throws(
+      () => openaiResponsesToolsToSdk([{ type: 'web_search' }]),
+      UnsupportedToolTypeError
+    )
+  })
+})
+
+describe('extractResponsesGenerationParams', () => {
+  it('maps max_output_tokens to predict', () => {
+    const p = extractResponsesGenerationParams({ max_output_tokens: 64 })
+    assert.equal(p!.predict, 64)
+  })
+})
+
+describe('extractResponsesResponseFormat', () => {
+  it('reads nested text.format', () => {
+    const f = extractResponsesResponseFormat({
+      text: { format: { type: 'json_object' } }
+    })
+    assert.ok(f && f.type === 'json_object')
+  })
+})
+
+describe('validateResponsesStatefulOptions', () => {
+  it('returns previous id and store default true', () => {
+    const r = validateResponsesStatefulOptions({ previous_response_id: 'resp_x', input: '' })
+    assert.equal(r.previousResponseId, 'resp_x')
+    assert.equal(r.storeEnabled, true)
+  })
+
+  it('store false opts out', () => {
+    const r = validateResponsesStatefulOptions({ store: false, input: '' })
+    assert.equal(r.storeEnabled, false)
+  })
+
+  it('throws on conversation', () => {
+    assert.throws(
+      () => validateResponsesStatefulOptions({ conversation: 'c1' }),
+      InvalidResponsesConversationError
+    )
+  })
+
+  it('throws on background true', () => {
+    assert.throws(
+      () => validateResponsesStatefulOptions({ background: true }),
+      InvalidResponsesBackgroundError
+    )
+  })
+})
+
+describe('normalizeResponsesInputItemsForStorage', () => {
+  it('wraps string input', () => {
+    const items = normalizeResponsesInputItemsForStorage('hi')
+    assert.equal(items.length, 1)
+    assert.equal((items[0] as { type: string }).type, 'message')
+  })
+})
+
+describe('historyPrefixFromStoredResponse', () => {
+  it('uses output_text shortcut when present', () => {
+    const prefix = historyPrefixFromStoredResponse({
+      inputItems: [{ type: 'message', id: '1', role: 'user', content: [{ type: 'input_text', text: 'u' }] }],
+      responseObject: { output_text: 'assistant reply', output: [] }
+    })
+    assert.deepEqual(prefix, [
+      { role: 'user', content: 'u' },
+      { role: 'assistant', content: 'assistant reply' }
+    ])
   })
 })


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## What problem does this PR solve?

- OpenAI-compatible clients expect **`/v1/responses`** (blocking, SSE streaming, retrieval by id, and **`previous_response_id`** chaining). The CLI HTTP server only exposed chat/completions-style paths, so those clients could not target QVAC through the same surface.

## How does it solve it?

- Implements **`POST /v1/responses`** (blocking and `stream: true` SSE) by translating the Responses request into the existing **`sdkCompletion`** path used for chat-style inference — same models and streaming behavior as the rest of the OpenAI adapter.
- Adds **`GET` / `DELETE` `/v1/responses/{id}`** and **`GET /v1/responses/{id}/input_items`** backed by a small **in-memory** store (LRU + TTL; default **on**; **`store: false`** skips persistence).
- Supports **`previous_response_id`** by prefixing stored prior output into the completion history; returns **`404`** with **`previous_response_not_found`** when the prior id is missing.
- Surfaces **`X-QVAC-Stub: responses-volatile`** on these routes and logs a one-line startup warning so operators know state is not durable.

## OpenAI API compatibility (what matches)

- Same URL shape and verbs for create, retrieve, delete, and input listing; SSE event framing for streaming where applicable.
- Request fields the adapter understands are translated to QVAC completion calls; response objects and stream events follow the same general shape clients expect for basic text / tool-call flows wired today.

## Caveats / gaps (notable)

- **State is volatile**: process memory only; restart or eviction loses ids — not OpenAI’s hosted persistence.
- **Intentionally rejected** with **`400`**: `conversation`, **`background: true`**, and **built-in** tools (e.g. `web_search`) not mapped to local inference yet.
- **Full parity** with every OpenAI Responses option, tool type, and edge case is **not** claimed; unknown or unsupported combinations should fail loudly rather than silently diverge.

## How was it tested?

- `packages/cli`: `npm run lint`, `npm run test:unit`, `npm run test:bats`, `npm run test:e2e` (e2e covers blocking + SSE + store + chain + validation paths in `e2e.bats`).

## API Changes

```bash
# Blocking create
curl -sS "$BASE/v1/responses" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"model":"'"$MODEL"'","input":"ping","store":true}'

# Streaming
curl -sN "$BASE/v1/responses" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"model":"'"$MODEL"'","input":"ping","stream":true,"store":true}'

# Chained follow-up (after capturing response id from prior call)
curl -sS "$BASE/v1/responses" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"model":"'"$MODEL"'","input":"and now?","previous_response_id":"resp_..."}'
```

