### PR TITLE
QVAC-20554 fix: bare-client close() must not exit in-process host

### DIFF
--- a/packages/sdk/client/rpc/bare-client.ts
+++ b/packages/sdk/client/rpc/bare-client.ts
@@ -26,7 +26,6 @@ import { resolveModelConfig } from "@/server/bare/registry/model-config-registry
 import { resolveConfig } from "@/client/config-loader/resolve-config.bare";
 import {
   initializeWorkerCore,
-  shutdownBareDirectWorker,
   cleanupForTerminate,
 } from "@/server/worker-core";
 import { assertLifecycleAllowed } from "@/server/bare/runtime-lifecycle";
@@ -325,7 +324,7 @@ export async function getRPC() {
 }
 
 export async function close() {
-  await shutdownBareDirectWorker("rpc-close");
+  await cleanupForTerminate();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- In-process Bare calling `close()` invoked `shutdownBareDirectWorker()`, which calls `process.exit()` and kills the host process
- Embedded/in-process consumers could not safely tear down SDK state without terminating themselves
- `__shutdown__` already used `cleanupForTerminate()` (cleanup only, no exit) — `close()` was inconsistent with that path

## 📝 How does it solve it?

- `bare-client.close()` now delegates to `cleanupForTerminate()` instead of `shutdownBareDirectWorker()`
- Aligns `close()` with the existing `__shutdown__` / pre-terminate cleanup semantics for direct Bare mode
- Standalone finite bare examples still exit naturally once top-level work finishes (verified: no hang after `void close()`)

## 🧪 How was it tested?

- Ran `download-with-cancel` and `parallel-download` under Bare (`bare:example`) with only `void close()` — both completed cleanup and exited code 0 on macOS