### PR TITLE
chore[notask|skiplog]: release @qvac/rag v0.6.2

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2]
+
+### Fixed
+
+- Add `./errors.js` export alias so TypeScript ESM emit (`@qvac/rag/errors.js`) resolves under Node package exports.
+
 ## [0.6.1]
 
 ### Added

--- a/packages/rag/changelog/0.6.2/CHANGELOG.md
+++ b/packages/rag/changelog/0.6.2/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.6.2
+
+Release Date: 2026-05-27
+
+## 🔌 API
+
+- Add `./errors.js` export alias so TypeScript ESM emit (`@qvac/rag/errors.js`) resolves under Node package exports.

--- a/packages/rag/changelog/0.6.2/CHANGELOG_LLM.md
+++ b/packages/rag/changelog/0.6.2/CHANGELOG_LLM.md
@@ -1,0 +1,15 @@
+# QVAC RAG v0.6.2 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.6.2
+
+This patch fixes a package exports gap that broke SDK consumer installs when TypeScript compiled `@qvac/rag/errors` imports to `@qvac/rag/errors.js`.
+
+---
+
+## 🔌 API
+
+### `./errors.js` export alias
+
+TypeScript ESM output appends `.js` to subpath imports. Node enforces `package.json#exports` strictly, so `@qvac/rag/errors.js` failed even though `@qvac/rag/errors` worked. This release adds a matching `./errors.js` export entry pointing at the same module as `./errors`.
+
+No API surface change — existing `@qvac/rag/errors` imports continue to work unchanged.

--- a/packages/rag/changelog/0.6.2/api.md
+++ b/packages/rag/changelog/0.6.2/api.md
@@ -1,0 +1,12 @@
+# 🔌 API Changes v0.6.2
+
+## Add `./errors.js` export alias
+
+TypeScript compiles `@qvac/rag/errors` imports to `@qvac/rag/errors.js` in ESM output. This release adds a matching export entry so consumers (notably `@qvac/sdk` re-exporting `RAG_ERROR_CODES`) resolve correctly at runtime.
+
+```typescript
+import { ERR_CODES } from "@qvac/rag/errors";
+// compiled dist may import "@qvac/rag/errors.js" — both now resolve
+```
+
+---

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "index.js",
   "scripts": {
     "lint": "standard",
@@ -34,6 +34,10 @@
       "default": "./index.js"
     },
     "./errors": {
+      "types": "./src/errors.d.ts",
+      "default": "./src/errors.js"
+    },
+    "./errors.js": {
       "types": "./src/errors.d.ts",
       "default": "./src/errors.js"
     }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Publish `@qvac/rag v0.6.2` so the `./errors.js` export alias reaches npm, unblocking `@qvac/sdk` consumer installs that re-export `RAG_ERROR_CODES` from `@qvac/rag/errors`.

## 📝 How does it solve it?

- Bump `@qvac/rag` from `0.6.1` to `0.6.2`.
- Add `./errors.js` to `package.json#exports` (same target as `./errors`).
- Add `[0.6.2]` changelog.

On merge to `release-rag-0.6.2`, the SDK pod publish workflow ships to npm.

## 🧪 How was it tested?

- `package.json` exports validated ( `./errors` + `./errors.js` both point at `src/errors.js`).

## 🔌 API Changes

```typescript
// Both resolve after this release:
import { ERR_CODES } from "@qvac/rag/errors";
import { ERR_CODES } from "@qvac/rag/errors.js";
```
