### PR TITLE
feat[api]: add opt-in Metal ggml backend to ocr-ggml

### DIFF
--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this package will be documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Opt-in **Metal** GPU backend on Apple via `params.backendDevice: 'metal'`,
+  extending the existing `backendDevice` option (`'cpu'` | `'vulkan'`). The
+  Metal backend is compiled into the addon (no extra shared library); requested
+  Metal transparently falls back to CPU — with an explicit `fallbackReason` —
+  when no Metal-capable device is present. Enabled by requesting the
+  `qvac-fabric` `gpu-backends` feature, which builds ggml with Metal on Apple.
+  Validated CPU↔Metal output parity on Apple M3 Ultra for both the EasyOCR and
+  DocTR pipelines.
+
 ## [0.1.1] - 2026-06-02
 
 ### Changed

--- a/packages/ocr-ggml/README.md
+++ b/packages/ocr-ggml/README.md
@@ -107,7 +107,7 @@ bare examples/quickstart.js \
 | `params.recognizerBatchSize` | `number` | | `32` | recognizer batch size (`easyocr` only) |
 | `params.nThreads` | `number` | | `0` (auto) | CPU thread count for GGML; `<0` leaves the GGML default |
 | `params.backendsDir` | `string` | | `<package>/prebuilds` | directory holding `libggml-*.so` backend shared libs |
