### PR TITLE
infra: fix windows bare tooling setup on windows when installing nodejs too (part 1)

### DIFF
--- a/.github/actions/setup-bare-tooling/action.yml
+++ b/.github/actions/setup-bare-tooling/action.yml
@@ -2,6 +2,10 @@ name: Setup Bare tooling
 description: Setup Node and install the global Bare runtime and bare-make tooling used by prebuild workflows.
 
 inputs:
+  shell_type:
+    description: "bash | powershell"
+    required: false
+    default: bash
   node-version:
     description: Node version to install
     required: false
@@ -20,5 +24,5 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Install global dependencies
-      shell: bash
+      shell: ${{ inputs.shell_type }}
       run: npm install -g --force bare-runtime bare-make ${{ inputs.extra-packages }}

--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -90,6 +90,8 @@ jobs:
 
       - name: Setup Bare tooling
         uses: tetherto/qvac/.github/actions/setup-bare-tooling@926f6f14092fbacaa3606ea475457fddf37d9838
+        with:
+          shell_type: ${{ matrix.platform == 'win32' && 'powershell' || 'bash' }}
 
       - name: Setup Apple Clang
         if: ${{ matrix.platform == 'darwin' }}

--- a/.github/workflows/integration-test-classification-ggml.yml
+++ b/.github/workflows/integration-test-classification-ggml.yml
@@ -61,16 +61,6 @@ jobs:
             arch: x64
 
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
-        with:
-          node-version: lts/*
-
-      - name: Windows — enable git long paths
-        if: ${{ matrix.platform == 'win32' }}
-        shell: bash
-        run: git config --system core.longpaths true
-
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
@@ -80,6 +70,8 @@ jobs:
 
       - name: Setup Bare runtime
         uses: tetherto/qvac/.github/actions/setup-bare-tooling@926f6f14092fbacaa3606ea475457fddf37d9838
+        with:
+          shell_type: ${{ matrix.platform == 'win32' && 'powershell' || 'bash' }}
 
       - name: Install npm dependencies
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -215,6 +215,8 @@ jobs:
 
       - name: Setup Bare tooling
         uses: tetherto/qvac/.github/actions/setup-bare-tooling@926f6f14092fbacaa3606ea475457fddf37d9838
+        with:
+          shell_type: ${{ matrix.platform == 'win32' && 'powershell' || 'bash' }}
 
       - name: Setup Apple Clang
         uses: tetherto/qvac/.github/actions/setup-apple-clang@1d9b2165867d03c6edd675e402ee101a5d48a6d8


### PR DESCRIPTION
## What problem does this PR solve?

Fixes exit code 127 (command not found) when npm install bare tooling runs after nodejs setup step in the bare tooling setup composite action

## How does it solve it?

ensures windows uses powershell rather than bash. all else, use bash by default.

a followup PR will be proposed to use the hash of the updated composite action (setup-bare-tooling)

## Breaking changes
none