### PR TITLE
QVAC-18802 fix[api]: throw InvalidArgument for multi-GPU params on Android/iOS (embed-llamacpp)

### DIFF
--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.18.2] - 2026-06-03
+
+### Fixed
+
+- **Multi-GPU params rejected on Android/iOS**: passing `split-mode` (non-`none`), `main-gpu`, or `tensor-split` on a mobile device now throws `InvalidArgument` immediately in `setupParams`, before any backend selection occurs. Previously these parameters could silently cause undefined behaviour on mobile. Use single-GPU config on mobile.
+
+## Pull Requests
+
+- [#2352](https://github.com/tetherto/qvac/pull/2352) - QVAC-18802: reject multi-GPU config on Android/iOS
+
 ## [0.18.1] - 2026-06-02
 
 ### Changed

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -10,6 +10,9 @@
 #include <llama.h>
 #include <llama/common/arg.h>
 #include <inference-addon-cpp/Errors.hpp>
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
 
 #include "BackendSelection.hpp"
 #include "LlamaLazyInitializeBackend.hpp"
@@ -299,6 +302,20 @@ common_params setupParams(
   configVector.emplace_back(modelGgufPath);
 
   llama_split_mode splitMode = parseSplitMode(configFilemap);
+
+#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
+  if (splitMode != LLAMA_SPLIT_MODE_NONE ||
+      configFilemap.count("main-gpu") > 0 ||
+      configFilemap.count("main_gpu") > 0 ||
+      configFilemap.count("tensor-split") > 0) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InvalidArgument),
+        "Multi-GPU parameters (split-mode, main-gpu, tensor-split) are not "
+        "supported on mobile (single-GPU device).");
+  }
+#endif
 
   auto deviceIt = configFilemap.find("device");
   if (deviceIt == configFilemap.end()) {

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -308,7 +308,8 @@ common_params setupParams(
   if (splitMode != LLAMA_SPLIT_MODE_NONE ||
       configFilemap.count("main-gpu") > 0 ||
       configFilemap.count("main_gpu") > 0 ||
-      configFilemap.count("tensor-split") > 0) {
+      configFilemap.count("tensor-split") > 0 ||
+      configFilemap.count("tensor_split") > 0) {
     throw qvac_errors::StatusError(
         ADDON_ID,
         qvac_errors::general_error::toString(

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -303,7 +303,8 @@ common_params setupParams(
 
   llama_split_mode splitMode = parseSplitMode(configFilemap);
 
-#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
+#if defined(__ANDROID__) ||                                                    \
+    (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
   if (splitMode != LLAMA_SPLIT_MODE_NONE ||
       configFilemap.count("main-gpu") > 0 ||
       configFilemap.count("main_gpu") > 0 ||

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Multi-GPU config parameters (`split-mode` != `none`, `main-gpu`, `tensor-split` / `tensor_split`) are not supported on mobile (single-GPU devices). While the crash was observed on the LLM addon, the embed addon exposes the same multi-GPU surface and should enforce the same constraint for consistency and safety.

## 📝 How does it solve it?

In `setupParams()`, after `parseSplitMode()` resolves the split-mode and before backend selection, add a compile-time platform guard (same pattern as `llm-llamacpp`):

```cpp
#if defined(__ANDROID__) || (defined(__APPLE__) && defined(TARGET_OS_IOS) && TARGET_OS_IOS)
  if (splitMode != LLAMA_SPLIT_MODE_NONE ||
      configFilemap.count("main-gpu") > 0 ||
      configFilemap.count("main_gpu") > 0 ||
      configFilemap.count("tensor-split") > 0 ||
      configFilemap.count("tensor_split") > 0) {
    throw qvac_errors::StatusError(ADDON_ID, InvalidArgument, "...");
  }
#endif
```

Throws `InvalidArgument` immediately. On desktop the guard compiles to nothing.

**Enforcement layering with SDK sibling (PR #2353):** the SDK strips multi-GPU keys before they reach the addon and emits a server-side warning, so normal SDK mobile callers get a clean load with single-GPU defaults rather than an error. This addon guard is the safety net for callers that reach the addon directly. Both layers are intentional: the SDK provides the friendlier user-facing path; the addon provides the hard rejection at the boundary.

Version bump: `0.18.0` → `0.18.1`

## 🧪 How was it tested?

- Compile-time conditional; cannot be exercised in desktop unit tests.
- Desktop unit tests (`npm run test:cpp`) are unaffected.
- Mobile coverage: same device farm smoke suite as the LLM addon — PR #1998 (merged) removed multi-GPU tests from the mobile consumer.

**CI runs (from original branch — same code, rebased onto current main):**
- [PR CI — on-pr-embed-llamacpp.yml](https://github.com/tetherto/qvac/actions/runs/26218350589): iOS passed; Android passed
- [Manual full-pipeline — tmp-QVAC-18802-embed](https://github.com/tetherto/qvac/actions/runs/26307978621): cpp-lint, cpp-tests, all prebuilds passed; iOS (iPhone 16 + iPhone 17) passed; Android passed

## 🔌 API Changes

`BertModel` now throws `InvalidArgument` on Android/iOS when any of `split-mode` (non-none), `main-gpu`, `tensor-split`, or their underscore aliases are present in the config.
