### PR TITLE
chore[notask|skiplog]: release @qvac/registry-client v0.6.0

### DIFF
--- a/packages/registry-server/client/CHANGELOG.md
+++ b/packages/registry-server/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.6.0]
+
+Release Date: 2026-05-25
+
+### 🔧 Changed
+
+- Upgrade to HyperDB 6 via `@qvac/registry-schema@^0.3.0` — move `corestore`, `hyperblobs`, and `hyperswarm` back to direct dependencies and drop the HyperDB 4 peer requirement (#2254).
+- Bump `@qvac/registry-schema` from `^0.2.0` to `^0.3.0`.
+
 ## [0.5.0]
 
 Release Date: 2026-05-14
@@ -123,3 +132,4 @@ Release Date: 2026-02-13
 - Model metadata retrieval from the distributed registry
 - Automatic peer discovery and replication via Hyperswarm
 - Compatible with Bare and Node.js runtimes
+

--- a/packages/registry-server/client/changelog/0.6.0/CHANGELOG.md
+++ b/packages/registry-server/client/changelog/0.6.0/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.6.0
+
+Release Date: 2026-05-25
+
+## 🔧 Changed
+
+- Upgrade to HyperDB 6 via `@qvac/registry-schema@^0.3.0` — move `corestore`, `hyperblobs`, and `hyperswarm` back to direct dependencies and drop the HyperDB 4 peer requirement (#2254).
+- Bump `@qvac/registry-schema` from `^0.2.0` to `^0.3.0`.

--- a/packages/registry-server/client/changelog/0.6.0/CHANGELOG_LLM.md
+++ b/packages/registry-server/client/changelog/0.6.0/CHANGELOG_LLM.md
@@ -1,0 +1,17 @@
+# @qvac/registry-client v0.6.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/registry-client/v/0.6.0
+
+This release completes the registry hyperdb v6 cascade on the client side. It pulls in `@qvac/registry-schema@^0.3.0` (HyperDB 6) and simplifies the install graph by owning the Holepunch libraries the client imports directly. The public `QVACRegistryClient` API is unchanged.
+
+---
+
+## 🔧 Changed
+
+### HyperDB 6 via updated schema dependency
+
+`@qvac/registry-schema` is bumped from `^0.2.0` to `^0.3.0`, which brings HyperDB 6 transitively. The client no longer lists `hyperdb` as a peer — HyperDB is owned by the schema package.
+
+### Dependency graph cleanup (#2254)
+
+`corestore`, `hyperblobs`, and `hyperswarm` move back from `peerDependencies` to direct `dependencies` (only the packages the client actually imports). This aligns with the hyperdb v6 migration and avoids peer-range drift when installed alongside `@qvac/sdk`.

--- a/packages/registry-server/client/package.json
+++ b/packages/registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "repository": {
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/registry-schema": "^0.2.0",
+    "@qvac/registry-schema": "^0.3.0",
     "b4a": "^1.6.7",
     "bare-fs": "^4.5.2",
     "bare-os": "^3.6.2",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Publish `@qvac/registry-client v0.6.0` so the HyperDB 6 dependency graph from #2254 reaches npm with `@qvac/registry-schema@^0.3.0` (now published).
- Unblocks the RAG hyperdb v6 cascade ([#2255](https://github.com/tetherto/qvac/pull/2255)).

## 📝 How does it solve it?

- Bump `@qvac/registry-client` from `0.5.0` to `0.6.0`.
- Bump `@qvac/registry-schema` from `^0.2.0` to `^0.3.0`.
- Add `[0.6.0]` changelog entry pointing at #2254.

On merge to `release-registry-client-0.6.0`, `publish-registry-server.yml` publishes to npm.

## 🧪 How was it tested?

- Clean `npm install` in `packages/registry-server/client` resolving `@qvac/registry-schema@0.3.0` from npm.
- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm run test:unit` — 19/19 tests, 87/87 assertions

### Follow-ups

- Backmerge version bump + changelog into `main`.
- Mark RAG hyperdb v6 draft ([#2255](https://github.com/tetherto/qvac/pull/2255)) ready for review.
