### PR TITLE
Enable vulkan sdk in reusable prebuilds

### DIFF
--- a/.github/workflows/prebuilds-fabric.yml
+++ b/.github/workflows/prebuilds-fabric.yml
@@ -42,4 +42,5 @@ jobs:
       ref: ${{ inputs.ref }}
       repository: ${{ inputs.repository }}
       artifact-name-prefix: fabric-
+      include-vulkan-sdk: true
     secrets: inherit


### PR DESCRIPTION
## What problem does this PR solve?

arm64 prebuilds failed due to missing vulkan sdk.

## How does it solve it?

Enables vulkan sdk in prebuilds action.

## Breaking changes

N/A