### PR TITLE
QVAC-19614 doc: fix docs sidebar jump and Mermaid layout shift

### DIFF
--- a/docs/website/content/docs/ai-capabilities/voice-assistant.mdx
+++ b/docs/website/content/docs/ai-capabilities/voice-assistant.mdx
@@ -14,11 +14,9 @@ flowchart LR
     LLM -->|response text| TTS[TTS<br/>Supertonic]
     TTS -->|audio| Spk([Speakers])
     Spk -.conversation loop.-> Mic
-
-    click ASR "/ai-capabilities/transcription" "Transcription"
-    click LLM "/ai-capabilities/text-generation" "Text generation"
-    click TTS "/ai-capabilities/text-to-speech" "Text-to-speech"
 ```
+
+Each stage maps to a QVAC capability — [Transcription](/ai-capabilities/transcription) (ASR), [Text generation](/ai-capabilities/text-generation) (LLM), and [Text-to-Speech](/ai-capabilities/text-to-speech) (TTS).
 
 Compared to using each capability individually, the key differences are:
 - You need to coordinate **three model loads** simultaneously (Whisper + VAD, LLM, and TTS bundle) — they all stay loaded for the duration of the session.

--- a/docs/website/patches/fumadocs-ui+16.3.2.patch
+++ b/docs/website/patches/fumadocs-ui+16.3.2.patch
@@ -1,7 +1,16 @@
 diff --git a/node_modules/fumadocs-ui/dist/components/sidebar/base.js b/node_modules/fumadocs-ui/dist/components/sidebar/base.js
-index 1de0767..223c00e 100644
+index 1de0767..0a1e1f1 100644
 --- a/node_modules/fumadocs-ui/dist/components/sidebar/base.js
 +++ b/node_modules/fumadocs-ui/dist/components/sidebar/base.js
+@@ -1,7 +1,7 @@
+ 'use client';
+ import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+ import { ChevronDown, ExternalLink } from '@fumadocs/ui/icons';
+-import { createContext, use, useEffect, useMemo, useRef, useState, } from 'react';
++import { createContext, use, useEffect, useLayoutEffect, useMemo, useRef, useState, } from 'react';
+ import Link from 'fumadocs-core/link';
+ import { useOnChange } from 'fumadocs-core/utils/use-on-change';
+ import { cn } from '@fumadocs/ui/cn';
 @@ -104,7 +104,7 @@ export function SidebarDrawerContent({ className, children, ...props }) {
      return (_jsx(Presence, { present: open, children: ({ present }) => (_jsx("aside", { id: "nd-sidebar-mobile", "data-state": state, className: cn(!present && 'invisible', className), ...props, children: children })) }));
  }
@@ -11,3 +20,22 @@ index 1de0767..223c00e 100644
                  maskImage: 'linear-gradient(to bottom, transparent, white 12px, white calc(100% - 12px), transparent)',
              }, children: props.children }) }));
  }
+@@ -173,9 +173,17 @@ export function SidebarCollapseTrigger(props) {
+             setCollapsed((prev) => !prev);
+         }, ...props, children: props.children }));
+ }
++// QVAC patch: reveal the active sidebar entry BEFORE paint instead of after.
++// The upstream `useEffect` runs post-paint, so the new page first paints with
++// a deep active entry (e.g. Voice assistant / API / Release notes) off-screen
++// and then the sidebar's internal scroll viewport snaps to it — the visible
++// "jump". A layout effect performs the same `scrollMode: 'if-needed'` scroll
++// before the browser paints, so the entry is already in place on first frame.
++// Guarded to `useEffect` on the server to avoid the SSR layout-effect warning.
++const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+ function useAutoScroll(active, ref) {
+     const { mode } = useSidebar();
+-    useEffect(() => {
++    useIsomorphicLayoutEffect(() => {
+         if (active && ref.current) {
+             scrollIntoView(ref.current, {
+                 boundary: document.getElementById(mode === 'drawer' ? 'nd-sidebar-mobile' : 'nd-sidebar'),

--- a/docs/website/src/components/mermaid.tsx
+++ b/docs/website/src/components/mermaid.tsx
@@ -1,7 +1,16 @@
 'use client';
 
-import { use, useEffect, useId, useState } from 'react';
+import { Suspense, use, useEffect, useId, useState } from 'react';
 import { useTheme } from 'next-themes';
+
+// Mermaid renders lazily on the client (dynamic `import('mermaid')` + an async
+// render surfaced through `use()`), so without a reserved box the diagram pops
+// in a frame or two after the rest of the page and shoves everything below it
+// down — a layout shift that reads as the content "flicker" on diagram pages.
+// Keep a stable minimum height across the pre-mount, suspended, and rendered
+// states; taller diagrams simply grow past it (downward growth from a floor is
+// not a shift). Sized to comfortably cover a small flowchart.
+const MERMAID_MIN_HEIGHT = 220;
 
 export function Mermaid({ chart }: { chart: string }) {
   const [mounted, setMounted] = useState(false);
@@ -10,8 +19,19 @@ export function Mermaid({ chart }: { chart: string }) {
     setMounted(true);
   }, []);
 
-  if (!mounted) return;
-  return <MermaidContent chart={chart} />;
+  // The reserved box is rendered identically on the server and client so the
+  // diagram swaps in without reflowing the surrounding content. The inner
+  // `Suspense` keeps the dynamic-import/render suspension local to this box
+  // instead of bubbling up and blanking a larger region of the page.
+  return (
+    <div style={{ minHeight: MERMAID_MIN_HEIGHT }}>
+      {mounted ? (
+        <Suspense fallback={null}>
+          <MermaidContent chart={chart} />
+        </Suspense>
+      ) : null}
+    </div>
+  );
 }
 
 const cache = new Map<string, Promise<unknown>>();
@@ -43,9 +63,10 @@ function MermaidContent({ chart }: { chart: string }) {
     // diagram (raw HTML / event handler / script tag injected via the
     // classDef bypasses fixed in 11.15.0) cannot reach the parent DOM,
     // cookies, localStorage, or run authenticated requests as the docs
-    // origin. The `allow-top-navigation-by-user-activation` permission
-    // keeps `click ...` directives working — see
-    // content/docs/sdk/examples/ai-tasks/voice-assistant.mdx.
+    // origin. Note this also means Mermaid `click ... "url"` directives are
+    // inert here — they rely on a JS handler the sandbox blocks — so diagrams
+    // must surface navigation as plain Markdown links beside the chart rather
+    // than as clickable nodes (see ai-capabilities/voice-assistant.mdx).
     securityLevel: 'sandbox',
     fontFamily: 'inherit',
     themeCSS: 'margin: 1.5rem auto 0;',


### PR DESCRIPTION
## What problem does this PR solve?

On the docs site, the left sidebar visibly "jumps" when navigating to a page whose sidebar entry sits below the fold (Voice assistant, API, Release notes), while top-of-list pages (e.g. Quickstart) are unaffected. The Voice assistant page additionally shifts its content when the Mermaid diagram renders, and the diagram's clickable nodes lead nowhere.

## How does it solve it?

- **Sidebar jump** — Fumadocs' notebook sidebar reveals the active entry in a post-paint `useEffect`, so the new page first paints with a deep active entry off-screen and then snaps the sidebar's scroll viewport to it. Extended the existing `docs/website/patches/fumadocs-ui+16.3.2.patch` so `useAutoScroll` runs the same `scrollMode: 'if-needed'` scroll in a pre-paint isomorphic layout effect (`useLayoutEffect` on the client, `useEffect` on the server). The entry is already in place on the first frame, so there is no visible snap.
- **Mermaid layout shift** — `docs/website/src/components/mermaid.tsx` now renders a stable `min-height` box and wraps the lazily-rendered diagram in a local `Suspense` boundary, so the SVG swaps in without reflowing the page and the suspension can't blank a larger region.
- **"Links lead nowhere"** — under `securityLevel: 'sandbox'` the diagram runs in a scriptless iframe, so Mermaid `click` directives can't fire (intentional security hardening). Removed the dead `click` directives from `voice-assistant.mdx` and added real Markdown links to the three capability pages.

## Notes

- The whole-page content flicker on the version switcher is driven by full-reload + CDN redirect chains and is handled in the separate redirects PR; it's out of scope here.
- Validated with a clean `next build` (124/124 pages, TypeScript passes) and the rendered output reflects all three changes; `npm test` passes (238/239, the one failure is a pre-existing `packages/sdk` TSDoc-coverage check unrelated to these files). The runtime "no jump" behavior still warrants a quick visual confirmation in a browser.

## Breaking changes

None.
