### PR TITLE
fix[api]: forward AbortSignal through embed-llamacpp run APIs

### DIFF
--- a/packages/embed-llamacpp/index.d.ts
+++ b/packages/embed-llamacpp/index.d.ts
@@ -37,6 +37,11 @@ export interface GGMLBertArgs {
   opts?: { stats?: boolean }
 }
 
+export interface RunOptions {
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
+}
+
 export interface AddonConfigurationParams {
   path: string
   config: GGMLConfig
@@ -61,7 +66,7 @@ export default class GGMLBert {
   constructor(args: GGMLBertArgs)
 
   load(): Promise<void>
-  run(text: string | string[]): Promise<QvacResponse>
+  run(text: string | string[], runOptions?: RunOptions): Promise<QvacResponse>
   unload(): Promise<void>
   cancel(): Promise<void>
   getState(): { configLoaded: boolean }

--- a/packages/embed-llamacpp/index.js
+++ b/packages/embed-llamacpp/index.js
@@ -94,11 +94,17 @@ class GGMLBert {
     }
   }
 
-  async run (input) {
-    return this._run(() => this._runInternal(input))
+  /**
+   * @param {string|string[]} input - Text (or array of texts) to embed.
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
+   * @returns {Promise<QvacResponse>}
+   */
+  async run (input, runOptions = {}) {
+    return this._run(() => this._runInternal(input, runOptions))
   }
 
-  async _runInternal (text) {
+  async _runInternal (text, runOptions = {}) {
     if (!this.addon) {
       throw new Error('Addon not initialized. Call load() first.')
     }
@@ -112,7 +118,7 @@ class GGMLBert {
       ? { type: 'sequences', input: text }
       : { type: 'text', input: text }
 
-    const response = this._job.start()
+    const response = this._job.start({ signal: runOptions && runOptions.signal })
 
     // addon-cpp guarantees no output events until runJob is fully accepted.
     // If runJob throws or returns false, no events will fire for this job.

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -70,7 +70,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-fs": "^4.5.1",
     "bare-path": "^3.0.0"

--- a/packages/embed-llamacpp/test/unit/signal-forwarding.test.js
+++ b/packages/embed-llamacpp/test/unit/signal-forwarding.test.js
@@ -1,0 +1,114 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run() is forwarded into the
+// returned QvacResponse, so aborting mid-inference (or passing an already-
+// aborted signal) settles the in-flight response with the abort reason. No
+// native cancel is invoked — abort only releases the waiter.
+
+const test = require('brittle')
+const GGMLBert = require('../../index.js')
+
+// Duck-typed AbortController: infer-base only touches `aborted` / `reason` /
+// `addEventListener` / `removeEventListener`, and Bare has no global
+// AbortController.
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once
+        ? () => { listeners.delete(wrapped); cb() }
+        : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) {
+        if (l === cb || l._original === cb) { listeners.delete(l); return }
+      }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Fake native addon that accepts runJob but never emits a terminal event, so
+// the response stays in-flight until the abort backstop fires.
+function buildModel () {
+  const model = new GGMLBert({ files: { model: ['/tmp/fake-embed-model.gguf'] } })
+  model._createAddon = () => ({
+    activate: async () => {},
+    runJob: async (job) => { model._capturedJob = job; return true },
+    cancel: async () => {},
+    unload: async () => {}
+  })
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try {
+    await promise
+  } catch (e) {
+    err = e
+  }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-inference rejects the response with the abort reason', async (t) => {
+  const model = buildModel()
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run('hello world', { signal })
+  const settled = response.await()
+
+  t.absent(model._capturedJob && 'signal' in model._capturedJob, 'signal not forwarded to native runJob')
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+
+  await model.unload()
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run('hello world', { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+
+  await model.unload()
+})
+
+test('run(): iterate() also rejects on abort', async (t) => {
+  const model = buildModel()
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run('hello world', { signal })
+
+  const drained = (async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of response.iterate()) { /* no output before abort */ }
+  })()
+
+  abort(new Error('iterate abort'))
+  await expectRejection(t, drained, /iterate abort/, 'iterate()')
+
+  await model.unload()
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `embed-llamacpp` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through the public run/runBatch entrypoints and strip it from native params.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
