### PR TITLE
infra[notask]: add --force to global npm install -g in CI

### DIFF
--- a/.github/actions/cpp-lint/action.yaml
+++ b/.github/actions/cpp-lint/action.yaml
@@ -92,7 +92,7 @@ runs:
       continue-on-error: true
       shell: bash
       run: |
-        npm install -g bare-make
+        npm install -g --force bare-make
 
     - name: Install vulkan
       continue-on-error: true

--- a/.github/actions/run-lint-and-integration-tests/action.yaml
+++ b/.github/actions/run-lint-and-integration-tests/action.yaml
@@ -66,7 +66,7 @@ runs:
       run: npm run lint
     - name: Install bare globally
       shell: bash
-      run: npm install -g bare
+      run: npm install -g --force bare
     - name: Run integration tests
       shell: bash
       working-directory: ${{ inputs.workdir }}

--- a/.github/actions/run-lint-and-unit-tests/action.yaml
+++ b/.github/actions/run-lint-and-unit-tests/action.yaml
@@ -70,7 +70,7 @@ runs:
       working-directory: ${{ inputs.workdir }}
     - name: Install bare
       shell: bash
-      run: npm install -g bare
+      run: npm install -g --force bare
       working-directory: ${{ inputs.workdir }}
     - name: Run tests
       shell: bash

--- a/.github/actions/setup-bare-tooling/action.yml
+++ b/.github/actions/setup-bare-tooling/action.yml
@@ -21,4 +21,4 @@ runs:
 
     - name: Install global dependencies
       shell: bash
-      run: npm install -g bare-runtime bare-make ${{ inputs.extra-packages }}
+      run: npm install -g --force bare-runtime bare-make ${{ inputs.extra-packages }}

--- a/.github/actions/setup-bare/action.yaml
+++ b/.github/actions/setup-bare/action.yaml
@@ -6,4 +6,4 @@ runs:
   steps:
     - name: Install Bare
       shell: bash
-      run: npm install -g bare-runtime bare-make
+      run: npm install -g --force bare-runtime bare-make

--- a/.github/workflows/benchmark-chatterbox-tts-onnx.yml
+++ b/.github/workflows/benchmark-chatterbox-tts-onnx.yml
@@ -118,8 +118,8 @@ jobs:
 
       - name: Install Bare runtime
         run: |
-          npm install -g bare-dev
-          npm install -g bare bare-make
+          npm install -g --force bare-dev
+          npm install -g --force bare bare-make
 
       - name: Determine addon version
         id: version

--- a/.github/workflows/benchmark-embed-llamacpp.yml
+++ b/.github/workflows/benchmark-embed-llamacpp.yml
@@ -241,7 +241,7 @@ jobs:
           cache-dependency-path: ${{ env.WORKDIR }}/benchmarks/client/requirements.txt
 
       - name: Install bare runtime
-        run: npm install -g bare
+        run: npm install -g --force bare
 
       - name: Get vcpkg cache (monorepo)
         if: inputs.addon_version == ''
@@ -270,7 +270,7 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/CodeQL /opt/ghc /usr/share/dotnet /usr/local/lib/android || true
           df -h
 
-          npm install -g bare-make
+          npm install -g --force bare-make
 
           # Configure vcpkg
           echo "VCPKG_INSTALLATION_ROOT=$VCPKG_INSTALLATION_ROOT"

--- a/.github/workflows/benchmark-llm-llamacpp.yml
+++ b/.github/workflows/benchmark-llm-llamacpp.yml
@@ -292,7 +292,7 @@ jobs:
 
       - name: Install bare runtime
         working-directory: ${{ inputs.workdir }}
-        run: npm install -g bare
+        run: npm install -g --force bare
 
       - name: Get vcpkg cache
         if: inputs.addon_version == ''
@@ -318,7 +318,7 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/CodeQL /opt/ghc /usr/share/dotnet /usr/local/lib/android
           df -h
 
