### PR TITLE
Fixed qvac-fabric version

### DIFF
--- a/packages/fabric/vcpkg.json
+++ b/packages/fabric/vcpkg.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "8828.2.0"
+      "version>=": "8828.1.0"
     },
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## What problem does this PR solve?

When removing the overlay port, the qvac-fabric version was mistakenly raised to a non-existent version.

## How does it solve it?

Sets the qvac-fabric vcpkf dependency back to the correct version.

## Breaking changes

N/A