### PR TITLE
QVAC-19900 chore: release @qvac/ai-sdk-provider v0.2.0

### DIFF
--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+---
+
+## [0.2.0]
+
+Release Date: 2026-06-10
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.2.0
+
 ### Added
 
 - **Managed mode (`mode: 'managed'`).** `createQvac({ mode: 'managed', models, ... })` returns a `Promise<ManagedQvacProvider>` that synthesizes an ephemeral `qvac.config.json` from a model list and brings up `qvac serve openai` for you — no hand-authored config or separate CLI step. Serves are **shared** across processes via a *fleet key* (model set + per-model config + host + binary + pinned port), owned by a **detached runner** that idle-reaps the serve once no consumer process remains for `serveIdleTimeout` (default 5 min). `close()` / `await using` detaches the calling process; a serve still in use by another consumer keeps running. Includes crash-recovery (`fetch` re-resolves and retries once on `ECONNREFUSED`) and a self-healing registry under `~/.qvac/managed-serves/`. New options: `models`, `servePort`, `serveHost`, `serveStartTimeout`, `serveBinPath`, `reuse`, `serveIdleTimeout`. New exports: `ManagedQvacProvider`, `QvacManagedOptions`, `QvacManagedModel`, `QvacExternalOptions`, and the managed error classes (`QvacManagedModeError` + subclasses) with the `QvacManagedErrorCode` union. Requires the optional `@qvac/cli` peer dependency. **External mode is unchanged**; the managed subsystem is dynamically imported only when `mode: 'managed'` is set.

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -4,9 +4,9 @@
 
 QVAC is an open-source, cross-platform ecosystem for **local-first, peer-to-peer AI** — LLMs, embeddings, transcription, translation, speech, OCR, and image generation, all running on the user's own hardware. This package is a thin, branded wrapper around [`@ai-sdk/openai-compatible`](https://www.npmjs.com/package/@ai-sdk/openai-compatible) that points at a running `qvac serve openai` HTTP server and re-exports QVAC's model metadata so callers can introspect typed model constants without an HTTP round-trip.
 
