### PR TITLE
fix[api]: forward AbortSignal through tts-onnx run APIs

### DIFF
--- a/packages/tts-onnx/index.d.ts
+++ b/packages/tts-onnx/index.d.ts
@@ -1,4 +1,4 @@
-import type QvacResponse from '@qvac/infer-base/src/QvacResponse'
+import type { QvacResponse } from '@qvac/infer-base'
 
 /**
  * LavaSR enhancer configuration.
@@ -147,9 +147,10 @@ declare class ONNXTTS {
    */
   run(
     input: ONNXTTS.TTSRunInput & { streamOutput: true },
+    runOptions?: ONNXTTS.TTSRunOptions,
   ): Promise<QvacResponse<ONNXTTS.TTSOutputChunk & ONNXTTS.SentenceStreamChunkMeta>>
 
-  run(input: ONNXTTS.TTSRunInput): Promise<QvacResponse<ONNXTTS.TTSOutputChunk>>
+  run(input: ONNXTTS.TTSRunInput, runOptions?: ONNXTTS.TTSRunOptions): Promise<QvacResponse<ONNXTTS.TTSOutputChunk>>
 
   /**
    * Chunked streaming synthesis: forwards to `run({ input: text, streamOutput: true, ... })`.
@@ -187,11 +188,18 @@ declare namespace ONNXTTS {
     sentenceChunk?: string
   }
 
+  export interface TTSRunOptions {
+    /** When aborted, the returned response fails with the abort reason. */
+    signal?: AbortSignal
+  }
+
   export interface SentenceStreamOptions {
     /** BCP-47 locale for Intl.Segmenter when available. */
     locale?: string
     /** Max graphemes per chunk (defaults: 300, or 120 when language is ko). */
     maxChunkScalars?: number
+    /** When aborted, the returned response fails with the abort reason. */
+    signal?: AbortSignal
   }
 
   /** Input accepted by `runStreaming`. */
@@ -215,6 +223,8 @@ declare namespace ONNXTTS {
     maxBufferScalars?: number
     /** Idle time after the last fragment before flushing the buffer (timer resets on each fragment). Default 500. */
     flushAfterMs?: number
+    /** When aborted, the returned response fails with the abort reason. */
+    signal?: AbortSignal
   }
 
   export type TTSRunInput = {
@@ -248,7 +258,8 @@ declare namespace ONNXTTS {
     RunStreamingOptions,
     TextStreamInput,
     TTSOutputChunk,
-    TTSRunInput
+    TTSRunInput,
+    TTSRunOptions
   }
 }
 

