### PR TITLE
infra: setup-build-host on GH hosted runners only

### DIFF
--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -62,14 +62,6 @@ jobs:
           echo "  HEAD_REPO=$HEAD_REPO"
           echo "  HEAD_REF=$HEAD_REF"
 
-      # - name: Setup build host
-      #   uses: tetherto/qvac/.github/actions/setup-build-host@df55c85d7b8004961e430557e85b6ec1b15cf170
-      #   with:
-      #     platform: linux
-      #     arch: x64
-
-      # - name: Setup LLVM
-      #   uses: tetherto/qvac/.github/actions/setup-llvm@0c819dd1110e4902223b1f7646cc0f1be2c9bc5c
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -56,7 +56,8 @@ jobs:
       WORKDIR: ${{ inputs.workdir }}
 
     steps:
-      - name: Setup build host
+      - name: Setup build host (github-hosted runners only)
+        if: runner.environment == 'github-hosted'
         uses: tetherto/qvac/.github/actions/setup-build-host@1d9b2165867d03c6edd675e402ee101a5d48a6d8
         with:
           platform: ${{ matrix.platform }}

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -168,7 +168,7 @@ jobs:
           echo "Matrix tags: $MATRIX_TAGS"
 
       - name: Setup build host (Linux arm and macOS)
-        if: matrix.arch == 'arm64' || matrix.os == 'macos-15' || matrix.os == 'macos-15-intel'
+        if: runner.environment == 'github-hosted'
         uses: tetherto/qvac/.github/actions/setup-build-host@df55c85d7b8004961e430557e85b6ec1b15cf170
         with:
           platform: ${{ matrix.platform }}
@@ -176,8 +176,9 @@ jobs:
           linux-extra-packages: ${{ inputs.linux-extra-packages }}
 
       - name: Setup LLVM (Linux arm and macOS)
-        if: matrix.arch == 'arm64' || matrix.os == 'macos-15' || matrix.os == 'macos-15-intel'
+        if: runner.environment == 'github-hosted'
         uses: tetherto/qvac/.github/actions/setup-llvm@0c819dd1110e4902223b1f7646cc0f1be2c9bc5c
+
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash


### PR DESCRIPTION
## What problem does this PR solve?
errors about sudo failing on self-hosted runners

## How does it solve it?
excludes steps already ensured on self-hosted runners, which require sudo

## Breaking changes
none