### PR TITLE
chore[notask|skiplog]: align ocr-ggml qvac-fabric pin to 8828.1.0

### DIFF
--- a/packages/ocr-ggml/vcpkg.json
+++ b/packages/ocr-ggml/vcpkg.json
@@ -16,7 +16,7 @@
     {
       "name": "qvac-fabric",
       "default-features": false,
-      "version>=": "8828.0.2",
+      "version>=": "8828.1.0",
       "features": [
         "gpu-backends"
       ]


### PR DESCRIPTION
## What

Bump `qvac-fabric` `version>=` in `packages/ocr-ggml/vcpkg.json` from `8828.0.2` → `8828.1.0`.

## Why

PR #2438 (`ce555bc81`, M-RoPE sliding context) bumped `qvac-fabric` to `8828.1.0` across **classification, embed, llm, translation, and vla**, but **missed `ocr-ggml`** — leaving it stranded at `8828.0.2`. This aligns ocr-ggml with the other five GGML addons so they all share the same `qvac-fabric` version.

## Verification

All six GGML addons now pin the same `qvac-fabric`:

| Addon | `qvac-fabric version>=` |
|---|---|
| embed-llamacpp | 8828.1.0 |
| translation-nmtcpp | 8828.1.0 |
| vla-ggml | 8828.1.0 |
| classification-ggml | 8828.1.0 |
| llm-llamacpp | 8828.1.0 |
| ocr-ggml | 8828.1.0 |

No `vcpkg-configuration.json` baseline change is needed — vcpkg resolves the explicit `version>=` from the registry independent of the baseline commit (mirroring exactly what #2438 did: a one-line version bump per addon, no baseline change).
