### PR TITLE
QVAC-19206 feat[api]: add --entry flag and workerEntry config to qvac bundle sdk

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -113,6 +113,7 @@ qvac bundle sdk [options]
 | `--config, -c <path>` | Config file path (default: auto-detect `qvac.config.*`) |
 | `--host <target>` | Target host (repeatable, default: all platforms) |
 | `--defer <module>` | Defer a module (repeatable, for mobile targets) |
+| `--entry <path>` | Use a custom worker entry file instead of generating one. Path is resolved against the project root (absolute paths are honored as-is). The entry must register its own plugins. Overrides `workerEntry` in `qvac.config.*`. |
 | `--quiet, -q` | Minimal output |
 | `--verbose, -v` | Detailed output |
 
@@ -130,17 +131,22 @@ qvac bundle sdk --config ./my-config.json
 
 # Verbose output for debugging
 qvac bundle sdk --verbose
+
+# Bundle a custom worker entry
+qvac bundle sdk --entry your-worker-entry.js
 ```
 
 **Output:**
 
 | File | Description |
 |------|-------------|
-| `qvac/worker.entry.mjs` | Standalone/Electron worker with RPC + lifecycle |
+| `qvac/worker.entry.mjs` | Standalone/Electron worker with RPC + lifecycle. **Not generated when `--entry` / `workerEntry` is set** — the custom entry is bundled directly. |
 | `qvac/worker.bundle.js` | Final bundle for mobile runtimes (Expo/BareKit) |
 | `qvac/addons.manifest.json` | Native addon allowlist for tree-shaking |
 
 > **Note:** Your project must have `@qvac/sdk` installed.
+
+> **Custom entry contract:** when `--entry` (or `workerEntry`) is set, `plugins` in `qvac.config.*` is ignored and the custom entry must call `registerPlugin()` for every plugin it depends on. Use `hasPlugin(modelType)` to guard against duplicate registration if your entry might be re-used by hosts that pre-register plugins.
 
 ### `verify deps`
 
@@ -316,13 +322,16 @@ If no config file is found, the CLI bundles all built-in plugins.
 
 > **Note:** `qvac.config.ts` is supported via `tsx` internally (no user setup required).
 
-This file is primarily the SDK runtime config, but `qvac bundle sdk` also reads this **bundler-only** key (ignored by the SDK at runtime):
+This file is primarily the SDK runtime config, but `qvac bundle sdk` also reads these **bundler-only** keys (ignored by the SDK at runtime):
 
 | Key | Type | Required | Description |
 |-----|------|----------|-------------|
-| `plugins` | `string[]` | No | Module specifiers, each ending with `/plugin` (defaults to all built-in plugins) |
+| `plugins` | `string[]` | No | Module specifiers, each ending with `/plugin` (defaults to all built-in plugins). Ignored when `workerEntry` is set. |
+| `workerEntry` | `string` | No | Path to a custom Bare worker entry, resolved relative to the project root (absolute paths honored as-is). When set, `qvac/worker.entry.mjs` is **not** generated and the custom entry is bundled directly. The CLI `--entry` flag overrides this value. |
 
 > **Custom plugin contract:** custom `*/plugin` modules must **default-export** the plugin object.
+
+> **Custom entry contract:** see the `bundle sdk` section above. The entry is responsible for calling `registerPlugin()` for every plugin it needs.
 
 **Built-in plugins:**
 

--- a/packages/cli/src/bundle-sdk/index.ts
+++ b/packages/cli/src/bundle-sdk/index.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { DEFAULT_HOSTS, DEFAULT_SDK_NAME } from './constants.js'
 import { createLogger } from '../logger.js'
 import { findConfigFile, loadConfig, CONFIG_CANDIDATES } from '../config.js'
-import { BareImportsMapNotFoundError } from '../errors.js'
+import { BareImportsMapNotFoundError, WorkerEntryNotFoundError } from '../errors.js'
 import { resolvePluginSpecifiers, parseBuiltinSpecifier } from './plugins.js'
 import { generateWorkerEntry } from './entry-gen.js'
 import { runBarePack } from './bare-pack.js'
@@ -15,6 +15,7 @@ export interface BundleSdkOptions {
   sdkPath?: string | undefined
   hosts?: string[] | undefined
   defer?: string[] | undefined
+  workerEntry?: string | undefined
   quiet?: boolean | undefined
   verbose?: boolean | undefined
 }
@@ -23,8 +24,14 @@ interface BundleSdkResult {
   bundlePath: string
   plugins: string[]
   addons: string[]
-  entryPaths: { worker: string }
+  entryPaths: { worker: string; generated: boolean }
   manifestPath: string
+}
+
+function resolveWorkerEntry (projectRoot: string, workerEntry: string): string {
+  return path.isAbsolute(workerEntry)
+    ? workerEntry
+    : path.resolve(projectRoot, workerEntry)
 }
 
 function resolveSdkPath (projectRoot: string, explicitSdkPath?: string): string {
@@ -67,7 +74,7 @@ export async function bundleSdk (options: BundleSdkOptions = {}): Promise<Bundle
 
   const projectRoot = options.projectRoot ?? process.cwd()
   const outputDir = path.join(projectRoot, 'qvac')
-  const entryPath = path.join(outputDir, 'worker.entry.mjs')
+  const generatedEntryPath = path.join(outputDir, 'worker.entry.mjs')
   const bundlePath = path.join(outputDir, 'worker.bundle.js')
 
   let logLevel = 'info'
@@ -80,10 +87,10 @@ export async function bundleSdk (options: BundleSdkOptions = {}): Promise<Bundle
 
   const configPath = findConfigFile(projectRoot, options.configPath)
 
-  let config: { plugins?: string[] } = {}
+  let config: { plugins?: string[]; workerEntry?: string } = {}
   if (configPath) {
     logger.info(`📄 Config: ${path.relative(projectRoot, configPath)}`)
-    config = await loadConfig(configPath) as { plugins?: string[] }
+    config = await loadConfig(configPath) as { plugins?: string[]; workerEntry?: string }
   } else {
     logger.info('📄 Config: (none)')
     logger.warn('No config file found — continuing with defaults.')
@@ -94,6 +101,10 @@ export async function bundleSdk (options: BundleSdkOptions = {}): Promise<Bundle
     )
   }
 
+  // CLI flag takes precedence over config.
+  const workerEntryOption = options.workerEntry ?? config.workerEntry
+  const usingCustomEntry = typeof workerEntryOption === 'string' && workerEntryOption.length > 0
+
   const sdkPath = resolveSdkPath(projectRoot, options.sdkPath)
   const sdkName = await resolveSdkName(sdkPath)
   logger.info(`📦 SDK: ${sdkName}`)
@@ -101,13 +112,23 @@ export async function bundleSdk (options: BundleSdkOptions = {}): Promise<Bundle
 
   const importsMapPath = resolveImportsMapPath(sdkPath, sdkName)
 
-  const pluginSpecifiers = resolvePluginSpecifiers(config, sdkName, logger)
-  logger.info(`\n📦 Plugins to include (${pluginSpecifiers.length}):`)
-  for (const spec of pluginSpecifiers) {
-    const label = parseBuiltinSpecifier(spec, sdkName)
-      ? '✓ built-in'
-      : '⊕ custom'
-    logger.info(`   ${label}: ${spec}`)
+  let pluginSpecifiers: string[] = []
+  if (usingCustomEntry) {
+    if (config.plugins && config.plugins.length > 0) {
+      logger.warn(
+        "workerEntry is set — 'plugins' from config will be ignored.\n" +
+        '   Your worker entry must call registerPlugin() for every plugin it needs.\n'
+      )
+    }
+  } else {
+    pluginSpecifiers = resolvePluginSpecifiers(config, sdkName, logger)
+    logger.info(`\n📦 Plugins to include (${pluginSpecifiers.length}):`)
+    for (const spec of pluginSpecifiers) {
+      const label = parseBuiltinSpecifier(spec, sdkName)
+        ? '✓ built-in'
+        : '⊕ custom'
+      logger.info(`   ${label}: ${spec}`)
+    }
   }
 
   const hosts =
@@ -117,11 +138,23 @@ export async function bundleSdk (options: BundleSdkOptions = {}): Promise<Bundle
 
   await fsp.mkdir(outputDir, { recursive: true })
 
-  logger.info('\n📝 Generating worker entry...')
-  const workerEntry = generateWorkerEntry(pluginSpecifiers, sdkName)
-  await fsp.writeFile(entryPath, workerEntry, 'utf8')
-  logger.info(`   Created: ${path.relative(projectRoot, entryPath)}`)
-  logger.info(`   Using: ${path.relative(projectRoot, importsMapPath)}`)
+  let entryPath: string
+  if (usingCustomEntry) {
+    const resolved = resolveWorkerEntry(projectRoot, workerEntryOption)
+    if (!fs.existsSync(resolved)) {
+      throw new WorkerEntryNotFoundError(workerEntryOption, resolved)
+    }
+    entryPath = resolved
+    logger.info(`\n📝 Worker entry: ${path.relative(projectRoot, entryPath)} (custom)`)
+    logger.info(`   Using: ${path.relative(projectRoot, importsMapPath)}`)
+  } else {
+    entryPath = generatedEntryPath
+    logger.info('\n📝 Generating worker entry...')
+    const workerEntrySource = generateWorkerEntry(pluginSpecifiers, sdkName)
+    await fsp.writeFile(entryPath, workerEntrySource, 'utf8')
+    logger.info(`   Created: ${path.relative(projectRoot, entryPath)}`)
+    logger.info(`   Using: ${path.relative(projectRoot, importsMapPath)}`)
+  }
 
   logger.info('\n🔨 Bundling with bare-pack...')
   logger.debug(`   Hosts: ${hosts.join(', ')}`)
@@ -154,24 +187,33 @@ export async function bundleSdk (options: BundleSdkOptions = {}): Promise<Bundle
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(2)
   logger.info(`\n🎉 Done in ${elapsed}s!\n`)
   logger.info('Generated files:')
-  logger.info(
-    '  - qvac/worker.entry.mjs    (standalone worker with RPC + lifecycle)'
-  )
+  if (!usingCustomEntry) {
+    logger.info(
+      '  - qvac/worker.entry.mjs    (standalone worker with RPC + lifecycle)'
+    )
+  }
   logger.info(
     '  - qvac/worker.bundle.js    (mobile bundle for Expo/React Native BareKit)'
   )
   logger.info('  - qvac/addons.manifest.json\n')
   logger.info('Mobile: Expo plugin auto-configures worker.bundle.js')
-  logger.info(
-    'Standalone: Import qvac/worker.entry.mjs for full worker with RPC\n'
-  )
+  if (usingCustomEntry) {
+    logger.info(
+      `Custom entry: ${path.relative(projectRoot, entryPath)} (provided by you)\n`
+    )
+  } else {
+    logger.info(
+      'Standalone: Import qvac/worker.entry.mjs for full worker with RPC\n'
+    )
+  }
 
   return {
     bundlePath,
     plugins: pluginSpecifiers,
     addons: manifestResult.addons,
     entryPaths: {
-      worker: entryPath
+      worker: entryPath,
+      generated: !usingCustomEntry
     },
     manifestPath: manifestResult.manifestPath
   }

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -54,6 +54,23 @@ export class BarePackError extends Error {
   }
 }
 
+export class WorkerEntryNotFoundError extends Error {
+  workerEntry: string
+  resolvedPath: string
+  constructor (workerEntry: string, resolvedPath: string) {
+    super(
+      'Custom worker entry not found.\n\n' +
+      `  Specified: ${workerEntry}\n` +
+      `  Resolved:  ${resolvedPath}\n\n` +
+      '  Set workerEntry in qvac.config.* or pass --entry <path>.\n' +
+      '  Paths are resolved relative to the project root.'
+    )
+    this.name = 'WorkerEntryNotFoundError'
+    this.workerEntry = workerEntry
+    this.resolvedPath = resolvedPath
+  }
+}
+
 export class BareImportsMapNotFoundError extends Error {
   sdkName: string
   expectedPath: string
@@ -75,6 +92,7 @@ const ERROR_LABELS: Record<string, string> = {
   InvalidPluginSpecifierError: 'Plugin Error',
   BarePackNotInstalledError: 'Bundler Error',
   BarePackError: 'Bundle Failed',
+  WorkerEntryNotFoundError: 'Worker Entry Error',
   BareImportsMapNotFoundError: 'SDK Error',
   LockfileReadError: 'Lockfile Error',
   LockfileNotFoundAtRefError: 'Lockfile Error',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,6 +31,12 @@ function setupCli (): void {
     .option('--sdk-path <path>', 'Path to SDK package (default: auto-detect in node_modules)')
     .option('--host <target>', 'Target host (repeatable)', collect, [])
     .option('--defer <module>', 'Defer a module (repeatable)', collect, [])
+    .option(
+      '--entry <path>',
+      'Use a custom worker entry file instead of generating one. ' +
+      'The entry must register its own plugins and (optionally) call ensureRPCSetup(). ' +
+      'Overrides workerEntry in qvac.config.*'
+    )
     .option('-q, --quiet', 'Minimal output')
     .option('-v, --verbose', 'Detailed output')
     .action(async (options: {
@@ -38,6 +44,7 @@ function setupCli (): void {
       sdkPath?: string
       host: string[]
       defer: string[]
+      entry?: string
       quiet?: boolean
       verbose?: boolean
     }) => {
@@ -48,6 +55,7 @@ function setupCli (): void {
           sdkPath: options.sdkPath,
           hosts: options.host.length > 0 ? options.host : undefined,
           defer: options.defer.length > 0 ? options.defer : undefined,
+          workerEntry: options.entry,
           quiet: options.quiet,
           verbose: options.verbose
         })

--- a/packages/cli/test/bundle-sdk.test.ts
+++ b/packages/cli/test/bundle-sdk.test.ts
@@ -1,0 +1,153 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { bundleSdk } from '../src/bundle-sdk/index.js'
+import { WorkerEntryNotFoundError } from '../src/errors.js'
+
+async function withFakeSdkProject (
+  fn: (dir: string) => Promise<void> | void,
+  configBody?: Record<string, unknown>
+): Promise<void> {
+  const dir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'qvac-bundle-sdk-test-'))
+  )
+  try {
+    const sdkDir = path.join(dir, 'node_modules', '@qvac', 'sdk')
+    fs.mkdirSync(sdkDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(sdkDir, 'package.json'),
+      JSON.stringify({ name: '@qvac/sdk', version: '0.0.0-test' })
+    )
+    // Minimal bare-imports.json so resolveImportsMapPath doesn't throw.
+    fs.writeFileSync(path.join(sdkDir, 'bare-imports.json'), JSON.stringify({}))
+
+    if (configBody !== undefined) {
+      fs.writeFileSync(
+        path.join(dir, 'qvac.config.json'),
+        JSON.stringify(configBody, null, 2)
+      )
+    }
+
+    await fn(dir)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('bundleSdk: custom workerEntry option', () => {
+  it('throws WorkerEntryNotFoundError when --entry points to a missing file', async () => {
+    await withFakeSdkProject(async (dir) => {
+      await assert.rejects(
+        () =>
+          bundleSdk({
+            projectRoot: dir,
+            workerEntry: 'worker/does-not-exist.js',
+            quiet: true
+          }),
+        (err: unknown) => {
+          assert.ok(err instanceof WorkerEntryNotFoundError)
+          assert.equal(err.workerEntry, 'worker/does-not-exist.js')
+          assert.equal(
+            err.resolvedPath,
+            path.resolve(dir, 'worker/does-not-exist.js')
+          )
+          assert.match(err.message, /Custom worker entry not found/)
+          return true
+        }
+      )
+    })
+  })
+
+  it('throws WorkerEntryNotFoundError when workerEntry from qvac.config.json is missing', async () => {
+    await withFakeSdkProject(
+      async (dir) => {
+        await assert.rejects(
+          () => bundleSdk({ projectRoot: dir, quiet: true }),
+          (err: unknown) => {
+            assert.ok(err instanceof WorkerEntryNotFoundError)
+            assert.equal(err.workerEntry, 'worker/index.js')
+            return true
+          }
+        )
+      },
+      { workerEntry: 'worker/index.js' }
+    )
+  })
+
+  it('CLI --entry takes precedence over workerEntry in config', async () => {
+    await withFakeSdkProject(
+      async (dir) => {
+        await assert.rejects(
+          () =>
+            bundleSdk({
+              projectRoot: dir,
+              workerEntry: 'cli-entry-missing.js',
+              quiet: true
+            }),
+          (err: unknown) => {
+            assert.ok(err instanceof WorkerEntryNotFoundError)
+            // Proves we used the CLI flag, not the config value.
+            assert.equal(err.workerEntry, 'cli-entry-missing.js')
+            assert.notEqual(err.workerEntry, 'config-entry.js')
+            return true
+          }
+        )
+      },
+      { workerEntry: 'config-entry.js' }
+    )
+  })
+
+  it('treats absolute workerEntry as-is (no projectRoot prefix)', async () => {
+    await withFakeSdkProject(async (dir) => {
+      const absMissing = path.join(dir, 'totally', 'absolute', 'path.js')
+      await assert.rejects(
+        () =>
+          bundleSdk({
+            projectRoot: dir,
+            workerEntry: absMissing,
+            quiet: true
+          }),
+        (err: unknown) => {
+          assert.ok(err instanceof WorkerEntryNotFoundError)
+          assert.equal(err.resolvedPath, absMissing)
+          return true
+        }
+      )
+    })
+  })
+
+  it('does not generate qvac/worker.entry.mjs when workerEntry is set', async () => {
+    await withFakeSdkProject(async (dir) => {
+      await assert.rejects(
+        () =>
+          bundleSdk({
+            projectRoot: dir,
+            workerEntry: 'worker/missing.js',
+            quiet: true
+          }),
+        WorkerEntryNotFoundError
+      )
+
+      // The generated entry path must NOT exist — we should fail before writing it.
+      const generated = path.join(dir, 'qvac', 'worker.entry.mjs')
+      assert.equal(fs.existsSync(generated), false)
+    })
+  })
+
+  it('ignores empty-string workerEntry and falls through to the default flow', async () => {
+    await withFakeSdkProject(async (dir) => {
+      // Empty string should NOT trigger the custom-entry branch. The bundle
+      // would fail later (no bare-pack here) but it must not throw
+      // WorkerEntryNotFoundError, which is what proves the branch was skipped.
+      await assert.rejects(
+        () => bundleSdk({ projectRoot: dir, workerEntry: '', quiet: true }),
+        (err: unknown) => {
+          assert.ok(!(err instanceof WorkerEntryNotFoundError))
+          return true
+        }
+      )
+    })
+  })
+})

--- a/packages/cli/test/cli.bats
+++ b/packages/cli/test/cli.bats
@@ -108,6 +108,7 @@ http_status() {
   [[ "${status}" -eq 0 ]]
   [[ "${output}" =~ "--config" ]]
   [[ "${output}" =~ "--sdk-path" ]]
+  [[ "${output}" =~ "--entry" ]]
 }
 
 @test "qvac verify deps --help shows options" {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Consumers who want `qvac bundle sdk` to wrap a **custom** Bare worker currently have to fork the CLI or hand-roll a separate `bare-pack` call. They lose JS tree-shaking via QVAC's plugin pipeline and the addons-manifest hand-off to `@qvac/sdk/expo-plugin`.
- There is no way today to tell `bundle sdk` "use this file as the bundle entry instead of the one you generate from `config.plugins`."

## 📝 How does it solve it?

- Adds `--entry <path>` CLI flag and `workerEntry` config key (CLI flag wins over config).
- When `workerEntry` is set:
  - `qvac/worker.entry.mjs` is **not** generated.
  - `config.plugins` is **ignored** (with a warning) — the custom entry owns plugin registration.
  - The custom entry is bundled directly into `qvac/worker.bundle.js`.
  - `qvac/addons.manifest.json` is still generated from the resulting bundle, so the Expo plugin's linker patch keeps working.
- New `WorkerEntryNotFoundError` (exported from `@qvac/cli/errors`) reports a missing entry with both the user-supplied and resolved paths.
- README documents the flag, config key, precedence, and the custom-entry contract (must call `registerPlugin()`; use `hasPlugin()` guard if the host may pre-register).

Example usage in an Expo app:

```json
// qvac.config.json
{ "workerEntry": "your-custom-worker/index.js" }
```

```sh
npx qvac bundle sdk
```

## 🧪 How was it tested?

- New `packages/cli/test/bundle-sdk.test.ts` with 6 unit tests covering:
  - `--entry` to a missing file throws `WorkerEntryNotFoundError`
  - `workerEntry` from config throws `WorkerEntryNotFoundError` when missing
  - CLI `--entry` takes precedence over `workerEntry` in config
  - Absolute `workerEntry` is honored as-is (no project-root prefix)
  - `qvac/worker.entry.mjs` is not generated when `workerEntry` is set
  - Empty-string `workerEntry` falls through to the default flow
- `cli.bats` extended to assert `qvac bundle sdk --help` lists `--entry`.
- `npm run lint` ✅, `npm run test:unit` ✅ (434 tests), `npm run build` ✅, `npm run test:bats` ✅ (87 tests).

## 🔌 API Changes

```typescript
import { bundleSdk, type BundleSdkOptions } from '@qvac/cli/bundle-sdk'
import { WorkerEntryNotFoundError } from '@qvac/cli/errors'

await bundleSdk({
  projectRoot: '/abs/path/to/app',
  workerEntry: 'node_modules/bare-translations/worker/index.js'
})
```

CLI:

```sh
qvac bundle sdk --entry your-custom-worker/index.js
```

`qvac.config.json`:

```json
{
  "workerEntry": "your-custom-worker/index.js"
}
```
