### PR TITLE
infra: unpin tmp-self-hosted-runners branch from all workflows

### DIFF
--- a/.github/workflows/on-pr-bci-whispercpp.yml
+++ b/.github/workflows/on-pr-bci-whispercpp.yml
@@ -153,7 +153,7 @@ jobs:
   cpp-lint:
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -170,7 +170,7 @@ jobs:
       id-token: write
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/cpp-test-coverage-bci-whispercpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-test-coverage-bci-whispercpp.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -184,7 +184,7 @@ jobs:
       id-token: write
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/prebuilds-bci-whispercpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-bci-whispercpp.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -197,7 +197,7 @@ jobs:
       id-token: write
     needs: [authorize, context, prebuild]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/integration-test-bci-whispercpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-bci-whispercpp.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -212,7 +212,7 @@ jobs:
       id-token: write
     needs: [authorize, context, prebuild]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-bci-whispercpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-bci-whispercpp.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}

--- a/.github/workflows/on-pr-decoder-audio.yml
+++ b/.github/workflows/on-pr-decoder-audio.yml
@@ -157,7 +157,7 @@ jobs:
       contents: read
       packages: read
       id-token: write
-    uses: tetherto/qvac/.github/workflows/integration-test-decoder-audio.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-decoder-audio.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -172,7 +172,7 @@ jobs:
       id-token: write
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-decoder-audio.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-decoder-audio.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}

--- a/.github/workflows/on-pr-diffusion-cpp.yml
+++ b/.github/workflows/on-pr-diffusion-cpp.yml
@@ -66,7 +66,7 @@ jobs:
   cpp-tests:
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, sanity-checks]
-    uses: tetherto/qvac/.github/workflows/cpp-tests-diffusion.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-tests-diffusion.yml
     secrets: inherit
     with:
       workdir: packages/diffusion-cpp
@@ -75,7 +75,7 @@ jobs:
 
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     needs: authorize
     secrets: inherit
     with:
@@ -119,7 +119,7 @@ jobs:
       packages: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/prebuilds-diffusion-cpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-diffusion-cpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -132,7 +132,7 @@ jobs:
       contents: read
       packages: read
       id-token: write
-    uses: tetherto/qvac/.github/workflows/integration-test-diffusion-cpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-diffusion-cpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -146,7 +146,7 @@ jobs:
       id-token: write
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, prebuild]
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-diffusion-cpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-diffusion-cpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/on-pr-embed-llamacpp.yml
+++ b/.github/workflows/on-pr-embed-llamacpp.yml
@@ -76,7 +76,7 @@ jobs:
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
     needs: authorize
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha }}
@@ -90,7 +90,7 @@ jobs:
       pull-requests: write
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, sanity-checks]
-    uses: tetherto/qvac/.github/workflows/cpp-tests-embed.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-tests-embed.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -133,7 +133,7 @@ jobs:
       id-token: write
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, sanity-checks]
-    uses: tetherto/qvac/.github/workflows/prebuilds-embed-llamacpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-embed-llamacpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -146,7 +146,7 @@ jobs:
       contents: read
       packages: read
       id-token: write
-    uses: tetherto/qvac/.github/workflows/integration-test-embed-llamacpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-embed-llamacpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -160,7 +160,7 @@ jobs:
       id-token: write
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, prebuild]
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-embed-llamacpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-embed-llamacpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/on-pr-llm-llamacpp.yml
+++ b/.github/workflows/on-pr-llm-llamacpp.yml
@@ -81,7 +81,7 @@ jobs:
   cpp-tests:
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, sanity-checks]
-    uses: tetherto/qvac/.github/workflows/cpp-tests-llm.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-tests-llm.yml
     secrets: inherit
     with:
       workdir: packages/llm-llamacpp
@@ -90,7 +90,7 @@ jobs:
 
   cpp-lint:
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     needs: authorize
     secrets: inherit
     with:
@@ -135,7 +135,7 @@ jobs:
       packages: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/prebuilds-llm-llamacpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-llm-llamacpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -148,7 +148,7 @@ jobs:
       contents: read
       packages: read
       id-token: write