-> **Status — managed mode is unreleased (lands in the next `0.2.0`; package is currently `0.1.0`).** Two modes:
-> - **External** (default, the published `0.1.0` surface): the package wraps a `qvac serve openai` HTTP endpoint that you run yourself.
-> - **Managed** (`mode: 'managed'`, unreleased): the provider synthesizes an ephemeral config from a model list, then spawns (or reuses) a shared `qvac serve` on a free port and keeps it alive for as long as anything is using it, reaping it automatically once everyone is done. See [Managed mode](#managed-mode) below. Requires the optional [`@qvac/cli`](https://www.npmjs.com/package/@qvac/cli) peer dependency.
+> **Status — `0.2.0`.** Two modes:
+> - **External** (default): the package wraps a `qvac serve openai` HTTP endpoint that you run yourself.
+> - **Managed** (`mode: 'managed'`): the provider synthesizes an ephemeral config from a model list, then spawns (or reuses) a shared `qvac serve` on a free port and keeps it alive for as long as anything is using it, reaping it automatically once everyone is done. See [Managed mode](#managed-mode) below. Requires the optional [`@qvac/cli`](https://www.npmjs.com/package/@qvac/cli) peer dependency.
 >
 > See the [QVAC-19194 epic](https://app.asana.com/1/45238840754660/task/1214968611313049).
 
@@ -313,7 +313,7 @@ type EndpointCategory =
   | 'image'
 ```
 
-The catalog is **codegen'd from the live QVAC P2P registry** at build time and committed to the package — `0.1.0` ships 729 OpenAI-surface model constants covering chat (`llamacpp-completion`), embeddings (`llamacpp-embedding`), transcription (`whispercpp-transcription`, `parakeet-transcription`), translation (`nmtcpp-translation`), speech (`onnx-tts`, `tts-ggml`), OCR (`onnx-ocr`), and image generation (`sdcpp-generation`). Regenerate against the live registry with:
+The catalog is **codegen'd from the live QVAC P2P registry** at build time and committed to the package, covering chat (`llamacpp-completion`), embeddings (`llamacpp-embedding`), transcription (`whispercpp-transcription`, `parakeet-transcription`), translation (`nmtcpp-translation`), speech (`onnx-tts`, `tts-ggml`), OCR (`onnx-ocr`), and image generation (`sdcpp-generation`). Regenerate against the live registry with:
 
 ```bash
 npm run update-models     # writes src/models/constants.ts + models/history/<sha>.txt

--- a/packages/ai-sdk-provider/changelog/0.2.0/CHANGELOG.md
+++ b/packages/ai-sdk-provider/changelog/0.2.0/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.2.0
+
+## Added
+
+- Add managed mode to `@qvac/ai-sdk-provider`, allowing `createQvac({ mode: 'managed', models })` to synthesize a temporary `qvac serve` config, spawn or reuse a shared serve, and clean it up once no consumers remain.
+- Add the public managed-mode option and type surface: `ManagedQvacProvider`, `QvacManagedOptions`, `QvacManagedModel`, `QvacExternalOptions`, managed setup errors, serve reuse controls, idle timeout controls, and optional `@qvac/cli` peer dependency resolution.
+- Add a friendly model catalog that maps public model ids such as `qwen3.5-9b` to SDK model constants for managed configs and models.dev-aligned integrations.
+
+## Notes
+
+- External mode is unchanged and remains the default synchronous provider path.
+- Managed mode is loaded only when `mode: 'managed'` is used.

--- a/packages/ai-sdk-provider/changelog/0.2.0/CHANGELOG_LLM.md
+++ b/packages/ai-sdk-provider/changelog/0.2.0/CHANGELOG_LLM.md
@@ -1,0 +1,28 @@
+# QVAC AI SDK Provider v0.2.0 Release Notes
+
+Release Date: 2026-06-10
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.2.0
+
+## Managed Mode
+
+`@qvac/ai-sdk-provider` can now run `qvac serve` for local applications instead of requiring users to start a separate server first. Calling `createQvac({ mode: 'managed', models })` creates an ephemeral serve config, starts the QVAC CLI on a free local port, waits for the OpenAI-compatible endpoint to become healthy, and returns a normal AI SDK provider pointed at that serve.
+
+Managed serves are shared by default. If another process requests the same model fleet and config, it attaches to the existing warm serve instead of spawning another process and loading the same model into memory again. A detached runner owns the serve and reaps it after the last consumer exits and the idle timeout expires.
+
+## Lifecycle Improvements
+
+The managed serve lifecycle is designed for coding agents and other local tools that may start, restart, or crash frequently:
+
+- `close()` and `await using` detach the current consumer without killing a serve that another session is still using.
+- `closeOnParentExit` lets plugin hosts clean up when their parent tool exits.
+- Process-group shutdown ensures the serve and its inference worker are terminated together.
+- Connection-refused recovery re-resolves a serve and retries once when the backing process has disappeared before a request starts.
+
+## Friendly Model Catalog
+
+The package now exposes a small public catalog that maps models.dev-style ids, such as `qwen3.5-9b`, to the SDK constants that `qvac serve` loads. This keeps model ids consistent across catalog UIs, provider configuration, and generated serve configs while preserving support for raw SDK constants.
+
+## Compatibility
+
+External mode is unchanged and remains the default synchronous path. Managed mode is loaded only when `mode: 'managed'` is used and requires `@qvac/cli` as an optional peer dependency.

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ai-sdk-provider",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Vercel AI SDK provider for the QVAC local AI runtime (chat, embeddings, transcription, translation, speech, OCR, image)",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Publishes the managed-mode provider work from QVAC-19900 as `@qvac/ai-sdk-provider` 0.2.0 so downstream integrations can depend on the auto-spawn/reuse lifecycle instead of requiring users to hand-run `qvac serve`.

## 📝 How does it solve it?

- Bumps `packages/ai-sdk-provider/package.json` to `0.2.0`.
- Moves the managed-mode changelog entry into a dated 0.2.0 release section and adds the per-version `changelog/0.2.0` release notes.
- Updates the README status wording so managed mode is documented as part of 0.2.0.
- Targets the `release-ai-sdk-provider-0.2.0` branch; merging this PR publishes the package to GPR. The follow-up is a backmerge PR from the release branch to `main` for the npm publish path.

## 🧪 How was it tested?

- `bun run lint` in `packages/ai-sdk-provider`
- `bun run build` in `packages/ai-sdk-provider`
- `bun run test` in `packages/ai-sdk-provider` — 75 pass / 1 skipped real-model integration test
- Attempted NOTICE regeneration for `ai-sdk-provider`, but the local environment is missing `GH_TOKEN` and `NPM_TOKEN`; this release commit does not add dependencies beyond the already-merged managed-mode change.