### PR TITLE
fix[api]: forward AbortSignal through transcription-parakeet run APIs

### DIFF
--- a/packages/transcription-parakeet/index.d.ts
+++ b/packages/transcription-parakeet/index.d.ts
@@ -1,4 +1,4 @@
-import QvacResponse from '@qvac/infer-base/src/QvacResponse'
+import type { QvacResponse } from '@qvac/infer-base'
 import type { LoggerInterface } from '@qvac/logging'
 import { Readable } from 'stream'
 
@@ -232,6 +232,16 @@ declare interface StreamingRunConfig {
   chunkRightContextMs?: number
   /** AOSC: FIFO-overflow pop-out count (overrides `streamingSpkCacheUpdatePeriod`). */
   spkCacheUpdatePeriod?: number
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
+}
+
+/**
+ * Per-call options for `TranscriptionParakeet.run()`.
+ */
+declare interface ParakeetRunOptions {
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
 }
 
 /**
@@ -293,7 +303,8 @@ declare class TranscriptionParakeet {
    * construction, `response.stats` matches {@link TranscriptionParakeet.RuntimeStats}.
    */
   run(
-    audioStream: Readable
+    audioStream: Readable,
+    runOptions?: ParakeetRunOptions
   ): Promise<QvacResponse<TranscriptionParakeet.ParakeetRunOutput>>
 
   /**
@@ -396,7 +407,8 @@ declare namespace TranscriptionParakeet {
     Addon,
     BackendId,
     InferenceClientState,
-    StreamingRunConfig
+    StreamingRunConfig,
+    ParakeetRunOptions
   }
 }
 

--- a/packages/transcription-parakeet/index.js
+++ b/packages/transcription-parakeet/index.js
@@ -166,11 +166,17 @@ class TranscriptionParakeet {
     this.state.weightsLoaded = true
   }
 
-  async run (input) {
+  /**
+   * @param {AsyncIterable<Buffer>|Buffer|Float32Array} input - audio input
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
+   * @returns {Promise<QvacResponse>}
+   */
+  async run (input, runOptions = {}) {
     if (this.exclusiveRun) {
-      return await this._withExclusiveRun(() => this._runInternal(input))
+      return await this._withExclusiveRun(() => this._runInternal(input, runOptions))
     }
-    return await this._runInternal(input)
+    return await this._runInternal(input, runOptions)
   }
 
   /**
@@ -196,6 +202,8 @@ class TranscriptionParakeet {
    *   segments on chunk boundaries (default true)
    * @param {boolean} [streamingConfig.emitEnergyVad] - surface
    *   energy-VAD events for CTC/TDT
+   * @param {AbortSignal} [streamingConfig.signal] - When aborted, the
+   *   returned response fails with the abort reason.
    * @returns {Promise<QvacResponse>} - response object exposing
    *   `onUpdate(seg => ...).await()`
    */
@@ -206,6 +214,17 @@ class TranscriptionParakeet {
       )
     }
     return await this._runStreamingInternal(audioStream, streamingConfig)
+  }
+
+  /**
+   * Removes `signal` from a per-call options object before it is forwarded to
+   * the native addon (which does not understand AbortSignal). Returns the
+   * extracted signal plus the cleaned object.
+   */
+  _extractSignal (options) {
+    if (!options || typeof options !== 'object') return { signal: undefined, rest: options }
+    const { signal, ...rest } = options
+    return { signal, rest }
   }
 
   async _withExclusiveRun (fn) {
@@ -238,8 +257,8 @@ class TranscriptionParakeet {
    * @param {AsyncIterable<Buffer>} audioStream - Stream of audio data (16kHz mono, Float32 or s16le)
    * @returns {Promise<QvacResponse>} - Response object for tracking the transcription job
    */
-  async _runInternal (audioStream) {
-    const response = this._job.start()
+  async _runInternal (audioStream, runOptions = {}) {
+    const response = this._job.start({ signal: runOptions && runOptions.signal })
 
     let normalized
     try {
@@ -257,11 +276,12 @@ class TranscriptionParakeet {
   }
 
   async _runStreamingInternal (audioStream, streamingConfig) {
+    const { signal, rest: nativeStreamingConfig } = this._extractSignal(streamingConfig)
     const normalized = this._normalizeAudioStream(audioStream)
-    const response = this._job.start()
+    const response = this._job.start({ signal })
 
     try {
-      await this.addon.startStreaming(streamingConfig || {})
+      await this.addon.startStreaming(nativeStreamingConfig || {})
     } catch (error) {
       this._job.fail(error)
       throw error

--- a/packages/transcription-parakeet/package.json
+++ b/packages/transcription-parakeet/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-fs": "^4.5.1",
     "bare-path": "^3.0.0"

--- a/packages/transcription-parakeet/test/unit/signal-forwarding.test.js
+++ b/packages/transcription-parakeet/test/unit/signal-forwarding.test.js
@@ -1,0 +1,103 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run()/runStreaming() is
+// forwarded into the returned QvacResponse, so aborting mid-transcription (or
+// passing an already-aborted signal) settles the in-flight response with the
+// abort reason.
+
+const test = require('brittle')
+const TranscriptionParakeet = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Bypass load()/native binding: inject a fake addon whose native entrypoints
+// accept work but never drive a terminal event, so the response stays in-flight
+// until the abort fires.
+function buildModel () {
+  const model = new TranscriptionParakeet({})
+  model.addon = {
+    append: async () => true,
+    startStreaming: async () => true,
+    appendStreamingAudio: async () => {},
+    endStreaming: async () => {},
+    cancel: async () => {}
+  }
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-transcription rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run(new Float32Array([0.1, 0.2, 0.3, 0.4]), { signal })
+  const settled = response.await()
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run(new Float32Array([0.1, 0.2, 0.3, 0.4]), { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})
+
+test('runStreaming(): aborting rejects with the abort reason (signal not leaked to native)', async (t) => {
+  const model = buildModel()
+
+  let startStreamingConfig
+  model.addon.startStreaming = async (cfg) => { startStreamingConfig = cfg }
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.runStreaming(pendingStream(), { signal, chunkMs: 2000 })
+  const settled = response.await()
+
+  t.absent(startStreamingConfig && 'signal' in startStreamingConfig, 'signal stripped from native streaming config')
+
+  abort(new Error('stream abort'))
+  await expectRejection(t, settled, /stream abort/, 'await()')
+})
+
+function pendingStream () {
+  return {
+    async * [Symbol.asyncIterator] () {
+      await new Promise(() => {})
+    }
+  }
+}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `transcription-parakeet` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through run; ensure `_extractSignal` strips it before native params are built.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
