### PR TITLE
fix[api]: forward AbortSignal through ocr-onnx run APIs

### DIFF
--- a/packages/ocr-onnx/index.d.ts
+++ b/packages/ocr-onnx/index.d.ts
@@ -36,6 +36,11 @@ export interface OCRRunParams {
   };
 }
 
+export interface RunOptions {
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal;
+}
+
 export interface OCRStats {
   detectionTime?: number;
   recognitionTime?: number;
@@ -60,7 +65,7 @@ export class ONNXOcr {
 
   getState(): InferenceClientState;
   load(): Promise<void>;
-  run(params: OCRRunParams): Promise<QvacResponse>;
+  run(params: OCRRunParams, runOptions?: RunOptions): Promise<QvacResponse>;
   unload(): Promise<void>;
   destroy(): Promise<void>;
 

--- a/packages/ocr-onnx/index.js
+++ b/packages/ocr-onnx/index.js
@@ -59,10 +59,12 @@ class ONNXOcr {
   /**
    * Runs inference on the given input.
    * @param {{ path: string, options?: Object }} input - Image input
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    * @returns {Promise<QvacResponse>}
    */
-  async run (input) {
-    return this._runInternal(input)
+  async run (input, runOptions = {}) {
+    return this._runInternal(input, runOptions)
   }
 
   _getDiagnosticsJSON () {
@@ -189,9 +191,9 @@ class ONNXOcr {
     this.state.destroyed = true
   }
 
-  async _runInternal (input) {
+  async _runInternal (input, runOptions = {}) {
     this.logger.info('Starting OCR inference')
-    const response = this._job.start()
+    const response = this._job.start({ signal: runOptions && runOptions.signal })
     try {
       const imageInput = this.getImage(input.path)
       await this.addon.runJob({

--- a/packages/ocr-onnx/package.json
+++ b/packages/ocr-onnx/package.json
@@ -73,7 +73,8 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
+    "@qvac/logging": "^0.1.0",
     "@qvac/onnx": "^0.15.0",
     "bare-fs": "^4.5.1",
     "bare-os": "^3.9.1"

--- a/packages/ocr-onnx/test/integration/signal-forwarding.test.js
+++ b/packages/ocr-onnx/test/integration/signal-forwarding.test.js
@@ -1,0 +1,86 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run() is forwarded into the
+// returned QvacResponse, so aborting mid-inference (or passing an already-
+// aborted signal) settles the in-flight response with the abort reason.
+//
+// Lives in the integration suite (not test/unit) because index.js eagerly
+// loads the native binding at require() time, so it can only be imported where
+// the prebuild is present. No real model weights are needed: the native addon
+// and image decoding are stubbed at the instance level.
+
+const test = require('brittle')
+const { ONNXOcr } = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Inject a fake native addon whose runJob accepts the job but never drives a
+// terminal event, and stub image decoding so run() reaches `_job.start({ signal })`
+// without weights.
+function buildModel () {
+  const model = new ONNXOcr({
+    params: { pathDetector: 'd.onnx', pathRecognizer: 'r.onnx', langList: ['en'] }
+  })
+  model.addon = {
+    runJob: async (job) => { model._capturedJob = job; return true },
+    cancel: async () => {},
+    destroy: async () => {}
+  }
+  model.getImage = () => ({ data: Buffer.from([0, 0, 0, 0]), isEncoded: true })
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-inference rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run({ path: 'image.png' }, { signal })
+  const settled = response.await()
+
+  t.absent(model._capturedJob && 'signal' in model._capturedJob, 'signal not forwarded to native runJob')
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run({ path: 'image.png' }, { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})

--- a/packages/ocr-onnx/test/mobile/integration.auto.cjs
+++ b/packages/ocr-onnx/test/mobile/integration.auto.cjs
@@ -81,3 +81,7 @@ async function runPipelineTest (options = {}) { // eslint-disable-line no-unused
 async function runRunInternalOrderingTest (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/run-internal-ordering.test.js', options)
 }
+
+async function runSignalForwardingTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/signal-forwarding.test.js', options)
+}

--- a/packages/ocr-onnx/test/mobile/test-groups.json
+++ b/packages/ocr-onnx/test/mobile/test-groups.json
@@ -20,7 +20,8 @@
       "runLifecycleTest",
       "runOcrBasicTest",
       "runParamValidationTest",
-      "runPipelineTest"
+      "runPipelineTest",
+      "runSignalForwardingTest"
     ]
   },
   "ios": {
@@ -44,7 +45,8 @@
       "runLifecycleTest",
       "runOcrBasicTest",
       "runParamValidationTest",
-      "runPipelineTest"
+      "runPipelineTest",
+      "runSignalForwardingTest"
     ]
   },
   "perf_report_filter": "clinical_chemistry|ct_scan_report|lab_results|liver_function_test"


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `ocr-onnx` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through the public run entrypoint and strip it from native params; wire the integration test into mobile test groups.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
