### PR TITLE
QVAC-14239: make SDK Pod PR checks a blocking merge gate

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -2,10 +2,11 @@ name: PR Checks (SDK Pod)
 
 on:
   # No trigger-level `paths:` filter on purpose: this workflow publishes the
-  # required "SDK Pod Checks" status. A path-skipped workflow would leave that
-  # required check stuck "Pending" and block unrelated PRs from merging.
-  # Path scoping happens inside the `changes` job instead, and the `gate` job
-  # passes cleanly when no SDK pod files changed.
+  # required "SDK Pod Checks" status, which must report on EVERY PR or GitHub
+  # blocks unrelated PRs ("waiting for status to be reported"). A trigger-level
+  # path filter would skip the whole workflow and wedge those PRs. Instead the
+  # single job below detects SDK pod changes itself and is a fast no-op when
+  # nothing relevant changed.
   pull_request_target:
     types:
       - opened
@@ -21,52 +22,136 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 # Package config lives in .github/sdk-pod-checks.json
 # Scripts (lint, build, test:unit) are auto-detected from each package's package.json
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # ---------------------------------------------------------------------------
-  # Security gate for pull_request_target
+  # Single required status check for SDK pod packages.
   #
-  # Trusted authors (org members, collaborators) and same-repo PRs run
-  # immediately. External fork PRs require the "safe-to-test" label applied
-  # by a team member after reviewing the PR code.
+  # Runs on every PR so the "SDK Pod Checks" context is always reported — a
+  # required check that is never reported blocks the PR forever. It is a fast
+  # no-op (detect step only) when no SDK pod files changed, so unrelated PRs are
+  # unaffected. Mark THIS job's name ("SDK Pod Checks") required in the ruleset.
+  #
+  #   - no SDK pod files changed     -> pass (no PR code is checked out or run)
+  #   - changed + checks pass        -> pass
+  #   - changed + unauthorized fork  -> fail (needs the safe-to-test label)
+  #   - changed + a check fails      -> fail (blocks the merge)
+  #   - changed + a check fails, but the 'skip-sdk-pod-checks' label is set
+  #                                  -> pass (audited override for e.g. a
+  #                                     confirmed false-positive test; the
+  #                                     failure is still run and logged)
+  #
+  # Security (pull_request_target): the PR head is only checked out / executed
+  # after the authorization gate passes. Trusted = same-repo PRs, actors with
+  # write, org members/collaborators, or fork PRs carrying the safe-to-test
+  # label. On a new push from an external fork the label is stripped first, to
+  # force re-review of the updated code.
+  #
+  # Packages are checked sequentially in this single job (instead of a parallel
+  # matrix) so that exactly one check appears on every PR.
   # ---------------------------------------------------------------------------
-  authorize:
+  sdk-pod-checks:
+    name: SDK Pod Checks
     runs-on: ubuntu-latest
-    outputs:
-      allowed: ${{ steps.check.outputs.allowed }}
-      has_write: ${{ steps.perm.outputs.has-permission }}
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
+      # Checkout the base branch (trusted). Used only to read the config and to
+      # diff changed file names — no PR code is executed in this step.
+      - name: Checkout base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed SDK pod packages
+        id: detect
+        shell: bash
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Default optional fields when not specified in config
+          ALL_PACKAGES=$(jq -c '[.[] | .pkg_manager //= "npm" | .needs_bare //= false | .tests_bare //= false]' .github/sdk-pod-checks.json)
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            # workflow_dispatch: run all packages
+            PACKAGES="$ALL_PACKAGES"
+          else
+            # Fetch PR head (available on base repo via pull refs)
+            git fetch origin "refs/pull/${PR_NUMBER}/head"
+
+            # Filter to only packages with changed files in this PR
+            CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+            PACKAGES=$(echo "$ALL_PACKAGES" | jq -c --arg files "$CHANGED_FILES" '[
+              .[] | select(.path as $p | $files | split("\n") | any(startswith($p + "/")))
+            ]')
+          fi
+
+          echo "packages=${PACKAGES}" >> "$GITHUB_OUTPUT"
+          has_changes=$(echo "$PACKAGES" | jq -r 'if length > 0 then "true" else "false" end')
+          echo "has_changes=${has_changes}" >> "$GITHUB_OUTPUT"
+
+          if [ "$has_changes" = "true" ]; then
+            echo "::notice::SDK pod packages changed: $(echo "$PACKAGES" | jq -r '[.[].package] | join(", ")')"
+          else
+            echo "::notice::No SDK pod package files changed - gate passes."
+          fi
+
+      # ----- Everything below runs only when SDK pod files changed -----
+
       - name: Check actor write permission
         id: perm
+        if: steps.detect.outputs.has_changes == 'true'
         uses: scherermichael-oss/action-has-permission@136e061bfe093832d87f090dd768e14e27a740d3 # 1.0.6
         with:
           required-permission: write
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Check authorization
-        id: check
+      - name: Authorize (strip stale safe-to-test on new fork pushes)
+        id: authz
+        if: steps.detect.outputs.has_changes == 'true'
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
           AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
           HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -uo pipefail
