### PR TITLE
chore: add Qwen3.5 Q4_1 registry entries

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -12001,6 +12001,22 @@
     "link": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF"
   },
   {
+    "source": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_1.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Qwen 3.5 0.8B multimodal model",
+    "quantization": "q4_1",
+    "params": "0.8B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "qwen3.5",
+      "instruct"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF"
+  },
+  {
     "source": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q6_K.gguf",
     "engine": "@qvac/llm-llamacpp",
     "description": "Qwen 3.5 0.8B multimodal model",
@@ -12053,6 +12069,22 @@
     "engine": "@qvac/llm-llamacpp",
     "description": "Qwen 3.5 2B multimodal model",
     "quantization": "q4_k_m",
+    "params": "2B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "qwen3.5",
+      "instruct"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/f6d5376be1edb4d416d56da11e5397a961aca8ae/Qwen3.5-2B-Q4_1.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Qwen 3.5 2B multimodal model",
+    "quantization": "q4_1",
     "params": "2B",
     "licenseId": "Apache-2.0",
     "tags": [
@@ -12129,6 +12161,22 @@
     "link": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF"
   },
   {
+    "source": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/e87f176479d0855a907a41277aca2f8ee7a09523/Qwen3.5-4B-Q4_1.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Qwen 3.5 4B multimodal model",
+    "quantization": "q4_1",
+    "params": "4B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "qwen3.5",
+      "instruct"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF"
+  },
+  {
     "source": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/e87f176479d0855a907a41277aca2f8ee7a09523/Qwen3.5-4B-Q6_K.gguf",
     "engine": "@qvac/llm-llamacpp",
     "description": "Qwen 3.5 4B multimodal model",
@@ -12181,6 +12229,22 @@
     "engine": "@qvac/llm-llamacpp",
     "description": "Qwen 3.5 9B multimodal model",
     "quantization": "q4_k_m",
+    "params": "9B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "qwen3.5",
+      "instruct"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/3885219b6810b007914f3a7950a8d1b469d598a5/Qwen3.5-9B-Q4_1.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Qwen 3.5 9B multimodal model",
+    "quantization": "q4_1",
     "params": "9B",
     "licenseId": "Apache-2.0",
     "tags": [


### PR DESCRIPTION
## Summary
- Add pinned Hugging Face Qwen3.5 Q4_1 GGUF artifacts for 0.8B, 2B, 4B, and 9B to `packages/registry-server/data/models.prod.json`.
- Reuse the existing Qwen3.5 registry metadata so the staging registry sync can upload them on merge.

## Test plan
- `npm run validate:models`


Made with [Cursor](https://cursor.com)