-| `params.backendDevice` | `'cpu'` \| `'vulkan'` | | `'cpu'` | ggml backend device. `'vulkan'` opts in to GPU inference with transparent CPU fallback — see [Backend device](#backend-device-cpu--vulkan) |
+| `params.backendDevice` | `'cpu'` \| `'vulkan'` \| `'metal'` | | `'cpu'` | ggml backend device. `'vulkan'` (Linux/Windows/Android) and `'metal'` (Apple) opt in to GPU inference with transparent CPU fallback — see [Backend device](#backend-device-cpu--vulkan--metal) |
 | `opts.stats` | `boolean` | | `false` | emit timing stats on `finish` |
 | `logger` | `Object` | | `null` | optional `{ info, warn, error, debug }` — receives C++ log lines |
 
@@ -121,10 +121,11 @@ bare examples/quickstart.js \
 - `getBackendInfo(): BackendInfo | null` — backend device resolved at `load()` (`{ requested, backendDevice, backendName, fallbackReason }`); `null` before `load()` / after `unload()`
 - `OcrGgml.getModelKey(): string` — `"ocr-ggml"`, used by the inference manager
 
-### Backend device (CPU / Vulkan)
+### Backend device (CPU / Vulkan / Metal)
 
 By default inference runs on the **CPU** ggml backend, which is always
-available. Set `params.backendDevice: 'vulkan'` to opt in to GPU inference:
+available. Set `params.backendDevice` to `'vulkan'` (Linux/Windows/Android) or
+`'metal'` (Apple) to opt in to GPU inference:
 
 ```js
 const ocr = new OcrGgml({
@@ -132,33 +133,46 @@ const ocr = new OcrGgml({
     pathDetector: '/abs/path/craft_mlt_25k.gguf',
     pathRecognizer: '/abs/path/english_g2.gguf',
     langList: ['en'],
-    backendDevice: 'vulkan'   // default is 'cpu'
+    backendDevice: 'metal'   // 'cpu' (default) | 'vulkan' | 'metal'
   }
 })
 await ocr.load()
 console.log(ocr.getBackendInfo())
 // Vulkan available → { requested: 'vulkan', backendDevice: 'GPU',  backendName: 'Vulkan0', fallbackReason: '' }
 // no Vulkan device → { requested: 'vulkan', backendDevice: 'CPU',  backendName: 'CPU',     fallbackReason: 'Vulkan backend requested but no Vulkan-capable GPU device was found; falling back to CPU' }
+// Metal available  → { requested: 'metal',  backendDevice: 'GPU',  backendName: 'Metal',   fallbackReason: '' }
+// no Metal device  → { requested: 'metal',  backendDevice: 'CPU',  backendName: 'CPU',     fallbackReason: 'Metal backend requested but no Metal-capable GPU device was found; falling back to CPU' }
 ```
 
 Behaviour and expectations:
 
-- **Transparent CPU fallback.** When `'vulkan'` is requested but no
-  Vulkan-capable GPU device is registered, the pipeline falls back to CPU and
+- **Transparent CPU fallback.** When `'vulkan'` / `'metal'` is requested but no
+  matching GPU device is registered, the pipeline falls back to CPU and
   records a non-empty `fallbackReason` (also reflected by the numeric
   `backendIsGpu` stat). It never silently does the wrong thing.
 - **Required backend libs.** Vulkan execution needs the `libggml-vulkan`
   backend shared library (`libggml-vulkan.so` / `.dll` / `.dylib`) present in
   `backendsDir` (default `<package>/prebuilds/<target>/`), plus a working
-  Vulkan driver/ICD and a Vulkan-capable GPU on the host. These libs are only
-  produced on platforms/feature sets where the upstream ggml port builds the
-  Vulkan backend; on other hosts the request quietly falls back to CPU.
+  Vulkan driver/ICD and a Vulkan-capable GPU on the host. **Metal** is compiled
+  into the addon (no extra shared library), and is available whenever ggml was
+  built with the qvac-fabric `gpu-backends` feature (the default on Apple).
+  These GPU backends are only produced on platforms/feature sets where the
+  upstream ggml port builds them; on other hosts the request quietly falls back
+  to CPU.
 - **DocTR recognizer.** Only the MobileNetV3 feature-extractor graph runs on
   the selected ggml device; the recognizer's downstream LSTM + linear
   classifier always run on CPU (plain C++, no ggml graph), regardless of
   `backendDevice`.
 - **Threads.** `nThreads` only affects the CPU backend; it is ignored when a
-  Vulkan device is selected.
+  Vulkan or Metal device is selected.
+- **Performance guidance (Metal).** The win depends on the detector. The
+  EasyOCR pipeline's CRAFT detector is dense-convolution and benefits strongly
+  from the GPU (≈4.5× faster on Metal on an Apple M3 Ultra vs CPU). The DocTR
+  detector is MobileNetV3 (depthwise-separable convolutions) — a low-arithmetic
+  -intensity, GPU-unfriendly workload that runs *slower* on Metal than on CPU;
+  output is identical either way. Recommended default: **EasyOCR → `'metal'`,
+  DocTR → `'cpu'`** on Apple. Since `backendDevice` is per-instance, you can mix
+  both. (Numbers are workload/hardware dependent — measure for your case.)
 
 ### `run(input)` shape
 
@@ -193,7 +207,7 @@ This is byte-for-byte the same shape `@qvac/ocr-onnx` returns.
   detectionTime: number,    // seconds (CRAFT inference)
   recognitionTime: number,  // seconds (CRNN inference)
   numBoxes: number,         // total boxes (aligned + unaligned)
-  backendIsGpu: number      // 1 if inference ran on a GPU (Vulkan) device, else 0
+  backendIsGpu: number      // 1 if inference ran on a GPU (Vulkan/Metal) device, else 0
 }
 ```
 

--- a/packages/ocr-ggml/README.md
+++ b/packages/ocr-ggml/README.md
@@ -140,7 +140,7 @@ await ocr.load()
 console.log(ocr.getBackendInfo())
 // Vulkan available → { requested: 'vulkan', backendDevice: 'GPU',  backendName: 'Vulkan0', fallbackReason: '' }
 // no Vulkan device → { requested: 'vulkan', backendDevice: 'CPU',  backendName: 'CPU',     fallbackReason: 'Vulkan backend requested but no Vulkan-capable GPU device was found; falling back to CPU' }
-// Metal available  → { requested: 'metal',  backendDevice: 'GPU',  backendName: 'Metal',   fallbackReason: '' }
+// Metal available  → { requested: 'metal',  backendDevice: 'GPU',  backendName: 'MTL0',    fallbackReason: '' }  // device name; 'MTL1'… on a multi-GPU host
 // no Metal device  → { requested: 'metal',  backendDevice: 'CPU',  backendName: 'CPU',     fallbackReason: 'Metal backend requested but no Metal-capable GPU device was found; falling back to CPU' }
 ```
 

--- a/packages/ocr-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/ocr-ggml/addon/src/addon/AddonJs.hpp
@@ -123,10 +123,11 @@ getPath(js_env_t* env, qvac_lib_inference_addon_cpp::js::String path) {
   return path.as<std::string>(env);
 }
 
-// Optional `params.backendDevice` ('cpu' | 'vulkan'). Default keeps CPU
-// inference; 'vulkan' requests a Vulkan-capable GPU with transparent CPU
-// fallback (see OcrBackendSelection). Extracted from createInstance to keep
-// that factory's cognitive complexity under the clang-tidy threshold.
+// Optional `params.backendDevice` ('cpu' | 'vulkan' | 'metal'). Default keeps
+// CPU inference; 'vulkan' (Linux/Windows/Android) and 'metal' (Apple) request a
+// matching GPU with transparent CPU fallback (see OcrBackendSelection).
+// Extracted from createInstance to keep that factory's cognitive complexity
+// under the clang-tidy threshold.
 void applyBackendDevice(
     js_env_t* env, qvac_lib_inference_addon_cpp::js::Object& params,
     OcrConfig& config) {
@@ -139,12 +140,14 @@ void applyBackendDevice(
   const auto backendDevice = optBackendDevice->as<std::string>(env);
   if (backendDevice == "vulkan") {
     config.backendDevice = BackendDevice::VULKAN;
+  } else if (backendDevice == "metal") {
+    config.backendDevice = BackendDevice::METAL;
   } else if (backendDevice == "cpu") {
     config.backendDevice = BackendDevice::CPU;
   } else {
     throw StatusError{
         general_error::InvalidArgument,
-        "backendDevice must be 'cpu' or 'vulkan'"};
+        "backendDevice must be 'cpu', 'vulkan', or 'metal'"};
   }
 }
 

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -43,8 +43,14 @@ const char* deviceTypeName(enum ggml_backend_dev_type type) {
   }
 }
 
