### PR TITLE
fix: ship core ggml/llama libs with DL .bare so GPU backends load on desktop

### DIFF
--- a/packages/llm-llamacpp/CMakeLists.txt
+++ b/packages/llm-llamacpp/CMakeLists.txt
@@ -59,6 +59,21 @@ if((ANDROID OR UNIX) AND NOT APPLE)
   foreach(_backend ${GGML_AVAILABLE_BACKENDS})
     list(APPEND BACKEND_DL_LIBS INSTALL TARGET ggml::${_backend})
   endforeach()
+  # When ggml is built with GGML_BACKEND_DL=ON, the .bare links the core
+  # ggml/llama libraries dynamically instead of embedding them statically, so
+  # they must ship in the backends dir alongside the backend modules (the .bare
+  # resolves them from its $ORIGIN/<module> RUNPATH). Static builds embedded
+  # these, so they were never installed; a DL .bare cannot load its own NEEDED
+  # libs without them.
+  if(GGML_BACKEND_DL)
+    list(APPEND BACKEND_DL_LIBS
+      INSTALL TARGET ggml::ggml
+      INSTALL TARGET ggml::ggml-base
+      INSTALL TARGET llama::llama)
+    if(TARGET llama::mtmd)
+      list(APPEND BACKEND_DL_LIBS INSTALL TARGET llama::mtmd)
+    endif()
+  endif()
 endif()
 
 add_bare_module(inference-addon-llama EXPORTS ${BACKEND_DL_LIBS})

--- a/packages/vla-ggml/CMakeLists.txt
+++ b/packages/vla-ggml/CMakeLists.txt
@@ -59,6 +59,17 @@ if((ANDROID OR UNIX) AND NOT APPLE)
   foreach(_backend ${GGML_AVAILABLE_BACKENDS})
     list(APPEND BACKEND_DL_LIBS INSTALL TARGET ggml::${_backend})
   endforeach()
+  # When ggml is built with GGML_BACKEND_DL=ON, the .bare links the core ggml
+  # libraries dynamically instead of embedding them statically, so they must
+  # ship in the backends dir alongside the backend modules (the .bare resolves
+  # them from its $ORIGIN/<module> RUNPATH). Static builds embedded these, so
+  # they were never installed; a DL .bare cannot load its own NEEDED libs
+  # without them.
+  if(GGML_BACKEND_DL)
+    list(APPEND BACKEND_DL_LIBS
+      INSTALL TARGET ggml::ggml
+      INSTALL TARGET ggml::ggml-base)
+  endif()
 endif()
 
 add_bare_module(qvac-lib-infer-vla EXPORTS ${BACKEND_DL_LIBS})

--- a/packages/vla-ggml/addon/src/utils/BackendSelection.cpp
+++ b/packages/vla-ggml/addon/src/utils/BackendSelection.cpp
@@ -58,6 +58,28 @@ ggml_backend_dev_t pickBestGpuDevice() {
   const size_t n = ggml_backend_dev_count();
   ggml_backend_dev_t fallbackGpu = nullptr;
 
+  // Device-enumeration diagnostics. In GGML_BACKEND_DL mode every backend
+  // (including CPU) is a separately-loaded .so; if discovery fails, this
+  // count is 0 and there is no compute device at all. Printing the full
+  // registered-device list makes "HIP/Vulkan selected" vs "silent CPU
+  // fallback" vs "zero backends -> crash" visible instead of guessable.
+  QLOG_IF(Priority::INFO, "vla_backend_selection: " + std::to_string(n) +
+                              " ggml device(s) registered");
+  for (size_t i = 0; i < n; ++i) {
+    ggml_backend_dev_t d = ggml_backend_dev_get(i);
+    const enum ggml_backend_dev_type dt = ggml_backend_dev_type(d);
+    const char* tstr = dt == GGML_BACKEND_DEVICE_TYPE_GPU    ? "GPU"
+                       : dt == GGML_BACKEND_DEVICE_TYPE_IGPU ? "iGPU"
+                       : dt == GGML_BACKEND_DEVICE_TYPE_CPU  ? "CPU"
+                                                            : "ACCEL";
+    const char* dn = ggml_backend_dev_name(d);
+    const char* dd = ggml_backend_dev_description(d);
+    QLOG_IF(Priority::INFO, "vla_backend_selection:   [" + std::to_string(i) +
+                                "] " + std::string(tstr) +
+                                " name=" + (dn ? dn : "?") +
+                                " desc=" + (dd ? dd : "?"));
+  }
+
   for (size_t i = 0; i < n; ++i) {
     ggml_backend_dev_t dev = ggml_backend_dev_get(i);
     const enum ggml_backend_dev_type t = ggml_backend_dev_type(dev);
@@ -118,6 +140,17 @@ ggml_backend_dev_t pickBestGpuDevice() {
     if (fallbackGpu == nullptr) {
       fallbackGpu = dev;
     }
+  }
+
+  if (fallbackGpu != nullptr) {
+    const char* sn = ggml_backend_dev_name(fallbackGpu);
+    const char* sd = ggml_backend_dev_description(fallbackGpu);
+    QLOG_IF(Priority::INFO,
+            "vla_backend_selection: SELECTED GPU name=" +
+                std::string(sn ? sn : "?") + " desc=" + (sd ? sd : "?"));
+  } else {
+    QLOG_IF(Priority::WARNING,
+            "vla_backend_selection: no GPU selected — using CPU backend");
   }
 
   return fallbackGpu;


### PR DESCRIPTION
Companion to tetherto/qvac-registry-vcpkg#176 (which enables `GGML_BACKEND_DL=ON` on desktop Linux).

## Problem

With `GGML_BACKEND_DL=ON`, every backend — including CPU — becomes a separately-loaded `.so`, and the `.bare` links the core `ggml`/`llama` libraries **dynamically** instead of embedding them. The addon `EXPORTS` list only shipped the ggml **backend modules** (cpu/vulkan), not the core `libggml`/`libggml-base`/`libllama`(+`libmtmd`). So a DL `.bare` could not resolve its own NEEDED libs at load time → ggml registered **zero** backends → no compute device → crash.

## Fix

- `llm-llamacpp` + `vla-ggml`: when `GGML_BACKEND_DL` is set, also install the core ggml/llama shared libs into the backends dir, so the `.bare` resolves them via its `$ORIGIN/<module>` RUNPATH. (Static builds embedded these; no change there.) `vla-ggml` ships ggml only; `llm-llamacpp` also ships llama (+mtmd when present).
- `vla-ggml/BackendSelection.cpp`: device-enumeration log so backend registration vs silent CPU fallback vs zero-backend crash is visible.

## Validation

Built a `GGML_BACKEND_DL=ON` ggml+llama prefix (clang/libc++) and rebuilt `llm-llamacpp` against it. After `rm -rf prebuilds` + rebuild, the backends dir auto-contains `libggml`/`libggml-base`/`libllama`/`libmtmd` + the backend modules (no manual copy), and the `.bare` resolves them all via `$ORIGIN`. Spliced into the Workbench desktop (Electron, asar:false) app: the addon **reported 2 GPU devices** in the running worker with no zero-backend crash.

Requires registry PR #176 to actually build DL on Linux; this PR makes the resulting `.bare` loadable.