### PR TITLE
chore[notask|skiplog]: release @qvac/registry-client v0.5.0

### DIFF
--- a/packages/registry-server/client/CHANGELOG.md
+++ b/packages/registry-server/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.5.0]
+
+Release Date: 2026-05-14
+
+### 🔧 Changed
+
+- **BREAKING (install-time)**: Move `corestore`, `hyperblobs`, `hyperdb`, and `hyperswarm` from `dependencies` to `peerDependencies` so consumer apps don't get duplicate copies of these stateful Holepunch singletons when `@qvac/registry-client` is installed alongside `@qvac/sdk` (#1905). Most consumers (npm 7+, pnpm, bun) auto-install peers and need no action. Standalone consumers using yarn 1 or `legacy-peer-deps=true` must now add `corestore`, `hyperblobs`, `hyperdb`, and `hyperswarm` to their own dependencies.
+- Bump `@qvac/registry-schema` to `^0.2.0` (also peers-cleaned in its own release).
+
 ## [0.4.1]
 
 Release Date: 2026-04-22

--- a/packages/registry-server/client/package.json
+++ b/packages/registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "repository": {
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/registry-schema": "^0.1.2",
+    "@qvac/registry-schema": "^0.2.0",
     "b4a": "^1.6.7",
     "bare-fs": "^4.5.2",
     "bare-os": "^3.6.2",


### PR DESCRIPTION
## What problem does this PR solve?

Publish `@qvac/registry-client v0.5.0` so the `peerDependencies`-only Holepunch-lib classification from #1905 actually reaches npm. The repo's `0.4.1` manifest was edited in place by #1905 but never re-published — the npm `0.4.1` artifact still ships `corestore`, `hyperblobs`, `hyperdb`, `hyperswarm` as hard `dependencies`, so SDK consumers still get duplicated singletons.

## How does it solve it?

- Bump `@qvac/registry-client` from `0.4.1` to `0.5.0`. Minor (not patch) so existing `^0.4.x` ranges in downstream consumers don't auto-promote — the install contract changed for standalone yarn-1 / `legacy-peer-deps=true` consumers and they need an explicit opt-in.
- Bump the `@qvac/registry-schema` dep from `^0.1.2` to `^0.2.0` to pull in the matching peers-cleaned schema release (#2034, merged and published as `@qvac/registry-schema@0.2.0` on npm).
- Add `[0.5.0]` changelog entry pointing at #1905.

On merge to `release-qvac-registry-client-0.5.0`, `publish-registry-server.yml` publishes to npm.

## How was it tested?

Metadata-only release; no code changes. `lint-and-test` resolves `@qvac/registry-schema@^0.2.0` from npm and passes. Once published, end-to-end dedup is validated by installing `@qvac/sdk` (with `@qvac/rag: ^0.5.0` — already in main via #2011 — and `@qvac/registry-client: ^0.5.0`) into a clean project and confirming a single copy of each Holepunch singleton in `node_modules`.

### Follow-ups

- Backmerge same `package.json` + `CHANGELOG.md` bumps into `main` (per gitflow step 4).
- SDK release bumping `@qvac/registry-client: ^0.5.0` so the dedup actually reaches `@qvac/sdk` consumers (rag side is already in main).
