### PR TITLE
QVAC-20472 fix[devops]: cancel Device Farm runs when GHA workflow is cancelled

### DIFF
--- a/.github/actions/run-mobile-integration-tests/cancel-device-farm-runs/action.yml
+++ b/.github/actions/run-mobile-integration-tests/cancel-device-farm-runs/action.yml
@@ -1,0 +1,65 @@
+name: Mobile Test — Cancel Device Farm Runs
+description: |
+  Cancellation handler for the mobile integration test pipeline.
+
+  Runs only when the GitHub Actions job is cancelled (e.g. by concurrency
+  cancel-in-progress). Calls `aws devicefarm stop-run` on every in-flight
+  Device Farm run so AWS stops billing metered device minutes immediately
+  instead of letting the run continue until jobTimeoutMinutes expires.
+
+inputs:
+  run-arns:
+    description: "JSON array of Device Farm run ARNs to cancel"
+    required: true
+  aws-role-to-assume:
+    description: "AWS IAM role ARN for OIDC"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # 6.0.0
+      with:
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        aws-region: us-west-2
+        role-duration-seconds: 900
+
+    - name: Stop Device Farm runs
+      shell: bash
+      env:
+        RUN_ARNS_JSON: ${{ inputs.run-arns }}
+      run: |
+        if [ -z "$RUN_ARNS_JSON" ] || [ "$RUN_ARNS_JSON" = "[]" ]; then
+          echo "No run ARNs to cancel"
+          exit 0
+        fi
+
+        echo "🛑 GitHub Actions job was cancelled — stopping Device Farm runs"
+
+        STOPPED=0
+        SKIPPED=0
+        FAILED=0
+
+        for ARN in $(echo "$RUN_ARNS_JSON" | jq -r '.[]'); do
+          STATUS=$(aws devicefarm get-run --arn "$ARN" --query 'run.status' --output text 2>/dev/null || echo "UNKNOWN")
+          echo "  Run $ARN: status=$STATUS"
+
+          if [ "$STATUS" = "RUNNING" ] || [ "$STATUS" = "PENDING" ] || \
+             [ "$STATUS" = "PENDING_CONCURRENCY" ] || [ "$STATUS" = "PENDING_DEVICE" ] || \
+             [ "$STATUS" = "SCHEDULING" ] || [ "$STATUS" = "PREPARING" ]; then
+            if aws devicefarm stop-run --arn "$ARN" 2>/dev/null; then
+              echo "    ✅ stop-run issued"
+              STOPPED=$((STOPPED + 1))
+            else
+              echo "    ⚠️  stop-run failed (run may have already completed)"
+              FAILED=$((FAILED + 1))
+            fi
+          else
+            echo "    ⏭️  already $STATUS, skipping"
+            SKIPPED=$((SKIPPED + 1))
+          fi
+        done
+
+        echo ""
+        echo "Summary: $STOPPED stopped, $SKIPPED already finished, $FAILED failed"

--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -158,6 +158,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-classification-ggml.yml
+++ b/.github/workflows/integration-mobile-test-classification-ggml.yml
@@ -159,6 +159,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-decoder-audio.yml
+++ b/.github/workflows/integration-mobile-test-decoder-audio.yml
@@ -151,6 +151,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -152,6 +152,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-embed-llamacpp.yml
@@ -141,6 +141,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-mobile-test-llm-llamacpp.yml
@@ -191,6 +191,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-ocr-ggml.yml
+++ b/.github/workflows/integration-mobile-test-ocr-ggml.yml
@@ -181,6 +181,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-ocr-onnx.yml
+++ b/.github/workflows/integration-mobile-test-ocr-onnx.yml
@@ -189,6 +189,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-mobile-test-transcription-parakeet.yml
@@ -191,6 +191,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
@@ -146,6 +146,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
+++ b/.github/workflows/integration-mobile-test-translation-nmtcpp.yml
@@ -161,6 +161,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-tts-ggml.yml
+++ b/.github/workflows/integration-mobile-test-tts-ggml.yml
@@ -148,6 +148,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-tts-onnx.yml
+++ b/.github/workflows/integration-mobile-test-tts-onnx.yml
@@ -170,6 +170,13 @@ jobs:
           run-count: ${{ steps.schedule.outputs.run-count }}
           max-wait-time-seconds: '10800'
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always() && !cancelled()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs

