### PR TITLE
fix[notask]: Update whisper-cpp port version to fix failing CPP Tests

### DIFF
--- a/packages/transcription-whispercpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg.json
@@ -28,7 +28,7 @@
     {
       "name": "whisper-cpp",
       "version": "1.8.4.3",
-      "port-version": 0
+      "port-version": 1
     }
   ]
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `cpp-test-coverage-transcription-whispercpp` fails on Linux when linking `test-whisper-core` with hundreds of undefined `std::__cxx11::*` / `std::filesystem::__cxx11::*` symbols.
- vcpkg-built `libggml.a` / `libwhisper.a` were compiled with **libstdc++** while the test binary is linked with **libc++** (`-stdlib=libc++`), i.e. a C++ ABI mismatch.
- Root cause is in the `whisper-cpp` vcpkg port (`1.8.4.3#0`): its portfile passed `-DCMAKE_CXX_FLAGS=...` for the spirv-headers include shim, which **clobbered** triplet-supplied flags (including `-stdlib=libc++` on Linux).

## 📝 How does it solve it?

- Bump the `whisper-cpp` override in `packages/transcription-whispercpp/vcpkg.json` from `1.8.4.3#0` to `1.8.4.3#1`.
- Port-version 1 ([qvac-registry-vcpkg PR #168](https://github.com/tetherto/qvac-registry-vcpkg/pull/168)) appends the spirv include flags to `VCPKG_C_FLAGS` / `VCPKG_CXX_FLAGS` instead of overriding `CMAKE_CXX_FLAGS`, preserving triplet libc++ settings through the vcpkg build.

## 🧪 How was it tested?

- [x] CI: `cpp-test-coverage-transcription-whispercpp` on `qvac-ubuntu2204-x64` (re-run after merge; expect vcpkg to fetch `whisper-cpp` `1.8.4.3#1` and link without ABI mismatches).

## 💥 Breaking Changes

N/A — vcpkg dependency override only; no public API or runtime behavior change in the published addon.

## 🔌 API Changes

N/A
