### PR TITLE
QVAC-19444 infra[skiplog]: drop check-models from ai-sdk-provider release CI

### DIFF
--- a/.github/workflows/trigger-reusable-lib-ai-sdk-provider.yml
+++ b/.github/workflows/trigger-reusable-lib-ai-sdk-provider.yml
@@ -136,10 +136,6 @@ jobs:
         working-directory: ${{ env.WORKDIR }}
         run: npm run lint
 
-      - name: Verify generated model constants are current
-        working-directory: ${{ env.WORKDIR }}
-        run: npm run check-models
-
       - name: Run tests
         working-directory: ${{ env.WORKDIR }}
         run: npm run test:unit

--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -6,6 +6,8 @@ Release Date: 2026-05-27
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.1.0
 
+> **Catalog snapshot.** The `src/models/constants.ts` shipped here is a snapshot of the QVAC P2P registry captured at release-prep time, not whatever the live registry returns at publish time. New models that land between prep and publish ship in the next release. This matches how `@qvac/sdk` ships its `models/registry/models.ts` — the codegen drift check is a developer / pre-commit tool, not a release gate.
+
 The first public release of `@qvac/ai-sdk-provider` — the [Vercel AI SDK](https://ai-sdk.dev) provider for the QVAC local AI runtime. Point it at a running `qvac serve openai` HTTP server and you get the full AI SDK surface (`streamText`, `generateText`, `embed`, `transcribe`, `generateImage`, …) backed by on-device chat, embeddings, transcription, translation, speech, OCR, and image-generation models. The package ships a typed catalog of every model in the QVAC P2P registry that has an OpenAI-shaped endpoint, so callers can introspect models without an HTTP round-trip to `/v1/models`.
 
 ---


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The first publish run on `release-ai-sdk-provider-0.1.0` after #2318 merged failed two checks (run [26571560714](https://github.com/tetherto/qvac/actions/runs/26571560714)) and blocked the npm publish:
  - **`Build package` → `Verify generated model constants are current`** failed because the live QVAC registry gained 3 new Parakeet models between #2295 (catalog committed) and #2318 (release PR merged):
    - `PARAKEET_TDT_PARAKEET_EOU_120M_V1_Q4_0_Q4_0`
    - `PARAKEET_TDT_PARAKEET_TDT_0_6B_V3_Q4_0_Q4_0`
    - `PARAKEET_TDT_Q4_0`
  - **`Release Merge Guard`** failed with `Missing CHANGELOG update — file not modified: packages/ai-sdk-provider/CHANGELOG.md` because #2318's diff was a README-only doc fix.
- Both failures are structural for the gitflow-endorsed "release prep on `main` first" path: the catalog is supposed to be a *snapshot* curated at prep time and the changelog is already on `main` before the release branch is cut, so neither file diverges in the release PR.

## 📝 How does it solve it?

- **Drop the `Verify generated model constants are current` step from `trigger-reusable-lib-ai-sdk-provider.yml`'s `Build package` job.** This matches the SDK pod's release pattern: `packages/sdk` has identical `check-models` / `update-models` scripts but `publish-sdk.yml` and the other SDK pod release workflows do *not* run `check-models` in CI. SDK trusts the snapshot committed at prep time and treats drift detection as a developer / pre-commit tool (see `packages/sdk/package.json`'s `check-models:hook` non-blocking variant for that wiring). `bun run check-models` stays available locally for day-to-day drift detection.
- **Annotate `packages/ai-sdk-provider/CHANGELOG.md` with the snapshot policy** under the `0.1.0` entry — useful documentation for downstream consumers ("why doesn't `0.1.0` have the Parakeet model that just landed in the registry?") and gives `release-merge-guard` the CHANGELOG diff it expects.

On merge to `release-ai-sdk-provider-0.1.0`:
- `release-merge-guard` sees `CHANGELOG.md` in the diff → passes.
- `build` no longer runs `check-models` → succeeds even when the live registry has drifted past the committed snapshot.
- `publish-release-npm` ships `@qvac/ai-sdk-provider@0.1.0` to npm.

## 🧪 How was it tested?

- `gh run view 26571560714 --repo tetherto/qvac --log-failed` — confirmed the two failure modes above and that nothing else in the build job is gating on registry connectivity.
- `rg 'check-models' .github/workflows` — confirmed `trigger-reusable-lib-ai-sdk-provider.yml` is the only release workflow that runs `check-models`. SDK pod release workflows (`publish-sdk.yml`, `pr-validation-sdk-pod.yml`, `pr-checks-sdk-pod.yml`, the various `test-*-sdk.yml`) do not.
- `git diff` — workflow change is a 4-line removal; CHANGELOG change is a single annotation paragraph. No source-code or generated-file changes.
- Local `bun run update-models` against the live registry returned `0 entries` from this workspace (Hyperswarm DHT bootstrap doesn't reach peers from here), confirming a regen-on-every-release-merge gate is hostile to anyone without registry connectivity.

## 🔄 Backmerge

A follow-up backmerge to `main` will land both changes (workflow + CHANGELOG annotation) so the policy is documented on the development line. The companion backmerge PR for the README fix (#2322) is unaffected — its single commit doesn't overlap with this fix.