### PR TITLE
infra: gate bare global npm installs in LLM and VLA CI workflows

### DIFF
--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -141,6 +141,10 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         run: |
           npm install
+
+      - name: Install bare tooling (macos)
+        if: matrix.platform == 'darwin'
+        run: |
           npm install -g bare bare-make
 
       - name: Download test models

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -122,6 +122,10 @@ jobs:
         shell: bash
         run: |
           npm install
+
+      - name: Install bare tooling (macos)
+        if: matrix.platform == 'darwin'
+        run: |
           npm install -g bare bare-make
 
       - if: ${{ matrix.os == 'ubuntu-24.04' }}

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -147,6 +147,11 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         run: |
           npm install
+
+
+      - name: Install bare tooling (macos and arm64 linux)
+        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
+        run: |
           npm install -g bare bare-make bare-runtime bare-https brittle
 
       - name: Download prebuilds (from artifacts)


### PR DESCRIPTION
## Summary

- Split `npm install -g bare bare-make` (and related packages for VLA integration) into dedicated steps so they no longer run on every CI matrix cell.
- **cpp-tests-llm** and **cpp-tests-vla**: install global bare tooling only on `darwin` (macOS self-hosted runners).
- **integration-test-vla**: install global bare tooling only on `darwin` or `arm64` Linux, matching other integration workflows.

Self-hosted Linux runners already have bare tooling available; unconditional global npm installs were redundant and could cause conflicts on those runners.

## Test plan

- [ ] Trigger `cpp-tests-llm` on macOS and Linux matrix and confirm bare steps run only on darwin
- [ ] Trigger `cpp-tests-vla` on macOS and Linux matrix and confirm bare steps run only on darwin
- [ ] Trigger `integration-test-vla` and confirm global bare install runs on macOS and arm64 Linux, not on x64 Linux
