### PR TITLE
QVAC-19560 doc: Redirects not working in docs website

### DIFF
--- a/docs/website/pr-body.mdx
+++ b/docs/website/pr-body.mdx
@@ -1,0 +1,75 @@
+## 🎯 What problem does this PR solve?
+
+- SDK TTS still used the deprecated `@qvac/tts-onnx` addon and multi-file ONNX `modelConfig`, blocking the `@qvac/tts-ggml` stack (Chatterbox, Supertonic).
+- Mobile/CLI bundles referenced `@qvac/sdk/onnx-tts/plugin`, which broke iOS/Android e2e prebuild after the plugin export moved.
+
+## 📝 How does it solve it?
+
+- Replace `onnx-tts` bare plugin with `tts-ggml` (`@qvac/tts-ggml`), wired via `ModelType.ttsGgml`; public alias `modelType: "tts"` now resolves to GGML.
+- Simplify load config: Chatterbox uses `s3genModelSrc` (+ optional `referenceAudioSrc`); Supertonic uses a single `modelSrc` with `voice` / speed / steps options.
+- Register 12 GGUF TTS models in the SDK registry; legacy ONNX multi-src fields return `LegacyTtsModelDeprecatedError`.
+- Update examples, unit tests, and `tests-qvac` desktop/mobile consumers (Q8 GGUF).
+- CLI: builtin plugin `onnx-tts` → `tts-ggml`; temporary `./onnx-tts/plugin` export alias for older CLI bundles.
+
+## 🧪 How was it tested?
+
+- `bun run lint` in `packages/sdk`
+- Unit tests updated: `model-types`, `tts-schemas`, `plugin-cancel-capability`
+- E2e consumers updated for Q8 Chatterbox / Supertonic (run via `qvac-test run:local` / `run:local:ios` with `--filter tts`)
+
+## 💥 Breaking Changes
+
+**BEFORE:**
+
+```typescript
+await loadModel({
+  modelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "chatterbox",
+    language: "en",
+    ttsSpeechEncoderSrc: TTS_MULTILINGUAL_SPEECH_ENCODER_CHATTERBOX.src,
+    ttsEmbedTokensSrc: TTS_MULTILINGUAL_EMBED_TOKENS_CHATTERBOX.src,
+    ttsConditionalDecoderSrc: TTS_MULTILINGUAL_CONDITIONAL_DECODER_CHATTERBOX.src,
+    ttsLanguageModelSrc: TTS_MULTILINGUAL_LANGUAGE_MODEL_CHATTERBOX.src,
+  },
+});
+```
+
+**AFTER:**
+
+```typescript
+await loadModel({
+  modelSrc: TTS_T3_TURBO_EN_CHATTERBOX_Q8_0.src,
+  modelType: "tts",
+  modelConfig: {
+    ttsEngine: "chatterbox",
+    language: "en",
+    s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX.src,
+  },
+});
+```
+
+Plugin import path: `@qvac/sdk/onnx-tts/plugin` → `@qvac/sdk/tts-ggml/plugin` (compat alias retained temporarily).
+
+## 📦 Models
+
+### Added models
+
+```
+TTS_S3GEN_MULTILINGUAL_CHATTERBOX
+TTS_S3GEN_EN_CHATTERBOX
+TTS_T3_MULTILINGUAL_CHATTERBOX_FP16
+TTS_T3_TURBO_EN_CHATTERBOX_FP16
+TTS_T3_MULTILINGUAL_CHATTERBOX_Q4_0
+TTS_T3_MULTILINGUAL_CHATTERBOX_Q8_0
+TTS_T3_TURBO_EN_CHATTERBOX_Q4_0
+TTS_T3_TURBO_EN_CHATTERBOX_Q8_0
+TTS_EN_SUPERTONIC_Q4_0
+TTS_EN_SUPERTONIC_Q8_0
+TTS_MULTILINGUAL_SUPERTONIC2_Q4_0
+TTS_MULTILINGUAL_SUPERTONIC2_Q8_0
+```
+
+---
+_Asana: https://app.asana.com/1/45238840754660/home/task/1215009851232537_

--- a/docs/website/public/_redirects
+++ b/docs/website/public/_redirects
@@ -3,9 +3,9 @@
 # every other page `/foo/bar/` maps to `/foo/bar.md`. We need both the
 # trailing-slash and no-slash variants so the `:splat` placeholder doesn't
 # produce `/foo/.md`.
-/                /index.md      301   Header:Accept=text/markdown
-/*/              /:splat.md     301   Header:Accept=text/markdown
-/*               /:splat.md     301   Header:Accept=text/markdown
+# /                /index.md      301   Header:Accept=text/markdown
+# /*/              /:splat.md     301   Header:Accept=text/markdown
+# /*               /:splat.md     301   Header:Accept=text/markdown
 
 # Sevalla CDN does not resolve directory-to-index.html for path segments
 # containing dots (e.g. `v0.7.0`). Each `:version` segment is rewritten to

--- a/docs/website/public/_redirects
+++ b/docs/website/public/_redirects
@@ -19,6 +19,26 @@
 # /reference/release-notes/:version/   /reference/release-notes/:version/index.html   200
 # /reference/release-notes/:version    /reference/release-notes/:version/index.html   200
 
