### PR TITLE
fix[api]: forward AbortSignal through vla-ggml run APIs

### DIFF
--- a/packages/vla-ggml/index.d.ts
+++ b/packages/vla-ggml/index.d.ts
@@ -81,6 +81,11 @@ export interface VlaModelOptions {
   opts?: { stats?: boolean }
 }
 
+export interface RunOptions {
+  /** When aborted, the returned response fails with the abort reason. */
+  signal?: AbortSignal
+}
+
 export interface QvacResponse {
   await(): Promise<VlaRunResult>
   cancel(): Promise<void>
@@ -96,7 +101,7 @@ export class VlaModel {
    */
   readonly backendName: string | null
   load (opts?: { backend?: 'auto' | 'cpu' }): Promise<void>
-  run (input: VlaRunInput): Promise<QvacResponse>
+  run (input: VlaRunInput, runOptions?: RunOptions): Promise<QvacResponse>
   pause (): Promise<void>
   cancel (): Promise<void>
   unload (): Promise<void>

--- a/packages/vla-ggml/index.js
+++ b/packages/vla-ggml/index.js
@@ -266,11 +266,17 @@ class VlaModel {
 
   get backendName () { return this._backendName }
 
-  async run (input) {
-    return this._run(() => this._runInternal(input))
+  /**
+   * @param {Object} input - VLA inference input (images, state, tokens, mask, …).
+   * @param {Object} [runOptions]
+   * @param {AbortSignal} [runOptions.signal] - When aborted, the returned response fails with the abort reason.
+   * @returns {Promise<QvacResponse>}
+   */
+  async run (input, runOptions = {}) {
+    return this._run(() => this._runInternal(input, runOptions))
   }
 
-  async _runInternal (input) {
+  async _runInternal (input, runOptions = {}) {
     if (!this._handle) {
       throw new QvacErrorAddonVla({ code: ERR_CODES.INSTANCE_NOT_INITIALIZED })
     }
@@ -282,7 +288,7 @@ class VlaModel {
 
     this.logger.info('Starting inference')
 
-    const response = this._job.start()
+    const response = this._job.start({ signal: runOptions && runOptions.signal })
     // Per-job accumulator. Two events flow through _onAddonEvent: the
     // Float32Array action chunk lands first, then the RuntimeStats object —
     // we resolve the response only when both have arrived.

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -52,7 +52,7 @@
   "homepage": "https://github.com/tetherto/qvac/tree/main/packages/vla-ggml#readme",
   "dependencies": {
     "@qvac/error": "^0.1.0",
-    "@qvac/infer-base": "^0.4.0",
+    "@qvac/infer-base": "^0.6.0",
     "@qvac/logging": "^0.1.0",
     "bare-fs": "^4.5.1",
     "bare-path": "^3.0.0"
@@ -70,7 +70,9 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
-    }
+    },
+    "./addon.js": "./addon.js",
+    "./binding.js": "./binding.js"
   },
   "main": "index.js",
   "types": "index.d.ts"

--- a/packages/vla-ggml/test/integration/signal-forwarding.test.js
+++ b/packages/vla-ggml/test/integration/signal-forwarding.test.js
@@ -1,0 +1,104 @@
+'use strict'
+
+// Verifies that a per-call AbortSignal passed to run() is forwarded into the
+// returned QvacResponse, so aborting mid-inference (or passing an already-
+// aborted signal) settles the in-flight response with the abort reason.
+//
+// Lives in the integration suite (not test/unit) because index.js eagerly
+// loads the native binding at require() time, so it can only be imported where
+// the prebuild is present. No real model weights are needed: the module-level
+// `binding.runJob` is monkeypatched (and restored) so _runInternal reaches
+// `_job.start({ signal })` and accepts the job without touching native state.
+
+const test = require('brittle')
+const { VlaModel } = require('../../index.js')
+const binding = require('../../binding')
+
+function makeAbortable () {
+  const listeners = new Set()
+  const signal = {
+    aborted: false,
+    reason: undefined,
+    addEventListener (event, cb, opts) {
+      if (event !== 'abort') return
+      const wrapped = opts && opts.once ? () => { listeners.delete(wrapped); cb() } : cb
+      wrapped._original = cb
+      listeners.add(wrapped)
+    },
+    removeEventListener (event, cb) {
+      if (event !== 'abort') return
+      for (const l of listeners) if (l === cb || l._original === cb) { listeners.delete(l); return }
+    }
+  }
+  return {
+    signal,
+    abort (reason) {
+      if (signal.aborted) return
+      signal.aborted = true
+      signal.reason = reason
+      for (const l of Array.from(listeners)) l()
+    }
+  }
+}
+
+// Build a model whose native handle and hparams are faked, with binding.runJob
+// stubbed to accept the job without emitting a terminal event.
+function buildModel () {
+  const model = new VlaModel({ files: { model: ['/tmp/model.gguf'] } })
+  model._handle = {}
+  model._hparams = {}
+  model.cancel = async () => {}
+  return model
+}
+
+function validInput () {
+  const w = 1
+  const h = 1
+  return {
+    imgWidth: w,
+    imgHeight: h,
+    images: [new Float32Array(3 * w * h)],
+    state: new Float32Array(1),
+    tokens: new Int32Array(1),
+    mask: new Uint8Array(1)
+  }
+}
+
+async function expectRejection (t, promise, re, message) {
+  let err
+  try { await promise } catch (e) { err = e }
+  t.ok(err, `${message}: rejected`)
+  t.ok(err && re.test(err.message), `${message}: reason "${err && err.message}" matches ${re}`)
+}
+
+test('run(): aborting mid-inference rejects with the abort reason', async (t) => {
+  const original = binding.runJob
+  let capturedJobParams
+  binding.runJob = (handle, params) => { capturedJobParams = params; return true }
+  t.teardown(() => { binding.runJob = original })
+
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  const response = await model.run(validInput(), { signal })
+  const settled = response.await()
+
+  t.absent(capturedJobParams && 'signal' in capturedJobParams, 'signal not forwarded to native runJob')
+
+  abort(new Error('aborted by caller'))
+  await expectRejection(t, settled, /aborted by caller/, 'await()')
+})
+
+test('run(): an already-aborted signal rejects immediately', async (t) => {
+  const original = binding.runJob
+  binding.runJob = () => true
+  t.teardown(() => { binding.runJob = original })
+
+  const model = buildModel()
+
+  const { signal, abort } = makeAbortable()
+  abort(new Error('pre-aborted'))
+
+  const response = await model.run(validInput(), { signal })
+  await expectRejection(t, response.await(), /pre-aborted/, 'await()')
+})

--- a/packages/vla-ggml/test/mobile/integration.auto.cjs
+++ b/packages/vla-ggml/test/mobile/integration.auto.cjs
@@ -20,3 +20,8 @@ async function runPi05Test (options = {}) { // eslint-disable-line no-unused-var
   if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runPi05Test')) return __FILTERED
   return runIntegrationModule('../integration/pi05.test.js', options)
 }
+
+async function runSignalForwardingTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runSignalForwardingTest')) return __FILTERED
+  return runIntegrationModule('../integration/signal-forwarding.test.js', options)
+}

--- a/packages/vla-ggml/test/mobile/test-groups.json
+++ b/packages/vla-ggml/test/mobile/test-groups.json
@@ -1,10 +1,10 @@
 {
   "ios": {
-    "smolvla": ["runAddonTest"],
+    "smolvla": ["runAddonTest", "runSignalForwardingTest"],
     "pi05":    ["runPi05Test"]
   },
   "android": {
-    "smolvla": ["runAddonTest"],
+    "smolvla": ["runAddonTest", "runSignalForwardingTest"],
     "pi05":    ["runPi05Test"]
   }
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- A per-call `AbortSignal` passed to `vla-ggml` addon APIs was not reliably honored, leaving in-flight `QvacResponse` objects hanging when the caller aborted.

## 📝 How does it solve it?

- Bumped `@qvac/infer-base` from `^0.4.0` to `^0.6.0`.
- Added an optional `runOptions.signal` (or `options.signal`) parameter to the public run entrypoints and forwarded it to `this._job.start({ signal })`.
- Forward signal through the public run entrypoint and strip it from native params; wire the integration test into mobile test groups.

## 🧪 How was it tested?

- Added `signal-forwarding` tests verifying that an aborted signal surfaces the abort reason on the returned response and that `signal` is not forwarded into native params.

## 🔌 API Changes

```typescript
const controller = new AbortController()

// Optional `signal` accepted on run entrypoints; when aborted,
// the returned response fails with the abort reason.
const response = await model.run(input, { signal: controller.signal })

controller.abort()
```

---

Split out of #2362 (one PR per addon package).