--- a/.github/workflows/integration-mobile-test-vla.yml
+++ b/.github/workflows/integration-mobile-test-vla.yml
@@ -285,6 +285,13 @@ jobs:
           run-arns: ${{ steps.schedule.outputs.run-arns }}
           run-count: ${{ steps.schedule.outputs.run-count }}
 
+      - name: Cancel Device Farm runs on workflow cancellation
+        if: cancelled() && steps.schedule.outputs.run-arns != '' && steps.schedule.outputs.run-arns != '[]'
+        uses: ./.github/actions/run-mobile-integration-tests/cancel-device-farm-runs
+        with:
+          run-arns: ${{ steps.schedule.outputs.run-arns }}
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Collect and upload Device Farm logs
         if: always()
         uses: ./.github/actions/run-mobile-integration-tests/collect-and-upload-logs


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- When GitHub Actions `cancel-in-progress` fires on parent `on-pr-*` workflows, the GHA job is killed but **in-flight AWS Device Farm runs keep executing** on metered devices until `jobTimeoutMinutes` expires (typically 120 min). This wastes significant Device Farm minutes and cost.
- Raised during the [AWS Device Farm usage analysis thread](https://app.asana.com/1/45238840754660/project/1214153063536860/task/1215451367970460) by Olu — concurrency controls cancel the GHA side but never call `aws devicefarm stop-run`, so orphaned runs continue burning metered minutes.

## 📝 How does it solve it?

- **New composite action `cancel-device-farm-runs/action.yml`**: authenticates via OIDC (15-min session), iterates each run ARN, checks its status, and calls `aws devicefarm stop-run` on any that are still active (`RUNNING`, `PENDING`, `PENDING_CONCURRENCY`, `PENDING_DEVICE`, `SCHEDULING`, `PREPARING`). Gracefully skips already-completed runs.
- **14 addon workflows updated**: added an `if: cancelled()` step between "Monitor" and "Collect Logs" in all `integration-mobile-test-*.yml` workflows. The step only fires when the GHA job is cancelled — normal success/failure flows are completely unaffected.

### Workflows updated

| Addon | Workflow |
|-------|----------|
| LLM | `integration-mobile-test-llm-llamacpp.yml` |
| Embed | `integration-mobile-test-embed-llamacpp.yml` |
| Diffusion | `integration-mobile-test-diffusion-cpp.yml` |
| Classification | `integration-mobile-test-classification-ggml.yml` |
| OCR GGML | `integration-mobile-test-ocr-ggml.yml` |
| OCR ONNX | `integration-mobile-test-ocr-onnx.yml` |
| NMT | `integration-mobile-test-translation-nmtcpp.yml` |
| Whisper | `integration-mobile-test-transcription-whispercpp.yml` |
| BCI Whisper | `integration-mobile-test-bci-whispercpp.yml` |
| Parakeet | `integration-mobile-test-transcription-parakeet.yml` |
| TTS ONNX | `integration-mobile-test-tts-onnx.yml` |
| TTS GGML | `integration-mobile-test-tts-ggml.yml` |
| Decoder | `integration-mobile-test-decoder-audio.yml` |
| VLA | `integration-mobile-test-vla.yml` |

## 🔐 Action pinning

- `aws-actions/configure-aws-credentials`: `8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # 6.0.0` (same pin used by existing `collect-and-upload-logs` and `upload-to-devicefarm` actions)


Made with [Cursor](https://cursor.com)