+# Versioned redirects hardcoded:
+
+/reference/api/v0.7.0/    /reference/api/v0.7.0/index.html    200
+/reference/api/v0.7.0     /reference/api/v0.7.0/index.html    200
+/reference/api/v0.8.0/    /reference/api/v0.8.0/index.html    200
+/reference/api/v0.8.0     /reference/api/v0.8.0/index.html    200
+/reference/api/v0.9.1/    /reference/api/v0.9.1/index.html    200
+/reference/api/v0.9.1     /reference/api/v0.9.1/index.html    200
+/reference/api/v0.10.0/   /reference/api/v0.10.0/index.html   200
+/reference/api/v0.10.0    /reference/api/v0.10.0/index.html   200
+
+/reference/release-notes/v0.7.0/    /reference/release-notes/v0.7.0/index.html    200
+/reference/release-notes/v0.7.0     /reference/release-notes/v0.7.0/index.html    200
+/reference/release-notes/v0.8.0/    /reference/release-notes/v0.8.0/index.html    200
+/reference/release-notes/v0.8.0     /reference/release-notes/v0.8.0/index.html    200
+/reference/release-notes/v0.9.1/    /reference/release-notes/v0.9.1/index.html    200
+/reference/release-notes/v0.9.1     /reference/release-notes/v0.9.1/index.html    200
+/reference/release-notes/v0.10.0/   /reference/release-notes/v0.10.0/index.html   200
+/reference/release-notes/v0.10.0    /reference/release-notes/v0.10.0/index.html   200
+
 # ======================================================================
 # PERMANENT REDIRECTS DUE TO CONTENT MOVE
 # ----------------------------------------------------------------------
@@ -94,24 +114,6 @@
 /sdk/examples/utilities/plugin-system         /configuration/plugins/                    301
 /sdk/examples/utilities/write-custom-plugin/  /configuration/plugins/write-custom-plugin/  301
 /sdk/examples/utilities/write-custom-plugin   /configuration/plugins/write-custom-plugin/  301
-
-# Section rename: /sdk/api → /reference/api, /sdk/release-notes → /reference/release-notes
-/sdk/api/                       /reference/api/                       301
-/sdk/api                        /reference/api/                       301
-/sdk/api/v0.7.0/                /reference/api/v0.7.0/                301
-/sdk/api/v0.7.0                 /reference/api/v0.7.0/                301
-/sdk/api/v0.8.0/                /reference/api/v0.8.0/                301
-/sdk/api/v0.8.0                 /reference/api/v0.8.0/                301
-/sdk/api/v0.9.1/                /reference/api/v0.9.1/                301
-/sdk/api/v0.9.1                 /reference/api/v0.9.1/                301
-/sdk/release-notes/             /reference/release-notes/             301
-/sdk/release-notes              /reference/release-notes/             301
-/sdk/release-notes/v0.7.0/      /reference/release-notes/v0.7.0/      301
-/sdk/release-notes/v0.7.0       /reference/release-notes/v0.7.0/      301
-/sdk/release-notes/v0.8.0/      /reference/release-notes/v0.8.0/      301
-/sdk/release-notes/v0.8.0       /reference/release-notes/v0.8.0/      301
-/sdk/release-notes/v0.9.1/      /reference/release-notes/v0.9.1/      301
-/sdk/release-notes/v0.9.1       /reference/release-notes/v0.9.1/      301
 
 # Section rename: /sdk/tutorials/* → /tutorials/*
 /sdk/tutorials/electron/   /tutorials/electron/   301

--- a/docs/website/public/_redirects
+++ b/docs/website/public/_redirects
@@ -13,11 +13,11 @@
 # only `/reference/api/vX.Y.Z[/]` (and the release-notes sibling) is
 # affected — anything deeper is left untouched.
 
-/reference/api/:version/   /reference/api/:version/index.html   200
-/reference/api/:version    /reference/api/:version/index.html   200
+# /reference/api/:version/   /reference/api/:version/index.html   200
+# /reference/api/:version    /reference/api/:version/index.html   200
 
-/reference/release-notes/:version/   /reference/release-notes/:version/index.html   200
-/reference/release-notes/:version    /reference/release-notes/:version/index.html   200
+# /reference/release-notes/:version/   /reference/release-notes/:version/index.html   200
+# /reference/release-notes/:version    /reference/release-notes/:version/index.html   200
 
 # ======================================================================
 # PERMANENT REDIRECTS DUE TO CONTENT MOVE


### PR DESCRIPTION
## Troubleshooting docs website

### Situation

Attempting to access a page that does not exist on the website:
https://docs.qvac.tether.io/dsdsds
This should result in a 404 error.
However, instead, it triggers a Cloudflare 1101 error from the Sevalla CDN.

Attempting to access a page that has moved but has a redirect configured:
https://docs.qvac.tether.io/sdk/getting-started/quickstart
This should redirect to:
https://docs.qvac.tether.io/quickstart
However, instead, it triggers a Cloudflare 1101 error from the Sevalla CDN.

### Cause

A merged PR introduced syntax that was theoretically correct according to https://docs.sevalla.com/static-sites/redirects; however, the Sevalla CDN does not handle this correctly, and the exception leaks to the end user instead of falling back to a 404 error.

- Bug introduced (deployment of PR #2269, merged into `main`): 2026-05-26 14:12 UTC.
- Bug went live in production: 2026-05-26 19:58 UTC.
- Bug reported via Slack: 2026-05-27 21:11 UTC.

### Solution

- Remove the redirect rule that introduced the bug.
- Quick fix: Re-add the hardcoded rules while testing the correct implementation of dynamic rules.

### Test

Use PR preview env to test it:
https://qvac-docs-staging-fazwv-commit-0fe6162.kinsta.page

Try the old URL (that now has a hardcoded redirect):
https://qvac-docs-staging-fazwv-commit-0fe6162.kinsta.page/sdk/getting-started/quickstart/
Redirect should work now.

Try a non-existent URL:
https://qvac-docs-staging-fazwv-commit-0fe6162.kinsta.page/non-existent-url-should-hit-404
It should hit 404