+
           if [ "$EVENT" = "workflow_dispatch" ]; then
             echo "allowed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          # New push from an external fork without write permission: strip the
+          # safe-to-test label so the updated code must be re-reviewed.
+          if [ "$HAS_WRITE" != "1" ] && [ "$ACTION" = "synchronize" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            gh api -X DELETE "repos/${BASE_REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
+            echo "::warning::Removed safe-to-test label - new commits pushed. Re-review required."
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Same-repo PRs are always trusted
           if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
-            echo "::notice::Same-repo PR — authorized"
+            echo "::notice::Same-repo PR - authorized"
             echo "allowed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -75,349 +160,203 @@ jobs:
 
           # Actor with write (or higher) is trusted even when author_association is not MEMBER/COLLABORATOR.
           if [ "$HAS_WRITE" = "1" ]; then
-            echo "::notice::Actor has write-or-higher permission — authorized"
+            echo "::notice::Actor has write-or-higher permission - authorized"
             echo "allowed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # Org members / collaborators (by author_association) are trusted even from forks
           if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
-            echo "::notice::Trusted author ($AUTHOR_ASSOC) — authorized"
+            echo "::notice::Trusted author ($AUTHOR_ASSOC) - authorized"
             echo "allowed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # External fork PRs require the safe-to-test label
           if [ "$HAS_LABEL" = "true" ]; then
-            echo "::notice::Fork PR with safe-to-test label — authorized"
+            echo "::notice::Fork PR with safe-to-test label - authorized"
             echo "allowed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::External fork PR without safe-to-test label — skipping checks"
-            echo "::warning::A team member must review the code and apply the 'safe-to-test' label"
+            echo "::warning::External fork PR without safe-to-test label - a team member must review the code and apply the 'safe-to-test' label"
             echo "allowed=false" >> "$GITHUB_OUTPUT"
           fi
 
-  # ---------------------------------------------------------------------------
-  # Strip safe-to-test label on new pushes from external contributors.
-  # Forces re-review before CI runs on updated code.
-  # Event actors with repo write permission are not stripped (from authorize output).
-  # ---------------------------------------------------------------------------
-  strip-label:
-    needs: authorize
-    if: |
-      needs.authorize.outputs.has_write != '1' &&
-      github.event.action == 'synchronize' &&
-      github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Log actor write permission check
+      - name: Block unauthorized fork PR
+        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed != 'true'
         shell: bash
         run: |
-          echo "::notice::Actor '${{ github.actor }}' has write-or-higher permission: ${{ needs.authorize.outputs.has_write }}"
+          echo "::error::SDK pod files changed but the checks are not authorized to run. A team member must review the code and apply the 'safe-to-test' label."
+          exit 1
 
-      - name: Remove safe-to-test label
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh api -X DELETE \
-            "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels/safe-to-test" \
-            2>/dev/null || true
-          echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
-
-  # Runs unconditionally (even for unauthorized fork PRs) so the `gate` job can
-  # always tell whether SDK pod files changed. Safe to run for anyone: it only
-  # reads the trusted base-branch config and diffs file names — it never
-  # executes PR code. The `check` job below stays gated on authorization.
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.detect.outputs.matrix }}
-      has_changes: ${{ steps.detect.outputs.has_changes }}
-    steps:
-      # Checkout base branch — config file is read from here (trusted)
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Detect changed packages
-        id: detect
-        shell: bash
-        run: |
-          # Default optional fields when not specified in config
-          ALL_PACKAGES=$(jq -c '[.[] | .pkg_manager //= "npm" | .needs_bare //= false | .tests_bare //= false]' .github/sdk-pod-checks.json)
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # workflow_dispatch: run all packages
-            MATRIX="$ALL_PACKAGES"
-          else
-            # Fetch PR head (available on base repo via pull refs)
-            git fetch origin "refs/pull/${{ github.event.pull_request.number }}/head"
-
-            # Filter to only packages with changed files in this PR
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-            CHANGED_FILES=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
-
-            MATRIX=$(echo "$ALL_PACKAGES" | jq -c --arg files "$CHANGED_FILES" '[
-              .[] | select(.path as $p | $files | split("\n") | any(startswith($p + "/")))
-            ]')
-          fi
-
-          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
-          has_changes=$(echo "$MATRIX" | jq -r 'if length > 0 then "true" else "false" end')
-          echo "has_changes=${has_changes}" >> "$GITHUB_OUTPUT"
-
-  check:
-    needs: [authorize, changes]
-    if: |
-      needs.authorize.outputs.allowed == 'true' &&
-      needs.changes.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include: ${{ fromJSON(needs.changes.outputs.matrix) }}
-      fail-fast: false
-    name: check (${{ matrix.package }})
-    defaults:
-      run:
-        working-directory: ${{ matrix.path }}
-    steps:
-      # Checkout PR head — this is the code we're actually testing
+      # PR head checkout and all script execution happen ONLY when authorized.
       - name: Checkout PR head
