### PR TITLE
infra: fix mobile int tests on linux due to now missing global nodejs

### DIFF
--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -120,13 +120,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-decoder-audio.yml
@@ -108,13 +108,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -79,13 +79,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-embed-llamacpp.yml
@@ -95,13 +95,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -118,13 +118,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -85,13 +85,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-transcription-parakeet.yml
@@ -115,13 +115,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
@@ -85,13 +85,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
@@ -84,13 +84,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-tts-ggml.yml
+++ b/.github/workflows/integration-mobile-test-tts-ggml.yml
@@ -132,13 +132,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest

--- a/.github/workflows/integration-mobile-test-tts-onnx.yml
+++ b/.github/workflows/integration-mobile-test-tts-onnx.yml
@@ -93,13 +93,11 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        if: matrix.platform == 'iOS'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install global dependencies
-        if: matrix.platform == 'iOS'
         run: |
           echo "Installing global dependencies..."
           npm install -g --force @expo/cli@latest


### PR DESCRIPTION
## What problem does this PR solve?

Fixes mobile tests on linux (android)

## How does it solve it?

allows nodejs setup on linux (and expo global install in runner agent's user's home)

## Breaking changes

None