### PR TITLE
infra[notask]: bump setup-vcpkg action pin to 98990f3d1

### DIFF
--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -82,7 +82,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
       - name: Setup vcpkg
-        uses: tetherto/qvac/.github/actions/setup-vcpkg@6e8d3c306a462a58589396cda428d65e015f0d8b
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/cpp-tests-classification.yml
+++ b/.github/workflows/cpp-tests-classification.yml
@@ -82,7 +82,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
       - name: Setup vcpkg
-        uses: tetherto/qvac/.github/actions/setup-vcpkg@6e8d3c306a462a58589396cda428d65e015f0d8b
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/cpp-tests-diffusion.yml
+++ b/.github/workflows/cpp-tests-diffusion.yml
@@ -74,7 +74,7 @@ jobs:
         run: echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
       - name: Setup vcpkg
-        uses: tetherto/qvac/.github/actions/setup-vcpkg@6e8d3c306a462a58589396cda428d65e015f0d8b
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/cpp-tests-embed.yml
+++ b/.github/workflows/cpp-tests-embed.yml
@@ -107,7 +107,7 @@ jobs:
         run: echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
 
       - name: Setup vcpkg
-        uses: tetherto/qvac/.github/actions/setup-vcpkg@6e8d3c306a462a58589396cda428d65e015f0d8b
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -75,7 +75,7 @@ jobs:
 
 
       - name: Setup vcpkg
-        uses: tetherto/qvac/.github/actions/setup-vcpkg@6e8d3c306a462a58589396cda428d65e015f0d8b
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/cpp-tests-vla.yml
+++ b/.github/workflows/cpp-tests-vla.yml
@@ -133,7 +133,7 @@ jobs:
         run: echo "VULKAN_SDK=/opt/vulkansdk/x86_64" >> $GITHUB_ENV
 
       - name: Setup vcpkg
-        uses: tetherto/qvac/.github/actions/setup-vcpkg@6e8d3c306a462a58589396cda428d65e015f0d8b
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -198,7 +198,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
       - name: Setup vcpkg
-        uses: tetherto/qvac/.github/actions/setup-vcpkg@6e8d3c306a462a58589396cda428d65e015f0d8b
+        uses: tetherto/qvac/.github/actions/setup-vcpkg@98990f3d11736a1ae88feddc514d14d78d7abdc7
         env:
           MODEL_S3_BUCKET: ${{ secrets.MODEL_S3_BUCKET }}
         with:


### PR DESCRIPTION
## What problem does this PR solve?

Workflows still pin `setup-vcpkg` at `6e8d3c306a462a58589396cda428d65e015f0d8b`, which bootstraps macOS vcpkg outside `$GITHUB_WORKSPACE` via `cd ..`. That leaves stale clones on persistent self-hosted runners between jobs.

## How does it solve it?

- Bump all `setup-vcpkg` action references to `98990f3d11736a1ae88feddc514d14d78d7abdc7` (merged in #2430)
- Updated workflows: `cpp-lint`, `cpp-tests-classification`, `cpp-tests-diffusion`, `cpp-tests-embed`, `cpp-tests-llm`, `cpp-tests-vla`, `reusable-prebuilds`

## Breaking changes

None.
