### PR TITLE
QVAC-19277: Added missing optional model to manifest

### DIFF
--- a/packages/llm-llamacpp/scripts/download-unit-test-models.js
+++ b/packages/llm-llamacpp/scripts/download-unit-test-models.js
@@ -333,6 +333,16 @@ const SINGLE_FILE_MANIFEST = [
     url: 'https://huggingface.co/gianni-cor/bitnet_b1_58-large-TQ2_0/resolve/main/bitnet_b1_58-large-TQ2_0.gguf',
     dest: 'bitnet_b1_58-large-TQ2_0.gguf',
     sha256: '281aafb18a9f4a3124c10a1d8683e2296f0cfe8a2944da0a5667d17488a951bb'
+  },
+  {
+    // Enables CacheManagementQwen3Test.* (tools_compact feature) which require
+    // a Qwen3 model and otherwise GTEST_SKIP. Upstream Qwen/Qwen3-1.7B-GGUF
+    // does not publish a Q4_0 quant; using the unsloth community quant which
+    // is what the original test author appears to have used.
+    scope: 'optional',
+    url: 'https://huggingface.co/unsloth/Qwen3-1.7B-GGUF/resolve/main/Qwen3-1.7B-Q4_0.gguf',
+    dest: 'Qwen3-1.7B-Q4_0.gguf',
+    sha256: 'c876f159707a4e4f70e045106c69db15bfc935a4981706fd4f65c6e7ea1e81c5'
   }
 ]
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- After #2194, a full local `npm run test:cpp:models` still skipped `CacheManagementQwen3Test.*` because those tests need a Qwen3 model path (`isQwen3ModelPath()` checks the filename) and fall back to Llama without `Qwen3-1.7B-Q4_0.gguf`.
- The CI manifest was complete; the optional local manifest was missing this fixture.

## 📝 How does it solve it?

- Adds `Qwen3-1.7B-Q4_0.gguf` to the `optional` scope in `scripts/download-unit-test-models.js` (not downloaded with `--ci`).
- Source: `unsloth/Qwen3-1.7B-GGUF` — upstream `Qwen/Qwen3-1.7B-GGUF` does not publish Q4_0; this matches what the original tests expected.
- Pinned SHA256: `c876f159707a4e4f70e045106c69db15bfc935a4981706fd4f65c6e7ea1e81c5`.
- No workflow, `package.json` script, or runner changes — manifest-only follow-up to merged #2194.

## 🧪 How was it tested?

- `npm run test:cpp:models` — downloads the new optional model (~1.1 GiB).
- `npm run test:cpp:run` — `CacheManagementQwen3Test.*` no longer `GTEST_SKIP` when the model is present.
- `npm run test:cpp:models:ci` — unchanged CI footprint (optional entry excluded).

## 💥 Breaking Changes

N/A — test tooling only; no public API or runtime behavior change.

## 🔌 API Changes

N/A
