### PR TITLE
infra[notask]: use setup-node and global bare install on all CI platforms

### DIFF
--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -102,12 +102,13 @@ jobs:
           rm -rf $VCPKG_ROOT/buildtrees/*
           rm -rf $VCPKG_ROOT/packages/*
 
-      # - name: Setup Bare tooling
-      #   uses: tetherto/qvac/.github/actions/setup-bare-tooling@0bbdca93da303a0b1634ba14a89cec085621078d
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
 
-      - name: Add bare tooling to PATH
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
-
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       # - if: ${{ inputs.include-vulkan-sdk }}
       #   name: Setup Vulkan SDK

--- a/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
@@ -60,15 +60,18 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           lfs: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
+
       - name: Install NPM dependencies
         working-directory: ${{ env.WORKDIR }}
         run: |
           npm install
-          # npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
           
       - if: ${{ matrix.os == 'ubuntu-22.04' }}
         name: Configure vcpkg in linux

--- a/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
@@ -65,15 +65,18 @@ jobs:
           path: ~/.cache/ccache
           restore-keys: ccache-cpp-coverage-parakeet-${{ matrix.platform }}-${{ matrix.arch }}-
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
+
       - name: Install NPM dependencies
         working-directory: ${{ env.PKG_DIR }}
         run: |
           npm install
-          # npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
           
       - if: ${{ matrix.os == 'ubuntu-22.04' }}
         name: Configure vcpkg in linux

--- a/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
@@ -60,11 +60,18 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           lfs: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
+
       - name: Install NPM dependencies
         working-directory: ${{ env.WORKDIR }}
         run: |
           npm install
-          # npm install -g bare bare-make
 
       - if: ${{ matrix.os == 'ubuntu-22.04' }}
         name: Configure vcpkg in linux
@@ -75,10 +82,6 @@ jobs:
         run: |
           rm -rf $VCPKG_ROOT/buildtrees/*
           rm -rf $VCPKG_ROOT/packages/*
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
 
       - name: Generate and build unit tests
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/cpp-test-coverage-tts-ggml.yml
+++ b/.github/workflows/cpp-test-coverage-tts-ggml.yml
@@ -68,15 +68,18 @@ jobs:
           path: ~/.cache/ccache
           restore-keys: ccache-cpp-coverage-tts-ggml-${{ matrix.platform }}-${{ matrix.arch }}-
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
+
       - name: Install NPM dependencies
         working-directory: ${{ env.PKG_DIR }}
         run: |
           npm install
-          # npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
           
       - if: ${{ matrix.os == 'ubuntu-22.04' }}
         name: Configure vcpkg in linux

--- a/.github/workflows/cpp-test-coverage-tts-onnx.yml
+++ b/.github/workflows/cpp-test-coverage-tts-onnx.yml
@@ -76,11 +76,18 @@ jobs:
           lfs: true
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
+
       - name: Install NPM dependencies
         working-directory: ${{ env.WORKDIR }}
         run: |
           npm install
-          # npm install -g bare bare-make
 
       - if: ${{ matrix.os == 'ubuntu-22.04' }}
         name: Configure vcpkg in linux
@@ -91,10 +98,6 @@ jobs:
         run: |
           rm -rf $VCPKG_ROOT/buildtrees/*
           rm -rf $VCPKG_ROOT/packages/*
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
 
       - name: Generate and build unit tests
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -136,7 +136,6 @@ jobs:
           restore-keys: cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch }}-
 
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -146,14 +145,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (macos)
-        if: matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: matrix.platform == 'linux'
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'macos-14' }}
         name: Download SD2 model for C++ tests

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -75,7 +75,6 @@ jobs:
           echo "workdir=$INPUT_WORKDIR"
 
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -97,14 +96,8 @@ jobs:
         run: |
           npm install
       
-      - name: Set Bare tooling on MacOS
-        if: matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: ${{ matrix.os == 'ubuntu-24.04' }}
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
 
       - if: ${{ matrix.os == 'windows-2025' }}

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -139,7 +139,6 @@ jobs:
           restore-keys: cpp-tests-v4-${{ matrix.platform }}-${{ matrix.arch || 'x64' }}-
 
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -149,10 +148,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (macos)
-        if: matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Download test models
         shell: bash

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -123,10 +123,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (macos)
-        if: matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - if: ${{ matrix.os == 'ubuntu-24.04' }}
         name: Set Vulkan SDK Path on Linux

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -68,7 +68,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -89,14 +88,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-decoder-audio.yml
+++ b/.github/workflows/integration-test-decoder-audio.yml
@@ -50,7 +50,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -71,14 +70,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Run integration test
         working-directory: ${{ inputs.workdir }}

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -75,7 +75,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -168,14 +167,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make bare-runtime bare-https brittle
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make bare-runtime bare-https brittle
 
       - run: mkdir -p ${{ runner.temp }}/qvac-diffusion-cpp
       - run: mkdir -p ${{ env.WORKDIR }}/prebuilds

--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -66,7 +66,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -87,14 +86,8 @@ jobs:
         run: |
           npm install
   
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Download prebuilds (from artifacts)
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -121,7 +121,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -156,14 +155,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make bare-runtime bare-https brittle
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make bare-runtime bare-https brittle
 
       - name: Download prebuilds (from artifacts)
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-ocr-onnx.yml
+++ b/.github/workflows/integration-test-ocr-onnx.yml
@@ -70,7 +70,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -92,14 +91,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-test-transcription-parakeet.yml
@@ -77,7 +77,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -98,14 +97,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - run: mkdir -p "${{ runner.temp }}/transcription-parakeet"
         shell: bash

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -108,7 +108,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -129,14 +128,8 @@ jobs:
         run: |
           npm install
       
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-test-translation-nmtcpp.yml
@@ -65,7 +65,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -86,14 +85,8 @@ jobs:
         run: |
           npm install
       
-      - name: Install Bare tooling on arm64 arch (ubuntu and mac)
-        if: ${{ matrix.arch == 'arm64' || matrix.platform == 'darwin' }}
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -97,7 +97,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -118,14 +117,8 @@ jobs:
         run: |
           npm install
   
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
 
       - run: mkdir -p "${{ runner.temp }}/tts-ggml"

--- a/.github/workflows/integration-test-tts-onnx.yml
+++ b/.github/workflows/integration-test-tts-onnx.yml
@@ -155,7 +155,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -182,14 +181,8 @@ jobs:
         run: |
           npm install
   
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}
@@ -331,7 +324,6 @@ jobs:
 
     steps:
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
@@ -407,14 +399,8 @@ jobs:
         run: |
           npm install
 
-      - name: Install bare tooling (arm64 and macos)
-        if: matrix.arch == 'arm64' || matrix.platform == 'darwin'
-        run: |
-          npm install -g bare bare-make
-
-      - name: Add bare tooling to PATH (Linux x64)
-        if: (matrix.platform == 'linux' && matrix.arch == 'x64')
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -149,10 +149,8 @@ jobs:
           npm install
 
 
-      - name: Install bare tooling (macos and arm64 linux)
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
-        run: |
-          npm install -g bare bare-make bare-runtime bare-https brittle
+      - name: Install bare tooling
+        run: npm install -g bare bare-make bare-runtime bare-https brittle
 
       - name: Download prebuilds (from artifacts)
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/pr-test-inference-addon-cpp-js.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp-js.yml
@@ -111,7 +111,6 @@ jobs:
           workdir: ${{ env.PKG_DIR }}
 
       - name: Setup Node.js
-        if: matrix.platform == 'darwin' || matrix.arch == 'arm64'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # 4.4.0
         with:
           node-version: 22

--- a/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
@@ -47,10 +47,9 @@ jobs:
       - name: Install NPM dependencies
         run: |
           npm install
-          # npm install -g bare bare-make
 
-      - name: Add bare tooling to PATH
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
+      - name: Install bare tooling
+        run: npm install -g bare bare-make
 
       - name: Configure vcpkg
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -213,13 +213,8 @@ jobs:
           rm -rf $VCPKG_ROOT/buildtrees/*
           rm -rf $VCPKG_ROOT/packages/*
 
-      - name: Setup Bare tooling (Linux ARM and macOS)
-        if: matrix.arch == 'arm64' || matrix.os == 'macos-15' || matrix.os == 'macos-15-intel'
+      - name: Setup Bare tooling
         uses: tetherto/qvac/.github/actions/setup-bare-tooling@0bbdca93da303a0b1634ba14a89cec085621078d
-
-      - name: Add linux x64 Bare tooling to PATH
-        if: matrix.os == 'ubuntu-22.04' && matrix.arch == 'x64'
-        run: echo "/usr/local/nvm/versions/node/v20.20.2/bin" >> $GITHUB_PATH
 
       - name: Setup Apple Clang
         uses: tetherto/qvac/.github/actions/setup-apple-clang@1d9b2165867d03c6edd675e402ee101a5d48a6d8


### PR DESCRIPTION
## What problem does this PR solve?

C++ test, integration, coverage, and prebuild workflows relied on a hardcoded NVM path (`/usr/local/nvm/versions/node/v20.20.2/bin`) for Linux x64 runners, while `actions/setup-node` and `npm install -g bare bare-make` were gated to macOS and/or arm64 only. That left Windows and Linux x64 without a consistent Node/bare toolchain.

## How does it solve it?

- Remove all "Add bare tooling to PATH" steps that appended the fixed NVM bin directory.
- Run `Setup Node.js` (`actions/setup-node`, `lts/*`) on every matrix OS/arch (Ubuntu 22.04/24.04 x64, Windows 2025, macOS, arm64).
- Run `npm install -g bare bare-make` (or the existing `setup-bare-tooling` composite in `reusable-prebuilds.yml`) unconditionally on all platforms.
- Add Node + bare install to coverage and `cpp-lint` workflows that previously only used the PATH hack.

Touched 25 workflows under `.github/workflows/`.

## Breaking changes

None.
