### PR TITLE
test[api]: run ocr-ggml Metal integration on real Apple GPUs (self-hosted M4 + iOS)

### DIFF
--- a/.github/workflows/integration-test-ocr-ggml.yml
+++ b/.github/workflows/integration-test-ocr-ggml.yml
@@ -162,6 +162,41 @@ jobs:
           sudo apt update
           sudo apt install -y g++-13
 
+      # The self-hosted mac-mini-m4-gpu runner does not ship the AWS CLI (hosted
+      # macOS runners do). Install it user-local (no sudo) so the S3 model
+      # download below works. Mirrors integration-test-vla.yml.
+      - if: ${{ matrix.platform == 'darwin' && matrix.arch == 'arm64' }}
+        name: Install AWS CLI on macOS (user-local fallback for runners without pre-installed aws)
+        shell: bash
+        run: |
+          # 1. Already on PATH?
+          if command -v aws >/dev/null 2>&1; then
+            echo "AWS CLI already on PATH: $(command -v aws)"
+            aws --version
+            exit 0
+          fi
+          # 2. Any known install location?
+          for p in /opt/homebrew/bin/aws /usr/local/bin/aws "$HOME/.local/aws-cli/aws"; do
+            if [ -x "$p" ]; then
+              echo "AWS CLI at $p; adding $(dirname "$p") to PATH"
+              echo "$(dirname "$p")" >> "$GITHUB_PATH"
+              "$p" --version
+              exit 0
+            fi
+          done
+          # 3. User-local install (extract AWSCLIV2.pkg into $HOME instead
+          # of using `installer -target /` which requires sudo).
+          echo "Installing AWS CLI v2 user-local..."
+          curl -sSL "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o /tmp/AWSCLIV2.pkg
+          rm -rf /tmp/awscli-expanded
+          pkgutil --expand-full /tmp/AWSCLIV2.pkg /tmp/awscli-expanded
+          mkdir -p "$HOME/.local"
+          rm -rf "$HOME/.local/aws-cli"
+          mv /tmp/awscli-expanded/aws-cli.pkg/Payload/aws-cli "$HOME/.local/aws-cli"
+          rm -rf /tmp/awscli-expanded /tmp/AWSCLIV2.pkg
+          echo "$HOME/.local/aws-cli" >> "$GITHUB_PATH"
+          "$HOME/.local/aws-cli/aws" --version
+
       - name: Download EasyOCR + Doctr GGUF model files
         working-directory: ${{ inputs.workdir || env.PKG_DIR }}
         shell: bash

--- a/.github/workflows/integration-test-ocr-ggml.yml
+++ b/.github/workflows/integration-test-ocr-ggml.yml
@@ -64,10 +64,16 @@ jobs:
             platform: linux
             arch: arm64
             runner: ubuntu-22.04-arm
-          - os: macos-15-xlarge
+          # Self-hosted Apple-silicon (M4) runner with a real Metal GPU. The
+          # GitHub-hosted macos-15-xlarge runner's virtualized Metal is
+          # unreliable for sustained GPU compute (the DocTR pipeline runs
+          # correctly on real M4 hardware but non-deterministically aborts /
+          # returns garbage on the hosted VM), so the darwin Metal leg runs on
+          # the same self-hosted M4 that diffusion-cpp uses for its GPU tests.
+          - os: mac-mini-m4
             platform: darwin
             arch: arm64
-            runner: macos-15-xlarge
+            runner: mac-mini-m4-gpu
           - os: windows-2025
             platform: win32
             arch: x64
@@ -87,6 +93,14 @@ jobs:
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "https://github.com/"
           git config --global url."https://${{ secrets.PAT_TOKEN }}:@github.com/".insteadOf "git@github.com:"
 
