### PR TITLE
infra[notask]: rotate devops roster handle GiacomoSorbiWork -> GSServita

### DIFF
--- a/.cursor/skills/qv-devops-pr-status/SKILL.md
+++ b/.cursor/skills/qv-devops-pr-status/SKILL.md
@@ -61,7 +61,7 @@ Required layout (in this exact order):
 2. **Headline summary** — one bold line restating the script summary counts (`N PRs need attention · X fully approved · Y need your re-review · Z stale`).
 3. **Roster line** — one-line listing of the roster:
    ```
-   Roster: `Proletter` (lead) + `darkynt`, `GiacomoSorbiWork`, `sidj-thr`, `tamer-hassan-tether`, `yauhenipankratovich-web`.
+   Roster: `Proletter` (lead) + `darkynt`, `GSServita`, `sidj-thr`, `tamer-hassan-tether`, `yauhenipankratovich-web`.
    ```
    Refresh from [.github/teams/devops.json](.github/teams/devops.json) on every run; do not hardcode if the file has drifted.
 4. **Headline analysis** — one short paragraph identifying the highest-leverage cluster in the queue (e.g., "Four `QVAC-18047` PRs all sit on team-lead approval only — fastest path to drain the queue."). Skip when the queue is empty.

--- a/.github/teams/devops.json
+++ b/.github/teams/devops.json
@@ -3,7 +3,7 @@
   "leads": ["Proletter"],
   "members": [
     "darkynt",
-    "GiacomoSorbiWork",
+    "GSServita",
     "sidj-thr",
     "tamer-hassan-tether",
     "yauhenipankratovich-web"


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Giacomo Sorbi's previous GitHub account `GiacomoSorbiWork` no longer resolves (404), so the DevOps Pod roster in `.github/teams/devops.json` points at a dead handle. Any automation that scopes to the roster (e.g. `qv-devops-pr-status`) silently drops his PRs.
- His confirmed current handle is `GSServita` (verified directly with him).

## 📝 How does it solve it?

- Replace `GiacomoSorbiWork` with `GSServita` in the DevOps Pod `members` list in `.github/teams/devops.json` (the source of truth for roster-scoped automation).
- Update the matching example roster line in `.cursor/skills/qv-devops-pr-status/SKILL.md` so the documented roster stays consistent with the source of truth.

## 🧪 How was it tested?

- Confirmed `GSServita` is a live GitHub account and `GiacomoSorbiWork` now returns 404 via `gh api`.
- Validated `.github/teams/devops.json` parses as valid JSON.
- Confirmed the branch diff vs `main` contains only the handle rotation (no unrelated feature-branch changes).
