### PR TITLE
chore[skiplog|notask]: backmerge release-qvac-registry-schema-0.2.0 — version bump & changelog

### DIFF
--- a/packages/registry-server/shared/CHANGELOG.md
+++ b/packages/registry-server/shared/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.0]
+
+Release Date: 2026-05-14
+
+### 🔧 Changed
+
+- **BREAKING (install-time)**: Move `hyperdb` from `dependencies` to `peerDependencies` so consumer apps don't get a duplicate copy of the singleton when installed alongside `@qvac/sdk` (#1905). Most consumers (npm 7+, pnpm, bun) auto-install peers and need no action. Standalone consumers using yarn 1 or `legacy-peer-deps=true` must now add `hyperdb` to their own dependencies.
+
 ## [0.1.2]
 
 Release Date: 2026-03-19

--- a/packages/registry-server/shared/package.json
+++ b/packages/registry-server/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-schema",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "HyperDB schema and database wrapper for QVAC Registry",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `@qvac/registry-schema@0.2.0` on `main`, per [docs/gitflow.md](../blob/main/docs/gitflow.md) "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs.

## Companion release PR

- #2034

## Files

- `packages/registry-server/shared/package.json` — version `0.1.2` → `0.2.0`
- `packages/registry-server/shared/CHANGELOG.md` — `[0.2.0]` entry referencing #1905
