### PR TITLE
QVAC-18588 feat[bc]: embed-llamacpp tech-debt — ctx_size cap (incl. streaming), RuntimeStats split, logger docs

### DIFF
--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.19.0] - 2026-06-02
+
+### Changed
+
+- `feat[bc]`: `RuntimeStats.context_size` now reports the active runtime llama context size. Use the new `RuntimeStats.trained_context_size` field for the model's trained context size.
+- The embed runtime now defaults `ctx_size` to the model's trained context size and caps oversized `ctx_size` requests to that value before creating the llama context.
+
+### Fixed
+
+- Context overflow validation now compares tokenized inputs against the active runtime context size (`llama_n_ctx`), which is itself capped to the trained context.
+
 ## [0.18.2] - 2026-06-03
 
 ### Fixed

--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixed
 
 - Context overflow validation now compares tokenized inputs against the active runtime context size (`llama_n_ctx`), which is itself capped to the trained context.
+- `BertModel::setWeightsForFile` now tracks fulfilled GGUF shards in a per-instance `std::atomic<int>` instead of a function-local `static int`, so multiple concurrent `BertInterface` instances no longer share (and miscount) shard-fulfillment state.
+- `readTrainedContextSize` now logs an `ERROR`-level diagnostic when GGUF metadata cannot be read on a non-streaming load (previously failed silently and reverted to llama.cpp's default `ctx_size`).
 
 ## [0.18.2] - 2026-06-03
 

--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -5,13 +5,14 @@
 ### Changed
 
 - `feat[bc]`: `RuntimeStats.context_size` now reports the active runtime llama context size. Use the new `RuntimeStats.trained_context_size` field for the model's trained context size.
-- The embed runtime now defaults `ctx_size` to the model's trained context size and caps oversized `ctx_size` requests to that value before creating the llama context.
+- The embed runtime now defaults `ctx_size` to the model's trained context size and caps oversized `ctx_size` requests to that value before creating the llama context. The cap also applies on streamed loads (single-GGUF and sharded) by parsing GGUF metadata from the first streamed chunk before the weights engine consumes it, mirroring the `ModelMetaData` pattern used by `llm-llamacpp`.
 
 ### Fixed
 
 - Context overflow validation now compares tokenized inputs against the active runtime context size (`llama_n_ctx`), which is itself capped to the trained context.
 - `BertModel::setWeightsForFile` now tracks fulfilled GGUF shards in a per-instance `std::atomic<int>` instead of a function-local `static int`, so multiple concurrent `BertInterface` instances no longer share (and miscount) shard-fulfillment state.
-- `readTrainedContextSize` now logs an `ERROR`-level diagnostic when GGUF metadata cannot be read on a non-streaming load (previously failed silently and reverted to llama.cpp's default `ctx_size`).
+- `BertModel` now resolves sharded model basenames to absolute paths relative to the model directory before metadata inspection and disk-shards loading, so the trained-context cap and `llama_model_load_from_splits` work correctly when the working directory differs from the model directory.
+- `readTrainedContextSize` now logs an `ERROR`-level diagnostic when GGUF metadata cannot be read on either streamed or non-streaming loads (previously failed silently and reverted to llama.cpp's default `ctx_size`).
 
 ## [0.18.2] - 2026-06-03
 

--- a/packages/embed-llamacpp/CMakeLists.txt
+++ b/packages/embed-llamacpp/CMakeLists.txt
@@ -69,6 +69,7 @@ target_sources(
   PRIVATE
   ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/utils.cpp
+  ${PROJECT_SOURCE_DIR}/addon/src/model-interface/AsyncWeightsLoader.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/BackendSelection.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/logging.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp

--- a/packages/embed-llamacpp/CMakeLists.txt
+++ b/packages/embed-llamacpp/CMakeLists.txt
@@ -72,6 +72,7 @@ target_sources(
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/BackendSelection.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/logging.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+  ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/BertModel.cpp
 )
 target_include_directories(

--- a/packages/embed-llamacpp/README.md
+++ b/packages/embed-llamacpp/README.md
@@ -134,13 +134,31 @@ The `config` is a plain JS object whose keys are forwarded directly to the nativ
 | `device`         | `"gpu"` \| `"cpu"`                            | `"gpu"`       | Device to run inference on                                                               |
 | `gpu_layers`     | string of integer                             | `"0"`         | Number of model layers to offload to GPU                                                 |
 | `batch_size`     | string of integer                             | `"2048"`      | Tokens processed per batch (input throughput)                                            |
-| `ctx_size`       | string of integer                             | model default | Maximum context window in tokens (llama.cpp `n_ctx`); capped by the model's trained context |
+| `ctx_size`       | string of integer                             | model's trained context size (`n_ctx_train`) | Runtime context window in tokens (llama.cpp `n_ctx`); oversized values are capped to the model's trained context |
 | `pooling`        | `"none"` \| `"mean"` \| `"cls"` \| `"last"` \| `"rank"` | model default | Pooling strategy used to collapse token embeddings into a single sequence vector        |
 | `attention`      | `"causal"` \| `"non-causal"`                  | model default | Attention type                                                                            |
 | `embd_normalize` | string of integer                             | `"2"`         | Embedding normalization (`-1` = none, `0` = max abs int16, `1` = taxicab, `2` = euclidean, `>2` = p-norm) |
 | `flash_attn`     | `"on"` \| `"off"` \| `"auto"`                 | `"auto"`      | Enable / disable flash attention                                                         |
 | `main-gpu`       | string of integer \| `"integrated"` \| `"dedicated"` | —      | GPU selection for multi-GPU systems                                                      |
-| `verbosity`      | string of `"0"`–`"3"` (0=ERROR, 1=WARN, 2=INFO, 3=DEBUG) | `"0"` | Logging verbosity level                                                                   |
+| `verbosity`      | string of `"0"`–`"3"` (0=ERROR, 1=WARN, 2=INFO, 3=DEBUG) | `"0"` | Native logging verbosity. The `addonLogging.setLogger` callback receives only messages at or above this threshold. Use `"2"` for llama.cpp INFO logs and `"3"` for DEBUG logs. |
+
+#### Native addon logging
+
+`@qvac/embed-llamacpp/addonLogging` exposes the native C++ logger:
+
+```js
+const { setLogger, releaseLogger } = require('@qvac/embed-llamacpp/addonLogging')
+
+setLogger((priority, message) => {
+  console.log(priority, message)
+})
+```
+
+The callback is wired before model load, but it still follows `config.verbosity`.
+With the default `"0"` setting, only native `ERROR` messages are delivered. Set
+`config.verbosity` to `"2"` to receive llama.cpp `INFO` diagnostics, or `"3"` for
+`DEBUG` messages. Some startup diagnostics printed directly by llama.cpp may
+still appear on `stderr` before the addon installs its callback.
 
 #### IGPU/GPU  selection logic:
 
@@ -176,7 +194,7 @@ const response = await model.run(query)
 const embeddings = await response.await()
 ```
 
-When `opts.stats` is enabled, `response.stats` includes runtime metrics such as `total_tokens`, `total_time_ms`, `tokens_per_second`, and `backendDevice` (`"cpu"` or `"gpu"`). `backendDevice` reflects the resolved device used at runtime after backend selection/fallback logic, not only the requested config.
+When `opts.stats` is enabled, `response.stats` includes runtime metrics such as `total_tokens`, `total_time_ms`, `tokens_per_second`, `context_size`, `trained_context_size`, and `backendDevice` (`"cpu"` or `"gpu"`). `context_size` is the active runtime llama context size, while `trained_context_size` is the model's trained context size. `backendDevice` reflects the resolved device used at runtime after backend selection/fallback logic, not only the requested config.
 
 ### 7. Release Resources
 

--- a/packages/embed-llamacpp/README.md
+++ b/packages/embed-llamacpp/README.md
@@ -140,7 +140,7 @@ The `config` is a plain JS object whose keys are forwarded directly to the nativ
 | `embd_normalize` | string of integer                             | `"2"`         | Embedding normalization (`-1` = none, `0` = max abs int16, `1` = taxicab, `2` = euclidean, `>2` = p-norm) |
 | `flash_attn`     | `"on"` \| `"off"` \| `"auto"`                 | `"auto"`      | Enable / disable flash attention                                                         |
 | `main-gpu`       | string of integer \| `"integrated"` \| `"dedicated"` | —      | GPU selection for multi-GPU systems                                                      |
-| `verbosity`      | string of `"0"`–`"3"` (0=ERROR, 1=WARN, 2=INFO, 3=DEBUG) | `"0"` | Native logging verbosity. The `addonLogging.setLogger` callback receives only messages at or above this threshold. Use `"2"` for llama.cpp INFO logs and `"3"` for DEBUG logs. |
+| `verbosity`      | string of `"0"`–`"3"` (0=ERROR, 1=WARNING, 2=INFO, 3=DEBUG) | `"0"` | Native logging verbosity. The `addonLogging.setLogger` callback receives only messages at or above this threshold. Use `"2"` for llama.cpp INFO logs and `"3"` for DEBUG logs. The verbosity level is process-global and is updated each time a model is constructed, so the most recently constructed model's `config.verbosity` wins for all subsequent native log dispatch. |
 
 #### Native addon logging
 
@@ -157,8 +157,11 @@ setLogger((priority, message) => {
 The callback is wired before model load, but it still follows `config.verbosity`.
 With the default `"0"` setting, only native `ERROR` messages are delivered. Set
 `config.verbosity` to `"2"` to receive llama.cpp `INFO` diagnostics, or `"3"` for
-`DEBUG` messages. Some startup diagnostics printed directly by llama.cpp may
-still appear on `stderr` before the addon installs its callback.
+`DEBUG` messages. The verbosity level is process-global and is updated each
+time a model is constructed, so when multiple models are loaded the most
+recently constructed model's `config.verbosity` wins for all subsequent
+native log dispatch. Some startup diagnostics printed directly by llama.cpp
+may still appear on `stderr` before the addon installs its callback.
 
 #### IGPU/GPU  selection logic:
 

--- a/packages/embed-llamacpp/addon/src/addon/BertErrors.hpp
+++ b/packages/embed-llamacpp/addon/src/addon/BertErrors.hpp
@@ -8,6 +8,7 @@ constexpr const char* ADDON_ID = "GTE";
 
 enum GteErrorCode : std::uint8_t {
   UnableToLoadModel,
+  UnableToLoadMetadata,
   InvalidConfiguration,
   UnsupportedEmbeddings,
   InputTokensExceedBatchSize,
@@ -23,6 +24,7 @@ inline std::string toString(GteErrorCode code)
   switch(code)
   {
     case UnableToLoadModel : return "UnableToLoadModel";
+    case UnableToLoadMetadata: return "UnableToLoadMetadata";
     case InvalidConfiguration : return "InvalidConfiguration";
     case UnsupportedEmbeddings : return "UnsupportedEmbeddings";
     case InputTokensExceedBatchSize : return "InputTokensExceedBatchSize";

--- a/packages/embed-llamacpp/addon/src/addon/BertErrors.hpp
+++ b/packages/embed-llamacpp/addon/src/addon/BertErrors.hpp
@@ -24,7 +24,8 @@ inline std::string toString(GteErrorCode code)
   switch(code)
   {
     case UnableToLoadModel : return "UnableToLoadModel";
-    case UnableToLoadMetadata: return "UnableToLoadMetadata";
+    case UnableToLoadMetadata:
+      return "UnableToLoadMetadata";
     case InvalidConfiguration : return "InvalidConfiguration";
     case UnsupportedEmbeddings : return "UnsupportedEmbeddings";
     case InputTokensExceedBatchSize : return "InputTokensExceedBatchSize";

--- a/packages/embed-llamacpp/addon/src/model-interface/AsyncWeightsLoader.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/AsyncWeightsLoader.cpp
@@ -1,0 +1,135 @@
+#include "model-interface/AsyncWeightsLoader.hpp"
+
+#include <chrono>
+
+#include "model-interface/ModelMetadata.hpp"
+
+using namespace qvac_lib_infer_llamacpp_embed::errors;
+
+AsyncWeightsLoader::AsyncWeightsLoader(
+    const GGUFShards& shards, InitLoader& initLoader,
+    const std::string& loadingContext, ModelMetaData* modelMetadata)
+    : shards_(shards), initLoader_(initLoader), loadingContext_(loadingContext),
+      modelMetadata_(modelMetadata) {}
+
+void AsyncWeightsLoader::setWeightsForFile(
+    const std::string& filename, std::unique_ptr<Buf>&& shard) {
+  const std::filesystem::path filenamePath(filename);
+  isStreaming_ = true;
+
+  // Surface first-shard worker errors immediately.
+  if (firstShardWorker_.valid() &&
+      firstShardWorker_.wait_for(std::chrono::seconds(0)) ==
+          std::future_status::ready) {
+    firstShardWorker_.get();
+  }
+
+  if (shards_.gguf_files.empty()) {
+    auto [streamedFilesIt, inserted] =
+        streamedFiles_.emplace(filename, SharedBuffer(std::move(shard)));
+    if (!inserted) {
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          toString(UnableToLoadModel),
+          "Duplicate streamed shard filename: " + filename);
+    }
+    if (shouldLendFirstShard(filenamePath)) {
+      modelMetadata_->firstFileFromGgufStreamState.provide(
+          streamedFilesIt->second);
+    }
+    return;
+  }
+
+  if (modelMetadata_ == nullptr || isFirstShard(filenamePath)) {
+    // This triggers BertModel::init().
+    //
+    // When using metadata, it should only start when the first shard is
+    // available. Otherwise init can time out waiting for the first shard while
+    // earlier companion files (for example .tensors.txt) are still being
+    // streamed through the addon framework.
+    initLoader_.ensureLoadInBackground();
+  }
+
+  if (shouldLendFirstShard(filenamePath)) {
+    // Launch asynchronously so the calling (download) thread is not blocked
+    // while waiting for metadata to release the shard.
+    if (firstShardWorker_.valid()) {
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          toString(UnableToLoadModel),
+          "First-shard worker already started.");
+    }
+    firstShardWorker_ = std::async(
+        std::launch::async,
+        [this, filename, lambdaShard = std::move(shard)]() mutable {
+          auto shard = lendFirstShardAndWaitForRelease(std::move(lambdaShard));
+          fulfillSplitFuture(filename, std::move(shard));
+        });
+  } else {
+    fulfillSplitFuture(filename, std::move(shard));
+  }
+
+  // Make sure that last-shard checks if first-shard did complete successfully.
+  //
+  // A model is treated as sharded only when it has at least 2 shard files.
+  // `gguf_files` may still contain a single-GGUF path for non-sharded loads.
+  // In that case `isLastShard()` should evaluate false and this is a no-op.
+  if (isLastShard(filenamePath)) {
+    joinFirstShardWorker();
+  }
+}
+
+void AsyncWeightsLoader::joinFirstShardWorker() {
+  if (!firstShardWorker_.valid()) {
+    return;
+  }
+  firstShardWorker_.get();
+}
+
+std::map<std::string, std::unique_ptr<AsyncWeightsLoader::Buf>>
+AsyncWeightsLoader::extractIndividualStreamedFiles() {
+  joinFirstShardWorker();
+  std::map<std::string, std::unique_ptr<Buf>> extracted;
+  for (auto& [filename, shard] : streamedFiles_) {
+    extracted[filename] = shard.reclaimUnique();
+  }
+  return extracted;
+}
+
+bool AsyncWeightsLoader::isFirstShard(
+    const std::filesystem::path& filenamePath) const {
+  const std::string normalizedFilename = filenamePath.filename().string();
+  const std::string firstShard =
+      shards_.gguf_files.empty()
+          ? normalizedFilename
+          : std::filesystem::path(shards_.gguf_files.front())
+                .filename()
+                .string();
+  return normalizedFilename == firstShard;
+}
+
+bool AsyncWeightsLoader::shouldLendFirstShard(
+    const std::filesystem::path& filenamePath) const {
+  return modelMetadata_ != nullptr && isFirstShard(filenamePath);
+}
+
+bool AsyncWeightsLoader::isLastShard(
+    const std::filesystem::path& filenamePath) const {
+  if (shards_.gguf_files.empty()) {
+    return false;
+  }
+  const std::string normalizedFilename = filenamePath.filename().string();
+  const std::string lastShard =
+      std::filesystem::path(shards_.gguf_files.back()).filename().string();
+  return normalizedFilename == lastShard;
+}
+
+std::unique_ptr<AsyncWeightsLoader::Buf>
+AsyncWeightsLoader::lendFirstShardAndWaitForRelease(
+    std::unique_ptr<Buf>&& shard) {
+  SharedBuffer lentShard(std::move(shard));
+  modelMetadata_->firstFileFromGgufStreamState.provide(lentShard);
+  modelMetadata_->firstFileFromGgufStreamState
+      .waitForRelease<METADATA_RELEASE_TIMEOUT_SEC>();
+  return lentShard.reclaimUnique();
+}

--- a/packages/embed-llamacpp/addon/src/model-interface/AsyncWeightsLoader.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/AsyncWeightsLoader.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <future>
+#include <map>
+#include <memory>
+#include <streambuf>
+#include <string>
+
+#include <common/common.h>
+#include <llama-cpp.h>
+
+#include "ModelMetadata.hpp"
+#include "addon/BertErrors.hpp"
+#include "inference-addon-cpp/Errors.hpp"
+#include "inference-addon-cpp/GGUFShards.hpp"
+#include "inference-addon-cpp/InitLoader.hpp"
+#include "utils/BorrowablePtr.hpp"
+
+/// @brief Encapsulates async/streaming weights loading for sharded and
+/// single-GGUF models. Owns the streaming state and the buffered file map,
+/// and delegates shard fulfillment to llama.cpp.
+class AsyncWeightsLoader {
+public:
+  using Buf = std::basic_streambuf<char>;
+  using SharedBuffer = BorrowablePtr<Buf>;
+
+  /// @param modelMetadata Optional. When provided, the first shard received
+  /// via setWeightsForFile is lent to modelMetadata so that metadata parsing
+  /// can proceed before the shard is handed to the weights engine.
+  AsyncWeightsLoader(
+      const GGUFShards& shards, InitLoader& initLoader,
+      const std::string& loadingContext,
+      ModelMetaData* modelMetadata = nullptr);
+
+  virtual ~AsyncWeightsLoader() = default;
+  AsyncWeightsLoader(const AsyncWeightsLoader&) = delete;
+  AsyncWeightsLoader& operator=(const AsyncWeightsLoader&) = delete;
+  AsyncWeightsLoader(AsyncWeightsLoader&&) = delete;
+  AsyncWeightsLoader& operator=(AsyncWeightsLoader&&) = delete;
+
+  /// @brief Accept a streamed shard. For single-GGUF models the buffer is
+  /// stored until init() consumes it; for sharded models the shard is
+  /// fulfilled asynchronously via llama_model_load_fulfill_split_future.
+  /// If a ModelMetaData was supplied at construction, the shard matching the
+  /// first shard filename is lent to it and ownership is recovered before
+  /// proceeding.
+  /// @note C++ side expectation: calls are externally serialized and come from
+  /// the same thread (typically the JS event-loop / download thread). If this
+  /// method is invoked concurrently from multiple native threads, additional
+  /// synchronization is required by the caller.
+  /// @note For sharded models, the caller is responsible for eventually
+  /// calling this with the last shard filename. If the last-shard call never
+  /// happens, downstream llama.cpp model initialization may block waiting for
+  /// shard completion.
+  void
+  setWeightsForFile(const std::string& filename, std::unique_ptr<Buf>&& shard);
+
+  [[nodiscard]] bool isStreaming() const { return isStreaming_; }
+
+  /// @brief Moves the unsharded files out of the AsyncWeightsLoader.
+  std::map<std::string, std::unique_ptr<Buf>> extractIndividualStreamedFiles();
+
+protected:
+  /// @brief Hands the shard to llama.cpp's split-future registry.
+  /// Override in tests to avoid touching the global promise registry.
+  virtual void fulfillSplitFuture(
+      const std::string& filename, std::unique_ptr<Buf>&& shard) {
+    using namespace qvac_lib_infer_llamacpp_embed::errors;
+    if (!llama_model_load_fulfill_split_future(
+            filename.c_str(), loadingContext_.c_str(), std::move(shard))) {
+      std::string errorMsg = string_format(
+          "%s: failed to load model from %s\n", __func__, filename.c_str());
+      throw qvac_errors::StatusError(
+          ADDON_ID, toString(UnableToLoadModel), errorMsg);
+    }
+  }
+
+private:
+  /// @brief Waits for the first-shard async worker (if started) and rethrows
+  /// any exception raised in that worker.
+  void joinFirstShardWorker();
+
+  [[nodiscard]] bool
+  isFirstShard(const std::filesystem::path& filenamePath) const;
+  [[nodiscard]] bool
+  shouldLendFirstShard(const std::filesystem::path& filenamePath) const;
+  [[nodiscard]] bool
+  isLastShard(const std::filesystem::path& filenamePath) const;
+
+  /// Lends @p shard to modelMetadata_ (sharded path only), blocks until
+  /// metadata releases its reference, then returns the unique_ptr to the
+  /// caller.
+  std::unique_ptr<Buf>
+  lendFirstShardAndWaitForRelease(std::unique_ptr<Buf>&& shard);
+
+  // Timeout for waitForRelease (seconds) - fires if the metadata parser
+  // gets stuck and never finishes consuming/releasing the streamed buffer.
+  static constexpr int64_t METADATA_RELEASE_TIMEOUT_SEC = 60;
+
+  // These references are safe because BertModel owns both the referenced
+  // objects and this AsyncWeightsLoader; C++ destroys members in reverse
+  // declaration order, so the loader is destroyed before its references.
+  const GGUFShards& shards_;
+  InitLoader& initLoader_;
+  const std::string& loadingContext_;
+  ModelMetaData* modelMetadata_ = nullptr;
+
+  bool isStreaming_ = false;
+  std::map<std::string, SharedBuffer> streamedFiles_;
+  std::future<void> firstShardWorker_;
+};

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -245,7 +245,8 @@ bool hasContextSizeConfig(
          configFilemap.contains("ctx-size");
 }
 
-int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) {
+int getEffectiveContextSize(
+    const llama_model* model, const llama_context* ctx) {
   return std::min(
       llama_model_n_ctx_train(model), static_cast<int>(llama_n_ctx(ctx)));
 }

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -536,7 +536,6 @@ BertModel::BertModel(
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
       shards_(GGUFShards::expandGGUFIntoShards(modelGgufPath)),
       asyncWeightsLoader_(shards_, initLoader_, loadingContext_, &metadata_) {
-  BertModel::resolveShardPaths(shards_, modelGgufPath);
   auto modelInit = [this](
                        const std::string& path,
                        const std::unordered_map<std::string, std::string>& cfg,
@@ -557,7 +556,6 @@ BertModel::BertModel(BertModelSetup& setup)
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
       shards_(GGUFShards::expandGGUFIntoShards(setup.params.model.path)),
       asyncWeightsLoader_(shards_, initLoader_, loadingContext_, &metadata_) {
-  BertModel::resolveShardPaths(shards_, setup.params.model.path);
   auto modelInit = [this](BertModelSetup s) { this->init(s); };
 
   initLoader_.init(InitLoader::LOADER_TYPE::DELAYED, modelInit, setup);
@@ -619,6 +617,10 @@ void BertModel::init(BertModelSetup& setup) {
   llama_numa_init(params.numa);
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
+
+  if (!asyncWeightsLoader_.isStreaming()) {
+    BertModel::resolveShardPaths(shards_, params.model.path);
+  }
 
   metadata_.parse(
       params.model.path, shards_, asyncWeightsLoader_.isStreaming(), ADDON_ID);

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -250,26 +250,6 @@ int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) 
       llama_model_n_ctx_train(model), static_cast<int>(llama_n_ctx(ctx)));
 }
 
-/// @brief Resolves shard basenames in-place to absolute paths relative to the
-/// parent directory of @p modelPath. `expandGGUFIntoShards` only populates
-/// basenames; resolving them is required for both pre-load metadata
-/// inspection and `llama_model_load_from_splits` when the working directory
-/// differs from the model directory.
-void resolveShardPaths(GGUFShards& shards, const std::string& modelPath) {
-  if (shards.gguf_files.empty()) {
-    return;
-  }
-  const std::filesystem::path baseDir =
-      std::filesystem::path(modelPath).parent_path();
-  if (baseDir.empty()) {
-    return;
-  }
-  for (std::string& f : shards.gguf_files) {
-    f = (baseDir / f).string();
-  }
-  shards.tensors_file = (baseDir / shards.tensors_file).string();
-}
-
 /// @brief Reads the model's trained context size from already-parsed GGUF
 /// metadata. Emits an ERROR-level diagnostic and returns nullopt when the
 /// architecture key or `<arch>.context_length` key is missing.
@@ -387,16 +367,12 @@ parseSplitMode(std::unordered_map<std::string, std::string>& configFilemap) {
   return splitMode;
 }
 
-// NOLINTBEGIN(bugprone-easily-swappable-parameters)
-common_params setupParams(
+BertModelSetup setupParams(
     const std::string& modelGgufPath,
-    std::unordered_map<std::string, std::string> configFilemap,
-    bool& ctxSizeConfigured,
-    int64_t& resolvedBackendDevice) {
-  // NOLINTEND(bugprone-easily-swappable-parameters)
-  // Default params
-  common_params params;
-  ctxSizeConfigured = hasContextSizeConfig(configFilemap);
+    std::unordered_map<std::string, std::string> configFilemap) {
+  BertModelSetup result{};
+  common_params& params = result.params;
+  result.ctxSizeConfigured = hasContextSizeConfig(configFilemap);
 
   // Override default params
   std::vector<std::string> configVector;
@@ -443,7 +419,7 @@ common_params setupParams(
         chooseBackend(preferredBackend, llamaLogCallback, mainGpu);
 
     if (chosenBackend.first == BackendType::GPU) {
-      resolvedBackendDevice = 1;
+      result.resolvedBackendDevice = 1;
       params.split_mode = splitMode;
 
       if (splitMode != LLAMA_SPLIT_MODE_NONE && mainGpu.has_value()) {
@@ -459,7 +435,7 @@ common_params setupParams(
         }
       }
     } else if (chosenBackend.first == BackendType::CPU) {
-      resolvedBackendDevice = 0;
+      result.resolvedBackendDevice = 0;
       params.split_mode = LLAMA_SPLIT_MODE_NONE;
       params.main_gpu = -1;
       if (splitMode != LLAMA_SPLIT_MODE_NONE) {
@@ -530,9 +506,25 @@ common_params setupParams(
         "Invalid configuration parameters.");
   }
 
-  return params;
+  return result;
 }
 } // namespace
+
+void BertModel::resolveShardPaths(
+    GGUFShards& shards, const std::string& modelPath) {
+  if (shards.gguf_files.empty()) {
+    return;
+  }
+  const std::filesystem::path baseDir =
+      std::filesystem::path(modelPath).parent_path();
+  if (baseDir.empty()) {
+    return;
+  }
+  for (std::string& f : shards.gguf_files) {
+    f = (baseDir / f).string();
+  }
+  shards.tensors_file = (baseDir / shards.tensors_file).string();
+}
 
 BertModel::BertModel(
     const std::string& modelGgufPath,
@@ -542,7 +534,7 @@ BertModel::BertModel(
       pooling_type(LLAMA_POOLING_TYPE_NONE), n_embd(0), is_loaded_(false),
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
       shards_(GGUFShards::expandGGUFIntoShards(modelGgufPath)) {
-  resolveShardPaths(shards_, modelGgufPath);
+  BertModel::resolveShardPaths(shards_, modelGgufPath);
   auto modelInit = [this](
                        const std::string& path,
                        const std::unordered_map<std::string, std::string>& cfg,
@@ -557,18 +549,15 @@ BertModel::BertModel(
       backendsDir);
 }
 
-BertModel::BertModel(common_params& params, bool ctxSizeConfigured)
+BertModel::BertModel(BertModelSetup& setup)
     : model_(nullptr), ctx_(nullptr), vocab_(nullptr), batch_{},
       pooling_type(LLAMA_POOLING_TYPE_NONE), n_embd(0), is_loaded_(false),
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
-      shards_(GGUFShards::expandGGUFIntoShards(params.model.path)),
-      ctxSizeConfigured_(ctxSizeConfigured) {
-  resolveShardPaths(shards_, params.model.path);
-  auto modelInit = [this](common_params commonParams) {
-    this->init(commonParams);
-  };
+      shards_(GGUFShards::expandGGUFIntoShards(setup.params.model.path)) {
+  BertModel::resolveShardPaths(shards_, setup.params.model.path);
+  auto modelInit = [this](BertModelSetup s) { this->init(s); };
 
-  initLoader_.init(InitLoader::LOADER_TYPE::DELAYED, modelInit, params);
+  initLoader_.init(InitLoader::LOADER_TYPE::DELAYED, modelInit, setup);
 }
 
 void BertModel::init(
@@ -592,12 +581,15 @@ void BertModel::init(
   lazyCommonInit();
   initializeBackend(backendsDir, openclCacheDir);
 
-  common_params params = setupParams(
-      modelGgufPath, configCopy, ctxSizeConfigured_, runtimeBackendDevice_);
-  BertModel::init(params);
+  BertModelSetup setup = setupParams(modelGgufPath, configCopy);
+  BertModel::init(setup);
 }
 
-void BertModel::init(common_params& params) {
+void BertModel::init(BertModelSetup& setup) {
+  ctxSizeConfigured_ = setup.ctxSizeConfigured;
+  runtimeBackendDevice_ = setup.resolvedBackendDevice;
+  common_params& params = setup.params;
+
   lazyCommonInit();
   initializeBackend();
 

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -257,9 +257,11 @@ int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) 
 /// diagnosable.
 std::optional<int> readTrainedContextSize(
     const std::string& modelPath, const GGUFShards& shards, bool isStreaming) {
-  // Streaming loads consume the GGUF stream during model load; pre-load
-  // metadata inspection is not supported on this path. Callers fall back to
-  // the llama.cpp default in that case.
+  // Intentional: sharded / streamed loads (setWeightsForFile path) consume the
+  // GGUF stream during model load, so pre-load metadata inspection isn't
+  // possible. Returning nullopt skips adjustEmbeddingContextSize, so the
+  // ctx_size default-/cap-to-n_ctx_train behavior does NOT apply on this path
+  // — streamed loads fall through to llama.cpp's built-in default ctx_size.
   if (isStreaming) {
     return std::nullopt;
   }

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -4,9 +4,11 @@
 #include <any>
 #include <cctype>
 #include <cstring>
+#include <ranges>
 #include <stdexcept>
 
 #include <common/common.h>
+#include <llama-cpp.h>
 #include <llama.h>
 #include <llama/common/arg.h>
 #include <inference-addon-cpp/Errors.hpp>
@@ -234,6 +236,90 @@ void logTokenizationIfVerbose(
   }
 }
 
+bool hasContextSizeConfig(
+    const std::unordered_map<std::string, std::string>& configFilemap) {
+  return configFilemap.find("ctx_size") != configFilemap.end() ||
+         configFilemap.find("ctx-size") != configFilemap.end();
+}
+
+int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) {
+  return std::min(
+      llama_model_n_ctx_train(model), static_cast<int>(llama_n_ctx(ctx)));
+}
+
+/// @brief Read the model's trained context size from GGUF metadata without
+/// loading model weights.
+/// @returns The trained context size, or std::nullopt if metadata cannot be
+/// read (e.g. streaming load where the file is not yet on disk, or the GGUF
+/// file lacks the expected keys).
+std::optional<int> readTrainedContextSize(
+    const std::string& modelPath, const GGUFShards& shards, bool isStreaming) {
+  // Streaming loads consume the GGUF stream during model load; pre-load
+  // metadata inspection is not supported on this path. Callers fall back to
+  // the llama.cpp default in that case.
+  if (isStreaming) {
+    return std::nullopt;
+  }
+
+  const std::string& sourcePath =
+      shards.gguf_files.empty() ? modelPath : shards.gguf_files.front();
+  if (sourcePath.empty() || !std::filesystem::exists(sourcePath)) {
+    return std::nullopt;
+  }
+
+  metadata_handle_ptr meta;
+  if (llama_model_meta_from_file(sourcePath.c_str(), &meta) !=
+      MetaResultStatus::SUCCESS) {
+    return std::nullopt;
+  }
+
+  std::string architecture;
+  if (llama_model_meta_get_str(meta, "general.architecture", &architecture) !=
+      MetaResultStatus::SUCCESS) {
+    return std::nullopt;
+  }
+
+  uint32_t trainedCtx = 0;
+  const std::string contextLengthKey = architecture + ".context_length";
+  if (llama_model_meta_get_u32(meta, contextLengthKey.c_str(), &trainedCtx) !=
+      MetaResultStatus::SUCCESS) {
+    return std::nullopt;
+  }
+
+  return static_cast<int>(trainedCtx);
+}
+
+/// @brief Adjusts @p params.n_ctx so the runtime context does not exceed the
+/// model's trained context. When the caller did not configure ctx_size, the
+/// trained context is used as the default (overriding llama.cpp's hard-coded
+/// 4096 fallback). When the caller configured an oversized ctx_size, it is
+/// capped and an ERROR-level message is emitted so users see it without
+/// bumping verbosity.
+void adjustEmbeddingContextSize(
+    common_params& params, int trainedCtx, bool ctxSizeConfigured) {
+  const int requestedCtx = params.n_ctx;
+
+  if (!ctxSizeConfigured) {
+    params.n_ctx = trainedCtx;
+    return;
+  }
+
+  if (requestedCtx > trainedCtx) {
+    params.n_ctx = trainedCtx;
+    qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
+        GGML_LOG_LEVEL_ERROR,
+        string_format(
+            "%s: requested ctx_size %d exceeds model trained context size %d; "
+            "capping to %d\n",
+            __func__,
+            requestedCtx,
+            trainedCtx,
+            trainedCtx)
+            .c_str(),
+        nullptr);
+  }
+}
+
 } // namespace
 
 BertEmbeddings::BertEmbeddings(
@@ -290,9 +376,11 @@ parseSplitMode(std::unordered_map<std::string, std::string>& configFilemap) {
 common_params setupParams(
     const std::string& modelGgufPath,
     std::unordered_map<std::string, std::string> configFilemap,
+    bool& ctxSizeConfigured,
     int64_t& resolvedBackendDevice) {
   // Default params
   common_params params;
+  ctxSizeConfigured = hasContextSizeConfig(configFilemap);
 
   // Override default params
   std::vector<std::string> configVector;
@@ -453,11 +541,12 @@ BertModel::BertModel(
       backendsDir);
 }
 
-BertModel::BertModel(common_params& params)
+BertModel::BertModel(common_params& params, bool ctxSizeConfigured)
     : model_(nullptr), ctx_(nullptr), vocab_(nullptr), batch_{},
       pooling_type(LLAMA_POOLING_TYPE_NONE), n_embd(0), is_loaded_(false),
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
-      shards_(GGUFShards::expandGGUFIntoShards(params.model.path)) {
+      shards_(GGUFShards::expandGGUFIntoShards(params.model.path)),
+      ctxSizeConfigured_(ctxSizeConfigured) {
   auto modelInit = [this](common_params commonParams) {
     this->init(commonParams);
   };
@@ -486,8 +575,8 @@ void BertModel::init(
   lazyCommonInit();
   initializeBackend(backendsDir, openclCacheDir);
 
-  common_params params =
-      setupParams(modelGgufPath, configCopy, runtimeBackendDevice_);
+  common_params params = setupParams(
+      modelGgufPath, configCopy, ctxSizeConfigured_, runtimeBackendDevice_);
   BertModel::init(params);
 }
 
@@ -518,6 +607,16 @@ void BertModel::init(common_params& params) {
   llama_numa_init(params.numa);
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
+
+  // Inspect GGUF metadata (no weight load) so we can default / cap the runtime
+  // context size before the llama context is created. Mirrors the pattern used
+  // by llm-llamacpp via ModelMetaData. When metadata cannot be read (e.g.
+  // streaming load), the runtime context falls back to llama.cpp's default.
+  if (auto trainedCtx = readTrainedContextSize(
+          params.model.path, shards_, isStreaming_)) {
+    adjustEmbeddingContextSize(params, *trainedCtx, ctxSizeConfigured_);
+  }
+
   common_init_result_ptr llamaInit = initFromConfig(
       params,
       params.model.path,
@@ -547,28 +646,12 @@ void BertModel::init(common_params& params) {
       },
       const_cast<BertModel*>(this));
 
-  int nCtxTrain = llama_model_n_ctx_train(model_);
-  int nCtx = static_cast<int>(llama_n_ctx(ctx_));
-
   if (llama_model_has_encoder(model_) && llama_model_has_decoder(model_)) {
     std::string msg = string_format(
         "%s: computing embeddings in encoder-decoder models is not supported",
         __func__);
     throw qvac_errors::StatusError(
         ADDON_ID, toString(UnsupportedEmbeddings), msg);
-  }
-
-  if (nCtx > nCtxTrain) {
-    qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
-        GGML_LOG_LEVEL_WARN,
-        string_format(
-            "%s: warning: model was trained on only %d context tokens (%d "
-            "specified)\n",
-            __func__,
-            nCtxTrain,
-            nCtx)
-            .c_str(),
-        nullptr);
   }
 
   // print system information
@@ -660,9 +743,8 @@ void BertModel::setWeightsForFile(
     throw std::runtime_error(msg);
   }
 
-  static int fulfilledFiles = 0;
-  fulfilledFiles++;
-  if (fulfilledFiles == static_cast<int>(shards_.gguf_files.size()) + 1) {
+  int current = fulfilledFiles_.fetch_add(1) + 1;
+  if (current == static_cast<int>(shards_.gguf_files.size()) + 1) {
     initLoader_.waitForLoadInitialization();
   }
 }
@@ -674,17 +756,18 @@ BertModel::tokenizeInput(const std::vector<std::string>& prompts) const {
   // tokenize all prompts first
   std::vector<std::vector<int32_t>> inputs = tokenizePrompts(ctx_, prompts);
 
-  // Check for context overflow: compare against model's training context size
-  int nCtxTrain = llama_model_n_ctx_train(model_);
+  // Check for context overflow against the active runtime context, capped by
+  // the model's trained context size.
+  int effectiveContextSize = getEffectiveContextSize(model_, ctx_);
   for (std::size_t i = 0; i < inputs.size(); ++i) {
-    if (static_cast<int>(inputs[i].size()) > nCtxTrain) {
+    if (static_cast<int>(inputs[i].size()) > effectiveContextSize) {
       std::string msg = string_format(
           "%s: context overflow: number of tokens in prompt %zu (%zu) exceeds "
-          "model training context size (%d)",
+          "effective context size (%d)",
           __func__,
           i,
           inputs[i].size(),
-          nCtxTrain);
+          effectiveContextSize);
       throw qvac_errors::StatusError(ADDON_ID, toString(ContextOverflow), msg);
     }
   }
@@ -824,7 +907,7 @@ BertEmbeddings BertModel::encodeHostF32Sequences(
   std::vector<std::vector<int32_t>> inputTokens;
   inputTokens.reserve(sequenceArray.size());
 
-  int nCtxTrain = llama_model_n_ctx_train(model_);
+  int effectiveContextSize = getEffectiveContextSize(model_, ctx_);
   for (std::size_t i = 0; i < sequenceArray.size(); ++i) {
     if (stopCancelled_.load()) {
       throw std::runtime_error("Job cancelled");
@@ -833,14 +916,14 @@ BertEmbeddings BertModel::encodeHostF32Sequences(
     std::vector<int32_t> tokens = common_tokenize(ctx_, sequence, true, true);
 
     // Validate context size during tokenization
-    if (static_cast<int>(tokens.size()) > nCtxTrain) {
+    if (static_cast<int>(tokens.size()) > effectiveContextSize) {
       std::string msg = string_format(
           "%s: context overflow: number of tokens in sequence %zu (%zu) "
-          "exceeds model training context size (%d)",
+          "exceeds effective context size (%d)",
           __func__,
           i,
           tokens.size(),
-          nCtxTrain);
+          effectiveContextSize);
       throw qvac_errors::StatusError(ADDON_ID, toString(ContextOverflow), msg);
     }
 
@@ -878,8 +961,10 @@ qvac_lib_inference_addon_cpp::RuntimeStats BertModel::runtimeStats() const {
     stats.emplace_back(
         "batch_size", static_cast<long long>(init_.params.n_batch));
     stats.emplace_back(
-        "context_size",
+        "trained_context_size",
         static_cast<long long>(llama_model_n_ctx_train(model_)));
+    stats.emplace_back(
+        "context_size", static_cast<long long>(llama_n_ctx(ctx_)));
     stats.emplace_back("backendDevice", runtimeBackendDevice_);
   }
 

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -19,11 +19,13 @@
 
 #include "BackendSelection.hpp"
 #include "LlamaLazyInitializeBackend.hpp"
+#include "ModelMetadata.hpp"
 #include "addon/BertErrors.hpp"
 #include "inference-addon-cpp/GGUFShards.hpp"
 #include "inference-addon-cpp/LlamacppUtils.hpp"
 #include "logging.hpp"
 #include "utils.hpp"
+#include "utils/BorrowablePtr.hpp"
 
 using namespace qvac_lib_infer_llamacpp_embed::errors;
 using namespace qvac_lib_infer_llamacpp_embed::logging;
@@ -248,65 +250,57 @@ int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) 
       llama_model_n_ctx_train(model), static_cast<int>(llama_n_ctx(ctx)));
 }
 
-/// @brief Read the model's trained context size from GGUF metadata without
-/// loading model weights.
-/// @returns The trained context size, or std::nullopt if metadata cannot be
-/// read. Legitimate skips (streaming load, file not yet on disk) are silent;
-/// unexpected metadata failures (read error, missing keys) emit an
-/// ERROR-level log so the silent fallback to llama.cpp's default ctx_size is
-/// diagnosable.
-std::optional<int> readTrainedContextSize(
-    const std::string& modelPath, const GGUFShards& shards, bool isStreaming) {
-  // Intentional: sharded / streamed loads (setWeightsForFile path) consume the
-  // GGUF stream during model load, so pre-load metadata inspection isn't
-  // possible. Returning nullopt skips adjustEmbeddingContextSize, so the
-  // ctx_size default-/cap-to-n_ctx_train behavior does NOT apply on this path
-  // — streamed loads fall through to llama.cpp's built-in default ctx_size.
-  if (isStreaming) {
-    return std::nullopt;
+/// @brief Resolves shard basenames in-place to absolute paths relative to the
+/// parent directory of @p modelPath. `expandGGUFIntoShards` only populates
+/// basenames; resolving them is required for both pre-load metadata
+/// inspection and `llama_model_load_from_splits` when the working directory
+/// differs from the model directory.
+void resolveShardPaths(GGUFShards& shards, const std::string& modelPath) {
+  if (shards.gguf_files.empty()) {
+    return;
   }
-
-  const std::string& sourcePath =
-      shards.gguf_files.empty() ? modelPath : shards.gguf_files.front();
-  if (sourcePath.empty() || !std::filesystem::exists(sourcePath)) {
-    return std::nullopt;
+  const std::filesystem::path baseDir =
+      std::filesystem::path(modelPath).parent_path();
+  if (baseDir.empty()) {
+    return;
   }
+  for (std::string& f : shards.gguf_files) {
+    f = (baseDir / f).string();
+  }
+  shards.tensors_file = (baseDir / shards.tensors_file).string();
+}
 
-  auto logMetaFailure = [&sourcePath](const std::string& detail) {
+/// @brief Reads the model's trained context size from already-parsed GGUF
+/// metadata. Emits an ERROR-level diagnostic and returns nullopt when the
+/// architecture key or `<arch>.context_length` key is missing.
+std::optional<int> readTrainedContextSize(const ModelMetaData& metadata) {
+  auto logMetaFailure = [](const std::string& detail) {
     qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
         GGML_LOG_LEVEL_ERROR,
         string_format(
-            "readTrainedContextSize: %s (path=%s); falling back to llama.cpp "
-            "default ctx_size\n",
-            detail.c_str(),
-            sourcePath.c_str())
+            "readTrainedContextSize: %s; falling back to llama.cpp default "
+            "ctx_size\n",
+            detail.c_str())
             .c_str(),
         nullptr);
   };
 
-  metadata_handle_ptr meta;
-  if (llama_model_meta_from_file(sourcePath.c_str(), &meta) !=
-      MetaResultStatus::SUCCESS) {
-    logMetaFailure("llama_model_meta_from_file failed");
-    return std::nullopt;
-  }
-
-  std::string architecture;
-  if (llama_model_meta_get_str(meta, "general.architecture", &architecture) !=
-      MetaResultStatus::SUCCESS) {
+  std::optional<std::string> architecture =
+      metadata.tryGetString("general.architecture");
+  if (!architecture.has_value() || architecture->empty()) {
     logMetaFailure("missing 'general.architecture' key");
     return std::nullopt;
   }
 
-  uint32_t trainedCtx = 0;
-  const std::string contextLengthKey = architecture + ".context_length";
-  if (llama_model_meta_get_u32(meta, contextLengthKey.c_str(), &trainedCtx) !=
-      MetaResultStatus::SUCCESS) {
+  const std::string contextLengthKey = *architecture + ".context_length";
+  std::optional<uint32_t> trainedCtx =
+      metadata.tryGetU32(contextLengthKey.c_str());
+  if (!trainedCtx.has_value()) {
     logMetaFailure("missing '" + contextLengthKey + "' key");
     return std::nullopt;
   }
 
-  return static_cast<int>(trainedCtx);
+  return static_cast<int>(*trainedCtx);
 }
 
 /// @brief Adjusts @p params.n_ctx so the runtime context does not exceed the
@@ -548,6 +542,7 @@ BertModel::BertModel(
       pooling_type(LLAMA_POOLING_TYPE_NONE), n_embd(0), is_loaded_(false),
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
       shards_(GGUFShards::expandGGUFIntoShards(modelGgufPath)) {
+  resolveShardPaths(shards_, modelGgufPath);
   auto modelInit = [this](
                        const std::string& path,
                        const std::unordered_map<std::string, std::string>& cfg,
@@ -568,6 +563,7 @@ BertModel::BertModel(common_params& params, bool ctxSizeConfigured)
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
       shards_(GGUFShards::expandGGUFIntoShards(params.model.path)),
       ctxSizeConfigured_(ctxSizeConfigured) {
+  resolveShardPaths(shards_, params.model.path);
   auto modelInit = [this](common_params commonParams) {
     this->init(commonParams);
   };
@@ -629,19 +625,23 @@ void BertModel::init(common_params& params) {
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
 
-  // Inspect GGUF metadata (no weight load) so we can default / cap the runtime
-  // context size before the llama context is created. Mirrors the pattern used
-  // by llm-llamacpp via ModelMetaData. When metadata cannot be read (e.g.
-  // streaming load), the runtime context falls back to llama.cpp's default.
-  if (auto trainedCtx = readTrainedContextSize(
-          params.model.path, shards_, isStreaming_)) {
+  metadata_.parse(params.model.path, shards_, isStreaming_, ADDON_ID);
+  if (std::optional<int> trainedCtx = readTrainedContextSize(metadata_)) {
     adjustEmbeddingContextSize(params, *trainedCtx, ctxSizeConfigured_);
   }
+
+  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>
+      reclaimedSingleGgufStreamedFiles;
+  for (auto& [filename, sharedBuf] : singleGgufStreamedFiles_) {
+    reclaimedSingleGgufStreamedFiles.emplace(
+        filename, sharedBuf.reclaimUnique());
+  }
+  singleGgufStreamedFiles_.clear();
 
   common_init_result_ptr llamaInit = initFromConfig(
       params,
       params.model.path,
-      singleGgufStreamedFiles_,
+      reclaimedSingleGgufStreamedFiles,
       shards_,
       loadingContext_,
       isStreaming_,
@@ -749,16 +749,40 @@ void BertModel::setWeightsForFile(
   isStreaming_ = true;
 
   if (shards_.gguf_files.empty()) {
-    // Store it and make it available when `init` is called
-    singleGgufStreamedFiles_[filename] = std::move(shard);
+    auto [it, inserted] = singleGgufStreamedFiles_.emplace(
+        filename, StreamedSharedBuffer(std::move(shard)));
+    if (!inserted) {
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          toString(UnableToLoadModel),
+          "BertModel::setWeightsForFile: duplicate streamed shard filename: " +
+              filename);
+    }
+    metadata_.firstFileFromGgufStreamState.provide(it->second);
     return;
   }
 
-  // Asynchronous shard loading - ensure background initialization has started
   initLoader_.ensureLoadInBackground();
 
+  const std::string firstShardName =
+      std::filesystem::path(shards_.gguf_files.front()).filename().string();
+  const std::string incomingName =
+      std::filesystem::path(filename).filename().string();
+
+  std::unique_ptr<std::basic_streambuf<char>> readyShard;
+  if (firstShardName == incomingName) {
+    static constexpr int64_t kMetadataReleaseTimeoutSec = 60;
+    StreamedSharedBuffer lent(std::move(shard));
+    metadata_.firstFileFromGgufStreamState.provide(lent);
+    metadata_.firstFileFromGgufStreamState
+        .waitForRelease<kMetadataReleaseTimeoutSec>();
+    readyShard = lent.reclaimUnique();
+  } else {
+    readyShard = std::move(shard);
+  }
+
   if (!llama_model_load_fulfill_split_future(
-          filename.c_str(), loadingContext_.c_str(), std::move(shard))) {
+          filename.c_str(), loadingContext_.c_str(), std::move(readyShard))) {
     std::string msg = string_format(
         "%s: failed to load model from %s", __func__, filename.c_str());
     throw std::runtime_error(msg);

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -6,12 +6,13 @@
 #include <cstring>
 #include <ranges>
 #include <stdexcept>
+#include <utility>
 
 #include <common/common.h>
+#include <inference-addon-cpp/Errors.hpp>
 #include <llama-cpp.h>
 #include <llama.h>
 #include <llama/common/arg.h>
-#include <inference-addon-cpp/Errors.hpp>
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #endif
@@ -19,9 +20,9 @@
 #include "BackendSelection.hpp"
 #include "LlamaLazyInitializeBackend.hpp"
 #include "addon/BertErrors.hpp"
-#include "logging.hpp"
 #include "inference-addon-cpp/GGUFShards.hpp"
 #include "inference-addon-cpp/LlamacppUtils.hpp"
+#include "logging.hpp"
 #include "utils.hpp"
 
 using namespace qvac_lib_infer_llamacpp_embed::errors;
@@ -238,8 +239,8 @@ void logTokenizationIfVerbose(
 
 bool hasContextSizeConfig(
     const std::unordered_map<std::string, std::string>& configFilemap) {
-  return configFilemap.find("ctx_size") != configFilemap.end() ||
-         configFilemap.find("ctx-size") != configFilemap.end();
+  return configFilemap.contains("ctx_size") ||
+         configFilemap.contains("ctx-size");
 }
 
 int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) {
@@ -390,11 +391,13 @@ parseSplitMode(std::unordered_map<std::string, std::string>& configFilemap) {
   return splitMode;
 }
 
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
 common_params setupParams(
     const std::string& modelGgufPath,
     std::unordered_map<std::string, std::string> configFilemap,
     bool& ctxSizeConfigured,
     int64_t& resolvedBackendDevice) {
+  // NOLINTEND(bugprone-easily-swappable-parameters)
   // Default params
   common_params params;
   ctxSizeConfigured = hasContextSizeConfig(configFilemap);
@@ -493,9 +496,8 @@ common_params setupParams(
     const bool isOpenCl =
         chosenBackend.first == BackendType::GPU &&
         chosenBackend.second.find("opencl") != std::string::npos;
-    const bool userSetFlashAttn =
-        configFilemap.find("flash-attn") != configFilemap.end() ||
-        configFilemap.find("flash_attn") != configFilemap.end();
+    const bool userSetFlashAttn = configFilemap.contains("flash-attn") ||
+                                  configFilemap.contains("flash_attn");
     if (isOpenCl && !userSetFlashAttn) {
       configFilemap["flash-attn"] = "off";
       qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
@@ -777,7 +779,7 @@ BertModel::tokenizeInput(const std::vector<std::string>& prompts) const {
   // the model's trained context size.
   int effectiveContextSize = getEffectiveContextSize(model_, ctx_);
   for (std::size_t i = 0; i < inputs.size(); ++i) {
-    if (static_cast<int>(inputs[i].size()) > effectiveContextSize) {
+    if (std::cmp_greater(inputs[i].size(), effectiveContextSize)) {
       std::string msg = string_format(
           "%s: context overflow: number of tokens in prompt %zu (%zu) exceeds "
           "effective context size (%d)",
@@ -933,7 +935,7 @@ BertEmbeddings BertModel::encodeHostF32Sequences(
     std::vector<int32_t> tokens = common_tokenize(ctx_, sequence, true, true);
 
     // Validate context size during tokenization
-    if (static_cast<int>(tokens.size()) > effectiveContextSize) {
+    if (std::cmp_greater(tokens.size(), effectiveContextSize)) {
       std::string msg = string_format(
           "%s: context overflow: number of tokens in sequence %zu (%zu) "
           "exceeds effective context size (%d)",

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -250,8 +250,10 @@ int getEffectiveContextSize(const llama_model* model, const llama_context* ctx) 
 /// @brief Read the model's trained context size from GGUF metadata without
 /// loading model weights.
 /// @returns The trained context size, or std::nullopt if metadata cannot be
-/// read (e.g. streaming load where the file is not yet on disk, or the GGUF
-/// file lacks the expected keys).
+/// read. Legitimate skips (streaming load, file not yet on disk) are silent;
+/// unexpected metadata failures (read error, missing keys) emit an
+/// ERROR-level log so the silent fallback to llama.cpp's default ctx_size is
+/// diagnosable.
 std::optional<int> readTrainedContextSize(
     const std::string& modelPath, const GGUFShards& shards, bool isStreaming) {
   // Streaming loads consume the GGUF stream during model load; pre-load
@@ -267,15 +269,29 @@ std::optional<int> readTrainedContextSize(
     return std::nullopt;
   }
 
+  auto logMetaFailure = [&sourcePath](const std::string& detail) {
+    qvac_lib_infer_llamacpp_embed::logging::llamaLogCallback(
+        GGML_LOG_LEVEL_ERROR,
+        string_format(
+            "readTrainedContextSize: %s (path=%s); falling back to llama.cpp "
+            "default ctx_size\n",
+            detail.c_str(),
+            sourcePath.c_str())
+            .c_str(),
+        nullptr);
+  };
+
   metadata_handle_ptr meta;
   if (llama_model_meta_from_file(sourcePath.c_str(), &meta) !=
       MetaResultStatus::SUCCESS) {
+    logMetaFailure("llama_model_meta_from_file failed");
     return std::nullopt;
   }
 
   std::string architecture;
   if (llama_model_meta_get_str(meta, "general.architecture", &architecture) !=
       MetaResultStatus::SUCCESS) {
+    logMetaFailure("missing 'general.architecture' key");
     return std::nullopt;
   }
 
@@ -283,6 +299,7 @@ std::optional<int> readTrainedContextSize(
   const std::string contextLengthKey = architecture + ".context_length";
   if (llama_model_meta_get_u32(meta, contextLengthKey.c_str(), &trainedCtx) !=
       MetaResultStatus::SUCCESS) {
+    logMetaFailure("missing '" + contextLengthKey + "' key");
     return std::nullopt;
   }
 

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.cpp
@@ -4,6 +4,7 @@
 #include <any>
 #include <cctype>
 #include <cstring>
+#include <map>
 #include <ranges>
 #include <stdexcept>
 #include <utility>
@@ -25,7 +26,6 @@
 #include "inference-addon-cpp/LlamacppUtils.hpp"
 #include "logging.hpp"
 #include "utils.hpp"
-#include "utils/BorrowablePtr.hpp"
 
 using namespace qvac_lib_infer_llamacpp_embed::errors;
 using namespace qvac_lib_infer_llamacpp_embed::logging;
@@ -534,7 +534,8 @@ BertModel::BertModel(
     : model_(nullptr), ctx_(nullptr), vocab_(nullptr), batch_{},
       pooling_type(LLAMA_POOLING_TYPE_NONE), n_embd(0), is_loaded_(false),
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
-      shards_(GGUFShards::expandGGUFIntoShards(modelGgufPath)) {
+      shards_(GGUFShards::expandGGUFIntoShards(modelGgufPath)),
+      asyncWeightsLoader_(shards_, initLoader_, loadingContext_, &metadata_) {
   BertModel::resolveShardPaths(shards_, modelGgufPath);
   auto modelInit = [this](
                        const std::string& path,
@@ -554,7 +555,8 @@ BertModel::BertModel(BertModelSetup& setup)
     : model_(nullptr), ctx_(nullptr), vocab_(nullptr), batch_{},
       pooling_type(LLAMA_POOLING_TYPE_NONE), n_embd(0), is_loaded_(false),
       loadingContext_(InitLoader::getLoadingContext("BertModel")),
-      shards_(GGUFShards::expandGGUFIntoShards(setup.params.model.path)) {
+      shards_(GGUFShards::expandGGUFIntoShards(setup.params.model.path)),
+      asyncWeightsLoader_(shards_, initLoader_, loadingContext_, &metadata_) {
   BertModel::resolveShardPaths(shards_, setup.params.model.path);
   auto modelInit = [this](BertModelSetup s) { this->init(s); };
 
@@ -618,26 +620,22 @@ void BertModel::init(BertModelSetup& setup) {
 
   const std::string errorWhenFailed = toString(UnableToLoadModel);
 
-  metadata_.parse(params.model.path, shards_, isStreaming_, ADDON_ID);
+  metadata_.parse(
+      params.model.path, shards_, asyncWeightsLoader_.isStreaming(), ADDON_ID);
   if (std::optional<int> trainedCtx = readTrainedContextSize(metadata_)) {
     adjustEmbeddingContextSize(params, *trainedCtx, ctxSizeConfigured_);
   }
 
   std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>
-      reclaimedSingleGgufStreamedFiles;
-  for (auto& [filename, sharedBuf] : singleGgufStreamedFiles_) {
-    reclaimedSingleGgufStreamedFiles.emplace(
-        filename, sharedBuf.reclaimUnique());
-  }
-  singleGgufStreamedFiles_.clear();
+      streamedFiles = asyncWeightsLoader_.extractIndividualStreamedFiles();
 
   common_init_result_ptr llamaInit = initFromConfig(
       params,
       params.model.path,
-      reclaimedSingleGgufStreamedFiles,
+      streamedFiles,
       shards_,
       loadingContext_,
-      isStreaming_,
+      asyncWeightsLoader_.isStreaming(),
       ADDON_ID,
       errorWhenFailed);
 
@@ -739,52 +737,7 @@ void BertModel::cancel() const { stopCancelled_.store(true); }
 void BertModel::setWeightsForFile(
     const std::string& filename,
     std::unique_ptr<std::basic_streambuf<char>>&& shard) {
-  isStreaming_ = true;
-
-  if (shards_.gguf_files.empty()) {
-    auto [it, inserted] = singleGgufStreamedFiles_.emplace(
-        filename, StreamedSharedBuffer(std::move(shard)));
-    if (!inserted) {
-      throw qvac_errors::StatusError(
-          ADDON_ID,
-          toString(UnableToLoadModel),
-          "BertModel::setWeightsForFile: duplicate streamed shard filename: " +
-              filename);
-    }
-    metadata_.firstFileFromGgufStreamState.provide(it->second);
-    return;
-  }
-
-  initLoader_.ensureLoadInBackground();
-
-  const std::string firstShardName =
-      std::filesystem::path(shards_.gguf_files.front()).filename().string();
-  const std::string incomingName =
-      std::filesystem::path(filename).filename().string();
-
-  std::unique_ptr<std::basic_streambuf<char>> readyShard;
-  if (firstShardName == incomingName) {
-    static constexpr int64_t kMetadataReleaseTimeoutSec = 60;
-    StreamedSharedBuffer lent(std::move(shard));
-    metadata_.firstFileFromGgufStreamState.provide(lent);
-    metadata_.firstFileFromGgufStreamState
-        .waitForRelease<kMetadataReleaseTimeoutSec>();
-    readyShard = lent.reclaimUnique();
-  } else {
-    readyShard = std::move(shard);
-  }
-
-  if (!llama_model_load_fulfill_split_future(
-          filename.c_str(), loadingContext_.c_str(), std::move(readyShard))) {
-    std::string msg = string_format(
-        "%s: failed to load model from %s", __func__, filename.c_str());
-    throw std::runtime_error(msg);
-  }
-
-  int current = fulfilledFiles_.fetch_add(1) + 1;
-  if (current == static_cast<int>(shards_.gguf_files.size()) + 1) {
-    initLoader_.waitForLoadInitialization();
-  }
+  asyncWeightsLoader_.setWeightsForFile(filename, std::move(shard));
 }
 
 std::vector<std::vector<int32_t>>

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
@@ -3,7 +3,6 @@
 #include <any>
 #include <atomic>
 #include <functional>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -16,6 +15,7 @@
 #include <llama/common/common.h>
 #include <llama/common/log.h>
 
+#include "AsyncWeightsLoader.hpp"
 #include "LlamaLazyInitializeBackend.hpp"
 #include "ModelMetadata.hpp"
 #include "inference-addon-cpp/GGUFShards.hpp"
@@ -23,7 +23,6 @@
 #include "inference-addon-cpp/ModelInterfaces.hpp"
 #include "inference-addon-cpp/RuntimeStats.hpp"
 #include "utils.hpp"
-#include "utils/BorrowablePtr.hpp"
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4244 4267) // possible loss of data
@@ -100,15 +99,12 @@ private:
   GGUFShards shards_;
   friend class InitLoader;
   InitLoader initLoader_;
-  bool isStreaming_ = false;
-  using StreamedSharedBuffer = BorrowablePtr<std::basic_streambuf<char>>;
-  std::map<std::string, StreamedSharedBuffer> singleGgufStreamedFiles_;
   std::optional<LlamaBackendsHandle> backendsHandle_;
   mutable std::atomic<bool> stopCancelled_{false};
   int64_t runtimeBackendDevice_ = 0;
   bool ctxSizeConfigured_ = false;
-  std::atomic<int> fulfilledFiles_{0};
   ModelMetaData metadata_;
+  AsyncWeightsLoader asyncWeightsLoader_;
 
 public:
   // These using definitions are accessed by the Addon<BertModel> template.

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
@@ -3,6 +3,8 @@
 #include <any>
 #include <atomic>
 #include <functional>
+#include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <span>
@@ -92,6 +94,8 @@ private:
   std::optional<LlamaBackendsHandle> backendsHandle_;
   mutable std::atomic<bool> stopCancelled_{false};
   int64_t runtimeBackendDevice_ = 0;
+  bool ctxSizeConfigured_ = false;
+  std::atomic<int> fulfilledFiles_{0};
 
 public:
   // These using definitions are accessed by the Addon<BertModel> template.
@@ -112,7 +116,8 @@ public:
       const std::string& backendsDir = "");
 
   /// @brief Construct with already parsed parameters.
-  explicit BertModel(common_params& params);
+  explicit BertModel(
+      common_params& params, bool ctxSizeConfigured = false);
 
   /// @see BertModel::BertModel(common_params)
   void init(common_params& params);
@@ -133,7 +138,7 @@ public:
   /// @brief Processes text to embeddings using Bert encoder and syncs the
   /// result back to the host. Processes the entire prompt as a single sequence
   /// without splitting. Throws ContextOverflow error if prompt exceeds model
-  /// training context size.
+  /// effective runtime context size.
   /// @returns A host vector of embeddings with one embedding per prompt.
   /// @note Awaits for initialization to finish if its loading .gguf shards
   /// asynchronously.
@@ -147,7 +152,7 @@ public:
   /// @brief Process an array of sequences. Each sequence is processed as-is
   /// without splitting by delimiter. Sequences are processed in batches and one
   /// embedding is returned per sequence. Throws ContextOverflow error if any
-  /// sequence exceeds model training context size.
+  /// sequence exceeds the effective runtime context size.
   /// @param sequenceArray Array of sequence strings to process (no
   /// preprocessing/splitting)
   /// @returns Embeddings with one embedding per sequence

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
@@ -17,11 +17,13 @@
 #include <llama/common/log.h>
 
 #include "LlamaLazyInitializeBackend.hpp"
+#include "ModelMetadata.hpp"
 #include "inference-addon-cpp/GGUFShards.hpp"
 #include "inference-addon-cpp/InitLoader.hpp"
 #include "inference-addon-cpp/ModelInterfaces.hpp"
 #include "inference-addon-cpp/RuntimeStats.hpp"
 #include "utils.hpp"
+#include "utils/BorrowablePtr.hpp"
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4244 4267) // possible loss of data
@@ -85,17 +87,18 @@ private:
   bool is_loaded_;
 
   const std::string loadingContext_;
-  const GGUFShards shards_;
+  GGUFShards shards_;
   friend class InitLoader;
   InitLoader initLoader_;
   bool isStreaming_ = false;
-  std::map<std::string, std::unique_ptr<std::basic_streambuf<char>>>
-      singleGgufStreamedFiles_;
+  using StreamedSharedBuffer = BorrowablePtr<std::basic_streambuf<char>>;
+  std::map<std::string, StreamedSharedBuffer> singleGgufStreamedFiles_;
   std::optional<LlamaBackendsHandle> backendsHandle_;
   mutable std::atomic<bool> stopCancelled_{false};
   int64_t runtimeBackendDevice_ = 0;
   bool ctxSizeConfigured_ = false;
   std::atomic<int> fulfilledFiles_{0};
+  ModelMetaData metadata_;
 
 public:
   // These using definitions are accessed by the Addon<BertModel> template.

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
@@ -61,6 +61,16 @@ struct BertCommonInitResult {
   common_init_result_ptr result;
 };
 
+/// @brief Bundle of parameters required to initialize a BertModel: the parsed
+/// llama.cpp common_params, plus addon-specific flags resolved during setup
+/// (whether the caller explicitly configured ctx_size, and which backend
+/// device was selected).
+struct BertModelSetup {
+  common_params params;
+  bool ctxSizeConfigured = false;
+  int64_t resolvedBackendDevice = 0;
+};
+
 /// @brief Instantiates a BERT language model. An open source architecture
 /// designed to help machines understand context in sentences and used for
 /// natural language processing (NLP) and understanding (NLU).
@@ -109,6 +119,14 @@ public:
 
   using TokenizerHandle = void*;
 
+  /// @brief Resolves shard basenames in-place to absolute paths relative to
+  /// the parent directory of @p modelPath. `GGUFShards::expandGGUFIntoShards`
+  /// only populates basenames; resolving them is required for both pre-load
+  /// metadata inspection and `llama_model_load_from_splits` when the working
+  /// directory differs from the model directory.
+  static void
+  resolveShardPaths(GGUFShards& shards, const std::string& modelPath);
+
   /// @brief This constructor allows to specify model to load more clearly and
   /// override default common params by a configuration object.
   ///
@@ -118,12 +136,12 @@ public:
       const std::unordered_map<std::string, std::string>& config,
       const std::string& backendsDir = "");
 
-  /// @brief Construct with already parsed parameters.
-  explicit BertModel(
-      common_params& params, bool ctxSizeConfigured = false);
+  /// @brief Construct with already parsed parameters bundled in a
+  /// @ref BertModelSetup.
+  explicit BertModel(BertModelSetup& setup);
 
-  /// @see BertModel::BertModel(common_params)
-  void init(common_params& params);
+  /// @see BertModel::BertModel(BertModelSetup&)
+  void init(BertModelSetup& setup);
 
   /// @see BertModel::BertModel(string, unordered_map)
   void init(

--- a/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/BertModel.hpp
@@ -23,7 +23,7 @@
 #include "inference-addon-cpp/RuntimeStats.hpp"
 #include "utils.hpp"
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #pragma warning(disable : 4244 4267) // possible loss of data
 #endif
 

--- a/packages/embed-llamacpp/addon/src/model-interface/ModelMetadata.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/ModelMetadata.cpp
@@ -1,0 +1,115 @@
+#include "model-interface/ModelMetadata.hpp"
+
+#include <common/common.h>
+#include <inference-addon-cpp/Errors.hpp>
+#include <llama-cpp.h>
+
+#include "addon/BertErrors.hpp"
+#include "model-interface/logging.hpp"
+
+using namespace qvac_lib_infer_llamacpp_embed::errors;
+using namespace qvac_lib_infer_llamacpp_embed::logging;
+
+void ModelMetaData::FirstFileFromGgufStreamState::provide(
+    ModelMetaData::SharedBuffer& firstFileFromGgufStreamIn) {
+  std::lock_guard<std::mutex> lock(firstFileFromGgufStreamMutex_);
+  auto borrowed = firstFileFromGgufStreamIn.borrow();
+  if (!borrowed) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToLoadModel),
+        "ModelMetaData::FirstFileFromGgufStreamState::provide: received empty "
+        "borrowed stream");
+  }
+  firstFileFromGgufStream_.emplace(std::move(borrowed));
+  hasProvidedFirstFileFromGgufStream_ = true;
+  firstFileFromGgufStreamCv_.notify_all();
+}
+
+void ModelMetaData::parse(
+    const std::string& modelPath, const GGUFShards& shards, bool isStreaming,
+    const char* addonId) {
+
+  if (metadata_ != nullptr) {
+    return;
+  }
+
+  auto loadFromStreambuf = [&modelPath,
+                            outMetadata = &this->metadata_,
+                            addonId](std::basic_streambuf<char>& streambuf) {
+    MetaResultStatus status =
+        llama_model_meta_from_streambuf(streambuf, outMetadata);
+    if (status != MetaResultStatus::SUCCESS) {
+      std::string statusStr = std::to_string(static_cast<int>(status));
+      std::string errorMsg = string_format(
+          "ModelMetadata::loadFromStreambuf: failed to load model metadata "
+          "while parsing GGUF, path=%s MetaResultStatus=%s\n",
+          modelPath.c_str(),
+          statusStr.c_str());
+      throw qvac_errors::StatusError(
+          addonId, toString(UnableToLoadMetadata), errorMsg);
+    }
+  };
+
+  auto loadFromDisk = [&modelPath, outMetadata = &this->metadata_, addonId](
+                          const std::string& diskPath) {
+    MetaResultStatus status =
+        llama_model_meta_from_file(diskPath.c_str(), outMetadata);
+    if (status != MetaResultStatus::SUCCESS) {
+      std::string statusStr = std::to_string(static_cast<int>(status));
+      std::string errorMsg = string_format(
+          "ModelMetadata::loadFromDisk: failed to load model metadata while "
+          "parsing GGUF, path=%s MetaResultStatus=%s\n",
+          diskPath.c_str(),
+          statusStr.c_str());
+      throw qvac_errors::StatusError(
+          addonId, toString(UnableToLoadMetadata), errorMsg);
+    }
+  };
+
+  if (isStreaming) {
+    llamaLogCallback(
+        GGML_LOG_LEVEL_INFO,
+        "ModelMetaData::parse: load the model metadata from memory.\n",
+        nullptr);
+    static constexpr int64_t waitFirstFileTimeoutSec = 15;
+    firstFileFromGgufStreamState.waitConsumeAndClear<waitFirstFileTimeoutSec>(
+        [&](ModelMetaData::Buf& firstFileFromGgufStream) {
+          loadFromStreambuf(firstFileFromGgufStream);
+        });
+  } else if (shards.gguf_files.empty()) {
+    llamaLogCallback(
+        GGML_LOG_LEVEL_INFO,
+        "ModelMetaData::parse: load the model metadata from disk file.\n",
+        nullptr);
+    loadFromDisk(modelPath);
+  } else {
+    llamaLogCallback(
+        GGML_LOG_LEVEL_INFO,
+        "ModelMetaData::parse: load the model metadata from disk shards.\n",
+        nullptr);
+    loadFromDisk(shards.gguf_files.front());
+  }
+}
+
+template <typename T, typename F>
+static std::optional<T>
+tryGet(const metadata_handle_ptr& metadata, const char* key, F&& getter) {
+  if (metadata == nullptr) {
+    return std::nullopt;
+  }
+  T value{};
+  MetaResultStatus status = getter(metadata, key, &value);
+  if (status != MetaResultStatus::SUCCESS) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+std::optional<uint32_t> ModelMetaData::tryGetU32(const char* key) const {
+  return tryGet<uint32_t>(metadata_, key, llama_model_meta_get_u32);
+}
+
+std::optional<std::string> ModelMetaData::tryGetString(const char* key) const {
+  return tryGet<std::string>(metadata_, key, llama_model_meta_get_str);
+}

--- a/packages/embed-llamacpp/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/ModelMetadata.hpp
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+// Needed for GGUFShards
+#include <iomanip>
+#include <sstream>
+
+#include <llama-cpp.h>
+
+#include "addon/BertErrors.hpp"
+#include "inference-addon-cpp/Errors.hpp"
+#include "inference-addon-cpp/GGUFShards.hpp"
+#include "utils/BorrowablePtr.hpp"
+
+/// @brief Access model metadata without loading weights into memory.
+/// @details After parse(), all GGUF key-values are held in-memory and can be
+/// queried without further disk or streambuf access.
+class ModelMetaData {
+  metadata_handle_ptr metadata_;
+  using Buf = std::basic_streambuf<char>;
+  using SharedBuffer = BorrowablePtr<Buf>;
+
+public:
+  ModelMetaData() = default;
+  ~ModelMetaData() = default;
+
+  ModelMetaData(const ModelMetaData&) = delete;
+  ModelMetaData& operator=(const ModelMetaData&) = delete;
+  ModelMetaData(ModelMetaData&&) = delete;
+  ModelMetaData& operator=(ModelMetaData&&) = delete;
+
+  /// @param modelPath Model to load (single .gguf).
+  /// @param shards Sharded files, if any.
+  /// @param isStreaming Whether metadata is loaded from streamed buffers.
+  /// @param addonId Identifier for error reporting.
+  void parse(
+      const std::string& modelPath, const GGUFShards& shards, bool isStreaming,
+      const char* addonId);
+
+  /// @brief Returns the u32 value at @p key, or nullopt if absent.
+  [[nodiscard]] std::optional<uint32_t> tryGetU32(const char* key) const;
+
+  /// @brief Returns the string value at @p key, or nullopt if absent or not a
+  /// string type.
+  [[nodiscard]] std::optional<std::string>
+  tryGetString(const char* key) const;
+
+  class FirstFileFromGgufStreamState {
+  public:
+    /// @brief Blocks until the metadata consumer finishes and releases the
+    /// streamed buffer, or throws on timeout.
+    template <int64_t TimeoutSeconds> void waitForRelease() {
+      std::unique_lock<std::mutex> lock(firstFileFromGgufStreamMutex_);
+      if (!firstFileFromGgufStreamCv_.wait_for(
+              lock, std::chrono::seconds(TimeoutSeconds), [this]() {
+                return hasProvidedFirstFileFromGgufStream_ &&
+                       !firstFileFromGgufStream_.has_value();
+              })) {
+        throw qvac_errors::StatusError(
+            qvac_lib_infer_llamacpp_embed::errors::ADDON_ID,
+            toString(qvac_lib_infer_llamacpp_embed::errors::UnableToLoadModel),
+            "ModelMetaData::waitForRelease: timed out waiting for metadata "
+            "consumer to release the streamed GGUF file");
+      }
+    }
+
+    /// @brief Provides the first streamed GGUF file.
+    /// @note To avoid deadlock, if ModelMetaData::parse() is already waiting
+    /// for the first streamed file, call this from another thread.
+    /// @note Underlying LLM engine should leave the streambuf pointing to the
+    /// beginning of the file.
+    void provide(SharedBuffer& firstFileFromGgufStream);
+
+  private:
+    friend class ModelMetaData;
+
+    template <int64_t TimeoutSeconds, typename Fn>
+    void waitConsumeAndClear(const Fn& processingFunction) {
+      auto clear = [this]() {
+        firstFileFromGgufStream_.reset();
+        firstFileFromGgufStreamCv_.notify_all();
+      };
+      std::unique_lock<std::mutex> lock(firstFileFromGgufStreamMutex_);
+      if (!firstFileFromGgufStreamCv_.wait_for(
+              lock, std::chrono::seconds(TimeoutSeconds), [this]() {
+                return firstFileFromGgufStream_.has_value();
+              })) {
+        throw qvac_errors::StatusError(
+            qvac_lib_infer_llamacpp_embed::errors::ADDON_ID,
+            toString(qvac_lib_infer_llamacpp_embed::errors::UnableToLoadModel),
+            "ModelMetaData::waitConsumeAndClear: timed out waiting for "
+            "first streamed GGUF file to be provided");
+      }
+      try {
+        processingFunction(firstFileFromGgufStream_->ref());
+      } catch (...) {
+        clear();
+        throw;
+      }
+      clear();
+    }
+
+    std::optional<SharedBuffer::Borrowed> firstFileFromGgufStream_;
+    std::mutex firstFileFromGgufStreamMutex_;
+    std::condition_variable firstFileFromGgufStreamCv_;
+    bool hasProvidedFirstFileFromGgufStream_ = false;
+  };
+  // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+  FirstFileFromGgufStreamState firstFileFromGgufStreamState;
+};

--- a/packages/embed-llamacpp/addon/src/model-interface/ModelMetadata.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/ModelMetadata.hpp
@@ -52,8 +52,7 @@ public:
 
   /// @brief Returns the string value at @p key, or nullopt if absent or not a
   /// string type.
-  [[nodiscard]] std::optional<std::string>
-  tryGetString(const char* key) const;
+  [[nodiscard]] std::optional<std::string> tryGetString(const char* key) const;
 
   class FirstFileFromGgufStreamState {
   public:

--- a/packages/embed-llamacpp/addon/src/utils/BorrowablePtr.hpp
+++ b/packages/embed-llamacpp/addon/src/utils/BorrowablePtr.hpp
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+
+/// @brief Borrow/reclaim wrapper around unique ptr. Allows owner thread
+//         to share pointer with other threads but eventually reclaim ownership.
+/// @details Borrow leases are thread-safe and can be released from any thread.
+/// Owner operations (`borrow()` and `reclaimUnique()`) are synchronized
+/// internally and safe to invoke from different threads.
+template <typename T> class BorrowablePtr {
+  struct State {
+    std::mutex mu;
+    std::size_t activeBorrows = 0;
+  };
+
+  struct Deleter {
+    std::unique_ptr<T> inner;
+    void operator()(T*) noexcept { /* inner self-deletes if not released */ }
+    std::unique_ptr<T> release() { return std::move(inner); }
+  };
+
+public:
+  class Borrowed {
+  public:
+    Borrowed() = default;
+    ~Borrowed() = default;
+
+    Borrowed(const Borrowed&) = delete;
+    Borrowed& operator=(const Borrowed&) = delete;
+    Borrowed(Borrowed&& other) noexcept = default;
+    Borrowed& operator=(Borrowed&& other) noexcept = default;
+
+    explicit operator bool() const { return static_cast<bool>(ptr_); }
+    T& ref() const { return *ptr_; }
+
+  private:
+    friend class BorrowablePtr<T>;
+    Borrowed(std::shared_ptr<T> ptr, std::shared_ptr<void> lease)
+        : ptr_(std::move(ptr)), lease_(std::move(lease)) {}
+
+    std::shared_ptr<T> ptr_;
+    std::shared_ptr<void> lease_;
+  };
+
+  explicit BorrowablePtr(std::unique_ptr<T>&& value)
+      : state_(std::make_shared<State>()) {
+    if (!value) {
+      throw std::invalid_argument("BorrowablePtr requires non-null value");
+    }
+    T* raw = value.get();
+    ptr_ = std::shared_ptr<T>(raw, Deleter{std::move(value)});
+  }
+
+  BorrowablePtr(const BorrowablePtr&) = delete;
+  BorrowablePtr& operator=(const BorrowablePtr&) = delete;
+  BorrowablePtr(BorrowablePtr&& other) {
+    std::lock_guard<std::mutex> otherLock(other.mainOwnerMu_);
+    ptr_ = std::move(other.ptr_);
+    state_ = std::move(other.state_);
+  }
+  BorrowablePtr& operator=(BorrowablePtr&& other) {
+    if (this == &other) {
+      return *this;
+    }
+    std::scoped_lock lock(mainOwnerMu_, other.mainOwnerMu_);
+    ptr_ = std::move(other.ptr_);
+    state_ = std::move(other.state_);
+    return *this;
+  }
+
+  Borrowed borrow() const {
+    std::lock_guard<std::mutex> ownerLock(mainOwnerMu_);
+    if (!ptr_ || !state_) {
+      return {};
+    }
+    std::shared_ptr<void> lease;
+    {
+      std::lock_guard<std::mutex> lock(state_->mu);
+      ++state_->activeBorrows;
+      lease = std::shared_ptr<void>(nullptr, [state = state_](void*) {
+        std::lock_guard<std::mutex> releaseLock(state->mu);
+        if (state->activeBorrows > 0) {
+          --state->activeBorrows;
+        }
+      });
+    }
+    return Borrowed(ptr_, std::move(lease));
+  }
+
+  std::unique_ptr<T> reclaimUnique() {
+    std::lock_guard<std::mutex> ownerLock(mainOwnerMu_);
+    if (!state_) {
+      return {};
+    }
+    {
+      std::lock_guard<std::mutex> lock(state_->mu);
+      if (state_->activeBorrows > 0) {
+        throw std::runtime_error(
+            "Cannot reclaim unique ownership while borrows are active");
+      }
+      std::unique_ptr<T> unique = std::get_deleter<Deleter>(ptr_)->release();
+      ptr_.reset();
+      state_.reset();
+      return unique;
+    }
+  }
+
+private:
+  mutable std::mutex mainOwnerMu_;
+  std::shared_ptr<T> ptr_;
+  std::shared_ptr<State> state_;
+};

--- a/packages/embed-llamacpp/addonLogging.d.ts
+++ b/packages/embed-llamacpp/addonLogging.d.ts
@@ -2,8 +2,12 @@ export interface AddonLogging {
   /**
    * Registers a callback for native addon logs.
    *
-   * The callback receives only messages allowed by the model's `config.verbosity`
-   * setting: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO, `"3"` = DEBUG.
+   * The callback receives only messages at or above the addon's current
+   * verbosity threshold: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO,
+   * `"3"` = DEBUG. The threshold is process-global and is updated from
+   * `config.verbosity` each time a model is constructed, so when multiple
+   * models are loaded the most recently constructed model's `config.verbosity`
+   * applies to all subsequent native log dispatch.
    */
   setLogger(callback: (priority: number, message: string) => void): void
   releaseLogger(): void

--- a/packages/embed-llamacpp/addonLogging.d.ts
+++ b/packages/embed-llamacpp/addonLogging.d.ts
@@ -1,4 +1,10 @@
 export interface AddonLogging {
+  /**
+   * Registers a callback for native addon logs.
+   *
+   * The callback receives only messages allowed by the model's `config.verbosity`
+   * setting: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO, `"3"` = DEBUG.
+   */
   setLogger(callback: (priority: number, message: string) => void): void
   releaseLogger(): void
 }

--- a/packages/embed-llamacpp/index.d.ts
+++ b/packages/embed-llamacpp/index.d.ts
@@ -71,18 +71,6 @@ export default class GGMLBert {
 
 export { GGMLBert }
 
-export interface AddonLogging {
-  /**
-   * Registers a callback for native addon logs.
-   *
-   * The callback receives only messages allowed by the model's `config.verbosity`
-   * setting: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO, `"3"` = DEBUG.
-   */
-  setLogger(callback: (priority: number, message: string) => void): void
-  releaseLogger(): void
-}
-export const addonLogging: AddonLogging
-
 export class BertInterface implements Addon {
   constructor(
     binding: unknown,

--- a/packages/embed-llamacpp/index.d.ts
+++ b/packages/embed-llamacpp/index.d.ts
@@ -17,6 +17,7 @@ export interface GGMLConfig {
   device: 'gpu' | 'cpu'
   gpu_layers?: NumericLike
   batch_size?: NumericLike
+  ctx_size?: NumericLike
   pooling?: 'none' | 'mean' | 'cls' | 'last' | 'rank'
   attention?: 'causal' | 'non-causal'
   embd_normalize?: NumericLike
@@ -48,6 +49,7 @@ export interface RuntimeStats {
   total_time_ms: number
   tokens_per_second?: number
   batch_size: number
+  trained_context_size: number
   context_size: number
   backendDevice: 'cpu' | 'gpu'
 }
@@ -70,6 +72,12 @@ export default class GGMLBert {
 export { GGMLBert }
 
 export interface AddonLogging {
+  /**
+   * Registers a callback for native addon logs.
+   *
+   * The callback receives only messages allowed by the model's `config.verbosity`
+   * setting: `"0"` = ERROR, `"1"` = WARNING, `"2"` = INFO, `"3"` = DEBUG.
+   */
   setLogger(callback: (priority: number, message: string) => void): void
   releaseLogger(): void
 }

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/embed-llamacpp/test/integration/addon.test.js
+++ b/packages/embed-llamacpp/test/integration/addon.test.js
@@ -148,8 +148,8 @@ createDeviceModelTest('Model inference works correctly with long string exceedin
   const repeatCount = Math.ceil((maxContextSize / 2) + 50) // Ensure we exceed the limit
   const longString = 'Hello world '.repeat(repeatCount)
 
-  // Verify that an error is thrown when input exceeds model training context size
-  // Expected error: "tokenizeInput: number of tokens in prompt 0 (XXX) exceeds model training context size (XXX)"
+  // Verify that an error is thrown when input exceeds the effective context size
+  // Expected error: "tokenizeInput: number of tokens in prompt 0 (XXX) exceeds effective context size (XXX)"
   let response = null
   let caughtError = null
 
@@ -184,7 +184,7 @@ createDeviceModelTest('Model inference works correctly with long string exceedin
 
   // Verify the error message matches expected format
   t.ok(errorMessage.includes('tokenizeInput'), 'Error should mention tokenizeInput')
-  t.ok(errorMessage.includes('exceeds model training context size'), 'Error should mention exceeding context size')
+  t.ok(errorMessage.includes('exceeds effective context size'), 'Error should mention exceeding context size')
   // Verify the error contains token count information
   t.ok(errorMessage.includes(String(maxContextSize)), `Error should mention context size limit (${maxContextSize})`)
   t.ok(/\d+/.test(errorMessage), 'Error should include token count')
@@ -214,9 +214,9 @@ createDeviceModelTest('Model inference works correctly with array input where on
     'This is a short third sequence'
   ]
 
-  // Verify that an error is thrown when one sequence exceeds model training context size
+  // Verify that an error is thrown when one sequence exceeds effective context size
   // Expected error: "encodeHostF32Sequences: number of tokens in sequence 1 (XXX)
-  // exceeds model training context size (XXX)"
+  // exceeds effective context size (XXX)"
   let response = null
   let caughtError = null
 
@@ -251,7 +251,7 @@ createDeviceModelTest('Model inference works correctly with array input where on
   const hasEncodeError = errorMessage.includes('encodeHostF32Sequences')
   const hasTokenizeError = errorMessage.includes('tokenizeInput')
   t.ok(hasEncodeError || hasTokenizeError, 'Error should mention encodeHostF32Sequences or tokenizeInput')
-  t.ok(errorMessage.includes('exceeds model training context size'), 'Error should mention exceeding context size')
+  t.ok(errorMessage.includes('exceeds effective context size'), 'Error should mention exceeding context size')
   t.ok(errorMessage.includes(String(maxContextSize)), `Error should mention context size limit (${maxContextSize})`)
   t.ok(/\d+/.test(errorMessage), 'Error should include token count')
   // Verify the error mentions which sequence is failing (sequence 1)

--- a/packages/embed-llamacpp/test/integration/http-loader.js
+++ b/packages/embed-llamacpp/test/integration/http-loader.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const https = require('bare-https')
+
+/**
+ * Minimal HTTP/HTTPS streamer used by the sharded-model integration test
+ * to download a small public sharded GGUF before constructing the addon.
+ *
+ * Standalone — does not extend any base loader class. The package no
+ * longer depends on `@qvac/dl-base` after the loader-removal refactor;
+ * this helper exists solely so the sharded model-loading test can fetch
+ * shard files without pulling a heavyweight loader implementation back
+ * into devDependencies.
+ *
+ * Only the surface used by `model-loading.test.js` is implemented:
+ *   - `new HttpDL({ baseUrl })`
+ *   - `getStream(filename)` — returns a Bare-https response stream that
+ *     can be piped into `fs.createWriteStream`.
+ *   - `close()` — destroys any in-flight streams the caller did not
+ *     consume to completion.
+ */
+class HttpDL {
+  constructor (opts) {
+    if (!opts || !opts.baseUrl) {
+      throw new Error('HttpDL requires a baseUrl option')
+    }
+
+    this.baseUrl = opts.baseUrl.endsWith('/') ? opts.baseUrl : opts.baseUrl + '/'
+    this._activeStreams = new Set()
+  }
+
+  /**
+   * Fetch a file by name and return it as a readable stream.
+   * The stream is tracked so that close() can destroy it if needed.
+   * @param {string} filename
+   * @returns {Promise<NodeJS.ReadableStream>}
+   */
+  async getStream (filename) {
+    const response = await this._request('GET', this.baseUrl + filename)
+    this._activeStreams.add(response)
+    const cleanup = () => this._activeStreams.delete(response)
+    response.on('end', cleanup)
+    response.on('close', cleanup)
+    response.on('error', cleanup)
+    return response
+  }
+
+  /**
+   * Destroy any tracked streams that have not finished on their own.
+   */
+  async close () {
+    for (const stream of this._activeStreams) {
+      stream.destroy()
+    }
+    this._activeStreams.clear()
+  }
+
+  _request (method, url, maxRedirects = 10) {
+    return new Promise((resolve, reject) => {
+      if (maxRedirects === 0) return reject(new Error(`Too many redirects for ${url}`))
+
+      const req = https.request(url, { method, agent: false }, (response) => {
+        if ([301, 302, 307, 308].includes(response.statusCode)) {
+          response.resume()
+          let loc = response.headers.location
+          if (loc && loc.startsWith('/')) {
+            const parsed = new URL(url)
+            loc = `${parsed.protocol}//${parsed.host}${loc}`
+          }
+          resolve(this._request(method, loc, maxRedirects - 1))
+          return
+        }
+
+        if (response.statusCode !== 200) {
+          response.resume()
+          reject(new Error(`HTTP ${response.statusCode} ${method} ${url}`))
+          return
+        }
+
+        resolve(response)
+      })
+
+      req.on('error', reject)
+      req.end()
+    })
+  }
+}
+
+module.exports = HttpDL