+        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Check for disallowed dependencies
-        shell: bash
-        id: check_dependencies
-        continue-on-error: true
-        run: |
-          deps=$(jq -r '([.dependencies, .devDependencies] | map(select(type=="object")) | add // {}) | to_entries[] | .value' package.json)
-          if echo "$deps" | grep -Eq '^(git\+https:\/\/github.com|[0-9]+\.[0-9]+\.[0-9]+-(dev|tmp)[^"]*)$'; then
-            echo "::error title=Disallowed dependency detected::Do not use git URLs or dev/tmp versions in dependencies"
-            exit 1
-          fi
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Bun
-        if: matrix.pkg_manager == 'bun'
+        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
         with:
           bun-version: latest
 
       - name: Setup Node
-        if: matrix.pkg_manager == 'npm'
+        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
 
-      - name: Install dependencies
-        shell: bash
-        run: |
-          if [ "${{ matrix.package }}" = "sdk" ]; then
-            bun install
-          else
-            ${{ matrix.pkg_manager }} install
-          fi
-
-      - name: Install Bare runtime
-        if: matrix.needs_bare == true
-        run: npm install -g --force bare
-
-      # All script steps use npm run --if-present (bun lacks --if-present).
-      # npm run just reads package.json scripts — works regardless of installer.
-
-      - name: Run lint
-        id: run_lint
-        continue-on-error: true
-        run: npm run --if-present lint
-
-      - name: Run build (types)
-        id: run_build_types
-        continue-on-error: true
-        run: npm run --if-present build:types
-
-      - name: Run build
-        id: run_build
-        continue-on-error: true
-        run: npm run --if-present build
-
-      - name: Run unit tests
-        id: run_tests
-        continue-on-error: true
-        run: npm run --if-present test:unit
-
-      - name: Run bare tests
-        id: run_bare_tests
-        if: matrix.tests_bare == true
-        continue-on-error: true
-        run: npm run --if-present test:bare
-
-      - name: Run e2e tests
-        id: run_e2e_tests
-        continue-on-error: true
-        run: npm run --if-present test:e2e
-
-      # Validates the SDK tarball installs cleanly for end consumers:
-      #   1. zero peer-dependency warnings on install
-      #   2. shared P2P packages resolve to a single copy
-      #   3. `import('@qvac/sdk')` resolves from a vanilla install
-      - name: Setup Node (for consumer install check)
-        if: matrix.package == 'sdk'
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
-        with:
-          node-version: 22
-
-      - name: Consumer install check
-        id: run_consumer_install
-        if: matrix.package == 'sdk'
-        continue-on-error: true
-        shell: bash
-        run: |
-          set -eo pipefail
-
-          # Pack the tarball produced by the preceding build step.
-          bun pm pack --destination dist/
-          tarball=$(ls dist/qvac-sdk-*.tgz | head -n1)
-          test -n "$tarball" || { echo "::error::No SDK tarball found after pack"; exit 1; }
-          tarball_abs="$(pwd)/$tarball"
-
-          # Run the same three checks (peer warnings, Holepunch dedup, smoke import)
-          # against a freshly installed consumer dir. install.log must already exist.
-          check_consumer() {
-            local consumer="$1" label="$2"
-            cd "$consumer"
-
-            if grep -Eq "ERESOLVE|npm warn peer" install.log; then
-              echo "::error title=Peer dependency drift (${label})::SDK consumer install surfaced peer warnings"
-              grep -E "ERESOLVE|npm warn peer" install.log || true
-              return 1
-            fi
-            echo "::notice::[${label}] 0 peer warnings"
-
-            local fail=0 tree copies
-            for pkg in corestore hyperswarm hyperdrive hyperdb hyperblobs hyperdht; do
-              tree=$(npm ls "$pkg" --all 2>&1)
-              copies=$(printf '%s\n' "$tree" | grep -E "[─ ]${pkg}@" | grep -vc "deduped" || true)
-              if [ "$copies" != "1" ]; then
-                echo "::error::[${label}] ${pkg} resolved to ${copies} copies (expected 1)"
-                printf '%s\n' "$tree"
-                fail=1
-              else
-                echo "  ok  [${label}] ${pkg} = 1 copy"
-              fi
-            done
-            [ "$fail" = "0" ] || return 1
-            echo "::notice::[${label}] Single-copy invariant holds for shared P2P packages"
-
-            node -e "import('@qvac/sdk').then(m => { if (Object.keys(m).length < 50) { console.error('FAIL: too few exports'); process.exit(1); } console.log('[${label}] import ok:', Object.keys(m).length, 'exports'); }).catch(e => { console.error('[${label}] FAIL:', e.message); process.exit(1); })"
-          }
-
-          # Scenario 1: default install (plug-n-play) — all optionalDependencies present.
-          # Catches Keet-style ERESOLVE from optional deps' peer ranges colliding with
-          # other deps, and validates the mobile/Pear consumer profile.
-          consumer_default=$(mktemp -d)
-          cd "$consumer_default"
-          npm init -y > /dev/null
-          npm pkg set type=module > /dev/null
-          npm install --no-fund --no-audit --ignore-scripts --loglevel=info \
-            "$tarball_abs" 2>&1 | tee install.log
-          check_consumer "$consumer_default" "default" || exit 1
-
-          # Scenario 2: lean backend install (--omit=optional) — no optionalDependencies.
-          # Catches (a) backend-required packages accidentally classified as optional,
-          # (b) SDK entry-point eagerly importing an optional module.
-          consumer_lean=$(mktemp -d)
-          cd "$consumer_lean"
-          npm init -y > /dev/null
-          npm pkg set type=module > /dev/null
-          npm install --no-fund --no-audit --ignore-scripts --omit=optional --loglevel=info \
-            "$tarball_abs" 2>&1 | tee install.log
-          check_consumer "$consumer_lean" "lean (--omit=optional)" || exit 1
-
-      - name: Check for errors
-        shell: bash
-        run: |
-          count=0
-          if [ "${{ steps.run_lint.outcome }}" = "failure" ]; then
-            echo "::error::Lint failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.run_build_types.outcome }}" = "failure" ]; then
-            echo "::error::Build (types) failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.run_build.outcome }}" = "failure" ]; then
-            echo "::error::Build failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.run_tests.outcome }}" = "failure" ]; then
-            echo "::error::Unit tests failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.run_bare_tests.outcome }}" = "failure" ]; then
-            echo "::error::Bare tests failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.run_e2e_tests.outcome }}" = "failure" ]; then
-            echo "::error::E2E tests failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.run_consumer_install.outcome }}" = "failure" ]; then
-            echo "::error::Consumer install check failed"
-            count=$((count + 1))
-          fi
-          if [ "${{ steps.check_dependencies.outcome }}" = "failure" ]; then
-            echo "::error::Disallowed dependencies detected"
-            count=$((count + 1))
-          fi
-          if [ $count -gt 0 ]; then
-            echo "::error::There were $count failed checks"
-            exit 1
-          fi
-
-  # ---------------------------------------------------------------------------
-  # Aggregator gate — the single required status check for SDK pod packages.
-  #
-  # Always runs (even when `check` is skipped) so the "SDK Pod Checks" context
-  # is reported on every PR and is never stuck "Pending". Mark THIS job's name
-  # ("SDK Pod Checks") as the required status check in the branch ruleset.
-  #
-  #   - no SDK pod files changed            -> pass (unrelated PRs unaffected)
-  #   - changed + all checks succeeded      -> pass
-  #   - changed + unauthorized fork PR      -> fail (needs safe-to-test label)
-  #   - changed + a check failed            -> fail (blocks the merge)
-  # ---------------------------------------------------------------------------
-  gate:
-    name: SDK Pod Checks
-    needs: [authorize, changes, check]
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Evaluate SDK pod check results
+      - name: Run SDK pod checks
+        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed == 'true'
         shell: bash
         env:
