### PR TITLE
QVAC-19777 chore[skiplog]: release sdk 0.12.1

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.12.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.12.1
+
+This is a patch release on top of v0.12.0. It surfaces two new error classes so callers can distinguish a crashed bare worker from an in-flight call cancelled by SDK shutdown, and it fixes a Qwen 3.5/3.6 tool-call regression where capitalised booleans were silently dropping the entire tool call.
+
+## New APIs
+
+### Distinguish bare worker crashes from shutdown cancellations
+
+Calls made through a bare worker (e.g. `sdk.embed`, `sdk.complete`) previously rejected with a generic RPC error if the worker process died mid-request or if `sdk.close()` was called while the request was in flight. Both cases looked identical to callers, so retry/UX logic had to guess.
+
+v0.12.1 introduces two structured RPC errors that propagate from the worker bridge:
+
+- `WorkerCrashedError` — the bare worker died unexpectedly. Exposes `exitCode` and `exitSignal` so you can tell a SIGKILL from a clean non-zero exit and decide whether to respawn.
+- `WorkerShutdownError` — the SDK is shutting down (`sdk.close()` was called) while this request was still in flight. Safe to swallow on intentional teardown; surfaces an actionable label for callers who want to log it.
+
+```typescript
+import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
+
+try {
+  await sdk.embed({ modelId, text: "hi" });
+} catch (err) {
+  if (err instanceof WorkerCrashedError) {
+    // err.exitCode, err.exitSignal — worker died, decide whether to respawn.
+  } else if (err instanceof WorkerShutdownError) {
+    // SDK is shutting down; this call was cancelled by close().
+  }
+}
+```
+
+Existing `catch (err)` blocks that don't narrow by class continue to work unchanged — the new classes both extend the same RPC error base.
+
+## Bug Fixes
+
+### Qwen 3.5/3.6 tool calls with capitalised booleans no longer drop silently
+
+Qwen 3.5/3.6 (the default tool-calling family) intermittently emits Python-style `True` / `False` for `boolean` parameters instead of the JSON-strict `true` / `false`. The qwen35 parser only accepted the exact lowercase literals, so coercion threw, the parser returned an empty `toolCalls` array, and the raw `<tool_call>…</tool_call>` markup leaked into the assistant's final text answer — there was no `PARSE_ERROR`, the tool call just vanished.
+
+v0.12.1 lowercases the value before comparing in the boolean coercion path, so `True`, `False`, `TRUE`, and `FALSE` all coerce correctly. Genuinely invalid values (`maybe`, `0`, `null`) still throw `PARSE_ERROR` — the relaxation is intentionally scoped to casing. Other tool-call dialects are unaffected.
+
 ## [0.12.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.12.0
@@ -1518,7 +1559,7 @@ Hotfix patch release. Single-fix patch — no API, behavioral, or model changes.
 
 ---
 
-## 🐞 Fixes
+## Fixes
 
 ### Fix `TypeError: z.xor is not a function` for consumers on zod < 4.3
 
@@ -1541,7 +1582,7 @@ Patch release with a minor documentation fix to the SDK README quickstart exampl
 
 ---
 
-## 📘 Docs
+## Docs
 
 - Remove trailing comma in quickstart import example.
 
@@ -1553,7 +1594,7 @@ This release significantly expands the SDK's capabilities with finetuning suppor
 
 ---
 
-## 💥 Breaking Changes
+## Breaking Changes
 
 ### `ping()` Replaced by `heartbeat()`
 
