### PR TITLE
QVAC-19213 transcription-parakeet: OpenCL-only overlay test PR for ex…

### DIFF
--- a/packages/transcription-parakeet/.gitignore
+++ b/packages/transcription-parakeet/.gitignore
@@ -22,6 +22,7 @@ Makefile
 !CMakeLists.txt
 !cmake/*.cmake
 !vcpkg/**/*.cmake
+!vcpkg-overlay-ports/**/*.cmake
 compile_commands.json
 .vscode/
 .idea/

--- a/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
+++ b/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
@@ -221,18 +221,6 @@ void ParakeetModel::cleanupTempFile_() {
 void ParakeetModel::load() {
   if (is_loaded_) return;
 
-  // Force useGPU to false in Android until Vulkan and OpenCL are stabilized
-#ifdef __ANDROID__
-  if (cfg_.useGPU) {
-    QLOG(
-        logger::Priority::WARNING,
-        "Parakeet: useGPU=true is currently ignored on Android "
-        "(GPU backends disabled at engine boundary pending Vulkan/Mali "
-        "and OpenCL/Adreno driver fixes); falling back to CPU.");
-    cfg_.useGPU = false;
-  }
-#endif
-
   QLOG(logger::Priority::INFO,
        "Loading Parakeet GGUF (modelType hint: " +
            std::to_string(static_cast<int>(cfg_.modelType)) + ")");

--- a/packages/transcription-parakeet/vcpkg-configuration.json
+++ b/packages/transcription-parakeet/vcpkg-configuration.json
@@ -15,5 +15,8 @@
         "spirv-headers"
       ]
     }
+  ],
+  "overlay-ports": [
+    "./vcpkg-overlay-ports"
   ]
 }

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
@@ -1,0 +1,23 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..11b501ab 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -7,6 +7,7 @@ if (POLICY CMP0147)
+ endif()
+ 
+ find_package(Vulkan COMPONENTS glslc REQUIRED)
++find_package(SPIRV-Headers QUIET)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     # Parallel build object files
+@@ -87,6 +88,10 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++
++    if (TARGET SPIRV-Headers::SPIRV-Headers)
++        target_link_libraries(ggml-vulkan PRIVATE SPIRV-Headers::SPIRV-Headers)
++    endif()
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/ggml-speech/portfile.cmake
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/ggml-speech/portfile.cmake
@@ -1,5 +1,5 @@
 # ggml-speech overlay -> tetherto/qvac-ext-ggml PR #19 head
-# (QVAC-19213-parakeet-opencl @ 89bbeeaa). Builds ggml-speech straight from the
+# (QVAC-19213-parakeet-opencl @ bff2347b). Builds ggml-speech straight from the
 # PR branch so the Adreno OpenCL fix can be exercised pre-merge. Mirrors the
 # registry port's per-platform backends (Metal on Apple, Vulkan on desktop,
 # OpenCL on Android) so CI matches baseline; only Android is OpenCL-only
