### PR TITLE
QVAC-19785 infra: fail sdk e2e on failed results

### DIFF
--- a/.github/actions/sdk-e2e-fail-on-failures/action.yml
+++ b/.github/actions/sdk-e2e-fail-on-failures/action.yml
@@ -1,0 +1,56 @@
+name: SDK E2E Fail On Failures
+description: >
+  Fails the calling step if any reports/results-*.json inside the given
+  report directory has summary.failed > 0, or if results are missing or
+  malformed. Designed to run as an inline step in the per-platform test
+  job so the red X appears on the exact matrix leg that failed.
+
+inputs:
+  report-dir:
+    description: Directory containing results-*.json files
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check e2e results
+      shell: node {0}
+      working-directory: ${{ inputs.report-dir }}
+      run: |
+        const fs = require('fs');
+
+        const resultFiles = fs.readdirSync('.')
+          .filter((file) => file.startsWith('results-') && file.endsWith('.json'))
+          .sort();
+        if (resultFiles.length === 0) {
+          console.error('❌ No results-*.json files found; cannot verify e2e result summary.');
+          process.exit(1);
+        }
+
+        let failed = 0;
+        let total = 0;
+        for (const file of resultFiles) {
+          let report;
+          try {
+            report = JSON.parse(fs.readFileSync(file, 'utf8'));
+          } catch (err) {
+            console.error(`❌ Failed to parse ${file}: ${err.message}`);
+            process.exit(1);
+          }
+          if (!report.summary || typeof report.summary.failed !== 'number') {
+            console.error(`❌ ${file} does not contain a numeric summary.failed value.`);
+            process.exit(1);
+          }
+
+          const fileTotal = typeof report.summary.total === 'number' ? report.summary.total : 0;
+          failed += report.summary.failed;
+          total += fileTotal;
+          console.log(`${file}: ${report.summary.failed} failed / ${fileTotal} total`);
+        }
+
+        if (failed > 0) {
+          console.error(`❌ E2E results contain ${failed} failed test(s) across ${resultFiles.length} report(s).`);
+          process.exit(1);
+        }
+
+        console.log(`✅ E2E result summaries are green (${total} total tests across ${resultFiles.length} report(s)).`);

--- a/.github/actions/sdk-e2e-report-finalize/action.yml
+++ b/.github/actions/sdk-e2e-report-finalize/action.yml
@@ -277,10 +277,14 @@ runs:
 
           const summaryPath = process.env.GITHUB_STEP_SUMMARY;
 
+          const failedPlatforms = [];
+          const missingPlatforms = [];
+
           for (const platform of platforms) {
             const resultsPath = findResultsJson(platform);
             let body;
             if (!resultsPath) {
+              missingPlatforms.push(platform);
               const linksLine = buildLinksLine(platform);
               body = [
                 marker(platform),
@@ -299,6 +303,11 @@ runs:
                 results = { summary: {}, categories: {}, tests: [] };
               }
               body = buildBody(platform, results);
+
+              const pFailed = Number(results.summary?.failed || 0);
+              if (pFailed > 0) {
+                failedPlatforms.push({ platform, failed: pFailed });
+              }
             }
 
             if (summaryPath && updateSummary) {
@@ -320,4 +329,16 @@ runs:
             } else if (pr) {
               core.info(`No comment-id recorded for ${platform}; skipping update.`);
             }
+          }
+
+          const problems = [];
+          if (failedPlatforms.length > 0) {
+            const details = failedPlatforms.map((p) => `${p.platform} (${p.failed} failed)`).join(', ');
+            problems.push(`test failures on: ${details}`);
+          }
+          if (missingPlatforms.length > 0) {
+            problems.push(`missing results for: ${missingPlatforms.join(', ')}`);
+          }
+          if (problems.length > 0) {
+            core.setFailed(`E2E aggregate check failed — ${problems.join('; ')}`);
           }

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -522,7 +522,9 @@ jobs:
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          sparse-checkout: ${{ inputs.project-directory }}
+          sparse-checkout: |
+            ${{ inputs.project-directory }}
+            .github/actions/sdk-e2e-fail-on-failures
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -735,6 +735,51 @@ jobs:
           retention-days: 90
           overwrite: true
 
