### PR TITLE
transcription-whispercpp: consume ggml-speech 2026-06-02 (Adreno OpenCL selection, QVAC-18993)

### DIFF
--- a/packages/transcription-whispercpp/vcpkg-configuration.json
+++ b/packages/transcription-whispercpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "a9d7e924de8cb7133c54c5b1d446e4d9c0508ec8",
+    "baseline": "bd344b13a30d2fc5133c4710964a2d3d53691d1c",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg"
   },
   "registries": [


### PR DESCRIPTION
## Summary

Phase 2 of QVAC-18993 — point the addon at the registry baseline that publishes **`ggml-speech 2026-06-02`** ([qvac-registry-vcpkg#178](https://github.com/tetherto/qvac-registry-vcpkg/pull/178), merged; REF `tetherto/qvac-ext-ggml@9bca9b3d` = [qvac-ext-ggml#18](https://github.com/tetherto/qvac-ext-ggml/pull/18)'s Adreno-aware Android OpenCL/Vulkan backend selection).

**One-line change**: `default-registry.baseline` `a9d7e924` → `bd344b13a30d2fc5133c4710964a2d3d53691d1c` (registry `main` after #178).

- That baseline already carries `whisper-cpp 1.8.5`, so the existing `whisper-cpp 1.8.5#0` **override is kept as-is**; whisper-cpp's `version>=ggml-speech 2026-05-27` now resolves to `2026-06-02`.
- **No overlay-ports, no override hacks** — the permanent, legitimate change.

## Local validation (x64-linux, no overlay, against the real merged registry)
vcpkg resolves `ggml-speech[core,vulkan]@2026-06-02` (`tetherto@9bca9b3d`) ← `whisper-cpp@1.8.5` ← `spirv-headers@1.4.341.0`; build clean; **test:cpp 111/111, test:unit 30/30, test:dts clean, test:integration 10/10, accuracy 8/8, chunking 1/1**.

The registry port itself was separately `vcpkg install`-verified (fetch + SHA512 + spirv-headers + patch + build) before #178 merged.

## Note
The baseline advance also moves `qvac-lint-cpp 1.4.4#3 → 1.4.5` (the only other non-pinned registry dep that moved); harmless (lint config; no C++ change in this PR). `qvac-lib-inference-addon-cpp` stays `1.2.1`.

## Relationship to the rest of QVAC-18993
- This propagates the **engine-level** Adreno policy (#18) to the addon.
- The **addon-level** changes (IGPU `backendId` reporting fix, Adreno `gpu_device` guard for the 700+ OpenCL pick, un-quarantined Android GPU test, ggml log forwarding) are in #2343 — complementary, both needed for the full Adreno 700+ behavior.

## Test plan
- [ ] on-pr `transcription-whispercpp` CI green (prebuild matrix + cpp/unit/dts + integration)
- [ ] device farm: Samsung S25 (Adreno) → OpenCL (no `vkCmdBindPipeline` crash), Pixel 9 (Mali) → Vulkan

Made with [Cursor](https://cursor.com)