### PR TITLE
fix[api]: forward AbortSignal through decoder-audio run APIs

### DIFF
--- a/packages/decoder-audio/index.d.ts
+++ b/packages/decoder-audio/index.d.ts
@@ -29,6 +29,11 @@ export interface DecoderOutput {
   outputArray: ArrayBuffer
 }
 
+export interface RunOptions {
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
+}
+
 interface RuntimeStats {
   decodeTimeMs: number
   inputBytes: number
@@ -48,7 +53,7 @@ declare class FFmpegDecoder {
 
   load(): Promise<void>
   unload(): Promise<void>
-  run(audioStream: AsyncIterable<Buffer>): QvacResponse<DecoderOutput>
+  run(audioStream: AsyncIterable<Buffer>, runOptions?: RunOptions): QvacResponse<DecoderOutput>
 
   runtimeStats(): RuntimeStats
 }

--- a/packages/decoder-audio/index.js
+++ b/packages/decoder-audio/index.js
@@ -132,9 +132,11 @@ class FFmpegDecoder {
   /**
    * Run the decoder on an audio stream
    * @param {Readable} audioStream - Input audio stream
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    * @returns {QvacResponse} Response with decoded audio
    */
-  run (audioStream) {
+  run (audioStream, runOptions = {}) {
     if (!this.isLoaded) {
       throw new QvacErrorDecoderAudio({ code: ERR_CODES.DECODER_NOT_LOADED })
     }
@@ -142,7 +144,7 @@ class FFmpegDecoder {
     this.logger.info('Starting new audio stream processing')
 
     this._cancelled = false
-    const response = this._job.start()
+    const response = this._job.start({ signal: runOptions && runOptions.signal })
 
     this._processStream(audioStream)
       .then(() => {

--- a/packages/decoder-audio/package.json
+++ b/packages/decoder-audio/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-ffmpeg": "^1.0.0-32"
   },

--- a/packages/decoder-audio/test/unit/signal-forwarding.test.js
+++ b/packages/decoder-audio/test/unit/signal-forwarding.test.js
@@ -1,0 +1,72 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run() is forwarded into the
+// returned QvacResponse, so aborting mid-decode (or passing an already-aborted
+// signal) settles the in-flight response with the abort reason.
+
+const test = require('brittle')
+const { FFmpegDecoder } = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Never-ending stream so the decode response stays in-flight until aborted.
+function pendingStream () {
+  return (async function * () {
+    await new Promise(() => {})
+  })()
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-decode rejects with the abort reason', async (t) => {
+  const decoder = new FFmpegDecoder()
+  await decoder.load()
+
+  const { signal, abort } = makeAbortable()
+  const response = decoder.run(pendingStream(), { signal })
+  const settled = response.await()
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const decoder = new FFmpegDecoder()
+  await decoder.load()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = decoder.run(pendingStream(), { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `decoder-audio` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through the public decode/run entrypoints and strip it from native params.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
