### PR TITLE
QVAC-19797 test[api]: ocr-ggml Metal GPU perf coverage + easyocr gallocr memory fix

### DIFF
--- a/packages/ocr-ggml/addon/src/model-interface/easyocr/pipeline/step_detection_inference.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/easyocr/pipeline/step_detection_inference.cpp
@@ -250,7 +250,20 @@ void StepDetectionInference::ensureGraph(int H, int W) {
     return;
   }
 
-  destroyGraph();
+  // Free only the size-specific graph context; deliberately KEEP
+  // graphCache_.gallocr (and its backing backend buffer) so it is reused — and
+  // resized in place by ggml_gallocr_alloc_graph below — across input sizes.
+  // Freeing and reallocating a differently-sized GPU buffer on every size
+  // change churns the backend heap and can trigger out-of-memory command-buffer
+  // failures on memory-constrained devices (phones, small CI runners), even
+  // when steady-state footprint stays flat.
+  if (graphCache_.gctx != nullptr) {
+    ggml_free(graphCache_.gctx);
+    graphCache_.gctx = nullptr;
+  }
+  graphCache_.gf = nullptr;
+  graphCache_.x = nullptr;
+  graphCache_.out = nullptr;
 
   const size_t graph_ctx_size =
       (ggml_tensor_overhead() * GGML_DEFAULT_GRAPH_SIZE) +
