### PR TITLE
QVAC-18802 fix: strip multi-GPU config params on mobile with warning

### DIFF
--- a/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
@@ -36,6 +36,8 @@ import {
 } from "@/server/bare/runtime";
 import { generateServerRequestId } from "@/server/bare/runtime/request-id";
 import { getServerLogger } from "@/logging";
+import { isMobile } from "@/server/bare/registry/runtime-context-registry";
+import { stripMultiGpuKeys } from "@/server/bare/plugins/utils/multi-gpu-mobile";
 
 
 function createLlmModel(
@@ -47,6 +49,17 @@ function createLlmModel(
   const logger = createStreamLogger(modelId, ModelType.llamacppCompletion);
   registerAddonLogger(modelId, ModelType.llamacppCompletion, logger);
   const llmConfigStrings = transformLlmConfig(llmConfig);
+
+  // Device patterns can't override user input; multi-GPU causes Adreno OpenCL SIGABRT on mobile.
+  if (isMobile()) {
+    const stripped = stripMultiGpuKeys(llmConfigStrings);
+    if (stripped.length > 0) {
+      getServerLogger().warn(
+        `[${ModelType.llamacppCompletion}:${modelId}] Multi-GPU parameters (${stripped.join(", ")}) are not supported on mobile (single-GPU device) — removing from config; model will load with single-GPU defaults`,
+      );
+    }
+  }
+
   const modelFiles = expandGGUFIntoShards(modelPath);
 
   const model = new LlmLlamacpp({

--- a/packages/sdk/server/bare/plugins/llamacpp-embedding/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-embedding/plugin.ts
@@ -12,10 +12,12 @@ import {
   type PluginModelResult,
   type EmbedConfig,
 } from "@/schemas";
-import { createStreamLogger, registerAddonLogger } from "@/logging";
+import { createStreamLogger, registerAddonLogger, getServerLogger } from "@/logging";
 import { expandGGUFIntoShards } from "@/server/utils";
 import { embed } from "@/server/bare/ops/embed";
 import { forwardModelExecution } from "@/profiling/model-execution";
+import { isMobile } from "@/server/bare/registry/runtime-context-registry";
+import { stripMultiGpuKeys } from "@/server/bare/plugins/utils/multi-gpu-mobile";
 
 function transformEmbedConfig(embedConfig: EmbedConfig): GGMLConfig {
   const config: GGMLConfig = {
@@ -75,6 +77,17 @@ function createEmbeddingsModel(
   registerAddonLogger(modelId, ModelType.llamacppEmbedding, logger);
 
   const config = transformEmbedConfig(embedConfig);
+
+  // Device patterns can't override user input; multi-GPU causes Adreno OpenCL SIGABRT on mobile.
+  if (isMobile()) {
+    const stripped = stripMultiGpuKeys(config);
+    if (stripped.length > 0) {
+      getServerLogger().warn(
+        `[${ModelType.llamacppEmbedding}:${modelId}] Multi-GPU parameters (${stripped.join(", ")}) are not supported on mobile (single-GPU device) — removing from config; model will load with single-GPU defaults`,
+      );
+    }
+  }
+
   const modelFiles = expandGGUFIntoShards(modelPath);
 
   const model = new EmbedLlamacpp({

--- a/packages/sdk/server/bare/plugins/utils/multi-gpu-mobile.ts
+++ b/packages/sdk/server/bare/plugins/utils/multi-gpu-mobile.ts
@@ -1,0 +1,11 @@
+export const MULTI_GPU_KEYS = ["main-gpu", "split-mode", "tensor-split"] as const;
+type MultiGpuKey = (typeof MULTI_GPU_KEYS)[number];
+
+// gpu_layers (single-GPU layer offload) is intentionally absent from MULTI_GPU_KEYS.
+export function stripMultiGpuKeys(
+  config: Record<string, unknown>,
+): readonly MultiGpuKey[] {
+  const stripped = MULTI_GPU_KEYS.filter((k) => k in config);
+  stripped.forEach((k) => delete config[k]);
+  return stripped;
+}

--- a/packages/sdk/test/unit/multi-gpu-mobile.test.ts
+++ b/packages/sdk/test/unit/multi-gpu-mobile.test.ts
@@ -1,0 +1,38 @@
+// @ts-expect-error brittle has no type declarations
+import test from "brittle";
+import { stripMultiGpuKeys, MULTI_GPU_KEYS } from "@/server/bare/plugins/utils/multi-gpu-mobile";
+
+test("stripMultiGpuKeys: removes all three multi-GPU keys when present", (t) => {
+  const config: Record<string, unknown> = {
+    "main-gpu": "0",
+    "split-mode": "layer",
+    "tensor-split": "1,1",
+    device: "gpu",
+    gpu_layers: "99",
+  };
+  const stripped = stripMultiGpuKeys(config);
+  t.alike([...stripped], [...MULTI_GPU_KEYS]);
+  t.absent("main-gpu" in config);
+  t.absent("split-mode" in config);
+  t.absent("tensor-split" in config);
+  t.ok("device" in config);
+  t.ok("gpu_layers" in config, "gpu_layers (single-GPU offload) must be preserved");
+});
+
+test("stripMultiGpuKeys: returns empty array and mutates nothing when no multi-GPU keys", (t) => {
+  const config: Record<string, unknown> = { device: "gpu", gpu_layers: "99" };
+  const stripped = stripMultiGpuKeys(config);
+  t.alike([...stripped], []);
+  t.ok("device" in config);
+  t.ok("gpu_layers" in config);
+});
+
+test("stripMultiGpuKeys: strips only the keys that are present", (t) => {
+  const config: Record<string, unknown> = { "tensor-split": "1,1", device: "gpu" };
+  const stripped = stripMultiGpuKeys(config);
+  t.alike([...stripped], ["tensor-split"]);
+  t.absent("tensor-split" in config);
+  t.ok("device" in config);
+  t.absent("main-gpu" in config);
+  t.absent("split-mode" in config);
+});


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Multi-GPU config params (`split-mode`, `main-gpu`, `tensor-split`) passed by a caller on mobile devices would previously reach the C++ addon unchanged, where they can trigger a native crash (Adreno OpenCL SIGABRT).
- The SDK JS plugin layer had no defence; callers passing these keys on mobile got no warning and unpredictable behaviour.

## 📝 How does it solve it?

- New shared helper `stripMultiGpuKeys` in `server/bare/plugins/utils/multi-gpu-mobile.ts` mutates the config in-place, removes the three multi-GPU keys, and returns the list of what was stripped.
- Both the LLM completion plugin (`llamacpp-completion/plugin.ts`) and the embedding plugin (`llamacpp-embedding/plugin.ts`) call `stripMultiGpuKeys` when `isMobile()` is true, then log a `warn` with the model type, model ID, and the names of the stripped keys.
- Extraction into a named helper makes the contract unit-testable without mocking global runtime state.

## 🧪 How was it tested?

- 3 unit tests in `test/unit/multi-gpu-mobile.test.ts` (brittle): all three keys present, none present, only one key present. All pass (`bun run test:unit`).
- Build passes: `bun run build` clean.