### PR TITLE
QVAC-19178 feat[mod]: add Q8_0 mmproj for Qwen3.5-0.8B and Gemma-4-E2B

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -12032,6 +12032,22 @@
     "link": "https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF"
   },
   {
+    "source": "https://huggingface.co/ggml-org/gemma-4-E2B-it-GGUF/resolve/a1dac71d3ab220618f5a7573a52acdc4baf3ae3b/mmproj-gemma-4-E2B-it-Q8_0.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Vision projector (mmproj) for Gemma 4 E2B",
+    "quantization": "q8_0",
+    "params": "2B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "gemma4",
+      "instruct"
+    ],
+    "notes": "Q8_0 vision projector from ggml-org (the registry's bartowski gemma-4-E2B-it repo ships only f16/bf16 mmproj). Same official google/gemma-4-E2B-it model; validated compatible with the registry main, no quality regression.",
+    "link": "https://huggingface.co/ggml-org/gemma-4-E2B-it-GGUF"
+  },
+  {
     "source": "https://huggingface.co/bartowski/google_gemma-4-E4B-it-GGUF/resolve/c04cb322fd63e347db759a08b6249b867488ccf8/google_gemma-4-E4B-it-Q4_K_M.gguf",
     "engine": "@qvac/llm-llamacpp",
     "description": "Gemma 4 E4B instruct multimodal model",
@@ -12222,6 +12238,22 @@
     ],
     "notes": "",
     "link": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/mradermacher/Qwen3.5-0.8B-GGUF/resolve/9d48fdbc0d8f133716da87ec1d904e5d2c7175a6/Qwen3.5-0.8B.mmproj-Q8_0.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Vision projector (mmproj) for Qwen 3.5 0.8B",
+    "quantization": "q8_0",
+    "params": "0.8B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "qwen3.5",
+      "instruct"
+    ],
+    "notes": "Q8_0 vision projector from mradermacher (the registry's unsloth Qwen3.5-0.8B repo ships only F16/BF16 mmproj). Same base Qwen3.5-0.8B model; validated compatible with the registry main, no quality regression.",
+    "link": "https://huggingface.co/mradermacher/Qwen3.5-0.8B-GGUF"
   },
   {
     "source": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/mmproj-BF16.gguf",


### PR DESCRIPTION
## What

Adds **Q8_0 vision projectors (mmproj)** for the two VLMs already in the registry:

| Model | Q8 mmproj source (pinned) |
|---|---|
| **Qwen3.5-0.8B** | `mradermacher/Qwen3.5-0.8B-GGUF@9d48fdbc` → `Qwen3.5-0.8B.mmproj-Q8_0.gguf` |
| **Gemma-4-E2B-it** | `ggml-org/gemma-4-E2B-it-GGUF@a1dac71d` → `mmproj-gemma-4-E2B-it-Q8_0.gguf` |

`licenseId: Apache-2.0` · `npm run validate:models` passes (794 models). Base models + their f16/bf16 mmproj already in the registry are left untouched.

## Why

Each model already ships its main GGUF + **f16/bf16 mmproj**, but no Q8. A Q8 mmproj is **~45% smaller** than f16 (Gemma 557 MB vs 986 MB; Qwen 116 MB vs 205 MB) and on GPU encodes images **as fast or faster** than f16 with **no measurable quality loss** — a smaller/faster projector option for consumers.

## ⚠️ Source note (please read)

The Q8 blobs come from **different HF repos than the existing entries**, because the registry's own model repos **don't publish a Q8 mmproj**:
- `unsloth/Qwen3.5-0.8B-GGUF` and `bartowski/google_gemma-4-E2B-it-GGUF` ship **only f16/bf16/f32** mmproj.
- A Q8 mmproj exists only elsewhere — **`ggml-org`** (official llama.cpp team) for Gemma, **`mradermacher`** for Qwen.

They are the **same base models** (official `google/gemma-4-E2B-it`; `Qwen3.5-0.8B`), and we validated compatibility + no regression against the registry's existing mains.

## Validation — CI (qvac addon, Linux CPU + GPU)

**Run (matrix + full HW/SW/model provenance on the summary):** https://github.com/tetherto/qvac/actions/runs/26901348381

Held the **registry main fixed**, compared **registry f16 vs candidate Q8** mmproj on the `@qvac/llm-llamacpp` addon:

- **Compatibility:** all cells load + run, **0 errors** — the cross-repo Q8 mmproj pair cleanly with the registry mains, CPU and GPU.
- **Quality** (lmms-eval: VQAv2 / TextVQA / DocVQA / ChartQA / ScienceQA): **Q8 ≈ f16** — Qwen **identical** (56.3% both), Gemma within ±4 pts (single-sample noise). **No regression.**
- **Speed** (mmproj vision-encode): Q8 **faster or equal** — CPU ~+20% (Gemma +22%, Qwen +20%); Qwen GPU dramatically faster (the unsloth f16 mmproj hits a slow Vulkan path on the runner).

## Honest caveat — f16 is sometimes faster

- **Gemma on GPU is a tie**: Q8 81.8 ms vs f16 80.4 ms (−1.7%).
- On a **CUDA** dev box, f16 edged Q8 on **CPU** (Gemma f16 ~8.2 s vs Q8 ~8.8 s/encode).

So the Q8 advantage is GPU-side + the ~45% size saving; on CPU it's roughly a wash. Quality is equal regardless.

## Mobile (Samsung S25 Ultra · AWS Device Farm · qvac addon)

The Q8 mmproj also runs **on-device**: quality identical to f16, and on the S25 GPU (Adreno/Vulkan) Q8 TTFT beat f16 (Qwen ~3.1 s vs ~4.1 s; Gemma ~7.3 s vs ~8.8 s) — confirming the projector loads and performs on real mobile hardware.

## Files
- `packages/registry-server/data/models.prod.json` — **+2 entries** (one Q8 mmproj per model).
