### PR TITLE
chore[notask|skiplog]: release @qvac/registry-schema v0.2.0

### DIFF
--- a/packages/registry-server/shared/CHANGELOG.md
+++ b/packages/registry-server/shared/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.0]
+
+Release Date: 2026-05-14
+
+### 🔧 Changed
+
+- **BREAKING (install-time)**: Move `hyperdb` from `dependencies` to `peerDependencies` so consumer apps don't get a duplicate copy of the singleton when installed alongside `@qvac/sdk` (#1905). Most consumers (npm 7+, pnpm, bun) auto-install peers and need no action. Standalone consumers using yarn 1 or `legacy-peer-deps=true` must now add `hyperdb` to their own dependencies.
+
 ## [0.1.2]
 
 Release Date: 2026-03-19

--- a/packages/registry-server/shared/package.json
+++ b/packages/registry-server/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-schema",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "HyperDB schema and database wrapper for QVAC Registry",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## What problem does this PR solve?

Publish `@qvac/registry-schema v0.2.0` so the `peerDependencies`-only Holepunch-lib classification from #1905 actually reaches npm. The repo's `0.1.2` manifest was edited in place by #1905 but never re-published — the npm artifact still ships `hyperdb` as a hard `dependency`, so SDK consumers still get duplicated singletons.

## How does it solve it?

- Bump `@qvac/registry-schema` from `0.1.2` to `0.2.0`. Minor (not patch) so existing `^0.1.x` ranges in downstream consumers don't auto-promote — the install contract changed for standalone yarn-1 / `legacy-peer-deps=true` consumers and they need an explicit opt-in.
- Add `[0.2.0]` changelog entry pointing at #1905.

On merge to `release-qvac-registry-schema-0.2.0`, `publish-registry-server.yml` publishes to npm.

## How was it tested?

Metadata-only release; no code changes. Verification of the dedup behaviour is done downstream once the SDK consumes the bumped peers (see follow-ups).

### Follow-ups

- Backmerge same `package.json` + `CHANGELOG.md` bumps into `main` (per gitflow step 4).
- Companion client release: `@qvac/registry-client v0.5.0` — separate release PR, currently draft, blocked on this one being published to npm.
- SDK release bumping `@qvac/registry-client: ^0.5.0` and `@qvac/rag: ^0.5.0` to actually deliver dedup to apps.
