### PR TITLE
chore: bump tts-ggml to tts-cpp port-version 1

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3]
+
+### Fixed
+
+- Consume `tts-cpp` `2026-05-20#1`, which disables host BLAS/OpenBLAS
+  auto-linking for Linux prebuilds.
+
 ## [0.1.2]
 
 ### Changed

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic engines from tts-cpp)",
   "addon": true,
   "engines": {

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-05-20"
+      "version>=": "2026-05-20#1"
     }
   ],
   "features": {


### PR DESCRIPTION
## Summary
- Bump `@qvac/tts-ggml` from `0.1.2` to `0.1.3`.
- Require `tts-cpp` `2026-05-20#1`, which disables host BLAS/OpenBLAS auto-linking in the registry port.
- Add a `0.1.3` changelog entry for the Linux prebuild dependency fix.

Depends on tetherto/qvac-registry-vcpkg#172.

## Test plan
- `python3 -m json.tool packages/tts-ggml/package.json`
- `python3 -m json.tool packages/tts-ggml/vcpkg.json`
- IDE lint diagnostics for touched files: clean.


Made with [Cursor](https://cursor.com)