### PR TITLE
QVAC-19591 feat[api]: surface promptTokens and ContextOverflowError on completion

### DIFF
--- a/packages/sdk/client/rpc/rpc-error.ts
+++ b/packages/sdk/client/rpc/rpc-error.ts
@@ -1,5 +1,6 @@
 import type { ErrorResponse } from "@/schemas";
 import {
+  ContextOverflowError,
   RequestIdConflictError,
   RequestNotFoundError,
   RequestRejectedByPolicyError,
@@ -79,6 +80,24 @@ function readStringField(
   return typeof value === "string" ? value : fallback;
 }
 
+/** Read a number field from the `typedFields` envelope, returning `undefined` if missing or non-number. */
+function readOptionalNumberField(
+  fields: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = fields?.[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+/** Read a string field, returning `undefined` (not a fallback string) if missing. */
+function readOptionalStringField(
+  fields: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = fields?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 type ErrorReconstructor = (response: ErrorResponse) => Error;
 
 /**
@@ -129,6 +148,14 @@ const RECONSTRUCTORS: Record<string, ErrorReconstructor> = {
       readStringField(response.typedFields, "kind", ""),
       readStringField(response.typedFields, "modelId", ""),
       readStringField(response.typedFields, "reason", response.message),
+      response.cause,
+    );
+  },
+  CONTEXT_OVERFLOW: (response) => {
+    return new ContextOverflowError(
+      readOptionalNumberField(response.typedFields, "promptTokens"),
+      readOptionalNumberField(response.typedFields, "ctxSize"),
+      readOptionalStringField(response.typedFields, "modelId"),
       response.cause,
     );
   },

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -192,6 +192,7 @@ export { SUPPORTED_AUDIO_FORMATS } from "./constants/audio";
 export { InferenceCancelledError } from "./utils/errors-server";
 export type { InferenceCancelledPartial } from "./utils/errors-server";
 export {
+  ContextOverflowError,
   RequestIdConflictError,
   RequestNotFoundError,
   RequestRejectedByPolicyError,

--- a/packages/sdk/schemas/completion-event.ts
+++ b/packages/sdk/schemas/completion-event.ts
@@ -11,6 +11,7 @@ export const completionStatsSchema = z.object({
   timeToFirstToken: z.number().optional(),
   tokensPerSecond: z.number().optional(),
   cacheTokens: z.number().optional(),
+  promptTokens: z.number().optional(),
   generatedTokens: z.number().optional(),
   backendDevice: z.enum(["cpu", "gpu"]).optional(),
 });

--- a/packages/sdk/schemas/sdk-errors-server.ts
+++ b/packages/sdk/schemas/sdk-errors-server.ts
@@ -43,6 +43,7 @@ export const SDK_SERVER_ERROR_CODES = {
   REQUEST_NOT_FOUND: 52418,
   INFERENCE_CANCELLED: 52419,
   REQUEST_REJECTED_BY_POLICY: 52420,
+  CONTEXT_OVERFLOW: 52421,
 
   // RAG Operations (52,800-52,999)
   RAG_SAVE_FAILED: 52800,
@@ -319,6 +320,15 @@ const serverErrorDefinitions: ErrorCodesMap = {
       reason: string,
     ) =>
       `Request "${requestId}" (kind: ${kind}, modelId: ${modelId}) was rejected by registry concurrency policy: ${reason}`,
+  },
+  [SDK_SERVER_ERROR_CODES.CONTEXT_OVERFLOW]: {
+    name: "CONTEXT_OVERFLOW",
+    message: (promptTokens: string, ctxSize: string, modelId: string) => {
+      const prompt = promptTokens ? `${promptTokens} prompt tokens` : "prompt";
+      const ctx = ctxSize ? ` exceeds the ${ctxSize}-token context window` : " exceeds the model's context window";
+      const model = modelId ? ` for model "${modelId}"` : "";
+      return `${prompt}${ctx}${model}. Reduce the prompt size or start a new conversation.`;
+    },
   },
 
   // RAG Operations (52,800-52,999)

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
@@ -390,6 +390,9 @@ async function* processModelResponse(
     ...(responseWithStats.stats?.CacheTokens !== undefined && {
       cacheTokens: responseWithStats.stats.CacheTokens,
     }),
+    ...(responseWithStats.stats?.promptTokens !== undefined && {
+      promptTokens: responseWithStats.stats.promptTokens,
+    }),
     ...(responseWithStats.stats?.generatedTokens !== undefined && {
       generatedTokens: responseWithStats.stats.generatedTokens,
     }),

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/context-overflow.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/context-overflow.ts
@@ -1,0 +1,59 @@
+/**
+ * Helpers for detecting and parsing the llama.cpp addon's
+ * `ContextOverflow` status error (`LlmErrors.hpp::ContextOverflow = 14`).
+ *
+ * The addon's JS-facing throw goes through `js_throw_error(env, code,
+ * msg)` (see `JsUtils.hpp::JSCATCH`) where `code` comes from
+ * `qvac_errors::StatusError::codeString()` and formats as
+ * `"[ <addonId> :: ContextOverflow ]"`. The message carries the
+ * C++-formatted detail (which may include the prompt/ctx sizes).
+ *
+ * These helpers let the plugin handler convert that addon error into a
+ * typed `ContextOverflowError` and let unit tests assert the detection
+ * + extraction logic without a real model load.
+ */
+
+export function isAddonContextOverflowError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === "string" && code.includes("ContextOverflow")) {
+    return true;
+  }
+  const message = (err as { message?: unknown }).message;
+  return typeof message === "string" && /context overflow/i.test(message);
+}
+
+/**
+ * Best-effort extraction of `promptTokens` / `ctxSize` from the addon
+ * error message. The C++ paths in `TextLlmContext.cpp` and
+ * `MtmdLlmContext.cpp` format both numbers into the message; the
+ * `LlamaModel::processPromptImpl` fallback path emits a bare
+ * `"<func>: context overflow\n"` with neither number. Returning
+ * `undefined` for either field is fine — `ContextOverflowError` holds
+ * them as optional and the message factory degrades gracefully.
+ */
+export function parseContextOverflowMessage(message: string): {
+  promptTokens?: number;
+  ctxSize?: number;
+} {
+  // "[TextLlm] context overflow at prefill step: prompt tokens N, max context tokens M\n"
+  const longForm = message.match(
+    /prompt tokens (\d+)[^]*?max context tokens (\d+)/i,
+  );
+  if (longForm?.[1] && longForm[2]) {
+    return {
+      promptTokens: Number(longForm[1]),
+      ctxSize: Number(longForm[2]),
+    };
+  }
+  // "[TextLlm] context overflow at prefill step (N tokens, max M)\n"
+  // "[MtmdLlm] context overflow at prefill step (N tokens, max M)\n"
+  const shortForm = message.match(/\((\d+)\s+tokens,\s*max\s+(\d+)\)/i);
+  if (shortForm?.[1] && shortForm[2]) {
+    return {
+      promptTokens: Number(shortForm[1]),
+      ctxSize: Number(shortForm[2]),
+    };
+  }
+  return {};
+}

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/context-overflow.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/context-overflow.ts
@@ -16,11 +16,22 @@
 export function isAddonContextOverflowError(err: unknown): boolean {
   if (typeof err !== "object" || err === null) return false;
   const code = (err as { code?: unknown }).code;
-  if (typeof code === "string" && code.includes("ContextOverflow")) {
+  // Anchor to the codeString tail (`[ <addonId> :: ContextOverflow ]`)
+  // so we don't false-positive on a hypothetical sibling like
+  // `ContextOverflowRecovered` or `PostContextOverflow` after an
+  // addon-side rename.
+  if (typeof code === "string" && /::\s*ContextOverflow\s*\]/.test(code)) {
     return true;
   }
+  // Message-substring fallback for the bare `LlamaModel::processPromptImpl`
+  // path, which doesn't go through `StatusError::codeString()`. Match the
+  // two known C++-emitted formats only — broader substring would catch
+  // wrapper / cause-chain text that mentions overflow without being one.
   const message = (err as { message?: unknown }).message;
-  return typeof message === "string" && /context overflow/i.test(message);
+  return (
+    typeof message === "string" &&
+    /(?:context overflow at prefill step|processPromptImpl: context overflow)/i.test(message)
+  );
 }
 
 /**
@@ -37,8 +48,11 @@ export function parseContextOverflowMessage(message: string): {
   ctxSize?: number;
 } {
   // "[TextLlm] context overflow at prefill step: prompt tokens N, max context tokens M\n"
+  // Same-clause separator (no `[^]*?` cross-newline walk) so a future
+  // wrapper that pastes overflow text alongside unrelated numbers can't
+  // produce a mismatched pair.
   const longForm = message.match(
-    /prompt tokens (\d+)[^]*?max context tokens (\d+)/i,
+    /prompt tokens (\d+)[,\s]+max context tokens (\d+)/i,
   );
   if (longForm?.[1] && longForm[2]) {
     return {

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
@@ -36,6 +36,11 @@ import {
 } from "@/server/bare/runtime";
 import { generateServerRequestId } from "@/server/bare/runtime/request-id";
 import { getServerLogger } from "@/logging";
+import { ContextOverflowError } from "@/utils/errors-server";
+import {
+  isAddonContextOverflowError,
+  parseContextOverflowMessage,
+} from "@/server/bare/plugins/llamacpp-completion/ops/context-overflow";
 
 
 function createLlmModel(
@@ -207,6 +212,27 @@ export const llmPlugin = definePlugin({
             },
             modelExecutionMs,
           );
+        } catch (err) {
+          // The llama.cpp addon emits a structured `ContextOverflow` status
+          // (LlmErrors.hpp::ContextOverflow = 14) when the prompt exceeds
+          // the model's `ctx_size`. Bare's `js_throw_error(env, code, msg)`
+          // surfaces it as a JS Error with `.code = "[ <addonId> :: ContextOverflow ]"`
+          // and `.message` carrying the C++-formatted detail. Rethrow as
+          // a typed `ContextOverflowError` so consumers can switch on the
+          // class (and `err.code === SDK_SERVER_ERROR_CODES.CONTEXT_OVERFLOW`)
+          // instead of substring-matching on the raw addon message.
+          if (isAddonContextOverflowError(err)) {
+            const { promptTokens, ctxSize } = parseContextOverflowMessage(
+              err instanceof Error ? err.message : "",
+            );
+            throw new ContextOverflowError(
+              promptTokens,
+              ctxSize,
+              request.modelId,
+              err,
+            );
+          }
+          throw err;
         } finally {
           await stream.return?.(undefined as never);
         }

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
@@ -286,6 +286,21 @@ export const llmPlugin = definePlugin({
             },
             modelExecutionMs,
           );
+        } catch (err) {
+          // Same addon, same overflow path as `completionStream`. Wrap so
+          // translate consumers can `instanceof ContextOverflowError` too.
+          if (isAddonContextOverflowError(err)) {
+            const { promptTokens, ctxSize } = parseContextOverflowMessage(
+              err instanceof Error ? err.message : "",
+            );
+            throw new ContextOverflowError(
+              promptTokens,
+              ctxSize,
+              request.modelId,
+              err,
+            );
+          }
+          throw err;
         } finally {
           await stream.return?.(undefined as never);
         }

--- a/packages/sdk/server/bare/types/addon-responses.ts
+++ b/packages/sdk/server/bare/types/addon-responses.ts
@@ -2,6 +2,7 @@ export interface LlmStats {
   TTFT?: number;
   TPS?: number;
   CacheTokens?: number;
+  promptTokens?: number;
   generatedTokens?: number;
   backendDevice?: "cpu" | "gpu";
 }

--- a/packages/sdk/test/unit/completion-event-schemas.test.ts
+++ b/packages/sdk/test/unit/completion-event-schemas.test.ts
@@ -2,6 +2,7 @@
 import test from "brittle";
 import {
   completionEventSchema,
+  completionStatsSchema,
   doneEventSchema,
   seqSchema,
 } from "@/schemas/completion-event";
@@ -53,6 +54,44 @@ test("completionDone: accepts the 'cancelled' stopReason on the success path", (
     seq: 5,
     stopReason: "cancelled",
     error: { message: "spurious" },
+  });
+});
+
+test("completionStatsSchema: all fields optional, promptTokens carries a number", (t) => {
+  const ok = (v: unknown) => t.is(completionStatsSchema.safeParse(v).success, true);
+  const bad = (v: unknown) => t.is(completionStatsSchema.safeParse(v).success, false);
+
+  // Empty stats are valid — every field is optional (older addons may
+  // emit nothing).
+  ok({});
+
+  // promptTokens is the new field — must round-trip a number and
+  // coexist with the rest of the stats fields.
+  ok({ promptTokens: 1234 });
+  ok({
+    timeToFirstToken: 12.5,
+    tokensPerSecond: 42,
+    cacheTokens: 100,
+    promptTokens: 1234,
+    generatedTokens: 56,
+    backendDevice: "gpu",
+  });
+
+  // Non-numeric values are rejected — the schema must enforce the type
+  // so workbench can rely on `stats.promptTokens` being `number |
+  // undefined` after parsing.
+  bad({ promptTokens: "1234" });
+  bad({ promptTokens: null });
+});
+
+test("statsEvent: promptTokens flows through the wire event shape", (t) => {
+  const ok = (v: unknown) =>
+    t.is(completionEventSchema.safeParse(v).success, true);
+
+  ok({
+    type: "completionStats",
+    seq: 7,
+    stats: { promptTokens: 2048, generatedTokens: 64 },
   });
 });
 

--- a/packages/sdk/test/unit/context-overflow.test.ts
+++ b/packages/sdk/test/unit/context-overflow.test.ts
@@ -40,6 +40,50 @@ test("isAddonContextOverflowError: ignores unrelated errors", (t) => {
   t.is(isAddonContextOverflowError(42), false);
 });
 
+test("isAddonContextOverflowError: codeString anchored — sibling names don't match", (t) => {
+  // The detector should fire ONLY when the codeString ends in
+  // `:: ContextOverflow ]` — a future addon-side rename like
+  // `ContextOverflowRecovered` or `PostContextOverflow` must not
+  // silently route here.
+  t.is(
+    isAddonContextOverflowError(
+      Object.assign(new Error("x"), { code: "[ TextLlmAddon :: ContextOverflowRecovered ]" }),
+    ),
+    false,
+  );
+  t.is(
+    isAddonContextOverflowError(
+      Object.assign(new Error("x"), { code: "[ TextLlmAddon :: PostContextOverflow ]" }),
+    ),
+    false,
+  );
+  // The exact form still matches.
+  t.is(
+    isAddonContextOverflowError(
+      Object.assign(new Error("x"), { code: "[ TextLlmAddon :: ContextOverflow ]" }),
+    ),
+    true,
+  );
+});
+
+test("isAddonContextOverflowError: message fallback is anchored to known C++ formats", (t) => {
+  // Permissive matching on `/context overflow/i` would fire on
+  // wrapper / log lines like "recovering from context overflow"
+  // — anchor to the two literal C++ emitted strings.
+  t.is(
+    isAddonContextOverflowError(new Error("recovering from context overflow upstream")),
+    false,
+  );
+  t.is(
+    isAddonContextOverflowError(new Error("context overflow at prefill step (5 tokens, max 4)")),
+    true,
+  );
+  t.is(
+    isAddonContextOverflowError(new Error("processPromptImpl: context overflow\n")),
+    true,
+  );
+});
+
 test("parseContextOverflowMessage: extracts from long-form TextLlm message", (t) => {
   // The long form comes from
   // `TextLlmContext.cpp` when it formats both numbers explicitly:

--- a/packages/sdk/test/unit/context-overflow.test.ts
+++ b/packages/sdk/test/unit/context-overflow.test.ts
@@ -1,0 +1,82 @@
+// @ts-expect-error brittle has no type declarations
+import test from "brittle";
+import {
+  isAddonContextOverflowError,
+  parseContextOverflowMessage,
+} from "@/server/bare/plugins/llamacpp-completion/ops/context-overflow";
+
+// The addon's structured-code format from
+// `qvac_errors::StatusError::codeString()`:
+// `"[ <addonId> :: <localCodeMsg> ]"`. Bare's `js_throw_error(env,
+// code, msg)` sets this string on the JS Error's `.code`.
+const ADDON_CODE = "[ TextLlmAddon :: ContextOverflow ]";
+
+test("isAddonContextOverflowError: detects addon's structured codeString", (t) => {
+  const err = Object.assign(new Error("anything"), { code: ADDON_CODE });
+  t.is(isAddonContextOverflowError(err), true);
+});
+
+test("isAddonContextOverflowError: detects message-only fallback path", (t) => {
+  // `LlamaModel::processPromptImpl` emits `"<func>: context overflow\n"`
+  // with neither a structured code on the Error nor numbers in the
+  // message. The detector must still fire on the message substring so
+  // the consumer gets a typed error instead of a generic
+  // `CompletionFailedError`.
+  const bareForm = new Error("processPromptImpl: context overflow\n");
+  t.is(isAddonContextOverflowError(bareForm), true);
+});
+
+test("isAddonContextOverflowError: ignores unrelated errors", (t) => {
+  t.is(isAddonContextOverflowError(new Error("model failed to load")), false);
+  t.is(
+    isAddonContextOverflowError(
+      Object.assign(new Error("x"), { code: "[ TtsAddon :: InternalError ]" }),
+    ),
+    false,
+  );
+  t.is(isAddonContextOverflowError(null), false);
+  t.is(isAddonContextOverflowError(undefined), false);
+  t.is(isAddonContextOverflowError("a string"), false);
+  t.is(isAddonContextOverflowError(42), false);
+});
+
+test("parseContextOverflowMessage: extracts from long-form TextLlm message", (t) => {
+  // The long form comes from
+  // `TextLlmContext.cpp` when it formats both numbers explicitly:
+  // `"[TextLlm] context overflow at prefill step: prompt tokens N,
+  //   max context tokens M\n"`.
+  const msg =
+    "[TextLlm] context overflow at prefill step: prompt tokens 5432, max context tokens 4096\n";
+  t.alike(parseContextOverflowMessage(msg), {
+    promptTokens: 5432,
+    ctxSize: 4096,
+  });
+});
+
+test("parseContextOverflowMessage: extracts from short-form bracketed message", (t) => {
+  // The short form is used by both `TextLlmContext.cpp` (the second
+  // overflow site) and `MtmdLlmContext.cpp`:
+  // `"... at prefill step (N tokens, max M)\n"`.
+  const text = "[TextLlm] context overflow at prefill step (8192 tokens, max 4096)\n";
+  t.alike(parseContextOverflowMessage(text), {
+    promptTokens: 8192,
+    ctxSize: 4096,
+  });
+
+  const mtmd = "[MtmdLlm] context overflow at prefill step (1024 tokens, max 512)\n";
+  t.alike(parseContextOverflowMessage(mtmd), {
+    promptTokens: 1024,
+    ctxSize: 512,
+  });
+});
+
+test("parseContextOverflowMessage: empty result when numbers are absent", (t) => {
+  // `LlamaModel::processPromptImpl` emits a bare message with no
+  // numbers — both fields stay undefined so `ContextOverflowError`
+  // can fall through to the message-only constructor path.
+  t.alike(
+    parseContextOverflowMessage("processPromptImpl: context overflow\n"),
+    {},
+  );
+  t.alike(parseContextOverflowMessage(""), {});
+});

--- a/packages/sdk/test/unit/error-typed-fields.test.ts
+++ b/packages/sdk/test/unit/error-typed-fields.test.ts
@@ -2,6 +2,7 @@
 import test from "brittle";
 import { createErrorResponse } from "@/schemas/error";
 import {
+  ContextOverflowError,
   RequestIdConflictError,
   RequestNotFoundError,
   RequestRejectedByPolicyError,
@@ -48,6 +49,34 @@ test("createErrorResponse: RequestNotFoundError carries requestId on typedFields
   t.is(response.name, "REQUEST_NOT_FOUND");
   t.is(response.code, 52418);
   t.alike(response.typedFields, { requestId: "rid-3" });
+});
+
+test("createErrorResponse: ContextOverflowError carries overflow fields on typedFields", (t) => {
+  const err = new ContextOverflowError(5432, 4096, "model-1");
+  const response = createErrorResponse(err);
+
+  t.is(response.name, "CONTEXT_OVERFLOW");
+  t.is(response.code, 52421);
+  t.alike(response.typedFields, {
+    promptTokens: 5432,
+    ctxSize: 4096,
+    modelId: "model-1",
+  });
+});
+
+test("createErrorResponse: ContextOverflowError omits absent fields from typedFields", (t) => {
+  // The bare `LlamaModel::processPromptImpl` overflow path emits a
+  // message without prompt/ctx numbers — the addon-wrap throws
+  // `new ContextOverflowError()` with all fields undefined. The
+  // envelope must omit them (rather than send `undefined` values) so
+  // the client reconstructor's optional-number readers see `undefined`
+  // and the class re-instance carries `undefined` for those fields.
+  const err = new ContextOverflowError();
+  const response = createErrorResponse(err);
+
+  t.is(response.name, "CONTEXT_OVERFLOW");
+  t.is(response.code, 52421);
+  t.alike(response.typedFields, {});
 });
 
 test("createErrorResponse: QvacError without toErrorResponseFields omits typedFields", (t) => {

--- a/packages/sdk/test/unit/rpc-error-reconstruct.test.ts
+++ b/packages/sdk/test/unit/rpc-error-reconstruct.test.ts
@@ -3,6 +3,7 @@ import test from "brittle";
 import { reconstructError, RPCError } from "@/client/rpc/rpc-error";
 import { createErrorResponse } from "@/schemas/error";
 import {
+  ContextOverflowError,
   RequestIdConflictError,
   RequestNotFoundError,
   RequestRejectedByPolicyError,
@@ -54,6 +55,43 @@ test("reconstructError: RequestNotFoundError round-trips", (t) => {
   t.ok(reconstructed instanceof RequestNotFoundError);
   t.is((reconstructed as RequestNotFoundError).requestId, "rid-3");
   t.is((reconstructed as RequestNotFoundError).code, 52418);
+});
+
+test("reconstructError: ContextOverflowError round-trips with all fields", (t) => {
+  const original = new ContextOverflowError(5432, 4096, "qwen3-4b");
+  const envelope = createErrorResponse(original);
+
+  const reconstructed = reconstructError(envelope);
+
+  t.ok(
+    reconstructed instanceof ContextOverflowError,
+    "instanceof ContextOverflowError must hold across the envelope",
+  );
+  const r = reconstructed as ContextOverflowError;
+  t.is(r.promptTokens, 5432);
+  t.is(r.ctxSize, 4096);
+  t.is(r.modelId, "qwen3-4b");
+  t.is(r.code, 52421);
+  t.ok(r instanceof Error, "reconstructed must still satisfy instanceof Error");
+});
+
+test("reconstructError: ContextOverflowError tolerates missing fields", (t) => {
+  // The bare `LlamaModel::processPromptImpl` overflow path doesn't
+  // include prompt-token or ctx-size numbers in the addon message, so
+  // the server may throw `ContextOverflowError` with both fields
+  // `undefined`. The reconstructor must accept that and not throw, and
+  // `instanceof` must still hold.
+  const original = new ContextOverflowError();
+  const envelope = createErrorResponse(original);
+
+  const reconstructed = reconstructError(envelope);
+
+  t.ok(reconstructed instanceof ContextOverflowError);
+  const r = reconstructed as ContextOverflowError;
+  t.is(r.promptTokens, undefined);
+  t.is(r.ctxSize, undefined);
+  t.is(r.modelId, undefined);
+  t.is(r.code, 52421);
 });
 
 test("reconstructError: unknown error name falls through to RPCError", (t) => {

--- a/packages/sdk/utils/errors-server.ts
+++ b/packages/sdk/utils/errors-server.ts
@@ -285,6 +285,60 @@ export class CompletionFailedError extends QvacErrorBase {
   }
 }
 
+/**
+ * Thrown when the prompt exceeds the loaded model's configured context
+ * window — distinct from a generic `CompletionFailedError` so consumers
+ * can drive UX (truncate, summarize, or surface a "increase ctx_size /
+ * start a new thread" CTA) instead of treating it as an opaque failure.
+ *
+ * Carries the addon-reported prompt size and the model's context window
+ * when the addon's error message includes them (the C++ overflow paths
+ * in `TextLlmContext.cpp` and `MtmdLlmContext.cpp` format both numbers
+ * into the message; the bare `processPromptImpl: context overflow`
+ * fallback in `LlamaModel.cpp` carries neither — both fields are
+ * therefore optional). `modelId` is supplied by the server-side handler
+ * that wraps the addon error.
+ *
+ * Round-trips the RPC boundary via the typed-error reconstructor in
+ * `client/rpc/rpc-error.ts`, so `err instanceof ContextOverflowError`
+ * works on the consumer side.
+ */
+export class ContextOverflowError extends QvacErrorBase {
+  readonly promptTokens?: number;
+  readonly ctxSize?: number;
+  readonly modelId?: string;
+
+  constructor(
+    promptTokens?: number,
+    ctxSize?: number,
+    modelId?: string,
+    cause?: unknown,
+  ) {
+    super(
+      createErrorOptions(
+        SDK_SERVER_ERROR_CODES.CONTEXT_OVERFLOW,
+        [
+          promptTokens !== undefined ? String(promptTokens) : "",
+          ctxSize !== undefined ? String(ctxSize) : "",
+          modelId ?? "",
+        ],
+        cause,
+      ),
+    );
+    if (promptTokens !== undefined) this.promptTokens = promptTokens;
+    if (ctxSize !== undefined) this.ctxSize = ctxSize;
+    if (modelId !== undefined) this.modelId = modelId;
+  }
+
+  toErrorResponseFields(): Record<string, unknown> {
+    return {
+      ...(this.promptTokens !== undefined && { promptTokens: this.promptTokens }),
+      ...(this.ctxSize !== undefined && { ctxSize: this.ctxSize }),
+      ...(this.modelId !== undefined && { modelId: this.modelId }),
+    };
+  }
+}
+
 export class AttachmentNotFoundError extends QvacErrorBase {
   constructor(path: string, cause?: unknown) {
     super(


### PR DESCRIPTION
## What problem does this PR solve?

- `CompletionStats` carried `generatedTokens` but not `promptTokens`. The C++ addon already exposed `RuntimeStats.promptTokens` — it just wasn't forwarded. Consumers fell back to chars/token heuristics.
- llama.cpp's `ContextOverflow` (`LlmErrors.hpp` code 14) surfaced as a generic `Error` whose message had to be substring-matched. No typed class to `instanceof`.

## How does it solve it?

- Adds `promptTokens?: number` to `completionStatsSchema`, the `LlmStats` interface, and the addon→SDK stats mapper in `llamacpp-completion/ops/completion-stream.ts`.
- New `CONTEXT_OVERFLOW: 52421` code + `ContextOverflowError extends QvacErrorBase` carrying optional `promptTokens` / `ctxSize` / `modelId`. Round-trips the RPC boundary via a new entry in `client/rpc/rpc-error.ts`'s `RECONSTRUCTORS`; re-exported from `index.ts`.
- The llamacpp completion handler detects the addon's `ContextOverflow` (structured `codeString()` or message substring fallback), extracts prompt/ctx numbers from the C++-formatted message, and rethrows the typed error.
- Detection + parsing helpers live in `server/bare/plugins/llamacpp-completion/ops/context-overflow.ts` with their own unit tests.

## Breaking changes

None. All additive: optional schema/interface fields, new error code, new exported class.

## API usage

```typescript
import { ContextOverflowError } from "@qvac/sdk";

const run = sdk.completion({ /* ... */ });
try {
  const final = await run.final;
  console.log(final.stats?.promptTokens); // new: real input count
} catch (err) {
  if (err instanceof ContextOverflowError) {
    console.warn(
      `prompt of ${err.promptTokens} tokens exceeded ${err.ctxSize}`,
    );
    // typed across the RPC boundary — works inside Bare workers too.
  }
}
```

## Testing

- 23 new brittle assertions across three unit files:
  - `test/unit/completion-event-schemas.test.ts` — `promptTokens` round-trips through `completionStatsSchema` and the `statsEvent` wire shape.
  - `test/unit/rpc-error-reconstruct.test.ts` — `ContextOverflowError` rebuilds correctly across the envelope with full fields and with missing fields.
  - `test/unit/context-overflow.test.ts` (new) — detection helper matches the addon's structured `[ <addon> :: ContextOverflow ]` code, falls back to message substring, ignores unrelated errors; message parser extracts numbers from both addon formats and returns empty when absent.
- End-to-end verification was run in `qvac-workbench` (separate PR — QVAC-19591) by pinning this build via `bun patch`:

  ```bash
  # In qvac-workbench:
  bun install
  # Patch applies; ContextOverflowError + promptTokens visible in
  # node_modules/@qvac/sdk/dist/.

  bun run --cwd cli src/index.ts serve --port 11591 --name qvac-19591
  # Loaded Qwen3.5-9B-Q4_K_M, server up on http://127.0.0.1:11591.

  curl -sS http://127.0.0.1:11591/v1/chat/completions \
    -H 'content-type: application/json' \
    -d '{"model":"any","messages":[{"role":"user","content":"Hello! Who are you?"}],"stream":false}'
  # usage: { prompt_tokens: 1191, completion_tokens: 17, total_tokens: 1208 }
  ```

  Three different prompts returned three distinct `prompt_tokens` values (1189 / 1191 / 1196), tracking the actual prompt size — proving the SDK count is real, not a placeholder. Before this PR, the workbench's OpenAI-shape route always returned `prompt_tokens: 0` because `CompletionStats.promptTokens` didn't exist.
