### PR TITLE
ci[classification-ggml]: add include-vulkan-sdk to prebuilds

### DIFF
--- a/.github/workflows/prebuilds-classification-ggml.yml
+++ b/.github/workflows/prebuilds-classification-ggml.yml
@@ -41,4 +41,10 @@ jobs:
       ref: ${{ inputs.ref }}
       repository: ${{ inputs.repository }}
       artifact-name-prefix: classification-ggml-
+      # classification-ggml builds the GGML_BACKEND_DL fabric (gpu-backends), so
+      # build hosts need the Vulkan SDK (incl. glslc) to compile the ggml-vulkan
+      # module from source on cache-miss — same as the other gpu-backends
+      # consumers (embed/llm/nmtcpp/ocr), which already set this. Without it the
+      # linux-arm64 / android-arm64 prebuilds fail to find glslc.
+      include-vulkan-sdk: true
     secrets: inherit


### PR DESCRIPTION
## What

Adds `include-vulkan-sdk: true` to `prebuilds-classification-ggml.yml`.

## Why

`classification-ggml` builds the `GGML_BACKEND_DL` fabric (gpu-backends). Build hosts need the Vulkan SDK (incl. `glslc`) to compile the `ggml-vulkan` module from source on a cache-miss.

Every **other** gpu-backends fabric consumer already sets this in its prebuild:

| consumer | `include-vulkan-sdk` on main |
|---|---|
| embed-llamacpp | ✅ |
| llm-llamacpp | ✅ |
| translation-nmtcpp | ✅ |
| ocr-ggml | ✅ |
| **classification-ggml** | ❌ (this PR) |

classification was the lone exception, so its `linux-arm64` / `android-arm64` prebuilds fail to find `glslc` once the DL fabric is in play. Because consumer CI uses `pull_request_target` (which reads workflow YAML from `main`), this line must live on `main` for those PR auto-runs to go green — it can't be fixed from a feature branch alone.

## Validation

Confirmed green via `workflow_dispatch` of the classification on-pr workflow on the DL-fabric branch (branch YAML carries this line): `linux-arm64` + `android-arm64` prebuilds and the linux-arm64 integration all pass.

## Scope

Workflow-only, one line. No code, no fabric, no other consumers touched.