### PR TITLE
infra[notask]: clean qvac self-hosted workspace before checkout

### DIFF
--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -70,6 +70,7 @@ jobs:
 
       # - name: Setup LLVM
       #   uses: tetherto/qvac/.github/actions/setup-llvm@0c819dd1110e4902223b1f7646cc0f1be2c9bc5c
+      - uses: AutoModality/action-clean@v1
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -70,7 +70,8 @@ jobs:
 
       # - name: Setup LLVM
       #   uses: tetherto/qvac/.github/actions/setup-llvm@0c819dd1110e4902223b1f7646cc0f1be2c9bc5c
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -72,6 +72,7 @@ jobs:
       #   uses: tetherto/qvac/.github/actions/setup-llvm@0c819dd1110e4902223b1f7646cc0f1be2c9bc5c
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
@@ -50,6 +50,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
@@ -48,6 +48,8 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg/cache,readwrite"
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
@@ -48,7 +48,8 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg/cache,readwrite"
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
@@ -37,6 +37,8 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg/cache,readwrite"
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
@@ -37,7 +37,8 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg/cache,readwrite"
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
@@ -50,6 +50,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
@@ -48,6 +48,8 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg/cache,readwrite"
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
@@ -48,7 +48,8 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg/cache,readwrite"
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-tts-ggml.yml
+++ b/.github/workflows/cpp-test-coverage-tts-ggml.yml
@@ -42,6 +42,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-tts-ggml.yml
+++ b/.github/workflows/cpp-test-coverage-tts-ggml.yml
@@ -40,6 +40,8 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg/cache,readwrite"
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-test-coverage-tts-ggml.yml
+++ b/.github/workflows/cpp-test-coverage-tts-ggml.yml
@@ -40,7 +40,8 @@ jobs:
       VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg/cache,readwrite"
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-tts-onnx.yml
+++ b/.github/workflows/cpp-test-coverage-tts-onnx.yml
@@ -63,7 +63,8 @@ jobs:
       WORKDIR: ${{ inputs.workdir || github.event.inputs.workdir || 'packages/tts-onnx' }}
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-tts-onnx.yml
+++ b/.github/workflows/cpp-test-coverage-tts-onnx.yml
@@ -65,6 +65,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-tts-onnx.yml
+++ b/.github/workflows/cpp-test-coverage-tts-onnx.yml
@@ -63,6 +63,8 @@ jobs:
       WORKDIR: ${{ inputs.workdir || github.event.inputs.workdir || 'packages/tts-onnx' }}
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -58,6 +58,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -56,6 +56,8 @@ jobs:
       GIT_TERMINAL_PROMPT: "0"
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -56,7 +56,8 @@ jobs:
       GIT_TERMINAL_PROMPT: "0"
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -81,6 +81,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -79,7 +79,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -79,6 +79,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -58,6 +58,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -56,6 +56,8 @@ jobs:
       GIT_TERMINAL_PROMPT: "0"
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -56,7 +56,8 @@ jobs:
       GIT_TERMINAL_PROMPT: "0"
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -78,7 +78,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -80,6 +80,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -78,6 +78,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -96,6 +96,8 @@ jobs:
           else
             echo "Prebuild source: workflow artifacts (current run)"
           fi
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -98,6 +98,7 @@ jobs:
           fi
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout addon repository

--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -96,7 +96,8 @@ jobs:
           else
             echo "Prebuild source: workflow artifacts (current run)"
           fi
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout addon repository

--- a/.github/workflows/integration-mobile-test-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-decoder-audio.yml
@@ -84,7 +84,8 @@ jobs:
           sudo apt-get clean || true
           echo "Disk space after cleanup:"
           df -h
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout monorepo (addon package lives under workdir)

--- a/.github/workflows/integration-mobile-test-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-decoder-audio.yml
@@ -84,6 +84,8 @@ jobs:
           sudo apt-get clean || true
           echo "Disk space after cleanup:"
           df -h
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout monorepo (addon package lives under workdir)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-decoder-audio.yml
@@ -86,6 +86,7 @@ jobs:
           df -h
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout monorepo (addon package lives under workdir)

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -56,6 +56,8 @@ jobs:
             runner: macos-14
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -56,7 +56,8 @@ jobs:
             runner: macos-14
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -58,6 +58,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-embed-llamacpp.yml
@@ -61,6 +61,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout monorepo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-embed-llamacpp.yml
@@ -59,7 +59,8 @@ jobs:
             runner: macos-14
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout monorepo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-embed-llamacpp.yml
@@ -59,6 +59,8 @@ jobs:
             runner: macos-14
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout monorepo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -94,6 +94,8 @@ jobs:
             echo "::error::Invalid package scope. Only @qvac/* is allowed."
             exit 1
           fi
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -94,7 +94,8 @@ jobs:
             echo "::error::Invalid package scope. Only @qvac/* is allowed."
             exit 1
           fi
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout addon repository

