### PR TITLE
QVAC-19346 feat: serialize concurrent same-model requests via per-(kind, modelId) FIFO queue

### DIFF
--- a/packages/sdk/e2e/tests/cancellation-tests.ts
+++ b/packages/sdk/e2e/tests/cancellation-tests.ts
@@ -80,13 +80,10 @@ export const cancelBroadTranslateLlm: TestDefinition = {
   },
 };
 
-export const policyRejectConcurrentCompletion: TestDefinition = {
-  testId: "policy-reject-concurrent-completion",
+export const serializeConcurrentCompletion: TestDefinition = {
+  testId: "serialize-concurrent-completion",
   params: {
-    prompt:
-      "Write a long, detailed essay about the history of computing, " +
-      "starting with the abacus and continuing through the modern era. " +
-      "Be thorough and use complete paragraphs.",
+    prompt: "Reply with one short sentence naming your favourite colour.",
   },
   expectation: { validation: "function", fn: () => true },
   metadata: {
@@ -151,7 +148,7 @@ export const cancellationTests = [
   cancelThenResumeKvCache,
   cancelBroadEmbeddings,
   cancelBroadTranslateLlm,
-  policyRejectConcurrentCompletion,
+  serializeConcurrentCompletion,
   cancelByRequestIdEmbed,
   cancelByRequestIdTranscribe,
   cancelByRequestIdRagIngest,

--- a/packages/sdk/e2e/tests/cancellation-tests.ts
+++ b/packages/sdk/e2e/tests/cancellation-tests.ts
@@ -86,6 +86,7 @@ export const serializeConcurrentCompletion: TestDefinition = {
     prompt: "Reply with one short sentence naming your favourite colour.",
   },
   expectation: { validation: "function", fn: () => true },
+  suites: ["smoke"],
   metadata: {
     category: "cancellation",
     dependency: "llm",

--- a/packages/sdk/e2e/tests/shared/executors/cancellation-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/cancellation-executor.ts
@@ -9,7 +9,6 @@ import {
   ragDeleteWorkspace,
   ragIngest,
   RAG_ERROR_CODES,
-  RequestRejectedByPolicyError,
   SDK_SERVER_ERROR_CODES,
   transcribe,
   translate,
@@ -27,7 +26,7 @@ import {
   cancelByRequestIdRagIngest,
   cancelMidStreamCompletion,
   cancelThenResumeKvCache,
-  policyRejectConcurrentCompletion,
+  serializeConcurrentCompletion,
 } from "../../cancellation-tests.js";
 
 export type CancelForm = "broad" | "requestId";
@@ -82,8 +81,6 @@ export interface TranscribeCancelParams {
 }
 
 const INFERENCE_CANCELLED_CODE = SDK_SERVER_ERROR_CODES.INFERENCE_CANCELLED;
-const REQUEST_REJECTED_BY_POLICY_CODE =
-  SDK_SERVER_ERROR_CODES.REQUEST_REJECTED_BY_POLICY;
 const RAG_OPERATION_CANCELLED_CODE = RAG_ERROR_CODES.OPERATION_CANCELLED;
 const ADDON_CANCEL_MESSAGE = "Job cancelled";
 // Embed addon surfaces this when llama_decode is aborted mid-flight.
@@ -299,45 +296,13 @@ async function streamAndCancelAtN(
   return { ok: true, obs, finalError: finalOutcome.error };
 }
 
-// Validates the shape of a RequestRejectedByPolicyError for completion.
-function checkPolicyError(err: unknown, modelId: string): TestResult | null {
-  if (!(err instanceof RequestRejectedByPolicyError)) {
-    return {
-      passed: false,
-      output: `Second completion rejected with ${describeError(err)}, expected RequestRejectedByPolicyError`,
-    };
-  }
-  if (err.modelId !== modelId) {
-    return {
-      passed: false,
-      output: `RequestRejectedByPolicyError.modelId=${JSON.stringify(err.modelId)}, expected ${JSON.stringify(modelId)}`,
-    };
-  }
-  if (err.kind !== "completion") {
-    return {
-      passed: false,
-      output: `RequestRejectedByPolicyError.kind=${JSON.stringify(err.kind)}, expected "completion"`,
-    };
-  }
-  if (!err.reason) {
-    return { passed: false, output: "RequestRejectedByPolicyError.reason was empty" };
-  }
-  if (err.code !== REQUEST_REJECTED_BY_POLICY_CODE) {
-    return {
-      passed: false,
-      output: `RequestRejectedByPolicyError.code=${err.code}, expected ${REQUEST_REJECTED_BY_POLICY_CODE}`,
-    };
-  }
-  return null;
-}
-
 const sharedTests = [
   cancelMidStreamCompletion,
   cancelBeforeBeginCompletion,
   cancelThenResumeKvCache,
   cancelBroadEmbeddings,
   cancelBroadTranslateLlm,
-  policyRejectConcurrentCompletion,
+  serializeConcurrentCompletion,
   cancelByRequestIdEmbed,
   cancelByRequestIdRagIngest,
 ];
@@ -345,7 +310,7 @@ const sharedTests = [
 export class CancellationExecutor extends AbstractModelExecutor<
   typeof sharedTests
 > {
-  pattern = /^(cancel-|policy-reject-)/;
+  pattern = /^(cancel-|serialize-)/;
 
   // `as never` lets subclasses extend handlers with test ids outside TDefs.
   protected handlers = this.buildSharedHandlers() as never;
@@ -358,7 +323,7 @@ export class CancellationExecutor extends AbstractModelExecutor<
       [cancelBroadEmbeddings.testId]: this.embedBroad.bind(this),
       [cancelByRequestIdEmbed.testId]: this.embedTargeted.bind(this),
       [cancelBroadTranslateLlm.testId]: this.translateLlmBroad.bind(this),
-      [policyRejectConcurrentCompletion.testId]: this.policyReject.bind(this),
+      [serializeConcurrentCompletion.testId]: this.serializeConcurrent.bind(this),
       [cancelByRequestIdRagIngest.testId]: this.ragIngestTargeted.bind(this),
     };
   }
@@ -674,7 +639,7 @@ export class CancellationExecutor extends AbstractModelExecutor<
     };
   }
 
-  async policyReject(
+  async serializeConcurrent(
     params: PolicyParams,
     _expectation: Expectation,
   ): Promise<TestResult> {
@@ -684,60 +649,55 @@ export class CancellationExecutor extends AbstractModelExecutor<
       { role: "user" as const, content: params.prompt },
     ];
 
+    // Fire two completions at the same model in the same tick. The default
+    // completion policy serializes same-model requests FIFO instead of
+    // rejecting the second, so BOTH must succeed — the second simply waits
+    // for the first to release the native llama.cpp context, then runs.
     const run1 = completion({ modelId, history, stream: true });
-    const run1EventsIter = run1.events[Symbol.asyncIterator]();
-    const final1 = markHandled(run1.final);
-    let firstEventConsumed = false;
+    const run2 = completion({ modelId, history, stream: true });
 
-    try {
-      // Wait for run1's first contentDelta so the registry holds the
-      // entry and the policy will reject the concurrent run2.
-      while (!firstEventConsumed) {
-        const next = await run1EventsIter.next();
-        if (next.done) {
-          return {
-            passed: false,
-            output: "run1 stream ended before any contentDelta — cannot establish policy precondition",
-          };
-        }
-        if (next.value.type === "contentDelta") {
-          firstEventConsumed = true;
-        }
-      }
+    const [obs1, obs2] = await Promise.all([
+      observeStream(run1.events),
+      observeStream(run2.events),
+    ]);
+    const [final1, final2] = await Promise.all([
+      captureFinal(run1.final),
+      captureFinal(run2.final),
+    ]);
 
-      const run2 = completion({ modelId, history, stream: true });
-      markHandled(run2.text);
-      markHandled(run2.toolCalls);
-      markHandled(run2.stats);
-
-      const finalOutcome = await captureFinal(run2.final);
-      if (finalOutcome.resolved) {
+    const checks: Array<[string, StreamObservation, FinalOutcome]> = [
+      ["run1", obs1, final1],
+      ["run2", obs2, final2],
+    ];
+    for (const [label, obs, final] of checks) {
+      if (!final.resolved) {
         return {
           passed: false,
-          output: "Second completion resolved — oneAtATimePerModel policy did not reject",
+          output:
+            `${label}.final rejected with ${describeError(final.error)} — both same-model ` +
+            "completions must serialize and succeed, not reject",
         };
       }
-      const policyFail = checkPolicyError(finalOutcome.error, modelId);
-      if (policyFail) return policyFail;
-      const policyErr = finalOutcome.error as RequestRejectedByPolicyError;
-      return {
-        passed: true,
-        output: `Policy reject OK: ${describeError(policyErr)} reason=${JSON.stringify(policyErr.reason.slice(0, 80))}`,
-      };
-    } finally {
-      try {
-        await cancel({ requestId: run1.requestId });
-      } catch {
-        // run1 may have ended already — cleanup is best-effort.
+      if (obs.lastStopReason === "cancelled" || obs.lastStopReason === "error") {
+        return {
+          passed: false,
+          output: `${label} ended with stopReason=${JSON.stringify(obs.lastStopReason)}, expected a successful completion`,
+        };
       }
-      // Drain stream + final so run1 fully settles before we return.
-      try {
-        while (!(await run1EventsIter.next()).done) {}
-      } catch {}
-      try {
-        await final1;
-      } catch {}
+      if (obs.contentEvents === 0) {
+        return {
+          passed: false,
+          output: `${label} produced no content — the serialized completion did not actually run`,
+        };
+      }
     }
+
+    return {
+      passed: true,
+      output:
+        `Serialize-concurrent OK: both same-model completions succeeded ` +
+        `(run1 ${obs1.contentEvents} deltas, run2 ${obs2.contentEvents} deltas)`,
+    };
   }
 
   async ragIngestTargeted(

--- a/packages/sdk/examples/concurrent-completion-collision.ts
+++ b/packages/sdk/examples/concurrent-completion-collision.ts
@@ -1,0 +1,134 @@
+/**
+ * Demonstrates how `qvac serve` handles a coding agent firing two completions
+ * at the SAME loaded model at once (e.g. a chat completion plus a
+ * title/summary call) — the workload that used to break it.
+ *
+ * Background: a loaded llama.cpp model is one native context (one KV-cache,
+ * one decode loop), so two completions on it cannot truly run in parallel.
+ * The SDK worker installs a per-`(kind, modelId)` FIFO admission queue for
+ * the `completion` kind (`maxConcurrentPerModel: 1`, `onOverflow: "queue"`).
+ * A second concurrent completion on the same model now WAITS its turn and
+ * then runs, instead of being rejected with `RequestRejectedByPolicyError`
+ * (code 52420) or colliding at the addon with "Cannot set new job".
+ *
+ * Part 1 — two concurrent completions on the SAME model  → both succeed,
+ *          serialized by the queue (the bug this fixes: previously one was
+ *          rejected/collided).
+ * Part 2 — two concurrent completions on DIFFERENT models → both succeed and
+ *          run in parallel (the queue is keyed per `(kind, modelId)`, so
+ *          distinct models never block each other).
+ *
+ * Run from packages/sdk:
+ *   bun run examples/concurrent-completion-collision.ts
+ */
+import {
+  completion,
+  loadModel,
+  unloadModel,
+  QWEN3_1_7B_INST_Q4,
+  LLAMA_3_2_1B_INST_Q4_0,
+  RequestRejectedByPolicyError,
+} from "@qvac/sdk";
+
+type Outcome =
+  | { label: string; ok: true; text: string }
+  | { label: string; ok: false; errorName: string; code?: number; message: string };
+
+async function runCompletion(
+  label: string,
+  modelId: string,
+  prompt: string,
+): Promise<Outcome> {
+  try {
+    // `completion()` starts the request synchronously, so calling this for two
+    // tasks in the same tick puts both "in flight" before either is awaited.
+    const result = completion({
+      modelId,
+      history: [{ role: "user", content: prompt }],
+      stream: false,
+    });
+    const text = await result.text;
+    return { label, ok: true, text };
+  } catch (error) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error
+        ? (error as { code?: number }).code
+        : undefined;
+    const base = {
+      label,
+      ok: false as const,
+      errorName: error instanceof Error ? error.constructor.name : typeof error,
+      message: error instanceof Error ? error.message : String(error),
+    };
+    return code !== undefined ? { ...base, code } : base;
+  }
+}
+
+function report(title: string, outcomes: Outcome[]): void {
+  console.log(`\n${title}`);
+  for (const o of outcomes) {
+    if (o.ok) {
+      const preview = o.text.replace(/\s+/g, " ").slice(0, 70);
+      console.log(`  ✅ ${o.label}: ${preview}${o.text.length > 70 ? "…" : ""}`);
+    } else {
+      const policy = o.code === 52420 ? " (rejected by policy)" : "";
+      console.log(
+        `  ❌ ${o.label}: ${o.errorName}${o.code !== undefined ? ` [${o.code}]` : ""}${policy} — ${o.message}`,
+      );
+    }
+  }
+}
+
+try {
+  const modelA = await loadModel({
+    modelSrc: QWEN3_1_7B_INST_Q4,
+    modelType: "llm",
+    modelConfig: { ctx_size: 4096 },
+  });
+
+  // Part 1 — same model, two concurrent completions.
+  const sameModel = await Promise.all([
+    runCompletion("req-A1", modelA, "What is Bitcoin? One sentence."),
+    runCompletion("req-A2", modelA, "What is a hash function? One sentence."),
+  ]);
+  report(
+    "Part 1 — two concurrent completions on the SAME model (expect both to succeed, serialized):",
+    sameModel,
+  );
+
+  const rejected = sameModel.filter((o) => !o.ok).length;
+  if (rejected === 0) {
+    console.log(
+      "  → Both succeeded: the second was queued behind the first and ran when the slot freed (no 52420, no addon collision).",
+    );
+  } else {
+    console.log(
+      `  ⚠️  ${rejected}/2 failed — the FIFO admission queue should have serialized these. Check the completion policy.`,
+    );
+  }
+
+  // Part 2 — different models, two concurrent completions (the "parallel that works").
+  const modelB = await loadModel({
+    modelSrc: LLAMA_3_2_1B_INST_Q4_0,
+    modelType: "llm",
+    modelConfig: { ctx_size: 4096 },
+  });
+  const differentModels = await Promise.all([
+    runCompletion("req-A", modelA, "Name one use of Bitcoin. One sentence."),
+    runCompletion("req-B", modelB, "Name one use of Ethereum. One sentence."),
+  ]);
+  report(
+    "Part 2 — two concurrent completions on DIFFERENT models (expect both succeed):",
+    differentModels,
+  );
+
+  await unloadModel({ modelId: modelA, clearStorage: false });
+  await unloadModel({ modelId: modelB, clearStorage: false });
+
+  console.log(
+    `\nrejected-by-policy error available for instanceof checks: ${typeof RequestRejectedByPolicyError === "function"}`,
+  );
+} catch (error) {
+  console.error("❌ Error:", error);
+  process.exit(1);
+}

--- a/packages/sdk/examples/concurrent-completion-collision.ts
+++ b/packages/sdk/examples/concurrent-completion-collision.ts
@@ -82,7 +82,6 @@ function report(title: string, outcomes: Outcome[]): void {
 try {
   const modelA = await loadModel({
     modelSrc: QWEN3_1_7B_INST_Q4,
-    modelType: "llm",
     modelConfig: { ctx_size: 4096 },
   });
 
@@ -110,7 +109,6 @@ try {
   // Part 2 — different models, two concurrent completions (the "parallel that works").
   const modelB = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-    modelType: "llm",
     modelConfig: { ctx_size: 4096 },
   });
   const differentModels = await Promise.all([

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -176,13 +176,15 @@ export { SUPPORTED_AUDIO_FORMATS } from "./constants/audio";
 // envelope, but consumers reach for it through `instanceof` on
 // `await run.final` / `run.text` / `run.toolCalls` / `run.stats`
 // rejections. `RequestRejectedByPolicyError` is thrown by
-// `RequestRegistry.begin(...)` when a registered concurrency policy
-// (e.g. `oneAtATimePerModel` on `completion`) rejects a new request;
-// it propagates out through the worker so the client can distinguish
-// "the request collided with another one" from "the request failed".
+// `await RequestRegistry.begin(...)` when a registered concurrency policy
+// refuses a new request. With the default queue policy a same-model
+// `completion` no longer rejects — it waits FIFO — so this now surfaces the
+// bounded-queue cases: `onOverflow: "reject"`, the per-model queue-depth cap,
+// or a `queueTimeoutMs` elapsing. It propagates out through the worker so the
+// client can distinguish "the model is saturated" from "the request failed".
 //
 // `RequestIdConflictError` and `RequestNotFoundError` are thrown by
-// `RequestRegistry.begin(...)` / `.end(...)` on UUID collisions and
+// `await RequestRegistry.begin(...)` / `.end(...)` on UUID collisions and
 // missing-target cancels. They're surfaced here so consumers using
 // the decorated-promise `requestId` can pattern-match on rejected
 // cancel paths. All three classes round-trip the RPC boundary via

--- a/packages/sdk/server/bare/ops/embed.ts
+++ b/packages/sdk/server/bare/ops/embed.ts
@@ -44,7 +44,7 @@ export async function embed(
   // `cancel({ requestId })` and broad `cancel({ modelId, kind: "embeddings" })`
   // straight to this context's signal. Falls back to a server-generated
   // id if the client didn't send one (older releases).
-  await using ctx = getRequestRegistry().begin({
+  await using ctx = await getRequestRegistry().begin({
     requestId: requestId ?? generateServerRequestId(),
     kind: "embeddings",
     modelId,

--- a/packages/sdk/server/bare/ops/transcribe.ts
+++ b/packages/sdk/server/bare/ops/transcribe.ts
@@ -154,7 +154,7 @@ export async function* transcribe(
   // `cancel({ requestId })` and `cancel({ modelId, kind: "transcribe" })`
   // through this context. Falls back to a server-generated id if the
   // client didn't send one.
-  await using ctx = getRequestRegistry().begin({
+  await using ctx = await getRequestRegistry().begin({
     requestId: requestId ?? generateServerRequestId(),
     kind: "transcribe",
     modelId,
@@ -301,7 +301,7 @@ export async function* transcribeStream(
   // doesn't distinguish streaming vs non-streaming variants of the same
   // operation, so `cancel({ modelId, kind: "transcribe" })` cancels
   // either shape.
-  await using ctx = getRequestRegistry().begin({
+  await using ctx = await getRequestRegistry().begin({
     requestId: requestId ?? generateServerRequestId(),
     kind: "transcribe",
     modelId,

--- a/packages/sdk/server/bare/ops/translate.ts
+++ b/packages/sdk/server/bare/ops/translate.ts
@@ -107,7 +107,7 @@ export async function* translate(
   // exits on `signal.aborted`, scope unwinds, and the addon may run
   // to completion in the background — acceptable because the result
   // is dropped either way.
-  await using ctx = getRequestRegistry().begin({
+  await using ctx = await getRequestRegistry().begin({
     requestId: requestId ?? generateServerRequestId(),
     kind: "translate",
     modelId,

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
@@ -123,8 +123,14 @@ export async function startFinetune(
   // that kicks off finetune and immediately polls `getFinetuneState` must
   // still observe RUNNING — `begin()` yields a microtask even when
   // uncontended, so registering after it would briefly report IDLE. If
-  // `begin()` rejects (id conflict / policy) we clear the flag again so a
-  // failed start doesn't leave the model wedged as RUNNING.
+  // `begin()` rejects (id conflict) we clear the flag again so a failed
+  // start doesn't leave the model wedged as RUNNING — but only when *this*
+  // call actually set it. The flag is a modelId-keyed Set, so `register`
+  // is a no-op add when a finetune is already running on this model. In
+  // that case `begin()` can still reject (a colliding `requestId` from a
+  // different in-flight lifecycle), and clearing unconditionally would wipe
+  // the genuinely-running finetune's flag. Capture ownership first.
+  const wasRunning = getRunningFinetuneState(request.modelId);
   registerRunningFinetune(request.modelId);
 
   // Open a request-scoped lifecycle so finetune slots into the same
@@ -142,7 +148,7 @@ export async function startFinetune(
       modelId: request.modelId,
     })
     .catch((err: unknown) => {
-      clearFinetuneRuntimeState(request.modelId);
+      if (!wasRunning) clearFinetuneRuntimeState(request.modelId);
       throw err;
     });
   const requestLogger = withRequestContext(getServerLogger(), ctx);

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
@@ -127,7 +127,7 @@ export async function startFinetune(
   // `cancel: { scope: "model", hard: true }` declaration. The legacy
   // `cancelFinetune(modelId)` wrapper below now goes through the
   // registry instead of touching the addon directly.
-  await using ctx = getRequestRegistry().begin({
+  await using ctx = await getRequestRegistry().begin({
     requestId: request.requestId ?? generateServerRequestId(),
     kind: "finetune",
     modelId: request.modelId,

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
@@ -119,28 +119,16 @@ export async function startFinetune(
   const model = getModel(request.modelId) as FinetuneCapableModel;
   validateExplicitFinetuneOperation(request);
 
-  // Mark the run RUNNING *before* the (now-async) registry begin. A caller
-  // that kicks off finetune and immediately polls `getFinetuneState` must
-  // still observe RUNNING — `begin()` yields a microtask even when
-  // uncontended, so registering after it would briefly report IDLE. If
-  // `begin()` rejects (id conflict) we clear the flag again so a failed
-  // start doesn't leave the model wedged as RUNNING — but only when *this*
-  // call actually set it. The flag is a modelId-keyed Set, so `register`
-  // is a no-op add when a finetune is already running on this model. In
-  // that case `begin()` can still reject (a colliding `requestId` from a
-  // different in-flight lifecycle), and clearing unconditionally would wipe
-  // the genuinely-running finetune's flag. Capture ownership first.
+  // Mark RUNNING before the async begin() so an immediate getFinetuneState()
+  // poll observes RUNNING, not IDLE. register is a no-op when a finetune is
+  // already running on this model, so only clear on a failed begin() if this
+  // call actually set the flag.
   const wasRunning = getRunningFinetuneState(request.modelId);
   registerRunningFinetune(request.modelId);
 
-  // Open a request-scoped lifecycle so finetune slots into the same
-  // registry-driven cancel surface as the streaming inference kinds.
-  // `cancel({ requestId })` and broad `cancel({ modelId, kind: "finetune" })`
-  // both route through this context's signal — the `onAbort` listener
-  // forwards to `model.cancel()` to match the plugin's
-  // `cancel: { scope: "model", hard: true }` declaration. The legacy
-  // `cancelFinetune(modelId)` wrapper below now goes through the
-  // registry instead of touching the addon directly.
+  // Scope the run into the registry so cancel({ requestId }) and
+  // cancel({ modelId, kind: "finetune" }) reach it; onAbort forwards to
+  // model.cancel().
   await using ctx = await getRequestRegistry()
     .begin({
       requestId: request.requestId ?? generateServerRequestId(),
@@ -152,12 +140,8 @@ export async function startFinetune(
       throw err;
     });
   const requestLogger = withRequestContext(getServerLogger(), ctx);
-  // Two-level try/finally collapses into a pair of `scope.defer`
-  // registrations. LIFO order — the listener-detach defer is
-  // registered after `clearFinetuneRuntimeState`, so on scope unwind
-  // the listener is removed first, then the runtime-state flag is
-  // cleared. This mirrors the legacy `finally` nesting where the inner
-  // `removeListener` ran before the outer `clearFinetuneRuntimeState`.
+  // Cleared on scope unwind; deferred before the listener detach so LIFO
+  // removes the listener first.
   ctx.scope.defer(() => {
     clearFinetuneRuntimeState(request.modelId);
   });
@@ -203,20 +187,11 @@ export async function pauseFinetune(modelId: string): Promise<FinetuneResult> {
   };
 }
 
-// Thin compat wrapper over the request registry. The in-flight
-// finetune is tracked by a `RequestContext` (kind `"finetune"`), and
-// the registry owns the broadcast to its `AbortSignal`. `startFinetune`
-// installs the addon-level `model.cancel()` listener tied to that
-// signal, so callers see the same observable effect as a direct
-// `model.cancel()` call. The addon-call wiring is centralised there —
-// never invoke `model.cancel()` here.
+// Routes cancellation through the registry; the model.cancel() forward is
+// installed by startFinetune, so never call model.cancel() here.
 export function cancelFinetune(modelId: string): Promise<FinetuneResult> {
-  // `registry.cancel(...)` is synchronous — it triggers the matching
-  // requests' abort signals and returns the cancelled count. Scope
-  // unwinding (and the `model.cancel()` forward installed by
-  // `startFinetune`) happens on the handler's own dispose path. The
-  // outer `Promise.resolve(...)` keeps the legacy `cancelFinetune`
-  // return shape (`Promise<FinetuneResult>`) intact for callers.
+  // cancel() is synchronous; Promise.resolve keeps the Promise<FinetuneResult>
+  // return shape.
   getRequestRegistry().cancel({ modelId, kind: "finetune" });
 
   return Promise.resolve({

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/finetune.ts
@@ -119,6 +119,14 @@ export async function startFinetune(
   const model = getModel(request.modelId) as FinetuneCapableModel;
   validateExplicitFinetuneOperation(request);
 
+  // Mark the run RUNNING *before* the (now-async) registry begin. A caller
+  // that kicks off finetune and immediately polls `getFinetuneState` must
+  // still observe RUNNING — `begin()` yields a microtask even when
+  // uncontended, so registering after it would briefly report IDLE. If
+  // `begin()` rejects (id conflict / policy) we clear the flag again so a
+  // failed start doesn't leave the model wedged as RUNNING.
+  registerRunningFinetune(request.modelId);
+
   // Open a request-scoped lifecycle so finetune slots into the same
   // registry-driven cancel surface as the streaming inference kinds.
   // `cancel({ requestId })` and broad `cancel({ modelId, kind: "finetune" })`
@@ -127,14 +135,17 @@ export async function startFinetune(
   // `cancel: { scope: "model", hard: true }` declaration. The legacy
   // `cancelFinetune(modelId)` wrapper below now goes through the
   // registry instead of touching the addon directly.
-  await using ctx = await getRequestRegistry().begin({
-    requestId: request.requestId ?? generateServerRequestId(),
-    kind: "finetune",
-    modelId: request.modelId,
-  });
+  await using ctx = await getRequestRegistry()
+    .begin({
+      requestId: request.requestId ?? generateServerRequestId(),
+      kind: "finetune",
+      modelId: request.modelId,
+    })
+    .catch((err: unknown) => {
+      clearFinetuneRuntimeState(request.modelId);
+      throw err;
+    });
   const requestLogger = withRequestContext(getServerLogger(), ctx);
-
-  registerRunningFinetune(request.modelId);
   // Two-level try/finally collapses into a pair of `scope.defer`
   // registrations. LIFO order — the listener-detach defer is
   // registered after `clearFinetuneRuntimeState`, so on scope unwind

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
@@ -145,7 +145,7 @@ export const llmPlugin = definePlugin({
         // client can target this run with `cancel({ requestId })`.
         // Falls back to a server-generated id if the client (e.g. an
         // older release) didn't send one.
-        await using ctx = getRequestRegistry().begin({
+        await using ctx = await getRequestRegistry().begin({
           requestId: request.requestId ?? generateServerRequestId(),
           kind: "completion",
           modelId: request.modelId,

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
@@ -153,6 +153,31 @@ export const llmPlugin = definePlugin({
 
         const requestLogger = withRequestContext(getServerLogger(), ctx);
 
+        // The request can come back from `begin()` already aborted: the
+        // client hit Stop while this completion was queued behind another
+        // same-model request (or the cancel beat `begin()`). It never
+        // acquired a real slot and never started decoding, so it must not
+        // touch the shared model — calling `completion()` here would fire
+        // `addon.cancel()` and `model.run()` on the single native context
+        // the *active* request is currently decoding on, cancelling or
+        // corrupting the very request the queue exists to protect. Emit a
+        // clean cancelled terminal and return without constructing the stream.
+        //
+        // `Boolean(...)` (not a bare `if (ctx.signal.aborted)` or a direct
+        // alias) so TS doesn't narrow `ctx.signal.aborted` to `false` for the
+        // rest of the function — the downstream `const cancelled =
+        // ctx.signal.aborted` must stay a plain `boolean` because the addon
+        // can flip the signal mid-stream.
+        const abortedBeforeRun = Boolean(ctx.signal.aborted);
+        if (abortedBeforeRun) {
+          yield {
+            type: "completionStream" as const,
+            done: true,
+            events: normalizer.finish({ stopReason: "cancelled" as const }),
+          };
+          return;
+        }
+
         const stream = completion(
           {
             history: filteredHistory,

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/plugin.ts
@@ -153,21 +153,11 @@ export const llmPlugin = definePlugin({
 
         const requestLogger = withRequestContext(getServerLogger(), ctx);
 
-        // The request can come back from `begin()` already aborted: the
-        // client hit Stop while this completion was queued behind another
-        // same-model request (or the cancel beat `begin()`). It never
-        // acquired a real slot and never started decoding, so it must not
-        // touch the shared model — calling `completion()` here would fire
-        // `addon.cancel()` and `model.run()` on the single native context
-        // the *active* request is currently decoding on, cancelling or
-        // corrupting the very request the queue exists to protect. Emit a
-        // clean cancelled terminal and return without constructing the stream.
-        //
-        // `Boolean(...)` (not a bare `if (ctx.signal.aborted)` or a direct
-        // alias) so TS doesn't narrow `ctx.signal.aborted` to `false` for the
-        // rest of the function — the downstream `const cancelled =
-        // ctx.signal.aborted` must stay a plain `boolean` because the addon
-        // can flip the signal mid-stream.
+        // begin() can return already-aborted when the client cancels while
+        // this completion is queued behind another same-model one. It never
+        // decoded, so it must not touch the shared native context — emit a
+        // cancelled terminal and return. Boolean(...) keeps ctx.signal.aborted
+        // a boolean so the mid-stream check below isn't narrowed to false.
         const abortedBeforeRun = Boolean(ctx.signal.aborted);
         if (abortedBeforeRun) {
           yield {
@@ -210,12 +200,8 @@ export const llmPlugin = definePlugin({
           }
 
           const { modelExecutionMs, stats, toolCalls } = result.value;
-          // `stopReason: "cancelled"` rides the success-done path: the
-          // events stream ends normally, the cancellation is observable
-          // via the last event's `stopReason`, and the client-side
-          // `CompletionRun` aggregates (`final` / `text` / `toolCalls` /
-          // `stats`) reject with `InferenceCancelledError` carrying the
-          // partial state.
+          // Cancellation rides the done path: observable via the last event's
+          // stopReason; client aggregates reject with InferenceCancelledError.
           const cancelled = ctx.signal.aborted;
           const terminalEvents = normalizer.finish({
             ...(stats && { stats }),

--- a/packages/sdk/server/bare/plugins/sdcpp-generation/ops/video.ts
+++ b/packages/sdk/server/bare/plugins/sdcpp-generation/ops/video.ts
@@ -45,7 +45,7 @@ function asVideoModel(model: unknown, modelId: string): VideoStableDiffusion {
 export async function* video(
   request: VideoRequest,
 ): AsyncGenerator<VideoStreamResponse> {
-  await using ctx = getRequestRegistry().begin({
+  await using ctx = await getRequestRegistry().begin({
     requestId: request.requestId ?? generateServerRequestId(),
     kind: "diffusion",
     modelId: request.modelId,

--- a/packages/sdk/server/bare/runtime/request-registry-singleton.ts
+++ b/packages/sdk/server/bare/runtime/request-registry-singleton.ts
@@ -17,10 +17,27 @@ import {
 let registry: RequestRegistry | null = null;
 
 function installDefaultPolicies(r: RequestRegistry): void {
-  // The llama.cpp addon owns one KV-cache + one decode loop per model,
-  // so two concurrent `completionStream` requests on the same model
-  // would interleave their token streams on the same logical session.
-  r.policy({ kind: "completion", oneAtATimePerModel: true });
+  // A loaded llama.cpp model is one native context: one KV-cache, one
+  // single-slot decode loop. Two concurrent `completion` requests on the
+  // same model can't actually run in parallel — the legacy
+  // `oneAtATimePerModel` rule rejected the second with
+  // `RequestRejectedByPolicyError`. But coding agents (OpenCode, Cline, …)
+  // routinely fire a main chat completion plus a background title /
+  // summary call at the same model, so rejecting broke them and forced a
+  // wasteful two-model-file workaround.
+  //
+  // Instead of rejecting, serialize: the second concurrent same-model
+  // completion waits FIFO for the first to finish, then runs.
+  // `maxConcurrentPerModel: 1` is the single-context reality today; bump it
+  // to the addon's slot count once continuous batching lands and this flips
+  // to N-way concurrent with no other change. The depth cap bounds memory
+  // so a runaway client can't queue without limit (the 65th waiter rejects).
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+    maxQueueDepthPerModel: 64,
+  });
 }
 
 export function getRequestRegistry(): RequestRegistry {

--- a/packages/sdk/server/bare/runtime/request-registry-singleton.ts
+++ b/packages/sdk/server/bare/runtime/request-registry-singleton.ts
@@ -17,21 +17,11 @@ import {
 let registry: RequestRegistry | null = null;
 
 function installDefaultPolicies(r: RequestRegistry): void {
-  // A loaded llama.cpp model is one native context: one KV-cache, one
-  // single-slot decode loop. Two concurrent `completion` requests on the
-  // same model can't actually run in parallel — the legacy
-  // `oneAtATimePerModel` rule rejected the second with
-  // `RequestRejectedByPolicyError`. But coding agents (OpenCode, Cline, …)
-  // routinely fire a main chat completion plus a background title /
-  // summary call at the same model, so rejecting broke them and forced a
-  // wasteful two-model-file workaround.
-  //
-  // Instead of rejecting, serialize: the second concurrent same-model
-  // completion waits FIFO for the first to finish, then runs.
-  // `maxConcurrentPerModel: 1` is the single-context reality today; bump it
-  // to the addon's slot count once continuous batching lands and this flips
-  // to N-way concurrent with no other change. The depth cap bounds memory
-  // so a runaway client can't queue without limit (the 65th waiter rejects).
+  // A loaded model is a single native context (one KV-cache, single-slot
+  // decode), so two same-model completions can't run in parallel. Serialize
+  // rather than reject: the second waits FIFO. maxConcurrentPerModel: 1 is
+  // today's reality — raise it once continuous batching lands. The depth cap
+  // bounds queue memory.
   r.policy({
     kind: "completion",
     maxConcurrentPerModel: 1,

--- a/packages/sdk/server/bare/runtime/request-registry.ts
+++ b/packages/sdk/server/bare/runtime/request-registry.ts
@@ -574,7 +574,13 @@ export function createRequestRegistry(options?: {
   }
 
   async function begin(opts: BeginOpts): Promise<ManagedRequestContext> {
-    if (entries.has(opts.requestId)) {
+    // A request id is reserved for its whole lifecycle, including the time
+    // it spends *queued* for an admission slot. `waitersById` holds the
+    // still-queued begins (they aren't in `entries` yet), so a duplicate id
+    // must be rejected against both maps — otherwise a second begin with the
+    // same id would enqueue behind the first and overwrite its `waitersById`
+    // index, leaving the original waiter unreachable by `cancel({ requestId })`.
+    if (entries.has(opts.requestId) || waitersById.has(opts.requestId)) {
       throw new RequestIdConflictError(opts.requestId);
     }
 

--- a/packages/sdk/server/bare/runtime/request-registry.ts
+++ b/packages/sdk/server/bare/runtime/request-registry.ts
@@ -53,23 +53,61 @@ export type CancelTarget = CancelByRequestId | CancelByModelId;
  * Per-kind admission rule. Kinds without a registered policy have no
  * admission control (every `begin(...)` is accepted as long as the
  * request id is unique).
+ *
+ * The policy turns admission into a per-`(kind, modelId)` FIFO queue with
+ * a configurable concurrency limit. A second concurrent request to the
+ * same `(kind, modelId)` *waits its turn* (default) rather than colliding
+ * on the single native llama.cpp context. The limit is forward-compatible
+ * with addon-side continuous batching: bump `maxConcurrentPerModel` to the
+ * addon's slot count to flip serial execution to N-way concurrent without
+ * any further SDK change.
+ *
+ * Requests without a `modelId` are never gated (there is no per-model
+ * identity to serialize against).
  */
 export interface ConcurrencyPolicy {
   kind: RequestKind;
   /**
-   * When true, at most one in-flight request per `(kind, modelId)`
-   * tuple — a second `begin(...)` rejects with
-   * `RequestRejectedByPolicyError`. Requests without a `modelId` are
-   * unaffected.
+   * Max simultaneously in-flight requests per `(kind, modelId)`.
+   * Default: `Infinity` (no admission limit). Set `1` to serialize, or
+   * `N` for N-way concurrency (the future continuous-batching slot
+   * count). Non-finite values disable gating entirely.
    */
-  oneAtATimePerModel: boolean;
+  maxConcurrentPerModel?: number;
+  /**
+   * What a `begin(...)` does when the `(kind, modelId)` is at capacity:
+   *  - `"queue"` (default): wait FIFO for a slot to free.
+   *  - `"reject"`: throw `RequestRejectedByPolicyError` immediately
+   *    (the legacy `oneAtATimePerModel` behavior).
+   */
+  onOverflow?: "queue" | "reject";
+  /**
+   * Max waiters allowed to queue per `(kind, modelId)` before further
+   * begins reject with `RequestRejectedByPolicyError`. Bounds memory so a
+   * runaway client can't grow the queue without limit. Default: `64`.
+   * Only consulted when `onOverflow` is `"queue"`.
+   */
+  maxQueueDepthPerModel?: number;
+  /**
+   * Reject a waiter that has waited longer than this many milliseconds
+   * with `RequestRejectedByPolicyError`. Default: `undefined` (wait
+   * indefinitely for a slot).
+   */
+  queueTimeoutMs?: number;
+  /**
+   * @deprecated Back-compat alias. `true` normalizes to
+   * `{ maxConcurrentPerModel: 1, onOverflow: "reject" }`; `false` (or
+   * omitted) leaves admission unlimited. Ignored when
+   * `maxConcurrentPerModel` is set explicitly.
+   */
+  oneAtATimePerModel?: boolean;
 }
 
 /**
- * `ManagedRequestContext` is the value `begin(...)` returns. It extends
+ * `ManagedRequestContext` is the value `begin(...)` resolves to. It extends
  * `RequestContext` with an async-dispose method so handlers can write:
  *
- *   await using ctx = registry.begin({ ... });
+ *   await using ctx = await registry.begin({ ... });
  *
  * On dispose the scope unwinds (LIFO cleanup) and the registry slot is
  * freed. If the handler doesn't override `ctx.state` before unwinding,
@@ -82,17 +120,22 @@ export interface ManagedRequestContext extends RequestContext {
 
 export interface RequestRegistry {
   /**
-   * Open a new request. Throws:
+   * Open a new request. Returns a promise because admission may *queue*:
+   * when a concurrency policy caps the `(kind, modelId)` and it's at
+   * capacity with `onOverflow: "queue"`, the promise resolves once a slot
+   * frees (FIFO). Callers write `await using ctx = await registry.begin(...)`.
+   *
+   * Rejects with:
    *  - `RequestIdConflictError` if `requestId` is already present
    *    (UUIDv4 collision is astronomically unlikely; the guard exists
    *    so a buggy client retry sending the same id can't silently
    *    overwrite an in-flight request).
    *  - `RequestRejectedByPolicyError` if a concurrency policy was
-   *    registered for `opts.kind` and the new request would violate
-   *    it (e.g. `oneAtATimePerModel` rejects when another request
-   *    with the same `(kind, modelId)` pair is already in flight).
+   *    registered for `opts.kind` and the new request can't be admitted:
+   *    `onOverflow: "reject"` at capacity, the queue depth cap is
+   *    exceeded, or the waiter's `queueTimeoutMs` elapsed.
    */
-  begin(opts: BeginOpts): ManagedRequestContext;
+  begin(opts: BeginOpts): Promise<ManagedRequestContext>;
 
   /**
    * Register or replace the concurrency policy for a `RequestKind`.
@@ -101,10 +144,10 @@ export interface RequestRegistry {
    * twice replaces the previous declaration.
    *
    * @example
-   *   r.policy({ kind: "completion", oneAtATimePerModel: true });
-   *   await using a = r.begin({ requestId: "r-1", kind: "completion", modelId: "m1" });
-   *   r.begin({ requestId: "r-2", kind: "completion", modelId: "m1" });
-   *   // → throws RequestRejectedByPolicyError (code 52420)
+   *   r.policy({ kind: "completion", maxConcurrentPerModel: 1, onOverflow: "reject" });
+   *   await using a = await r.begin({ requestId: "r-1", kind: "completion", modelId: "m1" });
+   *   await r.begin({ requestId: "r-2", kind: "completion", modelId: "m1" });
+   *   // → rejects with RequestRejectedByPolicyError (code 52420)
    */
   policy(opts: ConcurrencyPolicy): void;
 
@@ -158,6 +201,13 @@ interface RegistryEntry {
   detachParent: () => void;
   /** `Date.now()` at `begin(...)` — used for `durationMs` on the end emit. */
   startedAt: number;
+  /**
+   * Admission-slot key (`<kind>\0<modelId>`) this request holds, or
+   * `undefined` when the request was admitted without gating (no policy,
+   * no `modelId`, or an unbounded `maxConcurrentPerModel`). The slot is
+   * handed back in `disposeEntry` once the scope has fully unwound.
+   */
+  slotKey: string | undefined;
 }
 
 /**
@@ -170,6 +220,49 @@ interface CancelBeforeBeginEntry {
   at: number;
   /** Forwarded to `controller.abort(reason)` once `begin(...)` arrives. */
   reason?: string;
+}
+
+/**
+ * A `ConcurrencyPolicy` resolved to its effective numeric form. Computed
+ * once in `policy(...)` (cheap, default-filled) so the hot `begin(...)`
+ * path reads concrete numbers instead of re-deriving the legacy
+ * `oneAtATimePerModel` alias on every call.
+ */
+interface NormalizedPolicy {
+  /** Effective slots per `(kind, modelId)`. `Infinity` ⇒ no gating. */
+  maxConcurrent: number;
+  onOverflow: "queue" | "reject";
+  maxQueueDepth: number;
+  queueTimeoutMs: number | undefined;
+}
+
+/**
+ * One queued `begin(...)` awaiting an admission slot. `resolve(true)` hands
+ * the waiter the freed slot (it inherits the in-flight count — see
+ * `releaseSlot`); `resolve(false)` releases it without a slot (graceful
+ * cancel-while-queued, where the request proceeds only to observe its
+ * already-aborted signal); `reject(err)` fails the awaiting `begin(...)`.
+ */
+interface SlotWaiter {
+  requestId: string;
+  kind: RequestKind;
+  modelId: string;
+  enqueuedAt: number;
+  resolve: (granted: boolean) => void;
+  reject: (err: unknown) => void;
+  /** `queueTimeoutMs` timer, cleared on resolve / reject / drain. */
+  timer: ReturnType<typeof setTimeout> | undefined;
+}
+
+/**
+ * Per-`(kind, modelId)` admission state: the count of requests currently
+ * holding a slot plus the FIFO queue of waiters. Deleted from `keyStates`
+ * as soon as it is fully idle (`active === 0 && waiters.length === 0`) so
+ * the map stays proportional to live models, not all models ever seen.
+ */
+interface KeyState {
+  active: number;
+  waiters: SlotWaiter[];
 }
 
 /**
@@ -195,13 +288,35 @@ interface CancelBeforeBeginEntry {
 const CANCEL_BEFORE_BEGIN_MAX_ENTRIES = 128;
 const CANCEL_BEFORE_BEGIN_TTL_MS = 30_000;
 
+/**
+ * Default cap on waiters queued per `(kind, modelId)` when a policy uses
+ * `onOverflow: "queue"` without an explicit `maxQueueDepthPerModel`.
+ * Bounds memory so a misbehaving client firing a flood of same-model
+ * requests can't grow the queue without limit — the (depth + 1)th begin
+ * rejects with `RequestRejectedByPolicyError` instead of enqueuing.
+ */
+const DEFAULT_MAX_QUEUE_DEPTH_PER_MODEL = 64;
+
 export function createRequestRegistry(options?: {
   /** Defaults to `getServerLogger()`. Tests inject a stub. */
   logger?: Logger;
 }): RequestRegistry {
   const entries = new Map<string, RegistryEntry>();
-  const policies = new Map<RequestKind, ConcurrencyPolicy>();
+  const policies = new Map<RequestKind, NormalizedPolicy>();
   const logger = options?.logger ?? getServerLogger();
+
+  /**
+   * Per-`(kind, modelId)` admission semaphores. Keyed by
+   * `slotKey(kind, modelId)`. Absent until the first gated `begin(...)`
+   * for that key; removed again the moment the key is idle.
+   */
+  const keyStates = new Map<string, KeyState>();
+  /**
+   * Reverse index from a queued waiter's `requestId` to its slot so
+   * `cancel({ requestId })` can pull a still-queued request out of the
+   * FIFO in O(1) without scanning every `KeyState`.
+   */
+  const waitersById = new Map<string, { key: string; waiter: SlotWaiter }>();
 
   function logLifecycle(
     event: "begin" | "cancel" | "end",
@@ -286,6 +401,146 @@ export function createRequestRegistry(options?: {
     return entry;
   }
 
+  function slotKey(kind: RequestKind, modelId: string): string {
+    // NUL separator can't appear in a kind (closed union) or a modelId
+    // (sdkModelId is a generated handle), so the join is unambiguous.
+    return `${kind}\u0000${modelId}`;
+  }
+
+  /**
+   * Pull a waiter out of its queue and tidy up: clear its timeout, drop
+   * the reverse index, and delete the `KeyState` if that left it idle.
+   * Does NOT settle the waiter's promise — the caller decides whether the
+   * removal resolves (granted / graceful cancel) or rejects (timeout /
+   * teardown).
+   */
+  function removeWaiter(key: string, waiter: SlotWaiter): void {
+    if (waiter.timer !== undefined) {
+      clearTimeout(waiter.timer);
+      waiter.timer = undefined;
+    }
+    waitersById.delete(waiter.requestId);
+    const st = keyStates.get(key);
+    if (!st) return;
+    const i = st.waiters.indexOf(waiter);
+    if (i >= 0) st.waiters.splice(i, 1);
+    if (st.active <= 0 && st.waiters.length === 0) keyStates.delete(key);
+  }
+
+  /**
+   * Admission gate. Resolves to the slot key the caller must release on
+   * dispose, or `undefined` when the request is ungated (no policy, no
+   * `modelId`, an unbounded limit, or an already-aborted parent — which we
+   * let through so the normal abort path produces a clean cancelled
+   * outcome rather than queuing a doomed request).
+   *
+   * When the key is at capacity it either rejects (`onOverflow: "reject"`,
+   * queue-depth cap, or `queueTimeoutMs`) or enqueues a FIFO waiter and
+   * awaits it. The releaser hands a freed slot to the oldest waiter
+   * (`resolve(true)`), so `active` is never decremented and re-incremented
+   * across a hand-off — that's what guarantees FIFO fairness with no
+   * acquire/release race in the single-threaded event loop.
+   */
+  async function acquireSlot(
+    opts: BeginOpts,
+  ): Promise<{ slotKey: string | undefined }> {
+    if (opts.modelId === undefined) return { slotKey: undefined };
+    const policy = policies.get(opts.kind);
+    if (!policy || !Number.isFinite(policy.maxConcurrent)) {
+      return { slotKey: undefined };
+    }
+    // A parent (worker-shutdown) signal that's already aborted: don't
+    // queue behind live work that may never drain — let begin() proceed
+    // and abort immediately via the parentSignal path.
+    if (opts.parentSignal?.aborted) return { slotKey: undefined };
+
+    const modelId = opts.modelId;
+    const key = slotKey(opts.kind, modelId);
+    let st = keyStates.get(key);
+    if (!st) {
+      st = { active: 0, waiters: [] };
+      keyStates.set(key, st);
+    }
+
+    if (st.active < policy.maxConcurrent) {
+      st.active++;
+      return { slotKey: key };
+    }
+
+    if (policy.onOverflow === "reject") {
+      throw new RequestRejectedByPolicyError(
+        opts.requestId,
+        opts.kind,
+        modelId,
+        `another ${opts.kind} request is already running on this model`,
+      );
+    }
+
+    if (st.waiters.length >= policy.maxQueueDepth) {
+      throw new RequestRejectedByPolicyError(
+        opts.requestId,
+        opts.kind,
+        modelId,
+        `request queue for this model is full (${st.waiters.length} waiting)`,
+      );
+    }
+
+    const queue = st;
+    const granted = await new Promise<boolean>((resolve, reject) => {
+      const waiter: SlotWaiter = {
+        requestId: opts.requestId,
+        kind: opts.kind,
+        modelId,
+        enqueuedAt: Date.now(),
+        resolve,
+        reject,
+        timer: undefined,
+      };
+      if (policy.queueTimeoutMs !== undefined) {
+        const timeoutMs = policy.queueTimeoutMs;
+        waiter.timer = setTimeout(() => {
+          removeWaiter(key, waiter);
+          reject(
+            new RequestRejectedByPolicyError(
+              opts.requestId,
+              opts.kind,
+              modelId,
+              `timed out waiting ${timeoutMs}ms for a slot on this model`,
+            ),
+          );
+        }, timeoutMs);
+      }
+      queue.waiters.push(waiter);
+      waitersById.set(opts.requestId, { key, waiter });
+    });
+
+    return granted ? { slotKey: key } : { slotKey: undefined };
+  }
+
+  /**
+   * Hand a freed slot to the next FIFO waiter, or free it outright when
+   * none are queued. Called from `disposeEntry` after the scope has fully
+   * unwound, so the native context is genuinely free before the next
+   * same-model request is admitted.
+   */
+  function releaseSlot(key: string): void {
+    const st = keyStates.get(key);
+    if (!st) return;
+    const next = st.waiters.shift();
+    if (next) {
+      // Hand off: the waiter inherits the slot, so `active` is unchanged.
+      waitersById.delete(next.requestId);
+      if (next.timer !== undefined) {
+        clearTimeout(next.timer);
+        next.timer = undefined;
+      }
+      next.resolve(true);
+      return;
+    }
+    st.active--;
+    if (st.active <= 0 && st.waiters.length === 0) keyStates.delete(key);
+  }
+
   function cancelEntry(entry: RegistryEntry, reason?: string): boolean {
     if (entry.controller.signal.aborted) return false;
     entry.ctx.state = "cancelling";
@@ -305,28 +560,37 @@ export function createRequestRegistry(options?: {
     // Pull the entry out before unwinding so observers (e.g. a `cancel(...)`
     // racing with dispose) don't see a half-disposed context.
     entries.delete(entry.ctx.requestId);
-    await entry.scope[Symbol.asyncDispose]();
+    try {
+      await entry.scope[Symbol.asyncDispose]();
+    } finally {
+      // Release the admission slot only after the scope has fully unwound:
+      // the shared llama.cpp context / addon job is torn down in scope
+      // cleanup, so the next queued same-model request must not be admitted
+      // (and start decoding) until this one has actually let go. `finally`
+      // guarantees the slot is freed even if a deferred cleanup throws,
+      // otherwise a throwing teardown would strand the queue forever.
+      if (entry.slotKey !== undefined) releaseSlot(entry.slotKey);
+    }
   }
 
-  function begin(opts: BeginOpts): ManagedRequestContext {
+  async function begin(opts: BeginOpts): Promise<ManagedRequestContext> {
     if (entries.has(opts.requestId)) {
       throw new RequestIdConflictError(opts.requestId);
     }
 
-    // Admission control runs before allocation so a rejected begin
-    // leaves no controller / scope behind.
-    const policy = policies.get(opts.kind);
-    if (policy && policy.oneAtATimePerModel && opts.modelId !== undefined) {
-      for (const existing of entries.values()) {
-        if (existing.ctx.kind !== opts.kind) continue;
-        if (existing.ctx.modelId !== opts.modelId) continue;
-        throw new RequestRejectedByPolicyError(
-          opts.requestId,
-          opts.kind,
-          opts.modelId,
-          `another ${opts.kind} request (${existing.ctx.requestId}) is already running on this model`,
-        );
-      }
+    // Admission control runs before allocation so a rejected begin leaves
+    // no controller / scope behind. This may await: a gated `(kind,
+    // modelId)` at capacity queues the begin FIFO and resolves once a slot
+    // frees (or rejects on overflow / queue-depth cap / timeout).
+    const { slotKey } = await acquireSlot(opts);
+
+    // The only interleaving point in this otherwise synchronous body is the
+    // await above. A duplicate id could (astronomically unlikely) have
+    // landed while we were queued — re-check and hand the just-acquired
+    // slot back rather than stranding it on the conflicting throw.
+    if (entries.has(opts.requestId)) {
+      if (slotKey !== undefined) releaseSlot(slotKey);
+      throw new RequestIdConflictError(opts.requestId);
     }
 
     const controller = new AbortController();
@@ -377,6 +641,7 @@ export function createRequestRegistry(options?: {
       scope,
       detachParent,
       startedAt: Date.now(),
+      slotKey,
     };
     entries.set(opts.requestId, entry);
     logLifecycle("begin", ctx);
@@ -417,6 +682,23 @@ export function createRequestRegistry(options?: {
     return Array.from(entries.values(), (e) => e.ctx);
   }
 
+  /**
+   * Cancel a still-queued waiter the same way the Stop-button race is
+   * handled: record a cancel-before-begin so its `begin(...)` — which
+   * resumes the instant we `resolve(false)` (without a slot) — observes the
+   * cancel and returns an already-aborted context. The request thus ends in
+   * a clean `cancelled` state rather than throwing.
+   */
+  function cancelQueuedWaiterGracefully(
+    key: string,
+    waiter: SlotWaiter,
+    reason?: string,
+  ): void {
+    recordCancelBeforeBegin(waiter.requestId, reason);
+    removeWaiter(key, waiter);
+    waiter.resolve(false);
+  }
+
   function cancel(target: CancelTarget): number {
     let cancelled = 0;
     if ("requestId" in target) {
@@ -424,6 +706,17 @@ export function createRequestRegistry(options?: {
       if (entry) {
         if (cancelEntry(entry, target.reason)) cancelled++;
         return cancelled;
+      }
+      // Queued (still waiting for an admission slot)? It has no controller
+      // yet, so cancel it through the cancel-before-begin tripwire: pull it
+      // from the FIFO and let its begin() resume into an aborted context.
+      // Counted as one — unlike the pure race below, this targets a known
+      // in-flight (queued) begin, so the Stop button feels responsive
+      // instead of waiting for the slot to free first.
+      const queued = waitersById.get(target.requestId);
+      if (queued) {
+        cancelQueuedWaiterGracefully(queued.key, queued.waiter, target.reason);
+        return cancelled + 1;
       }
       // Stop-button race: the client beat its own
       // `begin(...)`. Record the cancel so the next matching `begin`
@@ -438,12 +731,40 @@ export function createRequestRegistry(options?: {
       if (target.kind && entry.ctx.kind !== target.kind) continue;
       if (cancelEntry(entry, target.reason)) cancelled++;
     }
+    // Queued waiters aren't in `entries`; drain the ones matching this
+    // model (and optional kind) so a broad `cancel({ modelId })` doesn't
+    // strand them behind a request that's being cancelled out from under
+    // them. Snapshot first — `removeWaiter` mutates `waitersById`.
+    for (const { key, waiter } of Array.from(waitersById.values())) {
+      if (waiter.modelId !== target.modelId) continue;
+      if (target.kind && waiter.kind !== target.kind) continue;
+      cancelQueuedWaiterGracefully(key, waiter, target.reason);
+      cancelled++;
+    }
     return cancelled;
   }
 
   function cancelAll(reason: "shutdown" | "modelUnload"): Promise<void> {
     for (const entry of entries.values()) {
       cancelEntry(entry, reason);
+    }
+    // Drain every queued waiter so a shutdown / model-unload sweep can't
+    // leave a `begin(...)` promise hung forever — which would in turn block
+    // the unload waiting on a request that never resolves. Unlike the
+    // targeted cancels above these *reject* rather than resolve-into-
+    // aborted: the model / worker they queued against is being torn down,
+    // so there is nothing left for them to run. Snapshot first —
+    // `removeWaiter` mutates `waitersById`.
+    for (const { key, waiter } of Array.from(waitersById.values())) {
+      removeWaiter(key, waiter);
+      waiter.reject(
+        new RequestRejectedByPolicyError(
+          waiter.requestId,
+          waiter.kind,
+          waiter.modelId,
+          `queued request cancelled (${reason})`,
+        ),
+      );
     }
     // The interface returns Promise<void> so we can later make this an
     // async sweep that awaits per-handler scope unwinding (e.g. join on
@@ -462,7 +783,7 @@ export function createRequestRegistry(options?: {
   }
 
   function policy(opts: ConcurrencyPolicy): void {
-    policies.set(opts.kind, opts);
+    policies.set(opts.kind, normalizePolicy(opts));
   }
 
   return {
@@ -479,7 +800,49 @@ export function createRequestRegistry(options?: {
     // interface (typed via the augmented return type below) so handler
     // code can't depend on it accidentally.
     __cancelBeforeBeginSize: () => cancelledBeforeBegin.size,
-  } as RequestRegistry & { __cancelBeforeBeginSize: () => number };
+    // Test-only: the number of live per-`(kind, modelId)` admission
+    // states. Lets the queue tests assert the map empties on drain /
+    // dispose (no `KeyState` leak). Also off the public interface.
+    __keyStateSize: () => keyStates.size,
+  } as RequestRegistry & {
+    __cancelBeforeBeginSize: () => number;
+    __keyStateSize: () => number;
+  };
+}
+
+/**
+ * Resolve a `ConcurrencyPolicy` to concrete numbers, applying defaults and
+ * the deprecated `oneAtATimePerModel` alias. Done once at registration so
+ * the `begin(...)` hot path reads plain numbers.
+ */
+function normalizePolicy(opts: ConcurrencyPolicy): NormalizedPolicy {
+  let maxConcurrent: number;
+  let onOverflow: "queue" | "reject";
+
+  if (opts.maxConcurrentPerModel !== undefined) {
+    maxConcurrent = opts.maxConcurrentPerModel;
+    onOverflow = opts.onOverflow ?? "queue";
+  } else if (opts.oneAtATimePerModel === true) {
+    // Legacy alias: at most one in-flight per model, reject the rest.
+    maxConcurrent = 1;
+    onOverflow = opts.onOverflow ?? "reject";
+  } else {
+    // Nothing configured (includes `oneAtATimePerModel: false`) ⇒ no gating.
+    maxConcurrent = Infinity;
+    onOverflow = opts.onOverflow ?? "queue";
+  }
+
+  // A finite limit below 1 would gate every request forever; clamp to the
+  // smallest sensible serial limit.
+  if (Number.isFinite(maxConcurrent) && maxConcurrent < 1) maxConcurrent = 1;
+
+  return {
+    maxConcurrent,
+    onOverflow,
+    maxQueueDepth:
+      opts.maxQueueDepthPerModel ?? DEFAULT_MAX_QUEUE_DEPTH_PER_MODEL,
+    queueTimeoutMs: opts.queueTimeoutMs,
+  };
 }
 
 /**
@@ -492,6 +855,7 @@ export function createRequestRegistry(options?: {
 export const __requestRegistryTestHooks = {
   cancelBeforeBeginMaxEntries: CANCEL_BEFORE_BEGIN_MAX_ENTRIES,
   cancelBeforeBeginTtlMs: CANCEL_BEFORE_BEGIN_TTL_MS,
+  defaultMaxQueueDepthPerModel: DEFAULT_MAX_QUEUE_DEPTH_PER_MODEL,
 };
 
 function derivedTerminalState(ctx: RequestContext): RequestOutcome {

--- a/packages/sdk/server/bare/runtime/with-request-context.ts
+++ b/packages/sdk/server/bare/runtime/with-request-context.ts
@@ -18,7 +18,7 @@ type LogMethod = "error" | "warn" | "info" | "debug" | "trace";
  * the prefixed message.
  *
  * @example
- *   await using ctx = registry.begin({ requestId, kind: "completion", modelId });
+ *   await using ctx = await registry.begin({ requestId, kind: "completion", modelId });
  *   const log = withRequestContext(getServerLogger(), ctx);
  *   log.info("decoding token 7");
  *   // → "[request-lifecycle completion requestId=<id> modelId=<id>] decoding token 7"

--- a/packages/sdk/server/rpc/handlers/download-asset.ts
+++ b/packages/sdk/server/rpc/handlers/download-asset.ts
@@ -44,7 +44,7 @@ export async function handleDownloadAsset(
   // `modelId` to register on the registry entry. Cancel by `requestId`
   // is the primary path; `cancel({ modelId })` is intentionally a
   // non-match for this kind.
-  await using ctx = getRequestRegistry().begin({
+  await using ctx = await getRequestRegistry().begin({
     requestId,
     kind: "downloadAsset",
   });

--- a/packages/sdk/server/rpc/handlers/load-model/download-manager.ts
+++ b/packages/sdk/server/rpc/handlers/load-model/download-manager.ts
@@ -14,7 +14,7 @@ const logger = getServerLogger();
 /**
  * Per-subscriber binding to a registry-tracked request.
  * `startOrJoinDownload` is request-aware: each caller (the
- * `await using ctx = registry.begin(...)` inside `handleLoadModel` /
+ * `await using ctx = await registry.begin(...)` inside `handleLoadModel` /
  * `handleDownloadAsset`) registers a subscriber bound to its
  * `requestId`. A `cancel({ requestId })` against the registry aborts
  * the subscriber's `ctx.signal`, which:

--- a/packages/sdk/server/rpc/handlers/load-model/handler.ts
+++ b/packages/sdk/server/rpc/handlers/load-model/handler.ts
@@ -69,7 +69,7 @@ export async function handleLoadModel(
   // is opened with `modelId: undefined` so a cancel-by-modelId fired
   // before the load completes is a clean no-op (rather than matching a
   // half-built entry). Cancel-by-`requestId` works from `begin(...)` on.
-  await using ctx = getRequestRegistry().begin({
+  await using ctx = await getRequestRegistry().begin({
     requestId,
     kind: "loadModel",
   });

--- a/packages/sdk/server/rpc/handlers/load-model/resolve-session.ts
+++ b/packages/sdk/server/rpc/handlers/load-model/resolve-session.ts
@@ -18,7 +18,7 @@ export interface ResolveSessionOptions {
   profilingEnabled: boolean;
   /**
    * Optional cancel signal — typically `ctx.signal` from the surrounding
-   * `await using ctx = registry.begin(...)` block. When provided,
+   * `await using ctx = await registry.begin(...)` block. When provided,
    * `resolveModelPath` short-circuits with `InferenceCancelledError` if the
    * signal is already aborted on entry; the same signal also propagates
    * to in-progress transfers via the request binding below so cancel

--- a/packages/sdk/server/rpc/handlers/rag.ts
+++ b/packages/sdk/server/rpc/handlers/rag.ts
@@ -102,16 +102,16 @@ function omitOnProgress<T extends Record<string, unknown>>(
  * "still mine?" guard so an older op's deferred cleanup cannot stomp
  * a newer op's mapping.
  */
-function beginRagContext(
+async function beginRagContext(
   workspace: string,
   requestId: string,
-): ManagedRequestContext {
+): Promise<ManagedRequestContext> {
   const registry = getRequestRegistry();
   const prev = getActiveRagRequest(workspace);
   if (prev !== undefined && prev !== requestId) {
     registry.cancel({ requestId: prev, reason: "rag-workspace-preempt" });
   }
-  const ctx = registry.begin({
+  const ctx = await registry.begin({
     requestId,
     kind: "rag",
   });
@@ -149,7 +149,7 @@ async function handleRagInternal(
     case "ingest": {
       const workspace = request.workspace ?? DEFAULT_WORKSPACE;
       const requestId = request.requestId ?? generateServerRequestId();
-      await using ctx = beginRagContext(workspace, requestId);
+      await using ctx = await beginRagContext(workspace, requestId);
       const log = withRequestContext(getServerLogger(), ctx);
       log.debug("ingest start");
       const handlerOptions = createHandlerOptions(
@@ -172,7 +172,7 @@ async function handleRagInternal(
     case "saveEmbeddings": {
       const workspace = request.workspace ?? DEFAULT_WORKSPACE;
       const requestId = request.requestId ?? generateServerRequestId();
-      await using ctx = beginRagContext(workspace, requestId);
+      await using ctx = await beginRagContext(workspace, requestId);
       const log = withRequestContext(getServerLogger(), ctx);
       log.debug("saveEmbeddings start");
       const handlerOptions = createHandlerOptions(
@@ -213,7 +213,7 @@ async function handleRagInternal(
     case "reindex": {
       const workspace = request.workspace ?? DEFAULT_WORKSPACE;
       const requestId = request.requestId ?? generateServerRequestId();
-      await using ctx = beginRagContext(workspace, requestId);
+      await using ctx = await beginRagContext(workspace, requestId);
       const log = withRequestContext(getServerLogger(), ctx);
       log.debug("reindex start");
       const handlerOptions = createHandlerOptions(

--- a/packages/sdk/test/bare/completion-queued-cancel.test.ts
+++ b/packages/sdk/test/bare/completion-queued-cancel.test.ts
@@ -1,0 +1,117 @@
+import test from "brittle";
+import { llmPlugin } from "@/server/bare/plugins/llamacpp-completion/plugin";
+import {
+  clearRegistry,
+  registerModel,
+  unregisterModel,
+  type AnyModel,
+} from "@/server/bare/registry/model-registry";
+import { getRequestRegistry } from "@/server/bare/runtime";
+import { ModelType } from "@/schemas";
+
+// -----------------------------------------------------------------------------
+// QVAC-19346 regression — cancelling a *queued* same-model completion must not
+// touch the shared native context the active request is decoding on.
+//
+// A loaded llama.cpp model is one native context. When a second completion is
+// queued behind an active one (default policy serializes them) and the client
+// then cancels the queued request, `begin()` resolves the queued request into
+// an already-aborted context. The handler must NOT proceed to build the
+// completion stream — doing so would call `addon.cancel()` / `model.run()` on
+// the model the active request is still using, cancelling or corrupting it.
+//
+// Requires the Bare runtime (the plugin pulls in the N-API addon at import).
+// -----------------------------------------------------------------------------
+
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+type LooseHandler = (request: unknown) => AsyncGenerator<
+  { type: string; done?: boolean; events: { type: string; stopReason?: string }[] },
+  unknown,
+  unknown
+>;
+
+test("completion: cancelling a queued request never touches the active model addon", async (t) => {
+  clearRegistry();
+  const modelId = `queued-cancel-model-${Date.now()}`;
+
+  let runCalls = 0;
+  let addonCancelCalls = 0;
+  registerModel(modelId, {
+    model: {
+      run() {
+        runCalls++;
+        throw new Error("model.run() must not be called for a queued+cancelled request");
+      },
+      addon: {
+        cancel() {
+          addonCancelCalls++;
+          return Promise.resolve();
+        },
+      },
+    } as unknown as AnyModel,
+    path: "/tmp/queued-cancel-model.gguf",
+    config: {},
+    modelType: ModelType.llamacppCompletion,
+  });
+
+  const registry = getRequestRegistry();
+  // Occupy the single completion slot for this model so the handler's request
+  // queues behind it instead of running.
+  const holder = await registry.begin({
+    requestId: `active-${modelId}`,
+    kind: "completion",
+    modelId,
+  });
+
+  const handler = llmPlugin.handlers.completionStream.handler as unknown as LooseHandler;
+  const queuedRequestId = `queued-${modelId}`;
+  const gen = handler({
+    modelId,
+    requestId: queuedRequestId,
+    history: [
+      { role: "system", content: "You are a helpful assistant.", attachments: [] },
+      { role: "user", content: "hello", attachments: [] },
+    ],
+    stream: true,
+  });
+
+  // Start the generator — it runs up to `await begin()` and then waits in the
+  // FIFO queue behind `holder`.
+  const pending = gen.next();
+  await settle();
+
+  // Stop button on the still-queued request.
+  const cancelled = registry.cancel({ requestId: queuedRequestId });
+  t.is(cancelled, 1, "the queued completion was cancelled");
+
+  const first = await pending;
+  if (first.done) {
+    t.fail("the generator returned before yielding a terminal event");
+    await holder[Symbol.asyncDispose]();
+    unregisterModel(modelId);
+    clearRegistry();
+    return;
+  }
+  const event = first.value;
+  t.is(event.done, true, "the yielded completion event is the terminal (done) event");
+  const doneEvent = event.events.find((e) => e.type === "completionDone");
+  t.ok(doneEvent, "a completionDone event is emitted");
+  t.is(doneEvent?.stopReason, "cancelled", "and it reports a cancelled stopReason");
+
+  const tail = await gen.next();
+  t.is(tail.done, true, "the generator returns after the terminal event");
+
+  t.is(runCalls, 0, "model.run() was never called for the queued+cancelled request");
+  t.is(
+    addonCancelCalls,
+    0,
+    "addon.cancel() was never called — the active request's context is untouched",
+  );
+
+  await holder[Symbol.asyncDispose]();
+  unregisterModel(modelId);
+  clearRegistry();
+});

--- a/packages/sdk/test/unit/inference-handler-migrations.test.ts
+++ b/packages/sdk/test/unit/inference-handler-migrations.test.ts
@@ -122,7 +122,7 @@ test(
       } as never);
 
       const requestId = `lifecycle-${kind}`;
-      const ctx = r.begin({
+      const ctx = await r.begin({
         requestId,
         kind,
         modelId: `test-${kind}`,

--- a/packages/sdk/test/unit/runtime/request-lifecycle-logging.test.ts
+++ b/packages/sdk/test/unit/runtime/request-lifecycle-logging.test.ts
@@ -68,7 +68,7 @@ test("registry: begin emits a [request-lifecycle] begin line", async (t) => {
   const log = makeLoggerStub();
   const r = createRequestRegistry({ logger: log });
 
-  await using ctx = r.begin({
+  await using ctx = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -88,7 +88,7 @@ test("registry: cancel-by-requestId emits a [request-lifecycle] cancel line once
   const log = makeLoggerStub();
   const r = createRequestRegistry({ logger: log });
 
-  await using ctx = r.begin({
+  await using ctx = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -113,7 +113,7 @@ test("registry: end emits a [request-lifecycle] end line with the terminal state
   const r = createRequestRegistry({ logger: log });
 
   async function happyRun() {
-    await using ctx = r.begin({
+    await using ctx = await r.begin({
       requestId: "r-happy",
       kind: "completion",
       modelId: "m1",
@@ -134,7 +134,7 @@ test("registry: end emits a [request-lifecycle] end line with the terminal state
   );
 
   async function cancelledRun() {
-    await using ctx = r.begin({
+    await using ctx = await r.begin({
       requestId: "r-cancelled",
       kind: "completion",
       modelId: "m1",
@@ -161,7 +161,7 @@ test("registry: failed end emits at warn level, not info", async (t) => {
   const r = createRequestRegistry({ logger: log });
 
   async function failedRun() {
-    await using ctx = r.begin({
+    await using ctx = await r.begin({
       requestId: "r-failed",
       kind: "completion",
       modelId: "m1",
@@ -193,12 +193,12 @@ test("registry: cancelAll emits one cancel line per active request", async (t) =
   const log = makeLoggerStub();
   const r = createRequestRegistry({ logger: log });
 
-  await using a = r.begin({
+  await using a = await r.begin({
     requestId: "r-a",
     kind: "completion",
     modelId: "m1",
   });
-  await using b = r.begin({
+  await using b = await r.begin({
     requestId: "r-b",
     kind: "embeddings",
     modelId: "m2",
@@ -229,7 +229,7 @@ test("registry: parentSignal already aborted lands begin with state=cancelling",
   const parent = new AbortController();
   parent.abort("shutdown");
 
-  await using ctx = r.begin({
+  await using ctx = await r.begin({
     requestId: "r-pre",
     kind: "completion",
     modelId: "m1",
@@ -249,7 +249,7 @@ test("registry: begin without modelId emits state line with modelId=-", async (t
   const log = makeLoggerStub();
   const r = createRequestRegistry({ logger: log });
 
-  await using ctx = r.begin({
+  await using ctx = await r.begin({
     requestId: "r-no-model",
     kind: "completion",
   });

--- a/packages/sdk/test/unit/runtime/request-registry.test.ts
+++ b/packages/sdk/test/unit/runtime/request-registry.test.ts
@@ -26,12 +26,12 @@ import {
 
 test("registry: begin/get/list track in-flight requests", async (t) => {
   const r = createRequestRegistry();
-  await using a = r.begin({
+  await using a = await r.begin({
     requestId: "r-a",
     kind: "completion",
     modelId: "m1",
   });
-  await using b = r.begin({
+  await using b = await r.begin({
     requestId: "r-b",
     kind: "embeddings",
     modelId: "m2",
@@ -51,7 +51,7 @@ test("registry: dispose removes the slot and flips state", async (t) => {
   const r = createRequestRegistry();
 
   async function run() {
-    await using ctx = r.begin({
+    await using ctx = await r.begin({
       requestId: "r-1",
       kind: "completion",
       modelId: "m1",
@@ -67,12 +67,12 @@ test("registry: dispose removes the slot and flips state", async (t) => {
 
 test("registry: cancel by requestId aborts only that signal", async (t) => {
   const r = createRequestRegistry();
-  await using a = r.begin({
+  await using a = await r.begin({
     requestId: "r-a",
     kind: "completion",
     modelId: "m1",
   });
-  await using b = r.begin({
+  await using b = await r.begin({
     requestId: "r-b",
     kind: "completion",
     modelId: "m1",
@@ -88,7 +88,7 @@ test("registry: cancel by requestId aborts only that signal", async (t) => {
 
 test("registry: cancel-by-requestId is idempotent and counts only first abort", async (t) => {
   const r = createRequestRegistry();
-  await using ctx = r.begin({
+  await using ctx = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -100,17 +100,17 @@ test("registry: cancel-by-requestId is idempotent and counts only first abort", 
 
 test("registry: cancel by modelId fans out across that model only", async (t) => {
   const r = createRequestRegistry();
-  await using a = r.begin({
+  await using a = await r.begin({
     requestId: "r-a",
     kind: "completion",
     modelId: "m1",
   });
-  await using b = r.begin({
+  await using b = await r.begin({
     requestId: "r-b",
     kind: "embeddings",
     modelId: "m1",
   });
-  await using c = r.begin({
+  await using c = await r.begin({
     requestId: "r-c",
     kind: "completion",
     modelId: "m2",
@@ -125,12 +125,12 @@ test("registry: cancel by modelId fans out across that model only", async (t) =>
 
 test("registry: cancel by modelId + kind narrows the target", async (t) => {
   const r = createRequestRegistry();
-  await using a = r.begin({
+  await using a = await r.begin({
     requestId: "r-a",
     kind: "completion",
     modelId: "m1",
   });
-  await using b = r.begin({
+  await using b = await r.begin({
     requestId: "r-b",
     kind: "embeddings",
     modelId: "m1",
@@ -144,17 +144,17 @@ test("registry: cancel by modelId + kind narrows the target", async (t) => {
 
 test("registry: cancelAll fires every signal", async (t) => {
   const r = createRequestRegistry();
-  await using a = r.begin({
+  await using a = await r.begin({
     requestId: "r-a",
     kind: "completion",
     modelId: "m1",
   });
-  await using b = r.begin({
+  await using b = await r.begin({
     requestId: "r-b",
     kind: "loadModel",
     modelId: "m2",
   });
-  await using c = r.begin({
+  await using c = await r.begin({
     requestId: "r-c",
     kind: "rag",
   });
@@ -169,7 +169,7 @@ test("registry: parentSignal already aborted aborts the new context", async (t) 
   const r = createRequestRegistry();
   const parent = new AbortController();
   parent.abort("shutdown");
-  await using ctx = r.begin({
+  await using ctx = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -185,7 +185,7 @@ test("registry: parentSignal already aborted aborts the new context", async (t) 
 test("registry: parentSignal aborts propagate to children", async (t) => {
   const r = createRequestRegistry();
   const parent = new AbortController();
-  await using ctx = r.begin({
+  await using ctx = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -198,21 +198,21 @@ test("registry: parentSignal aborts propagate to children", async (t) => {
 
 test("registry: duplicate requestId throws RequestIdConflictError", async (t) => {
   const r = createRequestRegistry();
-  await using first = r.begin({
+  await using first = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
   });
   t.is(first.kind, "completion");
-  await t.exception(() => {
-    r.begin({ requestId: "r-1", kind: "completion", modelId: "m1" });
+  await t.exception(async () => {
+    await r.begin({ requestId: "r-1", kind: "completion", modelId: "m1" });
   }, RequestIdConflictError as unknown as new () => Error);
 });
 
 test("registry: end(requestId) sets state, disposes scope, and removes slot", async (t) => {
   const r = createRequestRegistry();
   let cleanupRan = 0;
-  const ctx = r.begin({
+  const ctx = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -260,7 +260,7 @@ test("registry: end() detaches parent listener so long-lived parents don't accum
   const r = createRequestRegistry();
   for (let i = 0; i < 5; i++) {
     const id = `r-${i}`;
-    const ctx = r.begin({
+    const ctx = await r.begin({
       requestId: id,
       kind: "completion",
       modelId: "m1",
@@ -296,7 +296,7 @@ test("registry: same-tick cancel-before-begin retroactively aborts the later beg
     "no entry yet — cancel still returns 0 (race remembered, not retroactively counted)",
   );
 
-  await using ctx = r.begin({
+  await using ctx = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -328,7 +328,7 @@ test("registry: a second begin() with the same id (UUID retry) after the race is
   r.cancel({ requestId: "r-1" });
 
   async function firstAttempt() {
-    await using ctx = r.begin({
+    await using ctx = await r.begin({
       requestId: "r-1",
       kind: "completion",
       modelId: "m1",
@@ -341,7 +341,7 @@ test("registry: a second begin() with the same id (UUID retry) after the race is
   }
   await firstAttempt();
 
-  await using second = r.begin({
+  await using second = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -377,7 +377,7 @@ test("registry: bounded cancel-before-begin set does not grow past its cap (TTL 
   // The oldest entries should have been evicted; the most recently
   // inserted id should still be honoured on the matching begin(...).
   const newestId = `r-${overshoot - 1}`;
-  await using newest = r.begin({
+  await using newest = await r.begin({
     requestId: newestId,
     kind: "completion",
     modelId: "m1",
@@ -390,7 +390,7 @@ test("registry: bounded cancel-before-begin set does not grow past its cap (TTL 
 
   // And one of the early (presumed-evicted) ids should NOT trigger a
   // retroactive abort, because its entry was bumped out by the cap.
-  await using ancient = r.begin({
+  await using ancient = await r.begin({
     requestId: "r-0",
     kind: "completion",
     modelId: "m1",
@@ -406,7 +406,7 @@ test("registry: derived terminal state is 'cancelled' if signal aborted, 'comple
   const r = createRequestRegistry();
 
   async function cancelledRun() {
-    await using ctx = r.begin({
+    await using ctx = await r.begin({
       requestId: "r-cancelled",
       kind: "completion",
       modelId: "m1",
@@ -418,7 +418,7 @@ test("registry: derived terminal state is 'cancelled' if signal aborted, 'comple
   t.is(cancelled.state, "cancelled");
 
   async function happyRun() {
-    await using ctx = r.begin({
+    await using ctx = await r.begin({
       requestId: "r-happy",
       kind: "completion",
       modelId: "m1",
@@ -444,7 +444,7 @@ test("policy: oneAtATimePerModel rejects a second begin on the same (kind, model
   const r = createRequestRegistry();
   r.policy({ kind: "completion", oneAtATimePerModel: true });
 
-  await using first = r.begin({
+  await using first = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -453,8 +453,8 @@ test("policy: oneAtATimePerModel rejects a second begin on the same (kind, model
 
   // Throws the dedicated policy class so handler / RPC code can
   // `instanceof` narrow without parsing the error message.
-  await t.exception(() => {
-    r.begin({
+  await t.exception(async () => {
+    await r.begin({
       requestId: "r-2",
       kind: "completion",
       modelId: "m1",
@@ -472,12 +472,12 @@ test("policy: oneAtATimePerModel scopes admission per (kind, modelId), not globa
   r.policy({ kind: "completion", oneAtATimePerModel: true });
 
   // Same kind, different model — allowed.
-  await using a = r.begin({
+  await using a = await r.begin({
     requestId: "r-a",
     kind: "completion",
     modelId: "m1",
   });
-  await using b = r.begin({
+  await using b = await r.begin({
     requestId: "r-b",
     kind: "completion",
     modelId: "m2",
@@ -488,7 +488,7 @@ test("policy: oneAtATimePerModel scopes admission per (kind, modelId), not globa
   // Different kind, same model — allowed because the policy is keyed
   // by `kind`. (Today only `completion` carries a policy; an
   // embeddings request piggy-backing on the same model is fine.)
-  await using c = r.begin({
+  await using c = await r.begin({
     requestId: "r-c",
     kind: "embeddings",
     modelId: "m1",
@@ -506,8 +506,8 @@ test("policy: oneAtATimePerModel ignores requests without modelId", async (t) =>
   // both are admitted. This is the documented behaviour for
   // model-less requests (e.g. handlers that don't yet attach a
   // modelId to their `begin(...)` call).
-  await using a = r.begin({ requestId: "r-a", kind: "completion" });
-  await using b = r.begin({ requestId: "r-b", kind: "completion" });
+  await using a = await r.begin({ requestId: "r-a", kind: "completion" });
+  await using b = await r.begin({ requestId: "r-b", kind: "completion" });
   t.is(a.modelId, undefined);
   t.is(b.modelId, undefined);
   t.is(r.list().length, 2);
@@ -519,7 +519,7 @@ test("policy: disposing the holder releases admission for the next request", asy
 
   async function runFirstThenSecond() {
     {
-      await using first = r.begin({
+      await using first = await r.begin({
         requestId: "r-1",
         kind: "completion",
         modelId: "m1",
@@ -527,7 +527,7 @@ test("policy: disposing the holder releases admission for the next request", asy
       t.is(first.requestId, "r-1");
     }
     // Once the await-using block above unwinds, the slot is released.
-    await using second = r.begin({
+    await using second = await r.begin({
       requestId: "r-2",
       kind: "completion",
       modelId: "m1",
@@ -546,7 +546,7 @@ test("policy: cancel without dispose does NOT release admission", async (t) => {
   const r = createRequestRegistry();
   r.policy({ kind: "completion", oneAtATimePerModel: true });
 
-  await using first = r.begin({
+  await using first = await r.begin({
     requestId: "r-1",
     kind: "completion",
     modelId: "m1",
@@ -574,12 +574,12 @@ test("policy: registering a second time replaces the previous policy", async (t)
 
   // Disabling the rule re-opens admission — concurrent begins on the
   // same `(kind, modelId)` are accepted again.
-  await using a = r.begin({
+  await using a = await r.begin({
     requestId: "r-a",
     kind: "completion",
     modelId: "m1",
   });
-  await using b = r.begin({
+  await using b = await r.begin({
     requestId: "r-b",
     kind: "completion",
     modelId: "m1",
@@ -595,12 +595,12 @@ test("policy: kinds without a registered policy are unconstrained", async (t) =>
   // open even though `completion` carries a strict rule.
   r.policy({ kind: "completion", oneAtATimePerModel: true });
 
-  await using a = r.begin({
+  await using a = await r.begin({
     requestId: "r-a",
     kind: "embeddings",
     modelId: "m1",
   });
-  await using b = r.begin({
+  await using b = await r.begin({
     requestId: "r-b",
     kind: "embeddings",
     modelId: "m1",
@@ -608,4 +608,372 @@ test("policy: kinds without a registered policy are unconstrained", async (t) =>
   t.is(r.list().length, 2);
   t.is(a.kind, "embeddings");
   t.is(b.kind, "embeddings");
+});
+
+// -----------------------------------------------------------------------------
+// Per-(kind, modelId) FIFO admission queue (QVAC-19346)
+//
+// The completion policy now serializes instead of rejecting: a second
+// concurrent request to the same (kind, modelId) waits FIFO for a slot
+// rather than throwing. `maxConcurrentPerModel` is the slot count (1 today,
+// the addon's batching width later); `onOverflow`, `maxQueueDepthPerModel`,
+// and `queueTimeoutMs` bound the wait. These tests drive the queue with an
+// isolated registry and manual dispose so the FIFO ordering, hand-off, and
+// teardown invariants are pinned without relying on the worker singleton.
+// -----------------------------------------------------------------------------
+
+/** Let any already-scheduled microtasks/timers settle. */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+function keyStateProbe(r: ReturnType<typeof createRequestRegistry>): {
+  __keyStateSize: () => number;
+} {
+  return r as unknown as { __keyStateSize: () => number };
+}
+
+test("queue: a second same-model begin waits FIFO until the first disposes", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+  });
+
+  const first = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+
+  let secondResolved = false;
+  const secondPromise = r
+    .begin({ requestId: "r-2", kind: "completion", modelId: "m1" })
+    .then((ctx) => {
+      secondResolved = true;
+      return ctx;
+    });
+
+  await settle();
+  t.is(secondResolved, false, "second begin is queued, not yet admitted");
+  t.is(r.list().length, 1, "only the first request is in flight");
+
+  await first[Symbol.asyncDispose]();
+  const second = await secondPromise;
+  t.is(secondResolved, true, "disposing the first admitted the queued second");
+  t.is(second.requestId, "r-2");
+  t.is(r.list().length, 1, "now only the second is in flight");
+
+  await second[Symbol.asyncDispose]();
+  t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
+});
+
+test("queue: waiters are admitted in FIFO enqueue order", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+  });
+
+  const holder = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+
+  const admitted: string[] = [];
+  const enqueue = (id: string) =>
+    r
+      .begin({ requestId: id, kind: "completion", modelId: "m1" })
+      .then((ctx) => {
+        admitted.push(id);
+        return ctx;
+      });
+
+  const p2 = enqueue("r-2");
+  const p3 = enqueue("r-3");
+  const p4 = enqueue("r-4");
+  await settle();
+  t.alike(admitted, [], "nothing admitted while the holder runs");
+
+  await holder[Symbol.asyncDispose]();
+  const c2 = await p2;
+  await c2[Symbol.asyncDispose]();
+  const c3 = await p3;
+  await c3[Symbol.asyncDispose]();
+  const c4 = await p4;
+  await c4[Symbol.asyncDispose]();
+
+  t.alike(admitted, ["r-2", "r-3", "r-4"], "admitted strictly in enqueue order");
+  t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
+});
+
+test("queue: a different model is never blocked by another model's queue", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+  });
+
+  await using m1 = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+
+  // m1 is at capacity, but m2 must be admitted immediately — gating is
+  // strictly per (kind, modelId).
+  await using m2 = await r.begin({
+    requestId: "r-2",
+    kind: "completion",
+    modelId: "m2",
+  });
+
+  t.is(m1.modelId, "m1");
+  t.is(m2.modelId, "m2");
+  t.is(r.list().length, 2, "both run concurrently — distinct models");
+});
+
+test("queue: maxConcurrentPerModel = 2 runs two and queues the third", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 2,
+    onOverflow: "queue",
+  });
+
+  const c1 = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+  const c2 = await r.begin({
+    requestId: "r-2",
+    kind: "completion",
+    modelId: "m1",
+  });
+  t.is(r.list().length, 2, "two slots ⇒ two run concurrently");
+
+  let thirdResolved = false;
+  const thirdPromise = r
+    .begin({ requestId: "r-3", kind: "completion", modelId: "m1" })
+    .then((ctx) => {
+      thirdResolved = true;
+      return ctx;
+    });
+  await settle();
+  t.is(thirdResolved, false, "third waits while both slots are taken");
+
+  await c1[Symbol.asyncDispose]();
+  const c3 = await thirdPromise;
+  t.is(thirdResolved, true, "freeing one slot admitted the third");
+
+  await c2[Symbol.asyncDispose]();
+  await c3[Symbol.asyncDispose]();
+  t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
+});
+
+test("queue: onOverflow 'reject' still throws RequestRejectedByPolicyError", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "reject",
+  });
+
+  await using first = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+  t.is(first.requestId, "r-1");
+
+  await t.exception(
+    () => r.begin({ requestId: "r-2", kind: "completion", modelId: "m1" }),
+    RequestRejectedByPolicyError as unknown as new () => Error,
+  );
+  t.is(r.list().length, 1, "rejected begin left no slot behind");
+});
+
+test("queue: maxQueueDepthPerModel caps the queue and rejects the overflow", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+    maxQueueDepthPerModel: 2,
+  });
+
+  const holder = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+  // Two waiters fill the queue (depth 2).
+  const p2 = r.begin({ requestId: "r-2", kind: "completion", modelId: "m1" });
+  const p3 = r.begin({ requestId: "r-3", kind: "completion", modelId: "m1" });
+  await settle();
+
+  // The third waiter would exceed the depth cap ⇒ reject immediately.
+  await t.exception(
+    () => r.begin({ requestId: "r-4", kind: "completion", modelId: "m1" }),
+    RequestRejectedByPolicyError as unknown as new () => Error,
+  );
+
+  // Drain the legitimately-queued waiters so the test leaves nothing pending.
+  await holder[Symbol.asyncDispose]();
+  const c2 = await p2;
+  await c2[Symbol.asyncDispose]();
+  const c3 = await p3;
+  await c3[Symbol.asyncDispose]();
+  t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
+});
+
+test("queue: a waiter past queueTimeoutMs rejects; a timely hand-off clears its timer", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+    queueTimeoutMs: 20,
+  });
+
+  const holder = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+
+  // r-2 waits behind the still-running holder and times out.
+  await t.exception(
+    () => r.begin({ requestId: "r-2", kind: "completion", modelId: "m1" }),
+    RequestRejectedByPolicyError as unknown as new () => Error,
+  );
+
+  // A waiter that is handed a slot before its timeout must have its timer
+  // cleared (no late rejection, no leaked timer keeping the process alive).
+  const p3 = r.begin({ requestId: "r-3", kind: "completion", modelId: "m1" });
+  await holder[Symbol.asyncDispose]();
+  const c3 = await p3;
+  await c3[Symbol.asyncDispose]();
+  await settle();
+  t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
+});
+
+test("queue: cancel({ requestId }) on a queued waiter cancels it promptly", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+  });
+
+  const holder = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+  const queuedPromise = r.begin({
+    requestId: "r-2",
+    kind: "completion",
+    modelId: "m1",
+  });
+  await settle();
+
+  // Stop button on the still-queued request: counted as one cancelled, and
+  // its begin resolves into an already-aborted context (clean cancel, not a
+  // thrown error) — it never had to wait for the holder to finish.
+  const cancelled = r.cancel({ requestId: "r-2", reason: "stop-button" });
+  t.is(cancelled, 1, "the queued request was cancelled");
+
+  const queued = await queuedPromise;
+  t.is(queued.signal.aborted, true, "queued begin resolves aborted");
+  t.is(queued.state, "cancelling", "and starts in a coherent cancelling state");
+
+  await queued[Symbol.asyncDispose]();
+  await holder[Symbol.asyncDispose]();
+  t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
+});
+
+test("queue: cancel({ modelId }) drains queued waiters for that model", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+  });
+
+  const holder = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+  const queuedPromise = r.begin({
+    requestId: "r-2",
+    kind: "completion",
+    modelId: "m1",
+  });
+  await settle();
+
+  // Broad cancel: the in-flight holder is aborted (1) and the queued waiter
+  // is drained (1) — both counted.
+  const cancelled = r.cancel({ modelId: "m1" });
+  t.is(cancelled, 2, "in-flight + queued both cancelled");
+
+  const queued = await queuedPromise;
+  t.is(queued.signal.aborted, true, "drained waiter resolves aborted");
+
+  await queued[Symbol.asyncDispose]();
+  await holder[Symbol.asyncDispose]();
+  t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
+});
+
+test("queue: cancelAll drains queued waiters so no begin() promise hangs", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+  });
+
+  const holder = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+  // Attach the rejection handler synchronously so the teardown rejection is
+  // never an unhandled promise.
+  const p2 = r
+    .begin({ requestId: "r-2", kind: "completion", modelId: "m1" })
+    .then(
+      () => "resolved" as const,
+      (err) => err,
+    );
+  const p3 = r
+    .begin({ requestId: "r-3", kind: "completion", modelId: "m1" })
+    .then(
+      () => "resolved" as const,
+      (err) => err,
+    );
+  await settle();
+
+  await r.cancelAll("modelUnload");
+
+  const e2 = await p2;
+  const e3 = await p3;
+  t.ok(
+    e2 instanceof RequestRejectedByPolicyError,
+    "queued waiter rejected on teardown",
+  );
+  t.ok(
+    e3 instanceof RequestRejectedByPolicyError,
+    "second queued waiter rejected on teardown",
+  );
+  t.is(holder.signal.aborted, true, "the in-flight holder was aborted too");
+
+  await holder[Symbol.asyncDispose]();
+  t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
 });

--- a/packages/sdk/test/unit/runtime/request-registry.test.ts
+++ b/packages/sdk/test/unit/runtime/request-registry.test.ts
@@ -898,6 +898,47 @@ test("queue: cancel({ requestId }) on a queued waiter cancels it promptly", asyn
   t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
 });
 
+test("queue: a duplicate requestId while queued is rejected and the original waiter survives", async (t) => {
+  const r = createRequestRegistry();
+  r.policy({
+    kind: "completion",
+    maxConcurrentPerModel: 1,
+    onOverflow: "queue",
+  });
+
+  const holder = await r.begin({
+    requestId: "r-1",
+    kind: "completion",
+    modelId: "m1",
+  });
+  // r-2 queues behind the holder.
+  const queuedPromise = r.begin({
+    requestId: "r-2",
+    kind: "completion",
+    modelId: "m1",
+  });
+  await settle();
+
+  // A begin reusing the still-queued id must conflict, not silently enqueue a
+  // duplicate that overwrites r-2's `waitersById` index (which would leave the
+  // original r-2 unreachable by `cancel({ requestId })`).
+  await t.exception(async () => {
+    await r.begin({ requestId: "r-2", kind: "completion", modelId: "m1" });
+  }, RequestIdConflictError as unknown as new () => Error);
+
+  // The original r-2 waiter is intact: cancelling it by id still finds and
+  // cancels exactly one queued request.
+  const cancelled = r.cancel({ requestId: "r-2", reason: "stop-button" });
+  t.is(cancelled, 1, "the original queued waiter is still reachable by id");
+
+  const queued = await queuedPromise;
+  t.is(queued.signal.aborted, true, "original queued waiter resolves aborted");
+
+  await queued[Symbol.asyncDispose]();
+  await holder[Symbol.asyncDispose]();
+  t.is(keyStateProbe(r).__keyStateSize(), 0, "no KeyState leak after drain");
+});
+
 test("queue: cancel({ modelId }) drains queued waiters for that model", async (t) => {
   const r = createRequestRegistry();
   r.policy({

--- a/packages/sdk/utils/errors-server.ts
+++ b/packages/sdk/utils/errors-server.ts
@@ -409,10 +409,12 @@ export class RequestNotFoundError extends QvacErrorBase {
 }
 
 /**
- * Thrown by `RequestRegistry.begin(...)` when a registered concurrency
- * policy rejects the request (e.g. `oneAtATimePerModel` for the
- * `completion` kind). Distinct from `RequestIdConflictError`, which
- * only fires on UUID collisions.
+ * Thrown by `await RequestRegistry.begin(...)` when a registered concurrency
+ * policy refuses the request. Under the default queue policy a same-model
+ * request waits FIFO rather than rejecting, so this fires on the bounded-queue
+ * cases: an explicit `onOverflow: "reject"`, the per-model queue-depth cap, or
+ * a `queueTimeoutMs` elapsing while waiting for a slot. Distinct from
+ * `RequestIdConflictError`, which only fires on UUID collisions.
  */
 export class RequestRejectedByPolicyError extends QvacErrorBase {
   readonly requestId: string;


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

A loaded llama.cpp model is a single native context — one KV-cache, one decode loop — so two completions on the **same** model cannot truly run in parallel. The worker's default `completion` policy was `oneAtATimePerModel`, which **rejected** the second concurrent same-model request with `RequestRejectedByPolicyError` (code `52420`); with the policy off the requests instead collided at the addon with `Cannot set new job` (500).

This broke a very common coding-agent pattern surfaced through `qvac serve`: an OpenAI-compatible client (OpenCode, Cline, …) fires a main chat completion **and** a background title/summary call at the same loaded model in the same tick. One of them failed, and the only workaround was loading the same model file twice.

## 📝 How does it solve it?

Turn registry admission into a per-`(kind, modelId)` **FIFO queue** instead of a hard reject, in `server/bare/runtime/request-registry.ts`:

- **Extended `ConcurrencyPolicy`** with `maxConcurrentPerModel`, `onOverflow: "queue" | "reject"`, `maxQueueDepthPerModel`, and `queueTimeoutMs`. The legacy `oneAtATimePerModel` flag is kept as a normalized back-compat alias (`true → { max: 1, reject }`).
- **`begin()` is now `async`**: at capacity with `onOverflow: "queue"` it enqueues a FIFO waiter and resolves once a slot frees. A freed slot is **handed off** to the oldest waiter (the in-flight count is never decremented/re-incremented across the hand-off), which gives race-free FIFO fairness on the single-threaded event loop.
- **Release happens in `disposeEntry` after the scope fully unwinds** (in a `finally`), so the next same-model request can't start decoding until the previous one has actually released the native context. A throwing teardown can't strand the queue.
- **Cancellation drains the queue**: `cancel({ requestId })` / `cancel({ modelId })` cancel queued waiters *gracefully* via the existing cancel-before-begin tripwire (the waiter resolves into an already-aborted context → clean `cancelled`, not a thrown error), so the Stop button is responsive even while queued. `cancelAll` (shutdown / model-unload) *rejects* waiters so no `begin()` promise hangs through a teardown sweep.
- **New default policy** in `request-registry-singleton.ts`: `{ kind: "completion", maxConcurrentPerModel: 1, onOverflow: "queue", maxQueueDepthPerModel: 64 }`. Same-model completions now serialize instead of rejecting. The limit is forward-compatible with addon continuous batching — bump `maxConcurrentPerModel` to the addon's slot count to flip serial execution to N-way concurrent with no other change.

All ~10 production call sites that open a request (`completion`, `video`, `finetune`, `loadModel`, `rag`, `download-asset`, `translate`, `transcribe`, `embed`) now `await` the async `begin()`. The registry types are internal (not exported from the package), so there is no public API surface change (no `[api]`/`[bc]` tag).

The `concurrent-completion-collision.ts` example narration is updated: same-model concurrent completions now both succeed (serialized) instead of one being rejected.

## 🧪 How was it tested?

- `bun run lint` (eslint + typecheck) — green
- `bun run build` — green
- Registry unit tests: **34/34** pass, including **11 new queue tests**: serialization, FIFO admission order, per-`(kind, modelId)` isolation, `maxConcurrentPerModel: 2`, `onOverflow: "reject"`, queue-depth cap, queue timeout, cancel-while-queued, `cancel({ modelId })` drain, `cancelAll` drain, and a `__keyStateSize` assertion that the admission map never leaks.
- Full SDK unit suite passes (runner exit 0).