@@ -8,8 +8,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO tetherto/qvac-ext-ggml
-    REF 89bbeeaa5904a8f30a63c274614b0d6b48dca948
-    SHA512 11ec3cb7cf3f15203bfdaa7a4c7db58ccdc3b6f19b6da9670f02071953d1541c225b37dc2ef89b22fbe211a921a627d95631efbd345852d6f28e397b250b6633
+    REF bff2347b941f4e6741a0cb2a98fed9fcf23692d0
+    SHA512 cffb8927c2a97320a4ab801a06a9ae628bead220a37951df61faed57065b038a280c71c450c8c47b524c9b68312edb71bea4d8cda27a87fcf68fce626b67a5c4
     HEAD_REF QVAC-19213-parakeet-opencl
     PATCHES
         # PR #19's ggml-vulkan.cpp resolves <spirv/unified1/spirv.hpp> via

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/ggml-speech/portfile.cmake
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/ggml-speech/portfile.cmake
@@ -1,0 +1,105 @@
+# ggml-speech overlay -> tetherto/qvac-ext-ggml PR #19 head
+# (QVAC-19213-parakeet-opencl @ 89bbeeaa). Builds ggml-speech straight from the
+# PR branch so the Adreno OpenCL fix can be exercised pre-merge. Mirrors the
+# registry port's per-platform backends (Metal on Apple, Vulkan on desktop,
+# OpenCL on Android) so CI matches baseline; only Android is OpenCL-only
+# (no Vulkan). Drop this overlay once PR #19 merges and the registry ships it.
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tetherto/qvac-ext-ggml
+    REF 89bbeeaa5904a8f30a63c274614b0d6b48dca948
+    SHA512 11ec3cb7cf3f15203bfdaa7a4c7db58ccdc3b6f19b6da9670f02071953d1541c225b37dc2ef89b22fbe211a921a627d95631efbd345852d6f28e397b250b6633
+    HEAD_REF QVAC-19213-parakeet-opencl
+    PATCHES
+        # PR #19's ggml-vulkan.cpp resolves <spirv/unified1/spirv.hpp> via
+        # __has_include, but its CMakeLists never wires spirv-headers. Carry the
+        # registry's fix so the desktop Vulkan build links the vcpkg
+        # spirv-headers include dir. Inert on Metal/OpenCL builds (ggml-vulkan
+        # is not configured there).
+        patches/0001-ggml-vulkan-find-spirv-headers.patch
+)
+
+# Per-feature backend selection (mirrors the registry ggml-speech port).
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_OPENCL OFF)
+set(GGML_METAL_FUSE_MV_BIAS OFF)  # baseline default; fusion zeroes parakeet EOU on Metal
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+set(PLATFORM_OPTIONS)
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+if(VCPKG_TARGET_IS_ANDROID)
+    # Hybrid Android backend mode: GPU/CPU backends as MODULE .so loaded at
+    # runtime via dlopen (per-arch CPU variants picked at first use).
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=OFF
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_METAL_FUSE_MV_BIAS=${GGML_METAL_FUSE_MV_BIAS}
+        -DGGML_LIB_OUTPUT_PREFIX=qvac-speech-
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Android dynamic-backend mode builds the MODULE backend .so files into the
+# buildtree bin/; cmake install() doesn't move them by default.
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-speech-ggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/ggml-speech/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/ggml-speech/vcpkg.json
@@ -1,0 +1,52 @@
+{
+  "name": "ggml-speech",
+  "version-date": "2026-05-27",
+  "port-version": 1,
+  "description": "ggml-speech overlay pinned to tetherto/qvac-ext-ggml PR #19 (QVAC-19213-parakeet-opencl). Mirrors the registry port's per-platform backends (Metal on Apple, Vulkan on desktop, OpenCL on Android); Android is OpenCL-only. Temporary test-PR overlay; drop after the PR merges and the registry ships it.",
+  "homepage": "https://github.com/tetherto/qvac-ext-ggml/tree/QVAC-19213-parakeet-opencl",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux"
+    }
+  ],
+  "features": {
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    }
+  }
+}

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/portfile.cmake
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/portfile.cmake
@@ -1,0 +1,73 @@
+# parakeet-cpp overlay -> tetherto/qvac-ext-lib-whisper.cpp PR #38 head
+# (QVAC-19213-parakeet-opencl @ 01a71ec6). Built from the parakeet-cpp/
+# subfolder; consumes the ggml-speech overlay. Mirrors the registry port's
+# per-platform backends (Metal on Apple, Vulkan on desktop, OpenCL on Android);
+# only Android is OpenCL-only. Drop once PR #38 merges and the registry ships it.
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH WHISPER_CPP_SRC
+    REPO tetherto/qvac-ext-lib-whisper.cpp
+    REF 01a71ec6751e96af74b807f2e6504d8ed99905db
+    SHA512 1c4fe104154b82a0c598fafb70c7d4f1d849c9a0905e5d414fd7ca9908b5fb503bc95f77a09a6e7a905d7dcd2ced3968574af21fdd4cb7a8b359aa8d0e582e6d
+    HEAD_REF QVAC-19213-parakeet-opencl
+)
+
+set(SOURCE_PATH "${WHISPER_CPP_SRC}/parakeet-cpp")
+if (NOT EXISTS "${SOURCE_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "parakeet-cpp: ${SOURCE_PATH}/CMakeLists.txt missing; the parakeet-cpp/ "
+        "subfolder layout in qvac-ext-lib-whisper.cpp may have changed.")
+endif()
+
+# Per-feature backend selection (mirrors the registry parakeet-cpp port).
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_OPENCL OFF)
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DPARAKEET_BUILD_LIBRARY=ON
+        -DPARAKEET_BUILD_EXECUTABLES=OFF
+        -DPARAKEET_BUILD_TESTS=OFF
+        -DPARAKEET_BUILD_EXAMPLES=OFF
+        -DPARAKEET_INSTALL=ON
+        -DPARAKEET_USE_SYSTEM_GGML=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_OPENMP=OFF
+        -DPARAKEET_OPENMP=OFF
+        -DGGML_CCACHE=OFF
+        -DPARAKEET_CCACHE=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=OFF
+        -DGGML_OPENCL=${GGML_OPENCL}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME parakeet-cpp CONFIG_PATH share/parakeet-cpp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/portfile.cmake
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/portfile.cmake
@@ -1,5 +1,5 @@
 # parakeet-cpp overlay -> tetherto/qvac-ext-lib-whisper.cpp PR #38 head
