### PR TITLE
QVAC-19444 chore[skiplog]: release @qvac/ai-sdk-provider v0.1.0

### DIFF
--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -187,7 +187,14 @@ type EndpointCategory =
   | 'image'
 ```
 
-> The `0.1.0` release ships an **empty** model catalog as a placeholder. The full catalog lands in the follow-up codegen task — track [QVAC-19194 workstream 2](https://app.asana.com/0/0/1215054644422021). Until then, pass model aliases (e.g. `'qwen3-600m'`) as strings.
+The catalog is **codegen'd from the live QVAC P2P registry** at build time and committed to the package — `0.1.0` ships 729 OpenAI-surface model constants covering chat (`llamacpp-completion`), embeddings (`llamacpp-embedding`), transcription (`whispercpp-transcription`, `parakeet-transcription`), translation (`nmtcpp-translation`), speech (`onnx-tts`, `tts-ggml`), OCR (`onnx-ocr`), and image generation (`sdcpp-generation`). Regenerate against the live registry with:
+
+```bash
+npm run update-models     # writes src/models/constants.ts + models/history/<sha>.txt
+npm run check-models      # CI drift check; fails if regen would change anything
+```
+
+Registry entries for engines without an OpenAI-shaped surface (VAD, classification, VLA, …) are filtered out at codegen time. `check-models` runs in CI so the committed catalog cannot drift from the registry without a deliberate regen commit.
 
 ---
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Ship the first public release of `@qvac/ai-sdk-provider` (`0.1.0`) — the [Vercel AI SDK](https://ai-sdk.dev) provider for the QVAC local AI runtime.
- Devops + npm setup is now complete (per Giacomo): npm package created, trusted publishing configured, the dedicated `trigger-reusable-lib-ai-sdk-provider.yml` workflow + `release-merge-guard` are on `main`. Merging this PR is the trigger that publishes `@qvac/ai-sdk-provider@0.1.0` to npm.

## 📝 How does it solve it?

- All release metadata (`package.json` at `0.1.0`, `changelog/0.1.0/{CHANGELOG.md,CHANGELOG_LLM.md,models.md}`, root `CHANGELOG.md` aggregate, `NOTICE`, codegen'd `src/models/constants.ts` with 729 OpenAI-surface model constants) was prepared on `main` first via #2295 — gitflow.md "Preferred (planning discipline): the release branch is cut from a `main` that already contains the intended changelog/version context".
- Release branch `release-ai-sdk-provider-0.1.0` was cut from current `main` (`d22d294d2`); `release-merge-guard` validates the branch name + `package.json` version (`0.1.0` matches the branch).
- This PR carries a single follow-up commit: a documentation correctness fix in `packages/ai-sdk-provider/README.md`. The "Model metadata" section still claimed the `0.1.0` release ships an **empty** model catalog as a placeholder, which contradicts what `0.1.0` actually contains. Replaced with a description of the real codegen scope (engines included / filtered) and the `update-models` / `check-models` regen + drift-check commands.

On merge to `release-ai-sdk-provider-0.1.0`, the publish workflow (build → publish-release-npm) ships `@qvac/ai-sdk-provider@0.1.0` to npm.

A backmerge PR will follow to bring the README correction back to `main` (the rest of the release artifacts are already there from #2295).

## 🧪 How was it tested?

- `git diff packages/ai-sdk-provider/README.md` — single text block replaced; surrounding sections unchanged.
- Verified the catalog is actually populated (`grep -c 'endpointCategory:' packages/ai-sdk-provider/src/models/constants.ts` → 729) so the new wording is factually correct.
- Confirmed engine list in the README matches the codegen filter set documented in `changelog/0.1.0/CHANGELOG_LLM.md` (`llamacpp-completion`, `llamacpp-embedding`, `whispercpp-transcription`, `parakeet-transcription`, `nmtcpp-translation`, `onnx-tts`, `tts-ggml`, `onnx-ocr`, `sdcpp-generation`).
- Confirmed regen commands match `package.json#scripts` (`update-models`, `check-models`).
- No source/code changes — only the README narrative.