### PR TITLE
QVAC-20017 chore[skiplog]: release sdk 0.12.2

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -122,6 +122,11 @@
     "./commands": {
       "types": "./dist/_sdk/commands/index.d.ts",
       "import": "./dist/_sdk/commands/index.js"
+    },
+    "./models": {
+      "types": "./dist/_sdk/models/registry/index.d.ts",
+      "import": "./dist/_sdk/models/registry/index.js",
+      "require": "./dist/_sdk/models/registry/index.js"
     }
   },
   "imports": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.12.2]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.12.2
+
+This patch release unblocks React Native and BareKit apps that bundle `@qvac/sdk` or `@qvac/bare-sdk`. Metro and Bare static analysis no longer reject the config loader, and clients can import the model registry through a dedicated subpath without pulling the full SDK graph into the bundle.
+
+## New APIs
+
+### `@qvac/sdk/models` and `@qvac/bare-sdk/models` subpaths
+
+React Native apps that only need model constant names previously had to import from the package root, which dragged server-side modules into Metro. v0.12.2 adds a `./models` export on both `@qvac/sdk` and `@qvac/bare-sdk` so you can depend on the registry alone.
+
+```typescript
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk/models";
+// or on Bare-only clients:
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/bare-sdk/models";
+```
+
+## Bug Fixes
+
+### Bare config loader works under Metro static analysis
+
+BareKit and Expo consumers could fail at bundle time with errors such as `Invalid call: import(filePath)` when the SDK resolved `qvac.config.js`. The Bare config loader used dynamic `import()` with a runtime path, which Metro and Bare reject because the target is not a string literal.
+
+v0.12.2 loads `.js` and `.json` config files with `require(filePath)` instead, which satisfies static analysis while keeping the same resolution order (`QVAC_CONFIG_PATH`, then project-root `qvac.config.js` / `qvac.config.json`, then defaults). Supported extensions are centralized in `SUPPORTED_CONFIG_FILE_EXTS` so discovery and validation stay aligned. TypeScript config files (`.ts`) are explicitly rejected on the Bare path with a clear error — use `.js` or `.json` in RN/Bare projects.
+
 ## [0.12.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.12.1

