### PR TITLE
QVAC-17940 chore[skiplog]: backmerge release-sdk-0.11.0 — version bump, changelog, NOTICE, tooling

### DIFF
--- a/.cursor/skills/sdk-changelog/SKILL.md
+++ b/.cursor/skills/sdk-changelog/SKILL.md
@@ -129,28 +129,22 @@ local working artifact, not a committed deliverable. Never `git add` it.
 node scripts/sdk/generate-changelog-sdk-pod.cjs --package=<name> --generate-announcement-post
 ```
 
-The script parses `CHANGELOG.md` for the package's current version (from
-`package.json`) and emits the Slack template:
+The script emits the short Slack template — header + three links + optional
+breaking-changes block + footer. Per-section bullet lists are intentionally
+omitted; readers follow the full-changelog link for the detail.
+
+Layout:
 
 - `:qvac: SDK <version> :rocket: NPM Public release` header.
 - NPM, GitHub release, and full-changelog tree links.
-- `:warning: Breaking Changes` section (with link to `breaking.md`) — only if any
-  PR is breaking.
-- `Release Date: YYYY-MM-DD`.
-- One Slack section per CHANGELOG.md section (`:sparkles: Features`,
-  `:electric_plug: API`, `:ladybug: Fixes`, `:package: Models`, `:blue_book: Docs`,
-  `:test_tube: Tests`, `:broom: Chores`, `:gear: Infrastructure`).
-- Each bullet uses `•`, wraps the PR URL in `<...>` (suppresses Slack unfurl), and
-  appends ` :boom: breaking` when the bullet is breaking.
-- Sections are capped at `MAX_ANNOUNCEMENT_BULLETS` (currently **10**). The
-  `... And much more, see full list in changelog :memo:` line is only added
-  when a section has *more than 10* entries; anything 10 or fewer is emitted
-  verbatim.
+- `:warning: Breaking Changes` section with link to `breaking.md` — emitted
+  only when `breaking.md` exists in the version folder (i.e. at least one PR
+  carries the `[bc]` tag). Detected by file presence, not by parsing
+  CHANGELOG.md.
 - Footer: `Thanks to everyone on QVAC team :green_heart: :qvac: :green_heart:`.
 
-If the post needs hand-tuning (e.g. the Models section needs custom count summaries
-that the parser can't infer), edit the file directly. It's gitignored, so changes
-won't pollute the diff.
+If the post needs hand-tuning (e.g. a custom note for a specific release),
+edit the file directly. It's gitignored, so changes won't pollute the diff.
 
 ### Step 6: Update NOTICE file for the target package
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,666 @@
 # Changelog
 
+## [0.11.0]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.11.0
+
+This release completes the request-lifecycle and cancellation overhaul that began in
+0.10.0: every long-running SDK call — `completion`, `embed`, `transcribe`,
+`transcribeStream`, `translate`, `finetune`, `loadModel`, `downloadAsset`, and the
+cancellable `rag` operations — now flows through a unified `RequestRegistry`, exposes
+its `requestId` synchronously on the returned promise, and can be cancelled
+individually with `cancel({ requestId })`. The wire envelope for `cancel(...)` is
+consolidated to two shapes, two legacy call signatures are removed, and the SDK gains
+typed `instanceof` for policy/cancel errors across the RPC boundary. Alongside the
+lifecycle work, this release adds Harmony / Qwen3.5 / Gemma4 tool-call dialects,
+FLUX.2 multi-reference fusion and per-call LoRA on diffusion, ESRGAN upscaling (both
+as a post-step and as a standalone `upscale()` API), Whisper VAD and end-of-turn
+events, multi-GPU `split-mode` / `tensor-split` / `main-gpu` on the LLM and embed
+plugins, a `reasoning_budget` knob for Qwen/Gemma reasoning, and a fresh Parakeet
+0.4.0 GGUF backend with duplex streaming. The mobile build flow now auto-verifies the
+worker bundle through `qvac verify bundle`, and the model registry was regenerated
+against the upstream `base-memory` Bergamot fix (dropping the deprecated Marian Opus
+constants on the way).
+
+## Breaking Changes
+
+### `unloadModel` no longer auto-closes the Bare worker
+
+On Bare, `unloadModel` used to call `close()` whenever no models or providers were
+left, which terminated the worker host on every routine unload. Long-lived Bare
+workers either had to avoid `unloadModel` or work around the auto-close.
+
+The default now flips by runtime: Node and Electron preserve the existing
+auto-close behaviour (`autoClose: true` by default), while Bare leaves the
+connection open (`autoClose: false` by default). Pass the field explicitly to
+override.
+
+**Before (Bare):**
+
+```typescript
+import { unloadModel } from "@qvac/sdk";
+
+await unloadModel({ modelId });
+// RPC connection closed → Bare worker host terminated.
+```
+
+**After (Bare):**
+
+```typescript
+import { unloadModel } from "@qvac/sdk";
+
+await unloadModel({ modelId });
+// Worker survives; opt in to closing explicitly:
+await unloadModel({ modelId, autoClose: true });
+```
+
+### Parakeet plugin moves to the 0.4.0 single-file GGUF API
+
+`@qvac/transcription-parakeet` 0.4.0 replaced the legacy multi-file ONNX bundle
+(encoder + decoder + vocab + preprocessor, plus the CTC / Sortformer variants)
+with a single GGUF backed by `qvac-parakeet.cpp`. The SDK plugin now follows
+suit: every per-variant `parakeet*Src` field on `modelConfig` is gone, the
+`modelType` discriminator is gone, and the addon auto-detects TDT / CTC / EOU /
+Sortformer from GGUF metadata.
+
+**Before:**
+
+```typescript
+await loadModel({
+  modelSrc: PARAKEET_TDT_ENCODER_INT8,
+  modelType: "parakeet",
+  modelConfig: {
+    parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
+    parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
+    parakeetVocabSrc: PARAKEET_TDT_VOCAB,
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8,
+  },
+});
+
+await loadModel({
+  modelSrc: PARAKEET_CTC_FP32,
+  modelType: "parakeet",
+  modelConfig: {
+    modelType: "ctc",
+    parakeetCtcModelSrc: PARAKEET_CTC_FP32,
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
+```
+
+**After:**
+
+```typescript
+await loadModel({
+  modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
+  modelType: "parakeet",
+});
+
+await loadModel({
+  modelSrc: PARAKEET_CTC_0_6B_Q8_0,
+  modelType: "parakeet",
+});
+```
+
+The new GGUF constants (`PARAKEET_TDT_0_6B_V3_Q8_0`, `PARAKEET_CTC_0_6B_Q8_0`,
+`PARAKEET_SORTFORMER_4SPK_V1_Q8_0`, `PARAKEET_EOU_120M_V1_Q8_0`) are added in
+this release; the legacy multi-file constants are gone.
+
+### Two legacy `cancel(...)` call shapes are removed
+
+`cancel({ operation: "downloadAsset", downloadKey, clearCache })` and
+`cancel({ operation: "rag", workspace })` are removed because neither carried a
+`requestId` and neither can be mechanically back-mapped onto the new two-arm
+cancel wire envelope. Callers must migrate to the `requestId`-targeted cancel
+path (the primary one in 0.11.0) or to the broad cancel-by-`modelId` escape
+hatch.
+
+**Before — downloadAsset:**
+
+```typescript
+import { downloadAsset, cancel } from "@qvac/sdk";
+
+const op = downloadAsset({ assetSrc, onProgress });
+await cancel({ operation: "downloadAsset", downloadKey: assetSrc.key, clearCache: true });
+```
+
+**After — downloadAsset:** the decorated promise now exposes `op.requestId`
+synchronously, and `clearCache` is honoured on the `requestId` path.
+
+```typescript
+import { downloadAsset, cancel } from "@qvac/sdk";
+
+const op = downloadAsset({ assetSrc, onProgress });
+await cancel({ requestId: op.requestId, clearCache: true });
+```
+
+**Before — rag:**
+
+```typescript
+import { ragIngest, cancel } from "@qvac/sdk";
+
+ragIngest({ workspace: "my-workspace", documents });
+await cancel({ operation: "rag", workspace: "my-workspace" });
+```
+
+**After — rag (primary path, by `requestId`):**
+
+```typescript
+import { ragIngest, cancel } from "@qvac/sdk";
+
+const op = ragIngest({ workspace: "my-workspace", documents });
+await cancel({ requestId: op.requestId });
+```
+
+**After — rag (broad escape hatch, no `requestId` to hand):**
+
+```typescript
+import { cancel } from "@qvac/sdk";
+
+// Cancel every in-flight RAG operation running on the embedding model:
+await cancel({ modelId: ragEmbeddingModelId, kind: "rag" });
+```
+
+Every other `cancel(...)` shape still works: `cancel({ operation: "inference",
+modelId })`, `cancel({ operation: "embeddings", modelId })`, `cancel({ modelId
+})`, `cancel({ modelId, kind })`, and `cancel({ requestId })` are all preserved
+by the client-side normalisation layer.
+
+## New APIs and Capabilities
+
+### `requestId` exposed synchronously on every cancellable call
+
+Every long-running SDK call now returns a decorated promise (or run handle) that
+carries a `requestId` you can read on the same tick the call is dispatched.
+That lets you wire a Stop button to a specific in-flight call without racing the
+network round-trip. The pattern covers `completion`, `loadModel`, `embed`,
+`transcribe`, `transcribeStream`, `translate`, `finetune`, `downloadAsset`, and
+the three cancellable RAG ops (`ragIngest`, `ragSaveEmbeddings`, `ragReindex`).
+
+```typescript
+import {
+  completion,
+  loadModel,
+  embed,
+  downloadAsset,
+  ragIngest,
+  cancel,
+} from "@qvac/sdk";
+
+const run = completion({ modelId, history });
+console.log(run.requestId);
+
+const op = loadModel({ modelSrc: "..." });
+console.log(op.requestId);                    // synchronously, before await
+const modelId = await op;                     // legacy unwrap still works
+
+const handle = embed({ modelId, text: "hello" });
+console.log(handle.requestId);
+await handle;
+
+const download = downloadAsset({ assetSrc, onProgress });
+stopButton.onclick = () => cancel({ requestId: download.requestId });
+await download;                                // rejects with InferenceCancelledError if cancelled
+
+const ingest = ragIngest({ workspace: "ws-a", modelId, documents });
+console.log(ingest.requestId);
+await ingest;
+```
+
+The non-cancellable RAG ops (`ragChunk`, `ragSearch`, `ragDeleteEmbeddings`,
+`ragListWorkspaces`, `ragCloseWorkspace`, `ragDeleteWorkspace`) intentionally do
+not decorate — they're fast-path operations that don't register with the
+server-side request registry, so a `requestId` would point at nothing.
+
+### Typed errors that survive the RPC boundary
+
+`InferenceCancelledError`, `RequestRejectedByPolicyError`,
+`RequestIdConflictError`, and `RequestNotFoundError` are now re-exported from
+`@qvac/sdk` and reconstructed on the client side with their typed fields
+intact, so `err instanceof RequestRejectedByPolicyError` actually narrows and
+`err.modelId` / `err.reason` / `err.requestId` are populated from the
+server-side throw.
+
+`RequestRejectedByPolicyError` (code 52420) fires when an admission policy
+blocks the request — for example, the worker's default
+`oneAtATimePerModel: true` rule for `completion` kind, which promotes the
+llama.cpp addon's opaque "job already set" error into a typed framework-level
+rejection.
+
+```typescript
+import { completion, RequestRejectedByPolicyError } from "@qvac/sdk";
+
+try {
+  const run = completion({ modelId, history });
+  for await (const event of run.events) { /* ... */ }
+} catch (err) {
+  if (err instanceof RequestRejectedByPolicyError) {
+    showBusy({ modelId: err.modelId, reason: err.reason });
+    return;
+  }
+  throw err;
+}
+```
+
+### New broad-cancel sugar and consolidated wire envelope
+
+The `cancel` wire envelope shrinks to two shapes — request-targeted (`{
+operation: "request", requestId }`) and broad-by-model (`{ operation: "broad",
+modelId, kind? }`). Two new client sugars wrap the broad shape so callers don't
+have to think about the wire representation:
+
+```typescript
+import { cancel } from "@qvac/sdk";
+
+await cancel({ modelId: "llama-3.2-1b", kind: "completion" });
+await cancel({ modelId: "llama-3.2-1b" });
+```
+
+### Plugin authors: declare cancel scope per handler
+
+`PluginHandlerDefinition` gains an optional `cancel: { scope, hard? }` field so
+plugin authors can declare upfront whether each handler accepts a per-request
+cancel token, whether it cancels by model, or whether it has no addon-level
+cancel surface at all (soft-cancel only — the registry aborts the signal, the
+stream stops yielding, the C++ work runs to completion in the background).
+
+`scope` is `"request" | "model" | "none"`; `hard: true` documents that the
+addon-side cancel actually interrupts compute. Plugin manifests that omit the
+field still load — it's optional.
+
+```typescript
+import { definePlugin, defineHandler } from "@qvac/sdk";
+
+definePlugin({
+  manifestVersion: 1,
+  handlers: {
+    myStream: defineHandler({
+      requestSchema,
+      responseSchema,
+      streaming: true,
+      cancel: { scope: "model", hard: true },
+      handler: async function* (request, ctx) { /* ... */ },
+    }),
+  },
+});
+```
+
+### Multi-GPU `split-mode`, `tensor-split`, and `main-gpu` on LLM and embed
+
+LLM and embed model configs now expose the underlying llamacpp multi-GPU knobs.
+LLM uses the canonical hyphenated keys (`"split-mode"`, `"tensor-split"`,
+`"main-gpu"`) to mirror the llama.cpp CLI; embed uses the existing camelCase
+convention (`splitMode`, `tensorSplit`, `mainGpu`).
+
+```typescript
+// LLM
+await loadModel({
+  modelSrc: LLAMA_3_2_1B_INST_Q4_0,
+  modelType: "llm",
+  modelConfig: {
+    "split-mode": "layer",        // "none" | "layer" | "row"
+    "tensor-split": "1,1",        // proportional split across GPUs
+    "main-gpu": 0,                // integer index or "integrated" | "dedicated"
+  },
+});
+
+// Embed
+await loadModel({
+  modelSrc: EMBEDDING_GEMMA_300M_Q8_0,
+  modelType: "embed",
+  modelConfig: {
+    splitMode: "layer",
+    tensorSplit: "1,1",
+    mainGpu: 0,
+  },
+});
+```
+
+### Whisper VAD and end-of-turn events on `transcribeStream`
+
+`transcribeStream` gains a conversational mode opted into via `emitVadEvents:
+true`. The session yields a discriminated event stream that includes live
+voice-activity probabilities and turn boundaries, so apps can build push-to-talk
+or barge-in UX without poll-the-text hacks.
+
+```typescript
+import { transcribeStream } from "@qvac/sdk";
+
+const session = await transcribeStream({
+  modelId: "whisper-base",
+  emitVadEvents: true,
+  endOfTurnSilenceMs: 800,
+  vadRunIntervalMs: 100,
+});
+
+for await (const event of session) {
+  if (event.type === "vad") console.log("speaking:", event.speaking, event.probability);
+  else if (event.type === "endOfTurn") console.log("turn ended after", event.silenceDurationMs, "ms");
+  else if (event.type === "text") process.stdout.write(event.text);
+}
+
+session.write(audioChunk);
+session.end();
+```
+
+`TranscribeStreamEvent`, `VadStateEvent`, `EndOfTurnEvent`, and
+`TranscribeStreamConversationSession` are new exported types. The existing
+text-only, segment, and audio-chunk overloads are unchanged.
+
+### Parakeet duplex streaming with EOU events
+
+The new parakeet plugin (see Breaking Changes) ships a duplex
+`transcribeStream` session that mirrors the whisper one. EOU model checkpoints
+surface as `{ type: "endOfTurn" }` events on the same iterator as `{ type:
+"text" }`.
+
+```typescript
+const session = await transcribeStream({
+  modelId,
+  parakeetStreamingConfig: {
+    chunkMs: 1000,
+    emitPartials: true,
+  },
+});
+
+ffmpeg.stdout.on("data", (chunk: Buffer) => session.write(chunk));
+
+for await (const event of session) {
+  switch (event.type) {
+    case "text":
+      process.stdout.write(event.text);
+      break;
+    case "endOfTurn":
+      console.log("\n[endOfTurn] turn boundary detected\n");
+      break;
+  }
+}
+```
+
+Per-call streaming overrides — `chunkMs`, `historyMs`, `leftContextMs`,
+`rightLookaheadMs`, `emitPartials`, `emitEnergyVad` — are accepted on
+`parakeetStreamingConfig` and fall back to their `parakeetConfig.streaming*`
+load-time counterparts.
+
+### Harmony, Qwen3.5, and Gemma4 tool-call dialects
+
+`toolDialect` now covers `"hermes" | "pythonic" | "json" | "harmony"`, plus
+auto-detected `qwen35` and `gemma4` parsers. Harmony adds first-class support
+for GPT-OSS models — including streaming the final-channel content
+incrementally instead of buffering until `<|return|>`, so long GPT-OSS responses
+no longer stall — and fixes a regression where protocol markers
+(`<|channel|>analysis<|message|>...`, `<|start|>assistant`, `<|return|>`) were
+leaking into `contentDelta`. Qwen3.5 covers the Pythonic-XML
+`<tool_call><function=NAME><parameter=KEY>...</parameter></function></tool_call>`
+framing; Gemma4 covers the native
+`<|tool_call>call:NAME{key:<|"|>val<|"|>,...}<tool_call|>` framing.
+
+```typescript
+import { completion, type ToolDialect } from "@qvac/sdk";
+
+const result = completion({
+  modelId,                         // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  history,
+  tools,
+  toolDialect: "harmony",          // optional explicit override
+});
+
+const dialect: ToolDialect = "harmony";
+```
+
+Qwen3.5 / Qwen3.6 and Gemma4 are auto-detected from the model name; the parsers
+ship without any caller-side wiring. The `harmony` parser also surfaces
+malformed-JSON, unknown-tool, and non-object payloads as structured
+`ToolCallError`s instead of silently dropping the event.
+
+### `reasoning_budget` knob for thinking models
+
+`@qvac/llm-llamacpp@0.20.0` introduced a `reasoning_budget` parameter that gates
+how much "thinking" a reasoning model is allowed to produce: `-1` =
+unrestricted, `0` = disabled. The SDK exposes it both as a load-time default on
+`LlmConfig` and as a per-request override on `GenerationParams`.
+
+```typescript
+import { loadModel, completion } from "@qvac/sdk";
+
+const modelId = await loadModel({
+  modelSrc: "/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf",
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, reasoning_budget: -1 },
+});
+
+const run = completion({
+  modelId,
+  history: [{ role: "user", content: "Think step by step." }],
+  generationParams: { reasoning_budget: 0 }, // override per-request
+});
+```
+
+The same bump fixes a regression where `system_prompt` (a JS-only
+`completion-stream.ts` field) was being forwarded to the C++ arg parser as
+`--system-prompt`, which had been removed in llamacpp 8189+ — model loads were
+failing outright until this fix landed.
+
+### FLUX.2 multi-reference fusion and per-call LoRA for diffusion
+
+The diffusion API gains FLUX.2 multi-reference fusion (`init_images:
+Uint8Array[]`, mutually exclusive with the existing single `init_image`), FLUX.2
+reference-image tunables (`increase_ref_index`, `auto_resize_ref_image`), and a
+per-call `lora` field that takes an absolute filesystem path. A new load-time
+`lora_apply_mode` controls whether the adapter is fused permanently into the
+model or applied per-call (`"auto" | "immediately" | "at_runtime"`).
+
+```typescript
+const refA = fs.readFileSync("scientist-a.jpg");
+const refB = fs.readFileSync("scientist-b.jpg");
+const { outputs } = diffusion({
+  modelId,
+  prompt: "a portrait using most visual traits from @image1 and the eyes from @image2",
+  init_images: [refA, refB],
+  width: 768,
+  height: 768,
+});
+
+const { outputs: loraOutputs } = diffusion({
+  modelId,
+  prompt: "a watercolor cat",
+  lora: "/home/user/loras/watercolor.safetensors",
+});
+
+await loadModel(modelSrc, {
+  modelType: "diffusion",
+  modelConfig: { prediction: "flux2_flow", lora_apply_mode: "immediately" },
+});
+```
+
+Relative LoRA paths are rejected: the SDK runs across processes with differing
+cwds, so absolute paths (POSIX, Windows drive-letter, or UNC) are the only safe
+shape.
+
+### ESRGAN upscaling — post-step and standalone
+
+Two new paths land for ESRGAN upscalers. The first attaches an upscaler to a
+diffusion model and runs it as a post-step on every generated image. The second
+loads an ESRGAN file as a standalone `upscale()`-only model so consumers can
+feed an arbitrary PNG or JPEG into the SDK and get an upscaled image back —
+without standing up a full diffusion pipeline.
+
+```typescript
+// Post-step upscale during diffusion
+const modelId = await loadModel({
+  modelSrc: SD_V2_1_1B_Q8_0,
+  modelType: "diffusion",
+  modelConfig: {
+    prediction: "v",
+    upscaler: {
+      type: "esrgan",
+      model_src: "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth",
+      tile_size: 128,
+    },
+  },
+});
+
+const { outputs } = diffusion({
+  modelId,
+  prompt: "an illustrated red fox portrait",
+  width: 128,
+  height: 128,
+  upscale: { repeats: 2 },
+});
+```
+
+```typescript
+// Standalone upscale — no diffusion model required
+import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from "@qvac/sdk";
+
+const modelId = await loadModel(REALESRGAN_X4PLUS_ANIME_6B, {
+  modelType: "diffusion",
+  modelConfig: {
+    mode: "upscale",
+    upscaler: { tile_size: 128 },
+  },
+});
+
+const { outputs, stats } = upscale({
+  modelId,
+  image: pngBytes,        // Uint8Array (PNG/JPEG)
+  repeats: 1,             // each pass multiplies dims by the model's native scale factor
+});
+
+const [upscaledPng] = await outputs;
+console.log(await stats); // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
+```
+
+Calling `upscale()` against a model that wasn't loaded with `mode: "upscale"`
+raises `ModelOperationNotSupportedError` upfront, and loading a diffusion model
+with `modelConfig.upscaler` set but `model_src` missing fails fast with a
+structured `ModelLoadFailedError` instead of letting the native addon error
+mid-load.
+
+### Mobile build flow auto-verifies the worker bundle
+
+Expo prebuild now runs `qvac verify bundle` against the emitted
+`worker.mobile.bundle.js` before copying it into the SDK's `dist/`. The flow is
+`runBundler → assert bundle exists → runVerifier → copyFileSync`, so the SDK
+`dist/worker.mobile.bundle.js` only updates when verification passes. Failure
+preserves the last known-good artifact and fails Expo prebuild fast with a new
+`BundleVerificationFailedError` (code 50609).
+
+If a `qvac.config.{json,js,mjs,ts}` is present, ABI checks are pinned to its
+`bareRuntimeVersion`; without config, the CLI auto-detects from `node_modules`
+(`bare-runtime` → `bare`) and falls through to a warning only when neither is
+installed. `@qvac/cli` peer dep range moves from `^0.2.4` to `^0.4.0` — the
+first version that ships `qvac verify bundle` — with the existing npx fallback
+still in place for consumers that don't pin the dep.
+
+Pear consumers aren't auto-wired yet — run `qvac verify bundle --addons-source
+./node_modules --host <host> --config qvac.config.json` manually before `pear
+stage` / `pear run`.
+
+### `cancelFinetune` is now fire-and-forget
+
+`cancelFinetune(modelId)` used to await the addon's cancel flip before
+resolving. It now fires a synchronous registry cancel and returns immediately;
+the actual `model.cancel()` runs out-of-band via the new context's abort
+listener. The result shape is unchanged (`status: "CANCELLED"` still
+populated), but workbench / CLI / external consumers that gated subsequent
+calls on cancel-resolution timing should switch to `await cancel({ requestId
+})`, which has been synchronous-after-abort since the lifecycle work began.
+
+## Bug Fixes
+
+### Delegated inference connect is fast again
+
+The `loadModel.delegation.connection` regression introduced in 0.10.0 — where
+`@qvac/sdk` 0.9.0 → 0.10.0 took the consumer-side connect from ≈2.5s to ≈8.3s
+on first delegated call — is fixed by dropping the explicit `await
+swarm.dht.fullyBootstrapped()` block before `dht.connect()` in
+`ensureRPCConnection`. The SDK's normal init path already warms the routing
+table via `getSwarm()` during registry initialisation, so the explicit guard
+was redundant. Measured cold-start connect mean drops from 3.82s back down to
+1.18s (≈3.2× faster) on the same hardware and network.
+
+### KV cache priming no longer wastes a token
+
+`initSystemPromptCache` used to start generation and then race the first output
+token against a cancel. That always produced one token of unnecessary work and
+relied on a fragile output/cancel race. The SDK now uses the addon's new
+`prefill: true` runtime option (in `@qvac/llm-llamacpp ^0.17.3`) so priming
+ingests the prompt and tools into the KV cache without producing any output
+tokens. `initSystemPromptCache` resolves as soon as priming finishes.
+
+### React Native duplex RPC no longer uses Node-only `Buffer`
+
+The RN duplex RPC path was using Node's `Buffer` global, which isn't available
+on Hermes. The path now uses `Uint8Array` end-to-end so mobile consumers can
+use duplex streaming (transcribe, parakeet, tts) without hitting `Buffer is
+not defined`.
+
+### SDK bundles its own `worker.js` for packaged consumers
+
+Apps consuming the SDK from a bundler (Metro, esbuild, webpack) were missing
+`worker.js` from the published package, so consumers had to hand-copy it. The
+package now ships `worker.js` alongside `worker.mobile.bundle.js` so packaged
+consumers no longer need extra bundling steps.
+
+### Dedup of stateful Holepunch singletons
+
+The SDK and `@qvac/registry-client` had drifting declarations for
+`corestore`, `hyperblobs`, `hyperdb`, and `hyperswarm`: the SDK declared them
+as `peerDependencies`, the registry client declared them as hard
+`dependencies`, and the version ranges didn't match. The mismatch caused npm
+to install duplicate copies, producing separate DHT nodes and broken
+connectivity. Bumping `@qvac/registry-client` to `^0.5.0` (where those libs
+move to `peerDependencies`) and `@qvac/embed-llamacpp` to `^0.16.0` and
+`@qvac/transcription-whispercpp` to `^0.7.0` completes the dedup chain.
+
+## Model Registry Changes
+
+The Bergamot translation pairs `BERGAMOT_EN_IT` and `BERGAMOT_ES_EN` were
+pinned to the buggy `tiny` variant, which caused leading `"- "` hallucinations
+on short inputs and an en→it quality regression (~3 pp `chrF++` drop direct,
+~33 pp via Spanish pivot). The registry was regenerated against the upstream
+`base-memory` Bergamot fix (synced to the DHT on 2026-05-05); paths now point
+at `bergamot-{enit,esen}/2026-04-28/...` and `expectedSize` flipped from
+17.1 MB to 30.1 MB on both pairs, confirming the switch landed.
+
+The regeneration also picked up the auto-deprecation of the 32 Marian Opus NMT
+entries (`NMT_Q0F16` through `NMT_Q0F16_9`, `NMT_Q4_0` through `NMT_Q4_0_21`)
+that were superseded earlier in the release line. A separate fix corrects the
+Bergamot vocab being re-downloaded on every `loadModel` for shared-vocab pairs
+— the shared vocab is now cached and reused.
+
+### Added
+
+```
+PARAKEET_TDT_0_6B_V3_Q8_0
+PARAKEET_CTC_0_6B_Q8_0
+PARAKEET_SORTFORMER_4SPK_V1_Q8_0
+PARAKEET_EOU_120M_V1_Q8_0
+```
+
+### Removed
+
+```
+NMT_Q0F16 through NMT_Q0F16_9 (10 entries)
+NMT_Q4_0 through NMT_Q4_0_21 (22 entries)
+```
+
+The legacy multi-file Parakeet constants (`PARAKEET_TDT_ENCODER_INT8`,
+`PARAKEET_TDT_DECODER_INT8`, `PARAKEET_TDT_VOCAB`, `PARAKEET_TDT_PREPROCESSOR_INT8`,
+`PARAKEET_CTC_FP32`, `PARAKEET_CTC_TOKENIZER`, etc.) are gone alongside the
+plugin migration — see Breaking Changes above for the migration path.
+
+## Tests and Infrastructure
+
+- E2E bootstrap was scoped down to only the dependencies required by the
+  filtered test set, shortening cold CI runs.
+- Multi-GPU integration tests are now skipped on mobile (real multi-GPU hardware
+  isn't represented in the mobile farm; tests are validated against the
+  shared-dev `2× RTX 5090` rig in CI logs).
+- `@qvac/tts-onnx` bumped to `0.9.0` and `@qvac/transcription-parakeet` to
+  `0.5.0` to match the addon-side releases that land in this SDK version.
+
 ## [0.10.2]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.10.2

--- a/packages/sdk/NOTICE
+++ b/packages/sdk/NOTICE
@@ -61,6 +61,8 @@ Third-Party Model Licenses
 
 --- apache-2.0 (Apache License 2.0) ---
 
+  bci-embedder
+    https://github.com/tetherto/qvac/releases/download/bci-test-assets-v0.1.0/bci-embedder.bin
   crnn_mobilenet_v3_small
     https://github.com/felixdittrich92/OnnxTR
   db_mobilenet_v3_large
@@ -83,6 +85,14 @@ Third-Party Model Licenses
     https://huggingface.co/personalizedrefrigerator/whisper-base-fr
   fr-tiny-ggml-model-f16
     https://huggingface.co/JaepaX/whisper-tiny-fr
+  ggml-bci-windowed
+    https://github.com/tetherto/qvac/releases/download/bci-test-assets-v0.1.0/ggml-bci-windowed.bin
+  google_gemma-4-31B-it-GGUF
+    https://huggingface.co/bartowski/google_gemma-4-31B-it-GGUF
+  google_gemma-4-E2B-it-GGUF
+    https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF
+  google_gemma-4-E4B-it-GGUF
+    https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF
   gpt-oss-120b-Q4_K_M-00001-of-00002
     https://huggingface.co/unsloth/gpt-oss-120b-GGUF
   gpt-oss-20b-GGUF
@@ -123,6 +133,18 @@ Third-Party Model Licenses
     https://huggingface.co/Qwen/Qwen3-8B-GGUF
   Qwen3-VL-2B-Instruct-GGUF
     https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct-GGUF
+  Qwen3.5-0.8B-GGUF
+    https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF
+  Qwen3.5-2B-GGUF
+    https://huggingface.co/unsloth/Qwen3.5-2B-GGUF
+  Qwen3.5-4B-GGUF
+    https://huggingface.co/unsloth/Qwen3.5-4B-GGUF
+  Qwen3.5-9B-GGUF
+    https://huggingface.co/unsloth/Qwen3.5-9B-GGUF
+  Qwen3.6-27B-GGUF
+    https://huggingface.co/unsloth/Qwen3.6-27B-GGUF
+  Qwen3.6-35B-A3B-GGUF
+    https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF
   recognizer_arabic
     https://www.jaided.ai/easyocr/modelhub/
   recognizer_bengali
@@ -162,30 +184,41 @@ Third-Party Model Licenses
   SmolVLM2-500M-Video-Instruct-GGUF
     https://huggingface.co/ggml-org/SmolVLM2-500M-Video-Instruct-GGUF
 
+--- bsd-3-clause (BSD 3-Clause License) ---
+
+  RealESRGAN_x4plus
+    https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth
+  RealESRGAN_x4plus_anime_6B
+    https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth
+  RealESRNet_x4plus
+    https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.1/RealESRNet_x4plus.pth
+
 --- cc-by-4.0 (Creative Commons Attribution 4.0 International) ---
 
   AfriqueGemma-4B-GGUF
     https://huggingface.co/mradermacher/AfriqueGemma-4B-GGUF
-  decoder_joint_int8
-    https://huggingface.co/nasedkinpv/parakeet-tdt-0.6b-v3-onnx-int8
   decoder_joint-model
     https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
   diar_streaming_sortformer_4spk-v2-onnx
     https://huggingface.co/cgus/diar_streaming_sortformer_4spk-v2-onnx
-  encoder_int8
-    https://huggingface.co/nasedkinpv/parakeet-tdt-0.6b-v3-onnx-int8
   encoder-model
     https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
   parakeet-ctc-0.6b-ONNX
     https://huggingface.co/onnx-community/parakeet-ctc-0.6b-ONNX
+  parakeet-ctc-0.6b.q8_0
+    https://huggingface.co/nvidia/parakeet-ctc-0.6b
+  parakeet-eou-120m-v1.q8_0
+    https://huggingface.co/nvidia/parakeet_realtime_eou_120m-v1
   parakeet-rs
     https://huggingface.co/altunenes/parakeet-rs
   parakeet-tdt-0.6b-v3-onnx
     https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
+  parakeet-tdt-0.6b-v3.q8_0
+    https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3
   preprocessor
     https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx
-  sortformer_int8
-    https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2
+  sortformer-4spk-v1.q8_0
+    https://huggingface.co/nvidia/diar_sortformer_4spk-v1
 
 --- gemma (Gemma Terms of Use) ---
 
@@ -218,6 +251,14 @@ Third-Party Model Licenses
     https://huggingface.co/1bitLLM/bitnet_b1_58-xl
   chatterbox-multilingual-ONNX
     https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX
+  chatterbox-s3gen
+    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-s3gen.gguf
+  chatterbox-s3gen-mtl
+    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-s3gen-mtl.gguf
+  chatterbox-t3-mtl
+    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-t3-mtl.gguf
+  chatterbox-t3-turbo
+    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-t3-turbo.gguf
   chatterbox-turbo-ONNX
     https://huggingface.co/ResembleAI/chatterbox-turbo-ONNX
   de-base-ggml-model-f16
@@ -369,8 +410,6 @@ Third-Party Model Licenses
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/entr
   model.enuk.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enuk
-  model.enzh.intgemm.alphas
-    https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/enzh
   model.esen.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/esen
   model.eten.intgemm.alphas
@@ -379,8 +418,6 @@ Third-Party Model Licenses
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/faen
   model.fien.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/fien
-  model.fire.intgemm.alphas
-    https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/fire
   model.fren.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/fren
   model.guen.intgemm.alphas
@@ -449,17 +486,19 @@ Third-Party Model Licenses
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/uken
   model.vien.intgemm.alphas
     https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/vien
-  model.zhen.intgemm.alphas
-    https://github.com/mozilla/firefox-translations-models/tree/main/models/base-memory/zhen
 
 --- openrail ---
 
+  supertonic
+    s3:///qvac_models_compiled/supertonic/2026-05-08/supertonic.gguf
   supertonic
     https://huggingface.co/Supertone/supertonic
   supertonic-2
     https://huggingface.co/Supertone/supertonic-2
   Supertonic-TTS-ONNX
     https://huggingface.co/onnx-community/Supertonic-TTS-ONNX
+  supertonic2
+    s3:///qvac_models_compiled/supertonic/2026-05-08/supertonic2.gguf
 
 --- openrail++ ---
 
@@ -492,38 +531,41 @@ JavaScript Dependencies
   @qvac/decoder-audio@0.3.7
     https://github.com/tetherto/qvac
   @qvac/diagnostics@0.1.1
-  @qvac/diffusion-cpp@0.3.0
+  @qvac/diffusion-cpp@0.7.0
     https://github.com/tetherto/qvac
   @qvac/dl-base@0.1.1
   @qvac/dl-hyperdrive@0.1.1
-  @qvac/embed-llamacpp@0.14.0
+  @qvac/embed-llamacpp@0.16.0
     https://github.com/tetherto/qvac
   @qvac/error@0.1.1
   @qvac/infer-base@0.1.1
+  @qvac/infer-base@0.4.0
+    https://github.com/tetherto/qvac
   @qvac/infer-base@0.4.1
     https://github.com/tetherto/qvac
   @qvac/langdetect-text@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/llm-llamacpp@0.17.3
+  @qvac/llm-llamacpp@0.20.1
     https://github.com/tetherto/qvac
   @qvac/logging@0.1.0
-  @qvac/ocr-onnx@0.4.2
+  @qvac/ocr-onnx@0.5.0
     https://github.com/tetherto/qvac
-  @qvac/onnx@0.14.0
+  @qvac/onnx@0.15.0
     https://github.com/tetherto/qvac
-  @qvac/rag@0.4.4
+  @qvac/rag@0.5.0
     https://github.com/tetherto/qvac
-  @qvac/registry-client@0.4.1
+  @qvac/registry-client@0.5.0
     https://github.com/tetherto/qvac
-  @qvac/registry-schema@0.1.2
+  @qvac/registry-schema@0.2.0
+    https://github.com/tetherto/qvac
   @qvac/response@0.1.2
-  @qvac/transcription-parakeet@0.3.2
+  @qvac/transcription-parakeet@0.5.0
     https://github.com/tetherto/qvac
-  @qvac/transcription-whispercpp@0.6.7
+  @qvac/transcription-whispercpp@0.7.0
     https://github.com/tetherto/qvac
-  @qvac/translation-nmtcpp@2.1.0
+  @qvac/translation-nmtcpp@3.0.0
     https://github.com/tetherto/qvac
-  @qvac/tts-onnx@0.8.5
+  @qvac/tts-onnx@0.9.0
     https://github.com/tetherto/qvac
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
@@ -555,19 +597,19 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-events
   bare-events@2.8.2
     https://github.com/holepunchto/bare-events
-  bare-fetch@2.9.0
+  bare-fetch@2.8.1
     https://github.com/holepunchto/bare-fetch
   bare-ffmpeg@1.2.2
     https://github.com/holepunchto/bare-ffmpeg
   bare-form-data@1.2.1
     https://github.com/holepunchto/bare-form-data
-  bare-fs@4.7.1
+  bare-fs@4.6.0
     https://github.com/holepunchto/bare-fs
   bare-hrtime@2.1.1
     https://github.com/holepunchto/bare-hrtime
   bare-http-parser@1.1.3
     https://github.com/holepunchto/bare-http-parser
-  bare-http1@4.5.6
+  bare-http1@4.5.5
     https://github.com/holepunchto/bare-http1
   bare-https@2.1.3
     https://github.com/holepunchto/bare-https
@@ -577,9 +619,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-lief
   bare-link@3.2.1
     https://github.com/holepunchto/bare-link
-  bare-mime@1.0.0
-    https://github.com/holepunchto/bare-mime
-  bare-module@6.2.0
+  bare-module@6.1.3
     https://github.com/holepunchto/bare-module
   bare-module-lexer@1.4.7
     https://github.com/holepunchto/bare-module-lexer
@@ -593,7 +633,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-node
   bare-node-worker-threads@1.0.0
     https://github.com/holepunchto/bare-node
-  bare-os@3.9.0
+  bare-os@3.8.7
     https://github.com/holepunchto/bare-os
   bare-path@3.0.0
     https://github.com/holepunchto/bare-path
@@ -601,43 +641,45 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-pipe
   bare-process@4.4.1
     https://github.com/holepunchto/bare-process
-  bare-rpc@1.2.0
+  bare-rpc@1.3.2
     https://github.com/holepunchto/bare-rpc
-  bare-runtime@1.28.4
+  bare-runtime@1.28.1
     https://github.com/holepunchto/bare-runtime
-  bare-runtime-darwin-arm64@1.28.4
+  bare-runtime-darwin-arm64@1.28.1
     https://github.com/holepunchto/bare-runtime
-  bare-semver@1.0.3
+  bare-semver@1.0.2
     https://github.com/holepunchto/bare-semver
   bare-signals@4.2.0
     https://github.com/holepunchto/bare-signals
   bare-stdio@1.0.2
     https://github.com/holepunchto/bare-stdio
-  bare-stream@2.13.1
+  bare-stream@2.12.0
     https://github.com/holepunchto/bare-stream
-  bare-structured-clone@1.5.4
+  bare-structured-clone@1.5.3
     https://github.com/holepunchto/bare-structured-clone
   bare-subprocess@5.2.3
     https://github.com/holepunchto/bare-subprocess
-  bare-tcp@2.2.12
+  bare-tcp@2.2.7
     https://github.com/holepunchto/bare-tcp
   bare-thread@1.2.0
     https://github.com/holepunchto/bare-thread
-  bare-tls@2.2.3
+  bare-tls@2.2.1
     https://github.com/holepunchto/bare-tls
   bare-tty@5.1.0
     https://github.com/holepunchto/bare-tty
   bare-type@1.1.0
     https://github.com/holepunchto/bare-type
-  bare-url@2.4.2
+  bare-url@2.4.0
     https://github.com/holepunchto/bare-url
   bare-worker@4.1.6
     https://github.com/holepunchto/bare-worker
-  bare-zlib@1.3.3
+  bare-zlib@1.3.1
     https://github.com/holepunchto/bare-zlib
-  blind-relay@1.5.0
+  blind-relay@1.4.0
     https://github.com/holepunchto/blind-relay
   compact-encoding@2.19.2
+    https://github.com/holepunchto/compact-encoding
+  compact-encoding@3.0.1
     https://github.com/holepunchto/compact-encoding
   device-file@2.3.1
     https://github.com/holepunchto/device-file
@@ -645,7 +687,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/events-universal
   fd-lock@2.1.1
     https://github.com/holepunchto/fd-lock
-  fs-native-extensions@1.5.0
+  fs-native-extensions@1.4.5
     https://github.com/holepunchto/fs-native-extensions
   hyperblobs@2.11.1
     https://github.com/holepunchto/hyperblobs
@@ -659,11 +701,9 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore-storage
   hyperdb@4.22.3
     https://github.com/holepunchto/hyperdb
-  hyperdht-address@1.0.1
-    https://github.com/holepunchto/hyperdht-address
   hyperdht-stats@1.10.0
     https://github.com/holepunchto/hyperdht-stats
-  hyperdispatch@1.5.1
+  hyperdispatch@1.6.0
     https://github.com/holepunchto/hyperdispatch
   hyperdrive@13.3.2
     https://github.com/holepunchto/hyperdrive
@@ -673,7 +713,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperswarm-stats
   index-encoder@3.5.0
     https://github.com/holepunchto/index-encoder
-  mirror-drive@1.14.2
+  mirror-drive@1.14.1
     https://github.com/holepunchto/mirror-drive
   noise-handshake@4.2.0
     https://github.com/holepunchto/noise-handshake
@@ -745,8 +785,8 @@ JavaScript Dependencies
     https://github.com/holepunchto/corestore
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
-  dht-rpc@6.26.4
-    https://github.com/holepunchto/dht-rpc
+  dht-rpc@6.26.3
+    https://github.com/mafintosh/dht-rpc
   events@3.3.0
     https://github.com/Gozala/events
   fast-fifo@1.3.2
@@ -765,7 +805,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.6.1
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.30.0
+  hyperdht@6.29.6
     https://github.com/holepunchto/hyperdht
   hyperswarm@4.17.0
     https://github.com/holepunchto/hyperswarm
@@ -783,8 +823,8 @@ JavaScript Dependencies
     https://github.com/mafintosh/nat-sampler
   protocol-buffers-encodings@1.2.0
     https://github.com/mafintosh/protocol-buffers-encodings
-  protomux@3.10.3
-    https://github.com/holepunchto/protomux
+  protomux@3.10.1
+    https://github.com/mafintosh/protomux
   queue-tick@1.0.1
     https://github.com/mafintosh/queue-tick
   random-array-iterator@1.0.0
@@ -833,8 +873,6 @@ JavaScript Dependencies
     https://github.com/mafintosh/unix-path-resolve
   unordered-set@2.0.1
     https://github.com/mafintosh/unordered-set
-  uuid-random@1.3.2
-    https://github.com/jchook/uuid-random
   varint@5.0.0
     https://github.com/chrisdickinson/varint
   xache@1.2.1

--- a/packages/sdk/changelog/0.11.0/CHANGELOG.md
+++ b/packages/sdk/changelog/0.11.0/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog v0.11.0
+
+Release Date: 2026-05-16
+
+## ✨ Features
+
+- Migrate SDK parakeet plugin to 0.4.0 GGML + duplex streaming. (see PR [#2018](https://github.com/tetherto/qvac/pull/2018)) - See [breaking changes](./breaking.md)
+- CLI cancel bridge + cancelHandler retirement. (see PR [#2074](https://github.com/tetherto/qvac/pull/2074)) - See [breaking changes](./breaking.md)
+
+## 🔌 API
+
+- Expose split-mode and tensor-split in SDK LLM config. (see PR [#1759](https://github.com/tetherto/qvac/pull/1759)) - See [API changes](./api.md)
+- Add FLUX.2 multi-reference fusion and LoRA adapter support to diffusion API. (see PR [#1838](https://github.com/tetherto/qvac/pull/1838)) - See [API changes](./api.md)
+- Expose whisper VAD and end-of-turn events in transcribeStream. (see PR [#1848](https://github.com/tetherto/qvac/pull/1848)) - See [API changes](./api.md)
+- Add harmony tool-call dialect (gpt-oss). (see PR [#1878](https://github.com/tetherto/qvac/pull/1878)) - See [API changes](./api.md)
+- Add ESRGAN upscale support to SDK diffusion. (see PR [#1930](https://github.com/tetherto/qvac/pull/1930)) - See [API changes](./api.md)
+- Introduce request lifecycle primitives with signal-based cancel. (see PR [#1949](https://github.com/tetherto/qvac/pull/1949)) - See [API changes](./api.md)
+- Add Qwen3.5, Gemma4 tool-call dialects and reasoning_budget param. (see PR [#1974](https://github.com/tetherto/qvac/pull/1974)) - See [API changes](./api.md)
+- Add standalone image upscaling support to the SDK. (see PR [#1990](https://github.com/tetherto/qvac/pull/1990)) - See [API changes](./api.md)
+- Wire qvac verify bundle into Expo plugin. (see PR [#2000](https://github.com/tetherto/qvac/pull/2000)) - See [API changes](./api.md)
+- Typed cancel outcomes on the wire + atomic KV-cache via KvCacheSession. (see PR [#2007](https://github.com/tetherto/qvac/pull/2007)) - See [API changes](./api.md)
+- Add unloadModel autoClose option, default-off on Bare. (see PR [#2024](https://github.com/tetherto/qvac/pull/2024)) - See [breaking changes](./breaking.md), [API changes](./api.md)
+- Cancel capability + per-handler cancel scope + structured logging. (see PR [#2036](https://github.com/tetherto/qvac/pull/2036)) - See [API changes](./api.md)
+- Inference-handler migrations. (see PR [#2058](https://github.com/tetherto/qvac/pull/2058)) - See [API changes](./api.md)
+- Non-inference migrations + decorated-promise requestId. (see PR [#2060](https://github.com/tetherto/qvac/pull/2060)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Prime system-prompt KV cache via addon prefill instead of cancel-on-first-token. (see PR [#1880](https://github.com/tetherto/qvac/pull/1880))
+- Avoid Node-only Buffer in RN duplex RPC path. (see PR [#1915](https://github.com/tetherto/qvac/pull/1915))
+- Drop blocking dht.fullyBootstrapped() wait from delegated connect. (see PR [#1934](https://github.com/tetherto/qvac/pull/1934))
+- Bundle SDK worker.js for packaged consumers. (see PR [#2011](https://github.com/tetherto/qvac/pull/2011))
+- Bump @qvac/embed-llamacpp to ^0.16.0. (see PR [#2012](https://github.com/tetherto/qvac/pull/2012))
+- Bump @qvac/transcription-whispercpp to ^0.7.0 in SDK. (see PR [#2015](https://github.com/tetherto/qvac/pull/2015))
+- Bump @qvac/registry-client to ^0.5.0 in SDK. (see PR [#2076](https://github.com/tetherto/qvac/pull/2076))
+
+## 📦 Models
+
+- Bergamot vocab re-downloaded on every loadModel for shared-vocab pairs. (see PR [#1892](https://github.com/tetherto/qvac/pull/1892)) - See [model changes](./models.md)
+- Sync sdk model registry to bergamot base-memory and drop deprecated marian opus. (see PR [#1903](https://github.com/tetherto/qvac/pull/1903)) - See [model changes](./models.md)
+  Removed: NMT_Q0F16, NMT_Q0F16_1, NMT_Q0F16_2, NMT_Q0F16_3, NMT_Q0F16_4 (and 27 more)
+
+## 🧪 Tests
+
+- Skip multi-gpu tests on mobile. (see PR [#1998](https://github.com/tetherto/qvac/pull/1998))
+
+## 🧹 Chores
+
+- Move Holepunch libs to peerDependencies. (see PR [#1905](https://github.com/tetherto/qvac/pull/1905))
+- Update tts-onnx to 0.9.0 and transcription-parakeet to 0.5.0. (see PR [#2063](https://github.com/tetherto/qvac/pull/2063))
+
+## ⚙️ Infrastructure
+
+- Scope e2e bootstrap to deps required by filtered tests. (see PR [#1991](https://github.com/tetherto/qvac/pull/1991))
+

--- a/packages/sdk/changelog/0.11.0/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.11.0/CHANGELOG_LLM.md
@@ -1,0 +1,660 @@
+# QVAC SDK v0.11.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.11.0
+
+This release completes the request-lifecycle and cancellation overhaul that began in
+0.10.0: every long-running SDK call — `completion`, `embed`, `transcribe`,
+`transcribeStream`, `translate`, `finetune`, `loadModel`, `downloadAsset`, and the
+cancellable `rag` operations — now flows through a unified `RequestRegistry`, exposes
+its `requestId` synchronously on the returned promise, and can be cancelled
+individually with `cancel({ requestId })`. The wire envelope for `cancel(...)` is
+consolidated to two shapes, two legacy call signatures are removed, and the SDK gains
+typed `instanceof` for policy/cancel errors across the RPC boundary. Alongside the
+lifecycle work, this release adds Harmony / Qwen3.5 / Gemma4 tool-call dialects,
+FLUX.2 multi-reference fusion and per-call LoRA on diffusion, ESRGAN upscaling (both
+as a post-step and as a standalone `upscale()` API), Whisper VAD and end-of-turn
+events, multi-GPU `split-mode` / `tensor-split` / `main-gpu` on the LLM and embed
+plugins, a `reasoning_budget` knob for Qwen/Gemma reasoning, and a fresh Parakeet
+0.4.0 GGUF backend with duplex streaming. The mobile build flow now auto-verifies the
+worker bundle through `qvac verify bundle`, and the model registry was regenerated
+against the upstream `base-memory` Bergamot fix (dropping the deprecated Marian Opus
+constants on the way).
+
+## Breaking Changes
+
+### `unloadModel` no longer auto-closes the Bare worker
+
+On Bare, `unloadModel` used to call `close()` whenever no models or providers were
+left, which terminated the worker host on every routine unload. Long-lived Bare
+workers either had to avoid `unloadModel` or work around the auto-close.
+
+The default now flips by runtime: Node and Electron preserve the existing
+auto-close behaviour (`autoClose: true` by default), while Bare leaves the
+connection open (`autoClose: false` by default). Pass the field explicitly to
+override.
+
+**Before (Bare):**
+
+```typescript
+import { unloadModel } from "@qvac/sdk";
+
+await unloadModel({ modelId });
+// RPC connection closed → Bare worker host terminated.
+```
+
+**After (Bare):**
+
+```typescript
+import { unloadModel } from "@qvac/sdk";
+
+await unloadModel({ modelId });
+// Worker survives; opt in to closing explicitly:
+await unloadModel({ modelId, autoClose: true });
+```
+
+### Parakeet plugin moves to the 0.4.0 single-file GGUF API
+
+`@qvac/transcription-parakeet` 0.4.0 replaced the legacy multi-file ONNX bundle
+(encoder + decoder + vocab + preprocessor, plus the CTC / Sortformer variants)
+with a single GGUF backed by `qvac-parakeet.cpp`. The SDK plugin now follows
+suit: every per-variant `parakeet*Src` field on `modelConfig` is gone, the
+`modelType` discriminator is gone, and the addon auto-detects TDT / CTC / EOU /
+Sortformer from GGUF metadata.
+
+**Before:**
+
+```typescript
+await loadModel({
+  modelSrc: PARAKEET_TDT_ENCODER_INT8,
+  modelType: "parakeet",
+  modelConfig: {
+    parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
+    parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
+    parakeetVocabSrc: PARAKEET_TDT_VOCAB,
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8,
+  },
+});
+
+await loadModel({
+  modelSrc: PARAKEET_CTC_FP32,
+  modelType: "parakeet",
+  modelConfig: {
+    modelType: "ctc",
+    parakeetCtcModelSrc: PARAKEET_CTC_FP32,
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
+```
+
+**After:**
+
+```typescript
+await loadModel({
+  modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
+  modelType: "parakeet",
+});
+
+await loadModel({
+  modelSrc: PARAKEET_CTC_0_6B_Q8_0,
+  modelType: "parakeet",
+});
+```
+
+The new GGUF constants (`PARAKEET_TDT_0_6B_V3_Q8_0`, `PARAKEET_CTC_0_6B_Q8_0`,
+`PARAKEET_SORTFORMER_4SPK_V1_Q8_0`, `PARAKEET_EOU_120M_V1_Q8_0`) are added in
+this release; the legacy multi-file constants are gone.
+
+### Two legacy `cancel(...)` call shapes are removed
+
+`cancel({ operation: "downloadAsset", downloadKey, clearCache })` and
+`cancel({ operation: "rag", workspace })` are removed because neither carried a
+`requestId` and neither can be mechanically back-mapped onto the new two-arm
+cancel wire envelope. Callers must migrate to the `requestId`-targeted cancel
+path (the primary one in 0.11.0) or to the broad cancel-by-`modelId` escape
+hatch.
+
+**Before — downloadAsset:**
+
+```typescript
+import { downloadAsset, cancel } from "@qvac/sdk";
+
+const op = downloadAsset({ assetSrc, onProgress });
+await cancel({ operation: "downloadAsset", downloadKey: assetSrc.key, clearCache: true });
+```
+
+**After — downloadAsset:** the decorated promise now exposes `op.requestId`
+synchronously, and `clearCache` is honoured on the `requestId` path.
+
+```typescript
+import { downloadAsset, cancel } from "@qvac/sdk";
+
+const op = downloadAsset({ assetSrc, onProgress });
+await cancel({ requestId: op.requestId, clearCache: true });
+```
+
+**Before — rag:**
+
+```typescript
+import { ragIngest, cancel } from "@qvac/sdk";
+
+ragIngest({ workspace: "my-workspace", documents });
+await cancel({ operation: "rag", workspace: "my-workspace" });
+```
+
+**After — rag (primary path, by `requestId`):**
+
+```typescript
+import { ragIngest, cancel } from "@qvac/sdk";
+
+const op = ragIngest({ workspace: "my-workspace", documents });
+await cancel({ requestId: op.requestId });
+```
+
+**After — rag (broad escape hatch, no `requestId` to hand):**
+
+```typescript
+import { cancel } from "@qvac/sdk";
+
+// Cancel every in-flight RAG operation running on the embedding model:
+await cancel({ modelId: ragEmbeddingModelId, kind: "rag" });
+```
+
+Every other `cancel(...)` shape still works: `cancel({ operation: "inference",
+modelId })`, `cancel({ operation: "embeddings", modelId })`, `cancel({ modelId
+})`, `cancel({ modelId, kind })`, and `cancel({ requestId })` are all preserved
+by the client-side normalisation layer.
+
+## New APIs and Capabilities
+
+### `requestId` exposed synchronously on every cancellable call
+
+Every long-running SDK call now returns a decorated promise (or run handle) that
+carries a `requestId` you can read on the same tick the call is dispatched.
+That lets you wire a Stop button to a specific in-flight call without racing the
+network round-trip. The pattern covers `completion`, `loadModel`, `embed`,
+`transcribe`, `transcribeStream`, `translate`, `finetune`, `downloadAsset`, and
+the three cancellable RAG ops (`ragIngest`, `ragSaveEmbeddings`, `ragReindex`).
+
+```typescript
+import {
+  completion,
+  loadModel,
+  embed,
+  downloadAsset,
+  ragIngest,
+  cancel,
+} from "@qvac/sdk";
+
+const run = completion({ modelId, history });
+console.log(run.requestId);
+
+const op = loadModel({ modelSrc: "..." });
+console.log(op.requestId);                    // synchronously, before await
+const modelId = await op;                     // legacy unwrap still works
+
+const handle = embed({ modelId, text: "hello" });
+console.log(handle.requestId);
+await handle;
+
+const download = downloadAsset({ assetSrc, onProgress });
+stopButton.onclick = () => cancel({ requestId: download.requestId });
+await download;                                // rejects with InferenceCancelledError if cancelled
+
+const ingest = ragIngest({ workspace: "ws-a", modelId, documents });
+console.log(ingest.requestId);
+await ingest;
+```
+
+The non-cancellable RAG ops (`ragChunk`, `ragSearch`, `ragDeleteEmbeddings`,
+`ragListWorkspaces`, `ragCloseWorkspace`, `ragDeleteWorkspace`) intentionally do
+not decorate — they're fast-path operations that don't register with the
+server-side request registry, so a `requestId` would point at nothing.
+
+### Typed errors that survive the RPC boundary
+
+`InferenceCancelledError`, `RequestRejectedByPolicyError`,
+`RequestIdConflictError`, and `RequestNotFoundError` are now re-exported from
+`@qvac/sdk` and reconstructed on the client side with their typed fields
+intact, so `err instanceof RequestRejectedByPolicyError` actually narrows and
+`err.modelId` / `err.reason` / `err.requestId` are populated from the
+server-side throw.
+
+`RequestRejectedByPolicyError` (code 52420) fires when an admission policy
+blocks the request — for example, the worker's default
+`oneAtATimePerModel: true` rule for `completion` kind, which promotes the
+llama.cpp addon's opaque "job already set" error into a typed framework-level
+rejection.
+
+```typescript
+import { completion, RequestRejectedByPolicyError } from "@qvac/sdk";
+
+try {
+  const run = completion({ modelId, history });
+  for await (const event of run.events) { /* ... */ }
+} catch (err) {
+  if (err instanceof RequestRejectedByPolicyError) {
+    showBusy({ modelId: err.modelId, reason: err.reason });
+    return;
+  }
+  throw err;
+}
+```
+
+### New broad-cancel sugar and consolidated wire envelope
+
+The `cancel` wire envelope shrinks to two shapes — request-targeted (`{
+operation: "request", requestId }`) and broad-by-model (`{ operation: "broad",
+modelId, kind? }`). Two new client sugars wrap the broad shape so callers don't
+have to think about the wire representation:
+
+```typescript
+import { cancel } from "@qvac/sdk";
+
+await cancel({ modelId: "llama-3.2-1b", kind: "completion" });
+await cancel({ modelId: "llama-3.2-1b" });
+```
+
+### Plugin authors: declare cancel scope per handler
+
+`PluginHandlerDefinition` gains an optional `cancel: { scope, hard? }` field so
+plugin authors can declare upfront whether each handler accepts a per-request
+cancel token, whether it cancels by model, or whether it has no addon-level
+cancel surface at all (soft-cancel only — the registry aborts the signal, the
+stream stops yielding, the C++ work runs to completion in the background).
+
+`scope` is `"request" | "model" | "none"`; `hard: true` documents that the
+addon-side cancel actually interrupts compute. Plugin manifests that omit the
+field still load — it's optional.
+
+```typescript
+import { definePlugin, defineHandler } from "@qvac/sdk";
+
+definePlugin({
+  manifestVersion: 1,
+  handlers: {
+    myStream: defineHandler({
+      requestSchema,
+      responseSchema,
+      streaming: true,
+      cancel: { scope: "model", hard: true },
+      handler: async function* (request, ctx) { /* ... */ },
+    }),
+  },
+});
+```
+
+### Multi-GPU `split-mode`, `tensor-split`, and `main-gpu` on LLM and embed
+
+LLM and embed model configs now expose the underlying llamacpp multi-GPU knobs.
+LLM uses the canonical hyphenated keys (`"split-mode"`, `"tensor-split"`,
+`"main-gpu"`) to mirror the llama.cpp CLI; embed uses the existing camelCase
+convention (`splitMode`, `tensorSplit`, `mainGpu`).
+
+```typescript
+// LLM
+await loadModel({
+  modelSrc: LLAMA_3_2_1B_INST_Q4_0,
+  modelType: "llm",
+  modelConfig: {
+    "split-mode": "layer",        // "none" | "layer" | "row"
+    "tensor-split": "1,1",        // proportional split across GPUs
+    "main-gpu": 0,                // integer index or "integrated" | "dedicated"
+  },
+});
+
+// Embed
+await loadModel({
+  modelSrc: EMBEDDING_GEMMA_300M_Q8_0,
+  modelType: "embed",
+  modelConfig: {
+    splitMode: "layer",
+    tensorSplit: "1,1",
+    mainGpu: 0,
+  },
+});
+```
+
+### Whisper VAD and end-of-turn events on `transcribeStream`
+
+`transcribeStream` gains a conversational mode opted into via `emitVadEvents:
+true`. The session yields a discriminated event stream that includes live
+voice-activity probabilities and turn boundaries, so apps can build push-to-talk
+or barge-in UX without poll-the-text hacks.
+
+```typescript
+import { transcribeStream } from "@qvac/sdk";
+
+const session = await transcribeStream({
+  modelId: "whisper-base",
+  emitVadEvents: true,
+  endOfTurnSilenceMs: 800,
+  vadRunIntervalMs: 100,
+});
+
+for await (const event of session) {
+  if (event.type === "vad") console.log("speaking:", event.speaking, event.probability);
+  else if (event.type === "endOfTurn") console.log("turn ended after", event.silenceDurationMs, "ms");
+  else if (event.type === "text") process.stdout.write(event.text);
+}
+
+session.write(audioChunk);
+session.end();
+```
+
+`TranscribeStreamEvent`, `VadStateEvent`, `EndOfTurnEvent`, and
+`TranscribeStreamConversationSession` are new exported types. The existing
+text-only, segment, and audio-chunk overloads are unchanged.
+
+### Parakeet duplex streaming with EOU events
+
+The new parakeet plugin (see Breaking Changes) ships a duplex
+`transcribeStream` session that mirrors the whisper one. EOU model checkpoints
+surface as `{ type: "endOfTurn" }` events on the same iterator as `{ type:
+"text" }`.
+
+```typescript
+const session = await transcribeStream({
+  modelId,
+  parakeetStreamingConfig: {
+    chunkMs: 1000,
+    emitPartials: true,
+  },
+});
+
+ffmpeg.stdout.on("data", (chunk: Buffer) => session.write(chunk));
+
+for await (const event of session) {
+  switch (event.type) {
+    case "text":
+      process.stdout.write(event.text);
+      break;
+    case "endOfTurn":
+      console.log("\n[endOfTurn] turn boundary detected\n");
+      break;
+  }
+}
+```
+
+Per-call streaming overrides — `chunkMs`, `historyMs`, `leftContextMs`,
+`rightLookaheadMs`, `emitPartials`, `emitEnergyVad` — are accepted on
+`parakeetStreamingConfig` and fall back to their `parakeetConfig.streaming*`
+load-time counterparts.
+
+### Harmony, Qwen3.5, and Gemma4 tool-call dialects
+
+`toolDialect` now covers `"hermes" | "pythonic" | "json" | "harmony"`, plus
+auto-detected `qwen35` and `gemma4` parsers. Harmony adds first-class support
+for GPT-OSS models — including streaming the final-channel content
+incrementally instead of buffering until `<|return|>`, so long GPT-OSS responses
+no longer stall — and fixes a regression where protocol markers
+(`<|channel|>analysis<|message|>...`, `<|start|>assistant`, `<|return|>`) were
+leaking into `contentDelta`. Qwen3.5 covers the Pythonic-XML
+`<tool_call><function=NAME><parameter=KEY>...</parameter></function></tool_call>`
+framing; Gemma4 covers the native
+`<|tool_call>call:NAME{key:<|"|>val<|"|>,...}<tool_call|>` framing.
+
+```typescript
+import { completion, type ToolDialect } from "@qvac/sdk";
+
+const result = completion({
+  modelId,                         // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  history,
+  tools,
+  toolDialect: "harmony",          // optional explicit override
+});
+
+const dialect: ToolDialect = "harmony";
+```
+
+Qwen3.5 / Qwen3.6 and Gemma4 are auto-detected from the model name; the parsers
+ship without any caller-side wiring. The `harmony` parser also surfaces
+malformed-JSON, unknown-tool, and non-object payloads as structured
+`ToolCallError`s instead of silently dropping the event.
+
+### `reasoning_budget` knob for thinking models
+
+`@qvac/llm-llamacpp@0.20.0` introduced a `reasoning_budget` parameter that gates
+how much "thinking" a reasoning model is allowed to produce: `-1` =
+unrestricted, `0` = disabled. The SDK exposes it both as a load-time default on
+`LlmConfig` and as a per-request override on `GenerationParams`.
+
+```typescript
+import { loadModel, completion } from "@qvac/sdk";
+
+const modelId = await loadModel({
+  modelSrc: "/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf",
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, reasoning_budget: -1 },
+});
+
+const run = completion({
+  modelId,
+  history: [{ role: "user", content: "Think step by step." }],
+  generationParams: { reasoning_budget: 0 }, // override per-request
+});
+```
+
+The same bump fixes a regression where `system_prompt` (a JS-only
+`completion-stream.ts` field) was being forwarded to the C++ arg parser as
+`--system-prompt`, which had been removed in llamacpp 8189+ — model loads were
+failing outright until this fix landed.
+
+### FLUX.2 multi-reference fusion and per-call LoRA for diffusion
+
+The diffusion API gains FLUX.2 multi-reference fusion (`init_images:
+Uint8Array[]`, mutually exclusive with the existing single `init_image`), FLUX.2
+reference-image tunables (`increase_ref_index`, `auto_resize_ref_image`), and a
+per-call `lora` field that takes an absolute filesystem path. A new load-time
+`lora_apply_mode` controls whether the adapter is fused permanently into the
+model or applied per-call (`"auto" | "immediately" | "at_runtime"`).
+
+```typescript
+const refA = fs.readFileSync("scientist-a.jpg");
+const refB = fs.readFileSync("scientist-b.jpg");
+const { outputs } = diffusion({
+  modelId,
+  prompt: "a portrait using most visual traits from @image1 and the eyes from @image2",
+  init_images: [refA, refB],
+  width: 768,
+  height: 768,
+});
+
+const { outputs: loraOutputs } = diffusion({
+  modelId,
+  prompt: "a watercolor cat",
+  lora: "/home/user/loras/watercolor.safetensors",
+});
+
+await loadModel(modelSrc, {
+  modelType: "diffusion",
+  modelConfig: { prediction: "flux2_flow", lora_apply_mode: "immediately" },
+});
+```
+
+Relative LoRA paths are rejected: the SDK runs across processes with differing
+cwds, so absolute paths (POSIX, Windows drive-letter, or UNC) are the only safe
+shape.
+
+### ESRGAN upscaling — post-step and standalone
+
+Two new paths land for ESRGAN upscalers. The first attaches an upscaler to a
+diffusion model and runs it as a post-step on every generated image. The second
+loads an ESRGAN file as a standalone `upscale()`-only model so consumers can
+feed an arbitrary PNG or JPEG into the SDK and get an upscaled image back —
+without standing up a full diffusion pipeline.
+
+```typescript
+// Post-step upscale during diffusion
+const modelId = await loadModel({
+  modelSrc: SD_V2_1_1B_Q8_0,
+  modelType: "diffusion",
+  modelConfig: {
+    prediction: "v",
+    upscaler: {
+      type: "esrgan",
+      model_src: "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth",
+      tile_size: 128,
+    },
+  },
+});
+
+const { outputs } = diffusion({
+  modelId,
+  prompt: "an illustrated red fox portrait",
+  width: 128,
+  height: 128,
+  upscale: { repeats: 2 },
+});
+```
+
+```typescript
+// Standalone upscale — no diffusion model required
+import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from "@qvac/sdk";
+
+const modelId = await loadModel(REALESRGAN_X4PLUS_ANIME_6B, {
+  modelType: "diffusion",
+  modelConfig: {
+    mode: "upscale",
+    upscaler: { tile_size: 128 },
+  },
+});
+
+const { outputs, stats } = upscale({
+  modelId,
+  image: pngBytes,        // Uint8Array (PNG/JPEG)
+  repeats: 1,             // each pass multiplies dims by the model's native scale factor
+});
+
+const [upscaledPng] = await outputs;
+console.log(await stats); // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
+```
+
+Calling `upscale()` against a model that wasn't loaded with `mode: "upscale"`
+raises `ModelOperationNotSupportedError` upfront, and loading a diffusion model
+with `modelConfig.upscaler` set but `model_src` missing fails fast with a
+structured `ModelLoadFailedError` instead of letting the native addon error
+mid-load.
+
+### Mobile build flow auto-verifies the worker bundle
+
+Expo prebuild now runs `qvac verify bundle` against the emitted
+`worker.mobile.bundle.js` before copying it into the SDK's `dist/`. The flow is
+`runBundler → assert bundle exists → runVerifier → copyFileSync`, so the SDK
+`dist/worker.mobile.bundle.js` only updates when verification passes. Failure
+preserves the last known-good artifact and fails Expo prebuild fast with a new
+`BundleVerificationFailedError` (code 50609).
+
+If a `qvac.config.{json,js,mjs,ts}` is present, ABI checks are pinned to its
+`bareRuntimeVersion`; without config, the CLI auto-detects from `node_modules`
+(`bare-runtime` → `bare`) and falls through to a warning only when neither is
+installed. `@qvac/cli` peer dep range moves from `^0.2.4` to `^0.4.0` — the
+first version that ships `qvac verify bundle` — with the existing npx fallback
+still in place for consumers that don't pin the dep.
+
+Pear consumers aren't auto-wired yet — run `qvac verify bundle --addons-source
+./node_modules --host <host> --config qvac.config.json` manually before `pear
+stage` / `pear run`.
+
+### `cancelFinetune` is now fire-and-forget
+
+`cancelFinetune(modelId)` used to await the addon's cancel flip before
+resolving. It now fires a synchronous registry cancel and returns immediately;
+the actual `model.cancel()` runs out-of-band via the new context's abort
+listener. The result shape is unchanged (`status: "CANCELLED"` still
+populated), but workbench / CLI / external consumers that gated subsequent
+calls on cancel-resolution timing should switch to `await cancel({ requestId
+})`, which has been synchronous-after-abort since the lifecycle work began.
+
+## Bug Fixes
+
+### Delegated inference connect is fast again
+
+The `loadModel.delegation.connection` regression introduced in 0.10.0 — where
+`@qvac/sdk` 0.9.0 → 0.10.0 took the consumer-side connect from ≈2.5s to ≈8.3s
+on first delegated call — is fixed by dropping the explicit `await
+swarm.dht.fullyBootstrapped()` block before `dht.connect()` in
+`ensureRPCConnection`. The SDK's normal init path already warms the routing
+table via `getSwarm()` during registry initialisation, so the explicit guard
+was redundant. Measured cold-start connect mean drops from 3.82s back down to
+1.18s (≈3.2× faster) on the same hardware and network.
+
+### KV cache priming no longer wastes a token
+
+`initSystemPromptCache` used to start generation and then race the first output
+token against a cancel. That always produced one token of unnecessary work and
+relied on a fragile output/cancel race. The SDK now uses the addon's new
+`prefill: true` runtime option (in `@qvac/llm-llamacpp ^0.17.3`) so priming
+ingests the prompt and tools into the KV cache without producing any output
+tokens. `initSystemPromptCache` resolves as soon as priming finishes.
+
+### React Native duplex RPC no longer uses Node-only `Buffer`
+
+The RN duplex RPC path was using Node's `Buffer` global, which isn't available
+on Hermes. The path now uses `Uint8Array` end-to-end so mobile consumers can
+use duplex streaming (transcribe, parakeet, tts) without hitting `Buffer is
+not defined`.
+
+### SDK bundles its own `worker.js` for packaged consumers
+
+Apps consuming the SDK from a bundler (Metro, esbuild, webpack) were missing
+`worker.js` from the published package, so consumers had to hand-copy it. The
+package now ships `worker.js` alongside `worker.mobile.bundle.js` so packaged
+consumers no longer need extra bundling steps.
+
+### Dedup of stateful Holepunch singletons
+
+The SDK and `@qvac/registry-client` had drifting declarations for
+`corestore`, `hyperblobs`, `hyperdb`, and `hyperswarm`: the SDK declared them
+as `peerDependencies`, the registry client declared them as hard
+`dependencies`, and the version ranges didn't match. The mismatch caused npm
+to install duplicate copies, producing separate DHT nodes and broken
+connectivity. Bumping `@qvac/registry-client` to `^0.5.0` (where those libs
+move to `peerDependencies`) and `@qvac/embed-llamacpp` to `^0.16.0` and
+`@qvac/transcription-whispercpp` to `^0.7.0` completes the dedup chain.
+
+## Model Registry Changes
+
+The Bergamot translation pairs `BERGAMOT_EN_IT` and `BERGAMOT_ES_EN` were
+pinned to the buggy `tiny` variant, which caused leading `"- "` hallucinations
+on short inputs and an en→it quality regression (~3 pp `chrF++` drop direct,
+~33 pp via Spanish pivot). The registry was regenerated against the upstream
+`base-memory` Bergamot fix (synced to the DHT on 2026-05-05); paths now point
+at `bergamot-{enit,esen}/2026-04-28/...` and `expectedSize` flipped from
+17.1 MB to 30.1 MB on both pairs, confirming the switch landed.
+
+The regeneration also picked up the auto-deprecation of the 32 Marian Opus NMT
+entries (`NMT_Q0F16` through `NMT_Q0F16_9`, `NMT_Q4_0` through `NMT_Q4_0_21`)
+that were superseded earlier in the release line. A separate fix corrects the
+Bergamot vocab being re-downloaded on every `loadModel` for shared-vocab pairs
+— the shared vocab is now cached and reused.
+
+### Added
+
+```
+PARAKEET_TDT_0_6B_V3_Q8_0
+PARAKEET_CTC_0_6B_Q8_0
+PARAKEET_SORTFORMER_4SPK_V1_Q8_0
+PARAKEET_EOU_120M_V1_Q8_0
+```
+
+### Removed
+
+```
+NMT_Q0F16 through NMT_Q0F16_9 (10 entries)
+NMT_Q4_0 through NMT_Q4_0_21 (22 entries)
+```
+
+The legacy multi-file Parakeet constants (`PARAKEET_TDT_ENCODER_INT8`,
+`PARAKEET_TDT_DECODER_INT8`, `PARAKEET_TDT_VOCAB`, `PARAKEET_TDT_PREPROCESSOR_INT8`,
+`PARAKEET_CTC_FP32`, `PARAKEET_CTC_TOKENIZER`, etc.) are gone alongside the
+plugin migration — see Breaking Changes above for the migration path.
+
+## Tests and Infrastructure
+
+- E2E bootstrap was scoped down to only the dependencies required by the
+  filtered test set, shortening cold CI runs.
+- Multi-GPU integration tests are now skipped on mobile (real multi-GPU hardware
+  isn't represented in the mobile farm; tests are validated against the
+  shared-dev `2× RTX 5090` rig in CI logs).
+- `@qvac/tts-onnx` bumped to `0.9.0` and `@qvac/transcription-parakeet` to
+  `0.5.0` to match the addon-side releases that land in this SDK version.

--- a/packages/sdk/changelog/0.11.0/api.md
+++ b/packages/sdk/changelog/0.11.0/api.md
@@ -1,0 +1,514 @@
+# 🔌 API Changes v0.11.0
+
+## Expose split-mode and tensor-split in SDK LLM config
+
+PR: [#1759](https://github.com/tetherto/qvac/pull/1759)
+
+```typescript
+// LLM — LoadModelOptions.modelConfig now accepts:
+{
+  "split-mode": "none" | "layer" | "row",    // optional, default none
+  "tensor-split": "1,1",                     // optional, proportional split across GPUs
+  "main-gpu": 0 | "integrated" | "dedicated" // optional, primary GPU selection
+}
+
+// Embed — LoadModelOptions.modelConfig now accepts:
+{
+  splitMode: "none" | "layer" | "row",       // optional, default none
+  tensorSplit: "1,1",                        // optional, proportional split across GPUs
+  mainGpu: 0 | "integrated" | "dedicated"   // optional, primary GPU selection (was already supported)
+}
+```
+
+---
+
+## Add FLUX.2 multi-reference fusion and LoRA adapter support to diffusion API
+
+PR: [#1838](https://github.com/tetherto/qvac/pull/1838)
+
+```typescript
+// FLUX.2 multi-reference fusion (mutually exclusive with init_image)
+const refA = fs.readFileSync("scientist-a.jpg");
+const refB = fs.readFileSync("scientist-b.jpg");
+const { outputs } = diffusion({
+  modelId,
+  prompt: "a portrait using most visual traits from @image1 and the eyes from @image2",
+  init_images: [refA, refB],
+  width: 768,
+  height: 768,
+});
+
+// Per-call LoRA adapter (absolute path required)
+const { outputs } = diffusion({
+  modelId,
+  prompt: "a watercolor cat",
+  lora: "/home/user/loras/watercolor.safetensors",
+});
+
+// LoRA persistence mode is selected at loadModel time
+await loadModel(modelSrc, {
+  modelType: "diffusion",
+  modelConfig: { prediction: "flux2_flow", lora_apply_mode: "immediately" },
+});
+```
+
+---
+
+## Expose whisper VAD and end-of-turn events in transcribeStream
+
+PR: [#1848](https://github.com/tetherto/qvac/pull/1848)
+
+```typescript
+// NEW overload
+export function transcribeStream(
+  params: TranscribeStreamClientParams & { emitVadEvents: true },
+  options?: RPCOptions,
+): Promise<TranscribeStreamConversationSession>;
+```
+
+```typescript
+type TranscribeStreamClientParams = {
+  modelId: string;
+  prompt?: string;
+  metadata?: boolean;
+  // NEW:
+  emitVadEvents?: boolean;
+  endOfTurnSilenceMs?: number;
+  vadRunIntervalMs?: number;
+};
+```
+
+```typescript
+export type VadStateEvent = { speaking: boolean; probability: number };
+export type EndOfTurnEvent = { silenceDurationMs: number };
+
+export type TranscribeStreamEvent =
+  | { type: "text"; text: string }
+  | { type: "segment"; segment: TranscribeSegment }
+  | ({ type: "vad" } & VadStateEvent)
+  | ({ type: "endOfTurn" } & EndOfTurnEvent);
+
+export interface TranscribeStreamConversationSession {
+  write(audioChunk: Buffer): void;
+  end(): void;
+  destroy(): void;
+  [Symbol.asyncIterator](): AsyncIterator<TranscribeStreamEvent>;
+}
+```
+
+``` typescript
+import { transcribeStream } from "@tetherto/qvac-sdk";
+
+const session = await transcribeStream({
+  modelId: "whisper-base",
+  emitVadEvents: true,
+  endOfTurnSilenceMs: 800,
+  vadRunIntervalMs: 100,
+});
+
+for await (const event of session) {
+  if (event.type === "vad") console.log("speaking:", event.speaking, event.probability);
+  else if (event.type === "endOfTurn") console.log("turn ended after", event.silenceDurationMs, "ms");
+  else if (event.type === "text") process.stdout.write(event.text);
+}
+
+session.write(audioChunk);
+session.end();
+```
+
+---
+
+## Add harmony tool-call dialect (gpt-oss)
+
+PR: [#1878](https://github.com/tetherto/qvac/pull/1878)
+
+```typescript
+import { completion, type ToolDialect } from "@qvac/sdk";
+
+// New dialect value (existing override parameter, fourth enum value).
+const result = completion({
+  modelId,         // gpt-oss-20b-Q4_K_M auto-routes to "harmony"
+  history,
+  tools,
+  toolDialect: "harmony", // optional explicit override
+});
+
+// `ToolDialect` is now "hermes" | "pythonic" | "json" | "harmony".
+const dialect: ToolDialect = "harmony";
+```
+
+---
+
+## Add ESRGAN upscale support to SDK diffusion
+
+PR: [#1930](https://github.com/tetherto/qvac/pull/1930)
+
+```typescript
+const modelId = await loadModel({
+  modelSrc: SD_V2_1_1B_Q8_0,
+  modelType: "diffusion",
+  modelConfig: {
+    prediction: "v",
+    upscaler: {
+      type: "esrgan",
+      model_src: "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth",
+      tile_size: 128,
+      direct: false,
+      offload_params_to_cpu: false,
+      threads: -1,
+    },
+  },
+});
+
+const { outputs } = diffusion({
+  modelId,
+  prompt: "an illustrated red fox portrait",
+  width: 128,
+  height: 128,
+  upscale: { repeats: 2 },
+});
+```
+
+---
+
+## Introduce request lifecycle primitives with signal-based cancel
+
+PR: [#1949](https://github.com/tetherto/qvac/pull/1949)
+
+```ts
+const run = sdk.completion({ model: "...", prompt: "..." });
+
+// requestId is available immediately on the run handle
+const requestId = run.requestId;
+
+// new targeted cancellation path
+await sdk.cancel({ requestId });
+
+// existing broad-cancel escape hatch remains
+await sdk.cancel({ modelId: "my-model-id" });
+```
+
+---
+
+## Add Qwen3.5, Gemma4 tool-call dialects and reasoning_budget param
+
+PR: [#1974](https://github.com/tetherto/qvac/pull/1974)
+
+```ts
+import { loadModel, completion } from "@qvac/sdk";
+
+const modelId = await loadModel({
+  modelSrc: "/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf",
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, tools: true },
+});
+
+const run = completion({
+  modelId,
+  history: [{ role: "user", content: "What's the weather in Paris?" }],
+  tools: [weatherTool],
+  // toolDialect: "qwen35" — auto-detected; override only if needed
+});
+```
+
+```ts
+const modelId = await loadModel({
+  modelSrc: "/models/gemma-4-9b-it-Q4_K_M.gguf",
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, tools: true },
+});
+
+const run = completion({
+  modelId,
+  history: [{ role: "user", content: "What's the weather in Paris?" }],
+  tools: [weatherTool],
+  // toolDialect: "gemma4" — auto-detected; override only if needed
+});
+```
+
+```ts
+// -1 = unrestricted thinking, 0 = disabled
+const modelId = await loadModel({
+  modelSrc: "/models/Qwen3.5-7B-Instruct-Q4_K_M.gguf",
+  modelType: "llm",
+  modelConfig: { ctx_size: 4096, reasoning_budget: -1 },
+});
+
+const run = completion({
+  modelId,
+  history: [{ role: "user", content: "Think step by step." }],
+  generationParams: { reasoning_budget: 0 }, // override per-request
+});
+```
+
+---
+
+## Add standalone image upscaling support to the SDK
+
+PR: [#1990](https://github.com/tetherto/qvac/pull/1990)
+
+```typescript
+import { upscale, loadModel, REALESRGAN_X4PLUS_ANIME_6B } from "@qvac/sdk";
+
+// Load the ESRGAN model in standalone-upscale mode.
+const modelId = await loadModel(REALESRGAN_X4PLUS_ANIME_6B, {
+  modelType: "diffusion",
+  modelConfig: {
+    mode: "upscale",
+    upscaler: { tile_size: 128 }, // optional tuning
+  },
+});
+
+// Run an upscale job.
+const { outputs, stats } = upscale({
+  modelId,
+  image: pngBytes,   // Uint8Array (PNG/JPEG)
+  repeats: 1,        // optional, defaults to 1; each pass multiplies dims by the model's native scale factor
+});
+
+const [upscaledPng] = await outputs;
+console.log(await stats); // { upscaleMs, totalUpscaleMs, width, height, totalPixels, repeats, ... }
+```
+
+---
+
+## Wire qvac verify bundle into Expo plugin
+
+PR: [#2000](https://github.com/tetherto/qvac/pull/2000)
+
+```
+node "<…>/@qvac/cli/dist/index.js" verify bundle \
+  --addons-source "<…>/qvac/worker.bundle.js" \
+  --host android-arm64 --host ios-arm64 \
+  --host ios-arm64-simulator --host ios-x64-simulator \
+  --config "<…>/qvac.config.json"
+```
+
+---
+
+## Typed cancel outcomes on the wire + atomic KV-cache via KvCacheSession
+
+PR: [#2007](https://github.com/tetherto/qvac/pull/2007)
+
+```
+bun lint        # eslint + tsc, clean
+bun run build   # clean
+bun run test:unit  # 10/10 files, all asserts pass
+```
+
+```typescript
+import { completion, cancel, InferenceCancelledError } from "@qvac/sdk";
+
+const run = completion({ modelId, history, stream: true });
+
+// Iterating events stays unchanged — events end naturally with the
+// cancelled terminator on cancel, no thrown error:
+for await (const event of run.events) {
+  if (event.type === "completionDone" && event.stopReason === "cancelled") {
+    // request was cancelled — handle here if you want
+  }
+}
+
+// Awaiting promise-aggregates throws InferenceCancelledError on cancel:
+try {
+  await cancel({ requestId: run.requestId });
+  const text = await run.text;
+  // ...
+} catch (err) {
+  if (err instanceof InferenceCancelledError) {
+    console.log(`cancelled: requestId=${err.requestId}, partial=${err.partial.text}`);
+    // err.partial.toolCalls and err.partial.stats are also available
+  }
+}
+```
+
+---
+
+## Add unloadModel autoClose option, default-off on Bare
+
+PR: [#2024](https://github.com/tetherto/qvac/pull/2024)
+
+```typescript
+import { unloadModel } from "@qvac/sdk";
+
+await unloadModel({ modelId });
+// RPC connection closed → Bare worker host terminated. Long-lived workers
+// had to avoid unloadModel or work around the auto-close.
+```
+
+```typescript
+import { unloadModel } from "@qvac/sdk";
+
+await unloadModel({ modelId });
+// Connection stays open, worker survives. Opt in to closing explicitly:
+await unloadModel({ modelId, autoClose: true });
+```
+
+```typescript
+await unloadModel({ modelId });
+
+await unloadModel({ modelId, autoClose: true });
+
+await unloadModel({ modelId, autoClose: false });
+```
+
+---
+
+## Cancel capability + per-handler cancel scope + structured logging
+
+PR: [#2036](https://github.com/tetherto/qvac/pull/2036)
+
+```
+[request-lifecycle] begin  requestId=<id> kind=<kind> modelId=<id|"-"> state=running
+[request-lifecycle] cancel requestId=<id> kind=<kind> modelId=<id|"-"> state=cancelling
+[request-lifecycle] end    requestId=<id> kind=<kind> modelId=<id|"-"> state=<terminal> durationMs=<n>
+```
+
+```
+bun run lint        # eslint + tsc, clean
+bun run test:unit   # all files, all asserts pass
+```
+
+```typescript
+import { definePlugin, defineHandler } from "@qvac/sdk";
+
+definePlugin({
+  manifestVersion: 1,
+  handlers: {
+    myStream: defineHandler({
+      requestSchema,
+      responseSchema,
+      streaming: true,
+      cancel: { scope: "model", hard: true }, // <-- new
+      handler: async function* (request, ctx) { /* ... */ },
+    }),
+  },
+});
+```
+
+```typescript
+import { RequestRejectedByPolicyError } from "@qvac/sdk";
+
+try {
+  for await (const e of sdk.completion({ ... })) { /* ... */ }
+} catch (err) {
+  if (err instanceof RequestRejectedByPolicyError) {
+    showBusy({ modelId: err.modelId, reason: err.reason });
+  } else {
+    throw err;
+  }
+}
+```
+
+```typescript
+import { getRequestRegistry } from "@/server/bare/runtime";
+
+const registry = getRequestRegistry();
+registry.policy({ kind: "embeddings", oneAtATimePerModel: true });
+
+await using ctx = registry.begin({ requestId, kind: "embeddings", modelId });
+// ...
+```
+
+```typescript
+import { getRequestRegistry, withRequestContext } from "@/server/bare/runtime";
+import { getServerLogger } from "@/logging";
+
+const registry = getRequestRegistry();
+await using ctx = registry.begin({ requestId, kind: "completion", modelId });
+const logger = withRequestContext(getServerLogger(), ctx);
+
+logger.info("starting work"); // -> "[request-lifecycle completion requestId=... modelId=...] starting work"
+```
+
+---
+
+## Inference-handler migrations
+
+PR: [#2058](https://github.com/tetherto/qvac/pull/2058)
+
+```typescript
+import { v4 as uuid } from "uuid";
+
+const id = uuid();
+
+// Embed
+const embed = sdk.embed({ modelId, text: "hello", requestId: id });
+await sdk.cancel({ requestId: id });
+
+// Transcribe (single shot)
+const t = sdk.transcribe({ modelId, audioChunk, requestId: id });
+
+// Transcribe (duplex stream)
+const stream = sdk.transcribeStream({ modelId, requestId: id });
+
+// Translate (LLM and NMT both accept the field)
+const tr = sdk.translate({
+  modelId, text: "hi", from: "en", to: "fr", stream: true,
+  modelType: "llm", requestId: id,
+});
+
+// Finetune
+const ft = sdk.finetune({ modelId, options, requestId: id });
+```
+
+```typescript
+await sdk.cancel({ operation: "embeddings", modelId });
+```
+
+```typescript
+// Targeted: works for all four migrated kinds, today, end-to-end
+await sdk.cancel({ requestId: id });
+
+// Server-internal broad cancel: anyone holding a `RequestRegistry`
+// reference (handlers, the cancel op, future bridges) can fan out
+// across kinds without touching the wire schema
+getRequestRegistry().cancel({ modelId, kind: "transcribe" });
+getRequestRegistry().cancel({ modelId, kind: "translate" });
+getRequestRegistry().cancel({ modelId, kind: "finetune" });
+```
+
+---
+
+## Non-inference migrations + decorated-promise requestId
+
+PR: [#2060](https://github.com/tetherto/qvac/pull/2060)
+
+```typescript
+const modelId: string = await sdk.loadModel({ modelSrc: "..." });
+// No way to cancel this specific call without grabbing the modelId
+// out-of-band and calling cancel({ operation: "inference", modelId })
+// (which is broad-cancel — kills every in-flight request on that model).
+```
+
+```typescript
+const op = sdk.loadModel({ modelSrc: "..." });
+op.requestId;                              // ← synchronously available, before await
+const modelId: string = await op;          // ← legacy unwrap still works
+
+// Stop button → exactly this load, nothing else on the model:
+stopButton.onclick = () => sdk.cancel({ requestId: op.requestId });
+```
+
+```typescript
+const op = sdk.downloadAsset({ assetSrc: "https://example.com/big.gguf" });
+setTimeout(() => sdk.cancel({ requestId: op.requestId }), 1000);
+await op; // rejects with InferenceCancelledError if cancelled
+```
+
+```typescript
+const requestId = crypto.randomUUID();
+const result = sdk.rag({
+  type: "rag",
+  operation: "ingest",
+  workspace: "ws-a",
+  modelId: "m1",
+  documents: [...],
+  requestId, // optional on the wire; legacy clients omit it and the server generates one
+});
+
+await sdk.cancel({ requestId });
+```
+
+---
+

--- a/packages/sdk/changelog/0.11.0/breaking.md
+++ b/packages/sdk/changelog/0.11.0/breaking.md
@@ -1,0 +1,80 @@
+# 💥 Breaking Changes v0.11.0
+
+## Migrate SDK parakeet plugin to 0.4.0 GGML + duplex streaming
+
+PR: [#2018](https://github.com/tetherto/qvac/pull/2018)
+
+**BEFORE:**
+**
+
+```typescript
+await loadModel({
+  modelSrc: PARAKEET_TDT_ENCODER_INT8,
+  modelType: "parakeet",
+  modelConfig: {
+    parakeetEncoderSrc: PARAKEET_TDT_ENCODER_INT8,
+    parakeetDecoderSrc: PARAKEET_TDT_DECODER_INT8,
+    parakeetVocabSrc: PARAKEET_TDT_VOCAB,
+    parakeetPreprocessorSrc: PARAKEET_TDT_PREPROCESSOR_INT8,
+  },
+});
+
+await loadModel({
+  modelSrc: PARAKEET_CTC_FP32,
+  modelType: "parakeet",
+  modelConfig: {
+    modelType: "ctc",
+    parakeetCtcModelSrc: PARAKEET_CTC_FP32,
+    parakeetTokenizerSrc: PARAKEET_CTC_TOKENIZER,
+  },
+});
+```
+
+**
+
+**AFTER:**
+**
+
+---
+
+## Add unloadModel autoClose option, default-off on Bare
+
+PR: [#2024](https://github.com/tetherto/qvac/pull/2024)
+
+**BEFORE:**
+** (Bare)
+
+```typescript
+import { unloadModel } from "@qvac/sdk";
+
+await unloadModel({ modelId });
+// RPC connection closed → Bare worker host terminated. Long-lived workers
+// had to avoid unloadModel or work around the auto-close.
+```
+
+**
+
+**AFTER:**
+** (Bare)
+
+---
+
+## CLI cancel bridge + cancelHandler retirement
+
+PR: [#2074](https://github.com/tetherto/qvac/pull/2074)
+
+**BEFORE:**
+```typescript
+import { downloadAsset, cancel } from "@qvac/sdk";
+
+const op = downloadAsset({ assetSrc, onProgress });
+// ...some time later, user clicks Cancel:
+await cancel({ operation: "downloadAsset", downloadKey: assetSrc.key, clearCache: true });
+```
+
+**AFTER:**
+```typescript
+import { downloadAsset, cancel } from "@qvac/sdk";
+
+---
+

--- a/packages/sdk/changelog/0.11.0/models.md
+++ b/packages/sdk/changelog/0.11.0/models.md
@@ -1,0 +1,45 @@
+# 📦 Model Changes v0.11.0
+
+## Removed Models
+
+```
+NMT_Q0F16
+NMT_Q0F16_1
+NMT_Q0F16_2
+NMT_Q0F16_3
+NMT_Q0F16_4
+NMT_Q0F16_5
+NMT_Q0F16_6
+NMT_Q0F16_7
+NMT_Q0F16_8
+NMT_Q0F16_9
+NMT_Q4_0
+NMT_Q4_0_1
+NMT_Q4_0_10
+NMT_Q4_0_11
+NMT_Q4_0_12
+NMT_Q4_0_13
+NMT_Q4_0_14
+NMT_Q4_0_15
+NMT_Q4_0_16
+NMT_Q4_0_17
+NMT_Q4_0_18
+NMT_Q4_0_19
+NMT_Q4_0_2
+NMT_Q4_0_20
+NMT_Q4_0_21
+NMT_Q4_0_3
+NMT_Q4_0_4
+NMT_Q4_0_5
+NMT_Q4_0_6
+NMT_Q4_0_7
+NMT_Q4_0_8
+NMT_Q4_0_9
+```
+
+---
+
+### Related PRs
+
+- [#1892](https://github.com/tetherto/qvac/pull/1892) - Bergamot vocab re-downloaded on every loadModel for shared-vocab pairs
+- [#1903](https://github.com/tetherto/qvac/pull/1903) - Sync sdk model registry to bergamot base-memory and drop deprecated marian opus

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/scripts/sdk/generate-changelog-sdk-pod.cjs
+++ b/scripts/sdk/generate-changelog-sdk-pod.cjs
@@ -34,52 +34,35 @@ const SECTIONS = [
 ];
 
 /**
+ * Per-package PR exclusion list. The path-scope filter in
+ * `getPRNumbers(...)` picks up any PR whose diff touches `packages/<pkg>/**`,
+ * but cross-cutting monorepo chores (path renames, repo-wide reformats, etc.)
+ * often touch one tiny SDK-side file (a test executor, a historical changelog
+ * doc) and get pulled in as if they were SDK release items. Those PRs belong
+ * in the devops changelog, not the SDK changelog.
+ *
+ * The first-line defence is for the PR author to tag the title `[skiplog]` —
+ * that's free and retroactive only if the PR is still open. For already-merged
+ * cross-cutting PRs, list them here with a short rationale so future
+ * contributors understand why the exclusion exists.
+ *
+ * Keyed by package name. Values are `{ <prNumber>: "<rationale>" }`.
+ */
+const EXCLUDED_PRS = {
+  sdk: {
+    1860:
+      "Monorepo-wide path simplification across 26+ packages; only " +
+      "incidentally touched packages/sdk via a test executor and a " +
+      "historical changelog doc. Devops chore, not an SDK release item.",
+  },
+};
+
+/**
  * Maximum number of model entries to inline per section (Added/Updated/Removed)
  * in the main CHANGELOG.md. Anything beyond is collapsed to "(and N more)" and
  * the reader is expected to follow the link to models.md for the full list.
  */
 const MAX_INLINE_MODELS = 5;
-
-/**
- * Maximum number of bullets to include per section in the Slack announcement
- * post. Anything beyond is collapsed to "... And much more, see full list in
- * changelog :memo:". Sections with 10 or fewer entries are emitted verbatim;
- * the "And much more" suffix only appears when a section has *more than 10*
- * entries.
- */
-const MAX_ANNOUNCEMENT_BULLETS = 10;
-
-/**
- * Map of section keys to Slack-style emoji headings used in the
- * announcement-post.txt template. Slack does not render the unicode emojis
- * we use in CHANGELOG.md, so we translate to shortcodes here.
- */
-const SLACK_SECTION_HEADINGS = {
-  feat: ":sparkles: Features",
-  api: ":electric_plug: API",
-  fix: ":ladybug: Fixes",
-  mod: ":package: Models",
-  doc: ":blue_book: Docs",
-  test: ":test_tube: Tests",
-  chore: ":broom: Chores",
-  infra: ":gear: Infrastructure",
-};
-
-/**
- * Map from the unicode emoji used in CHANGELOG.md headings back to the
- * internal section key, so the announcement generator can parse a freshly
- * written CHANGELOG.md without re-running the upstream PR fetch.
- */
-const CHANGELOG_HEADING_TO_KEY = {
-  "✨": "feat",
-  "🔌": "api",
-  "🐞": "fix",
-  "📦": "mod",
-  "📘": "doc",
-  "🧪": "test",
-  "🧹": "chore",
-  "⚙️": "infra",
-};
 
 /**
  * Extract code blocks from markdown
@@ -790,12 +773,22 @@ function isBackmergeSubject(subject) {
 /**
  * Process raw PRs with SDK-specific validation and filtering
  * @param {Array<{number: number, title: string, body: string, url: string}>} rawPRs
+ * @param {string} [packageName] - Package being released; used to apply per-package
+ *   PR exclusions from `EXCLUDED_PRS`.
  * @returns {Array} Validated PRs with parsed metadata
  */
-function processSDKPRs(rawPRs) {
+function processSDKPRs(rawPRs, packageName) {
   const prs = [];
+  const exclusions = (packageName && EXCLUDED_PRS[packageName]) || {};
 
   for (const pr of rawPRs) {
+    if (Object.prototype.hasOwnProperty.call(exclusions, pr.number)) {
+      console.log(
+        `  ⏭️  PR #${pr.number} is on the ${packageName} exclusion list, excluding from changelog: ${exclusions[pr.number]}`,
+      );
+      continue;
+    }
+
     const validation = validatePR(pr.title, pr.body);
 
     if (!validation.valid) {
@@ -803,6 +796,18 @@ function processSDKPRs(rawPRs) {
         `  ⚠️  PR #${pr.number} has invalid format: ${validation.error}`,
       );
       console.warn(`      Skipping...`);
+      continue;
+    }
+
+    // PR titles that match validator exceptions (Merge / Revert / Squash /
+    // Version-bump / Release-PR) bypass format parsing entirely — `parsed`
+    // is undefined for these. They carry no structured metadata, so we have
+    // nothing meaningful to render in the changelog and skip them with a
+    // warning rather than crashing downstream.
+    if (!validation.parsed) {
+      console.warn(
+        `  ⏭️  PR #${pr.number} bypassed format validation (e.g. revert/merge/version bump), excluding from changelog: ${pr.title}`,
+      );
       continue;
     }
 
@@ -916,151 +921,18 @@ function rebuildRootChangelog(packageName) {
 }
 
 /**
- * Parse a generated CHANGELOG.md into structured sections with bullet entries.
- * Used by the announcement-post generator so it can transform the canonical
- * release changelog without re-fetching PRs from GitHub.
+ * Generate `announcement-post.txt` for a release.
  *
- * @param {string} markdown - Contents of CHANGELOG.md
- * @returns {{
- *   version: string|null,
- *   releaseDate: string|null,
- *   sections: Array<{ key: string, heading: string, bullets: Array<{
- *     text: string,
- *     prNumber: string|null,
- *     prUrl: string|null,
- *     isBreaking: boolean,
- *     isApi: boolean,
- *     isModels: boolean,
- *   }> }>,
- * }}
- */
-function parseChangelogMarkdown(markdown) {
-  const out = { version: null, releaseDate: null, sections: [] };
-
-  const versionMatch = markdown.match(/^# Changelog v(\d+\.\d+\.\d+)/m);
-  if (versionMatch) out.version = versionMatch[1];
-
-  const dateMatch = markdown.match(/^Release Date:\s*(\S+)/m);
-  if (dateMatch) out.releaseDate = dateMatch[1];
-
-  const lines = markdown.split("\n");
-  let current = null;
-  let currentBullet = null;
-
-  for (const rawLine of lines) {
-    const line = rawLine.replace(/\r$/, "");
-
-    // ## <emoji> <Title>
-    const headingMatch = line.match(/^##\s+(\S+)\s+(.+?)\s*$/);
-    if (headingMatch) {
-      const [, emoji, title] = headingMatch;
-      const key = CHANGELOG_HEADING_TO_KEY[emoji];
-      if (key) {
-        current = { key, heading: `${emoji} ${title}`, bullets: [] };
-        out.sections.push(current);
-        currentBullet = null;
-        continue;
-      }
-      // Unknown heading — close the current section so stray bullets don't
-      // get attached to a previous, unrelated section.
-      current = null;
-      currentBullet = null;
-      continue;
-    }
-
-    if (!current) continue;
-
-    if (line.startsWith("- ")) {
-      // New bullet; flush the running bullet reference.
-      const prMatch = line.match(/\(see PR \[#(\d+)\]\(([^)]+)\)\)/);
-      const prNumber = prMatch ? prMatch[1] : null;
-      const prUrl = prMatch ? prMatch[2] : null;
-
-      let text = line.slice(2);
-      if (prMatch) {
-        text = text.slice(0, prMatch.index - 2).trim();
-      }
-      text = text.replace(/\s*-\s*See\s+\[.*$/, "").trim();
-      text = text.replace(/\.+$/, "").trim();
-
-      const linkSuffix = line.slice(
-        prMatch ? prMatch.index + prMatch[0].length : 0,
-      );
-      const isBreaking = /\[breaking changes\]/i.test(linkSuffix);
-      const isApi = /\[API changes\]/i.test(linkSuffix);
-      const isModels = /\[model changes\]/i.test(linkSuffix);
-
-      currentBullet = {
-        text,
-        prNumber,
-        prUrl,
-        isBreaking,
-        isApi,
-        isModels,
-        continuation: [],
-      };
-      current.bullets.push(currentBullet);
-      continue;
-    }
-
-    // Indented continuation line (markdown convention: 2+ leading spaces or
-    // tab under the bullet). Preserve trimmed content so the announcement
-    // formatter can re-indent for Slack.
-    if (currentBullet && /^(\s{2,}|\t)/.test(line) && line.trim().length > 0) {
-      currentBullet.continuation.push(line.trim());
-      continue;
-    }
-
-    // Blank line or other content — close the running bullet so subsequent
-    // indented text doesn't accidentally attach to an unrelated bullet.
-    if (line.trim().length === 0) {
-      currentBullet = null;
-    }
-  }
-
-  return out;
-}
-
-/**
- * Format a single bullet for the Slack announcement post.
- *
- * Continuation lines (e.g. `Added: …` / `Removed: …` for [mod] PRs) are
- * preserved as separate lines indented by two spaces under the bullet.
- *
- * @param {{
- *   text: string,
- *   prUrl: string|null,
- *   isBreaking: boolean,
- *   continuation?: string[],
- * }} bullet
- * @returns {string}
- */
-function formatAnnouncementBullet(bullet) {
-  let line = `• ${bullet.text}`;
-  if (bullet.prUrl) line += ` (<${bullet.prUrl}>)`;
-  if (bullet.isBreaking) line += ` :boom: breaking`;
-
-  if (bullet.continuation && bullet.continuation.length > 0) {
-    for (const cont of bullet.continuation) {
-      line += `\n  ${cont}`;
-    }
-  }
-
-  return line;
-}
-
-/**
- * Generate `announcement-post.txt` from a per-version CHANGELOG.md.
- *
- * The output is plaintext sized to be copy-pasted into Slack: shortcode
- * emojis, `<url>` link wrapping (suppresses Slack unfurl), bullet rows kept
- * on a single line, sections capped at MAX_ANNOUNCEMENT_BULLETS with an
- * "...And much more" suffix when truncated.
+ * Short Slack-ready plaintext: header, three links (NPM / GitHub release /
+ * full changelog tree), an optional breaking-changes block when `breaking.md`
+ * exists in the version folder, and a thanks footer. Per-section bullet lists
+ * are intentionally omitted — readers follow the full-changelog link for the
+ * detail.
  *
  * @param {string} packageName
  * @param {string} version
- * @returns {string|null} The output path on success, or null if CHANGELOG.md
- *   for the requested version wasn't found.
+ * @returns {string|null} The output path on success, or null if the version
+ *   folder doesn't exist yet (run the main generator first).
  */
 function generateAnnouncementPost(packageName, version) {
   const repoRoot = getRepoRoot();
@@ -1071,17 +943,11 @@ function generateAnnouncementPost(packageName, version) {
     "changelog",
     version,
   );
-  const changelogPath = path.join(versionDir, "CHANGELOG.md");
 
-  if (!fs.existsSync(changelogPath)) {
-    console.warn(`⚠️ No CHANGELOG.md found at ${changelogPath}`);
+  if (!fs.existsSync(versionDir)) {
+    console.warn(`⚠️ No changelog directory found at ${versionDir}`);
     return null;
   }
-
-  const markdown = fs.readFileSync(changelogPath, "utf8");
-  const parsed = parseChangelogMarkdown(markdown);
-  const releaseDate =
-    parsed.releaseDate || new Date().toISOString().split("T")[0];
 
   const repoUrl = "https://github.com/tetherto/qvac";
   const npmName = `@qvac/${packageName}`;
@@ -1091,49 +957,21 @@ function generateAnnouncementPost(packageName, version) {
   const releaseTagUrl = `${repoUrl}/releases/tag/${tagName}`;
   const npmUrl = `https://www.npmjs.com/package/${npmName}/v/${version}`;
 
-  const hasBreaking = parsed.sections.some((s) =>
-    s.bullets.some((b) => b.isBreaking),
-  );
+  // The breaking-changes block only appears when there are breaking PRs.
+  // `breaking.md` is only written by `generateChangelogFiles` when at least
+  // one PR carries the [bc] tag, so its presence on disk is the authoritative
+  // signal — no need to re-parse CHANGELOG.md to figure it out.
+  const hasBreaking = fs.existsSync(path.join(versionDir, "breaking.md"));
 
   let post = "";
-
-  // Header
   post += `:qvac: SDK ${version} :rocket: NPM Public release\n\n`;
-
-  // Links
   post += `:package: NPM: ${npmUrl}\n`;
   post += `:technologist: Github release: ${releaseTagUrl}\n`;
   post += `:page_facing_up: Full Changelog: ${changelogTreeUrl}\n\n`;
 
-  // Breaking
   if (hasBreaking) {
     post += `:warning: Breaking Changes\n`;
     post += `See full migration guide: ${breakingMdUrl}\n\n`;
-  }
-
-  post += `Release Date: ${releaseDate}\n\n`;
-
-  // Sections — preserve the canonical order from SECTIONS, render only the
-  // ones that have bullets in the parsed changelog.
-  for (const section of SECTIONS) {
-    const heading = SLACK_SECTION_HEADINGS[section.key];
-    if (!heading) continue;
-
-    const matched = parsed.sections.find((s) => s.key === section.key);
-    if (!matched || matched.bullets.length === 0) continue;
-
-    post += `${heading}\n`;
-
-    const shown = matched.bullets.slice(0, MAX_ANNOUNCEMENT_BULLETS);
-    for (const bullet of shown) {
-      post += formatAnnouncementBullet(bullet) + "\n";
-    }
-
-    if (matched.bullets.length > MAX_ANNOUNCEMENT_BULLETS) {
-      post += `... And much more, see full list in changelog :memo:\n`;
-    }
-
-    post += "\n";
   }
 
   post += `Thanks to everyone on QVAC team :green_heart: :qvac: :green_heart:\n`;
@@ -1232,7 +1070,7 @@ async function main() {
 
     // Apply SDK-specific validation and filtering
     console.log("🔍 Validating PR formats...");
-    const validPRs = processSDKPRs(data.prs);
+    const validPRs = processSDKPRs(data.prs, packageName);
 
     console.log(`\n✅ ${validPRs.length} valid PRs for changelog\n`);
 
@@ -1273,7 +1111,6 @@ module.exports = {
   generateChangelogEntry,
   generateChangelogFiles,
   processSDKPRs,
-  parseChangelogMarkdown,
   generateAnnouncementPost,
   SECTIONS,
 };


### PR DESCRIPTION
## Companion release PR

- https://github.com/tetherto/qvac/pull/2090

This PR lands the same release metadata on `main` per [gitflow.md](../docs/gitflow.md) "Keep main aligned". Content is identical to PR #2090 (same single cherry-picked commit). Tagged `[skiplog]` so it does not appear in future changelogs.

---

## 🎯 What problem does this PR solve?

`@qvac/sdk` is ready to cut **v0.11.0**. 29 PRs have landed on `main` between the `sdk-v0.10.0` tag and the current `release-sdk-0.11.0` tip (`e282e704`), and the package version bump + changelog set need to land on the release branch so the publish workflow can ship to npm.

The release completes the request-lifecycle and cancellation overhaul that began in 0.10.0: every long-running SDK call now flows through a unified `RequestRegistry`, exposes its `requestId` synchronously on the returned promise, and can be cancelled individually with `cancel({ requestId })`. The `cancel(...)` wire envelope is consolidated to two shapes, two legacy call signatures are removed (`cancel({operation:"downloadAsset", downloadKey})` and `cancel({operation:"rag", workspace})`), and the SDK gains typed `instanceof` for policy/cancel errors across the RPC boundary.

Alongside the lifecycle work the release adds: Harmony / Qwen3.5 / Gemma4 tool-call dialects, FLUX.2 multi-reference fusion + per-call LoRA on diffusion, ESRGAN upscaling (post-step + standalone `upscale()` API), Whisper VAD + end-of-turn events, multi-GPU `split-mode` / `tensor-split` / `main-gpu` on LLM and embed, a `reasoning_budget` knob for thinking models, and a Parakeet 0.4.0 GGUF backend with duplex streaming.

Full per-PR breakdown in [`changelog/0.11.0/CHANGELOG.md`](./packages/sdk/changelog/0.11.0/CHANGELOG.md); human-readable narrative in [`CHANGELOG_LLM.md`](./packages/sdk/changelog/0.11.0/CHANGELOG_LLM.md); breaking-change migration guides in [`breaking.md`](./packages/sdk/changelog/0.11.0/breaking.md); API code samples in [`api.md`](./packages/sdk/changelog/0.11.0/api.md).

## 📝 How does it solve it?

**Release metadata:**

- Bump `packages/sdk/package.json` from `0.10.2` to `0.11.0`.
- Add `packages/sdk/changelog/0.11.0/` with:
  - `CHANGELOG.md` — sectioned entries (✨ Features, 🔌 API, 🐞 Fixes, 📦 Models, 🧪 Tests, 🧹 Chores, ⚙️ Infrastructure), one bullet per valid PR (29 total after filtering [skiplog] / invalid-format / revert / exclusion-listed).
  - `breaking.md` — auto-extracted BEFORE/AFTER for the three `[bc]` PRs (#2018 parakeet GGUF migration, #2024 `unloadModel` `autoClose`, #2074 cancel-shape removals).
  - `api.md` — auto-extracted code samples for the 13 `[api]` PRs.
  - `models.md` — added/removed model constants (Parakeet GGUF additions, Marian Opus NMT removals).
  - `CHANGELOG_LLM.md` — hand-authored narrative release notes following the v0.10.0 shape.
- Rebuild the root `packages/sdk/CHANGELOG.md` aggregate (15 versions, 0.11.0 first; prefers per-version `CHANGELOG_LLM.md`).
- Regenerate `packages/sdk/NOTICE` against the current `packages/sdk` production dependency tree (178 JS deps + 209 models).

**Tooling improvements bundled with the release** (surfaced during changelog generation, kept together for a single release-line touch — see "🧪 How was it tested?" for the specific failure modes that motivated each):

- `scripts/sdk/generate-changelog-sdk-pod.cjs`:
  - **Crash guard** — `processSDKPRs` no longer throws `Cannot read properties of undefined (reading 'tags')` when a PR title matches a validator exception (`Merge` / `Revert` / `Squash` / version-bump / `release(...)`). Previously fatal; now warned and skipped. Triggered in this release by PR #2059 (`Revert qvac 17869 parakeet ggml`).
  - **Per-package PR exclusion table** (`EXCLUDED_PRS`) for already-merged cross-cutting chores that incidentally touch a package path. Seeded with `sdk.1860` (monorepo-wide path simplification across 26+ packages — only incidentally touched `packages/sdk` via a test executor and a historical changelog doc).
  - **Short `announcement-post.txt` format** — `generateAnnouncementPost` rewritten to emit a Slack-ready post containing header + 3 links + optional breaking-changes block + thanks footer, matching the team's new convention (mirrors the 0.10.0 Slack post). Dropped ~180 lines of dead helpers (`parseChangelogMarkdown`, `formatAnnouncementBullet`, `CHANGELOG_HEADING_TO_KEY`, `SLACK_SECTION_HEADINGS`, `MAX_ANNOUNCEMENT_BULLETS`). Breaking-changes detection now keys on `breaking.md` file presence (structurally direct — if there's a migration guide, link to it) instead of re-parsing CHANGELOG.md.
- `.cursor/skills/sdk-changelog/SKILL.md` — Step 5 updated to document the new short format and the file-presence detection contract.

## 🧪 How was it tested?

- `node scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk` — exited cleanly after the bypass-validation crash guard + #1860 exclusion landed; fetched all 47 candidate PRs, filtered to 29 valid, generated `CHANGELOG.md` / `breaking.md` / `api.md` / `models.md` and rebuilt the root aggregate.
- `node scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk --update-root-changelog` — picked up the hand-authored `CHANGELOG_LLM.md` and re-rendered the root aggregate (root prefers LLM file when present).
- `node scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk --generate-announcement-post` — emits the new short format. Cross-validated against the v0.10.0 Slack post screenshot: header / 3 links / breaking-changes block (gated on `breaking.md` presence) / footer. Smoke-tested the no-breaking branch by re-generating against v0.9.1 (which has no `breaking.md`) — confirmed the breaking-changes block is correctly skipped.
- `node .cursor/skills/notice-generate/scripts/generate-notice.js sdk` — license-checker against `packages/sdk/node_modules` (178 production JS deps) + model attributions from `models.prod.json` (209 models). Sorted deterministically; re-runs produce byte-identical output.
- Two PRs hit format-validator warnings and were surfaced but not blocked (per skill: "warned, not silently dropped"): #1948 (`[mod]` tag requires a Models section in the body — missing) and #1999 (extra space before colon in title). Both excluded from the changelog with explicit warnings; will be flagged to PR authors for fix-and-backport if desired.
- No source-code changes in `packages/sdk/` itself — release content + tooling improvements only.

## 💥 Breaking Changes

Three `[bc]` PRs are folded into this release (full BEFORE/AFTER in [`changelog/0.11.0/breaking.md`](./packages/sdk/changelog/0.11.0/breaking.md)):

1. **`unloadModel` no longer auto-closes the Bare worker** (#2024). Default `autoClose` flips by runtime: `true` on Node/Electron (unchanged behaviour), `false` on Bare. Pass `autoClose: true | false` to override explicitly.
2. **Parakeet plugin moves to the 0.4.0 single-file GGUF API** (#2018). Multi-file `parakeet*Src` config fields removed; the addon auto-detects TDT / CTC / EOU / Sortformer from GGUF metadata. Legacy multi-file constants (`PARAKEET_TDT_ENCODER_INT8`, `PARAKEET_TDT_DECODER_INT8`, etc.) replaced by single GGUF constants (`PARAKEET_TDT_0_6B_V3_Q8_0`, `PARAKEET_CTC_0_6B_Q8_0`, `PARAKEET_SORTFORMER_4SPK_V1_Q8_0`, `PARAKEET_EOU_120M_V1_Q8_0`).
3. **Two legacy `cancel(...)` call shapes removed** (#2074). `cancel({operation:"downloadAsset", downloadKey, clearCache})` and `cancel({operation:"rag", workspace})` removed because neither carried a `requestId`. Migrate to `cancel({requestId: op.requestId})` via the decorated promise (primary path) or `cancel({modelId, kind: "rag"})` broad-cancel (escape hatch). Every other `cancel(...)` shape is preserved by client-side normalization.

## 🔌 API Changes

13 `[api]` PRs land on the public SDK surface — full per-PR code samples in [`changelog/0.11.0/api.md`](./packages/sdk/changelog/0.11.0/api.md). Highlights:

- **Request lifecycle + per-request cancel** (#1949, #2007, #2036, #2058, #2060, #2074) — every long-running call (`completion`, `loadModel`, `embed`, `transcribe`, `transcribeStream`, `translate`, `finetune`, `downloadAsset`, and the three cancellable RAG ops) returns a decorated promise with synchronously-readable `requestId`. New `RequestRejectedByPolicyError` (52420) and `InferenceCancelledError` (52419) round-trip across the RPC boundary with their typed fields intact.
- **Multi-GPU support on LLM + embed** (#1759) — `split-mode`, `tensor-split`, `main-gpu` on LLM (hyphenated); `splitMode`, `tensorSplit`, `mainGpu` on embed (camelCase).
- **Diffusion enhancements** (#1838, #1930, #1990) — FLUX.2 multi-reference fusion (`init_images: Uint8Array[]`), per-call LoRA, ESRGAN as post-step or standalone `upscale()` API.
- **Whisper VAD + end-of-turn events** (#1848) — `transcribeStream({ emitVadEvents: true })` opt-in mode yields a discriminated event stream with live VAD probabilities + turn boundaries.
- **New tool-call dialects** (#1878, #1974) — Harmony (GPT-OSS), Qwen3.5 Pythonic-XML, Gemma4 native; `reasoning_budget` knob for thinking models.
- **Standalone CLI bundle verification** (#2000) — Expo prebuild now runs `qvac verify bundle` against the worker bundle before the SDK `dist/` copy; new `BundleVerificationFailedError` (50609).
