### PR TITLE
chore[notask|skiplog]: backmerge release-rag-0.6.1 — version bump, changelog, NOTICE

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1]
+
+### Added
+
+- Published `@qvac/rag/errors` subpath for importing `ERR_CODES` and `QvacErrorRAG` without loading the full package entry (#2303).
+
+### Fixed
+
+- Load RAG hard dependencies (`hyperdb`, `hyperschema`, `llm-splitter`, `#fetch`) via synchronous `require()` instead of dynamic `await import()` for Pear/CJS compatibility (#2284).
+
 ## [0.6.0]
 
 ### Changed

--- a/packages/rag/NOTICE
+++ b/packages/rag/NOTICE
@@ -10,6 +10,11 @@ listed below.
 JavaScript Dependencies
 =========================================================================
 
+--- (mit AND bsd-3-clause) ---
+
+  sha.js@2.4.12
+    https://github.com/crypto-browserify/sha.js
+
 --- apache-2.0 (Apache License 2.0) ---
 
   @hyperswarm/secret-stream@6.9.1
@@ -17,7 +22,7 @@ JavaScript Dependencies
   @qvac/error@0.1.1
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
-  b4a@1.8.0
+  b4a@1.8.1
     https://github.com/holepunchto/b4a
   bare-addon-resolve@1.10.0
     https://github.com/holepunchto/bare-addon-resolve
@@ -25,98 +30,314 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-ansi-escapes
   bare-assert@1.2.0
     https://github.com/holepunchto/bare-assert
+  bare-buffer@3.6.0
+    https://github.com/holepunchto/bare-buffer
+  bare-crypto@1.13.7
+    https://github.com/holepunchto/bare-crypto
+  bare-dns@2.1.4
+    https://github.com/holepunchto/bare-dns
   bare-events@2.4.2
     https://github.com/holepunchto/bare-events
-  bare-events@2.8.2
+  bare-events@2.8.3
     https://github.com/holepunchto/bare-events
-  bare-fs@4.5.6
+  bare-fetch@2.9.1
+    https://github.com/holepunchto/bare-fetch
+  bare-form-data@1.2.2
+    https://github.com/holepunchto/bare-form-data
+  bare-fs@4.7.1
     https://github.com/holepunchto/bare-fs
+  bare-http-parser@1.1.4
+    https://github.com/holepunchto/bare-http-parser
+  bare-http1@4.5.6
+    https://github.com/holepunchto/bare-http1
+  bare-https@3.0.0
+    https://github.com/holepunchto/bare-https
   bare-inspect@3.1.4
     https://github.com/holepunchto/bare-inspect
-  bare-module-resolve@1.12.1
+  bare-mime@1.0.0
+    https://github.com/holepunchto/bare-mime
+  bare-module-resolve@1.12.2
     https://github.com/holepunchto/bare-module-resolve
-  bare-os@3.8.6
+  bare-net@2.3.1
+    https://github.com/holepunchto/bare-net
+  bare-os@3.9.1
     https://github.com/holepunchto/bare-os
   bare-path@3.0.0
     https://github.com/holepunchto/bare-path
-  bare-semver@1.0.2
+  bare-pipe@4.1.5
+    https://github.com/holepunchto/bare-pipe
+  bare-semver@1.0.3
     https://github.com/holepunchto/bare-semver
-  bare-stream@2.11.0
+  bare-stream@2.13.1
     https://github.com/holepunchto/bare-stream
+  bare-tcp@2.2.13
+    https://github.com/holepunchto/bare-tcp
+  bare-tls@3.1.5
+    https://github.com/holepunchto/bare-tls
   bare-type@1.1.0
     https://github.com/holepunchto/bare-type
-  bare-url@2.4.0
+  bare-url@2.4.3
     https://github.com/holepunchto/bare-url
-  blind-relay@1.4.0
+  bare-zlib@1.3.3
+    https://github.com/holepunchto/bare-zlib
+  blind-relay@1.6.1
     https://github.com/holepunchto/blind-relay
-  compact-encoding@2.19.2
+  compact-encoding@3.1.0
     https://github.com/holepunchto/compact-encoding
+  compact-encoding-bitfield@1.1.0
+    https://github.com/compact-encoding/compact-encoding-bitfield
+  compact-encoding-net@1.3.0
+    https://github.com/compact-encoding/compact-encoding-net
+  device-file@2.3.1
+    https://github.com/holepunchto/device-file
   events-universal@1.0.1
     https://github.com/holepunchto/events-universal
+  fd-lock@2.1.1
+    https://github.com/holepunchto/fd-lock
+  fs-native-extensions@1.5.0
+    https://github.com/holepunchto/fs-native-extensions
+  hypercore-errors@1.5.0
+    https://github.com/holepunchto/hypercore-errors
   hypercore-id-encoding@1.3.0
     https://github.com/holepunchto/hypercore-id-encoding
-  hyperschema@1.20.1
+  hypercore-storage@2.9.0
+    https://github.com/holepunchto/hypercore-storage
+  hyperdb@6.7.0
+    https://github.com/holepunchto/hyperdb
+  hyperdht-address@1.1.1
+    https://github.com/holepunchto/hyperdht-address
+  hyperschema@1.21.0
     https://github.com/holepunchto/hyperschema
+  index-encoder@3.5.0
+    https://github.com/holepunchto/index-encoder
   noise-handshake@4.2.0
     https://github.com/holepunchto/noise-handshake
+  quickbit-native@2.4.8
+    https://github.com/holepunchto/quickbit-native
+  rache@1.0.0
+    https://github.com/holepunchto/rache
+  refcounter@1.0.0
+    https://github.com/holepunchto/refcounter
   require-addon@1.2.0
     https://github.com/holepunchto/require-addon
+  resource-on-exit@1.0.0
+    https://github.com/holepunchto/bare-teardown
+  rocksdb-native@3.15.1
+    https://github.com/holepunchto/rocksdb-native
+  scope-lock@1.2.4
+    https://github.com/holepunchto/scope-lock
+  simdle-native@1.3.9
+    https://github.com/holepunchto/simdle-native
   text-decoder@1.2.7
     https://github.com/holepunchto/text-decoder
   udx-native@1.19.2
     https://github.com/holepunchto/udx-native
   unslab@1.3.0
     https://github.com/holepunchto/unslab
-  which-runtime@1.3.2
+  which-runtime@1.4.0
     https://github.com/holepunchto/which-runtime
 
 --- isc (ISC License) ---
 
   bits-to-bytes@1.3.0
     https://github.com/holepunchto/bits-to-bytes
-  compact-encoding-bitfield@1.0.0
-    https://github.com/compact-encoding/compact-encoding-bitfield
-  compact-encoding-net@1.2.0
-    https://github.com/compact-encoding/compact-encoding-net
+  browserify-sign@4.2.6
+    https://github.com/crypto-browserify/browserify-sign
+  inherits@2.0.4
+    https://github.com/isaacs/inherits
+  minimalistic-assert@1.0.1
+    https://github.com/calvinmetcalf/minimalistic-assert
   nanoassert@2.0.0
     https://github.com/emilbayes/nanoassert
   noise-curve-ed@2.1.0
     https://github.com/chm-diederichs/noise-curve-ed
+  parse-asn1@5.1.9
+    https://github.com/crypto-browserify/parse-asn1
+  quickbit-universal@2.2.0
+    https://github.com/holepunchto/quickbit-universal
+  simdle-universal@1.1.2
+    https://github.com/holepunchto/simdle-universal
 
 --- mit (MIT License) ---
 
-  bogon@1.2.0
+  asn1.js@4.10.1
+    https://github.com/indutny/asn1.js
+  available-typed-arrays@1.0.7
+    https://github.com/inspect-js/available-typed-arrays
+  big-sparse-array@1.0.3
+    https://github.com/mafintosh/big-sparse-array
+  bn.js@4.12.3
+    https://github.com/indutny/bn.js
+  bn.js@5.2.3
+    https://github.com/indutny/bn.js
+  bogon@1.3.0
     https://github.com/mafintosh/bogon
-  dht-rpc@6.26.3
-    https://github.com/mafintosh/dht-rpc
+  brorand@1.1.0
+    https://github.com/indutny/brorand
+  browserify-aes@1.2.0
+    https://github.com/crypto-browserify/browserify-aes
+  browserify-cipher@1.0.1
+    https://github.com/crypto-browserify/browserify-cipher
+  browserify-des@1.0.2
+    https://github.com/crypto-browserify/browserify-des
+  browserify-rsa@4.1.1
+    https://github.com/crypto-browserify/browserify-rsa
+  buffer-xor@1.0.3
+    https://github.com/crypto-browserify/buffer-xor
+  call-bind@1.0.9
+    https://github.com/ljharb/call-bind
+  call-bind-apply-helpers@1.0.2
+    https://github.com/ljharb/call-bind-apply-helpers
+  call-bound@1.0.4
+    https://github.com/ljharb/call-bound
+  cipher-base@1.0.7
+    https://github.com/crypto-browserify/cipher-base
+  codecs@3.1.0
+    https://github.com/mafintosh/codecs
+  core-util-is@1.0.3
+    https://github.com/isaacs/core-util-is
+  create-ecdh@4.0.4
+    https://github.com/crypto-browserify/createECDH
+  create-hash@1.2.0
+    https://github.com/crypto-browserify/createHash
+  create-hmac@1.1.7
+    https://github.com/crypto-browserify/createHmac
+  crypto-browserify@3.12.1
+    https://github.com/browserify/crypto-browserify
+  debounceify@1.1.0
+    https://github.com/mafintosh/debounceify
+  define-data-property@1.1.4
+    https://github.com/ljharb/define-data-property
+  des.js@1.1.0
+    https://github.com/indutny/des.js
+  dht-rpc@6.27.0
+    https://github.com/holepunchto/dht-rpc
+  diffie-hellman@5.0.3
+    https://github.com/crypto-browserify/diffie-hellman
+  dunder-proto@1.0.1
+    https://github.com/es-shims/dunder-proto
+  elliptic@6.6.1
+    https://github.com/indutny/elliptic
+  es-define-property@1.0.1
+    https://github.com/ljharb/es-define-property
+  es-errors@1.3.0
+    https://github.com/ljharb/es-errors
+  es-object-atoms@1.1.2
+    https://github.com/ljharb/es-object-atoms
+  evp_bytestokey@1.0.3
+    https://github.com/crypto-browserify/EVP_BytesToKey
   fast-fifo@1.3.2
     https://github.com/mafintosh/fast-fifo
+  flat-tree@1.13.0
+    https://github.com/mafintosh/flat-tree
+  for-each@0.3.5
+    https://github.com/Raynos/for-each
+  function-bind@1.1.2
+    https://github.com/Raynos/function-bind
   generate-object-property@2.0.0
     https://github.com/mafintosh/generate-object-property
   generate-string@1.0.1
     https://github.com/mafintosh/generate-string
-  hypercore-crypto@3.6.1
+  get-intrinsic@1.3.0
+    https://github.com/ljharb/get-intrinsic
+  get-proto@1.0.1
+    https://github.com/ljharb/get-proto
+  gopd@1.2.0
+    https://github.com/ljharb/gopd
+  has-property-descriptors@1.0.2
+    https://github.com/inspect-js/has-property-descriptors
+  has-symbols@1.1.0
+    https://github.com/inspect-js/has-symbols
+  has-tostringtag@1.0.2
+    https://github.com/inspect-js/has-tostringtag
+  hash-base@3.0.5
+    https://github.com/crypto-browserify/hash-base
+  hash-base@3.1.2
+    https://github.com/crypto-browserify/hash-base
+  hash.js@1.1.7
+    https://github.com/indutny/hash.js
+  hasown@2.0.3
+    https://github.com/inspect-js/hasOwn
+  hmac-drbg@1.0.1
+    https://github.com/indutny/hmac-drbg
+  hyperbee@2.27.3
+    https://github.com/holepunchto/hyperbee
+  hypercore@11.30.2
+    https://github.com/holepunchto/hypercore
+  hypercore-crypto@3.7.0
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.29.6
+  hyperdht@6.32.0
     https://github.com/holepunchto/hyperdht
+  is-callable@1.2.7
+    https://github.com/inspect-js/is-callable
+  is-options@1.0.2
+    https://github.com/mafintosh/is-options
   is-property@1.0.2
     https://github.com/mikolalysenko/is-property
+  is-typed-array@1.1.15
+    https://github.com/inspect-js/is-typed-array
+  isarray@1.0.0
+    https://github.com/juliangruber/isarray
+  isarray@2.0.5
+    https://github.com/juliangruber/isarray
   kademlia-routing-table@1.0.6
     https://github.com/mafintosh/kademlia-routing-table
+  llm-splitter@0.2.0
+    https://github.com/nearform/llm-splitter
+  math-intrinsics@1.1.0
+    https://github.com/es-shims/math-intrinsics
+  md5.js@1.3.5
+    https://github.com/crypto-browserify/md5.js
+  miller-rabin@4.0.1
+    https://github.com/indutny/miller-rabin
+  minimalistic-crypto-utils@1.0.1
+    https://github.com/indutny/minimalistic-crypto-utils
+  mutexify@1.4.0
+    https://github.com/mafintosh/mutexify
   nat-sampler@1.0.1
     https://github.com/mafintosh/nat-sampler
-  protomux@3.10.1
-    https://github.com/mafintosh/protomux
+  pbkdf2@3.1.5
+    https://github.com/browserify/pbkdf2
+  possible-typed-array-names@1.1.0
+    https://github.com/ljharb/possible-typed-array-names
+  process-nextick-args@2.0.1
+    https://github.com/calvinmetcalf/process-nextick-args
+  protocol-buffers-encodings@1.2.0
+    https://github.com/mafintosh/protocol-buffers-encodings
+  protomux@3.11.0
+    https://github.com/holepunchto/protomux
+  public-encrypt@4.0.3
+    https://github.com/crypto-browserify/publicEncrypt
   queue-tick@1.0.1
     https://github.com/mafintosh/queue-tick
+  random-array-iterator@1.0.0
+    https://github.com/mafintosh/random-array-iterator
+  randombytes@2.1.0
+    https://github.com/crypto-browserify/randombytes
+  randomfill@1.0.4
+    https://github.com/crypto-browserify/randomfill
+  readable-stream@2.3.8
+    https://github.com/nodejs/readable-stream
   ready-resource@1.2.0
     https://github.com/holepunchto/ready-resource
   record-cache@1.2.0
     https://github.com/mafintosh/record-cache
+  resolve-reject-promise@1.1.0
+    https://github.com/mafintosh/resolve-reject-promise
+  ripemd160@2.0.3
+    https://github.com/crypto-browserify/ripemd160
+  safe-buffer@5.1.2
+    https://github.com/feross/safe-buffer
+  safe-buffer@5.2.1
+    https://github.com/feross/safe-buffer
   safety-catch@1.0.3
     https://github.com/mafintosh/safety-catch
+  set-function-length@1.2.2
+    https://github.com/ljharb/set-function-length
   signal-promise@1.0.3
     https://github.com/mafintosh/signal-promise
+  signed-varint@2.0.1
+    https://github.com/dominictarr/signed-varint
   sodium-native@5.1.0
     https://github.com/holepunchto/sodium-native
   sodium-secretstream@1.2.0
@@ -125,16 +346,28 @@ JavaScript Dependencies
     https://github.com/holepunchto/sodium-universal
   streamx@2.25.0
     https://github.com/mafintosh/streamx
+  string_decoder@1.1.1
+    https://github.com/nodejs/string_decoder
   teex@1.0.1
     https://github.com/mafintosh/teex
   time-ordered-set@2.0.1
     https://github.com/mafintosh/time-ordered-set
   timeout-refresh@2.0.1
     https://github.com/mafintosh/timeout-refresh
+  to-buffer@1.2.2
+    https://github.com/browserify/to-buffer
+  typed-array-buffer@1.0.3
+    https://github.com/inspect-js/typed-array-buffer
+  util-deprecate@1.0.2
+    https://github.com/TooTallNate/util-deprecate
+  varint@5.0.0
+    https://github.com/chrisdickinson/varint
+  which-typed-array@1.1.20
+    https://github.com/inspect-js/which-typed-array
   xache@1.2.1
     https://github.com/mafintosh/xache
   z32@1.1.0
     https://github.com/mafintosh/z32
-  zod@4.3.6
+  zod@4.4.3
     https://github.com/colinhacks/zod
 

--- a/packages/rag/changelog/0.6.1/CHANGELOG.md
+++ b/packages/rag/changelog/0.6.1/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.6.1
+
+Release Date: 2026-05-27
+
+## 🔌 API
+
+- Expose @qvac/rag/errors subpath for consumers. (see PR [#2303](https://github.com/tetherto/qvac/pull/2303)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Load RAG hard deps with require() for Pear/CJS compatibility. (see PR [#2284](https://github.com/tetherto/qvac/pull/2284))
+

--- a/packages/rag/changelog/0.6.1/CHANGELOG_LLM.md
+++ b/packages/rag/changelog/0.6.1/CHANGELOG_LLM.md
@@ -1,0 +1,31 @@
+# QVAC RAG v0.6.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.6.1
+
+This patch restores Pear/CJS compatibility for RAG adapters and adds a lightweight `./errors` subpath so SDK consumers can import error codes without pulling in the full package entry.
+
+---
+
+## 🐞 Fixes
+
+### Pear/CJS compatibility (#2284)
+
+RAG adapters now load hard dependencies (`hyperdb`, `hyperschema`, `llm-splitter`, `#fetch`) via synchronous `require()` instead of dynamic `await import()`. This fixes `MODULE_NOT_FOUND` failures when running RAG under Pear, where ESM dynamic imports are unavailable in the CJS module graph.
+
+---
+
+## 🔌 API
+
+### `@qvac/rag/errors` subpath (#2303)
+
+Consumers can now import RAG error codes and the error class from a dedicated subpath that does not transitively load `HyperDBAdapter` or other heavy runtime deps:
+
+```typescript
+import { ERR_CODES, QvacErrorRAG } from "@qvac/rag/errors";
+
+if (err instanceof QvacErrorRAG && err.code === ERR_CODES.OPERATION_CANCELLED) {
+  // handle cancellation
+}
+```
+
+Existing `import { ERR_CODES } from "@qvac/rag"` continues to work unchanged.

--- a/packages/rag/changelog/0.6.1/api.md
+++ b/packages/rag/changelog/0.6.1/api.md
@@ -1,0 +1,16 @@
+# 🔌 API Changes v0.6.1
+
+## Expose @qvac/rag/errors subpath for consumers
+
+PR: [#2303](https://github.com/tetherto/qvac/pull/2303)
+
+```typescript
+import { ERR_CODES, QvacErrorRAG } from "@qvac/rag/errors";
+
+if (err instanceof QvacErrorRAG && err.code === ERR_CODES.OPERATION_CANCELLED) {
+  // handle cancellation
+}
+```
+
+---
+

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "index.js",
   "scripts": {
     "lint": "standard",


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `rag@0.6.1` on `main`, per gitflow "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs.

## Companion release PR

- https://github.com/tetherto/qvac/pull/2304

## Files

- `packages/rag/package.json` — version `0.6.0` → `0.6.1`
- `packages/rag/changelog/0.6.1/` — generated changelog files
- `packages/rag/CHANGELOG.md` — Keep a Changelog entry for 0.6.1
- `packages/rag/NOTICE` — updated dependency attributions