--- a/packages/tts-onnx/index.js
+++ b/packages/tts-onnx/index.js
@@ -346,8 +346,11 @@ class ONNXTTS {
    * @param {boolean} [input.streamOutput=false] - When true, chunked streaming output (optional `locale`, `maxChunkScalars`; same as `runStream`)
    * @param {string} [input.locale] - BCP-47 locale for chunking when `streamOutput`
    * @param {number} [input.maxChunkScalars] - Max graphemes per chunk when `streamOutput`
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
    */
-  async run (input) {
+  async run (input, runOptions = {}) {
+    const signal = runOptions && runOptions.signal
     if (input && typeof input === 'object' && input.streamOutput === true) {
       if (typeof input.input !== 'string' || input.input.trim().length === 0) {
         throw new QvacErrorAddonTTS({
@@ -357,7 +360,8 @@ class ONNXTTS {
       }
       const streamOpts = {
         locale: input.locale,
-        maxChunkScalars: input.maxChunkScalars
+        maxChunkScalars: input.maxChunkScalars,
+        signal
       }
       if (this.exclusiveRun) {
         return await this._enqueueExclusiveTtsResponse(() =>
@@ -366,7 +370,7 @@ class ONNXTTS {
       }
       return this._runStreamOrchestrator(input.input, streamOpts)
     }
-    return this._runExclusive(() => this._runInternal(input))
+    return this._runExclusive(() => this._runInternal(input, signal))
   }
 
   /**
@@ -396,7 +400,7 @@ class ONNXTTS {
    * Equivalent to `run({ input: text, streamOutput: true, ...options })`.
    *
    * @param {string} text
-   * @param {{ locale?: string, maxChunkScalars?: number }} [options]
+   * @param {{ locale?: string, maxChunkScalars?: number, signal?: AbortSignal }} [options]
    */
   async runStream (text, options = {}) {
     const opts = options == null || typeof options !== 'object' ? {} : options
@@ -405,7 +409,7 @@ class ONNXTTS {
       streamOutput: true,
       locale: opts.locale,
       maxChunkScalars: opts.maxChunkScalars
-    })
+    }, { signal: opts.signal })
   }
 
   /**
@@ -439,10 +443,10 @@ class ONNXTTS {
     }
     if (this.exclusiveRun) {
       return await this._enqueueExclusiveTtsResponse(() =>
-        this._runTextStreamOrchestrator(normalized)
+        this._runTextStreamOrchestrator(normalized, options && options.signal)
       )
     }
-    return this._runTextStreamOrchestrator(normalized)
+    return this._runTextStreamOrchestrator(normalized, options && options.signal)
   }
 
   /**
@@ -515,8 +519,8 @@ class ONNXTTS {
    * Starts a {@link QvacResponse} and schedules chunk synthesis without awaiting completion
    * (so callers can attach `onUpdate` before audio callbacks run).
    */
-  _runTextStreamOrchestrator (asyncTextSource) {
-    const response = this._job.start()
+  _runTextStreamOrchestrator (asyncTextSource, signal) {
+    const response = this._job.start({ signal })
     this._sentenceStreamCtx = {
       textStreamMode: true,
       asyncTextSource,
@@ -622,7 +626,7 @@ class ONNXTTS {
       })
     }
 
-    const response = this._job.start()
+    const response = this._job.start({ signal: options && options.signal })
     this._sentenceStreamCtx = {
       chunks,
       chunkIdx: 0,
@@ -772,8 +776,8 @@ class ONNXTTS {
     this.state.destroyed = true
   }
 
-  async _runInternal (input) {
-    const response = this._job.start()
+  async _runInternal (input, signal) {
+    const response = this._job.start({ signal })
     try {
       const jobData = {
         type: input.type || 'text',

--- a/packages/tts-onnx/package.json
+++ b/packages/tts-onnx/package.json
@@ -95,7 +95,7 @@
   "dependencies": {
     "@qvac/error": "^0.1.0",
     "@qvac/onnx": "^0.15.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "bare-fs": "^4.5.6",
     "bare-os": "^3.8.0",
     "bare-path": "^3.0.0"

--- a/packages/tts-onnx/test/unit/signal-forwarding.test.js
+++ b/packages/tts-onnx/test/unit/signal-forwarding.test.js
@@ -1,0 +1,91 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run()/runStream()/
+// runStreaming() is forwarded into the returned QvacResponse, so aborting
+// mid-synthesis (or passing an already-aborted signal) settles the in-flight
+// response with the abort reason.
+
+const test = require('brittle')
+const ONNXTTS = require('../../index.js')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Inject a fake native addon whose runJob accepts the job but never emits a
+// terminal event, so the response stays in-flight until the abort backstop fires.
+// Bypasses load().
+function buildModel () {
+  const model = new ONNXTTS({})
+  model.addon = {
+    activate: async () => {},
+    runJob: async (job) => { model._capturedJob = job; return true },
+    cancel: async () => {},
+    destroyInstance: async () => {}
+  }
+  return model
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-synthesis rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run({ input: 'hello there' }, { signal })
+  const settled = response.await()
+
+  t.absent(model._capturedJob && 'signal' in model._capturedJob, 'signal not forwarded to native runJob')
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run({ input: 'hello there' }, { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})
+
+test('runStreaming(): aborting rejects with the abort reason', async (t) => {
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.runStreaming(['hello there'], { signal })
+  const settled = response.await()
+
+  abort(new Error('stream abort'))
+  await expectRejection(t, settled, /stream abort/, 'await()')
+})


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `tts-onnx` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through run/runStream; ensure it is stripped from stream options before native params are built.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
