### PR TITLE
fix[api]: forward AbortSignal through diffusion-cpp run APIs

### DIFF
--- a/packages/diffusion-cpp/index.d.ts
+++ b/packages/diffusion-cpp/index.d.ts
@@ -231,6 +231,13 @@ export interface EsrganUpscalerArgs {
 
 export interface EsrganUpscaleOptions {
   repeats?: number
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
+}
+
+export interface RunOptions {
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
 }
 
 export interface GenerationParams {
@@ -409,7 +416,7 @@ export default class ImgStableDiffusion {
 
   load(): Promise<void>
 
-  run(params: GenerationParams): Promise<QvacResponse>
+  run(params: GenerationParams, runOptions?: RunOptions): Promise<QvacResponse>
 
   unload(): Promise<void>
 

--- a/packages/diffusion-cpp/index.js
+++ b/packages/diffusion-cpp/index.js
@@ -256,13 +256,15 @@ class ImgStableDiffusion {
    *                                                   conditioning. Addressed in the prompt as
    *                                                   `@image1 … @imageN`. Mutually exclusive
    *                                                   with `init_image`.
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    * @returns {Promise<QvacResponse>}
    */
-  async run (params) {
-    return this._run(() => this._runInternal(params))
+  async run (params, runOptions = {}) {
+    return this._run(() => this._runInternal(params, runOptions))
   }
 
-  async _runInternal (params) {
+  async _runInternal (params, runOptions = {}) {
     // Validate inputs first so callers get precise errors before any
     // readiness/busy checks.
 
@@ -498,7 +500,9 @@ class ImgStableDiffusion {
       throw new Error(RUN_BUSY_ERROR_MESSAGE)
     }
 
-    const response = this._job.start()
+    const signal = runOptions && runOptions.signal
+
+    const response = this._job.start({ signal })
 
     let accepted
     try {
@@ -664,6 +668,7 @@ class EsrganUpscaler {
    * @param {Uint8Array} imageBytes - Encoded PNG/JPEG input image bytes
    * @param {object} [options]
    * @param {number} [options.repeats=1] - Number of ESRGAN passes
+   * @param {AbortSignal} [options.signal] - When aborted, the returned response fails with the abort reason.
    * @returns {Promise<QvacResponse>}
    */
   async upscale (imageBytes, options) {
@@ -685,7 +690,7 @@ class EsrganUpscaler {
       throw new Error(RUN_BUSY_ERROR_MESSAGE)
     }
 
-    const response = this._job.start()
+    const response = this._job.start({ signal: options && options.signal })
 
     let accepted
     try {

--- a/packages/diffusion-cpp/package.json
+++ b/packages/diffusion-cpp/package.json
@@ -78,7 +78,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-path": "^3.0.0"
   },

--- a/packages/diffusion-cpp/test/unit/signal-forwarding.test.js
+++ b/packages/diffusion-cpp/test/unit/signal-forwarding.test.js
@@ -1,0 +1,123 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to the image/video/upscale run
+// methods is forwarded into the returned QvacResponse, so aborting mid-job (or
+// passing an already-aborted signal) settles the in-flight response with the
+// abort reason. The signal must NOT be part of native runJob params.
+
+const test = require('brittle')
+const { ImgStableDiffusion, VideoStableDiffusion, EsrganUpscaler } = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+// Records the params handed to runJob so we can assert `signal` is not present.
+function fakeAddonFactory (sink) {
+  return () => ({
+    activate: async () => {},
+    runJob: async (a) => { sink.lastJobParams = a; return true },
+    cancel: async () => {},
+    unload: async () => {}
+  })
+}
+
+test('ImgStableDiffusion.run(): aborting rejects with reason and keeps signal out of native params', async (t) => {
+  const sink = {}
+  const model = new ImgStableDiffusion({ files: { model: '/tmp/fake-sd.gguf' }, config: {} })
+  model._createAddon = fakeAddonFactory(sink)
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run({ prompt: 'a cat' }, { signal })
+  const settled = response.await()
+
+  t.absent(sink.lastJobParams && 'signal' in sink.lastJobParams, 'signal not forwarded to runJob')
+
+  abort(new Error('img abort'))
+  await expectRejection(t, settled, /img abort/, 'await()')
+
+  await model.unload()
+})
+
+test('ImgStableDiffusion.run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = new ImgStableDiffusion({ files: { model: '/tmp/fake-sd.gguf' }, config: {} })
+  model._createAddon = fakeAddonFactory({})
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run({ prompt: 'a cat' }, { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+
+  await model.unload()
+})
+
+test('VideoStableDiffusion.run(): aborting rejects with reason and keeps signal out of native params', async (t) => {
+  const sink = {}
+  const model = new VideoStableDiffusion({ files: { model: '/tmp/fake-wan.gguf' }, config: {} })
+  model._createAddon = fakeAddonFactory(sink)
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run({ mode: 'txt2vid', prompt: 'a wave' }, { signal })
+  const settled = response.await()
+
+  t.absent(sink.lastJobParams && 'signal' in sink.lastJobParams, 'signal not forwarded to runJob')
+
+  abort(new Error('video abort'))
+  await expectRejection(t, settled, /video abort/, 'await()')
+
+  await model.unload()
+})
+
+test('EsrganUpscaler.upscale(): aborting rejects with the abort reason', async (t) => {
+  const model = new EsrganUpscaler({ files: { esrgan: '/tmp/fake-esrgan.gguf' }, config: {} })
+  model._createAddon = () => ({
+    activate: async () => {},
+    runJob: async () => true,
+    cancel: async () => {},
+    unload: async () => {}
+  })
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.upscale(new Uint8Array([1, 2, 3]), { signal })
+  const settled = response.await()
+
+  abort(new Error('upscale abort'))
+  await expectRejection(t, settled, /upscale abort/, 'await()')
+
+  await model.unload()
+})

--- a/packages/diffusion-cpp/video.d.ts
+++ b/packages/diffusion-cpp/video.d.ts
@@ -1,6 +1,6 @@
 import type { QvacResponse } from '@qvac/infer-base'
 import type QvacLogger from '@qvac/logging'
-import type { SamplerMethod, ScheduleType, SdConfig, CacheMode } from './index'
+import type { SamplerMethod, ScheduleType, SdConfig, CacheMode, RunOptions } from './index'
 
 /** Supported video-generation modes for `VideoStableDiffusion.run()`. */
 export type VideoMode = 'txt2vid' | 'img2vid'
@@ -174,7 +174,7 @@ export default class VideoStableDiffusion {
    * stream carries one final `Uint8Array` (MJPG AVI buffer) and JSON
    * progress-tick strings throughout denoising.
    */
-  run (params: VideoGenerationParams): Promise<QvacResponse>
+  run (params: VideoGenerationParams, runOptions?: RunOptions): Promise<QvacResponse>
 
   /** Cancel the in-flight video generation job. */
   cancel (): Promise<void>

--- a/packages/diffusion-cpp/video.js
+++ b/packages/diffusion-cpp/video.js
@@ -308,13 +308,15 @@ class VideoStableDiffusion {
    * @param {string} [params.cache_mode]
    * @param {string} [params.cache_preset]
    * @param {number} [params.cache_threshold]
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    * @returns {Promise<QvacResponse>}
    */
-  async run (params) {
-    return this._run(() => this._runInternal(params))
+  async run (params, runOptions = {}) {
+    return this._run(() => this._runInternal(params, runOptions))
   }
 
-  async _runInternal (params) {
+  async _runInternal (params, runOptions = {}) {
     if (!params || typeof params !== 'object') {
       throw new TypeError('run(params): params must be an object')
     }
@@ -535,7 +537,9 @@ class VideoStableDiffusion {
       throw new Error(RUN_BUSY_ERROR_MESSAGE)
     }
 
-    const response = this._job.start()
+    const signal = runOptions && runOptions.signal
+
+    const response = this._job.start({ signal })
 
     let accepted
     try {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `diffusion-cpp` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through image run, video run, and the ESRGAN `upscale` entrypoints; strip it from native params.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
