### PR TITLE
chore: prepare diagnostics v0.1.2 release

### DIFF
--- a/packages/diagnostics/CHANGELOG.md
+++ b/packages/diagnostics/CHANGELOG.md
@@ -5,7 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+
+## [0.1.2] - 2026-06-04
+
+This patch aligns `@qvac/diagnostics` with the monorepo’s simplified package layout and streamlines runtime and OS detection when building diagnostic reports.
+
+## Features
+
+### Monorepo layout alignment
+
+The package now lives under the standard `packages/diagnostics` tree from the monorepo path simplification. Published entry points are unchanged; release and CI follow the same patterns as other QVAC add-on libraries.
+
+## Other
+
+### Simpler runtime and environment detection
+
+Environment collection uses `which-runtime` for platform, architecture, and runtime version, and resolves `os` through package `imports` so Bare and Node get the right implementation without probing `bare-process` or multiple fallback `require` paths at load time.
+
+```javascript
+const w = require('which-runtime')
+const os = (w.isNode || w.isBare) ? require('os') : null
+```
+
+Hardware probing (CPU model, core count, memory) still uses `os` when available.
+
+## Pull Requests
+
+- [#1860](https://github.com/tetherto/qvac/pull/1860) - QVAC-16441 feat: simplify package folders, files and paths in the monorepo
+- [#2157](https://github.com/tetherto/qvac/pull/2157) - simplify
 
 ## [0.1.0] - 2026-03-10
 

--- a/packages/diagnostics/NOTICE
+++ b/packages/diagnostics/NOTICE
@@ -1,4 +1,19 @@
 @qvac/diagnostics
 Copyright 2026 Tether Data, S.A. de C.V.
 
-This product includes software developed by Tether Data, S.A. de C.V.
+This product includes third-party components under their
+respective licenses. @qvac/diagnostics itself is licensed under
+Apache-2.0; bundled dependencies are governed by the licenses
+listed below.
+
+=========================================================================
+JavaScript Dependencies
+=========================================================================
+
+--- apache-2.0 (Apache License 2.0) ---
+
+  bare-os@3.9.1
+    https://github.com/holepunchto/bare-os
+  which-runtime@1.4.0
+    https://github.com/holepunchto/which-runtime
+

--- a/packages/diagnostics/package.json
+++ b/packages/diagnostics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/diagnostics",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Diagnostic report generation library for QVAC",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/diagnostics` is still at `0.1.1` on the release line while `main` already includes post-`0.1.1` changes (monorepo path alignment and runtime simplification from #1860 / #2157).
- NPM publish from `release-diagnostics-0.1.2` needs a version bump, release notes, and an updated NOTICE for current dependencies.

## 📝 How does it solve it?

- Bump `packages/diagnostics/package.json` to `0.1.2`.
- Add `## [0.1.2] - 2026-06-04` to `CHANGELOG.md` (Keep a Changelog format for the GitHub release workflow).
- Regenerate `NOTICE` for `bare-os` and `which-runtime`.

## 🧪 How was it tested?

- Release notes generated with `/qv-addon-changelog` from `diagnostics-v0.1.1..HEAD` scoped to `packages/diagnostics/`.
- NOTICE regenerated via `qv-notice-generate`.
- No runtime code changes in this PR — functional changes already merged via #1860 and #2157.