+      - name: Fail on e2e result failures
+        if: success() || failure()
+        working-directory: ${{ inputs.working-directory }}
+        shell: node {0}
+        run: |
+          const fs = require('fs');
+          const path = require('path');
+
+          const reportDir = 'reports';
+          if (!fs.existsSync(reportDir)) {
+            console.error('❌ No reports directory found; cannot verify e2e result summary.');
+            process.exit(1);
+          }
+
+          const resultFiles = fs.readdirSync(reportDir)
+            .filter((file) => file.startsWith('results-') && file.endsWith('.json'))
+            .sort();
+          if (resultFiles.length === 0) {
+            console.error('❌ No results-*.json files found; cannot verify e2e result summary.');
+            process.exit(1);
+          }
+
+          let failed = 0;
+          let total = 0;
+          for (const file of resultFiles) {
+            const fullPath = path.join(reportDir, file);
+            const report = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+            if (!report.summary || typeof report.summary.failed !== 'number') {
+              console.error(`❌ ${fullPath} does not contain a numeric summary.failed value.`);
+              process.exit(1);
+            }
+
+            const fileTotal = typeof report.summary.total === 'number' ? report.summary.total : 0;
+            failed += report.summary.failed;
+            total += fileTotal;
+            console.log(`${file}: ${report.summary.failed} failed / ${fileTotal} total`);
+          }
+
+          if (failed > 0) {
+            console.error(`❌ E2E results contain ${failed} failed test(s) across ${resultFiles.length} report(s).`);
+            process.exit(1);
+          }
+
+          console.log(`✅ E2E result summaries are green (${total} total tests across ${resultFiles.length} report(s)).`);
+
   cleanup-device-farm:
     name: "[android] cleanup-device-farm"
     needs: [build, run-producer, device-farm]

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -737,48 +737,9 @@ jobs:
 
       - name: Fail on e2e result failures
         if: success() || failure()
-        working-directory: ${{ inputs.working-directory }}
-        shell: node {0}
-        run: |
-          const fs = require('fs');
-          const path = require('path');
-
-          const reportDir = 'reports';
-          if (!fs.existsSync(reportDir)) {
-            console.error('❌ No reports directory found; cannot verify e2e result summary.');
-            process.exit(1);
-          }
-
-          const resultFiles = fs.readdirSync(reportDir)
-            .filter((file) => file.startsWith('results-') && file.endsWith('.json'))
-            .sort();
-          if (resultFiles.length === 0) {
-            console.error('❌ No results-*.json files found; cannot verify e2e result summary.');
-            process.exit(1);
-          }
-
-          let failed = 0;
-          let total = 0;
-          for (const file of resultFiles) {
-            const fullPath = path.join(reportDir, file);
-            const report = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-            if (!report.summary || typeof report.summary.failed !== 'number') {
-              console.error(`❌ ${fullPath} does not contain a numeric summary.failed value.`);
-              process.exit(1);
-            }
-
-            const fileTotal = typeof report.summary.total === 'number' ? report.summary.total : 0;
-            failed += report.summary.failed;
-            total += fileTotal;
-            console.log(`${file}: ${report.summary.failed} failed / ${fileTotal} total`);
-          }
-
-          if (failed > 0) {
-            console.error(`❌ E2E results contain ${failed} failed test(s) across ${resultFiles.length} report(s).`);
-            process.exit(1);
-          }
-
-          console.log(`✅ E2E result summaries are green (${total} total tests across ${resultFiles.length} report(s)).`);
+        uses: ./.github/actions/sdk-e2e-fail-on-failures
+        with:
+          report-dir: ${{ inputs.working-directory }}/reports
 
   cleanup-device-farm:
     name: "[android] cleanup-device-farm"

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -616,6 +616,51 @@ jobs:
           retention-days: 90
           overwrite: true
 
+      - name: Fail on e2e result failures
+        if: success() || failure()
+        working-directory: ${{ inputs.working-directory }}
+        shell: node {0}
+        run: |
+          const fs = require('fs');
+          const path = require('path');
+
+          const reportDir = 'reports';
+          if (!fs.existsSync(reportDir)) {
+            console.error('❌ No reports directory found; cannot verify e2e result summary.');
+            process.exit(1);
+          }
+
+          const resultFiles = fs.readdirSync(reportDir)
+            .filter((file) => file.startsWith('results-') && file.endsWith('.json'))
+            .sort();
+          if (resultFiles.length === 0) {
+            console.error('❌ No results-*.json files found; cannot verify e2e result summary.');
+            process.exit(1);
+          }
+
+          let failed = 0;
+          let total = 0;
+          for (const file of resultFiles) {
+            const fullPath = path.join(reportDir, file);
+            const report = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+            if (!report.summary || typeof report.summary.failed !== 'number') {
+              console.error(`❌ ${fullPath} does not contain a numeric summary.failed value.`);
+              process.exit(1);
+            }
+
+            const fileTotal = typeof report.summary.total === 'number' ? report.summary.total : 0;
+            failed += report.summary.failed;
+            total += fileTotal;
+            console.log(`${file}: ${report.summary.failed} failed / ${fileTotal} total`);
+          }
+
+          if (failed > 0) {
+            console.error(`❌ E2E results contain ${failed} failed test(s) across ${resultFiles.length} report(s).`);
+            process.exit(1);
+          }
+
+          console.log(`✅ E2E result summaries are green (${total} total tests across ${resultFiles.length} report(s)).`);
+
       - name: Show consumer log on failure
         if: failure()
         shell: node {0}

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -618,48 +618,9 @@ jobs:
 
       - name: Fail on e2e result failures
         if: success() || failure()
