### PR TITLE
fix[api]: forward AbortSignal through translation-nmtcpp run APIs

### DIFF
--- a/packages/translation-nmtcpp/index.d.ts
+++ b/packages/translation-nmtcpp/index.d.ts
@@ -93,6 +93,11 @@ export interface InferenceClientState {
   destroyed: boolean
 }
 
+export interface RunOptions {
+  /** When aborted, the returned promise rejects with the abort reason. */
+  signal?: AbortSignal
+}
+
 /**
  * Stats returned via `response.stats` when the addon is constructed with
  * `opts.stats = true`. Field set differs by backend:
@@ -123,8 +128,8 @@ export default class TranslationNmtcpp {
   constructor(args: TranslationNmtcppArgs)
   getState(): InferenceClientState
   load(): Promise<void>
-  run(input: string): Promise<QvacResponse<string>>
-  runBatch(texts: string[]): Promise<string[]>
+  run(input: string, runOptions?: RunOptions): Promise<QvacResponse<string>>
+  runBatch(texts: string[], runOptions?: RunOptions): Promise<string[]>
   unload(): Promise<void>
   destroy(): Promise<void>
 

--- a/packages/translation-nmtcpp/index.js
+++ b/packages/translation-nmtcpp/index.js
@@ -141,10 +141,12 @@ class TranslationNmtcpp {
   /**
    * Runs inference on the given input. Serialized — only one job at a time.
    * @param {string} input - Text to translate
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    * @returns {Promise<QvacResponse>}
    */
