### PR TITLE
infra: pass GITHUB_TOKEN to setup-node in workflows

### DIFF
--- a/.github/workflows/benchmark-embed-llamacpp.yml
+++ b/.github/workflows/benchmark-embed-llamacpp.yml
@@ -232,6 +232,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0

--- a/.github/workflows/benchmark-llm-llamacpp.yml
+++ b/.github/workflows/benchmark-llm-llamacpp.yml
@@ -282,6 +282,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0

--- a/.github/workflows/benchmark-ocr-onnx.yml
+++ b/.github/workflows/benchmark-ocr-onnx.yml
@@ -98,6 +98,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install global dependencies
         run: npm install -g --force bare-make bare-runtime
@@ -201,6 +202,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bare-runtime
         if: needs.setup.outputs.qvac_needed == 'true'

--- a/.github/workflows/benchmark-performance-infer-llm-llamacpp.yml
+++ b/.github/workflows/benchmark-performance-infer-llm-llamacpp.yml
@@ -166,6 +166,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # 4.4.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all perf report artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1

--- a/.github/workflows/benchmark-performance-tts-onnx.yml
+++ b/.github/workflows/benchmark-performance-tts-onnx.yml
@@ -222,6 +222,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0

--- a/.github/workflows/benchmark-rtf-tts-onnx.yml
+++ b/.github/workflows/benchmark-rtf-tts-onnx.yml
@@ -115,6 +115,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Windows - enable git long paths
         if: ${{ matrix.platform == 'win32' }}
@@ -306,6 +307,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/benchmark-translation-nmtcpp.yml
+++ b/.github/workflows/benchmark-translation-nmtcpp.yml
@@ -171,6 +171,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install global dependencies
         run: npm install -g --force bare-make bare-runtime
@@ -349,6 +350,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bare-runtime
         run: npm install -g --force bare-runtime

--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -98,6 +98,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bare tooling
         run: npm install -g --force bare bare-make

--- a/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
@@ -64,6 +64,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bare tooling
         run: npm install -g --force bare bare-make

--- a/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bare tooling
         run: npm install -g --force bare bare-make

--- a/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
@@ -64,6 +64,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bare tooling
         run: npm install -g --force bare bare-make

--- a/.github/workflows/cpp-test-coverage-tts-ggml.yml
+++ b/.github/workflows/cpp-test-coverage-tts-ggml.yml
@@ -72,6 +72,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bare tooling
         run: npm install -g --force bare bare-make

--- a/.github/workflows/cpp-test-coverage-tts-onnx.yml
+++ b/.github/workflows/cpp-test-coverage-tts-onnx.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install bare tooling
         run: npm install -g --force bare bare-make

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -109,6 +109,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install NPM dependencies
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -110,6 +110,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install NPM dependencies
         working-directory: ${{ env.WORKDIR }}

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -253,6 +253,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Combine performance reports
         uses: ./.github/actions/run-mobile-integration-tests/combine-perf-reports

--- a/.github/workflows/integration-mobile-test-vla.yml
+++ b/.github/workflows/integration-mobile-test-vla.yml
@@ -139,6 +139,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure scoped registry for @qvac and @tetherto packages
         env:

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/integration-test-decoder-audio.yml
+++ b/.github/workflows/integration-test-decoder-audio.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Windows - configure git credentials
         if: ${{ matrix.platform == 'win32' }}

--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -69,6 +69,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -124,6 +124,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Windows - configure git
         if: ${{ matrix.platform == 'win32' }}

--- a/.github/workflows/integration-test-ocr-onnx.yml
+++ b/.github/workflows/integration-test-ocr-onnx.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/integration-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-test-transcription-parakeet.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -111,6 +111,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/integration-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-test-translation-nmtcpp.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -100,6 +100,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/integration-test-tts-onnx.yml
+++ b/.github/workflows/integration-test-tts-onnx.yml
@@ -158,6 +158,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
@@ -327,6 +328,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         if: (matrix.platform == 'linux' || matrix.platform == 'darwin') && matrix.arch == 'arm64'

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash

--- a/.github/workflows/on-merge-diffusion-cpp.yml
+++ b/.github/workflows/on-merge-diffusion-cpp.yml
@@ -178,6 +178,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
@@ -238,6 +239,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1

--- a/.github/workflows/on-merge-llm-llamacpp.yml
+++ b/.github/workflows/on-merge-llm-llamacpp.yml
@@ -178,6 +178,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
@@ -238,6 +239,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download prebuild artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -111,6 +111,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies
         run: npm install --ignore-scripts
       - name: Type declaration check

--- a/.github/workflows/on-pr-diffusion-cpp.yml
+++ b/.github/workflows/on-pr-diffusion-cpp.yml
@@ -121,6 +121,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies
         working-directory: packages/diffusion-cpp
         run: npm install

--- a/.github/workflows/on-pr-embed-llamacpp.yml
+++ b/.github/workflows/on-pr-embed-llamacpp.yml
@@ -135,6 +135,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         working-directory: packages/embed-llamacpp

--- a/.github/workflows/on-pr-llm-llamacpp.yml
+++ b/.github/workflows/on-pr-llm-llamacpp.yml
@@ -136,6 +136,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         working-directory: packages/llm-llamacpp
@@ -256,6 +257,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # 4.4.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all perf report artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1

--- a/.github/workflows/on-pr-translation-nmtcpp.yml
+++ b/.github/workflows/on-pr-translation-nmtcpp.yml
@@ -129,6 +129,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/on-pr-vla.yml
+++ b/.github/workflows/on-pr-vla.yml
@@ -136,6 +136,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         working-directory: packages/vla-ggml

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate performance report (manual)
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -213,6 +213,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         shell: bash
@@ -264,6 +265,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Consumer install check
         id: run_consumer_install

--- a/.github/workflows/pr-models-validation-registry-server.yml
+++ b/.github/workflows/pr-models-validation-registry-server.yml
@@ -152,6 +152,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         working-directory: ${{ env.PKG_DIR }}
@@ -178,6 +179,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         working-directory: ${{ env.PKG_DIR }}
@@ -241,6 +243,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         working-directory: ${{ env.PKG_DIR }}
@@ -282,6 +285,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install server dependencies
         working-directory: ${{ env.PKG_DIR }}

--- a/.github/workflows/pr-test-inference-addon-cpp-js.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp-js.yml
@@ -110,6 +110,7 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # 4.4.0
         with:
           node-version: 22
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Bare tooling
         run: npm install -g --force bare bare-make

--- a/.github/workflows/public-delete-npm-versions.yml
+++ b/.github/workflows/public-delete-npm-versions.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
           registry-url: "https://npm.pkg.github.com/"
           scope: "@tetherto"
 

--- a/.github/workflows/publish-registry-server.yml
+++ b/.github/workflows/publish-registry-server.yml
@@ -369,6 +369,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure npm for package registries
         shell: bash

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install NPM dependencies
         run: |

--- a/.github/workflows/sdk-install-check.yml
+++ b/.github/workflows/sdk-install-check.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: lts/*
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure public npm registry
         run: |

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -130,6 +130,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
         with:
@@ -526,6 +527,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
         with:

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -149,6 +149,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
         with:

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -143,6 +143,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
         with:
@@ -645,6 +646,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
         with:

--- a/.github/workflows/trigger-reusable-lib-cli.yml
+++ b/.github/workflows/trigger-reusable-lib-cli.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## Summary
- Add `token: ${{ secrets.GITHUB_TOKEN }}` to every `actions/setup-node` step across 52 workflow files (65 call sites)
- Ensures Node.js distribution downloads can authenticate against GitHub when required by `setup-node`
- No `node-version` or other `setup-node` inputs were changed

## Test plan
- [ ] CI workflows run successfully on this PR (spot-check a few representative jobs: cpp-tests, SDK pod checks, integration tests)
