### PR TITLE
infra[notask]: bootstrap macOS vcpkg inside GITHUB_WORKSPACE

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -30,7 +30,6 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        cd ..
         # Shallow + blobless + sparse clone; ports/ and versions/ are not
         # needed when consuming the S3 binary cache, so skip them to cut
         # the download to ~a few MB.


### PR DESCRIPTION
## Summary

On macOS self-hosted runners, the `setup-vcpkg` action bootstrapped vcpkg with `cd ..` before `git clone`. That placed the vcpkg checkout **outside** `$GITHUB_WORKSPACE`.

Persistent self-hosted runners only wipe the workspace at job start (Manual Workspace Cleanup). A clone in the parent directory survives between runs, accumulates stale state, and can cause confusing bootstrap failures on later jobs.

This PR removes the `cd ..` so macOS vcpkg is cloned into the repository root (`$GITHUB_WORKSPACE`), where normal job cleanup applies.

## Test plan

- [ ] Run a macOS self-hosted workflow that uses `setup-vcpkg` (e.g. cpp-tests on `mac-mini-m4-gpu`)
- [ ] Confirm vcpkg is cloned under `$GITHUB_WORKSPACE/vcpkg`, not in the parent directory
- [ ] Confirm a second run on the same runner succeeds without leftover clone conflicts
