### PR TITLE
QVAC-20017 chore[skiplog]: backmerge release-sdk-0.12.2 — version bump and changelog

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [0.12.2]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.12.2
+
+This patch release unblocks React Native and BareKit apps that bundle `@qvac/sdk` or `@qvac/bare-sdk`. Metro and Bare static analysis no longer reject the config loader, and clients can import the model registry through a dedicated subpath without pulling the full SDK graph into the bundle.
+
+## New APIs
+
+### `@qvac/sdk/models` and `@qvac/bare-sdk/models` subpaths
+
+React Native apps that only need model constant names previously had to import from the package root, which dragged server-side modules into Metro. v0.12.2 adds a `./models` export on both `@qvac/sdk` and `@qvac/bare-sdk` so you can depend on the registry alone.
+
+```typescript
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk/models";
+// or on Bare-only clients:
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/bare-sdk/models";
+```
+
+## Bug Fixes
+
+### Bare config loader works under Metro static analysis
+
+BareKit and Expo consumers could fail at bundle time with errors such as `Invalid call: import(filePath)` when the SDK resolved `qvac.config.js`. The Bare config loader used dynamic `import()` with a runtime path, which Metro and Bare reject because the target is not a string literal.
+
+v0.12.2 loads `.js` and `.json` config files with `require(filePath)` instead, which satisfies static analysis while keeping the same resolution order (`QVAC_CONFIG_PATH`, then project-root `qvac.config.js` / `qvac.config.json`, then defaults). Supported extensions are centralized in `SUPPORTED_CONFIG_FILE_EXTS` so discovery and validation stay aligned. TypeScript config files (`.ts`) are explicitly rejected on the Bare path with a clear error — use `.js` or `.json` in RN/Bare projects.
+
 ## [0.12.1]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.12.1

--- a/packages/sdk/changelog/0.12.2/CHANGELOG.md
+++ b/packages/sdk/changelog/0.12.2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.12.2
+
+Release Date: 2026-06-04
+
+## 🐞 Fixes
+
+- Bare config loader require() and models subpath for Metro. (see PR [#2431](https://github.com/tetherto/qvac/pull/2431))
+

--- a/packages/sdk/changelog/0.12.2/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.12.2/CHANGELOG_LLM.md
@@ -1,0 +1,25 @@
+# QVAC SDK v0.12.2 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.12.2
+
+This patch release unblocks React Native and BareKit apps that bundle `@qvac/sdk` or `@qvac/bare-sdk`. Metro and Bare static analysis no longer reject the config loader, and clients can import the model registry through a dedicated subpath without pulling the full SDK graph into the bundle.
+
+## New APIs
+
+### `@qvac/sdk/models` and `@qvac/bare-sdk/models` subpaths
+
+React Native apps that only need model constant names previously had to import from the package root, which dragged server-side modules into Metro. v0.12.2 adds a `./models` export on both `@qvac/sdk` and `@qvac/bare-sdk` so you can depend on the registry alone.
+
+```typescript
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk/models";
+// or on Bare-only clients:
+import { LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/bare-sdk/models";
+```
+
+## Bug Fixes
+
+### Bare config loader works under Metro static analysis
+
+BareKit and Expo consumers could fail at bundle time with errors such as `Invalid call: import(filePath)` when the SDK resolved `qvac.config.js`. The Bare config loader used dynamic `import()` with a runtime path, which Metro and Bare reject because the target is not a string literal.
+
+v0.12.2 loads `.js` and `.json` config files with `require(filePath)` instead, which satisfies static analysis while keeping the same resolution order (`QVAC_CONFIG_PATH`, then project-root `qvac.config.js` / `qvac.config.json`, then defaults). Supported extensions are centralized in `SUPPORTED_CONFIG_FILE_EXTS` so discovery and validation stay aligned. TypeScript config files (`.ts`) are explicitly rejected on the Bare path with a clear error — use `.js` or `.json` in RN/Bare projects.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `sdk@0.12.2` on `main`, per [gitflow.md](https://github.com/tetherto/qvac/blob/main/docs/gitflow.md) "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs.

The #2431 fix is already on `main`; this backmerge only carries the version bump and changelog.

## Companion release PR

- https://github.com/tetherto/qvac/pull/2445

## Files

- `packages/sdk/package.json` — version `0.12.1` → `0.12.2`
- `packages/bare-sdk/package.json` — version `0.12.1` → `0.12.2`
- `packages/sdk/changelog/0.12.2/` — generated changelog files
- `packages/sdk/CHANGELOG.md` — aggregated changelog
