### PR TITLE
QVAC-20364 infra: cancel Device Farm runs when GHA workflow is cancelled

### DIFF
--- a/.github/workflows/test-android-sdk.yml
+++ b/.github/workflows/test-android-sdk.yml
@@ -743,6 +743,32 @@ jobs:
         with:
           report-dir: ${{ inputs.working-directory }}/reports
 
+      - name: Download run ARNs for cancellation cleanup
+        if: cancelled()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          pattern: device-farm-arn-${{ needs.build.outputs.runId }}-*
+          path: ./run-arns
+          merge-multiple: true
+
+      - name: Configure AWS credentials for cancellation cleanup
+        if: cancelled()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # 6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Stop Device Farm runs on cancellation
+        if: cancelled()
+        run: |
+          for f in ./run-arns/*.txt; do
+            [ -f "$f" ] || continue
+            arn=$(cat "$f")
+            echo "Stopping Device Farm run: $arn"
+            aws devicefarm stop-run --arn "$arn" || echo "stop-run failed for $arn"
+          done
+
   cleanup-device-farm:
     name: "[android] cleanup-device-farm"
     needs: [build, run-producer, device-farm]

--- a/.github/workflows/test-ios-sdk.yml
+++ b/.github/workflows/test-ios-sdk.yml
@@ -861,6 +861,32 @@ jobs:
         with:
           report-dir: ${{ inputs.working-directory }}/reports
 
+      - name: Download run ARNs for cancellation cleanup
+        if: cancelled()
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          pattern: device-farm-arn-ios-${{ needs.build.outputs.runId }}-*
+          path: ./run-arns
+          merge-multiple: true
+
+      - name: Configure AWS credentials for cancellation cleanup
+        if: cancelled()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # 6.0.0
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Stop Device Farm runs on cancellation
+        if: cancelled()
+        run: |
+          for f in ./run-arns/*.txt; do
+            [ -f "$f" ] || continue
+            arn=$(cat "$f")
+            echo "Stopping Device Farm run: $arn"
+            aws devicefarm stop-run --arn "$arn" || echo "stop-run failed for $arn"
+          done
+
   cleanup-device-farm:
     name: "[ios] cleanup-device-farm"
     needs: [build, run-producer, device-farm]


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

When GitHub Actions cancels a workflow run via \`concurrency: cancel-in-progress: true\` (e.g. new commit pushed to an open PR), the runner is killed but AWS Device Farm has no visibility — dispatched runs keep consuming metered minutes until their own timeout fires.

The existing \`cleanup-device-farm\` job calls \`stop-run\` but is a separate downstream job that GitHub may never dispatch when the entire workflow run is cancelled, even with \`if: always()\`.

## 📝 How does it solve it?

Three \`if: cancelled()\` steps added at the end of the \`run-producer\` job in both \`test-android-sdk.yml\` and \`test-ios-sdk.yml\`.

\`run-producer\` is the right place — it has \`timeout-minutes: 90\` and stays alive for the full duration of the Device Farm run (producer ↔ device over MQTT). When \`cancel-in-progress\` fires mid-run, this is the job that receives the cancellation signal.

- **Download ARNs** — fetches \`device-farm-arn-$runId-*\` artifacts (same pattern as \`cleanup-device-farm\`). \`continue-on-error: true\` handles the edge case where \`device-farm\` was cancelled before its upload completed.
- **Configure AWS credentials** — OIDC via \`AWS_OIDC_ROLE_ARN\` (same pin as the rest of the file).
- **Stop runs** — iterates each ARN file, calls \`aws devicefarm stop-run\`. Failures are logged (\`|| echo\`) rather than silently swallowed.

All three steps are gated on \`if: cancelled()\` — zero overhead on normal success/failure runs.

## 🧪 How was it tested?

- \`actionlint\` on both modified files — zero new errors.
- Logic review: \`run-producer\` has \`needs: build\` so \`needs.build.outputs.runId\` is accessible; \`environment: release\` gives access to \`AWS_OIDC_ROLE_ARN\`; \`id-token: write\` is set at workflow level for OIDC.

_Generated with Cursor_