+      # Self-hosted runners (e.g. mac-mini-m4-gpu) keep their workspace between
+      # jobs; wipe it before checkout so each run starts clean. No-op on
+      # GitHub-hosted runners. See docs/ci/SELF-HOSTED-RUNNERS.md.
+      - name: Manual Workspace Cleanup
+        run: rm -rf "$GITHUB_WORKSPACE" && mkdir -p "$GITHUB_WORKSPACE"
+        shell: bash
+        working-directory: .
+        if: runner.environment != 'github-hosted'
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -109,7 +123,9 @@ jobs:
         shell: bash
         run: |
           npm install
-          npm install -g bare bare-make
+          # --force so the global install succeeds on the persistent
+          # self-hosted runner where these may already be present.
+          npm install -g --force bare bare-make
 
       - name: Download prebuilds from artifact
         if: ${{ !inputs.prebuild_package }}

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -67,6 +67,34 @@ struct MatchingDevice {
   std::string description;
 };
 
+// True for GPU devices whose ggml backend path is known to be numerically
+// broken, so selection must skip them and fall back to CPU rather than emit
+// wrong results. Currently: Qualcomm Adreno via Vulkan — `vla-ggml` measured
+// cos-sim ~0.73 vs PyTorch on Adreno 830 Vulkan, while every other accepted
+// Vulkan/Metal target (Apple Metal, NVIDIA, Intel Iris, Mali) sits >0.999.
+//
+// The defect is specific to Adreno's *Vulkan* path, so the check is scoped to
+// the Vulkan backend rather than the GPU name alone: Adreno's OpenCL backend is
+// numerically sound, and OpenCL support for Adreno is planned, so an
+// Adreno-via-OpenCL device must NOT be rejected here. Apple Metal devices are
+// never Adreno, so the Metal path is unaffected.
+bool isBrokenGpuDevice(ggml_backend_dev_t dev) {
+  const char* descRaw = ggml_backend_dev_description(dev);
+  if (descRaw == nullptr ||
+      toLower(descRaw).find("adreno") == std::string::npos) {
+    return false;
+  }
+  // Adreno is only broken under Vulkan; let OpenCL (and any future backend)
+  // through. Check both the device name ("Vulkan0") and the reg name
+  // ("Vulkan"), mirroring enumerateMatchingDevices's matching.
+  const char* devNameRaw = ggml_backend_dev_name(dev);
+  ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+  const char* regNameRaw =
+      (reg != nullptr) ? ggml_backend_reg_name(reg) : nullptr;
+  return (devNameRaw != nullptr && isVulkanBackendName(devNameRaw)) ||
+         (regNameRaw != nullptr && isVulkanBackendName(regNameRaw));
+}
+
 // All GPU/iGPU devices whose backend name satisfies `matches`, in ggml
 // enumeration order. Used to resolve both Vulkan and Metal requests.
 //
