### PR TITLE
QVAC-19213 chore: [DO NOT MERGE] pin transcription-whispercpp registry to Adreno fix…

### DIFF
--- a/packages/transcription-whispercpp/test/integration/mobile-perf-tiny-gpu.test.js
+++ b/packages/transcription-whispercpp/test/integration/mobile-perf-tiny-gpu.test.js
@@ -1,23 +1,15 @@
 'use strict'
 
 const test = require('brittle')
-const { detectPlatform } = require('./helpers.js')
 const { runMobilePerfCase } = require('./mobile-perf-runner.js')
 
 test('Mobile perf tiny GPU', { timeout: 600000 }, async (t) => {
-  // Whisper's GPU teardown crashes the bare app on Samsung Galaxy S25 Ultra
-  // (State=1 after-test:runMobilePerfTinyGpuTest in the Device Farm wdio
-  // crash detector). Pixel 9 Pro XL handles the same path fine, but the
-  // mobile workflow runs both devices off a single test spec so we can't
-  // skip the case per-device. Mirrors parakeet's "iOS Sortformer GPU"
-  // quarantine — keep the case skip-as-pass on Android until the
-  // underlying whisper GPU shutdown issue is fixed and the Samsung path
-  // is stable.
-  if (detectPlatform().startsWith('android')) {
-    t.pass('Whisper tiny GPU quarantined on Android pending Samsung crash investigation')
-    return
-  }
-
+  // QVAC-19213: un-quarantined on Android to verify the Adreno 740 Vulkan
+  // fix (mul_mat_vec subgroup->shmem on Qualcomm) on the AWS Device Farm.
+  // Ordered LAST in the suite (see integration.auto.cjs) so that if the
+  // separate GPU-teardown crash (whisper.cpp#2373) still fires on the
+  // Samsung S25 Ultra, it cannot abort the other integration cases — the
+  // bare app shares one process per device (wdio.template.js checkAppCrash).
   await runMobilePerfCase(t, {
     modelFile: 'ggml-tiny.bin',
     useGPU: true

--- a/packages/transcription-whispercpp/test/mobile/integration.auto.cjs
+++ b/packages/transcription-whispercpp/test/mobile/integration.auto.cjs
@@ -31,14 +31,21 @@ async function runMobilePerfTinyCpuTest (options = {}) { // eslint-disable-line 
   return runIntegrationModule('../integration/mobile-perf-tiny-cpu.test.js', options)
 }
 
-async function runMobilePerfTinyGpuTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/mobile-perf-tiny-gpu.test.js', options)
-}
-
 async function runModelFileValidationTest (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/model-file-validation.test.js', options)
 }
 
 async function runMultipleTranscriptionsTest (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/multiple-transcriptions.test.js', options)
+}
+
+// QVAC-19213: ordered LAST on purpose. The mobile harness runs these test
+// functions in source order (build-test-app.js parseAsyncFunctions, no sort),
+// and the bare app shares one process per device — a GPU-teardown crash
+// (whisper.cpp#2373) triggers process.exit (wdio.template.js checkAppCrash),
+// aborting everything after it. Keeping the GPU case last means that if the
+// teardown crash still fires on the Samsung S25 Ultra, the other integration
+// cases have already completed and reported.
+async function runMobilePerfTinyGpuTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/mobile-perf-tiny-gpu.test.js', options)
 }

--- a/packages/transcription-whispercpp/vcpkg-configuration.json
+++ b/packages/transcription-whispercpp/vcpkg-configuration.json
@@ -17,5 +17,8 @@
         "spirv-headers"
       ]
     }
