### PR TITLE
fix[classification-ggml]: satisfy clang-tidy readability-identifier-naming

### DIFF
--- a/packages/classification-ggml/README.md
+++ b/packages/classification-ggml/README.md
@@ -215,7 +215,7 @@ For this MobileNetV3-Small the GGML CPU backend is, in most configurations, slow
 
 ## Converting a new model
 
-If you fine-tune or swap the underlying MobileNetV3 model, follow `[docs/onnx-to-gguf-conversion.md](docs/onnx-to-gguf-conversion.md)`. The graph construction is parameterised by `kBlocks` in `MobileNetGraph.hpp` — only classes and weights change between fine-tunes.
+If you fine-tune or swap the underlying MobileNetV3 model, follow `[docs/onnx-to-gguf-conversion.md](docs/onnx-to-gguf-conversion.md)`. The graph construction is parameterised by `BLOCKS` in `MobileNetGraph.hpp` — only classes and weights change between fine-tunes.
 
 ## Troubleshooting
 

--- a/packages/classification-ggml/addon/src/model-interface/ClassificationModel.cpp
+++ b/packages/classification-ggml/addon/src/model-interface/ClassificationModel.cpp
@@ -35,7 +35,7 @@ using qvac_errors::general_error::InternalError;
 using qvac_errors::general_error::InvalidArgument;
 
 namespace {
-constexpr const char* kModelName = "mobilenetv3-small-ggml-classification";
+constexpr const char* MODEL_NAME = "mobilenetv3-small-ggml-classification";
 } // namespace
 
 ClassificationModel::ClassificationModel(std::string modelPath)
@@ -52,9 +52,7 @@ ClassificationModel::~ClassificationModel() {
   }
 }
 