-          HAS_CHANGES: ${{ needs.changes.outputs.has_changes }}
-          ALLOWED: ${{ needs.authorize.outputs.allowed }}
-          CHECK_RESULT: ${{ needs.check.result }}
+          PACKAGES: ${{ steps.detect.outputs.packages }}
+          # Maintainer escape hatch: when this label is present the gate still
+          # runs and logs failures, but reports success so an urgent fix can
+          # land over a confirmed false-positive check. Audited via the label
+          # and the warning below; does NOT bypass the authorization gate.
+          OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'skip-sdk-pod-checks') }}
         run: |
-          if [ "$HAS_CHANGES" != "true" ]; then
-            echo "::notice::No SDK pod package files changed - gate passes."
-            exit 0
+          set -uo pipefail
+          WS="$GITHUB_WORKSPACE"
+          fail=0
+
+          # Run a single check; record (don't abort on) failures so every check runs.
+          run() {
+            local label="$1"
+            shift
+            if "$@"; then
+              echo "  ok  [$PKG] $label"
+            else
+              echo "::error::[$PKG] $label failed"
+              fail=$((fail + 1))
+            fi
+          }
+
+          # Validates the SDK tarball installs cleanly for end consumers:
+          #   1. zero peer-dependency warnings on install
+          #   2. shared P2P packages resolve to a single copy
+          #   3. import('@qvac/sdk') resolves from a vanilla install
+          # Runs in a subshell so its directory changes do not leak.
+          consumer_install_check() (
+            set -eo pipefail
+            cd "$WS/packages/sdk"
+
+            # Pack the tarball produced by the preceding build step.
+            bun pm pack --destination dist/
+            tarball=$(ls dist/qvac-sdk-*.tgz | head -n1)
+            test -n "$tarball" || { echo "::error::No SDK tarball found after pack"; exit 1; }
+            tarball_abs="$(pwd)/$tarball"
+
+            check_consumer() {
+              local consumer="$1" label="$2"
+              cd "$consumer"
+
+              if grep -Eq "ERESOLVE|npm warn peer" install.log; then
+                echo "::error title=Peer dependency drift (${label})::SDK consumer install surfaced peer warnings"
+                grep -E "ERESOLVE|npm warn peer" install.log || true
+                return 1
+              fi
+              echo "::notice::[${label}] 0 peer warnings"
+
+              local f=0 tree copies
+              for pkg in corestore hyperswarm hyperdrive hyperdb hyperblobs hyperdht; do
+                tree=$(npm ls "$pkg" --all 2>&1)
+                copies=$(printf '%s\n' "$tree" | grep -E "[─ ]${pkg}@" | grep -vc "deduped" || true)
+                if [ "$copies" != "1" ]; then
+                  echo "::error::[${label}] ${pkg} resolved to ${copies} copies (expected 1)"
+                  printf '%s\n' "$tree"
+                  f=1
+                else
+                  echo "  ok  [${label}] ${pkg} = 1 copy"
+                fi
+              done
+              [ "$f" = "0" ] || return 1
+              echo "::notice::[${label}] Single-copy invariant holds for shared P2P packages"
+
+              node -e "import('@qvac/sdk').then(m => { if (Object.keys(m).length < 50) { console.error('FAIL: too few exports'); process.exit(1); } console.log('[${label}] import ok:', Object.keys(m).length, 'exports'); }).catch(e => { console.error('[${label}] FAIL:', e.message); process.exit(1); })"
+            }
+
+            # Scenario 1: default install (plug-n-play) - all optionalDependencies present.
+            consumer_default=$(mktemp -d)
+            cd "$consumer_default"
+            npm init -y > /dev/null
+            npm pkg set type=module > /dev/null
+            npm install --no-fund --no-audit --ignore-scripts --loglevel=info "$tarball_abs" 2>&1 | tee install.log
+            check_consumer "$consumer_default" "default"
+
+            # Scenario 2: lean backend install (--omit=optional) - no optionalDependencies.
+            consumer_lean=$(mktemp -d)
+            cd "$consumer_lean"
+            npm init -y > /dev/null
+            npm pkg set type=module > /dev/null
+            npm install --no-fund --no-audit --ignore-scripts --omit=optional --loglevel=info "$tarball_abs" 2>&1 | tee install.log
+            check_consumer "$consumer_lean" "lean (--omit=optional)"
+          )
+
+          # Install the Bare runtime once if any changed package needs it.
+          if echo "$PACKAGES" | jq -e 'any(.[]; .needs_bare == true)' > /dev/null; then
+            echo "::group::Install Bare runtime"
+            npm install -g --force bare
+            echo "::endgroup::"
           fi