-        working-directory: ${{ inputs.working-directory }}
-        shell: node {0}
-        run: |
-          const fs = require('fs');
-          const path = require('path');
-
-          const reportDir = 'reports';
-          if (!fs.existsSync(reportDir)) {
-            console.error('❌ No reports directory found; cannot verify e2e result summary.');
-            process.exit(1);
-          }
-
-          const resultFiles = fs.readdirSync(reportDir)
-            .filter((file) => file.startsWith('results-') && file.endsWith('.json'))
-            .sort();
-          if (resultFiles.length === 0) {
-            console.error('❌ No results-*.json files found; cannot verify e2e result summary.');
-            process.exit(1);
-          }
-
-          let failed = 0;
-          let total = 0;
-          for (const file of resultFiles) {
-            const fullPath = path.join(reportDir, file);
-            const report = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-            if (!report.summary || typeof report.summary.failed !== 'number') {
-              console.error(`❌ ${fullPath} does not contain a numeric summary.failed value.`);
-              process.exit(1);
-            }
-
-            const fileTotal = typeof report.summary.total === 'number' ? report.summary.total : 0;
-            failed += report.summary.failed;
-            total += fileTotal;
-            console.log(`${file}: ${report.summary.failed} failed / ${fileTotal} total`);
-          }
-
-          if (failed > 0) {
-            console.error(`❌ E2E results contain ${failed} failed test(s) across ${resultFiles.length} report(s).`);
-            process.exit(1);
-          }
-
-          console.log(`✅ E2E result summaries are green (${total} total tests across ${resultFiles.length} report(s)).`);
+        uses: ./.github/actions/sdk-e2e-fail-on-failures
+        with:
+          report-dir: ${{ inputs.working-directory }}/reports
 
       - name: Show consumer log on failure
         if: failure()

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -145,7 +145,9 @@ jobs:
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          sparse-checkout: ${{ inputs.project-directory }}
+          sparse-checkout: |
+            ${{ inputs.project-directory }}
+            .github/actions/sdk-e2e-fail-on-failures
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -855,48 +855,9 @@ jobs:
 
       - name: Fail on e2e result failures
         if: success() || failure()
-        working-directory: ${{ inputs.working-directory }}
-        shell: node {0}
-        run: |
-          const fs = require('fs');
-          const path = require('path');
-
-          const reportDir = 'reports';
-          if (!fs.existsSync(reportDir)) {
-            console.error('❌ No reports directory found; cannot verify e2e result summary.');
-            process.exit(1);
-          }
-
-          const resultFiles = fs.readdirSync(reportDir)
-            .filter((file) => file.startsWith('results-') && file.endsWith('.json'))
-            .sort();
-          if (resultFiles.length === 0) {
-            console.error('❌ No results-*.json files found; cannot verify e2e result summary.');
-            process.exit(1);
-          }
-
-          let failed = 0;
-          let total = 0;
-          for (const file of resultFiles) {
-            const fullPath = path.join(reportDir, file);
-            const report = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-            if (!report.summary || typeof report.summary.failed !== 'number') {
-              console.error(`❌ ${fullPath} does not contain a numeric summary.failed value.`);
-              process.exit(1);
-            }
-
-            const fileTotal = typeof report.summary.total === 'number' ? report.summary.total : 0;
-            failed += report.summary.failed;
-            total += fileTotal;
-            console.log(`${file}: ${report.summary.failed} failed / ${fileTotal} total`);
-          }
-
-          if (failed > 0) {
-            console.error(`❌ E2E results contain ${failed} failed test(s) across ${resultFiles.length} report(s).`);
-            process.exit(1);
-          }
-
-          console.log(`✅ E2E result summaries are green (${total} total tests across ${resultFiles.length} report(s)).`);
+        uses: ./.github/actions/sdk-e2e-fail-on-failures
+        with:
+          report-dir: ${{ inputs.working-directory }}/reports
 
   cleanup-device-farm:
     name: "[ios] cleanup-device-farm"

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -853,6 +853,51 @@ jobs:
           retention-days: 90
           overwrite: true
 
