### PR TITLE
DevOps: fix macOS self-hosted runner workspace cleanup

### DIFF
--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        if: runner.environment != 'github-hosted'
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: ${{ !startsWith(matrix.runner, 'ubuntu-') && !startsWith(matrix.runner, 'macos-') && !startsWith(matrix.runner, 'windows-') }}
+        if: ${{ startsWith(matrix.runner, 'qvac-') || startsWith(matrix.runner, 'mac-mini-m4-gpu') }}
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: ${{ startsWith(matrix.runner, 'qvac-') || startsWith(matrix.runner, 'mac-mini-m4-gpu') }}
+        if: runner.environment != 'github-hosted'
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: runner.environment != 'github-hosted'
+        if: ${{ !startsWith(matrix.runner, 'ubuntu-') && !startsWith(matrix.runner, 'macos-') && !startsWith(matrix.runner, 'windows-') }}
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2


### PR DESCRIPTION
## Summary

Fixes workspace cleanup condition in integration test workflow to properly support all self-hosted runners, including macOS runners that don't follow the `qvac-` naming convention.

**Problem:** 
- The original condition `startsWith(matrix.runner, 'qvac-')` only applied to runners with the `qvac-` prefix
- macOS self-hosted runners like `mac-mini-m4-gpu` were not getting workspace cleanup
- GitHub-hosted ARM runners like `ubuntu-24.04-arm` need to be excluded from cleanup (they're GitHub-provided)

**Solution:**
- Changed to explicit exclusion of standard GitHub runner prefixes: `!startsWith(matrix.runner, 'ubuntu-') && !startsWith(matrix.runner, 'macos-') && !startsWith(matrix.runner, 'windows-')`
- This ensures ALL self-hosted runners get cleanup while GitHub-hosted runners (including ARM) are skipped

## Test plan

- [ ] DevOps review and approve
- [ ] Verify integration tests pass with this workflow change
- [ ] Confirm macOS self-hosted runners receive proper workspace cleanup

## Files changed

- `.github/workflows/integration-test-diffusion-cpp.yml` — Updated workspace cleanup condition (2 commits)

**Commits:**
1. `f94c467f` - fix: correct workspace cleanup condition for all self-hosted runners
2. `45ef7815` - fix: refine workspace cleanup condition to avoid GitHub-hosted ARM runners

Made with [Cursor](https://cursor.com)