### PR TITLE
QVAC-19194 chore: add @qvac/ai-sdk-provider logo SVG (currentColor)

### DIFF
--- a/packages/ai-sdk-provider/assets/logo.svg
+++ b/packages/ai-sdk-provider/assets/logo.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  QVAC logo mark - single-color, currentColor-aware.
+
+  Geometry: extracted verbatim from docs/website/public/qvac-icon.svg
+  (the canonical Q-mark used on docs.qvac.tether.io). Rewritten to fill
+  with currentColor so the mark inherits the surrounding text color,
+  as required by models.dev's catalog convention, the AI SDK community-
+  providers page, and any theme-adaptive consumer (light + dark modes
+  without forking the asset).
+
+  Render targets validated against the docs site's existing usage at
+  the same viewBox: 16px catalog list, 256px provider detail.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 48" fill="none">
+  <path
+    d="M46.0067 25.3175H43.5317V20.5455C43.5317 20.2954 43.4385 20.0581 43.2689 19.8758L38.713 14.9936C38.5265 14.7944 38.268 14.6799 37.9925 14.6799H9.91516C9.64392 14.6799 9.38116 14.7944 9.19469 14.9936L4.63874 19.8716C4.46921 20.0538 4.37598 20.2954 4.37598 20.5412V27.5086C4.37598 27.7587 4.46921 27.996 4.63874 28.1783L9.19469 33.0563C9.38116 33.2555 9.63969 33.3699 9.91516 33.3699H52.6902C52.9615 33.3657 53.2242 33.2513 53.4107 33.0521C53.4107 33.0521 46.5535 25.3133 46.011 25.3133L46.0067 25.3175ZM35.4793 24.3301C35.4793 24.8725 35.0386 25.3133 34.4961 25.3133H13.4116C13.1403 25.3133 12.8776 25.1989 12.6911 24.9997C12.5216 24.8174 12.4284 24.5759 12.4284 24.3301V23.7198C12.4284 23.4697 12.5216 23.2324 12.6953 23.0502C12.8818 22.851 13.1403 22.7365 13.4158 22.7365H34.4791C34.7419 22.7365 34.9919 22.8383 35.1742 23.0247L35.1954 23.0459C35.3819 23.2324 35.4836 23.4824 35.4836 23.741V24.3301H35.4793Z"
+    fill="currentColor"
+  />
+</svg>

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -20,6 +20,7 @@
   },
   "files": [
     "dist/**/*",
+    "assets/**/*",
     "README.md",
     "LICENSE",
     "NOTICE"

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -16,6 +16,7 @@
       "types": "./dist/models/index.d.ts",
       "import": "./dist/models/index.js"
     },
+    "./assets/logo.svg": "./assets/logo.svg",
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
> **Stacked on top of #2234** (the scaffold PR). Targets `main` because cross-fork PRs can't use a fork-only branch as the base — review only the topmost commit (`packages/ai-sdk-provider/assets/logo.svg` + the one-line `package.json` `files` field addition). PR diff will collapse to just that commit once #2234 merges. Codegen PR #2235 has the same stacked-on-#2234 structure.

## 🎯 What problem does this PR solve?

The `@qvac/ai-sdk-provider` package (scaffolded in #2234) needs a brand asset to ship with 0.1.0. Several downstream v1 deliverables under epic QVAC-19194 require a logo:

- **models.dev catalog entry** ([anomalyco/models.dev](https://github.com/anomalyco/models.dev) — convention is `providers/<id>/logo.svg`, single-color `currentColor` SVG so the catalog can render against light and dark themes).
- **AI SDK community-providers** listing (Vercel docs — same pattern).
- **OpenCode `/connect`** auto-discovery (renders the model from the models.dev entry).
- **OpenCode / Continue / Cline / Roo Code / Aider** docs recipes (embed the logo next to the QVAC section heading).

Without a canonical \`currentColor\` SVG in the package, every downstream PR has to either fork-and-recolor the docs site asset or commission a separate file — neither scales.

## 📝 How does it solve it?

Adds \`packages/ai-sdk-provider/assets/logo.svg\` derived from the existing canonical Q-mark:

- **Geometry** copied verbatim from \`docs/website/public/qvac-icon.svg\` (the mark currently rendered on [docs.qvac.tether.io](https://docs.qvac.tether.io), Inkeep search avatar, and the workbench-desktop \`QvacIcon.tsx\` component). No new artwork commissioned — same Q-mark every internal surface already uses, so the package's identity matches the rest of the product.
- **Color**: swapped \`fill=\"#16E3C1\"\` for \`fill=\"currentColor\"\` so the mark inherits the surrounding text color. Theme-adaptive hosts (models.dev catalog, AI SDK community-providers page) render correctly without forking the asset.
- **Cleanup**: removed the source's no-op alpha mask (the path was already fully inside the viewBox; the mask did nothing).
- **viewBox preserved** at \`0 0 56 48\` to stay byte-for-byte compatible with the existing in-repo precedent (\`features-infographic.tsx\`'s \`Q_PATH\` constant, which already renders this exact path with \`fill=\"currentColor\"\` in production on the docs site).

Also adds \`\"assets/**/*\"\` to the package.json \`files\` whitelist so the SVG ships in the published npm tarball — without this, \`npm publish\` would exclude the new directory.

## 🧪 How was it tested?

1. **XML well-formedness** (\`xmllint --noout\`): passes — strict parser, no warnings.
2. **Render at acceptance-criteria sizes** (\`qlmanage -t\`): 16px catalog list and 256px provider detail both render crisp, no anti-aliasing artefacts on the Q's inner slot.
3. **Intermediate sizes** (32px, 64px) also rendered to confirm scaling behaviour stays clean across the catalog → detail → embed gradient.
4. **currentColor inheritance**: verified via inline \`<svg><use href>\` test page against light theme (#171817 text), dark theme (#F2F1EF text), and brand green (#16E3C1 / #00AF92) backgrounds. Mark recolors correctly in all four contexts because the only fill in the asset resolves through the CSS cascade.
5. **Provenance audit**: the geometry is the same path data already running on \`docs.qvac.tether.io\` and proven \`currentColor\`-correct via \`features-infographic.tsx\` — zero risk of geometric regression.

Closes Asana subtask [\`1215054617539055\`](https://app.asana.com/0/0/1215054617539055) (one of the 14 subtasks under epic [QVAC-19194](https://app.asana.com/0/0/1214968611313049)).