### PR TITLE
QVAC-18802 fix[api]: throw InvalidArgument for multi-GPU params on Android/iOS (llm-llamacpp)

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.22.0] - 2026-05-20
+
+### Changed
+
+- **Multi-GPU params rejected on Android/iOS**: passing `split-mode` (non-`none`), `main-gpu`, or `tensor-split` on a mobile device now throws `InvalidArgument` immediately in `commonParamsParse`, before any backend selection occurs. Previously these parameters could reach the Adreno OpenCL backend and trigger a native `ggml_abort` (SIGABRT) after a full inference suite. Use single-GPU config (`split-mode: "none"` or omit the field) on mobile.
+
+## Pull Requests
+
+- [#2147](https://github.com/tetherto/qvac/pull/2147) - QVAC-18802: reject multi-GPU config on Android/iOS
+
 ## [0.21.0] - 2026-05-13
 
 This release is a pure internal C++ refactor of the addon: the LoRA finetuning pipeline now lives in its own `LlamaFinetuner` class instead of inside `LlamaModel`. There are no JS API changes and no behaviour changes — finetune training, pause/resume, and adapter save go through exactly the same code paths.

--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Pull Requests
 
-- [#2147](https://github.com/tetherto/qvac/pull/2147) - QVAC-18802: reject multi-GPU config on Android/iOS
+- [#2150](https://github.com/tetherto/qvac/pull/2150) - QVAC-18802: reject multi-GPU config on Android/iOS
 
 ## [0.21.0] - 2026-05-13
 

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -19,6 +19,9 @@
 #include <common/log.h>
 #include <inference-addon-cpp/Errors.hpp>
 #include <llama.h>
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
 #include <llama/mtmd/mtmd.h>
 #include <picojson/picojson.h>
 
@@ -851,6 +854,18 @@ void LlamaModel::commonParamsParse(
     }
     configFilemap.erase(it);
   }
+
+#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
+  if (splitMode != LLAMA_SPLIT_MODE_NONE ||
+      configFilemap.count("main-gpu") > 0 ||
+      configFilemap.count("main_gpu") > 0 ||
+      configFilemap.count("tensor-split") > 0) {
+    throw qvac_errors::StatusError(
+        qvac_errors::general_error::InvalidArgument,
+        "Multi-GPU parameters (split-mode, main-gpu, tensor-split) are not "
+        "supported on mobile (single-GPU device).");
+  }
+#endif
 
   auto deviceIt = configFilemap.find("device");
   if (deviceIt == configFilemap.end()) {

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
<!--
Style guide for this PR description:
- Be concise; prefer bullet points.
- Delete sections that don't apply.
- Keep code examples minimal.
-->

## 🎯 What problem does this PR solve?

- Multi-GPU config params (`split-mode`, `main-gpu`, `tensor-split`) passed to the LLM addon on Android or iOS reach the Adreno OpenCL backend and trigger a native `ggml_abort` (SIGABRT) after a full inference suite.
- Mobile devices have a single GPU; there is no valid multi-GPU use case on these platforms.

-
-

## 📝 How does it solve it?

- Added a compile-time platform guard in `commonParamsParse` (`LlamaModel.cpp`) using `#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)`.
- If any of `split-mode` (non-`none`), `main-gpu`, or `tensor-split` are present at that point, throws `InvalidArgument` immediately — before any backend selection occurs.
- Guard fires in C++ regardless of what the JS layer did, providing a hard safety net.

-
-

## 🧪 How was it tested?

**Delete this section if not applicable.**

-
-

## 💥 Breaking Changes

**Delete this section if not applicable.**

**BEFORE:**

```typescript
// old code example
```

**AFTER:**

```typescript
// new code example
```

## 🔌 API Changes

**Delete this section if not applicable.**

```typescript
// new API usage example
```