### PR TITLE
QVAC-19252 fix[tts-ggml]: keep S3Gen spk_embed_affine out of block-quant (sub-f16 NaN audio)

### DIFF
--- a/packages/tts-ggml/scripts/requantize-gguf.py
+++ b/packages/tts-ggml/scripts/requantize-gguf.py
@@ -70,6 +70,10 @@ import gguf
 _DENY_SUBSTRINGS = (
     # Raw-F32 access in the C++ loader
     "flow/input_embedding",     # S3Gen speech embedding table (read as F32 for CPU-side lookup)
+    "flow/spk_embed_affine",    # speaker-embedding affine (w + b): read as raw F32 by
+                                # cached_cpu_weights_f32 in the s3gen synth path, so a
+                                # block-quantized tensor would be byte-reinterpreted as
+                                # float -> NaN speaker embedding -> all-NaN mel -> noise.
     "/builtin/",                # voice conditioning tensors, loaded directly
     # Embedding tables (accessed via ggml_get_rows — safer as F16/F32)
     "text_emb",                 # T3 text token embedding

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-05-20#2"
+      "version>=": "2026-06-02#0"
     }
   ],
   "features": {


### PR DESCRIPTION
## What problem does this PR solve?

S3Gen GGUFs quantized below f16 (`q8_0` / `q5_0` / `q4_0`) produced **NaN / noise audio**. `flow/spk_embed_affine/w` is read as raw F32 by the C++ synth path (`cached_cpu_weights_f32`), but the addon's vendored `requantize-gguf.py` deny-list was missing it, so it got block-quantized — the quantized bytes were reinterpreted as floats → NaN speaker embedding → all-NaN mel → noise. Backend-independent; every sub-f16 level.

Mirrors the upstream root-cause + fix in `qvac-ext-lib-whisper.cpp` **PR #37** (verified there end-to-end: broken q8 cos 0.003 vs f16 → fixed q8 cos 0.990).

## How does it solve it?

`packages/tts-ggml/scripts/requantize-gguf.py` — add `"flow/spk_embed_affine"` to `_DENY_SUBSTRINGS` so the affine weights (w + b) stay F32. Surgical: one fewer tensor block-quantized; `encoder_proj` stays quantized (consumed via `ggml_mul_mat`, dequantized correctly).

Verified: `should_quantize("flow/spk_embed_affine/w", (80,192), Q8_0)` now returns **kept (F32)** against the edited policy.

The matching C++ runtime guard (also in PR #37) reaches the addon later via a `tts-cpp` vcpkg port REF bump — not part of this PR.

## Breaking changes

None.
