### PR TITLE
QVAC-20065 test[skiplog]: apply e2e download config to mobile consumer from bundled fixture

### DIFF
--- a/packages/sdk/e2e/qvac-test.config.js
+++ b/packages/sdk/e2e/qvac-test.config.js
@@ -50,6 +50,7 @@ export default {
           "./assets/audio/**/*",
           "./assets/images/**/*",
           "./assets/documents/**/*",
+          "./fixtures/**/*",
         ],
       },
     },

--- a/packages/sdk/e2e/tests/desktop/consumer.ts
+++ b/packages/sdk/e2e/tests/desktop/consumer.ts
@@ -409,22 +409,27 @@ resources.define("upscaler-cpu", {
   },
 });
 
-export async function bootstrap(filteredTests?: TestDefinition[]) {
-  // Point the SDK at the committed e2e fixture unless the developer
-  // already provided their own qvac.config.json / QVAC_CONFIG_PATH.
-  // This exercises the registryDownloadMaxRetries + registryStreamTimeoutMs
-  // propagation end-to-end (see tests/config-tests.ts).
+// Exercises registryDownloadMaxRetries + registryStreamTimeoutMs end-to-end (see config-tests.ts).
+function ensureDesktopE2EConfig() {
   if (!process.env["QVAC_CONFIG_PATH"]) {
     process.env["QVAC_CONFIG_PATH"] = path.resolve(
       process.cwd(),
       "fixtures/qvac.config.e2e.json",
     );
+    console.log(`📦 Desktop e2e config set to ${process.env["QVAC_CONFIG_PATH"]}`);
+  } else {
+    console.log(`📦 Desktop e2e config: QVAC_CONFIG_PATH already set to ${process.env["QVAC_CONFIG_PATH"]}, skipping`);
   }
+}
+
+export async function bootstrap(filteredTests?: TestDefinition[]) {
+  ensureDesktopE2EConfig();
+
   // `filteredTests` (when present) is the producer's post-filter test list
   // delivered via register-ack; absence keeps the legacy "warm everything" path.
   const allowedDeps = filteredTests ? collectTestDeps(filteredTests) : undefined;
   await resources.downloadAllOnce(console.log, { allowedDeps });
-};
+}
 
 export const executor = createExecutor({
   handlers: [

--- a/packages/sdk/e2e/tests/mobile/consumer.ts
+++ b/packages/sdk/e2e/tests/mobile/consumer.ts
@@ -298,7 +298,39 @@ function skipTests(testIds: string[], reason: string) {
   return new SkipExecutor(new RegExp(`^(${testIds.join("|")})$`), reason);
 }
 
+async function ensureMobileE2EConfig() {
+  const env = typeof process !== "undefined" ? process.env : undefined;
+  if (env?.["QVAC_CONFIG_PATH"]) {
+    console.log(`📦 Mobile e2e config: QVAC_CONFIG_PATH already set to ${env["QVAC_CONFIG_PATH"]}, skipping write`);
+    return;
+  }
+
+  // @ts-ignore - assets.ts generated at consumer build time (consumer root, 3 levels up from dist/tests/mobile/)
+  const assets = await import("../../../assets");
+  const qvacE2EConfig = assets.other?.["qvac.config.e2e.json"];
+  if (!qvacE2EConfig || typeof qvacE2EConfig !== "object") {
+    throw new Error(
+      "qvac.config.e2e.json fixture not found in mobile assets — ensure ./fixtures/**/* is listed in qvac-test.config.js mobile.assets.patterns",
+    );
+  }
+
+  // @ts-ignore - expo-file-system is a peer dependency available in mobile context
+  const { File, Paths } = await import("expo-file-system");
+  const configFile = new File(Paths.document, "qvac.config.json");
+  if (!configFile.exists) {
+    configFile.create();
+  }
+  await configFile.write(`${JSON.stringify(qvacE2EConfig, null, 2)}\n`);
+  const cfg = qvacE2EConfig as Record<string, unknown>;
+  console.log(
+    `📦 Mobile e2e config written to ${configFile.uri} ` +
+    `(registryStreamTimeoutMs=${cfg["registryStreamTimeoutMs"]}, registryDownloadMaxRetries=${cfg["registryDownloadMaxRetries"]})`,
+  );
+}
+
 export async function bootstrap(filteredTests?: TestDefinition[]) {
+  await ensureMobileE2EConfig();
+
   // `filteredTests` (when present) is the producer's post-filter test list
   // delivered via register-ack; absence keeps the legacy "warm everything" path.
   const allowedDeps = filteredTests ? collectTestDeps(filteredTests) : undefined;


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Mobile E2E consumers were bootstrapping with SDK defaults (`registryStreamTimeoutMs=60s`, `registryDownloadMaxRetries=3`) instead of the extended fixture values (`120s`, `5 retries`).
- On slow AWS Device Farm networks this caused `REQUEST_TIMEOUT` failures during model download, with consumers never reaching `bootstrapped=true`.
- Desktop consumers already set `QVAC_CONFIG_PATH` but had no logging, making it hard to verify config application in CI artifacts.

## 📝 How does it solve it?

- **Mobile**: adds `ensureMobileE2EConfig()` — reads `qvac.config.e2e.json` from the bundled app assets (loaded via the generated `assets.ts`) and writes it to the device's document directory as `qvac.config.json`, where the Expo config resolver picks it up.
- **Asset bundling**: adds `./fixtures/**/*` to `qvac-test.config.js` mobile asset patterns so the fixture is included in every mobile consumer build.
- **Desktop**: extracts the inline `QVAC_CONFIG_PATH` setup into `ensureDesktopE2EConfig()` with explicit log output, mirroring the mobile approach.

## 🧪 How was it tested?

- Local iOS smoke suite: **81/93 passed, 12 skipped (OOM/platform), 0 failed** — device log confirmed `📦 Mobile e2e config written to .../qvac.config.json (registryStreamTimeoutMs=120000, registryDownloadMaxRetries=5)`.
- Local desktop smoke suite: **93/93 passed, 0 failed** — producer log confirmed `📦 Desktop e2e config set to .../fixtures/qvac.config.e2e.json`.

Made with [Cursor](https://cursor.com)