### PR TITLE
infra[notask]: use setup-vcpkg action in cpp test workflows

### DIFF
--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -72,37 +72,15 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         run: echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
-      - if: ${{ matrix.os == 'windows-2025' }}
-        name: Clone and bootstrap vcpkg (Windows)
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git
-          ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
-          echo ("VCPKG_ROOT=$env:GITHUB_WORKSPACE/vcpkg" -replace '\\', '/') >> $env:GITHUB_ENV
+      - name: Setup vcpkg
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@1d9b2165867d03c6edd675e402ee101a5d48a6d8
+        env:
+          MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
+        with:
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
 
-      - if: ${{ matrix.os == 'macos-14' }}
-        name: Install vcpkg on macOS
-        working-directory: ${{ env.WORKDIR }}
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git vcpkg_microsoft
-          cd vcpkg_microsoft && ./bootstrap-vcpkg.sh -disableMetrics
-          VCPKG_ROOT="$(pwd)"
-          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
-          echo "$VCPKG_ROOT" >> $GITHUB_PATH
-          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
-
-      - if: ${{ matrix.os == 'ubuntu-24.04' }}
-        name: Install vcpkg on linux
-        working-directory: ${{ env.WORKDIR }}
-        shell: bash
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git vcpkg_microsoft
-          cd vcpkg_microsoft && ./bootstrap-vcpkg.sh -disableMetrics
-          VCPKG_ROOT="$(pwd)"
-          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
-          echo "$VCPKG_ROOT" >> $GITHUB_PATH
-
-      - if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'windows-2025' }}
-        name: Cleanup vcpkg
+      - name: Cleanup vcpkg
         shell: bash
         run: |
           rm -rf $VCPKG_ROOT/buildtrees/*
@@ -116,17 +94,9 @@ jobs:
           echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR_PLATFORM=x64" >> $env:GITHUB_ENV
 
-      - name: Create vcpkg cache location (non-Windows)
-        if: ${{ matrix.os != 'windows-2025' }}
-        working-directory: ${{ env.WORKDIR }}
-        run: mkdir -p vcpkg/cache
-
-      - name: Create vcpkg cache location (Windows)
-        if: ${{ matrix.os == 'windows-2025' }}
-        shell: powershell
-        working-directory: ${{ env.WORKDIR }}
-        run: |
-          New-Item -ItemType Directory -Force -Path "vcpkg/cache" | Out-Null
+      - name: Create vcpkg cache location (package-local)
+        shell: bash
+        run: mkdir -p "${{ env.WORKDIR }}/vcpkg/cache"
 
       - name: Get vcpkg cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -105,36 +105,15 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         run: echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
-      - if: ${{ startsWith(matrix.os, 'macos') }}
-        name: Install vcpkg on macOS
-        shell: bash
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git vcpkg_microsoft
-          cd vcpkg_microsoft && ./bootstrap-vcpkg.sh -disableMetrics
-          VCPKG_ROOT=$(pwd)
-          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
-          echo "$VCPKG_ROOT" >> $GITHUB_PATH
-          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+      - name: Setup vcpkg
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@1d9b2165867d03c6edd675e402ee101a5d48a6d8
+        env:
+          MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
+        with:
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
 
-      - if: ${{ matrix.os == 'ubuntu-24.04' }}
-        name: Install vcpkg on linux
-        shell: bash
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git vcpkg_microsoft
-          cd vcpkg_microsoft && ./bootstrap-vcpkg.sh -disableMetrics
-          VCPKG_ROOT="$(pwd)"
-          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
-          echo "$VCPKG_ROOT" >> $GITHUB_PATH
-
-      - if: ${{ matrix.os == 'windows-2025' }}
-        name: Clone and bootstrap vcpkg (Windows)
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git
-          ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
-          echo ("VCPKG_ROOT=$env:GITHUB_WORKSPACE/vcpkg" -replace '\\', '/') >> $env:GITHUB_ENV
-
-      - if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'windows-2025' }}
-        name: Cleanup vcpkg
+      - name: Cleanup vcpkg
         shell: bash
         run: |
           rm -rf $VCPKG_ROOT/buildtrees/*

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -73,38 +73,15 @@ jobs:
         run: echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
 
-      - if: ${{ matrix.os == 'windows-2025' }}
-        name: Clone and bootstrap vcpkg (Windows)
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git
-          ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
-          echo ("VCPKG_ROOT=$env:GITHUB_WORKSPACE/vcpkg" -replace '\\', '/') >> $env:GITHUB_ENV
+      - name: Setup vcpkg
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@1d9b2165867d03c6edd675e402ee101a5d48a6d8
+        env:
+          MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
+        with:
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
 
-      - if: ${{ matrix.os == 'macos-14' }}
-        name: Install vcpkg on macOS
-        working-directory: ${{ env.WORKDIR }}
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git vcpkg_microsoft
-          cd vcpkg_microsoft && ./bootstrap-vcpkg.sh -disableMetrics
-          VCPKG_ROOT="$(pwd)"
-          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
-          echo "$VCPKG_ROOT" >> $GITHUB_PATH
-          # Set deployment target for C++20 std::format support
-          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
-
-      - if: ${{ matrix.os == 'ubuntu-24.04' }}
-        name: Install vcpkg on linux
-        working-directory: ${{ env.WORKDIR }}
-        shell: bash
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git vcpkg_microsoft
-          cd vcpkg_microsoft && ./bootstrap-vcpkg.sh -disableMetrics
-          VCPKG_ROOT="$(pwd)"
-          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
-          echo "$VCPKG_ROOT" >> $GITHUB_PATH
-
-      - if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'windows-2025' }}
-        name: Cleanup vcpkg
+      - name: Cleanup vcpkg
         shell: bash
         run: |
           rm -rf $VCPKG_ROOT/buildtrees/*
@@ -118,18 +95,9 @@ jobs:
           echo "CMAKE_GENERATOR=Visual Studio 17 2022" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR_PLATFORM=x64" >> $env:GITHUB_ENV
 
-      # mkdir -p is not portable to pwsh; do per-OS
-      - name: Create vcpkg cache location (non-Windows)
-        if: ${{ matrix.os != 'windows-2025' }}
-        working-directory: ${{ env.WORKDIR }}
-        run: mkdir -p vcpkg/cache
-
-      - name: Create vcpkg cache location (Windows)
-        if: ${{ matrix.os == 'windows-2025' }}
-        shell: powershell
-        working-directory: ${{ env.WORKDIR }}
-        run: |
-          New-Item -ItemType Directory -Force -Path "vcpkg/cache" | Out-Null
+      - name: Create vcpkg cache location (package-local)
+        shell: bash
+        run: mkdir -p "${{ env.WORKDIR }}/vcpkg/cache"
 
       - name: Get vcpkg cache
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -131,40 +131,15 @@ jobs:
         shell: bash
         run: echo "VULKAN_SDK=/opt/vulkansdk/x86_64" >> $GITHUB_ENV
 
-      - if: ${{ matrix.os == 'windows-2025' }}
-        name: Set Vulkan SDK Path on Windows
-        run: echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
+      - name: Setup vcpkg
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@1d9b2165867d03c6edd675e402ee101a5d48a6d8
+        env:
+          MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
+        with:
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
 
-      - if: ${{ startsWith(matrix.os, 'macos') }}
-        name: Install vcpkg on macOS
-        shell: bash
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git vcpkg_microsoft
-          cd vcpkg_microsoft && ./bootstrap-vcpkg.sh -disableMetrics
-          VCPKG_ROOT=$(pwd)
-          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
-          echo "$VCPKG_ROOT" >> $GITHUB_PATH
-          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
-
-      - if: ${{ matrix.os == 'ubuntu-24.04' }}
-        name: Clone and bootstrap vcpkg (Linux)
-        shell: bash
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git vcpkg_microsoft
-          cd vcpkg_microsoft && ./bootstrap-vcpkg.sh -disableMetrics
-          VCPKG_ROOT="$(pwd)"
-          echo "VCPKG_ROOT=$VCPKG_ROOT" >> $GITHUB_ENV
-          echo "$VCPKG_ROOT" >> $GITHUB_PATH
-
-      - if: ${{ matrix.os == 'windows-2025' }}
-        name: Clone and bootstrap vcpkg (Windows)
-        run: |
-          git clone --branch 2025.12.12 --single-branch https://github.com/microsoft/vcpkg.git
-          ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
-          echo ("VCPKG_ROOT=$env:GITHUB_WORKSPACE/vcpkg" -replace '\\', '/') >> $env:GITHUB_ENV
-
-      - if: ${{ matrix.os == 'ubuntu-24.04' || matrix.os == 'windows-2025' }}
-        name: Cleanup vcpkg
+      - name: Cleanup vcpkg
         shell: bash
         run: |
           rm -rf $VCPKG_ROOT/buildtrees/*

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -196,10 +196,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
-      - name: Use vcpkg in user profile on windows
-        if: matrix.os == 'windows-2025'
-        run: echo "VCPKG_INSTALLATION_ROOT=$HOME\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Append
-
       - name: Setup vcpkg
         uses: tetherto/qvac/.github/actions/setup-vcpkg@1d9b2165867d03c6edd675e402ee101a5d48a6d8
         env:


### PR DESCRIPTION
## Summary

- Replace duplicated per-OS vcpkg clone/bootstrap steps in cpp test workflows with the shared `setup-vcpkg` composite action
- Unify vcpkg cache directory creation across platforms using bash `mkdir -p`
- Remove the obsolete Windows `VCPKG_INSTALLATION_ROOT` override from `reusable-prebuilds.yml`

## Test plan

- [ ] Trigger cpp test workflows (llm, embed, diffusion, vla) on Linux, macOS, and Windows and confirm vcpkg setup succeeds
- [ ] Confirm reusable prebuilds still bootstrap vcpkg correctly on Windows