-// First Vulkan-capable GPU/iGPU device, or nullptr if none is registered.
-ggml_backend_dev_t findVulkanGpuDevice() {
+// First GPU/iGPU device whose backend name satisfies `matches`, or nullptr if
+// none is registered. Used to resolve both Vulkan and Metal requests.
+//
+// Matches against BOTH the device name and its backend-registration name: ggml
+// names Vulkan devices "Vulkan0" (so the device name carries the backend), but
+// Metal devices are named "MTL0"/"MTL1" while the backing registration is named
+// "Metal". Checking the reg name lets the Metal request resolve correctly.
+ggml_backend_dev_t findGpuDeviceByName(bool (*matches)(std::string_view)) {
   const size_t count = ggml_backend_dev_count();
   for (size_t i = 0; i < count; ++i) {
     ggml_backend_dev_t dev = ggml_backend_dev_get(i);
@@ -56,8 +62,14 @@ ggml_backend_dev_t findVulkanGpuDevice() {
         type != GGML_BACKEND_DEVICE_TYPE_IGPU) {
       continue;
     }
-    const char* nameRaw = ggml_backend_dev_name(dev);
-    if (isVulkanBackendName(nameRaw != nullptr ? nameRaw : "")) {
+    const char* devNameRaw = ggml_backend_dev_name(dev);
+    if (matches(devNameRaw != nullptr ? devNameRaw : "")) {
+      return dev;
+    }
+    ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+    const char* regNameRaw =
+        (reg != nullptr) ? ggml_backend_reg_name(reg) : nullptr;
+    if (matches(regNameRaw != nullptr ? regNameRaw : "")) {
       return dev;
     }
   }
@@ -84,29 +96,66 @@ bool isVulkanBackendName(std::string_view backendName) {
   return toLower(backendName).find("vulkan") != std::string::npos;
 }
 
+bool isMetalBackendName(std::string_view backendName) {
+  // ggml's Metal backend identifies as "MTL": the backend registration is named
+  // "MTL" and devices are "MTL0"/"MTL1"… (the human-readable description carries
+  // the GPU model, e.g. "Apple M3 Ultra", and varies per device). Match the
+  // stable "mtl" token so selection is generic across all Apple GPUs; also
+  // accept "metal" defensively in case a future ggml renames the backend.
+  const std::string lower = toLower(backendName);
+  return lower.find("mtl") != std::string::npos ||
+         lower.find("metal") != std::string::npos;
+}
+
+namespace {
+
+// Resolve a GPU-backed request (Vulkan or Metal). On success fills `sel` with
+// the matched device and returns true; otherwise records a CPU-fallback reason
+// and returns false (the caller then resolves the CPU device).
+bool trySelectGpu(
+    BackendSelection& sel, const char* label,
+    bool (*matches)(std::string_view)) {
+  ggml_backend_dev_t dev = findGpuDeviceByName(matches);
+  if (dev != nullptr) {
+    sel.device = dev;
+    const char* nameRaw = ggml_backend_dev_name(dev);
+    sel.backendName = (nameRaw != nullptr) ? nameRaw : label;
+    sel.backendDevice = deviceTypeName(ggml_backend_dev_type(dev));
+    const char* descRaw = ggml_backend_dev_description(dev);
+    QLOG(
+        Priority::INFO,
+        std::string("ocr-ggml: selected ") + label + " backend '" +
+            sel.backendName + "' (" + sel.backendDevice + ", " +
+            (descRaw != nullptr ? descRaw : "") + ")");
+    return true;
+  }
+  sel.fallbackReason = std::string(label) +
+      " backend requested but no " + label +
+      "-capable GPU device was found; falling back to CPU";
+  QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
+  return false;
+}
+
+} // namespace
+
 BackendSelection selectBackendDevice(BackendDevice requested) {
   BackendSelection sel;
-  sel.requested = (requested == BackendDevice::VULKAN) ? "vulkan" : "cpu";
-
-  if (requested == BackendDevice::VULKAN) {
-    ggml_backend_dev_t vulkanDev = findVulkanGpuDevice();
-    if (vulkanDev != nullptr) {
-      sel.device = vulkanDev;
-      const char* nameRaw = ggml_backend_dev_name(vulkanDev);
-      sel.backendName = (nameRaw != nullptr) ? nameRaw : "vulkan";
-      sel.backendDevice = deviceTypeName(ggml_backend_dev_type(vulkanDev));
-      const char* descRaw = ggml_backend_dev_description(vulkanDev);
-      QLOG(
-          Priority::INFO,
-          std::string("ocr-ggml: selected Vulkan backend '") + sel.backendName +
-              "' (" + sel.backendDevice + ", " +
-              (descRaw != nullptr ? descRaw : "") + ")");
+  switch (requested) {
+  case BackendDevice::VULKAN:
+    sel.requested = "vulkan";
+    if (trySelectGpu(sel, "Vulkan", isVulkanBackendName)) {
       return sel;
     }
-    sel.fallbackReason =
-        "Vulkan backend requested but no Vulkan-capable GPU device was found; "
-        "falling back to CPU";
-    QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
+    break;
+  case BackendDevice::METAL:
+    sel.requested = "metal";
+    if (trySelectGpu(sel, "Metal", isMetalBackendName)) {
+      return sel;
+    }
+    break;
+  case BackendDevice::CPU:
+    sel.requested = "cpu";
+    break;
   }
 
   sel = selectCpu(std::move(sel));

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -100,11 +100,13 @@ bool isMetalBackendName(std::string_view backendName) {
   // ggml's Metal backend identifies as "MTL": the backend registration is named
   // "MTL" and devices are "MTL0"/"MTL1"… (the human-readable description carries
   // the GPU model, e.g. "Apple M3 Ultra", and varies per device). Match the
-  // stable "mtl" token so selection is generic across all Apple GPUs; also
-  // accept "metal" defensively in case a future ggml renames the backend.
+  // stable "MTL" prefix so selection is generic across all Apple GPUs; also
+  // accept a "metal" prefix defensively in case a future ggml renames the
+  // backend. Prefix (not substring) matching mirrors tts-ggml /
+  // transcription-parakeet and avoids false positives on unrelated names that
+  // merely contain "mtl".
   const std::string lower = toLower(backendName);
-  return lower.find("mtl") != std::string::npos ||
-         lower.find("metal") != std::string::npos;
+  return lower.rfind("mtl", 0) == 0 || lower.rfind("metal", 0) == 0;
 }
 
 namespace {
@@ -155,6 +157,15 @@ BackendSelection selectBackendDevice(BackendDevice requested) {
     break;
   case BackendDevice::CPU:
     sel.requested = "cpu";
+    break;
+  default:
+    // Defensive: a BackendDevice value added without updating this switch must
+    // not silently masquerade as an explicit CPU request. Record the fallback
+    // so getBackendInfo() surfaces the gap instead of reporting a clean CPU.
+    sel.requested = "unknown";
+    sel.fallbackReason =
+        "Unsupported backendDevice value; falling back to CPU";
+    QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
     break;
   }
 

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <format>
 #include <string>
 #include <string_view>
 
@@ -115,26 +116,32 @@ namespace {
 // the matched device and returns true; otherwise records a CPU-fallback reason
 // and returns false (the caller then resolves the CPU device).
 bool trySelectGpu(
-    BackendSelection& sel, const char* label,
+    BackendSelection& sel, std::string_view label,
     bool (*matches)(std::string_view)) {
   ggml_backend_dev_t dev = findGpuDeviceByName(matches);
   if (dev != nullptr) {
     sel.device = dev;
     const char* nameRaw = ggml_backend_dev_name(dev);
-    sel.backendName = (nameRaw != nullptr) ? nameRaw : label;
+    sel.backendName =
+        (nameRaw != nullptr) ? std::string(nameRaw) : std::string(label);
     sel.backendDevice = deviceTypeName(ggml_backend_dev_type(dev));
     const char* descRaw = ggml_backend_dev_description(dev);
     QLOG(
         Priority::INFO,
-        std::string("ocr-ggml: selected ") + label + " backend '" +
-            sel.backendName + "' (" + sel.backendDevice + ", " +
-            (descRaw != nullptr ? descRaw : "") + ")");
+        std::format(
+            "ocr-ggml: selected {} backend '{}' ({}, {})",
+            label,
+            sel.backendName,
+            sel.backendDevice,
+            descRaw != nullptr ? descRaw : ""));
     return true;
   }
-  sel.fallbackReason = std::string(label) + " backend requested but no " +
-                       label +
-                       "-capable GPU device was found; falling back to CPU";
-  QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
+  sel.fallbackReason = std::format(
+      "{} backend requested but no {}-capable GPU device was found; falling "
+      "back to CPU",
+      label,
+      label);
+  QLOG(Priority::WARN, std::format("ocr-ggml: {}", sel.fallbackReason));
   return false;
 }
 
@@ -164,14 +171,14 @@ BackendSelection selectBackendDevice(BackendDevice requested) {
     // so getBackendInfo() surfaces the gap instead of reporting a clean CPU.
     sel.requested = "unknown";
     sel.fallbackReason = "Unsupported backendDevice value; falling back to CPU";
-    QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
+    QLOG(Priority::WARN, std::format("ocr-ggml: {}", sel.fallbackReason));
     break;
   }
 
   sel = selectCpu(std::move(sel));
   QLOG(
       Priority::INFO,
-      std::string("ocr-ggml: using CPU backend '") + sel.backendName + "'");
+      std::format("ocr-ggml: using CPU backend '{}'", sel.backendName));
   return sel;
 }
 

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -98,9 +98,9 @@ bool isVulkanBackendName(std::string_view backendName) {
 
 bool isMetalBackendName(std::string_view backendName) {
   // ggml's Metal backend identifies as "MTL": the backend registration is named
-  // "MTL" and devices are "MTL0"/"MTL1"… (the human-readable description carries
-  // the GPU model, e.g. "Apple M3 Ultra", and varies per device). Match the
-  // stable "MTL" prefix so selection is generic across all Apple GPUs; also
+  // "MTL" and devices are "MTL0"/"MTL1"… (the human-readable description
+  // carries the GPU model, e.g. "Apple M3 Ultra", and varies per device). Match
+  // the stable "MTL" prefix so selection is generic across all Apple GPUs; also
   // accept a "metal" prefix defensively in case a future ggml renames the
   // backend. Prefix (not substring) matching mirrors tts-ggml /
   // transcription-parakeet and avoids false positives on unrelated names that
@@ -131,9 +131,9 @@ bool trySelectGpu(
             (descRaw != nullptr ? descRaw : "") + ")");
     return true;
   }
-  sel.fallbackReason = std::string(label) +
-      " backend requested but no " + label +
-      "-capable GPU device was found; falling back to CPU";
+  sel.fallbackReason = std::string(label) + " backend requested but no " +
+                       label +
+                       "-capable GPU device was found; falling back to CPU";
   QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
   return false;
 }
@@ -163,8 +163,7 @@ BackendSelection selectBackendDevice(BackendDevice requested) {
     // not silently masquerade as an explicit CPU request. Record the fallback
     // so getBackendInfo() surfaces the gap instead of reporting a clean CPU.
     sel.requested = "unknown";
-    sel.fallbackReason =
-        "Unsupported backendDevice value; falling back to CPU";
+    sel.fallbackReason = "Unsupported backendDevice value; falling back to CPU";
     QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
     break;
   }

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -64,13 +64,13 @@ ggml_backend_dev_t findGpuDeviceByName(bool (*matches)(std::string_view)) {
       continue;
     }
     const char* devNameRaw = ggml_backend_dev_name(dev);
-    if (matches(devNameRaw != nullptr ? devNameRaw : "")) {
+    if (devNameRaw != nullptr && matches(devNameRaw)) {
       return dev;
     }
     ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
     const char* regNameRaw =
         (reg != nullptr) ? ggml_backend_reg_name(reg) : nullptr;
-    if (matches(regNameRaw != nullptr ? regNameRaw : "")) {
+    if (regNameRaw != nullptr && matches(regNameRaw)) {
       return dev;
     }
   }

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.hpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.hpp
@@ -10,6 +10,9 @@
 //   - `BackendDevice::VULKAN` -> the first Vulkan-capable GPU/iGPU device
 //     (backend name contains "vulkan", case-insensitive). When none is present
 //     the result falls back to the CPU device and records a `fallbackReason`.
+//   - `BackendDevice::METAL` -> the first Metal-capable GPU device (backend
+//     name contains "metal", case-insensitive; Apple only). Same CPU-fallback
+//     behaviour as Vulkan when no Metal device is present.
 //   - `BackendDevice::CPU` (default) -> the CPU device.
 //
 // The returned device is then handed to each step's `ggml_backend_dev_init`.
@@ -52,5 +55,9 @@ BackendSelection selectBackendDevice(BackendDevice requested);
 // True if the backend name contains "vulkan" (case-insensitive). Exposed for
 // unit testing / reuse.
 [[nodiscard]] bool isVulkanBackendName(std::string_view backendName);
+
+// True if the backend name contains "metal" (case-insensitive). Exposed for
+// unit testing / reuse.
+[[nodiscard]] bool isMetalBackendName(std::string_view backendName);
 
 } // namespace qvac_lib_infer_ocr_ggml::ocr_backend_selection

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.hpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.hpp
@@ -11,8 +11,8 @@
 //     (backend name contains "vulkan", case-insensitive). When none is present
 //     the result falls back to the CPU device and records a `fallbackReason`.
 //   - `BackendDevice::METAL` -> the first Metal-capable GPU device (backend
-//     name contains "metal", case-insensitive; Apple only). Same CPU-fallback
-//     behaviour as Vulkan when no Metal device is present.
+//     name begins with "MTL"/"metal", case-insensitive; Apple only). Same
+//     CPU-fallback behaviour as Vulkan when no Metal device is present.
 //   - `BackendDevice::CPU` (default) -> the CPU device.
 //
 // The returned device is then handed to each step's `ggml_backend_dev_init`.
@@ -33,7 +33,7 @@ namespace qvac_lib_infer_ocr_ggml::ocr_backend_selection {
 // the string fields are surfaced to JS for diagnostics / logging.
 struct BackendSelection {
   ggml_backend_dev_t device{nullptr};
-  // Requested device as a lowercase string ("cpu" | "vulkan").
+  // Requested device as a lowercase string ("cpu" | "vulkan" | "metal").
   std::string requested;
   // Resolved device-type string ("CPU" | "GPU" | "IGPU" | "ACCEL").
   std::string backendDevice;
@@ -56,8 +56,9 @@ BackendSelection selectBackendDevice(BackendDevice requested);
 // unit testing / reuse.
 [[nodiscard]] bool isVulkanBackendName(std::string_view backendName);
 
-// True if the backend name contains "metal" (case-insensitive). Exposed for
-// unit testing / reuse.
+// True if the backend name begins with "MTL" or "metal" (case-insensitive) —
+// matches both the ggml device name ("MTL0"/"MTL1") and the "Metal" backend
+// registration name. Exposed for unit testing / reuse.
 [[nodiscard]] bool isMetalBackendName(std::string_view backendName);
 
 } // namespace qvac_lib_infer_ocr_ggml::ocr_backend_selection

--- a/packages/ocr-ggml/addon/src/model-interface/OcrTypes.hpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrTypes.hpp
@@ -28,11 +28,11 @@ enum class PipelineMode : std::uint8_t {
 };
 
 // Selects which ggml backend device the inference steps run on. `CPU` is the
-// always-available default; `VULKAN` opts in to GPU execution when a
-// Vulkan-capable device is present, otherwise the steps fall back to CPU
-// (see `OcrBackendSelection`). Mirrors the opt-in GPU pattern in
-// `vla_backend_selection`.
-enum class BackendDevice : std::uint8_t { CPU, VULKAN };
+// always-available default; `VULKAN` (Linux/Windows/Android) and `METAL`
+// (Apple) opt in to GPU execution when a matching device is present, otherwise
+// the steps fall back to CPU (see `OcrBackendSelection`). Mirrors the opt-in
+// GPU pattern in `vla_backend_selection`.
+enum class BackendDevice : std::uint8_t { CPU, VULKAN, METAL };
 
 // Mirrors @qvac/ocr-onnx's PipelineInput so the JS side can interchangeably
 // drive both addons. Either pass an encoded JPEG/PNG byte buffer (set
@@ -73,8 +73,8 @@ struct OcrConfig {
   // path.
   std::string backendsDir;
   // Requested ggml backend device. CPU is the default and is always available;
-  // VULKAN opts in to GPU inference and transparently falls back to CPU when no
-  // Vulkan-capable device is present (mapped from `params.backendDevice` in
+  // VULKAN / METAL opt in to GPU inference and transparently fall back to CPU
+  // when no matching device is present (mapped from `params.backendDevice` in
   // AddonJs.hpp).
   BackendDevice backendDevice{BackendDevice::CPU};
 };

--- a/packages/ocr-ggml/index.d.ts
+++ b/packages/ocr-ggml/index.d.ts
@@ -58,13 +58,17 @@ export interface OcrGgmlParams {
   /**
    * Requested ggml backend device. Default: `'cpu'`.
    *   - `'cpu'`: run inference on the CPU backend (always available).
-   *   - `'vulkan'`: opt in to GPU inference on a Vulkan-capable device. When no
-   *     Vulkan device is present the pipeline transparently falls back to CPU
-   *     and records the reason (see {@link BackendInfo.fallbackReason}).
-   * Requires the `libggml-vulkan` backend shared library to be present in
-   * `backendsDir`.
+   *   - `'vulkan'`: opt in to GPU inference on a Vulkan-capable device
+   *     (Linux/Windows/Android). Requires the `libggml-vulkan` backend shared
+   *     library to be present in `backendsDir`.
+   *   - `'metal'`: opt in to GPU inference on a Metal-capable device (Apple).
+   *     The Metal backend is compiled into the addon, so no extra shared
+   *     library is required.
+   * When the requested GPU device is not present the pipeline transparently
+   * falls back to CPU and records the reason (see
+   * {@link BackendInfo.fallbackReason}).
    */
-  backendDevice?: 'cpu' | 'vulkan'
+  backendDevice?: 'cpu' | 'vulkan' | 'metal'
 }
 
 /**
@@ -72,7 +76,7 @@ export interface OcrGgmlParams {
  * {@link OcrGgml.getBackendInfo}.
  */
 export interface BackendInfo {
-  /** Requested device (`'cpu'` | `'vulkan'`). */
+  /** Requested device (`'cpu'` | `'vulkan'` | `'metal'`). */
   requested: string
   /** Resolved device type (`'CPU'` | `'GPU'` | `'IGPU'` | `'ACCEL'`). */
   backendDevice: string

--- a/packages/ocr-ggml/index.js
+++ b/packages/ocr-ggml/index.js
@@ -28,7 +28,7 @@ class OcrGgml {
    * @param {number} [args.params.recognizerBatchSize]
    * @param {number} [args.params.nThreads] - 0=auto (physical cores), >0=explicit, <0=leave default
    * @param {string} [args.params.backendsDir] - override directory for ggml backend shared libs
-   * @param {'cpu'|'vulkan'} [args.params.backendDevice='cpu'] - requested ggml backend device. `'vulkan'` opts in to GPU inference with transparent CPU fallback when no Vulkan device is present.
+   * @param {'cpu'|'vulkan'|'metal'} [args.params.backendDevice='cpu'] - requested ggml backend device. `'vulkan'` (Linux/Windows/Android) and `'metal'` (Apple) opt in to GPU inference with transparent CPU fallback when no matching device is present.
    * @param {Object} [args.opts]
    * @param {boolean} [args.opts.stats] - emit timing stats on finish
    * @param {Object} [args.logger]

--- a/packages/ocr-ggml/test/integration/backend-device.test.js
+++ b/packages/ocr-ggml/test/integration/backend-device.test.js
@@ -4,7 +4,7 @@ const { OcrGgml } = require('../..')
 const test = require('brittle')
 const fs = require('bare-fs')
 const path = require('bare-path')
-const { isMobile, getImagePath, ensureModelPath, safeUnload } = require('./utils')
+const { isMobile, platform, getImagePath, ensureModelPath, safeUnload } = require('./utils')
 
 // QVAC-19797: opt-in Vulkan GGML backend. Requesting `backendDevice: 'vulkan'`
 // must EITHER run inference on a Vulkan device, OR report an explicit CPU
@@ -124,6 +124,94 @@ test('backendDevice vulkan: selects Vulkan or reports an explicit CPU fallback',
     t.ok(outputTexts.includes('normal'), 'recognized expected text "normal"')
 
     t.pass('backendDevice vulkan path exercised (' + backendInfo.backendDevice + ')')
+  } finally {
+    await safeUnload(ocrGgml)
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  }
+})
+
+// QVAC-19797 (Metal follow-up): opt-in Metal GGML backend on Apple. Requesting
+// `backendDevice: 'metal'` must EITHER run inference on a Metal device, OR
+// report an explicit CPU fallback — never silently produce wrong behaviour.
+//
+// Unlike Vulkan (a separate libggml-vulkan shared library), the Metal backend
+// is compiled into the addon when ggml is built with the qvac-fabric
+// `gpu-backends` feature (default on Apple). There is therefore no backend lib
+// file to probe; we gate on the host platform instead. On an Apple host whose
+// ggml was built CPU-only, the selection falls back to CPU and we assert the
+// fallback is reported explicitly.
+const shouldSkipMetal = isMobile || platform !== 'darwin'
+
+test('backendDevice metal: selects Metal or reports an explicit CPU fallback', { timeout: TEST_TIMEOUT, skip: shouldSkipMetal }, async function (t) {
+  const detectorPath = await ensureModelPath('detector_craft')
+  const recognizerPath = await ensureModelPath('recognizer_latin')
+  const imagePath = getImagePath('/test/images/basic_test.bmp')
+
+  const ocrGgml = new OcrGgml({
+    params: {
+      pathDetector: detectorPath,
+      pathRecognizer: recognizerPath,
+      langList: ['en'],
+      backendDevice: 'metal'
+    },
+    opts: { stats: true }
+  })
+
+  await ocrGgml.load()
+  t.pass('loaded with backendDevice: metal')
+
+  const backendInfo = ocrGgml.getBackendInfo()
+  t.ok(backendInfo, 'getBackendInfo() returns backend info after load')
+  t.is(backendInfo.requested, 'metal', 'requested device recorded as metal')
+  t.comment('Resolved backend info: ' + JSON.stringify(backendInfo))
+
+  const metalSelected =
+    backendInfo.backendDevice === 'GPU' || backendInfo.backendDevice === 'IGPU'
+
+  if (metalSelected) {
+    t.is(backendInfo.fallbackReason, '', 'no fallback reason when Metal is selected')
+    // ggml names Metal devices "MTL0"/"MTL1" (the backing registration is
+    // "Metal"); accept either form.
+    t.ok(/metal|mtl/i.test(backendInfo.backendName), 'selected backend name is a Metal device (' + backendInfo.backendName + ')')
+  } else {
+    // No Metal device available: the fallback to CPU MUST be reported.
+    t.is(backendInfo.backendDevice, 'CPU', 'fell back to the CPU device')
+    t.ok(backendInfo.fallbackReason.length > 0, 'explicit CPU fallback reason reported')
+    t.comment('CPU fallback reason: ' + backendInfo.fallbackReason)
+  }
+
+  try {
+    const response = await ocrGgml.run({
+      path: imagePath,
+      options: { paragraph: false }
+    })
+
+    let outputTexts = []
+    await response
+      .onUpdate(output => {
+        t.ok(Array.isArray(output), 'output should be an array')
+        outputTexts = output.map(o => o[1])
+      })
+      .onError(error => {
+        t.fail('unexpected error: ' + JSON.stringify(error))
+      })
+      .await()
+
+    const stats = response.stats || {}
+    t.comment('Native addon stats: ' + JSON.stringify(stats))
+
+    // The numeric `backendIsGpu` stat must agree with the resolved device.
+    t.is(
+      stats.backendIsGpu,
+      metalSelected ? 1 : 0,
+      'backendIsGpu stat matches the resolved backend (' + backendInfo.backendDevice + ')'
+    )
+
+    // Inference must succeed regardless of which backend was used.
+    t.ok(outputTexts.length > 0, 'inference produced text regions')
+    t.ok(outputTexts.includes('normal'), 'recognized expected text "normal"')
+
+    t.pass('backendDevice metal path exercised (' + backendInfo.backendDevice + ')')
   } finally {
     await safeUnload(ocrGgml)
     await new Promise(resolve => setTimeout(resolve, 1000))


### PR DESCRIPTION
## Summary

Adds an opt-in **Metal** GPU backend to `@qvac/ocr-ggml`, extending the
`backendDevice` option (`'cpu'` | `'vulkan'`) with `'metal'` for Apple hosts.
Both the EasyOCR and DocTR pipelines can now run on the Metal GPU, with
transparent CPU fallback (and an explicit `fallbackReason`) when no Metal
device is present. Builds directly on the opt-in backend-device framework
added for Vulkan (#2398).

## What changed

- `OcrTypes.hpp` — add `BackendDevice::METAL`.
- `OcrBackendSelection.{hpp,cpp}` — resolve a GPU/IGPU device by **type + the
  backend registration name** (`MTL`). ggml names the Metal *device* `MTL0`/`MTL1`
  (and the description is the GPU model, which varies per machine), so matching
  the stable reg name keeps selection generic across all Apple GPUs — mirroring
  the type-based selection used by the LLM/VLA addons.
- `AddonJs.hpp` — accept `backendDevice: 'metal'`.
- `index.js` / `index.d.ts` / `README.md` / `CHANGELOG.md` — document `'metal'`.
- `test/integration/backend-device.test.js` — Metal selection /
  explicit-CPU-fallback test, gated to `darwin`.

No build-system change is required: the Metal backend is compiled into the addon
via the qvac-fabric `gpu-backends` feature (already enabled, default on Apple);
`ggml::ggml` transitively links and self-registers `ggml-metal` (no
whole-archive / force-load needed).

## Validation (Apple M3 Ultra)

- `backend-device.test.js` passes: `requested=metal`, `backendDevice=GPU`,
  `backendName=MTL0`, `backendIsGpu=1`.
- CPU vs Metal output **parity** verified for both pipelines:
  - EasyOCR: identical text, **~4.5x faster** on Metal (0.27s vs 1.21s).
  - DocTR: identical text; **slower** on Metal (3.4s vs 1.9s) — its MobileNetV3
    detector is a low-arithmetic-intensity, GPU-unfriendly workload. Output is
    correct; this is an inherent characteristic, not a regression.
- `standard` lint and `tsc` (`test:dts`) pass. (clang-tidy runs in CI.)

## Recommended usage

`backendDevice` is per-instance, so on Apple: **EasyOCR → `'metal'`,
DocTR → `'cpu'`** (documented in the README). A follow-up to make DocTR fast on
Metal via a ResNet50 DBNet detector is tracked separately in Asana.

## Notes

- No public breaking change — purely additive (`'metal'` is a new accepted value).
