### PR TITLE
Revert QVAC-19131 feat: enable OpenMP for Android ARM64

### DIFF
--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -13,7 +13,6 @@
 - `BertModel::setWeightsForFile` now tracks fulfilled GGUF shards in a per-instance `std::atomic<int>` instead of a function-local `static int`, so multiple concurrent `BertInterface` instances no longer share (and miscount) shard-fulfillment state.
 - `BertModel` now resolves sharded model basenames to absolute paths relative to the model directory before metadata inspection and disk-shards loading, so the trained-context cap and `llama_model_load_from_splits` work correctly when the working directory differs from the model directory.
 - `readTrainedContextSize` now logs an `ERROR`-level diagnostic when GGUF metadata cannot be read on either streamed or non-streaming loads (previously failed silently and reverted to llama.cpp's default `ctx_size`).
-
 ## [0.18.2] - 2026-06-03
 
 ### Fixed

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.19.0",
+  "version": "0.18.2",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/embed-llamacpp/vcpkg.json
+++ b/packages/embed-llamacpp/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "8828.0.2#1"
+      "version>=": "8828.0.2"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
@@ -29,7 +29,6 @@
       "dependencies": [
         {
           "name": "qvac-fabric",
-          "version>=": "8828.0.2#1",
           "features": [
             "force-profiler"
           ]

--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## [0.24.0] - 2026-06-04
-
-### Changed
-
-- Updated the `qvac-fabric` vcpkg dependency to registry version `8828.0.2#1`.
-
-### Added
-
-- **OpenMP feature for Android**: Added `openmp` default feature that enables OpenMP support on Android ARM64 via the `qvac-fabric` dependency. This improves parallelization on supported Android devices.
-
 ## [0.23.2] - 2026-06-03
 
 ### Fixed

--- a/packages/llm-llamacpp/CMakeLists.txt
+++ b/packages/llm-llamacpp/CMakeLists.txt
@@ -47,41 +47,7 @@ find_package(nlohmann_json CONFIG REQUIRED)
 if(WIN32)
   add_definitions( -DNOMINMAX -DWIN32_MEAN_AND_LEAN -DNOGDI )
 endif()
-if(ANDROID AND "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64")
-  if(NOT IS_DIRECTORY "$ENV{ANDROID_NDK}")
-    message(FATAL_ERROR "ANDROID_NDK is not set or does not point to a valid directory: '$ENV{ANDROID_NDK}'")
-  endif()
 
-  if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-    set(NDK_HOST "windows-x86_64")
-  elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-    set(NDK_HOST "linux-x86_64")
-  else()
-    set(NDK_HOST "darwin-x86_64")
-  endif()
-
-  set(NDK_PREBUILT "$ENV{ANDROID_NDK}/toolchains/llvm/prebuilt/${NDK_HOST}")
-
-  # Discover libomp.so for the correct ABI via version-agnostic glob.
-  # NDK LLVM major changes per release (r26→17, r27→18, r28→19, r29→21),
-  # so we avoid hardcoding a specific clang version.
-  file(GLOB LIBOMP_CANDIDATES "${NDK_PREBUILT}/lib/clang/*/lib/linux/aarch64/libomp.so")
-  if(NOT LIBOMP_CANDIDATES)
-    file(GLOB LIBOMP_CANDIDATES "${NDK_PREBUILT}/lib64/clang/*/lib/linux/aarch64/libomp.so")
-  endif()
-
-  set(LIBOMP_FOUND_PATH "")
-  if(LIBOMP_CANDIDATES)
-    list(GET LIBOMP_CANDIDATES 0 LIBOMP_FOUND_PATH)
-    message(STATUS "Found libomp.so for aarch64: ${LIBOMP_FOUND_PATH}")
-  else()
-    message(FATAL_ERROR
-      "libomp.so not found under ${NDK_PREBUILT}/lib/clang/*/lib/linux/aarch64/. "
-      "OpenMP is enabled via the 'openmp' vcpkg feature but the NDK does not "
-      "provide libomp.so for aarch64. Check your NDK installation."
-    )
-  endif()
-endif()
 bare_target(bare_target_value)
 bare_module_target("." unused_target NAME module_name VERSION unused_version)
 set(BACKENDS_SUBDIR_VALUE "${bare_target_value}/${module_name}")
@@ -96,30 +62,6 @@ if((ANDROID OR UNIX) AND NOT APPLE)
 endif()
 
 add_bare_module(inference-addon-llama EXPORTS ${BACKEND_DL_LIBS})
-
-if(ANDROID AND "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64" AND LIBOMP_FOUND_PATH)
-  message(STATUS "Installing libomp.so from: ${LIBOMP_FOUND_PATH}")
-
-  install(FILES ${LIBOMP_FOUND_PATH}
-    DESTINATION ${BACKENDS_SUBDIR_VALUE}
-    RENAME libomp.so
-  )
-
-  add_library(OpenMP::omp SHARED IMPORTED)
-  set_target_properties(OpenMP::omp PROPERTIES IMPORTED_LOCATION "${LIBOMP_FOUND_PATH}")
-
-  target_link_libraries(${inference-addon-llama} PRIVATE OpenMP::omp)
-  target_compile_options(${inference-addon-llama} PRIVATE -fopenmp)
-  target_link_libraries(${inference-addon-llama}_module PRIVATE OpenMP::omp)
-  target_compile_options(${inference-addon-llama}_module PRIVATE -fopenmp)
-
-  add_custom_command(TARGET ${inference-addon-llama}_module POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      ${LIBOMP_FOUND_PATH}
-      $<TARGET_FILE_DIR:${inference-addon-llama}_module>/libomp.so
-    COMMENT "Copying libomp.so to build directory"
-  )
-endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   target_link_options(${inference-addon-llama}_module PRIVATE -Wl,--exclude-libs,ALL)

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.24.0",
+  "version": "0.23.2",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/llm-llamacpp/vcpkg.json
+++ b/packages/llm-llamacpp/vcpkg.json
@@ -8,7 +8,7 @@
     "nlohmann-json",
     {
       "name": "qvac-fabric",
-      "version>=": "8828.0.2#1"
+      "version>=": "8828.0.2"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",
@@ -18,9 +18,6 @@
       "name": "qvac-lint-cpp",
       "version>=": "1.4.4#3"
     }
-  ],
-  "default-features": [
-    "openmp"
   ],
   "features": {
     "tests": {
@@ -34,23 +31,9 @@
       "dependencies": [
         {
           "name": "qvac-fabric",
-          "version>=": "8828.0.2#1",
           "features": [
             "force-profiler"
           ]
-        }
-      ]
-    },
-    "openmp": {
-      "description": "Enable openmp on Android.",
-      "dependencies": [
-        {
-          "name": "qvac-fabric",
-          "version>=": "8828.0.2#1",
-          "features": [
-            "openmp"
-          ],
-          "platform": "android & arm64"
         }
       ]
     }

--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [5.1.0] - 2026-06-04
-
-### Changed
-
-- Updated the `qvac-fabric` vcpkg dependency to registry version `8828.0.2#1` (sync update with `llm-llamacpp`, no functional changes).
-
 ## [5.0.0] - 2026-06-02
 
 ### Changed

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "5.1.0",
+  "version": "5.0.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/vcpkg.json
+++ b/packages/translation-nmtcpp/vcpkg.json
@@ -13,7 +13,7 @@
     "ssplit",
     {
       "name": "qvac-fabric",
-      "version>=": "8828.0.2#1",
+      "version>=": "8828.0.2",
       "default-features": false,
       "features": [
         "gpu-backends"


### PR DESCRIPTION
## What problem does this PR solve?

- Reverts PR #2380 (QVAC-19131) which enabled OpenMP for Android ARM64
- The original PR introduced `qvac-fabric` vcpkg dependency bump (`8828.0.2` to `8828.0.2#1`) and OpenMP wiring in `llm-llamacpp` CMakeLists

## How does it solve it?

- Removes the OpenMP discovery/linking CMake block from `llm-llamacpp`
- Reverts `qvac-fabric` version and `openmp` feature/default-features from `llm-llamacpp/vcpkg.json`
- Reverts sync version bumps in `embed-llamacpp` and `translation-nmtcpp` (vcpkg.json + package.json)
- Removes associated changelog entries from all three packages

## Breaking changes

None. This is a clean revert of an additive feature that was gated to Android ARM64.
