### PR TITLE
tts-ggml: bump tts-cpp dependency to 2026-05-07#1

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1]
+
+### Fixed
+
+- Fixed two issues when loading chatterbox on iOS:
+  - gguf_init_from_file race: bake_voice_conditioning() now runs before s3gen_preload_thread is spawned, so the two gguf_init_from_file calls no longer race against ggml's process-global state (previously aborted in ggml_abort on iOS).
+  - Metal shared-buffer-type init race when unload is called immediately after load
+
 ## [0.1.0]
 
 Initial release of `@qvac/tts-ggml`, a GGML-backed TTS addon wrapping the

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic engines from tts-cpp)",
   "addon": true,
   "engines": {

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-05-07"
+      "version>=": "2026-05-07#1"
     }
   ],
   "features": {


### PR DESCRIPTION
## [0.1.1]

### Fixed

- Fixed two issues when loading chatterbox on iOS:
  - gguf_init_from_file race: bake_voice_conditioning() now runs before s3gen_preload_thread is spawned, so the two gguf_init_from_file calls no longer race against ggml's process-global state (previously aborted in ggml_abort on iOS).
  - Metal shared-buffer-type init race when unload is called immediately after load
