### PR TITLE
QVAC-19119 test(llm-llamacpp): overlay qvac-fabric for Qwen3VL multi-tile batching

### DIFF
--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -1019,6 +1019,32 @@ void LlamaModel::commonParamsParse(
     }
   }
 
+  // parse image-tile-mode (not in LLAMA_EXAMPLE_COMMON, must be handled
+  // manually)
+  for (const std::string &key : {"image-tile-mode", "image_tile_mode"}) {
+    if (auto it = configFilemap.find(key); it != configFilemap.end()) {
+      const std::string &val = it->second;
+      if (val == "0" || val == "batched") {
+        params.image_tile_mode = COMMON_IMAGE_TILE_MODE_BATCHED;
+      } else if (val == "1" || val == "sequential") {
+        params.image_tile_mode = COMMON_IMAGE_TILE_MODE_SEQUENTIAL;
+      } else if (val == "2" || val == "baseline") {
+        params.image_tile_mode = COMMON_IMAGE_TILE_MODE_BASELINE;
+      } else {
+        throw qvac_errors::StatusError(
+            ADDON_ID,
+            qvac_errors::general_error::toString(
+                qvac_errors::general_error::InvalidArgument),
+            string_format(
+                "%s: invalid image-tile-mode '%s', must be batched/0, "
+                "sequential/1, or baseline/2\n",
+                __func__, val.c_str()));
+      }
+      configFilemap.erase(it);
+      break;
+    }
+  }
+
   // parse custom nDiscarded from config (apply only if > 0)
   if (auto iter = configFilemap.find("n_discarded");
       iter != configFilemap.end()) {

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -1021,9 +1021,9 @@ void LlamaModel::commonParamsParse(
 
   // parse image-tile-mode (not in LLAMA_EXAMPLE_COMMON, must be handled
   // manually)
-  for (const std::string &key : {"image-tile-mode", "image_tile_mode"}) {
+  for (const std::string& key : {"image-tile-mode", "image_tile_mode"}) {
     if (auto it = configFilemap.find(key); it != configFilemap.end()) {
-      const std::string &val = it->second;
+      const std::string& val = it->second;
       if (val == "0" || val == "batched") {
         params.image_tile_mode = COMMON_IMAGE_TILE_MODE_BATCHED;
       } else if (val == "1" || val == "sequential") {
@@ -1038,7 +1038,8 @@ void LlamaModel::commonParamsParse(
             string_format(
                 "%s: invalid image-tile-mode '%s', must be batched/0, "
                 "sequential/1, or baseline/2\n",
-                __func__, val.c_str()));
+                __func__,
+                val.c_str()));
       }
       configFilemap.erase(it);
       break;

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -130,6 +130,7 @@ void MtmdLlmContext::initVisionContext() {
       params_.mmproj_backend.empty() ? nullptr : params_.mmproj_backend.c_str();
   mparams.print_timings = true;
   mparams.n_threads = params_.cpuparams.n_threads;
+  mparams.image_tile_mode = params_.image_tile_mode;
   ctxVision_.reset(mtmd_init_from_file(clipPath, modelCtx_.model, mparams));
   if (ctxVision_.get() == nullptr) {
     std::string errorMsg = string_format(

--- a/packages/llm-llamacpp/test/integration/_vlm-image-perf.js
+++ b/packages/llm-llamacpp/test/integration/_vlm-image-perf.js
@@ -96,7 +96,7 @@ const GEMMA4_MODEL = {
 }
 
 const QWEN35_MODEL = {
-  perfLabel: 'qwen3.5-vl',
+  perfLabel: 'qwen3.5-vl-batched',
   llmModel: {
     modelName: 'Qwen3.5-0.8B-Q8_0.gguf',
     downloadUrl: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q8_0.gguf'
@@ -105,7 +105,37 @@ const QWEN35_MODEL = {
     modelName: 'mmproj-Qwen3.5-0.8B-F16.gguf',
     downloadUrl: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-F16.gguf'
   },
-  extraConfig: {},
+  extraConfig: { 'image-tile-mode': '0' },
+  ctxFor: (imageCase) => imageCase.qwenCtxSize
+}
+
+const QWEN35_SEQUENTIAL_MODEL = {
+  perfLabel: 'qwen3.5-vl-sequential',
+  llmModel: {
+    modelName: 'Qwen3.5-0.8B-Q8_0.gguf',
+    downloadUrl: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q8_0.gguf'
+  },
+  projModel: {
+    modelName: 'mmproj-Qwen3.5-0.8B-F16.gguf',
+    downloadUrl: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-F16.gguf'
+  },
+  extraConfig: { 'image-tile-mode': '1' },
+  ctxFor: (imageCase) => imageCase.qwenCtxSize
+}
+
+// Baseline mode: replicates pre-PR (master) behaviour — whole image resized
+// via dyn_size, no tiling. Used to verify perf parity with master.
+const QWEN35_BASELINE_MODEL = {
+  perfLabel: 'qwen3.5-vl-baseline',
+  llmModel: {
+    modelName: 'Qwen3.5-0.8B-Q8_0.gguf',
+    downloadUrl: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q8_0.gguf'
+  },
+  projModel: {
+    modelName: 'mmproj-Qwen3.5-0.8B-F16.gguf',
+    downloadUrl: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-F16.gguf'
+  },
+  extraConfig: { 'image-tile-mode': 'baseline' },
   ctxFor: (imageCase) => imageCase.qwenCtxSize
 }
 
@@ -217,5 +247,7 @@ module.exports = {
   GEMMA4_MODEL,
   QWEN35_MODEL,
   skipHeavyImages,
+  QWEN35_SEQUENTIAL_MODEL,
+  QWEN35_BASELINE_MODEL,
   runVlmImagePerf
 }

--- a/packages/llm-llamacpp/test/integration/qwen3-5-image-elephant-baseline-perf.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5-image-elephant-baseline-perf.test.js
@@ -1,0 +1,15 @@
+'use strict'
+// Baseline (no multi-tile) counterpart to qwen3-5-image-elephant-perf.test.js.
+// Uses --image-tile-mode baseline which routes through dyn_size (same as
+// master), giving a direct pre-PR vs PR perf comparison on the same runner.
+
+const test = require('brittle')
+const { QWEN35_BASELINE_MODEL, IMAGE_CASES, runVlmImagePerf } = require('./_vlm-image-perf.js')
+
+test('Qwen3.5-VL image perf baseline [elephant]', { timeout: 1_800_000 }, async t => {
+  await runVlmImagePerf(t, QWEN35_BASELINE_MODEL, IMAGE_CASES.elephant)
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/llm-llamacpp/test/integration/qwen3-5-image-elephant-sequential-perf.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5-image-elephant-sequential-perf.test.js
@@ -1,0 +1,11 @@
+'use strict'
+const test = require('brittle')
+const { QWEN35_SEQUENTIAL_MODEL, IMAGE_CASES, runVlmImagePerf } = require('./_vlm-image-perf.js')
+
+test('Qwen3.5-VL image perf sequential [elephant]', { timeout: 1_800_000 }, async t => {
+  await runVlmImagePerf(t, QWEN35_SEQUENTIAL_MODEL, IMAGE_CASES.elephant)
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/llm-llamacpp/test/integration/qwen3-5-image-fruit-plate-baseline-perf.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5-image-fruit-plate-baseline-perf.test.js
@@ -1,0 +1,15 @@
+'use strict'
+// Baseline (no multi-tile) counterpart to qwen3-5-image-fruit-plate-perf.test.js.
+// Uses --image-tile-mode baseline which routes through dyn_size (same as
+// master), giving a direct pre-PR vs PR perf comparison on the same runner.
+
+const test = require('brittle')
+const { QWEN35_BASELINE_MODEL, IMAGE_CASES, runVlmImagePerf } = require('./_vlm-image-perf.js')
+
+test('Qwen3.5-VL image perf baseline [fruit plate]', { timeout: 1_800_000 }, async t => {
+  await runVlmImagePerf(t, QWEN35_BASELINE_MODEL, IMAGE_CASES['fruit-plate'])
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/llm-llamacpp/test/integration/qwen3-5-image-fruit-plate-sequential-perf.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5-image-fruit-plate-sequential-perf.test.js
@@ -1,0 +1,11 @@
+'use strict'
+const test = require('brittle')
+const { QWEN35_SEQUENTIAL_MODEL, IMAGE_CASES, runVlmImagePerf } = require('./_vlm-image-perf.js')
+
+test('Qwen3.5-VL image perf sequential [fruit plate]', { timeout: 1_800_000 }, async t => {
+  await runVlmImagePerf(t, QWEN35_SEQUENTIAL_MODEL, IMAGE_CASES['fruit-plate'])
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/llm-llamacpp/test/integration/qwen3-5-image-high-res-aurora-baseline-perf.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5-image-high-res-aurora-baseline-perf.test.js
@@ -1,0 +1,15 @@
+'use strict'
+// Baseline (no multi-tile) counterpart to qwen3-5-image-high-res-aurora-perf.test.js.
+// Uses --image-tile-mode baseline which routes through dyn_size (same as
+// master), giving a direct pre-PR vs PR perf comparison on the same runner.
+
+const test = require('brittle')
+const { QWEN35_BASELINE_MODEL, IMAGE_CASES, runVlmImagePerf } = require('./_vlm-image-perf.js')
+
+test('Qwen3.5-VL image perf baseline [high-res aurora]', { timeout: 1_800_000 }, async t => {
+  await runVlmImagePerf(t, QWEN35_BASELINE_MODEL, IMAGE_CASES['high-res-aurora'])
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/llm-llamacpp/test/integration/qwen3-5-image-high-res-aurora-sequential-perf.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5-image-high-res-aurora-sequential-perf.test.js
@@ -1,0 +1,11 @@
+'use strict'
+const test = require('brittle')
+const { QWEN35_SEQUENTIAL_MODEL, IMAGE_CASES, runVlmImagePerf } = require('./_vlm-image-perf.js')
+
+test('Qwen3.5-VL image perf sequential [high-res aurora]', { timeout: 1_800_000 }, async t => {
+  await runVlmImagePerf(t, QWEN35_SEQUENTIAL_MODEL, IMAGE_CASES['high-res-aurora'])
+})
+
+setImmediate(() => {
+  setTimeout(() => {}, 500)
+})

--- a/packages/llm-llamacpp/test/mobile/integration.auto.cjs
+++ b/packages/llm-llamacpp/test/mobile/integration.auto.cjs
@@ -116,9 +116,24 @@ async function runQuantizedKvcacheTest (options = {}) { // eslint-disable-line n
   return runIntegrationModule('../integration/quantized-kvcache.test.js', options)
 }
 
+async function runQwen35ImageElephantBaselinePerfTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runQwen35ImageElephantBaselinePerfTest')) return __FILTERED
+  return runIntegrationModule('../integration/qwen3-5-image-elephant-baseline-perf.test.js', options)
+}
+
 async function runQwen35ImageElephantPerfTest (options = {}) { // eslint-disable-line no-unused-vars
   if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runQwen35ImageElephantPerfTest')) return __FILTERED
   return runIntegrationModule('../integration/qwen3-5-image-elephant-perf.test.js', options)
+}
+
+async function runQwen35ImageElephantSequentialPerfTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runQwen35ImageElephantSequentialPerfTest')) return __FILTERED
+  return runIntegrationModule('../integration/qwen3-5-image-elephant-sequential-perf.test.js', options)
+}
+
+async function runQwen35ImageFruitPlateBaselinePerfTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runQwen35ImageFruitPlateBaselinePerfTest')) return __FILTERED
+  return runIntegrationModule('../integration/qwen3-5-image-fruit-plate-baseline-perf.test.js', options)
 }
 
 async function runQwen35ImageFruitPlatePerfTest (options = {}) { // eslint-disable-line no-unused-vars
@@ -126,9 +141,24 @@ async function runQwen35ImageFruitPlatePerfTest (options = {}) { // eslint-disab
   return runIntegrationModule('../integration/qwen3-5-image-fruit-plate-perf.test.js', options)
 }
 
+async function runQwen35ImageFruitPlateSequentialPerfTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runQwen35ImageFruitPlateSequentialPerfTest')) return __FILTERED
+  return runIntegrationModule('../integration/qwen3-5-image-fruit-plate-sequential-perf.test.js', options)
+}
+
+async function runQwen35ImageHighResAuroraBaselinePerfTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runQwen35ImageHighResAuroraBaselinePerfTest')) return __FILTERED
+  return runIntegrationModule('../integration/qwen3-5-image-high-res-aurora-baseline-perf.test.js', options)
+}
+
 async function runQwen35ImageHighResAuroraPerfTest (options = {}) { // eslint-disable-line no-unused-vars
   if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runQwen35ImageHighResAuroraPerfTest')) return __FILTERED
   return runIntegrationModule('../integration/qwen3-5-image-high-res-aurora-perf.test.js', options)
+}
+
+async function runQwen35ImageHighResAuroraSequentialPerfTest (options = {}) { // eslint-disable-line no-unused-vars
+  if (typeof __shouldRunTest === 'function' && !__shouldRunTest('runQwen35ImageHighResAuroraSequentialPerfTest')) return __FILTERED
+  return runIntegrationModule('../integration/qwen3-5-image-high-res-aurora-sequential-perf.test.js', options)
 }
 
 async function runQwen35Test (options = {}) { // eslint-disable-line no-unused-vars

--- a/packages/llm-llamacpp/test/mobile/test-groups.json
+++ b/packages/llm-llamacpp/test/mobile/test-groups.json
@@ -38,6 +38,16 @@
       "runQwen35ImageElephantPerfTest",
       "runQwen35ImageFruitPlatePerfTest",
       "runQwen35ImageHighResAuroraPerfTest"
+    ],
+    "vlmPerfQwen35Sequential": [
+      "runQwen35ImageElephantSequentialPerfTest",
+      "runQwen35ImageFruitPlateSequentialPerfTest",
+      "runQwen35ImageHighResAuroraSequentialPerfTest"
+    ],
+    "vlmPerfQwen35Baseline": [
+      "runQwen35ImageElephantBaselinePerfTest",
+      "runQwen35ImageFruitPlateBaselinePerfTest",
+      "runQwen35ImageHighResAuroraBaselinePerfTest"
     ]
   },
   "android": {
@@ -87,6 +97,16 @@
       "runQwen35ImageElephantPerfTest",
       "runQwen35ImageFruitPlatePerfTest",
       "runQwen35ImageHighResAuroraPerfTest"
+    ],
+    "vlmPerfQwen35Sequential": [
+      "runQwen35ImageElephantSequentialPerfTest",
+      "runQwen35ImageFruitPlateSequentialPerfTest",
+      "runQwen35ImageHighResAuroraSequentialPerfTest"
+    ],
+    "vlmPerfQwen35Baseline": [
+      "runQwen35ImageElephantBaselinePerfTest",
+      "runQwen35ImageFruitPlateBaselinePerfTest",
+      "runQwen35ImageHighResAuroraBaselinePerfTest"
     ]
   }
 }

--- a/packages/llm-llamacpp/vcpkg-configuration.json
+++ b/packages/llm-llamacpp/vcpkg-configuration.json
@@ -4,6 +4,9 @@
     "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
+  "overlay-ports": [
+    "vcpkg/ports"
+  ],
   "registries": [
     {
       "kind": "git",

--- a/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
+++ b/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
@@ -1,0 +1,36 @@
+# Function to detect Vulkan version from NDK vulkan_core.h
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    # CMAKE_HOST_SYSTEM_PROCESSOR is unavailable here. Use a glob pattern to complete the folder instead.
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+
+     # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract major.minor version from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+endfunction()

--- a/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/portfile.cmake
+++ b/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,169 @@
+# DEV OVERLAY — points to yingying0906/qvac-fabric-llm.cpp feat/qwen3vl-multi-tile-batching
+# Remove this directory to restore the registry version.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO yingying0906/qvac-fabric-llm.cpp
+  REF 2b1c17f8bc79ddbaa9b80417337e0cc5ec5e30bf
+  SHA512 5f80deb3552fa556aa40d6121fbae5a76544fe2e02e5ba024e26563ed2cb3a65c25b37b8a88775f85a3d47f96173b88427c2723e59e20f250979738b4f337c97
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+    llama BUILD_LLAMA
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS _PORTFILE_FEATURE_OPTIONS
+  FEATURES
+    gpu-backends BUILD_GPU_BACKENDS
+    kleidiai BUILD_KLEIDIAI
+    openmp BUILD_OPENMP
+)
+
+if(NOT BUILD_GPU_BACKENDS)
+  message(STATUS "qvac-fabric: gpu-backends feature OFF — building CPU-only ggml (no Metal/Vulkan/CUDA/OpenCL)")
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+  detect_ndk_vulkan_version()
+  message(STATUS "Using Vulkan C++ wrappers from version: ${vulkan_version}")
+  file(DOWNLOAD
+    "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+    "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    TLS_VERIFY ON
+  )
+  file(ARCHIVE_EXTRACT
+    INPUT "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    DESTINATION "${SOURCE_PATH}"
+    PATTERNS "*.hpp"
+  )
+  file(RENAME
+    "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}"
+    "${SOURCE_PATH}/ggml/src/ggml-vulkan/vulkan_cpp_wrapper"
+  )
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(NOT BUILD_GPU_BACKENDS)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_METAL=OFF
+    -DGGML_VULKAN=OFF
+    -DGGML_CUDA=OFF
+    -DGGML_OPENCL=OFF
+  )
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+elseif (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID)
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_KLEIDIAI)
+  message(STATUS "qvac-fabric: kleidiai feature ON — building with ARM KleidiAI optimized kernels")
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_CPU_KLEIDIAI=ON
+    -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+  )
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_OPENMP)
+  message(STATUS "qvac-fabric: OpenMP for Android enabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=ON)
+else()
+  message(STATUS "qvac-fabric: OpenMP Disabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENCL=ON)
+endif()
+
+if(BUILD_GPU_BACKENDS AND NOT VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_IS_IOS)
+  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    string(APPEND VCPKG_C_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+  else()
+    string(APPEND VCPKG_C_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+  endif()
+endif()
+
+set(LLAMA_OPTIONS)
+if("llama" IN_LIST FEATURES)
+  list(APPEND LLAMA_OPTIONS -DLLAMA_MTMD=ON)
+else()
+  list(APPEND LLAMA_OPTIONS
+    -DLLAMA_MTMD=OFF
+    -DLLAMA_BUILD_COMMON=OFF
+  )
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${LLAMA_OPTIONS}
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml)
+
+if(BUILD_LLAMA)
+  vcpkg_cmake_config_fixup(PACKAGE_NAME llama)
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+if(BUILD_LLAMA)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+  file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+  endif()
+endif()
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/vcpkg.json
+++ b/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,47 @@
+{
+  "name": "qvac-fabric",
+  "version": "8828.2.0-dev",
+  "description": "DEV OVERLAY — yingying0906/qvac-fabric-llm.cpp feat/qwen3vl-multi-tile-batching",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "gpu-backends",
+    "llama"
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    },
+    "gpu-backends": {
+      "description": "Build the GPU backends ggml ships per platform: Metal on Apple, Vulkan on Linux/Windows/Android, plus the Android backend-DL hybrid mode and OpenCL. Default-on so existing consumers (llamacpp-llm, llamacpp-embed, nmtcpp, diffusion-cpp) keep their current behaviour with default features. Disable to produce a CPU-only ggml build (useful for consumers like @qvac/classification-ggml that don't need GPU paths and want to skip the vulkan-sdk / metal / opencl build cost). Orthogonal to the 'llama' feature.",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "platform": "!osx & !ios",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    },
+    "kleidiai": {
+      "description": "Enable ARM KleidiAI optimized kernels on Android."
+    },
+    "llama": {
+      "description": "Build llama components."
+    },
+    "openmp": {
+      "description": "Enable openmp on Android."
+    }
+  }
+}


### PR DESCRIPTION
## What problem does this PR solve?

This PR is for CI testing only and will not be merged.

1. Qwen3.5 lacked multi-tile support. Images were always processed as a single tile regardless of resolution, losing detail on high-resolution inputs.
2. Even where multi-tiling existed, the vision encoder ran N sequential forward passes, one per tile. On GPU backends this is inefficient; a single batched dispatch over all tiles produces identical embeddings with far less overhead.

## How does it solve it?

Implements multi-tile image preprocessing for Qwen3.5 (using the `qwen3vl` encoder path it shares with Qwen3VL), and replaces the N sequential vision encoder forward passes with a single batched forward pass over all tiles (batch dim = N tiles).

A new `--image-tile-mode` flag controls the dispatch mode:

| Mode | Behaviour |
|---|---|
| `batched` | Single GPU forward pass over all tiles |
| `sequential` | Original N sequential passes (for benchmarking) |
| `baseline` | Single-tile dyn_size path, matches current master behaviour (default) |

Preliminary benchmark (Qwen3.5-2B Q4_K_M, F16 mmproj, 1920x1280 image, 4 tiles):

MacBook (M5 Pro, Metal):

| Variant | Encode (ms) | Prompt eval (ms) | Decode (tok/s) |
|---|---|---|---|
| Baseline (master) | 3,503 | 5,104 | 63.6 |
| Sequential | **1,723** | **3,258** | 62.4 |
| Batched | **1,762** | **3,297** | 63.0 |

Samsung S25 Ultra (Adreno 830, OpenCL):

| Variant | Encode (ms) | Prompt eval (ms / tok) | Prompt eval (tok/s) |
|---|---|---|---|
| Baseline (master) | 57,288 | 199,552 / 2418 tok | 12.1 |
| Sequential | 24,991 | 139,200 / 2322 tok | 16.7 |
| Batched | **15,865** | **117,811** / 2322 tok | **19.7** |

## Breaking changes

None. To revert: delete `packages/llm-llamacpp/vcpkg/ports/qvac-fabric/` and remove the `VCPKG_OVERLAY_PORTS` line from `CMakeLists.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)