### PR TITLE
feat[api]: run DocTR depthwise convs on the direct Metal CONV_2D_DW kernel

### DIFF
--- a/packages/ocr-ggml/addon/src/model-interface/doctr/MobileNetGraph.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/doctr/MobileNetGraph.cpp
@@ -197,14 +197,13 @@ struct GraphBuilder {
     // kernel.
     struct ggml_tensor* conv =
         ggml_conv_2d(ctx, kernelT, x, stride, stride, pad, pad, 1, 1);
-    conv = ggml_add(ctx, conv, t(convPrefix + ".bias_br"));
-
-    struct ggml_tensor* bn = applyFoldedBn(
-        ctx, conv, t(bnPrefix + ".scale"), t(bnPrefix + ".shift"));
+    // BN scale folded into the conv weights at load time; `.shift` carries the
+    // combined (conv bias + BN shift) offset. One add instead of add+mul+add.
+    conv = ggml_add(ctx, conv, t(bnPrefix + ".shift"));
     if (!activate) {
-      return bn;
+      return conv;
     }
-    return this->activate(bn, useHardswish);
+    return this->activate(conv, useHardswish);
   }
 
   struct ggml_tensor*
@@ -370,10 +369,10 @@ struct GraphBuilder {
     // (decomposes into Metal-supported ops).
     struct ggml_tensor* conv =
         ggml_conv_2d_dw(ctx, kernelT, x, stride, stride, pad, pad, 1, 1);
-    conv = ggml_add(ctx, conv, t(convPrefix + ".bias_br"));
-    struct ggml_tensor* bn = applyFoldedBn(
-        ctx, conv, t(bnPrefix + ".scale"), t(bnPrefix + ".shift"));
-    return activate(bn, useHardswish);
+    // BN scale folded into the depthwise weights at load time; `.shift` carries
+    // the combined (conv bias + BN shift) offset.
+    conv = ggml_add(ctx, conv, t(bnPrefix + ".shift"));
+    return activate(conv, useHardswish);
   }
 
   /// Squeeze-and-excite block: global avg pool → 1x1 conv (reduce) → ReLU →
@@ -899,42 +898,94 @@ WeightsBundle loadWeights(
     ggml_backend_tensor_set(dst, buf.data(), 0, buf.size() * sizeof(float));
   };
 
