### PR TITLE
QVAC-18417 tts-ggml: bump tts-cpp to 2026-06-03 (23 multilingual languages, #19)

### DIFF
--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "74d2dfd03d1c2c0767bac6d892ec43a2a0e29c10",
+    "baseline": "9eb53a42b95efdab147c321c8d3d7fc4f03f498f",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "9eb53a42b95efdab147c321c8d3d7fc4f03f498f",
+    "baseline": "88663627cb9667b04b2b034045b7d3d65e8b8fc4",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-06-03"
+      "version>=": "2026-06-03#1"
     }
   ],
   "features": {

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-06-02#1"
+      "version>=": "2026-06-03"
     }
   ],
   "features": {


### PR DESCRIPTION
## What

Bumps the `tts-cpp` dependency to `2026-06-03` (TTS GGML support for all 23
multilingual languages — qvac-ext-lib-whisper.cpp PR #19, merged to master as
`c1fd35d8`) and moves the vcpkg registry baseline to the qvac-registry-vcpkg
commit that serves that version.

## Changes

- `packages/tts-ggml/vcpkg-configuration.json`: registry baseline `74d2dfd0` → `9eb53a42`.
- `packages/tts-ggml/vcpkg.json`: `tts-cpp` `version>=` `2026-06-02#1` → `2026-06-03`.

## Test plan

- [ ] CI green: tts-ggml resolves and builds `tts-cpp@2026-06-03`.