### PR TITLE
QVAC-19247 feat[api]: expose @qvac/rag/errors subpath for consumers

### DIFF
--- a/packages/rag/index.d.ts
+++ b/packages/rag/index.d.ts
@@ -1,7 +1,7 @@
 import QvacResponse = require("@qvac/response");
 import ReadyResource = require("ready-resource");
-import { QvacErrorBase } from "@qvac/error";
 import type { LoggerInterface } from "@qvac/logging";
+import { ERR_CODES, QvacErrorRAG } from "./src/errors";
 
 type Logger = LoggerInterface;
 
@@ -534,36 +534,6 @@ declare class LLMChunkAdapter extends BaseChunkAdapter {
    */
   chunkText(input: string | string[], opts?: LLMChunkOpts): Promise<Doc[]>;
 }
-
-/**
- * Custom error class for QVAC RAG library
- * Extends QvacErrorBase for consistent error handling
- */
-export declare class QvacErrorRAG extends QvacErrorBase {}
-
-/**
- * Error codes used throughout the QVAC RAG library
- */
-export declare const ERR_CODES: Readonly<{
-  ABSTRACT_CLASS: 14001;
-  DB_ADAPTER_NOT_INITIALIZED: 14002;
-  DB_ADAPTER_REQUIRED: 14003;
-  CENTROIDS_INITIALIZATION_FAILURE: 14004;
-  LLM_REQUIRED: 14005;
-  EMBEDDING_FUNCTION_REQUIRED: 14006;
-  NOT_IMPLEMENTED: 14007;
-  INVALID_INPUT: 14008;
-  INVALID_PARAMS: 14009;
-  DUPLICATE_DOCUMENT_ID: 14010;
-  GENERATION_FAILED: 14011;
-  CHUNKING_FAILED: 14012;
-  INVALID_CHUNKER: 14013;
-  DB_OPERATION_FAILED: 14014;
-  DEPENDENCY_REQUIRED: 14015;
-  OPERATION_CANCELLED: 14016;
-  EMBEDDING_MODEL_MISMATCH: 14017;
-  EMBEDDING_DIMENSION_MISMATCH: 14018;
-}>;
 
 export {
   RAG,

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -27,6 +27,17 @@
     "NOTICE"
   ],
   "types": "index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./errors": {
+      "types": "./src/errors.d.ts",
+      "default": "./src/errors.js"
+    }
+  },
   "imports": {
     "#crypto": {
       "bare": "bare-crypto",

--- a/packages/rag/src/errors.d.ts
+++ b/packages/rag/src/errors.d.ts
@@ -1,0 +1,31 @@
+import { QvacErrorBase } from "@qvac/error";
+
+/**
+ * Custom error class for QVAC RAG library
+ * Extends QvacErrorBase for consistent error handling
+ */
+export declare class QvacErrorRAG extends QvacErrorBase {}
+
+/**
+ * Error codes used throughout the QVAC RAG library
+ */
+export declare const ERR_CODES: Readonly<{
+  ABSTRACT_CLASS: 14001;
+  DB_ADAPTER_NOT_INITIALIZED: 14002;
+  DB_ADAPTER_REQUIRED: 14003;
+  CENTROIDS_INITIALIZATION_FAILURE: 14004;
+  LLM_REQUIRED: 14005;
+  EMBEDDING_FUNCTION_REQUIRED: 14006;
+  NOT_IMPLEMENTED: 14007;
+  INVALID_INPUT: 14008;
+  INVALID_PARAMS: 14009;
+  DUPLICATE_DOCUMENT_ID: 14010;
+  GENERATION_FAILED: 14011;
+  CHUNKING_FAILED: 14012;
+  INVALID_CHUNKER: 14013;
+  DB_OPERATION_FAILED: 14014;
+  DEPENDENCY_REQUIRED: 14015;
+  OPERATION_CANCELLED: 14016;
+  EMBEDDING_MODEL_MISMATCH: 14017;
+  EMBEDDING_DIMENSION_MISMATCH: 14018;
+}>;


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- SDK consumers can't import `@qvac/rag` error codes without dragging in `HyperDBAdapter`, which breaks `bare-pack` (transitive `node:crypto` via the `#crypto` alias).
- No published subpath exists today for the codes alone.

## 📝 How does it solve it?

- Adds an `exports` field with a new `./errors` subpath (resolves to `src/errors.js` — only requires `@qvac/error`, no Bare/Holepunch deps).
- Ships `src/errors.d.ts` with literal-typed `ERR_CODES` and `QvacErrorRAG`.
- `index.d.ts` re-exports them from `./src/errors`, collapsing the previous inline duplicate.

## 🧪 How was it tested?

- `npm run lint` + `tsc --noEmit` (strict, nodenext) on `index.d.ts` and `src/errors.d.ts`: clean.
- `rg "['\"]@qvac/rag/"` across the monorepo: no existing deep imports shadowed by the new `exports`.

## 🔌 API Changes

```typescript
import { ERR_CODES, QvacErrorRAG } from "@qvac/rag/errors";

if (err instanceof QvacErrorRAG && err.code === ERR_CODES.OPERATION_CANCELLED) {
  // handle cancellation
}
```
