### PR TITLE
QVAC-20485 fix: handle language "auto" so audio is transcribed after detection

### DIFF
--- a/packages/transcription-whispercpp/addon/src/model-interface/whisper.cpp/WhisperHandlers.cpp
+++ b/packages/transcription-whispercpp/addon/src/model-interface/whisper.cpp/WhisperHandlers.cpp
@@ -243,8 +243,12 @@ const std::unordered_map<std::string, HandlerFunction<whisper_full_params>>
            }
 
            if (language == "auto") {
+             // A null language triggers whisper.cpp's built-in auto-detection,
+             // which then proceeds to transcribe. detect_language must stay
+             // false here: setting it true makes whisper_full return
+             // immediately after detecting the language, emitting no segments.
              params.language = nullptr;
-             params.detect_language = true;
+             params.detect_language = false;
              return;
            }
 

--- a/packages/transcription-whispercpp/package.json
+++ b/packages/transcription-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/transcription-whispercpp/test/integration/accuracy-multilang.test.js
+++ b/packages/transcription-whispercpp/test/integration/accuracy-multilang.test.js
@@ -66,6 +66,16 @@ const LANGUAGE_TESTS = {
     code: 'ja',
     sampleFile: 'sample_ja.raw',
     expected: 'インターネットで 敵対的環境コース について検索すると おそらく現地企業の住所が出てくるでしょう'
+  },
+  auto: {
+    name: 'Auto-detect',
+    code: 'auto',
+    sampleFile: 'sample.raw',
+    // Reuses the English sample. With language "auto" whisper must auto-detect
+    // the language AND transcribe. A regression where detect_language is forced
+    // true would only detect the language and return zero segments, so this
+    // case guards against empty output as well as accuracy.
+    expected: 'Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do. Once or twice she had peeped into the book her sister was reading but it had no pictures or conversations in it. And what is the use of a book thought Alice without pictures or conversations?'
   }
 }
 
@@ -185,4 +195,12 @@ test('Accuracy test - Russian', { timeout: 300000 }, async (t) => {
 
 test('Accuracy test - Japanese', { timeout: 300000 }, async (t) => {
   await runLanguageAccuracyTest(t, LANGUAGE_TESTS.ja)
+})
+
+test('Accuracy test - Auto language detection', { timeout: 300000 }, async (t) => {
+  const result = await runLanguageAccuracyTest(t, LANGUAGE_TESTS.auto)
+  if (!result.skipped) {
+    t.ok(result.actualText && result.actualText.length > 0,
+      'Auto-detect should produce a non-empty transcription, not just detect the language')
+  }
 })


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Setting `whisperConfig.language` to `"auto"` produced **no transcription output** (zero segments). It worked fine for explicit codes like `"en"`, but `"auto"` silently returned empty results — particularly visible in live/streaming transcription.
- Root cause: the `"auto"` branch set `detect_language = true`. In whisper.cpp, `detect_language = true` means "detect the language, then return immediately" — `whisper_full` returns right after detection without ever transcribing.

## 📝 How does it solve it?

- In the `language` handler (`WhisperHandlers.cpp`), the `"auto"` case now sets `detect_language = false` while keeping `params.language = nullptr`.
- A `nullptr` language already triggers whisper.cpp's built-in auto-detection, and with `detect_language = false` it proceeds to transcribe normally instead of returning early.
- Behavior is unchanged for explicit 2-letter language codes. Existing C++ unit tests around `detect_language` validation remain valid (the ordered `std::map` config means the `language` handler always has the final say on `detect_language`).

## 🧪 How was it tested?

- Added integration test `Accuracy test - Auto language detection` in `test/integration/accuracy-multilang.test.js`. It runs the English sample with `language: "auto"` and asserts both a non-empty transcription and WER accuracy — directly guarding the empty-output regression.
- Verified manually via `examples/example.live-transcription.js` with `language: "auto"`: 291 chunks → 129 segments, full accurate English transcription (previously empty).
- `npx standard` passes on the edited test file.

## 🔌 API Changes

No type-level API change — `language` is still `string`. This corrects the runtime behavior of the already-supported `"auto"` value so it auto-detects **and** transcribes.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215539484661531