### PR TITLE
QVAC-20016 fix: bare config loader require() and models subpath for Metro

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -122,6 +122,11 @@
     "./commands": {
       "types": "./dist/_sdk/commands/index.d.ts",
       "import": "./dist/_sdk/commands/index.js"
+    },
+    "./models": {
+      "types": "./dist/_sdk/models/registry/index.d.ts",
+      "import": "./dist/_sdk/models/registry/index.js",
+      "require": "./dist/_sdk/models/registry/index.js"
     }
   },
   "imports": {

--- a/packages/sdk/client/config-loader/resolve-config.bare.ts
+++ b/packages/sdk/client/config-loader/resolve-config.bare.ts
@@ -6,7 +6,10 @@ import fs from "bare-fs";
 import path from "bare-path";
 import process from "bare-process";
 import { validateConfig, type QvacConfig } from "./config-utils";
-import { ConfigFileParseFailedError } from "@/utils/errors-client";
+import {
+  ConfigFileInvalidError,
+  ConfigFileParseFailedError,
+} from "@/utils/errors-client";
 import { getClientLogger } from "@/logging";
 
 declare function require(modulePath: string): { default?: unknown };
@@ -21,7 +24,18 @@ function fileExists(filePath: string): boolean {
   return fs.existsSync(filePath);
 }
 
+function assertBareConfigExtension(filePath: string) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === ".ts" || ext === ".mts" || ext === ".cts") {
+    throw new ConfigFileInvalidError(
+      filePath,
+      "TypeScript config is not supported. Use qvac.config.js or qvac.config.json in the project root, or set QVAC_CONFIG_PATH to a .js or .json file.",
+    );
+  }
+}
+
 function loadConfigFromPath(filePath: string): QvacConfig {
+  assertBareConfigExtension(filePath);
   try {
     const configModule: { default?: unknown } = require(filePath);
     return validateConfig(configModule.default || configModule);
@@ -35,11 +49,7 @@ function loadConfigFromPath(filePath: string): QvacConfig {
 }
 
 function findConfigFile(searchDir: string): string | undefined {
-  const configFiles = [
-    "qvac.config.ts",
-    "qvac.config.js",
-    "qvac.config.json",
-  ];
+  const configFiles = ["qvac.config.js", "qvac.config.json"];
 
   for (const name of configFiles) {
     const filePath = path.resolve(searchDir, name);
@@ -54,7 +64,7 @@ function findConfigFile(searchDir: string): string | undefined {
 /**
  * Resolution order for Bare:
  * 1. QVAC_CONFIG_PATH environment variable
- * 2. Config file in project root (qvac.config.ts, qvac.config.js, qvac.config.json)
+ * 2. Config file in project root (qvac.config.js, qvac.config.json)
  * 3. SDK defaults
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- matches Node/Expo resolver signature

--- a/packages/sdk/client/config-loader/resolve-config.bare.ts
+++ b/packages/sdk/client/config-loader/resolve-config.bare.ts
@@ -14,6 +14,8 @@ import { getClientLogger } from "@/logging";
 
 declare function require(modulePath: string): { default?: unknown };
 
+const SUPPORTED_CONFIG_FILE_EXTS = [".js", ".json"];
+
 const logger = getClientLogger();
 
 function findProjectRoot(): string {
@@ -26,10 +28,10 @@ function fileExists(filePath: string): boolean {
 
 function assertBareConfigExtension(filePath: string) {
   const ext = path.extname(filePath).toLowerCase();
-  if (ext === ".ts" || ext === ".mts" || ext === ".cts") {
+  if (!SUPPORTED_CONFIG_FILE_EXTS.includes(ext)) {
     throw new ConfigFileInvalidError(
       filePath,
-      "TypeScript config is not supported. Use qvac.config.js or qvac.config.json in the project root, or set QVAC_CONFIG_PATH to a .js or .json file.",
+      "Given config file format unsupported on this platform. Use qvac.config.js or qvac.config.json in the project root, or set QVAC_CONFIG_PATH to a .js or .json file.",
     );
   }
 }
@@ -49,7 +51,9 @@ function loadConfigFromPath(filePath: string): QvacConfig {
 }
 
 function findConfigFile(searchDir: string): string | undefined {
-  const configFiles = ["qvac.config.js", "qvac.config.json"];
+  const configFiles = SUPPORTED_CONFIG_FILE_EXTS.map(
+    (ext) => `qvac.config${ext}`,
+  );
 
   for (const name of configFiles) {
     const filePath = path.resolve(searchDir, name);

--- a/packages/sdk/client/config-loader/resolve-config.bare.ts
+++ b/packages/sdk/client/config-loader/resolve-config.bare.ts
@@ -5,11 +5,7 @@
 import fs from "bare-fs";
 import path from "bare-path";
 import process from "bare-process";
-import {
-  validateConfig,
-  parseJsonConfig,
-  type QvacConfig,
-} from "./config-utils";
+import { validateConfig, type QvacConfig } from "./config-utils";
 import { ConfigFileParseFailedError } from "@/utils/errors-client";
 import { getClientLogger } from "@/logging";
 
@@ -25,18 +21,7 @@ function fileExists(filePath: string): boolean {
   return fs.existsSync(filePath);
 }
 
-function readFile(filePath: string): string {
-  const result = fs.readFileSync(filePath, "utf-8");
-  return typeof result === "string" ? result : result.toString("utf-8");
-}
-
-function loadJsonConfig(filePath: string): QvacConfig {
-  const content = readFile(filePath);
-  const parsed = parseJsonConfig(content, filePath);
-  return validateConfig(parsed);
-}
-
-function loadJsConfig(filePath: string): QvacConfig {
+function loadConfigFromPath(filePath: string): QvacConfig {
   try {
     const configModule: { default?: unknown } = require(filePath);
     return validateConfig(configModule.default || configModule);
@@ -49,19 +34,17 @@ function loadJsConfig(filePath: string): QvacConfig {
   }
 }
 
-function findConfigFile(
-  searchDir: string,
-): { path: string; type: "json" | "js" | "ts" } | undefined {
+function findConfigFile(searchDir: string): string | undefined {
   const configFiles = [
-    { name: "qvac.config.ts", type: "ts" as const },
-    { name: "qvac.config.js", type: "js" as const },
-    { name: "qvac.config.json", type: "json" as const },
+    "qvac.config.ts",
+    "qvac.config.js",
+    "qvac.config.json",
   ];
 
-  for (const { name, type } of configFiles) {
+  for (const name of configFiles) {
     const filePath = path.resolve(searchDir, name);
     if (fileExists(filePath)) {
-      return { path: filePath, type };
+      return filePath;
     }
   }
 
@@ -82,15 +65,7 @@ export async function resolveConfig(): Promise<QvacConfig | undefined> {
     const normalizedPath = path.resolve(configPath);
 
     if (fileExists(normalizedPath)) {
-      const ext = normalizedPath.endsWith(".json")
-        ? "json"
-        : normalizedPath.endsWith(".ts")
-          ? "ts"
-          : "js";
-      const config =
-        ext === "json"
-          ? loadJsonConfig(normalizedPath)
-          : loadJsConfig(normalizedPath);
+      const config = loadConfigFromPath(normalizedPath);
 
       logger.info(`✅ Loaded config from: ${normalizedPath}`);
       return config;
@@ -99,14 +74,11 @@ export async function resolveConfig(): Promise<QvacConfig | undefined> {
 
   const projectRoot = findProjectRoot();
   if (projectRoot) {
-    const configFile = findConfigFile(projectRoot);
-    if (configFile) {
-      const config =
-        configFile.type === "json"
-          ? loadJsonConfig(configFile.path)
-          : loadJsConfig(configFile.path);
+    const configFilePath = findConfigFile(projectRoot);
+    if (configFilePath) {
+      const config = loadConfigFromPath(configFilePath);
 
-      logger.info(`✅ Loaded config from: ${configFile.path}`);
+      logger.info(`✅ Loaded config from: ${configFilePath}`);
       return config;
     }
   }

--- a/packages/sdk/client/config-loader/resolve-config.bare.ts
+++ b/packages/sdk/client/config-loader/resolve-config.bare.ts
@@ -13,6 +13,8 @@ import {
 import { ConfigFileParseFailedError } from "@/utils/errors-client";
 import { getClientLogger } from "@/logging";
 
+declare function require(modulePath: string): { default?: unknown };
+
 const logger = getClientLogger();
 
 function findProjectRoot(): string {
@@ -34,10 +36,9 @@ function loadJsonConfig(filePath: string): QvacConfig {
   return validateConfig(parsed);
 }
 
-async function loadJsConfig(filePath: string): Promise<QvacConfig> {
+function loadJsConfig(filePath: string): QvacConfig {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const configModule: { default?: unknown } = await import(filePath);
+    const configModule: { default?: unknown } = require(filePath);
     return validateConfig(configModule.default || configModule);
   } catch (error) {
     throw new ConfigFileParseFailedError(
@@ -73,6 +74,7 @@ function findConfigFile(
  * 2. Config file in project root (qvac.config.ts, qvac.config.js, qvac.config.json)
  * 3. SDK defaults
  */
+// eslint-disable-next-line @typescript-eslint/require-await -- matches Node/Expo resolver signature
 export async function resolveConfig(): Promise<QvacConfig | undefined> {
   const configPath = process.env["QVAC_CONFIG_PATH"];
 
@@ -88,7 +90,7 @@ export async function resolveConfig(): Promise<QvacConfig | undefined> {
       const config =
         ext === "json"
           ? loadJsonConfig(normalizedPath)
-          : await loadJsConfig(normalizedPath);
+          : loadJsConfig(normalizedPath);
 
       logger.info(`✅ Loaded config from: ${normalizedPath}`);
       return config;
@@ -102,7 +104,7 @@ export async function resolveConfig(): Promise<QvacConfig | undefined> {
       const config =
         configFile.type === "json"
           ? loadJsonConfig(configFile.path)
-          : await loadJsConfig(configFile.path);
+          : loadJsConfig(configFile.path);
 
       logger.info(`✅ Loaded config from: ${configFile.path}`);
       return config;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -131,6 +131,11 @@
       "types": "./dist/commands/index.d.ts",
       "import": "./dist/commands/index.js"
     },
+    "./models": {
+      "types": "./dist/models/registry/index.d.ts",
+      "import": "./dist/models/registry/index.js",
+      "require": "./dist/models/registry/index.js"
+    },
     "./pear-pre": "./dist/pear/pre.js"
   },
   "imports": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- BareKit / Expo consumers crashed at bundle time with `Invalid call at line 30: import(filePath)` when loading `@qvac/sdk` / `@qvac/bare-sdk`.
- Root cause: `resolve-config.bare.ts` used dynamic `import(filePath)` for JS/TS config files. Bare and Metro static analysis reject non-literal dynamic `import()`.
- React Native apps that imported `@qvac/bare-sdk` for model constants pulled the full SDK graph (server/fs) into Metro when using the package root export.

## 📝 How does it solve it?

- Load JS/TS config via `require(filePath)` instead of `await import(filePath)` so bundlers accept the call while keeping `.json` / `.js` / `.ts` config support.
- Add `@qvac/sdk/models` and `@qvac/bare-sdk/models` subpath exports so RN/Bare clients can import the model registry without entering the main SDK entrypoint.

## 🧪 How was it tested?

- `bun run build` in `packages/sdk` (lint + typecheck + compile).
- End-to-end in `bare-translations` test app (iOS simulator): SDK init, model load and translation with a local `@qvac/bare-sdk` tarball containing this fix.
