### PR TITLE
QVAC-19986 feat[api]: gpuDevice selection + prefer-discrete default for ocr-ggml

### DIFF
--- a/packages/ocr-ggml/README.md
+++ b/packages/ocr-ggml/README.md
@@ -108,6 +108,7 @@ bare examples/quickstart.js \
 | `params.nThreads` | `number` | | `0` (auto) | CPU thread count for GGML; `<0` leaves the GGML default |
 | `params.backendsDir` | `string` | | `<package>/prebuilds` | directory holding `libggml-*.so` backend shared libs |
 | `params.backendDevice` | `'cpu'` \| `'vulkan'` \| `'metal'` | | `'cpu'` | ggml backend device. `'vulkan'` (Linux/Windows/Android) and `'metal'` (Apple) opt in to GPU inference with transparent CPU fallback — see [Backend device](#backend-device-cpu--vulkan--metal) |
+| `params.gpuDevice` | `number` | | _prefer discrete_ | 0-based index into the matching GPU/iGPU devices for `'vulkan'`/`'metal'`; out-of-range → CPU fallback — see [Selecting a specific GPU](#selecting-a-specific-gpu-gpudevice) |
 | `opts.stats` | `boolean` | | `false` | emit timing stats on `finish` |
 | `logger` | `Object` | | `null` | optional `{ info, warn, error, debug }` — receives C++ log lines |
 
@@ -118,7 +119,7 @@ bare examples/quickstart.js \
 - `unload(): Promise<void>` — frees the addon (destroys ggml contexts + backends)
 - `destroy(): Promise<void>` — marks the instance as destroyed (no further use)
 - `getState(): InferenceClientState`
-- `getBackendInfo(): BackendInfo | null` — backend device resolved at `load()` (`{ requested, backendDevice, backendName, fallbackReason }`); `null` before `load()` / after `unload()`
+- `getBackendInfo(): BackendInfo | null` — backend device resolved at `load()` (`{ requested, backendDevice, backendName, deviceIndex, backendDescription, fallbackReason }`); `null` before `load()` / after `unload()`. `deviceIndex` is the ggml device index of the selected device (or `-1` on CPU); `backendDescription` is the human-readable model (e.g. `'NVIDIA GeForce RTX 4090'`, `'Apple M3'`)
 - `OcrGgml.getModelKey(): string` — `"ocr-ggml"`, used by the inference manager
 
 ### Backend device (CPU / Vulkan / Metal)
@@ -138,10 +139,10 @@ const ocr = new OcrGgml({
 })
 await ocr.load()
 console.log(ocr.getBackendInfo())
-// Vulkan available → { requested: 'vulkan', backendDevice: 'GPU',  backendName: 'Vulkan0', fallbackReason: '' }
-// no Vulkan device → { requested: 'vulkan', backendDevice: 'CPU',  backendName: 'CPU',     fallbackReason: 'Vulkan backend requested but no Vulkan-capable GPU device was found; falling back to CPU' }
-// Metal available  → { requested: 'metal',  backendDevice: 'GPU',  backendName: 'MTL0',    fallbackReason: '' }  // device name; 'MTL1'… on a multi-GPU host
-// no Metal device  → { requested: 'metal',  backendDevice: 'CPU',  backendName: 'CPU',     fallbackReason: 'Metal backend requested but no Metal-capable GPU device was found; falling back to CPU' }
+// Vulkan available → { requested: 'vulkan', backendDevice: 'GPU', backendName: 'Vulkan0', deviceIndex: 1, backendDescription: 'NVIDIA GeForce RTX 4090', fallbackReason: '' }
+// no Vulkan device → { requested: 'vulkan', backendDevice: 'CPU', backendName: 'CPU', deviceIndex: -1, backendDescription: '…', fallbackReason: 'Vulkan backend requested but no Vulkan-capable GPU device was found; falling back to CPU' }
+// Metal available  → { requested: 'metal',  backendDevice: 'GPU', backendName: 'MTL0', deviceIndex: 1, backendDescription: 'Apple M3 Ultra', fallbackReason: '' }  // device name; 'MTL1'… on a multi-GPU host
+// no Metal device  → { requested: 'metal',  backendDevice: 'CPU', backendName: 'CPU', deviceIndex: -1, backendDescription: '…', fallbackReason: 'Metal backend requested but no Metal-capable GPU device was found; falling back to CPU' }
 ```
 
 Behaviour and expectations:
@@ -173,6 +174,57 @@ Behaviour and expectations:
   output is identical either way. Recommended default: **EasyOCR → `'metal'`,
   DocTR → `'cpu'`** on Apple. Since `backendDevice` is per-instance, you can mix
   both. (Numbers are workload/hardware dependent — measure for your case.)
+
+### Selecting a specific GPU (`gpuDevice`)
+
+On a host with more than one GPU (e.g. a discrete GPU plus an integrated GPU,
+or two discrete GPUs) the backend resolves which device to use as follows:
+
+- **Default (no `gpuDevice`): prefer discrete.** Selection enumerates every
+  GPU/iGPU device that matches the requested backend (Vulkan or Metal) and
+  picks the first **discrete** GPU (`GGML_BACKEND_DEVICE_TYPE_GPU`); if none is
+  discrete it uses the first **integrated** GPU. This avoids accidentally
+  pinning inference to a weaker iGPU on laptops/APUs.
+- **Explicit `gpuDevice: N`.** Pass a 0-based index to pin a specific device.
+  The index counts only the **matching** devices, in ggml enumeration order
+  (so `gpuDevice: 0` is the first matching device, `gpuDevice: 1` the second,
+  …). An **out-of-range** index transparently falls back to CPU and records a
+  `fallbackReason` naming the requested index and how many matching devices
+  were found. The resolved ggml device index is reported as
+  `getBackendInfo().deviceIndex` (and `-1` on CPU).
+
+```js
+const ocr = new OcrGgml({
+  params: {
+    pathDetector: '/abs/path/craft_mlt_25k.gguf',
+    pathRecognizer: '/abs/path/english_g2.gguf',
+    langList: ['en'],
+    backendDevice: 'vulkan',
+    gpuDevice: 1            // pin the 2nd matching Vulkan device
+  }
+})
+await ocr.load()
+console.log(ocr.getBackendInfo())
+// → { requested: 'vulkan', backendDevice: 'GPU', backendName: 'Vulkan1',
+//     deviceIndex: 1, backendDescription: 'NVIDIA GeForce RTX 4090', fallbackReason: '' }
+// out-of-range gpuDevice (e.g. 99) →
+//   { requested: 'vulkan', backendDevice: 'CPU', backendName: 'CPU', deviceIndex: -1,
+//     backendDescription: '…',
+//     fallbackReason: 'Vulkan backend requested with gpuDevice index 99 but only N matching device(s) were found; falling back to CPU' }
+```
+
+`gpuDevice` applies to **both** Vulkan and Metal (the prefer-discrete default
+and the index selection share one code path).
+
+- **Interim env lever (`GGML_VK_VISIBLE_DEVICES`).** For pinning or reordering
+  Vulkan devices *without code*, ggml's Vulkan backend honours the
+  `GGML_VK_VISIBLE_DEVICES` environment variable — a comma-separated list of
+  device indices (e.g. `GGML_VK_VISIBLE_DEVICES=1,0`) that restricts and
+  reorders the Vulkan devices ggml exposes. Because this is applied by ggml
+  *before* the addon enumerates devices, it composes with `gpuDevice`: the
+  addon's index counts the (already filtered/reordered) visible devices. Use it
+  as an interim lever (e.g. in CI or a launcher script) when you cannot pass
+  `gpuDevice` through the API. It does not affect Metal.
 
 ### `run(input)` shape
 

--- a/packages/ocr-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/ocr-ggml/addon/src/addon/AddonJs.hpp
@@ -241,6 +241,11 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
       optThreads) {
     config.nThreads = static_cast<int>(optThreads->as<double>(env));
   }
+  if (auto optGpuDevice =
+          args1.getOptionalProperty<js::Number>(env, "gpuDevice");
+      optGpuDevice) {
+    config.gpuDevice = static_cast<int>(optGpuDevice->as<double>(env));
+  }
   if (auto optBackendsDir =
           args1.getOptionalProperty<js::String>(env, "backendsDir");
       optBackendsDir) {
@@ -343,9 +348,10 @@ inline js_value_t* runJob(js_env_t* env, js_callback_info_t* info) try {
 JSCATCH
 
 // Returns the backend device the pipeline resolved for inference as a JS
-// object: `{ requested, backendDevice, backendName, fallbackReason }`. This is
-// the programmatic surface for the selected ggml backend (RuntimeStats can only
-// carry numbers, so backend identity strings are exposed here). Consumed by
+// object: `{ requested, backendDevice, backendName, deviceIndex,
+// backendDescription, fallbackReason }`. This is the programmatic surface for
+// the selected ggml backend (RuntimeStats can only carry numbers, so backend
+// identity strings are exposed here). Consumed by
 // `OcrGgml._getDiagnosticsJSON()` and the Vulkan integration test.
 inline js_value_t* getBackendInfo(js_env_t* env, js_callback_info_t* info) try {
   using namespace qvac_lib_inference_addon_cpp;
@@ -373,6 +379,12 @@ inline js_value_t* getBackendInfo(js_env_t* env, js_callback_info_t* info) try {
       env, "backendDevice", js::String::create(env, backendInfo.backendDevice));
   result.setProperty(
       env, "backendName", js::String::create(env, backendInfo.backendName));
+  result.setProperty(
+      env, "deviceIndex", js::Number::create(env, backendInfo.deviceIndex));
+  result.setProperty(
+      env,
+      "backendDescription",
+      js::String::create(env, backendInfo.backendDescription));
   result.setProperty(
       env,
       "fallbackReason",

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -2,8 +2,11 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <ggml-backend.h>
 
@@ -43,14 +46,26 @@ const char* deviceTypeName(enum ggml_backend_dev_type type) {
   }
 }
 
-// First GPU/iGPU device whose backend name satisfies `matches`, or nullptr if
-// none is registered. Used to resolve both Vulkan and Metal requests.
+// A GPU/iGPU device matched against the requested backend, retaining its ggml
+// enumeration index so the resolved `deviceIndex` can be reported to JS.
+struct MatchingDevice {
+  ggml_backend_dev_t dev{nullptr};
+  size_t index{0}; // index passed to ggml_backend_dev_get
+  enum ggml_backend_dev_type type { GGML_BACKEND_DEVICE_TYPE_GPU };
+  std::string name;
+  std::string description;
+};
+
+// All GPU/iGPU devices whose backend name satisfies `matches`, in ggml
+// enumeration order. Used to resolve both Vulkan and Metal requests.
 //
 // Matches against BOTH the device name and its backend-registration name: ggml
 // names Vulkan devices "Vulkan0" (so the device name carries the backend), but
 // Metal devices are named "MTL0"/"MTL1" while the backing registration is named
 // "Metal". Checking the reg name lets the Metal request resolve correctly.
-ggml_backend_dev_t findGpuDeviceByName(bool (*matches)(std::string_view)) {
+std::vector<MatchingDevice>
+enumerateMatchingDevices(bool (*matches)(std::string_view)) {
+  std::vector<MatchingDevice> result;
   const size_t count = ggml_backend_dev_count();
   for (size_t i = 0; i < count; ++i) {
     ggml_backend_dev_t dev = ggml_backend_dev_get(i);
@@ -63,17 +78,68 @@ ggml_backend_dev_t findGpuDeviceByName(bool (*matches)(std::string_view)) {
       continue;
     }
     const char* devNameRaw = ggml_backend_dev_name(dev);
-    if (devNameRaw != nullptr && matches(devNameRaw)) {
-      return dev;
+    bool nameMatches = devNameRaw != nullptr && matches(devNameRaw);
+    if (!nameMatches) {
+      ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+      const char* regNameRaw =
+          (reg != nullptr) ? ggml_backend_reg_name(reg) : nullptr;
+      nameMatches = regNameRaw != nullptr && matches(regNameRaw);
     }
-    ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
-    const char* regNameRaw =
-        (reg != nullptr) ? ggml_backend_reg_name(reg) : nullptr;
-    if (regNameRaw != nullptr && matches(regNameRaw)) {
-      return dev;
+    if (!nameMatches) {
+      continue;
+    }
+    const char* descRaw = ggml_backend_dev_description(dev);
+    result.push_back(
+        MatchingDevice{
+            .dev = dev,
+            .index = i,
+            .type = type,
+            .name = (devNameRaw != nullptr) ? std::string(devNameRaw)
+                                            : std::string(),
+            .description =
+                (descRaw != nullptr) ? std::string(descRaw) : std::string()});
+  }
+  return result;
+}
+
+// Pick which matching device to use. With an explicit `gpuDevice` index, the
+// Nth matching device (0-based) is selected, or nullopt when out of range.
+// Without one, prefer the first discrete GPU and otherwise the first matching
+// (integrated) device. Returns nullopt when no device matched.
+std::optional<size_t> chooseMatchingDevice(
+    const std::vector<MatchingDevice>& matching, std::optional<int> gpuDevice) {
+  if (matching.empty()) {
+    return std::nullopt;
+  }
+  if (gpuDevice.has_value()) {
+    const int idx = *gpuDevice;
+    if (idx < 0 || static_cast<size_t>(idx) >= matching.size()) {
+      return std::nullopt;
+    }
+    return static_cast<size_t>(idx);
+  }
+  for (size_t i = 0; i < matching.size(); ++i) {
+    if (matching[i].type == GGML_BACKEND_DEVICE_TYPE_GPU) {
+      return i;
     }
   }
-  return nullptr;
+  return static_cast<size_t>(0);
+}
+
+// Human-readable dump of the enumerated matching devices for logging.
+std::string describeMatchingDevices(
+    std::string_view label, const std::vector<MatchingDevice>& matching) {
+  std::string msg = "ocr-ggml: " + std::string(label) + " matching devices (" +
+                    std::to_string(matching.size()) + "):";
+  for (const auto& md : matching) {
+    msg += " [" + std::to_string(md.index) + " " + deviceTypeName(md.type) +
+           " '" + md.name + "'";
+    if (!md.description.empty()) {
+      msg += " " + md.description;
+    }
+    msg += "]";
+  }
+  return msg;
 }
 
 BackendSelection selectCpu(BackendSelection sel) {
@@ -81,9 +147,12 @@ BackendSelection selectCpu(BackendSelection sel) {
       ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
   sel.device = cpuDev;
   sel.backendDevice = "CPU";
+  sel.deviceIndex = -1;
   if (cpuDev != nullptr) {
     const char* nameRaw = ggml_backend_dev_name(cpuDev);
     sel.backendName = (nameRaw != nullptr) ? nameRaw : "CPU";
+    const char* descRaw = ggml_backend_dev_description(cpuDev);
+    sel.backendDescription = (descRaw != nullptr) ? descRaw : "";
   } else {
     sel.backendName = "CPU";
   }
@@ -112,47 +181,66 @@ bool isMetalBackendName(std::string_view backendName) {
 namespace {
 
 // Resolve a GPU-backed request (Vulkan or Metal). On success fills `sel` with
-// the matched device and returns true; otherwise records a CPU-fallback reason
-// and returns false (the caller then resolves the CPU device).
+// the matched device (including its ggml index and description) and returns
+// true; otherwise records a CPU-fallback reason and returns false (the caller
+// then resolves the CPU device).
+//
+// `gpuDevice` selects the Nth matching device (0-based); when unset, a discrete
+// GPU is preferred over an integrated one.
 bool trySelectGpu(
     BackendSelection& sel, std::string_view label,
-    bool (*matches)(std::string_view)) {
-  ggml_backend_dev_t dev = findGpuDeviceByName(matches);
-  if (dev != nullptr) {
-    sel.device = dev;
-    const char* nameRaw = ggml_backend_dev_name(dev);
-    sel.backendName =
-        (nameRaw != nullptr) ? std::string(nameRaw) : std::string(label);
-    sel.backendDevice = deviceTypeName(ggml_backend_dev_type(dev));
-    const char* descRaw = ggml_backend_dev_description(dev);
-    QLOG(
-        Priority::INFO,
-        std::string("ocr-ggml: selected ") + std::string(label) +
-            " backend '" + sel.backendName + "' (" + sel.backendDevice + ", " +
-            (descRaw != nullptr ? descRaw : "") + ")");
-    return true;
+    bool (*matches)(std::string_view), std::optional<int> gpuDevice) {
+  const std::vector<MatchingDevice> matching =
+      enumerateMatchingDevices(matches);
+  QLOG(Priority::INFO, describeMatchingDevices(label, matching));
+
+  const std::optional<size_t> chosen =
+      chooseMatchingDevice(matching, gpuDevice);
+  if (!chosen.has_value()) {
+    if (gpuDevice.has_value()) {
+      sel.fallbackReason =
+          std::string(label) + " backend requested with gpuDevice index " +
+          std::to_string(*gpuDevice) + " but only " +
+          std::to_string(matching.size()) +
+          " matching device(s) were found; falling back to CPU";
+    } else {
+      sel.fallbackReason = std::string(label) + " backend requested but no " +
+                           std::string(label) +
+                           "-capable GPU device was found; falling back to CPU";
+    }
+    QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
+    return false;
   }
-  sel.fallbackReason = std::string(label) + " backend requested but no " +
-                       std::string(label) +
-                       "-capable GPU device was found; falling back to CPU";
-  QLOG(Priority::WARN, std::string("ocr-ggml: ") + sel.fallbackReason);
-  return false;
+
+  const MatchingDevice& md = matching[*chosen];
+  sel.device = md.dev;
+  sel.backendName = !md.name.empty() ? md.name : std::string(label);
+  sel.backendDevice = deviceTypeName(md.type);
+  sel.deviceIndex = static_cast<int>(md.index);
+  sel.backendDescription = md.description;
+  QLOG(
+      Priority::INFO,
+      std::string("ocr-ggml: selected ") + std::string(label) + " backend '" +
+          sel.backendName + "' (" + sel.backendDevice + ", " + md.description +
+          ") at ggml device index " + std::to_string(md.index));
+  return true;
 }
 
 } // namespace
 
-BackendSelection selectBackendDevice(BackendDevice requested) {
+BackendSelection
+selectBackendDevice(BackendDevice requested, std::optional<int> gpuDevice) {
   BackendSelection sel;
   switch (requested) {
   case BackendDevice::VULKAN:
     sel.requested = "vulkan";
-    if (trySelectGpu(sel, "Vulkan", isVulkanBackendName)) {
+    if (trySelectGpu(sel, "Vulkan", isVulkanBackendName, gpuDevice)) {
       return sel;
     }
     break;
   case BackendDevice::METAL:
     sel.requested = "metal";
-    if (trySelectGpu(sel, "Metal", isMetalBackendName)) {
+    if (trySelectGpu(sel, "Metal", isMetalBackendName, gpuDevice)) {
       return sel;
     }
     break;

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.hpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.hpp
@@ -19,6 +19,7 @@
 // Thread-count tuning (`ggml_backend_set_n_threads`) is only meaningful for the
 // CPU device, so callers gate it on `selectedIsCpu()`.
 
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -39,6 +40,14 @@ struct BackendSelection {
   std::string backendDevice;
   // ggml backend/device name of the resolved device (e.g. "Vulkan0", "CPU").
   std::string backendName;
+  // ggml device index (the `i` passed to `ggml_backend_dev_get`) of the
+  // resolved device, or -1 when the CPU backend was selected (including
+  // fallback). Surfaced to JS so callers can identify which physical device a
+  // multi-GPU host ran on.
+  int deviceIndex{-1};
+  // Human-readable device description (e.g. "NVIDIA GeForce RTX 4090",
+  // "Apple M3 Ultra"); empty when ggml provides none.
+  std::string backendDescription;
   // Empty when the requested device was selected as-is; otherwise a
   // human-readable explanation of why the selection fell back to CPU.
   std::string fallbackReason;
@@ -50,7 +59,15 @@ struct BackendSelection {
 // Resolve the backend device for `requested`, enumerating the loaded ggml
 // devices. Must be called after backends have been loaded. Logs the outcome
 // via the package logging macros.
-BackendSelection selectBackendDevice(BackendDevice requested);
+//
+// `gpuDevice` is an optional 0-based index into the GPU/iGPU devices that match
+// the requested backend, in ggml enumeration order. When set, the Nth matching
+// device is selected; an out-of-range index falls back to CPU with a clear
+// reason. When unset, selection prefers a discrete GPU
+// (`GGML_BACKEND_DEVICE_TYPE_GPU`) and otherwise the first integrated GPU. The
+// option is ignored for `BackendDevice::CPU`.
+BackendSelection selectBackendDevice(
+    BackendDevice requested, std::optional<int> gpuDevice = std::nullopt);
 
 // True if the backend name contains "vulkan" (case-insensitive). Exposed for
 // unit testing / reuse.

--- a/packages/ocr-ggml/addon/src/model-interface/OcrTypes.hpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrTypes.hpp
@@ -77,6 +77,13 @@ struct OcrConfig {
   // when no matching device is present (mapped from `params.backendDevice` in
   // AddonJs.hpp).
   BackendDevice backendDevice{BackendDevice::CPU};
+  // Optional explicit GPU device selection (mapped from `params.gpuDevice`).
+  // 0-based index into the matching GPU/iGPU devices for the requested backend,
+  // in ggml enumeration order. When unset (the default), selection prefers a
+  // discrete GPU and falls back to an integrated GPU. When set out of range,
+  // the pipeline falls back to CPU (see `OcrBackendSelection`). Ignored for the
+  // CPU backend.
+  std::optional<int> gpuDevice;
 };
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 

--- a/packages/ocr-ggml/addon/src/model-interface/Pipeline.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/Pipeline.cpp
@@ -116,8 +116,8 @@ Pipeline::Pipeline(
   // to enumerate devices and resolve the requested backend. The resolved
   // device is handed to every inference step; CPU is selected when VULKAN was
   // requested but unavailable (see OcrBackendSelection).
-  backendInfo_ =
-      ocr_backend_selection::selectBackendDevice(config_.backendDevice);
+  backendInfo_ = ocr_backend_selection::selectBackendDevice(
+      config_.backendDevice, config_.gpuDevice);
   ggml_backend_dev_t selectedDevice = backendInfo_.device;
 
   if (config_.mode == PipelineMode::DOCTR) {

--- a/packages/ocr-ggml/index.d.ts
+++ b/packages/ocr-ggml/index.d.ts
@@ -69,6 +69,20 @@ export interface OcrGgmlParams {
    * {@link BackendInfo.fallbackReason}).
    */
   backendDevice?: 'cpu' | 'vulkan' | 'metal'
+  /**
+   * Explicit GPU device selection for `'vulkan'` / `'metal'`. 0-based index
+   * into the GPU/iGPU devices that match the requested backend, in ggml
+   * enumeration order (the resolved index is reported as
+   * {@link BackendInfo.deviceIndex}).
+   *   - When omitted (default), selection prefers a discrete GPU and otherwise
+   *     falls back to an integrated GPU.
+   *   - When out of range, the pipeline falls back to CPU and records the
+   *     reason (see {@link BackendInfo.fallbackReason}).
+   * Ignored for `backendDevice: 'cpu'`. For pinning/reordering Vulkan devices
+   * without code you can also set the `GGML_VK_VISIBLE_DEVICES` env var (see
+   * the README).
+   */
+  gpuDevice?: number
 }
 
 /**
@@ -82,6 +96,13 @@ export interface BackendInfo {
   backendDevice: string
   /** ggml backend/device name of the resolved device (e.g. `'Vulkan0'`, `'CPU'`). */
   backendName: string
+  /**
+   * ggml device index of the selected device (the index into the loaded ggml
+   * devices), or `-1` when the CPU backend was selected (including fallback).
+   */
+  deviceIndex: number
+  /** Human-readable device description (e.g. `'NVIDIA GeForce RTX 4090'`, `'Apple M3'`); empty when ggml provides none. */
+  backendDescription: string
   /** Empty when the requested device was used; otherwise why it fell back to CPU. */
   fallbackReason: string
 }

--- a/packages/ocr-ggml/index.js
+++ b/packages/ocr-ggml/index.js
@@ -29,6 +29,7 @@ class OcrGgml {
    * @param {number} [args.params.nThreads] - 0=auto (physical cores), >0=explicit, <0=leave default
    * @param {string} [args.params.backendsDir] - override directory for ggml backend shared libs
    * @param {'cpu'|'vulkan'|'metal'} [args.params.backendDevice='cpu'] - requested ggml backend device. `'vulkan'` (Linux/Windows/Android) and `'metal'` (Apple) opt in to GPU inference with transparent CPU fallback when no matching device is present.
+   * @param {number} [args.params.gpuDevice] - explicit 0-based index into the matching GPU/iGPU devices for `'vulkan'`/`'metal'`. Omit to prefer a discrete GPU (then integrated); out-of-range falls back to CPU. Ignored for `'cpu'`.
    * @param {Object} [args.opts]
    * @param {boolean} [args.opts.stats] - emit timing stats on finish
    * @param {Object} [args.logger]
@@ -77,7 +78,7 @@ class OcrGgml {
   /**
    * Backend device the C++ pipeline resolved for inference. Available after
    * `load()`; `null` before load or after unload.
-   * @returns {{ requested: string, backendDevice: string, backendName: string, fallbackReason: string }|null}
+   * @returns {{ requested: string, backendDevice: string, backendName: string, deviceIndex: number, backendDescription: string, fallbackReason: string }|null}
    */
   getBackendInfo () {
     return this._backendInfo
@@ -151,7 +152,8 @@ class OcrGgml {
       'recognizerBatchSize',
       'nThreads',
       'pipelineType',
-      'backendDevice'
+      'backendDevice',
+      'gpuDevice'
     ]
     for (const field of optionalFields) {
       if (this.params[field] !== undefined) {

--- a/packages/ocr-ggml/ocr-ggml.js
+++ b/packages/ocr-ggml/ocr-ggml.js
@@ -95,7 +95,7 @@ class OcrGgmlInterface {
 
   /**
    * Returns the backend device the C++ pipeline resolved for inference.
-   * @returns {{ requested: string, backendDevice: string, backendName: string, fallbackReason: string }}
+   * @returns {{ requested: string, backendDevice: string, backendName: string, deviceIndex: number, backendDescription: string, fallbackReason: string }}
    */
   getBackendInfo () {
     if (this._handle === null) {

--- a/packages/ocr-ggml/test/integration/backend-device.test.js
+++ b/packages/ocr-ggml/test/integration/backend-device.test.js
@@ -48,6 +48,8 @@ test('backendDevice vulkan: selects Vulkan or reports an explicit CPU fallback',
   const backendInfo = ocrGgml.getBackendInfo()
   t.ok(backendInfo, 'getBackendInfo() returns backend info after load')
   t.is(backendInfo.requested, 'vulkan', 'requested device recorded as vulkan')
+  t.is(typeof backendInfo.deviceIndex, 'number', 'deviceIndex is a number')
+  t.is(typeof backendInfo.backendDescription, 'string', 'backendDescription is a string')
   t.comment('Resolved backend info: ' + JSON.stringify(backendInfo))
 
   const vulkanSelected =
@@ -56,10 +58,13 @@ test('backendDevice vulkan: selects Vulkan or reports an explicit CPU fallback',
   if (vulkanSelected) {
     t.is(backendInfo.fallbackReason, '', 'no fallback reason when Vulkan is selected')
     t.ok(/vulkan/i.test(backendInfo.backendName), 'selected backend name mentions Vulkan')
+    // A selected GPU device reports its ggml device index (>= 0).
+    t.ok(backendInfo.deviceIndex >= 0, 'selected GPU reports a non-negative ggml deviceIndex')
   } else {
     // No Vulkan device available: the fallback to CPU MUST be reported.
     t.is(backendInfo.backendDevice, 'CPU', 'fell back to the CPU device')
     t.ok(backendInfo.fallbackReason.length > 0, 'explicit CPU fallback reason reported')
+    t.is(backendInfo.deviceIndex, -1, 'CPU fallback reports deviceIndex -1')
     t.comment('CPU fallback reason: ' + backendInfo.fallbackReason)
   }
 
@@ -101,6 +106,51 @@ test('backendDevice vulkan: selects Vulkan or reports an explicit CPU fallback',
   }
 })
 
+// QVAC-19986: explicit GPU device selection. Requesting the Vulkan backend with
+// an out-of-range `gpuDevice` index MUST fall back to CPU and report an
+// explicit reason (never select a wrong device or crash). Gated on the same
+// Vulkan-lib presence as the test above so it skips cleanly on hosts that never
+// built the Vulkan backend. This holds regardless of how many Vulkan devices
+// the host has (0 → no matching device; N → index 99 is still out of range), so
+// it is verifiable here and on the GPU runner alike.
+test('backendDevice vulkan: out-of-range gpuDevice falls back to CPU with a reason', { timeout: TEST_TIMEOUT, skip: shouldSkip }, async function (t) {
+  const detectorPath = await ensureModelPath('detector_craft')
+  const recognizerPath = await ensureModelPath('recognizer_latin')
+
+  const OUT_OF_RANGE_INDEX = 99
+  const ocrGgml = new OcrGgml({
+    params: {
+      pathDetector: detectorPath,
+      pathRecognizer: recognizerPath,
+      langList: ['en'],
+      backendDevice: 'vulkan',
+      gpuDevice: OUT_OF_RANGE_INDEX
+    }
+  })
+
+  try {
+    await ocrGgml.load()
+    t.pass('loaded with backendDevice: vulkan, gpuDevice: ' + OUT_OF_RANGE_INDEX)
+
+    const backendInfo = ocrGgml.getBackendInfo()
+    t.ok(backendInfo, 'getBackendInfo() returns backend info after load')
+    t.is(backendInfo.requested, 'vulkan', 'requested device recorded as vulkan')
+    t.comment('Resolved backend info: ' + JSON.stringify(backendInfo))
+
+    // An out-of-range device index must never silently pick a device.
+    t.is(backendInfo.backendDevice, 'CPU', 'out-of-range gpuDevice falls back to the CPU device')
+    t.is(backendInfo.deviceIndex, -1, 'CPU fallback reports deviceIndex -1')
+    t.ok(backendInfo.fallbackReason.length > 0, 'explicit CPU fallback reason reported')
+    t.ok(
+      backendInfo.fallbackReason.includes(String(OUT_OF_RANGE_INDEX)),
+      'fallback reason names the requested gpuDevice index'
+    )
+  } finally {
+    await safeUnload(ocrGgml)
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  }
+})
+
 // QVAC-19797 (Metal follow-up): opt-in Metal GGML backend on Apple. Requesting
 // `backendDevice: 'metal'` must EITHER run inference on a Metal device, OR
 // report an explicit CPU fallback — never silently produce wrong behaviour.
@@ -134,6 +184,8 @@ test('backendDevice metal: selects Metal or reports an explicit CPU fallback', {
   const backendInfo = ocrGgml.getBackendInfo()
   t.ok(backendInfo, 'getBackendInfo() returns backend info after load')
   t.is(backendInfo.requested, 'metal', 'requested device recorded as metal')
+  t.is(typeof backendInfo.deviceIndex, 'number', 'deviceIndex is a number')
+  t.is(typeof backendInfo.backendDescription, 'string', 'backendDescription is a string')
   t.comment('Resolved backend info: ' + JSON.stringify(backendInfo))
 
   const metalSelected =
@@ -144,10 +196,13 @@ test('backendDevice metal: selects Metal or reports an explicit CPU fallback', {
     // ggml names Metal devices "MTL0"/"MTL1" (the backing registration is
     // "Metal"); accept either form.
     t.ok(/metal|mtl/i.test(backendInfo.backendName), 'selected backend name is a Metal device (' + backendInfo.backendName + ')')
+    // A selected GPU device reports its ggml device index (>= 0).
+    t.ok(backendInfo.deviceIndex >= 0, 'selected GPU reports a non-negative ggml deviceIndex')
   } else {
     // No Metal device available: the fallback to CPU MUST be reported.
     t.is(backendInfo.backendDevice, 'CPU', 'fell back to the CPU device')
     t.ok(backendInfo.fallbackReason.length > 0, 'explicit CPU fallback reason reported')
+    t.is(backendInfo.deviceIndex, -1, 'CPU fallback reports deviceIndex -1')
     t.comment('CPU fallback reason: ' + backendInfo.fallbackReason)
   }
 

--- a/packages/ocr-ggml/test/integration/utils.js
+++ b/packages/ocr-ggml/test/integration/utils.js
@@ -386,11 +386,20 @@ function createOcrGgml (params = {}, opts) {
 }
 
 /**
- * Records the resolved GPU/backend name on the shared performance reporter's
- * device block so `performance-report.json` carries a concrete name (e.g.
- * 'Vulkan0') on GPU runs even when the host's GPU probe returns null on a
- * minimal runner container. Only acts when a GPU backend was actually selected
- * and the name is non-empty; CPU runs leave `device.gpu` null.
+ * Records the resolved accelerator on the shared performance reporter's device
+ * block so `performance-report.json` (and the combined report's column header /
+ * per-device subline) names the ACTUAL hardware that ran inference rather than
+ * the bare ggml ordinal.
+ *
+ * The ggml backend name is just an ordinal (`Vulkan0`, `Vulkan1`, …) which is
+ * meaningless on its own — reviewers can't tell which physical GPU `Vulkan1`
+ * is (QVAC-19986 review feedback). `getBackendInfo()` also exposes
+ * `backendDescription` (the ggml device description, i.e. the real GPU model,
+ * e.g. "NVIDIA RTX A4000") and `deviceIndex`, so we surface the description and
+ * keep the ordinal as a suffix for provenance: `"NVIDIA RTX A4000 (Vulkan0)"`.
+ *
+ * Only acts when a GPU backend was actually selected; CPU runs leave
+ * `device.gpu` null. Falls back to the ordinal when no description is reported.
  *
  * @param {Object} ocrGgml - A loaded OcrGgml instance (call after `load()`)
  */
@@ -401,9 +410,18 @@ function setReportedGpuName (ocrGgml) {
     if (!info) return
     const isGpu = info.backendDevice === 'GPU' || info.backendDevice === 'IGPU'
     if (!isGpu) return
-    if (info.backendName && typeof _perfReporter.setDeviceGpu === 'function') {
-      _perfReporter.setDeviceGpu(info.backendName)
+    if (typeof _perfReporter.setDeviceGpu !== 'function') return
+
+    const ordinal = (info.backendName || '').trim()
+    const description = (info.backendDescription || '').trim()
+    // Prefer the real hardware description; append the ggml ordinal so a
+    // multi-GPU host still disambiguates which device served the run. Avoid a
+    // redundant "(Vulkan0)" when the description already equals the ordinal.
+    let label = description || ordinal
+    if (description && ordinal && description !== ordinal) {
+      label = `${description} (${ordinal})`
     }
+    if (label) _perfReporter.setDeviceGpu(label)
   } catch (_) {}
 }
 

--- a/scripts/test-utils/performance-reporter.js
+++ b/scripts/test-utils/performance-reporter.js
@@ -269,6 +269,83 @@ function _detectGpu (platform) {
   return null
 }
 
+// Standalone synchronous command runner (module scope) so the CPU probe below
+// can reuse the same Node/Bare subprocess adaptation as `_detectGpu`'s nested
+// `_safeExec` without coupling to it. Returns trimmed stdout, or null on any
+// failure / missing subprocess driver.
+function _safeExecCmd (cmd) {
+  if (!subprocessMod) return null
+  const nodeExecSync = subprocessMod.execSync || null
+  const bareSpawnSync = !nodeExecSync && subprocessMod.spawnSync
+    ? subprocessMod.spawnSync
+    : null
+  if (!nodeExecSync && !bareSpawnSync) return null
+  if (nodeExecSync) {
+    try {
+      return nodeExecSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }).trim()
+    } catch (_) {
+      return null
+    }
+  }
+  try {
+    const parts = cmd.split(/\s+/).filter(Boolean)
+    if (!parts.length) return null
+    const res = bareSpawnSync(parts[0], parts.slice(1), { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000 })
+    if (!res || res.status !== 0) return null
+    const out = res.stdout
+    const str = out && typeof out.toString === 'function' ? out.toString('utf-8') : String(out || '')
+    return str.trim()
+  } catch (_) {
+    return null
+  }
+}
+
+// QVAC-19986 (review): label the actual host CPU/SoC for runs that don't use a
+// GPU (e.g. the CPU-only matrix legs), the same way `_detectGpu` labels the GPU.
+// Best-effort; returns null when no probe works. Runs once per reporter.
+function _detectCpu (platform) {
+  if (platform === 'darwin') {
+    const brand = _safeExecCmd('sysctl -n machdep.cpu.brand_string')
+    if (brand) return brand
+    const hw = _safeExecCmd('system_profiler SPHardwareDataType')
+    if (hw) {
+      const chip = hw.match(/^\s*Chip:\s*(.+)$/m)
+      if (chip) return chip[1].trim()
+      const proc = hw.match(/^\s*Processor Name:\s*(.+)$/m)
+      if (proc) return proc[1].trim()
+    }
+    return null
+  }
+
+  if (platform === 'linux') {
+    // `lscpu` exposes a friendly "Model name" on both x86 (AMD EPYC …) and
+    // ARM (Neoverse-N1 …); /proc/cpuinfo "model name" is the x86-only fallback.
+    const lscpu = _safeExecCmd('lscpu')
+    if (lscpu) {
+      const m = lscpu.match(/^Model name:\s*(.+)$/m)
+      if (m && m[1].trim() && m[1].trim() !== '-') return m[1].trim()
+    }
+    try {
+      const fsM = fs || require('fs')
+      const txt = fsM.readFileSync('/proc/cpuinfo', 'utf8')
+      const m = txt.match(/^model name\s*:\s*(.+)$/m)
+      if (m) return m[1].trim()
+    } catch (_) {}
+    return null
+  }
+
+  if (platform === 'win32') {
+    const wmic = _safeExecCmd('wmic cpu get name')
+    if (wmic) {
+      const lines = wmic.split('\n').slice(1).map(l => l.trim()).filter(Boolean)
+      if (lines.length) return lines[0]
+    }
+    return null
+  }
+
+  return null
+}
+
 function detectDevice () {
   const platform = osMod.platform ? osMod.platform() : processMod.platform
   const arch = osMod.arch ? osMod.arch() : processMod.arch
@@ -283,20 +360,36 @@ function detectDevice () {
       os_version: getEnvVar('DEVICE_FARM_DEVICE_OS_VERSION') || '',
       arch,
       gpu: null,
+      cpu: null,
       runner: 'device-farm'
     }
   }
 
   const runnerName = getEnvVar('RUNNER_NAME')
   const runnerOs = getEnvVar('RUNNER_OS')
-  const prettyName = runnerName || `${platform}-${arch}`
+  const cpu = _detectCpu(platform)
+
+  // GitHub-hosted runners report an opaque, per-run RUNNER_NAME like
+  // "GitHub Actions 1000595630" which is meaningless in the report (and changes
+  // every run, so it never grouped). Replace it with a stable, human-readable
+  // platform label from ImageOS (ubuntu24 / macos15 / win25 …) + arch, plus the
+  // probed CPU when available — mirroring how the GPU columns now name the real
+  // accelerator. Self-hosted runners (qvac-*) already carry descriptive names,
+  // so keep those untouched.
+  let name = runnerName || `${platform}-${arch}`
+  if (!runnerName || /^GitHub Actions\b/i.test(runnerName)) {
+    const imageOs = getEnvVar('ImageOS')
+    const base = imageOs ? `${imageOs}-${arch}` : `${platform}-${arch}`
+    name = cpu ? `${base} (${cpu})` : base
+  }
 
   return {
-    name: prettyName,
+    name,
     platform,
     os_version: runnerOs || '',
     arch,
     gpu: _detectGpu(platform),
+    cpu,
     runner: getEnvVar('GITHUB_ACTIONS') ? 'github-actions' : 'local'
   }
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/ocr-ggml`'s Vulkan/Metal selection picked the **first** matching GPU/iGPU device, so on a host with a slow integrated GPU (`Vulkan0`) plus a faster discrete GPU it could pick the iGPU. There was no way to target a specific device.
- Adds a **prefer-discrete default** and an optional **explicit device index**, and reports the chosen device — applied to the shared GPU path so it covers **both Vulkan and Metal**.
- Asana: [QVAC-19986](https://app.asana.com/1/45238840754660/task/1215365849477326) (subtask of QVAC-19797; raised in #2398 review by @DmitryMalishev)

## 📝 How does it solve it?

- **New option `gpuDevice?: number`** — 0-based index into the *matching* GPU/iGPU devices for the requested backend (in ggml enumeration order). Out-of-range → transparent CPU fallback with a clear reason; omitted → prefer-discrete default; ignored for `'cpu'`.
- **Prefer-discrete default** — `OcrBackendSelection` now enumerates *all* matching devices (retaining each device's ggml index/type/name/description) and selects the first `GGML_BACKEND_DEVICE_TYPE_GPU` (discrete), else the first integrated GPU.
- **Observability** — `getBackendInfo()` now also returns `deviceIndex` (the ggml device index, `-1` on CPU) and `backendDescription` (e.g. `"NVIDIA GeForce RTX 4090"`, `"Apple M3"`); the enumerated devices + final choice are logged.
- Shared via `trySelectGpu` / `selectBackendDevice(requested, gpuDevice)`, threaded from `Pipeline` — so the same index/preference logic applies to Vulkan and Metal.
- All log/string building uses `std::string` concatenation (no `std::format`, which is unsafe on the macOS deployment target).

## 🧪 How was it tested?

- Local (Linux, no GPU): clean `bare-make generate/build/install` (no warnings); clang-format-22 + clang-tidy clean on changed C++; `npm run lint`, `test:dts`, `test:mobile:generate`/`validate` pass.
- `getBackendInfo()` confirmed to report `deviceIndex: -1` on CPU; the **out-of-range** path (`gpuDevice: 99` → 0 matching → CPU fallback with the exact reason) verified live.
- `backend-device.test.js` extended: asserts `deviceIndex`/`backendDescription`, the CPU `deviceIndex:-1`, and the out-of-range→CPU case; gated on a shipped Vulkan lib (skips cleanly otherwise).

> CI-only: multi-GPU **prefer-discrete** and **in-range index** selection (`deviceIndex >= 0`) need a GPU/multi-GPU runner — validated by the OCR Vulkan/GPU CI lane, not on this host.

## 🔌 API Changes

```typescript
const ocr = new OcrGgml({
  params: {
    pathDetector, pathRecognizer, langList: ['en'],
    backendDevice: 'vulkan',   // or 'metal'
    gpuDevice: 1               // NEW: 0-based index into matching GPU devices; omit to prefer discrete
  }
})
await ocr.load()
ocr.getBackendInfo() // { requested, backendDevice, backendName, fallbackReason, deviceIndex, backendDescription }
```