--- a/packages/embed-llamacpp/test/integration/model-loading.test.js
+++ b/packages/embed-llamacpp/test/integration/model-loading.test.js
@@ -1,0 +1,127 @@
+'use strict'
+
+const fs = require('bare-fs')
+const os = require('bare-os')
+const path = require('bare-path')
+
+const GGMLBert = require('../../index.js')
+const HttpDL = require('./http-loader')
+const { safeTest } = require('./utils')
+
+const platform = os.platform()
+const isMobile = platform === 'ios' || platform === 'android'
+
+const SHARDED_MODEL = {
+  baseUrl: 'https://huggingface.co/gianni-cor/gte-large_fp16-sharded/resolve/main/',
+  embeddingDimension: 1024,
+  files: [
+    {
+      name: 'gte-large_fp16.tensors.txt',
+      size: 8966
+    },
+    {
+      name: 'gte-large_fp16-00001-of-00005.gguf',
+      size: 156815424
+    },
+    {
+      name: 'gte-large_fp16-00002-of-00005.gguf',
+      size: 159721216
+    },
+    {
+      name: 'gte-large_fp16-00003-of-00005.gguf',
+      size: 159737792
+    },
+    {
+      name: 'gte-large_fp16-00004-of-00005.gguf',
+      size: 159721120
+    },
+    {
+      name: 'gte-large_fp16-00005-of-00005.gguf',
+      size: 33608768
+    }
+  ]
+}
+
+async function ensureShardedModel (modelDir) {
+  fs.mkdirSync(modelDir, { recursive: true })
+
+  const loader = new HttpDL({ baseUrl: SHARDED_MODEL.baseUrl })
+  try {
+    for (const file of SHARDED_MODEL.files) {
+      const dest = path.join(modelDir, file.name)
+      if (fs.existsSync(dest)) {
+        const stat = fs.statSync(dest)
+        if (stat.size === file.size) {
+          continue
+        }
+        console.log(`[download] Removing incomplete shard: ${file.name} (${stat.size} bytes)`)
+        fs.unlinkSync(dest)
+      }
+
+      console.log(`[download] Downloading sharded embed model file: ${file.name}`)
+      const stream = await loader.getStream(file.name)
+      const ws = fs.createWriteStream(dest)
+      for await (const chunk of stream) {
+        ws.write(chunk)
+      }
+      ws.end()
+      await new Promise(resolve => ws.on('close', resolve))
+
+      const stat = fs.statSync(dest)
+      if (stat.size !== file.size) {
+        fs.unlinkSync(dest)
+        throw new Error(`${file.name}: expected ${file.size} bytes, got ${stat.size}`)
+      }
+    }
+  } finally {
+    await loader.close().catch(() => {})
+  }
+
+  return SHARDED_MODEL.files.map(file => path.join(modelDir, file.name))
+}
+
+safeTest('sharded embed model can run inference end-to-end', {
+  timeout: 10 * 60 * 1000,
+  skip: isMobile
+}, async t => {
+  const modelDir = path.resolve(__dirname, '../model')
+  const modelFiles = await ensureShardedModel(modelDir)
+
+  const addon = new GGMLBert({
+    files: { model: modelFiles },
+    config: {
+      device: 'cpu',
+      gpu_layers: '0',
+      batch_size: '512',
+      ctx_size: '512',
+      openclCacheDir: modelDir,
+      verbosity: '2'
+    },
+    logger: console,
+    opts: { stats: true }
+  })
+
+  try {
+    await addon.load()
+    const response = await addon.run([
+      'That is a happy person',
+      'This is a sad person'
+    ])
+    const embeddings = await response.await()
+
+    t.is(embeddings[0].length, 2, 'should return one embedding per input sequence')
+    t.is(
+      embeddings[0][0].length,
+      SHARDED_MODEL.embeddingDimension,
+      'should generate gte-large embeddings with expected dimension'
+    )
+    t.is(response.stats.backendDevice, 'cpu', 'should report cpu backend')
+    t.is(response.stats.context_size, 512, 'should use configured runtime context size')
+    t.ok(
+      response.stats.trained_context_size >= response.stats.context_size,
+      'trained context should be at least the runtime context'
+    )
+  } finally {
+    await addon.unload().catch(() => {})
+  }
+})

