### PR TITLE
QVAC-18588 feat[api]: expose loadModelFrom* helpers in LlamacppUtils (1.2.1)

### DIFF
--- a/packages/inference-addon-cpp/src/inference-addon-cpp/LlamacppUtils.hpp
+++ b/packages/inference-addon-cpp/src/inference-addon-cpp/LlamacppUtils.hpp
@@ -11,56 +11,34 @@
 #include "GGUFShards.hpp"
 #include "common/common.h"
 
-/// @note async version
-inline common_init_result_ptr initFromShards(
-    const GGUFShards& shards, common_params& params,
+inline llama_model* loadModelFromShardsAsync(
+    const GGUFShards& shards, const llama_model_params& modelParams,
     const std::string& loadingContext) {
-  LOG_INF(
-      "%s: load the model from async shards and apply lora adapter, if any.\n",
-      __func__);
-  llama_model_params mparams = common_model_params_to_llama(params);
   auto pathsView =
       shards.gguf_files |
       std::views::transform([](const std::string& str) { return str.c_str(); });
   std::vector<const char*> pathsVec(pathsView.begin(), pathsView.end());
-  llama_model* model = llama_model_load_from_split_futures(
+  return llama_model_load_from_split_futures(
       pathsVec.data(),
       pathsVec.size(),
       loadingContext.c_str(),
       shards.tensors_file.c_str(),
-      mparams);
-  return common_init_from_model_and_params(model, params);
+      modelParams);
 }
 
-/// @note from disk
-inline common_init_result_ptr
-initFromShards(const GGUFShards& shards, common_params& params) {
-  LOG_INF(
-      "%s: load the model from disk shards and apply lora adapter, if any.\n",
-      __func__);
-  llama_model_params mparams = common_model_params_to_llama(params);
+inline llama_model* loadModelFromShardsDisk(
+    const GGUFShards& shards, const llama_model_params& modelParams) {
   auto pathsView =
       shards.gguf_files |
       std::views::transform([](const std::string& str) { return str.c_str(); });
   std::vector<const char*> pathsVec(pathsView.begin(), pathsView.end());
-  llama_model* model =
-      llama_model_load_from_splits(pathsVec.data(), pathsVec.size(), mparams);
-  return common_init_from_model_and_params(model, params);
+  return llama_model_load_from_splits(
+      pathsVec.data(), pathsVec.size(), modelParams);
 }
 
-/// @brief Initializes a model from a single gguf stream stored in memory
-/// @note For performance reasons `initFromShards` should be preferably used
-/// with streams. However, this function is still offered to unify the Js
-/// interface of the addon and separate concerns.
-inline common_init_result_ptr initFromMemory(
+inline llama_model* loadModelFromMemory(
     std::unique_ptr<std::basic_streambuf<char>>&& streambuf,
-    common_params& params) {
-  LOG_INF(
-      "%s: load the model from single GGUF stream and apply lora adapter, if "
-      "any.\n",
-      __func__);
-  llama_model_params mparams = common_model_params_to_llama(params);
-
+    const llama_model_params& modelParams) {
   // Transfer the (Js) blobs to a contiguous memory block
   // Potential for optimization here. However for performance reasons,
   // sharded models should be used instead.
@@ -79,29 +57,55 @@ inline common_init_result_ptr initFromMemory(
     stream.read(reinterpret_cast<char*>(contiguousData.data()), size);
   }
 
-  llama_model* model =
-      llama_model_load_from_buffer(std::move(contiguousData), mparams);
+  return llama_model_load_from_buffer(std::move(contiguousData), modelParams);
+}
+
+/// @note async version
+inline common_init_result_ptr initFromShards(
+    const GGUFShards& shards, common_params& params,
+    const std::string& loadingContext) {
+  LOG_INF(
+      "%s: load the model from async shards and apply lora adapter, if any.\n",
+      __func__);
+  llama_model_params mparams = common_model_params_to_llama(params);
+  llama_model* model = loadModelFromShardsAsync(shards, mparams, loadingContext);
   return common_init_from_model_and_params(model, params);
 }
 
-/// @brief Initialize a model handling streaming, not-streaming, sharded or
-/// unsharded
-/// @param modelPath Model to load (single .gguf)
-/// @param singleGgufStreamedFiles Map containing .gguf files that finished
-/// streaming
-/// @param shards Containing sharded files, if any
-/// @param loading_context What context to use when asynchronously loading
-/// shards
-/// @param isStreaming Should be set to true when `setWeightsForFile` is
-/// being used to populate `singleGgufStreamedFiles` or call
-/// `llama_model_load_fulfill_split_future`
-inline common_init_result_ptr initFromConfig(
+/// @note from disk
+inline common_init_result_ptr
+initFromShards(const GGUFShards& shards, common_params& params) {
+  LOG_INF(
+      "%s: load the model from disk shards and apply lora adapter, if any.\n",
+      __func__);
+  llama_model_params mparams = common_model_params_to_llama(params);
+  llama_model* model = loadModelFromShardsDisk(shards, mparams);
+  return common_init_from_model_and_params(model, params);
+}
+
+/// @brief Initializes a model from a single gguf stream stored in memory
+/// @note For performance reasons `initFromShards` should be preferably used
+/// with streams. However, this function is still offered to unify the Js
+/// interface of the addon and separate concerns.
+inline common_init_result_ptr initFromMemory(
+    std::unique_ptr<std::basic_streambuf<char>>&& streambuf,
+    common_params& params) {
+  LOG_INF(
+      "%s: load the model from single GGUF stream and apply lora adapter, if "
+      "any.\n",
+      __func__);
+  llama_model_params mparams = common_model_params_to_llama(params);
+  llama_model* model = loadModelFromMemory(std::move(streambuf), mparams);
+  return common_init_from_model_and_params(model, params);
+}
+
+inline llama_model* loadModelFromConfig(
     common_params& params, const std::string& modelPath,
     std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>&
         singleGgufStreamedFiles,
     const GGUFShards& shards, const std::string loading_context,
     const bool isStreaming, const char* AddonID, const std::string& error) {
-  common_init_result_ptr llamaInit;
+  llama_model_params modelParams = common_model_params_to_llama(params);
   // Stream should have been awaited by the time activate is called from JS
   // and init is triggered. isStreaming should be (thread) safe to use at this
   // point because `setWeightsForFile` has already finished.
@@ -137,35 +141,63 @@ inline common_init_result_ptr initFromConfig(
             availableFiles.c_str());
         throw qvac_errors::StatusError(AddonID, error, errorMsg);
       }
-      llamaInit =
-          std::move(initFromMemory(std::move(itGgufModelPath->second), params));
+
+      llama_model* model =
+          loadModelFromMemory(std::move(itGgufModelPath->second), modelParams);
       singleGgufStreamedFiles.erase(itGgufModelPath);
-    } else {
-      LOG_INF(
-          "%s: load the sharded model and apply lora adapter, if any.\n",
-          __func__);
-      llamaInit = std::move(initFromShards(shards, params, loading_context));
+      return model;
     }
-  } else {
-    if (shards.gguf_files.empty()) {
-      LOG_INF(
-          "%s: load the model from disk file and apply lora adapter, if any.\n",
-          __func__);
-      if (!std::filesystem::exists(modelPath)) {
-        throw qvac_errors::StatusError(
-            AddonID,
-            error,
-            string_format(
-                "%s: model file not found: %s\n", __func__, modelPath.c_str()));
-      }
-      llamaInit = std::move(common_init_from_params(params));
-    } else {
-      LOG_INF(
-          "%s: load the model shards from disk file and apply lora adapter, if "
-          "any.\n",
-          __func__);
-      llamaInit = std::move(initFromShards(shards, params));
-    }
+
+    LOG_INF("%s: load the sharded model and apply lora adapter, if any.\n", __func__);
+    return loadModelFromShardsAsync(shards, modelParams, loading_context);
   }
-  return llamaInit;
+
+  if (shards.gguf_files.empty()) {
+    LOG_INF(
+        "%s: load the model from disk file and apply lora adapter, if any.\n",
+        __func__);
+    if (!std::filesystem::exists(modelPath)) {
+      throw qvac_errors::StatusError(
+          AddonID,
+          error,
+          string_format(
+              "%s: model file not found: %s\n", __func__, modelPath.c_str()));
+    }
+    return llama_model_load_from_file(modelPath.c_str(), modelParams);
+  }
+
+  LOG_INF(
+      "%s: load the model shards from disk file and apply lora adapter, if "
+      "any.\n",
+      __func__);
+  return loadModelFromShardsDisk(shards, modelParams);
+}
+
+/// @brief Initialize a model handling streaming, not-streaming, sharded or
+/// unsharded
+/// @param modelPath Model to load (single .gguf)
+/// @param singleGgufStreamedFiles Map containing .gguf files that finished
+/// streaming
+/// @param shards Containing sharded files, if any
+/// @param loading_context What context to use when asynchronously loading
+/// shards
+/// @param isStreaming Should be set to true when `setWeightsForFile` is
+/// being used to populate `singleGgufStreamedFiles` or call
+/// `llama_model_load_fulfill_split_future`
+inline common_init_result_ptr initFromConfig(
+    common_params& params, const std::string& modelPath,
+    std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>&
+        singleGgufStreamedFiles,
+    const GGUFShards& shards, const std::string loading_context,
+    const bool isStreaming, const char* AddonID, const std::string& error) {
+  llama_model* model = loadModelFromConfig(
+      params,
+      modelPath,
+      singleGgufStreamedFiles,
+      shards,
+      loading_context,
+      isStreaming,
+      AddonID,
+      error);
+  return common_init_from_model_and_params(model, params);
 }

--- a/packages/inference-addon-cpp/vcpkg.json
+++ b/packages/inference-addon-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qvac-lib-inference-addon-cpp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "dependencies": [
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## Summary

Splits the existing `initFromConfig` / `initFromShards` / `initFromMemory` helpers into two layers:

- New `loadModelFromConfig`, `loadModelFromShardsAsync`, `loadModelFromShardsDisk`, `loadModelFromMemory` — each returns a raw `llama_model*`.
- Existing `initFromConfig` / `initFromShards` / `initFromMemory` remain unchanged externally; they are now thin wrappers that call the new loader + `common_init_from_model_and_params`.

Bumps `qvac-lib-inference-addon-cpp` to `1.2.1`.

## Why

`embed-llamacpp` needs to read `llama_model_n_ctx_train(model)` and adjust `common_params.n_ctx` *before* the llama context is created, so that:

- when the caller doesn't set `ctx_size`, the runtime context defaults to the model's trained context size instead of llama.cpp's hard-coded 4096;
- when the caller sets `ctx_size` higher than the trained context, the value is actually capped (today it only logs a WARN that is suppressed by default verbosity).

The previous `initFromConfig` did model load + context creation atomically, leaving no seam to inspect the model in between. Exposing the model-load step as its own helper provides that seam without changing the existing public API used by other addons.

## Impact

- API-additive only. No signature or behavior change for `initFromConfig` / `initFromShards` / `initFromMemory`.
- Header-only library, so no ABI implications.
- Consumed downstream by `embed-llamacpp` in a follow-up PR that pins `qvac-lib-inference-addon-cpp >=1.2.1`. The other 9 consumer packages do not need to bump.