### PR TITLE
QVAC-20053: fix docs-release patch PR step (drop git-ignored api-data.json from add-paths)

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -145,13 +145,14 @@ jobs:
           title: "doc[notask]: release docs v${{ steps.setup.outputs.version }} (${{ steps.kind.outputs.kind }})"
           # `add-paths` restricts what gets staged to the generated surfaces;
           # anything else accidentally modified by the run is dropped.
-          # Minor releases also touch `api-data.json`; patch releases don't,
-          # but listing the path here is harmless when nothing changed.
+          # NB: api-data.json is intentionally git-ignored (a generated TypeDoc
+          # artifact) so it is never committed on any flow. It must NOT be listed
+          # here: as a literal pathspec it makes `git add` fail fatally on patch
+          # runs, which never regenerate it (`pathspec ... did not match any files`).
           add-paths: |
             docs/website/content/docs/reference/api/**
             docs/website/content/docs/reference/release-notes/**
             docs/website/src/lib/versions.ts
-            docs/website/scripts/api-docs/api-data.json
           labels: documentation, auto-generated
           body: |
             ## Auto-generated ${{ steps.kind.outputs.kind }} release docs


### PR DESCRIPTION
## Summary

The `Docs Release` workflow (`.github/workflows/docs-release.yml`) failed on the **patch** release `v0.12.1` while succeeding on the **minor** `v0.12.0`. The failure was in the `peter-evans/create-pull-request` step:

```
fatal: pathspec 'docs/website/scripts/api-docs/api-data.json' did not match any files
```

**Root cause:** `add-paths` listed `docs/website/scripts/api-docs/api-data.json`, which is a **git-ignored, generated TypeDoc artifact** (`.gitignore:93`; only `api-data.schema.json` is committed). The action stages via `git add -- <paths>`, and a *literal* pathspec that matches no file on disk is fatal.

- **Minor** runs TypeDoc (`generate-api-docs.ts` → `extract.ts`), which writes `api-data.json` to disk → `git add` only prints a harmless "ignored" advisory → PR opens.
- **Patch** never runs TypeDoc (`releasePatch()` skips it) → the file is absent → fatal `git add` error → job fails.

Because the file is git-ignored it was never actually committed on either flow, so removing it from `add-paths` has no effect on minor and fixes patch.

## Change

- Dropped `docs/website/scripts/api-docs/api-data.json` from `add-paths`.
- Rewrote the adjacent comment to document why it must not be listed.

## Test plan

- [x] `actionlint .github/workflows/docs-release.yml` clean
- [ ] Re-run `Docs Release` (`workflow_dispatch`, version `0.12.1`) and confirm the PR opens and stages only `api/**`, `release-notes/**`, `versions.ts`
- [ ] Confirm the next minor release still stages the API surface as before


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215364219420875