### PR TITLE
fix[api]: forward AbortSignal through ocr-ggml run APIs

### DIFF
--- a/packages/ocr-ggml/index.d.ts
+++ b/packages/ocr-ggml/index.d.ts
@@ -78,6 +78,11 @@ export interface OcrGgmlRunInput {
   options?: OcrGgmlRunOptions
 }
 
+export interface RunOptions {
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
+}
+
 /**
  * One detected text region. Shape matches `@qvac/ocr-onnx` so downstream
  * consumers can swap backends without changing data handling code.
@@ -112,7 +117,7 @@ export class OcrGgml {
   constructor(args: OcrGgmlArgs)
   getState(): InferenceClientState
   load(): Promise<void>
-  run(input: OcrGgmlRunInput): Promise<QvacResponse<InferredText[]>>
+  run(input: OcrGgmlRunInput, runOptions?: RunOptions): Promise<QvacResponse<InferredText[]>>
   unload(): Promise<void>
   destroy(): Promise<void>
 

--- a/packages/ocr-ggml/index.js
+++ b/packages/ocr-ggml/index.js
@@ -66,10 +66,12 @@ class OcrGgml {
 
   /**
    * @param {{ path: string, options?: Object }} input
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    * @returns {Promise<import('@qvac/infer-base').QvacResponse>}
    */
-  async run (input) {
-    return this._run(() => this._runInternal(input))
+  async run (input, runOptions = {}) {
+    return this._run(() => this._runInternal(input, runOptions))
   }
 
   async unload () {
@@ -170,7 +172,7 @@ class OcrGgml {
     )
   }
 
-  async _runInternal (input) {
+  async _runInternal (input, runOptions = {}) {
     this.logger.info('Starting OCR inference')
 
     if (!this.addon) {
@@ -180,7 +182,7 @@ class OcrGgml {
       })
     }
 
-    const response = this._job.start()
+    const response = this._job.start({ signal: runOptions && runOptions.signal })
     try {
       const imageInput = this._readImage(input.path)
       await this.addon.runJob({

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0"
   },
   "exports": {

--- a/packages/ocr-ggml/test/unit/signal-forwarding.test.js
+++ b/packages/ocr-ggml/test/unit/signal-forwarding.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run() is forwarded into the
+// returned QvacResponse, so aborting mid-inference (or passing an already-
+// aborted signal) settles the in-flight response with the abort reason.
+
+const test = require('brittle')
+const { OcrGgml } = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Bypass load()/native binding: inject a fake addon and stub image decoding so
+// run() reaches `_job.start({ signal })` without touching the filesystem.
+function buildModel () {
+  const model = new OcrGgml({
+    params: { pathDetector: 'd.gguf', pathRecognizer: 'r.gguf', langList: ['en'] }
+  })
+  model.addon = {
+    runJob: async (job) => { model._capturedJob = job; return true },
+    cancel: async () => {},
+    destroy: async () => {}
+  }
+  model._readImage = () => ({ data: Buffer.from([0, 0, 0, 0]), isEncoded: true })
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-inference rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run({ path: 'image.png' }, { signal })
+  const settled = response.await()
+
+  t.absent(model._capturedJob && 'signal' in model._capturedJob, 'signal not forwarded to native runJob')
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run({ path: 'image.png' }, { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `ocr-ggml` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through the public run entrypoint and strip it from native params.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
