### PR TITLE
QVAC-18612 test[notask]: validate merged label-gate fan-out (will be closed)

### DIFF
--- a/packages/embed-llamacpp/README.md
+++ b/packages/embed-llamacpp/README.md
@@ -263,3 +263,5 @@ C++ unit tests live under [`addon/test/`](./addon/test/) and exercise the native
 This project is licensed under the Apache-2.0 [License](./LICENSE) – see the LICENSE file for details.
 
 _For questions or issues, please open an issue on the GitHub repository._
+
+<!-- QVAC-18612 label-gate validation: trivial whitespace-only edit, will be reverted -->

--- a/packages/llm-llamacpp/README.md
+++ b/packages/llm-llamacpp/README.md
@@ -446,3 +446,5 @@ These tests validate the native implementation and help catch issues early in de
 This project is licensed under the Apache-2.0 [License](./LICENSE) – see the LICENSE file for details.
 
 _For questions or issues, please open an issue on the GitHub repository._
+
+<!-- QVAC-18612 label-gate validation: trivial whitespace-only edit, will be reverted -->

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -254,3 +254,5 @@ This will:
 4. Generate `changelog/<version>/CHANGELOG.md`
 5. Generate `changelog/<version>/breaking.md` for BC changes (with code examples)
 6. Generate `changelog/<version>/api.md` for API changes (with code examples)
+
+<!-- QVAC-18612 label-gate validation: trivial whitespace-only edit, will be reverted -->


### PR DESCRIPTION
## Purpose

Runtime validation of the merged [PR #2023](https://github.com/tetherto/qvac/pull/2023) (`label-gate` fan-out). **This PR will be closed without merging** after the validation matrix passes.

## What this PR triggers

Trivial README appends to:
- `packages/embed-llamacpp/README.md` → triggers `on-pr-embed-llamacpp.yml`
- `packages/llm-llamacpp/README.md`   → triggers `on-pr-llm-llamacpp.yml`
- `packages/sdk/README.md`             → triggers `on-pr-test-sdk.yml`, `pr-checks-sdk-pod.yml`, `pr-validation-sdk-pod.yml`

## Validation matrix (mirrors qvac-internal#12)

| # | Scenario | Expected |
|---|----------|----------|
| 1 | PR opened, **no** `verified` label | `label-gate` jobs report `authorised=false`; downstream secret-bearing jobs SKIPPED |
| 2 | `verified` label applied by trusted maintainer (Olutest, member of `qvac-internal-{dev,merge,release}`) | `label-gate` jobs report `authorised=true`; downstream gated jobs RUN; **no caller-cap validation errors** (the #1997 failure mode) |
| 3 | (Implicit) Reusable callees (`integration-test-llm-llamacpp.yml`, `integration-test-embed-llamacpp.yml`, etc.) execute via `if: needs.label-gate.outputs.authorised == 'true'` from caller | Reusable invocations succeed |

If all three pass, this validates the architectural fix shipped in #2023.

Refs: QVAC-18612.

Made with [Cursor](https://cursor.com)