### PR TITLE
[BCI] Enable Vulkan & OpenCL GPUs as explicit per-platform features (QVAC-19234)

### DIFF
--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0]
+
+Explicit per-platform GPU backend selection (QVAC-19234). Vulkan and
+OpenCL GPU acceleration on Android, Vulkan on Linux/Windows, Metal on
+macOS — declared as explicit `whisper-cpp` features instead of relying
+on `ggml-speech`'s platform default-features.
+
+### Changed
+
+- `vcpkg.json`: the bare `whisper-cpp` dependency is replaced with
+  per-platform feature selections mirroring `transcription-whispercpp`:
+  - `whisper-cpp[opencl, vulkan]` on `android`
+  - `whisper-cpp[vulkan]` on `!(osx | ios | android)` (Linux / Windows)
+  - `whisper-cpp[metal]` on `osx`
+  - `whisper-cpp` (no GPU feature) on `ios` — iOS stays CPU-only until
+    the upstream Metal XPC issue is resolved (parity with the
+    `whisper-cpp` port's iOS `GGML_METAL=OFF`).
+
+### Why explicit (vs. relying on defaults)
+
+`0.1.3` already pulled the Android GPU backends transitively because
+`ggml-speech` lists `opencl`/`vulkan` as Android default-features. This
+release makes the selection **explicit and deterministic** so
+`bci-whispercpp` owns its GPU matrix: a future change to `ggml-speech`'s
+default-features can no longer silently add or drop a backend, and the
+desktop (Vulkan) / Apple (Metal) / iOS (CPU) choices are now intentional
+and reviewer-auditable.
+
+### Android prebuild (verified locally via NDK cross-build)
+
+`prebuilds/android-arm64/qvac__bci-whispercpp/` ships the dynamically
+loaded backend modules picked up at runtime by
+`ensureBackendsLoadedAndroid()`:
+
+```
+libqvac-speech-ggml-cpu-android_armv8.0_1.so   (+ 8.2_1, 8.2_2, 8.6_1,
+                                                  9.0_1, 9.2_1, 9.2_2)
+libqvac-speech-ggml-opencl.so
+libqvac-speech-ggml-vulkan.so
+```
+
+The active backend is reported through `RuntimeStats.backendId`
+(OpenCL = 4, Vulkan = 3, CPU = 0) captured by `captureActiveBackendInfo()`,
+which walks the GPU **and IGPU** device list and applies the Adreno
+OpenCL preference (mirrors `transcription-whispercpp` #2343).
+
 ## [0.1.3]
 
 vcpkg dependency consistency with `transcription-whispercpp` (QVAC-19009).

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bci-whispercpp",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Brain-Computer Interface (BCI) neural signal transcription addon for qvac, powered by whisper.cpp",
   "addon": true,
   "engines": {

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -10,7 +10,25 @@
       "name": "qvac-lint-cpp",
       "version>=": "1.4.4#3"
     },
-    "whisper-cpp"
+    {
+      "name": "whisper-cpp",
+      "features": ["opencl", "vulkan"],
+      "platform": "android"
+    },
+    {
+      "name": "whisper-cpp",
+      "features": ["vulkan"],
+      "platform": "!(osx | ios | android)"
+    },
+    {
+      "name": "whisper-cpp",
+      "features": ["metal"],
+      "platform": "osx"
+    },
+    {
+      "name": "whisper-cpp",
+      "platform": "ios"
+    }
   ],
   "features": {
     "tests": {


### PR DESCRIPTION
## Summary

PR **3 of 3** for the BCI GPU rollout. Replaces the bare `whisper-cpp`
dependency with explicit per-platform GPU feature selections, mirroring
`transcription-whispercpp 0.9.0`:

| Platform | `whisper-cpp` features |
|---|---|
| `android` | `[opencl, vulkan]` |
| `!(osx \| ios \| android)` (Linux / Windows) | `[vulkan]` |
| `osx` | `[metal]` |
| `ios` | none (CPU-only; matches the port's `GGML_METAL=OFF` on iOS) |

> **Stacked on #2337 (QVAC-19009), which is stacked on #2326 (QVAC-19235).**
> Review/merge order: **#2326 → #2337 → this**. Until the parents merge,
> this diff includes their commits.

## Why explicit (the actual QVAC-19234 ask)

PR 2 (#2337) already pulled the Android GPU backends *transitively*,
because `ggml-speech` lists `opencl`/`vulkan` as Android default-features.
This PR makes that selection **explicit and deterministic** so
`bci-whispercpp` owns its GPU matrix:

- A future change to `ggml-speech`'s default-features can no longer
  silently add or drop a backend.
- The desktop (Vulkan) / Apple (Metal) / iOS (CPU-only) choices become
  intentional and reviewer-auditable.
- Parity with how `transcription-whispercpp` declares the same matrix.

No JS / native / C++ source changes — `vcpkg.json` only (plus version +
changelog).

## What ships in the Android prebuild

Verified locally by cross-building `android-arm64` with the NDK —
`whisper-cpp` now resolves `[core,opencl,vulkan]` **explicitly**, and
`prebuilds/android-arm64/qvac__bci-whispercpp/` contains:

```
libqvac-speech-ggml-cpu-android_armv8.0_1.so   ┐ 7 per-arch CPU variants
…_armv8.2_1 / 8.2_2 / 8.6_1 / 9.0_1 / 9.2_1 / 9.2_2.so   ┘ (GGML_BACKEND_DL=ON)
libqvac-speech-ggml-opencl.so
libqvac-speech-ggml-vulkan.so
```

This matches the QVAC-19234 acceptance tree. The active backend is
reported via `RuntimeStats.backendId` (OpenCL = 4, Vulkan = 3, CPU = 0)
by PR 1's `captureActiveBackendInfo()`. PR 1's
`ensureBackendsLoadedAndroid()` `dlopen`s these modules at runtime.

## Test plan

- [x] **android-arm64** (NDK cross-build): explicit `[core,opencl,vulkan]` resolution; prebuild contains all 7 CPU variants + `opencl` + `vulkan` `.so`
- [x] **Source unchanged from #2337** — host `test:cpp` (22/22) / `test:unit` (21/21) / `test:integration` (6/6) / `test:dts` / `lint` already green there
- [ ] CI: full prebuild matrix + integration
- [ ] CI: **Device Farm (Android)** — the key gate; confirms the GPU backend is selected (or cleanly falls back to CPU) on real devices. On-device GPU selection depends on device class (e.g. Adreno 7xx+ for usable OpenCL); CPU fallback is expected and safe elsewhere.

## Labels

Please apply `verified` + `verify`.

Version: `0.1.2` → `0.2.0` (new user-visible GPU acceleration capability).

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215009851232548