### PR TITLE
[BCI] Bump whisper-cpp 1.8.4.2 -> 1.8.5 for vcpkg consistency (QVAC-19009)

### DIFF
--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3]
+
+vcpkg dependency consistency with `transcription-whispercpp` (QVAC-19009).
+Bumps the whisper-cpp port to `1.8.5#1` (which consumes
+`ggml-speech@2026-06-02`) and aligns the shared C++ dependencies. No
+JS/native source changes; no public API change.
+
+### Changed
+
+- `vcpkg.json`: `whisper-cpp` override `1.8.4.2` → `1.8.5#1`
+  (matches `transcription-whispercpp`'s current pin, which pulls
+  `ggml-speech@2026-06-02`); `qvac-lint-cpp` (unpinned) → `>=1.4.4#3`.
+  `qvac-lib-inference-addon-cpp` is already `>=1.2.1` on `main` (#2355).
+- `vcpkg-configuration.json`: `default-registry.baseline`
+  `acdd94de…` → `a9d7e924…` — the **same baseline
+  `transcription-whispercpp` uses**, not registry HEAD. The newer
+  `whisper-cpp` / `ggml-speech` are pulled from the registry's version
+  history via the `overrides` + transitive `version>=` constraints, not
+  by moving the baseline to HEAD; the baseline only had to advance far
+  enough to contain a `ggml-speech` port entry (bci's previous
+  `acdd94de` predated that port).
+- `vcpkg-configuration.json`: route `vulkan` / `vulkan-headers` /
+  `vulkan-loader` / `spirv-headers` to the Microsoft registry — required
+  for baseline validation because `ggml-speech` (pulled transitively by
+  `whisper-cpp`) declares a `vulkan` default-feature whose
+  `spirv-headers` dependency the qvac registry does not vendor.
+
+### Android: dynamic backend loading activates
+
+`whisper-cpp@1.8.5#1` consumes the `ggml-speech` port, which on Android
+builds ggml with `GGML_BACKEND_DL=ON` + `GGML_CPU_ALL_VARIANTS=ON`. The
+android-arm64 prebuild now ships the per-arch CPU backend modules
+(`libqvac-speech-ggml-cpu-android_armv8.0_1.so` …
+`…_armv9.2_2.so`) loaded at runtime via `dlopen`. The loader added in
+`0.1.2` (`ensureBackendsLoadedAndroid()`) is what makes this safe. No
+GPU backends yet (that is `0.2.0` / QVAC-19234). Verified locally by
+cross-building the android-arm64 prebuild with the NDK.
+
 ## [0.1.2]
 
 Android dynamic-backend-loading infrastructure (QVAC-19235). Behaviour

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bci-whispercpp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Brain-Computer Interface (BCI) neural signal transcription addon for qvac, powered by whisper.cpp",
   "addon": true,
   "engines": {

--- a/packages/bci-whispercpp/vcpkg-configuration.json
+++ b/packages/bci-whispercpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "acdd94de3e3938d44eea422876adb23c2b33d3a0",
+    "baseline": "a9d7e924de8cb7133c54c5b1d446e4d9c0508ec8",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
@@ -10,7 +10,11 @@
       "baseline": "16c71a39e5a0fc0bdb3fad03beef8f38ee00ee3b",
       "repository": "https://github.com/microsoft/vcpkg",
       "packages": [
-        "gtest"
+        "gtest",
+        "vulkan",
+        "vulkan-headers",
+        "vulkan-loader",
+        "spirv-headers"
       ]
     }
   ]

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -6,7 +6,10 @@
       "name": "qvac-lib-inference-addon-cpp",
       "version>=": "1.2.1"
     },
-    "qvac-lint-cpp",
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.4#3"
+    },
     "whisper-cpp"
   ],
   "features": {
@@ -20,7 +23,8 @@
   "overrides": [
     {
       "name": "whisper-cpp",
-      "version": "1.8.4.2"
+      "version": "1.8.5",
+      "port-version": 1
     }
   ]
 }


### PR DESCRIPTION
## Summary

PR **2 of 3** for the BCI GPU rollout. Aligns `bci-whispercpp`'s vcpkg
dependencies with `transcription-whispercpp 0.9.0` and activates the
Android dynamic-backend path that PR 1 (#2326) was built to absorb.

> **Stacked on #2326 (QVAC-19235).** Until #2326 merges, the diff here
> includes its loader commit. Review/merge order: **#2326 → this → GPU-features PR**.
> Merging this **before** #2326 would reintroduce the Android `SIGABRT`
> on model load (see #2326 / `aiDocs/15-android-mobile-test-crash-fix.md`).

## Changes

`vcpkg.json`:
- `whisper-cpp` override `1.8.4.2` → `1.8.5#0`
- `qvac-lib-inference-addon-cpp` `>=1.2.0` → `>=1.2.1`
- `qvac-lint-cpp` (unpinned) → `>=1.4.4#3`

`vcpkg-configuration.json`:
- `default-registry.baseline` `acdd94de…` → `b54eb179…` (current
  `tetherto/qvac-registry-vcpkg` HEAD). **Mandatory** — the old baseline
  predates the version-database entries for `whisper-cpp@1.8.5#0`,
  `qvac-lib-inference-addon-cpp@1.2.1` and `qvac-lint-cpp@1.4.x`, so
  resolution fails (`no version database entry`) without it.
- Route `vulkan` / `vulkan-headers` / `vulkan-loader` / `spirv-headers`
  to the Microsoft registry — required for baseline validation because
  `ggml-speech` (pulled transitively by `whisper-cpp@1.8.5`) declares a
  `vulkan` default-feature whose `spirv-headers` dep the qvac registry
  does not vendor.

## What this delivers on Android

`whisper-cpp@1.8.5` consumes the `ggml-speech` port, which on Android
builds ggml with `GGML_BACKEND_DL=ON` + `GGML_CPU_ALL_VARIANTS=ON`. The
`android-arm64` prebuild now ships the per-arch CPU backend `.so` modules
loaded at runtime via `dlopen`. PR 1's `ensureBackendsLoadedAndroid()` is
what keeps this safe (no NULL-CPU-device `SIGABRT`).

Note: `ggml-speech`'s per-platform default-features mean the GPU backends
(`opencl`/`vulkan` on Android) also ride along with this bump. The
follow-up PR (QVAC-19234) makes that per-platform GPU selection **explicit
and deterministic** rather than relying on upstream defaults.

## Test plan

Validated locally:
- [x] **linux-x64**: `npm run build`, `test:cpp` (22/22), `test:unit` (21/21), `test:dts`, `test:integration` (6/6), `lint` — all green against whisper 1.8.5
- [x] **android-arm64**: cross-built with the NDK; prebuild contains the 7 per-arch CPU variants (`libqvac-speech-ggml-cpu-android_armv8.0_1.so` … `_armv9.2_2.so`)
- [ ] CI: sanity / cpp-lint / cpp-tests-coverage
- [ ] CI: 9-triplet prebuild matrix incl. `android-arm64`
- [ ] CI: integration + Device Farm (Android + iOS) — confirms the now-active dynamic backend loading runs cleanly on real devices

## Labels

Please apply `verified` + `verify` so `label-gate` / `merge-guard` run the prebuild matrix and Device Farm jobs.

Version: `0.1.1` → `0.1.2` (dependency bump, no public API change).

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214848635445444