### PR TITLE
infra: fix Manual Workspace Cleanup cwd on self-hosted runners

### DIFF
--- a/.cursor/rules/devops/github-actions.mdc
+++ b/.cursor/rules/devops/github-actions.mdc
@@ -88,6 +88,30 @@ Pod scope and high-level principles live in `.cursor/rules/devops/main.mdc`. Thi
 - Matrix dimension names are concrete and stable: `os`, `arch`, `node-version`, `target` — not `config`, `variant`, `flavor`.
 - `include` and `exclude` are documented in a comment when used; they obscure the matrix.
 
+## Self-hosted runners — Manual Workspace Cleanup
+
+Persistent self-hosted runners (`qvac-*` labels) reuse disk between jobs. Workflows that checkout the default `$GITHUB_WORKSPACE` on those runners should start with a step named **Manual Workspace Cleanup** (before `actions/checkout`). Full rationale: [`docs/ci/SELF-HOSTED-RUNNERS.md`](../../../docs/ci/SELF-HOSTED-RUNNERS.md).
+
+**Required shape** when the job matrix mixes GitHub-hosted and self-hosted runners:
+
+```yaml
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
+        working-directory: .
+        if: runner.environment != 'github-hosted'
+```
+
+| Field | Why |
+|-------|-----|
+| `working-directory: .` | Job- or step-level defaults often set `packages/<pkg>/`. Without an explicit `.`, the shell runs in the package directory and cleanup behavior diverges from intent even though `$GITHUB_WORKSPACE` is absolute. |
+| `if: runner.environment != 'github-hosted'` | Cleanup is only needed on persistent self-hosted machines. Prefer this over `startsWith(matrix.runner, 'qvac-')` / `startsWith(matrix.os, 'qvac-')` so hosted matrix rows (`ubuntu-*`, `macos-*`) skip the step without coupling to label strings. |
+
+- **Do not** use `startsWith(matrix.runner, 'qvac-')` on new or edited cleanup steps; use `runner.environment`.
+- **Omit** the `if` only when the job never runs on `github-hosted` (self-hosted-only job).
+- **Omit** the whole step when the workflow no longer does a full-repo checkout at `$GITHUB_WORKSPACE` (some mobile/refactored flows).
+- Gate [`.github/actions/cache-models`](../../../.github/actions/cache-models/action.yml) with the same `runner.environment` condition.
+
 ## Environments
 
 - **Production deployments target a GitHub Environment** with required reviewers configured in the GitHub UI, not in YAML.

--- a/.cursor/rules/devops/main.mdc
+++ b/.cursor/rules/devops/main.mdc
@@ -26,6 +26,7 @@ Owns CI/CD pipelines (GitHub Actions workflows + composite actions), repo-wide a
 | Rule | Scope | When it applies |
 |---|---|---|
 | `.cursor/rules/devops/github-actions.mdc` | `.github/workflows/**`, `.github/actions/**` | Authoring or modifying any workflow or composite action |
+| `docs/ci/SELF-HOSTED-RUNNERS.md` | `.github/workflows/**` (self-hosted / `qvac-*` runners) | Manual Workspace Cleanup, `working-directory: .`, `runner.environment` gating |
 | `.cursor/rules/devops/secrets-and-credentials.mdc` | `.github/**`, `scripts/**` | Anything that can read, derive, or transmit a secret |
 | `.cursor/rules/devops/agentic-automation.mdc` | `.cursor/skills/**`, `.cursor/rules/**`, `.cursor/hooks/**`, `.github/workflows/**`, `.github/scripts/**`, `scripts/**` | Authoring skills, hooks, MCP integrations, or any AI-driven DevOps workflow |
 
@@ -40,6 +41,7 @@ These are the bar; the deep-dive lives in the topic files above.
 - Top-level `permissions:` is mandatory and defaults to `contents: read`.
 - `pull_request_target` never checks out untrusted PR HEAD ("pwn request" pattern).
 - Use OIDC for cloud auth; long-lived credentials are the fallback, not the default.
+- **Manual Workspace Cleanup** on self-hosted jobs: `working-directory: .` plus `if: runner.environment != 'github-hosted'` (see `docs/ci/SELF-HOSTED-RUNNERS.md`).
 
 ### Secrets
 - Never inline a secret value. Always reference via `${{ secrets.X }}`.

--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -65,6 +65,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-bci-whispercpp.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-parakeet.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
+++ b/.github/workflows/cpp-test-coverage-transcription-whispercpp.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-test-coverage-tts-ggml.yml
+++ b/.github/workflows/cpp-test-coverage-tts-ggml.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-test-coverage-tts-onnx.yml
+++ b/.github/workflows/cpp-test-coverage-tts-onnx.yml
@@ -66,7 +66,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
 
       - name: Setup build host (github-hosted runners only)
         if: runner.environment == 'github-hosted'

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-decoder-audio.yml
+++ b/.github/workflows/integration-test-decoder-audio.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-ocr-onnx.yml
+++ b/.github/workflows/integration-test-ocr-onnx.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-test-transcription-parakeet.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-test-translation-nmtcpp.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-tts-onnx.yml
+++ b/.github/workflows/integration-test-tts-onnx.yml
@@ -161,6 +161,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
         if: runner.environment != 'github-hosted'
 
       - name: Checkout code

