### PR TITLE
QVAC-18588 feat[bc]: embed-llamacpp tech-debt — ctx_size cap, RuntimeStats split, logger docs

### DIFF
--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixed
 
 - Context overflow validation now compares tokenized inputs against the active runtime context size (`llama_n_ctx`), which is itself capped to the trained context.
+- `BertModel::setWeightsForFile` now tracks fulfilled GGUF shards in a per-instance `std::atomic<int>` instead of a function-local `static int`, so multiple concurrent `BertInterface` instances no longer share (and miscount) shard-fulfillment state.
+- `readTrainedContextSize` now logs an `ERROR`-level diagnostic when GGUF metadata cannot be read on a non-streaming load (previously failed silently and reverted to llama.cpp's default `ctx_size`).
 
 ## [0.18.0] - 2026-05-29
 

--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.19.0] - 2026-06-01
+
+### Changed
+
+- `feat[bc]`: `RuntimeStats.context_size` now reports the active runtime llama context size. Use the new `RuntimeStats.trained_context_size` field for the model's trained context size.
+- The embed runtime now defaults `ctx_size` to the model's trained context size and caps oversized `ctx_size` requests to that value before creating the llama context.
+
+### Fixed
+
+- Context overflow validation now compares tokenized inputs against the active runtime context size (`llama_n_ctx`), which is itself capped to the trained context.
+
 ## [0.18.0] - 2026-05-29
 
 ### Fixed

--- a/packages/embed-llamacpp/README.md
+++ b/packages/embed-llamacpp/README.md
@@ -134,13 +134,31 @@ The `config` is a plain JS object whose keys are forwarded directly to the nativ
 | `device`         | `"gpu"` \| `"cpu"`                            | `"gpu"`       | Device to run inference on                                                               |
 | `gpu_layers`     | string of integer                             | `"0"`         | Number of model layers to offload to GPU                                                 |
 | `batch_size`     | string of integer                             | `"2048"`      | Tokens processed per batch (input throughput)                                            |
-| `ctx_size`       | string of integer                             | model default | Maximum context window in tokens (llama.cpp `n_ctx`); capped by the model's trained context |
+| `ctx_size`       | string of integer                             | model's trained context size (`n_ctx_train`) | Runtime context window in tokens (llama.cpp `n_ctx`); oversized values are capped to the model's trained context |
 | `pooling`        | `"none"` \| `"mean"` \| `"cls"` \| `"last"` \| `"rank"` | model default | Pooling strategy used to collapse token embeddings into a single sequence vector        |
 | `attention`      | `"causal"` \| `"non-causal"`                  | model default | Attention type                                                                            |
 | `embd_normalize` | string of integer                             | `"2"`         | Embedding normalization (`-1` = none, `0` = max abs int16, `1` = taxicab, `2` = euclidean, `>2` = p-norm) |
 | `flash_attn`     | `"on"` \| `"off"` \| `"auto"`                 | `"auto"`      | Enable / disable flash attention                                                         |
 | `main-gpu`       | string of integer \| `"integrated"` \| `"dedicated"` | —      | GPU selection for multi-GPU systems                                                      |
-| `verbosity`      | string of `"0"`–`"3"` (0=ERROR, 1=WARN, 2=INFO, 3=DEBUG) | `"0"` | Logging verbosity level                                                                   |
+| `verbosity`      | string of `"0"`–`"3"` (0=ERROR, 1=WARN, 2=INFO, 3=DEBUG) | `"0"` | Native logging verbosity. The `addonLogging.setLogger` callback receives only messages at or above this threshold. Use `"2"` for llama.cpp INFO logs and `"3"` for DEBUG logs. |
+
+#### Native addon logging
+
+`@qvac/embed-llamacpp/addonLogging` exposes the native C++ logger:
+
+```js
+const { setLogger, releaseLogger } = require('@qvac/embed-llamacpp/addonLogging')
+
+setLogger((priority, message) => {
+  console.log(priority, message)
+})
+```
+
+The callback is wired before model load, but it still follows `config.verbosity`.
+With the default `"0"` setting, only native `ERROR` messages are delivered. Set
+`config.verbosity` to `"2"` to receive llama.cpp `INFO` diagnostics, or `"3"` for
+`DEBUG` messages. Some startup diagnostics printed directly by llama.cpp may
+still appear on `stderr` before the addon installs its callback.
 
 #### IGPU/GPU  selection logic:
 