-    uses: tetherto/qvac/.github/workflows/integration-test-llm-llamacpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-llm-llamacpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -162,7 +162,7 @@ jobs:
       id-token: write
     if: needs.authorize.outputs.allowed == 'true'
     needs: [authorize, prebuild]
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-llm-llamacpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-llm-llamacpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -159,7 +159,7 @@ jobs:
   cpp-lint:
     needs: [authorize, changes]
     if: needs.authorize.outputs.allowed == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -179,7 +179,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         needs.authorize.outputs.allowed == 'true'
       )
-    uses: tetherto/qvac/.github/workflows/prebuilds-ocr-onnx.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-ocr-onnx.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -197,7 +197,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         needs.authorize.outputs.allowed == 'true'
       )
-    uses: tetherto/qvac/.github/workflows/integration-test-ocr-onnx.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-ocr-onnx.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -216,7 +216,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         needs.authorize.outputs.allowed == 'true'
       )
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-ocr-onnx.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-ocr-onnx.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/on-pr-onnx.yml
+++ b/.github/workflows/on-pr-onnx.yml
@@ -156,7 +156,7 @@ jobs:
   cpp-lint:
     needs: [authorize, changes]
     if: needs.authorize.outputs.allowed == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.sha }}
@@ -176,7 +176,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         needs.authorize.outputs.allowed == 'true'
       )
-    uses: tetherto/qvac/.github/workflows/prebuilds-onnx.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-onnx.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/on-pr-transcription-parakeet.yml
+++ b/.github/workflows/on-pr-transcription-parakeet.yml
@@ -138,7 +138,7 @@ jobs:
   cpp-lint:
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -155,7 +155,7 @@ jobs:
       actions: read
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/cpp-test-coverage-transcription-parakeet.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-test-coverage-transcription-parakeet.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -169,7 +169,7 @@ jobs:
       id-token: write
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/prebuilds-transcription-parakeet.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-transcription-parakeet.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -182,7 +182,7 @@ jobs:
       id-token: write
     needs: [context, prebuild]
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/integration-test-transcription-parakeet.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-transcription-parakeet.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -196,7 +196,7 @@ jobs:
       id-token: write
     needs: [context, prebuild]
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-transcription-parakeet.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-transcription-parakeet.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}

--- a/.github/workflows/on-pr-transcription-whispercpp.yml
+++ b/.github/workflows/on-pr-transcription-whispercpp.yml
@@ -153,7 +153,7 @@ jobs:
   cpp-lint:
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -170,7 +170,7 @@ jobs:
       id-token: write
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -197,7 +197,7 @@ jobs:
       id-token: write
     needs: [authorize, context, prebuild]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/integration-test-transcription-whispercpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-transcription-whispercpp.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -212,7 +212,7 @@ jobs:
       id-token: write
     needs: [authorize, context, prebuild]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-transcription-whispercpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-transcription-whispercpp.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}

--- a/.github/workflows/on-pr-translation-nmtcpp.yml
+++ b/.github/workflows/on-pr-translation-nmtcpp.yml
@@ -118,7 +118,7 @@ jobs:
       always() &&
        needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     secrets: inherit
     with:
       sha: ${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}
@@ -136,7 +136,7 @@ jobs:
       always() &&
       needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
     secrets: inherit
     with:
       ref: ${{ github.event.pull_request.head.ref }}
@@ -153,7 +153,7 @@ jobs:
       always() &&
       needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac/.github/workflows/prebuilds-translation-nmtcpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-translation-nmtcpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -169,7 +169,7 @@ jobs:
       contents: read
       packages: read
       id-token: write
