### PR TITLE
chore[notask]: bump @qvac/tts-ggml to ^0.1.4

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -202,7 +202,7 @@
     "@qvac/transcription-parakeet": "^0.6.0",
     "@qvac/transcription-whispercpp": "^0.7.0",
     "@qvac/translation-nmtcpp": "^4.0.0",
-    "@qvac/tts-ggml": "^0.1.2",
+    "@qvac/tts-ggml": "^0.1.4",
     "@qvac/vla-ggml": "^0.2.0",
     "bare-abort-controller": "^1.0.0",
     "bare-crypto": "^1.13.4",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `packages/sdk` was pinned to `@qvac/tts-ggml@^0.1.2`, missing the latest published patch (`0.1.4`).
- This was causing failures of check(cli) due to missing `libopenblas`

## 📝 How does it solve it?

- Bump `@qvac/tts-ggml` dependency in `packages/sdk/package.json` from `^0.1.2` → `^0.1.4` (latest patch on the 0.1.x line; 0.1.3 was never published).
