### PR TITLE
fix[api]: forward AbortSignal through classification-ggml run APIs

### DIFF
--- a/packages/classification-ggml/index.d.ts
+++ b/packages/classification-ggml/index.d.ts
@@ -27,6 +27,8 @@ export interface ClassifyOptions {
   height?: number;
   /** Channel count. Must be `3` when passing raw RGB bytes. */
   channels?: 3;
+  /** When aborted, the in-flight inference rejects with the abort reason. */
+  signal?: AbortSignal;
 }
 
 export interface ImageClassifierLogger {

--- a/packages/classification-ggml/index.js
+++ b/packages/classification-ggml/index.js
@@ -108,6 +108,7 @@ class ImageClassifier {
    * @param {number} [options.width]   raw RGB width (required for raw input)
    * @param {number} [options.height]  raw RGB height (required for raw input)
    * @param {number} [options.channels] raw RGB channel count (must be 3)
+   * @param {AbortSignal} [options.signal] when aborted, the in-flight inference rejects with the abort reason
    * @returns {Promise<Array<{label: string, confidence: number}>>}
    *          sorted by `confidence` descending. Always returns all classes
    *          unless `options.topK` is set.
@@ -132,7 +133,7 @@ class ImageClassifier {
       if (options.topK !== undefined) job.topK = options.topK
     }
 
-    const response = this._job.start()
+    const response = this._job.start({ signal: options && options.signal })
 
     let accepted
     try {

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -65,7 +65,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-env": "^3.0.0",
     "bare-fs": "^4.5.1",

--- a/packages/classification-ggml/test/unit/all.js
+++ b/packages/classification-ggml/test/unit/all.js
@@ -8,6 +8,7 @@ async function runTests () {
   test.pause()
 
   await import('./map-addon-event.test.js')
+  await import('./signal-forwarding.test.js')
 
   test.resume()
 }

--- a/packages/classification-ggml/test/unit/signal-forwarding.test.js
+++ b/packages/classification-ggml/test/unit/signal-forwarding.test.js
@@ -1,0 +1,76 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to classify() is forwarded into
+// the underlying QvacResponse, so aborting mid-inference (or passing an
+// already-aborted signal) rejects the classify() promise with the abort
+// reason. No native cancel is invoked — abort only releases the waiter.
+
+const test = require('brittle')
+const ImageClassifier = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Inject a fake native addon that accepts the job but never emits a terminal
+// event, bypassing load() so no model file / native binding is required.
+function buildModel () {
+  const model = new ImageClassifier()
+  model._addon = {
+    runJob: async (job) => { model._capturedJob = job; return true },
+    cancel: async () => {},
+    unload: async () => {}
+  }
+  model.state.configLoaded = true
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('classify(): aborting mid-inference rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const pending = model.classify(new Uint8Array([1, 2, 3, 4]), { signal })
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, pending, /aborted by caller/, 'classify()')
+  t.absent(model._capturedJob && 'signal' in model._capturedJob, 'signal not forwarded to native runJob')
+})
+
+test('classify(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  await expectRejection(t, model.classify(new Uint8Array([1, 2, 3, 4]), { signal }), /pre-aborted/, 'classify()')
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `classification-ggml` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through the public run entrypoint and strip it from native params.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