-    uses: tetherto/qvac/.github/workflows/integration-test-translation-nmtcpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-translation-nmtcpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -186,7 +186,7 @@ jobs:
       always() &&
       needs.authorize.outputs.allowed == 'true' &&
       (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-translation-nmtcpp.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-translation-nmtcpp.yml
     secrets: inherit
     with:
       repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/on-pr-tts-ggml.yml
+++ b/.github/workflows/on-pr-tts-ggml.yml
@@ -138,7 +138,7 @@ jobs:
   cpp-lint:
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -160,7 +160,7 @@ jobs:
       actions: read
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/cpp-test-coverage-tts-ggml.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-test-coverage-tts-ggml.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -174,7 +174,7 @@ jobs:
       id-token: write
     needs: context
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/prebuilds-tts-ggml.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-tts-ggml.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -187,7 +187,7 @@ jobs:
       id-token: write
     needs: [context, prebuild]
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/integration-test-tts-ggml.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-tts-ggml.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -201,7 +201,7 @@ jobs:
       id-token: write
     needs: [context, prebuild]
     if: needs.context.outputs.run_verify == 'true' || github.event_name == 'workflow_dispatch'
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-tts-ggml.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-tts-ggml.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}

--- a/.github/workflows/on-pr-tts-onnx.yml
+++ b/.github/workflows/on-pr-tts-onnx.yml
@@ -177,7 +177,7 @@ jobs:
   cpp-lint:
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/cpp-lint.yaml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-lint.yaml
     secrets: inherit
     with:
       sha: ${{ needs.context.outputs.base_sha }}
@@ -194,7 +194,7 @@ jobs:
       actions: read
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/cpp-test-coverage-tts-onnx.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/cpp-test-coverage-tts-onnx.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -209,7 +209,7 @@ jobs:
       id-token: write
     needs: [authorize, context]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/prebuilds-tts-onnx.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/prebuilds-tts-onnx.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -223,7 +223,7 @@ jobs:
       id-token: write
     needs: [authorize, context, prebuild]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/integration-test-tts-onnx.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-test-tts-onnx.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}
@@ -240,7 +240,7 @@ jobs:
       id-token: write
     needs: [authorize, context, prebuild]
     if: needs.authorize.outputs.allowed == 'true'
-    uses: tetherto/qvac/.github/workflows/integration-mobile-test-tts-onnx.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/integration-mobile-test-tts-onnx.yml
     secrets: inherit
     with:
       repository: ${{ needs.context.outputs.repository }}

--- a/.github/workflows/prebuilds-bci-whispercpp.yml
+++ b/.github/workflows/prebuilds-bci-whispercpp.yml
@@ -34,7 +34,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/prebuilds-diffusion-cpp.yml
+++ b/.github/workflows/prebuilds-diffusion-cpp.yml
@@ -35,7 +35,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/prebuilds-embed-llamacpp.yml
+++ b/.github/workflows/prebuilds-embed-llamacpp.yml
@@ -43,7 +43,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/prebuilds-llm-llamacpp.yml
+++ b/.github/workflows/prebuilds-llm-llamacpp.yml
@@ -43,7 +43,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/prebuilds-ocr-onnx.yml
+++ b/.github/workflows/prebuilds-ocr-onnx.yml
@@ -35,7 +35,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/prebuilds-onnx.yml
+++ b/.github/workflows/prebuilds-onnx.yml
@@ -36,7 +36,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/prebuilds-transcription-parakeet.yml
+++ b/.github/workflows/prebuilds-transcription-parakeet.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/prebuilds-translation-nmtcpp.yml
+++ b/.github/workflows/prebuilds-translation-nmtcpp.yml
@@ -35,7 +35,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/prebuilds-tts-ggml.yml
+++ b/.github/workflows/prebuilds-tts-ggml.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/prebuilds-tts-onnx.yml
+++ b/.github/workflows/prebuilds-tts-onnx.yml
@@ -35,7 +35,7 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-    uses: tetherto/qvac/.github/workflows/reusable-prebuilds.yml@tmp-self-hosted-runners
+    uses: ./.github/workflows/reusable-prebuilds.yml
     with:
       workdir: ${{ inputs.workdir }}
       ref: ${{ inputs.ref }}


### PR DESCRIPTION
## What problem does this PR solve?

Cleanup after testing and merging to main of PR #2021

## How does it solve it?

Reverts all changes that pinned the tmp branch, to point back to main with relative path

## Breaking changes