--- a/packages/embed-llamacpp/test/unit/CMakeLists.txt
+++ b/packages/embed-llamacpp/test/unit/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 add_executable(
   addon-test
   test_addon_cpp.cpp
+  test_async_weights_loader.cpp
   test_backend_selection.cpp
   test_cancel_stale_flag.cpp
   test_bert_model.cpp
@@ -14,6 +15,7 @@ add_executable(
   test_logging.cpp
   test_model_metadata.cpp
   test_utils.cpp
+  ${CMAKE_SOURCE_DIR}/addon/src/model-interface/AsyncWeightsLoader.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/BackendSelection.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/BertModel.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp

--- a/packages/embed-llamacpp/test/unit/CMakeLists.txt
+++ b/packages/embed-llamacpp/test/unit/CMakeLists.txt
@@ -12,10 +12,12 @@ add_executable(
   test_bert_model.cpp
   test_llama_lazy_init_backend.cpp
   test_logging.cpp
+  test_model_metadata.cpp
   test_utils.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/BackendSelection.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/BertModel.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
+  ${CMAKE_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/logging.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/utils.cpp
 )

--- a/packages/embed-llamacpp/test/unit/map-addon-event.test.js
+++ b/packages/embed-llamacpp/test/unit/map-addon-event.test.js
@@ -29,6 +29,13 @@ test('stats payload leaves unknown backendDevice values as-is', function (t) {
   t.is(result.data.backendDevice, 2)
 })
 
+test('stats payload with trained_context_size maps to JobEnded', function (t) {
+  const result = mapAddonEvent('Stats', { trained_context_size: 512, context_size: 512 }, null)
+  t.is(result.type, 'JobEnded')
+  t.is(result.data.trained_context_size, 512)
+  t.is(result.data.context_size, 512)
+})
+
 test('Error event name maps to Error type carrying rawError', function (t) {
   const err = new Error('boom')
   const result = mapAddonEvent('SomeError', null, err)

--- a/packages/embed-llamacpp/test/unit/test_async_weights_loader.cpp
+++ b/packages/embed-llamacpp/test/unit/test_async_weights_loader.cpp
@@ -1,0 +1,129 @@
+#include <condition_variable>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "inference-addon-cpp/GGUFShards.hpp"
+#include "inference-addon-cpp/InitLoader.hpp"
+#include "model-interface/AsyncWeightsLoader.hpp"
+#include "model-interface/ModelMetadata.hpp"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string findTestModelPath() {
+  fs::path backendDir;
+#ifdef TEST_BINARY_DIR
+  backendDir = fs::path(TEST_BINARY_DIR);
+#endif
+
+  std::vector<fs::path> candidates = {
+      fs::path{"models/unit-test/test-model.gguf"},
+      fs::path{"../../../models/unit-test/test-model.gguf"},
+      backendDir.parent_path().parent_path().parent_path() / "models" /
+          "unit-test" / "test-model.gguf",
+      fs::current_path() / "models" / "unit-test" / "test-model.gguf",
+  };
+  for (const auto& candidate : candidates) {
+    if (fs::exists(candidate)) {
+      return fs::absolute(candidate).string();
+    }
+  }
+  return "";
+}
+
+std::unique_ptr<std::basic_streambuf<char>>
+readFileToStreambufBinary(const std::string& path) {
+  auto filebuf = std::make_unique<std::filebuf>();
+  if (filebuf->open(path, std::ios::in | std::ios::binary) == nullptr) {
+    return nullptr;
+  }
+  filebuf->pubseekpos(0, std::ios::in);
+  return filebuf;
+}
+
+class MockAsyncWeightsLoader : public AsyncWeightsLoader {
+public:
+  using AsyncWeightsLoader::AsyncWeightsLoader;
+
+  std::multiset<std::string> fulfilledFilenames;
+
+  void waitForFulfillCount(std::size_t n) {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_.wait(lock, [&] { return fulfilledFilenames.size() >= n; });
+  }
+
+protected:
+  void fulfillSplitFuture(
+      const std::string& filename,
+      std::unique_ptr<Buf>&& shard) override {
+    if (shard == nullptr) {
+      throw std::runtime_error("MockAsyncWeightsLoader received null shard");
+    }
+    {
+      std::lock_guard<std::mutex> lock(mu_);
+      fulfilledFilenames.insert(filename);
+    }
+    cv_.notify_all();
+  }
+
+private:
+  std::mutex mu_;
+  std::condition_variable cv_;
+};
+
+} // namespace
+
+class AsyncWeightsLoaderTest : public ::testing::Test {
+protected:
+  void SetUp() override { testModelPath_ = findTestModelPath(); }
+
+  std::string testModelPath_;
+};
+
+TEST_F(
+    AsyncWeightsLoaderTest,
+    ShardedStreamingAllowsTensorsBeforeFirstGgufShard) {
+  if (!fs::exists(testModelPath_)) {
+    GTEST_SKIP() << "Test model not found at: " << testModelPath_;
+  }
+
+  GGUFShards shards;
+  shards.tensors_file = "test-model.tensors.txt";
+  shards.gguf_files = {"test-model-00001-of-00001.gguf"};
+
+  InitLoader initLoader;
+  ModelMetaData meta;
+  initLoader.init(InitLoader::LOADER_TYPE::DELAYED, [&]() {
+    meta.parse(testModelPath_, shards, true /* isStreaming */, "Test");
+  });
+
+  const std::string loadingContext =
+      InitLoader::getLoadingContext("EmbedAsyncWeightsLoaderTest");
+  MockAsyncWeightsLoader loader(shards, initLoader, loadingContext, &meta);
+
+  loader.setWeightsForFile(
+      shards.tensors_file, std::make_unique<std::stringbuf>("tensors"));
+  EXPECT_EQ(loader.fulfilledFilenames.count(shards.tensors_file), 1u);
+
+  std::unique_ptr<std::basic_streambuf<char>> firstShardBuf =
+      readFileToStreambufBinary(testModelPath_);
+  ASSERT_NE(firstShardBuf, nullptr);
+  loader.setWeightsForFile(shards.gguf_files.front(), std::move(firstShardBuf));
+
+  loader.waitForFulfillCount(2);
+  initLoader.waitForLoadInitialization();
+
+  EXPECT_EQ(loader.fulfilledFilenames.count(shards.tensors_file), 1u);
+  EXPECT_EQ(loader.fulfilledFilenames.count(shards.gguf_files.front()), 1u);
+  EXPECT_TRUE(loader.isStreaming());
+}

--- a/packages/embed-llamacpp/test/unit/test_bert_model.cpp
+++ b/packages/embed-llamacpp/test/unit/test_bert_model.cpp
@@ -1,5 +1,7 @@
 #include <chrono>
 #include <filesystem>
+#include <fstream>
+#include <memory>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -805,6 +807,33 @@ TEST_F(BertModelTest, ContextOverflowUsesRuntimeContextSizeForSequences) {
 
   EXPECT_THROW(
       { model.encodeHostF32Sequences(sequences); }, qvac_errors::StatusError);
+}
+
+TEST_F(BertModelTest, StreamingSingleGgufAppliesContextCap) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  std::unordered_map<std::string, std::string> config = {{"device", "cpu"}};
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+
+  std::unique_ptr<std::filebuf> filebuf = std::make_unique<std::filebuf>();
+  ASSERT_NE(
+      filebuf->open(getValidModelPath(), std::ios::in | std::ios::binary),
+      nullptr);
+  filebuf->pubseekpos(0, std::ios::in);
+  std::unique_ptr<std::basic_streambuf<char>> sb(std::move(filebuf));
+
+  const std::string filename =
+      fs::path(getValidModelPath()).filename().string();
+  model.setWeightsForFile(filename, std::move(sb));
+  model.waitForLoadInitialization();
+
+  ASSERT_TRUE(model.isLoaded());
+  EXPECT_EQ(
+      static_cast<int>(llama_n_ctx(model.getCtx())),
+      llama_model_n_ctx_train(model.getModel()));
 }
 
 TEST_F(BertModelTest, ProcessWithContextOverflow) {

--- a/packages/embed-llamacpp/test/unit/test_bert_model.cpp
+++ b/packages/embed-llamacpp/test/unit/test_bert_model.cpp
@@ -21,6 +21,15 @@
 namespace fs = std::filesystem;
 using namespace qvac_lib_inference_addon_cpp::logger;
 
+// Test fixtures intentionally hold members directly and many tests assert
+// against literal sample values; the noisy clang-tidy checks below add no
+// value in a unit-test context.
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers,
+// readability-magic-numbers,
+// readability-function-cognitive-complexity,
+// cppcoreguidelines-non-private-member-variables-in-classes,
+// bugprone-unchecked-optional-access)
+
 namespace {
 double getStatValue(
     const qvac_lib_inference_addon_cpp::RuntimeStats& stats,
@@ -57,12 +66,12 @@ getModelFromAddon(qvac_lib_inference_addon_cpp::AddonCpp* addon) {
 class BertEmbeddingsTest : public ::testing::Test {};
 
 TEST_F(BertEmbeddingsTest, ConstructorWithValidLayout) {
-  std::vector<float> data(10 * 5);
+  std::vector<float> data(std::size_t{10} * 5);
   for (std::size_t i = 0; i < data.size(); ++i) {
     data[i] = static_cast<float>(i);
   }
 
-  BertEmbeddings::Layout layout{10, 5};
+  BertEmbeddings::Layout layout{.embeddingCount = 10, .embeddingSize = 5};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), 10);
@@ -70,8 +79,8 @@ TEST_F(BertEmbeddingsTest, ConstructorWithValidLayout) {
 }
 
 TEST_F(BertEmbeddingsTest, SingleEmbedding) {
-  std::vector<float> data{1.0f, 2.0f, 3.0f};
-  BertEmbeddings::Layout layout{1, 3};
+  std::vector<float> data{1.0F, 2.0F, 3.0F};
+  BertEmbeddings::Layout layout{.embeddingCount = 1, .embeddingSize = 3};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), 1);
@@ -79,14 +88,14 @@ TEST_F(BertEmbeddingsTest, SingleEmbedding) {
 
   auto embedding = embeddings[0];
   EXPECT_EQ(embedding.size(), 3);
-  EXPECT_FLOAT_EQ(embedding[0], 1.0f);
-  EXPECT_FLOAT_EQ(embedding[1], 2.0f);
-  EXPECT_FLOAT_EQ(embedding[2], 3.0f);
+  EXPECT_FLOAT_EQ(embedding[0], 1.0F);
+  EXPECT_FLOAT_EQ(embedding[1], 2.0F);
+  EXPECT_FLOAT_EQ(embedding[2], 3.0F);
 }
 
 TEST_F(BertEmbeddingsTest, MultipleEmbeddings) {
-  std::vector<float> data{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
-  BertEmbeddings::Layout layout{2, 3};
+  std::vector<float> data{1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F};
+  BertEmbeddings::Layout layout{.embeddingCount = 2, .embeddingSize = 3};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), 2);
@@ -94,20 +103,20 @@ TEST_F(BertEmbeddingsTest, MultipleEmbeddings) {
 
   auto embedding0 = embeddings[0];
   EXPECT_EQ(embedding0.size(), 3);
-  EXPECT_FLOAT_EQ(embedding0[0], 1.0f);
-  EXPECT_FLOAT_EQ(embedding0[1], 2.0f);
-  EXPECT_FLOAT_EQ(embedding0[2], 3.0f);
+  EXPECT_FLOAT_EQ(embedding0[0], 1.0F);
+  EXPECT_FLOAT_EQ(embedding0[1], 2.0F);
+  EXPECT_FLOAT_EQ(embedding0[2], 3.0F);
 
   auto embedding1 = embeddings[1];
   EXPECT_EQ(embedding1.size(), 3);
-  EXPECT_FLOAT_EQ(embedding1[0], 4.0f);
-  EXPECT_FLOAT_EQ(embedding1[1], 5.0f);
-  EXPECT_FLOAT_EQ(embedding1[2], 6.0f);
+  EXPECT_FLOAT_EQ(embedding1[0], 4.0F);
+  EXPECT_FLOAT_EQ(embedding1[1], 5.0F);
+  EXPECT_FLOAT_EQ(embedding1[2], 6.0F);
 }
 
 TEST_F(BertEmbeddingsTest, EmptyEmbeddings) {
   std::vector<float> data;
-  BertEmbeddings::Layout layout{0, 0};
+  BertEmbeddings::Layout layout{.embeddingCount = 0, .embeddingSize = 0};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), 0);
@@ -122,14 +131,14 @@ TEST_F(BertEmbeddingsTest, AccessAllEmbeddings) {
     data[i] = static_cast<float>(i);
   }
 
-  BertEmbeddings::Layout layout{count, size};
+  BertEmbeddings::Layout layout{.embeddingCount = count, .embeddingSize = size};
   BertEmbeddings embeddings(std::move(data), layout);
 
   for (std::size_t i = 0; i < count; ++i) {
     auto embedding = embeddings[i];
     EXPECT_EQ(embedding.size(), size);
     for (std::size_t j = 0; j < size; ++j) {
-      EXPECT_FLOAT_EQ(embedding[j], static_cast<float>(i * size + j));
+      EXPECT_FLOAT_EQ(embedding[j], static_cast<float>((i * size) + j));
     }
   }
 }
@@ -139,10 +148,10 @@ TEST_F(BertEmbeddingsTest, LargeEmbeddings) {
   const std::size_t size = 768;
   std::vector<float> data(count * size);
   for (std::size_t i = 0; i < data.size(); ++i) {
-    data[i] = static_cast<float>(i) * 0.001f;
+    data[i] = static_cast<float>(i) * 0.001F;
   }
 
-  BertEmbeddings::Layout layout{count, size};
+  BertEmbeddings::Layout layout{.embeddingCount = count, .embeddingSize = size};
   BertEmbeddings embeddings(std::move(data), layout);
 
   EXPECT_EQ(embeddings.size(), count);
@@ -150,7 +159,7 @@ TEST_F(BertEmbeddingsTest, LargeEmbeddings) {
 
   auto embedding = embeddings[50];
   EXPECT_EQ(embedding.size(), size);
-  EXPECT_FLOAT_EQ(embedding[0], 50.0f * size * 0.001f);
+  EXPECT_FLOAT_EQ(embedding[0], 50.0F * size * 0.001F);
 }
 
 class BertModelTest : public ::testing::Test {
@@ -199,7 +208,7 @@ protected:
   std::string test_model_path;
 
   std::string getValidModelPath() { return test_model_path; }
-  std::string getInvalidModelPath() { return "nonexistent_model.gguf"; }
+  static std::string getInvalidModelPath() { return "nonexistent_model.gguf"; }
 };
 
 TEST_F(BertModelTest, IsLoadedBeforeInit) {
@@ -381,20 +390,20 @@ TEST_F(BertModelTest, RuntimeStatsAfterProcessing) {
 }
 
 TEST_F(BertModelTest, ConstructorWithInvalidPath) {
-  std::string invalid_path = getInvalidModelPath();
+  std::string invalidPath = getInvalidModelPath();
   std::unordered_map<std::string, std::string> config = {{"device", "cpu"}};
   EXPECT_NO_THROW({
-    BertModel model(invalid_path, config);
+    BertModel model(invalidPath, config);
     EXPECT_FALSE(model.isLoaded());
   });
 }
 
 TEST_F(BertModelTest, ConstructorWithEmptyConfig) {
-  std::string invalid_path = getInvalidModelPath();
+  std::string invalidPath = getInvalidModelPath();
   std::unordered_map<std::string, std::string> config;
 
   EXPECT_NO_THROW({
-    BertModel model(invalid_path, config);
+    BertModel model(invalidPath, config);
     EXPECT_FALSE(model.isLoaded());
   });
 }
@@ -427,9 +436,9 @@ TEST_F(BertModelTest, ModelLoadsSuccessfully) {
 }
 
 TEST_F(BertModelTest, ModelFailsToLoadWithInvalidPath) {
-  std::string invalid_path = getInvalidModelPath();
+  std::string invalidPath = getInvalidModelPath();
   std::unordered_map<std::string, std::string> config = {{"device", "cpu"}};
-  BertModel model(invalid_path, config);
+  BertModel model(invalidPath, config);
   model.initializeBackend(test_backends_dir);
 
   // waitForLoadInitialization() throws an exception when model file doesn't
@@ -464,7 +473,7 @@ TEST_F(BertModelTest, EncodeHostF32SingleString) {
   // Verify embedding values are not all zeros
   bool hasNonZero = false;
   for (float val : embeddings[0]) {
-    if (val != 0.0f) {
+    if (val != 0.0F) {
       hasNonZero = true;
       break;
     }
@@ -525,7 +534,7 @@ TEST_F(BertModelTest, EncodeHostF32EmptyString) {
     FAIL() << "Model failed to load";
   }
 
-  std::string prompt = "";
+  std::string prompt;
   BertEmbeddings embeddings = model.encodeHostF32(prompt);
 
   EXPECT_EQ(embeddings.size(), 1);
@@ -593,7 +602,7 @@ TEST_F(BertModelTest, ProcessWithStringInput) {
   instance.addon->activate();
 
   auto* model = getModelFromAddon(instance.addon.get());
-  if (model && !model->isLoaded()) {
+  if (model != nullptr && !model->isLoaded()) {
     FAIL() << "Model failed to load";
   }
 
@@ -606,7 +615,7 @@ TEST_F(BertModelTest, ProcessWithStringInput) {
   ASSERT_TRUE(maybeEmbeddings.has_value())
       << "Timeout waiting for embeddings output";
 
-  BertEmbeddings embeddings = maybeEmbeddings.value();
+  const auto& embeddings = maybeEmbeddings.value();
 
   EXPECT_EQ(embeddings.size(), 1);
   EXPECT_GT(embeddings.embeddingSize(), 0);
@@ -628,7 +637,7 @@ TEST_F(BertModelTest, ProcessWithVectorInput) {
   instance.addon->activate();
 
   auto* model = getModelFromAddon(instance.addon.get());
-  if (model && !model->isLoaded()) {
+  if (model != nullptr && !model->isLoaded()) {
     FAIL() << "Model failed to load";
   }
 
@@ -641,7 +650,7 @@ TEST_F(BertModelTest, ProcessWithVectorInput) {
   ASSERT_TRUE(maybeEmbeddings.has_value())
       << "Timeout waiting for embeddings output";
 
-  BertEmbeddings embeddings = maybeEmbeddings.value();
+  const auto& embeddings = maybeEmbeddings.value();
 
   EXPECT_EQ(embeddings.size(), 3);
   EXPECT_GT(embeddings.embeddingSize(), 0);
@@ -842,7 +851,7 @@ TEST_F(BertModelTest, ModelLoadsAndProcessesMultipleTimes) {
   instance.addon->activate();
 
   auto* model = getModelFromAddon(instance.addon.get());
-  if (model && !model->isLoaded()) {
+  if (model != nullptr && !model->isLoaded()) {
     FAIL() << "Model failed to load";
   }
 
@@ -857,8 +866,7 @@ TEST_F(BertModelTest, ModelLoadsAndProcessesMultipleTimes) {
     ASSERT_TRUE(maybeEmbeddings.has_value())
         << "Timeout waiting for embeddings output on job " << i;
 
-    BertEmbeddings embeddings =
-        std::any_cast<BertEmbeddings>(maybeEmbeddings.value());
+    auto embeddings = std::any_cast<BertEmbeddings>(maybeEmbeddings.value());
 
     EXPECT_EQ(embeddings.size(), 1);
     EXPECT_GT(embeddings.embeddingSize(), 0);
@@ -1101,3 +1109,9 @@ TEST_F(BertModelTest, CancelMidDecode_ThrowsJobCancelled) {
          "Got: "
       << errorMsg;
 }
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers,
+// readability-magic-numbers,
+// readability-function-cognitive-complexity,
+// cppcoreguidelines-non-private-member-variables-in-classes,
+// bugprone-unchecked-optional-access)

--- a/packages/embed-llamacpp/test/unit/test_bert_model.cpp
+++ b/packages/embed-llamacpp/test/unit/test_bert_model.cpp
@@ -15,9 +15,11 @@
 #include "addon/AddonCpp.hpp"
 #include "addon/BertErrors.hpp"
 #include "model-interface/BertModel.hpp"
+#include "model-interface/logging.hpp"
 #include "test_common.hpp"
 
 namespace fs = std::filesystem;
+using namespace qvac_lib_inference_addon_cpp::logger;
 
 namespace {
 double getStatValue(
@@ -161,6 +163,7 @@ protected:
     backendDir = fs::current_path() / "build" / "test" / "unit";
 #endif
     test_backends_dir = backendDir.string();
+    qvac_lib_infer_llamacpp_embed::logging::g_verbosityLevel = Priority::ERROR;
 
     // Try multiple possible locations for the model file
     std::vector<fs::path> possiblePaths = {
@@ -186,6 +189,10 @@ protected:
     if (test_model_path.empty()) {
       test_model_path = "models/unit-test/test-model.gguf";
     }
+  }
+
+  void TearDown() override {
+    qvac_lib_infer_llamacpp_embed::logging::g_verbosityLevel = Priority::ERROR;
   }
 
   std::string test_backends_dir;
@@ -258,6 +265,7 @@ TEST_F(BertModelTest, RuntimeStatsBeforeProcessing) {
   // is loaded
   bool hasBatchSize = false;
   bool hasContextSize = false;
+  bool hasTrainedContextSize = false;
   for (const auto& stat : stats) {
     if (stat.first == "batch_size") {
       hasBatchSize = true;
@@ -265,12 +273,73 @@ TEST_F(BertModelTest, RuntimeStatsBeforeProcessing) {
     if (stat.first == "context_size") {
       hasContextSize = true;
     }
+    if (stat.first == "trained_context_size") {
+      hasTrainedContextSize = true;
+    }
   }
   // These should be present if model is loaded
   EXPECT_TRUE(hasBatchSize);
   EXPECT_TRUE(hasContextSize);
+  EXPECT_TRUE(hasTrainedContextSize);
+  EXPECT_EQ(
+      getStatValue(stats, "context_size"),
+      static_cast<double>(llama_n_ctx(model.getCtx())));
+  EXPECT_EQ(
+      getStatValue(stats, "trained_context_size"),
+      static_cast<double>(llama_model_n_ctx_train(model.getModel())));
   double backendDevice = getStatValue(stats, "backendDevice");
   EXPECT_TRUE(backendDevice == 0.0 || backendDevice == 1.0);
+}
+
+TEST_F(BertModelTest, DefaultContextSizeMatchesTrainedContext) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  std::unordered_map<std::string, std::string> config = {{"device", "cpu"}};
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+
+  ASSERT_TRUE(model.isLoaded());
+  EXPECT_EQ(
+      static_cast<int>(llama_n_ctx(model.getCtx())),
+      llama_model_n_ctx_train(model.getModel()));
+}
+
+TEST_F(BertModelTest, ContextSizeAboveTrainingContextIsCapped) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  std::unordered_map<std::string, std::string> config = {
+      {"device", "cpu"}, {"ctx_size", "999999"}};
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+
+  ASSERT_TRUE(model.isLoaded());
+  EXPECT_EQ(
+      static_cast<int>(llama_n_ctx(model.getCtx())),
+      llama_model_n_ctx_train(model.getModel()));
+}
+
+TEST_F(BertModelTest, DefaultContextSizeDoesNotWarnWhenUnconfigured) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  std::unordered_map<std::string, std::string> config = {
+      {"device", "cpu"}, {"verbosity", "1"}};
+
+  testing::internal::CaptureStdout();
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+  const std::string output = testing::internal::GetCapturedStdout();
+
+  ASSERT_TRUE(model.isLoaded());
+  EXPECT_EQ(output.find("requested ctx_size"), std::string::npos);
 }
 
 TEST_F(BertModelTest, RuntimeStatsAfterProcessing) {
@@ -670,6 +739,61 @@ TEST_F(BertModelTest, ContextOverflowSequences) {
   std::vector<std::string> sequences = {"Normal sequence", longString};
 
   using namespace qvac_lib_infer_llamacpp_embed::errors;
+  EXPECT_THROW(
+      { model.encodeHostF32Sequences(sequences); }, qvac_errors::StatusError);
+}
+
+TEST_F(BertModelTest, ContextOverflowUsesRuntimeContextSizeForPrompts) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  // Configure a runtime context smaller than the model's trained context so we
+  // can verify validation triggers on the runtime ctx, not the trained ctx.
+  std::unordered_map<std::string, std::string> config = {
+      {"device", "cpu"}, {"ctx_size", "256"}, {"batch_size", "256"}};
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+
+  ASSERT_TRUE(model.isLoaded());
+  const int runtimeCtx = static_cast<int>(llama_n_ctx(model.getCtx()));
+  const int trainedCtx = llama_model_n_ctx_train(model.getModel());
+  ASSERT_LT(runtimeCtx, trainedCtx);
+
+  // Build an input that overflows the runtime ctx but stays under the trained
+  // ctx, so only the runtime-ctx check can catch it.
+  std::string longString = "Hello world ";
+  for (int i = 0; i < 200; ++i) {
+    longString += "Hello world ";
+  }
+
+  EXPECT_THROW({ model.encodeHostF32(longString); }, qvac_errors::StatusError);
+}
+
+TEST_F(BertModelTest, ContextOverflowUsesRuntimeContextSizeForSequences) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+
+  std::unordered_map<std::string, std::string> config = {
+      {"device", "cpu"}, {"ctx_size", "256"}, {"batch_size", "256"}};
+  BertModel model(getValidModelPath(), config);
+  model.initializeBackend(test_backends_dir);
+  model.waitForLoadInitialization();
+
+  ASSERT_TRUE(model.isLoaded());
+  const int runtimeCtx = static_cast<int>(llama_n_ctx(model.getCtx()));
+  const int trainedCtx = llama_model_n_ctx_train(model.getModel());
+  ASSERT_LT(runtimeCtx, trainedCtx);
+
+  std::string longString = "Hello world ";
+  for (int i = 0; i < 200; ++i) {
+    longString += "Hello world ";
+  }
+
+  std::vector<std::string> sequences = {"Normal sequence", longString};
+
   EXPECT_THROW(
       { model.encodeHostF32Sequences(sequences); }, qvac_errors::StatusError);
 }

--- a/packages/embed-llamacpp/test/unit/test_logging.cpp
+++ b/packages/embed-llamacpp/test/unit/test_logging.cpp
@@ -133,6 +133,38 @@ TEST_F(LoggingTest, DefaultVerbosityLevel) {
   EXPECT_EQ(g_verbosityLevel, Priority::ERROR);
 }
 
+#ifndef JS_LOGGER
+TEST_F(LoggingTest, LlamaLogCallbackEmitsErrorsAtDefaultVerbosity) {
+  testing::internal::CaptureStdout();
+
+  llamaLogCallback(GGML_LOG_LEVEL_ERROR, "Test error message", nullptr);
+
+  std::string output = testing::internal::GetCapturedStdout();
+  EXPECT_NE(output.find("ERROR"), std::string::npos);
+  EXPECT_NE(output.find("Test error message"), std::string::npos);
+}
+
+TEST_F(LoggingTest, LlamaLogCallbackSuppressesInfoAtDefaultVerbosity) {
+  testing::internal::CaptureStdout();
+
+  llamaLogCallback(GGML_LOG_LEVEL_INFO, "Test info message", nullptr);
+
+  std::string output = testing::internal::GetCapturedStdout();
+  EXPECT_EQ(output, "");
+}
+
+TEST_F(LoggingTest, LlamaLogCallbackEmitsInfoWhenVerbosityAllowsInfo) {
+  g_verbosityLevel = Priority::INFO;
+  testing::internal::CaptureStdout();
+
+  llamaLogCallback(GGML_LOG_LEVEL_INFO, "Test info message", nullptr);
+
+  std::string output = testing::internal::GetCapturedStdout();
+  EXPECT_NE(output.find("INFO"), std::string::npos);
+  EXPECT_NE(output.find("Test info message"), std::string::npos);
+}
+#endif
+
 TEST_F(LoggingTest, LlamaLogCallbackError) {
   EXPECT_NO_THROW({
     llamaLogCallback(GGML_LOG_LEVEL_ERROR, "Test error message", nullptr);

--- a/packages/embed-llamacpp/test/unit/test_model_metadata.cpp
+++ b/packages/embed-llamacpp/test/unit/test_model_metadata.cpp
@@ -60,8 +60,7 @@ TEST_F(ModelMetadataTest, DiskSingleFileParsesArchitectureAndContextLength) {
 
   ModelMetaData meta;
   GGUFShards emptyShards;
-  meta.parse(
-      test_model_path_, emptyShards, false /* isStreaming */, "Test");
+  meta.parse(test_model_path_, emptyShards, false /* isStreaming */, "Test");
 
   std::optional<std::string> architecture =
       meta.tryGetString("general.architecture");
@@ -82,8 +81,7 @@ TEST_F(ModelMetadataTest, TryGetU32ReturnsNulloptForUnknownKey) {
 
   ModelMetaData meta;
   GGUFShards emptyShards;
-  meta.parse(
-      test_model_path_, emptyShards, false /* isStreaming */, "Test");
+  meta.parse(test_model_path_, emptyShards, false /* isStreaming */, "Test");
 
   EXPECT_FALSE(meta.tryGetU32("definitely.not.a.real.key").has_value());
 }

--- a/packages/embed-llamacpp/test/unit/test_model_metadata.cpp
+++ b/packages/embed-llamacpp/test/unit/test_model_metadata.cpp
@@ -1,0 +1,132 @@
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "inference-addon-cpp/GGUFShards.hpp"
+#include "model-interface/ModelMetadata.hpp"
+#include "utils/BorrowablePtr.hpp"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+std::string findTestModelPath() {
+  fs::path backendDir;
+#ifdef TEST_BINARY_DIR
+  backendDir = fs::path(TEST_BINARY_DIR);
+#endif
+
+  std::vector<fs::path> candidates = {
+      fs::path{"models/unit-test/test-model.gguf"},
+      fs::path{"../../../models/unit-test/test-model.gguf"},
+      backendDir.parent_path().parent_path().parent_path() / "models" /
+          "unit-test" / "test-model.gguf",
+      fs::current_path() / "models" / "unit-test" / "test-model.gguf",
+  };
+  for (const auto& candidate : candidates) {
+    if (fs::exists(candidate)) {
+      return fs::absolute(candidate).string();
+    }
+  }
+  return "";
+}
+
+std::unique_ptr<std::basic_streambuf<char>>
+readFileToStreambufBinary(const std::string& path) {
+  auto filebuf = std::make_unique<std::filebuf>();
+  if (filebuf->open(path, std::ios::in | std::ios::binary) == nullptr) {
+    return nullptr;
+  }
+  filebuf->pubseekpos(0, std::ios::in);
+  return filebuf;
+}
+
+} // namespace
+
+class ModelMetadataTest : public ::testing::Test {
+protected:
+  void SetUp() override { test_model_path_ = findTestModelPath(); }
+
+  std::string test_model_path_;
+};
+
+TEST_F(ModelMetadataTest, DiskSingleFileParsesArchitectureAndContextLength) {
+  if (!fs::exists(test_model_path_)) {
+    GTEST_SKIP() << "Test model not found at: " << test_model_path_;
+  }
+
+  ModelMetaData meta;
+  GGUFShards emptyShards;
+  meta.parse(
+      test_model_path_, emptyShards, false /* isStreaming */, "Test");
+
+  std::optional<std::string> architecture =
+      meta.tryGetString("general.architecture");
+  ASSERT_TRUE(architecture.has_value());
+  EXPECT_FALSE(architecture->empty());
+
+  const std::string contextLengthKey = *architecture + ".context_length";
+  std::optional<uint32_t> contextLength =
+      meta.tryGetU32(contextLengthKey.c_str());
+  ASSERT_TRUE(contextLength.has_value());
+  EXPECT_GT(*contextLength, 0U);
+}
+
+TEST_F(ModelMetadataTest, TryGetU32ReturnsNulloptForUnknownKey) {
+  if (!fs::exists(test_model_path_)) {
+    GTEST_SKIP() << "Test model not found at: " << test_model_path_;
+  }
+
+  ModelMetaData meta;
+  GGUFShards emptyShards;
+  meta.parse(
+      test_model_path_, emptyShards, false /* isStreaming */, "Test");
+
+  EXPECT_FALSE(meta.tryGetU32("definitely.not.a.real.key").has_value());
+}
+
+TEST_F(ModelMetadataTest, StreamingSingleFileMatchesDiskParse) {
+  if (!fs::exists(test_model_path_)) {
+    GTEST_SKIP() << "Test model not found at: " << test_model_path_;
+  }
+
+  ModelMetaData diskMeta;
+  GGUFShards emptyShards;
+  diskMeta.parse(
+      test_model_path_, emptyShards, false /* isStreaming */, "Test");
+  std::optional<std::string> diskArch =
+      diskMeta.tryGetString("general.architecture");
+  ASSERT_TRUE(diskArch.has_value());
+  const std::string contextLengthKey = *diskArch + ".context_length";
+  std::optional<uint32_t> diskCtx =
+      diskMeta.tryGetU32(contextLengthKey.c_str());
+  ASSERT_TRUE(diskCtx.has_value());
+
+  std::unique_ptr<std::basic_streambuf<char>> streambuf =
+      readFileToStreambufBinary(test_model_path_);
+  ASSERT_NE(streambuf, nullptr);
+  BorrowablePtr<std::basic_streambuf<char>> firstFileFromGgufStream(
+      std::move(streambuf));
+
+  ModelMetaData streamMeta;
+  std::thread lender([&]() {
+    streamMeta.firstFileFromGgufStreamState.provide(firstFileFromGgufStream);
+  });
+  streamMeta.parse(
+      test_model_path_, emptyShards, true /* isStreaming */, "Test");
+  lender.join();
+
+  std::optional<std::string> streamArch =
+      streamMeta.tryGetString("general.architecture");
+  ASSERT_TRUE(streamArch.has_value());
+  EXPECT_EQ(*streamArch, *diskArch);
+  std::optional<uint32_t> streamCtx =
+      streamMeta.tryGetU32(contextLengthKey.c_str());
+  ASSERT_TRUE(streamCtx.has_value());
+  EXPECT_EQ(*streamCtx, *diskCtx);
+
+  EXPECT_NO_THROW(firstFileFromGgufStream.reclaimUnique());
+}


### PR DESCRIPTION
> Recreated from #2370, which was opened from a fork that no longer has push access for the rebased branch. #2370 itself was recreated from #2069 (opened before the `main` history rewrite). This branch is rebased cleanly onto current `main` and additionally addresses the review comment on #2370 about applying the `ctx_size` cap on the streaming load path and resolving sharded basenames to absolute paths. The net change versus #2370 is the streaming-cap + `resolveShardPaths` work; the original six tech-debt items are unchanged in scope.

## 🎯 What problem does this PR solve?

Cleans up six embed-llamacpp tech-debt items, plus addresses one follow-up review comment from #2370. All are addon-internal correctness / observability fixes around `ctx_size`, runtime stats, validation, and the native logger bridge.

Issues fixed:

* **Issue 1 — `ctx_size` default was `4096`, not "model default"**
  When `ctx_size` was omitted, the addon kept llama.cpp's hard-coded `common_params{}` default of `4096`, silently exceeding the trained context on models like `gte-large` (512) or `embeddinggemma-300M` (2048). The runtime now defaults `ctx_size` to the model's `n_ctx_train`.
* **Issue 2 — "capped by trained context" claim was false**
  Oversized `ctx_size` only produced a `WARN` log (suppressed at the default verbosity of `0`). It is now actually capped to `n_ctx_train` before the llama context is created, with an `ERROR`-level message so users see it without bumping verbosity.
* **Issue 3 — `ctx_size` missing from `GGMLConfig` TypeScript surface**
  Was only type-checked via the open index signature. Added `ctx_size?: NumericLike` to `GGMLConfig` in `index.d.ts`.
* **Issue 4 — `RuntimeStats.context_size` reported the trained context, not the runtime context**
  `context_size` now reports the active runtime context (`llama_n_ctx`). A new `trained_context_size` field exposes `llama_model_n_ctx_train`. This is a behavior change for existing consumers of `context_size`.
* **Issue 5 — Tokenization validation compared against trained ctx, not runtime ctx**
  Both prompt and sequence validators now compare against the effective runtime context (`min(n_ctx_train, llama_n_ctx)`), so a smaller configured `ctx_size` correctly triggers the friendly `ContextOverflow` error instead of falling through to llama.cpp.
* **Issue 6 — `addonLogging.setLogger` callback documentation**
  The bridge is wired before model load, but messages are still gated by `config.verbosity` (default `0` = `ERROR` only). Documented this explicitly in `README.md` and on `setLogger` in `addonLogging.d.ts` / `index.d.ts` so users know to set `verbosity: "2"`/`"3"` to receive `INFO`/`DEBUG`.
* **Issue 7 (new in this PR) — `ctx_size` cap was skipped on streaming loads, and sharded basenames were not resolved**
  The previous PR's `readTrainedContextSize` returned `nullopt` for streaming loads (single-GGUF and sharded), so the cap silently no-op'd on the path that actually needs it most. Sharded loads also passed bare basenames into disk-based metadata inspection and `llama_model_load_from_splits`, which fails when CWD differs from the model directory. Both are now fixed by parsing GGUF metadata from the first streamed chunk (mirroring the `firstFileFromGgufStreamState` pattern in `llm-llamacpp/ModelMetadata.cpp`) and resolving shard basenames to absolute paths via a new `resolveShardPaths` helper.

## 📝 How does it solve it?

* `BertModel::setupParams` records whether the caller configured `ctx_size`. After the model is loaded, the cap path either sets `params.n_ctx = n_ctx_train` (unconfigured case) or caps an oversized request to `n_ctx_train` (configured case) and emits an `ERROR`-level log line.
* **Streaming-cap (new):** `BorrowablePtr` and a trimmed `ModelMetaData` class are ported from `llm-llamacpp` into `embed-llamacpp`. `BertModel::setWeightsForFile` lends the first streamed shard (single-GGUF or shard `00001-of-NNNNN`) into `metadata_.parse(streambuf, …)` before the weights engine consumes it, then reclaims the buffer. `BertModel::init` then runs the same cap logic uniformly across all four cases: single-disk, single-stream, sharded-disk, sharded-stream.
* **`resolveShardPaths` (new):** Constructors call `resolveShardPaths(modelDir, shards_)` right after `expandGGUFIntoShards`, so `shards_.shardFiles` always holds absolute paths. Fixes both disk-shards metadata inspection and `llama_model_load_from_splits` when CWD differs from the model directory.
* `RuntimeStats` now emits `context_size = llama_n_ctx(ctx_)` and the new `trained_context_size = llama_model_n_ctx_train(model_)`. `mapAddonEvent` forwards `trained_context_size` through to `JobEnded`.
* Context-overflow validation in both `encodeHostF32` (prompts) and `encodeHostF32Sequences` (sequences) was switched to use the effective runtime context size. Error message updated from "model training context size" to "effective context size".
* `fulfilledFiles_` moved from a function-local `static int` to a per-instance `std::atomic<int>` so concurrent `BertInterface` instances no longer share shard-fulfillment counters.
* `readTrainedContextSize` now logs an `ERROR`-level diagnostic when GGUF metadata cannot be read on either path (previously failed silently and reverted to llama.cpp's default `ctx_size`).
* `GGMLConfig.ctx_size` and `RuntimeStats.trained_context_size` added to `index.d.ts`; `setLogger` doc-comment added in both `index.d.ts` and `addonLogging.d.ts`; `README.md` updated for the new defaults, the new stat field, and a native-addon logging subsection.

## 🧪 How was it tested?

* New C++ unit tests in `test_bert_model.cpp`:
  * `DefaultContextSizeMatchesTrainedContext`
  * `ContextSizeAboveTrainingContextIsCapped`
  * `DefaultContextSizeDoesNotWarnWhenUnconfigured`
  * `ContextOverflowUsesRuntimeContextSizeForPrompts`
  * `ContextOverflowUsesRuntimeContextSizeForSequences`
  * `StreamingSingleGgufAppliesContextCap` (new) — pumps the gte-large fixture through an in-memory streambuf and asserts the cap is applied on the streaming path.
  * Extended `RuntimeStatsBeforeProcessing` to assert both `context_size` and `trained_context_size`.
* New C++ unit tests in `test_model_metadata.cpp` (new file):
  * Disk-based GGUF parse (`general.architecture`, `<arch>.context_length`).
  * Streamed GGUF parse via `BorrowablePtr` lend, including reclaim semantics.
  * Error paths: missing file, malformed buffer, missing keys.
* Existing logging unit tests in `test_logging.cpp` covering `llamaLogCallback` at default and elevated verbosity.
* JS unit test in `map-addon-event.test.js` asserting `trained_context_size` is forwarded through `JobEnded`.
* Updated integration test in `addon.test.js` to expect the new "effective context size" error message.
* Full C++ unit suite locally: 154 passed, 3 skipped (env-gated `AddonCpp` cases unrelated to this PR).

## 💥 Breaking Changes

`RuntimeStats.context_size` semantics changed: it now reports the active runtime context (`llama_n_ctx`) instead of the model's trained context. Consumers that relied on the previous meaning should switch to the new `trained_context_size` field.

**BEFORE:**

```js
// context_size = model's trained context (llama_model_n_ctx_train)
const trained = response.stats.context_size
```
**AFTER:**
```js
// context_size         = runtime llama context (llama_n_ctx), capped to trained
// trained_context_size = model's trained context (llama_model_n_ctx_train)
const runtime = response.stats.context_size
const trained = response.stats.trained_context_size
```
## 🔌 API Changes
```
interface GGMLConfig {
  // ...
  ctx_size?: NumericLike // newly declared (was only accessible via index signature)
}
interface RuntimeStats {
  // ...
  context_size: number          // now: runtime llama context
  trained_context_size: number  // new: model's trained context
}
```

## Closes
Supersedes [#2370](https://github.com/tetherto/qvac/pull/2370) (and #2069). Please close #2370 in favour of this PR.