@@ -176,7 +194,7 @@ const response = await model.run(query)
 const embeddings = await response.await()
 ```
 
-When `opts.stats` is enabled, `response.stats` includes runtime metrics such as `total_tokens`, `total_time_ms`, `tokens_per_second`, and `backendDevice` (`"cpu"` or `"gpu"`). `backendDevice` reflects the resolved device used at runtime after backend selection/fallback logic, not only the requested config.
+When `opts.stats` is enabled, `response.stats` includes runtime metrics such as `total_tokens`, `total_time_ms`, `tokens_per_second`, `context_size`, `trained_context_size`, and `backendDevice` (`"cpu"` or `"gpu"`). `context_size` is the active runtime llama context size, while `trained_context_size` is the model's trained context size. `backendDevice` reflects the resolved device used at runtime after backend selection/fallback logic, not only the requested config.
 
 ### 7. Release Resources
 

--- a/packages/embed-llamacpp/README.md
+++ b/packages/embed-llamacpp/README.md
@@ -140,7 +140,7 @@ The `config` is a plain JS object whose keys are forwarded directly to the nativ
 | `embd_normalize` | string of integer                             | `"2"`         | Embedding normalization (`-1` = none, `0` = max abs int16, `1` = taxicab, `2` = euclidean, `>2` = p-norm) |
 | `flash_attn`     | `"on"` \| `"off"` \| `"auto"`                 | `"auto"`      | Enable / disable flash attention                                                         |
 | `main-gpu`       | string of integer \| `"integrated"` \| `"dedicated"` | —      | GPU selection for multi-GPU systems                                                      |
-| `verbosity`      | string of `"0"`–`"3"` (0=ERROR, 1=WARN, 2=INFO, 3=DEBUG) | `"0"` | Native logging verbosity. The `addonLogging.setLogger` callback receives only messages at or above this threshold. Use `"2"` for llama.cpp INFO logs and `"3"` for DEBUG logs. |
+| `verbosity`      | string of `"0"`–`"3"` (0=ERROR, 1=WARNING, 2=INFO, 3=DEBUG) | `"0"` | Native logging verbosity. The `addonLogging.setLogger` callback receives only messages at or above this threshold. Use `"2"` for llama.cpp INFO logs and `"3"` for DEBUG logs. The verbosity level is process-global and is updated each time a model is constructed, so the most recently constructed model's `config.verbosity` wins for all subsequent native log dispatch. |
 
 #### Native addon logging
 
@@ -157,8 +157,11 @@ setLogger((priority, message) => {
 The callback is wired before model load, but it still follows `config.verbosity`.
 With the default `"0"` setting, only native `ERROR` messages are delivered. Set
 `config.verbosity` to `"2"` to receive llama.cpp `INFO` diagnostics, or `"3"` for
-`DEBUG` messages. Some startup diagnostics printed directly by llama.cpp may
-still appear on `stderr` before the addon installs its callback.
+`DEBUG` messages. The verbosity level is process-global and is updated each
+time a model is constructed, so when multiple models are loaded the most
+recently constructed model's `config.verbosity` wins for all subsequent
+native log dispatch. Some startup diagnostics printed directly by llama.cpp
+may still appear on `stderr` before the addon installs its callback.
 
 #### IGPU/GPU  selection logic:
 

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -247,8 +247,10 @@ int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) 
 /// @brief Read the model's trained context size from GGUF metadata without
 /// loading model weights.
 /// @returns The trained context size, or std::nullopt if metadata cannot be
-/// read (e.g. streaming load where the file is not yet on disk, or the GGUF
-/// file lacks the expected keys).
+/// read. Legitimate skips (streaming load, file not yet on disk) are silent;
+/// unexpected metadata failures (read error, missing keys) emit an
+/// ERROR-level log so the silent fallback to llama.cpp's default ctx_size is
+/// diagnosable.
 std::optional<int> readTrainedContextSize(
     const std::string& modelPath, const GGUFShards& shards, bool isStreaming) {
   // Streaming loads consume the GGUF stream during model load; pre-load
@@ -264,15 +266,29 @@ std::optional<int> readTrainedContextSize(
     return std::nullopt;
   }
 
+  auto logMetaFailure = [&sourcePath](const std::string& detail) {
+    qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
+        GGML_LOG_LEVEL_ERROR,
+        string_format(
+            "readTrainedContextSize: %s (path=%s); falling back to llama.cpp "
+            "default ctx_size\n",
+            detail.c_str(),
+            sourcePath.c_str())
+            .c_str(),
+        nullptr);
+  };
+
   metadata_handle_ptr meta;
   if (llama_model_meta_from_file(sourcePath.c_str(), &meta) !=
       MetaResultStatus::SUCCESS) {
+    logMetaFailure("llama_model_meta_from_file failed");
     return std::nullopt;
   }
 
   std::string architecture;
   if (llama_model_meta_get_str(meta, "general.architecture", &architecture) !=
       MetaResultStatus::SUCCESS) {
+    logMetaFailure("missing 'general.architecture' key");
     return std::nullopt;
   }
 
@@ -280,6 +296,7 @@ std::optional<int> readTrainedContextSize(
   const std::string contextLengthKey = architecture + ".context_length";
   if (llama_model_meta_get_u32(meta, contextLengthKey.c_str(), &trainedCtx) !=
       MetaResultStatus::SUCCESS) {
+    logMetaFailure("missing '" + contextLengthKey + "' key");
     return std::nullopt;
   }
 

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -4,9 +4,11 @@
 #include <any>
 #include <cctype>
 #include <cstring>
+#include <ranges>
 #include <stdexcept>
 
 #include <common/common.h>
+#include <llama-cpp.h>
 #include <llama.h>
 #include <llama/common/arg.h>
 #include <inference-addon-cpp/Errors.hpp>
@@ -231,6 +233,90 @@ void logTokenizationIfVerbose(
   }
 }
 
+bool hasContextSizeConfig(
+    const std::unordered_map<std::string, std::string>& configFilemap) {
+  return configFilemap.find("ctx_size") != configFilemap.end() ||
+         configFilemap.find("ctx-size") != configFilemap.end();
+}
+
+int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) {
+  return std::min(
+      llama_model_n_ctx_train(model), static_cast<int>(llama_n_ctx(ctx)));
+}
+
+/// @brief Read the model's trained context size from GGUF metadata without
+/// loading model weights.
+/// @returns The trained context size, or std::nullopt if metadata cannot be
+/// read (e.g. streaming load where the file is not yet on disk, or the GGUF
+/// file lacks the expected keys).
+std::optional<int> readTrainedContextSize(
+    const std::string& modelPath, const GGUFShards& shards, bool isStreaming) {
+  // Streaming loads consume the GGUF stream during model load; pre-load
+  // metadata inspection is not supported on this path. Callers fall back to
+  // the llama.cpp default in that case.
+  if (isStreaming) {
+    return std::nullopt;
+  }
+
+  const std::string& sourcePath =
+      shards.gguf_files.empty() ? modelPath : shards.gguf_files.front();
+  if (sourcePath.empty() || !std::filesystem::exists(sourcePath)) {
+    return std::nullopt;
+  }
+
+  metadata_handle_ptr meta;
+  if (llama_model_meta_from_file(sourcePath.c_str(), &meta) !=
+      MetaResultStatus::SUCCESS) {
+    return std::nullopt;
+  }
+
+  std::string architecture;
+  if (llama_model_meta_get_str(meta, "general.architecture", &architecture) !=
+      MetaResultStatus::SUCCESS) {
+    return std::nullopt;
+  }
+
+  uint32_t trainedCtx = 0;
+  const std::string contextLengthKey = architecture + ".context_length";
+  if (llama_model_meta_get_u32(meta, contextLengthKey.c_str(), &trainedCtx) !=
+      MetaResultStatus::SUCCESS) {
+    return std::nullopt;
+  }
+
+  return static_cast<int>(trainedCtx);
+}
+
+/// @brief Adjusts @p params.n_ctx so the runtime context does not exceed the
+/// model's trained context. When the caller did not configure ctx_size, the
+/// trained context is used as the default (overriding llama.cpp's hard-coded
+/// 4096 fallback). When the caller configured an oversized ctx_size, it is
+/// capped and an ERROR-level message is emitted so users see it without
+/// bumping verbosity.
+void adjustEmbeddingContextSize(
+    common_params& params, int trainedCtx, bool ctxSizeConfigured) {
+  const int requestedCtx = params.n_ctx;
+
+  if (!ctxSizeConfigured) {
+    params.n_ctx = trainedCtx;
+    return;
+  }
+
+  if (requestedCtx > trainedCtx) {
+    params.n_ctx = trainedCtx;
+    qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
+        GGML_LOG_LEVEL_ERROR,
+        string_format(
+            "%s: requested ctx_size %d exceeds model trained context size %d; "
+            "capping to %d\n",
+            __func__,
+            requestedCtx,
+            trainedCtx,
+            trainedCtx)
+            .c_str(),
+        nullptr);
+  }
+}
+
 } // namespace
 
 BertEmbeddings::BertEmbeddings(
@@ -287,9 +373,11 @@ parseSplitMode(std::unordered_map<std::string, std::string>& configFilemap) {
 common_params setupParams(
     const std::string& modelGgufPath,
     std::unordered_map<std::string, std::string> configFilemap,
+    bool& ctxSizeConfigured,
     int64_t& resolvedBackendDevice) {
   // Default params
   common_params params;
+  ctxSizeConfigured = hasContextSizeConfig(configFilemap);
 
   // Override default params
   std::vector<std::string> configVector;
@@ -434,11 +522,12 @@ BertModel::BertModel(
       backendsDir);
 }
 
-BertModel::BertModel(common_params& params)
+BertModel::BertModel(common_params& params, bool ctxSizeConfigured)
     : model_(nullptr), ctx_(nullptr), vocab_(nullptr), batch_{},
       pooling_type(LLAMA_POOLING_TYPE_NONE), n_embd(0), is_loaded_(false),
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
-      shards_(GGUFShards::expandGGUFIntoShards(params.model.path)) {
+      shards_(GGUFShards::expandGGUFIntoShards(params.model.path)),
+      ctxSizeConfigured_(ctxSizeConfigured) {
   auto modelInit = [this](common_params commonParams) {
     this->init(commonParams);
   };
@@ -467,8 +556,8 @@ void BertModel::init(
   lazyCommonInit();
   initializeBackend(backendsDir, openclCacheDir);
 
-  common_params params =
-      setupParams(modelGgufPath, configCopy, runtimeBackendDevice_);
+  common_params params = setupParams(
+      modelGgufPath, configCopy, ctxSizeConfigured_, runtimeBackendDevice_);
   BertModel::init(params);
 }
 
@@ -499,6 +588,16 @@ void BertModel::init(common_params& params) {
   llama_numa_init(params.numa);
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
+
+  // Inspect GGUF metadata (no weight load) so we can default / cap the runtime
+  // context size before the llama context is created. Mirrors the pattern used
+  // by llm-llamacpp via ModelMetaData. When metadata cannot be read (e.g.
+  // streaming load), the runtime context falls back to llama.cpp's default.
+  if (auto trainedCtx = readTrainedContextSize(
+          params.model.path, shards_, isStreaming_)) {
+    adjustEmbeddingContextSize(params, *trainedCtx, ctxSizeConfigured_);
+  }
+
   common_init_result_ptr llamaInit = initFromConfig(
       params,
       params.model.path,
@@ -528,28 +627,12 @@ void BertModel::init(common_params& params) {
       },
       const_cast<BertModel*>(this));
 
-  int nCtxTrain = llama_model_n_ctx_train(model_);
-  int nCtx = static_cast<int>(llama_n_ctx(ctx_));
-
   if (llama_model_has_encoder(model_) && llama_model_has_decoder(model_)) {
     std::string msg = string_format(
         "%s: computing embeddings in encoder-decoder models is not supported",
         __func__);
     throw qvac_errors::StatusError(
         ADDON_ID, toString(UnsupportedEmbeddings), msg);
-  }
-
-  if (nCtx > nCtxTrain) {
-    qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
-        GGML_LOG_LEVEL_WARN,
-        string_format(
-            "%s: warning: model was trained on only %d context tokens (%d "
-            "specified)\n",
-            __func__,
-            nCtxTrain,
-            nCtx)
-            .c_str(),
-        nullptr);
   }
 
   // print system information
@@ -641,9 +724,8 @@ void BertModel::setWeightsForFile(
     throw std::runtime_error(msg);
   }
 
-  static int fulfilledFiles = 0;
-  fulfilledFiles++;
-  if (fulfilledFiles == static_cast<int>(shards_.gguf_files.size()) + 1) {
+  int current = fulfilledFiles_.fetch_add(1) + 1;
+  if (current == static_cast<int>(shards_.gguf_files.size()) + 1) {
     initLoader_.waitForLoadInitialization();
   }
 }
@@ -655,17 +737,18 @@ BertModel::tokenizeInput(const std::vector<std::string>& prompts) const {
   // tokenize all prompts first
   std::vector<std::vector<int32_t>> inputs = tokenizePrompts(ctx_, prompts);
 
-  // Check for context overflow: compare against model's training context size
-  int nCtxTrain = llama_model_n_ctx_train(model_);
+  // Check for context overflow against the active runtime context, capped by
+  // the model's trained context size.
+  int effectiveContextSize = getEffectiveContextSize(model_, ctx_);
   for (std::size_t i = 0; i < inputs.size(); ++i) {
-    if (static_cast<int>(inputs[i].size()) > nCtxTrain) {
+    if (static_cast<int>(inputs[i].size()) > effectiveContextSize) {
       std::string msg = string_format(
           "%s: context overflow: number of tokens in prompt %zu (%zu) exceeds "
-          "model training context size (%d)",
+          "effective context size (%d)",
           __func__,
           i,
           inputs[i].size(),
-          nCtxTrain);
+          effectiveContextSize);
       throw qvac_errors::StatusError(ADDON_ID, toString(ContextOverflow), msg);
     }
   }
@@ -805,7 +888,7 @@ BertEmbeddings BertModel::encodeHostF32Sequences(
   std::vector<std::vector<int32_t>> inputTokens;
   inputTokens.reserve(sequenceArray.size());
 
-  int nCtxTrain = llama_model_n_ctx_train(model_);
+  int effectiveContextSize = getEffectiveContextSize(model_, ctx_);
   for (std::size_t i = 0; i < sequenceArray.size(); ++i) {
     if (stopCancelled_.load()) {
       throw std::runtime_error("Job cancelled");
@@ -814,14 +897,14 @@ BertEmbeddings BertModel::encodeHostF32Sequences(
     std::vector<int32_t> tokens = common_tokenize(ctx_, sequence, true, true);
 
     // Validate context size during tokenization
-    if (static_cast<int>(tokens.size()) > nCtxTrain) {
+    if (static_cast<int>(tokens.size()) > effectiveContextSize) {
       std::string msg = string_format(
           "%s: context overflow: number of tokens in sequence %zu (%zu) "
-          "exceeds model training context size (%d)",
+          "exceeds effective context size (%d)",
           __func__,
           i,
           tokens.size(),
-          nCtxTrain);
+          effectiveContextSize);
       throw qvac_errors::StatusError(ADDON_ID, toString(ContextOverflow), msg);
     }
 
@@ -859,8 +942,10 @@ qvac_lib_inference_addon_cpp::RuntimeStats BertModel::runtimeStats() const {
     stats.emplace_back(
         "batch_size", static_cast<long long>(init_.params.n_batch));
     stats.emplace_back(
-        "context_size",
+        "trained_context_size",
         static_cast<long long>(llama_model_n_ctx_train(model_)));
+    stats.emplace_back(
+        "context_size", static_cast<long long>(llama_n_ctx(ctx_)));
     stats.emplace_back("backendDevice", runtimeBackendDevice_);
   }
 

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -6,19 +6,20 @@
 #include <cstring>
 #include <ranges>
 #include <stdexcept>
+#include <utility>
 
 #include <common/common.h>
+#include <inference-addon-cpp/Errors.hpp>
 #include <llama-cpp.h>
 #include <llama.h>
 #include <llama/common/arg.h>
-#include <inference-addon-cpp/Errors.hpp>
 
 #include "BackendSelection.hpp"
 #include "LlamaLazyInitializeBackend.hpp"
 #include "addon/BertErrors.hpp"
-#include "logging.hpp"
 #include "inference-addon-cpp/GGUFShards.hpp"
 #include "inference-addon-cpp/LlamacppUtils.hpp"
+#include "logging.hpp"
 #include "utils.hpp"
 
 using namespace qvac_lib_infer_llamacpp_embed::errors;
@@ -235,8 +236,8 @@ void logTokenizationIfVerbose(
 
 bool hasContextSizeConfig(
     const std::unordered_map<std::string, std::string>& configFilemap) {
-  return configFilemap.find("ctx_size") != configFilemap.end() ||
-         configFilemap.find("ctx-size") != configFilemap.end();
+  return configFilemap.contains("ctx_size") ||
+         configFilemap.contains("ctx-size");
 }
 
 int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) {
@@ -387,11 +388,13 @@ parseSplitMode(std::unordered_map<std::string, std::string>& configFilemap) {
   return splitMode;
 }
 
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
 common_params setupParams(
     const std::string& modelGgufPath,
     std::unordered_map<std::string, std::string> configFilemap,
     bool& ctxSizeConfigured,
     int64_t& resolvedBackendDevice) {
+  // NOLINTEND(bugprone-easily-swappable-parameters)
   // Default params
   common_params params;
   ctxSizeConfigured = hasContextSizeConfig(configFilemap);
@@ -474,9 +477,8 @@ common_params setupParams(
     const bool isOpenCl =
         chosenBackend.first == BackendType::GPU &&
         chosenBackend.second.find("opencl") != std::string::npos;
-    const bool userSetFlashAttn =
-        configFilemap.find("flash-attn") != configFilemap.end() ||
-        configFilemap.find("flash_attn") != configFilemap.end();
+    const bool userSetFlashAttn = configFilemap.contains("flash-attn") ||
+                                  configFilemap.contains("flash_attn");
     if (isOpenCl && !userSetFlashAttn) {
       configFilemap["flash-attn"] = "off";
       qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
@@ -758,7 +760,7 @@ BertModel::tokenizeInput(const std::vector<std::string>& prompts) const {
   // the model's trained context size.
   int effectiveContextSize = getEffectiveContextSize(model_, ctx_);
   for (std::size_t i = 0; i < inputs.size(); ++i) {
-    if (static_cast<int>(inputs[i].size()) > effectiveContextSize) {
+    if (std::cmp_greater(inputs[i].size(), effectiveContextSize)) {
       std::string msg = string_format(
           "%s: context overflow: number of tokens in prompt %zu (%zu) exceeds "
           "effective context size (%d)",
@@ -914,7 +916,7 @@ BertEmbeddings BertModel::encodeHostF32Sequences(
     std::vector<int32_t> tokens = common_tokenize(ctx_, sequence, true, true);
 
     // Validate context size during tokenization
-    if (static_cast<int>(tokens.size()) > effectiveContextSize) {
+    if (std::cmp_greater(tokens.size(), effectiveContextSize)) {
       std::string msg = string_format(
           "%s: context overflow: number of tokens in sequence %zu (%zu) "
           "exceeds effective context size (%d)",

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -254,9 +254,11 @@ int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) 
 /// diagnosable.
 std::optional<int> readTrainedContextSize(
     const std::string& modelPath, const GGUFShards& shards, bool isStreaming) {
-  // Streaming loads consume the GGUF stream during model load; pre-load
-  // metadata inspection is not supported on this path. Callers fall back to
-  // the llama.cpp default in that case.
+  // Intentional: sharded / streamed loads (setWeightsForFile path) consume the
+  // GGUF stream during model load, so pre-load metadata inspection isn't
+  // possible. Returning nullopt skips adjustEmbeddingContextSize, so the
+  // ctx_size default-/cap-to-n_ctx_train behavior does NOT apply on this path
+  // — streamed loads fall through to llama.cpp's built-in default ctx_size.
   if (isStreaming) {
     return std::nullopt;
   }

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
@@ -3,6 +3,8 @@
 #include <any>
 #include <atomic>
 #include <functional>
+#include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <span>
@@ -92,6 +94,8 @@ private:
   std::optional<LlamaBackendsHandle> backendsHandle_;
   mutable std::atomic<bool> stopCancelled_{false};
   int64_t runtimeBackendDevice_ = 0;
+  bool ctxSizeConfigured_ = false;
+  std::atomic<int> fulfilledFiles_{0};
 
 public:
   // These using definitions are accessed by the Addon<BertModel> template.
@@ -112,7 +116,8 @@ public:
       const std::string& backendsDir = "");
 
   /// @brief Construct with already parsed parameters.
-  explicit BertModel(common_params& params);
+  explicit BertModel(
+      common_params& params, bool ctxSizeConfigured = false);
 
   /// @see BertModel::BertModel(common_params)
   void init(common_params& params);
@@ -133,7 +138,7 @@ public:
   /// @brief Processes text to embeddings using Bert encoder and syncs the
   /// result back to the host. Processes the entire prompt as a single sequence
   /// without splitting. Throws ContextOverflow error if prompt exceeds model
-  /// training context size.
+  /// effective runtime context size.
   /// @returns A host vector of embeddings with one embedding per prompt.
   /// @note Awaits for initialization to finish if its loading .gguf shards
   /// asynchronously.
@@ -147,7 +152,7 @@ public:
   /// @brief Process an array of sequences. Each sequence is processed as-is
   /// without splitting by delimiter. Sequences are processed in batches and one
   /// embedding is returned per sequence. Throws ContextOverflow error if any
-  /// sequence exceeds model training context size.
+  /// sequence exceeds the effective runtime context size.
   /// @param sequenceArray Array of sequence strings to process (no
   /// preprocessing/splitting)
   /// @returns Embeddings with one embedding per sequence

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
@@ -23,7 +23,7 @@
 #include "inference-addon-cpp/RuntimeStats.hpp"
 #include "utils.hpp"
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #pragma warning(disable : 4244 4267) // possible loss of data
 #endif
 

--- a/packages/embed-llamacpp/addonLogging.d.ts
+++ b/packages/embed-llamacpp/addonLogging.d.ts
@@ -2,8 +2,12 @@ export interface AddonLogging {
   /**
    * Registers a callback for native addon logs.
    *
-   * The callback receives only messages allowed by the model's `config.verbosity`
-   * setting: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO, `"3"` = DEBUG.
+   * The callback receives only messages at or above the addon's current
+   * verbosity threshold: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO,
+   * `"3"` = DEBUG. The threshold is process-global and is updated from
+   * `config.verbosity` each time a model is constructed, so when multiple
+   * models are loaded the most recently constructed model's `config.verbosity`
+   * applies to all subsequent native log dispatch.
    */
   setLogger(callback: (priority: number, message: string) => void): void
   releaseLogger(): void

--- a/packages/embed-llamacpp/addonLogging.d.ts
+++ b/packages/embed-llamacpp/addonLogging.d.ts
@@ -1,4 +1,10 @@
 export interface AddonLogging {
+  /**
+   * Registers a callback for native addon logs.
+   *
+   * The callback receives only messages allowed by the model's `config.verbosity`
+   * setting: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO, `"3"` = DEBUG.
+   */
   setLogger(callback: (priority: number, message: string) => void): void
   releaseLogger(): void
 }

--- a/packages/embed-llamacpp/index.d.ts
+++ b/packages/embed-llamacpp/index.d.ts
@@ -71,18 +71,6 @@ export default class GGMLBert {
 
 export { GGMLBert }
 
-export interface AddonLogging {
-  /**
-   * Registers a callback for native addon logs.
-   *
-   * The callback receives only messages allowed by the model's `config.verbosity`
-   * setting: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO, `"3"` = DEBUG.
-   */
-  setLogger(callback: (priority: number, message: string) => void): void
-  releaseLogger(): void
-}
-export const addonLogging: AddonLogging
-
 export class BertInterface implements Addon {
   constructor(
     binding: unknown,

--- a/packages/embed-llamacpp/index.d.ts
+++ b/packages/embed-llamacpp/index.d.ts
@@ -17,6 +17,7 @@ export interface GGMLConfig {
   device: 'gpu' | 'cpu'
   gpu_layers?: NumericLike
   batch_size?: NumericLike
+  ctx_size?: NumericLike
   pooling?: 'none' | 'mean' | 'cls' | 'last' | 'rank'
   attention?: 'causal' | 'non-causal'
   embd_normalize?: NumericLike
@@ -48,6 +49,7 @@ export interface RuntimeStats {
   total_time_ms: number
   tokens_per_second?: number
   batch_size: number
+  trained_context_size: number
   context_size: number
   backendDevice: 'cpu' | 'gpu'
 }
@@ -70,6 +72,12 @@ export default class GGMLBert {
 export { GGMLBert }
 
 export interface AddonLogging {
+  /**
+   * Registers a callback for native addon logs.
+   *
+   * The callback receives only messages allowed by the model's `config.verbosity`
+   * setting: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO, `"3"` = DEBUG.
+   */
   setLogger(callback: (priority: number, message: string) => void): void
   releaseLogger(): void
 }

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/embed-llamacpp/test/integration/addon.test.js
+++ b/packages/embed-llamacpp/test/integration/addon.test.js
@@ -148,8 +148,8 @@ createDeviceModelTest('Model inference works correctly with long string exceedin
   const repeatCount = Math.ceil((maxContextSize / 2) + 50) // Ensure we exceed the limit
   const longString = 'Hello world '.repeat(repeatCount)
 
-  // Verify that an error is thrown when input exceeds model training context size
-  // Expected error: "tokenizeInput: number of tokens in prompt 0 (XXX) exceeds model training context size (XXX)"
+  // Verify that an error is thrown when input exceeds the effective context size
+  // Expected error: "tokenizeInput: number of tokens in prompt 0 (XXX) exceeds effective context size (XXX)"
   let response = null
   let caughtError = null
 
@@ -184,7 +184,7 @@ createDeviceModelTest('Model inference works correctly with long string exceedin
 
   // Verify the error message matches expected format
   t.ok(errorMessage.includes('tokenizeInput'), 'Error should mention tokenizeInput')
-  t.ok(errorMessage.includes('exceeds model training context size'), 'Error should mention exceeding context size')
+  t.ok(errorMessage.includes('exceeds effective context size'), 'Error should mention exceeding context size')
   // Verify the error contains token count information
   t.ok(errorMessage.includes(String(maxContextSize)), `Error should mention context size limit (${maxContextSize})`)
   t.ok(/\d+/.test(errorMessage), 'Error should include token count')
@@ -214,9 +214,9 @@ createDeviceModelTest('Model inference works correctly with array input where on
     'This is a short third sequence'
   ]
 
-  // Verify that an error is thrown when one sequence exceeds model training context size
+  // Verify that an error is thrown when one sequence exceeds effective context size
   // Expected error: "encodeHostF32Sequences: number of tokens in sequence 1 (XXX)
-  // exceeds model training context size (XXX)"
+  // exceeds effective context size (XXX)"
   let response = null
   let caughtError = null
 
@@ -251,7 +251,7 @@ createDeviceModelTest('Model inference works correctly with array input where on
   const hasEncodeError = errorMessage.includes('encodeHostF32Sequences')
   const hasTokenizeError = errorMessage.includes('tokenizeInput')
   t.ok(hasEncodeError || hasTokenizeError, 'Error should mention encodeHostF32Sequences or tokenizeInput')
-  t.ok(errorMessage.includes('exceeds model training context size'), 'Error should mention exceeding context size')
+  t.ok(errorMessage.includes('exceeds effective context size'), 'Error should mention exceeding context size')
   t.ok(errorMessage.includes(String(maxContextSize)), `Error should mention context size limit (${maxContextSize})`)
   t.ok(/\d+/.test(errorMessage), 'Error should include token count')
   // Verify the error mentions which sequence is failing (sequence 1)

--- a/packages/embed-llamacpp/test/unit/map-addon-event.test.js
+++ b/packages/embed-llamacpp/test/unit/map-addon-event.test.js
@@ -29,6 +29,13 @@ test('stats payload leaves unknown backendDevice values as-is', function (t) {
   t.is(result.data.backendDevice, 2)
 })
 
+test('stats payload with trained_context_size maps to JobEnded', function (t) {
+  const result = mapAddonEvent('Stats', { trained_context_size: 512, context_size: 512 }, null)
+  t.is(result.type, 'JobEnded')
+  t.is(result.data.trained_context_size, 512)
+  t.is(result.data.context_size, 512)
+})
+
 test('Error event name maps to Error type carrying rawError', function (t) {
   const err = new Error('boom')
   const result = mapAddonEvent('SomeError', null, err)

--- a/packages/embed-llamacpp/test/unit/test_bert_model.cpp
+++ b/packages/embed-llamacpp/test/unit/test_bert_model.cpp
@@ -21,6 +21,15 @@
 namespace fs = std::filesystem;
 using namespace qvac_lib_inference_addon_cpp::logger;
 
+// Test fixtures intentionally hold members directly and many tests assert
+// against literal sample values; the noisy clang-tidy checks below add no
+// value in a unit-test context.
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,
+// readability-magic-numbers,
+// readability-function-cognitive-complexity,
+// cppcoreguidelines-non-private-member-variables-in-classes,
+// bugprone-unchecked-optional-access)
+
 namespace {
 double getStatValue(
     const qvac_lib_inference_addon_cpp::RuntimeStats& stats,
@@ -57,12 +66,12 @@ getModelFromAddon(qvac_lib_inference_addon_cpp::AddonCpp* addon) {
 class BertEmbeddingsTest : public ::testing::Test {};
 
 TEST_F(BertEmbeddingsTest, ConstructorWithValidLayout) {
-  std::vector<float> data(10 * 5);
+  std::vector<float> data(std::size_t{10} * 5);
   for (std::size_t i = 0; i < data.size(); ++i) {
     data[i] = static_cast<float>(i);
   }
 
-  BertEmbeddings::Layout layout{10, 5};
+  BertEmbeddings::Layout layout{.embeddingCount = 10, .embeddingSize = 5};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), 10);
@@ -70,8 +79,8 @@ TEST_F(BertEmbeddingsTest, ConstructorWithValidLayout) {
 }
 
 TEST_F(BertEmbeddingsTest, SingleEmbedding) {
-  std::vector<float> data{1.0f, 2.0f, 3.0f};
-  BertEmbeddings::Layout layout{1, 3};
+  std::vector<float> data{1.0F, 2.0F, 3.0F};
+  BertEmbeddings::Layout layout{.embeddingCount = 1, .embeddingSize = 3};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), 1);
@@ -79,14 +88,14 @@ TEST_F(BertEmbeddingsTest, SingleEmbedding) {
 
   auto embedding = embeddings[0];
   EXPECT_EQ(embedding.size(), 3);
-  EXPECT_FLOAT_EQ(embedding[0], 1.0f);
-  EXPECT_FLOAT_EQ(embedding[1], 2.0f);
-  EXPECT_FLOAT_EQ(embedding[2], 3.0f);
+  EXPECT_FLOAT_EQ(embedding[0], 1.0F);
+  EXPECT_FLOAT_EQ(embedding[1], 2.0F);
+  EXPECT_FLOAT_EQ(embedding[2], 3.0F);
 }
 
 TEST_F(BertEmbeddingsTest, MultipleEmbeddings) {
-  std::vector<float> data{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
-  BertEmbeddings::Layout layout{2, 3};
+  std::vector<float> data{1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F};
+  BertEmbeddings::Layout layout{.embeddingCount = 2, .embeddingSize = 3};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), 2);
@@ -94,20 +103,20 @@ TEST_F(BertEmbeddingsTest, MultipleEmbeddings) {
 
   auto embedding0 = embeddings[0];
   EXPECT_EQ(embedding0.size(), 3);
-  EXPECT_FLOAT_EQ(embedding0[0], 1.0f);
-  EXPECT_FLOAT_EQ(embedding0[1], 2.0f);
-  EXPECT_FLOAT_EQ(embedding0[2], 3.0f);
+  EXPECT_FLOAT_EQ(embedding0[0], 1.0F);
+  EXPECT_FLOAT_EQ(embedding0[1], 2.0F);
+  EXPECT_FLOAT_EQ(embedding0[2], 3.0F);
 
   auto embedding1 = embeddings[1];
   EXPECT_EQ(embedding1.size(), 3);
-  EXPECT_FLOAT_EQ(embedding1[0], 4.0f);
-  EXPECT_FLOAT_EQ(embedding1[1], 5.0f);
-  EXPECT_FLOAT_EQ(embedding1[2], 6.0f);
+  EXPECT_FLOAT_EQ(embedding1[0], 4.0F);
+  EXPECT_FLOAT_EQ(embedding1[1], 5.0F);
+  EXPECT_FLOAT_EQ(embedding1[2], 6.0F);
 }
 
 TEST_F(BertEmbeddingsTest, EmptyEmbeddings) {
   std::vector<float> data;
-  BertEmbeddings::Layout layout{0, 0};
+  BertEmbeddings::Layout layout{.embeddingCount = 0, .embeddingSize = 0};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), 0);
@@ -122,14 +131,14 @@ TEST_F(BertEmbeddingsTest, AccessAllEmbeddings) {
     data[i] = static_cast<float>(i);
   }
 
-  BertEmbeddings::Layout layout{count, size};
+  BertEmbeddings::Layout layout{.embeddingCount = count, .embeddingSize = size};
   BertEmbeddings embeddings(std::move(data), layout);
 
   for (std::size_t i = 0; i < count; ++i) {
     auto embedding = embeddings[i];
     EXPECT_EQ(embedding.size(), size);
     for (std::size_t j = 0; j < size; ++j) {
-      EXPECT_FLOAT_EQ(embedding[j], static_cast<float>(i * size + j));
+      EXPECT_FLOAT_EQ(embedding[j], static_cast<float>((i * size) + j));
     }
   }
 }
@@ -139,10 +148,10 @@ TEST_F(BertEmbeddingsTest, LargeEmbeddings) {
   const std::size_t size = 768;
   std::vector<float> data(count * size);
   for (std::size_t i = 0; i < data.size(); ++i) {
-    data[i] = static_cast<float>(i) * 0.001f;
+    data[i] = static_cast<float>(i) * 0.001F;
   }
 
-  BertEmbeddings::Layout layout{count, size};
+  BertEmbeddings::Layout layout{.embeddingCount = count, .embeddingSize = size};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), count);
@@ -150,7 +159,7 @@ TEST_F(BertEmbeddingsTest, LargeEmbeddings) {
 
   auto embedding = embeddings[50];
   EXPECT_EQ(embedding.size(), size);
-  EXPECT_FLOAT_EQ(embedding[0], 50.0f * size * 0.001f);
+  EXPECT_FLOAT_EQ(embedding[0], 50.0F * size * 0.001F);
 }
 
 class BertModelTest : public ::testing::Test {
@@ -199,7 +208,7 @@ protected:
   std::string test_model_path;
 
   std::string getValidModelPath() { return test_model_path; }
-  std::string getInvalidModelPath() { return "nonexistent_model.gguf"; }
+  static std::string getInvalidModelPath() { return "nonexistent_model.gguf"; }
 };
 
 TEST_F(BertModelTest, IsLoadedBeforeInit) {
@@ -381,20 +390,20 @@ TEST_F(BertModelTest, RuntimeStatsAfterProcessing) {
 }
 
 TEST_F(BertModelTest, ConstructorWithInvalidPath) {
-  std::string invalid_path = getInvalidModelPath();
+  std::string invalidPath = getInvalidModelPath();
   std::unordered_map<std::string, std::string> config = {{"device", "cpu"}};
   EXPECT_NO_THROW({
-    BertModel model(invalid_path, config);
+    BertModel model(invalidPath, config);
     EXPECT_FALSE(model.isLoaded());
   });
 }
 
 TEST_F(BertModelTest, ConstructorWithEmptyConfig) {
-  std::string invalid_path = getInvalidModelPath();
+  std::string invalidPath = getInvalidModelPath();
   std::unordered_map<std::string, std::string> config;
 
   EXPECT_NO_THROW({
-    BertModel model(invalid_path, config);
+    BertModel model(invalidPath, config);
     EXPECT_FALSE(model.isLoaded());
   });
 }
@@ -427,9 +436,9 @@ TEST_F(BertModelTest, ModelLoadsSuccessfully) {
 }
 
 TEST_F(BertModelTest, ModelFailsToLoadWithInvalidPath) {
-  std::string invalid_path = getInvalidModelPath();
+  std::string invalidPath = getInvalidModelPath();
   std::unordered_map<std::string, std::string> config = {{"device", "cpu"}};
-  BertModel model(invalid_path, config);
+  BertModel model(invalidPath, config);
   model.initializeBackend(test_backends_dir);
 
   // waitForLoadInitialization() throws an exception when model file doesn't
@@ -464,7 +473,7 @@ TEST_F(BertModelTest, EncodeHostF32SingleString) {
   // Verify embedding values are not all zeros
   bool hasNonZero = false;
   for (float val : embeddings[0]) {
-    if (val != 0.0f) {
+    if (val != 0.0F) {
       hasNonZero = true;
       break;
     }
@@ -525,7 +534,7 @@ TEST_F(BertModelTest, EncodeHostF32EmptyString) {
     FAIL() << "Model failed to load";
   }
 
-  std::string prompt = "";
+  std::string prompt;
   BertEmbeddings embeddings = model.encodeHostF32(prompt);
 
   EXPECT_EQ(embeddings.size(), 1);
@@ -593,7 +602,7 @@ TEST_F(BertModelTest, ProcessWithStringInput) {
   instance.addon->activate();
 
   auto* model = getModelFromAddon(instance.addon.get());
-  if (model && !model->isLoaded()) {
+  if (model != nullptr && !model->isLoaded()) {
     FAIL() << "Model failed to load";
   }
 
@@ -606,7 +615,7 @@ TEST_F(BertModelTest, ProcessWithStringInput) {
   ASSERT_TRUE(maybeEmbeddings.has_value())
       << "Timeout waiting for embeddings output";
 
-  BertEmbeddings embeddings = maybeEmbeddings.value();
+  const auto& embeddings = maybeEmbeddings.value();
 
   EXPECT_EQ(embeddings.size(), 1);
   EXPECT_GT(embeddings.embeddingSize(), 0);
@@ -628,7 +637,7 @@ TEST_F(BertModelTest, ProcessWithVectorInput) {
   instance.addon->activate();
 
   auto* model = getModelFromAddon(instance.addon.get());
-  if (model && !model->isLoaded()) {
+  if (model != nullptr && !model->isLoaded()) {
     FAIL() << "Model failed to load";
   }
 
@@ -641,7 +650,7 @@ TEST_F(BertModelTest, ProcessWithVectorInput) {
   ASSERT_TRUE(maybeEmbeddings.has_value())
       << "Timeout waiting for embeddings output";
 
-  BertEmbeddings embeddings = maybeEmbeddings.value();
+  const auto& embeddings = maybeEmbeddings.value();
 
   EXPECT_EQ(embeddings.size(), 3);
   EXPECT_GT(embeddings.embeddingSize(), 0);
@@ -842,7 +851,7 @@ TEST_F(BertModelTest, ModelLoadsAndProcessesMultipleTimes) {
   instance.addon->activate();
 
   auto* model = getModelFromAddon(instance.addon.get());
-  if (model && !model->isLoaded()) {
+  if (model != nullptr && !model->isLoaded()) {
     FAIL() << "Model failed to load";
   }
 
@@ -857,8 +866,7 @@ TEST_F(BertModelTest, ModelLoadsAndProcessesMultipleTimes) {
     ASSERT_TRUE(maybeEmbeddings.has_value())
         << "Timeout waiting for embeddings output on job " << i;
 
-    BertEmbeddings embeddings =
-        std::any_cast<BertEmbeddings>(maybeEmbeddings.value());
+    auto embeddings = std::any_cast<BertEmbeddings>(maybeEmbeddings.value());
 
     EXPECT_EQ(embeddings.size(), 1);
     EXPECT_GT(embeddings.embeddingSize(), 0);
@@ -1101,3 +1109,9 @@ TEST_F(BertModelTest, CancelMidDecode_ThrowsJobCancelled) {
          "Got: "
       << errorMsg;
 }
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,
+// readability-magic-numbers,
+// readability-function-cognitive-complexity,
+// cppcoreguidelines-non-private-member-variables-in-classes,
+// bugprone-unchecked-optional-access)

--- a/packages/embed-llamacpp/test/unit/test_bert_model.cpp
+++ b/packages/embed-llamacpp/test/unit/test_bert_model.cpp
@@ -15,9 +15,11 @@
 #include "addon/AddonCpp.hpp"
 #include "addon/BertErrors.hpp"
 #include "model-interface/BertModel.hpp"
+#include "model-interface/logging.hpp"
 #include "test_common.hpp"
 
 namespace fs = std::filesystem;
+using namespace qvac_lib_inference_addon_cpp::logger;
 
 namespace {
 double getStatValue(
@@ -161,6 +163,7 @@ protected:
     backendDir = fs::current_path() / "build" / "test" / "unit";
 #endif
     test_backends_dir = backendDir.string();
+    qvac_lib_infer_llamacpp_embed::logging::g_verbosityLevel = Priority::ERROR;
 
     // Try multiple possible locations for the model file
     std::vector<fs::path> possiblePaths = {
@@ -186,6 +189,10 @@ protected:
     if (test_model_path.empty()) {
       test_model_path = "models/unit-test/test-model.gguf";
     }
+  }
+
+  void TearDown() override {
+    qvac_lib_infer_llamacpp_embed::logging::g_verbosityLevel = Priority::ERROR;
   }
 
   std::string test_backends_dir;
@@ -258,6 +265,7 @@ TEST_F(BertModelTest, RuntimeStatsBeforeProcessing) {
   // is loaded
   bool hasBatchSize = false;
   bool hasContextSize = false;
+  bool hasTrainedContextSize = false;
   for (const auto& stat : stats) {
     if (stat.first == "batch_size") {
       hasBatchSize = true;
@@ -265,12 +273,73 @@ TEST_F(BertModelTest, RuntimeStatsBeforeProcessing) {
     if (stat.first == "context_size") {
       hasContextSize = true;
     }
+    if (stat.first == "trained_context_size") {
+      hasTrainedContextSize = true;
+    }
   }
   // These should be present if model is loaded
   EXPECT_TRUE(hasBatchSize);
   EXPECT_TRUE(hasContextSize);
+  EXPECT_TRUE(hasTrainedContextSize);
+  EXPECT_EQ(
+      getStatValue(stats, "context_size"),
+      static_cast<double>(llama_n_ctx(model.getCtx())));
+  EXPECT_EQ(
+      getStatValue(stats, "trained_context_size"),
+      static_cast<double>(llama_model_n_ctx_train(model.getModel())));
   double backendDevice = getStatValue(stats, "backendDevice");
   EXPECT_TRUE(backendDevice == 0.0 || backendDevice == 1.0);
+}
+
+TEST_F(BertModelTest, DefaultContextSizeMatchesTrainedContext) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  std::unordered_map<std::string, std::string> config = {{"device", "cpu"}};
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+
+  ASSERT_TRUE(model.isLoaded());
+  EXPECT_EQ(
+      static_cast<int>(llama_n_ctx(model.getCtx())),
+      llama_model_n_ctx_train(model.getModel()));
+}
+
+TEST_F(BertModelTest, ContextSizeAboveTrainingContextIsCapped) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  std::unordered_map<std::string, std::string> config = {
+      {"device", "cpu"}, {"ctx_size", "999999"}};
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+
+  ASSERT_TRUE(model.isLoaded());
+  EXPECT_EQ(
+      static_cast<int>(llama_n_ctx(model.getCtx())),
+      llama_model_n_ctx_train(model.getModel()));
+}
+
+TEST_F(BertModelTest, DefaultContextSizeDoesNotWarnWhenUnconfigured) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  std::unordered_map<std::string, std::string> config = {
+      {"device", "cpu"}, {"verbosity", "1"}};
+
+  testing::internal::CaptureStdout();
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+  const std::string output = testing::internal::GetCapturedStdout();
+
+  ASSERT_TRUE(model.isLoaded());
+  EXPECT_EQ(output.find("requested ctx_size"), std::string::npos);
 }
 
 TEST_F(BertModelTest, RuntimeStatsAfterProcessing) {
@@ -670,6 +739,61 @@ TEST_F(BertModelTest, ContextOverflowSequences) {
   std::vector<std::string> sequences = {"Normal sequence", longString};
 
   using namespace qvac_lib_infer_llamacpp_embed::errors;
+  EXPECT_THROW(
+      { model.encodeHostF32Sequences(sequences); }, qvac_errors::StatusError);
+}
+
+TEST_F(BertModelTest, ContextOverflowUsesRuntimeContextSizeForPrompts) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  // Configure a runtime context smaller than the model's trained context so we
+  // can verify validation triggers on the runtime ctx, not the trained ctx.
+  std::unordered_map<std::string, std::string> config = {
+      {"device", "cpu"}, {"ctx_size", "256"}, {"batch_size", "256"}};
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+
+  ASSERT_TRUE(model.isLoaded());
+  const int runtimeCtx = static_cast<int>(llama_n_ctx(model.getCtx()));
+  const int trainedCtx = llama_model_n_ctx_train(model.getModel());
+  ASSERT_LT(runtimeCtx, trainedCtx);
+
+  // Build an input that overflows the runtime ctx but stays under the trained
+  // ctx, so only the runtime-ctx check can catch it.
+  std::string longString = "Hello world ";
+  for (int i = 0; i < 200; ++i) {
+    longString += "Hello world ";
+  }
+
+  EXPECT_THROW({ model.encodeHostF32(longString); }, qvac_errors::StatusError);
+}
+
+TEST_F(BertModelTest, ContextOverflowUsesRuntimeContextSizeForSequences) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  std::unordered_map<std::string, std::string> config = {
+      {"device", "cpu"}, {"ctx_size", "256"}, {"batch_size", "256"}};
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+
+  ASSERT_TRUE(model.isLoaded());
+  const int runtimeCtx = static_cast<int>(llama_n_ctx(model.getCtx()));
+  const int trainedCtx = llama_model_n_ctx_train(model.getModel());
+  ASSERT_LT(runtimeCtx, trainedCtx);
+
+  std::string longString = "Hello world ";
+  for (int i = 0; i < 200; ++i) {
+    longString += "Hello world ";
+  }
+
+  std::vector<std::string> sequences = {"Normal sequence", longString};
+
   EXPECT_THROW(
       { model.encodeHostF32Sequences(sequences); }, qvac_errors::StatusError);
 }

--- a/packages/embed-llamacpp/test/unit/test_logging.cpp
+++ b/packages/embed-llamacpp/test/unit/test_logging.cpp
@@ -133,6 +133,38 @@ TEST_F(LoggingTest, DefaultVerbosityLevel) {
   EXPECT_EQ(g_verbosityLevel, Priority::ERROR);
 }
 
+#ifndef JS_LOGGER
+TEST_F(LoggingTest, LlamaLogCallbackEmitsErrorsAtDefaultVerbosity) {
+  testing::internal::CaptureStdout();
+
+  llamaLogCallback(GGML_LOG_LEVEL_ERROR, "Test error message", nullptr);
+
+  std::string output = testing::internal::GetCapturedStdout();
+  EXPECT_NE(output.find("ERROR"), std::string::npos);
+  EXPECT_NE(output.find("Test error message"), std::string::npos);
+}
+
+TEST_F(LoggingTest, LlamaLogCallbackSuppressesInfoAtDefaultVerbosity) {
+  testing::internal::CaptureStdout();
+
+  llamaLogCallback(GGML_LOG_LEVEL_INFO, "Test info message", nullptr);
+
+  std::string output = testing::internal::GetCapturedStdout();
+  EXPECT_EQ(output, "");
+}
+
+TEST_F(LoggingTest, LlamaLogCallbackEmitsInfoWhenVerbosityAllowsInfo) {
+  g_verbosityLevel = Priority::INFO;
+  testing::internal::CaptureStdout();
+
+  llamaLogCallback(GGML_LOG_LEVEL_INFO, "Test info message", nullptr);
+
+  std::string output = testing::internal::GetCapturedStdout();
+  EXPECT_NE(output.find("INFO"), std::string::npos);
+  EXPECT_NE(output.find("Test info message"), std::string::npos);
+}
+#endif
+
 TEST_F(LoggingTest, LlamaLogCallbackError) {
   EXPECT_NO_THROW({
     llamaLogCallback(GGML_LOG_LEVEL_ERROR, "Test error message", nullptr);


### PR DESCRIPTION
> Recreated from #2069, which was opened before the `main` history rewrite. This branch is rebased cleanly onto the new `main`; the net change is identical (version renumbered to `0.19.0` and changelog re-ordered to sit above the `0.18.0`/`0.17.x` releases that landed on the new `main`).

## 🎯 What problem does this PR solve?

Cleans up six embed-llamacpp tech-debt items. All are addon-internal correctness / observability fixes around `ctx_size`, runtime stats, validation, and the native logger bridge.

Issues fixed:

- **Issue 1 — `ctx_size` default was `4096`, not "model default"**
  When `ctx_size` was omitted, the addon kept llama.cpp's hard-coded `common_params{}` default of `4096`, silently exceeding the trained context on models like `gte-large` (512) or `embeddinggemma-300M` (2048). The runtime now defaults `ctx_size` to the model's `n_ctx_train`.
- **Issue 2 — "capped by trained context" claim was false**
  Oversized `ctx_size` only produced a `WARN` log (suppressed at the default verbosity of `0`). It is now actually capped to `n_ctx_train` before the llama context is created, with an `ERROR`-level message so users see it without bumping verbosity.
- **Issue 3 — `ctx_size` missing from `GGMLConfig` TypeScript surface**
  Was only type-checked via the open index signature. Added `ctx_size?: NumericLike` to `GGMLConfig` in `index.d.ts`.
- **Issue 4 — `RuntimeStats.context_size` reported the trained context, not the runtime context**
  `context_size` now reports the active runtime context (`llama_n_ctx`). A new `trained_context_size` field exposes `llama_model_n_ctx_train`. This is a behavior change for existing consumers of `context_size`.
- **Issue 5 — Tokenization validation compared against trained ctx, not runtime ctx**
  Both prompt and sequence validators now compare against the effective runtime context (`min(n_ctx_train, llama_n_ctx)`), so a smaller configured `ctx_size` correctly triggers the friendly `ContextOverflow` error instead of falling through to llama.cpp.
- **Issue 6 — `addonLogging.setLogger` callback documentation**
  The bridge is wired before model load, but messages are still gated by `config.verbosity` (default `0` = `ERROR` only). Documented this explicitly in `README.md` and on `setLogger` in `addonLogging.d.ts` / `index.d.ts` so users know to set `verbosity: "2"`/`"3"` to receive `INFO`/`DEBUG`.

## 📝 How does it solve it?

- `BertModel::setupParams` now records whether the caller configured `ctx_size`. After the model is loaded, `adjustEmbeddingContextSize` either sets `params.n_ctx = n_ctx_train` (unconfigured case) or caps an oversized request to `n_ctx_train` (configured case) and emits an `ERROR`-level log line. Trained-context metadata is read from GGUF without loading weights when possible.
- `RuntimeStats` now emits `context_size = llama_n_ctx(ctx_)` and the new `trained_context_size = llama_model_n_ctx_train(model_)`. `mapAddonEvent` forwards `trained_context_size` through to `JobEnded`.
- Context-overflow validation in both `encodeHostF32` (prompts) and `encodeHostF32Sequences` (sequences) was switched to use the effective runtime context size. Error message updated from "model training context size" to "effective context size".
- `GGMLConfig.ctx_size` and `RuntimeStats.trained_context_size` added to `index.d.ts`; `setLogger` doc-comment added in both `index.d.ts` and `addonLogging.d.ts`; `README.md` updated for the new defaults, the new stat field, and a native-addon logging subsection.

## 🧪 How was it tested?

- New C++ unit tests in `test_bert_model.cpp`:
  - `DefaultContextSizeMatchesTrainedContext`
  - `ContextSizeAboveTrainingContextIsCapped`
  - `DefaultContextSizeDoesNotWarnWhenUnconfigured`
  - `ContextOverflowUsesRuntimeContextSizeForPrompts`
  - `ContextOverflowUsesRuntimeContextSizeForSequences`
  - Extended `RuntimeStatsBeforeProcessing` to assert both `context_size` and `trained_context_size`.
- New logging unit tests in `test_logging.cpp` covering `llamaLogCallback` at default and elevated verbosity.
- New JS unit test in `map-addon-event.test.js` asserting `trained_context_size` is forwarded through `JobEnded`.
- Updated integration test in `addon.test.js` to expect the new "effective context size" error message.

## 💥 Breaking Changes

`RuntimeStats.context_size` semantics changed: it now reports the active runtime context (`llama_n_ctx`) instead of the model's trained context. Consumers that relied on the previous meaning should switch to the new `trained_context_size` field.

**BEFORE:**

```typescript
// context_size = model's trained context (llama_model_n_ctx_train)
const trained = response.stats.context_size
```

**AFTER:**

```typescript
// context_size  = runtime llama context (llama_n_ctx), capped to trained
// trained_context_size = model's trained context (llama_model_n_ctx_train)
const runtime = response.stats.context_size
const trained = response.stats.trained_context_size
```

## 🔌 API Changes

```typescript
interface GGMLConfig {
  // ...
  ctx_size?: NumericLike // newly declared (was only accessible via index signature)
}

interface RuntimeStats {
  // ...
  context_size: number          // now: runtime llama context
  trained_context_size: number  // new: model's trained context
}
```