-          if [ "$ALLOWED" != "true" ]; then
-            echo "::error::SDK pod files changed but checks were not authorized. A maintainer must apply the 'safe-to-test' label, then re-run."
+
+          len=$(echo "$PACKAGES" | jq 'length')
+          i=0
+          while [ "$i" -lt "$len" ]; do
+            PKG=$(echo "$PACKAGES" | jq -r ".[$i].package")
+            P_PATH=$(echo "$PACKAGES" | jq -r ".[$i].path")
+            PM=$(echo "$PACKAGES" | jq -r ".[$i].pkg_manager")
+            TESTS_BARE=$(echo "$PACKAGES" | jq -r ".[$i].tests_bare")
+            i=$((i + 1))
+
+            echo "::group::SDK pod checks - $PKG"
+            cd "$WS/$P_PATH"
+
+            # Disallowed dependencies: no git URLs or dev/tmp versions.
+            deps=$(jq -r '([.dependencies, .devDependencies] | map(select(type=="object")) | add // {}) | to_entries[] | .value' package.json)
+            if echo "$deps" | grep -Eq '^(git\+https:\/\/github.com|[0-9]+\.[0-9]+\.[0-9]+-(dev|tmp)[^"]*)$'; then
+              echo "::error::[$PKG] disallowed dependency detected (git URL or dev/tmp version)"
+              fail=$((fail + 1))
+            fi
+
+            # npm run --if-present reads package.json scripts and works regardless
+            # of the installer (bun lacks --if-present).
+            if [ "$PKG" = "sdk" ]; then
+              run "install" bun install
+            else
+              run "install" "$PM" install
+            fi
+
+            run "lint" npm run --if-present lint
+            run "build:types" npm run --if-present build:types
+            run "build" npm run --if-present build
+            run "test:unit" npm run --if-present test:unit
+            if [ "$TESTS_BARE" = "true" ]; then
+              run "test:bare" npm run --if-present test:bare
+            fi
+            run "test:e2e" npm run --if-present test:e2e
+
+            if [ "$PKG" = "sdk" ]; then
+              if consumer_install_check; then
+                echo "  ok  [$PKG] consumer install"
+              else
+                echo "::error::[$PKG] consumer install check failed"
+                fail=$((fail + 1))
+              fi
+            fi
+
+            cd "$WS"
+            echo "::endgroup::"
+          done
+
+          if [ "$fail" -gt 0 ]; then
+            if [ "$OVERRIDE" = "true" ]; then
+              echo "::warning::$fail SDK pod check(s) failed, but the 'skip-sdk-pod-checks' label is applied - overriding to allow this merge (e.g. a confirmed false-positive test). Fix the failing check in a follow-up."
+              exit 0
+            fi
+            echo "::error::There were $fail failed SDK pod check(s)"
             exit 1
           fi
