### PR TITLE
fix[api]: forward AbortSignal through bci-whispercpp run APIs

### DIFF
--- a/packages/bci-whispercpp/index.d.ts
+++ b/packages/bci-whispercpp/index.d.ts
@@ -1,4 +1,4 @@
-import QvacResponse from '@qvac/infer-base/src/QvacResponse'
+import type { QvacResponse } from '@qvac/infer-base'
 import type { LoggerInterface } from '@qvac/logging'
 
 declare interface BCIConfig {
@@ -77,6 +77,11 @@ declare interface TranscriptSegment {
   id: number
 }
 
+declare interface BCIRunOptions {
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
+}
+
 declare interface BCIWhispercppState {
   configLoaded: boolean
   destroyed: boolean
@@ -97,10 +102,10 @@ declare class BCIWhispercpp {
   load(): Promise<void>
 
   /** Transcribe a neural signal binary file (convenience wrapper). */
-  transcribeFile(filePath: string): Promise<QvacResponse>
+  transcribeFile(filePath: string, runOptions?: BCIRunOptions): Promise<QvacResponse>
 
   /** Transcribe a neural signal buffer (batch mode). */
-  transcribe(neuralData: Uint8Array): Promise<QvacResponse>
+  transcribe(neuralData: Uint8Array, runOptions?: BCIRunOptions): Promise<QvacResponse>
 
   /** Cancel the in-flight inference, if any. */
   cancel(): Promise<void>
@@ -134,7 +139,8 @@ declare namespace BCIWhispercpp {
     BCIWhispercppArgs,
     BCIWhispercppConfig,
     BCIWhispercppState,
-    TranscriptSegment
+    TranscriptSegment,
+    BCIRunOptions
   }
 }
 

--- a/packages/bci-whispercpp/index.js
+++ b/packages/bci-whispercpp/index.js
@@ -224,9 +224,9 @@ class BCIWhispercpp {
    * @param {string} filePath - path to .bin neural signal file
    * @returns {Promise<QvacResponse>}
    */
-  async transcribeFile (filePath) {
+  async transcribeFile (filePath, runOptions = {}) {
     const data = fs.readFileSync(filePath)
-    return this.transcribe(new Uint8Array(data))
+    return this.transcribe(new Uint8Array(data), runOptions)
   }
 
   /**
@@ -234,12 +234,14 @@ class BCIWhispercpp {
    * Returns a QvacResponse; use response.await() for the final output array,
    * response.onUpdate() for streaming updates, response.stats for runtime stats.
    * @param {Uint8Array} neuralData - binary neural signal
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    * @returns {Promise<QvacResponse>}
    */
-  async transcribe (neuralData) {
+  async transcribe (neuralData, runOptions = {}) {
     this._assertReadyForInference()
     return await this._enqueueInference(async () => {
-      const response = this._job.start()
+      const response = this._job.start({ signal: runOptions && runOptions.signal })
 
       let accepted
       try {
@@ -301,6 +303,8 @@ class BCIWhispercpp {
    * @param {'delta'|'full'} [streamOpts.emit='delta'] - whether each
    *   update carries only the newly-discovered tail ('delta') or the
    *   full running transcript ('full').
+   * @param {AbortSignal} [streamOpts.signal] - When aborted, the returned
+   *   response fails with the abort reason.
    * @returns {Promise<QvacResponse>}
    */
   async transcribeStream (neuralStream, streamOpts = {}) {
@@ -311,11 +315,13 @@ class BCIWhispercpp {
 
     const opts = this._validateStreamOpts(streamOpts)
     const iterable = this._normalizeNeuralStream(neuralStream)
+    const signal = streamOpts && streamOpts.signal
 
     return await this._enqueueInference(async () => {
       this._streamAborted = false
       const response = new QvacResponse({
-        cancelHandler: async () => { await this.cancel() }
+        cancelHandler: async () => { await this.cancel() },
+        signal
       })
       this._streamResponse = response
 

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-fs": "^4.5.1",
     "bare-path": "^3.0.0"

--- a/packages/bci-whispercpp/test/unit/signal-forwarding.test.js
+++ b/packages/bci-whispercpp/test/unit/signal-forwarding.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to transcribe()/transcribeStream()
+// is forwarded into the returned QvacResponse, so aborting mid-inference (or
+// passing an already-aborted signal) settles the in-flight response with the
+// abort reason.
+
+const test = require('brittle')
+const BCIWhispercpp = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Bypass load()/native binding: inject a fake addon whose runJob accepts the
+// job (returns true) but never drives a terminal event, so the response stays
+// in-flight until the abort backstop fires.
+function buildModel () {
+  const model = new BCIWhispercpp({ files: { model: 'model.bin' } }, {})
+  model.addon = {
+    runJob: async (job) => { model._capturedJob = job; return true },
+    cancel: async () => {},
+    destroyInstance: async () => {}
+  }
+  model.state.configLoaded = true
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('transcribe(): aborting mid-inference rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.transcribe(new Uint8Array([1, 2, 3, 4]), { signal })
+  const settled = response.await()
+
+  t.absent(model._capturedJob && 'signal' in model._capturedJob, 'signal not forwarded to native runJob')
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('transcribe(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.transcribe(new Uint8Array([1, 2, 3, 4]), { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `bci-whispercpp` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through the public run entrypoints and strip it from native params.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