-          npm install -g bare-make
+          npm install -g --force bare-make
 
           echo "VCPKG_INSTALLATION_ROOT=$VCPKG_INSTALLATION_ROOT"
           if [ -n "${VCPKG_INSTALLATION_ROOT:-}" ] && [ -d "$VCPKG_INSTALLATION_ROOT" ]; then

--- a/.github/workflows/benchmark-ocr-onnx.yml
+++ b/.github/workflows/benchmark-ocr-onnx.yml
@@ -100,7 +100,7 @@ jobs:
           node-version: lts/*
 
       - name: Install global dependencies
-        run: npm install -g bare-make bare-runtime
+        run: npm install -g --force bare-make bare-runtime
 
       - name: Configure vcpkg
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV
@@ -204,7 +204,7 @@ jobs:
 
       - name: Install bare-runtime
         if: needs.setup.outputs.qvac_needed == 'true'
-        run: npm install -g bare-runtime
+        run: npm install -g --force bare-runtime
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0

--- a/.github/workflows/benchmark-performance-tts-onnx.yml
+++ b/.github/workflows/benchmark-performance-tts-onnx.yml
@@ -295,7 +295,7 @@ jobs:
 
       - name: Install Bare runtime
         run: |
-          npm install -g bare bare-make
+          npm install -g --force bare bare-make
 
       - name: Download merged prebuilds
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1

--- a/.github/workflows/benchmark-rtf-tts-onnx.yml
+++ b/.github/workflows/benchmark-rtf-tts-onnx.yml
@@ -138,7 +138,7 @@ jobs:
         working-directory: ${{ env.ADDON_DIR }}
         run: |
           npm install
-          npm install -g bare bare-make
+          npm install -g --force bare bare-make
 
       - name: Download prebuilds from artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
@@ -343,7 +343,7 @@ jobs:
         working-directory: ${{ env.ADDON_DIR }}
         run: |
           npm install
-          npm install -g bare bare-make
+          npm install -g --force bare bare-make
 
       - name: Download prebuilds from artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1

--- a/.github/workflows/benchmark-supertonic-tts-onnx.yml
+++ b/.github/workflows/benchmark-supertonic-tts-onnx.yml
@@ -101,8 +101,8 @@ jobs:
 
       - name: Install Bare runtime
         run: |
-          npm install -g bare-dev
-          npm install -g bare bare-make
+          npm install -g --force bare-dev
+          npm install -g --force bare bare-make
 
       - name: Determine addon version
         id: version

--- a/.github/workflows/benchmark-transcription-parakeet.yml
+++ b/.github/workflows/benchmark-transcription-parakeet.yml
@@ -204,8 +204,8 @@ jobs:
 
       - name: Install Bare runtime
         run: |
-          npm install -g bare-dev
-          npm install -g bare bare-make
+          npm install -g --force bare-dev
+          npm install -g --force bare bare-make
 
       - name: Download prebuilds
         id: prebuilds

--- a/.github/workflows/benchmark-transcription-whispercpp.yml
+++ b/.github/workflows/benchmark-transcription-whispercpp.yml
@@ -344,8 +344,8 @@ jobs:
 
       - name: Install Bare runtime
         run: |
-          npm install -g bare-dev
-          npm install -g bare bare-make
+          npm install -g --force bare-dev
+          npm install -g --force bare bare-make
 
       - name: Download prebuilds
         id: prebuilds

--- a/.github/workflows/benchmark-translation-nmtcpp.yml
+++ b/.github/workflows/benchmark-translation-nmtcpp.yml
@@ -173,7 +173,7 @@ jobs:
           node-version: lts/*
 
       - name: Install global dependencies
-        run: npm install -g bare-make bare-runtime
+        run: npm install -g --force bare-make bare-runtime
 
       - name: Replace bare-make's CMake with compatible version
         shell: bash
@@ -351,7 +351,7 @@ jobs:
           node-version: 20
 
       - name: Install bare-runtime
-        run: npm install -g bare-runtime
+        run: npm install -g --force bare-runtime
 
       - name: Download build artifact
         if: needs.build.result == 'success'

--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -108,7 +108,7 @@ jobs:
           node-version: lts/*
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       # - if: ${{ inputs.include-vulkan-sdk }}
       #   name: Setup Vulkan SDK

--- a/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
@@ -66,7 +66,7 @@ jobs:
           node-version: lts/*
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Install NPM dependencies
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
@@ -71,7 +71,7 @@ jobs:
           node-version: lts/*
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Install NPM dependencies
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
@@ -66,7 +66,7 @@ jobs:
           node-version: lts/*
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Install NPM dependencies
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/cpp-test-coverage-tts-ggml.yml
+++ b/.github/workflows/cpp-test-coverage-tts-ggml.yml
@@ -74,7 +74,7 @@ jobs:
           node-version: lts/*
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Install NPM dependencies
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/cpp-test-coverage-tts-onnx.yml
+++ b/.github/workflows/cpp-test-coverage-tts-onnx.yml
@@ -82,7 +82,7 @@ jobs:
           node-version: lts/*
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Install NPM dependencies
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -146,7 +146,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'macos-14' }}
         name: Download SD2 model for C++ tests

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -97,7 +97,7 @@ jobs:
           npm install
       
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
 
       - if: ${{ matrix.os == 'windows-2025' }}

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -149,7 +149,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Download test models
         shell: bash

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -124,7 +124,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - if: ${{ matrix.os == 'ubuntu-24.04' }}
         name: Set Vulkan SDK Path on Linux

--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -129,7 +129,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && steps.resolve_prebuild.outputs.prebuild_package == ''

--- a/.github/workflows/integration-mobile-test-classification-ggml.yml
+++ b/.github/workflows/integration-mobile-test-classification-ggml.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Install global dependencies
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest --ignore-scripts
+          npm install -g --force @expo/cli@latest --ignore-scripts
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package

--- a/.github/workflows/integration-mobile-test-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-decoder-audio.yml
@@ -117,7 +117,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Verify test files exist
         env:

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -88,7 +88,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package

--- a/.github/workflows/integration-mobile-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-embed-llamacpp.yml
@@ -104,7 +104,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package

--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -127,7 +127,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -94,7 +94,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package

--- a/.github/workflows/integration-mobile-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-transcription-parakeet.yml
@@ -124,7 +124,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       # Prebuild source selection.
       #

--- a/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
@@ -94,7 +94,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && github.event_name != 'workflow_dispatch'

--- a/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
@@ -93,7 +93,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package

--- a/.github/workflows/integration-mobile-test-tts-ggml.yml
+++ b/.github/workflows/integration-mobile-test-tts-ggml.yml
@@ -141,7 +141,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       # Prebuild source selection.
       #

--- a/.github/workflows/integration-mobile-test-tts-onnx.yml
+++ b/.github/workflows/integration-mobile-test-tts-onnx.yml
@@ -102,7 +102,7 @@ jobs:
         if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && github.event_name != 'workflow_dispatch'

--- a/.github/workflows/integration-mobile-test-vla.yml
+++ b/.github/workflows/integration-mobile-test-vla.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Install global dependencies
         run: |
           echo "Installing global dependencies..."
-          npm install -g @expo/cli@latest
+          npm install -g --force @expo/cli@latest
 
       - name: Download Android prebuilds (from artifacts)
         if: matrix.platform == 'Android' && !inputs.package

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -89,7 +89,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-decoder-audio.yml
+++ b/.github/workflows/integration-test-decoder-audio.yml
@@ -71,7 +71,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Run integration test
         working-directory: ${{ inputs.workdir }}

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -168,7 +168,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make bare-runtime bare-https brittle
+        run: npm install -g --force bare bare-make bare-runtime bare-https brittle
 
       - run: mkdir -p ${{ runner.temp }}/qvac-diffusion-cpp
       - run: mkdir -p ${{ env.WORKDIR }}/prebuilds

--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -87,7 +87,7 @@ jobs:
           npm install
   
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Download prebuilds (from artifacts)
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -156,7 +156,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make bare-runtime bare-https brittle
+        run: npm install -g --force bare bare-make bare-runtime bare-https brittle
 
       - name: Download prebuilds (from artifacts)
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-ocr-onnx.yml
+++ b/.github/workflows/integration-test-ocr-onnx.yml
@@ -92,7 +92,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-test-transcription-parakeet.yml
@@ -98,7 +98,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - run: mkdir -p "${{ runner.temp }}/transcription-parakeet"
         shell: bash

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -129,7 +129,7 @@ jobs:
           npm install
       
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-test-translation-nmtcpp.yml
@@ -86,7 +86,7 @@ jobs:
           npm install
       
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -118,7 +118,7 @@ jobs:
           npm install
   
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
 
       - run: mkdir -p "${{ runner.temp }}/tts-ggml"

--- a/.github/workflows/integration-test-tts-onnx.yml
+++ b/.github/workflows/integration-test-tts-onnx.yml
@@ -182,7 +182,7 @@ jobs:
           npm install
   
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}
@@ -400,7 +400,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -150,7 +150,7 @@ jobs:
 
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make bare-runtime bare-https brittle
+        run: npm install -g --force bare bare-make bare-runtime bare-https brittle
 
       - name: Download prebuilds (from artifacts)
         if: ${{ !inputs.prebuild_package }}

--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -225,7 +225,7 @@ jobs:
 
       - name: Install Bare runtime
         if: matrix.package == 'rag' || matrix.package == 'error'
-        run: npm install -g bare
+        run: npm install -g --force bare
 
       # All script steps use npm run --if-present (bun lacks --if-present).
       # npm run just reads package.json scripts — works regardless of installer.

--- a/.github/workflows/pr-test-inference-addon-cpp-js.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp-js.yml
@@ -116,7 +116,7 @@ jobs:
           node-version: 22
 
       - name: Install Bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - if: ${{ matrix.platform == 'win32' }}
         name: Setup CMake on Windows

--- a/.github/workflows/publish-registry-server.yml
+++ b/.github/workflows/publish-registry-server.yml
@@ -386,7 +386,7 @@ jobs:
 
       - name: Install bare globally
         shell: bash
-        run: npm install -g bare
+        run: npm install -g --force bare
 
       - name: Lint
         working-directory: ${{ env.PKG_DIR }}/client

--- a/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
@@ -49,7 +49,7 @@ jobs:
           npm install
 
       - name: Install bare tooling
-        run: npm install -g bare bare-make
+        run: npm install -g --force bare bare-make
 
       - name: Configure vcpkg
         run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_ENV

--- a/packages/ocr-onnx/ci/integration-test.sh
+++ b/packages/ocr-onnx/ci/integration-test.sh
@@ -33,7 +33,7 @@ cd ..
 # Setup OCR addon
 git clone https://github.com/tetherto/inference-addon-onnx-ocr-fasttext.git
 cd inference-addon-onnx-ocr-fasttext/
-npm install -g bare bare-make
+npm install -g --force bare bare-make
 npm install
 
 # Build addon


### PR DESCRIPTION
## What problem does this PR solve?

Global `npm install -g` steps in CI can fail or leave stale binaries when a package is already installed at a different version (bare, bare-make, bare-runtime, `@expo/cli`, etc.).

## How does it solve it?

- Adds `--force` to every `npm install -g` for bare tooling across workflows and composite actions (`setup-bare`, `setup-bare-tooling`, lint/test actions).
- Adds `--force` to `@expo/cli` installs in mobile integration workflows.
- Updates `packages/ocr-onnx/ci/integration-test.sh` for consistency.

## Breaking changes

None.