-std::string ClassificationModel::getName() const {
-  return kModelName;
-}
+std::string ClassificationModel::getName() const { return MODEL_NAME; }
 
 qvac_lib_inference_addon_cpp::RuntimeStats
 ClassificationModel::runtimeStats() const {
@@ -181,18 +179,20 @@ void ClassificationModel::load() {
   {
     constexpr uint32_t kWarmupSide = 32;
     std::vector<uint8_t> warmupRgb(
-        static_cast<size_t>(kWarmupSide) * kWarmupSide * preprocess::kChannels);
+        static_cast<size_t>(kWarmupSide) * kWarmupSide * preprocess::CHANNELS);
     for (size_t i = 0; i < warmupRgb.size(); ++i) {
       warmupRgb[i] = static_cast<uint8_t>((i * 7) & 0xFFU);
     }
     std::vector<float> warmupTensor = preprocess::preprocessToTensor(
         std::span<const uint8_t>(warmupRgb.data(), warmupRgb.size()),
-        kWarmupSide, kWarmupSide, preprocess::kChannels);
+        kWarmupSide,
+        kWarmupSide,
+        preprocess::CHANNELS);
     ggml_backend_tensor_set(
         compute_.input, warmupTensor.data(), 0,
         warmupTensor.size() * sizeof(float));
     (void)ggml_backend_graph_compute(backend_, compute_.graph);
-    float warmupLogits[graph::kNumClasses] = {0.0F};
+    float warmupLogits[graph::NUM_CLASSES] = {0.0F};
     ggml_backend_tensor_get(
         compute_.output, warmupLogits, 0, sizeof(warmupLogits));
     (void)warmupLogits;
@@ -231,8 +231,8 @@ std::any ClassificationModel::process(const std::any& input) {
       std::span<const uint8_t>(inPtr->data.data(), inPtr->data.size()),
       rawW, rawH, rawC);
 
-  const size_t expected = static_cast<size_t>(preprocess::kInputSize) *
-                          preprocess::kInputSize * preprocess::kChannels;
+  const size_t expected = static_cast<size_t>(preprocess::INPUT_SIZE) *
+                          preprocess::INPUT_SIZE * preprocess::CHANNELS;
   if (inputTensor.size() != expected) {
     throw StatusError(
         InternalError, "ClassificationModel: preprocessed tensor has wrong size");
@@ -250,11 +250,12 @@ std::any ClassificationModel::process(const std::any& input) {
                            std::to_string(static_cast<int>(status)));
   }
 
-  float logits[graph::kNumClasses] = {0.0F};
+  float logits[graph::NUM_CLASSES] = {0.0F};
   ggml_backend_tensor_get(
       compute_.output, logits, 0, sizeof(logits));
 
-  std::vector<float> probs = softmax(std::span<const float>(logits, graph::kNumClasses));
+  std::vector<float> probs =
+      softmax(std::span<const float>(logits, graph::NUM_CLASSES));
 
   ClassifyOutput output;
   output.results.reserve(probs.size());

--- a/packages/classification-ggml/addon/src/model-interface/ImagePreprocessor.cpp
+++ b/packages/classification-ggml/addon/src/model-interface/ImagePreprocessor.cpp
@@ -20,7 +20,7 @@ namespace {
 using qvac_errors::general_error::InvalidArgument;
 using qvac_errors::StatusError;
 
-constexpr size_t kDecodedChannels = 3;
+constexpr size_t DECODED_CHANNELS = 3;
 
 [[noreturn]] void raise(const std::string& message) {
   throw StatusError(InvalidArgument, message);
@@ -76,13 +76,14 @@ std::vector<uint8_t> decodeToRgb(
       if (infoWidth <= 0 || infoHeight <= 0) {
         raise("Decoded image has invalid dimensions");
       }
-      if (static_cast<uint32_t>(infoWidth) > kMaxImageDimension ||
-          static_cast<uint32_t>(infoHeight) > kMaxImageDimension) {
+      if (static_cast<uint32_t>(infoWidth) > MAX_IMAGE_DIMENSION ||
+          static_cast<uint32_t>(infoHeight) > MAX_IMAGE_DIMENSION) {
         raise(
             "Image exceeds maximum allowed dimension (" +
-            std::to_string(kMaxImageDimension) + " px per axis); header "
-            "reported " + std::to_string(infoWidth) + "x" +
-            std::to_string(infoHeight));
+            std::to_string(MAX_IMAGE_DIMENSION) +
+            " px per axis); header "
+            "reported " +
+            std::to_string(infoWidth) + "x" + std::to_string(infoHeight));
       }
     }
   }
@@ -92,8 +93,12 @@ std::vector<uint8_t> decodeToRgb(
   int channelsIgnored = 0;
   // Force 3 output channels — downstream never deals with alpha/grayscale.
   uint8_t* pixels = stbi_load_from_memory(
-      encodedBuffer.data(), static_cast<int>(encodedBuffer.size()), &width,
-      &height, &channelsIgnored, static_cast<int>(kDecodedChannels));
+      encodedBuffer.data(),
+      static_cast<int>(encodedBuffer.size()),
+      &width,
+      &height,
+      &channelsIgnored,
+      static_cast<int>(DECODED_CHANNELS));
 
   if (pixels == nullptr) {
     const char* reason = stbi_failure_reason();
@@ -109,16 +114,16 @@ std::vector<uint8_t> decodeToRgb(
     stbi_image_free(pixels);
     raise("Decoded image has invalid dimensions");
   }
-  if (static_cast<uint32_t>(width) > kMaxImageDimension ||
-      static_cast<uint32_t>(height) > kMaxImageDimension) {
+  if (static_cast<uint32_t>(width) > MAX_IMAGE_DIMENSION ||
+      static_cast<uint32_t>(height) > MAX_IMAGE_DIMENSION) {
     stbi_image_free(pixels);
     raise(
         "Image exceeds maximum allowed dimension (" +
-        std::to_string(kMaxImageDimension) + " px per axis)");
+        std::to_string(MAX_IMAGE_DIMENSION) + " px per axis)");
   }
 
   const size_t byteCount = static_cast<size_t>(width) *
-                           static_cast<size_t>(height) * kDecodedChannels;
+                           static_cast<size_t>(height) * DECODED_CHANNELS;
   std::vector<uint8_t> out(pixels, pixels + byteCount);
   stbi_image_free(pixels);
 
@@ -133,7 +138,7 @@ void validateRawRgb(
   if (rawBuffer.empty()) {
     raise("Raw image buffer is empty");
   }
-  if (channels != kChannels) {
+  if (channels != CHANNELS) {
     raise(
         "Raw image must have exactly 3 channels (RGB); got " +
         std::to_string(channels));
@@ -141,10 +146,10 @@ void validateRawRgb(
   if (width == 0 || height == 0) {
     raise("Raw image width and height must be greater than zero");
   }
-  if (width > kMaxImageDimension || height > kMaxImageDimension) {
+  if (width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION) {
     raise(
         "Raw image exceeds maximum allowed dimension (" +
-        std::to_string(kMaxImageDimension) + " px per axis)");
+        std::to_string(MAX_IMAGE_DIMENSION) + " px per axis)");
   }
   const size_t expected = static_cast<size_t>(width) *
                           static_cast<size_t>(height) *
@@ -160,12 +165,17 @@ void validateRawRgb(
 
 std::vector<uint8_t> resizeToInput(
     std::span<const uint8_t> srcRgb, uint32_t srcWidth, uint32_t srcHeight) {
-  std::vector<uint8_t> out(kInputSize * kInputSize * kChannels);
+  std::vector<uint8_t> out(INPUT_SIZE * INPUT_SIZE * CHANNELS);
   unsigned char* ok = stbir_resize_uint8_linear(
-      srcRgb.data(), static_cast<int>(srcWidth), static_cast<int>(srcHeight),
-      static_cast<int>(srcWidth * kChannels), out.data(),
-      static_cast<int>(kInputSize), static_cast<int>(kInputSize),
-      static_cast<int>(kInputSize * kChannels), STBIR_RGB);
+      srcRgb.data(),
+      static_cast<int>(srcWidth),
+      static_cast<int>(srcHeight),
+      static_cast<int>(srcWidth * CHANNELS),
+      out.data(),
+      static_cast<int>(INPUT_SIZE),
+      static_cast<int>(INPUT_SIZE),
+      static_cast<int>(INPUT_SIZE * CHANNELS),
+      STBIR_RGB);
   if (ok == nullptr) {
     raise("Failed to resize image to 224x224");
   }
@@ -174,25 +184,25 @@ std::vector<uint8_t> resizeToInput(
 
 std::vector<float> normalizeToWhcn(std::span<const uint8_t> rgb224) {
   if (rgb224.size() !=
-      static_cast<size_t>(kInputSize) * kInputSize * kChannels) {
+      static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE * CHANNELS) {
     raise("Internal error: resized buffer does not have expected size");
   }
   constexpr float kUnit = 1.0F / 255.0F;
 
   // ggml WHCN: contiguous, fastest-varying axis = width.
   // offset(w, h, c) = c*H*W + h*W + w
-  std::vector<float> out(static_cast<size_t>(kInputSize) * kInputSize * kChannels);
-  const size_t plane = static_cast<size_t>(kInputSize) * kInputSize;
+  std::vector<float> out(
+      static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE * CHANNELS);
+  const size_t plane = static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE;
 
-  for (uint32_t y = 0; y < kInputSize; ++y) {
-    for (uint32_t x = 0; x < kInputSize; ++x) {
+  for (uint32_t y = 0; y < INPUT_SIZE; ++y) {
+    for (uint32_t x = 0; x < INPUT_SIZE; ++x) {
       const size_t srcIdx =
-          (static_cast<size_t>(y) * kInputSize + x) * kChannels;
-      const size_t dstBase = static_cast<size_t>(y) * kInputSize + x;
-      for (uint32_t c = 0; c < kChannels; ++c) {
+          (static_cast<size_t>(y) * INPUT_SIZE + x) * CHANNELS;
+      const size_t dstBase = static_cast<size_t>(y) * INPUT_SIZE + x;
+      for (uint32_t c = 0; c < CHANNELS; ++c) {
         const float pixel = static_cast<float>(rgb224[srcIdx + c]) * kUnit;
-        out[c * plane + dstBase] =
-            (pixel - kImageNetMean[c]) / kImageNetStd[c];
+        out[c * plane + dstBase] = (pixel - IMAGENET_MEAN[c]) / IMAGENET_STD[c];
       }
     }
   }

--- a/packages/classification-ggml/addon/src/model-interface/ImagePreprocessor.hpp
+++ b/packages/classification-ggml/addon/src/model-interface/ImagePreprocessor.hpp
@@ -7,14 +7,14 @@
 
 namespace classification_ggml::preprocess {
 
-constexpr uint32_t kInputSize = 224;
-constexpr uint32_t kChannels = 3;
+constexpr uint32_t INPUT_SIZE = 224;
+constexpr uint32_t CHANNELS = 3;
 /// OOM defence — reject inputs larger than this on either axis.
-constexpr uint32_t kMaxImageDimension = 16384;
+constexpr uint32_t MAX_IMAGE_DIMENSION = 16384;
 
 /// ImageNet per-channel normalization, matching torchvision's MobileNetV3.
-constexpr std::array<float, 3> kImageNetMean = {0.485F, 0.456F, 0.406F};
-constexpr std::array<float, 3> kImageNetStd = {0.229F, 0.224F, 0.225F};
+constexpr std::array<float, 3> IMAGENET_MEAN = {0.485F, 0.456F, 0.406F};
+constexpr std::array<float, 3> IMAGENET_STD = {0.229F, 0.224F, 0.225F};
 
 /// True for JPEG/PNG magic bytes; false routes to the raw-RGB path.
 bool isEncodedImage(std::span<const uint8_t> buffer);
@@ -25,16 +25,16 @@ std::vector<uint8_t> decodeToRgb(
     uint32_t& outHeight);
 
 /// Throws StatusError if the buffer doesn't match the declared shape,
-/// channels != 3, or dimensions exceed `kMaxImageDimension`.
+/// channels != 3, or dimensions exceed `MAX_IMAGE_DIMENSION`.
 void validateRawRgb(
     std::span<const uint8_t> rawBuffer, uint32_t width, uint32_t height,
     uint32_t channels);
 
-/// Bilinear resize (stb_image_resize2) to `kInputSize` square.
+/// Bilinear resize (stb_image_resize2) to `INPUT_SIZE` square.
 std::vector<uint8_t> resizeToInput(
     std::span<const uint8_t> srcRgb, uint32_t srcWidth, uint32_t srcHeight);
 
-/// `kInputSize` × `kInputSize` RGB → FP32 WHCN tensor, ImageNet-normalized.
+/// `INPUT_SIZE` × `INPUT_SIZE` RGB → FP32 WHCN tensor, ImageNet-normalized.
 std::vector<float> normalizeToWhcn(std::span<const uint8_t> rgb224);
 
 /// Full pipeline: encoded-or-raw buffer → FP32 WHCN tensor.

--- a/packages/classification-ggml/addon/src/model-interface/MobileNetGraph.cpp
+++ b/packages/classification-ggml/addon/src/model-interface/MobileNetGraph.cpp
@@ -62,9 +62,10 @@ struct ggml_tensor* cloneRaw(
 
 /// Like cloneRaw but forces the destination dtype to F32.
 struct ggml_tensor* cloneAsFp32(
-    struct ggml_context* bundleCtx, const char* name, int n_dims,
+    struct ggml_context* bundleCtx, const char* name, int nDims,
     const int64_t* ne) {
-  struct ggml_tensor* dst = ggml_new_tensor(bundleCtx, GGML_TYPE_F32, n_dims, ne);
+  struct ggml_tensor* dst =
+      ggml_new_tensor(bundleCtx, GGML_TYPE_F32, nDims, ne);
   ggml_set_name(dst, name);
   return dst;
 }
@@ -317,7 +318,7 @@ WeightsBundle loadWeights(
 
   // Default to the architecture-standard 0.001 (PyTorch's BN default).
   // Never silently fall back to torchvision's 1e-5 reference value.
-  float bnEps = kBatchNormEpsilon;
+  float bnEps = BATCH_NORM_EPSILON;
   {
     const int64_t epsIdx = gguf_find_key(gguf, "mobilenet.bn_eps");
     if (epsIdx >= 0) {
@@ -326,19 +327,19 @@ WeightsBundle loadWeights(
   }
 
   {
-    uint32_t numClasses = kNumClasses;
+    uint32_t numClasses = NUM_CLASSES;
     const int64_t idxN = gguf_find_key(gguf, "mobilenet.num_classes");
     if (idxN >= 0) {
       numClasses = gguf_get_val_u32(gguf, static_cast<int>(idxN));
     }
     // Mismatch silently corrupts the classifier upload and the per-call
     // tensor_get; reject up front.
-    if (numClasses != kNumClasses) {
+    if (numClasses != NUM_CLASSES) {
       raiseInvalid(
           "GGUF metadata 'mobilenet.num_classes' (" +
           std::to_string(numClasses) +
           ") does not match the addon's compiled-in class count (" +
-          std::to_string(kNumClasses) +
+          std::to_string(NUM_CLASSES) +
           "); rebuild @qvac/classification-ggml against this model or use "
           "a GGUF with the expected number of classes");
     }
@@ -408,9 +409,9 @@ WeightsBundle loadWeights(
   };
 
   addConvWeight("features.0.0.weight");
-  addFoldedBn("features.0.1", kStemOutChannels);
+  addFoldedBn("features.0.1", STEM_OUT_CHANNELS);
 
-  for (const BlockConfig& cfg : kBlocks) {
+  for (const BlockConfig& cfg : BLOCKS) {
     const std::string base = "features." + std::to_string(cfg.featuresIndex);
     const bool hasExpand = cfg.expandedChannels != cfg.inputChannels;
     int dwIdx = 0;
@@ -452,12 +453,12 @@ WeightsBundle loadWeights(
   }
 
   addConvWeight("features.12.0.weight");
-  addFoldedBn("features.12.1", kTailOutChannels);
+  addFoldedBn("features.12.1", TAIL_OUT_CHANNELS);
 
-  addFcWeightFp32("classifier.0.weight", kTailOutChannels, kClassifierHidden);
-  addFcBiasFp32("classifier.0.bias", kClassifierHidden);
-  addFcWeightFp32("classifier.3.weight", kClassifierHidden, kNumClasses);
-  addFcBiasFp32("classifier.3.bias", kNumClasses);
+  addFcWeightFp32("classifier.0.weight", TAIL_OUT_CHANNELS, CLASSIFIER_HIDDEN);
+  addFcBiasFp32("classifier.0.bias", CLASSIFIER_HIDDEN);
+  addFcWeightFp32("classifier.3.weight", CLASSIFIER_HIDDEN, NUM_CLASSES);
+  addFcBiasFp32("classifier.3.bias", NUM_CLASSES);
 
   bundle.backendBuffer =
       ggml_backend_alloc_ctx_tensors(bundle.ctx.get(), backend);
@@ -524,7 +525,7 @@ WeightsBundle loadWeights(
   };
 
   foldBn("features.0.1");
-  for (const BlockConfig& cfg : kBlocks) {
+  for (const BlockConfig& cfg : BLOCKS) {
     const std::string base = "features." + std::to_string(cfg.featuresIndex);
     const bool hasExpand = cfg.expandedChannels != cfg.inputChannels;
     int dwIdx = 0;
@@ -580,8 +581,7 @@ ComputeGraph buildGraph(const WeightsBundle& weights, ggml_backend_t backend) {
   struct ggml_context* ctx = cg.ctx.get();
 
   // WHCN: width, height, channels, batch.
-  cg.input =
-      ggml_new_tensor_4d(ctx, GGML_TYPE_F32, kInputHw, kInputHw, 3, 1);
+  cg.input = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, INPUT_HW, INPUT_HW, 3, 1);
   ggml_set_name(cg.input, "input");
 
   GraphBuilder gb{ctx, weights.tensors};
@@ -590,9 +590,9 @@ ComputeGraph buildGraph(const WeightsBundle& weights, ggml_backend_t backend) {
       cg.input, "features.0.0", "features.0.1", /*stride=*/2, /*kernel=*/3,
       /*activate=*/true, /*useHardswish=*/true);
 
-  int spatial = kInputHw / 2;
+  int spatial = INPUT_HW / 2;
 
-  for (const BlockConfig& cfg : kBlocks) {
+  for (const BlockConfig& cfg : BLOCKS) {
     x = gb.invertedResidual(x, cfg, spatial);
     if (cfg.stride == 2) {
       spatial = (spatial + 1) / 2;
@@ -605,7 +605,7 @@ ComputeGraph buildGraph(const WeightsBundle& weights, ggml_backend_t backend) {
 
   struct ggml_tensor* pooled = ggml_pool_2d(
       ctx, x, GGML_OP_POOL_AVG, spatial, spatial, spatial, spatial, 0, 0);
-  struct ggml_tensor* flat = ggml_reshape_1d(ctx, pooled, kTailOutChannels);
+  struct ggml_tensor* flat = ggml_reshape_1d(ctx, pooled, TAIL_OUT_CHANNELS);
 
   struct ggml_tensor* fc0 = ggml_mul_mat(
       ctx, gb.t("classifier.0.weight"), flat);
@@ -619,15 +619,15 @@ ComputeGraph buildGraph(const WeightsBundle& weights, ggml_backend_t backend) {
   cg.output = fc3;
   ggml_set_name(cg.output, "logits");
 
-  // The warmup and process() paths both read sizeof(float)*kNumClasses
+  // The warmup and process() paths both read sizeof(float)*NUM_CLASSES
   // bytes from cg.output; mismatch silently truncates or reads OOB.
-  if (ggml_nelements(cg.output) != static_cast<int64_t>(kNumClasses)) {
+  if (ggml_nelements(cg.output) != static_cast<int64_t>(NUM_CLASSES)) {
     raise(
         "Compute graph output has " +
-        std::to_string(ggml_nelements(cg.output)) +
-        " elements, expected " + std::to_string(kNumClasses) +
+        std::to_string(ggml_nelements(cg.output)) + " elements, expected " +
+        std::to_string(NUM_CLASSES) +
         "; classifier wiring or GGUF weight shapes are inconsistent with "
-        "graph::kNumClasses");
+        "graph::NUM_CLASSES");
   }
 
   cg.graph = ggml_new_graph_custom(ctx, 8192, /*grads=*/false);

--- a/packages/classification-ggml/addon/src/model-interface/MobileNetGraph.hpp
+++ b/packages/classification-ggml/addon/src/model-interface/MobileNetGraph.hpp
@@ -25,8 +25,8 @@ struct BlockConfig {
   int seReducedChannels;
 };
 
-inline constexpr int kNumBlocks = 11;
-inline constexpr std::array<BlockConfig, kNumBlocks> kBlocks = {{
+inline constexpr int NUM_BLOCKS = 11;
+inline constexpr std::array<BlockConfig, NUM_BLOCKS> BLOCKS = {{
     // idx  inC  expC  outC  k  s  hs     se     seR
     {1, 16, 16, 16, 3, 2, false, true, 8},
     {2, 16, 72, 24, 3, 2, false, false, 0},
@@ -41,12 +41,12 @@ inline constexpr std::array<BlockConfig, kNumBlocks> kBlocks = {{
     {11, 96, 576, 96, 5, 1, true, true, 144},
 }};
 
-inline constexpr int kStemOutChannels = 16;
-inline constexpr int kTailOutChannels = 576;
-inline constexpr int kClassifierHidden = 1024;
-inline constexpr int kNumClasses = 3;
-inline constexpr float kBatchNormEpsilon = 0.001F;
-inline constexpr int kInputHw = 224;
+inline constexpr int STEM_OUT_CHANNELS = 16;
+inline constexpr int TAIL_OUT_CHANNELS = 576;
+inline constexpr int CLASSIFIER_HIDDEN = 1024;
+inline constexpr int NUM_CLASSES = 3;
+inline constexpr float BATCH_NORM_EPSILON = 0.001F;
+inline constexpr int INPUT_HW = 224;
 
 /// ggml context + name→tensor map for every weight, plus the backing
 /// backend buffer. Lives for the entire model lifetime.

--- a/packages/classification-ggml/docs/architecture.md
+++ b/packages/classification-ggml/docs/architecture.md
@@ -49,7 +49,7 @@ rationale for the key implementation choices.
 |   - buildGraph(): static forward compute     |
 |     graph wired to pre-allocated buffers     |
 |     (asserts ggml_nelements(output) ==       |
-|     kNumClasses before allocation)           |
+|     NUM_CLASSES before allocation)           |
 +----------------------------------------------+
 |  libggml (CPU backend only, via qvac-fabric) |
 |   - desktop/iOS: CPU statically linked into  |

--- a/packages/classification-ggml/docs/onnx-to-gguf-conversion.md
+++ b/packages/classification-ggml/docs/onnx-to-gguf-conversion.md
@@ -36,7 +36,7 @@ This guide describes how to convert a retrained (or freshly exported)
 MobileNetV3-Small PyTorch model into the GGUF container consumed by
 `@qvac/classification-ggml`. It is intentionally minimal — the graph
 construction in `MobileNetGraph.cpp` is parameterised only by the block
-table `kBlocks` and the label metadata inside the GGUF, so swapping in
+table `BLOCKS` and the label metadata inside the GGUF, so swapping in
 new classes (or a different fine-tune) does not require any C++ changes
 as long as the architecture stays MobileNetV3-Small.
 
@@ -150,10 +150,10 @@ any private validation data into the public package.
 ## 5. Supporting a new block table (advanced)
 
 If you switch to a different MobileNet variant (V3-Large, V4, etc.),
-update `kBlocks` in `MobileNetGraph.hpp` to reflect the new
+update `BLOCKS` in `MobileNetGraph.hpp` to reflect the new
 expand/project channels, kernel sizes, strides, SE reducer sizes,
 and HardSwish/ReLU flags. The graph construction loop iterates over
-`kBlocks`; no other change is required as long as the GGUF tensor
+`BLOCKS`; no other change is required as long as the GGUF tensor
 naming follows `features.<N>.block.<idx>.*` conventions.
 
 ## Known pitfalls

--- a/packages/classification-ggml/test/unit/classification_model_test.cpp
+++ b/packages/classification-ggml/test/unit/classification_model_test.cpp
@@ -52,7 +52,7 @@ TEST(MobileNetGraphTest, ArchitectureMatches34ConvAnd2Linear) {
   // Static architecture sanity check: 1 (stem) + Σ convs-per-block + 1 (tail) = 34
   int totalConvs = 1 /*stem*/ + 1 /*tail*/;
   int totalSeBlocks = 0;
-  for (const qgraph::BlockConfig& b : qgraph::kBlocks) {
+  for (const qgraph::BlockConfig& b : qgraph::BLOCKS) {
     const bool hasExpand = b.expandedChannels != b.inputChannels;
     // expand + depthwise + project
     totalConvs += (hasExpand ? 1 : 0) + 1 + 1;
@@ -69,17 +69,16 @@ TEST_F(ClassificationModelTest, LoadSucceedsAndRunsInference) {
 
   // Feed a neutral gray image; we only care that it runs and returns 3 valid
   // probabilities, not about accuracy in this test.
-  std::vector<uint8_t> rawGray(qpp::kInputSize * qpp::kInputSize * 3, 128);
+  std::vector<uint8_t> rawGray(qpp::INPUT_SIZE * qpp::INPUT_SIZE * 3, 128);
   qcc::ClassifyInput input;
   input.data = rawGray;
-  input.rawRgb =
-      qcc::RawRgbDims{qpp::kInputSize, qpp::kInputSize, 3};
+  input.rawRgb = qcc::RawRgbDims{qpp::INPUT_SIZE, qpp::INPUT_SIZE, 3};
 
   std::any out;
   ASSERT_NO_THROW(out = model.process(input));
   const auto* result = std::any_cast<qcc::ClassifyOutput>(&out);
   ASSERT_NE(result, nullptr);
-  ASSERT_EQ(result->results.size(), qgraph::kNumClasses);
+  ASSERT_EQ(result->results.size(), qgraph::NUM_CLASSES);
 
   float sum = 0.0F;
   for (const qcc::ClassifyResult& r : result->results) {
@@ -97,11 +96,10 @@ TEST_F(ClassificationModelTest, SequentialInferenceIsDeterministic) {
   qcc::ClassificationModel model(weightsPath_);
   ASSERT_NO_THROW(model.load());
 
-  std::vector<uint8_t> rawGray(qpp::kInputSize * qpp::kInputSize * 3, 128);
+  std::vector<uint8_t> rawGray(qpp::INPUT_SIZE * qpp::INPUT_SIZE * 3, 128);
   qcc::ClassifyInput input;
   input.data = rawGray;
-  input.rawRgb =
-      qcc::RawRgbDims{qpp::kInputSize, qpp::kInputSize, 3};
+  input.rawRgb = qcc::RawRgbDims{qpp::INPUT_SIZE, qpp::INPUT_SIZE, 3};
 
   std::any a = model.process(input);
   std::any b = model.process(input);
@@ -120,11 +118,10 @@ TEST_F(ClassificationModelTest, TopKFiltersResults) {
   qcc::ClassificationModel model(weightsPath_);
   ASSERT_NO_THROW(model.load());
 
-  std::vector<uint8_t> rawGray(qpp::kInputSize * qpp::kInputSize * 3, 128);
+  std::vector<uint8_t> rawGray(qpp::INPUT_SIZE * qpp::INPUT_SIZE * 3, 128);
   qcc::ClassifyInput input;
   input.data = rawGray;
-  input.rawRgb =
-      qcc::RawRgbDims{qpp::kInputSize, qpp::kInputSize, 3};
+  input.rawRgb = qcc::RawRgbDims{qpp::INPUT_SIZE, qpp::INPUT_SIZE, 3};
   input.topK = 1;
 
   std::any out = model.process(input);
@@ -138,5 +135,5 @@ TEST(BatchNormFoldingTest, EpsilonIsZeroPointZeroZeroOne) {
   // original MobileNetV3 paper and the torchvision `mobilenet_v3_small`
   // default). Guards against a regression to the generic 1e-5 that causes
   // normalisation drift to accumulate across all 34 layers of the network.
-  EXPECT_FLOAT_EQ(qgraph::kBatchNormEpsilon, 0.001F);
+  EXPECT_FLOAT_EQ(qgraph::BATCH_NORM_EPSILON, 0.001F);
 }

--- a/packages/classification-ggml/test/unit/preprocessor_test.cpp
+++ b/packages/classification-ggml/test/unit/preprocessor_test.cpp
@@ -72,10 +72,10 @@ TEST(PreprocessorTest, EmptyBufferIsRejected) {
 }
 
 TEST(PreprocessorTest, NormalizeToWhcnProducesExpectedSize) {
-  std::vector<uint8_t> rgb(kInputSize * kInputSize * kChannels, 128);
+  std::vector<uint8_t> rgb(INPUT_SIZE * INPUT_SIZE * CHANNELS, 128);
   std::vector<float> out = normalizeToWhcn(rgb);
-  EXPECT_EQ(out.size(),
-            static_cast<size_t>(kInputSize) * kInputSize * kChannels);
+  EXPECT_EQ(
+      out.size(), static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE * CHANNELS);
   // Pixel value 128/255 is close to 0.502; subtracting ImageNet means and
   // dividing by std should produce values well inside [-3, 3] for all
   // channels.
@@ -88,24 +88,25 @@ TEST(PreprocessorTest, NormalizeToWhcnProducesExpectedSize) {
 TEST(PreprocessorTest, ResizeProducesExpectedDimensions) {
   std::vector<uint8_t> src(10 * 10 * 3, 200);
   std::vector<uint8_t> resized = resizeToInput(src, 10, 10);
-  EXPECT_EQ(resized.size(),
-            static_cast<size_t>(kInputSize) * kInputSize * kChannels);
+  EXPECT_EQ(
+      resized.size(), static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE * CHANNELS);
 }
 
 TEST(PreprocessorTest, NormalizeToWhcnChannelFirstLayout) {
   // Fill plane with (255, 0, 0) red; verify R channel first, then G, then B.
-  std::vector<uint8_t> rgb(kInputSize * kInputSize * kChannels, 0);
-  for (size_t i = 0; i < static_cast<size_t>(kInputSize) * kInputSize; ++i) {
+  std::vector<uint8_t> rgb(INPUT_SIZE * INPUT_SIZE * CHANNELS, 0);
+  for (size_t i = 0; i < static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE; ++i) {
     rgb[i * 3 + 0] = 255; // R
   }
   std::vector<float> out = normalizeToWhcn(rgb);
-  const size_t plane = static_cast<size_t>(kInputSize) * kInputSize;
+  const size_t plane = static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE;
   // R channel plane: normalized (1.0 - 0.485) / 0.229 ≈ 2.248
-  EXPECT_NEAR(out[0], (1.0F - kImageNetMean[0]) / kImageNetStd[0], 1e-3F);
+  EXPECT_NEAR(out[0], (1.0F - IMAGENET_MEAN[0]) / IMAGENET_STD[0], 1e-3F);
   // G channel plane (offset = plane) starts from 0.
-  EXPECT_NEAR(out[plane], (0.0F - kImageNetMean[1]) / kImageNetStd[1], 1e-3F);
+  EXPECT_NEAR(out[plane], (0.0F - IMAGENET_MEAN[1]) / IMAGENET_STD[1], 1e-3F);
   // B channel plane (offset = 2*plane) starts from 0.
-  EXPECT_NEAR(out[2 * plane], (0.0F - kImageNetMean[2]) / kImageNetStd[2], 1e-3F);
+  EXPECT_NEAR(
+      out[2 * plane], (0.0F - IMAGENET_MEAN[2]) / IMAGENET_STD[2], 1e-3F);
 }
 
 // -------- decodeToRgb coverage --------
@@ -120,11 +121,9 @@ TEST(PreprocessorTest, DecodeToRgbDecodesValidJpeg) {
   std::vector<uint8_t> rgb = decodeToRgb(jpeg, width, height);
   EXPECT_GT(width, 0u);
   EXPECT_GT(height, 0u);
-  EXPECT_LE(width, kMaxImageDimension);
-  EXPECT_LE(height, kMaxImageDimension);
-  EXPECT_EQ(
-      rgb.size(),
-      static_cast<size_t>(width) * height * kChannels);
+  EXPECT_LE(width, MAX_IMAGE_DIMENSION);
+  EXPECT_LE(height, MAX_IMAGE_DIMENSION);
+  EXPECT_EQ(rgb.size(), static_cast<size_t>(width) * height * CHANNELS);
 }
 
 TEST(PreprocessorTest, DecodeToRgbRejectsEmptyBuffer) {
@@ -167,8 +166,7 @@ TEST(PreprocessorTest, PreprocessToTensorAcceptsEncodedJpeg) {
   }
   std::vector<float> out = preprocessToTensor(jpeg, 0, 0, 0);
   EXPECT_EQ(
-      out.size(),
-      static_cast<size_t>(kInputSize) * kInputSize * kChannels);
+      out.size(), static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE * CHANNELS);
   for (float v : out) {
     EXPECT_TRUE(std::isfinite(v));
   }
@@ -177,12 +175,10 @@ TEST(PreprocessorTest, PreprocessToTensorAcceptsEncodedJpeg) {
 TEST(PreprocessorTest, PreprocessToTensorAcceptsRawRgb) {
   // 16x16 raw RGB block, every channel = 64.
   constexpr uint32_t kSide = 16;
-  std::vector<uint8_t> raw(
-      static_cast<size_t>(kSide) * kSide * kChannels, 64);
-  std::vector<float> out = preprocessToTensor(raw, kSide, kSide, kChannels);
+  std::vector<uint8_t> raw(static_cast<size_t>(kSide) * kSide * CHANNELS, 64);
+  std::vector<float> out = preprocessToTensor(raw, kSide, kSide, CHANNELS);
   EXPECT_EQ(
-      out.size(),
-      static_cast<size_t>(kInputSize) * kInputSize * kChannels);
+      out.size(), static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE * CHANNELS);
   for (float v : out) {
     EXPECT_TRUE(std::isfinite(v));
   }
@@ -227,20 +223,20 @@ TEST(PreprocessorTest, ValidateRawRgbRejectsOverKMaxImageDimensionWidth) {
   // must reject before any other validation.
   std::vector<uint8_t> buf(8, 0);
   EXPECT_THROW(
-      validateRawRgb(buf, kMaxImageDimension + 1, 1, 3), std::exception);
+      validateRawRgb(buf, MAX_IMAGE_DIMENSION + 1, 1, 3), std::exception);
 }
 
 TEST(PreprocessorTest, ValidateRawRgbRejectsOverKMaxImageDimensionHeight) {
   std::vector<uint8_t> buf(8, 0);
   EXPECT_THROW(
-      validateRawRgb(buf, 1, kMaxImageDimension + 1, 3), std::exception);
+      validateRawRgb(buf, 1, MAX_IMAGE_DIMENSION + 1, 3), std::exception);
 }
 
 // -------- normalizeToWhcn invalid input size --------
 
 TEST(PreprocessorTest, NormalizeToWhcnRejectsWrongInputSize) {
-  // One byte short of the expected (kInputSize^2 * kChannels) buffer.
+  // One byte short of the expected (INPUT_SIZE^2 * CHANNELS) buffer.
   std::vector<uint8_t> buf(
-      static_cast<size_t>(kInputSize) * kInputSize * kChannels - 1, 0);
+      static_cast<size_t>(INPUT_SIZE) * INPUT_SIZE * CHANNELS - 1, 0);
   EXPECT_THROW(normalizeToWhcn(buf), std::exception);
 }


### PR DESCRIPTION
## What

Renames the MobileNet / image-preprocessor global constants in `classification-ggml` from k-prefixed CamelCase (`kInputSize`, `kChannels`, `kNumClasses`, `kBlocks`, `kBatchNormEpsilon`, …) to `UPPER_CASE` (`INPUT_SIZE`, `CHANNELS`, `NUM_CLASSES`, `BLOCKS`, `BATCH_NORM_EPSILON`, …).

Pure rename — no behavior change. ~14 constants across the model-interface sources, tests, and docs. clang-format reflow applied only on the touched lines.

## Why

The package's `.clang-tidy` mandates:

```
readability-identifier-naming.GlobalConstantCase: UPPER_CASE
readability-identifier-naming.GlobalConstantPrefix: ''
```

The `kFoo` constants violate this. They **pre-date this PR and are latent on main**: `cpp-lint` runs `clang-tidy` / `git-clang-format` only on files a PR *touches*, so the violations stay invisible until some PR edits `ClassificationModel.cpp` or the `model-interface` headers — at which point clang-tidy fails with `invalid case style for global constant ... [readability-identifier-naming,-warnings-as-errors]`.

This surfaced while bringing `classification-ggml` onto the `GGML_BACKEND_DL` fabric (that work edits `ClassificationModel.cpp`). Renaming the constants up front, as a standalone change, unblocks those PRs' lint without entangling it with the fabric work. Mirrors the `vla-ggml` naming cleanup, which renamed identifiers to the `.clang-tidy` contract rather than relaxing it.

## Validation

`git-clang-format-19 --diff origin/main -- packages/classification-ggml` → *"clang-format did not modify any files"* (with the lint-cpp `.clang-format` in place, as CI provisions it). No `kFoo` identifiers remain in the package.

## Scope

`classification-ggml` only. No fabric, no workflows, no other packages.