### PR TITLE
fix[notask]: ship Parakeet CPU-only on Android to stop Adreno Vulkan SIGABRT

### DIFF
--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-06-10
+
+### Fixed
+
+- **Android: ship Parakeet CPU-only by dropping the Adreno GPU backends, fixing a
+  SIGABRT during model load.** Parakeet already forces `useGPU=false` on Android at
+  the engine boundary (`ParakeetModel::load`, "pending Vulkan/Mali and OpenCL/Adreno
+  driver fixes"), but the addon still *shipped* the
+  `libqvac-speech-ggml-{vulkan,opencl}.so` backends, and `parakeet-cpp`'s
+  `ggml_backend_load_all_from_path()` initialises the Adreno Vulkan device regardless
+  of `n_gpu_layers=0`. After `parakeet-cpp 2026-06-04#0` (#2461) added robust
+  Adreno-generation detection, that init now engages the Adreno Vulkan backend on
+  devices like the Samsung S25 Ultra and aborts in `ggml` graph compute ~8 s into
+  loading `parakeet-tdt-0.6b-v3`, killing the Bare worklet (SIGABRT) and every
+  subsequent test. (Confirmed identical on device-farm runs 27282459468 and
+  27286841825; the same `parakeet@0.7.1` passed on Android on Jun 5 with the older
+  `parakeet-cpp 2026-05-26#2`, which did not detect the Adreno → stayed on CPU.)
+  Drop the `vulkan`/`opencl` vcpkg features from the Android `parakeet-cpp`
+  dependency so the Android prebuild is CPU-only — no GPU backend `.so` is shipped,
+  so nothing initialises the Adreno driver. iOS (Metal) and desktop
+  (Vulkan) builds are unchanged. The Android GPU path can be re-enabled once the
+  upstream Adreno Vulkan/OpenCL `ggml` instability is fixed.
+
 ## [0.7.1] - 2026-06-02
 
 ### Changed

--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.2] - 2026-06-10
+## [0.7.2]
 
 ### Fixed
 

--- a/packages/transcription-parakeet/package.json
+++ b/packages/transcription-parakeet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-parakeet",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "High-performance speech-to-text inference addon using NVIDIA Parakeet models for Bare runtime",
   "addon": true,
   "engines": {

--- a/packages/transcription-parakeet/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg.json
@@ -11,7 +11,6 @@
     {
       "name": "parakeet-cpp",
       "version>=": "2026-06-04#0",
-      "features": ["vulkan", "opencl"],
       "platform": "android"
     },
     {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- With the tts-ggml bootstrap crash fixed (#2502), the Android e2e now boots — but **crashes on the first Parakeet test** (`parakeet-tdt-wav`), killing the consumer and failing the whole batch ("All consumers are dead"). Android-only.
- Confirmed on device-farm runs **27282459468** (PR #2479) and **27286841825** (19-test parakeet-only run), Samsung S25 Ultra: `SIGABRT` on the `mqt_v_js` worklet ~8 s into loading `parakeet-tdt-0.6b-v3`, with the backtrace **entirely inside `libqvac__transcription-parakeet.0.7.1.so`** and the crash immediately preceded by `AdrenoVK-0: Application Name: ggml-vulkan`.

## 📝 How does it solve it?

**Root cause:** `ParakeetModel::load` already forces `useGPU=false` on Android (`n_gpu_layers=0`) *"pending Vulkan/Mali and OpenCL/Adreno driver fixes"* — but the addon still **ships** the `libqvac-speech-ggml-{vulkan,opencl}.so` backends, and `parakeet-cpp`'s `ggml_backend_load_all_from_path()` initialises the **Adreno Vulkan device regardless of `n_gpu_layers`**. Once `parakeet-cpp 2026-06-04#0` (#2461) added robust Adreno-generation detection, that init engages the Adreno Vulkan backend on the S25 Ultra and aborts in `ggml`.

**Evidence it's a dependency regression (not the addon code):** the *same* `transcription-parakeet@0.7.1` passed Parakeet **4/4 on Android on Jun 5** (run `27030121365`) — that build used the older `parakeet-cpp 2026-05-26#2`, which didn't detect the Adreno and stayed on CPU.

**Fix:** drop the `vulkan`/`opencl` vcpkg features from the **Android** `parakeet-cpp` dependency, so the Android prebuild is CPU-only — no GPU backend `.so` is shipped, so nothing initialises the Adreno driver. This completes the existing engine-boundary GPU-disable policy. **iOS (Metal) and desktop (Vulkan) are unchanged.** Version `0.7.1` → `0.7.2` (SDK pins `^0.7.1`, so it picks this up).

This is the same class of Android Adreno-GPU `ggml` instability as the tts-ggml / Supertonic defect.

## 🧪 How was it tested?

- Root-caused from two independent device-farm crashes (same `ggml-vulkan` init → SIGABRT signature) + a known-good comparison (Jun 5 green run on old parakeet-cpp = CPU).
- ⚠️ I could not build the Android prebuild locally — **needs the `verified` label** to run the prebuild + Device Farm parakeet suite to confirm CPU-only loads cleanly. The `readelf`-style ground truth here is the Device Farm run getting past `parakeet-tdt-wav`.

## 💥 Breaking Changes

- Parakeet on Android is now **CPU-only at the build level** (GPU was already disabled at runtime via the engine-boundary `useGPU=false`, so no behavior change for callers). Re-enable once the upstream Adreno Vulkan/OpenCL `ggml` path is fixed.

## ➡️ Follow-up
- Track the upstream `parakeet-cpp` / `ggml` Adreno Vulkan/OpenCL instability (same root family as the Supertonic-Adreno abort) so GPU can be re-enabled on Android.
- A ticket should be linked (used `[notask]` as a placeholder).

---
<sub>Drafted by a Cursor agent.</sub>
