### PR TITLE
fix[notask]: resolve SDK package from ancestor node_modules in monorepo setups

### DIFF
--- a/packages/sdk/expo/plugins/resolve-sdk-package-dir.ts
+++ b/packages/sdk/expo/plugins/resolve-sdk-package-dir.ts
@@ -16,19 +16,37 @@ type SDKPackageInfo = {
   name: string;
 };
 
+function findInAncestorNodeModules(startDir: string, name: string): string | null {
+  let dir = startDir;
+  let parent = path.dirname(dir);
+  for (; dir !== parent; dir = parent, parent = path.dirname(dir)) {
+    const candidate = path.join(dir, "node_modules", name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
 /**
  * Resolves the installed SDK package directory from node_modules.
  *
  * Checks all known published package names and returns the one that exists.
  * Throws if none found or if multiple are found (ambiguous installation).
+ *
+ * Walks up the directory tree from projectRoot so packages hoisted to a
+ * monorepo root (e.g. by bun or yarn workspaces) are found correctly.
  */
 function resolveSDKPackageDir(projectRoot: string): SDKPackageInfo {
   const found: SDKPackageInfo[] = [];
 
   for (const name of SDK_PACKAGE_NAMES) {
-    const dir = path.join(projectRoot, "node_modules", name);
-    if (fs.existsSync(dir)) {
+    const dir = findInAncestorNodeModules(projectRoot, name);
+    if (dir !== null) {
       found.push({ name, dir });
+      console.debug(`[resolveSDKPackageDir] resolved "${name}" at "${dir}"`);
+    } else {
+      console.debug(
+        `[resolveSDKPackageDir] could not find "${name}" in any node_modules from "${projectRoot}" upward`,
+      );
     }
   }
 

--- a/packages/sdk/test/unit/expo/resolve-sdk-package-dir.test.ts
+++ b/packages/sdk/test/unit/expo/resolve-sdk-package-dir.test.ts
@@ -1,0 +1,121 @@
+import test from "brittle";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { resolveSDKPackageDir } from "@/expo/plugins/resolve-sdk-package-dir";
+import {
+  SDKNotFoundInNodeModulesError,
+  MultipleSDKInstallationsError,
+} from "@/utils/errors-client";
+
+function makeTempProject(packageNames: string[] = []): {
+  root: string;
+  cleanup: () => void;
+} {
+  const root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "resolve-sdk-test-")),
+  );
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "test-project" }),
+  );
+  for (const name of packageNames) {
+    const pkgDir = path.join(root, "node_modules", ...name.split("/"));
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, "index.js"), "module.exports = {}");
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name, main: "index.js" }),
+    );
+  }
+  return {
+    root,
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+test("resolves @qvac/sdk when present in projectRoot/node_modules", (t) => {
+  const { root, cleanup } = makeTempProject(["@qvac/sdk"]);
+  try {
+    const result = resolveSDKPackageDir(root);
+    t.is(result.name, "@qvac/sdk");
+    t.is(result.dir, path.join(root, "node_modules", "@qvac", "sdk"));
+  } finally {
+    cleanup();
+  }
+});
+
+test("resolves @tetherto/sdk-mono when present", (t) => {
+  const { root, cleanup } = makeTempProject(["@tetherto/sdk-mono"]);
+  try {
+    const result = resolveSDKPackageDir(root);
+    t.is(result.name, "@tetherto/sdk-mono");
+    t.is(result.dir, path.join(root, "node_modules", "@tetherto", "sdk-mono"));
+  } finally {
+    cleanup();
+  }
+});
+
+test("resolves package hoisted to a parent directory (monorepo)", (t) => {
+  const root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "resolve-sdk-mono-")),
+  );
+  const projectRoot = path.join(root, "mobile");
+  try {
+    fs.mkdirSync(projectRoot);
+    fs.writeFileSync(
+      path.join(projectRoot, "package.json"),
+      JSON.stringify({ name: "mobile" }),
+    );
+    // Package is hoisted to root, not in mobile/node_modules
+    const pkgDir = path.join(root, "node_modules", "@qvac", "sdk");
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, "index.js"), "module.exports = {}");
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({ name: "@qvac/sdk", main: "index.js" }),
+    );
+
+    const result = resolveSDKPackageDir(projectRoot);
+    t.is(result.name, "@qvac/sdk");
+    t.is(result.dir, pkgDir);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("throws SDKNotFoundInNodeModulesError when no SDK package is present", (t) => {
+  const { root, cleanup } = makeTempProject([]);
+  try {
+    let threw: unknown;
+    try {
+      resolveSDKPackageDir(root);
+    } catch (err) {
+      threw = err;
+    }
+    t.ok(threw instanceof SDKNotFoundInNodeModulesError, "should throw SDKNotFoundInNodeModulesError");
+  } finally {
+    cleanup();
+  }
+});
+
+test("throws MultipleSDKInstallationsError when more than one SDK package is present", (t) => {
+  const { root, cleanup } = makeTempProject(["@qvac/sdk", "@tetherto/sdk-mono"]);
+  try {
+    let threw: unknown;
+    try {
+      resolveSDKPackageDir(root);
+    } catch (err) {
+      threw = err;
+    }
+    t.ok(threw instanceof MultipleSDKInstallationsError, "should throw MultipleSDKInstallationsError");
+    t.ok(
+      threw instanceof MultipleSDKInstallationsError &&
+        threw.message.includes("@qvac/sdk") &&
+        threw.message.includes("@tetherto/sdk-mono"),
+      "error message should list conflicting package names",
+    );
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## What problem does this PR solve?

In monorepo setups where bun or yarn workspaces hoist the SDK package to a root-level `node_modules`, the Expo plugin would throw `SDKNotFoundInNodeModulesError` at build time — even though the SDK was correctly installed. The plugin only looked in `<projectRoot>/node_modules`, not in ancestor directories.

## How does it solve it?

Replaces the single-directory lookup with an ancestor walk: starting from `projectRoot`, it checks each `node_modules` directory up the tree until it finds the package or reaches the filesystem root. This matches how Node.js itself resolves modules.

## How was it tested?

New unit test suite covering all cases against a real (temp) filesystem:

- SDK in `projectRoot/node_modules` (direct install)
- SDK hoisted to a parent directory (monorepo)
- No SDK installed → `SDKNotFoundInNodeModulesError`
- Multiple SDK packages installed → `MultipleSDKInstallationsError` with package names in the message