--- a/packages/sdk/changelog/0.12.2/CHANGELOG.md
+++ b/packages/sdk/changelog/0.12.2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.12.2
+
+Release Date: 2026-06-04
+
+## 🐞 Fixes
+
+- Bare config loader require() and models subpath for Metro. (see PR [#2431](https://github.com/tetherto/qvac/pull/2431))
+

--- a/packages/sdk/changelog/0.12.2/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.12.2/CHANGELOG_LLM.md
@@ -1,0 +1,25 @@
+# QVAC SDK v0.12.2 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.12.2
+
+This patch release unblocks React Native and BareKit apps that bundle `@qvac/sdk` or `@qvac/bare-sdk`. Metro and Bare static analysis no longer reject the config loader, and clients can import the model registry through a dedicated subpath without pulling the full SDK graph into the bundle.
+
+## New APIs
+
+### `@qvac/sdk/models` and `@qvac/bare-sdk/models` subpaths
+
+React Native apps that only need model constant names previously had to import from the package root, which dragged server-side modules into Metro. v0.12.2 adds a `./models` export on both `@qvac/sdk` and `@qvac/bare-sdk` so you can depend on the registry alone.
+
+```typescript
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk/models";
+// or on Bare-only clients:
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/bare-sdk/models";
+```
+
+## Bug Fixes
+
+### Bare config loader works under Metro static analysis
+
+BareKit and Expo consumers could fail at bundle time with errors such as `Invalid call: import(filePath)` when the SDK resolved `qvac.config.js`. The Bare config loader used dynamic `import()` with a runtime path, which Metro and Bare reject because the target is not a string literal.
+
+v0.12.2 loads `.js` and `.json` config files with `require(filePath)` instead, which satisfies static analysis while keeping the same resolution order (`QVAC_CONFIG_PATH`, then project-root `qvac.config.js` / `qvac.config.json`, then defaults). Supported extensions are centralized in `SUPPORTED_CONFIG_FILE_EXTS` so discovery and validation stay aligned. TypeScript config files (`.ts`) are explicitly rejected on the Bare path with a clear error — use `.js` or `.json` in RN/Bare projects.

--- a/packages/sdk/client/config-loader/resolve-config.bare.ts
+++ b/packages/sdk/client/config-loader/resolve-config.bare.ts
@@ -5,13 +5,16 @@
 import fs from "bare-fs";
 import path from "bare-path";
 import process from "bare-process";
+import { validateConfig, type QvacConfig } from "./config-utils";
 import {
-  validateConfig,
-  parseJsonConfig,
-  type QvacConfig,
-} from "./config-utils";
-import { ConfigFileParseFailedError } from "@/utils/errors-client";
+  ConfigFileInvalidError,
+  ConfigFileParseFailedError,
+} from "@/utils/errors-client";
 import { getClientLogger } from "@/logging";
+
+declare function require(modulePath: string): { default?: unknown };
+
+const SUPPORTED_CONFIG_FILE_EXTS = [".js", ".json"];
 
 const logger = getClientLogger();
 
@@ -23,21 +26,20 @@ function fileExists(filePath: string): boolean {
   return fs.existsSync(filePath);
 }
 
-function readFile(filePath: string): string {
-  const result = fs.readFileSync(filePath, "utf-8");
-  return typeof result === "string" ? result : result.toString("utf-8");
+function assertBareConfigExtension(filePath: string) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (!SUPPORTED_CONFIG_FILE_EXTS.includes(ext)) {
+    throw new ConfigFileInvalidError(
+      filePath,
+      "Given config file format unsupported on this platform. Use qvac.config.js or qvac.config.json in the project root, or set QVAC_CONFIG_PATH to a .js or .json file.",
+    );
+  }
 }
 
-function loadJsonConfig(filePath: string): QvacConfig {
-  const content = readFile(filePath);
-  const parsed = parseJsonConfig(content, filePath);
-  return validateConfig(parsed);
-}
-
-async function loadJsConfig(filePath: string): Promise<QvacConfig> {
+function loadConfigFromPath(filePath: string): QvacConfig {
+  assertBareConfigExtension(filePath);
   try {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const configModule: { default?: unknown } = await import(filePath);
+    const configModule: { default?: unknown } = require(filePath);
     return validateConfig(configModule.default || configModule);
   } catch (error) {
     throw new ConfigFileParseFailedError(
@@ -48,19 +50,15 @@ async function loadJsConfig(filePath: string): Promise<QvacConfig> {
   }
 }
 
-function findConfigFile(
-  searchDir: string,
-): { path: string; type: "json" | "js" | "ts" } | undefined {
-  const configFiles = [
-    { name: "qvac.config.ts", type: "ts" as const },
-    { name: "qvac.config.js", type: "js" as const },
-    { name: "qvac.config.json", type: "json" as const },
-  ];
+function findConfigFile(searchDir: string): string | undefined {
+  const configFiles = SUPPORTED_CONFIG_FILE_EXTS.map(
+    (ext) => `qvac.config${ext}`,
+  );
 
-  for (const { name, type } of configFiles) {
+  for (const name of configFiles) {
     const filePath = path.resolve(searchDir, name);
     if (fileExists(filePath)) {
-      return { path: filePath, type };
+      return filePath;
     }
   }
 
@@ -70,9 +68,10 @@ function findConfigFile(
 /**
  * Resolution order for Bare:
  * 1. QVAC_CONFIG_PATH environment variable
- * 2. Config file in project root (qvac.config.ts, qvac.config.js, qvac.config.json)
+ * 2. Config file in project root (qvac.config.js, qvac.config.json)
  * 3. SDK defaults
  */
+// eslint-disable-next-line @typescript-eslint/require-await -- matches Node/Expo resolver signature
 export async function resolveConfig(): Promise<QvacConfig | undefined> {
   const configPath = process.env["QVAC_CONFIG_PATH"];
 
@@ -80,15 +79,7 @@ export async function resolveConfig(): Promise<QvacConfig | undefined> {
     const normalizedPath = path.resolve(configPath);
 
     if (fileExists(normalizedPath)) {
-      const ext = normalizedPath.endsWith(".json")
-        ? "json"
-        : normalizedPath.endsWith(".ts")
-          ? "ts"
-          : "js";
-      const config =
-        ext === "json"
-          ? loadJsonConfig(normalizedPath)
-          : await loadJsConfig(normalizedPath);
+      const config = loadConfigFromPath(normalizedPath);
 
       logger.info(`✅ Loaded config from: ${normalizedPath}`);
       return config;
@@ -97,14 +88,11 @@ export async function resolveConfig(): Promise<QvacConfig | undefined> {
 
   const projectRoot = findProjectRoot();
   if (projectRoot) {
-    const configFile = findConfigFile(projectRoot);
-    if (configFile) {
-      const config =
-        configFile.type === "json"
-          ? loadJsonConfig(configFile.path)
-          : await loadJsConfig(configFile.path);
+    const configFilePath = findConfigFile(projectRoot);
+    if (configFilePath) {
+      const config = loadConfigFromPath(configFilePath);
 
-      logger.info(`✅ Loaded config from: ${configFile.path}`);
+      logger.info(`✅ Loaded config from: ${configFilePath}`);
       return config;
     }
   }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -131,6 +131,11 @@
       "types": "./dist/commands/index.d.ts",
       "import": "./dist/commands/index.js"
     },
+    "./models": {
+      "types": "./dist/models/registry/index.d.ts",
+      "import": "./dist/models/registry/index.js",
+      "require": "./dist/models/registry/index.js"
+    },
     "./pear-pre": "./dist/pear/pre.js"
   },
   "imports": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Ship SDK **0.12.2** on the `release-sdk-0.12.2` line with the fix from [#2431](https://github.com/tetherto/qvac/pull/2431) (Bare/Metro config loader + `./models` subpath).
- Keeps `@qvac/sdk` and `@qvac/bare-sdk` at the same version for npm.

## 📝 How does it solve it?

- Cherry-pick of #2431 onto `release-sdk-0.12.2`.
- Bump `packages/sdk` and `packages/bare-sdk` to `0.12.2`.
- Changelog for `0.12.2` (`CHANGELOG_LLM.md` + aggregated `packages/sdk/CHANGELOG.md`).

## 🧪 How was it tested?

- `node scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk` (base `sdk-v0.12.1`, includes #2431 only).
- `node .cursor/skills/qv-sdk-bare-sdk-sync/scripts/sync.mjs` → no drift.
- `cd packages/bare-sdk && bun run check:deps-vs-sdk` → pass.
- NOTICE regenerated for `sdk` and `bare-sdk` (no file changes).
- Fix validated in #2431: `bun run build` in `packages/sdk`; bare-translations on iOS simulator.
