### PR TITLE
fix[api]: forward AbortSignal through tts-ggml run APIs

### DIFF
--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -1,4 +1,4 @@
-import type QvacResponse from '@qvac/infer-base/src/QvacResponse'
+import type { QvacResponse } from '@qvac/infer-base'
 
 /**
  * Model file paths for the GGML TTS backend.  Engine is auto-detected
@@ -119,9 +119,10 @@ declare class TTSGgml {
    */
   run(
     input: TTSGgml.TTSRunInput & { streamOutput: true },
+    runOptions?: TTSGgml.TTSRunOptions,
   ): Promise<QvacResponse<TTSGgml.TTSOutputChunk & TTSGgml.SentenceStreamChunkMeta>>
 
-  run(input: TTSGgml.TTSRunInput): Promise<QvacResponse<TTSGgml.TTSOutputChunk>>
+  run(input: TTSGgml.TTSRunInput, runOptions?: TTSGgml.TTSRunOptions): Promise<QvacResponse<TTSGgml.TTSOutputChunk>>
 
   /**
    * Chunked streaming synthesis: forwards to `run({ input: text, streamOutput: true, ... })`.
@@ -167,11 +168,18 @@ declare namespace TTSGgml {
     isLast?: boolean
   }
 
+  export interface TTSRunOptions {
+    /** When aborted, the returned response fails with the abort reason. */
+    signal?: AbortSignal
+  }
+
   export interface SentenceStreamOptions {
     /** BCP-47 locale for Intl.Segmenter when available. */
     locale?: string
     /** Max graphemes per chunk (defaults: 300, or 120 when language is ko). */
     maxChunkScalars?: number
+    /** When aborted, the returned response fails with the abort reason. */
+    signal?: AbortSignal
   }
 
   /** Input accepted by `runStreaming`. */
@@ -187,6 +195,8 @@ declare namespace TTSGgml {
     sentenceDelimiterPreset?: 'latin' | 'cjk' | 'multilingual'
     maxBufferScalars?: number
     flushAfterMs?: number
+    /** When aborted, the returned response fails with the abort reason. */
+    signal?: AbortSignal
   }
 
   export type TTSRunInput = {
@@ -209,7 +219,8 @@ declare namespace TTSGgml {
     RunStreamingOptions,
     TextStreamInput,
     TTSOutputChunk,
-    TTSRunInput
+    TTSRunInput,
+    TTSRunOptions
   }
 }
 

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -404,8 +404,11 @@ class TTSGgml {
    * @param {boolean} [input.streamOutput=false] - Chunked streaming output
    * @param {string} [input.locale] - BCP-47 locale for chunking when `streamOutput`
    * @param {number} [input.maxChunkScalars] - Max graphemes per chunk when `streamOutput`
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    */
-  async run (input) {
+  async run (input, runOptions = {}) {
+    const signal = runOptions && runOptions.signal
     if (input && typeof input === 'object' && input.streamOutput === true) {
       if (typeof input.input !== 'string' || input.input.trim().length === 0) {
         throw new QvacErrorAddonTTSGgml({
@@ -415,7 +418,8 @@ class TTSGgml {
       }
       const streamOpts = {
         locale: input.locale,
-        maxChunkScalars: input.maxChunkScalars
+        maxChunkScalars: input.maxChunkScalars,
+        signal
       }
       if (this.exclusiveRun) {
         return await this._enqueueExclusiveTtsResponse(() =>
@@ -424,7 +428,7 @@ class TTSGgml {
       }
       return this._runStreamOrchestrator(input.input, streamOpts)
     }
-    return this._runExclusive(() => this._runInternal(input))
+    return this._runExclusive(() => this._runInternal(input, signal))
   }
 
   /**
@@ -454,7 +458,7 @@ class TTSGgml {
    * Equivalent to `run({ input: text, streamOutput: true, ...options })`.
    *
    * @param {string} text
-   * @param {{ locale?: string, maxChunkScalars?: number }} [options]
+   * @param {{ locale?: string, maxChunkScalars?: number, signal?: AbortSignal }} [options]
    */
   async runStream (text, options = {}) {
     const opts = options == null || typeof options !== 'object' ? {} : options
@@ -463,7 +467,7 @@ class TTSGgml {
       streamOutput: true,
       locale: opts.locale,
       maxChunkScalars: opts.maxChunkScalars
-    })
+    }, { signal: opts.signal })
   }
 
   /**
@@ -499,10 +503,10 @@ class TTSGgml {
     }
     if (this.exclusiveRun) {
       return await this._enqueueExclusiveTtsResponse(() =>
-        this._runTextStreamOrchestrator(normalized)
+        this._runTextStreamOrchestrator(normalized, options && options.signal)
       )
     }
-    return this._runTextStreamOrchestrator(normalized)
+    return this._runTextStreamOrchestrator(normalized, options && options.signal)
   }
 
   _resolveRunStreamingOptions (textStream, options) {
@@ -567,8 +571,8 @@ class TTSGgml {
     })
   }
 
-  _runTextStreamOrchestrator (asyncTextSource) {
-    const response = this._job.start()
+  _runTextStreamOrchestrator (asyncTextSource, signal) {
+    const response = this._job.start({ signal })
     this._sentenceStreamCtx = {
       textStreamMode: true,
       asyncTextSource,
@@ -670,7 +674,7 @@ class TTSGgml {
       })
     }
 
-    const response = this._job.start()
+    const response = this._job.start({ signal: options && options.signal })
     this._sentenceStreamCtx = {
       chunks,
       chunkIdx: 0,
@@ -810,8 +814,8 @@ class TTSGgml {
     this.state.destroyed = true
   }
 
-  async _runInternal (input) {
-    const response = this._job.start()
+  async _runInternal (input, signal) {
+    const response = this._job.start({ signal })
     try {
       // Per-request overrides (e.g. input.outputSampleRate) are not
       // honoured by the native engine today — all synthesis knobs are

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -98,7 +98,7 @@
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-fs": "^4.5.6",
     "bare-os": "^3.8.0",

--- a/packages/tts-ggml/test/unit/signal-forwarding.test.js
+++ b/packages/tts-ggml/test/unit/signal-forwarding.test.js
@@ -1,0 +1,88 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run()/runStream()/
+// runStreaming() is forwarded into the returned QvacResponse, so aborting
+// mid-synthesis (or passing an already-aborted signal) settles the in-flight
+// response with the abort reason.
+
+const test = require('brittle')
+const TTSGgml = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+function buildModel () {
+  const model = new TTSGgml({})
+  model.addon = {
+    activate: async () => {},
+    runJob: async (job) => { model._capturedJob = job; return true },
+    cancel: async () => {},
+    destroyInstance: async () => {}
+  }
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-synthesis rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run({ input: 'hello there' }, { signal })
+  const settled = response.await()
+
+  t.absent(model._capturedJob && 'signal' in model._capturedJob, 'signal not forwarded to native runJob')
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run({ input: 'hello there' }, { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})
+
+test('runStreaming(): aborting rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.runStreaming(['hello there'], { signal })
+  const settled = response.await()
+
+  abort(new Error('stream abort'))
+  await expectRejection(t, settled, /stream abort/, 'await()')
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `tts-ggml` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through run/runStream; ensure it is stripped from stream options before native params are built.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