@@ -1582,7 +1623,7 @@ await heartbeat({
 
 ---
 
-## 🔌 New APIs
+## New APIs
 
 ### Finetuning
 
@@ -1710,7 +1751,7 @@ console.log(stats?.backendDevice); // "cpu" | "gpu"
 
 ---
 
-## ✨ Features
+## Features
 
 - **CLD2 language detection** is now integrated into the SDK for automatic language identification.
 - **OCR plugin updated** to work with `@qvac/ocr-onnx@0.4.0`.
@@ -1718,7 +1759,7 @@ console.log(stats?.backendDevice); // "cpu" | "gpu"
 
 ---
 
-## 🐞 Bug Fixes
+## Bug Fixes
 
 - **KV cache preserved across tool-call round-trips** — multi-turn tool-calling completions no longer lose context between rounds.
 - **KV cache save race condition** fixed in tool-calling completions — concurrent saves no longer corrupt the cache.
@@ -1735,7 +1776,7 @@ console.log(stats?.backendDevice); // "cpu" | "gpu"
 
 ---
 
-## 📦 Model Changes
+## Model Changes
 
 Model registry updated: 312 → 653 (+341). See [model changes](./changelog/0.9.0/models.md) for the full list.
 
@@ -1747,7 +1788,7 @@ Model registry updated: 312 → 653 (+341). See [model changes](./changelog/0.9.
 
 ---
 
-## 🧹 Other Changes
+## Other Changes
 
 - Updated addon dependencies: `@qvac/tts-onnx` to v0.6.7, `@qvac/transcription-whispercpp` to latest, Parakeet to v0.2.7, `@qvac/diffusion-cpp` to ^0.1.3.
 - Replaced FeatureBase support links with Discord channel.
@@ -1763,7 +1804,7 @@ This is a patch release that fixes a race condition in the KV cache save path du
 
 ---
 
-## 🐞 Bug Fixes
+## Bug Fixes
 
 ### KV Cache Save Race Condition in Tool-Calling Completions
 
@@ -1779,7 +1820,7 @@ The fix ensures the save command receives the correct session path and the SDK a
 
 ---
 
-## 📘 Documentation
+## Documentation
 
 - Added npm keywords to `package.json` for better discoverability on the npm registry, covering AI/ML, inference engines, supported platforms, and P2P capabilities.
 - Added a link to the consolidated plaintext documentation export (`llms-full.txt`) in the SDK README for AI/LLM tool consumption.
@@ -1792,7 +1833,7 @@ This is a maintenance release that refreshes the SDK README with a streamlined q
 
 ---
 
-## 📘 Documentation
+## Documentation
 
 ### README Rewrite
 
@@ -1807,7 +1848,7 @@ Key changes:
 
 ---
 
-## ⚙️ Infrastructure
+## Infrastructure
 
 - SDK dependency installs in CI publish and pod check workflows are now frozen to prevent unexpected version drift during builds.
 
@@ -1819,7 +1860,7 @@ This release introduces a heartbeat mechanism for proactive provider health moni
 
 ---
 
-## 💥 Breaking Changes
+## Breaking Changes
 
 ### Heartbeat Replaces Ping
 
@@ -1848,7 +1889,7 @@ await heartbeat({
 
 ---
 
-## 🔌 New APIs
+## New APIs
 
 ### RPC Health Probe for Delegation
 
@@ -1885,7 +1926,7 @@ await cancel({
 
 ---
 
-## 🐞 Bug Fixes
+## Bug Fixes
 
 - **IndicTrans model type unblocked** — The NMT translation plugin no longer incorrectly blocks IndicTrans models from loading, restoring multi-engine translation support.
 - **Accurate download progress** — Registry downloads now report progress from the network layer instead of disk I/O polling, giving real-time progress that reflects actual bytes received.
@@ -1895,13 +1936,13 @@ await cancel({
 
 ---
 
-## 📘 Documentation
+## Documentation
 
 - All SDK READMEs now reference the `@qvac` npm namespace instead of the legacy `@tetherto` scope.
 
 ---
 
-## 🧪 Testing
+## Testing
 
 - New E2E tests cover parallel download scenarios and cancel isolation to prevent race conditions between concurrent operations.
 - The mobile E2E test executor has been refactored to an asset-based architecture for more reliable cross-platform testing.
@@ -1914,7 +1955,7 @@ This release adds Parakeet as a new transcription engine alongside Whisper, deco
 
 ---
 
-## 💥 Breaking Changes
+## Breaking Changes
 
 ### Embedding Model Config Uses Structured Fields
 
@@ -2028,7 +2069,7 @@ All existing Parakeet model constants now include a variant prefix (`TDT_`) to d
 
 ---
 
-## 🔌 New APIs
+## New APIs
 
 ### Parakeet Transcription Plugin
 
@@ -2118,7 +2159,7 @@ await embed(
 
 ---
 
-## ✨ Features
+## Features
 
 ### CTC and Sortformer Transcription Models
 
@@ -2165,7 +2206,7 @@ The profiler now captures detailed load/download metrics and stream profiling da
 
 ---
 
-## 🐞 Bug Fixes
+## Bug Fixes
 
 - **Addon logging fixed across all plugins** — Logging callbacks were not being properly attached to some addon plugins, resulting in missing addon-level logs. All plugins now correctly route native addon logs through the SDK logging system.
 - **Parakeet addon logger** now uses the correct `params.modelId` for log routing.
@@ -2175,7 +2216,7 @@ The profiler now captures detailed load/download metrics and stream profiling da
 
 ---
 
-## 📦 Model Changes
+## Model Changes
 
 ### Added Models
 
@@ -2206,7 +2247,7 @@ The following unprefixed Parakeet constants were replaced by their `TDT_` equiva
 
 ---
 
-## 🧹 Other Changes
+## Other Changes
 
 - Consolidated transcription schemas and shared ops into a unified structure.
 - Updated `@qvac/tts-onnx` to v0.6.1 and `@qvac/transcription-whispercpp` addon.

--- a/packages/sdk/NOTICE
+++ b/packages/sdk/NOTICE
@@ -266,21 +266,13 @@ Third-Party Model Licenses
   chatterbox-multilingual-ONNX
     https://huggingface.co/onnx-community/chatterbox-multilingual-ONNX
   chatterbox-s3gen
-    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-s3gen.gguf
+    https://huggingface.co/ResembleAI/chatterbox-turbo
   chatterbox-s3gen-mtl
-    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-s3gen-mtl.gguf
+    https://huggingface.co/ResembleAI/chatterbox
   chatterbox-t3-mtl
-    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-t3-mtl.gguf
-  chatterbox-t3-mtl-q4_0
-    s3:///qvac_models_compiled/ggml/chatterbox/2026-05-18/chatterbox-t3-mtl-q4_0.gguf
-  chatterbox-t3-mtl-q8_0
-    s3:///qvac_models_compiled/ggml/chatterbox/2026-05-18/chatterbox-t3-mtl-q8_0.gguf
+    https://huggingface.co/ResembleAI/chatterbox
   chatterbox-t3-turbo
-    s3:///qvac_models_compiled/chatterbox/2026-05-08/chatterbox-t3-turbo.gguf
-  chatterbox-t3-turbo-q4_0
-    s3:///qvac_models_compiled/ggml/chatterbox/2026-05-18/chatterbox-t3-turbo-q4_0.gguf
-  chatterbox-t3-turbo-q8_0
-    s3:///qvac_models_compiled/ggml/chatterbox/2026-05-18/chatterbox-t3-turbo-q8_0.gguf
+    https://huggingface.co/ResembleAI/chatterbox-turbo
   chatterbox-turbo-ONNX
     https://huggingface.co/ResembleAI/chatterbox-turbo-ONNX
   de-base-ggml-model-f16

--- a/packages/sdk/changelog/0.12.1/CHANGELOG.md
+++ b/packages/sdk/changelog/0.12.1/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.12.1
+
+Release Date: 2026-06-02
+
+## 🔌 API
+
+- Surface bare worker crash and shutdown as RPC errors. (see PR [#2350](https://github.com/tetherto/qvac/pull/2350)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Accept non-lowercase booleans in qwen35 tool-call parser. (see PR [#2372](https://github.com/tetherto/qvac/pull/2372))
+

--- a/packages/sdk/changelog/0.12.1/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.12.1/CHANGELOG_LLM.md
@@ -1,0 +1,40 @@
+# QVAC SDK v0.12.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.12.1
+
+This is a patch release on top of v0.12.0. It surfaces two new error classes so callers can distinguish a crashed bare worker from an in-flight call cancelled by SDK shutdown, and it fixes a Qwen 3.5/3.6 tool-call regression where capitalised booleans were silently dropping the entire tool call.
+
+## New APIs
+
+### Distinguish bare worker crashes from shutdown cancellations
+
+Calls made through a bare worker (e.g. `sdk.embed`, `sdk.complete`) previously rejected with a generic RPC error if the worker process died mid-request or if `sdk.close()` was called while the request was in flight. Both cases looked identical to callers, so retry/UX logic had to guess.
+
+v0.12.1 introduces two structured RPC errors that propagate from the worker bridge:
+
+- `WorkerCrashedError` — the bare worker died unexpectedly. Exposes `exitCode` and `exitSignal` so you can tell a SIGKILL from a clean non-zero exit and decide whether to respawn.
+- `WorkerShutdownError` — the SDK is shutting down (`sdk.close()` was called) while this request was still in flight. Safe to swallow on intentional teardown; surfaces an actionable label for callers who want to log it.
+
+```typescript
+import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
+
+try {
+  await sdk.embed({ modelId, text: "hi" });
+} catch (err) {
+  if (err instanceof WorkerCrashedError) {
+    // err.exitCode, err.exitSignal — worker died, decide whether to respawn.
+  } else if (err instanceof WorkerShutdownError) {
+    // SDK is shutting down; this call was cancelled by close().
+  }
+}
+```
+
+Existing `catch (err)` blocks that don't narrow by class continue to work unchanged — the new classes both extend the same RPC error base.
+
+## Bug Fixes
+
+### Qwen 3.5/3.6 tool calls with capitalised booleans no longer drop silently
+
+Qwen 3.5/3.6 (the default tool-calling family) intermittently emits Python-style `True` / `False` for `boolean` parameters instead of the JSON-strict `true` / `false`. The qwen35 parser only accepted the exact lowercase literals, so coercion threw, the parser returned an empty `toolCalls` array, and the raw `<tool_call>…</tool_call>` markup leaked into the assistant's final text answer — there was no `PARSE_ERROR`, the tool call just vanished.
+
+v0.12.1 lowercases the value before comparing in the boolean coercion path, so `True`, `False`, `TRUE`, and `FALSE` all coerce correctly. Genuinely invalid values (`maybe`, `0`, `null`) still throw `PARSE_ERROR` — the relaxation is intentionally scoped to casing. Other tool-call dialects are unaffected.

--- a/packages/sdk/changelog/0.12.1/api.md
+++ b/packages/sdk/changelog/0.12.1/api.md
@@ -1,0 +1,22 @@
+# 🔌 API Changes v0.12.1
+
+## Surface bare worker crash and shutdown as RPC errors
+
+PR: [#2350](https://github.com/tetherto/qvac/pull/2350)
+
+```typescript
+import { WorkerCrashedError, WorkerShutdownError } from "@qvac/sdk";
+
+try {
+  await sdk.embed({ modelId, text: "hi" });
+} catch (err) {
+  if (err instanceof WorkerCrashedError) {
+    // err.exitCode, err.exitSignal — bare worker died unexpectedly.
+  } else if (err instanceof WorkerShutdownError) {
+    // SDK is shutting down; this call was in-flight when close() ran.
+  }
+}
+```
+
+---
+

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Note**: be concise and prefer bullet points.

## 🎯 What problem does this PR solve?

Ship `@qvac/sdk@0.12.1` (and `@qvac/bare-sdk@0.12.1` in lockstep) from the release branch (fresh cut from upstream `release-sdk-0.12.1`).

## 🔧 How does it solve it?

- Bump `packages/sdk` to `0.12.1`
- Bump `packages/bare-sdk` to `0.12.1` (lockstep, via `qv-sdk-bare-sdk-sync`; `check:deps-vs-sdk` passing)
- Generate changelog for 2 PRs since `sdk-v0.12.0` (3 PRs tagged `[skiplog]` excluded automatically)
- Add human-readable release notes in `CHANGELOG_LLM.md`
- Regenerate root `CHANGELOG.md` and `NOTICE`

## Highlights since 0.12.0

- **New APIs** — `WorkerCrashedError` / `WorkerShutdownError` propagate from the bare worker bridge so callers can distinguish a crashed worker (with `exitCode` / `exitSignal`) from an in-flight call cancelled by `sdk.close()` (see PR [#2350](https://github.com/tetherto/qvac/pull/2350))
- **Fix** — qwen35 tool-call parser accepts capitalised booleans (`True` / `False` / `TRUE` / `FALSE`); previously these silently dropped the entire tool call and leaked raw `<tool_call>…</tool_call>` markup into the assistant's final text answer (see PR [#2372](https://github.com/tetherto/qvac/pull/2372))

## 🧪 How was this tested?

- Changelog generated via `generate-changelog-sdk-pod.cjs --package=sdk` (2 valid PRs)
- bare-sdk sync verified via `bun run check:deps-vs-sdk`
- NOTICE regenerated via `generate-notice.js sdk` and `generate-notice.js bare-sdk`

## 📋 Checklist

- [x] Version bump in `packages/sdk/package.json`
- [x] Version bump in `packages/bare-sdk/package.json` (lockstep)
- [x] Changelog files in `changelog/0.12.1/`
- [x] Root `CHANGELOG.md` rebuilt
- [x] `NOTICE` updated (sdk + bare-sdk)