-          if [ "$CHECK_RESULT" = "success" ]; then
-            echo "::notice::All SDK pod checks passed."
-            exit 0
-          fi
-          echo "::error::SDK pod checks did not pass (result: $CHECK_RESULT)."
-          exit 1
+          echo "All SDK pod checks passed."

--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -1,13 +1,17 @@
 name: PR Checks (SDK Pod)
 
 on:
+  # Plain `pull_request` (NOT pull_request_target): fork PRs run with a
+  # read-only token and no secrets, so it is safe to check out and execute PR
+  # code (install/lint/build/test). These checks need no secrets, so the
+  # privileged context would buy nothing and only add "pwn request" risk.
+  #
   # No trigger-level `paths:` filter on purpose: this workflow publishes the
   # required "SDK Pod Checks" status, which must report on EVERY PR or GitHub
-  # blocks unrelated PRs ("waiting for status to be reported"). A trigger-level
-  # path filter would skip the whole workflow and wedge those PRs. Instead the
-  # single job below detects SDK pod changes itself and is a fast no-op when
-  # nothing relevant changed.
-  pull_request_target:
+  # blocks unrelated PRs ("waiting for status to be reported"). The single job
+  # below detects SDK pod changes itself and is a fast no-op when nothing
+  # relevant changed.
+  pull_request:
     types:
       - opened
       - synchronize
@@ -39,36 +43,30 @@ jobs:
   # no-op (detect step only) when no SDK pod files changed, so unrelated PRs are
   # unaffected. Mark THIS job's name ("SDK Pod Checks") required in the ruleset.
   #
-  #   - no SDK pod files changed     -> pass (no PR code is checked out or run)
+  #   - no SDK pod files changed     -> pass (no checks run)
   #   - changed + checks pass        -> pass
-  #   - changed + unauthorized fork  -> fail (needs the safe-to-test label)
   #   - changed + a check fails      -> fail (blocks the merge)
   #   - changed + a check fails, but the 'skip-sdk-pod-checks' label is set
   #                                  -> pass (audited override for e.g. a
   #                                     confirmed false-positive test; the
   #                                     failure is still run and logged)
   #
-  # Security (pull_request_target): the PR head is only checked out / executed
-  # after the authorization gate passes. Trusted = same-repo PRs, actors with
-  # write, org members/collaborators, or fork PRs carrying the safe-to-test
-  # label. On a new push from an external fork the label is stripped first, to
-  # force re-review of the updated code.
-  #
+  # The package config and the diff baseline are read from the trusted base
+  # commit (not the PR), so a PR cannot edit the config to skip its own checks.
   # Packages are checked sequentially in this single job (instead of a parallel
   # matrix) so that exactly one check appears on every PR.
   # ---------------------------------------------------------------------------
   sdk-pod-checks:
     name: SDK Pod Checks
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
-      # Checkout the base branch (trusted). Used only to read the config and to
-      # diff changed file names — no PR code is executed in this step.
+      # Checkout the trusted base commit. The package config and the diff
+      # baseline are read from here — never from the PR — so a PR cannot edit
+      # the config to exclude itself from its own checks.
       - name: Checkout base
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.ref }}
           fetch-depth: 0
 
       - name: Detect changed SDK pod packages
@@ -80,6 +78,10 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # Fail closed: any error here (git fetch/diff, jq) fails the step and
+          # therefore the whole "SDK Pod Checks" job — never a silent green.
+          set -euo pipefail
+
           # Default optional fields when not specified in config
           ALL_PACKAGES=$(jq -c '[.[] | .pkg_manager //= "npm" | .needs_bare //= false | .tests_bare //= false]' .github/sdk-pod-checks.json)
 
@@ -87,7 +89,7 @@ jobs:
             # workflow_dispatch: run all packages
             PACKAGES="$ALL_PACKAGES"
           else
-            # Fetch PR head (available on base repo via pull refs)
+            # Fetch PR head (available on the repo via pull refs)
             git fetch origin "refs/pull/${PR_NUMBER}/head"
 
             # Filter to only packages with changed files in this PR
@@ -109,113 +111,35 @@ jobs:
 
       # ----- Everything below runs only when SDK pod files changed -----
 