--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -96,6 +96,7 @@ jobs:
           fi
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout addon repository

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -64,6 +64,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository (monorepo)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -62,7 +62,8 @@ jobs:
             runner: macos-14
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository (monorepo)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -62,6 +62,8 @@ jobs:
             runner: macos-14
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository (monorepo)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/integration-mobile-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-transcription-parakeet.yml
@@ -92,6 +92,8 @@ jobs:
             runner: macos-14
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/integration-mobile-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-transcription-parakeet.yml
@@ -94,6 +94,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-transcription-parakeet.yml
@@ -92,7 +92,8 @@ jobs:
             runner: macos-14
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
@@ -62,7 +62,8 @@ jobs:
             os: macos-14
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
@@ -64,6 +64,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
@@ -62,6 +62,8 @@ jobs:
             os: macos-14
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
@@ -61,6 +61,8 @@ jobs:
             os: macos-14
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout monorepo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
@@ -61,7 +61,8 @@ jobs:
             os: macos-14
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout monorepo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
@@ -63,6 +63,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout monorepo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-tts-ggml.yml
+++ b/.github/workflows/integration-mobile-test-tts-ggml.yml
@@ -109,6 +109,8 @@ jobs:
             runner: macos-14
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/integration-mobile-test-tts-ggml.yml
+++ b/.github/workflows/integration-mobile-test-tts-ggml.yml
@@ -109,7 +109,8 @@ jobs:
             runner: macos-14
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-tts-ggml.yml
+++ b/.github/workflows/integration-mobile-test-tts-ggml.yml
@@ -111,6 +111,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-tts-onnx.yml
+++ b/.github/workflows/integration-mobile-test-tts-onnx.yml
@@ -70,6 +70,8 @@ jobs:
             runner: macos-14
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/integration-mobile-test-tts-onnx.yml
+++ b/.github/workflows/integration-mobile-test-tts-onnx.yml
@@ -70,7 +70,8 @@ jobs:
             runner: macos-14
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-tts-onnx.yml
+++ b/.github/workflows/integration-mobile-test-tts-onnx.yml
@@ -72,6 +72,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout addon repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-vla.yml
+++ b/.github/workflows/integration-mobile-test-vla.yml
@@ -102,6 +102,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout monorepo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-vla.yml
+++ b/.github/workflows/integration-mobile-test-vla.yml
@@ -100,7 +100,8 @@ jobs:
             runner: macos-14
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout monorepo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-mobile-test-vla.yml
+++ b/.github/workflows/integration-mobile-test-vla.yml
@@ -100,6 +100,8 @@ jobs:
             runner: macos-14
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout monorepo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -72,6 +72,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -72,7 +72,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -74,6 +74,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-decoder-audio.yml
+++ b/.github/workflows/integration-test-decoder-audio.yml
@@ -54,7 +54,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-decoder-audio.yml
+++ b/.github/workflows/integration-test-decoder-audio.yml
@@ -54,6 +54,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-decoder-audio.yml
+++ b/.github/workflows/integration-test-decoder-audio.yml
@@ -56,6 +56,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -86,6 +86,8 @@ jobs:
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "https://github.com/"
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "git@github.com:"
         shell: powershell
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -86,7 +86,8 @@ jobs:
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "https://github.com/"
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "git@github.com:"
         shell: powershell
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -88,6 +88,7 @@ jobs:
         shell: powershell
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -70,7 +70,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -70,6 +70,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -72,6 +72,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -133,6 +133,8 @@ jobs:
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "https://github.com/"
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "git@github.com:"
         shell: powershell
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -133,7 +133,8 @@ jobs:
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "https://github.com/"
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "git@github.com:"
         shell: powershell
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -135,6 +135,7 @@ jobs:
         shell: powershell
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-ocr-onnx.yml
+++ b/.github/workflows/integration-test-ocr-onnx.yml
@@ -74,7 +74,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-ocr-onnx.yml
+++ b/.github/workflows/integration-test-ocr-onnx.yml
@@ -74,6 +74,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-ocr-onnx.yml
+++ b/.github/workflows/integration-test-ocr-onnx.yml
@@ -76,6 +76,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-test-transcription-parakeet.yml
@@ -81,7 +81,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-test-transcription-parakeet.yml
@@ -83,6 +83,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-test-transcription-parakeet.yml
@@ -81,6 +81,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -112,7 +112,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -114,6 +114,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -112,6 +112,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-test-translation-nmtcpp.yml
@@ -69,6 +69,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-test-translation-nmtcpp.yml
@@ -69,7 +69,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-test-translation-nmtcpp.yml
@@ -71,6 +71,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -101,7 +101,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -101,6 +101,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -103,6 +103,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-tts-onnx.yml
+++ b/.github/workflows/integration-test-tts-onnx.yml
@@ -159,6 +159,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-tts-onnx.yml
+++ b/.github/workflows/integration-test-tts-onnx.yml
@@ -159,7 +159,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-tts-onnx.yml
+++ b/.github/workflows/integration-test-tts-onnx.yml
@@ -161,6 +161,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -75,7 +75,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -75,6 +75,8 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -77,6 +77,7 @@ jobs:
           node-version: lts/*
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout code

--- a/.github/workflows/pr-test-inference-addon-cpp-js.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp-js.yml
@@ -96,6 +96,8 @@ jobs:
         shell: bash
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/pr-test-inference-addon-cpp-js.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp-js.yml
@@ -98,6 +98,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/pr-test-inference-addon-cpp-js.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp-js.yml
@@ -96,7 +96,8 @@ jobs:
         shell: bash
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/pr-test-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp.yml
@@ -92,10 +92,12 @@ jobs:
             arch: x64
             runner: qvac-win25-x64
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/pr-test-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp.yml
@@ -98,6 +98,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/pr-test-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp.yml
@@ -96,7 +96,8 @@ jobs:
     name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
 
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
@@ -29,7 +29,8 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
@@ -29,6 +29,7 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
+      - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -178,6 +178,8 @@ jobs:
       - name: Setup LLVM (Linux arm and macOS)
         if: matrix.arch == 'arm64' || matrix.os == 'macos-15' || matrix.os == 'macos-15-intel'
         uses: tetherto/qvac/.github/actions/setup-llvm@0c819dd1110e4902223b1f7646cc0f1be2c9bc5c
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -178,7 +178,8 @@ jobs:
       - name: Setup LLVM (Linux arm and macOS)
         if: matrix.arch == 'arm64' || matrix.os == 'macos-15' || matrix.os == 'macos-15-intel'
         uses: tetherto/qvac/.github/actions/setup-llvm@0c819dd1110e4902223b1f7646cc0f1be2c9bc5c
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout repository

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -180,6 +180,7 @@ jobs:
         uses: tetherto/qvac/.github/actions/setup-llvm@0c819dd1110e4902223b1f7646cc0f1be2c9bc5c
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.runner, 'qvac-')
 
       - name: Checkout repository

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -118,7 +118,8 @@ jobs:
       MQTT_USERNAME: ${{ secrets.MQTT_USERNAME }}
       MQTT_PASSWORD: ${{ secrets.MQTT_PASSWORD }}
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -120,6 +120,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -118,6 +118,7 @@ jobs:
       MQTT_USERNAME: ${{ secrets.MQTT_USERNAME }}
       MQTT_PASSWORD: ${{ secrets.MQTT_PASSWORD }}
     steps:
+      - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -136,7 +136,8 @@ jobs:
       MQTT_USERNAME: ${{ secrets.MQTT_USERNAME }}
       MQTT_PASSWORD: ${{ secrets.MQTT_PASSWORD }}
     steps:
-      - uses: AutoModality/action-clean@v1
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         if: startsWith(matrix.os, 'qvac-')
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -136,6 +136,8 @@ jobs:
       MQTT_USERNAME: ${{ secrets.MQTT_USERNAME }}
       MQTT_PASSWORD: ${{ secrets.MQTT_PASSWORD }}
     steps:
+      - uses: AutoModality/action-clean@v1
+        if: startsWith(matrix.os, 'qvac-')
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -138,6 +138,7 @@ jobs:
     steps:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
         if: startsWith(matrix.os, 'qvac-')
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:


### PR DESCRIPTION
## What problem does this PR solve?

Self-hosted `qvac-*` runners can retain leftover workspace state between jobs (build artifacts, partial checkouts, caches), which causes flaky or misleading CI failures on subsequent runs.

## How does it solve it?

- Adds `AutoModality/action-clean@v1` immediately before the first `actions/checkout` step in workflows that run on `qvac-*` self-hosted runners.
- Uses `if: startsWith(matrix.runner, 'qvac-')` (or `matrix.os` where runner labels are passed via the desktop SDK matrix) on mixed matrices so GitHub-hosted and macOS entries are unaffected.
- Updates `pr-test-inference-addon-cpp.yml` to use `runs-on: ${{ matrix.runner || matrix.os }}` so matrix `runner: qvac-*` entries actually schedule on the self-hosted pool.

Touched workflows: prebuilds, cpp lint/tests/coverage, integration and mobile integration suites, SDK android/desktop test jobs, and related PR test pipelines (40 workflow files).

## Breaking changes

None.