-  async run (input) {
-    return this._run(() => this._runInternal(input))
+  async run (input, runOptions = {}) {
+    return this._run(() => this._runInternal(input, runOptions))
   }
 
   /**
@@ -298,7 +300,7 @@ class TranslationNmtcpp {
    * @param {string} input - Input text to translate
    * @returns {Promise<QvacIndicTransResponse>} Translation response
    */
-  async _runIndicTrans (input) {
+  async _runIndicTrans (input, signal) {
     const processor = new IndicProcessor()
     const [processedText] = processor.preprocessBatch(
       [input],
@@ -306,18 +308,25 @@ class TranslationNmtcpp {
       this._params.dstLang
     )
 
-    await this.addon.runJob({
-      type: 'text',
-      input: processedText
-    })
-
     const response = new QvacIndicTransResponse(
       processor,
       this._params.dstLang,
-      { cancelHandler: () => this.addon.cancel() }
+      { cancelHandler: () => this.addon.cancel(), signal }
     )
 
-    return this._job.startWith(response)
+    this._job.startWith(response)
+
+    try {
+      await this.addon.runJob({
+        type: 'text',
+        input: processedText
+      })
+    } catch (error) {
+      this._job.fail(error)
+      throw error
+    }
+
+    return response
   }
 
   /**
@@ -338,8 +347,8 @@ class TranslationNmtcpp {
    * @private
    * @returns {QvacResponse} Response object with configured handlers
    */
-  _createStandardResponse () {
-    const response = new QvacResponse({ cancelHandler: () => this.addon.cancel() })
+  _createStandardResponse (signal) {
+    const response = new QvacResponse({ cancelHandler: () => this.addon.cancel(), signal })
 
     const originalOnUpdate = response.onUpdate.bind(response)
     response.onUpdate = function (callback) {
@@ -358,28 +367,39 @@ class TranslationNmtcpp {
    * @param {string} input - Input text to translate
    * @returns {Promise<QvacResponse>} Translation response
    */
-  async _runStandardTranslation (input) {
+  async _runStandardTranslation (input, signal) {
     const text = this._prepareInputText(input)
-    await this.addon.runJob({ type: 'text', input: text })
-    const response = this._createStandardResponse()
+    const response = this._createStandardResponse(signal)
 
-    return this._job.startWith(response)
+    this._job.startWith(response)
+
+    try {
+      await this.addon.runJob({ type: 'text', input: text })
+    } catch (error) {
+      this._job.fail(error)
+      throw error
+    }
+
+    return response
   }
 
-  async _runInternal (input) {
+  async _runInternal (input, runOptions = {}) {
+    const signal = runOptions && runOptions.signal
     if (this._modelType === TranslationNmtcpp.ModelTypes.IndicTrans) {
-      return this._runIndicTrans(input)
+      return this._runIndicTrans(input, signal)
     }
-    return this._runStandardTranslation(input)
+    return this._runStandardTranslation(input, signal)
   }
 
   /**
    * Translates multiple texts in a single batch for better performance.
    *
    * @param {string[]} texts - Array of texts to translate
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned promise rejects with the abort reason.
    * @returns {Promise<string[]>} - Array of translated texts (same order as input)
    */
-  async runBatch (texts) {
+  async runBatch (texts, runOptions = {}) {
     if (!this.addon) {
       throw new Error('Model not loaded. Call load() first.')
     }
@@ -402,11 +422,9 @@ class TranslationNmtcpp {
       processedTexts = texts.map(text => this._prepareInputText(text))
     }
 
-    await this.addon.runJob({ type: 'sequences', input: processedTexts })
+    const response = this._job.start({ signal: runOptions && runOptions.signal })
 
-    const response = this._job.start()
-
-    return new Promise((resolve, reject) => {
+    const settled = new Promise((resolve, reject) => {
       response.onFinish(([batchResults]) => {
         if (this._modelType === TranslationNmtcpp.ModelTypes.IndicTrans && processor) {
           resolve(processor.postprocessBatch(batchResults, this._params.dstLang))
@@ -420,6 +438,14 @@ class TranslationNmtcpp {
         reject(error)
       })
     })
+
+    try {
+      await this.addon.runJob({ type: 'sequences', input: processedTexts })
+    } catch (error) {
+      this._job.fail(error)
+    }
+
+    return settled
   }
 
   _addonOutputCallback (addon, event, data, error) {

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-path": "^3.0.0"
   },

--- a/packages/translation-nmtcpp/test/integration/signal-forwarding.test.js
+++ b/packages/translation-nmtcpp/test/integration/signal-forwarding.test.js
@@ -1,0 +1,119 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run()/runBatch() is forwarded
+// into the QvacResponse, so aborting mid-inference (or passing an already-
+// aborted signal) settles the in-flight response with the abort reason.
+//
+// Lives in the integration suite (not test/unit) because index.js eagerly
+// loads the native binding (via ./marian) at require() time, so it can only be
+// imported where the prebuild is present. No real model weights are needed:
+// the native addon is stubbed at the instance level.
+
+const test = require('brittle')
+const TranslationNmtcpp = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Inject a fake native addon whose runJob never drives a terminal event, so the
+// response stays in-flight until the abort backstop fires. runJob still resolves
+// acceptance, matching the native contract the response should be wired around.
+// Bypasses load().
+function buildModel () {
+  const acceptedJobs = []
+  const model = new TranslationNmtcpp({
+    files: { model: 'model.bin' },
+    params: { srcLang: 'en', dstLang: 'fr' },
+    config: { modelType: 'Bergamot' }
+  })
+  model.addon = {
+    runJob: async (job) => { acceptedJobs.push(job); return true },
+    cancel: async () => {},
+    destroy: async () => {}
+  }
+  model._acceptedJobs = acceptedJobs
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-inference rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run('hello world', { signal })
+  const settled = response.await()
+
+  t.is(model._acceptedJobs.length, 1, 'native job was accepted before abort')
+  t.absent('signal' in model._acceptedJobs[0], 'signal not forwarded to native runJob')
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run('hello world', { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})
+
+test('runBatch(): aborting rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const settled = model.runBatch(['hello', 'world'], { signal })
+  settled.catch(() => {})
+  await Promise.resolve()
+
+  t.is(model._acceptedJobs.length, 1, 'native batch job was accepted before abort')
+
+  abort(new Error('batch abort'))
+  await expectRejection(t, settled, /batch abort/, 'runBatch()')
+})
+
+test('runBatch(): a native runJob failure rejects with the addon error', async (t) => {
+  const model = buildModel()
+  model.addon.runJob = async () => { throw new Error('native crash') }
+
+  await expectRejection(t, model.runBatch(['hello', 'world']), /native crash/, 'runBatch()')
+})
+
+test('run(): a native runJob failure rejects with the addon error', async (t) => {
+  const model = buildModel()
+  model.addon.runJob = async () => { throw new Error('native crash') }
+
+  await expectRejection(t, model.run('hello world'), /native crash/, 'run()')
+})

--- a/packages/translation-nmtcpp/test/mobile/integration.auto.cjs
+++ b/packages/translation-nmtcpp/test/mobile/integration.auto.cjs
@@ -18,3 +18,7 @@ async function runOpenclCache (options = {}) { // eslint-disable-line no-unused-
 async function runPivotBergamot (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/pivot-bergamot.test.js', options)
 }
+
+async function runSignalForwarding (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/signal-forwarding.test.js', options)
+}

--- a/packages/translation-nmtcpp/test/unit/opus-deprecation.test.js
+++ b/packages/translation-nmtcpp/test/unit/opus-deprecation.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const test = require('brittle')
-const FakeDL = require('../mocks/loader.fake.js')
 
 // Mock TranslationNmtcpp to test Opus deprecation without loading the native addon.
 // The real index.js eagerly loads the C++ binding via require('./marian') → require('./binding')
@@ -9,16 +8,13 @@ const FakeDL = require('../mocks/loader.fake.js')
 // These tests only verify JS-level behavior (ModelTypes enum and constructor guard),
 // so we replicate the relevant logic from index.js here.
 
-const BaseInference = require('@qvac/infer-base/WeightsProvider/BaseInference')
-
-class MockTranslationNmtcpp extends BaseInference {
+class MockTranslationNmtcpp {
   static ModelTypes = {
     IndicTrans: 'IndicTrans',
     Bergamot: 'Bergamot'
   }
 
-  constructor ({ loader, diskPath, modelName, params, logger = null, exclusiveRun = true, ...args }, config = {}) {
-    super({ logger, exclusiveRun, ...args })
+  constructor ({ config = {} } = {}) {
     const { modelType } = config
 
     if (modelType === 'Opus') {
@@ -44,16 +40,8 @@ test('ModelTypes.IndicTrans equals "IndicTrans"', (t) => {
 })
 
 test('Constructor throws deprecation error when modelType is Opus', (t) => {
-  const fakeDL = new FakeDL({})
-  const args = {
-    loader: fakeDL,
-    diskPath: '/tmp/fake',
-    modelName: 'fake-model.bin',
-    params: { srcLang: 'en', dstLang: 'fr' }
-  }
-
   try {
-    const _ = new MockTranslationNmtcpp(args, { modelType: 'Opus' }) // eslint-disable-line no-unused-vars
+    const _ = new MockTranslationNmtcpp({ config: { modelType: 'Opus' } }) // eslint-disable-line no-unused-vars
     t.fail('Expected constructor to throw for Opus modelType')
   } catch (err) {
     t.ok(err.message.includes('deprecated'), 'Error message mentions deprecation')


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `translation-nmtcpp` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Reorder so the response/job is started before `addon.runJob(...)` is awaited, with try/catch calling `this._job.fail(error)` to close the cancellation race.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
