### PR TITLE
fix[notask]: bump @qvac/registry-client to ^0.5.0 in SDK

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -181,7 +181,7 @@
     "@qvac/logging": "^0.1.0",
     "@qvac/ocr-onnx": "^0.5.0",
     "@qvac/rag": "^0.5.0",
-    "@qvac/registry-client": "^0.4.1",
+    "@qvac/registry-client": "^0.5.0",
     "@qvac/transcription-parakeet": "^0.5.0",
     "@qvac/transcription-whispercpp": "^0.7.0",
     "@qvac/translation-nmtcpp": "^3.0.0",


### PR DESCRIPTION
## ⏳ Blocked

**Do not merge until `@qvac/registry-client@0.5.0` is published to npm (release PR #2035).** Drop out of draft once it's live.

## What problem does this PR solve?

`@qvac/registry-client` declared `corestore`, `hyperblobs`, `hyperdb`, and `hyperswarm` as hard `dependencies`, while the SDK declared them as `peerDependencies` with potentially different ranges. The mismatch caused npm to install duplicate copies of these stateful Holepunch singletons in consumer trees — separate DHT nodes, separate corestores, broken connectivity (see #1905).

`@qvac/registry-client@0.5.0` (#2035) moves those libs to `peerDependencies`, but the SDK still ranges `^0.4.1` so consumers don't pick up the fix.

## How does it solve it?

Bumps `@qvac/registry-client` dep from `^0.4.1` to `^0.5.0`. Pairs with the `@qvac/rag@^0.5.0` bump that already landed on main via #2011 — together they complete the dedup chain for SDK consumers.

## How was it tested?

Metadata-only dep-range update; no source changes. Once `@qvac/registry-client@0.5.0` is on npm:

- `npm view @qvac/registry-client versions` confirms `0.5.0` is published.
- `bun install` in `packages/sdk` resolves without conflicts.
- Verification of dedup: install `@qvac/sdk` into a clean project, run `npm ls --all corestore hyperblobs hyperdb hyperswarm` — expect a single copy of each.

## 🔌 API Changes

None.