@@ -74,6 +102,9 @@ struct MatchingDevice {
 // names Vulkan devices "Vulkan0" (so the device name carries the backend), but
 // Metal devices are named "MTL0"/"MTL1" while the backing registration is named
 // "Metal". Checking the reg name lets the Metal request resolve correctly.
+//
+// A name-matched device that `isBrokenGpuDevice()` rejects is skipped (the loop
+// keeps looking; if no usable GPU remains, the caller falls back to CPU).
 std::vector<MatchingDevice>
 enumerateMatchingDevices(bool (*matches)(std::string_view)) {
   std::vector<MatchingDevice> result;
@@ -97,6 +128,15 @@ enumerateMatchingDevices(bool (*matches)(std::string_view)) {
       nameMatches = regNameRaw != nullptr && matches(regNameRaw);
     }
     if (!nameMatches) {
+      continue;
+    }
+    if (isBrokenGpuDevice(dev)) {
+      const char* descRaw = ggml_backend_dev_description(dev);
+      QLOG(
+          Priority::WARN,
+          std::string("ocr-ggml: skipping known-broken GPU '") +
+              (descRaw != nullptr ? descRaw : "?") +
+              "' (numerically unreliable backend); falling back to CPU");
       continue;
     }
     const char* descRaw = ggml_backend_dev_description(dev);

--- a/packages/ocr-ggml/addon/src/model-interface/easyocr/pipeline/step_detection_inference.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/easyocr/pipeline/step_detection_inference.cpp
@@ -250,7 +250,20 @@ void StepDetectionInference::ensureGraph(int H, int W) {
     return;
   }
 
-  destroyGraph();
+  // Free only the size-specific graph context; deliberately KEEP
+  // graphCache_.gallocr (and its backing backend buffer) so it is reused — and
+  // resized in place by ggml_gallocr_alloc_graph below — across input sizes.
+  // Freeing and reallocating a differently-sized GPU buffer on every size
+  // change churns the backend heap and can trigger out-of-memory command-buffer
+  // failures on memory-constrained devices (phones, small CI runners), even
+  // when steady-state footprint stays flat.
+  if (graphCache_.gctx != nullptr) {
+    ggml_free(graphCache_.gctx);
+    graphCache_.gctx = nullptr;
+  }
+  graphCache_.gf = nullptr;
+  graphCache_.x = nullptr;
+  graphCache_.out = nullptr;
 
   const size_t graph_ctx_size =
       (ggml_tensor_overhead() * GGML_DEFAULT_GRAPH_SIZE) +
@@ -275,8 +288,10 @@ void StepDetectionInference::ensureGraph(int H, int W) {
       ggml_new_graph_custom(graphCache_.gctx, GGML_DEFAULT_GRAPH_SIZE, false);
   ggml_build_forward_expand(graphCache_.gf, graphCache_.out);
 
-  graphCache_.gallocr =
-      ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+  if (graphCache_.gallocr == nullptr) {
+    graphCache_.gallocr =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+  }
   if (!ggml_gallocr_alloc_graph(graphCache_.gallocr, graphCache_.gf)) {
     destroyGraph();
     throw std::runtime_error(

--- a/packages/ocr-ggml/addon/src/model-interface/easyocr/pipeline/step_recognize_text.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/easyocr/pipeline/step_recognize_text.cpp
@@ -1104,7 +1104,20 @@ void StepRecognizeText::ensureRecognizerGraph(
     return;
   }
 
-  destroyRecognizerGraph();
+  // Free only the size-specific graph context; deliberately KEEP
+  // recognizerGraphCache_.gallocr so its backing backend buffer is reused (and
+  // resized in place by ggml_gallocr_alloc_graph below) across region sizes.
+  // EasyOCR rebuilds this graph once per distinct text-region width, so
+  // freeing+reallocating the gallocr buffer every time is the heaviest source
+  // of backend-heap churn — which fragments the Metal heap and can trigger
+  // out-of-memory command-buffer failures on memory-constrained devices.
+  if (recognizerGraphCache_.gctx != nullptr) {
+    ggml_free(recognizerGraphCache_.gctx);
+    recognizerGraphCache_.gctx = nullptr;
+  }
+  recognizerGraphCache_.graph = nullptr;
+  recognizerGraphCache_.input = nullptr;
+  recognizerGraphCache_.output = nullptr;
 
   const size_t graphCtxSize = (ggml_tensor_overhead() * graphSize) +
                               ggml_graph_overhead_custom(graphSize, false);
@@ -1130,8 +1143,10 @@ void StepRecognizeText::ensureRecognizerGraph(
   ggml_build_forward_expand(
       recognizerGraphCache_.graph, recognizerGraphCache_.output);
 
-  recognizerGraphCache_.gallocr =
-      ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+  if (recognizerGraphCache_.gallocr == nullptr) {
+    recognizerGraphCache_.gallocr =
+        ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_));
+  }
   if (!ggml_gallocr_alloc_graph(
           recognizerGraphCache_.gallocr, recognizerGraphCache_.graph)) {
     destroyRecognizerGraph();

--- a/packages/ocr-ggml/test/integration/backend-device.test.js
+++ b/packages/ocr-ggml/test/integration/backend-device.test.js
@@ -158,10 +158,12 @@ test('backendDevice vulkan: out-of-range gpuDevice falls back to CPU with a reas
 // Unlike Vulkan (a separate libggml-vulkan shared library), the Metal backend
 // is compiled into the addon when ggml is built with the qvac-fabric
 // `gpu-backends` feature (default on Apple). There is therefore no backend lib
-// file to probe; we gate on the host platform instead. On an Apple host whose
-// ggml was built CPU-only, the selection falls back to CPU and we assert the
-// fallback is reported explicitly.
-const shouldSkipMetal = isMobile || platform !== 'darwin'
+// file to probe; we gate on the host platform instead. This runs on every
+// Apple platform — desktop `darwin` AND iOS (whose device-farm devices have
+// real Metal GPUs) — and skips elsewhere. On an Apple target whose ggml was
+// built CPU-only, or with no Metal device present, the selection falls back to
+// CPU and we assert the fallback is reported explicitly.
+const shouldSkipMetal = platform !== 'darwin' && platform !== 'ios'
 
 test('backendDevice metal: selects Metal or reports an explicit CPU fallback', { timeout: TEST_TIMEOUT, skip: shouldSkipMetal }, async function (t) {
   const detectorPath = await ensureModelPath('detector_craft')

--- a/packages/ocr-ggml/test/integration/utils.js
+++ b/packages/ocr-ggml/test/integration/utils.js
@@ -339,10 +339,12 @@ function findVulkanBackendLib (dir) {
  *      accepts a known GPU backend ('vulkan' or 'metal', case-insensitive),
  *      else 'cpu'. This preserves a manual override (e.g. workflow_dispatch /
  *      forcing CPU, or forcing a specific GPU backend).
- *   2. Else, on Apple desktop (darwin), select 'metal'. ggml's Metal backend is
- *      compiled into the addon on darwin (no separate loadable lib to probe), so
- *      the suites request Metal directly; the addon falls back to CPU if no
- *      Metal device is present.
+ *   2. Else, on any Apple platform (desktop `darwin` AND iOS), select 'metal'.
+ *      ggml's Metal backend is compiled into the addon on every Apple target
+ *      via the qvac-fabric `gpu-backends` feature (no separate loadable lib to
+ *      probe), so the suites request Metal directly; the addon falls back to CPU
+ *      if no Metal device is present. iOS device-farm devices have real
+ *      (non-virtualized) Metal GPUs, so the iOS leg exercises Metal like desktop.
  *   3. On Android, auto-select 'vulkan': the `android-arm64` prebuild always
  *      ships `libqvac-ggml-vulkan.so`, so the suite (and the CPU↔Vulkan perf
  *      comparison) exercises Vulkan on-device. Mali GPUs (e.g. Pixel) run on
@@ -355,7 +357,7 @@ function findVulkanBackendLib (dir) {
  *      Local dev without merged prebuilds (no lib) stays on CPU. The addon
  *      gracefully falls back to CPU when no Vulkan GPU is present, so requesting
  *      'vulkan' is safe on non-GPU hosts.
- *   5. Else 'cpu' (iOS, and desktop without a GPU backend).
+ *   5. Else 'cpu' (desktop without a GPU backend).
  * @returns {'cpu'|'vulkan'|'metal'}
  */
 function getBackendDevice () {
@@ -366,11 +368,11 @@ function getBackendDevice () {
   if (override !== '') {
     return (override === 'vulkan' || override === 'metal') ? override : 'cpu'
   }
-  // Apple desktop ships the Metal backend compiled into the addon.
-  if (platform === 'darwin') return 'metal'
+  // Apple platforms (desktop + iOS) ship the Metal backend; request it on both.
+  if (platform === 'darwin' || platform === 'ios') return 'metal'
   // Android always ships the Vulkan backend lib; request Vulkan so the perf
   // suite fills the GPU column on Mali devices (Adreno safely falls back to CPU
-  // via the addon's Adreno guard). iOS has no Vulkan → CPU.
+  // via the addon's Adreno guard). (iOS is handled by the Metal branch above.)
   if (isMobile) return platform === 'android' ? 'vulkan' : 'cpu'
   if (findVulkanBackendLib(PREBUILDS_DIR)) return 'vulkan'
   return 'cpu'

--- a/packages/ocr-ggml/test/integration/utils.js
+++ b/packages/ocr-ggml/test/integration/utils.js
@@ -336,30 +336,38 @@ function findVulkanBackendLib (dir) {
  *
  * Precedence:
  *   1. Explicit `OCR_GGML_BACKEND` (via `os.getEnv` then `process.env`) wins —
- *      'vulkan' only when exactly `vulkan` (case-insensitive), else 'cpu'. This
- *      preserves a manual override (e.g. workflow_dispatch / forcing CPU).
- *   2. On Android, auto-select 'vulkan': the `android-arm64` prebuild always
+ *      accepts a known GPU backend ('vulkan' or 'metal', case-insensitive),
+ *      else 'cpu'. This preserves a manual override (e.g. workflow_dispatch /
+ *      forcing CPU, or forcing a specific GPU backend).
+ *   2. Else, on Apple desktop (darwin), select 'metal'. ggml's Metal backend is
+ *      compiled into the addon on darwin (no separate loadable lib to probe), so
+ *      the suites request Metal directly; the addon falls back to CPU if no
+ *      Metal device is present.
+ *   3. On Android, auto-select 'vulkan': the `android-arm64` prebuild always
  *      ships `libqvac-ggml-vulkan.so`, so the suite (and the CPU↔Vulkan perf
  *      comparison) exercises Vulkan on-device. Mali GPUs (e.g. Pixel) run on
  *      Vulkan; Adreno GPUs auto-fall-back to CPU via the OcrBackendSelection
- *      Adreno guard. iOS has no Vulkan (Metal/MoltenVK) so it stays on CPU.
- *   3. Else, on desktop, auto-select 'vulkan' when a `ggml-vulkan` backend lib
+ *      Adreno guard.
+ *   4. Else, on desktop, auto-select 'vulkan' when a `ggml-vulkan` backend lib
  *      is shipped in prebuilds/. On desktop CI the merged prebuilds/ contains
  *      that lib, so the suites attempt Vulkan; only the GPU runner actually
  *      executes on Vulkan, while other runners report an explicit CPU fallback.
  *      Local dev without merged prebuilds (no lib) stays on CPU. The addon
  *      gracefully falls back to CPU when no Vulkan GPU is present, so requesting
  *      'vulkan' is safe on non-GPU hosts.
- *   4. Else 'cpu'.
- * @returns {'cpu'|'vulkan'}
+ *   5. Else 'cpu' (iOS, and desktop without a GPU backend).
+ * @returns {'cpu'|'vulkan'|'metal'}
  */
 function getBackendDevice () {
   let raw = ''
   if (typeof os.getEnv === 'function') raw = os.getEnv('OCR_GGML_BACKEND') || ''
   if (!raw && process.env) raw = process.env.OCR_GGML_BACKEND || ''
-  if (String(raw).trim() !== '') {
-    return String(raw).trim().toLowerCase() === 'vulkan' ? 'vulkan' : 'cpu'
+  const override = String(raw).trim().toLowerCase()
+  if (override !== '') {
+    return (override === 'vulkan' || override === 'metal') ? override : 'cpu'
   }
+  // Apple desktop ships the Metal backend compiled into the addon.
+  if (platform === 'darwin') return 'metal'
   // Android always ships the Vulkan backend lib; request Vulkan so the perf
   // suite fills the GPU column on Mali devices (Adreno safely falls back to CPU
   // via the addon's Adreno guard). iOS has no Vulkan → CPU.


### PR DESCRIPTION
## Summary

Enables and tests the **Metal GGML backend** for ocr-ggml on Apple platforms (desktop **and** iOS), and makes the darwin integration leg actually exercise it by running on a real GPU.

Previously the DocTR pipeline was forced onto CPU under Metal because the integration suite aborted non-deterministically on the GitHub-hosted `macos-15-xlarge` runner. This PR removes that workaround — the Metal code is correct, the runner was the problem.

## Root cause

The failures (`[DoctrRecognitionGGML] ggml backend graph compute failed with status -1` → exit 134, and detection silently collapsing to garbage) **only occur on the GitHub-hosted `macos-15-xlarge` runner**, whose Metal GPU is **virtualized** and unreliable for sustained compute (first backend instance works, then returns garbage / aborts).

On **real Apple-silicon hardware** (an M4 mac mini) the exact same code + models run correctly every time. Verified locally:

| DocTR suite (on Metal, M4) | Result |
|---|---|
| doctr-basic | 5/5 tests, 28/28 asserts |
| doctr-clinical-chemistry | 31/31 |
| doctr-ct-scan | 47/47 |
| doctr-lab-results | 43/43 |
| doctr-liver-function | 43/43 |
| doctr-models (incl. batch-equivalence) | 350/350 |
| doctr-param-validation | 12/12 |

…plus 11+ sustained fresh instances with zero crashes, detection region counts and recognized text matching the CPU baseline exactly.

## Changes

- **Run the darwin/arm64 integration leg on the self-hosted `mac-mini-m4-gpu` runner** (real GPU — the same runner `integration-test-diffusion-cpp.yml` uses for Metal), instead of the hosted `macos-15-xlarge`. Adds the standard Manual Workspace Cleanup step (see `docs/ci/SELF-HOSTED-RUNNERS.md`).
- **Install the AWS CLI on the self-hosted macOS runner** (user-local, no sudo) for the S3 model download — the runner doesn't ship `aws`. Mirrors `integration-test-vla.yml`.
- **Exercise Metal on all Apple platforms**: `getBackendDevice()` returns `metal` on `darwin` **and** `ios` (Android stays Vulkan; it has no Metal), and the explicit Metal backend-device test now runs on iOS. iOS device-farm devices have real (non-virtualized) Metal GPUs, so the iOS leg now exercises the Metal path instead of CPU.
- Carries the prior gpu-test-coverage work this builds on: select Metal in the suite, the EasyOCR `ggml_gallocr` heap-churn stability fix, and the numerically-broken-Adreno guard (re-applied onto main's refactored backend selection).

The "run DocTR on CPU under Metal" workaround is **gone** (dropped from history), so DocTR genuinely runs on Metal. This is a real fix, not a CPU fallback.

## Validation

CI run on this branch — all integration legs green:
- `test-darwin-arm64` ✅ (DocTR on **Metal**, self-hosted M4, ~8 min)
- iOS device-farm ✅ (now on **Metal**)
- Android ✅ (Vulkan/CPU, unaffected)
- linux x64/arm64, win32 ✅; prebuilds, sanity, cpp-lint, ts-checks ✅

(The `merge-guard / validate-pr` check only reports the missing `verified` label — apply it to merge.)

## Follow-up (not in this PR)

DocTR **detection** is correct but slow on Metal (~16 s vs ~1.4 s CPU per image at 1024², even on the M4) — the MobileNetV3-large + FPN graph hits ggml-Metal's weaker ops (depthwise conv, SE pooling, FPN bilinear upsample). EasyOCR's CRAFT detector is fast on Metal. The suite still passes well within timeout; a Metal **perf** optimization for these ops is a separate task.