-# (QVAC-19213-parakeet-opencl @ 01a71ec6). Built from the parakeet-cpp/
+# (QVAC-19213-parakeet-opencl @ 1cc29a3b). Built from the parakeet-cpp/
 # subfolder; consumes the ggml-speech overlay. Mirrors the registry port's
 # per-platform backends (Metal on Apple, Vulkan on desktop, OpenCL on Android);
 # only Android is OpenCL-only. Drop once PR #38 merges and the registry ships it.
@@ -10,8 +10,8 @@ set(VCPKG_BUILD_TYPE release)
 vcpkg_from_github(
     OUT_SOURCE_PATH WHISPER_CPP_SRC
     REPO tetherto/qvac-ext-lib-whisper.cpp
-    REF 01a71ec6751e96af74b807f2e6504d8ed99905db
-    SHA512 1c4fe104154b82a0c598fafb70c7d4f1d849c9a0905e5d414fd7ca9908b5fb503bc95f77a09a6e7a905d7dcd2ced3968574af21fdd4cb7a8b359aa8d0e582e6d
+    REF 1cc29a3b37c897ca5b2f11e19e623b710eaf6e04
+    SHA512 2667f92ea2d397623db8d38912f3bde75c791fc506d271552f443fc1116df36f8785e6a120e9b72859bc18ef6d25d59e7d9e5f7f69d5deab79bb19cda259897a
     HEAD_REF QVAC-19213-parakeet-opencl
 )
 

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/vcpkg.json
@@ -1,0 +1,71 @@
+{
+  "name": "parakeet-cpp",
+  "version-date": "2026-05-26",
+  "port-version": 2,
+  "description": "parakeet-cpp overlay pinned to tetherto/qvac-ext-lib-whisper.cpp PR #38 (QVAC-19213-parakeet-opencl). Mirrors the registry port's per-platform backends (Metal on Apple, Vulkan on desktop, OpenCL on Android); Android is OpenCL-only. Temporary test-PR overlay; drop after the PR merges and the registry ships it.",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/QVAC-19213-parakeet-opencl/parakeet-cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "version>=": "2026-05-27"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux"
+    }
+  ],
+  "features": {
+    "metal": {
+      "description": "Enable Metal GPU acceleration (macOS / iOS)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "metal"
+          ]
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "vulkan"
+          ]
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android / Adreno)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "opencl"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/transcription-parakeet/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg.json
@@ -11,7 +11,8 @@
     {
       "name": "parakeet-cpp",
       "version>=": "2026-05-26#2",
-      "features": ["vulkan", "opencl"],
+      "features": ["opencl"],
+      "default-features": false,
       "platform": "android"
     },
     {


### PR DESCRIPTION
…t-ggml #19 + whisper #38

Pin the addon's ggml-speech + parakeet-cpp vcpkg ports to the two open fix-PR heads (qvac-ext-ggml#19 @89bbeeaa, qvac-ext-lib-whisper.cpp#38 @01a71ec6) via OpenCL-only overlay ports, so the Adreno OpenCL fix can be exercised before the PRs merge. Android features narrowed to opencl; the Android useGPU=false guard is removed so OpenCL is actually used. Temporary -- drop the overlays and bump version>= once the PRs land. Registry baseline untouched.

<!--
Style guide for this PR description:
- Be concise; prefer bullet points.
- Delete sections that don't apply.
- Keep code examples minimal.
-->

## What problem does this PR solve?

## How does it solve it?

## Breaking changes