@@ -275,8 +288,10 @@ void StepDetectionInference::ensureGraph(int H, int W) {
       ggml_new_graph_custom(graphCache_.gctx, GGML_DEFAULT_GRAPH_SIZE, false);
   ggml_build_forward_expand(graphCache_.gf, graphCache_.out);
 
-  graphCache_.gallocr =
-      ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+  if (graphCache_.gallocr == nullptr) {
+    graphCache_.gallocr =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+  }
   if (!ggml_gallocr_alloc_graph(graphCache_.gallocr, graphCache_.gf)) {
     destroyGraph();
     throw std::runtime_error(

--- a/packages/ocr-ggml/addon/src/model-interface/easyocr/pipeline/step_recognize_text.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/easyocr/pipeline/step_recognize_text.cpp
@@ -1104,7 +1104,20 @@ void StepRecognizeText::ensureRecognizerGraph(
     return;
   }
 
-  destroyRecognizerGraph();
+  // Free only the size-specific graph context; deliberately KEEP
+  // recognizerGraphCache_.gallocr so its backing backend buffer is reused (and
+  // resized in place by ggml_gallocr_alloc_graph below) across region sizes.
+  // EasyOCR rebuilds this graph once per distinct text-region width, so
+  // freeing+reallocating the gallocr buffer every time is the heaviest source
+  // of backend-heap churn — which fragments the Metal heap and can trigger
+  // out-of-memory command-buffer failures on memory-constrained devices.
+  if (recognizerGraphCache_.gctx != nullptr) {
+    ggml_free(recognizerGraphCache_.gctx);
+    recognizerGraphCache_.gctx = nullptr;
+  }
+  recognizerGraphCache_.graph = nullptr;
+  recognizerGraphCache_.input = nullptr;
+  recognizerGraphCache_.output = nullptr;
 
   const size_t graphCtxSize = (ggml_tensor_overhead() * graphSize) +
                               ggml_graph_overhead_custom(graphSize, false);
@@ -1130,8 +1143,10 @@ void StepRecognizeText::ensureRecognizerGraph(
   ggml_build_forward_expand(
       recognizerGraphCache_.graph, recognizerGraphCache_.output);
 
-  recognizerGraphCache_.gallocr =
-      ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+  if (recognizerGraphCache_.gallocr == nullptr) {
+    recognizerGraphCache_.gallocr =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+  }
   if (!ggml_gallocr_alloc_graph(
           recognizerGraphCache_.gallocr, recognizerGraphCache_.graph)) {
     destroyRecognizerGraph();

--- a/packages/ocr-ggml/test/integration/doctr-ct-scan.test.js
+++ b/packages/ocr-ggml/test/integration/doctr-ct-scan.test.js
@@ -40,10 +40,11 @@ function runCtScanTest (device, run) {
     t.comment(`Testing DocTR on CT scan diagnostic report image [${tag}] (run ${run}/${PERF_RUNS})`)
     t.comment('Detector: db_mobilenet_v3_large, Recognizer: crnn_mobilenet_v3_small (CTC)')
 
-    // On a GPU host this records a Vulkan ([GPU]) and a forced-CPU ([CPU]) row
-    // for the same test; on non-GPU/local it stays a single CPU pass. The
-    // assertions run on each pass. The `[${tag}]` token (always CPU here) is
-    // normalized to the actual backend by formatOCRPerformanceMetrics.
+    // On a Vulkan GPU host this records a [GPU] and a forced-CPU [CPU] row for
+    // the same test; on non-GPU/local it stays a single CPU pass. The
+    // assertions run on each pass. On Apple/Metal runDoctrComparison forces CPU
+    // (the DocTR recognizer is unstable on the constrained macOS CI runner), so
+    // this stays CPU-only on Metal while Vulkan still records a [GPU] row.
     await runDoctrComparison(t, {
       params: {
         pathDetector: DB_MOBILENET,

--- a/packages/ocr-ggml/test/integration/doctr-models.test.js
+++ b/packages/ocr-ggml/test/integration/doctr-models.test.js
@@ -110,16 +110,21 @@ test('DocTR recognizerBatchSize - batch=1 vs batch=16 both produce valid output'
   const imagePath = getImagePath('/test/images/english.bmp')
   t.comment('Testing recognizerBatchSize=1 vs recognizerBatchSize=16')
 
+  // Backend-agnostic correctness check (batch=1 vs batch=16 output identity),
+  // not a perf comparison — force CPU so it stays deterministic and avoids the
+  // DocTR-recognizer-on-Metal instability on the constrained macOS CI runner.
   const { results: resultsBatch1 } = await runDoctrOCR(t, {
     pathDetector: DB_MOBILENET,
     pathRecognizer: CRNN_MOBILENET,
-    recognizerBatchSize: 1
+    recognizerBatchSize: 1,
+    backendDevice: 'cpu'
   }, imagePath)
 
   const { results: resultsBatch16 } = await runDoctrOCR(t, {
     pathDetector: DB_MOBILENET,
     pathRecognizer: CRNN_MOBILENET,
-    recognizerBatchSize: 16
+    recognizerBatchSize: 16,
+    backendDevice: 'cpu'
   }, imagePath)
 
   const textsBatch1 = resultsBatch1.map(r => r.text)

--- a/packages/ocr-ggml/test/integration/utils.js
+++ b/packages/ocr-ggml/test/integration/utils.js
@@ -336,34 +336,44 @@ function findVulkanBackendLib (dir) {
  *
  * Precedence:
  *   1. Explicit `OCR_GGML_BACKEND` (via `os.getEnv` then `process.env`) wins —
- *      'vulkan' only when exactly `vulkan` (case-insensitive), else 'cpu'. This
- *      preserves a manual override (e.g. workflow_dispatch / forcing CPU).
+ *      accepts a known GPU backend ('vulkan' or 'metal', case-insensitive),
+ *      else 'cpu'. This preserves a manual override (e.g. workflow_dispatch /
+ *      forcing CPU, or forcing a specific GPU backend).
  *   2. On Android, auto-select 'vulkan': the `android-arm64` prebuild always
  *      ships `libqvac-ggml-vulkan.so`, so the suite (and the CPU↔Vulkan perf
  *      comparison) exercises Vulkan on-device. Mali GPUs (e.g. Pixel) run on
  *      Vulkan; Adreno GPUs auto-fall-back to CPU via the OcrBackendSelection
  *      Adreno guard. iOS has no Vulkan (Metal/MoltenVK) so it stays on CPU.
- *   3. Else, on desktop, auto-select 'vulkan' when a `ggml-vulkan` backend lib
- *      is shipped in prebuilds/. On desktop CI the merged prebuilds/ contains
+ *   3. Else, on Apple desktop, select 'metal'. ggml's Metal backend is compiled
+ *      into the addon on darwin (there is no separate loadable lib to probe, so
+ *      the Vulkan-lib check below does not apply), so the suites request Metal
+ *      directly; the addon falls back to CPU if no Metal device is present.
+ *   4. Else, on other desktop, auto-select 'vulkan' when a `ggml-vulkan` backend
+ *      lib is shipped in prebuilds/. On desktop CI the merged prebuilds/ contains
  *      that lib, so the suites attempt Vulkan; only the GPU runner actually
  *      executes on Vulkan, while other runners report an explicit CPU fallback.
  *      Local dev without merged prebuilds (no lib) stays on CPU. The addon
  *      gracefully falls back to CPU when no Vulkan GPU is present, so requesting
  *      'vulkan' is safe on non-GPU hosts.
- *   4. Else 'cpu'.
- * @returns {'cpu'|'vulkan'}
+ *   5. Else 'cpu' (iOS, and desktop without a GPU backend).
+ * @returns {'cpu'|'vulkan'|'metal'}
  */
 function getBackendDevice () {
   let raw = ''
   if (typeof os.getEnv === 'function') raw = os.getEnv('OCR_GGML_BACKEND') || ''
   if (!raw && process.env) raw = process.env.OCR_GGML_BACKEND || ''
-  if (String(raw).trim() !== '') {
-    return String(raw).trim().toLowerCase() === 'vulkan' ? 'vulkan' : 'cpu'
+  const override = String(raw).trim().toLowerCase()
+  if (override !== '') {
+    return (override === 'vulkan' || override === 'metal') ? override : 'cpu'
   }
   // Android always ships the Vulkan backend lib; request Vulkan so the perf
   // suite fills the GPU column on Mali devices (Adreno safely falls back to CPU
   // via the addon's Adreno guard). iOS has no Vulkan → CPU.
   if (isMobile) return platform === 'android' ? 'vulkan' : 'cpu'
+  // Apple desktop: ggml's Metal backend is compiled into the addon (no loadable
+  // lib to probe), so request Metal directly; the addon falls back to CPU if no
+  // Metal device is present.
+  if (platform === 'darwin') return 'metal'
   if (findVulkanBackendLib(PREBUILDS_DIR)) return 'vulkan'
   return 'cpu'
 }

--- a/packages/ocr-ggml/test/integration/utils.js
+++ b/packages/ocr-ggml/test/integration/utils.js
@@ -975,7 +975,21 @@ async function runOcrComparison (t, cfg) {
 async function runDoctrComparison (t, cfg) {
   const { params, imagePath, perfLabel, perfOpts, assertResult } = cfg
 
-  const pass1 = await runDoctrOCR(t, params, imagePath)
+  // Metal scoping: the DocTR recognizer runs ggml_backend_graph_compute once
+  // per detected region, and on the constrained `macos-15-xlarge` CI runner the
+  // Metal backend is non-deterministically unstable under that sustained load —
+  // it either aborts the suite ("[DoctrRecognitionGGML] ggml backend graph
+  // compute failed with status -1", exit 134) or silently collapses detection
+  // to garbage. The same image's BMP passes while its JPEG/PNG fail, so there is
+  // no stable per-test subset. Force CPU for ALL DocTR tests when the
+  // auto-selected backend is Metal; Vulkan keeps its GPU pass, and EasyOCR
+  // (runOcrComparison, a different recognizer path) keeps Metal. See the
+  // ocr-ggml Metal memory-pressure investigation.
+  const pass1Params = (getBackendDevice() === 'metal')
+    ? { ...params, backendDevice: 'cpu' }
+    : params
+
+  const pass1 = await runDoctrOCR(t, pass1Params, imagePath)
   const isGpuPass1 = !!(pass1.stats && pass1.stats.backendIsGpu === 1)
   if (perfLabel) {
     t.comment(formatOCRPerformanceMetrics(perfLabel, pass1.stats, pass1.results.map(r => r.text), perfOpts))


### PR DESCRIPTION
## Summary

Adds Metal GPU performance coverage to the ocr-ggml CI perf table plus an EasyOCR backend-memory fix. Rebased onto current `main` (after #2457 landed the Adreno guard + Android-Vulkan, and alongside in-flight #2458 for the CPU-vs-Vulkan benchmark).

### Commits
- **fix[api]: reuse `ggml_gallocr` across input sizes** (easyocr detection + recognition steps) — keep the gallocr/backing buffer alive and resize in place across region widths instead of free+recreate per size. Cuts the backend-heap churn that fragments the Metal heap and triggers OOM command-buffer failures on memory-constrained devices.
- **test[api]: select Metal on Apple desktop** — `getBackendDevice()` returns `metal` on darwin (was vulkan|cpu only), so the macOS leg records Metal `[GPU]` rows. Merged with main's Android-Vulkan selection; the `OCR_GGML_BACKEND` override now also accepts `metal`.
- **test[api]: run DocTR on CPU under Metal** — the DocTR recognizer's per-region ggml compute is non-deterministically unstable on the constrained `macos-15-xlarge` runner (aborts `status -1` / silent detection collapse). DocTR forces CPU on Metal; EasyOCR (stable on Metal) keeps its Metal GPU pass. This is a **deliberate scope, not a fix** — see follow-up below.

### Backend coverage in the combined perf table
| Backend | Coverage |
|---|---|
| CPU | all platforms |
| Vulkan `[GPU]` | Linux (ubuntu-24.04) + Windows (EasyOCR + DocTR); Android Mali via #2458 |
| Metal `[GPU]` | macOS — EasyOCR (DocTR CPU-only there by design) |

### Follow-up (separate work)
- **DocTR-on-Metal stability** — the real fix is an open GPU-memory-pressure investigation (couldn't reproduce on the 192 GB M3 Ultra; next step is repro on the constrained `mac-mini-1` M4 with GPU-allocation tracking). Tracked separately so this PR isn't blocked on it.
- Mobile GPU beyond Android-Vulkan and the Adreno guard already on main.
