### PR TITLE
QVAC-19533 doc: Fix support to LLMs requesting content in markdown format

### DIFF
--- a/docs/website/public/_redirects
+++ b/docs/website/public/_redirects
@@ -1,12 +1,3 @@
-# Markdown content negotiation — serve the .md sibling of a page when the
-# client asks for it via `Accept: text/markdown`. Home maps to `/index.md`;
-# every other page `/foo/bar/` maps to `/foo/bar.md`. We need both the
-# trailing-slash and no-slash variants so the `:splat` placeholder doesn't
-# produce `/foo/.md`.
-/                /index.md      301   Header:Accept=text/markdown
-/*/              /:splat.md     301   Header:Accept=text/markdown
-/*               /:splat.md     301   Header:Accept=text/markdown
-
 # Sevalla CDN does not resolve directory-to-index.html for path segments
 # containing dots (e.g. `v0.7.0`). Each `:version` segment is rewritten to
 # its index.html explicitly. `:version` matches a single path segment, so
@@ -122,3 +113,35 @@
 # Section rename: /http-server → /cli/http-server
 /http-server/   /cli/http-server/   301
 /http-server    /cli/http-server/   301
+
+# ======================================================================
+# MARKDOWN CONTENT NEGOTIATION
+# ----------------------------------------------------------------------
+# Serve the .md sibling of a page when the client asks for it via
+# `Accept: text/markdown`. Home maps to `/index.md`; every other page
+# `/foo/bar/` maps to `/foo/bar.md`. We need both the trailing-slash and
+# no-slash variants so the `:splat` placeholder doesn't produce `/foo/.md`.
+#
+# These rules MUST stay at the bottom of the file: `_redirects` is
+# evaluated top-to-bottom with first-match-wins, and the wildcard
+# `/*` here would otherwise shadow every legacy 301 and version rewrite
+# above when a client sends `Accept: text/markdown` (producing a `.md`
+# path that doesn't exist for moved pages).
+#
+# Why `200!` (rewrite, force) instead of `301`/`302`:
+#   - Content negotiation: HTML and Markdown are two representations of
+#     the same resource, not different resources, so a rewrite (same URL,
+#     different body) is the semantically correct answer.
+#   - No redirect cache pitfall: a 301 captured by an intermediary while
+#     a markdown-asking client was talking to it can be replayed for a
+#     normal browser request (browsers/proxies do not reliably vary their
+#     redirect cache by `Accept`). With a rewrite there is no redirect
+#     to cache.
+#   - The `!` (force) is required because the original path resolves to
+#     a real static file (e.g. `/quickstart/index.html`); without it the
+#     rule is never consulted.
+# ======================================================================
+
+/                /index.md      200!  Header:Accept=text/markdown
+/*/              /:splat.md     200!  Header:Accept=text/markdown
+/*               /:splat.md     200!  Header:Accept=text/markdown

--- a/docs/website/src/app/llms.txt/route.ts
+++ b/docs/website/src/app/llms.txt/route.ts
@@ -15,10 +15,10 @@ const ROOT_SECTION = '(root)';
 /**
  * Generates the `llms.txt` agent index at build time.
  *
- * Format follows the de-facto convention popularized by https://llmstxt.org/:
- * an H1 with the project name, a short paragraph describing the site, a
- * "Guidance" preamble, and one `## Section` per top-level slug whose body is
- * a bullet list of `- [Title](url): description` entries.
+ * Format follows the spec at https://llmstxt.org/#format: an H1 with the
+ * project name, a blockquote with a short summary, optional non-heading
+ * details (here, a "Guidance" preamble), and one H2 section per top-level
+ * slug whose body is a bullet list of `- [Title](url): description` entries.
  *
  * Archived per-section versions (e.g. `/reference/api/v0.7.0`) are filtered
  * out via `isArchivedPage` so the index advertises only the latest canonical
@@ -36,7 +36,7 @@ export function GET() {
   const lines: string[] = [
     '# QVAC Documentation',
     '',
-    "Agent index for the QVAC developer documentation. QVAC is Tether's local-first AI SDK for cross-platform, peer-to-peer applications.",
+    "> Agent index for the QVAC developer documentation. QVAC is Tether's local-first AI SDK for cross-platform, peer-to-peer applications.",
     '',
     '## Guidance',
     '',


### PR DESCRIPTION
## What problem does this PR solve?

- Our goal is to provide full support for LLMs/AI agents on the documentation website.
- In a previous PR, we added redirect rules as described at https://docs.sevalla.com/changelog#may-22-2026-2
- The problem is that there appears to be another rule within Sevalla stating that: if the original page exists, NO REDIRECT RULE is applied—unless the `!` character is used.
- Consequently, the redirect rule we created to serve Markdown instead of HTML—when the "accept: text/markdown" header is present—is not working.

## How does it solve it?

- Added the `!` character to the redirect rules to ensure Markdown is served when requested by LLMs (via HTTP header).
- Additionally, this PR takes the opportunity to implement minor housekeeping improvements related to redirects and LLMs:
- A reviewer of the previous PR noted that `301` was not the correct status code for responding to these requests. Solution: Changed the response status from `301` to `200`. Rationale: This is the semantically correct status code for this specific use case. 
- A reviewer of the previous PR noted that permanent redirects must take precedence over the "Markdown negotiation" redirects. Otherwise, the Markdown negotiation wildcard would match the request and attempt to fetch a Markdown page that does not exist. Solution: Implemented the suggestion and reordered the rules. 
- To ensure 100% compliance with https://llmstxt.org/, a blockquote was added to the project description.
