### PR TITLE
transcription-whispercpp + transcription-parakeet: bump to registry whisper-cpp 1.8.5#2 / parakeet-cpp 2026-06-04#0

### DIFF
--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -42,7 +42,7 @@
     {
       "name": "whisper-cpp",
       "version": "1.8.5",
-      "port-version": 1
+      "port-version": 3
     }
   ]
 }

--- a/packages/transcription-parakeet/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg.json
@@ -4,19 +4,19 @@
   "dependencies": [
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-05-26#2",
+      "version>=": "2026-06-04#0",
       "features": ["metal"],
       "platform": "osx | ios"
     },
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-05-26#2",
+      "version>=": "2026-06-04#0",
       "features": ["vulkan", "opencl"],
       "platform": "android"
     },
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-05-26#2",
+      "version>=": "2026-06-04#0",
       "features": ["vulkan"],
       "platform": "!(osx | ios | android)"
     },

--- a/packages/transcription-whispercpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg.json
@@ -33,7 +33,7 @@
     {
       "name": "whisper-cpp",
       "version": "1.8.5",
-      "port-version": 2
+      "port-version": 3
     }
   ]
 }

--- a/packages/transcription-whispercpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg.json
@@ -33,7 +33,7 @@
     {
       "name": "whisper-cpp",
       "version": "1.8.5",
-      "port-version": 1
+      "port-version": 2
     }
   ]
 }


### PR DESCRIPTION
## Summary
Dependencies-only bump of the **whisper** and **parakeet** transcription addons onto the C++ ports just
merged into `qvac-registry-vcpkg` (PR [#183](https://github.com/tetherto/qvac-registry-vcpkg/pull/183),
registry `main` = `75bc60c4`). This lets CI validate the newly-shipped registry ports end-to-end.

| Addon | Port | Pin | Mechanism |
|---|---|---|---|
| `transcription-whispercpp` | `whisper-cpp` | `1.8.5#1 → 1.8.5#2` | `overrides.port-version` |
| `transcription-parakeet` | `parakeet-cpp` | `2026-05-26#2 → 2026-06-04#0` | 3× platform `version>=` |

`ggml-speech 2026-06-04` is pulled **transitively** by both ports (it is the registry baseline default), so
neither addon needs a direct `ggml-speech` edit.

## What the new ports carry
- **whisper-cpp 1.8.5#2** — qvac-ext-lib-whisper.cpp PR #34: KV-cache CPU-buffer fallback when a single
  K/V tensor exceeds the backend's max single-tensor size (Adreno-740 `whisper-cli` fix). whisper version
  unchanged (`1.8.5`); only `port-version` increments.
- **parakeet-cpp 2026-06-04#0** — qvac-ext-lib-whisper.cpp PR #38: `std::regex` `parse_adreno_version()`
  for robust Adreno-generation detection + backend-select diagnostics.

## No baseline change (intentional)
Only the version pins move; the `default-registry.baseline` in each addon's `vcpkg-configuration.json` is
**untouched**. `version>=` / `overrides` resolve forward of the pinned baseline — the same way `main` already
consumes `parakeet-cpp 2026-05-26#2` and `whisper-cpp 1.8.5#1`, neither of which exists at its addon's
pinned baseline commit.

## Verification
Local `vcpkg install --dry-run` resolves clean for **both** addons on `arm64-osx` (metal) and `x64-linux`
(vulkan), pulling the exact registry git-trees:
- `whisper-cpp[core,metal|vulkan]@1.8.5#2 → 6111cf47…`
- `parakeet-cpp[core,metal|vulkan]@2026-06-04#0 → 90f6d24c…`
- `ggml-speech[core,metal|vulkan]@2026-06-04`

CI (`on-pr-transcription-whispercpp` + `on-pr-transcription-parakeet`, triggered by the `packages/<addon>/**`
path filters) is the final arbiter.

## Out of scope
`tts-ggml` addon and the `tts-cpp` registry port (handled separately); no source/code changes.
