### PR TITLE
fix: configure pnpm supportedArchitectures for cross-platform bare-runtime prebuilds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,10 @@
+# Tell pnpm to install bare-runtime prebuilds for all supported platforms.
+# Without this, a lockfile generated on Linux omits win32 / darwin binaries,
+# causing "No binaries found for target 'win32-x64'" at runtime (issue #1492).
+# See: https://pnpm.io/package_json#pnpmsupportedarchitectures
+
+supported-architectures[os][]=linux
+supported-architectures[os][]=win32
+supported-architectures[os][]=darwin
+supported-architectures[cpu][]=x64
+supported-architectures[cpu][]=arm64


### PR DESCRIPTION
## Problem

Running \`qvac serve openai\` on Windows (or native Linux) fails with:

\`\`\`
Error: No binaries found for target 'win32-x64'
    at runtime (bare-runtime/index.js:23:13)
\`\`\`

Reported in #1492. Affects Windows x64 and non-WSL Linux.

## Root cause

\`bare-runtime\` distributes platform binaries as \`optionalDependencies\`. pnpm only installs optional deps matching the **current** host platform, so a lockfile generated on Linux never fetches \`bare-runtime-win32-x64\`.

The same pattern affects \`@rollup/rollup\`, \`@swc/core\`, and \`esbuild\` — they all require \`supportedArchitectures\` to work cross-platform with pnpm.

## Fix

Add a root \`.npmrc\` with [\`supportedArchitectures\`](https://pnpm.io/package_json#pnpmsupportedarchitectures):

\`\`\`ini
supported-architectures[os][]=linux
supported-architectures[os][]=win32
supported-architectures[os][]=darwin
supported-architectures[cpu][]=x64
supported-architectures[cpu][]=arm64
\`\`\`

This tells pnpm to install bare-runtime prebuilds for all listed platforms during \`pnpm install\`, regardless of host machine.

## Verification

\`\`\`bash
rm pnpm-lock.yaml && pnpm install
ls node_modules/.pnpm | grep bare-runtime-win32
# → bare-runtime-win32-x64@1.28.x  ✓
\`\`\`

Then \`qvac serve openai\` works on Windows without the manual \`pnpm add bare-runtime-win32-x64\` workaround.

Closes #1492