### PR TITLE
fix[api]: forward AbortSignal through llm-llamacpp run APIs

### DIFF
--- a/packages/llm-llamacpp/index.d.ts
+++ b/packages/llm-llamacpp/index.d.ts
@@ -148,6 +148,8 @@ export interface RunOptions {
   generationParams?: GenerationParams
   cacheKey?: string
   saveCacheToDisk?: boolean
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
 }
 
 export interface RuntimeStats {
@@ -231,6 +233,8 @@ export interface FinetuneOptions {
   warmupStepsSet?: boolean
   /** Weight decay. Default 0.01. */
   weightDecay?: number
+  /** When aborted, the returned finetune handle fails with the abort reason. */
+  signal?: AbortSignal
 }
 
 export interface FinetuneProgressStats {

--- a/packages/llm-llamacpp/index.js
+++ b/packages/llm-llamacpp/index.js
@@ -251,7 +251,8 @@ class LlmLlamacpp {
   /**
    * Public API entrypoint for inference.
    * @param {Message[]} prompt - Input prompt array of messages
-   * @param {RunOptions} [runOptions] - Optional run settings (prefill, generationParams, cacheKey, saveCacheToDisk)
+   * @param {RunOptions} [runOptions] - Optional run settings (prefill, generationParams, cacheKey, saveCacheToDisk, signal)
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    * @returns {Promise<QvacResponse>}
    */
   async run (prompt, runOptions = {}) {
@@ -270,6 +271,7 @@ class LlmLlamacpp {
       throw new TypeError('Prompt input must be Message[]')
     }
     const { prefill, generationParams, cacheKey, saveCacheToDisk } = normalizeRunOptions(runOptions)
+    const signal = runOptions && runOptions.signal
 
     this.logger.info('Starting inference with prompt:', sanitizePromptForLog(prompt))
 
@@ -304,7 +306,7 @@ class LlmLlamacpp {
       saveCacheToDisk
     })
 
-    const response = this._job.start()
+    const response = this._job.start({ signal })
 
     let accepted
     try {
@@ -333,9 +335,12 @@ class LlmLlamacpp {
     if (!finetuningOptions) {
       throw new Error('Finetuning parameters are required.')
     }
-    const paramsToSend = normalizeFinetuneParams(finetuningOptions)
+    // Pull `signal` out before normalization so it forwards to the response
+    // (abort backstop) without leaking into the native finetune params.
+    const { signal, ...finetuneParams } = finetuningOptions
+    const paramsToSend = normalizeFinetuneParams(finetuneParams)
     this.logger.info('finetune() called')
-    this.logger.info('Finetuning parameters:', finetuningOptions)
+    this.logger.info('Finetuning parameters:', finetuneParams)
 
     return this._run(async () => {
       if (!this.addon) {
@@ -348,7 +353,7 @@ class LlmLlamacpp {
         this._checkpointSaveDir = finetuningOptions.checkpointSaveDir
       }
 
-      const response = this._job.start()
+      const response = this._job.start({ signal })
       let accepted
       try {
         accepted = await this.addon.finetune(paramsToSend)

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -73,7 +73,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-fs": "^4.5.1",
     "bare-path": "^3.0.0"

--- a/packages/llm-llamacpp/test/unit/finetuning.test.js
+++ b/packages/llm-llamacpp/test/unit/finetuning.test.js
@@ -442,10 +442,12 @@ test('_skipNextRuntimeStats prevents finetune TPS from ending a subsequent infer
 
   model.addon.runJob.callsFake(() => true)
   const inferResponse = await model._runInternal([{ role: 'user', content: 'Hello' }])
+  let inferenceFinished = false
+  inferResponse.onFinish(() => { inferenceFinished = true })
 
   model._addonOutputCallback(null, 'Output', { TPS: 0, tokens: 0 }, null)
   t.is(model._addonEventState.skipNextRuntimeStats, false, 'flag should reset after consuming stale TPS')
-  t.is(inferResponse.getStatus(), 'running', 'inference must still be running after stale TPS was swallowed')
+  t.absent(inferenceFinished, 'inference must still be running after stale TPS was swallowed')
 
   model._addonOutputCallback(null, 'Output', 'answer', null)
   model._addonOutputCallback(null, 'Output', { TPS: 50.0, tokens: 5 }, null)

--- a/packages/llm-llamacpp/test/unit/signal-forwarding.test.js
+++ b/packages/llm-llamacpp/test/unit/signal-forwarding.test.js
@@ -1,0 +1,128 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run()/finetune() is forwarded
+// into the returned QvacResponse, so aborting mid-inference (or passing an
+// already-aborted signal) settles the in-flight response with the abort
+// reason. No native cancel is invoked — abort only releases the waiter.
+
+const test = require('brittle')
+const LlmLlamacpp = require('../../index.js')
+
+// Duck-typed AbortController: infer-base only touches `aborted` / `reason` /
+// `addEventListener` / `removeEventListener`, and Bare has no global one.
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Fake native addon: accepts runJob/finetune but never emits a terminal event,
+// so the response stays in-flight until the abort backstop fires.
+function buildModel () {
+  const model = new LlmLlamacpp({ files: { model: ['/tmp/fake-llm-model.gguf'] }, config: {} })
+  model._createAddon = () => ({
+    activate: async () => {},
+    runJob: async () => true,
+    finetune: async () => true,
+    cancel: async () => {},
+    unload: async () => {}
+  })
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-inference rejects with the abort reason', async (t) => {
+  const model = buildModel()
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run([{ role: 'user', content: 'hi' }], { signal })
+  const settled = response.await()
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+
+  await model.unload()
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run([{ role: 'user', content: 'hi' }], { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+
+  await model.unload()
+})
+
+test('run(): iterate() also rejects on abort', async (t) => {
+  const model = buildModel()
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run([{ role: 'user', content: 'hi' }], { signal })
+
+  const drained = (async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of response.iterate()) { /* no output before abort */ }
+  })()
+
+  abort(new Error('iterate abort'))
+  await expectRejection(t, drained, /iterate abort/, 'iterate()')
+
+  await model.unload()
+})
+
+test('finetune(): aborting rejects with the abort reason (signal not leaked to native params)', async (t) => {
+  const model = buildModel()
+  let finetuneParams = null
+  model._createAddon = () => ({
+    activate: async () => {},
+    runJob: async () => true,
+    finetune: async (params) => { finetuneParams = params; return true },
+    cancel: async () => {},
+    unload: async () => {}
+  })
+  await model.load()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.finetune({ validation: { type: 'none' }, signal })
+  const settled = response.await()
+
+  t.absent(finetuneParams && 'signal' in finetuneParams, 'signal is stripped from native finetune params')
+
+  abort(new Error('finetune abort'))
+  await expectRejection(t, settled, /finetune abort/, 'await()')
+
+  await model.unload()
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `llm-llamacpp` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through run/runStream/finetune; ensure it is stripped before native finetune params are built.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