+      - name: Fail on e2e result failures
+        if: success() || failure()
+        working-directory: ${{ inputs.working-directory }}
+        shell: node {0}
+        run: |
+          const fs = require('fs');
+          const path = require('path');
+
+          const reportDir = 'reports';
+          if (!fs.existsSync(reportDir)) {
+            console.error('❌ No reports directory found; cannot verify e2e result summary.');
+            process.exit(1);
+          }
+
+          const resultFiles = fs.readdirSync(reportDir)
+            .filter((file) => file.startsWith('results-') && file.endsWith('.json'))
+            .sort();
+          if (resultFiles.length === 0) {
+            console.error('❌ No results-*.json files found; cannot verify e2e result summary.');
+            process.exit(1);
+          }
+
+          let failed = 0;
+          let total = 0;
+          for (const file of resultFiles) {
+            const fullPath = path.join(reportDir, file);
+            const report = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+            if (!report.summary || typeof report.summary.failed !== 'number') {
+              console.error(`❌ ${fullPath} does not contain a numeric summary.failed value.`);
+              process.exit(1);
+            }
+
+            const fileTotal = typeof report.summary.total === 'number' ? report.summary.total : 0;
+            failed += report.summary.failed;
+            total += fileTotal;
+            console.log(`${file}: ${report.summary.failed} failed / ${fileTotal} total`);
+          }
+
+          if (failed > 0) {
+            console.error(`❌ E2E results contain ${failed} failed test(s) across ${resultFiles.length} report(s).`);
+            process.exit(1);
+          }
+
+          console.log(`✅ E2E result summaries are green (${total} total tests across ${resultFiles.length} report(s)).`);
+
   cleanup-device-farm:
     name: "[ios] cleanup-device-farm"
     needs: [build, run-producer, device-farm]

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -640,7 +640,9 @@ jobs:
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.PAT_TOKEN }}
-          sparse-checkout: ${{ inputs.project-directory }}
+          sparse-checkout: |
+            ${{ inputs.project-directory }}
+            .github/actions/sdk-e2e-fail-on-failures
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:

--- a/packages/sdk/e2e/package.json
+++ b/packages/sdk/e2e/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@qvac/sdk": "file:..",
-    "@tetherto/qvac-test-suite": "0.6.5-tmp.pr-72.runid-26887411586",
+    "@tetherto/qvac-test-suite": "^0.6.4",
     "mqtt": "^5.14.1",
     "react-native": "0.81.5",
     "react-native-bare-kit": "^0.14.0"

--- a/packages/sdk/e2e/package.json
+++ b/packages/sdk/e2e/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@qvac/sdk": "file:..",
-    "@tetherto/qvac-test-suite": "^0.6.4",
+    "@tetherto/qvac-test-suite": "0.6.5-tmp.pr-72.runid-26749246506",
     "mqtt": "^5.14.1",
     "react-native": "0.81.5",
     "react-native-bare-kit": "^0.14.0"

--- a/packages/sdk/e2e/package.json
+++ b/packages/sdk/e2e/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@qvac/sdk": "file:..",
-    "@tetherto/qvac-test-suite": "0.6.5-tmp.pr-72.runid-26807983105",
+    "@tetherto/qvac-test-suite": "0.6.5-tmp.pr-72.runid-26887411586",
     "mqtt": "^5.14.1",
     "react-native": "0.81.5",
     "react-native-bare-kit": "^0.14.0"

--- a/packages/sdk/e2e/package.json
+++ b/packages/sdk/e2e/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@qvac/sdk": "file:..",
-    "@tetherto/qvac-test-suite": "^0.6.5",
+    "@tetherto/qvac-test-suite": "0.6.5-tmp.pr-72.runid-26807983105",
     "mqtt": "^5.14.1",
     "react-native": "0.81.5",
     "react-native-bare-kit": "^0.14.0"

--- a/packages/sdk/e2e/package.json
+++ b/packages/sdk/e2e/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@qvac/sdk": "file:..",
-    "@tetherto/qvac-test-suite": "0.6.5-tmp.pr-72.runid-26749246506",
+    "@tetherto/qvac-test-suite": "^0.6.5",
     "mqtt": "^5.14.1",
     "react-native": "0.81.5",
     "react-native-bare-kit": "^0.14.0"


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- SDK e2e jobs can stay green even when `results-*.json` contains failed tests — the producer can exit `0` while consumers stay alive, so GitHub marks the job as passed.
- If a test leg crashes before uploading artifacts (OOM, runner timeout), there is no check that catches missing results.

## 📝 How does it solve it?

**Per-leg failure gate (composite action)**
- Extracted the inline 45-line results gate into `.github/actions/sdk-e2e-fail-on-failures` — single source of truth for desktop, Android, and iOS workflows.
- Parses `reports/results-*.json` and fails the step if `summary.failed > 0` or results are missing/malformed.
- Red X appears on the exact matrix leg that failed.

**Aggregate safety net (report-finalize)**
- `sdk-e2e-report-finalize` now calls `core.setFailed()` after writing comments/summary if any platform has `failed > 0` or produced no results artifact.
- Catches the case where a leg crashes before reaching the per-leg gate.

## 🧪 How was it tested?

- Verified all three workflow YAML files call the same composite action with identical inputs.
- Prior CI run with inline gate: https://github.com/tetherto/qvac/actions/runs/26749931659
