### PR TITLE
infra[notask]: route classification cpp-tests linux to self-hosted

### DIFF
--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -36,9 +36,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             platform: linux
             arch: x64
+            runner: qvac-ubuntu2404-x64
           - os: macos-15
             platform: darwin
             arch: arm64
@@ -46,7 +47,7 @@ jobs:
             platform: win32
             arch: x64
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
     name: cpp-tests-${{ matrix.platform }}-${{ matrix.arch }}
 

--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -43,9 +43,10 @@ jobs:
           - os: macos-15
             platform: darwin
             arch: arm64
-          - os: windows-2022
+          - os: windows-2025
             platform: win32
             arch: x64
+            runner: qvac-win25-x64
 
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release


### PR DESCRIPTION
## Summary

- Move classification-ggml's cpp-tests Linux entry off GitHub-hosted `ubuntu-22.04` onto self-hosted `qvac-ubuntu2404-x64` (ubuntu-24.04).
- Matches the pattern every other addon's cpp-tests workflow uses (`vla`, `llm`, `embed`, `diffusion`).
- Windows + macOS entries unchanged — they're currently green on GitHub-hosted.

## Why

On GitHub-hosted jammy, `setup-llvm` apt-installs `clang-19` + `libc++-19` headers but does **not** run `update-alternatives`, so the unversioned `/usr/bin/clang++` keeps resolving to the stock jammy `clang-14`. vcpkg then builds `qvac-fabric`/`ggml` with clang-14 against the libc++-19 headers and dies:

```
[1/30] /usr/bin/clang++ ... -stdlib=libc++ -std=gnu++17 ...
FAILED: ggml/src/CMakeFiles/ggml-base.dir/ggml.cpp.o
warning "Libc++ only supports Clang 17 and later"
error: expected identifier or '{'
_LIBCPP_BEGIN_NAMESPACE_STD
error: 'std' is not a class, namespace, or enumeration
...
error: building qvac-fabric:x64-linux failed with: BUILD_FAILED
```

(Example: [run 26306239236 / job 77450659161](https://github.com/tetherto/qvac/actions/runs/26306239236/job/77450659161).)

CLAUDE.md's setup-llvm guidance covers this:

> every package's `linux-clang.cmake` now uses unversioned `clang`/`clang++`, so pointing them at a different version only requires `update-alternatives` on your machine

Self-hosted `qvac-ubuntu2404-x64` is provisioned per that guidance (clang-22 + alternatives wired up), so the build resolves the right compiler. Classification's workflow was simply missed when sister workflows were migrated.

## Comparison

| Addon | Linux cpp-tests runner |
|---|---|
| **classification-ggml** (before this PR) | `ubuntu-22.04` (GitHub-hosted, default clang-14) ❌ |
| **classification-ggml** (after this PR) | `qvac-ubuntu2404-x64` (self-hosted, clang-22) ✅ |
| vla-ggml | `qvac-ubuntu2404-x64` |
| llm-llamacpp | `qvac-ubuntu2404-x64` |
| embed-* | `qvac-ubuntu2404-x64` |
| diffusion-cpp | `qvac-ubuntu2404-x64` |

## Test plan

- [ ] CI runs `cpp-tests-classification.yml`; the linux-x64 entry should go green on `qvac-ubuntu2404-x64`.
- [ ] macOS + Windows entries unaffected.
