### PR TITLE
test[notask|skiplog]: e2e guard for dynamic-tools kvCache reuse across model reload

### DIFF
--- a/packages/sdk/e2e/tests/desktop/consumer.ts
+++ b/packages/sdk/e2e/tests/desktop/consumer.ts
@@ -140,6 +140,12 @@ resources.define("tools-qwen35", {
   config: { ctx_size: 4096, tools: true },
 });
 
+resources.define("tools-qwen35-dynamic", {
+  constant: QWEN3_5_0_8B_MULTIMODAL_Q4_K_M,
+  type: "llm",
+  config: { ctx_size: 4096, tools: true, toolsMode: "dynamic" },
+});
+
 resources.define("tools-gemma4", {
   constant: GEMMA4_2B_MULTIMODAL_Q4_K_M,
   type: "llm",

--- a/packages/sdk/e2e/tests/desktop/consumer.ts
+++ b/packages/sdk/e2e/tests/desktop/consumer.ts
@@ -140,12 +140,6 @@ resources.define("tools-qwen35", {
   config: { ctx_size: 4096, tools: true },
 });
 
-resources.define("tools-qwen35-dynamic", {
-  constant: QWEN3_5_0_8B_MULTIMODAL_Q4_K_M,
-  type: "llm",
-  config: { ctx_size: 4096, tools: true, toolsMode: "dynamic" },
-});
-
 resources.define("tools-gemma4", {
   constant: GEMMA4_2B_MULTIMODAL_Q4_K_M,
   type: "llm",

--- a/packages/sdk/e2e/tests/kv-cache-tests.ts
+++ b/packages/sdk/e2e/tests/kv-cache-tests.ts
@@ -269,40 +269,6 @@ export const kvCacheToolsDynamicReuse: TestDefinition = {
   metadata: { category: "kv-cache", dependency: "tools-dynamic", estimatedDurationMs: 120000 },
 };
 
-// Same scenario as above on a qwen35-dialect model
-// (`QWEN3_5_0_8B_MULTIMODAL_Q4_K_M`). The hermes-dialect variant above proves
-// the cache mechanics; this one proves the `<function=…>` qwen35 tool-call
-// parser keeps firing under dynamic mode + kvCache reuse + reload.
-export const kvCacheToolsDynamicReuseQwen35: TestDefinition = {
-  testId: "kv-cache-tools-dynamic-reuse-qwen35",
-  params: {
-    cacheKey: "tools-dynamic-reuse-qwen35-session",
-    resourceKey: "tools-qwen35-dynamic",
-    toolDialect: "qwen35",
-    firstUserMessage: "What is 10 + 20?",
-    secondUserMessage: "Now what is 5 + 5?",
-    toolResult: "30",
-    tools: [
-      {
-        type: "function",
-        name: "calculator",
-        description: "Performs basic math operations",
-        parameters: {
-          type: "object",
-          properties: {
-            operation: { type: "string", enum: ["add", "subtract", "multiply", "divide"] },
-            a: { type: "number" },
-            b: { type: "number" },
-          },
-          required: ["operation", "a", "b"],
-        },
-      },
-    ],
-  },
-  expectation: { validation: "type", expectedType: "string" },
-  metadata: { category: "kv-cache", dependency: "tools-qwen35-dynamic", estimatedDurationMs: 120000 },
-};
-
 export const kvCacheCancelThenNewPrompt: TestDefinition = {
   testId: "kv-cache-cancel-then-new-prompt",
   params: {
@@ -339,6 +305,5 @@ export const kvCacheTests = [
   kvCacheNoSystemPrompt,
   kvCacheToolsSequentialSave,
   kvCacheToolsDynamicReuse,
-  kvCacheToolsDynamicReuseQwen35,
   kvCacheCancelThenNewPrompt,
 ];

--- a/packages/sdk/e2e/tests/kv-cache-tests.ts
+++ b/packages/sdk/e2e/tests/kv-cache-tests.ts
@@ -233,6 +233,76 @@ export const kvCacheToolsSequentialSave: TestDefinition = {
   metadata: { category: "kv-cache", dependency: "tools", estimatedDurationMs: 90000 },
 };
 
+// Dynamic tools mode + custom kvCache key across a multi-round tool chain,
+// with a model evict/reload in the middle. No other test covers this
+// intersection: `toolsMode: "dynamic"` exercises the per-turn fragment cache
+// path (trailing-tool / [assistant,user] slicing in `completion-stream.ts`),
+// and evict/reload simulates a model reload after priming (in-memory savedCount
+// and addon anchoring cleared, on-disk `.bin` retained). The executor asserts
+// that tool calls still parse on cached/reloaded rounds and that the on-disk
+// cache is reused (`cacheTokens > 0`).
+export const kvCacheToolsDynamicReuse: TestDefinition = {
+  testId: "kv-cache-tools-dynamic-reuse",
+  params: {
+    cacheKey: "tools-dynamic-reuse-session",
+    firstUserMessage: "What is 10 + 20?",
+    secondUserMessage: "Now what is 5 + 5?",
+    toolResult: "30",
+    tools: [
+      {
+        type: "function",
+        name: "calculator",
+        description: "Performs basic math operations",
+        parameters: {
+          type: "object",
+          properties: {
+            operation: { type: "string", enum: ["add", "subtract", "multiply", "divide"] },
+            a: { type: "number" },
+            b: { type: "number" },
+          },
+          required: ["operation", "a", "b"],
+        },
+      },
+    ],
+  },
+  expectation: { validation: "type", expectedType: "string" },
+  metadata: { category: "kv-cache", dependency: "tools-dynamic", estimatedDurationMs: 120000 },
+};
+
+// Same scenario as above on a qwen35-dialect model
+// (`QWEN3_5_0_8B_MULTIMODAL_Q4_K_M`). The hermes-dialect variant above proves
+// the cache mechanics; this one proves the `<function=…>` qwen35 tool-call
+// parser keeps firing under dynamic mode + kvCache reuse + reload.
+export const kvCacheToolsDynamicReuseQwen35: TestDefinition = {
+  testId: "kv-cache-tools-dynamic-reuse-qwen35",
+  params: {
+    cacheKey: "tools-dynamic-reuse-qwen35-session",
+    resourceKey: "tools-qwen35-dynamic",
+    toolDialect: "qwen35",
+    firstUserMessage: "What is 10 + 20?",
+    secondUserMessage: "Now what is 5 + 5?",
+    toolResult: "30",
+    tools: [
+      {
+        type: "function",
+        name: "calculator",
+        description: "Performs basic math operations",
+        parameters: {
+          type: "object",
+          properties: {
+            operation: { type: "string", enum: ["add", "subtract", "multiply", "divide"] },
+            a: { type: "number" },
+            b: { type: "number" },
+          },
+          required: ["operation", "a", "b"],
+        },
+      },
+    ],
+  },
+  expectation: { validation: "type", expectedType: "string" },
+  metadata: { category: "kv-cache", dependency: "tools-qwen35-dynamic", estimatedDurationMs: 120000 },
+};
+
 export const kvCacheCancelThenNewPrompt: TestDefinition = {
   testId: "kv-cache-cancel-then-new-prompt",
   params: {
@@ -268,5 +338,7 @@ export const kvCacheTests = [
   kvCacheStatsVerification,
   kvCacheNoSystemPrompt,
   kvCacheToolsSequentialSave,
+  kvCacheToolsDynamicReuse,
+  kvCacheToolsDynamicReuseQwen35,
   kvCacheCancelThenNewPrompt,
 ];

--- a/packages/sdk/e2e/tests/shared/executors/kv-cache-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/kv-cache-executor.ts
@@ -24,7 +24,6 @@ export class KvCacheExecutor extends AbstractModelExecutor<typeof kvCacheTests> 
       if (test.testId === "kv-cache-stats-verification") return [test.testId, this.statsVerification.bind(this)];
       if (test.testId === "kv-cache-tools-sequential-save") return [test.testId, this.toolsSequentialSave.bind(this)];
       if (test.testId === "kv-cache-tools-dynamic-reuse") return [test.testId, this.toolsDynamicReuse.bind(this)];
-      if (test.testId === "kv-cache-tools-dynamic-reuse-qwen35") return [test.testId, this.toolsDynamicReuse.bind(this)];
       if (test.testId === "kv-cache-cancel-then-new-prompt") return [test.testId, this.cancelThenNewPrompt.bind(this)];
       if (test.testId.startsWith("kv-cache-delete-") || test.testId === "kv-cache-hypercore-deletion") {
         return [test.testId, this.deleteCacheOp.bind(this)];
@@ -455,16 +454,10 @@ export class KvCacheExecutor extends AbstractModelExecutor<typeof kvCacheTests> 
       firstUserMessage: string;
       secondUserMessage: string;
       toolResult: string;
-      // Which dynamic-tools resource to exercise. Defaults to the
-      // hermes-dialect `tools-dynamic` (Qwen3-1.7B); the qwen35 variant
-      // passes `tools-qwen35-dynamic` so the `<function=…>` qwen35 parser
-      // path is covered too.
-      resourceKey?: string;
-      toolDialect?: string;
     },
     expectation: Expectation,
   ): Promise<TestResult> {
-    const resourceKey = params.resourceKey ?? "tools-dynamic";
+    const resourceKey = "tools-dynamic";
     let modelId = await this.resources.ensureLoaded(resourceKey);
 
     const runTurn = (history: ChatMessage[]) =>
@@ -475,7 +468,6 @@ export class KvCacheExecutor extends AbstractModelExecutor<typeof kvCacheTests> 
           stream: false,
           kvCache: params.cacheKey,
           tools: params.tools as never,
-          ...(params.toolDialect ? { toolDialect: params.toolDialect as never } : {}),
         });
         const text = await result.text;
         const toolCalls = result.toolCalls
@@ -557,8 +549,7 @@ export class KvCacheExecutor extends AbstractModelExecutor<typeof kvCacheTests> 
       }
 
       const summary =
-        `Dynamic tools + kvCache reuse OK [${resourceKey}` +
-        `${params.toolDialect ? `/${params.toolDialect}` : ""}]: ` +
+        `Dynamic tools + kvCache reuse OK [${resourceKey}]: ` +
         `r1Calls=${r1.toolCalls.length}, ` +
         `r2CacheTokens=${r2.cacheTokens} (post-reload reuse), ` +
         `r3Calls=${r3.toolCalls.length} (warm), r3CacheTokens=${r3.cacheTokens}`;

--- a/packages/sdk/e2e/tests/shared/executors/kv-cache-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/kv-cache-executor.ts
@@ -23,6 +23,8 @@ export class KvCacheExecutor extends AbstractModelExecutor<typeof kvCacheTests> 
       if (test.testId === "kv-cache-different-system-prompts") return [test.testId, this.differentSystemPrompts.bind(this)];
       if (test.testId === "kv-cache-stats-verification") return [test.testId, this.statsVerification.bind(this)];
       if (test.testId === "kv-cache-tools-sequential-save") return [test.testId, this.toolsSequentialSave.bind(this)];
+      if (test.testId === "kv-cache-tools-dynamic-reuse") return [test.testId, this.toolsDynamicReuse.bind(this)];
+      if (test.testId === "kv-cache-tools-dynamic-reuse-qwen35") return [test.testId, this.toolsDynamicReuse.bind(this)];
       if (test.testId === "kv-cache-cancel-then-new-prompt") return [test.testId, this.cancelThenNewPrompt.bind(this)];
       if (test.testId.startsWith("kv-cache-delete-") || test.testId === "kv-cache-hypercore-deletion") {
         return [test.testId, this.deleteCacheOp.bind(this)];
@@ -425,6 +427,148 @@ export class KvCacheExecutor extends AbstractModelExecutor<typeof kvCacheTests> 
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       return { passed: false, output: `Tools sequential save failed: ${errorMsg}` };
+    }
+  }
+
+  /**
+   * Dynamic tools mode (`toolsMode: "dynamic"`) + a custom kvCache key across a
+   * three-round tool chain, with a model evict/reload after the prime turn.
+   *
+   * Covers a combination no other kv-cache test exercises:
+   *
+   *   - Round 1 (prime): a user prompt must yield a PARSEABLE tool call under
+   *     dynamic mode while the kvCache key is being primed.
+   *   - evict + reload: drops the addon's in-memory KV session and the SDK's
+   *     in-memory `savedCount` / anchoring, leaving only the on-disk `.bin`.
+   *   - Round 2 (continuation, history ends in a `tool` message): exercises the
+   *     dynamic "trailing tool messages" fragment branch. Must REUSE the
+   *     on-disk cache (`cacheTokens > 0`) after the reload, and stay coherent.
+   *   - Round 3 (new prompt, history ends `assistant` then `user`): exercises
+   *     the dynamic "[assistant, user]" fragment branch on a warm cache. Must
+   *     again yield a PARSEABLE tool call — proving cache reuse did not corrupt
+   *     tool parsing.
+   */
+  async toolsDynamicReuse(
+    params: {
+      cacheKey: string;
+      tools: unknown[];
+      firstUserMessage: string;
+      secondUserMessage: string;
+      toolResult: string;
+      // Which dynamic-tools resource to exercise. Defaults to the
+      // hermes-dialect `tools-dynamic` (Qwen3-1.7B); the qwen35 variant
+      // passes `tools-qwen35-dynamic` so the `<function=…>` qwen35 parser
+      // path is covered too.
+      resourceKey?: string;
+      toolDialect?: string;
+    },
+    expectation: Expectation,
+  ): Promise<TestResult> {
+    const resourceKey = params.resourceKey ?? "tools-dynamic";
+    let modelId = await this.resources.ensureLoaded(resourceKey);
+
+    const runTurn = (history: ChatMessage[]) =>
+      callWhenAddonIdle(async () => {
+        const result = completion({
+          modelId,
+          history,
+          stream: false,
+          kvCache: params.cacheKey,
+          tools: params.tools as never,
+          ...(params.toolDialect ? { toolDialect: params.toolDialect as never } : {}),
+        });
+        const text = await result.text;
+        const toolCalls = result.toolCalls
+          ? ((await result.toolCalls) as Array<{ id: string; name: string }>)
+          : [];
+        const stats = (await result.stats) as Record<string, unknown> | undefined;
+        const cacheTokens = (stats?.cacheTokens as number) ?? 0;
+        return { text, toolCalls, cacheTokens };
+      });
+
+    try {
+      try { await deleteCache({ kvCacheKey: params.cacheKey }); } catch { /* ignore ENOENT */ }
+
+      const system: ChatMessage = {
+        role: "system",
+        content: "You are a helpful assistant with access to tools. Be brief.",
+      };
+
+      // ---- Round 1: prime. Expect a parseable tool call under dynamic mode.
+      const r1History: ChatMessage[] = [
+        system,
+        { role: "user", content: params.firstUserMessage },
+      ];
+      const r1 = await runTurn(r1History);
+      if (r1.toolCalls.length === 0) {
+        return {
+          passed: false,
+          output:
+            `Round 1 (prime) under dynamic mode emitted no parseable tool call. ` +
+            `Dynamic tool-call format instruction not surfaced, or kvCache prime corrupted the prompt. ` +
+            `text=${JSON.stringify(r1.text).slice(0, 200)}`,
+        };
+      }
+
+      // Feed back the assistant tool-call turn + a tool result (standard
+      // agentic loop). History now ends in a `tool` message.
+      const r2History: ChatMessage[] = [
+        ...r1History,
+        { role: "assistant", content: r1.text },
+        {
+          role: "tool",
+          content: `[Tool: ${r1.toolCalls[0]!.name} (${r1.toolCalls[0]!.id})]\n${params.toolResult}`,
+        },
+      ];
+
+      // ---- Evict + reload: clear in-memory KV session, savedCount, anchoring.
+      // Only the on-disk `.bin` survives — the reload-desync scenario.
+      await this.resources.evict(resourceKey);
+      modelId = await this.resources.ensureLoaded(resourceKey);
+
+      // ---- Round 2: continuation on the reloaded cache (trailing-tool branch).
+      // Must reuse the on-disk cache.
+      const r2 = await runTurn(r2History);
+      if (r2.cacheTokens <= 0) {
+        return {
+          passed: false,
+          output:
+            `Round 2 (post-reload continuation) did not reuse the on-disk dynamic-tools cache: ` +
+            `cacheTokens=${r2.cacheTokens}. The on-disk cache file was not picked up after reload.`,
+        };
+      }
+
+      // ---- Round 3: new user prompt after the chain ([assistant, user] branch)
+      // on a warm cache. Must still yield a parseable tool call.
+      const r3History: ChatMessage[] = [
+        ...r2History,
+        { role: "assistant", content: r2.text },
+        { role: "user", content: params.secondUserMessage },
+      ];
+      const r3 = await runTurn(r3History);
+      if (r3.toolCalls.length === 0) {
+        return {
+          passed: false,
+          output:
+            `Round 3 (new prompt on warm dynamic-tools cache) emitted no parseable tool call — ` +
+            `cache reuse corrupted tool parsing. r2CacheTokens=${r2.cacheTokens}, ` +
+            `r3CacheTokens=${r3.cacheTokens}, text=${JSON.stringify(r3.text).slice(0, 200)}`,
+        };
+      }
+
+      const summary =
+        `Dynamic tools + kvCache reuse OK [${resourceKey}` +
+        `${params.toolDialect ? `/${params.toolDialect}` : ""}]: ` +
+        `r1Calls=${r1.toolCalls.length}, ` +
+        `r2CacheTokens=${r2.cacheTokens} (post-reload reuse), ` +
+        `r3Calls=${r3.toolCalls.length} (warm), r3CacheTokens=${r3.cacheTokens}`;
+      // The harness only surfaces `output` on failure, so log the numbers
+      // explicitly — otherwise a passing run hides the reuse magnitude.
+      console.log(`[kv-cache-tools-dynamic-reuse] ${summary}`);
+      return ValidationHelpers.validate(summary, expectation);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      return { passed: false, output: `Dynamic tools reuse failed: ${errorMsg}` };
     }
   }
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- No existing e2e test covers the intersection of `toolsMode: "dynamic"`, a custom `kvCache` key, and a model evict/reload mid-conversation.
- Assisstant depends on this path staying coherent after reload (in-memory KV session and `savedCount` gone, on-disk `.bin` retained). Without a guard, a regression would only show up in manual workbench testing.

## 📝 How does it solve it?

- Adds `kv-cache-tools-dynamic-reuse` — three-round tool chain (prime → evict/reload → continuation → new prompt) using the hermes-dialect `tools-dynamic` resource.
- New `toolsDynamicReuse` executor asserts:
  - Round 1 yields a parseable tool call while priming the cache.
  - Round 2 (post-reload, history ending in `tool`) reuses the on-disk cache (`cacheTokens > 0`).
  - Round 3 (history ending `assistant` → `user`) still yields a parseable tool call on the warm cache.

## 🧪 How was it tested?

- E2e definitions and executor added; run locally with:
  ```bash
  cd packages/sdk/e2e
  npm run install:build
  npx qvac-test run:local:desktop --filter kv-cache-tools-dynamic-reuse
  ```

