### PR TITLE
chore[skiplog|notask]: backmerge release-qvac-registry-client-0.5.0 — version bump & changelog

### DIFF
--- a/packages/registry-server/client/CHANGELOG.md
+++ b/packages/registry-server/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.5.0]
+
+Release Date: 2026-05-14
+
+### 🔧 Changed
+
+- **BREAKING (install-time)**: Move `corestore`, `hyperblobs`, `hyperdb`, and `hyperswarm` from `dependencies` to `peerDependencies` so consumer apps don't get duplicate copies of these stateful Holepunch singletons when `@qvac/registry-client` is installed alongside `@qvac/sdk` (#1905). Most consumers (npm 7+, pnpm, bun) auto-install peers and need no action. Standalone consumers using yarn 1 or `legacy-peer-deps=true` must now add `corestore`, `hyperblobs`, `hyperdb`, and `hyperswarm` to their own dependencies.
+- Bump `@qvac/registry-schema` to `^0.2.0` (also peers-cleaned in its own release).
+
 ## [0.4.1]
 
 Release Date: 2026-04-22

--- a/packages/registry-server/client/package.json
+++ b/packages/registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "repository": {
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/registry-schema": "^0.1.2",
+    "@qvac/registry-schema": "^0.2.0",
     "b4a": "^1.6.7",
     "bare-fs": "^4.5.2",
     "bare-os": "^3.6.2",


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `@qvac/registry-client@0.5.0` on `main`, per [docs/gitflow.md](../blob/main/docs/gitflow.md) "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs.

## Companion release PR

- #2035

## Files

- `packages/registry-server/client/package.json` — version `0.4.1` → `0.5.0`; `@qvac/registry-schema` dep `^0.1.2` → `^0.2.0`
- `packages/registry-server/client/CHANGELOG.md` — `[0.5.0]` entry referencing #1905
