### PR TITLE
QVAC-19135 fix[bc]: widen react-native-bare-kit peer to ^0.14.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -215,7 +215,7 @@
     "hyperdb": "^4.16.1",
     "pear-pipe": "^1.0.6",
     "prettier": "^3.6.2",
-    "react-native-bare-kit": "0.12.3",
+    "react-native-bare-kit": "^0.14.0",
     "remark-cli": "^12.0.1",
     "remark-code-import": "^1.2.0",
     "remark-frontmatter": "^5.0.0",
@@ -258,7 +258,7 @@
     "hyperswarm": "^4.14.0",
     "llm-splitter": "~0.2.0",
     "pear-pipe": "^1.0.6",
-    "react-native-bare-kit": "0.12.3",
+    "react-native-bare-kit": "^0.14.0",
     "tar-stream": "^3.1.8"
   },
   "peerDependenciesMeta": {

--- a/packages/sdk/tests-qvac/package.json
+++ b/packages/sdk/tests-qvac/package.json
@@ -19,7 +19,7 @@
     "@tetherto/qvac-test-suite": "^0.6.3",
     "mqtt": "^5.14.1",
     "react-native": "0.81.5",
-    "react-native-bare-kit": "0.12.3"
+    "react-native-bare-kit": "^0.14.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Consumers using `@qvac/sdk@^0.11.0` together with `cross-worker-bare-kit@^2.0.0` (used by Keet) cannot install. `npm install` fails with `ERESOLVE`: the SDK pins `react-native-bare-kit` to exact `0.12.3` as `peerOptional`, while `cross-worker-bare-kit@2.x` requires `react-native-bare-kit@^0.14.0`. The `optional` flag does not bypass the constraint once another package brings the peer in.

## 📝 How does it solve it?

- Widen the `react-native-bare-kit` peer (and matching dev-dependency) in `packages/sdk/package.json` from `0.12.3` to `^0.14.0`, plus the same bump in `packages/sdk/tests-qvac/package.json` to keep the test consumer aligned.
- API-safe: the SDK only uses the `Worklet` constructor, `start(filename, source, args)`, `IPC`, and `terminate()`, all unchanged between `react-native-bare-kit` 0.12.3 and 0.14.1. The only diff in `index.d.ts` is `WorkletEvents` payloads (`suspend`/`wakeup` now carry args, `idle` added, `start`/`terminate` events removed), and the SDK does not subscribe to those events.
- Vendored Expo plugin overlays (`expo/plugins/patches/{ios,android}-link.mjs`) still align — upstream `link.mjs` is byte-identical between 0.12.3 and 0.14.1.

## 🧪 How was it tested?

**Install resolution**

- Reproduced the original `ERESOLVE` in a sandbox MRE (`@qvac/sdk@0.11.0` + `cross-worker-bare-kit@^2.0.0` → install fails).
- Repackaged `@qvac/sdk@0.11.0` with the peer widened to `^0.14.0`, installed in the same MRE → resolves cleanly, `react-native-bare-kit@0.14.1` deduped under both `@qvac/sdk` and `cross-worker-bare-kit@2.0.1` peers, no `--legacy-peer-deps` needed.

**Mobile E2E — local (Pixel 9 Pro, Android 0.14.1 worklet bootstrap)**

- `npx qvac-test run:local:android --filter config` on a Pixel 9 Pro device:
  - 8/8 passed, 33.7s, 100% success rate
  - Covered tests: `config-reload-whisper-language`, `config-reload-whisper-params`, `config-reload-preserves-id`, `config-reload-invalid-model-id`, `config-reload-wrong-model-type`, `config-reload-then-transcribe`, `config-registry-download-smoke`, `config-registry-download-respects-cancel`
  - Exercises the changed code path: full Bare worklet boot through `react-native-bare-kit@0.14.x`, RPC IPC roundtrips, config reload, transcription, and registry download/cancel — all green.

**CI smoke E2E (`test-e2e-smoke` label, all platforms)**

| Platform | Pass / Total | Duration | Skipped |
|---|---|---|---|
| windows | 91/91 | 429s | 0 |
| linux | 91/91 | 353s | 0 |
| macos | 91/91 | 345s | 0 |
| android | 83/91 | 2273s | 8 (platform-skips, not failures) |
| ios | 82/91 | 919s | 9 (platform-skips, not failures) |

Mobile skips correspond to `SkipExecutor` entries in `tests/mobile/consumer.ts` (e.g. `no-lingering-bare-*` lifecycle tests intentionally desktop-only); no test failed.

## 💥 Breaking Changes

Existing Expo apps pinned to `react-native-bare-kit@0.12.3` need to bump to `^0.14.0`.

**BEFORE:**

```json
// consumer package.json
{
  "dependencies": {
    "@qvac/sdk": "^0.11.0",
    "react-native-bare-kit": "0.12.3"
  }
}
```

**AFTER:**

```json
// consumer package.json
{
  "dependencies": {
    "@qvac/sdk": "^0.12.0",
    "react-native-bare-kit": "^0.14.0"
  }
}
```

Public docs (`docs/website/content/docs/installation.mdx`, `tutorials/expo.mdx`) currently mention `^0.11.5` and will be updated in a follow-up docs-only PR.

---

Asana: https://app.asana.com/1/45238840754660/project/1214153063536860/task/1214938146429581 (attached to QVAC SDK Release 0.12.0; requested by Keet)
