### PR TITLE
fix[notask]: pass registry indexer keys to sync workflow

### DIFF
--- a/.github/workflows/pr-models-validation-registry-server.yml
+++ b/.github/workflows/pr-models-validation-registry-server.yml
@@ -219,6 +219,7 @@ jobs:
       QVAC_REGISTRY_CORE_KEY: ${{ secrets.QVAC_REGISTRY_CORE_KEY }}
       QVAC_WRITER_PUBLIC_KEY: ${{ secrets.QVAC_WRITER_PUBLIC_KEY }}
       QVAC_WRITER_SECRET_KEY: ${{ secrets.QVAC_WRITER_SECRET_KEY }}
+      QVAC_INDEXER_KEYS: ${{ secrets.QVAC_INDEXER_KEYS }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The registry staging sync workflow can only use topic-based RPC discovery because it does not expose configured indexer keys to `sync-models.js`.
- Without direct indexer keys, sync jobs cannot target the known registry indexers even when the `QVAC_INDEXER_KEYS` secret exists.

## 📝 How does it solve it?

- Passes `QVAC_INDEXER_KEYS` from the release environment secrets into the `sync-staging` job environment.
- Leaves existing required-secret validation unchanged, so missing indexer keys still fall back to topic discovery.

## 🧪 How was it tested?

- Reviewed `git diff main...origin/fix-registry-sync-indexer-keys`.
- `actionlint .github/workflows/pr-models-validation-registry-server.yml` could not run because `actionlint` is not installed locally.

