### PR TITLE
QVAC-18802 fix[api]: throw InvalidArgument for multi-GPU params on Android/iOS (llm-llamacpp)

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.23.2] - 2026-06-03
+
+### Fixed
+
+- **Multi-GPU params rejected on Android/iOS**: passing `split-mode` (non-`none`), `main-gpu`, or `tensor-split` on a mobile device now throws `InvalidArgument` immediately in `commonParamsParse`, before any backend selection occurs. Previously these parameters could reach the Adreno OpenCL backend and trigger a native `ggml_abort` (SIGABRT) after a full inference suite. Use single-GPU config (`split-mode: "none"` or omit the field) on mobile.
+
+## Pull Requests
+
+- [#2351](https://github.com/tetherto/qvac/pull/2351) - QVAC-18802: reject multi-GPU config on Android/iOS
+
 ## [0.23.1] - 2026-06-02
 
 ### Changed

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -895,7 +895,8 @@ void LlamaModel::commonParamsParse(
     configFilemap.erase(it);
   }
 
-#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
+#if defined(__ANDROID__) ||                                                    \
+    (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
   if (splitMode != LLAMA_SPLIT_MODE_NONE ||
       configFilemap.count("main-gpu") > 0 ||
       configFilemap.count("main_gpu") > 0 ||

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -19,6 +19,9 @@
 #include <common/log.h>
 #include <inference-addon-cpp/Errors.hpp>
 #include <llama.h>
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
 #include <llama/mtmd/mtmd.h>
 #include <picojson/picojson.h>
 
@@ -891,6 +894,18 @@ void LlamaModel::commonParamsParse(
     }
     configFilemap.erase(it);
   }
+
+#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
+  if (splitMode != LLAMA_SPLIT_MODE_NONE ||
+      configFilemap.count("main-gpu") > 0 ||
+      configFilemap.count("main_gpu") > 0 ||
+      configFilemap.count("tensor-split") > 0) {
+    throw qvac_errors::StatusError(
+        qvac_errors::general_error::InvalidArgument,
+        "Multi-GPU parameters (split-mode, main-gpu, tensor-split) are not "
+        "supported on mobile (single-GPU device).");
+  }
+#endif
 
   auto deviceIt = configFilemap.find("device");
   if (deviceIt == configFilemap.end()) {

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -900,7 +900,8 @@ void LlamaModel::commonParamsParse(
   if (splitMode != LLAMA_SPLIT_MODE_NONE ||
       configFilemap.count("main-gpu") > 0 ||
       configFilemap.count("main_gpu") > 0 ||
-      configFilemap.count("tensor-split") > 0) {
+      configFilemap.count("tensor-split") > 0 ||
+      configFilemap.count("tensor_split") > 0) {
     throw qvac_errors::StatusError(
         qvac_errors::general_error::InvalidArgument,
         "Multi-GPU parameters (split-mode, main-gpu, tensor-split) are not "

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Multi-GPU config parameters (`split-mode` != `none`, `main-gpu`, `tensor-split` / `tensor_split`) passed by a mobile caller cause a native `ggml_abort` (SIGABRT) inside the Adreno OpenCL backend after accumulated LLM inference state on Android. Multi-GPU is not a supported topology on mobile (single-GPU devices).

## 📝 How does it solve it?

In `LlamaModel::commonParamsParse()`, after `split-mode` is parsed and before backend selection, add a compile-time platform guard:

```cpp
#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
  if (splitMode != LLAMA_SPLIT_MODE_NONE ||
      configFilemap.count("main-gpu") > 0 ||
      configFilemap.count("main_gpu") > 0 ||
      configFilemap.count("tensor-split") > 0 ||
      configFilemap.count("tensor_split") > 0) {
    throw qvac_errors::StatusError(InvalidArgument, "...");
  }
#endif
```

Throws `InvalidArgument` immediately so the caller gets a clear error rather than a native crash. On desktop the guard compiles to nothing — zero overhead.

**Enforcement layering with SDK sibling (PR #2353):** the SDK strips multi-GPU keys before they reach the addon and emits a server-side warning, so normal SDK mobile callers get a clean load with single-GPU defaults rather than an error. This addon guard is the safety net for callers that reach the addon directly (e.g. non-SDK embedders, future integrations). Both layers are intentional: the SDK provides the friendlier user-facing path; the addon provides the hard rejection at the boundary.

Version bump: `0.22.1` → `0.22.2`

## 🧪 How was it tested?

- The guard is compile-time conditional (`#if defined(__ANDROID__) || TARGET_OS_IOS`); it cannot be exercised in desktop unit tests.
- Tested via the mobile device farm smoke suite: after PR #1998 (merged) removed multi-GPU tests from the mobile consumer, no multi-GPU configs reach the addon on Android/iOS in CI.
- Desktop unit tests (`npm run test:cpp`) are unaffected — the guard compiles out on Linux/macOS/Windows.

**CI runs (from original branch — same code, rebased onto current main):**
- [PR CI — on-pr-llm-llamacpp.yml](https://github.com/tetherto/qvac/actions/runs/26218347091): iOS 72/72 tests passed (24 devices); Android 0 test case failures (26/27 devices, 1 STOPPED)
- [Manual full-pipeline — tmp-QVAC-18802-llm](https://github.com/tetherto/qvac/actions/runs/26227656505): cpp-lint, cpp-tests, all prebuilds (Android/iOS/desktop) passed; Android device farm rerun in progress

## 🔌 API Changes

`LlamaModel` now throws `InvalidArgument` on Android/iOS when any of `split-mode` (non-none), `main-gpu`, `tensor-split`, or their underscore aliases are present in the config. Previously, these params could silently proceed and trigger a native SIGABRT.
