### PR TITLE
fix[api]: avoid std::format in ocr-ggml backend selection (macOS build)

### DIFF
--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <format>
 #include <string>
 #include <string_view>
 
@@ -128,20 +127,15 @@ bool trySelectGpu(
     const char* descRaw = ggml_backend_dev_description(dev);
     QLOG(
         Priority::INFO,
-        std::format(
-            "ocr-ggml: selected {} backend '{}' ({}, {})",
-            label,
-            sel.backendName,
-            sel.backendDevice,
-            descRaw != nullptr ? descRaw : ""));
+        std::string("ocr-ggml: selected ") + std::string(label) +
+            " backend '" + sel.backendName + "' (" + sel.backendDevice + ", " +
+            (descRaw != nullptr ? descRaw : "") + ")");
     return true;
   }
-  sel.fallbackReason = std::format(
-      "{} backend requested but no {}-capable GPU device was found; falling "
-      "back to CPU",
-      label,
-      label);
-  QLOG(Priority::WARN, std::format("ocr-ggml: {}", sel.fallbackReason));
+  sel.fallbackReason = std::string(label) + " backend requested but no " +
+                       std::string(label) +
+                       "-capable GPU device was found; falling back to CPU";
+  QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
   return false;
 }
 
@@ -171,14 +165,14 @@ BackendSelection selectBackendDevice(BackendDevice requested) {
     // so getBackendInfo() surfaces the gap instead of reporting a clean CPU.
     sel.requested = "unknown";
     sel.fallbackReason = "Unsupported backendDevice value; falling back to CPU";
-    QLOG(Priority::WARN, std::format("ocr-ggml: {}", sel.fallbackReason));
+    QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
     break;
   }
 
   sel = selectCpu(std::move(sel));
   QLOG(
       Priority::INFO,
-      std::format("ocr-ggml: using CPU backend '{}'", sel.backendName));
+      std::string("ocr-ggml: using CPU backend '") + sel.backendName + "'");
   return sel;
 }
 


### PR DESCRIPTION
## Problem

`main`'s `on-merge-ocr-ggml` is **red** — the macOS prebuild (and ocr-ggml publishing) fails to compile. Root cause is in `OcrBackendSelection.cpp`, which began using `std::format` in #2429.

libc++'s `std::format` unconditionally instantiates the floating-point formatter, which depends on `std::to_chars(float)` — and Apple's libc++ gates float `to_chars` to **macOS 13.3+**. The addon builds with `-mmacosx-version-min=12.0`, so compilation fails:

```
OcrBackendSelection.cpp:131  std::format(...)
  → __format/formatter_floating_point.h
error: 'to_chars' is unavailable: introduced in macOS 13.3
```

This happens **even though every formatted argument here is a string** — libc++ instantiates the whole formatter set regardless of the actual arg types, so `std::format` is effectively unusable below the 13.3 deployment target.

## Fix

Revert the five `std::format` calls to plain string concatenation (the form used before #2429) and drop `#include <format>`. No behavior change — same log strings, same `fallbackReason`.

## Validation

Reproduced the failure and verified the fix on an M3 Ultra (macOS 15.5, Apple clang, MacOSX15.5 SDK, `-mmacosx-version-min=12.0`):

- **Before:** `error: 'to_chars' is unavailable: introduced in macOS 13.3`
- **After:** `OcrBackendSelection.cpp.o` compiles and the `.bare` links cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
