### PR TITLE
QVAC-19557 test[skiplog]: skip all chatterbox tts on ios

### DIFF
--- a/packages/sdk/e2e/tests/mobile/consumer.ts
+++ b/packages/sdk/e2e/tests/mobile/consumer.ts
@@ -338,11 +338,8 @@ export const executor = createExecutor({
       "lifecycle-suspend-during-inference",
     ], "suspend() hangs the runner on mobile"),
     ...(Platform.OS === "ios" ? [
-      // QVAC-19557: Flaky on iOS Device Farm under current memory budget.
-      skipTests([
-        "tts-chatterbox-short-text",
-        "tts-chatterbox-medium-text",
-      ], "Chatterbox TTS is flaky on iOS under Device Farm memory pressure (peak 3.2GB)"),
+      // QVAC-19557: Chatterbox TTS variants OOM on iOS Device Farm under the current memory budget.
+      new SkipExecutor(/^tts-chatterbox-/, "Chatterbox TTS is flaky on iOS under Device Farm memory pressure (OOM)"),
       skipTests([
         "ocr-sign-image",
         "ocr-chart-image",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- iOS Device Farm can OOM on Chatterbox TTS e2e tests, not only the short/medium variants, also tts-chatterbox-streaming test - CI run: [Link](https://github.com/tetherto/qvac/actions/runs/26556886357/job/78231569375#step:12:3422)
- Leaving other `tts-chatterbox-*` cases enabled can trigger the same memory failure pattern.

## 📝 How does it solve it?

- Quarantines all `tts-chatterbox-*` tests on iOS with a single prefix-based skip. Slack discussion [here](https://itrexgroup.slack.com/archives/C09MQ34GCH5/p1779877147039659)
- Keeps Chatterbox coverage enabled on desktop and non-iOS platforms.

## 🧪 How was it tested?

- Ran `npm run typecheck` in `packages/sdk/e2e`.
- CI run: https://github.com/tetherto/qvac/actions/runs/26559046521
