### PR TITLE
QVAC-18802 fix[api]: throw InvalidArgument for multi-GPU params on Android/iOS (embed-llamacpp)

### DIFF
--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.17.0] - 2026-05-20
+
+### Changed
+
+- **Multi-GPU params rejected on Android/iOS**: passing `split-mode` (non-`none`), `main-gpu`, or `tensor-split` on a mobile device now throws `InvalidArgument` immediately in `setupParams`, before any backend selection occurs. Previously these parameters could silently cause undefined behaviour on mobile. Use single-GPU config on mobile.
+
+## Pull Requests
+
+- [#2148](https://github.com/tetherto/qvac/pull/2148) - QVAC-18802: reject multi-GPU config on Android/iOS
+
 ## [0.16.0] - 2026-05-10
 
 ### Changed

--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Pull Requests
 
-- [#2148](https://github.com/tetherto/qvac/pull/2148) - QVAC-18802: reject multi-GPU config on Android/iOS
+- [#2151](https://github.com/tetherto/qvac/pull/2151) - QVAC-18802: reject multi-GPU config on Android/iOS
 
 ## [0.16.0] - 2026-05-10
 

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -10,6 +10,9 @@
 #include <llama.h>
 #include <llama/common/arg.h>
 #include <inference-addon-cpp/Errors.hpp>
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
 
 #include "BackendSelection.hpp"
 #include "LlamaLazyInitializeBackend.hpp"
@@ -299,6 +302,20 @@ common_params setupParams(
   configVector.emplace_back(modelGgufPath);
 
   llama_split_mode splitMode = parseSplitMode(configFilemap);
+
+#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
+  if (splitMode != LLAMA_SPLIT_MODE_NONE ||
+      configFilemap.count("main-gpu") > 0 ||
+      configFilemap.count("main_gpu") > 0 ||
+      configFilemap.count("tensor-split") > 0) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InvalidArgument),
+        "Multi-GPU parameters (split-mode, main-gpu, tensor-split) are not "
+        "supported on mobile (single-GPU device).");
+  }
+#endif
 
   auto deviceIt = configFilemap.find("device");
   if (deviceIt == configFilemap.end()) {

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Multi-GPU config params (`split-mode`, `main-gpu`, `tensor-split`) passed to the embedding addon on Android or iOS reach the Adreno OpenCL backend and can trigger undefined behaviour / native crash.
- Mobile devices have a single GPU; there is no valid multi-GPU use case on these platforms.

## 📝 How does it solve it?

- Added a compile-time platform guard in `setupParams` (`BertModel.cpp`) using `#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)`.
- If any of `split-mode` (non-`none`), `main-gpu`, or `tensor-split` are present, throws `InvalidArgument` immediately before any backend selection occurs.
- Guard fires in C++ regardless of what the JS layer did, providing a hard safety net.

## 🔌 API Changes

Passing multi-GPU parameters on Android/iOS now throws `InvalidArgument` instead of silently proceeding:

```typescript
// On mobile — throws InvalidArgument
await model.embed({ text: '...' }, { splitMode: 'layer', tensorSplit: '1,1' });

// Use single-GPU config instead
await model.embed({ text: '...' }, { device: 'gpu', gpuLayers: 99 });
```