### PR TITLE
infra[notask]: route classification cpp-tests linux to self-hosted (#…

### DIFF
--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -36,17 +36,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             platform: linux
             arch: x64
+            runner: qvac-ubuntu2404-x64
           - os: macos-15
             platform: darwin
             arch: arm64
-          - os: windows-2022
+          - os: windows-2025
             platform: win32
             arch: x64
+            runner: qvac-win25-x64
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
     name: cpp-tests-${{ matrix.platform }}-${{ matrix.arch }}
 


### PR DESCRIPTION
…2212)

* infra[notask]: route classification cpp-tests linux to self-hosted

Move the classification-ggml cpp-tests Linux entry off GitHub-hosted ubuntu-22.04 onto qvac-ubuntu2404-x64 (ubuntu-24.04), matching every other addon's cpp-tests workflow (vla, llm, embed, diffusion).

Why: on GitHub-hosted jammy, `setup-llvm` apt-installs clang-19 + libc++-19 but does not run `update-alternatives`, so the unversioned `/usr/bin/clang++` keeps resolving to the system default clang-14. The vcpkg build then compiles ggml with clang-14 against libc++-19 headers and fails on the new `__verbose_abort` / `_LIBCPP_BEGIN_NAMESPACE_STD` macros (warning literally says "Libc++ only supports Clang 17 and later").

Self-hosted qvac-ubuntu2404-x64 is provisioned with clang-22 and the alternatives wired correctly per CLAUDE.md's setup-llvm guidance, so the unversioned `clang++` invocations resolve as expected.

Windows + macOS entries left as-is — they're currently green.

* infra[notask]: also route classification cpp-tests windows to self-hosted

Per review feedback on PR #2212 — bump windows-2022 → windows-2025 and add runner: qvac-win25-x64, matching llm/embed/vla/diffusion cpp-tests.

<!--
Style guide for this PR description:
- Be concise; prefer bullet points.
- Delete sections that don't apply.
- Keep code examples minimal.
-->

## What problem does this PR solve?

## How does it solve it?

## Breaking changes
