### PR TITLE
infra[notask]: restore classification-ggml mobile asset prep

### DIFF
--- a/.github/workflows/integration-mobile-test-classification-ggml.yml
+++ b/.github/workflows/integration-mobile-test-classification-ggml.yml
@@ -103,6 +103,16 @@ jobs:
           prebuild-artifact-prefix: 'classification-ggml-'
           pat-token: ${{ secrets.PAT_TOKEN }}
 
+      # The shared composite handles prebuild fan-out, but classification-ggml
+      # also needs `weights/*.gguf` copied into `test/mobile/testAssets/<file>.gguf.bin`
+      # (plus `test/images/*` staged) so the React Native bundler packs them into
+      # the APK/IPA. Without this `resolveModelPath()` in test/integration/utils.js
+      # throws at runtime: "Mobile asset not found in global.assetPaths:
+      # mobilenetv3_3class_v3_fp16.gguf.bin". See scripts/copy-mobile-test-assets.js.
+      - name: Copy mobile test assets (weights + images)
+        working-directory: addon/${{ inputs.workdir || 'packages/classification-ggml' }}
+        run: npm run mobile:copy-prebuilds
+
       - name: Build mobile app
         id: build
         uses: ./.github/actions/run-mobile-integration-tests/build-mobile-app


### PR DESCRIPTION
## Summary

- Restores the `npm run mobile:copy-prebuilds` step for classification-ggml's mobile E2E workflow, which was dropped when #2153 migrated the workflow onto the shared composite action.
- Without it, the GGUF weights bundle never lands in `test/mobile/testAssets/`, so the React Native bundler doesn't pack it, `global.assetPaths` has no entry for `mobilenetv3_3class_v3_fp16.gguf.bin`, and the bare runtime aborts on every device.
- Mirrors the existing pattern in `integration-mobile-test-vla.yml`.

## Why

`scripts/copy-mobile-test-assets.js` has three responsibilities:
1. Fan out the arm64 prebuild into per-flavour directories under `prebuilds/` — the shared composite now handles this.
2. Copy `weights/mobilenetv3_3class_v3_fp16.gguf` → `test/mobile/testAssets/mobilenetv3_3class_v3_fp16.gguf.bin` (`.bin` suffix because the bundler doesn't treat `.gguf` as a binary asset).
3. Stage `test/images/*` into `testAssets/` so `loadImage()` can resolve them via `global.assetPaths`.

The composite only covers (1). (2) and (3) are addon-specific and were lost in the refactor.

## Evidence

- **Last known-good Android E2E on main**: run [26168109084](https://github.com/tetherto/qvac/actions/runs/26168109084) at 2026-05-20 14:10Z.
- **First failure**: 2026-05-20 ~16:02Z, immediately after `2125b47a` (#2153) landed.
- **Symptom**: Every device aborts identically (`SIGABRT` in `libbare-kit.so → js_callback_s::on_call`) from this uncaught rejection on the bare thread:
  ```
  Uncaught (in promise) Error: Mobile asset not found in global.assetPaths:
    mobilenetv3_3class_v3_fp16.gguf.bin.
  Did 'npm run mobile:copy-prebuilds' run during test setup, ...
      at resolveModelPath (file:///app.bundle/backend/test/integration/utils.js:126:11)
      at makeClassifier (file:///app.bundle/backend/test/integration/utils.js:169:16)
      at file:///app.bundle/backend/test/integration/classify.test.js:17:22
  ```

## Scope

Only `classification-ggml` is fixed here. Other addons migrated in #2153 (tts-ggml, embed-llamacpp, diffusion-cpp, etc.) may have similar gaps if they also relied on an addon-specific asset-prep script — worth a follow-up audit, possibly by adding an opt-in `mobile-prep-script` input to the shared composite so addons can register their script in one place.

## Test plan

- [ ] CI runs `on-pr-classification-ggml.yml`; verify `Build Android and Run E2E Tests` passes (3/3 devices green, `runClassify` test PASS instead of crash).
- [ ] iOS E2E continues to behave the same (was already failing for unrelated reasons; this change shouldn't make iOS worse).
- [ ] Confirm `Copy mobile test assets (weights + images)` step appears in the Android job log and reports `[mobile:copy-prebuilds] Done.`.