-      - name: Check actor write permission
-        id: perm
-        if: steps.detect.outputs.has_changes == 'true'
-        uses: scherermichael-oss/action-has-permission@136e061bfe093832d87f090dd768e14e27a740d3 # 1.0.6
-        with:
-          required-permission: write
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Authorize (strip stale safe-to-test on new fork pushes)
-        id: authz
-        if: steps.detect.outputs.has_changes == 'true'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT: ${{ github.event_name }}
-          ACTION: ${{ github.event.action }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.repository }}
-          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
-          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
-          HAS_WRITE: ${{ steps.perm.outputs.has-permission }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -uo pipefail
-
-          if [ "$EVENT" = "workflow_dispatch" ]; then
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # New push from an external fork without write permission: strip the
-          # safe-to-test label so the updated code must be re-reviewed.
-          if [ "$HAS_WRITE" != "1" ] && [ "$ACTION" = "synchronize" ] && [ "$HEAD_REPO" != "$BASE_REPO" ]; then
-            gh api -X DELETE "repos/${BASE_REPO}/issues/${PR_NUMBER}/labels/safe-to-test" 2>/dev/null || true
-            echo "::warning::Removed safe-to-test label - new commits pushed. Re-review required."
-            echo "allowed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Same-repo PRs are always trusted
-          if [ "$HEAD_REPO" = "$BASE_REPO" ]; then
-            echo "::notice::Same-repo PR - authorized"
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "::notice::Actor '$GITHUB_ACTOR' has write-or-higher permission: $HAS_WRITE"
-
-          # Actor with write (or higher) is trusted even when author_association is not MEMBER/COLLABORATOR.
-          if [ "$HAS_WRITE" = "1" ]; then
-            echo "::notice::Actor has write-or-higher permission - authorized"
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Org members / collaborators (by author_association) are trusted even from forks
-          if [[ "$AUTHOR_ASSOC" =~ ^(MEMBER|OWNER|COLLABORATOR)$ ]]; then
-            echo "::notice::Trusted author ($AUTHOR_ASSOC) - authorized"
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # External fork PRs require the safe-to-test label
-          if [ "$HAS_LABEL" = "true" ]; then
-            echo "::notice::Fork PR with safe-to-test label - authorized"
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::External fork PR without safe-to-test label - a team member must review the code and apply the 'safe-to-test' label"
-            echo "allowed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Block unauthorized fork PR
-        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed != 'true'
-        shell: bash
-        run: |
-          echo "::error::SDK pod files changed but the checks are not authorized to run. A team member must review the code and apply the 'safe-to-test' label."
-          exit 1
-
-      # PR head checkout and all script execution happen ONLY when authorized.
+      # Safe under `pull_request`: fork PRs get a read-only token and no secrets,
+      # so checking out and executing PR code cannot exfiltrate anything.
       - name: Checkout PR head
-        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Bun
-        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # 2.2.0
         with:
           bun-version: latest
 
       - name: Setup Node
-        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
         with:
           node-version: 22
 
       - name: Run SDK pod checks
-        if: steps.detect.outputs.has_changes == 'true' && steps.authz.outputs.allowed == 'true'
+        if: steps.detect.outputs.has_changes == 'true'
         shell: bash
         env:
           PACKAGES: ${{ steps.detect.outputs.packages }}
           # Maintainer escape hatch: when this label is present the gate still
           # runs and logs failures, but reports success so an urgent fix can
           # land over a confirmed false-positive check. Audited via the label
-          # and the warning below; does NOT bypass the authorization gate.
+          # and the warning below.
           OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'skip-sdk-pod-checks') }}
         run: |
           set -uo pipefail

--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -1,19 +1,17 @@
 name: PR Checks (SDK Pod)
 
 on:
+  # No trigger-level `paths:` filter on purpose: this workflow publishes the
+  # required "SDK Pod Checks" status. A path-skipped workflow would leave that
+  # required check stuck "Pending" and block unrelated PRs from merging.
+  # Path scoping happens inside the `changes` job instead, and the `gate` job
+  # passes cleanly when no SDK pod files changed.
   pull_request_target:
     types:
       - opened
       - synchronize
       - reopened
       - labeled
-    paths:
-      - "packages/sdk/**"
-      - "packages/cli/**"
-      - "packages/rag/**"
-      - "packages/logging/**"
-      - "packages/error/**"
-      - "packages/ai-sdk-provider/**"
     branches:
       - main
       - release-*
@@ -129,9 +127,11 @@ jobs:
             2>/dev/null || true
           echo "::warning::Removed safe-to-test label — new commits pushed. Re-review required."
 
+  # Runs unconditionally (even for unauthorized fork PRs) so the `gate` job can
+  # always tell whether SDK pod files changed. Safe to run for anyone: it only
+  # reads the trusted base-branch config and diffs file names — it never
+  # executes PR code. The `check` job below stays gated on authorization.
   changes:
-    needs: authorize
-    if: needs.authorize.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.detect.outputs.matrix }}
@@ -379,3 +379,45 @@ jobs:
             echo "::error::There were $count failed checks"
             exit 1
           fi
