### PR TITLE
QVAC-19320 test: use quantised s3gen (q4) models in sdk e2e consumers

### DIFF
--- a/packages/sdk/e2e/tests/desktop/consumer.ts
+++ b/packages/sdk/e2e/tests/desktop/consumer.ts
@@ -15,7 +15,7 @@ import {
   MARIAN_EN_HI_INDIC_200M_Q4_0,
   MARIAN_HI_EN_INDIC_200M_Q4_0,
   TTS_T3_TURBO_EN_CHATTERBOX_Q8_0,
-  TTS_S3GEN_EN_CHATTERBOX,
+  TTS_S3GEN_EN_CHATTERBOX_Q4_0,
   TTS_EN_SUPERTONIC_Q8_0,
   TTS_MULTILINGUAL_SUPERTONIC2_Q8_0,
   PARAKEET_TDT_0_6B_V3_Q8_0,
@@ -255,7 +255,7 @@ resources.define("tts-chatterbox", {
   config: {
     ttsEngine: "chatterbox",
     language: "en",
-    s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX,
+    s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX_Q4_0,
     referenceAudioSrc: path.resolve(
       process.cwd(),
       "assets/audio",

--- a/packages/sdk/e2e/tests/mobile/consumer.ts
+++ b/packages/sdk/e2e/tests/mobile/consumer.ts
@@ -17,7 +17,7 @@ import {
   MARIAN_EN_HI_INDIC_200M_Q4_0,
   MARIAN_HI_EN_INDIC_200M_Q4_0,
   TTS_T3_TURBO_EN_CHATTERBOX_Q8_0,
-  TTS_S3GEN_EN_CHATTERBOX,
+  TTS_S3GEN_EN_CHATTERBOX_Q4_0,
   TTS_EN_SUPERTONIC_Q8_0,
   TTS_MULTILINGUAL_SUPERTONIC2_Q8_0,
   PARAKEET_TDT_0_6B_V3_Q8_0,
@@ -236,7 +236,7 @@ resources.define("tts-chatterbox", {
   config: async () => ({
     ttsEngine: "chatterbox",
     language: "en",
-    s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX,
+    s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX_Q4_0,
     referenceAudioSrc: await resolveBundledAudioUri("transcription-short-wav.wav"),
   }),
 });


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Chatterbox TTS e2e tests loaded the full-precision `TTS_S3GEN_EN_CHATTERBOX` S3Gen companion (~1 GB f16), inflating model download/load time and mobile asset footprint in CI.

## 📝 How does it solve it?

- Switch the `tts-chatterbox` resource definition in both desktop and mobile e2e consumers to the quantised `TTS_S3GEN_EN_CHATTERBOX_Q4_0` variant.

## 🧪 How was it tested?

- Rebuild e2e tests package (`npm run install:build`) to confirm imports/types resolve.
- `npx qvac-test run:local:desktop --filter tts` Chatterbox suite passes with the Q4 S3Gen model.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215067585812195