### PR TITLE
infra: correct setup-bare-tooling composite action version pin

### DIFF
--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -87,7 +87,7 @@ jobs:
           rm -rf $VCPKG_ROOT/packages/*
 
       - name: Setup Bare tooling
-        uses: tetherto/qvac/.github/actions/setup-bare-tooling@0bbdca93da303a0b1634ba14a89cec085621078d
+        uses: tetherto/qvac/.github/actions/setup-bare-tooling@926f6f14092fbacaa3606ea475457fddf37d9838
 
       - name: Setup Apple Clang
         if: ${{ matrix.platform == 'darwin' }}

--- a/.github/workflows/integration-test-classification-ggml.yml
+++ b/.github/workflows/integration-test-classification-ggml.yml
@@ -79,7 +79,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup Bare runtime
-        uses: tetherto/qvac/.github/actions/setup-bare-tooling@0bbdca93da303a0b1634ba14a89cec085621078d
+        uses: tetherto/qvac/.github/actions/setup-bare-tooling@926f6f14092fbacaa3606ea475457fddf37d9838
 
       - name: Install npm dependencies
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -214,7 +214,7 @@ jobs:
           rm -rf $VCPKG_ROOT/packages/*
 
       - name: Setup Bare tooling
-        uses: tetherto/qvac/.github/actions/setup-bare-tooling@0bbdca93da303a0b1634ba14a89cec085621078d
+        uses: tetherto/qvac/.github/actions/setup-bare-tooling@926f6f14092fbacaa3606ea475457fddf37d9838
 
       - name: Setup Apple Clang
         uses: tetherto/qvac/.github/actions/setup-apple-clang@1d9b2165867d03c6edd675e402ee101a5d48a6d8


### PR DESCRIPTION
## What problem does this PR solve?

latest changes to composite action `setup-bare-tooling` weren't reflected in a few places, due to pinning of version to older commit hash.

## How does it solve it?

updates pinned version of composite action `setup-bare-tooling` to latest changes which uses `--force` for global npm installs.

## Breaking changes

None