+
+  # ---------------------------------------------------------------------------
+  # Aggregator gate — the single required status check for SDK pod packages.
+  #
+  # Always runs (even when `check` is skipped) so the "SDK Pod Checks" context
+  # is reported on every PR and is never stuck "Pending". Mark THIS job's name
+  # ("SDK Pod Checks") as the required status check in the branch ruleset.
+  #
+  #   - no SDK pod files changed            -> pass (unrelated PRs unaffected)
+  #   - changed + all checks succeeded      -> pass
+  #   - changed + unauthorized fork PR      -> fail (needs safe-to-test label)
+  #   - changed + a check failed            -> fail (blocks the merge)
+  # ---------------------------------------------------------------------------
+  gate:
+    name: SDK Pod Checks
+    needs: [authorize, changes, check]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Evaluate SDK pod check results
+        shell: bash
+        env:
+          HAS_CHANGES: ${{ needs.changes.outputs.has_changes }}
+          ALLOWED: ${{ needs.authorize.outputs.allowed }}
+          CHECK_RESULT: ${{ needs.check.result }}
+        run: |
+          if [ "$HAS_CHANGES" != "true" ]; then
+            echo "::notice::No SDK pod package files changed - gate passes."
+            exit 0
+          fi
+          if [ "$ALLOWED" != "true" ]; then
+            echo "::error::SDK pod files changed but checks were not authorized. A maintainer must apply the 'safe-to-test' label, then re-run."
+            exit 1
+          fi
+          if [ "$CHECK_RESULT" = "success" ]; then
+            echo "::notice::All SDK pod checks passed."
+            exit 0
+          fi
+          echo "::error::SDK pod checks did not pass (result: $CHECK_RESULT)."
+          exit 1

--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -59,6 +59,10 @@ jobs:
   sdk-pod-checks:
     name: SDK Pod Checks
     runs-on: ubuntu-latest
+    # Hard cap so a hung job can't hog runners or burn minutes. Slightly above
+    # the 30-min default because this rollup runs up to 6 packages sequentially
+    # (incl. the SDK build + bare/e2e tests and the two consumer installs).
+    timeout-minutes: 45
     steps:
       # Checkout the trusted base commit. The package config and the diff
       # baseline are read from here — never from the PR — so a PR cannot edit
@@ -71,6 +75,7 @@ jobs:
 
       - name: Detect changed SDK pod packages
         id: detect
+        timeout-minutes: 5
         shell: bash
         env:
           EVENT: ${{ github.event_name }}
@@ -133,6 +138,7 @@ jobs:
 
       - name: Run SDK pod checks
         if: steps.detect.outputs.has_changes == 'true'
+        timeout-minutes: 40
         shell: bash
         env:
           PACKAGES: ${{ steps.detect.outputs.packages }}


### PR DESCRIPTION
## Summary

The PR Checks (SDK Pod) workflow (`pr-checks-sdk-pod.yml`) runs lint, build, and tests for the SDK pod packages, but it was never enforced as a merge gate — PRs could merge to `main` even when these checks failed. That is how the stale `bun.lock` landed on `main` via #895.

This PR converts the workflow into a path-scoped, always-reporting merge gate:

- **Removes the trigger-level `paths:` filter.** A workflow skipped by a trigger-level path filter leaves its required check stuck "Pending", which would block every unrelated PR ([GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)). Path scoping already happens inside the `changes` job, so the heavy `check` matrix still only runs when SDK pod files change.
- **Runs the `changes` job unconditionally** so the gate can tell whether SDK pod files changed even on unauthorized fork PRs. It only reads the trusted base-branch config and diffs file names — it never executes PR code. The `check` job stays gated on authorization.
- **Adds a single `SDK Pod Checks` aggregator job** (`if: always()`) that:
  - passes when no SDK pod files changed (unrelated PRs unaffected),
  - passes when SDK pod files changed and all checks succeeded,
  - fails when checks failed, or when an unauthorized fork PR touching SDK pod packages still needs the `safe-to-test` label.

Scope is unchanged: all six SDK pod packages, driven by `.github/sdk-pod-checks.json`.

## Follow-up (not in this PR)

Making this a hard merge gate requires adding `SDK Pod Checks` as a required status check on the `main` ruleset. That branch-protection change is applied separately, **after** this PR merges and the `SDK Pod Checks` context has reported at least once — otherwise every PR would block on a not-yet-existing check.

## Test plan

- [x] `actionlint .github/workflows/pr-checks-sdk-pod.yml` passes (verified locally — clean).
- [ ] `yamlfmt` check passes in CI.
- [ ] After merge: a PR that does **not** touch SDK pod packages reports `SDK Pod Checks` as success.
- [ ] After merge: a PR touching an SDK pod package with a deliberately failing lint/test makes `SDK Pod Checks` fail.
- [ ] After merge: confirm the `SDK Pod Checks` context appears, then add it to the `main` ruleset.

> Note: `pull_request_target` always uses the workflow definition from the base branch (`main`), so this new gate does not run on this PR itself — it takes effect for PRs opened after merge.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213682500910485