+  ],
+  "overlay-ports": [
+    "./vcpkg-overlay-ports"
   ]
 }

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/android-vulkan-version.cmake
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/android-vulkan-version.cmake
@@ -1,0 +1,36 @@
+# Function to detect Vulkan version from NDK vulkan_core.h
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    # CMAKE_HOST_SYSTEM_PROCESSOR is unavailable here. Use a glob pattern to complete the folder instead. 
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT vulkan_core_h)
+        message(FATAL "vulkan_core.h not found, using default version")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL "Could not extract VK_HEADER_VERSION from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+
+     # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL "Could not extract major.minor version from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+endfunction()

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/portfile.cmake
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/portfile.cmake
@@ -1,0 +1,158 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac-ext-lib-whisper.cpp
+  # QVAC-19213: testing pin to validate the Adreno 740 Vulkan fix
+  # (mul_mat_vec subgroup->shmem on Qualcomm, H001-H008) end-to-end through
+  # the qvac mobile CI / device farm before merge. This commit = whisper-cpp
+  # 1.8.4.3 (f3102199, incl. QVAC-18993 Android dynamic backends) + the
+  # latest ggml upstream sync + the Adreno Vulkan fix (PR #30). Revert to
+  # REF v${VERSION} once the fix lands on a release tag.
+  REF 4273e2710e877c527a52f1efc78bf0b576662208
+  SHA512 fc57be0dd6b2725edd78f4617c967c5b83114e0dae3c4151971f7b226afb506f6b32758ece5a74c0f16b737fe756625e94dfec627745f79ec5d29e6e68b68ff9
+  HEAD_REF master
+)
+
+if (VCPKG_TARGET_IS_ANDROID)
+  # NDK only comes with C headers.
+  # Make sure C++ header exists, it will be used by ggml tensor library.
+  # Need to determine installed vulkan version and download correct headers
+  include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+  detect_ndk_vulkan_version()
+  message(STATUS "Using Vulkan C++ wrappers from version: ${vulkan_version}")
+  file(DOWNLOAD
+    "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+    "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    TLS_VERIFY ON
+  )
+
+  file(ARCHIVE_EXTRACT
+    INPUT "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    DESTINATION "${SOURCE_PATH}"
+  )
+
+  # Copy the Vulkan headers to where the build system expects them
+  # The build system looks for vulkan/vulkan.hpp with include path pointing to ggml/src/
+  file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+       DESTINATION "${SOURCE_PATH}/ggml/src/")
+  
+  # Clean up the temporary extracted directory
+  file(REMOVE_RECURSE "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if (VCPKG_TARGET_IS_OSX)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+elseif (VCPKG_TARGET_IS_IOS)
+  # Intentionally NOT -DGGML_METAL=ON. iOS bare-kit builds were hitting
+  # a separate Metal/Compiler XPC crash during transcribe() on physical
+  # iPhone (XPC_ERROR_CONNECTION_INTERRUPTED / MTLCompiler peer-unloaded)
+  # that is being investigated independently of the OutputCallBackJs
+  # teardown UAF. Force the flag OFF so it overrides any upstream default
+  # and stays explicit in the build log; iOS falls back to the CPU
+  # backend until the Metal-side issue is fixed.
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=OFF)
+elseif("vulkan" IN_LIST FEATURES)
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=OFF)
+endif()
+
+# Android: ship the same dynamic-backend + CPU-variant recipe llama-cpp
+# already uses on this triplet. GGML_BACKEND_DL=ON makes ggml load the
+# backend implementations as separate .so files at runtime (one per
+# backend, picked by the device caps), so a single APK ships all the
+# variants and the consumer's binary only statically links the dispatcher.
+# GGML_CPU_ALL_VARIANTS + GGML_CPU_REPACK gives one tuned CPU .so per
+# microarch (armv8.0/armv8.2-fp16/armv8.2-fp16+dotprod/armv8.7-i8mm), and
+# COOPMAT[2] are disabled because the Vulkan validation layer's coopmat
+# extensions are unstable on Adreno NDK headers.
+# OpenCL is gated behind the `opencl` feature so non-Adreno Android
+# consumers don't pull in an unused backend.
+# Android dynamic-backend mode: per-microarch CPU + GPU backends ship as
+# MODULE .so files dlopen'd at runtime, while the dispatcher
+# (libwhisper.a, libggml.a, libggml-base.a) stays static — same shape
+# as the speech-stack uses for parakeet-cpp/tts-cpp.
+#
+# The REF pin (QVAC-19213, PR #30) is whisper-cpp 1.8.4.3 with QVAC-18993
+# already merged in, so the GGML_BACKEND_DL combo above works end-to-end on
+# Android. The two QVAC-18993 commits (now on tetherto/master as part of
+# 1.8.4.3) are:
+#   400bf929  ggml : allow GGML_BACKEND_DL with a static core
+#             (removes the FATAL_ERROR + flips PIC/GGML_BUILD on)
+#   c1d7a6c9  ggml-backend : android per-arch CPU variant dlopen fallback
+#             (lets ggml_backend_load_best resolve libggml-cpu-android_armv*_*.so
+#              via Android's in-APK linker when there's no on-disk lib dir)
+# The QVAC-19213 REF merges tetherto/master (1.8.4.3) in on top of the ggml
+# upstream sync; re-point to REF v${VERSION} once the Adreno fix is tagged.
+if(VCPKG_TARGET_IS_ANDROID)
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON
+    -DGGML_VULKAN_DISABLE_COOPMAT=ON
+    -DGGML_VULKAN_DISABLE_COOPMAT2=ON)
+  if("opencl" IN_LIST FEATURES)
+    list(APPEND PLATFORM_OPTIONS -DGGML_OPENCL=ON)
+  endif()
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+# Same spirv-headers include-shim as in the ggml-speech port: upstream
+# ggml v0.10.2 uses spv::* enums unconditionally in ggml-vulkan.cpp, and
+# ggml-vulkan's CMakeLists.txt does not call find_package(SpirvHeaders)
+# so the vcpkg-installed include prefix isn't visible to it by default.
+# MSVC's cl.exe does not understand `-isystem` (it treats the flag as a
+# positional source file argument and tries to compile the include path),
+# so use `/I` there and the GCC/Clang `-isystem` form elsewhere.
+set(SPIRV_HEADERS_CFLAGS "")
+if("vulkan" IN_LIST FEATURES)
+  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    set(SPIRV_HEADERS_CFLAGS "-DCMAKE_CXX_FLAGS=/I${CURRENT_INSTALLED_DIR}/include")
+  else()
+    set(SPIRV_HEADERS_CFLAGS "-DCMAKE_CXX_FLAGS=-isystem ${CURRENT_INSTALLED_DIR}/include")
+  endif()
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_CCACHE=OFF
+    -DGGML_OPENMP=OFF
+    -DGGML_NATIVE=OFF
+    -DWHISPER_BUILD_TESTS=OFF
+    -DWHISPER_BUILD_EXAMPLES=OFF
+    -DWHISPER_BUILD_SERVER=OFF
+    -DBUILD_SHARED_LIBS=OFF
+    -DGGML_BUILD_NUMBER=1
+    ${PLATFORM_OPTIONS}
+    ${SPIRV_HEADERS_CFLAGS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME whisper
+  CONFIG_PATH share/whisper
+)
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (NOT DL_BACKENDS AND VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  # On dynamic-backend Android the ggml backend .so files live in bin/
+  # alongside the static dispatcher; wiping bin/ here would silently
+  # ship a runtime that loads no backends. Only wipe for true
+  # static-only triplets.
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/portfile.cmake
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/portfile.cmake
@@ -100,20 +100,24 @@ else()
   set(DL_BACKENDS OFF)
 endif()
 
-# Same spirv-headers include-shim as in the ggml-speech port: upstream
-# ggml v0.10.2 uses spv::* enums unconditionally in ggml-vulkan.cpp, and
-# ggml-vulkan's CMakeLists.txt does not call find_package(SpirvHeaders)
-# so the vcpkg-installed include prefix isn't visible to it by default.
-# MSVC's cl.exe does not understand `-isystem` (it treats the flag as a
-# positional source file argument and tries to compile the include path),
-# so use `/I` there and the GCC/Clang `-isystem` form elsewhere.
+# spirv-headers include shim: ggml-vulkan.cpp #includes
+# <spirv/unified1/spirv.hpp> unconditionally, but ggml-vulkan's
+# CMakeLists.txt does not call find_package(SpirvHeaders), so the
+# vcpkg-installed spirv-headers include prefix must be added explicitly.
+#
+# QVAC-19213: add it via CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES (a dedicated
+# system-include variable, emitted as -isystem / /external:I per compiler for
+# every C++ target) instead of stuffing it into CMAKE_CXX_FLAGS. Passing
+# `-DCMAKE_CXX_FLAGS=...` *replaced* the triplet's VCPKG_CXX_FLAGS — notably
+# `-stdlib=libc++` on the x64-linux / arm64-linux triplets — so ggml/whisper
+# built against GNU libstdc++ while the addon links libc++, producing
+# undefined-symbol link errors (std::__cxx11::*, std::filesystem::__cxx11::*,
+# std::_V2::system_category) in the addon's C++ unit tests. This variable
+# leaves CMAKE_CXX_FLAGS untouched, so the triplet's stdlib choice is honored
+# on every platform (Android keeps using the NDK libc++ as before).
 set(SPIRV_HEADERS_CFLAGS "")
 if("vulkan" IN_LIST FEATURES)
-  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
-    set(SPIRV_HEADERS_CFLAGS "-DCMAKE_CXX_FLAGS=/I${CURRENT_INSTALLED_DIR}/include")
-  else()
-    set(SPIRV_HEADERS_CFLAGS "-DCMAKE_CXX_FLAGS=-isystem ${CURRENT_INSTALLED_DIR}/include")
-  endif()
+  set(SPIRV_HEADERS_CFLAGS "-DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES=${CURRENT_INSTALLED_DIR}/include")
 endif()
 
 vcpkg_cmake_configure(

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/vcpkg.json
@@ -1,0 +1,42 @@
+{
+  "name": "whisper-cpp",
+  "version": "1.8.4.3",
+  "port-version": 1,
+  "description": "High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android-only; targets Adreno via the ggml-opencl backend).",
+      "dependencies": [
+        {
+          "name": "opencl",
+          "platform": "android"
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "platform": "!osx & !ios"
+        },
+        {
+          "name": "vulkan",
+          "platform": "!osx & !ios"
+        }
+      ]
+    }
+  }
+}

--- a/packages/transcription-whispercpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg.json
@@ -23,12 +23,5 @@
       "platform": "osx | ios"
     },
     "gtest"
-  ],
-  "overrides": [
-    {
-      "name": "whisper-cpp",
-      "version": "1.8.4.3",
-      "port-version": 0
-    }
   ]
 }


### PR DESCRIPTION
… baseline

Point the transcription-whispercpp vcpkg default-registry baseline at qvac-registry-vcpkg@dcadb1f, which repoints the whisper-cpp port to qvac-ext-lib-whisper.cpp@a028350b (Adreno 740 Vulkan fix). Lets the qvac mobile integration pipeline build + run the fix on real Qualcomm hardware (AWS Device Farm) to validate cross-repo sync before merge.

Testing baseline; revert once the fix lands on a whisper-cpp release tag.

<!--
Style guide for this PR description:
- Be concise; prefer bullet points.
- Delete sections that don't apply.
- Keep code examples minimal.
-->

## What problem does this PR solve?

## How does it solve it?

## Breaking changes
