### PR TITLE
QVAC-18941 chore[skiplog]: bump bare-rpc to ^1.3.2 and drop android duplex stream skip

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -240,7 +240,7 @@
     "bare-os": "^3.6.2",
     "bare-path": "^3.0.0",
     "bare-process": "^4.2.2",
-    "bare-rpc": "^1.0.0",
+    "bare-rpc": "^1.3.2",
     "bare-runtime": "^1.24.2",
     "bare-stream": "^2.7.0",
     "bare-subprocess": "^5.2.3",

--- a/packages/sdk/tests-qvac/tests/mobile/consumer.ts
+++ b/packages/sdk/tests-qvac/tests/mobile/consumer.ts
@@ -398,13 +398,6 @@ export const executor = createExecutor({
       ], "OCR disabled on iOS (ONNX/CoreML OOM)"),
       new SkipExecutor(/^translation-afriquegemma-/, "AfriqueGemma 4B (~2.7 GB) exceeds iOS memory budget"),
     ] : []),
-    // TODO(QVAC-18941): drop once `holepunchto/bare-rpc` null-guards `_onstreamopen` (race crashes duplex `transcribeStream` under the full Android suite).
-    ...(Platform.OS === "android" ? [
-      new SkipExecutor(
-        /^(transcription-metadata-streaming|transcribe-stream-events-.+)$/,
-        "Android: bare-rpc duplex stream crash — QVAC-18941",
-      ),
-    ] : []),
 
     // Real executors
     new ModelLoadingExecutor(resources),


### PR DESCRIPTION
<!--
Style guide for this PR description:
- Be concise; prefer bullet points.
- Delete sections that don't apply.
- Keep code examples minimal.
-->

## 🎯 What problem does this PR solve?

- Android e2e suite was skipping `transcription-metadata-streaming` and `transcribe-stream-events-*` because the duplex `transcribeStream` race crashed `bare-rpc`'s `_onstream*` handlers under the full Android run (`TypeError: Cannot read property '_pendingOpen' of null`, QVAC-18941).
- Same crash already affects shipped SDK 0.10.2 in production whenever Android consumers open multiple duplex streams under memory pressure — not specific to tests.

## 📝 How does it solve it?

- Bump `bare-rpc` floor in `packages/sdk/package.json` from `^1.0.0` to `^1.3.2` to pull in the upstream null-guard fix.
- Drop the Android-only `SkipExecutor` block (and its TODO) from `packages/sdk/tests-qvac/tests/mobile/consumer.ts` so those tests run on Android again.

### Expected impact of the bump

- **Fixes:** Android crash on concurrent duplex streams (`_onstream{open,close,pause,resume,data,end,destroy}` no longer dereference a null `request._requestStream`).
- **Risk:** Low. Pure defensive null-guards in the upstream handlers; no public API change, no behaviour change on the happy path.
- **Beyond tests:** Unblocks proper worklet termination on Android and stabilises memory across long-running sessions for end users on the next SDK release.

### Upstream references

- Fix PR: [holepunchto/bare-rpc#18 — fix: null-guard request stream lookups in `_onstream*` handlers](https://github.com/holepunchto/bare-rpc/pull/18)
- Release: [bare-rpc v1.3.2](https://github.com/holepunchto/bare-rpc/releases/tag/v1.3.2)

## 🧪 How was it tested?

- Verified locally that the regex-matched tests (`transcription-metadata-streaming`, `transcribe-stream-events-*`) are no longer skipped on Android.
- Upstream author confirmed the full Android suite passes locally with `bare-rpc@1.3.2`.
- Real validation comes from the Android e2e suite running on this PR — `verify` label is already applied.