--- a/.github/workflows/pr-test-inference-addon-cpp-js.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp-js.yml
@@ -95,7 +95,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/pr-test-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp.yml
@@ -94,7 +94,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - name: Checkout source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:

--- a/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
+++ b/.github/workflows/reusable-cpp-tests-translation-nmtcpp.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           repository: ${{ inputs.repository || github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -182,7 +182,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.runner, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2

--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
+        working-directory: .
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test-desktop-sdk.yml
+++ b/.github/workflows/test-desktop-sdk.yml
@@ -139,7 +139,8 @@ jobs:
       - name: Manual Workspace Cleanup
         run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
         shell: bash
-        if: startsWith(matrix.os, 'qvac-')
+        working-directory: .
+        if: runner.environment != 'github-hosted'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: ${{ inputs.test-version || github.event.pull_request.head.sha || github.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,7 @@ When a question relates to one of these topics, read the corresponding knowledge
 | Topic | When to read | File |
 |-------|-------------|------|
 | CI / GitHub Actions | CI failures, workflow triggers, validation, publishing | `packages/ocr-onnx/.agent/knowledge/ci-validation.md` |
+| Self-hosted CI runners | Manual Workspace Cleanup, `working-directory: .`, `runner.environment`, `qvac-*` labels | `docs/ci/SELF-HOSTED-RUNNERS.md` |
 | vcpkg / native builds | vcpkg deps, triplets, registries, CMake integration, build failures | `packages/ocr-onnx/.agent/knowledge/vcpkg-management.md` |
 | llama.cpp Android | Cross-compiling llama.cpp, ADB deployment, Vulkan GPU, Android inference | `packages/ocr-onnx/.agent/knowledge/llama-cpp-android.md` |
 | Model registry | Adding/updating models, registry format, vcpkg port config | `packages/ocr-onnx/.agent/knowledge/registry-models.md` |

--- a/docs/ci/LABELS.md
+++ b/docs/ci/LABELS.md
@@ -69,6 +69,7 @@ If you previously thought "review" was a label, it's not — it's an issue/PR co
 
 ## See also
 
+- [`docs/ci/SELF-HOSTED-RUNNERS.md`](SELF-HOSTED-RUNNERS.md) — Manual Workspace Cleanup, `working-directory: .`, and `runner.environment` on `qvac-*` workflows.
 - [`docs/ci/TEAMS.md`](TEAMS.md) — who is in `qvac-internal-dev` / `merge` / `release` / `qvac-external`, and what they can do.
 - [`.github/actions/label-gate/README.md`](../../.github/actions/label-gate/README.md) — full `label-gate` trust model and configuration reference.
 - [`docs/gitflow.md`](../gitflow.md) — branch model and release flow.

--- a/docs/ci/SELF-HOSTED-RUNNERS.md
+++ b/docs/ci/SELF-HOSTED-RUNNERS.md
@@ -1,0 +1,85 @@
+# Self-hosted runners and workspace cleanup
+
+QVAC CI uses a mix of **GitHub-hosted** runners (`ubuntu-*`, `macos-*`, `windows-*`) and **self-hosted** runners (labels such as `qvac-ubuntu2204-x64-gpu`, `qvac-win25-x64`). Self-hosted machines are persistent: the job workspace on disk can survive between runs unless it is cleared explicitly.
+
+This document explains the **Manual Workspace Cleanup** step used at the start of many workflows, and why two fields are required on that step.
+
+## Manual Workspace Cleanup
+
+Several workflows begin with a step named **Manual Workspace Cleanup** that runs before `actions/checkout`:
+
+```yaml
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
+        working-directory: .
+        if: runner.environment != 'github-hosted'
+```
+
+### Why this step exists
+
+On self-hosted runners, leftover files from a previous job (failed run, cancelled run, or partial checkout) can pollute the next run. GitHub-hosted runners start from a fresh VM; self-hosted runners do not.
+
+Deleting and recreating `$GITHUB_WORKSPACE` gives each job a clean tree before checkout, matching the isolation developers expect from hosted runners.
+
+### `working-directory: .`
+
+**Problem:** Many jobs set a default working directory at the job or workflow level, often `packages/<addon>/` via `env.WORKDIR` and per-step `working-directory: ${{ env.WORKDIR }}`. Step-level defaults are inherited unless overridden.
+
+If Manual Workspace Cleanup does not set `working-directory`, the `run` script may execute under `packages/<addon>/` instead of the repository root. Then `rm -rf "$GITHUB_WORKSPACE"` still targets the correct path variable, but the step’s cwd is wrong, which has caused subtle cleanup failures and confusion when debugging paths.
+
+**Fix:** Always set `working-directory: .` on this step so it runs at the repository root and overrides any job- or workflow-level default.
+
+### `if: runner.environment != 'github-hosted'`
+
+**Problem:** The cleanup is only needed on self-hosted runners. Running it on GitHub-hosted runners adds latency and is unnecessary.
+
+Historically, workflows used `if: startsWith(matrix.runner, 'qvac-')` or `if: startsWith(matrix.os, 'qvac-')`. That couples behavior to label naming, breaks when a matrix row uses a hosted label (for example `ubuntu-22.04-arm`) alongside `qvac-*` rows, and must be updated whenever runner labels change.
+
+**Fix:** Use GitHub’s runner metadata:
+
+```yaml
+if: runner.environment != 'github-hosted'
+```
+
+This is true for self-hosted runners regardless of the matrix label string, and false for GitHub-hosted runners including `macos-14` and `ubuntu-*` matrix entries.
+
+**When to omit `if`:** Only when the job **always** runs on self-hosted runners (no hosted matrix rows). Example: a job that only uses `qvac-*` labels and never `ubuntu-latest` / `macos-*` hosted labels. If the job is mixed, keep the `if`.
+
+**When the step is absent:** Some workflows were refactored (for example mobile integration flows that checkout sparse paths first) and no longer use Manual Workspace Cleanup. Do not add the step unless the job checks out the full repo on a persistent self-hosted runner at `$GITHUB_WORKSPACE`.
+
+## Related patterns
+
+### Model cache on self-hosted runners
+
+The composite action [`.github/actions/cache-models`](../../.github/actions/cache-models/action.yml) should be gated the same way:
+
+```yaml
+if: runner.environment != 'github-hosted'
+```
+
+Self-hosted runners use a transparent local cache; hosted runners should use normal download paths.
+
+### Setup steps that only apply on hosted runners
+
+The inverse condition is also common:
+
+```yaml
+if: runner.environment == 'github-hosted'
+```
+
+Example: [`.github/workflows/cpp-tests-classification.yml`](../../.github/workflows/cpp-tests-classification.yml) runs **Setup build host** only on GitHub-hosted runners.
+
+## Checklist when adding or editing workflows
+
+1. If the job uses self-hosted runners and checks out the default workspace, add **Manual Workspace Cleanup** as the first step (before checkout).
+2. Include `working-directory: .` on that step.
+3. Include `if: runner.environment != 'github-hosted'` when the matrix mixes hosted and self-hosted runners.
+4. Prefer `runner.environment` over `startsWith(matrix.runner, 'qvac-')` for any self-hosted-only step.
+
+## See also
+
+- [`.cursor/rules/devops/github-actions.mdc`](../../.cursor/rules/devops/github-actions.mdc) — Cursor rule for workflow authors
+- [`packages/ocr-onnx/.agent/knowledge/ci-validation.md`](../../packages/ocr-onnx/.agent/knowledge/ci-validation.md) — agent knowledge for CI troubleshooting
+- [`docs/ci/LABELS.md`](LABELS.md) — PR label gating
+- [`docs/ci/TEAMS.md`](TEAMS.md) — who can apply privileged labels

--- a/packages/ocr-onnx/.agent/knowledge/ci-validation.md
+++ b/packages/ocr-onnx/.agent/knowledge/ci-validation.md
@@ -170,6 +170,17 @@ Note: integration tests run with `continue-on-error: true` — failures are repo
 
 Both use `continue-on-error: true`.
 
+## Self-hosted runners
+
+Many addon workflows run on persistent **self-hosted** runners (`qvac-*` labels) as well as GitHub-hosted matrix rows. Those jobs often start with **Manual Workspace Cleanup** before checkout.
+
+When adding or editing that step:
+
+- Set **`working-directory: .`** so `rm -rf "$GITHUB_WORKSPACE"` runs from the repo root, not from an inherited `packages/<pkg>/` default.
+- Gate with **`if: runner.environment != 'github-hosted'`** (not `startsWith(matrix.runner, 'qvac-')`) when the matrix mixes hosted and self-hosted runners.
+
+Full rationale and checklist: [`docs/ci/SELF-HOSTED-RUNNERS.md`](../../../docs/ci/SELF-HOSTED-RUNNERS.md). Workflow authoring rule: [`.cursor/rules/devops/github-actions.mdc`](../../../.cursor/rules/devops/github-actions.mdc) (section **Self-hosted runners — Manual Workspace Cleanup**).
+
 ## Failure Classification Guide
 
 ### Infra failures (CI specialist can fix)


### PR DESCRIPTION
## What problem does this PR solve?

Manual Workspace Cleanup steps can inherit a job- or workflow-level `working-directory`, so `rm -rf "$GITHUB_WORKSPACE"` may run outside the repository root on self-hosted runners. Some workflows also gated cleanup with `startsWith(matrix.runner|os, 'qvac-')`, which is brittle as runner labels evolve.

## How does it solve it?

- Add `working-directory: .` to every **Manual Workspace Cleanup** step so cleanup always runs at the repo root.
- Gate those steps with `if: runner.environment != 'github-hosted'` instead of `startsWith(..., 'qvac-')` where applicable (29 workflows).

## Breaking changes

None.
