### PR TITLE
fix[api]: forward AbortSignal through transcription-whispercpp run APIs

### DIFF
--- a/packages/transcription-whispercpp/index.d.ts
+++ b/packages/transcription-whispercpp/index.d.ts
@@ -1,4 +1,4 @@
-import QvacResponse from "@qvac/infer-base/src/QvacResponse";
+import type { QvacResponse } from "@qvac/infer-base";
 import type { LoggerInterface } from "@qvac/logging";
 import { Readable } from "stream";
 
@@ -69,6 +69,13 @@ declare interface WhisperStreamingOptions {
   conversationMode?: boolean;
   endOfTurnSilenceMs?: number;
   vadRunIntervalMs?: number;
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal;
+}
+
+declare interface WhisperRunOptions {
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal;
 }
 
 declare interface VadStateEvent {
@@ -131,7 +138,8 @@ declare class TranscriptionWhispercpp {
    * Run transcription on an audio stream. When `opts.stats` was set on construction, `response.stats` matches {@link TranscriptionWhispercpp.RuntimeStats}.
    */
   run(
-    audioStream: Readable
+    audioStream: Readable,
+    runOptions?: WhisperRunOptions
   ): Promise<QvacResponse<TranscriptionWhispercpp.WhisperRunOutput>>;
 
   runStreaming(
@@ -242,6 +250,7 @@ declare namespace TranscriptionWhispercpp {
     TranscriptionWhispercppConfig,
     WhisperTranscriptionSegment,
     WhisperStreamingOptions,
+    WhisperRunOptions,
     VadStateEvent,
     EndOfTurnEvent,
     InferenceClientState,

--- a/packages/transcription-whispercpp/index.js
+++ b/packages/transcription-whispercpp/index.js
@@ -218,11 +218,17 @@ class TranscriptionWhispercpp {
     return response
   }
 
-  async run (input) {
+  /**
+   * @param {*} input - audio input (stream, Uint8Array, or chunk array)
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
+   * @returns {Promise<QvacResponse>}
+   */
+  async run (input, runOptions = {}) {
     if (this.exclusiveRun) {
-      return await this._enqueueExclusiveRunResponse(() => this._runInternal(input))
+      return await this._enqueueExclusiveRunResponse(() => this._runInternal(input, runOptions))
     }
-    return await this._runInternal(input)
+    return await this._runInternal(input, runOptions)
   }
 
   async runStreaming (audioStream, opts = {}) {
@@ -241,17 +247,17 @@ class TranscriptionWhispercpp {
       return this._runStreaming(normalizedAudioStream, opts)
     }
 
-    return this._runBatchTranscription(normalizedAudioStream)
+    return this._runBatchTranscription(normalizedAudioStream, opts.signal)
   }
 
   /** Batch runJob path: `_job` / response setup; audio via {@link #_handleAudioStream}. */
-  async _runBatchTranscription (normalizedAudioStream) {
+  async _runBatchTranscription (normalizedAudioStream, signal) {
     this._pendingWhisperJobId = await this.addon.append({
       type: 'audio',
       input: new Uint8Array()
     })
 
-    const response = this._job.start()
+    const response = this._job.start({ signal })
     const finalized = response.await()
     finalized.catch(() => {})
     response.await = () => finalized
@@ -291,7 +297,7 @@ class TranscriptionWhispercpp {
     this.addon.startStreaming(streamingConfig)
 
     this._pendingWhisperJobId = null
-    const response = this._job.start()
+    const response = this._job.start({ signal: streamingOpts && streamingOpts.signal })
     const finalized = response.await().finally(() => {
       this.addon._activeJobId = null
       this.addon._setState('listening')

--- a/packages/transcription-whispercpp/package.json
+++ b/packages/transcription-whispercpp/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-fs": "^4.7.1",
     "bare-path": "^3.0.0"

--- a/packages/transcription-whispercpp/test/unit/signal-forwarding.test.js
+++ b/packages/transcription-whispercpp/test/unit/signal-forwarding.test.js
@@ -1,0 +1,82 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run()/runStreaming() is
+// forwarded into the returned QvacResponse, so aborting mid-transcription (or
+// passing an already-aborted signal) settles the in-flight response with the
+// abort reason.
+
+const test = require('brittle')
+const TranscriptionWhispercpp = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Bypass load()/native binding: the constructor's validateModelFiles() needs a
+// real path, so point it at this test file. Inject a fake addon whose append()
+// never drives a terminal event so the response stays in-flight.
+function buildModel () {
+  const model = new TranscriptionWhispercpp(
+    { files: { model: 'model.bin' } },
+    { whisperConfig: {}, path: __filename }
+  )
+  model.addon = {
+    append: async (job) => { model._capturedJob = job; return 'job-1' },
+    cancel: async () => {},
+    _activeJobId: 'job-1'
+  }
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-transcription rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run(new Uint8Array([1, 2, 3, 4]), { signal })
+  const settled = response.await()
+
+  t.absent(model._capturedJob && 'signal' in model._capturedJob, 'signal not forwarded to native append')
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run(new Uint8Array([1, 2, 3, 4]), { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `transcription-whispercpp` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through the public run entrypoint and strip it from native params.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
