### PR TITLE
QVAC-19690 doc: VLA and image classification

### DIFF
--- a/docs/website/content/docs/ai-capabilities/image-classification.mdx
+++ b/docs/website/content/docs/ai-capabilities/image-classification.mdx
@@ -1,0 +1,84 @@
+---
+title: Image classification
+description: Assign one or more class labels to an input image with confidence scores.
+schemaType: HowTo
+---
+
+## Overview
+
+Image classification uses a **GGML** inference engine ([`@qvac/classification-ggml`](https://github.com/tetherto/qvac/tree/main/packages/classification-ggml)). Load a model using `modelType: "classification"`. The addon ships with a bundled MobileNetV3-Small that classifies images into three labels — `"food"`, `"report"`, and `"other"` — so no `modelSrc` and no model download are required out of the box. Custom GGUF classifiers are supported by passing your own `modelSrc`.
+
+Provide an image to `classify()` as a `Uint8Array` of either:
+* an encoded **JPEG or PNG** buffer; or
+* **raw RGB** bytes, alongside `width`, `height`, and `channels: 3`.
+
+`classify()` returns `ClassificationResult[]` — an array of `{ label, confidence }` entries sorted by confidence in descending order. Use `topK` to limit the number of results returned, either as a load-time default (`modelConfig.topK`) or as a per-call override.
+
+## Functions
+
+Use the following sequence of function calls:
+1. [`loadModel()`](/reference/api#loadmodel)
+2. [`classify()`](/reference/api#classify)
+3. [`unloadModel()`](/reference/api#unloadmodel)
+
+For how to use each function, see [SDK — API reference](/reference/api/).
+
+## Models
+
+The `@qvac/classification-ggml` addon bundles **MobileNetV3-Small** inside the package itself, so loading with no `modelSrc` is enough to get started:
+
+```ts
+const modelId = await loadModel({
+  modelType: "classification",
+});
+```
+
+To use a custom GGUF classifier, pass the file path (or any other supported model source) as `modelSrc`:
+
+```ts
+const modelId = await loadModel({
+  modelType: "classification",
+  modelSrc: "/abs/path/to/my-classifier.gguf",
+});
+```
+
+You can also set a load-time default for `topK` via `modelConfig`. Per-call `topK` on `classify()` overrides this default:
+
+```ts
+const modelId = await loadModel({
+  modelType: "classification",
+  modelConfig: { topK: 3 },
+});
+```
+
+For models available as constants, see [SDK — Models](/introduction#models).
+
+<Callout type="info">
+**On labels:** the bundled MobileNetV3-Small emits the fixed labels `"food"`, `"report"`, and `"other"`. Custom GGUF classifiers may emit different labels — the label set is sourced from the GGUF metadata.
+</Callout>
+
+## Example
+
+The following script classifies a JPEG image using the bundled MobileNetV3-Small model:
+
+<Tabs>
+<Tab value="js" label="JavaScript" default>
+<WrapCode>
+
+```js file=<rootDir>/packages/sdk/dist/examples/classification/classify-image.js title="classify-image.js" lineNumbers
+```
+</WrapCode>
+</Tab>
+
+<Tab value="ts" label="TypeScript">
+<WrapCode>
+
+```ts file=<rootDir>/packages/sdk/examples/classification/classify-image.ts title="classify-image.ts" lineNumbers
+```
+</WrapCode>
+</Tab>
+</Tabs>
+
+<Callout type="success">
+**Tip:** all examples throughout this documentation are self-contained and runnable. For instructions on how to run them, see [SDK quickstart](/quickstart).
+</Callout>

--- a/docs/website/content/docs/ai-capabilities/image-classification.mdx
+++ b/docs/website/content/docs/ai-capabilities/image-classification.mdx
@@ -25,36 +25,14 @@ For how to use each function, see [SDK — API reference](/reference/api/).
 
 ## Models
 
-The `@qvac/classification-ggml` addon bundles **MobileNetV3-Small** inside the package itself, so loading with no `modelSrc` is enough to get started:
+Supported model families and their file layouts:
 
-```ts
-const modelId = await loadModel({
-  modelType: "classification",
-});
-```
-
-To use a custom GGUF classifier, pass the file path (or any other supported model source) as `modelSrc`:
-
-```ts
-const modelId = await loadModel({
-  modelType: "classification",
-  modelSrc: "/abs/path/to/my-classifier.gguf",
-});
-```
-
-You can also set a load-time default for `topK` via `modelConfig`. Per-call `topK` on `classify()` overrides this default:
-
-```ts
-const modelId = await loadModel({
-  modelType: "classification",
-  modelConfig: { topK: 3 },
-});
-```
+- **MobileNetV3-Small**: single all-in-one `*.gguf` file — the base model or any fine-tune of the same architecture (converted to GGUF). Fine-tunes may define their own classes and labels; the label set is sourced from the GGUF metadata.
 
 For models available as constants, see [SDK — Models](/introduction#models).
 
 <Callout type="info">
-**On labels:** the bundled MobileNetV3-Small emits the fixed labels `"food"`, `"report"`, and `"other"`. Custom GGUF classifiers may emit different labels — the label set is sourced from the GGUF metadata.
+**Default model:** alternatively, you can load no model at all. In that case the base **MobileNetV3-Small** classifier is loaded automatically — no `modelSrc` and no download required. It emits the following fixed labels: `"food"`, `"report"`, and `"other"`.
 </Callout>
 
 ## Example

--- a/docs/website/content/docs/ai-capabilities/vla.mdx
+++ b/docs/website/content/docs/ai-capabilities/vla.mdx
@@ -1,6 +1,6 @@
 ---
 title: VLA
-description: Vision-language-action inference — turns camera frames, robot state, and a natural-language instruction into an action chunk.
+description: Vision-language-action inference — run a VLA policy that turns camera frames, robot state, and a natural-language instruction into an action chunk.
 schemaType: HowTo
 ---
 

--- a/docs/website/content/docs/ai-capabilities/vla.mdx
+++ b/docs/website/content/docs/ai-capabilities/vla.mdx
@@ -1,12 +1,12 @@
 ---
 title: VLA
-description: Vision-language-action inference — run a SmolVLA policy that turns camera frames, robot state, and a natural-language instruction into an action chunk.
+description: Vision-language-action inference — turns camera frames, robot state, and a natural-language instruction into an action chunk.
 schemaType: HowTo
 ---
 
 ## Overview
 
-Vision-language-action (VLA) inference uses a **GGML** engine ([`@qvac/vla-ggml`](https://github.com/tetherto/qvac/tree/main/packages/vla-ggml)) to run [SmolVLA](https://huggingface.co/lerobot/smolvla_base) policies. Load a model using `modelType: "vla"`. Then, feed it preprocessed camera frames, the robot's current state, and a tokenized natural-language instruction; the model returns an **action chunk** — `chunkSize` future timesteps of an `actionDim`-dimensional action vector — to drive the robot's actuators.
+Vision-language-action (VLA) inference uses a **GGML** engine ([`@qvac/vla-ggml`](https://github.com/tetherto/qvac/tree/main/packages/vla-ggml)) to run VLA policies. Load a model using `modelType: "vla"`. Then, feed it preprocessed camera frames, the robot's current state, and a tokenized natural-language instruction; the model returns an **action chunk** — `chunkSize` future timesteps of an `actionDim`-dimensional action vector — to drive the robot's actuators.
 
 `vla()` returns `{ actions, actionDim, chunkSize, stats }`, where `actions` is a `Float32Array` of length `chunkSize * actionDim` and `stats` reports per-stage timings (`vision_ms`, `smollm2_total_ms`, `ode_ms`, `total_ms`).
 
@@ -24,33 +24,11 @@ For how to use each function, see [SDK — API reference](/reference/api/).
 
 ## Models
 
-Load SmolVLA-LIBERO directly from our model registry:
+Supported model families and their file layouts:
 
-```ts
-const modelId = await loadModel({
-  modelSrc: SMOLVLA_LIBERO_VISION_Q8,
-  modelType: "vla",
-});
-```
+- **[SmolVLA](https://huggingface.co/lerobot/smolvla_base)**: single all-in-one `*.gguf` file. Available constant: `SMOLVLA_LIBERO_VISION_Q8`.
 
-To use a custom GGUF, pass the file path as `modelSrc`:
-
-```ts
-const modelId = await loadModel({
-  modelSrc: "/abs/path/to/my-smolvla.gguf",
-  modelType: "vla",
-});
-```
-
-You can also pin the GGML backend at load time via `modelConfig`:
-
-```ts
-const modelId = await loadModel({
-  modelSrc: SMOLVLA_LIBERO_VISION_Q8,
-  modelType: "vla",
-  modelConfig: { backend: "auto" }, // "auto" | "cpu"
-});
-```
+More VLA families are planned, and will load through the same `modelType: "vla"` interface.
 
 For models available as constants, see [SDK — Models](/introduction#models).
 

--- a/docs/website/content/docs/ai-capabilities/vla.mdx
+++ b/docs/website/content/docs/ai-capabilities/vla.mdx
@@ -1,0 +1,85 @@
+---
+title: VLA
+description: Vision-language-action inference — run a SmolVLA policy that turns camera frames, robot state, and a natural-language instruction into an action chunk.
+schemaType: HowTo
+---
+
+## Overview
+
+Vision-language-action (VLA) inference uses a **GGML** engine ([`@qvac/vla-ggml`](https://github.com/tetherto/qvac/tree/main/packages/vla-ggml)) to run [SmolVLA](https://huggingface.co/lerobot/smolvla_base) policies. Load a model using `modelType: "vla"`. Then, feed it preprocessed camera frames, the robot's current state, and a tokenized natural-language instruction; the model returns an **action chunk** — `chunkSize` future timesteps of an `actionDim`-dimensional action vector — to drive the robot's actuators.
+
+`vla()` returns `{ actions, actionDim, chunkSize, stats }`, where `actions` is a `Float32Array` of length `chunkSize * actionDim` and `stats` reports per-stage timings (`vision_ms`, `smollm2_total_ms`, `ode_ms`, `total_ms`).
+
+## Functions
+
+Use the following sequence of function calls:
+1. [`loadModel()`](/reference/api#loadmodel)
+2. [`vlaHparams()`](/reference/api#vlahparams) — to size your input buffers
+3. [`vla()`](/reference/api#vla)
+4. [`unloadModel()`](/reference/api#unloadmodel)
+
+The SDK also exposes two pure-JS input helpers — `vlaPreprocessImage()` and `vlaPadState()` — to prepare the wire-format tensors expected by `vla()`. They are inlined client-side (no native binding required), so they work under Node, Bun, and Expo even without VLA prebuilds.
+
+For how to use each function, see [SDK — API reference](/reference/api/).
+
+## Models
+
+Load SmolVLA-LIBERO directly from our model registry:
+
+```ts
+const modelId = await loadModel({
+  modelSrc: SMOLVLA_LIBERO_VISION_Q8,
+  modelType: "vla",
+});
+```
+
+To use a custom GGUF, pass the file path as `modelSrc`:
+
+```ts
+const modelId = await loadModel({
+  modelSrc: "/abs/path/to/my-smolvla.gguf",
+  modelType: "vla",
+});
+```
+
+You can also pin the GGML backend at load time via `modelConfig`:
+
+```ts
+const modelId = await loadModel({
+  modelSrc: SMOLVLA_LIBERO_VISION_Q8,
+  modelType: "vla",
+  modelConfig: { backend: "auto" }, // "auto" | "cpu"
+});
+```
+
+For models available as constants, see [SDK — Models](/introduction#models).
+
+<Callout type="info">
+**On the input buffers:** `vla()` expects typed-array inputs sized exactly to the model's hparams — images of `hparams.visionImageSize × hparams.visionImageSize`, state of `hparams.maxStateDim`, tokens / mask of `hparams.tokenizerMaxLength`, and an optional noise prior of `hparams.chunkSize × hparams.maxActionDim`. Always call `vlaHparams()` first to size your buffers, and use `vlaPreprocessImage()` / `vlaPadState()` to produce the correct CHW image layout in `[-1, 1]` and zero-padded state vector. The instruction is tokenized on the consumer side using the **SmolVLM2** tokenizer.
+</Callout>
+
+## Example
+
+The following script loads SmolVLA-LIBERO from the registry, builds synthetic inputs (zero-filled gray images + BOS-only tokens + zero state), and runs a single inference pass — printing the produced action chunk and per-stage timings:
+
+<Tabs>
+<Tab value="js" label="JavaScript" default>
+<WrapCode>
+
+```js file=<rootDir>/packages/sdk/dist/examples/vla-smolvla.js title="vla-smolvla.js" lineNumbers
+```
+</WrapCode>
+</Tab>
+
+<Tab value="ts" label="TypeScript">
+<WrapCode>
+
+```ts file=<rootDir>/packages/sdk/examples/vla-smolvla.ts title="vla-smolvla.ts" lineNumbers
+```
+</WrapCode>
+</Tab>
+</Tabs>
+
+<Callout type="success">
+**Tip:** all examples throughout this documentation are self-contained and runnable. For instructions on how to run them, see [SDK quickstart](/quickstart).
+</Callout>

--- a/docs/website/content/docs/index.mdx
+++ b/docs/website/content/docs/index.mdx
@@ -4,7 +4,7 @@ description: A local AI SDK for building cross-platform, P2P applications and sy
 ogImage: /og-home.png
 ---
 
-import { MessagesSquare, Hash, Languages, Mic, Speech, Volume2, ScanText, Image as ImageIcon, Video, GalleryHorizontal, FlaskConical, ScanSearch, Map, Rocket, Server, MonitorPlay } from 'lucide-react'
+import { MessagesSquare, Hash, Languages, Mic, Speech, Volume2, ScanText, Image as ImageIcon, Video, GalleryHorizontal, FlaskConical, ScanSearch, Shapes, Map, Rocket, Server, MonitorPlay } from 'lucide-react'
 
 ## Why QVAC?
 
@@ -55,6 +55,9 @@ QVAC is Tether's answer to centralized AI by ensuring AI is not tied to massive 
   </Card>
   <Card href="/ai-capabilities/ocr" title={<span className="inline-flex items-center gap-2"><ScanText className="size-4 text-[var(--color-fd-primary)]" />OCR</span>}>
     Optical character recognition for extracting text from images via ONNX Runtime.
+  </Card>
+  <Card href="/ai-capabilities/image-classification" title={<span className="inline-flex items-center gap-2"><Shapes className="size-4 text-[var(--color-fd-primary)]" />Image classification</span>}>
+    Classify images into labels with confidence scores via a customized GGML backend.
   </Card>
 </Cards>
 

--- a/docs/website/content/docs/index.mdx
+++ b/docs/website/content/docs/index.mdx
@@ -4,7 +4,7 @@ description: A local AI SDK for building cross-platform, P2P applications and sy
 ogImage: /og-home.png
 ---
 
-import { MessagesSquare, Hash, Languages, Mic, Speech, Volume2, ScanText, Image as ImageIcon, Video, GalleryHorizontal, FlaskConical, ScanSearch, Shapes, Map, Rocket, Server, MonitorPlay } from 'lucide-react'
+import { MessagesSquare, Hash, Languages, Mic, Speech, Volume2, ScanText, Image as ImageIcon, Video, GalleryHorizontal, FlaskConical, ScanSearch, Shapes, Eye, Map, Rocket, Server, MonitorPlay } from 'lucide-react'
 
 ## Why QVAC?
 
@@ -52,6 +52,9 @@ QVAC is Tether's answer to centralized AI by ensuring AI is not tied to massive 
   </Card>
   <Card href="/ai-capabilities/translation" title={<span className="inline-flex items-center gap-2"><Languages className="size-4 text-[var(--color-fd-primary)]" />Translation</span>}>
     Text-to-text neural machine translation (NMT), via Fabric LLM and Bergamot.
+  </Card>
+  <Card href="/ai-capabilities/vla" title={<span className="inline-flex items-center gap-2"><Eye className="size-4 text-[var(--color-fd-primary)]" />VLA</span>}>
+    Vision-language-action for robot control via a customized GGML backend.
   </Card>
   <Card href="/ai-capabilities/ocr" title={<span className="inline-flex items-center gap-2"><ScanText className="size-4 text-[var(--color-fd-primary)]" />OCR</span>}>
     Optical character recognition for extracting text from images via ONNX Runtime.

--- a/docs/website/content/docs/introduction.mdx
+++ b/docs/website/content/docs/introduction.mdx
@@ -58,6 +58,7 @@ The JS SDK is cross-platform, type-safe, and pluggable, exposing all QVAC capabi
 * [**Voice assistant:**](/ai-capabilities/voice-assistant) real-time voice conversation pipeline chaining transcription, text generation, and text-to-speech.
 * [**Translation:**](/ai-capabilities/translation) text-to-text neural machine translation (NMT), via `qvac-fabric-llm.cpp` and [Bergamot](https://browser.mt).
 * [**OCR:**](/ai-capabilities/ocr) optical character recognition (OCR) for extracting text from images via ONNX runtime.
+* [**Image classification:**](/ai-capabilities/image-classification) assigning class labels with confidence scores to images, via [a customized GGML backend](https://github.com/tetherto/qvac/tree/main/packages/classification-ggml).
 
 ### P2P capabilities
 

--- a/docs/website/content/docs/introduction.mdx
+++ b/docs/website/content/docs/introduction.mdx
@@ -57,6 +57,7 @@ The JS SDK is cross-platform, type-safe, and pluggable, exposing all QVAC capabi
 * [**Text-to-Speech:**](/ai-capabilities/text-to-speech) speech synthesis for text-to-speech (TTS) via [a customized GGML backend](https://github.com/tetherto/qvac/tree/main/packages/tts-ggml).
 * [**Voice assistant:**](/ai-capabilities/voice-assistant) real-time voice conversation pipeline chaining transcription, text generation, and text-to-speech.
 * [**Translation:**](/ai-capabilities/translation) text-to-text neural machine translation (NMT), via `qvac-fabric-llm.cpp` and [Bergamot](https://browser.mt).
+* [**VLA:**](/ai-capabilities/vla) vision-language-action that turns camera frames, robot state, and natural-language instruction into action chunks for robot control, via [a customized GGML backend](https://github.com/tetherto/qvac/tree/main/packages/vla-ggml).
 * [**OCR:**](/ai-capabilities/ocr) optical character recognition (OCR) for extracting text from images via ONNX runtime.
 * [**Image classification:**](/ai-capabilities/image-classification) assigning class labels with confidence scores to images, via [a customized GGML backend](https://github.com/tetherto/qvac/tree/main/packages/classification-ggml).
 

--- a/docs/website/src/lib/custom-tree.ts
+++ b/docs/website/src/lib/custom-tree.ts
@@ -173,6 +173,12 @@ export const customTree: Node[] = [
     icon: resolveIcon('ScanText'),
   },
   {
+    name: 'Image classification',
+    url: '/ai-capabilities/image-classification',
+    type: 'page',
+    icon: resolveIcon('Shapes'),
+  },
+  {
     type: 'separator',
     name: 'P2P capabilities',
   },

--- a/docs/website/src/lib/custom-tree.ts
+++ b/docs/website/src/lib/custom-tree.ts
@@ -167,6 +167,12 @@ export const customTree: Node[] = [
     icon: resolveIcon('Languages'),
   },
   {
+    name: 'VLA',
+    url: '/ai-capabilities/vla',
+    type: 'page',
+    icon: resolveIcon('Eye'),
+  },
+  {
     name: 'OCR',
     url: '/ai-capabilities/ocr',
     type: 'page',


### PR DESCRIPTION
## What problem does this PR solve?

Two new features have been added to the SDK:
- VLA: https://github.com/tetherto/qvac/pull/2190
- Image classification: https://github.com/tetherto/qvac/pull/2236/changes

This PR adds documentation for these features, following the same standard used to document all AI capabilities.

## How does it solve it?

- New "VLA" page
- New "Image classification" page
- Updated Home, Sidebar, and Introduction pages.

## Preview

- https://qvac-docs-staging-fazwv-commit-45a7aa7.kinsta.page/#ai-capabilities
- https://qvac-docs-staging-fazwv-commit-45a7aa7.kinsta.page/introduction/#ai-tasks
- https://qvac-docs-staging-fazwv-commit-45a7aa7.kinsta.page/ai-capabilities/vla/
- https://qvac-docs-staging-fazwv-commit-45a7aa7.kinsta.page/ai-capabilities/image-classification/