-  auto foldBnWithEps = [&](const std::string& bnPrefix, float eps) {
-    // When running stats are absent the BN was already folded offline into the
-    // conv weights/biases. Upload identity (scale=1, shift=0) so that
-    // applyFoldedBn becomes a no-op and the conv bias carries the offset.
-    if (gguf_find_tensor(gguf, (bnPrefix + ".running_mean").c_str()) < 0) {
-      const size_t n =
-          static_cast<size_t>(ggml_nelements(tensors.at(bnPrefix + ".scale")));
-      std::vector<float> ones(n, 1.0F);
-      std::vector<float> zeros(n, 0.0F);
-      uploadF32(tensors.at(bnPrefix + ".scale"), ones);
-      uploadF32(tensors.at(bnPrefix + ".shift"), zeros);
-      return;
+  // Fold the BN per-channel scale into the preceding conv's F16 weights and
+  // combine the conv bias + BN shift into a single bias, so the runtime graph
+  // collapses `conv + add(bias) + mul(scale) + add(shift)` down to
+  // `conv + add(combined)`. Removing two full-tensor elementwise passes per
+  // conv is exact (out = scale*(W*x + bias) + shift = (scale*W)*x +
+  // (scale*bias + shift)) and matters most on bandwidth-bound mobile GPUs.
+  // The conv tensor for a BN named "<P>.1" is "<P>.0.weight" and its broadcast
+  // bias is "<P>.0.bias_br" (both already uploaded before this pass runs).
+  auto foldScaleIntoConv = [&](const std::string& bnPrefix,
+                               const std::vector<float>& scale,
+                               std::vector<float>& shift) {
+    if (bnPrefix.size() < 2 || bnPrefix.substr(bnPrefix.size() - 2) != ".1") {
+      raise("BN fold expects a '<prefix>.1' name, got " + bnPrefix);
     }
-    std::vector<float> w = loadVector1d(gguf, ggmlCtx, bnPrefix + ".scale");
-    std::vector<float> b = loadVector1d(gguf, ggmlCtx, bnPrefix + ".shift");
-    std::vector<float> m =
-        loadVector1d(gguf, ggmlCtx, bnPrefix + ".running_mean");
-    std::vector<float> v =
-        loadVector1d(gguf, ggmlCtx, bnPrefix + ".running_var");
-    const size_t n = w.size();
-    if (b.size() != n || m.size() != n || v.size() != n) {
-      raise("BN param size mismatch for " + bnPrefix);
+    const std::string stem = bnPrefix.substr(0, bnPrefix.size() - 2);
+    const std::string convName = stem + ".0.weight";
+    auto wIt = tensors.find(convName);
+    if (wIt == tensors.end()) {
+      raise("BN fold: conv weight not found: " + convName);
     }
-    std::vector<float> scale(n);
-    std::vector<float> shift(n);
-    for (size_t i = 0; i < n; ++i) {
-      const float invStd = 1.0F / std::sqrt(v[i] + eps);
-      scale[i] = w[i] * invStd;
-      shift[i] = b[i] - (m[i] * scale[i]);
+    struct ggml_tensor* wTensor = wIt->second;
+    if (wTensor->type != GGML_TYPE_F16) {
+      raise("BN fold: expected F16 conv weight for " + convName);
+    }
+    const int64_t oc = wTensor->ne[3];
+    if (static_cast<size_t>(oc) != scale.size()) {
+      raise("BN fold: output-channel mismatch for " + convName);
+    }
+    const int64_t perOc = wTensor->ne[0] * wTensor->ne[1] * wTensor->ne[2];
+    const size_t n = static_cast<size_t>(oc * perOc);
+    std::vector<ggml_fp16_t> wbuf(n);
+    ggml_backend_tensor_get(wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
+    for (int64_t o = 0; o < oc; ++o) {
+      const float s = scale[static_cast<size_t>(o)];
+      for (int64_t i = 0; i < perOc; ++i) {
+        const size_t idx = static_cast<size_t>((o * perOc) + i);
+        wbuf[idx] = ggml_fp32_to_fp16(ggml_fp16_to_fp32(wbuf[idx]) * s);
+      }
+    }
+    ggml_backend_tensor_set(wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
+
+    // combined bias = scale * bias_br + shift (bias_br is zeros for bias=False
+    // convs, the offset for offline-folded models).
+    auto bIt = tensors.find(stem + ".0.bias_br");
+    if (bIt != tensors.end()) {
+      std::vector<float> biasBr(scale.size());
+      ggml_backend_tensor_get(
+          bIt->second, biasBr.data(), 0, biasBr.size() * sizeof(float));
+      for (size_t i = 0; i < shift.size(); ++i) {
+        shift[i] += scale[i] * biasBr[i];
+      }
+    }
+  };
+
+  auto foldBnWithEps = [&](const std::string& bnPrefix, float eps,
+                           bool foldIntoConv) {
+    const size_t n =
+        static_cast<size_t>(ggml_nelements(tensors.at(bnPrefix + ".scale")));
+    std::vector<float> scale(n, 1.0F);
+    std::vector<float> shift(n, 0.0F);
+    // When running stats are present compute the standard BN fold; otherwise
+    // the BN was already folded offline (identity scale/shift; any offset is
+    // carried by the conv bias, which foldScaleIntoConv absorbs).
+    if (gguf_find_tensor(gguf, (bnPrefix + ".running_mean").c_str()) >= 0) {
+      std::vector<float> w = loadVector1d(gguf, ggmlCtx, bnPrefix + ".scale");
+      std::vector<float> b = loadVector1d(gguf, ggmlCtx, bnPrefix + ".shift");
+      std::vector<float> m =
+          loadVector1d(gguf, ggmlCtx, bnPrefix + ".running_mean");
+      std::vector<float> v =
+          loadVector1d(gguf, ggmlCtx, bnPrefix + ".running_var");
+      if (w.size() != n || b.size() != n || m.size() != n || v.size() != n) {
+        raise("BN param size mismatch for " + bnPrefix);
+      }
+      for (size_t i = 0; i < n; ++i) {
+        const float invStd = 1.0F / std::sqrt(v[i] + eps);
+        scale[i] = w[i] * invStd;
+        shift[i] = b[i] - (m[i] * scale[i]);
+      }
+    }
+    if (foldIntoConv) {
+      foldScaleIntoConv(bnPrefix, scale, shift);
     }
     uploadF32(tensors.at(bnPrefix + ".scale"), scale);
     uploadF32(tensors.at(bnPrefix + ".shift"), shift);
   };
 
   auto foldBn = [&](const std::string& bnPrefix) {
-    foldBnWithEps(bnPrefix, bnEps);
+    foldBnWithEps(bnPrefix, bnEps, /*foldIntoConv=*/true);
   };
 
   for (auto& [name, dst] : tensors) {
@@ -976,16 +1027,19 @@ WeightsBundle loadWeights(
 
   for (int branch = 0; branch < fpnInBranchCount; ++branch) {
     const std::string base = "dbnet.fpn.in_branches." + std::to_string(branch);
-    foldBnWithEps(base + ".1", dbnetBatchNormEpsilon);
+    foldBnWithEps(base + ".1", dbnetBatchNormEpsilon, /*foldIntoConv=*/true);
   }
 
   for (int branch = 0; branch < fpnInBranchCount; ++branch) {
     const std::string base = "dbnet.fpn.out_branches." + std::to_string(branch);
-    foldBnWithEps(base + ".1", dbnetBatchNormEpsilon);
+    foldBnWithEps(base + ".1", dbnetBatchNormEpsilon, /*foldIntoConv=*/true);
   }
 
-  foldBnWithEps("dbnet.prob_head.1", dbnetBatchNormEpsilon);
-  foldBnWithEps("dbnet.prob_head.4", dbnetBatchNormEpsilon);
+  // prob_head.0 is a plain 3x3 conv (foldable); prob_head.3/.4 is the
+  // sub-pixel transposed conv whose weight is reshaped at graph build, so its
+  // BN stays as a runtime scale/shift (applyFoldedBn in convTransposeBnAct).
+  foldBnWithEps("dbnet.prob_head.1", dbnetBatchNormEpsilon, /*foldIntoConv=*/true);
+  foldBnWithEps("dbnet.prob_head.4", dbnetBatchNormEpsilon, /*foldIntoConv=*/false);
 
   // Classifier FC tensors stay FP16 and are copied directly from GGUF bytes.
   // auto uploadClassifierTensor = [&](const std::string& name) {

--- a/packages/ocr-ggml/addon/src/model-interface/doctr/MobileNetGraph.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/doctr/MobileNetGraph.cpp
@@ -364,11 +364,11 @@ struct GraphBuilder {
       bool useHardswish) const {
     struct ggml_tensor* kernelT = t(convPrefix + ".weight");
     const int pad = samePadding(kernel);
-    // NOTE: Metal does not implement GGML_OP_CONV_2D_DW, so the direct
-    // depthwise variant aborts there. Keep the im2col + mul_mat path
-    // (decomposes into Metal-supported ops).
+    // Direct depthwise kernel (GGML_OP_CONV_2D_DW) — much faster than the
+    // im2col + per-channel batched matmul on GPU backends. Weight is [KW,KH,1,C]
+    // and promoted to F32 (see addConvWeight) so it runs on every backend.
     struct ggml_tensor* conv =
-        ggml_conv_2d_dw(ctx, kernelT, x, stride, stride, pad, pad, 1, 1);
+        ggml_conv_2d_dw_direct(ctx, kernelT, x, stride, stride, pad, pad, 1, 1);
     // BN scale folded into the depthwise weights at load time; `.shift` carries
     // the combined (conv bias + BN shift) offset.
     conv = ggml_add(ctx, conv, t(bnPrefix + ".shift"));
@@ -690,8 +690,14 @@ WeightsBundle loadWeights(
           "Expected convolution weight tensor name to end with .weight: " +
           name);
     }
+    // Depthwise weights ([KW,KH,1,C], KW>1) are promoted to F32 so the direct
+    // GGML_OP_CONV_2D_DW kernel runs on every backend (CPU requires F32).
+    struct ggml_tensor* srcW = ggml_get_tensor(ggmlCtx, name.c_str());
+    const bool isDw = srcW != nullptr && srcW->ne[2] == 1 && srcW->ne[0] > 1;
     struct ggml_tensor* weightTensor =
-        cloneRaw(bundle.ctx.get(), gguf, ggmlCtx, name.c_str());
+        isDw ? cloneAsFp32(
+                   bundle.ctx.get(), name.c_str(), ggml_n_dims(srcW), srcW->ne)
+             : cloneRaw(bundle.ctx.get(), gguf, ggmlCtx, name.c_str());
     registerTensor(weightTensor);
     addBiasBroadcast(
         name.substr(0, name.size() - std::string(".weight").size()) + ".bias");
@@ -845,10 +851,17 @@ WeightsBundle loadWeights(
     if (src == nullptr) {
       raise("Source tensor missing from GGUF: " + name);
     }
-    if (src->type != dst->type) {
+    if (src->type == dst->type) {
+      ggml_backend_tensor_set(dst, src->data, 0, ggml_nbytes(src));
+    } else if (dst->type == GGML_TYPE_F32 && src->type == GGML_TYPE_F16) {
+      // Depthwise weights are promoted to F32 (see addConvWeight).
+      const size_t count = ggml_nelements(src);
+      std::vector<float> values(count);
+      fp16ToFp32(src->data, values.data(), count);
+      ggml_backend_tensor_set(dst, values.data(), 0, count * sizeof(float));
+    } else {
       raise("Dtype mismatch while copying tensor: " + name);
     }
-    ggml_backend_tensor_set(dst, src->data, 0, ggml_nbytes(src));
   }
 
   // Kept for the future classifier-bytes upload path (see commented-out
@@ -919,25 +932,39 @@ WeightsBundle loadWeights(
       raise("BN fold: conv weight not found: " + convName);
     }
     struct ggml_tensor* wTensor = wIt->second;
-    if (wTensor->type != GGML_TYPE_F16) {
-      raise("BN fold: expected F16 conv weight for " + convName);
-    }
     const int64_t oc = wTensor->ne[3];
     if (static_cast<size_t>(oc) != scale.size()) {
       raise("BN fold: output-channel mismatch for " + convName);
     }
     const int64_t perOc = wTensor->ne[0] * wTensor->ne[1] * wTensor->ne[2];
     const size_t n = static_cast<size_t>(oc * perOc);
-    std::vector<ggml_fp16_t> wbuf(n);
-    ggml_backend_tensor_get(wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
-    for (int64_t o = 0; o < oc; ++o) {
-      const float s = scale[static_cast<size_t>(o)];
-      for (int64_t i = 0; i < perOc; ++i) {
-        const size_t idx = static_cast<size_t>((o * perOc) + i);
-        wbuf[idx] = ggml_fp32_to_fp16(ggml_fp16_to_fp32(wbuf[idx]) * s);
+    // Pointwise/regular conv weights are F16; depthwise weights are F32 (see
+    // addConvWeight). Fold the per-channel scale in whichever dtype.
+    if (wTensor->type == GGML_TYPE_F16) {
+      std::vector<ggml_fp16_t> wbuf(n);
+      ggml_backend_tensor_get(wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
+      for (int64_t o = 0; o < oc; ++o) {
+        const float s = scale[static_cast<size_t>(o)];
+        for (int64_t i = 0; i < perOc; ++i) {
+          const size_t idx = static_cast<size_t>((o * perOc) + i);
+          wbuf[idx] = ggml_fp32_to_fp16(ggml_fp16_to_fp32(wbuf[idx]) * s);
+        }
       }
+      ggml_backend_tensor_set(wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
+    } else if (wTensor->type == GGML_TYPE_F32) {
+      std::vector<float> wbuf(n);
+      ggml_backend_tensor_get(wTensor, wbuf.data(), 0, n * sizeof(float));
+      for (int64_t o = 0; o < oc; ++o) {
+        const float s = scale[static_cast<size_t>(o)];
+        for (int64_t i = 0; i < perOc; ++i) {
+          const size_t idx = static_cast<size_t>((o * perOc) + i);
+          wbuf[idx] *= s;
+        }
+      }
+      ggml_backend_tensor_set(wTensor, wbuf.data(), 0, n * sizeof(float));
+    } else {
+      raise("BN fold: unexpected conv weight dtype for " + convName);
     }
-    ggml_backend_tensor_set(wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
 
     // combined bias = scale * bias_br + shift (bias_br is zeros for bias=False
     // convs, the offset for offline-folded models).

--- a/packages/ocr-ggml/addon/src/model-interface/doctr/StepDoctrRecognitionGGML.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/doctr/StepDoctrRecognitionGGML.cpp
@@ -451,8 +451,11 @@ struct GraphBuilder {
 
   struct ggml_tensor*
   applyBn(struct ggml_tensor* x, const std::string& bnPrefix) const {
-    struct ggml_tensor* scaled = ggml_mul(ctx, x, t(bnPrefix + ".scale"));
-    return ggml_add(ctx, scaled, t(bnPrefix + ".shift"));
+    // The BN per-channel scale is folded into the preceding conv's weights at
+    // load time (see the ".scale" loop in load()), so only the shift remains.
+    // This drops one full-tensor multiply per conv from the feature-extractor
+    // graph, which runs once per recognition batch (many times per page).
+    return ggml_add(ctx, x, t(bnPrefix + ".shift"));
   }
 
   struct ggml_tensor* convBnAct(
@@ -1174,6 +1177,40 @@ private:
       }
       ggml_backend_tensor_set(
           dst, scale.data(), 0, scale.size() * sizeof(float));
+
+      // Fold this BN scale into the preceding conv's F16 weights (per output
+      // channel) so applyBn only needs the shift add. The BN named "<P>.1"
+      // belongs to the conv weight "<P>.0.weight"; both are already uploaded.
+      if (prefix.size() >= 2 && prefix.substr(prefix.size() - 2) == ".1") {
+        const std::string convWeightName =
+            prefix.substr(0, prefix.size() - 2) + ".0.weight";
+        auto it = graph.weights.find(convWeightName);
+        if (it != graph.weights.end()) {
+          struct ggml_tensor* wTensor = it->second;
+          if (wTensor->type != GGML_TYPE_F16) {
+            raise("BN fold: expected F16 conv weight for " + convWeightName);
+          }
+          const int64_t oc = wTensor->ne[3];
+          if (static_cast<size_t>(oc) != scale.size()) {
+            raise("BN fold: output-channel mismatch for " + convWeightName);
+          }
+          const int64_t perOc = wTensor->ne[0] * wTensor->ne[1] * wTensor->ne[2];
+          const size_t n = static_cast<size_t>(oc * perOc);
+          std::vector<ggml_fp16_t> wbuf(n);
+          ggml_backend_tensor_get(
+              wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
+          for (int64_t o = 0; o < oc; ++o) {
+            const float s = scale[static_cast<size_t>(o)];
+            for (int64_t i = 0; i < perOc; ++i) {
+              const size_t idx = static_cast<size_t>((o * perOc) + i);
+              wbuf[idx] =
+                  ggml_fp32_to_fp16(ggml_fp16_to_fp32(wbuf[idx]) * s);
+            }
+          }
+          ggml_backend_tensor_set(
+              wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
+        }
+      }
     }
 
     for (const auto& [name, dst] : graph.weights) {

--- a/packages/ocr-ggml/addon/src/model-interface/doctr/StepDoctrRecognitionGGML.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/doctr/StepDoctrRecognitionGGML.cpp
@@ -362,6 +362,26 @@ struct ggml_tensor* newF16TensorLike(
   return tensor;
 }
 
+struct ggml_tensor* newF32TensorLike(
+    struct ggml_context* ctx, struct ggml_tensor* src,
+    const std::string& name) {
+  struct ggml_tensor* tensor = ggml_new_tensor(
+      ctx,
+      GGML_TYPE_F32,
+      ggml_n_dims(src),
+      src->ne); // NOLINT(hicpp-no-array-decay) - ggml struct member is C array
+  ggml_set_name(tensor, name.c_str());
+  return tensor;
+}
+
+// Depthwise conv weights have shape [KW, KH, 1, C] with KW>1 (single input
+// channel per group). They are kept F32 so the direct GGML_OP_CONV_2D_DW kernel
+// runs on every backend (the CPU/Vulkan f32 paths require F32 weights; Metal
+// and Vulkan also accept f16 but CPU does not).
+bool isDepthwiseWeight(const struct ggml_tensor* src) {
+  return src->ne[2] == 1 && src->ne[0] > 1;
+}
+
 int samePadding(int kernel) { return (kernel - 1) / 2; }
 
 float sigmoid(float value) { return 1.0F / (1.0F + std::exp(-value)); }
@@ -482,7 +502,10 @@ struct GraphBuilder {
       // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
       const std::string& convPrefix, const std::string& bnPrefix, int strideW,
       int strideH, int kernel, bool useHardswish) const {
-    struct ggml_tensor* conv = ggml_conv_2d_dw(
+    // Depthwise via the direct Metal kernel (GGML_OP_CONV_2D_DW) instead of the
+    // im2col + per-channel batched matmul, which is pathologically slow on Metal
+    // (it dominated recognition latency). Weight is [KW,KH,1,C] as required.
+    struct ggml_tensor* conv = ggml_conv_2d_dw_direct(
         ctx,
         t(convPrefix + ".weight"),
         x,
@@ -1020,7 +1043,9 @@ private:
         raise("missing GGUF tensor: " + name);
       }
       struct ggml_tensor* dst =
-          newF16TensorLike(graph.weightsCtx.get(), src, name);
+          isDepthwiseWeight(src)
+              ? newF32TensorLike(graph.weightsCtx.get(), src, name)
+              : newF16TensorLike(graph.weightsCtx.get(), src, name);
       graph.weights.emplace(name, dst);
       return dst;
     };
@@ -1142,6 +1167,11 @@ private:
             static_cast<int64_t>(count));
         ggml_backend_tensor_set(
             dst, values.data(), 0, values.size() * sizeof(ggml_fp16_t));
+      } else if (dst->type == GGML_TYPE_F32 && src->type == GGML_TYPE_F16) {
+        // Depthwise weights are promoted to F32 (see isDepthwiseWeight).
+        const std::vector<float> values = tensorToF32(src, name);
+        ggml_backend_tensor_set(
+            dst, values.data(), 0, values.size() * sizeof(float));
       } else {
         raise("unsupported tensor dtype conversion while uploading: " + name);
       }
@@ -1187,28 +1217,43 @@ private:
         auto it = graph.weights.find(convWeightName);
         if (it != graph.weights.end()) {
           struct ggml_tensor* wTensor = it->second;
-          if (wTensor->type != GGML_TYPE_F16) {
-            raise("BN fold: expected F16 conv weight for " + convWeightName);
-          }
           const int64_t oc = wTensor->ne[3];
           if (static_cast<size_t>(oc) != scale.size()) {
             raise("BN fold: output-channel mismatch for " + convWeightName);
           }
           const int64_t perOc = wTensor->ne[0] * wTensor->ne[1] * wTensor->ne[2];
           const size_t n = static_cast<size_t>(oc * perOc);
-          std::vector<ggml_fp16_t> wbuf(n);
-          ggml_backend_tensor_get(
-              wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
-          for (int64_t o = 0; o < oc; ++o) {
-            const float s = scale[static_cast<size_t>(o)];
-            for (int64_t i = 0; i < perOc; ++i) {
-              const size_t idx = static_cast<size_t>((o * perOc) + i);
-              wbuf[idx] =
-                  ggml_fp32_to_fp16(ggml_fp16_to_fp32(wbuf[idx]) * s);
+          // Pointwise/regular conv weights are F16; depthwise weights are F32
+          // (see isDepthwiseWeight). Fold the per-channel scale in either dtype.
+          if (wTensor->type == GGML_TYPE_F16) {
+            std::vector<ggml_fp16_t> wbuf(n);
+            ggml_backend_tensor_get(
+                wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
+            for (int64_t o = 0; o < oc; ++o) {
+              const float s = scale[static_cast<size_t>(o)];
+              for (int64_t i = 0; i < perOc; ++i) {
+                const size_t idx = static_cast<size_t>((o * perOc) + i);
+                wbuf[idx] = ggml_fp32_to_fp16(ggml_fp16_to_fp32(wbuf[idx]) * s);
+              }
             }
+            ggml_backend_tensor_set(
+                wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
+          } else if (wTensor->type == GGML_TYPE_F32) {
+            std::vector<float> wbuf(n);
+            ggml_backend_tensor_get(
+                wTensor, wbuf.data(), 0, n * sizeof(float));
+            for (int64_t o = 0; o < oc; ++o) {
+              const float s = scale[static_cast<size_t>(o)];
+              for (int64_t i = 0; i < perOc; ++i) {
+                const size_t idx = static_cast<size_t>((o * perOc) + i);
+                wbuf[idx] *= s;
+              }
+            }
+            ggml_backend_tensor_set(
+                wTensor, wbuf.data(), 0, n * sizeof(float));
+          } else {
+            raise("BN fold: unexpected conv weight dtype for " + convWeightName);
           }
-          ggml_backend_tensor_set(
-              wTensor, wbuf.data(), 0, n * sizeof(ggml_fp16_t));
         }
       }
     }

--- a/packages/ocr-ggml/vcpkg-configuration.json
+++ b/packages/ocr-ggml/vcpkg-configuration.json
@@ -1,7 +1,8 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "c5955445a221df255d2204be964647c08c82c28f",
+    "baseline": "d63ab6db5b54088a8fe80ee804fd507739f51f49",
+    "reference": "test/ocr-metal-conv2d-dw",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/ocr-ggml/vcpkg-configuration.json
+++ b/packages/ocr-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "d63ab6db5b54088a8fe80ee804fd507739f51f49",
+    "baseline": "462b86eb48a9fc4091bf64ddcea034b1e2faad1c",
     "reference": "test/ocr-metal-conv2d-dw",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },

--- a/packages/ocr-ggml/vcpkg-configuration.json
+++ b/packages/ocr-ggml/vcpkg-configuration.json
@@ -1,10 +1,12 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "462b86eb48a9fc4091bf64ddcea034b1e2faad1c",
-    "reference": "test/ocr-metal-conv2d-dw",
+    "baseline": "c5955445a221df255d2204be964647c08c82c28f",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
+  "overlay-ports": [
+    "vcpkg-overlay-ports"
+  ],
   "registries": [
     {
       "kind": "git",

--- a/packages/ocr-ggml/vcpkg-overlay-ports/qvac-fabric/android-vulkan-version.cmake
+++ b/packages/ocr-ggml/vcpkg-overlay-ports/qvac-fabric/android-vulkan-version.cmake
@@ -1,0 +1,36 @@
+# Function to detect Vulkan version from NDK vulkan_core.h
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    # CMAKE_HOST_SYSTEM_PROCESSOR is unavailable here. Use a glob pattern to complete the folder instead. 
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT vulkan_core_h)
+        message(FATAL_ERROR "vulkan_core.h not found, using default version")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+
+     # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract major.minor version from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+endfunction()

--- a/packages/ocr-ggml/vcpkg-overlay-ports/qvac-fabric/portfile.cmake
+++ b/packages/ocr-ggml/vcpkg-overlay-ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,193 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac-fabric-llm.cpp
+  # Overlay (test): pin the temp-8828 merge commit of the Metal CONV_2D_DW
+  # kernel (PR tetherto/qvac-fabric-llm.cpp#148) so the addon can be tested on
+  # Device Farm before this is cut as a tag (8828.1.1) and a registry port.
+  REF 7bcd140f7933c44df6fab972297ffca326bbb8c5
+  SHA512 80c1a5ab758cab65ad00a9500ff3cdbae3fafb925b345612ee60d0bbdc6cf44ba6bd30e80b57243dc3344743b6ebe4d2a06de3f5db1e3de7e4eaff44f85c270c
+)
+
+# Upstream CMake options only — passed through to vcpkg_cmake_configure.
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+    llama BUILD_LLAMA
+)
+
+# Portfile-only feature flags (drive PLATFORM_OPTIONS; not upstream cache vars).
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS _PORTFILE_FEATURE_OPTIONS
+  FEATURES
+    gpu-backends BUILD_GPU_BACKENDS
+    kleidiai BUILD_KLEIDIAI
+    openmp BUILD_OPENMP
+)
+
+# gpu-backends is default-on via default-features in vcpkg.json. CPU-only
+# consumers (e.g. @qvac/classification-ggml) disable it with
+# default-features:false (and re-add 'llama' if needed).
+if(NOT BUILD_GPU_BACKENDS)
+  message(STATUS "qvac-fabric: gpu-backends feature OFF — building CPU-only ggml (no Metal/Vulkan/CUDA/OpenCL)")
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  # NDK only comes with C headers.
+  # Make sure C++ header exists, it will be used by ggml tensor library.
+  # Need to determine installed vulkan version and download correct headers
+  include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+  detect_ndk_vulkan_version()
+  message(STATUS "Using Vulkan C++ wrappers from version: ${vulkan_version}")
+  file(DOWNLOAD
+    "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+    "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    TLS_VERIFY ON
+  )
+
+  file(ARCHIVE_EXTRACT
+    INPUT "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    DESTINATION "${SOURCE_PATH}"
+    PATTERNS "*.hpp"
+  )
+
+  file(RENAME
+    "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}"
+    "${SOURCE_PATH}/ggml/src/ggml-vulkan/vulkan_cpp_wrapper"
+  )
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(NOT BUILD_GPU_BACKENDS)
+  # Force every GPU backend off explicitly, in case upstream defaults change.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_METAL=OFF
+    -DGGML_VULKAN=OFF
+    -DGGML_CUDA=OFF
+    -DGGML_OPENCL=OFF
+  )
+  if (VCPKG_TARGET_IS_IOS)
+    # Same iOS BLAS/Accelerate gating as the GPU-on path; unrelated to the
+    # CPU-vs-GPU split, an iOS-toolchain workaround for missing frameworks.
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+elseif (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+# Android: always build CPU variants (NEON_DOTPROD, NEON_I8MM, etc.) and CPU
+# repacking. These are CPU-only runtime optimizations selected based on the
+# device's SIMD capabilities at load time, completely orthogonal to the GPU
+# backends. Bundling them is essential for good CPU inference performance on
+# the wide range of arm64 devices the addons ship to. Requires GGML_BACKEND_DL
+# to dispatch the variants at runtime; the existing #ifdef guard around
+# `ggml_backend_load_all_from_path()` in ggml-backend-reg.cpp keeps the search
+# scoped to the consumer's own prebuilds dir.
+if(VCPKG_TARGET_IS_ANDROID)
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_KLEIDIAI)
+  message(STATUS "qvac-fabric: kleidiai feature ON — building with ARM KleidiAI optimized kernels")
+  # ggml only vendors KleidiAI via FetchContent; registry vcpkg-cmake sets
+  # FETCHCONTENT_FULLY_DISCONNECTED=ON globally, so allow the download here.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_CPU_KLEIDIAI=ON
+    -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+  )
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_OPENMP)
+  message(STATUS "qvac-fabric: OpenMP for Android enabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=ON)
+else()
+  message(STATUS "qvac-fabric: OpenMP Disabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENCL=ON)
+endif()
+
+if(BUILD_GPU_BACKENDS AND NOT VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_IS_IOS)
+  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    string(APPEND VCPKG_C_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+  else()
+    string(APPEND VCPKG_C_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+  endif()
+endif()
+
+set(LLAMA_OPTIONS)
+if("llama" IN_LIST FEATURES)
+  list(APPEND LLAMA_OPTIONS -DLLAMA_MTMD=ON)
+else()
+  list(APPEND LLAMA_OPTIONS
+    -DLLAMA_MTMD=OFF
+    -DLLAMA_BUILD_COMMON=OFF
+  )
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${LLAMA_OPTIONS}
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME ggml)
+
+if(BUILD_LLAMA)
+  vcpkg_cmake_config_fixup(PACKAGE_NAME llama)
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+if(BUILD_LLAMA)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+  file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+endif()
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/ocr-ggml/vcpkg-overlay-ports/qvac-fabric/vcpkg.json
+++ b/packages/ocr-ggml/vcpkg-overlay-ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,49 @@
+{
+  "name": "qvac-fabric",
+  "version": "8828.1.1",
+  "description": "LLM inference in C/C++",
+  "homepage": "https://github.com/tetherto/qvac-fabric-llm.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "gpu-backends",
+    "llama"
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    },
+    "gpu-backends": {
+      "description": "Build the GPU backends ggml ships per platform: Metal on Apple, Vulkan on Linux/Windows/Android, plus the Android backend-DL hybrid mode and OpenCL. Default-on so existing consumers (llamacpp-llm, llamacpp-embed, nmtcpp, diffusion-cpp) keep their current behaviour with default features. Disable to produce a CPU-only ggml build (useful for consumers like @qvac/classification-ggml that don't need GPU paths and want to skip the vulkan-sdk / metal / opencl build cost). Orthogonal to the 'llama' feature.",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "platform": "!osx & !ios",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    },
+    "kleidiai": {
+      "description": "Enable ARM KleidiAI optimized kernels on Android."
+    },
+    "llama": {
+      "description": "Build llama components."
+    },
+    "openmp": {
+      "description": "Enable openmp on Android."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Makes the DocTR pipeline (DBNet detector + CRNN recognizer, both MobileNetV3) run its **depthwise convolutions on the direct Metal kernel** instead of ggml's `im2col + per-channel batched matmul` lowering, which is pathologically slow on Metal. A skip-test showed depthwise was ~all of recognition and ~100 ms of detection — the dominant cost of the whole pipeline on Apple GPUs.

Changes:
- Switch both feature extractors from `ggml_conv_2d_dw` → **`ggml_conv_2d_dw_direct`** (`GGML_OP_CONV_2D_DW`), which needs the companion Metal kernel added in fabric (see *Depends on*).
- Promote depthwise weights to **F32** at load (`isDepthwiseWeight`: `ne[2]==1 && ne[0]>1`) so the op runs on every backend — CPU's `conv_2d_dw` reference is F32-only; Metal/Vulkan accept it too. F32 is perf-neutral on GPU (the tiny K×K-per-channel weights are register-resident; the F32 activations dominate bandwidth either way).
- Fold each **BatchNorm scale into the conv weights** + combine bias/shift into a single add (detection + recognizer), removing ~60 elementwise passes.

## Results (warm, GPU)

**Apple M4 (Metal):** clinical 858→584, ct_scan 1173→754, lab 838→579, liver 841→569 ms (~31–36%).

**Real iOS devices (AWS Device Farm):**

| Doc | iPhone 17 before → after | iPhone 16 before → after |
|---|---|---|
| clinical_chemistry | 1803 → 1276 ms (−29%) | 2303 → 2029 ms (−12%) |
| ct_scan_report | 2059 → 1127 ms (**−45%**) | 2780 → 1866 ms (−33%) |
| lab_results | 1453 → 893 ms (−39%) | 1933 → 1441 ms (−25%) |
| liver_function | 1471 → 871 ms (−41%) | 1941 → 1433 ms (−26%) |

Recognition (the depthwise-dominated stage) roughly halves; on iPhone 17 lab + liver drop under 1 s. (iPhone 16 detection shows run-to-run thermal variance that masks some of the total on the lighter docs.)

## Correctness

All DocTR integration quality tests pass on **Metal and forced-CPU** (region counts identical, keyword assertions intact), on M4 and on real iPhones (Device Farm iOS E2E job green).

## Depends on

- tetherto/qvac-fabric-llm.cpp#148 — the Metal `CONV_2D_DW` kernel (merged to `temp-8828`, commit `7bcd140f`).

## ⚠️ Before merge

This PR currently pins fabric via a **temporary overlay port** (`packages/ocr-ggml/vcpkg-overlay-ports/qvac-fabric`, `REF 7bcd140f`) so it can be validated on Device Farm before the kernel is tagged. **Before merging:** tag fabric `8828.1.1`, cut the registry port, then **remove the overlay** and bump the registry baseline to the tagged port.
