### PR TITLE
QVAC-20424 feat[api]: img2vid for POST /v1/videos

### DIFF
--- a/docs/website/content/docs/ai-capabilities/video-generation.mdx
+++ b/docs/website/content/docs/ai-capabilities/video-generation.mdx
@@ -6,9 +6,12 @@ schemaType: HowTo
 
 ## Overview
 
-Video generation runs on a **customized Diffusion engine** ([`qvac-ext-stable-diffusion.cpp`](https://github.com/tetherto/qvac-ext-stable-diffusion.cpp)). Load a supported model using `modelType: "diffusion"` with `modelConfig.mode: "video"`. Then call `video()`, selecting the generation `mode`:
-- `txt2vid`: animate a scene from a text `prompt`.
-- `img2vid`: animate a first-frame `init_image` (a `Uint8Array`) guided by a motion `prompt`, with an optional denoise `strength` in `[0, 1]`. Load the model with `modelConfig.clipVisionModelSrc` set.
+Video generation runs on a **customized Diffusion engine** ([`qvac-ext-stable-diffusion.cpp`](https://github.com/tetherto/qvac-ext-stable-diffusion.cpp)). Load a supported model using `modelType: "diffusion"` with `modelConfig.mode: "video"`. Then call `video()` with a `mode` and `prompt`.
+
+Two generation modes are supported:
+
+- **`txt2vid`** — generate a video from a text prompt alone.
+- **`img2vid`** — animate a still image. Pass `init_image` (a `Uint8Array` of PNG or JPEG bytes) and optionally `strength` (0–1) to control how much the output diverges from the first frame. Requires a model loaded with `clipVisionModelSrc` (OpenCLIP ViT-H/14).
 
 `video()` returns `{ progressStream, outputs, stats }`. `outputs` resolves to one or more generated videos as `Uint8Array` buffers (AVI). Use `progressStream` to track generation step-by-step.
 
@@ -35,12 +38,12 @@ For how to use each function, see [SDK — API reference](/reference/api/).
 
 Supported model families and their file layouts:
 
-- **WAN 2.1 T2V**: split layout — diffusion model + UMT5-XXL text encoder (via `t5XxlModelSrc`) + VAE (via `vaeModelSrc`). Available constants: `WAN2_1_T2V_1_3B_FP16`, `UMT5_XXL_FP16`, `WAN_2_1_COMFYUI_REPACKAGED_VAE`.
-- **WAN 2.1 I2V** (for `img2vid`): split layout — diffusion model + UMT5-XXL text encoder (via `t5XxlModelSrc`) + VAE (via `vaeModelSrc`) + CLIP vision encoder (via `clipVisionModelSrc`). Available constants: `WAN2_1_I2V_14B_Q4_K_M` (with its companion shard `WAN2_1_I2V_14B_Q4_K_M_1`), `CLIP_VISION_H`, `UMT5_XXL_FP16`, `WAN_2_1_COMFYUI_REPACKAGED_VAE`.
+- **WAN 2.1 T2V** (txt2vid): split layout — diffusion model + UMT5-XXL text encoder (via `t5XxlModelSrc`) + VAE (via `vaeModelSrc`). Available constants: `WAN2_1_T2V_1_3B_FP16`, `UMT5_XXL_FP16`, `WAN_2_1_COMFYUI_REPACKAGED_VAE`.
+- **WAN 2.1 I2V** (img2vid): same split layout as T2V, plus an OpenCLIP ViT-H/14 vision encoder (via `clipVisionModelSrc`). Available constants: `WAN2_1_I2V_14B_Q4_K_M`, `CLIP_VISION_H`, `UMT5_XXL_FP16`, `WAN_2_1_COMFYUI_REPACKAGED_VAE`.
 
 For models available as constants, see [SDK — Models](/introduction#models).
 
-## Example
+## Examples
 
 ### Text-to-video (WAN 2.1)
 

--- a/docs/website/content/docs/cli/http-server/index.mdx
+++ b/docs/website/content/docs/cli/http-server/index.mdx
@@ -1016,7 +1016,14 @@ Search returns OpenAI-shaped `vector_store.search_results.page` objects. Each ch
 
 ### Videos
 
-OpenAI-compatible **async** text-to-video, backed by the SDK's `video({ mode: "txt2vid" })`. Creating a job returns immediately with `status: "queued"`; the generation runs in the background. Poll for status, then download the bytes. Image-to-video and the OpenAI sub-routes `/edits`, `/remix`, `/extensions`, and `/characters` are not implemented (the SDK exposes no underlying modes for them).
+OpenAI-compatible **async** video generation backed by the SDK's `video()`. Creating a job returns immediately with `status: "queued"`; the generation runs in the background. Poll for status, then download the bytes.
+
+Two modes are supported:
+
+- **txt2vid** — JSON body with `prompt` only. No image needed.
+- **img2vid** — include `input_reference` as a multipart file field (OpenAI SDK `Uploadable`), or JSON `{ image_url }` (base64 data URI or HTTP(S) URL), or JSON `{ file_id }` (file uploaded via `POST /v1/files`). Mode is inferred automatically.
+
+The OpenAI sub-routes `/edits`, `/remix`, `/extensions`, and `/characters` are not implemented.
 
 #### Loaded model
 
@@ -1045,7 +1052,7 @@ Clients select the model by passing the alias key (or its `src` string) in the r
 
 #### `POST /v1/videos`
 
-Create a generation job. The endpoint accepts `application/json` only — the SDK has no image-to-video mode, so multipart with `init_image` is not accepted.
+Create a generation job. Accepts `application/json` (txt2vid or img2vid via `{ image_url }` / `{ file_id }`) **or** `multipart/form-data` (img2vid via a binary `input_reference` file field — this is what the OpenAI SDK sends when given a local `File`/`Blob`).
 
 Returns `200` with the `Video` resource at `status: "queued"`.
 
@@ -1072,7 +1079,7 @@ curl http://localhost:11434/v1/videos \
 | --- | --- | --- |
 | `model` | Alias declared under `serve.models` (endpoint category `video`). | Yes |
 | `prompt` | Text prompt, 1–32000 characters. | Yes |
-| `size` | `"WIDTHxHEIGHT"` with both dimensions multiples of 8. Accepts any `WxH` in addition to OpenAI's 4-value enum. When omitted, the size is backfilled from the model output. | No |
+| `size` | `"WIDTHxHEIGHT"` with both dimensions multiples of 16. Accepts any `WxH` in addition to OpenAI's 4-value enum. When omitted, the size is backfilled from the model output. | No |
 | `seconds` | Target duration as a **string** (e.g. `"2"`; OpenAI uses `"4"` / `"8"` / `"12"`). Mapped together with `fps` to the addon's `video_frames` (rounded to the nearest `4k+1`). | No |
 | `fps` | QVAC extension. `0 < fps ≤ 120`, default `16`. | No |
 | `steps` | QVAC extension. Diffusion sampler step count. | No |
@@ -1080,9 +1087,11 @@ curl http://localhost:11434/v1/videos \
 | `negative_prompt` | QVAC extension. Negative prompt for the sampler. | No |
 | `cfg_scale` | QVAC extension. Classifier-free guidance scale (Wan range ~5–8). | No |
 | `flow_shift` | QVAC extension. Flow-matching shift; Wan 2.1 T2V needs `3.0` for visible motion. | No |
+| `input_reference` | img2vid reference image. Multipart file field, JSON `{ image_url }` (data URI or HTTP(S) URL, ≤ 100 MB / 30 s), or JSON `{ file_id }`. When present the job runs in img2vid mode; omit for txt2vid. | No |
+| `strength` | QVAC extension. img2vid denoise strength `[0, 1]`. Only meaningful with `input_reference`. | No |
 
 <Callout type="info">
-OpenAI's `input_reference` (image-to-video) is rejected with `400 unsupported_param` — the SDK exposes only text-to-video.
+**img2vid via `input_reference`** — supply the reference image as a multipart file field named `input_reference` (OpenAI SDK `Uploadable`), or as JSON `{ "image_url": "data:image/jpeg;base64,..." }` (data URI or HTTP(S) URL up to 100 MB), or as JSON `{ "file_id": "file-…" }` (file uploaded via `POST /v1/files`). Omit `input_reference` entirely for txt2vid.
 </Callout>
 
 The `Video` resource returned by `POST` (and by `GET /v1/videos/:id`):

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .DS_Store
 package-lock.json
+bun.lock

--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -591,10 +591,11 @@ Requires an alias whose **endpoint category** is `video` (SDK addon
 Two generation modes, both via JSON body:
 
 - **txt2vid** — `prompt` only. No image required.
-- **img2vid** — add `input_reference: { image_url: { url } }` where `url` is
-  a base64 data URI (`data:image/jpeg;base64,...`) or an HTTP(S) URL the server
-  will fetch. Mode is inferred from the presence of `input_reference`; no
-  explicit `mode` field needed. `strength` (0–1) controls denoise intensity.
+- **img2vid** — add `input_reference: { image_url }` where `image_url` is a
+  base64 data URI (`data:image/jpeg;base64,...`) or an HTTP(S) URL the server
+  will fetch; or `input_reference: { file_id }` to reference a file uploaded
+  via `POST /v1/files`. Mode is inferred from the presence of `input_reference`;
+  no explicit `mode` field needed. `strength` (0–1) controls denoise intensity.
 
 `/edits`, `/remix`, `/extensions`, and `/characters` are not implemented.
 
@@ -613,12 +614,13 @@ Two generation modes, both via JSON body:
 - `size` accepts any `WxH` (multiples of 16) in addition to OpenAI's 4-value enum.
 - `Content-Type: video/mp4` is produced by a server-side ffmpeg transcode; `?format=avi` returns the native container.
 - The list endpoint is **in-memory only** — a restart clears it.
+- Raw multipart file upload for `input_reference` (OpenAI SDK `Uploadable`) is not supported. Use `{ image_url }` with a base64 data URI, or upload the file first via `POST /v1/files` and reference it with `{ file_id }`.
 
 ### Errors
 
 | HTTP | `error.code` | When |
 |------|--------------|------|
-| 400 | `invalid_input_reference` | `input_reference.image_url.url` is not a data URI or HTTP URL, decode failed, or HTTP fetch returned non-200 |
+| 400 | `invalid_input_reference` | `input_reference.image_url` is not a valid data URI or HTTP URL (decode failed, fetch returned non-200); or `file_id` not found |
 | 400 | `invalid_strength` | `strength` outside `[0, 1]` or non-numeric |
 | 400 | `invalid_model_type` | Alias is not a `video` model |
 | 404 | `video_not_found` | Unknown job id |

--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -588,14 +588,16 @@ in the background. Poll `GET /v1/videos/{id}` until `status` is `completed` (or
 Requires an alias whose **endpoint category** is `video` (SDK addon
 `sdcpp-video`). Register it in `serve.models`.
 
-Two generation modes, both via JSON body:
+Two generation modes:
 
-- **txt2vid** — `prompt` only. No image required.
-- **img2vid** — add `input_reference: { image_url }` where `image_url` is a
-  base64 data URI (`data:image/jpeg;base64,...`) or an HTTP(S) URL the server
-  will fetch; or `input_reference: { file_id }` to reference a file uploaded
-  via `POST /v1/files`. Mode is inferred from the presence of `input_reference`;
-  no explicit `mode` field needed. `strength` (0–1) controls denoise intensity.
+- **txt2vid** — JSON body with `prompt` only. No image required.
+- **img2vid** — include `input_reference` in one of these forms:
+  - **multipart file field** — send `multipart/form-data` with `input_reference` as a file field (this is what the OpenAI SDK sends when you pass a local `File`/`Blob`/`fs.ReadStream` as `Uploadable`)
+  - **JSON `{ image_url }`** — base64 data URI (`data:image/jpeg;base64,...`) or an HTTP(S) URL (the server fetches it; 100 MB / 30 s limits apply)
+  - **JSON `{ file_id }`** — ID of a file previously uploaded via `POST /v1/files`
+
+  Mode is inferred from the presence of `input_reference`; no explicit `mode` field needed.
+  `strength` (0–1) controls denoise intensity.
 
 `/edits`, `/remix`, `/extensions`, and `/characters` are not implemented.
 
@@ -614,13 +616,13 @@ Two generation modes, both via JSON body:
 - `size` accepts any `WxH` (multiples of 16) in addition to OpenAI's 4-value enum.
 - `Content-Type: video/mp4` is produced by a server-side ffmpeg transcode; `?format=avi` returns the native container.
 - The list endpoint is **in-memory only** — a restart clears it.
-- Raw multipart file upload for `input_reference` (OpenAI SDK `Uploadable`) is not supported. Use `{ image_url }` with a base64 data URI, or upload the file first via `POST /v1/files` and reference it with `{ file_id }`.
+- HTTP(S) URL fetches for `input_reference.image_url` are capped at 100 MB and 30 s.
 
 ### Errors
 
 | HTTP | `error.code` | When |
 |------|--------------|------|
-| 400 | `invalid_input_reference` | `input_reference.image_url` is not a valid data URI or HTTP URL (decode failed, fetch returned non-200); or `file_id` not found |
+| 400 | `invalid_input_reference` | Data URI has invalid base64, decodes to empty bytes, or is missing the comma separator; HTTP(S) URL returned non-200, timed out, or exceeded the 100 MB limit; `file_id` not found |
 | 400 | `invalid_strength` | `strength` outside `[0, 1]` or non-numeric |
 | 400 | `invalid_model_type` | Alias is not a `video` model |
 | 404 | `video_not_found` | Unknown job id |

--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -25,6 +25,11 @@ This document describes the supported routes and how to configure `serve.models`
 | `GET` | `/v1/audio/models` | List READY text-to-speech models |
 | `POST` | `/v1/images/generations` | Diffusion txt2img (blocking + SSE) |
 | `POST` | `/v1/images/edits` | Diffusion img2img (multipart; blocking + SSE) |
+| `POST` | `/v1/videos` | Async video generation — txt2vid (JSON) or img2vid (multipart with `init_image`); returns a queued job |
+| `GET` | `/v1/videos` | List video generation jobs |
+| `GET` | `/v1/videos/{id}` | Get video job status and progress |
+| `GET` | `/v1/videos/{id}/content` | Download rendered video (`video/mp4` or `video/avi`) |
+| `DELETE` | `/v1/videos/{id}` | Cancel and remove a video job |
 | `POST` | `/v1/files` | Upload a file into the in-memory store (used by image URL responses + vector stores) |
 | `GET` | `/v1/files` | List in-memory files |
 | `GET` | `/v1/files/{id}` | File metadata |

--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -41,11 +41,6 @@ This document describes the supported routes and how to configure `serve.models`
 | `DELETE` | `/v1/vector_stores/{id}` | Delete a vector store |
 | `POST` | `/v1/vector_stores/{id}/search` | Semantic search over a store (needs a loaded `embedding` model) |
 | `POST` | `/v1/vector_stores/{id}/files` | Attach + embed a previously-uploaded file |
-| `POST` | `/v1/videos` | Create a text-to-video job (async; backed by the SDK's `video({ mode: "txt2vid" })`) |
-| `GET` | `/v1/videos` | List video jobs (in-memory only) |
-| `GET` | `/v1/videos/{id}` | Poll job status |
-| `GET` | `/v1/videos/{id}/content` | Download bytes (`video/mp4` via ffmpeg transcode; `?format=avi` for native MJPG-AVI) |
-| `DELETE` | `/v1/videos/{id}` | Abort the job and drop its assets |
 
 Other OpenAI routes may be added over time; this file is updated when they ship.
 
@@ -585,20 +580,22 @@ Lists loaded (READY) text-to-speech models — the speech-capable subset of `/v1
 
 ## `POST /v1/videos` (and job lifecycle)
 
-OpenAI-compatible **async** video surface, backed by the SDK's
-`video({ mode: "txt2vid" })`. `POST` creates a job and returns immediately with
-`status: "queued"`; the generation runs in the background. Poll `GET
-/v1/videos/{id}` until `status` is `completed` (or `failed`), then fetch the
-bytes from `GET /v1/videos/{id}/content`.
+OpenAI-compatible **async** video surface backed by the SDK's `video()`. `POST`
+creates a job and returns immediately with `status: "queued"`; generation runs
+in the background. Poll `GET /v1/videos/{id}` until `status` is `completed` (or
+`failed`), then fetch bytes from `GET /v1/videos/{id}/content`.
 
 Requires an alias whose **endpoint category** is `video` (SDK addon
-`sdcpp-video`). Register it in `serve.models` and add a
-`serve.openai.videos.models` aliasing block so OpenAI SDK clients can use a
-hard-coded model name.
+`sdcpp-video`). Register it in `serve.models`.
 
-**Scope: text-to-video only.** `input_reference` is rejected with `400
-unsupported_param` (no img2vid in the SDK); `/edits`, `/remix`, `/extensions`,
-and `/characters` are not implemented.
+Two generation modes:
+
+- **txt2vid** — JSON body with `prompt`. No image required.
+- **img2vid** — `multipart/form-data` with `init_image` (PNG or JPEG file
+  field). Mode is inferred from the presence of `init_image`; no explicit
+  `mode` field needed. `strength` (0–1) controls denoise intensity.
+
+`/edits`, `/remix`, `/extensions`, and `/characters` are not implemented.
 
 ### Endpoints
 
@@ -612,8 +609,7 @@ and `/characters` are not implemented.
 
 ### Deviations from the OpenAI spec
 
-- `input_reference` → `400 unsupported_param`.
-- `size` accepts any `WxH` (multiples of 8) in addition to OpenAI's 4-value enum.
+- `size` accepts any `WxH` (multiples of 16) in addition to OpenAI's 4-value enum.
 - `Content-Type: video/mp4` is produced by a server-side ffmpeg transcode; `?format=avi` returns the native container.
 - The list endpoint is **in-memory only** — a restart clears it.
 
@@ -621,7 +617,7 @@ and `/characters` are not implemented.
 
 | HTTP | `error.code` | When |
 |------|--------------|------|
-| 400 | `unsupported_param` | `input_reference` sent (no img2vid) |
+| 400 | `invalid_strength` | `strength` outside `[0, 1]` or non-numeric |
 | 400 | `invalid_model_type` | Alias is not a `video` model |
 | 404 | `video_not_found` | Unknown job id |
 | 501 | `unsupported_variant` | `GET …/content?variant=` other than `video` |

--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -25,7 +25,7 @@ This document describes the supported routes and how to configure `serve.models`
 | `GET` | `/v1/audio/models` | List READY text-to-speech models |
 | `POST` | `/v1/images/generations` | Diffusion txt2img (blocking + SSE) |
 | `POST` | `/v1/images/edits` | Diffusion img2img (multipart; blocking + SSE) |
-| `POST` | `/v1/videos` | Async video generation — txt2vid (JSON) or img2vid (multipart with `init_image`); returns a queued job |
+| `POST` | `/v1/videos` | Async video generation — txt2vid (JSON) or img2vid (JSON with `input_reference`); returns a queued job |
 | `GET` | `/v1/videos` | List video generation jobs |
 | `GET` | `/v1/videos/{id}` | Get video job status and progress |
 | `GET` | `/v1/videos/{id}/content` | Download rendered video (`video/mp4` or `video/avi`) |
@@ -588,12 +588,13 @@ in the background. Poll `GET /v1/videos/{id}` until `status` is `completed` (or
 Requires an alias whose **endpoint category** is `video` (SDK addon
 `sdcpp-video`). Register it in `serve.models`.
 
-Two generation modes:
+Two generation modes, both via JSON body:
 
-- **txt2vid** — JSON body with `prompt`. No image required.
-- **img2vid** — `multipart/form-data` with `init_image` (PNG or JPEG file
-  field). Mode is inferred from the presence of `init_image`; no explicit
-  `mode` field needed. `strength` (0–1) controls denoise intensity.
+- **txt2vid** — `prompt` only. No image required.
+- **img2vid** — add `input_reference: { image_url: { url } }` where `url` is
+  a base64 data URI (`data:image/jpeg;base64,...`) or an HTTP(S) URL the server
+  will fetch. Mode is inferred from the presence of `input_reference`; no
+  explicit `mode` field needed. `strength` (0–1) controls denoise intensity.
 
 `/edits`, `/remix`, `/extensions`, and `/characters` are not implemented.
 
@@ -617,6 +618,7 @@ Two generation modes:
 
 | HTTP | `error.code` | When |
 |------|--------------|------|
+| 400 | `invalid_input_reference` | `input_reference.image_url.url` is not a data URI or HTTP URL, decode failed, or HTTP fetch returned non-200 |
 | 400 | `invalid_strength` | `strength` outside `[0, 1]` or non-numeric |
 | 400 | `invalid_model_type` | Alias is not a `video` model |
 | 404 | `video_not_found` | Unknown job id |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
     "@fastify/multipart": "^9.0.0",
     "@fastify/swagger": "^9.0.0",
     "@fastify/swagger-ui": "^5.0.0",
-    "@qvac/sdk": "^0.12.0",
+    "@qvac/sdk": "^0.13.1",
     "close-with-grace": "^2.1.0",
     "commander": "^14.0.3",
     "fastify": "^5.0.0",

--- a/packages/cli/src/serve/aliases/sdcpp-video.ts
+++ b/packages/cli/src/serve/aliases/sdcpp-video.ts
@@ -16,6 +16,7 @@ export const SDCPP_VIDEO_TYPE = 'sdcpp-video'
 const NESTED_MODEL_SRC_KEYS = [
   'clipLModelSrc',
   'clipGModelSrc',
+  'clipVisionModelSrc',
   't5XxlModelSrc',
   'llmModelSrc',
   'vaeModelSrc',

--- a/packages/cli/src/serve/lib/multipart.ts
+++ b/packages/cli/src/serve/lib/multipart.ts
@@ -1,4 +1,4 @@
-import type { preValidationAsyncHookHandler } from 'fastify'
+import type { FastifyRequest, preValidationAsyncHookHandler } from 'fastify'
 import { HttpError } from './http-error.js'
 
 export interface ParsedFile {
@@ -8,12 +8,7 @@ export interface ParsedFile {
   buffer: Buffer
 }
 
-export const multipartToBody: preValidationAsyncHookHandler = async function multipartToBody (req) {
-  const contentType = req.headers['content-type'] ?? ''
-  if (!contentType.includes('multipart/form-data')) {
-    throw new HttpError(400, 'invalid_content_type', 'Content-Type must be multipart/form-data.')
-  }
-
+async function parseMultipart (req: FastifyRequest): Promise<void> {
   const fields: Record<string, string | Buffer> = {}
   const files: ParsedFile[] = []
 
@@ -49,3 +44,18 @@ export const multipartToBody: preValidationAsyncHookHandler = async function mul
   req.body = fields
   req.multipartFiles = files
 }
+
+export const multipartToBody: preValidationAsyncHookHandler = async function multipartToBody (req) {
+  const contentType = req.headers['content-type'] ?? ''
+  if (!contentType.includes('multipart/form-data')) {
+    throw new HttpError(400, 'invalid_content_type', 'Content-Type must be multipart/form-data.')
+  }
+  await parseMultipart(req)
+}
+
+export const multipartToBodyOptional: preValidationAsyncHookHandler =
+  async function multipartToBodyOptional (req) {
+    const contentType = req.headers['content-type'] ?? ''
+    if (!contentType.includes('multipart/form-data')) return
+    await parseMultipart(req)
+  }

--- a/packages/cli/src/serve/lib/multipart.ts
+++ b/packages/cli/src/serve/lib/multipart.ts
@@ -10,9 +10,7 @@ export interface ParsedFile {
 
 export const multipartToBody: preValidationAsyncHookHandler = async function multipartToBody (req) {
   const contentType = req.headers['content-type'] ?? ''
-  if (!contentType.includes('multipart/form-data')) {
-    throw new HttpError(400, 'invalid_content_type', 'Content-Type must be multipart/form-data.')
-  }
+  if (!contentType.includes('multipart/form-data')) return
 
   const fields: Record<string, string | Buffer> = {}
   const files: ParsedFile[] = []

--- a/packages/cli/src/serve/lib/multipart.ts
+++ b/packages/cli/src/serve/lib/multipart.ts
@@ -10,7 +10,9 @@ export interface ParsedFile {
 
 export const multipartToBody: preValidationAsyncHookHandler = async function multipartToBody (req) {
   const contentType = req.headers['content-type'] ?? ''
-  if (!contentType.includes('multipart/form-data')) return
+  if (!contentType.includes('multipart/form-data')) {
+    throw new HttpError(400, 'invalid_content_type', 'Content-Type must be multipart/form-data.')
+  }
 
   const fields: Record<string, string | Buffer> = {}
   const files: ParsedFile[] = []

--- a/packages/cli/src/serve/plugins/error-handler.ts
+++ b/packages/cli/src/serve/plugins/error-handler.ts
@@ -105,8 +105,7 @@ const ZOD_PATH_TO_CODE: Record<string, string> = {
   voice: 'missing_voice',
   mask: 'mask_not_supported',
   size: 'invalid_size',
-  seconds: 'invalid_seconds',
-  input_reference: 'unsupported_param'
+  seconds: 'invalid_seconds'
 }
 
 function headFromInstancePath (instancePath: string | undefined): string {

--- a/packages/cli/src/serve/routes/videos.ts
+++ b/packages/cli/src/serve/routes/videos.ts
@@ -4,6 +4,7 @@ import { video, cancel } from '@qvac/sdk'
 import type { VideoClientParams } from '@qvac/sdk'
 import { HttpError } from '../lib/http-error.js'
 import { requireModel } from '../plugins/require-model.js'
+import { multipartToBody } from '../lib/multipart.js'
 import {
   videosCreateBody,
   videoResource,
@@ -12,7 +13,8 @@ import {
   videoIdParam,
   videosListQuery,
   videoContentQuery,
-  extractVideoCreateParams
+  extractVideoCreateParams,
+  InvalidVideoStrengthError
 } from '../schemas/videos.js'
 import type { VideoJob } from '../core/video-jobs-store.js'
 import { videoJobResource } from '../core/video-jobs-store.js'
@@ -21,11 +23,17 @@ import type { QvacContext } from '../lib/types.js'
 
 const descriptions = {
   create: `
-Async text-to-video. Returns immediately with \`status: queued\`; poll
+Async video generation. Returns immediately with \`status: queued\`; poll
 \`GET /v1/videos/{id}\` and fetch bytes from \`GET /v1/videos/{id}/content\`
-once \`status: completed\`. JSON body only — multipart isn't accepted because
-the only OpenAI use for it is \`input_reference\`, which this server rejects
-(no image-to-video in the SDK).
+once \`status: completed\`.
+
+**Text-to-video (txt2vid):** send a JSON body with \`prompt\` (and optional
+parameters). No image required.
+
+**Image-to-video (img2vid):** send a \`multipart/form-data\` request with an
+\`init_image\` file field (PNG or JPEG). Mode is inferred from the presence
+of the image — no explicit \`mode\` field needed. Add \`strength\` (0–1) to
+control how much the output diverges from the first frame.
 
 **Job store is in-memory only.** IDs and rendered bytes are lost on restart.
 `.trim(),
@@ -281,13 +289,22 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
       tags: ['Videos'],
       summary: 'Create a video generation job',
       description: descriptions.create,
+      consumes: ['application/json', 'multipart/form-data'],
       response: { 200: videoResource }
     },
+    preValidation: multipartToBody,
     preHandler: requireModel('video')
   }, async (req, reply) => {
     const ctx = app.qvac
     const { alias, sdkModelId } = req.qvacModel!
-    const params = extractVideoCreateParams(req.body, sdkModelId)
+    const initImageFile = (req.multipartFiles ?? []).find((f) => f.fieldname === 'init_image')
+    let params: VideoClientParams
+    try {
+      params = extractVideoCreateParams(req.body, initImageFile?.buffer, sdkModelId)
+    } catch (err) {
+      if (err instanceof InvalidVideoStrengthError) throw new HttpError(400, 'invalid_strength', err.message)
+      throw err
+    }
 
     const job = ctx.videoJobsStore.create({
       model: alias,

--- a/packages/cli/src/serve/routes/videos.ts
+++ b/packages/cli/src/serve/routes/videos.ts
@@ -4,7 +4,6 @@ import { video, cancel } from '@qvac/sdk'
 import type { VideoClientParams } from '@qvac/sdk'
 import { HttpError } from '../lib/http-error.js'
 import { requireModel } from '../plugins/require-model.js'
-import { multipartToBody } from '../lib/multipart.js'
 import {
   videosCreateBody,
   videoResource,
@@ -27,13 +26,13 @@ Async video generation. Returns immediately with \`status: queued\`; poll
 \`GET /v1/videos/{id}\` and fetch bytes from \`GET /v1/videos/{id}/content\`
 once \`status: completed\`.
 
-**Text-to-video (txt2vid):** send a JSON body with \`prompt\` (and optional
-parameters). No image required.
+**Text-to-video (txt2vid):** send a JSON body with \`prompt\`. No image needed.
 
-**Image-to-video (img2vid):** send a \`multipart/form-data\` request with an
-\`init_image\` file field (PNG or JPEG). Mode is inferred from the presence
-of the image — no explicit \`mode\` field needed. Add \`strength\` (0–1) to
-control how much the output diverges from the first frame.
+**Image-to-video (img2vid):** include \`input_reference: { image_url: { url } }\`
+where \`url\` is a base64 data URI (\`data:image/...;base64,...\`) or an HTTP(S)
+URL. Mode is inferred from the presence of \`input_reference\` — no explicit
+\`mode\` field needed. Add \`strength\` (0–1) to control divergence from the
+first frame.
 
 **Job store is in-memory only.** IDs and rendered bytes are lost on restart.
 `.trim(),
@@ -95,6 +94,39 @@ function tearDownJob (ctx: QvacContext, job: VideoJob): void {
 }
 
 export { tearDownJob }
+
+async function resolveInputReferenceImage (url: string): Promise<Uint8Array> {
+  if (url.startsWith('data:')) {
+    const commaIdx = url.indexOf(',')
+    if (commaIdx === -1) {
+      throw new HttpError(400, 'invalid_input_reference',
+        'input_reference.image_url.url: data URI is missing the comma separator.')
+    }
+    const header = url.slice(5, commaIdx)
+    if (!header.endsWith(';base64')) {
+      throw new HttpError(400, 'invalid_input_reference',
+        'input_reference.image_url.url: only base64-encoded data URIs are supported (e.g. data:image/jpeg;base64,...).')
+    }
+    return Buffer.from(url.slice(commaIdx + 1), 'base64')
+  }
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    let res: Response
+    try {
+      res = await fetch(url)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new HttpError(400, 'invalid_input_reference',
+        `input_reference.image_url.url: failed to fetch image — ${message}`)
+    }
+    if (!res.ok) {
+      throw new HttpError(400, 'invalid_input_reference',
+        `input_reference.image_url.url: server returned HTTP ${res.status}.`)
+    }
+    return new Uint8Array(await res.arrayBuffer())
+  }
+  throw new HttpError(400, 'invalid_input_reference',
+    'input_reference.image_url.url must be a base64 data URI or an HTTP(S) URL.')
+}
 
 async function runVideoJob (ctx: QvacContext, jobId: string, params: VideoClientParams, alias: string): Promise<void> {
   const store = ctx.videoJobsStore
@@ -289,18 +321,18 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
       tags: ['Videos'],
       summary: 'Create a video generation job',
       description: descriptions.create,
-      consumes: ['application/json', 'multipart/form-data'],
       response: { 200: videoResource }
     },
-    preValidation: multipartToBody,
     preHandler: requireModel('video')
   }, async (req, reply) => {
     const ctx = app.qvac
     const { alias, sdkModelId } = req.qvacModel!
-    const initImageFile = (req.multipartFiles ?? []).find((f) => f.fieldname === 'init_image')
+    const initImage = req.body.input_reference
+      ? await resolveInputReferenceImage(req.body.input_reference.image_url.url)
+      : undefined
     let params: VideoClientParams
     try {
-      params = extractVideoCreateParams(req.body, initImageFile?.buffer, sdkModelId)
+      params = extractVideoCreateParams(req.body, initImage, sdkModelId)
     } catch (err) {
       if (err instanceof InvalidVideoStrengthError) throw new HttpError(400, 'invalid_strength', err.message)
       throw err

--- a/packages/cli/src/serve/routes/videos.ts
+++ b/packages/cli/src/serve/routes/videos.ts
@@ -3,6 +3,7 @@ import type { FastifyReply } from 'fastify'
 import { video, cancel } from '@qvac/sdk'
 import type { VideoClientParams } from '@qvac/sdk'
 import { HttpError } from '../lib/http-error.js'
+import { multipartToBodyOptional } from '../lib/multipart.js'
 import { requireModel } from '../plugins/require-model.js'
 import {
   videosCreateBody,
@@ -28,12 +29,13 @@ once \`status: completed\`.
 
 **Text-to-video (txt2vid):** send a JSON body with \`prompt\`. No image needed.
 
-**Image-to-video (img2vid):** include \`input_reference: { image_url }\` where
-\`image_url\` is a base64 data URI (\`data:image/...;base64,...\`) or an HTTP(S)
-URL; or \`input_reference: { file_id }\` to reference a file uploaded via
-\`POST /v1/files\`. Mode is inferred from the presence of \`input_reference\` —
-no explicit \`mode\` field needed. Add \`strength\` (0–1) to control divergence
-from the first frame.
+**Image-to-video (img2vid):** include \`input_reference\` as one of:
+- a multipart file field (OpenAI SDK \`Uploadable\` — the SDK sends this when you pass a local \`File\`/\`Blob\`)
+- JSON \`{ image_url }\` where \`image_url\` is a base64 data URI (\`data:image/...;base64,...\`) or an HTTP(S) URL (100 MB / 30 s limit)
+- JSON \`{ file_id }\` to reference a file uploaded via \`POST /v1/files\`
+
+Mode is inferred from the presence of \`input_reference\` — no explicit \`mode\` field needed.
+Add \`strength\` (0–1) to control divergence from the first frame.
 
 **Job store is in-memory only.** IDs and rendered bytes are lost on restart.
 `.trim(),
@@ -96,7 +98,11 @@ function tearDownJob (ctx: QvacContext, job: VideoJob): void {
 
 export { tearDownJob }
 
-async function resolveInputReferenceImage (
+const MAX_IMAGE_BYTES = 100 * 1024 * 1024
+const FETCH_TIMEOUT_MS = 30_000
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/
+
+export async function resolveInputReferenceImage (
   ref: { image_url?: string | undefined; file_id?: string | undefined },
   ctx: QvacContext
 ): Promise<Uint8Array> {
@@ -121,13 +127,28 @@ async function resolveInputReferenceImage (
       throw new HttpError(400, 'invalid_input_reference',
         'input_reference.image_url: only base64-encoded data URIs are supported (e.g. data:image/jpeg;base64,...).')
     }
-    return Buffer.from(url.slice(commaIdx + 1), 'base64')
+    const b64Data = url.slice(commaIdx + 1)
+    if (!BASE64_RE.test(b64Data)) {
+      throw new HttpError(400, 'invalid_input_reference',
+        'input_reference.image_url: data URI contains invalid base64 characters.')
+    }
+    const decoded = Buffer.from(b64Data, 'base64')
+    if (decoded.length === 0) {
+      throw new HttpError(400, 'invalid_input_reference',
+        'input_reference.image_url: data URI decoded to empty bytes.')
+    }
+    return decoded
   }
   if (url.startsWith('http://') || url.startsWith('https://')) {
     let res: Response
     try {
-      res = await fetch(url)
+      res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
     } catch (err) {
+      const isTimeout = err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
+      if (isTimeout) {
+        throw new HttpError(400, 'invalid_input_reference',
+          `input_reference.image_url: timed out after ${FETCH_TIMEOUT_MS / 1000}s.`)
+      }
       const message = err instanceof Error ? err.message : String(err)
       throw new HttpError(400, 'invalid_input_reference',
         `input_reference.image_url: failed to fetch image — ${message}`)
@@ -136,7 +157,38 @@ async function resolveInputReferenceImage (
       throw new HttpError(400, 'invalid_input_reference',
         `input_reference.image_url: server returned HTTP ${res.status}.`)
     }
-    return new Uint8Array(await res.arrayBuffer())
+    const chunks: Uint8Array[] = []
+    let totalBytes = 0
+    const reader = res.body!.getReader()
+    try {
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) break
+        totalBytes += value.length
+        if (totalBytes > MAX_IMAGE_BYTES) {
+          await reader.cancel()
+          throw new HttpError(400, 'invalid_input_reference',
+            `input_reference.image_url: image exceeds the ${MAX_IMAGE_BYTES / (1024 * 1024)} MB limit.`)
+        }
+        chunks.push(value)
+      }
+    } catch (err) {
+      if (err instanceof HttpError) throw err
+      const isTimeout = err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')
+      throw new HttpError(400, 'invalid_input_reference',
+        isTimeout
+          ? `input_reference.image_url: timed out after ${FETCH_TIMEOUT_MS / 1000}s.`
+          : `input_reference.image_url: failed reading response body.`)
+    } finally {
+      reader.releaseLock()
+    }
+    const result = new Uint8Array(totalBytes)
+    let offset = 0
+    for (const chunk of chunks) {
+      result.set(chunk, offset)
+      offset += chunk.length
+    }
+    return result
   }
   throw new HttpError(400, 'invalid_input_reference',
     'input_reference.image_url must be a base64 data URI or an HTTP(S) URL.')
@@ -335,15 +387,24 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
       tags: ['Videos'],
       summary: 'Create a video generation job',
       description: descriptions.create,
+      consumes: ['application/json', 'multipart/form-data'],
       response: { 200: videoResource }
     },
+    preValidation: multipartToBodyOptional,
     preHandler: requireModel('video')
   }, async (req, reply) => {
     const ctx = app.qvac
     const { alias, sdkModelId } = req.qvacModel!
-    const initImage = req.body.input_reference
-      ? await resolveInputReferenceImage(req.body.input_reference, ctx)
-      : undefined
+    const inputRef = req.body.input_reference
+    let initImage: Uint8Array | undefined
+    if (inputRef instanceof Buffer) {
+      initImage = new Uint8Array(inputRef)
+    } else if (inputRef !== undefined) {
+      initImage = await resolveInputReferenceImage(
+        inputRef as { image_url?: string | undefined; file_id?: string | undefined },
+        ctx
+      )
+    }
     let params: VideoClientParams
     try {
       params = extractVideoCreateParams(req.body, initImage, sdkModelId)

--- a/packages/cli/src/serve/routes/videos.ts
+++ b/packages/cli/src/serve/routes/videos.ts
@@ -137,7 +137,7 @@ export async function resolveInputReferenceImage (
       throw new HttpError(400, 'invalid_input_reference',
         'input_reference.image_url: data URI decoded to empty bytes.')
     }
-    return decoded
+    return new Uint8Array(decoded)
   }
   if (url.startsWith('http://') || url.startsWith('https://')) {
     let res: Response

--- a/packages/cli/src/serve/routes/videos.ts
+++ b/packages/cli/src/serve/routes/videos.ts
@@ -28,11 +28,12 @@ once \`status: completed\`.
 
 **Text-to-video (txt2vid):** send a JSON body with \`prompt\`. No image needed.
 
-**Image-to-video (img2vid):** include \`input_reference: { image_url: { url } }\`
-where \`url\` is a base64 data URI (\`data:image/...;base64,...\`) or an HTTP(S)
-URL. Mode is inferred from the presence of \`input_reference\` — no explicit
-\`mode\` field needed. Add \`strength\` (0–1) to control divergence from the
-first frame.
+**Image-to-video (img2vid):** include \`input_reference: { image_url }\` where
+\`image_url\` is a base64 data URI (\`data:image/...;base64,...\`) or an HTTP(S)
+URL; or \`input_reference: { file_id }\` to reference a file uploaded via
+\`POST /v1/files\`. Mode is inferred from the presence of \`input_reference\` —
+no explicit \`mode\` field needed. Add \`strength\` (0–1) to control divergence
+from the first frame.
 
 **Job store is in-memory only.** IDs and rendered bytes are lost on restart.
 `.trim(),
@@ -95,17 +96,30 @@ function tearDownJob (ctx: QvacContext, job: VideoJob): void {
 
 export { tearDownJob }
 
-async function resolveInputReferenceImage (url: string): Promise<Uint8Array> {
+async function resolveInputReferenceImage (
+  ref: { image_url?: string | undefined; file_id?: string | undefined },
+  ctx: QvacContext
+): Promise<Uint8Array> {
+  if (ref.file_id !== undefined) {
+    const record = ctx.ephemeralFiles.get(ref.file_id)
+    if (!record) {
+      throw new HttpError(400, 'invalid_input_reference',
+        `input_reference.file_id: file "${ref.file_id}" not found — upload the image via POST /v1/files first.`)
+    }
+    return new Uint8Array(record.data)
+  }
+
+  const url = ref.image_url!
   if (url.startsWith('data:')) {
     const commaIdx = url.indexOf(',')
     if (commaIdx === -1) {
       throw new HttpError(400, 'invalid_input_reference',
-        'input_reference.image_url.url: data URI is missing the comma separator.')
+        'input_reference.image_url: data URI is missing the comma separator.')
     }
     const header = url.slice(5, commaIdx)
     if (!header.endsWith(';base64')) {
       throw new HttpError(400, 'invalid_input_reference',
-        'input_reference.image_url.url: only base64-encoded data URIs are supported (e.g. data:image/jpeg;base64,...).')
+        'input_reference.image_url: only base64-encoded data URIs are supported (e.g. data:image/jpeg;base64,...).')
     }
     return Buffer.from(url.slice(commaIdx + 1), 'base64')
   }
@@ -116,16 +130,16 @@ async function resolveInputReferenceImage (url: string): Promise<Uint8Array> {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       throw new HttpError(400, 'invalid_input_reference',
-        `input_reference.image_url.url: failed to fetch image — ${message}`)
+        `input_reference.image_url: failed to fetch image — ${message}`)
     }
     if (!res.ok) {
       throw new HttpError(400, 'invalid_input_reference',
-        `input_reference.image_url.url: server returned HTTP ${res.status}.`)
+        `input_reference.image_url: server returned HTTP ${res.status}.`)
     }
     return new Uint8Array(await res.arrayBuffer())
   }
   throw new HttpError(400, 'invalid_input_reference',
-    'input_reference.image_url.url must be a base64 data URI or an HTTP(S) URL.')
+    'input_reference.image_url must be a base64 data URI or an HTTP(S) URL.')
 }
 
 async function runVideoJob (ctx: QvacContext, jobId: string, params: VideoClientParams, alias: string): Promise<void> {
@@ -328,7 +342,7 @@ const plugin: FastifyPluginAsyncZod = async (app) => {
     const ctx = app.qvac
     const { alias, sdkModelId } = req.qvacModel!
     const initImage = req.body.input_reference
-      ? await resolveInputReferenceImage(req.body.input_reference.image_url.url)
+      ? await resolveInputReferenceImage(req.body.input_reference, ctx)
       : undefined
     let params: VideoClientParams
     try {

--- a/packages/cli/src/serve/schemas/videos.ts
+++ b/packages/cli/src/serve/schemas/videos.ts
@@ -55,10 +55,21 @@ export const videosCreateBody = z.object({
     'QVAC extension. Flow-matching shift. Wan 2.1 T2V needs `flow_shift: 3.0` for visible motion.'
   ),
   input_reference: z.object({
-    image_url: z.object({ url: z.string() })
-  }).optional().describe(
-    'OpenAI img2vid. Reference image as a data URI (`data:image/...;base64,...`) or an HTTP(S) URL. ' +
-    'When present the job runs in img2vid mode; omit for text-to-video.'
+    image_url: z.string().optional().describe(
+      'Base64 data URI (`data:image/...;base64,...`) or HTTP(S) URL of the reference image.'
+    ),
+    file_id: z.string().optional().describe(
+      'ID of a file previously uploaded via POST /v1/files.'
+    )
+  })
+  .refine(ref => ref.image_url !== undefined || ref.file_id !== undefined, {
+    message: 'input_reference must contain either image_url or file_id.'
+  })
+  .optional()
+  .describe(
+    'OpenAI img2vid. Provide the reference image via `image_url` (data URI or HTTP URL) or `file_id` ' +
+    '(a file uploaded via POST /v1/files). When present the job runs in img2vid mode; omit for txt2vid. ' +
+    'Raw multipart file upload (OpenAI SDK `Uploadable`) is not supported — use `image_url` with a data URI instead.'
   ),
   strength: z.union([z.string(), z.number()]).optional().describe(
     'QVAC extension. img2vid denoise strength [0, 1]. Only meaningful when `input_reference` is provided.'

--- a/packages/cli/src/serve/schemas/videos.ts
+++ b/packages/cli/src/serve/schemas/videos.ts
@@ -46,12 +46,12 @@ export const videosCreateBody = z.object({
     })
     .optional()
     .describe('"WIDTHxHEIGHT" with W,H multiples of 8. Accepts OpenAI\'s 4-value enum plus any sized WxH.'),
-  fps: z.number().positive().max(120).optional().describe('QVAC extension. 0 < fps ≤ 120, default 16.'),
-  steps: z.number().int().positive().optional().describe('QVAC extension. Diffusion sampler step count.'),
-  seed: z.number().int().optional().describe('QVAC extension. Random seed; SDK picks one when omitted.'),
+  fps: z.coerce.number().positive().max(120).optional().describe('QVAC extension. 0 < fps ≤ 120, default 16.'),
+  steps: z.coerce.number().int().positive().optional().describe('QVAC extension. Diffusion sampler step count.'),
+  seed: z.coerce.number().int().optional().describe('QVAC extension. Random seed; SDK picks one when omitted.'),
   negative_prompt: z.string().optional().describe('QVAC extension. Negative prompt for the diffusion sampler.'),
-  cfg_scale: z.number().positive().optional().describe('QVAC extension. Classifier-free guidance scale (Wan range 5-8).'),
-  flow_shift: z.number().optional().describe(
+  cfg_scale: z.coerce.number().positive().optional().describe('QVAC extension. Classifier-free guidance scale (Wan range 5-8).'),
+  flow_shift: z.coerce.number().optional().describe(
     'QVAC extension. Flow-matching shift. Wan 2.1 T2V needs `flow_shift: 3.0` for visible motion.'
   ),
   init_image: z.instanceof(Buffer).optional().describe(

--- a/packages/cli/src/serve/schemas/videos.ts
+++ b/packages/cli/src/serve/schemas/videos.ts
@@ -40,12 +40,12 @@ export const videosCreateBody = z.object({
         ctx.addIssue({ code: 'custom', message: `"size" dimensions must be positive (got ${JSON.stringify(raw)}).` })
         return
       }
-      if (width % 8 !== 0 || height % 8 !== 0) {
-        ctx.addIssue({ code: 'custom', message: `"size" dimensions must be multiples of 8 (got ${width}x${height}).` })
+      if (width % 16 !== 0 || height % 16 !== 0) {
+        ctx.addIssue({ code: 'custom', message: `"size" dimensions must be multiples of 16 (got ${width}x${height}).` })
       }
     })
     .optional()
-    .describe('"WIDTHxHEIGHT" with W,H multiples of 8. Accepts OpenAI\'s 4-value enum plus any sized WxH.'),
+    .describe('"WIDTHxHEIGHT" with W,H multiples of 16. Accepts OpenAI\'s 4-value enum plus any sized WxH.'),
   fps: z.coerce.number().positive().max(120).optional().describe('QVAC extension. 0 < fps ≤ 120, default 16.'),
   steps: z.coerce.number().int().positive().optional().describe('QVAC extension. Diffusion sampler step count.'),
   seed: z.coerce.number().int().optional().describe('QVAC extension. Random seed; SDK picks one when omitted.'),

--- a/packages/cli/src/serve/schemas/videos.ts
+++ b/packages/cli/src/serve/schemas/videos.ts
@@ -168,9 +168,9 @@ export function extractVideoCreateParams (
   initImage: Uint8Array | undefined,
   modelId: string
 ): VideoClientParams {
-  const direct: Partial<VideoClientParams> = {}
+  const direct: Record<string, unknown> = {}
   for (const key of DIRECT_PARAM_KEYS) {
-    if (body[key] !== undefined) (direct as Record<string, unknown>)[key] = body[key]
+    if (body[key] !== undefined) direct[key] = body[key]
   }
   const base = {
     modelId,
@@ -181,7 +181,6 @@ export function extractVideoCreateParams (
   }
   if (initImage !== undefined) {
     const strength = coerceStrength(body.strength as string | number | undefined)
-    // TODO: remove cast once SDK PR #2436 (VideoImg2vidClientParams) lands
     return {
       ...base,
       mode: 'img2vid' as const,
@@ -189,7 +188,7 @@ export function extractVideoCreateParams (
       ...(strength !== undefined ? { strength } : {})
     } as unknown as VideoClientParams
   }
-  return { ...base, mode: 'txt2vid' }
+  return { ...base, mode: 'txt2vid' } as unknown as VideoClientParams
 }
 
 export { DEFAULT_FPS }

--- a/packages/cli/src/serve/schemas/videos.ts
+++ b/packages/cli/src/serve/schemas/videos.ts
@@ -1,6 +1,15 @@
 import { z } from 'zod'
 import type { VideoClientParams } from '@qvac/sdk'
 
+// ─── Errors ──────────────────────────────────────────────────────────
+
+export class InvalidVideoStrengthError extends Error {
+  constructor (message: string) {
+    super(message)
+    this.name = 'InvalidVideoStrengthError'
+  }
+}
+
 // ─── Constants ───────────────────────────────────────────────────────
 
 const SIZE_PATTERN = /^(\d+)x(\d+)$/
@@ -45,9 +54,13 @@ export const videosCreateBody = z.object({
   flow_shift: z.number().optional().describe(
     'QVAC extension. Flow-matching shift. Wan 2.1 T2V needs `flow_shift: 3.0` for visible motion.'
   ),
-  input_reference: z.never({
-    message: '"input_reference" (image-to-video) is not supported — the SDK exposes only text-to-video (txt2vid).'
-  }).optional()
+  init_image: z.instanceof(Buffer).optional().describe(
+    'QVAC extension. First-frame image for image-to-video (img2vid). Send as a multipart file field (PNG or JPEG). ' +
+    'When present the job runs in img2vid mode; omit for text-to-video.'
+  ),
+  strength: z.union([z.string(), z.number()]).optional().describe(
+    'QVAC extension. img2vid denoise strength [0, 1]. Only meaningful when `init_image` is provided.'
+  )
 }).passthrough()
 
 export type VideosCreateBody = z.infer<typeof videosCreateBody>
@@ -138,19 +151,45 @@ function videoFramesFor (seconds: string, fps: number | undefined): number {
 // extractor doesn't repeat itself per field.
 const DIRECT_PARAM_KEYS = ['fps', 'seed', 'steps', 'negative_prompt', 'cfg_scale', 'flow_shift'] as const
 
-export function extractVideoCreateParams (body: VideosCreateBody, modelId: string): VideoClientParams {
+function coerceStrength (raw: string | number | undefined): number | undefined {
+  if (raw === undefined) return undefined
+  const value = typeof raw === 'string' ? parseFloat(raw) : raw
+  if (Number.isNaN(value)) {
+    throw new InvalidVideoStrengthError(`"strength" must be a number in [0, 1] (got ${JSON.stringify(raw)}).`)
+  }
+  if (value < 0 || value > 1) {
+    throw new InvalidVideoStrengthError(`"strength" must be in [0, 1] (got ${value}).`)
+  }
+  return value
+}
+
+export function extractVideoCreateParams (
+  body: VideosCreateBody,
+  initImage: Uint8Array | undefined,
+  modelId: string
+): VideoClientParams {
   const direct: Partial<VideoClientParams> = {}
   for (const key of DIRECT_PARAM_KEYS) {
     if (body[key] !== undefined) (direct as Record<string, unknown>)[key] = body[key]
   }
-  return {
+  const base = {
     modelId,
-    mode: 'txt2vid',
     prompt: body.prompt,
     ...direct,
     ...(body.size !== undefined ? parseSizeFields(body.size) : {}),
     ...(body.seconds !== undefined ? { video_frames: videoFramesFor(body.seconds, body.fps) } : {})
   }
+  if (initImage !== undefined) {
+    const strength = coerceStrength(body.strength as string | number | undefined)
+    // TODO: remove cast once SDK PR #2436 (VideoImg2vidClientParams) lands
+    return {
+      ...base,
+      mode: 'img2vid' as const,
+      init_image: initImage,
+      ...(strength !== undefined ? { strength } : {})
+    } as unknown as VideoClientParams
+  }
+  return { ...base, mode: 'txt2vid' }
 }
 
 export { DEFAULT_FPS }

--- a/packages/cli/src/serve/schemas/videos.ts
+++ b/packages/cli/src/serve/schemas/videos.ts
@@ -46,24 +46,23 @@ export const videosCreateBody = z.object({
     })
     .optional()
     .describe('"WIDTHxHEIGHT" with W,H multiples of 16. Accepts OpenAI\'s 4-value enum plus any sized WxH.'),
-  fps: z.coerce.number().positive().max(120).optional().describe('QVAC extension. 0 < fps ≤ 120, default 16.'),
-  steps: z.coerce.number().int().positive().optional().describe('QVAC extension. Diffusion sampler step count.'),
-  seed: z.coerce.number().int().optional().describe('QVAC extension. Random seed; SDK picks one when omitted.'),
+  fps: z.number().positive().max(120).optional().describe('QVAC extension. 0 < fps ≤ 120, default 16.'),
+  steps: z.number().int().positive().optional().describe('QVAC extension. Diffusion sampler step count.'),
+  seed: z.number().int().optional().describe('QVAC extension. Random seed; SDK picks one when omitted.'),
   negative_prompt: z.string().optional().describe('QVAC extension. Negative prompt for the diffusion sampler.'),
-  cfg_scale: z.coerce.number().positive().optional().describe('QVAC extension. Classifier-free guidance scale (Wan range 5-8).'),
-  flow_shift: z.coerce.number().optional().describe(
+  cfg_scale: z.number().positive().optional().describe('QVAC extension. Classifier-free guidance scale (Wan range 5-8).'),
+  flow_shift: z.number().optional().describe(
     'QVAC extension. Flow-matching shift. Wan 2.1 T2V needs `flow_shift: 3.0` for visible motion.'
   ),
-  init_image: z.instanceof(Buffer).optional().describe(
-    'QVAC extension. First-frame image for image-to-video (img2vid). Send as a multipart file field (PNG or JPEG). ' +
+  input_reference: z.object({
+    image_url: z.object({ url: z.string() })
+  }).optional().describe(
+    'OpenAI img2vid. Reference image as a data URI (`data:image/...;base64,...`) or an HTTP(S) URL. ' +
     'When present the job runs in img2vid mode; omit for text-to-video.'
   ),
   strength: z.union([z.string(), z.number()]).optional().describe(
-    'QVAC extension. img2vid denoise strength [0, 1]. Only meaningful when `init_image` is provided.'
-  ),
-  input_reference: z.never({
-    message: '"input_reference" is not supported — send `init_image` as a multipart file field for image-to-video.'
-  }).optional()
+    'QVAC extension. img2vid denoise strength [0, 1]. Only meaningful when `input_reference` is provided.'
+  )
 }).passthrough()
 
 export type VideosCreateBody = z.infer<typeof videosCreateBody>

--- a/packages/cli/src/serve/schemas/videos.ts
+++ b/packages/cli/src/serve/schemas/videos.ts
@@ -60,7 +60,10 @@ export const videosCreateBody = z.object({
   ),
   strength: z.union([z.string(), z.number()]).optional().describe(
     'QVAC extension. img2vid denoise strength [0, 1]. Only meaningful when `init_image` is provided.'
-  )
+  ),
+  input_reference: z.never({
+    message: '"input_reference" is not supported — send `init_image` as a multipart file field for image-to-video.'
+  }).optional()
 }).passthrough()
 
 export type VideosCreateBody = z.infer<typeof videosCreateBody>

--- a/packages/cli/src/serve/schemas/videos.ts
+++ b/packages/cli/src/serve/schemas/videos.ts
@@ -46,30 +46,33 @@ export const videosCreateBody = z.object({
     })
     .optional()
     .describe('"WIDTHxHEIGHT" with W,H multiples of 16. Accepts OpenAI\'s 4-value enum plus any sized WxH.'),
-  fps: z.number().positive().max(120).optional().describe('QVAC extension. 0 < fps ≤ 120, default 16.'),
-  steps: z.number().int().positive().optional().describe('QVAC extension. Diffusion sampler step count.'),
-  seed: z.number().int().optional().describe('QVAC extension. Random seed; SDK picks one when omitted.'),
+  fps: z.coerce.number().positive().max(120).optional().describe('QVAC extension. 0 < fps ≤ 120, default 16.'),
+  steps: z.coerce.number().int().positive().optional().describe('QVAC extension. Diffusion sampler step count.'),
+  seed: z.coerce.number().int().optional().describe('QVAC extension. Random seed; SDK picks one when omitted.'),
   negative_prompt: z.string().optional().describe('QVAC extension. Negative prompt for the diffusion sampler.'),
-  cfg_scale: z.number().positive().optional().describe('QVAC extension. Classifier-free guidance scale (Wan range 5-8).'),
-  flow_shift: z.number().optional().describe(
+  cfg_scale: z.coerce.number().positive().optional().describe('QVAC extension. Classifier-free guidance scale (Wan range 5-8).'),
+  flow_shift: z.coerce.number().optional().describe(
     'QVAC extension. Flow-matching shift. Wan 2.1 T2V needs `flow_shift: 3.0` for visible motion.'
   ),
-  input_reference: z.object({
-    image_url: z.string().optional().describe(
-      'Base64 data URI (`data:image/...;base64,...`) or HTTP(S) URL of the reference image.'
-    ),
-    file_id: z.string().optional().describe(
-      'ID of a file previously uploaded via POST /v1/files.'
-    )
-  })
-  .refine(ref => ref.image_url !== undefined || ref.file_id !== undefined, {
-    message: 'input_reference must contain either image_url or file_id.'
-  })
+  input_reference: z.union([
+    z.instanceof(Buffer),
+    z.object({
+      image_url: z.string().optional().describe(
+        'Base64 data URI (`data:image/...;base64,...`) or HTTP(S) URL of the reference image.'
+      ),
+      file_id: z.string().optional().describe(
+        'ID of a file previously uploaded via POST /v1/files.'
+      )
+    })
+    .refine(ref => ref.image_url !== undefined || ref.file_id !== undefined, {
+      message: 'input_reference must contain either image_url or file_id.'
+    })
+  ])
   .optional()
   .describe(
-    'OpenAI img2vid. Provide the reference image via `image_url` (data URI or HTTP URL) or `file_id` ' +
-    '(a file uploaded via POST /v1/files). When present the job runs in img2vid mode; omit for txt2vid. ' +
-    'Raw multipart file upload (OpenAI SDK `Uploadable`) is not supported — use `image_url` with a data URI instead.'
+    'OpenAI img2vid. Provide the reference image as a multipart file field (OpenAI SDK `Uploadable`), ' +
+    'via `image_url` (data URI or HTTP URL), or via `file_id` (file uploaded via POST /v1/files). ' +
+    'When present the job runs in img2vid mode; omit for txt2vid.'
   ),
   strength: z.union([z.string(), z.number()]).optional().describe(
     'QVAC extension. img2vid denoise strength [0, 1]. Only meaningful when `input_reference` is provided.'

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -610,7 +610,7 @@ TXT
 @test "legacy completions: blocking returns text_completion shape" {
   local body
   body=$(json_post "/v1/completions" \
-    "{\"model\":\"${LLM_ALIAS}\",\"prompt\":\"Say hello and nothing else.\",\"max_tokens\":512}")
+    "{\"model\":\"${LLM_ALIAS}\",\"prompt\":\"Say hello and nothing else.\",\"max_tokens\":4096}")
 
   echo "${body}" | jq -e '.id | startswith("cmpl-")' >/dev/null
   echo "${body}" | jq -e '.object == "text_completion"' >/dev/null

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -742,6 +742,8 @@ TXT
 # reach requireModel and get 503 model_not_ready without GPU inference.
 
 VIDEO_ALIAS="test-video"
+# 1×1 transparent PNG, base64-encoded — minimal valid image for data URI tests.
+TINY_PNG_B64="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 
 @test "videos: JSON txt2vid reaches model check (returns 503 model_not_ready)" {
   local body
@@ -749,30 +751,25 @@ VIDEO_ALIAS="test-video"
   assert_error "${body}" "model_not_ready"
 }
 
-@test "videos: multipart without init_image reaches model check (returns 503 model_not_ready)" {
-  local body
-  body=$(curl -s "${BASE}/v1/videos" \
-    -F "model=${VIDEO_ALIAS}" \
-    -F "prompt=a bird flies")
-  assert_error "${body}" "model_not_ready"
-}
-
-@test "videos: multipart with init_image reaches model check (returns 503 model_not_ready)" {
-  local img_path="${BATS_TEST_TMPDIR}/fake.png"
-  printf '\x89PNG\r\n\x1a\n' > "${img_path}"
-  local body
-  body=$(curl -s "${BASE}/v1/videos" \
-    -F "model=${VIDEO_ALIAS}" \
-    -F "prompt=subject turns" \
-    -F "init_image=@${img_path};type=image/png")
-  assert_error "${body}" "model_not_ready"
-}
-
-@test "videos: input_reference field rejected with 400 unsupported_param" {
+@test "videos: JSON img2vid with data URI reaches model check (returns 503 model_not_ready)" {
   local body
   body=$(json_post "/v1/videos" \
-    "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"p\",\"input_reference\":{\"image_url\":{\"url\":\"x\"}}}")
-  assert_error "${body}" "unsupported_param"
+    "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"subject turns\",\"input_reference\":{\"image_url\":{\"url\":\"data:image/png;base64,${TINY_PNG_B64}\"}}}")
+  assert_error "${body}" "model_not_ready"
+}
+
+@test "videos: JSON img2vid with HTTP URL reaches model check (returns 503 model_not_ready)" {
+  local body
+  body=$(json_post "/v1/videos" \
+    "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"subject turns\",\"input_reference\":{\"image_url\":{\"url\":\"http://127.0.0.1:${E2E_PORT}/v1/models\"}}}")
+  assert_error "${body}" "model_not_ready"
+}
+
+@test "videos: input_reference with wrong shape returns 400 invalid_request" {
+  local body
+  body=$(json_post "/v1/videos" \
+    "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"p\",\"input_reference\":{\"not_image_url\":\"x\"}}")
+  assert_error "${body}" "invalid_request"
 }
 
 # ── Model lifecycle ───────────────────────────────────────────────────

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -63,6 +63,11 @@ setup_file() {
         "model": "WHISPER_EN_TINY_Q8_0",
         "type": "whispercpp-audio-translation",
         "preload": true
+      },
+      "test-video": {
+        "src": "placeholder",
+        "type": "sdcpp-video",
+        "preload": false
       }
     }
   }
@@ -730,6 +735,44 @@ TXT
   local body
   body=$(json_post "/v1/responses" "{\"model\":\"${EMBED_ALIAS}\",\"input\":\"hello\"}")
   assert_error "${body}" "invalid_model_type"
+}
+
+# ── Videos (HTTP-layer only; model not loaded) ───────────────────────
+# test-video has preload:false so all requests that pass schema validation
+# reach requireModel and get 503 model_not_ready without GPU inference.
+
+VIDEO_ALIAS="test-video"
+
+@test "videos: JSON txt2vid reaches model check (returns 503 model_not_ready)" {
+  local body
+  body=$(json_post "/v1/videos" "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"a bird flies\"}")
+  assert_error "${body}" "model_not_ready"
+}
+
+@test "videos: multipart without init_image reaches model check (returns 503 model_not_ready)" {
+  local body
+  body=$(curl -s "${BASE}/v1/videos" \
+    -F "model=${VIDEO_ALIAS}" \
+    -F "prompt=a bird flies")
+  assert_error "${body}" "model_not_ready"
+}
+
+@test "videos: multipart with init_image reaches model check (returns 503 model_not_ready)" {
+  local img_path="${BATS_TEST_TMPDIR}/fake.png"
+  printf '\x89PNG\r\n\x1a\n' > "${img_path}"
+  local body
+  body=$(curl -s "${BASE}/v1/videos" \
+    -F "model=${VIDEO_ALIAS}" \
+    -F "prompt=subject turns" \
+    -F "init_image=@${img_path};type=image/png")
+  assert_error "${body}" "model_not_ready"
+}
+
+@test "videos: input_reference field rejected with 400 unsupported_param" {
+  local body
+  body=$(json_post "/v1/videos" \
+    "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"p\",\"input_reference\":{\"image_url\":{\"url\":\"x\"}}}")
+  assert_error "${body}" "unsupported_param"
 }
 
 # ── Model lifecycle ───────────────────────────────────────────────────

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -772,6 +772,19 @@ TINY_PNG_B64="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDw
   assert_error "${body}" "invalid_request"
 }
 
+@test "videos: multipart POST with input_reference file reaches model check (503 model_not_ready)" {
+  local tmpimg
+  tmpimg=$(mktemp /tmp/tiny-ref-XXXXXX.png)
+  printf '%s' "${TINY_PNG_B64}" | base64 --decode > "${tmpimg}"
+  local body
+  body=$(curl -s -X POST "${BASE}/v1/videos" \
+    --form "model=${VIDEO_ALIAS}" \
+    --form "prompt=subject turns" \
+    --form "input_reference=@${tmpimg}")
+  rm -f "${tmpimg}"
+  assert_error "${body}" "model_not_ready"
+}
+
 # ── Model lifecycle ───────────────────────────────────────────────────
 # Run last — unloading a model affects subsequent tests.
 

--- a/packages/cli/test/e2e.bats
+++ b/packages/cli/test/e2e.bats
@@ -754,14 +754,14 @@ TINY_PNG_B64="iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDw
 @test "videos: JSON img2vid with data URI reaches model check (returns 503 model_not_ready)" {
   local body
   body=$(json_post "/v1/videos" \
-    "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"subject turns\",\"input_reference\":{\"image_url\":{\"url\":\"data:image/png;base64,${TINY_PNG_B64}\"}}}")
+    "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"subject turns\",\"input_reference\":{\"image_url\":\"data:image/png;base64,${TINY_PNG_B64}\"}}")
   assert_error "${body}" "model_not_ready"
 }
 
 @test "videos: JSON img2vid with HTTP URL reaches model check (returns 503 model_not_ready)" {
   local body
   body=$(json_post "/v1/videos" \
-    "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"subject turns\",\"input_reference\":{\"image_url\":{\"url\":\"http://127.0.0.1:${E2E_PORT}/v1/models\"}}}")
+    "{\"model\":\"${VIDEO_ALIAS}\",\"prompt\":\"subject turns\",\"input_reference\":{\"image_url\":\"http://127.0.0.1:${E2E_PORT}/v1/models\"}}")
   assert_error "${body}" "model_not_ready"
 }
 

--- a/packages/cli/test/videos.test.ts
+++ b/packages/cli/test/videos.test.ts
@@ -4,6 +4,7 @@ import {
   videosCreateBody,
   extractVideoCreateParams,
   nearestVideoFrameCount,
+  InvalidVideoStrengthError,
   DEFAULT_FPS
 } from '../src/serve/schemas/videos.js'
 import { createVideoJobsStore, type VideoJob } from '../src/serve/core/video-jobs-store.js'
@@ -75,9 +76,19 @@ describe('videosCreateBody (Zod validation)', () => {
     })
   })
 
-  it('rejects input_reference (img2vid not supported)', () => {
-    const result = expectIssue({ prompt: 'p', input_reference: { image_url: 'x' } }, 'input_reference')
-    assert.match(result.message, /image-to-video|not supported/i)
+  it('accepts init_image as a Buffer', () => {
+    const buf = Buffer.from('fake-png-bytes')
+    assert.equal(videosCreateBody.safeParse({ prompt: 'p', init_image: buf }).success, true)
+  })
+
+  it('accepts strength as a number', () => {
+    assert.equal(videosCreateBody.safeParse({ prompt: 'p', strength: 0.85 }).success, true)
+    assert.equal(videosCreateBody.safeParse({ prompt: 'p', strength: 0 }).success, true)
+    assert.equal(videosCreateBody.safeParse({ prompt: 'p', strength: 1 }).success, true)
+  })
+
+  it('accepts strength as a numeric string (multipart coercion handled by extractor)', () => {
+    assert.equal(videosCreateBody.safeParse({ prompt: 'p', strength: '0.85' }).success, true)
   })
 })
 
@@ -99,8 +110,8 @@ describe('nearestVideoFrameCount', () => {
 })
 
 describe('extractVideoCreateParams', () => {
-  it('returns mode=txt2vid and the modelId', () => {
-    const params = extractVideoCreateParams({ prompt: 'a cat surfing' }, 'sdk-vid-1')
+  it('returns mode=txt2vid when no initImage', () => {
+    const params = extractVideoCreateParams({ prompt: 'a cat surfing' }, undefined, 'sdk-vid-1')
     assert.equal(params.modelId, 'sdk-vid-1')
     assert.equal(params.mode, 'txt2vid')
     assert.equal(params.prompt, 'a cat surfing')
@@ -111,26 +122,70 @@ describe('extractVideoCreateParams', () => {
   })
 
   it('translates size → width/height', () => {
-    const params = extractVideoCreateParams({ prompt: 'p', size: '480x832' }, 'm')
+    const params = extractVideoCreateParams({ prompt: 'p', size: '480x832' }, undefined, 'm')
     assert.equal(params.width, 480)
     assert.equal(params.height, 832)
   })
 
   it('translates seconds → video_frames using default fps', () => {
-    const params = extractVideoCreateParams({ prompt: 'p', seconds: '4' }, 'm')
+    const params = extractVideoCreateParams({ prompt: 'p', seconds: '4' }, undefined, 'm')
     assert.equal(params.video_frames, 4 * DEFAULT_FPS + 1)
   })
 
   it('translates seconds → video_frames using explicit fps', () => {
-    const params = extractVideoCreateParams({ prompt: 'p', seconds: '2', fps: 24 }, 'm')
+    const params = extractVideoCreateParams({ prompt: 'p', seconds: '2', fps: 24 }, undefined, 'm')
     assert.equal(params.fps, 24)
     assert.equal(params.video_frames, 49)
   })
 
   it('passes through seed and steps when present', () => {
-    const params = extractVideoCreateParams({ prompt: 'p', seed: 42, steps: 1 }, 'm')
+    const params = extractVideoCreateParams({ prompt: 'p', seed: 42, steps: 1 }, undefined, 'm')
     assert.equal(params.seed, 42)
     assert.equal(params.steps, 1)
+  })
+
+  describe('img2vid mode', () => {
+    const initImage = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+
+    it('returns mode=img2vid with init_image when initImage is provided', () => {
+      const params = extractVideoCreateParams({ prompt: 'turns and smiles' }, initImage, 'm')
+      assert.equal(params.mode, 'img2vid')
+      assert.equal((params as Record<string, unknown>).init_image, initImage)
+      assert.equal(params.prompt, 'turns and smiles')
+    })
+
+    it('includes coerced strength when provided as number', () => {
+      const params = extractVideoCreateParams({ prompt: 'p', strength: 0.85 }, initImage, 'm')
+      assert.equal((params as Record<string, unknown>).strength, 0.85)
+    })
+
+    it('coerces strength from string to float', () => {
+      const params = extractVideoCreateParams({ prompt: 'p', strength: '0.5' }, initImage, 'm')
+      assert.equal((params as Record<string, unknown>).strength, 0.5)
+    })
+
+    it('omits strength when not provided', () => {
+      const params = extractVideoCreateParams({ prompt: 'p' }, initImage, 'm')
+      assert.equal('strength' in params, false)
+    })
+
+    it('throws InvalidVideoStrengthError for out-of-range strength', () => {
+      assert.throws(
+        () => extractVideoCreateParams({ prompt: 'p', strength: 1.5 }, initImage, 'm'),
+        InvalidVideoStrengthError
+      )
+      assert.throws(
+        () => extractVideoCreateParams({ prompt: 'p', strength: -0.1 }, initImage, 'm'),
+        InvalidVideoStrengthError
+      )
+    })
+
+    it('throws InvalidVideoStrengthError for non-numeric strength string', () => {
+      assert.throws(
+        () => extractVideoCreateParams({ prompt: 'p', strength: 'high' }, initImage, 'm'),
+        InvalidVideoStrengthError
+      )
+    })
   })
 })
 

--- a/packages/cli/test/videos.test.ts
+++ b/packages/cli/test/videos.test.ts
@@ -91,6 +91,10 @@ describe('videosCreateBody (Zod validation)', () => {
   it('accepts strength as a numeric string (multipart coercion handled by extractor)', () => {
     assert.equal(videosCreateBody.safeParse({ prompt: 'p', strength: '0.85' }).success, true)
   })
+
+  it('rejects input_reference — unsupported OpenAI img2vid field', () => {
+    expectIssue({ prompt: 'p', input_reference: { image_url: { url: 'x' } } }, 'input_reference')
+  })
 })
 
 describe('nearestVideoFrameCount', () => {

--- a/packages/cli/test/videos.test.ts
+++ b/packages/cli/test/videos.test.ts
@@ -8,7 +8,7 @@ import {
   DEFAULT_FPS
 } from '../src/serve/schemas/videos.js'
 import { createVideoJobsStore, type VideoJob } from '../src/serve/core/video-jobs-store.js'
-import { tearDownJob } from '../src/serve/routes/videos.js'
+import { tearDownJob, resolveInputReferenceImage } from '../src/serve/routes/videos.js'
 import type { QvacContext } from '../src/serve/lib/types.js'
 
 function expectIssue (input: unknown, path: string): { message: string } {
@@ -103,6 +103,11 @@ describe('videosCreateBody (Zod validation)', () => {
 
   it('accepts strength as a number or numeric string', () => {
     assert.equal(videosCreateBody.safeParse({ prompt: 'p', strength: '0.85' }).success, true)
+  })
+
+  it('accepts input_reference as a Buffer (multipart file)', () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    assert.equal(videosCreateBody.safeParse({ prompt: 'p', input_reference: buf }).success, true)
   })
 })
 
@@ -327,6 +332,24 @@ function makeJob (overrides: Partial<VideoJob> = {}): VideoJob {
   }
   return { ...base, ...overrides }
 }
+
+describe('resolveInputReferenceImage', () => {
+  it('rejects data URI with invalid base64 characters', async () => {
+    const ctx = makeCtxStub()
+    await assert.rejects(
+      () => resolveInputReferenceImage({ image_url: 'data:image/jpeg;base64,!!!invalid!!!' }, ctx),
+      (err: unknown) => err instanceof Error && err.message.includes('invalid base64 characters')
+    )
+  })
+
+  it('rejects data URI that decodes to empty bytes', async () => {
+    const ctx = makeCtxStub()
+    await assert.rejects(
+      () => resolveInputReferenceImage({ image_url: 'data:image/jpeg;base64,' }, ctx),
+      (err: unknown) => err instanceof Error && err.message.includes('empty bytes')
+    )
+  })
+})
 
 describe('tearDownJob', () => {
   it('aborts the controller and cancels the SDK request for in-progress jobs', () => {

--- a/packages/cli/test/videos.test.ts
+++ b/packages/cli/test/videos.test.ts
@@ -77,9 +77,16 @@ describe('videosCreateBody (Zod validation)', () => {
     })
   })
 
-  it('accepts init_image as a Buffer', () => {
-    const buf = Buffer.from('fake-png-bytes')
-    assert.equal(videosCreateBody.safeParse({ prompt: 'p', init_image: buf }).success, true)
+  it('accepts input_reference with image_url.url', () => {
+    const r = videosCreateBody.safeParse({
+      prompt: 'p',
+      input_reference: { image_url: { url: 'data:image/jpeg;base64,/9j/' } }
+    })
+    assert.equal(r.success, true)
+  })
+
+  it('rejects input_reference missing image_url', () => {
+    expectIssue({ prompt: 'p', input_reference: { not_image_url: 'x' } }, 'input_reference/image_url')
   })
 
   it('accepts strength as a number', () => {
@@ -88,12 +95,8 @@ describe('videosCreateBody (Zod validation)', () => {
     assert.equal(videosCreateBody.safeParse({ prompt: 'p', strength: 1 }).success, true)
   })
 
-  it('accepts strength as a numeric string (multipart coercion handled by extractor)', () => {
+  it('accepts strength as a number or numeric string', () => {
     assert.equal(videosCreateBody.safeParse({ prompt: 'p', strength: '0.85' }).success, true)
-  })
-
-  it('rejects input_reference — unsupported OpenAI img2vid field', () => {
-    expectIssue({ prompt: 'p', input_reference: { image_url: { url: 'x' } } }, 'input_reference')
   })
 })
 

--- a/packages/cli/test/videos.test.ts
+++ b/packages/cli/test/videos.test.ts
@@ -77,16 +77,22 @@ describe('videosCreateBody (Zod validation)', () => {
     })
   })
 
-  it('accepts input_reference with image_url.url', () => {
-    const r = videosCreateBody.safeParse({
+  it('accepts input_reference with image_url as a flat string', () => {
+    assert.equal(videosCreateBody.safeParse({
       prompt: 'p',
-      input_reference: { image_url: { url: 'data:image/jpeg;base64,/9j/' } }
-    })
-    assert.equal(r.success, true)
+      input_reference: { image_url: 'data:image/jpeg;base64,/9j/' }
+    }).success, true)
   })
 
-  it('rejects input_reference missing image_url', () => {
-    expectIssue({ prompt: 'p', input_reference: { not_image_url: 'x' } }, 'input_reference/image_url')
+  it('accepts input_reference with file_id', () => {
+    assert.equal(videosCreateBody.safeParse({
+      prompt: 'p',
+      input_reference: { file_id: 'file-abc123' }
+    }).success, true)
+  })
+
+  it('rejects input_reference with neither image_url nor file_id', () => {
+    expectIssue({ prompt: 'p', input_reference: { not_image_url: 'x' } }, 'input_reference')
   })
 
   it('accepts strength as a number', () => {

--- a/packages/cli/test/videos.test.ts
+++ b/packages/cli/test/videos.test.ts
@@ -298,16 +298,32 @@ describe('createVideoJobsStore', () => {
 function makeCtxStub (opts: {
   cancelOverride?: QvacContext['cancelOverride']
   removed?: string[]
+  files?: Record<string, { data: Buffer } | undefined>
 } = {}): QvacContext {
   const removed = opts.removed ?? []
+  const files = opts.files ?? {}
   const stub = {
     logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
-    ephemeralFiles: { remove: (id: string) => { removed.push(id) } }
+    ephemeralFiles: {
+      remove: (id: string) => { removed.push(id) },
+      get: (id: string) => files[id]
+    }
   } as unknown as QvacContext
   if (opts.cancelOverride) {
     (stub as { cancelOverride?: QvacContext['cancelOverride'] }).cancelOverride = opts.cancelOverride
   }
   return stub
+}
+
+// Temporarily replaces globalThis.fetch for a single async test body; always restores.
+async function withMockFetch<T> (mock: typeof globalThis.fetch, fn: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch
+  globalThis.fetch = mock
+  try {
+    return await fn()
+  } finally {
+    globalThis.fetch = original
+  }
 }
 
 function makeJob (overrides: Partial<VideoJob> = {}): VideoJob {
@@ -334,6 +350,24 @@ function makeJob (overrides: Partial<VideoJob> = {}): VideoJob {
 }
 
 describe('resolveInputReferenceImage', () => {
+  // ── data URI ─────────────────────────────────────────────────────────
+
+  it('rejects data URI missing the comma separator', async () => {
+    const ctx = makeCtxStub()
+    await assert.rejects(
+      () => resolveInputReferenceImage({ image_url: 'data:image/jpeg;base64' }, ctx),
+      (err: unknown) => err instanceof Error && err.message.includes('comma separator')
+    )
+  })
+
+  it('rejects data URI with non-base64 encoding header', async () => {
+    const ctx = makeCtxStub()
+    await assert.rejects(
+      () => resolveInputReferenceImage({ image_url: 'data:image/jpeg;utf8,hello' }, ctx),
+      (err: unknown) => err instanceof Error && err.message.includes('base64-encoded')
+    )
+  })
+
   it('rejects data URI with invalid base64 characters', async () => {
     const ctx = makeCtxStub()
     await assert.rejects(
@@ -347,6 +381,129 @@ describe('resolveInputReferenceImage', () => {
     await assert.rejects(
       () => resolveInputReferenceImage({ image_url: 'data:image/jpeg;base64,' }, ctx),
       (err: unknown) => err instanceof Error && err.message.includes('empty bytes')
+    )
+  })
+
+  it('returns decoded bytes for a valid data URI', async () => {
+    const ctx = makeCtxStub()
+    // "AQID" is base64 for [0x01, 0x02, 0x03]
+    const result = await resolveInputReferenceImage({ image_url: 'data:image/png;base64,AQID' }, ctx)
+    assert.deepEqual(result, new Uint8Array([0x01, 0x02, 0x03]))
+  })
+
+  // ── unknown scheme ───────────────────────────────────────────────────
+
+  it('rejects an unknown URL scheme', async () => {
+    const ctx = makeCtxStub()
+    await assert.rejects(
+      () => resolveInputReferenceImage({ image_url: 'ftp://example.com/img.png' }, ctx),
+      (err: unknown) => err instanceof Error && err.message.includes('base64 data URI or an HTTP(S) URL')
+    )
+  })
+
+  // ── file_id ──────────────────────────────────────────────────────────
+
+  it('rejects an unknown file_id', async () => {
+    const ctx = makeCtxStub({ files: {} })
+    await assert.rejects(
+      () => resolveInputReferenceImage({ file_id: 'file-missing' }, ctx),
+      (err: unknown) => err instanceof Error && err.message.includes('not found')
+    )
+  })
+
+  it('returns bytes for a known file_id', async () => {
+    const data = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+    const ctx = makeCtxStub({ files: { 'file-abc': { data } } })
+    const result = await resolveInputReferenceImage({ file_id: 'file-abc' }, ctx)
+    assert.deepEqual(result, new Uint8Array([0x89, 0x50, 0x4e, 0x47]))
+  })
+
+  // ── HTTP fetch ───────────────────────────────────────────────────────
+
+  it('rejects HTTP URL that returns a non-200 response', async () => {
+    const ctx = makeCtxStub()
+    await withMockFetch(
+      async () => ({ ok: false, status: 404 } as Response),
+      async () => {
+        await assert.rejects(
+          () => resolveInputReferenceImage({ image_url: 'https://example.com/img.png' }, ctx),
+          (err: unknown) => err instanceof Error && err.message.includes('HTTP 404')
+        )
+      }
+    )
+  })
+
+  it('rejects HTTP URL when fetch throws a network error', async () => {
+    const ctx = makeCtxStub()
+    await withMockFetch(
+      async () => { throw new Error('ECONNREFUSED') },
+      async () => {
+        await assert.rejects(
+          () => resolveInputReferenceImage({ image_url: 'https://example.com/img.png' }, ctx),
+          (err: unknown) => err instanceof Error && err.message.includes('ECONNREFUSED')
+        )
+      }
+    )
+  })
+
+  it('rejects HTTP URL when fetch times out on initial connect', async () => {
+    const ctx = makeCtxStub()
+    const timeoutErr = Object.assign(new Error('fetch timed out'), { name: 'TimeoutError' })
+    await withMockFetch(
+      async () => { throw timeoutErr },
+      async () => {
+        await assert.rejects(
+          () => resolveInputReferenceImage({ image_url: 'https://example.com/img.png' }, ctx),
+          (err: unknown) => err instanceof Error && err.message.includes('timed out after')
+        )
+      }
+    )
+  })
+
+  it('rejects HTTP URL when response body exceeds the 100 MB limit', async () => {
+    const ctx = makeCtxStub()
+    const bigChunk = new Uint8Array(101 * 1024 * 1024)
+    await withMockFetch(
+      async () => ({
+        ok: true,
+        status: 200,
+        body: {
+          getReader: () => ({
+            read: async () => ({ done: false, value: bigChunk }),
+            cancel: async () => {},
+            releaseLock: () => {}
+          })
+        }
+      } as unknown as Response),
+      async () => {
+        await assert.rejects(
+          () => resolveInputReferenceImage({ image_url: 'https://example.com/big.png' }, ctx),
+          (err: unknown) => err instanceof Error && err.message.includes('exceeds')
+        )
+      }
+    )
+  })
+
+  it('rejects HTTP URL when body read throws an error', async () => {
+    const ctx = makeCtxStub()
+    await withMockFetch(
+      async () => ({
+        ok: true,
+        status: 200,
+        body: {
+          getReader: () => ({
+            read: async () => { throw new Error('stream error') },
+            cancel: async () => {},
+            releaseLock: () => {}
+          })
+        }
+      } as unknown as Response),
+      async () => {
+        await assert.rejects(
+          () => resolveInputReferenceImage({ image_url: 'https://example.com/img.png' }, ctx),
+          (err: unknown) => err instanceof Error && err.message.includes('failed reading response body')
+        )
+      }
     )
   })
 })

--- a/packages/cli/test/videos.test.ts
+++ b/packages/cli/test/videos.test.ts
@@ -30,14 +30,15 @@ describe('videosCreateBody (Zod validation)', () => {
   })
 
   describe('size', () => {
-    it('accepts WxH multiples of 8', () => {
+    it('accepts WxH multiples of 16', () => {
       assert.equal(videosCreateBody.safeParse({ prompt: 'p', size: '480x832' }).success, true)
       assert.equal(videosCreateBody.safeParse({ prompt: 'p', size: '720x1280' }).success, true)
     })
 
-    it('rejects non-multiples of 8', () => {
+    it('rejects non-multiples of 16', () => {
       expectIssue({ prompt: 'p', size: '481x832' }, 'size')
       expectIssue({ prompt: 'p', size: '480x833' }, 'size')
+      expectIssue({ prompt: 'p', size: '488x832' }, 'size')
     })
 
     it('rejects malformed', () => {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `POST /v1/videos` only supported text-to-video; callers had no way to animate a still image via the CLI OpenAI server.
- When using the OpenAI SDK with a local file (`Uploadable`), the SDK sends `multipart/form-data` with `input_reference` as a binary file field — this was not accepted.
- Remote HTTP images fetched for `input_reference.image_url` had no size cap or timeout.
- Invalid base64 in a data URI was silently stripped by `Buffer.from()` instead of being rejected.

## 📝 How does it solve it?

- Adds `multipartToBodyOptional` hook — no-op for JSON, parses multipart otherwise; wired as `preValidation` on `POST /v1/videos` only (existing routes unchanged).
- `input_reference` schema becomes `z.union([z.instanceof(Buffer), z.object({ image_url, file_id })])` — Buffer path handles the multipart file field, object path handles the existing JSON forms.
- `z.coerce.number()` on `fps`, `steps`, `seed`, `cfg_scale`, `flow_shift` so multipart text-delivered values are coerced before validation.
- Strict base64: `/^[A-Za-z0-9+/]*={0,2}$/` validates the full payload before `Buffer.from()`; empty decode is also rejected with `400 invalid_input_reference`.
- Bounded HTTP fetch: `AbortSignal.timeout(30 s)` on initial connect; streaming `getReader()` byte-count aborts and returns `400 invalid_input_reference` if the image exceeds 100 MB.
- `strength` (0–1) controls denoise intensity; coerced from string for multipart compatibility.

## 🔌 API Changes

**img2vid via local file (OpenAI SDK `Uploadable`):**

```typescript
import OpenAI, { toFile } from 'openai'
import fs from 'node:fs'

const client = new OpenAI({ baseURL: 'http://localhost:11434/v1' })

const job = await client.videos.create({
  model: 'wan-i2v',
  prompt: 'subject slowly turns and smiles',
  input_reference: await toFile(fs.createReadStream('./frame.png'), 'frame.png'),
})
```

**img2vid via data URI or file_id (JSON):**

```typescript
const job = await client.videos.create({
  model: 'wan-i2v',
  prompt: 'subject slowly turns and smiles',
  input_reference: { image_url: 'data:image/png;base64,...' },
})
```

## 🧪 How was it tested?

- Unit tests cover all `resolveInputReferenceImage` paths: Buffer schema, data URI error cases (invalid chars, empty decode, missing comma, non-base64 header), unknown scheme, `file_id` (found/not-found), HTTP fetch (non-200, network error, timeout, >100 MB body, read error), and happy paths (400/400 pass).
- BATS e2e: multipart `POST /v1/videos` with `input_reference` file field reaches `requireModel` and returns `503 model_not_ready` (139/139 pass).
- Tested locally with workspace SDK (`npm run sdk-source:workspace`); `package.json` not committed.
- Actual img2vid execution requires a model loaded with `clipVisionModelSrc` and hardware — functional tests are a follow-up.