### PR TITLE
chore[notask|skiplog]: bump @qvac/bare-sdk to 0.12.0

### DIFF
--- a/packages/bare-sdk/NOTICE
+++ b/packages/bare-sdk/NOTICE
@@ -266,21 +266,13 @@ Third-Party Model Licenses
   chatterbox-multilingual-ONNX
     https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX
   chatterbox-s3gen
-    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-s3gen.gguf
+    https://huggingface.co/ResembleAI/chatterbox-turbo
   chatterbox-s3gen-mtl
-    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-s3gen-mtl.gguf
+    https://huggingface.co/ResembleAI/chatterbox
   chatterbox-t3-mtl
-    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-t3-mtl.gguf
-  chatterbox-t3-mtl-q4_0
-    s3:///qvac_models_compiled/ggml/chatterbox/2026-05-18/chatterbox-t3-mtl-q4_0.gguf
-  chatterbox-t3-mtl-q8_0
-    s3:///qvac_models_compiled/ggml/chatterbox/2026-05-18/chatterbox-t3-mtl-q8_0.gguf
+    https://huggingface.co/ResembleAI/chatterbox
   chatterbox-t3-turbo
-    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-t3-turbo.gguf
-  chatterbox-t3-turbo-q4_0
-    s3:///qvac_models_compiled/ggml/chatterbox/2026-05-18/chatterbox-t3-turbo-q4_0.gguf
-  chatterbox-t3-turbo-q8_0
-    s3:///qvac_models_compiled/ggml/chatterbox/2026-05-18/chatterbox-t3-turbo-q8_0.gguf
+    https://huggingface.co/ResembleAI/chatterbox-turbo
   chatterbox-turbo-ONNX
     https://huggingface.co/ResembleAI/chatterbox-turbo-ONNX
   de-base-ggml-model-f16

--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

- `@qvac/sdk` shipped **0.12.0** on `main`; `@qvac/bare-sdk` was still **0.11.0**, so Bare consumers could not align on the same release line as the SDK.
- NOTICE model attribution for chatterbox entries was stale (S3 URLs / removed quantised variants) relative to the current registry.

## 📝 How does it solve it?

- Bump `packages/bare-sdk/package.json` version **0.11.0 → 0.12.0** (dependency ranges already in sync with `@qvac/sdk` via `qv-sdk-bare-sdk-sync`).
- Regenerate `packages/bare-sdk/NOTICE` (`qv-notice-generate bare-sdk`) — chatterbox model links updated to HuggingFace sources; dropped obsolete GGUF NOTICE lines.

## 🧪 How was it tested?

- `node .cursor/skills/qv-sdk-bare-sdk-sync/scripts/sync.mjs` → `OK: no drift`
- `cd packages/bare-sdk && bun run check:deps-vs-sdk` → pass
- `qv-notice-generate bare-sdk` → NOTICE written (`@qvac/bare-sdk` header verified)
