### PR TITLE
QVAC-19983: Continuous Batching (Single-job MTMD)

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,26 +1,3 @@
-## [0.28.0] - 2026-06-17
-
-### Added
-
-- Multimodal (vision) model support in continuous batching: vision models now enter the batch scheduler via a new `DriverFactory` pattern that decouples the scheduler from concrete context types. Admits multiple prompts containing images and text.
-- `PrefillPlan` for sequencing media evaluation: prefill stream now carries text tokens plus `MediaBarrier` entries. The scheduler pauses slots at barriers and evaluates media between batch steps, allowing other slots to progress while vision processing is underway.
-- `SequenceDriver` abstraction: `MtmdLlmContext` and `TextLlmContext` now both implement a common interface, enabling the scheduler to work with any driver type without hardcoded multimodal checks.
-
-### Fixed
-
-- Isolated media-evaluation failures to the offending slot's request group, preventing cascade cancellations when vision processing fails mid-batch.
-- Improved KV-cell accounting for media slots in overlapping batch admissions.
-- Fixed Windows path serialization in JSON by using `generic_string()` instead of `string()` (forward slashes instead of backslashes).
-
-### Changed
-
-- `BatchPrompt.prompt` now accepts any `Message` type (previously text-only), enabling multimodal batches.
-- `ContinuousBatchScheduler` no longer imports or references concrete context types; driver selection fully delegated to the model layer.
-- Consolidated sequence KV cleanup into a single `clearSeqKv()` helper, eliminating six inline copies across slot-teardown paths.
-
-## Pull Requests
-
-- [#2543](https://github.com/tetherto/qvac/pull/2543) - QVAC-19983: Continuous Batching (Single-job MTMD)
 # Changelog
 ## [0.30.2] - 2026-06-29
 

--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [0.28.0] - 2026-06-17
+
+### Added
+
+- Multimodal (vision) model support in continuous batching: vision models now enter the batch scheduler via a new `DriverFactory` pattern that decouples the scheduler from concrete context types. Admits multiple prompts containing images and text.
+- `PrefillPlan` for sequencing media evaluation: prefill stream now carries text tokens plus `MediaBarrier` entries. The scheduler pauses slots at barriers and evaluates media between batch steps, allowing other slots to progress while vision processing is underway.
+- `SequenceDriver` abstraction: `MtmdLlmContext` and `TextLlmContext` now both implement a common interface, enabling the scheduler to work with any driver type without hardcoded multimodal checks.
+
+### Fixed
+
+- Isolated media-evaluation failures to the offending slot's request group, preventing cascade cancellations when vision processing fails mid-batch.
+- Improved KV-cell accounting for media slots in overlapping batch admissions.
+- Fixed Windows path serialization in JSON by using `generic_string()` instead of `string()` (forward slashes instead of backslashes).
+
+### Changed
+
+- `BatchPrompt.prompt` now accepts any `Message` type (previously text-only), enabling multimodal batches.
+- `ContinuousBatchScheduler` no longer imports or references concrete context types; driver selection fully delegated to the model layer.
+- Consolidated sequence KV cleanup into a single `clearSeqKv()` helper, eliminating six inline copies across slot-teardown paths.
+
+## Pull Requests
+
+- [#2543](https://github.com/tetherto/qvac/pull/2543) - QVAC-19983: Continuous Batching (Single-job MTMD)
 # Changelog
 ## [0.30.2] - 2026-06-29
 

--- a/packages/llm-llamacpp/CMakeLists.txt
+++ b/packages/llm-llamacpp/CMakeLists.txt
@@ -84,6 +84,7 @@ endif()
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaFinetuner.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaFinetuningHelpers.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MediaLoadOrder.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MtmdLlmContext.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MultiRequestBatcher.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/TextLlmContext.cpp
@@ -137,6 +138,7 @@ if(BUILD_CLI)
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaFinetuner.cpp
+    ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MediaLoadOrder.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MtmdLlmContext.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/MultiRequestBatcher.cpp
     ${PROJECT_SOURCE_DIR}/addon/src/model-interface/TextLlmContext.cpp

--- a/packages/llm-llamacpp/addon/src/model-interface/BatchEntryGuard.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/BatchEntryGuard.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+
+namespace qvac_lib_inference_addon_llama::batching {
+
+/// RAII guard for `LlamaModel::activeBatchJobs_`, the counter that tracks how
+/// many batch jobs are in flight. The counter must be balanced even when the
+/// per-job entry validation throws: a leaked count makes `cancel()` believe a
+/// batch is still active (it would call `requestCancelAll()` on an idle
+/// engine) and makes the next batch entry observe a non-zero prior count and
+/// skip the first-batch cache invalidation / KV wipe.
+///
+/// The guard runs `validate` and increments the counter in its constructor and
+/// decrements it in its destructor, so the counter is always restored on the
+/// throwing path.
+class BatchEntryGuard {
+public:
+  /// `validate` is the throwing entry validation (e.g. quantization checks).
+  BatchEntryGuard(
+      std::atomic<unsigned>& counter, const std::function<void()>& validate)
+      : counter_(counter) {
+    // Validate before incrementing: a thrown validation leaves the counter
+    // untouched, so the count never leaks on the failure path.
+    validate();
+    prior_ = counter_.fetch_add(1);
+  }
+
+  ~BatchEntryGuard() { counter_.fetch_sub(1); }
+
+  BatchEntryGuard(const BatchEntryGuard&) = delete;
+  BatchEntryGuard& operator=(const BatchEntryGuard&) = delete;
+  BatchEntryGuard(BatchEntryGuard&&) = delete;
+  BatchEntryGuard& operator=(BatchEntryGuard&&) = delete;
+
+  /// Number of batch jobs already in flight before this one (0 for the first).
+  [[nodiscard]] unsigned prior() const { return prior_; }
+
+private:
+  std::atomic<unsigned>& counter_;
+  unsigned prior_ = 0;
+};
+
+} // namespace qvac_lib_inference_addon_llama::batching

--- a/packages/llm-llamacpp/addon/src/model-interface/CacheManager.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/CacheManager.cpp
@@ -9,6 +9,7 @@
 
 #include "addon/LlmErrors.hpp"
 #include "utils/LoggingMacros.hpp"
+#include "utils/ScopeGuard.hpp"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -21,24 +22,40 @@ using namespace qvac_lib_inference_addon_llama::logging;
 namespace {
 
 struct SessionMetadata {
-  std::array<llama_token, 4> tokens = {};
+  std::array<llama_token, SESSION_METADATA_FIELD_COUNT> tokens = {};
 
   static SessionMetadata fromContext(const LlmContext& context) {
-    return {
-        {static_cast<llama_token>(context.getNPast()),
-         static_cast<llama_token>(context.getFirstMsgTokens()),
-         static_cast<llama_token>(context.getCacheTokens()),
-         static_cast<llama_token>(context.getFirstMsgCacheTokens())}};
+    SessionMetadata metadata;
+    auto& tokens = metadata.tokens;
+    using Field = SessionMetadataField;
+    tokens[static_cast<size_t>(Field::NPast)] =
+        static_cast<llama_token>(context.getNPast());
+    tokens[static_cast<size_t>(Field::FirstMsgTokens)] =
+        static_cast<llama_token>(context.getFirstMsgTokens());
+    tokens[static_cast<size_t>(Field::CacheTokens)] =
+        static_cast<llama_token>(context.getCacheTokens());
+    tokens[static_cast<size_t>(Field::FirstMsgCacheTokens)] =
+        static_cast<llama_token>(context.getFirstMsgCacheTokens());
+    return metadata;
   }
 
   llama_token* data() { return tokens.data(); }
   const llama_token* data() const { return tokens.data(); }
   size_t size() const { return tokens.size(); }
 
-  llama_token nPast() const { return tokens[0]; }
-  llama_token firstMsgTokens() const { return tokens[1]; }
-  llama_token cacheTokens() const { return tokens[2]; }
-  llama_token firstMsgCacheTokens() const { return tokens[3]; }
+  llama_token field(SessionMetadataField which) const {
+    return tokens[static_cast<size_t>(which)];
+  }
+  llama_token nPast() const { return field(SessionMetadataField::NPast); }
+  llama_token firstMsgTokens() const {
+    return field(SessionMetadataField::FirstMsgTokens);
+  }
+  llama_token cacheTokens() const {
+    return field(SessionMetadataField::CacheTokens);
+  }
+  llama_token firstMsgCacheTokens() const {
+    return field(SessionMetadataField::FirstMsgCacheTokens);
+  }
 
   void applyTo(LlmContext& context) const {
     context.setNPast(nPast());
@@ -165,12 +182,13 @@ bool CacheManager::loadCache() {
     return false;
   }
 
-  if (!llama_state_load_file(
+  if (llama_state_seq_load_file(
           ctx,
           sessionPath_.c_str(),
+          llmContext_->getSeqId(),
           sessionMetadata.data(),
           sessionMetadata.size(),
-          &nTokenCount)) {
+          &nTokenCount) == 0) {
     std::string errorMsg = string_format(
         "%s: failed to load session file '%s'\n",
         __func__,
@@ -180,6 +198,17 @@ bool CacheManager::loadCache() {
   }
 
   QLOG_IF(Priority::DEBUG, string_format("%s: loaded a session\n", __func__));
+
+  // The load above already restored this sequence's KV cells. Any path that
+  // rejects the session below (or returns false without accepting it) must roll
+  // those cells back, otherwise a failed/declined load strands live KV under
+  // getSeqId() while the caller believes nothing was loaded. Arm the rollback
+  // now and dismiss it only on the single accepted path.
+  ScopeGuard restoredKvGuard([this, ctx] {
+    if (auto* mem = llama_get_memory(ctx); mem != nullptr) {
+      llama_memory_seq_rm(mem, llmContext_->getSeqId(), -1, -1);
+    }
+  });
 
   if (nTokenCount > 1 && nTokenCount < sessionMetadata.size()) {
     std::string errorMsg = string_format(
@@ -192,73 +221,75 @@ bool CacheManager::loadCache() {
         ADDON_ID, toString(UnableToLoadSessionFile), errorMsg);
   }
 
-  if (nTokenCount >= sessionMetadata.size()) {
-    if (sessionMetadata.nPast() > llama_n_ctx(ctx)) {
-      std::string errorMsg = string_format(
-          "%s: cache file '%s' contains %zu tokens, which exceeds the current "
-          "context size of %d tokens\n",
-          __func__,
-          sessionPath_.c_str(),
-          static_cast<size_t>(sessionMetadata.nPast()),
-          llama_n_ctx(ctx));
-      throw qvac_errors::StatusError(
-          ADDON_ID, toString(ContextLengthExeeded), errorMsg);
-    }
-    sessionMetadata.applyTo(*llmContext_);
-
-    if (configuredNDiscarded_ >
-        llama_n_ctx(ctx) - llmContext_->getFirstMsgTokens()) {
-      llmContext_->setNDiscarded(
-          llama_n_ctx(ctx) - llmContext_->getFirstMsgTokens() - 1);
-    } else {
-      llmContext_->setNDiscarded(configuredNDiscarded_);
-    }
-
-    auto* mem = llama_get_memory(ctx);
-    if (mem == nullptr) {
-      throw qvac_errors::StatusError(
-          ADDON_ID,
-          toString(UnableToLoadSessionFile),
-          string_format(
-              "%s: llama memory is null after loading session file '%s'\n",
-              __func__,
-              sessionPath_.c_str()));
-    }
-
-    const llama_pos restoredNPast =
-        llama_memory_seq_pos_max(mem, llmContext_->getSeqId()) + 1;
-    const auto expectedNPast = static_cast<llama_pos>(sessionMetadata.nPast());
-    if (restoredNPast != expectedNPast) {
-      throw qvac_errors::StatusError(
-          ADDON_ID,
-          toString(UnableToLoadSessionFile),
-          string_format(
-              "%s: cache file '%s' restored nPast=%d, but metadata expected "
-              "nPast=%d\n",
-              __func__,
-              sessionPath_.c_str(),
-              restoredNPast,
-              expectedNPast));
-    }
-    const llama_pos restoredCacheTokens = static_cast<llama_pos>(
-        llama_memory_seq_token_count(mem, llmContext_->getSeqId()));
-    const auto expectedCacheTokens =
-        static_cast<llama_pos>(sessionMetadata.cacheTokens());
-    if (restoredCacheTokens != expectedCacheTokens) {
-      throw qvac_errors::StatusError(
-          ADDON_ID,
-          toString(UnableToLoadSessionFile),
-          string_format(
-              "%s: cache file '%s' restored cacheTokens=%d, but metadata "
-              "expected cacheTokens=%d\n",
-              __func__,
-              sessionPath_.c_str(),
-              restoredCacheTokens,
-              expectedCacheTokens));
-    }
-    return true;
+  if (nTokenCount < sessionMetadata.size()) {
+    return false;
   }
-  return false;
+  if (sessionMetadata.nPast() > llama_n_ctx(ctx)) {
+    std::string errorMsg = string_format(
+        "%s: cache file '%s' contains %zu tokens, which exceeds the current "
+        "context size of %d tokens\n",
+        __func__,
+        sessionPath_.c_str(),
+        static_cast<size_t>(sessionMetadata.nPast()),
+        llama_n_ctx(ctx));
+    throw qvac_errors::StatusError(
+        ADDON_ID, toString(ContextLengthExeeded), errorMsg);
+  }
+  sessionMetadata.applyTo(*llmContext_);
+
+  if (configuredNDiscarded_ >
+      llama_n_ctx(ctx) - llmContext_->getFirstMsgTokens()) {
+    llmContext_->setNDiscarded(
+        llama_n_ctx(ctx) - llmContext_->getFirstMsgTokens() - 1);
+  } else {
+    llmContext_->setNDiscarded(configuredNDiscarded_);
+  }
+
+  auto* mem = llama_get_memory(ctx);
+  if (mem == nullptr) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToLoadSessionFile),
+        string_format(
+            "%s: llama memory is null after loading session file '%s'\n",
+            __func__,
+            sessionPath_.c_str()));
+  }
+
+  const llama_pos restoredNPast =
+      llama_memory_seq_pos_max(mem, llmContext_->getSeqId()) + 1;
+  const auto expectedNPast = static_cast<llama_pos>(sessionMetadata.nPast());
+  if (restoredNPast != expectedNPast) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToLoadSessionFile),
+        string_format(
+            "%s: cache file '%s' restored nPast=%d, but metadata expected "
+            "nPast=%d\n",
+            __func__,
+            sessionPath_.c_str(),
+            restoredNPast,
+            expectedNPast));
+  }
+  const llama_pos restoredCacheTokens = static_cast<llama_pos>(
+      llama_memory_seq_token_count(mem, llmContext_->getSeqId()));
+  const auto expectedCacheTokens =
+      static_cast<llama_pos>(sessionMetadata.cacheTokens());
+  if (restoredCacheTokens != expectedCacheTokens) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToLoadSessionFile),
+        string_format(
+            "%s: cache file '%s' restored cacheTokens=%d, but metadata "
+            "expected cacheTokens=%d\n",
+            __func__,
+            sessionPath_.c_str(),
+            restoredCacheTokens,
+            expectedCacheTokens));
+  }
+  llama_memory_seq_rm(mem, -1, sessionMetadata.nPast(), -1);
+  restoredKvGuard.dismiss();
+  return true;
 }
 
 void CacheManager::saveCache() {
@@ -280,11 +311,12 @@ void CacheManager::writeCacheFile(const std::string& path) {
       string_format("%s: saving cache to '%s'\n", __func__, path.c_str()));
   const SessionMetadata sessionMetadata =
       SessionMetadata::fromContext(*llmContext_);
-  if (!llama_state_save_file(
+  if (llama_state_seq_save_file(
           ctx,
           tmpPath.c_str(),
+          llmContext_->getSeqId(),
           sessionMetadata.data(),
-          sessionMetadata.size())) {
+          sessionMetadata.size()) == 0) {
     std::error_code ec;
     std::filesystem::remove(tmpPath, ec);
     throw qvac_errors::StatusError(

--- a/packages/llm-llamacpp/addon/src/model-interface/CacheManager.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/CacheManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <string>
@@ -8,6 +9,7 @@
 #include <llama.h>
 
 #include "LlmContext.hpp"
+#include "MediaLoadOrder.hpp"
 #include "ToolsCompactController.hpp"
 #include "common/chat.h"
 
@@ -15,6 +17,15 @@ struct ParsedPromptPayload {
   std::vector<common_chat_msg> chatMsgs;
   std::vector<common_chat_tool> tools;
   PromptLayout layout;
+  /// Absolute file paths of string-mode media messages, in prompt order. The
+  /// single-prompt path collects them here; `formatPrompt` only collects them
+  /// and never loads media itself. Both paths now load via `mediaPlan`.
+  std::vector<std::string> mediaPaths;
+  /// Every media marker in prompt order, byte buffers and paths interleaved as
+  /// they appear in the prompt. Used by both the single-prompt and batch paths
+  /// to load media in the same order the MTMD markers are emitted, so bitmaps
+  /// bind to the correct markers (see `computeMediaLoadOrder`).
+  std::vector<PlannedMedia> mediaPlan;
 };
 
 class CacheManager {

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
@@ -29,6 +29,33 @@ using namespace qvac_lib_inference_addon_cpp::logger;
 
 namespace {
 
+// Emit a best-effort teardown-failure log that can never throw. Composing the
+// message and invoking the logger both allocate (so they may throw, e.g.
+// std::bad_alloc); doing that inside this swallowing try is what lets the
+// noexcept teardown paths log without risking std::terminate when logging
+// itself fails. `detail` may be null when no exception message is available.
+void logTeardownFailureNoexcept(
+    const char* what, uint32_t seqId, const char* detail) noexcept {
+  try {
+    std::string msg = std::string("[ContinuousBatch] ") + what +
+                      " for seqId " + std::to_string(seqId);
+    if (detail != nullptr) {
+      msg += ": ";
+      msg += detail;
+    }
+    QLOG_IF(Priority::WARNING, msg);
+  } catch (...) {
+    // Logging is best-effort; never let a logging failure abort teardown.
+  }
+}
+
+void logTeardownFailureNoexcept(const char* what) noexcept {
+  try {
+    QLOG_IF(Priority::WARNING, std::string("[ContinuousBatch] ") + what);
+  } catch (...) {
+  }
+}
+
 /// Partition the whole-context KV pool uniformly across slots. Mirrors
 /// llama.cpp's `server` example which uses `n_ctx_slot = n_ctx /
 /// n_parallel` as the per-sequence hard ceiling.
@@ -482,7 +509,7 @@ ContinuousBatchScheduler::prefillCompleteFn() {
       };
 }
 
-void ContinuousBatchScheduler::clearSeqKv(uint32_t seqId) {
+void ContinuousBatchScheduler::clearSeqKv(uint32_t seqId) noexcept {
   auto* mem = llama_get_memory(shared_.lctx);
   if (mem != nullptr) {
     llama_memory_seq_rm(mem, static_cast<llama_seq_id>(seqId), -1, -1);
@@ -518,8 +545,16 @@ ContinuousBatchScheduler::StepUnlockGuard::StepUnlockGuard(
   }
 }
 
-ContinuousBatchScheduler::StepUnlockGuard::~StepUnlockGuard() {
+ContinuousBatchScheduler::StepUnlockGuard::~StepUnlockGuard() noexcept(false) {
   if (lock_ != nullptr) {
+    // applyDeferredTeardownLocked() is noexcept, so the teardown below cannot
+    // throw. The re-acquire can: std::mutex::lock() may raise std::system_error
+    // on an unrecoverable lock failure (the OS failing to meet its
+    // pthread_mutex_lock specification for an initialised normal mutex). It is
+    // intentionally not caught -- the scheduler's only mutex is then gone, so
+    // there is no slot state we could safely touch to recover. The destructor
+    // is noexcept(false) so this single, unrecoverable system_error propagates
+    // instead of being turned into std::terminate here.
     lock_->lock();
     scheduler_.applyDeferredTeardownLocked();
   }
@@ -829,25 +864,54 @@ bool ContinuousBatchScheduler::cancel(uint32_t seqId) {
   return occupied;
 }
 
-void ContinuousBatchScheduler::cancelSlotLocked(uint32_t seqId) {
+void ContinuousBatchScheduler::cancelSlotLocked(uint32_t seqId) noexcept {
   const bool occupied = seqId < slots_.size() && slots_[seqId].has_value();
   if (!occupied) {
     return;
   }
   const Request* req = batcher_.requestAt(seqId);
   if (slots_[seqId]->driver) {
-    slots_[seqId]->driver->onCancel({});
-    if (req != nullptr) {
-      accumulateSlotRuntimeStats(*slots_[seqId], *req);
+    // Best-effort driver teardown on a cancelled slot. onCancel finalizes (and
+    // mutates) the slot's KV and saveCacheForSlot persists it, so contain both
+    // in one try: a throw here would otherwise escape this noexcept function
+    // (it runs from the noexcept StepUnlockGuard destructor) and std::terminate
+    // the process, and a failed finalize must skip the save rather than persist
+    // inconsistent state. The cleanup tail below (notifyDone/freeSlot) runs
+    // regardless, so the slot is always freed. The normal-completion save in
+    // drainFinishedLocked() is left throwing so live requests still surface the
+    // error.
+    try {
+      slots_[seqId]->driver->onCancel({});
+      if (req != nullptr) {
+        accumulateSlotRuntimeStats(*slots_[seqId], *req);
+      }
+      saveCacheForSlot(seqId, *slots_[seqId]);
+    } catch (const std::exception& e) {
+      logTeardownFailureNoexcept("cancel teardown failed", seqId, e.what());
+    } catch (...) {
+      logTeardownFailureNoexcept("cancel teardown failed", seqId, nullptr);
     }
-    saveCacheForSlot(seqId, *slots_[seqId]);
   }
   notifyDone(seqId);
-  batcher_.cancel(seqId, [this](uint32_t s) { clearSeqKv(s); });
+  // batcher_.cancel takes a KvClearFn callback so it is not noexcept; the
+  // clearSeqKv lambda cannot throw, but wrap defensively so this noexcept path
+  // cannot terminate if that ever changes.
+  try {
+    batcher_.cancel(seqId, [this](uint32_t s) { clearSeqKv(s); });
+  } catch (...) {
+    logTeardownFailureNoexcept("cancel: batcher_.cancel threw", seqId, nullptr);
+  }
+  // freeSlot runs regardless of the defensive catch above. If batcher_.cancel
+  // ever threw, its clear-KV-before-reset order leaves the batcher slot
+  // occupied, so admission — gated on the batcher's free list — never re-admits
+  // that seqId over un-cleared KV: the slot leaks but cannot corrupt. Freeing
+  // the scheduler SlotState anyway is the lesser leak (releases driver+sampler)
+  // and cannot make it worse, so free unconditionally rather than gate on the
+  // cancel succeeding.
   freeSlot(seqId);
 }
 
-void ContinuousBatchScheduler::applyDeferredTeardownLocked() {
+void ContinuousBatchScheduler::applyDeferredTeardownLocked() noexcept {
   for (const uint32_t seqId : pendingSlotCancels_) {
     cancelSlotLocked(seqId);
   }
@@ -873,21 +937,38 @@ void ContinuousBatchScheduler::clear() {
   }
 }
 
-void ContinuousBatchScheduler::clearLocked() {
+void ContinuousBatchScheduler::clearLocked() noexcept {
   for (uint32_t seqId = 0; seqId < slots_.size(); seqId++) {
     if (slots_[seqId].has_value()) {
       if (slots_[seqId]->driver) {
-        slots_[seqId]->driver->onSequenceEnd({});
+        // onSequenceEnd is a virtual driver call (flushes buffered output) and
+        // may throw; contain it so this noexcept teardown cannot terminate.
+        try {
+          slots_[seqId]->driver->onSequenceEnd({});
+        } catch (const std::exception& e) {
+          logTeardownFailureNoexcept(
+              "clear: onSequenceEnd threw", seqId, e.what());
+        } catch (...) {
+          logTeardownFailureNoexcept(
+              "clear: onSequenceEnd threw", seqId, nullptr);
+        }
       }
       notifyDone(seqId);
       freeSlot(seqId);
     }
   }
-  batcher_.clear([this](uint32_t s) { clearSeqKv(s); });
+  // batcher_.clear takes a KvClearFn callback so it is not noexcept; the
+  // clearSeqKv lambda cannot throw, but wrap defensively so this noexcept path
+  // cannot terminate if that ever changes.
+  try {
+    batcher_.clear([this](uint32_t s) { clearSeqKv(s); });
+  } catch (...) {
+    logTeardownFailureNoexcept("clear: batcher_.clear threw unexpectedly");
+  }
 }
 
 void ContinuousBatchScheduler::completeGroupRequestLocked(
-    const std::shared_ptr<BatchGroup>& group) {
+    const std::shared_ptr<BatchGroup>& group) noexcept {
   if (!group || group->done) {
     return;
   }
@@ -948,17 +1029,28 @@ void ContinuousBatchScheduler::cancelPendingLocked() {
   }
 }
 
-void ContinuousBatchScheduler::notifyDone(uint32_t seqId) {
+void ContinuousBatchScheduler::notifyDone(uint32_t seqId) noexcept {
   auto& slot = slots_[seqId];
   if (slot.has_value() && slot->streams.onDone) {
-    slot->streams.onDone(seqId);
+    // The onDone stream callback is caller/JS-provided and may throw. Contain
+    // it here, not at the call site: this keeps cancelSlotLocked's noexcept
+    // contract honest (notifyDone runs on that teardown path), and — crucially
+    // — still runs completeGroupRequestLocked below, so a throwing callback
+    // can never leave the submitting caller blocked forever on the group.
+    try {
+      slot->streams.onDone(seqId);
+    } catch (const std::exception& e) {
+      logTeardownFailureNoexcept("onDone callback threw", seqId, e.what());
+    } catch (...) {
+      logTeardownFailureNoexcept("onDone callback threw", seqId, nullptr);
+    }
   }
   if (slot.has_value() && slot->group) {
     completeGroupRequestLocked(slot->group);
   }
 }
 
-void ContinuousBatchScheduler::freeSlot(uint32_t seqId) {
+void ContinuousBatchScheduler::freeSlot(uint32_t seqId) noexcept {
   if (seqId < slots_.size()) {
     slots_[seqId].reset();
   }

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
@@ -38,8 +38,8 @@ namespace {
 void logTeardownFailureNoexcept(
     const char* what, uint32_t seqId, const char* detail) noexcept {
   try {
-    std::string msg = std::string("[ContinuousBatch] ") + what +
-                      " for seqId " + std::to_string(seqId);
+    std::string msg = std::string("[ContinuousBatch] ") + what + " for seqId " +
+                      std::to_string(seqId);
     if (detail != nullptr) {
       msg += ": ";
       msg += detail;
@@ -565,8 +565,9 @@ ContinuousBatchScheduler::StepUnlockGuard::~StepUnlockGuard() noexcept {
       try {
         QLOG_IF(
             Priority::ERROR,
-            std::string("[ContinuousBatch] fatal: unrecoverable failure "
-                        "reacquiring scheduler mutex, aborting: ") +
+            std::string(
+                "[ContinuousBatch] fatal: unrecoverable failure "
+                "reacquiring scheduler mutex, aborting: ") +
                 e.what());
       } catch (...) {
       }

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
@@ -758,7 +758,7 @@ bool ContinuousBatchScheduler::hasWork() const {
   return hasWorkLocked();
 }
 
-bool ContinuousBatchScheduler::hasWorkLocked() const {
+bool ContinuousBatchScheduler::hasWorkLocked() const noexcept {
   return numActiveLocked() > 0;
 }
 
@@ -767,7 +767,7 @@ unsigned ContinuousBatchScheduler::numActive() const {
   return numActiveLocked();
 }
 
-unsigned ContinuousBatchScheduler::numActiveLocked() const {
+unsigned ContinuousBatchScheduler::numActiveLocked() const noexcept {
   unsigned count = 0;
   for (const auto& s : slots_) {
     if (s.has_value()) {
@@ -981,7 +981,8 @@ void ContinuousBatchScheduler::completeGroupRequestLocked(
 }
 
 void ContinuousBatchScheduler::failGroupLocked(
-    const std::shared_ptr<BatchGroup>& group, std::exception_ptr error) {
+    const std::shared_ptr<BatchGroup>& group,
+    std::exception_ptr error) noexcept {
   if (!group || group->done) {
     return;
   }
@@ -989,18 +990,16 @@ void ContinuousBatchScheduler::failGroupLocked(
   group->stats = stats_;
   group->done = true;
 
+  // Per-slot teardown is identical to a cancel, so delegate to cancelSlotLocked
+  // rather than re-implement onCancel/save/notify/free here: it is noexcept and
+  // already contains every throwing step, which keeps this function noexcept on
+  // the worker error-recovery path (where a throw would escape the worker
+  // thread and std::terminate). The group is marked done above, so the
+  // completeGroupRequestLocked inside notifyDone no-ops rather than
+  // double-counting.
   for (uint32_t seqId = 0; seqId < slots_.size(); seqId++) {
     if (slots_[seqId].has_value() && slots_[seqId]->group == group) {
-      if (slots_[seqId]->driver) {
-        slots_[seqId]->driver->onCancel({});
-        if (const Request* req = batcher_.requestAt(seqId); req != nullptr) {
-          accumulateSlotRuntimeStats(*slots_[seqId], *req);
-        }
-        saveCacheForSlot(seqId, *slots_[seqId]);
-      }
-      notifyDone(seqId);
-      batcher_.cancel(seqId, [this](uint32_t s) { clearSeqKv(s); });
-      freeSlot(seqId);
+      cancelSlotLocked(seqId);
     }
   }
   workCv_.notify_all();

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
@@ -1,5 +1,7 @@
 #include "ContinuousBatchScheduler.hpp"
 
+#include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <exception>
 #include <filesystem>
@@ -15,7 +17,6 @@
 #include <llama.h>
 
 #include "GenerationParamsApply.hpp"
-#include "TextLlmContext.hpp"
 #include "addon/LlmErrors.hpp"
 #include "inference-addon-cpp/Logger.hpp"
 #include "utils/LoggingMacros.hpp"
@@ -55,21 +56,47 @@ void finalizeTerminalDriver(
   }
 }
 
+bool computeSlideCapable(
+    const SequenceDriver& driver, bool slideConfigured, bool isPrefill) {
+  return slideConfigured && !isPrefill && driver.supportsSliding();
+}
+
+bool generationBudgetExceeded(
+    unsigned promptSize, unsigned promptKvSize, int nPredict,
+    unsigned perSeqMaxTokens) {
+  // promptKvSize >= promptSize always (KV cells >= positions), so the KV-cell
+  // span is the binding budget and subsumes the position check.
+  const auto budgetSize = std::max(promptSize, promptKvSize);
+  return nPredict > 0 &&
+         budgetSize + static_cast<unsigned>(nPredict) > perSeqMaxTokens;
+}
+
 ContinuousBatchScheduler::ContinuousBatchScheduler(
     LlmModelContext shared, unsigned maxChunkSize, unsigned ctxTotalTokens,
     size_t batchSize, int32_t batchCapacity, const common_params& baseParams,
     llama_pos configuredNDiscarded,
-    std::optional<ToolsCompactProfile> toolsCompactProfile)
+    std::optional<ToolsCompactProfile> toolsCompactProfile,
+    DriverFactory driverFactory)
     : shared_(shared), baseSampling_(baseParams.sampling),
       baseNPredict_(baseParams.n_predict), baseParams_(baseParams),
       configuredNDiscarded_(configuredNDiscarded),
       toolsCompactProfile_(std::move(toolsCompactProfile)),
+      driverFactory_(std::move(driverFactory)),
       perSeqMaxTokens_(perSeqCeiling(ctxTotalTokens, batchSize)),
       batcher_(maxChunkSize, perSeqMaxTokens_, batchSize),
       batch_(batchCapacity, 0, static_cast<int32_t>(batchSize)),
       slots_(batchSize), decodeFunc_([](llama_context* ctx, llama_batch& b) {
         return llama_decode(ctx, b);
-      }) {
+      }),
+      evalMediaFunc_(
+          [](SequenceDriver& driver, size_t mediaIndex, llama_pos pos) {
+            return driver.evalMediaSegment(mediaIndex, pos);
+          }) {
+  if (!driverFactory_) {
+    throw std::invalid_argument(
+        "ContinuousBatchScheduler: a driver factory is required (the model "
+        "layer owns text-vs-multimodal driver selection)");
+  }
 
   const bool ctxValid = shared_.lctx != nullptr && shared_.model != nullptr &&
                         shared_.vocab != nullptr;
@@ -270,12 +297,8 @@ uint32_t ContinuousBatchScheduler::submitLocked(QueuedRequest&& queued) {
   }
   const uint32_t seqId = *maybeSeqId;
   auto tools = std::make_unique<ToolsCompactController>(toolsCompactProfile_);
-  std::unique_ptr<SequenceDriver> driver = std::make_unique<TextLlmContext>(
-      tmpParams,
-      shared_,
-      *tools,
-      seqId,
-      static_cast<llama_pos>(perSeqMaxTokens_));
+  std::unique_ptr<SequenceDriver> driver = driverFactory_(
+      tmpParams, *tools, seqId, static_cast<llama_pos>(perSeqMaxTokens_));
 
   // `applyGenerationParamsToContext` above resolves the sampling/n_predict/
   // reasoning_budget overrides into `tmpParams` (which the driver copies),
@@ -302,18 +325,35 @@ uint32_t ContinuousBatchScheduler::submitLocked(QueuedRequest&& queued) {
   const bool isCacheLoaded =
       driver->loadCache(request.cacheKey, configuredNDiscarded_);
 
-  ScopeGuard cacheGuard([this, seqId] {
-    auto* mem = llama_get_memory(shared_.lctx);
-    if (mem != nullptr) {
-      llama_memory_seq_rm(mem, static_cast<llama_seq_id>(seqId), -1, -1);
-    }
-  });
+  ScopeGuard cacheGuard([this, seqId] { clearSeqKv(seqId); });
 
-  auto tokens = driver->preparePrefill(
-      request.chatMsgs, request.tools, isCacheLoaded, request.prefill);
+  PrefillPlan plan = driver->preparePrefill(
+      request.chatMsgs,
+      request.tools,
+      request.media,
+      request.mediaPlan,
+      isCacheLoaded,
+      request.prefill);
 
   const auto promptSize = static_cast<unsigned>(driver->getNPast()) +
-                          static_cast<unsigned>(tokens.size());
+                          static_cast<unsigned>(plan.totalPositions());
+  // M-RoPE media consumes more KV cells than positions; the cells must also
+  // fit under the per-sequence cap or the slot's KV-cache overruns. Size this
+  // from the physical KV-cell usage (getKvCellsUsed), which for a cache-loaded
+  // M-RoPE sequence exceeds getNPast(); they coincide for text.
+  const auto promptKvSize = static_cast<unsigned>(driver->getKvCellsUsed()) +
+                            static_cast<unsigned>(plan.totalKvTokens());
+  if (promptKvSize > perSeqMaxTokens_) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InvalidArgument),
+        "ContinuousBatchScheduler::submit: prompt of " +
+            std::to_string(promptKvSize) +
+            " KV cells exceeds per-sequence cap " +
+            std::to_string(perSeqMaxTokens_) +
+            " (ctxTotalTokens / n_parallel)");
+  }
   if (!request.prefill && promptSize >= perSeqMaxTokens_) {
     throw qvac_errors::StatusError(
         ADDON_ID,
@@ -336,24 +376,30 @@ uint32_t ContinuousBatchScheduler::submitLocked(QueuedRequest&& queued) {
             std::to_string(perSeqMaxTokens_) +
             " (ctxTotalTokens / n_parallel)");
   }
-  if (!request.prefill && tmpParams.n_predict > 0 &&
-      promptSize + static_cast<unsigned>(tmpParams.n_predict) >
-          perSeqMaxTokens_) {
+  if (!request.prefill &&
+      generationBudgetExceeded(
+          promptSize, promptKvSize, tmpParams.n_predict, perSeqMaxTokens_)) {
     throw qvac_errors::StatusError(
         ADDON_ID,
         qvac_errors::general_error::toString(
             qvac_errors::general_error::InvalidArgument),
         "ContinuousBatchScheduler::submit: n_predict " +
             std::to_string(tmpParams.n_predict) + " + prompt " +
-            std::to_string(promptSize) + " exceeds per-sequence cap " +
+            std::to_string(promptKvSize) +
+            " KV cells exceeds per-sequence cap " +
             std::to_string(perSeqMaxTokens_) +
             " (ctxTotalTokens / n_parallel)");
   }
 
   StreamCallbacks streamsLocal = std::move(request.streams);
-  const bool slideCapable = configuredNDiscarded_ > 0 && !request.prefill;
+  const bool slideCapable =
+      computeSlideCapable(*driver, configuredNDiscarded_ > 0, request.prefill);
   if (auto status = batcher_.addRequestAt(
-          seqId, std::move(tokens), driver->getNPast(), slideCapable);
+          seqId,
+          std::move(plan),
+          driver->getNPast(),
+          slideCapable,
+          driver->getKvCellsUsed());
       status != MultiRequestBatcher::AddStatus::Ok) {
     throw qvac_errors::StatusError(
         ADDON_ID,
@@ -402,12 +448,6 @@ ContinuousBatchScheduler::getOutputCallback(SlotState& slot, uint32_t seqId) {
 }
 
 void ContinuousBatchScheduler::finalizeFinishedSequences() {
-  auto kvClear = [this](uint32_t seqId) {
-    llama_memory_t mem = llama_get_memory(shared_.lctx);
-    if (mem != nullptr) {
-      llama_memory_seq_rm(mem, static_cast<llama_seq_id>(seqId), -1, -1);
-    }
-  };
   auto finished = batcher_.extractFinished();
   for (const auto& req : finished) {
     if (hasValidDriverF()(req)) {
@@ -415,26 +455,162 @@ void ContinuousBatchScheduler::finalizeFinishedSequences() {
       finalizeTerminalDriver(
           *slot.driver, req.stopReason, slot.prefillOnly, {});
     }
-    kvClear(req.seqId);
+    clearSeqKv(req.seqId);
+    notifyDone(req.seqId);
+    freeSlot(req.seqId);
+  }
+}
+
+MultiRequestBatcher::PrefillCompleteFn
+ContinuousBatchScheduler::prefillCompleteFn() {
+  return
+      [this](uint32_t seqId, llama_pos currentPos, size_t prefillTokenCount) {
+        auto& slot = slots_[seqId];
+        if (!slot.has_value() || !slot->driver) {
+          throw qvac_errors::StatusError(
+              ADDON_ID,
+              qvac_errors::general_error::toString(
+                  qvac_errors::general_error::InternalError),
+              "ContinuousBatchScheduler::step: missing sequence driver for "
+              "prefill-complete seqId " +
+                  std::to_string(seqId));
+        }
+        slot->driver->onPrefillComplete(currentPos, prefillTokenCount);
+        if (slot->prefillOnly) {
+          batcher_.markFinished(seqId);
+        }
+      };
+}
+
+void ContinuousBatchScheduler::clearSeqKv(uint32_t seqId) {
+  auto* mem = llama_get_memory(shared_.lctx);
+  if (mem != nullptr) {
+    llama_memory_seq_rm(mem, static_cast<llama_seq_id>(seqId), -1, -1);
+  }
+}
+
+void ContinuousBatchScheduler::failSlotLocked(
+    uint32_t seqId, std::exception_ptr error) {
+  auto& slot = slots_[seqId];
+  if (!slot.has_value()) {
+    return;
+  }
+  if (slot->group) {
+    failGroupLocked(slot->group, error);
+    return;
+  }
+  if (slot->driver) {
+    slot->driver->onCancel({});
+    if (const Request* req = batcher_.requestAt(seqId); req != nullptr) {
+      accumulateSlotRuntimeStats(*slot, *req);
+    }
+  }
+  notifyDone(seqId);
+  batcher_.cancel(seqId, [this](uint32_t sid) { clearSeqKv(sid); });
+  freeSlot(seqId);
+}
+
+ContinuousBatchScheduler::StepUnlockGuard::StepUnlockGuard(
+    ContinuousBatchScheduler& scheduler, std::unique_lock<std::mutex>* lock)
+    : scheduler_(scheduler), lock_(lock) {
+  if (lock_ != nullptr) {
+    lock_->unlock();
+  }
+}
+
+ContinuousBatchScheduler::StepUnlockGuard::~StepUnlockGuard() {
+  if (lock_ != nullptr) {
+    lock_->lock();
+    scheduler_.applyDeferredTeardownLocked();
+  }
+}
+
+void ContinuousBatchScheduler::serviceNextMediaSegmentLocked(
+    std::unique_lock<std::mutex>* lock) {
+  const auto awaiting = batcher_.nextAwaitingMedia();
+  if (!awaiting.has_value()) {
+    return;
+  }
+  auto& slot = slots_[awaiting->seqId];
+  if (!slot.has_value() || !slot->driver) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InternalError),
+        "ContinuousBatchScheduler::step: missing sequence driver for "
+        "media-awaiting seqId " +
+            std::to_string(awaiting->seqId));
+  }
+
+  SequenceDriver& driver = *slot->driver;
+  llama_pos newPos = awaiting->currentPos;
+  std::exception_ptr error;
+  std::chrono::steady_clock::duration evalDuration{};
+  {
+    StepUnlockGuard unlockGuard(*this, lock);
+    const auto evalStart = std::chrono::steady_clock::now();
+    try {
+      newPos =
+          evalMediaFunc_(driver, awaiting->mediaIndex, awaiting->currentPos);
+    } catch (...) {
+      error = std::current_exception();
+    }
+    evalDuration = std::chrono::steady_clock::now() - evalStart;
+  }
+
+  if (error) {
+    failSlotLocked(awaiting->seqId, error);
+    return;
+  }
+  assert(
+      newPos >= awaiting->currentPos &&
+      "media segment must not move the sequence position backwards");
+  const auto mediaPositions =
+      static_cast<uint64_t>(newPos - awaiting->currentPos);
+  stats_.recordDecodeStep(
+      numActiveLocked(),
+      mediaPositions,
+      0,
+      std::chrono::duration_cast<std::chrono::nanoseconds>(evalDuration));
+  batcher_.completeMediaBarrier(awaiting->seqId, newPos, prefillCompleteFn());
+}
+
+void ContinuousBatchScheduler::drainFinishedLocked() {
+  auto finished = batcher_.extractFinished();
+  for (const auto& req : finished | std::views::filter(hasValidDriverF())) {
+    auto& slot = *slots_[req.seqId];
+    auto outputCallback = getOutputCallback(slot, req.seqId);
+    finalizeTerminalDriver(
+        *slot.driver, req.stopReason, slot.prefillOnly, outputCallback);
+    accumulateSlotRuntimeStats(slot, req);
+    saveCacheForSlot(req.seqId, *slots_[req.seqId]);
+  }
+  for (const auto& req : finished) {
+    clearSeqKv(req.seqId);
     notifyDone(req.seqId);
     freeSlot(req.seqId);
   }
 }
 
 bool ContinuousBatchScheduler::stepLocked(std::unique_lock<std::mutex>* lock) {
+  serviceNextMediaSegmentLocked(lock);
+
   const auto fillResult = batcher_.fillBatch(batch_);
   if (fillResult.chunkSize == 0) {
+    // A media segment serviced above can finish a slot (prefill-only
+    // request or per-sequence cap) without leaving tokens to feed; drain
+    // here or the worker would spin on the occupied slot forever.
+    drainFinishedLocked();
     return true;
   }
 
-  if (lock != nullptr) {
-    lock->unlock();
-  }
-  const auto decodeStart = std::chrono::steady_clock::now();
-  const int decodeRc = decodeFunc_(shared_.lctx, *batch_);
-  const auto decodeDuration = std::chrono::steady_clock::now() - decodeStart;
-  if (lock != nullptr) {
-    lock->lock();
+  int decodeRc = 0;
+  std::chrono::steady_clock::duration decodeDuration{};
+  {
+    StepUnlockGuard unlockGuard(*this, lock);
+    const auto decodeStart = std::chrono::steady_clock::now();
+    decodeRc = decodeFunc_(shared_.lctx, *batch_);
+    decodeDuration = std::chrono::steady_clock::now() - decodeStart;
   }
 
   if (decodeRc != 0) {
@@ -471,24 +647,7 @@ bool ContinuousBatchScheduler::stepLocked(std::unique_lock<std::mutex>* lock) {
       decodeTokens,
       std::chrono::duration_cast<std::chrono::nanoseconds>(decodeDuration));
 
-  batcher_.advance(
-      fillResult.chunkSize,
-      [this](uint32_t seqId, llama_pos currentPos, size_t prefillTokenCount) {
-        auto& slot = slots_[seqId];
-        if (!slot.has_value() || !slot->driver) {
-          throw qvac_errors::StatusError(
-              ADDON_ID,
-              qvac_errors::general_error::toString(
-                  qvac_errors::general_error::InternalError),
-              "ContinuousBatchScheduler::step: missing sequence driver for "
-              "prefill-complete seqId " +
-                  std::to_string(seqId));
-        }
-        slot->driver->onPrefillComplete(currentPos, prefillTokenCount);
-        if (slot->prefillOnly) {
-          batcher_.markFinished(seqId);
-        }
-      });
+  batcher_.advance(fillResult.chunkSize, prefillCompleteFn());
 
   if (!cancelRequested_.load()) {
     batcher_.sampleAndAppendIdle([this](uint32_t seqId, int logitIdx) {
@@ -554,26 +713,7 @@ bool ContinuousBatchScheduler::stepLocked(std::unique_lock<std::mutex>* lock) {
     batcher_.markAllFinished(StopReason::Cancelled);
   }
 
-  auto kvClear = [this](uint32_t seqId) {
-    auto* mem = llama_get_memory(shared_.lctx);
-    if (mem != nullptr) {
-      llama_memory_seq_rm(mem, static_cast<llama_seq_id>(seqId), -1, -1);
-    }
-  };
-  auto finished = batcher_.extractFinished();
-  for (const auto& req : finished | std::views::filter(hasValidDriverF())) {
-    auto& slot = *slots_[req.seqId];
-    auto outputCallback = getOutputCallback(slot, req.seqId);
-    finalizeTerminalDriver(
-        *slot.driver, req.stopReason, slot.prefillOnly, outputCallback);
-    accumulateSlotRuntimeStats(slot, req);
-    saveCacheForSlot(req.seqId, *slots_[req.seqId]);
-  }
-  for (const auto& req : finished) {
-    kvClear(req.seqId);
-    notifyDone(req.seqId);
-    freeSlot(req.seqId);
-  }
+  drainFinishedLocked();
 
   return true;
 }
@@ -637,7 +777,15 @@ void RuntimeStatsSnapshot::accumulateSlot(
   contextSlides += nSlides;
   thinkingBlockDiscards += thinkingDiscards;
   generatedTokens += static_cast<int64_t>(req.generatedTokens.size());
-  promptTokens += static_cast<int64_t>(req.prefillTokenCount);
+  // Count tokens actually prefilled, not the prompt size planned at admission:
+  // once prefill completes, prefillFedCount is reset to 0, so the full prompt
+  // is read from prefillTokenCount; a request cancelled mid/pre-prefill instead
+  // reports the partial prefillFedCount (0 if no step ever ran). This keeps the
+  // `cacheTokens ~= promptTokens + generatedTokens` invariant honest on the
+  // cancel path.
+  promptTokens += req.isPrefillComplete()
+                      ? static_cast<int64_t>(req.prefillTokenCount)
+                      : static_cast<int64_t>(req.prefillFedCount);
 }
 
 double RuntimeStatsSnapshot::avgConcurrentSeq() const {
@@ -695,13 +843,7 @@ void ContinuousBatchScheduler::cancelSlotLocked(uint32_t seqId) {
     saveCacheForSlot(seqId, *slots_[seqId]);
   }
   notifyDone(seqId);
-  auto kvClear = [this](uint32_t s) {
-    auto* mem = llama_get_memory(shared_.lctx);
-    if (mem != nullptr) {
-      llama_memory_seq_rm(mem, static_cast<llama_seq_id>(s), -1, -1);
-    }
-  };
-  batcher_.cancel(seqId, kvClear);
+  batcher_.cancel(seqId, [this](uint32_t s) { clearSeqKv(s); });
   freeSlot(seqId);
 }
 
@@ -741,13 +883,7 @@ void ContinuousBatchScheduler::clearLocked() {
       freeSlot(seqId);
     }
   }
-  auto kvClear = [this](uint32_t s) {
-    auto* mem = llama_get_memory(shared_.lctx);
-    if (mem != nullptr) {
-      llama_memory_seq_rm(mem, static_cast<llama_seq_id>(s), -1, -1);
-    }
-  };
-  batcher_.clear(kvClear);
+  batcher_.clear([this](uint32_t s) { clearSeqKv(s); });
 }
 
 void ContinuousBatchScheduler::completeGroupRequestLocked(
@@ -772,12 +908,6 @@ void ContinuousBatchScheduler::failGroupLocked(
   group->stats = stats_;
   group->done = true;
 
-  auto kvClear = [this](uint32_t seqId) {
-    auto* mem = llama_get_memory(shared_.lctx);
-    if (mem != nullptr) {
-      llama_memory_seq_rm(mem, static_cast<llama_seq_id>(seqId), -1, -1);
-    }
-  };
   for (uint32_t seqId = 0; seqId < slots_.size(); seqId++) {
     if (slots_[seqId].has_value() && slots_[seqId]->group == group) {
       if (slots_[seqId]->driver) {
@@ -788,7 +918,7 @@ void ContinuousBatchScheduler::failGroupLocked(
         saveCacheForSlot(seqId, *slots_[seqId]);
       }
       notifyDone(seqId);
-      batcher_.cancel(seqId, kvClear);
+      batcher_.cancel(seqId, [this](uint32_t s) { clearSeqKv(s); });
       freeSlot(seqId);
     }
   }

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
@@ -532,7 +532,7 @@ void ContinuousBatchScheduler::failSlotLocked(
       accumulateSlotRuntimeStats(*slot, *req);
     }
   }
-  notifyDone(seqId);
+  notifyDoneNoexcept(seqId);
   batcher_.cancel(seqId, [this](uint32_t sid) { clearSeqKv(sid); });
   freeSlot(seqId);
 }
@@ -892,7 +892,7 @@ void ContinuousBatchScheduler::cancelSlotLocked(uint32_t seqId) noexcept {
       logTeardownFailureNoexcept("cancel teardown failed", seqId, nullptr);
     }
   }
-  notifyDone(seqId);
+  notifyDoneNoexcept(seqId);
   // batcher_.cancel takes a KvClearFn callback so it is not noexcept; the
   // clearSeqKv lambda cannot throw, but wrap defensively so this noexcept path
   // cannot terminate if that ever changes.
@@ -953,7 +953,7 @@ void ContinuousBatchScheduler::clearLocked() noexcept {
               "clear: onSequenceEnd threw", seqId, nullptr);
         }
       }
-      notifyDone(seqId);
+      notifyDoneNoexcept(seqId);
       freeSlot(seqId);
     }
   }
@@ -1028,14 +1028,31 @@ void ContinuousBatchScheduler::cancelPendingLocked() {
   }
 }
 
-void ContinuousBatchScheduler::notifyDone(uint32_t seqId) noexcept {
+void ContinuousBatchScheduler::notifyDone(uint32_t seqId) {
+  // Normal-completion path: a throwing onDone propagates so the worker loop
+  // fails the batch (failGroupLocked) instead of completing it as a success;
+  // teardown paths use notifyDoneNoexcept. The throw then skips freeSlot below,
+  // so recovery re-runs teardown (onCancel/saveCache/onDone) on this slot. That
+  // is benign and only happens when onDone itself threw: onGenerationFinished's
+  // generationStarted_ guard makes the re-run a no-op, recovery's onCancel({})
+  // re-emits nothing, and saveCache just rewrites the same file.
+  auto& slot = slots_[seqId];
+  if (slot.has_value() && slot->streams.onDone) {
+    slot->streams.onDone(seqId);
+  }
+  if (slot.has_value() && slot->group) {
+    completeGroupRequestLocked(slot->group);
+  }
+}
+
+void ContinuousBatchScheduler::notifyDoneNoexcept(uint32_t seqId) noexcept {
   auto& slot = slots_[seqId];
   if (slot.has_value() && slot->streams.onDone) {
     // The onDone stream callback is caller/JS-provided and may throw. Contain
-    // it here, not at the call site: this keeps cancelSlotLocked's noexcept
-    // contract honest (notifyDone runs on that teardown path), and — crucially
-    // — still runs completeGroupRequestLocked below, so a throwing callback
-    // can never leave the submitting caller blocked forever on the group.
+    // it here, not at the call site: this keeps the noexcept teardown contract
+    // honest (cancel/clear/fail paths run it), and — crucially — still runs
+    // completeGroupRequestLocked below, so a throwing callback can never leave
+    // the submitting caller blocked forever on the group.
     try {
       slot->streams.onDone(seqId);
     } catch (const std::exception& e) {

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <chrono>
+#include <cstdlib>
 #include <exception>
 #include <filesystem>
 #include <optional>
@@ -545,17 +546,32 @@ ContinuousBatchScheduler::StepUnlockGuard::StepUnlockGuard(
   }
 }
 
-ContinuousBatchScheduler::StepUnlockGuard::~StepUnlockGuard() noexcept(false) {
+ContinuousBatchScheduler::StepUnlockGuard::~StepUnlockGuard() noexcept {
   if (lock_ != nullptr) {
     // applyDeferredTeardownLocked() is noexcept, so the teardown below cannot
     // throw. The re-acquire can: std::mutex::lock() may raise std::system_error
     // on an unrecoverable lock failure (the OS failing to meet its
-    // pthread_mutex_lock specification for an initialised normal mutex). It is
-    // intentionally not caught -- the scheduler's only mutex is then gone, so
-    // there is no slot state we could safely touch to recover. The destructor
-    // is noexcept(false) so this single, unrecoverable system_error propagates
-    // instead of being turned into std::terminate here.
-    lock_->lock();
+    // pthread_mutex_lock specification for an initialised normal mutex). If it
+    // does, the scheduler's only mutex is gone and we are NOT holding it, so
+    // letting it propagate would hand a lock-free, mid-teardown state to the
+    // worker's catch handler -- which assumes the lock is held and would race
+    // concurrent cancel()/submit() before hitting a UB wait() on an unowned
+    // lock. Stop cleanly at the point of failure instead: log and abort.
+    try {
+      lock_->lock();
+    } catch (const std::system_error& e) {
+      // Composing/emitting the message can itself throw (allocation); swallow
+      // that so abort() always runs.
+      try {
+        QLOG_IF(
+            Priority::ERROR,
+            std::string("[ContinuousBatch] fatal: unrecoverable failure "
+                        "reacquiring scheduler mutex, aborting: ") +
+                e.what());
+      } catch (...) {
+      }
+      std::abort();
+    }
     scheduler_.applyDeferredTeardownLocked();
   }
 }

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
@@ -333,8 +333,8 @@ private:
   void drainFinishedLocked();
   [[nodiscard]] bool hasWorkLocked() const noexcept;
   [[nodiscard]] unsigned numActiveLocked() const noexcept;
-  void completeGroupRequestLocked(
-      const std::shared_ptr<BatchGroup>& group) noexcept;
+  void
+  completeGroupRequestLocked(const std::shared_ptr<BatchGroup>& group) noexcept;
   void failGroupLocked(
       const std::shared_ptr<BatchGroup>& group,
       std::exception_ptr error) noexcept;

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
@@ -18,9 +18,15 @@
 #include <llama.h>
 
 #include "LlmContext.hpp"
+#include "MediaLoadOrder.hpp"
 #include "MultiRequestBatcher.hpp"
 #include "SequenceDriver.hpp"
 #include "ToolsCompactController.hpp"
+
+/// Defined in test/unit/test_internal_peers.hpp (tests only); befriended below
+/// so unit tests can inject decode/media-eval stubs. Never defined in
+/// production builds, where it is only ever named as a friend.
+class ContinuousBatchSchedulerTestPeer;
 
 namespace qvac_lib_inference_addon_llama::batching {
 
@@ -33,6 +39,23 @@ void finalizeTerminalDriver(
     SequenceDriver& driver, StopReason reason, bool prefillOnly,
     const std::function<void(const std::string&)>& outputCallback);
 
+/// Decide whether a generating slot may temporarily touch its per-slot token
+/// cap because the driver will slide its window back below the ceiling on the
+/// next step. Slides only happen during generation (never prefill) and only
+/// when sliding is configured.
+[[nodiscard]] bool computeSlideCapable(
+    const SequenceDriver& driver, bool slideConfigured, bool isPrefill);
+
+/// Whether prompt + generation budget overruns the per-sequence cap at
+/// admission. `promptSize` is the position span and `promptKvSize` the KV-cell
+/// span of the prompt; for M-RoPE media `promptKvSize >= promptSize`, so the
+/// KV-cell span is the binding quantity that must also leave room for
+/// `nPredict`. `nPredict <= 0` means "no scheduler cap" (the batcher's ceiling
+/// governs), so the budget is never exceeded in that case.
+[[nodiscard]] bool generationBudgetExceeded(
+    unsigned promptSize, unsigned promptKvSize, int nPredict,
+    unsigned perSeqMaxTokens);
+
 /// Per-request streaming sinks. Both are optional; missing callbacks
 /// are no-ops.
 struct StreamCallbacks {
@@ -44,6 +67,16 @@ struct SubmitRequest {
   std::vector<common_chat_msg> chatMsgs;
   std::vector<common_chat_tool> tools;
   PromptLayout layout;
+  /// Raw media payloads (images/audio) referenced by the prompt. Only
+  /// accepted when the scheduler's driver factory builds multimodal
+  /// drivers; text drivers reject a non-empty list at admission.
+  std::vector<std::vector<uint8_t>> media;
+  /// Every media marker in prompt order, byte buffers and paths interleaved as
+  /// they appear in the prompt. The per-slot driver loads media via this plan
+  /// (see `computeMediaLoadOrder`), consuming byte payloads from `media` by
+  /// index and paths inline, so each bitmap binds to its marker in order. Like
+  /// `media`, only multimodal drivers accept a non-empty list.
+  std::vector<PlannedMedia> mediaPlan;
   bool prefill = false;
   std::string cacheKey;
   bool saveCacheToDisk = false;
@@ -109,6 +142,14 @@ struct BatchResult {
   RuntimeStatsSnapshot stats;
 };
 
+/// Builds the per-slot `SequenceDriver` at admission time. The model layer
+/// owns the concrete context selection (text vs multimodal) and supplies this
+/// factory, so the scheduler depends on no concrete driver type. `params`
+/// already carries the merged per-request sampling overrides.
+using DriverFactory = std::function<std::unique_ptr<SequenceDriver>(
+    const common_params& params, ToolsCompactController& tools, uint32_t seqId,
+    llama_pos perSeqCtxCeiling)>;
+
 /// Continuous-batching driver: owns the underlying `MultiRequestBatcher`,
 /// per-slot `common_sampler` + UTF-8 buffers, and the production wiring
 /// to `llama_decode`, `common_sampler_*`, `common_token_to_piece`,
@@ -131,11 +172,16 @@ public:
   /// @param baseParams          Baseline llama/common params copied into each
   ///                            admitted slot policy before request overrides
   ///                            are applied.
+  /// @param driverFactory       Per-slot driver builder. Required and
+  ///                            non-empty: the model layer owns the single
+  ///                            text-vs-multimodal selection, so the scheduler
+  ///                            never names a concrete driver type.
   ContinuousBatchScheduler(
       LlmModelContext shared, unsigned maxChunkSize, unsigned ctxTotalTokens,
       size_t batchSize, int32_t batchCapacity, const common_params& baseParams,
       llama_pos configuredNDiscarded,
-      std::optional<ToolsCompactProfile> toolsCompactProfile);
+      std::optional<ToolsCompactProfile> toolsCompactProfile,
+      DriverFactory driverFactory);
 
   ContinuousBatchScheduler(const ContinuousBatchScheduler&) = delete;
   ContinuousBatchScheduler& operator=(const ContinuousBatchScheduler&) = delete;
@@ -195,13 +241,43 @@ public:
   /// is running, for the same reason as `cancel(seqId)`.
   void clear();
 
-  /// Override the decode function used by stepLocked(). For unit tests only --
-  /// inject a stub that returns a non-zero rc to exercise the decode-error
-  /// path without a real llama_decode call succeeding.
+  /// Decode function used by stepLocked() (defaults to llama_decode) and the
+  /// media-segment eval used by serviceNextMediaSegmentLocked() (defaults to
+  /// driver.evalMediaSegment()). Unit tests override them through
+  /// ContinuousBatchSchedulerTestPeer to inject failing/blocking stubs.
   using DecodeFunc = std::function<int(llama_context*, llama_batch&)>;
-  void setDecodeFuncForTesting(DecodeFunc fn) { decodeFunc_ = std::move(fn); }
+  using EvalMediaFunc =
+      std::function<llama_pos(SequenceDriver&, size_t, llama_pos)>;
 
 private:
+  // Test peer (global namespace) sets decodeFunc_/evalMediaFunc_ directly.
+  // See test_internal_peers.hpp.
+  friend class ::ContinuousBatchSchedulerTestPeer;
+
+  /// RAII for the two points where a step must drop `mutex_` for a blocking
+  /// call (media-segment eval, `llama_decode`): unlocks on construction, and
+  /// on destruction reacquires the lock and applies any teardown
+  /// (`cancel(seqId)` / `clear()`) recorded while it was dropped, before the
+  /// step touches slot state again. Reconciling on every reacquisition is the
+  /// invariant that stops a concurrently-cancelled/cleared slot from being
+  /// decoded, advanced, or streamed after the unlock window. A null `lock`
+  /// (no worker driving the step) is a no-op on both ends.
+  class StepUnlockGuard {
+  public:
+    StepUnlockGuard(
+        ContinuousBatchScheduler& scheduler,
+        std::unique_lock<std::mutex>* lock);
+    ~StepUnlockGuard();
+    StepUnlockGuard(const StepUnlockGuard&) = delete;
+    StepUnlockGuard& operator=(const StepUnlockGuard&) = delete;
+    StepUnlockGuard(StepUnlockGuard&&) = delete;
+    StepUnlockGuard& operator=(StepUnlockGuard&&) = delete;
+
+  private:
+    ContinuousBatchScheduler& scheduler_;
+    std::unique_lock<std::mutex>* lock_;
+  };
+
   struct BatchGroup {
     explicit BatchGroup(size_t requestCount) : outputs(requestCount) {}
 
@@ -235,6 +311,16 @@ private:
   void admitPendingIntoFreeSlotsLocked();
   [[nodiscard]] uint32_t submitLocked(QueuedRequest&& queued);
   [[nodiscard]] bool stepLocked(std::unique_lock<std::mutex>* lock = nullptr);
+  /// Evaluate the head media barrier of one awaiting slot (lowest seqId)
+  /// via its driver, unlocking around the embedded `llama_decode`. A
+  /// media failure only fails that slot's request, never the whole
+  /// scheduler.
+  void serviceNextMediaSegmentLocked(std::unique_lock<std::mutex>* lock);
+  void failSlotLocked(uint32_t seqId, std::exception_ptr error);
+  [[nodiscard]] MultiRequestBatcher::PrefillCompleteFn prefillCompleteFn();
+  /// Extract finished requests and run the full per-slot drain (terminal
+  /// driver hook with output flushing, stats, cache save, KV clear).
+  void drainFinishedLocked();
   [[nodiscard]] bool hasWorkLocked() const;
   [[nodiscard]] unsigned numActiveLocked() const;
   void completeGroupRequestLocked(const std::shared_ptr<BatchGroup>& group);
@@ -249,6 +335,9 @@ private:
   void applyDeferredTeardownLocked();
   void notifyDone(uint32_t seqId);
   void freeSlot(uint32_t seqId);
+  /// Remove every KV-cache cell owned by `seqId` from the shared context.
+  /// Single home for the cleanup repeated across all slot-teardown paths.
+  void clearSeqKv(uint32_t seqId);
   void finalizeFinishedSequences();
   std::function<void(const std::string&)>
   getOutputCallback(SlotState& slot, uint32_t seqId);
@@ -265,6 +354,7 @@ private:
   common_params baseParams_;
   llama_pos configuredNDiscarded_;
   std::optional<ToolsCompactProfile> toolsCompactProfile_;
+  DriverFactory driverFactory_;
 
   /// Per-seq hard ceiling = ctxTotalTokens / batchSize. Drives prompt-size
   /// admission and per-request `prompt + n_predict` validation.
@@ -283,9 +373,14 @@ private:
   bool clearRequested_ = false;
   RuntimeStatsSnapshot stats_;
 
-  /// Decode function used in stepLocked(). Defaults to llama_decode; can be
-  /// overridden via setDecodeFuncForTesting() to inject a failing stub.
+  /// Decode function used in stepLocked(). Defaults to llama_decode; a test
+  /// stub can be injected via ContinuousBatchSchedulerTestPeer::setDecodeFunc().
   DecodeFunc decodeFunc_;
+
+  /// Media-segment eval used in serviceNextMediaSegmentLocked(). Defaults to
+  /// driver.evalMediaSegment(); a test stub can be injected via
+  /// ContinuousBatchSchedulerTestPeer::setEvalMediaFunc().
+  EvalMediaFunc evalMediaFunc_;
 };
 
 } // namespace qvac_lib_inference_addon_llama::batching

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
@@ -374,7 +374,8 @@ private:
   RuntimeStatsSnapshot stats_;
 
   /// Decode function used in stepLocked(). Defaults to llama_decode; a test
-  /// stub can be injected via ContinuousBatchSchedulerTestPeer::setDecodeFunc().
+  /// stub can be injected via
+  /// ContinuousBatchSchedulerTestPeer::setDecodeFunc().
   DecodeFunc decodeFunc_;
 
   /// Media-segment eval used in serviceNextMediaSegmentLocked(). Defaults to

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
@@ -351,10 +351,15 @@ private:
   /// StepUnlockGuard destructor's teardown step cannot throw -- the only thing
   /// that destructor can throw is the mutex re-acquire (see its declaration).
   void applyDeferredTeardownLocked() noexcept;
-  /// `noexcept`: invoked on the teardown path. Contains the caller-provided
-  /// onDone callback internally so a throwing callback can neither escape nor
-  /// skip the group-completion below.
-  void notifyDone(uint32_t seqId) noexcept;
+  /// Fire the slot's onDone stream callback, then complete its group. Throwing
+  /// variant for the normal-completion path: a throwing onDone propagates so
+  /// the worker loop surfaces it as a batch error rather than silently
+  /// completing the group as a success.
+  void notifyDone(uint32_t seqId);
+  /// `noexcept` teardown variant (cancel/clear/fail paths). Contains the
+  /// caller-provided onDone internally so a throwing callback can neither
+  /// escape a noexcept path nor skip the group-completion below.
+  void notifyDoneNoexcept(uint32_t seqId) noexcept;
   void freeSlot(uint32_t seqId) noexcept;
   /// Remove every KV-cache cell owned by `seqId` from the shared context.
   /// Single home for the cleanup repeated across all slot-teardown paths.

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
@@ -267,16 +267,17 @@ private:
     StepUnlockGuard(
         ContinuousBatchScheduler& scheduler,
         std::unique_lock<std::mutex>* lock);
-    /// `noexcept(false)`: the deferred-teardown work it runs is `noexcept`, but
-    /// re-acquiring `mutex_` is not. The only exception it can throw is the
-    /// `std::system_error` `std::mutex::lock()` is permitted to raise on an
+    /// `noexcept`: the deferred-teardown work it runs is `noexcept`, but
+    /// re-acquiring `mutex_` is not. The only exception that step can raise is
+    /// the `std::system_error` `std::mutex::lock()` is permitted to throw on an
     /// unrecoverable lock failure -- i.e. the OS failing to honour its
     /// `pthread_mutex_lock` contract for an initialised normal mutex. That is
-    /// not a recoverable condition (the worker's sole mutex is gone, so no slot
-    /// state can be touched safely), so it is left to propagate rather than be
-    /// swallowed; the implicit `noexcept` is dropped only so the throw is not
-    /// converted into a less informative `std::terminate` at this boundary.
-    ~StepUnlockGuard() noexcept(false);
+    /// not recoverable: the worker's sole mutex is gone and, crucially, we are
+    /// no longer holding it, so letting it escape would hand a lock-free state
+    /// to the worker's catch handler (which assumes the lock is held). The
+    /// destructor catches it, logs, and `std::abort()`s instead -- a clean stop
+    /// at the point of failure rather than UB downstream.
+    ~StepUnlockGuard() noexcept;
     StepUnlockGuard(const StepUnlockGuard&) = delete;
     StepUnlockGuard& operator=(const StepUnlockGuard&) = delete;
     StepUnlockGuard(StepUnlockGuard&&) = delete;

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
@@ -330,12 +330,13 @@ private:
   /// Extract finished requests and run the full per-slot drain (terminal
   /// driver hook with output flushing, stats, cache save, KV clear).
   void drainFinishedLocked();
-  [[nodiscard]] bool hasWorkLocked() const;
-  [[nodiscard]] unsigned numActiveLocked() const;
+  [[nodiscard]] bool hasWorkLocked() const noexcept;
+  [[nodiscard]] unsigned numActiveLocked() const noexcept;
   void completeGroupRequestLocked(
       const std::shared_ptr<BatchGroup>& group) noexcept;
   void failGroupLocked(
-      const std::shared_ptr<BatchGroup>& group, std::exception_ptr error);
+      const std::shared_ptr<BatchGroup>& group,
+      std::exception_ptr error) noexcept;
   void cancelPendingLocked();
   void clearLocked() noexcept;
   /// Tear down a single slot (cancel path). `noexcept`: callers run it from

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
@@ -267,7 +267,16 @@ private:
     StepUnlockGuard(
         ContinuousBatchScheduler& scheduler,
         std::unique_lock<std::mutex>* lock);
-    ~StepUnlockGuard();
+    /// `noexcept(false)`: the deferred-teardown work it runs is `noexcept`, but
+    /// re-acquiring `mutex_` is not. The only exception it can throw is the
+    /// `std::system_error` `std::mutex::lock()` is permitted to raise on an
+    /// unrecoverable lock failure -- i.e. the OS failing to honour its
+    /// `pthread_mutex_lock` contract for an initialised normal mutex. That is
+    /// not a recoverable condition (the worker's sole mutex is gone, so no slot
+    /// state can be touched safely), so it is left to propagate rather than be
+    /// swallowed; the implicit `noexcept` is dropped only so the throw is not
+    /// converted into a less informative `std::terminate` at this boundary.
+    ~StepUnlockGuard() noexcept(false);
     StepUnlockGuard(const StepUnlockGuard&) = delete;
     StepUnlockGuard& operator=(const StepUnlockGuard&) = delete;
     StepUnlockGuard(StepUnlockGuard&&) = delete;
@@ -323,21 +332,32 @@ private:
   void drainFinishedLocked();
   [[nodiscard]] bool hasWorkLocked() const;
   [[nodiscard]] unsigned numActiveLocked() const;
-  void completeGroupRequestLocked(const std::shared_ptr<BatchGroup>& group);
+  void completeGroupRequestLocked(
+      const std::shared_ptr<BatchGroup>& group) noexcept;
   void failGroupLocked(
       const std::shared_ptr<BatchGroup>& group, std::exception_ptr error);
   void cancelPendingLocked();
-  void clearLocked();
-  void cancelSlotLocked(uint32_t seqId);
+  void clearLocked() noexcept;
+  /// Tear down a single slot (cancel path). `noexcept`: callers run it from
+  /// the StepUnlockGuard destructor and the worker loop, so the teardown itself
+  /// must never throw. Every throwing step (driver finalize + cache save, and
+  /// the onDone callback inside notifyDone) is contained; the cleanup tail
+  /// (notifyDone/batcher cancel/freeSlot) always runs.
+  void cancelSlotLocked(uint32_t seqId) noexcept;
   /// Apply teardown requests recorded by cancel()/clear() while the
   /// worker was mid-step. Must run before admitting pending requests so
-  /// a deferred cancel can never hit a freed-and-reused slot.
-  void applyDeferredTeardownLocked();
-  void notifyDone(uint32_t seqId);
-  void freeSlot(uint32_t seqId);
+  /// a deferred cancel can never hit a freed-and-reused slot. `noexcept` so the
+  /// StepUnlockGuard destructor's teardown step cannot throw -- the only thing
+  /// that destructor can throw is the mutex re-acquire (see its declaration).
+  void applyDeferredTeardownLocked() noexcept;
+  /// `noexcept`: invoked on the teardown path. Contains the caller-provided
+  /// onDone callback internally so a throwing callback can neither escape nor
+  /// skip the group-completion below.
+  void notifyDone(uint32_t seqId) noexcept;
+  void freeSlot(uint32_t seqId) noexcept;
   /// Remove every KV-cache cell owned by `seqId` from the shared context.
   /// Single home for the cleanup repeated across all slot-teardown paths.
-  void clearSeqKv(uint32_t seqId);
+  void clearSeqKv(uint32_t seqId) noexcept;
   void finalizeFinishedSequences();
   std::function<void(const std::string&)>
   getOutputCallback(SlotState& slot, uint32_t seqId);

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <sstream>
 #include <stdexcept>
@@ -26,6 +27,8 @@
 #include <llama/mtmd/mtmd.h>
 #include <picojson/picojson.h>
 
+#include "BatchEntryGuard.hpp"
+#include "MediaLoadOrder.hpp"
 #include "MtmdLlmContext.hpp"
 #include "TextLlmContext.hpp"
 #include "addon/LlmErrors.hpp"
@@ -441,9 +444,37 @@ void LlamaModel::init(bool acquireLock) {
 }
 
 bool LlamaModel::isMultiBatchActivated(ReloadableState& state) {
-  return state.llmContext_ && state.isTextLlm_ &&
-         llama_n_seq_max(state.llmContext_->getCtx()) > 1;
+  return state.llmContext_ && llama_n_seq_max(state.llmContext_->getCtx()) > 1;
 }
+
+namespace {
+
+// Single source of truth for per-slot driver selection. The model layer owns
+// this decision because driver construction needs model-owned handles (the
+// shared llama context and the already-loaded mmproj); the scheduler stays
+// agnostic of any concrete driver type. `sharedVision` is the loaded mmproj
+// (`state.llmContext_` outlives the scheduler, see ReloadableState
+// declaration order); null for text-only contexts selects the text driver.
+// Capability is queried via `visionContext()` rather than an RTTI cast, so a
+// future multimodal context is picked up without inheriting MtmdLlmContext.
+batching::DriverFactory
+buildDriverFactory(LlmModelContext shared, mtmd_context* sharedVision) {
+  return [shared, sharedVision](
+             const common_params& params,
+             ToolsCompactController& tools,
+             uint32_t seqId,
+             llama_pos perSeqCtxCeiling) -> std::unique_ptr<SequenceDriver> {
+    const auto sid = static_cast<llama_seq_id>(seqId);
+    if (sharedVision != nullptr) {
+      return std::make_unique<MtmdLlmContext>(
+          params, shared, tools, sharedVision, sid, perSeqCtxCeiling);
+    }
+    return std::make_unique<TextLlmContext>(
+        params, shared, tools, sid, perSeqCtxCeiling);
+  };
+}
+
+} // namespace
 
 std::unique_ptr<batching::ContinuousBatchScheduler>
 LlamaModel::initBatchScheduler(ReloadableState& state) {
@@ -467,15 +498,8 @@ LlamaModel::initBatchScheduler(ReloadableState& state) {
       batchCapacity,
       cparams,
       state.configuredNDiscarded_,
-      state.toolsCompact_ ? state.toolsCompact_->profile() : std::nullopt);
-}
-
-batching::ContinuousBatchScheduler* LlamaModel::batchSchedulerForTesting() {
-  std::shared_lock lock(stateMtx_);
-  if (!state_) {
-    return nullptr;
-  }
-  return state_->batchScheduler_.get();
+      state.toolsCompact_ ? state.toolsCompact_->profile() : std::nullopt,
+      buildDriverFactory(shared, state.llmContext_->visionContext()));
 }
 
 void LlamaModel::setWeightsForFile(
@@ -620,6 +644,24 @@ std::any LlamaModel::process(const std::any& input) {
 LlamaModel::ResolvedPrompt
 LlamaModel::resolveChatAndTools(const Prompt& prompt) {
   ResolvedPrompt resolved;
+  // Load all prompt media (hoisted byte buffers and inline paths) in
+  // prompt-marker order so each bitmap binds to its own MTMD marker.
+  auto loadPlannedMedia = [this, &prompt](const ParsedPromptPayload& parsed) {
+    if (state_->isTextLlm_ && !parsed.mediaPlan.empty()) {
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          toString(MediaNotSupported),
+          "Media not supported by text-only models");
+    }
+    validateByteBufferCount(parsed.mediaPlan, prompt.media.size());
+    for (const auto& step : computeMediaLoadOrder(parsed.mediaPlan)) {
+      if (step.source == MediaSource::ByteBuffer) {
+        loadMedia(prompt.media[step.byteIndex]);
+      } else {
+        state_->llmContext_->loadMedia(step.path);
+      }
+    }
+  };
   if (state_->cacheManager_.has_value()) {
     ParsedPromptPayload parsedPrompt;
     resolved.isCacheLoaded = state_->cacheManager_->handleCache(
@@ -629,6 +671,7 @@ LlamaModel::resolveChatAndTools(const Prompt& prompt) {
           return this->formatPrompt(inputPrompt);
         },
         prompt.cacheKey);
+    loadPlannedMedia(parsedPrompt);
     resolved.chatMsgs = std::move(parsedPrompt.chatMsgs);
     resolved.tools = std::move(parsedPrompt.tools);
     resolved.layout = std::move(parsedPrompt.layout);
@@ -637,6 +680,7 @@ LlamaModel::resolveChatAndTools(const Prompt& prompt) {
         !state_->cacheManager_->wasCacheUsedInLastPrompt();
   } else {
     ParsedPromptPayload parsedPrompt = formatPrompt(prompt.input);
+    loadPlannedMedia(parsedPrompt);
     resolved.chatMsgs = std::move(parsedPrompt.chatMsgs);
     resolved.tools = std::move(parsedPrompt.tools);
     resolved.layout = std::move(parsedPrompt.layout);
@@ -663,10 +707,8 @@ std::string LlamaModel::processPromptImpl(const Prompt& prompt) {
   state_->llmContext_->resetNSlides();
   state_->llmContext_->resetThinkingBlockDiscards();
 
-  for (const auto& media : prompt.media) {
-    loadMedia(media);
-  }
-
+  // Prompt media (both hoisted byte buffers and inline paths) is loaded by
+  // resolveChatAndTools in prompt-marker order; see computeMediaLoadOrder.
   std::string out;
   ResolvedPrompt resolved = resolveChatAndTools(prompt);
 
@@ -756,26 +798,39 @@ bool LlamaModel::supportsBatching() const {
 
 std::vector<std::string>
 LlamaModel::processPromptBatchImpl(const std::vector<Prompt>& prompts) {
-  activeBatchJobs_.fetch_add(1);
-  ScopeGuard jobGuard([this] { activeBatchJobs_.fetch_sub(1); });
-  validateBitnetQuantization();
-  state_->lastRun_ = {};
-  state_->lastRun_.wasBatch = true;
+  // Serialize the entry section (prior-count check, cache invalidation, KV
+  // wipe) under batchEntryMutex_. Without it a second caller can see
+  // activeBatchJobs_ == 0 before the first caller increments it, skip the wipe,
+  // and reach scheduler.processBatch() while the first caller is still clearing
+  // KV — wiping the second caller's sequences. The lock is released before
+  // scheduler.processBatch() so concurrent batch calls still overlap during
+  // generation; jobGuard outlives the lock so its decrement spans the whole
+  // job.
+  std::optional<batching::BatchEntryGuard> jobGuard;
+  {
+    std::lock_guard<std::mutex> entryLock(state_->batchEntryMutex_);
+    jobGuard.emplace(
+        activeBatchJobs_, [this] { validateBitnetQuantization(); });
+    const unsigned priorBatchJobs = jobGuard->prior();
+    state_->lastRun_ = {};
+    state_->lastRun_.wasBatch = true;
 
-  // Invalidate single-prompt cache state and clear any stale KV data left by
-  // single-prompt runs. The batch scheduler will manage KV slots itself.
-  if (state_->cacheManager_.has_value()) {
-    state_->cacheManager_->invalidate();
-  }
-  llama_context* lctx = getContext();
-  if (lctx != nullptr) {
-    llama_memory_t mem = llama_get_memory(lctx);
-    if (mem != nullptr) {
-      // Clear all sequences to ensure batch scheduler starts with clean KV
-      // state
-      const int nSeqMax = llama_n_seq_max(lctx);
-      for (int seqId = 0; seqId < nSeqMax; seqId++) {
-        llama_memory_seq_rm(mem, static_cast<llama_seq_id>(seqId), -1, -1);
+    // Invalidate single-prompt cache state and clear any stale KV left by
+    // single-prompt runs so the batch scheduler starts on clean KV. Only the
+    // first batch job entering does this: while another batch job is already in
+    // flight the scheduler owns the live KV slots, and an unconditional wipe
+    // here would clear that active job's sequences before its own admission.
+    if (priorBatchJobs == 0) {
+      if (state_->cacheManager_.has_value()) {
+        state_->cacheManager_->invalidate();
+      }
+      if (llama_context* lctx = getContext(); lctx != nullptr) {
+        if (llama_memory_t mem = llama_get_memory(lctx); mem != nullptr) {
+          const int nSeqMax = llama_n_seq_max(lctx);
+          for (int seqId = 0; seqId < nSeqMax; seqId++) {
+            llama_memory_seq_rm(mem, static_cast<llama_seq_id>(seqId), -1, -1);
+          }
+        }
       }
     }
   }
@@ -788,8 +843,8 @@ LlamaModel::processPromptBatchImpl(const std::vector<Prompt>& prompts) {
     throw qvac_errors::StatusError(
         ADDON_ID,
         toString(qvac_errors::general_error::InvalidArgument),
-        "Model is not configured for continuous batching: requires a "
-        "text-only model with n_seq_max > 1");
+        "Model is not configured for continuous batching: requires "
+        "n_seq_max > 1");
   }
   auto& scheduler = *state_->batchScheduler_;
 
@@ -807,11 +862,11 @@ LlamaModel::processPromptBatchImpl(const std::vector<Prompt>& prompts) {
               "' with saveCacheToDisk in the same batch would overwrite "
               "itself; each saved cache must use a distinct key");
     }
-    if (!prompt.media.empty()) {
+    if (!prompt.media.empty() && state_->isTextLlm_) {
       throw qvac_errors::StatusError(
           ADDON_ID,
           toString(qvac_errors::general_error::InvalidArgument),
-          "processPromptBatch: media is not supported in batch mode");
+          "processPromptBatch: media requires a multimodal model");
     }
     if (prompt.finetuningParams.has_value()) {
       throw qvac_errors::StatusError(
@@ -826,10 +881,18 @@ LlamaModel::processPromptBatchImpl(const std::vector<Prompt>& prompts) {
           toString(EmptyPrompt),
           "processPromptBatch: prompt produced no chat messages");
     }
+    if (!parsed.mediaPaths.empty() && state_->isTextLlm_) {
+      throw qvac_errors::StatusError(
+          ADDON_ID,
+          toString(qvac_errors::general_error::InvalidArgument),
+          "processPromptBatch: media requires a multimodal model");
+    }
     batching::SubmitRequest sr;
     sr.chatMsgs = std::move(parsed.chatMsgs);
     sr.tools = std::move(parsed.tools);
     sr.layout = std::move(parsed.layout);
+    sr.media = prompt.media;
+    sr.mediaPlan = std::move(parsed.mediaPlan);
     sr.prefill = prompt.prefill;
     sr.cacheKey = prompt.cacheKey;
     sr.saveCacheToDisk = prompt.saveCacheToDisk;
@@ -1522,7 +1585,10 @@ ParsedPromptPayload LlamaModel::formatPrompt(const std::string& input) {
           }
 
           if (!content.empty()) {
-            state_->llmContext_->loadMedia(content);
+            parsed.mediaPaths.push_back(content);
+            parsed.mediaPlan.push_back({MediaSource::Path, content});
+          } else {
+            parsed.mediaPlan.push_back({MediaSource::ByteBuffer, ""});
           }
           addMediaPlaceholder++;
           isNextUser = true;

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.hpp
@@ -199,7 +199,8 @@ public:
 private:
   friend class LlamaFinetuner;
   // Unit tests reach internals (scheduler, single-prompt context) through this
-  // peer instead of public `*ForTesting()` accessors. See test_internal_peers.hpp.
+  // peer instead of public `*ForTesting()` accessors. See
+  // test_internal_peers.hpp.
   friend class LlamaModelTestPeer;
 
   // Impl without mutexes

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.hpp
@@ -126,16 +126,18 @@ public:
 
   /// Run several prompts in parallel via the continuous-batching session
   /// and return their generated texts in input order. Each output entry
-  /// matches the prompt at the same index. Throws when batching is
-  /// unsupported (multimodal context) or any prompt is rejected by the
-  /// session (oversize, empty, or capacity exhausted with no room to
-  /// queue). Output streaming via `Prompt::outputCallback` is honoured
-  /// per-slot.
+  /// matches the prompt at the same index. Media prompts are accepted on
+  /// multimodal models, and per-prompt cache (`cacheKey` / `saveCacheToDisk`)
+  /// round-trips media KV via the shared GGSQ sequence-state format. Throws
+  /// when batching is unsupported or any prompt is rejected by the session
+  /// (oversize,
+  /// empty, or capacity exhausted with no room to queue). Output
+  /// streaming via `Prompt::outputCallback` is honoured per-slot.
   std::vector<std::string>
   processPromptBatch(const std::vector<Prompt>& prompts);
 
   /// @brief True when the model was loaded with continuous batching active
-  /// (text-only context with `n_seq_max > 1`, i.e. `parallel >= 2`).
+  /// (`n_seq_max > 1`, i.e. `parallel >= 2`).
   [[nodiscard]] bool supportsBatching() const;
 
   /**
@@ -194,13 +196,11 @@ public:
   LlamaFinetuner& finetuner() { return finetuner_; }
   const LlamaFinetuner& finetuner() const { return finetuner_; }
 
-  /// For unit tests only: access the internal batch scheduler so tests can
-  /// inject a decode stub via setDecodeFuncForTesting(). Returns null when
-  /// batching is not active (n_parallel < 2 or multimodal model).
-  batching::ContinuousBatchScheduler* batchSchedulerForTesting();
-
 private:
   friend class LlamaFinetuner;
+  // Unit tests reach internals (scheduler, single-prompt context) through this
+  // peer instead of public `*ForTesting()` accessors. See test_internal_peers.hpp.
+  friend class LlamaModelTestPeer;
 
   // Impl without mutexes
   std::string processPromptImpl(const Prompt& prompt);
@@ -264,11 +264,17 @@ private:
       bool wasBatch = false;
     };
     LastRunInfo lastRun_;
+
+    /// Serializes the entry section of processPromptBatchImpl (the
+    /// activeBatchJobs_ check, cache invalidation, and KV wipe). Released
+    /// before scheduler.processBatch() so concurrent batch calls can still
+    /// overlap during generation.
+    std::mutex batchEntryMutex_;
   };
 
-  /// Continuous-batching gate. Active when the model is text-only and the
-  /// user opted into multi-sequence decoding via `n_parallel >= 2`
-  /// (which llama.cpp maps directly to `n_seq_max`).
+  /// Continuous-batching gate. Active when the user opted into multi-sequence
+  /// decoding via `n_parallel >= 2` (which llama.cpp maps directly to
+  /// `n_seq_max`); applies to text and multimodal models alike.
   static bool isMultiBatchActivated(ReloadableState& state);
 
   static std::unique_ptr<batching::ContinuousBatchScheduler>

--- a/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <string>
@@ -14,6 +15,7 @@
 using namespace qvac_lib_inference_addon_llama::errors;
 
 struct PromptLayout;
+struct mtmd_context;
 
 struct GenerationParams {
   std::optional<int> n_predict;
@@ -159,6 +161,26 @@ struct LlmModelContext {
   const llama_vocab* vocab = nullptr;
 };
 
+/// Canonical layout of the per-session cache metadata that every cache
+/// (de)serializer must persist and restore. Any driver implementing
+/// `loadCache`/`saveCache` MUST round-trip all four fields in this order.
+///
+/// `cacheTokens`/`firstMsgCacheTokens` (physical KV-cell usage) are owned
+/// separately from `nPast`/`firstMsgTokens` (logical positional span) because
+/// multimodal M-RoPE media can occupy more KV cells than its positional span.
+/// Persisting only the two positional fields would lose the media KV-cell
+/// counts and break context shifting after restore. See `getCacheTokens` /
+/// `getFirstMsgCacheTokens` below for the divergence these fields capture.
+enum class SessionMetadataField : uint8_t {
+  NPast = 0,
+  FirstMsgTokens = 1,
+  CacheTokens = 2,
+  FirstMsgCacheTokens = 3,
+};
+
+/// Number of `llama_token` fields in the session metadata contract above.
+inline constexpr size_t SESSION_METADATA_FIELD_COUNT = 4;
+
 class LlmContext { // NOLINT(cppcoreguidelines-special-member-functions)
 public:
   LlmContext() = default;
@@ -230,6 +252,13 @@ public:
    * associated with this context.
    */
   virtual common_params& getParams() = 0;
+
+  /**
+   * The llama-side sequence id this context owns (0 for the single-prompt
+   * path, the scheduler-assigned slot id under continuous batching). Used as
+   * the `seq_id` argument when persisting/restoring per-sequence cache state.
+   */
+  [[nodiscard]] llama_seq_id getSeqId() const { return seqId_; }
 
   /**
    * The get nPast method. It returns the nPast.
@@ -375,7 +404,10 @@ public:
     (void)hasKvCacheContext;
   }
 
-  [[nodiscard]] llama_seq_id getSeqId() const { return seqId_; }
+  /// Loaded multimodal (mmproj) context this LLM context can hand to
+  /// per-slot batch drivers, or null for text-only contexts. Used by the
+  /// scheduler factory to detect media capability without a `dynamic_cast`.
+  [[nodiscard]] virtual mtmd_context* visionContext() const { return nullptr; }
 
 protected:
   void clearSequenceMemory(

--- a/packages/llm-llamacpp/addon/src/model-interface/MediaLoadOrder.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MediaLoadOrder.cpp
@@ -1,0 +1,41 @@
+#include "MediaLoadOrder.hpp"
+
+#include <inference-addon-cpp/Errors.hpp>
+
+#include "addon/LlmErrors.hpp"
+
+using namespace qvac_lib_inference_addon_llama::errors;
+
+void validateByteBufferCount(
+    const std::vector<PlannedMedia>& plan, size_t bufferCount) {
+  size_t required = 0;
+  for (const auto& pm : plan) {
+    if (pm.source == MediaSource::ByteBuffer) {
+      required++;
+    }
+  }
+  if (required != bufferCount) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(qvac_errors::general_error::InvalidArgument),
+        "media buffer count does not match byte-buffer media markers in the "
+        "prompt");
+  }
+}
+
+std::vector<MediaLoadStep>
+computeMediaLoadOrder(const std::vector<PlannedMedia>& plan) {
+  std::vector<MediaLoadStep> steps;
+  steps.reserve(plan.size());
+
+  size_t byteIndex = 0;
+  for (const auto& item : plan) {
+    if (item.source == MediaSource::ByteBuffer) {
+      steps.push_back({MediaSource::ByteBuffer, byteIndex++, ""});
+    } else {
+      steps.push_back({MediaSource::Path, 0, item.path});
+    }
+  }
+
+  return steps;
+}

--- a/packages/llm-llamacpp/addon/src/model-interface/MediaLoadOrder.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MediaLoadOrder.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/// Whether a media marker is satisfied by a hoisted byte buffer (carried out
+/// of band in `Prompt::media`) or by an inline file path.
+enum class MediaSource : uint8_t { ByteBuffer, Path };
+
+/// One media marker in prompt order. `path` is set iff `source == Path`.
+struct PlannedMedia {
+  MediaSource source;
+  std::string path;
+};
+
+/// One media load step. A `ByteBuffer` step consumes the next hoisted buffer
+/// from the request's `media` vector (`byteIndex` into it); a `Path` step names
+/// the file to load. Steps are returned in prompt-marker order so bitmaps bind
+/// to the correct markers. Used by both the single-prompt and batch paths.
+struct MediaLoadStep {
+  MediaSource source;
+  size_t byteIndex;
+  std::string path;
+};
+
+/// Throw StatusError(InvalidArgument) when the number of byte-buffer markers
+/// in `plan` does not equal `bufferCount`. Call before any loadMedia loop to
+/// catch both missing-buffer and surplus-buffer mismatches.
+void validateByteBufferCount(
+    const std::vector<PlannedMedia>& plan, size_t bufferCount);
+
+/// Turn an ordered media plan into a load sequence. Byte-buffer markers are
+/// assigned ascending `byteIndex` (0, 1, 2…) in the order they appear in
+/// `plan`; path markers carry their path. The output preserves `plan` order.
+std::vector<MediaLoadStep>
+computeMediaLoadOrder(const std::vector<PlannedMedia>& plan);

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 #include <cassert>
+#include <filesystem>
+#include <system_error>
 
 #include <common/log.h>
 #include <gguf.h>
@@ -11,6 +13,7 @@
 
 #include "ContextSlider.hpp"
 #include "GenerationParamsApply.hpp"
+#include "MediaLoadOrder.hpp"
 #include "addon/LlmErrors.hpp"
 #include "inference-addon-cpp/Logger.hpp"
 #include "utils/ChatTemplateUtils.hpp"
@@ -22,6 +25,14 @@ using namespace qvac_lib_inference_addon_llama::errors;
 using namespace qvac_lib_inference_addon_cpp::logger;
 using namespace qvac_lib_inference_addon_llama::utils;
 
+namespace {
+bool isFileInitialized(const std::filesystem::path& path) {
+  std::error_code errorCode;
+  const auto size = std::filesystem::file_size(path, errorCode);
+  return !errorCode && size != 0;
+}
+} // namespace
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 MtmdLlmContext::MtmdLlmContext(
     common_params& commonParams, common_init_result_ptr llamaInit,
@@ -29,7 +40,27 @@ MtmdLlmContext::MtmdLlmContext(
     : tools_(tools), llamaInit_(std::move(llamaInit)), params_(commonParams) {
   modelCtx_.model = llamaInit_->model();
   modelCtx_.lctx = llamaInit_->context();
+  initializeCommonState();
+}
 
+MtmdLlmContext::MtmdLlmContext(
+    const common_params& commonParams, const LlmModelContext& shared,
+    ToolsCompactController& tools, mtmd_context* sharedVision,
+    llama_seq_id seqId, llama_pos perSeqCtxCeiling)
+    : tools_(tools), sharedVision_(sharedVision), modelCtx_(shared),
+      params_(commonParams), perSeqCtxCeiling_(perSeqCtxCeiling) {
+  seqId_ = seqId;
+  if (sharedVision_ == nullptr) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToLoadModel),
+        "MtmdLlmContext: per-slot driver requires a shared vision context");
+  }
+  initializeCommonState();
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void MtmdLlmContext::initializeCommonState() {
   if (modelCtx_.model == nullptr) {
     throw qvac_errors::StatusError(
         ADDON_ID,
@@ -44,7 +75,9 @@ MtmdLlmContext::MtmdLlmContext(
         "Failed to initialize context");
   }
 
-  modelCtx_.vocab = llama_model_get_vocab(modelCtx_.model);
+  if (modelCtx_.vocab == nullptr) {
+    modelCtx_.vocab = llama_model_get_vocab(modelCtx_.model);
+  }
 
   std::string chatTemplate =
       getChatTemplate(modelCtx_.model, params_, tools_.enabled());
@@ -83,7 +116,9 @@ MtmdLlmContext::MtmdLlmContext(
         "Model does not have chat template");
   }
 
-  initVisionContext();
+  if (sharedVision_ == nullptr) {
+    initVisionContext();
+  }
 
   // antiprompt init
   for (const std::string& antiprompt : params_.antiprompt) {
@@ -362,7 +397,7 @@ void MtmdLlmContext::tokenizeChat(
 
   auto bitmapsCPtr = bitmaps_.c_ptr();
   int32_t res = mtmd_tokenize(
-      ctxVision_.get(),
+      visionContext(),
       chunks.ptr.get(), // output
       &text,            // text
       bitmapsCPtr.data(),
@@ -389,7 +424,7 @@ void MtmdLlmContext::tokenizeChat(
 
       mtmd::input_chunks chunksNoTools(mtmd_input_chunks_init());
       int32_t resNoTools = mtmd_tokenize(
-          ctxVision_.get(),
+          visionContext(),
           chunksNoTools.ptr.get(),
           &textNoTools,
           bitmapsCPtr.data(),
@@ -544,7 +579,7 @@ bool MtmdLlmContext::evalMessageWithTools(
       return false;
     }
     int32_t res = mtmd_helper_eval_chunk_single(
-        ctxVision_.get(),
+        visionContext(),
         modelCtx_.lctx,
         chunk,
         nPastLocal,
@@ -881,7 +916,26 @@ llama_context* MtmdLlmContext::getCtx() { return modelCtx_.lctx; }
 
 llama_pos MtmdLlmContext::getNPast() const { return current_.pos; }
 
+llama_pos MtmdLlmContext::getKvCellsUsed() const {
+  return current_.cacheTokens;
+}
+
 void MtmdLlmContext::setNPast(llama_pos nPast) { current_.pos = nPast; }
+
+void MtmdLlmContext::advanceTextSpan(llama_pos newPos) {
+  current_.cacheTokens += newPos - current_.pos;
+  current_.pos = newPos;
+}
+
+// Scheduler-fed generated tokens are decoded by the batcher, not by this
+// driver, which learns of them only through syncPosition(). Each generated
+// token is text: it advances the logical position and consumes exactly one
+// KV cell, so advance both in lockstep. Without this, the per-slot KV-cell
+// cap in onLogitsReady() is checked against the frozen prefill count and an
+// M-RoPE slot (cacheTokens > pos) can generate past its KV-cell budget.
+void MtmdLlmContext::syncPosition(llama_pos currentPos) {
+  advanceTextSpan(currentPos);
+}
 
 llama_pos MtmdLlmContext::getCacheTokens() const {
   return current_.cacheTokens;
@@ -1054,7 +1108,7 @@ void MtmdLlmContext::loadMedia(const std::vector<uint8_t>& media) {
         errorMsg);
   }
 
-  if (ctxVision_.get() == nullptr) {
+  if (visionContext() == nullptr) {
     resetMedia();
     const char* errorMsg = "[MtmdLlm] Vision context is not initialized\n";
     throw qvac_errors::StatusError(
@@ -1062,7 +1116,7 @@ void MtmdLlmContext::loadMedia(const std::vector<uint8_t>& media) {
   }
 
   mtmd::bitmap bmp(mtmd_helper_bitmap_init_from_buf(
-      ctxVision_.get(), media.data(), media.size()));
+      visionContext(), media.data(), media.size()));
   if (!bmp.ptr) {
     resetMedia();
     const char* errorMsg =
@@ -1087,7 +1141,7 @@ void MtmdLlmContext::loadMedia(const std::string& fname) {
         errorMsg);
   }
 
-  if (ctxVision_.get() == nullptr) {
+  if (visionContext() == nullptr) {
     resetMedia();
     const char* errorMsg = "[MtmdLlm] Vision context is not initialized\n";
     throw qvac_errors::StatusError(
@@ -1095,7 +1149,7 @@ void MtmdLlmContext::loadMedia(const std::string& fname) {
   }
 
   mtmd::bitmap bmp(
-      mtmd_helper_bitmap_init_from_file(ctxVision_.get(), fname.c_str()));
+      mtmd_helper_bitmap_init_from_file(visionContext(), fname.c_str()));
   if (!bmp.ptr) {
     resetMedia();
     std::string errorMsg = string_format(
@@ -1180,4 +1234,374 @@ llama_pos MtmdLlmContext::removeLastNTokens(llama_pos count) {
   // future sampling since they're no longer in the KV cache.
 
   return tokensToRemove;
+}
+
+llama_pos MtmdLlmContext::ctxCeiling() const {
+  return perSeqCtxCeiling_ > 0
+             ? perSeqCtxCeiling_
+             : static_cast<llama_pos>(llama_n_ctx(modelCtx_.lctx));
+}
+
+PrefillPlan MtmdLlmContext::preparePrefill(
+    const std::vector<common_chat_msg>& chatMsgs,
+    const std::vector<common_chat_tool>& tools,
+    const std::vector<std::vector<uint8_t>>& media,
+    const std::vector<PlannedMedia>& mediaPlan, bool isCacheLoaded,
+    bool isPrefillOnlyRequest) {
+  resetMedia();
+  validateByteBufferCount(mediaPlan, media.size());
+  // Load media in prompt-marker order: byte buffers consume the next hoisted
+  // payload from `media` by index, paths load inline. This binds each bitmap
+  // to its own marker even when byte and path media interleave.
+  for (const auto& step : computeMediaLoadOrder(mediaPlan)) {
+    if (step.source == MediaSource::ByteBuffer) {
+      loadMedia(media[step.byteIndex]);
+    } else {
+      loadMedia(step.path);
+    }
+  }
+
+  mtmd::input_chunks chunks(mtmd_input_chunks_init());
+  tokenizeChat(chatMsgs, tools, chunks, isCacheLoaded);
+
+  const size_t nChunks = chunks.size();
+  if (nChunks == 0) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(EncoderFailed),
+        "[MtmdLlm] preparePrefill: prompt produced no chunks");
+  }
+
+  PrefillPlan plan;
+  for (size_t i = 0; i < nChunks; i++) {
+    const mtmd_input_chunk* chunk = chunks[i];
+    if (mtmd_input_chunk_get_type(chunk) == MTMD_INPUT_CHUNK_TYPE_TEXT) {
+      size_t nTokens = 0;
+      const llama_token* tokens =
+          mtmd_input_chunk_get_tokens_text(chunk, &nTokens);
+      plan.tokens.insert(plan.tokens.end(), tokens, tokens + nTokens);
+    } else {
+      plan.mediaBarriers.push_back(
+          MediaBarrier{
+              .afterTextTokens = plan.tokens.size(),
+              .mediaIndex = i,
+              .nPos = mtmd_input_chunk_get_n_pos(chunk),
+              .nKvTokens = static_cast<llama_pos>(
+                  mtmd_input_chunk_get_n_tokens(chunk))});
+    }
+  }
+
+  // The batcher can only request logits on text tokens it feeds, so a
+  // generating request must end on text (chat templates append the
+  // generation prompt after the last media item, so this only rejects
+  // malformed prompts).
+  const bool endsWithMedia =
+      !plan.mediaBarriers.empty() &&
+      plan.mediaBarriers.back().afterTextTokens == plan.tokens.size();
+  if (endsWithMedia && !isPrefillOnlyRequest) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InvalidArgument),
+        "[MtmdLlm] preparePrefill: prompt must end with text after the "
+        "last media item");
+  }
+
+  // M-RoPE media spans fewer positions than the KV cells it occupies, so both
+  // totals must clear the ceiling independently.
+  if (exceedsContextWindow(
+          plan.totalPositions(), ctxCeiling(), isPrefillOnlyRequest) ||
+      exceedsContextWindow(
+          plan.totalKvTokens(), ctxCeiling(), isPrefillOnlyRequest)) {
+    std::string errorMsg = string_format(
+        "[MtmdLlm] context overflow at batch prefill step: prompt spans %d "
+        "positions / %d KV cells, max context tokens %d\n",
+        plan.totalPositions(),
+        plan.totalKvTokens(),
+        ctxCeiling());
+    throw qvac_errors::StatusError(
+        ADDON_ID, toString(ContextOverflow), errorMsg);
+  }
+
+  // mtmd::input_chunks has a user-declared destructor and therefore no
+  // move assignment; transfer the owning pointer directly.
+  stagedChunks_.ptr = std::move(chunks.ptr);
+  pendingBatchFirstMsg_ = current_.pos == 0;
+  return plan;
+}
+
+llama_pos MtmdLlmContext::evalMediaSegment(size_t mediaIndex, llama_pos pos) {
+  const bool indexInRange =
+      stagedChunks_.ptr &&
+      mediaIndex < mtmd_input_chunks_size(stagedChunks_.ptr.get());
+  const mtmd_input_chunk* chunk =
+      indexInRange ? mtmd_input_chunks_get(stagedChunks_.ptr.get(), mediaIndex)
+                   : nullptr;
+  if (chunk == nullptr) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InternalError),
+        "[MtmdLlm] evalMediaSegment: no staged media segment " +
+            std::to_string(mediaIndex));
+  }
+
+  llama_pos newPos = pos;
+  constexpr bool logitsLast = false;
+  const int32_t res = mtmd_helper_eval_chunk_single(
+      visionContext(),
+      modelCtx_.lctx,
+      chunk,
+      pos,
+      seqId_,
+      params_.n_batch,
+      logitsLast,
+      &newPos);
+  if (res != 0) {
+    std::string errorMsg = string_format(
+        "[MtmdLlm] evalMediaSegment: failed to eval media chunk %zu "
+        "(res=%d)\n",
+        mediaIndex,
+        res);
+    throw qvac_errors::StatusError(ADDON_ID, toString(EncoderFailed), errorMsg);
+  }
+
+  // Commit accounting only after a successful eval, so a throwing/failing
+  // eval leaves cacheTokens and pos consistent. Trailing text the scheduler
+  // fed since the last driver sync advances positions and KV cells 1:1; the
+  // media chunk then adds its own cells on top while positions advance to
+  // newPos.
+  advanceTextSpan(pos);
+  current_.cacheTokens +=
+      static_cast<llama_pos>(mtmd_input_chunk_get_n_tokens(chunk));
+  current_.pos = newPos;
+  return newPos;
+}
+
+void MtmdLlmContext::onPrefillComplete(
+    llama_pos currentPos, size_t prefillTokenCount) {
+  // Trailing text advances positions and KV cells 1:1; media cells were
+  // already accounted by evalMediaSegment.
+  advanceTextSpan(currentPos);
+  if (pendingBatchFirstMsg_) {
+    protectedPrefix_ = current_;
+    const llama_pos ctxSize = ctxCeiling();
+    if (nDiscarded_ >= ctxSize - protectedPrefix_.pos) {
+      nDiscarded_ = ctxSize - protectedPrefix_.pos - 1;
+    }
+    pendingBatchFirstMsg_ = false;
+  }
+  tools_.onEvalComplete(
+      current_.pos, static_cast<llama_pos>(prefillTokenCount));
+}
+
+SequenceStepResult MtmdLlmContext::onLogitsReady(
+    int logitIdx, unsigned generatedAfterAccept,
+    const std::function<void(const std::string&)>& outputCallback,
+    LlamaBatch* inlineDecodeBatch) {
+  if (stopGeneration_.load()) {
+    stopGeneration_.store(false);
+    flushPendingUtf8ToCallback(outputCallback);
+    const llama_token eot = llama_vocab_eot(modelCtx_.vocab);
+    return {
+        .token =
+            eot == LLAMA_TOKEN_NULL ? llama_vocab_eos(modelCtx_.vocab) : eot,
+        .finished = true};
+  }
+
+  if ((current_.pos + 1 > ctxCeiling() ||
+       current_.cacheTokens + 1 > ctxCeiling()) &&
+      nDiscarded_ == 0) {
+    QLOG_IF(
+        Priority::WARNING,
+        string_format(
+            "[MtmdLlm] generation overflow: per-slot context is full and "
+            "nDiscarded is 0 (nPast=%d, cacheTokens=%d, ceiling=%d)\n",
+            current_.pos,
+            current_.cacheTokens,
+            ctxCeiling()));
+    return {.finished = true, .contextOverflow = true};
+  }
+  // No applyContextDiscard here: the batcher's per-sequence cap stops a
+  // slot before its window fills, and sliding a sequence that holds
+  // media cells would discard image KV entries mid-generation.
+
+  llama_token tokenId =
+      common_sampler_sample(smpl_.get(), modelCtx_.lctx, logitIdx);
+  common_sampler_accept(smpl_.get(), tokenId, true);
+
+  std::string tokenStr =
+      common_token_to_piece(modelCtx_.lctx, tokenId, params_.special);
+  const std::string completeChars = utf8Buffer_.addToken(tokenStr);
+  if (!completeChars.empty() && outputCallback) {
+    outputCallback(completeChars);
+  }
+
+  const bool isEos = llama_vocab_is_eog(modelCtx_.vocab, tokenId);
+  if (isEos && isHarmonyModel_ && params_.use_jinja &&
+      tokenId == harmonyCallToken_) {
+    QLOG_IF(
+        Priority::DEBUG,
+        string_format(
+            "[MtmdLlm] Harmony <|call|> stop: tokenId=%d\n", tokenId));
+    if (outputCallback) {
+      const std::string callMarker =
+          common_token_to_piece(modelCtx_.lctx, tokenId, true);
+      if (!callMarker.empty()) {
+        outputCallback(callMarker);
+      }
+    }
+    flushPendingUtf8ToCallback(outputCallback);
+    return {.token = tokenId, .finished = true};
+  }
+
+  // Batch path only: scheduler stops solely on `finished` (see
+  // TextLlmContext::onLogitsReady for the single-prompt rationale).
+  const bool reachedBudget =
+      inlineDecodeBatch == nullptr && params_.n_predict > 0 &&
+      generatedAfterAccept >= static_cast<unsigned>(params_.n_predict);
+  const bool finished = isEos || reachedBudget || checkAntiprompt();
+  if (finished) {
+    flushPendingUtf8ToCallback(outputCallback);
+  }
+  return {.token = tokenId, .finished = finished};
+}
+
+void MtmdLlmContext::onSequenceEnd(
+    const std::function<void(const std::string&)>& outputCallback) {
+  flushPendingUtf8ToCallback(outputCallback);
+}
+
+void MtmdLlmContext::onGenerationFinished(
+    const std::function<void(const std::string&)>& outputCallback) {
+  onSequenceEnd(outputCallback);
+}
+
+void MtmdLlmContext::onCancel(
+    const std::function<void(const std::string&)>& outputCallback) {
+  onGenerationFinished(outputCallback);
+}
+
+void MtmdLlmContext::validatePromptPolicy(
+    const std::vector<common_chat_msg>& chatMsgs,
+    const std::vector<common_chat_tool>& tools, const PromptLayout& layout,
+    bool hasKvCacheContext) const {
+  tools_.validatePrompt(chatMsgs, tools, layout, hasKvCacheContext);
+}
+
+/// Prompt caching on the multimodal batch path round-trips the full four-field
+/// session-metadata contract (`SessionMetadataField` in LlmContext.hpp),
+/// exactly as `CacheManager` does. All four fields are required: copying only
+/// the text path's two positional fields would drop
+/// `cacheTokens`/`firstMsgCacheTokens`, and for M-RoPE media those KV-cell
+/// counts diverge from the positional span (`current_.pos` vs
+/// `current_.cacheTokens`), so losing them would break context shifting after
+/// restore.
+static_assert(
+    SESSION_METADATA_FIELD_COUNT == 4,
+    "MTMD cache (de)serialization must persist all four session-metadata "
+    "fields; update the implementation when the contract changes");
+
+bool MtmdLlmContext::loadCache(
+    const std::string& cacheKey, llama_pos configuredNDiscarded) {
+  nDiscarded_ = configuredNDiscarded;
+  if (cacheKey.empty() || !isFileInitialized(cacheKey)) {
+    return false;
+  }
+
+  // Restore the full four-field metadata contract (SessionMetadataField order:
+  // NPast, FirstMsgTokens, CacheTokens, FirstMsgCacheTokens). For M-RoPE media
+  // the KV-cell counts diverge from the positional span, so all four must
+  // survive — see the static_assert above. The per-cell llama_kv_cell_ext
+  // (x/y) is restored by the GGSQ sequence-state loader itself.
+  size_t tokenCount = 0;
+  llama_token sessionTokens[SESSION_METADATA_FIELD_COUNT] = {0, 0, 0, 0};
+  const auto loadedBytes = llama_state_seq_load_file(
+      modelCtx_.lctx,
+      cacheKey.c_str(),
+      seqId_,
+      sessionTokens,
+      SESSION_METADATA_FIELD_COUNT,
+      &tokenCount);
+  if (loadedBytes == 0) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToLoadSessionFile),
+        "MtmdLlmContext::loadCache: failed to load cache '" + cacheKey + "'");
+  }
+
+  // `llama_state_seq_load_file` has already restored this sequence's KV cells.
+  // Accepting a partial header would leave `cacheTokens`/`firstMsgCacheTokens`
+  // defaulted to zero (they diverge from `nPast` under M-RoPE, breaking later
+  // cap checks), and silently returning here would strand the restored cells
+  // as orphan KV. Require the full four-field contract; on any other count
+  // clear the sequence KV and reject, mirroring `CacheManager::loadCache`.
+  if (!mtmdSessionMetadataIsComplete(tokenCount)) {
+    if (auto* mem = llama_get_memory(modelCtx_.lctx); mem != nullptr) {
+      llama_memory_seq_rm(mem, seqId_, -1, -1);
+    }
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToLoadSessionFile),
+        "MtmdLlmContext::loadCache: cache '" + cacheKey +
+            "' has incomplete session metadata (" + std::to_string(tokenCount) +
+            " of " + std::to_string(SESSION_METADATA_FIELD_COUNT) + " fields)");
+  }
+
+  setNPast(sessionTokens[static_cast<size_t>(SessionMetadataField::NPast)]);
+  setFirstMsgTokens(
+      sessionTokens[static_cast<size_t>(SessionMetadataField::FirstMsgTokens)]);
+  setCacheTokens(
+      sessionTokens[static_cast<size_t>(SessionMetadataField::CacheTokens)]);
+  setFirstMsgCacheTokens(
+      sessionTokens[static_cast<size_t>(
+          SessionMetadataField::FirstMsgCacheTokens)]);
+
+  if (getNPast() > llama_n_ctx(modelCtx_.lctx)) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(ContextLengthExeeded),
+        "MtmdLlmContext::loadCache: cache '" + cacheKey +
+            "' exceeds current context size");
+  }
+
+  // Clamp discard to the per-slot window (ctxCeiling), not the physical
+  // context, mirroring TextLlmContext::loadCache.
+  const llama_pos window = ctxCeiling();
+  if (configuredNDiscarded > window - getFirstMsgTokens()) {
+    nDiscarded_ = window - getFirstMsgTokens() - 1;
+  } else {
+    nDiscarded_ = configuredNDiscarded;
+  }
+
+  if (auto* mem = llama_get_memory(modelCtx_.lctx); mem != nullptr) {
+    llama_memory_seq_rm(mem, seqId_, getNPast(), -1);
+  }
+  return true;
+}
+
+void MtmdLlmContext::saveCache(const std::string& cacheKey) const {
+  if (cacheKey.empty()) {
+    return;
+  }
+
+  // Persist all four metadata fields in SessionMetadataField order so the
+  // physical KV-cell counts that diverge under M-RoPE survive restore.
+  const llama_token sessionTokens[SESSION_METADATA_FIELD_COUNT] = {
+      static_cast<llama_token>(getNPast()),
+      static_cast<llama_token>(getFirstMsgTokens()),
+      static_cast<llama_token>(getCacheTokens()),
+      static_cast<llama_token>(getFirstMsgCacheTokens())};
+  const auto savedBytes = llama_state_seq_save_file(
+      modelCtx_.lctx,
+      cacheKey.c_str(),
+      seqId_,
+      sessionTokens,
+      SESSION_METADATA_FIELD_COUNT);
+  if (savedBytes == 0) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(InvalidInputFormat),
+        "MtmdLlmContext::saveCache: failed to save cache '" + cacheKey + "'");
+  }
 }

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -18,6 +18,7 @@
 #include "inference-addon-cpp/Logger.hpp"
 #include "utils/ChatTemplateUtils.hpp"
 #include "utils/LoggingMacros.hpp"
+#include "utils/ScopeGuard.hpp"
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 
@@ -1531,15 +1532,29 @@ bool MtmdLlmContext::loadCache(
   }
 
   // `llama_state_seq_load_file` has already restored this sequence's KV cells.
+  // Every validation below runs after that restore, and the scheduler installs
+  // its per-slot cleanup guard only once this function returns, so any throw in
+  // between would strand the restored cells as orphan KV on the slot. Roll the
+  // sequence (and the metadata it stamped) back unless we reach the accept
+  // point, mirroring `TextLlmContext::loadCache` and `CacheManager::loadCache`.
+  ScopeGuard restoredKvGuard([this]() noexcept {
+    try {
+      clearSequenceMemory(modelCtx_.lctx);
+    } catch (...) {
+      QLOG_IF(
+          Priority::ERROR,
+          "[MtmdLlm] failed to clear sequence after invalid cache load\n");
+    }
+    current_ = {};
+    protectedPrefix_ = {};
+    tools_.reset();
+  });
+
   // Accepting a partial header would leave `cacheTokens`/`firstMsgCacheTokens`
   // defaulted to zero (they diverge from `nPast` under M-RoPE, breaking later
-  // cap checks), and silently returning here would strand the restored cells
-  // as orphan KV. Require the full four-field contract; on any other count
-  // clear the sequence KV and reject, mirroring `CacheManager::loadCache`.
+  // cap checks). Require the full four-field contract; the guard above clears
+  // the restored KV on reject, mirroring `CacheManager::loadCache`.
   if (!mtmdSessionMetadataIsComplete(tokenCount)) {
-    if (auto* mem = llama_get_memory(modelCtx_.lctx); mem != nullptr) {
-      llama_memory_seq_rm(mem, seqId_, -1, -1);
-    }
     throw qvac_errors::StatusError(
         ADDON_ID,
         toString(UnableToLoadSessionFile),
@@ -1577,6 +1592,7 @@ bool MtmdLlmContext::loadCache(
   if (auto* mem = llama_get_memory(modelCtx_.lctx); mem != nullptr) {
     llama_memory_seq_rm(mem, seqId_, getNPast(), -1);
   }
+  restoredKvGuard.dismiss();
   return true;
 }
 

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
@@ -10,10 +10,27 @@
 #include "../utils/UTF8TokenBuffer.hpp"
 #include "ContextSlider.hpp"
 #include "LlmContext.hpp"
+#include "SequenceDriver.hpp"
 #include "ToolsCompactController.hpp"
 #include "inference-addon-cpp/Logger.hpp"
 
-class MtmdLlmContext : public LlmContext {
+/// A multimodal session cache is only safe to restore when its header carries
+/// the full four-field metadata contract (`SessionMetadataField`). The GGSQ
+/// loader restores the sequence KV before this check, so any other count — a
+/// truncated/legacy header (`< 4`) or an unexpected layout (`> 4`) — must be
+/// rejected and the restored KV cleared, never accepted with defaulted
+/// `cacheTokens`/`firstMsgCacheTokens`. See `MtmdLlmContext::loadCache`.
+[[nodiscard]] inline bool mtmdSessionMetadataIsComplete(size_t tokenCount) {
+  return tokenCount == SESSION_METADATA_FIELD_COUNT;
+}
+
+/// Multimodal LLM context. Implements both the legacy `LlmContext` API
+/// (driven by the single-prompt path in `LlamaModel`) and the per-sequence
+/// `SequenceDriver` API (driven by the `ContinuousBatchScheduler`).
+/// Per-slot driver instances share the model's `mtmd_context` (mmproj
+/// weights) instead of loading their own; safe because the scheduler's
+/// single worker thread serialises all media encodes.
+class MtmdLlmContext : public LlmContext, public SequenceDriver {
 public:
   /**
    * The constructor.
@@ -26,6 +43,14 @@ public:
   MtmdLlmContext(
       common_params& commonParams, common_init_result_ptr llamaInit,
       ToolsCompactController& tools);
+
+  /// Per-slot driver constructor for the continuous-batching path. Does
+  /// not own llama handles or the vision context; `sharedVision` must
+  /// outlive this instance.
+  MtmdLlmContext(
+      const common_params& commonParams, const LlmModelContext& shared,
+      ToolsCompactController& tools, mtmd_context* sharedVision,
+      llama_seq_id seqId, llama_pos perSeqCtxCeiling = -1);
 
   /**
    * The destructor.
@@ -104,12 +129,20 @@ public:
    */
   [[nodiscard]] llama_pos getNPast() const override;
 
+  /// SequenceDriver KV-cell usage: M-RoPE media commits more KV cells than
+  /// positions, so admission must size the cap from `cacheTokens`, not
+  /// `nPast`. Diverges from the base default after a cache load restores
+  /// `cacheTokens > nPast`.
+  [[nodiscard]] llama_pos getKvCellsUsed() const override;
+
   /**
    * The set n_past method. It sets the n_past.
    *
    * @param n_past - the n_past.
    */
   void setNPast(llama_pos nPast) override;
+
+  void syncPosition(llama_pos currentPos) override;
 
   [[nodiscard]] llama_pos getCacheTokens() const override;
   void setCacheTokens(llama_pos cacheTokens) override;
@@ -143,6 +176,8 @@ public:
 
   [[nodiscard]] int32_t getThinkingBlockDiscards() const override;
   void resetThinkingBlockDiscards() override;
+
+  [[nodiscard]] bool supportsSliding() const override { return false; }
 
   /**
    * The load media method. It loads the media from memory buffer.
@@ -180,6 +215,54 @@ public:
    */
   void resetMedia() override;
 
+  /// Raw vision context in use: the shared one in per-slot driver mode,
+  /// else the owned one. Exposed so `LlamaModel` can hand the loaded
+  /// mmproj to per-slot batch drivers.
+  [[nodiscard]] mtmd_context* visionContext() const override {
+    return sharedVision_ != nullptr ? sharedVision_ : ctxVision_.get();
+  }
+
+  // SequenceDriver interface (continuous-batching path)
+
+  PrefillPlan preparePrefill(
+      const std::vector<common_chat_msg>& chatMsgs,
+      const std::vector<common_chat_tool>& tools,
+      const std::vector<std::vector<uint8_t>>& media,
+      const std::vector<PlannedMedia>& mediaPlan, bool isCacheLoaded,
+      bool isPrefillOnlyRequest) override;
+
+  llama_pos evalMediaSegment(size_t mediaIndex, llama_pos pos) override;
+
+  void
+  onPrefillComplete(llama_pos currentPos, size_t prefillTokenCount) override;
+
+  SequenceStepResult onLogitsReady(
+      int logitIdx, unsigned generatedAfterAccept,
+      const std::function<void(const std::string&)>& outputCallback,
+      LlamaBatch* inlineDecodeBatch = nullptr) override;
+
+  void onSequenceEnd(
+      const std::function<void(const std::string&)>& outputCallback) override;
+
+  void onGenerationFinished(
+      const std::function<void(const std::string&)>& outputCallback) override;
+
+  void onCancel(
+      const std::function<void(const std::string&)>& outputCallback) override;
+
+  void validatePromptPolicy(
+      const std::vector<common_chat_msg>& chatMsgs,
+      const std::vector<common_chat_tool>& tools, const PromptLayout& layout,
+      bool hasKvCacheContext) const override;
+
+  /// Disk prompt-cache for a multimodal batch slot, round-tripping the full
+  /// four-field session metadata (see MtmdLlmContext.cpp). `loadCache` records
+  /// the discard budget and returns false (cache miss) on an empty key, a
+  /// missing file, or a header that fails the four-field metadata check.
+  [[nodiscard]] bool loadCache(
+      const std::string& cacheKey, llama_pos configuredNDiscarded) override;
+  void saveCache(const std::string& cacheKey) const override;
+
 private:
   /**
    * The check antiprompt method. It checks the antiprompt.
@@ -210,8 +293,16 @@ private:
   void flushPendingUtf8ToCallback(
       const std::function<void(const std::string&)>& outputCallback);
   void refreshCurrentCacheTokensFromMemory();
+  /// Advance the logical position to `newPos`, growing physical KV-cell usage
+  /// 1:1. Prompt trailing text and every scheduler-fed generated token consume
+  /// one KV cell per position; media cells are added separately by
+  /// evalMediaSegment(). Single source of truth tying cacheTokens to pos for
+  /// text spans, so every position advance keeps the KV-cell count honest.
+  void advanceTextSpan(llama_pos newPos);
   void applyContextDiscard();
   void handleStopRequestAndAddEot(LlamaBatch& batchPtr);
+  void initializeCommonState();
+  [[nodiscard]] llama_pos ctxCeiling() const;
 
   // Reasoning-block KV-cache compaction helpers. Single-block policy:
   // at most one `<think>...</think>` block is tracked per inference.
@@ -226,6 +317,9 @@ private:
   ToolsCompactController& tools_;
   common_init_result_ptr llamaInit_;
   mtmd::context_ptr ctxVision_;
+  /// Non-owning vision context for per-slot batch drivers; null in
+  /// single-prompt mode (where `ctxVision_` owns the mmproj).
+  mtmd_context* sharedVision_ = nullptr;
   LlmModelContext modelCtx_;
   CommonSamplerPtr smpl_;
 
@@ -234,10 +328,15 @@ private:
   std::vector<llama_token> antipromptTokens_;
 
   mtmd::bitmaps bitmaps_;
+  /// Chunks staged by `preparePrefill` for the batch path; media barriers
+  /// index into this container until the scheduler evaluates them.
+  mtmd::input_chunks stagedChunks_;
   ContextUsage current_;
   ContextUsage protectedPrefix_;
   llama_pos nDiscarded_ = 0;
+  llama_pos perSeqCtxCeiling_ = -1;
   int32_t nSlides_ = 0;
+  bool pendingBatchFirstMsg_ = false;
 
   // UTF-8 token buffer for handling incomplete emoji sequences
   qvac_lib_inference_addon_llama::UTF8TokenBuffer utf8Buffer_;

--- a/packages/llm-llamacpp/addon/src/model-interface/MultiRequestBatcher.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MultiRequestBatcher.cpp
@@ -352,11 +352,11 @@ void MultiRequestBatcher::sampleAndAppendIdle(const SamplerFn& samplerFn) {
   }
 }
 
-bool MultiRequestBatcher::isValid(uint32_t seqId) const {
+bool MultiRequestBatcher::isValid(uint32_t seqId) const noexcept {
   return seqId < slots_.size() && slots_[seqId].has_value();
 }
 
-const Request* MultiRequestBatcher::requestAt(uint32_t seqId) const {
+const Request* MultiRequestBatcher::requestAt(uint32_t seqId) const noexcept {
   if (!isValid(seqId)) {
     return nullptr;
   }

--- a/packages/llm-llamacpp/addon/src/model-interface/MultiRequestBatcher.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MultiRequestBatcher.cpp
@@ -8,14 +8,28 @@ namespace qvac_lib_inference_addon_llama::batching {
 namespace views = std::views;
 
 Request::Request(
+    uint32_t rid, PrefillPlan&& plan, unsigned maxTokens, llama_pos initialPos,
+    bool canSlide)
+    : seqId(rid), pendingPrefillTokens(std::move(plan.tokens)),
+      pendingMediaBarriers(std::move(plan.mediaBarriers)),
+      currentPos(initialPos), slideCapable(canSlide),
+      maxTokensPerSequence(maxTokens) {
+  prefillTokenCount = pendingPrefillTokens.size();
+  for (const auto& barrier : pendingMediaBarriers) {
+    prefillTokenCount += static_cast<size_t>(barrier.nPos);
+  }
+}
+
+Request::Request(
     uint32_t rid, std::vector<llama_token>&& toks, unsigned maxTokens,
     llama_pos initialPos, bool canSlide)
-    : seqId(rid), pendingPrefillTokens(std::move(toks)),
-      prefillTokenCount(pendingPrefillTokens.size()), currentPos(initialPos),
-      slideCapable(canSlide), maxTokensPerSequence(maxTokens) {}
+    : Request(
+          rid, PrefillPlan{.tokens = std::move(toks)}, maxTokens, initialPos,
+          canSlide) {}
 
 bool Request::isPrefillComplete() const {
-  return prefillFedCount >= pendingPrefillTokens.size();
+  return prefillFedCount >= pendingPrefillTokens.size() &&
+         pendingMediaBarriers.empty();
 }
 
 bool Request::exceededLimit() const {
@@ -47,6 +61,15 @@ bool Request::isOptPrefillPending(const std::optional<Request>& slot) {
   return slot.has_value() && slot->isPrefillPending();
 }
 
+bool Request::isAwaitingMedia() const {
+  return isPrefillPending() && !pendingMediaBarriers.empty() &&
+         prefillFedCount >= pendingMediaBarriers.front().afterTextTokens;
+}
+
+bool Request::isOptAwaitingMedia(const std::optional<Request>& slot) {
+  return slot.has_value() && slot->isAwaitingMedia();
+}
+
 bool Request::isGenerationIdle() const {
   return !isFinished() && isPrefillComplete() && !hasUnfedSample;
 }
@@ -64,7 +87,7 @@ bool Request::isOptGenerationPending(const std::optional<Request>& slot) {
 }
 
 bool Request::hasTokensToFeed() const {
-  return isPrefillPending() || isGenerationPending();
+  return (isPrefillPending() && !isAwaitingMedia()) || isGenerationPending();
 }
 
 bool Request::isOptHasTokensToFeed(const std::optional<Request>& slot) {
@@ -73,7 +96,17 @@ bool Request::isOptHasTokensToFeed(const std::optional<Request>& slot) {
 
 unsigned Request::remainingToFeed() const {
   if (!isPrefillComplete()) {
-    return static_cast<unsigned>(pendingPrefillTokens.size() - prefillFedCount);
+    // Text feeding stops at the head media barrier; the segment past it
+    // only unblocks once the scheduler completes the barrier.
+    const size_t feedLimit =
+        pendingMediaBarriers.empty()
+            ? pendingPrefillTokens.size()
+            : std::min(
+                  pendingPrefillTokens.size(),
+                  pendingMediaBarriers.front().afterTextTokens);
+    return feedLimit > prefillFedCount
+               ? static_cast<unsigned>(feedLimit - prefillFedCount)
+               : 0u;
   }
   return hasUnfedSample ? 1u : 0u;
 }
@@ -86,7 +119,16 @@ llama_token Request::tokenToFeedAt(llama_pos pos) const {
 }
 
 bool Request::chunkConsumesAllUnfed(unsigned chunkSize) const {
-  return chunkSize == remainingToFeed();
+  if (chunkSize != remainingToFeed()) {
+    return false;
+  }
+  if (isPrefillComplete()) {
+    return true;
+  }
+  // Mid-prefill a chunk can also drain `remainingToFeed` by hitting a
+  // media barrier; logits belong only to the true end of the prompt.
+  return pendingMediaBarriers.empty() &&
+         prefillFedCount + chunkSize >= pendingPrefillTokens.size();
 }
 
 MultiRequestBatcher::AddStatus MultiRequestBatcher::addRequest(
@@ -102,23 +144,50 @@ MultiRequestBatcher::AddStatus MultiRequestBatcher::addRequest(
 
 MultiRequestBatcher::AddStatus MultiRequestBatcher::addRequestAt(
     uint32_t seqId, std::vector<llama_token>&& tokens, llama_pos initialPos,
-    bool slideCapable) {
-  if (tokens.empty()) {
+    bool slideCapable, llama_pos initialKvCells) {
+  return addRequestAt(
+      seqId,
+      PrefillPlan{.tokens = std::move(tokens)},
+      initialPos,
+      slideCapable,
+      initialKvCells);
+}
+
+MultiRequestBatcher::AddStatus MultiRequestBatcher::addRequestAt(
+    uint32_t seqId, PrefillPlan&& plan, llama_pos initialPos, bool slideCapable,
+    llama_pos initialKvCells) {
+  if (plan.tokens.empty() && plan.mediaBarriers.empty()) {
     return AddStatus::ErrEmptyTokens;
   }
-  const auto totalTokens = static_cast<size_t>(initialPos) + tokens.size();
-  if (totalTokens > maxTokensPerSequence_) {
+  const bool barriersValid =
+      std::ranges::is_sorted(
+          plan.mediaBarriers, {}, &MediaBarrier::afterTextTokens) &&
+      std::ranges::all_of(plan.mediaBarriers, [&](const MediaBarrier& b) {
+        return b.afterTextTokens <= plan.tokens.size() && b.nPos > 0;
+      });
+  if (!barriersValid) {
+    return AddStatus::ErrInvalidPlan;
+  }
+  // M-RoPE media occupies more KV cells than positions, so both the
+  // position span and the KV-cell span must fit the per-sequence cap. The
+  // KV-cell span is sized from the physical cell count already committed
+  // (`initialKvCells`), which for a cache-loaded M-RoPE sequence exceeds the
+  // logical position count (`initialPos`); a negative default means "same as
+  // initialPos" (text, where cells and positions coincide).
+  const llama_pos kvBase = initialKvCells < 0 ? initialPos : initialKvCells;
+  const auto totalPositions = static_cast<size_t>(initialPos) +
+                              static_cast<size_t>(plan.totalPositions());
+  const auto totalKvTokens =
+      static_cast<size_t>(kvBase) + static_cast<size_t>(plan.totalKvTokens());
+  if (totalPositions > maxTokensPerSequence_ ||
+      totalKvTokens > maxTokensPerSequence_) {
     return AddStatus::ErrTokensTooLarge;
   }
   if (seqId >= slots_.size() || slots_[seqId].has_value()) {
     return AddStatus::ErrNoFreeSlot;
   }
   slots_[seqId].emplace(
-      seqId,
-      std::move(tokens),
-      maxTokensPerSequence_,
-      initialPos,
-      slideCapable);
+      seqId, std::move(plan), maxTokensPerSequence_, initialPos, slideCapable);
   return AddStatus::Ok;
 }
 
@@ -208,18 +277,25 @@ MultiRequestBatcher::fillBatch(LlamaBatch& batch) {
 }
 
 namespace {
+void finishPrefillIfComplete(
+    Request& req,
+    const MultiRequestBatcher::PrefillCompleteFn& onPrefillComplete) {
+  if (!req.isPrefillComplete()) {
+    return;
+  }
+  if (onPrefillComplete) {
+    onPrefillComplete(req.seqId, req.currentPos, req.prefillTokenCount);
+  }
+  req.pendingPrefillTokens.clear();
+  req.pendingPrefillTokens.shrink_to_fit();
+  req.prefillFedCount = 0;
+}
+
 void advanceReqPrefill(
     Request& req, llama_pos chunk,
     const MultiRequestBatcher::PrefillCompleteFn& onPrefillComplete) {
   req.prefillFedCount += static_cast<size_t>(chunk);
-  if (req.isPrefillComplete()) {
-    if (onPrefillComplete) {
-      onPrefillComplete(req.seqId, req.currentPos, req.prefillTokenCount);
-    }
-    req.pendingPrefillTokens.clear();
-    req.pendingPrefillTokens.shrink_to_fit();
-    req.prefillFedCount = 0;
-  }
+  finishPrefillIfComplete(req, onPrefillComplete);
 }
 } // namespace
 
@@ -238,6 +314,34 @@ void MultiRequestBatcher::advance(
       req.hasUnfedSample = false;
     }
   }
+}
+
+std::optional<MultiRequestBatcher::AwaitingMedia>
+MultiRequestBatcher::nextAwaitingMedia() const {
+  for (const auto& slot : slots_ | views::filter(Request::isOptAwaitingMedia)) {
+    return AwaitingMedia{
+        .seqId = slot->seqId,
+        .mediaIndex = slot->pendingMediaBarriers.front().mediaIndex,
+        .currentPos = slot->currentPos};
+  }
+  return std::nullopt;
+}
+
+bool MultiRequestBatcher::completeMediaBarrier(
+    uint32_t seqId, llama_pos newPos,
+    const PrefillCompleteFn& onPrefillComplete) {
+  const bool hasBarrier =
+      isValid(seqId) && !slots_[seqId]->pendingMediaBarriers.empty();
+  if (hasBarrier) {
+    Request& req = *slots_[seqId];
+    req.pendingMediaBarriers.erase(req.pendingMediaBarriers.begin());
+    req.currentPos = newPos;
+    if (req.exceededLimit() && req.stopReason == StopReason::None) {
+      req.stopReason = StopReason::LimitReached;
+    }
+    finishPrefillIfComplete(req, onPrefillComplete);
+  }
+  return hasBarrier;
 }
 
 void MultiRequestBatcher::sampleAndAppendIdle(const SamplerFn& samplerFn) {

--- a/packages/llm-llamacpp/addon/src/model-interface/MultiRequestBatcher.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MultiRequestBatcher.hpp
@@ -206,9 +206,9 @@ public:
   /// previously occupied slot, in seqId order.
   void clear(const KvClearFn& kvClear = {});
 
-  [[nodiscard]] bool isValid(uint32_t seqId) const;
+  [[nodiscard]] bool isValid(uint32_t seqId) const noexcept;
 
-  [[nodiscard]] const Request* requestAt(uint32_t seqId) const;
+  [[nodiscard]] const Request* requestAt(uint32_t seqId) const noexcept;
 
 private:
   unsigned maxChunkSize_, maxTokensPerSequence_;

--- a/packages/llm-llamacpp/addon/src/model-interface/MultiRequestBatcher.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MultiRequestBatcher.hpp
@@ -9,6 +9,7 @@
 #include <llama.h>
 
 #include "LlmContext.hpp"
+#include "SequenceDriver.hpp"
 
 namespace qvac_lib_inference_addon_llama::batching {
 
@@ -23,6 +24,10 @@ enum class StopReason : uint8_t {
 struct Request {
   uint32_t seqId;
   std::vector<llama_token> pendingPrefillTokens;
+  /// Media barriers not yet evaluated, ordered by `afterTextTokens`.
+  /// The slot stops feeding text once `prefillFedCount` reaches the head
+  /// barrier's anchor and waits for `completeMediaBarrier`.
+  std::vector<MediaBarrier> pendingMediaBarriers;
   size_t prefillTokenCount = 0;
   size_t prefillFedCount = 0;
   std::vector<llama_token> generatedTokens;
@@ -37,6 +42,9 @@ struct Request {
   unsigned maxTokensPerSequence;
 
   Request(
+      uint32_t rid, PrefillPlan&& plan, unsigned maxTokens,
+      llama_pos initialPos = 0, bool canSlide = false);
+  Request(
       uint32_t rid, std::vector<llama_token>&& toks, unsigned maxTokens,
       llama_pos initialPos = 0, bool canSlide = false);
 
@@ -47,6 +55,11 @@ struct Request {
   static bool isOptActive(const std::optional<Request>& slot);
   [[nodiscard]] bool isPrefillPending() const;
   static bool isOptPrefillPending(const std::optional<Request>& slot);
+  /// True when the slot's prefill is blocked on its head media barrier:
+  /// every text token before the barrier has been fed and the scheduler
+  /// must run `SequenceDriver::evalMediaSegment` before more can flow.
+  [[nodiscard]] bool isAwaitingMedia() const;
+  static bool isOptAwaitingMedia(const std::optional<Request>& slot);
   [[nodiscard]] bool isGenerationIdle() const;
   static bool isOptGenerationIdle(const std::optional<Request>& slot);
   [[nodiscard]] bool isGenerationPending() const;
@@ -83,13 +96,28 @@ public:
     ErrNoFreeSlot,
     ErrTokensTooLarge,
     ErrEmptyTokens,
+    ErrInvalidPlan,
   };
 
   [[nodiscard]] AddStatus
   addRequest(std::vector<llama_token>&& tokens, uint32_t& seqId);
   [[nodiscard]] AddStatus addRequestAt(
       uint32_t seqId, std::vector<llama_token>&& tokens,
-      llama_pos initialPos = 0, bool slideCapable = false);
+      llama_pos initialPos = 0, bool slideCapable = false,
+      llama_pos initialKvCells = -1);
+  /// Plan-aware admission: text tokens plus interleaved media barriers.
+  /// Barriers must be sorted by `afterTextTokens` and anchored within
+  /// `plan.tokens` (`ErrInvalidPlan` otherwise). Sizing uses
+  /// `plan.totalPositions()` so media spans count against the cap.
+  ///
+  /// `initialKvCells` is the physical KV-cell count already committed for this
+  /// sequence (e.g. a restored cache). It defaults (negative) to `initialPos`,
+  /// which is correct for text where cells and positions coincide; for a
+  /// cache-loaded M-RoPE sequence the cells exceed the positions, so the
+  /// KV-cap check must use this value rather than `initialPos`.
+  [[nodiscard]] AddStatus addRequestAt(
+      uint32_t seqId, PrefillPlan&& plan, llama_pos initialPos = 0,
+      bool slideCapable = false, llama_pos initialKvCells = -1);
 
   [[nodiscard]] std::optional<uint32_t> firstFreeSeqId() const;
 
@@ -141,6 +169,29 @@ public:
 
   void
   advance(unsigned chunkSize, const PrefillCompleteFn& onPrefillComplete = {});
+
+  /// A slot blocked on its head media barrier, ready for the scheduler
+  /// to run `SequenceDriver::evalMediaSegment(mediaIndex, currentPos)`.
+  struct AwaitingMedia {
+    uint32_t seqId;
+    size_t mediaIndex;
+    llama_pos currentPos;
+  };
+
+  /// First slot (lowest seqId) whose prefill is blocked on a media
+  /// barrier, or nullopt. Lowest-seqId order keeps servicing
+  /// deterministic; a slot is serviced one barrier per call so text
+  /// slots interleave between media evaluations.
+  [[nodiscard]] std::optional<AwaitingMedia> nextAwaitingMedia() const;
+
+  /// Consume the head media barrier of `seqId` after the scheduler
+  /// evaluated it. `newPos` is the position returned by
+  /// `evalMediaSegment`. Fires `onPrefillComplete` if the barrier was
+  /// the final pending prefill work. Returns false when the slot is
+  /// missing or has no pending barrier.
+  bool completeMediaBarrier(
+      uint32_t seqId, llama_pos newPos,
+      const PrefillCompleteFn& onPrefillComplete = {});
 
   /// Extract finished requests and free their slots. Callers are responsible
   /// for clearing the freed seqIds' KV-cache entries before reusing the slots.

--- a/packages/llm-llamacpp/addon/src/model-interface/SequenceDriver.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/SequenceDriver.hpp
@@ -1,12 +1,18 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <numeric>
 #include <string>
 #include <vector>
 
 #include <common/chat.h>
+#include <inference-addon-cpp/Errors.hpp>
 #include <llama.h>
+
+#include "MediaLoadOrder.hpp"
+#include "addon/LlmErrors.hpp"
 
 class LlamaBatch;
 struct PromptLayout;
@@ -25,6 +31,65 @@ struct SequenceStepResult {
   /// before feeding the next token.
   llama_pos discarded = 0;
 };
+
+/// A non-token unit of prefill work (image/audio embedding chunk) staged
+/// between text tokens. `afterTextTokens` anchors the barrier inside
+/// `PrefillPlan::tokens`: the batcher stops feeding that slot once it has
+/// fed this many text tokens and waits for the scheduler to call
+/// `SequenceDriver::evalMediaSegment(mediaIndex, pos)`. `nPos` is the
+/// positional span the segment will occupy (M-RoPE media can occupy fewer
+/// positions than KV cells) and is only used for admission-time sizing;
+/// the authoritative post-eval position comes from `evalMediaSegment`.
+/// `nKvTokens` is the number of KV cells the segment consumes; for M-RoPE
+/// media `nKvTokens >= nPos`, so both must be checked against their caps
+/// at admission time.
+struct MediaBarrier {
+  size_t afterTextTokens = 0;
+  size_t mediaIndex = 0;
+  llama_pos nPos = 0;
+  llama_pos nKvTokens = 0;
+};
+
+/// Staged prefill returned by `SequenceDriver::preparePrefill`: the flat
+/// text-token stream plus the media barriers interleaved into it, ordered
+/// by `afterTextTokens`. Text-only drivers return an empty barrier list.
+struct PrefillPlan {
+  std::vector<llama_token> tokens;
+  std::vector<MediaBarrier> mediaBarriers;
+
+  /// Total positional span of the staged prompt (text + media).
+  [[nodiscard]] llama_pos totalPositions() const {
+    return std::accumulate(
+        mediaBarriers.begin(),
+        mediaBarriers.end(),
+        static_cast<llama_pos>(tokens.size()),
+        [](llama_pos acc, const MediaBarrier& b) { return acc + b.nPos; });
+  }
+
+  /// Total KV cells the staged prompt consumes (text + media). For M-RoPE
+  /// media this exceeds `totalPositions()`, so admission must check it
+  /// against the KV-cache budget independently of the position span.
+  [[nodiscard]] llama_pos totalKvTokens() const {
+    return std::accumulate(
+        mediaBarriers.begin(),
+        mediaBarriers.end(),
+        static_cast<llama_pos>(tokens.size()),
+        [](llama_pos acc, const MediaBarrier& b) { return acc + b.nKvTokens; });
+  }
+};
+
+/// Whether `count` tokens (or KV cells) are too many for a `ceiling`-sized
+/// per-slot window. Shared by every driver's prefill admission so the text and
+/// MTMD paths apply the same rule and match the scheduler's own admission.
+///
+/// A prefill-only request may exactly fill the window: even when it is fully
+/// occupied it will not generate more tokens later, so exactly full is fine and
+/// only strictly over is rejected. A request that will generate needs at least
+/// one more free slot for the next token, so a full window is already too many.
+[[nodiscard]] inline bool exceedsContextWindow(
+    llama_pos count, llama_pos ceiling, bool isPrefillOnlyRequest) {
+  return isPrefillOnlyRequest ? count > ceiling : count >= ceiling;
+}
 
 /// Standalone per-sequence driver interface exercised by the
 /// `ContinuousBatchScheduler`. One instance owns the state of a single
@@ -51,6 +116,13 @@ public:
 
   [[nodiscard]] virtual llama_pos getNPast() const = 0;
 
+  /// Physical KV-cell usage already committed for this sequence (e.g. a
+  /// restored cache). Defaults to `getNPast()` for text drivers, where cells
+  /// and positions coincide. M-RoPE media drivers commit more cells than
+  /// positions, so admission must size the KV-cap and generation-budget checks
+  /// from this value rather than `getNPast()`.
+  [[nodiscard]] virtual llama_pos getKvCellsUsed() const { return getNPast(); }
+
   [[nodiscard]] virtual int32_t getNSlides() const = 0;
 
   [[nodiscard]] virtual int32_t getThinkingBlockDiscards() const { return 0; }
@@ -61,7 +133,14 @@ public:
   // directly because each slot has a fresh driver per request, so no
   // restore is needed. Default no-op for drivers without compaction
   // support.
+
   virtual void setRemoveThinkingFromContext(bool value) { (void)value; }
+  /// Whether this driver slides its KV-cache window during generation when
+  /// the per-slot context fills. Text drivers slide; multimodal drivers hold
+  /// media KV cells fixed and never slide. The scheduler keeps the per-slot
+  /// token cap enforced for drivers that cannot slide, since they never
+  /// recover a slot that reaches its ceiling.
+  [[nodiscard]] virtual bool supportsSliding() const = 0;
 
   /// Reject prompts that violate per-sequence admission policy (size,
   /// layout, KV-cache state). Called once per `submit` before any state
@@ -72,12 +151,35 @@ public:
       bool hasKvCacheContext) const = 0;
 
   /// Tokenize the prompt and stage it for prefill (without running
-  /// generation). Returns the tokens still pending decode by the
-  /// scheduler at admission time.
-  virtual std::vector<llama_token> preparePrefill(
+  /// generation). Returns the text tokens still pending decode by the
+  /// scheduler at admission time plus any media barriers interleaved
+  /// into that stream. `media` carries the raw inline byte payloads and
+  /// `mediaPlan` the ordered media markers (byte buffers and paths interleaved
+  /// in prompt order); the driver loads them via `computeMediaLoadOrder` so
+  /// each bitmap binds to its marker. Text-only drivers must reject a
+  /// non-empty `media` or `mediaPlan`.
+  virtual PrefillPlan preparePrefill(
       const std::vector<common_chat_msg>& chatMsgs,
-      const std::vector<common_chat_tool>& tools, bool isCacheLoaded,
-      bool prefill) = 0;
+      const std::vector<common_chat_tool>& tools,
+      const std::vector<std::vector<uint8_t>>& media,
+      const std::vector<PlannedMedia>& mediaPlan, bool isCacheLoaded,
+      bool isPrefillOnlyRequest) = 0;
+
+  /// Evaluate the staged media segment `mediaIndex` (an image/audio
+  /// chunk produced by `preparePrefill`) at absolute position `pos` for
+  /// this driver's sequence. Runs its own `llama_decode` internally
+  /// (embedding batch), so the scheduler must NOT hold a batch in
+  /// flight. Returns the new position past the segment. Text-only drivers
+  /// stage no media barriers, so the default rejects any such call.
+  virtual llama_pos evalMediaSegment(size_t mediaIndex, llama_pos pos) {
+    (void)mediaIndex;
+    (void)pos;
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InternalError),
+        "SequenceDriver::evalMediaSegment: driver stages no media segments");
+  }
 
   /// Notify the driver that the scheduler has finished prefill-decoding
   /// `prefillTokenCount` tokens up to absolute position `currentPos`.

--- a/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
@@ -19,6 +19,7 @@
 #include "utils/ChatTemplateUtils.hpp"
 #include "utils/LoggingMacros.hpp"
 #include "utils/ReasoningUtils.hpp"
+#include "utils/ScopeGuard.hpp"
 
 using namespace qvac_lib_inference_addon_llama::errors;
 using namespace qvac_lib_inference_addon_cpp::logger;
@@ -424,7 +425,7 @@ bool TextLlmContext::evalMessageWithTools(
     const std::vector<common_chat_tool>& tools, bool isCacheLoaded,
     bool prefill) {
   const std::vector<llama_token> inputTokens =
-      preparePrefill(chatMsgs, tools, isCacheLoaded, prefill);
+      preparePrefill(chatMsgs, tools, {}, {}, isCacheLoaded, prefill).tokens;
   const auto nTokens = static_cast<llama_pos>(inputTokens.size());
   LlamaBatch textBatch(params_.n_batch, 0, 1);
 
@@ -432,8 +433,8 @@ bool TextLlmContext::evalMessageWithTools(
   llama_pos tokenIndex = 0;
   while (tokenIndex < nTokens) {
     if (stopGeneration_.load()) {
-      // [TODO] Temporary recurrent-memory fix: removeLastNTokens() may no-op for
-      // hybrid/SSM models. A proper cancellation rollback needs llama.cpp
+      // [TODO] Temporary recurrent-memory fix: removeLastNTokens() may no-op
+      // for hybrid/SSM models. A proper cancellation rollback needs llama.cpp
       // sequence checkpoint save + restore so partially evaluated tokens can
       // be restored without corrupting recurrent state.
       removeLastNTokens(tokenIndex);
@@ -476,11 +477,19 @@ bool TextLlmContext::evalMessageWithTools(
   return true;
 }
 
-std::vector<llama_token> TextLlmContext::preparePrefill(
+PrefillPlan TextLlmContext::preparePrefill(
     const std::vector<common_chat_msg>& chatMsgs,
-    const std::vector<common_chat_tool>& tools, bool isCacheLoaded,
-    bool prefill) {
-  (void)prefill;
+    const std::vector<common_chat_tool>& tools,
+    const std::vector<std::vector<uint8_t>>& media,
+    const std::vector<PlannedMedia>& mediaPlan, bool isCacheLoaded,
+    bool isPrefillOnlyRequest) {
+  if (!media.empty() || !mediaPlan.empty()) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        qvac_errors::general_error::toString(
+            qvac_errors::general_error::InvalidArgument),
+        "TextLlmContext::preparePrefill: media requires a multimodal model");
+  }
 
   std::vector<llama_token> inputTokens;
   tokenizeChat(chatMsgs, tools, inputTokens, isCacheLoaded);
@@ -494,7 +503,10 @@ std::vector<llama_token> TextLlmContext::preparePrefill(
   // being rejected by the scheduler.
   const llama_pos ceiling = ctxCeiling();
 
-  if (nTokens >= static_cast<size_t>(ceiling)) {
+  // exceedsContextWindow mirrors the scheduler's admission, so the driver never
+  // rejects a prompt the scheduler already let in.
+  if (exceedsContextWindow(
+          static_cast<llama_pos>(nTokens), ceiling, isPrefillOnlyRequest)) {
     std::string errorMsg = string_format(
         "[TextLlm] context overflow at batch prefill step: prompt tokens %ld, "
         "max context tokens %d\n",
@@ -503,7 +515,10 @@ std::vector<llama_token> TextLlmContext::preparePrefill(
     throw qvac_errors::StatusError(
         ADDON_ID, toString(ContextOverflow), errorMsg);
   }
-  if (nPast_ + static_cast<llama_pos>(nTokens) >= ceiling) {
+  if (exceedsContextWindow(
+          nPast_ + static_cast<llama_pos>(nTokens),
+          ceiling,
+          isPrefillOnlyRequest)) {
     auto outcome = trySlidePrefill(
         modelCtx_.lctx,
         seqId_,
@@ -549,7 +564,7 @@ std::vector<llama_token> TextLlmContext::preparePrefill(
     }
   }
 
-  return inputTokens;
+  return PrefillPlan{.tokens = std::move(inputTokens)};
 }
 
 void TextLlmContext::syncPosition(llama_pos currentPos) { nPast_ = currentPos; }
@@ -1068,10 +1083,19 @@ bool TextLlmContext::loadCache(
     return false;
   }
 
+  // Read the shared four-field metadata contract (SessionMetadataField order)
+  // so this path round-trips caches written by CacheManager and the MTMD
+  // driver. Text has no positional/cache divergence, so the last two fields
+  // mirror the first two and are not applied separately.
   size_t tokenCount = 0;
-  llama_token sessionTokens[2] = {0, 0};
+  llama_token sessionTokens[SESSION_METADATA_FIELD_COUNT] = {0, 0, 0, 0};
   const auto loadedBytes = llama_state_seq_load_file(
-      modelCtx_.lctx, cacheKey.c_str(), seqId_, sessionTokens, 2, &tokenCount);
+      modelCtx_.lctx,
+      cacheKey.c_str(),
+      seqId_,
+      sessionTokens,
+      SESSION_METADATA_FIELD_COUNT,
+      &tokenCount);
   if (loadedBytes == 0) {
     throw qvac_errors::StatusError(
         ADDON_ID,
@@ -1079,7 +1103,8 @@ bool TextLlmContext::loadCache(
         "TextLlmContext::loadCache: failed to load cache '" + cacheKey + "'");
   }
 
-  auto clearLoadedSequence = [this]() noexcept {
+  // load already wrote KV; roll back unless we accept
+  ScopeGuard restoredKvGuard([this]() noexcept {
     try {
       clearSequenceMemory(modelCtx_.lctx);
     } catch (...) {
@@ -1090,60 +1115,55 @@ bool TextLlmContext::loadCache(
     nPast_ = 0;
     firstMsgTokens_ = 0;
     tools_.reset();
-  };
+  });
 
-  try {
-    if (tokenCount <= 1) {
-      clearLoadedSequence();
-      return false;
-    }
-    const llama_pos metadataNPast = sessionTokens[0];
-    const llama_pos metadataFirstMsgTokens = sessionTokens[1];
-    if (metadataNPast > llama_n_ctx(modelCtx_.lctx)) {
-      throw qvac_errors::StatusError(
-          ADDON_ID,
-          toString(ContextLengthExeeded),
-          "TextLlmContext::loadCache: cache '" + cacheKey +
-              "' exceeds current context size");
-    }
-
-    auto* mem = llama_get_memory(modelCtx_.lctx);
-    if (mem == nullptr) {
-      throw qvac_errors::StatusError(
-          ADDON_ID,
-          toString(UnableToLoadSessionFile),
-          "TextLlmContext::loadCache: llama memory is null after loading "
-          "cache '" +
-              cacheKey + "'");
-    }
-
-    const llama_pos restoredNPast = llama_memory_seq_pos_max(mem, seqId_) + 1;
-    if (restoredNPast != metadataNPast) {
-      throw qvac_errors::StatusError(
-          ADDON_ID,
-          toString(UnableToLoadSessionFile),
-          string_format(
-              "TextLlmContext::loadCache: cache '%s' restored nPast=%d, but "
-              "metadata expected nPast=%d",
-              cacheKey.c_str(),
-              restoredNPast,
-              metadataNPast));
-    }
-
-    nPast_ = metadataNPast;
-    firstMsgTokens_ = metadataFirstMsgTokens;
-    // Clamp discard to the per-slot window (ctxCeiling), not the physical
-    // context: in batch mode the slot ceiling is ctx / n_parallel.
-    const llama_pos window = ctxCeiling();
-    if (configuredNDiscarded > window - firstMsgTokens_) {
-      nDiscarded_ = window - firstMsgTokens_ - 1;
-    } else {
-      nDiscarded_ = configuredNDiscarded;
-    }
-  } catch (...) {
-    clearLoadedSequence();
-    throw;
+  if (tokenCount <= 1) {
+    return false;
   }
+  const llama_pos metadataNPast = sessionTokens[0];
+  const llama_pos metadataFirstMsgTokens = sessionTokens[1];
+  if (metadataNPast > llama_n_ctx(modelCtx_.lctx)) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(ContextLengthExeeded),
+        "TextLlmContext::loadCache: cache '" + cacheKey +
+            "' exceeds current context size");
+  }
+
+  auto* mem = llama_get_memory(modelCtx_.lctx);
+  if (mem == nullptr) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToLoadSessionFile),
+        "TextLlmContext::loadCache: llama memory is null after loading "
+        "cache '" +
+            cacheKey + "'");
+  }
+
+  const llama_pos restoredNPast = llama_memory_seq_pos_max(mem, seqId_) + 1;
+  if (restoredNPast != metadataNPast) {
+    throw qvac_errors::StatusError(
+        ADDON_ID,
+        toString(UnableToLoadSessionFile),
+        string_format(
+            "TextLlmContext::loadCache: cache '%s' restored nPast=%d, but "
+            "metadata expected nPast=%d",
+            cacheKey.c_str(),
+            restoredNPast,
+            metadataNPast));
+  }
+
+  nPast_ = metadataNPast;
+  firstMsgTokens_ = metadataFirstMsgTokens;
+  // Clamp discard to the per-slot window (ctxCeiling), not the physical
+  // context: in batch mode the slot ceiling is ctx / n_parallel.
+  const llama_pos window = ctxCeiling();
+  if (configuredNDiscarded > window - firstMsgTokens_) {
+    nDiscarded_ = window - firstMsgTokens_ - 1;
+  } else {
+    nDiscarded_ = configuredNDiscarded;
+  }
+  restoredKvGuard.dismiss();
   return true;
 }
 
@@ -1152,11 +1172,20 @@ void TextLlmContext::saveCache(const std::string& cacheKey) const {
     return;
   }
 
-  const llama_token sessionTokens[2] = {
-      static_cast<llama_token>(nPast_),
-      static_cast<llama_token>(firstMsgTokens_)};
+  // Persist the full four-field metadata contract so the file is loadable by
+  // every path (CacheManager, MTMD). For text the cache-token counts equal the
+  // positional counts, so the getters supply mirrored values.
+  const llama_token sessionTokens[SESSION_METADATA_FIELD_COUNT] = {
+      static_cast<llama_token>(getNPast()),
+      static_cast<llama_token>(getFirstMsgTokens()),
+      static_cast<llama_token>(getCacheTokens()),
+      static_cast<llama_token>(getFirstMsgCacheTokens())};
   const auto savedBytes = llama_state_seq_save_file(
-      modelCtx_.lctx, cacheKey.c_str(), seqId_, sessionTokens, 2);
+      modelCtx_.lctx,
+      cacheKey.c_str(),
+      seqId_,
+      sessionTokens,
+      SESSION_METADATA_FIELD_COUNT);
   if (savedBytes == 0) {
     throw qvac_errors::StatusError(
         ADDON_ID,

--- a/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.hpp
@@ -151,6 +151,8 @@ public:
 
   void setRemoveThinkingFromContext(bool value) override;
 
+  [[nodiscard]] bool supportsSliding() const override { return true; }
+
   /**
    * The reset state method. It resets the context.
    *
@@ -168,10 +170,12 @@ public:
    */
   llama_pos removeLastNTokens(llama_pos count) override;
 
-  std::vector<llama_token> preparePrefill(
+  PrefillPlan preparePrefill(
       const std::vector<common_chat_msg>& chatMsgs,
-      const std::vector<common_chat_tool>& tools, bool isCacheLoaded,
-      bool prefill) override;
+      const std::vector<common_chat_tool>& tools,
+      const std::vector<std::vector<uint8_t>>& media,
+      const std::vector<PlannedMedia>& mediaPlan, bool isCacheLoaded,
+      bool isPrefillOnlyRequest) override;
 
   void
   onPrefillComplete(llama_pos currentPos, size_t prefillTokenCount) override;

--- a/packages/llm-llamacpp/batchHandler.js
+++ b/packages/llm-llamacpp/batchHandler.js
@@ -113,7 +113,7 @@ class BatchHandler {
         !Array.isArray(item) &&
         Array.isArray(item.prompt)
       const prompt = isWrapped ? item.prompt : item
-      const itemRunOptions = isWrapped && item.runOptions ? item.runOptions : {}
+      const itemRunOptions = isWrapped && item.runOptions !== undefined ? item.runOptions : {}
       const unwrapped = { messages: this._parsePrompt(prompt, itemRunOptions) }
       if (isWrapped && item.id !== undefined) unwrapped.id = item.id
       return unwrapped

--- a/packages/llm-llamacpp/docs/cache-api.md
+++ b/packages/llm-llamacpp/docs/cache-api.md
@@ -1,6 +1,16 @@
 # KV Cache API
 
-Cache control is managed through `runOptions`, the second argument to `model.run()`.
+Cache control is managed through `runOptions`. For a single prompt, pass `runOptions` as the second argument to `model.run(prompt, runOptions)`.
+
+For a batch (`model.run([...])`) there is no top-level second argument — set cache options **per prompt** in `BatchPrompt.runOptions` (`cacheKey`, `saveCacheToDisk`, `prefill`, `generationParams`). Passing a second argument to a batch `run()` throws.
+
+```js
+// Batch: cache options go per item, not as a second run() argument.
+await model.run([
+  { prompt: [{ role: 'user', content: 'Hi' }], runOptions: { cacheKey: 'a.bin', saveCacheToDisk: true } },
+  { prompt: [{ role: 'user', content: 'Yo' }], runOptions: { cacheKey: 'b.bin' } },
+])
+```
 
 ## runOptions reference
 

--- a/packages/llm-llamacpp/docs/continuous-batching.md
+++ b/packages/llm-llamacpp/docs/continuous-batching.md
@@ -50,7 +50,7 @@ const model = new LlmLlamacpp({
 
 `parallel` maps to `n_seq_max` in llama.cpp. The KV cache is split uniformly: with `ctx_size: '8192'` and `parallel: '4'`, each slot gets a 2048-token window. Values less than 2 leave the single-prompt path active; batch `run()` calls throw `InvalidArgument` in that case.
 
-Continuous batching works on text-only models. Multimodal (vision) models use a separate context type and do not support batch mode.
+Continuous batching works on both text and multimodal (vision) models. A batch prompt may include media messages; each sequence runs its own per-slot MTMD driver that loads its media, sharing the model's mmproj weights.
 
 ---
 
@@ -305,6 +305,12 @@ Two restrictions apply in batch mode:
 
 ---
 
+## KV reuse: single-prompt vs batch
+
+The single-prompt path keeps one `TextLlmContext` for the model's lifetime, so its KV survives across `run()` calls and a follow-up only evaluates the new tokens. The batch path is the reverse: each `submit` gets a fresh `SequenceDriver` on a recycled slot (`nPast_ = 0`, empty KV) because slots serve unrelated requests, so a cache miss costs a full prefill. That is also why a rejected `loadCache` must clear the cells it restored: otherwise they strand under the slot's `seqId`, contaminating an empty batch slot or following the single-prompt sequence for the rest of the session.
+
+---
+
 ## Cancellation semantics
 
 Cancellation behaves differently depending on where a prompt is when `cancel()` fires:
@@ -344,7 +350,7 @@ When the batch completes, `BatchResult.stats` carries the full snapshot. `LlamaM
 | Feature | Batch mode |
 |---------|-----------|
 | Text models | Supported |
-| Multimodal / vision models | Not supported (separate context type) |
+| Multimodal / vision models | Supported (per-slot MTMD driver; batch prompts may include media messages) |
 | Tools | Supported (per-slot `ToolsCompactController`) |
 | `tools_compact` | Supported |
 | Per-prompt `cacheKey` | Supported (read sharing allowed; write sharing rejected) |

--- a/packages/llm-llamacpp/index.d.ts
+++ b/packages/llm-llamacpp/index.d.ts
@@ -84,8 +84,10 @@ export interface LlamaConfig {
   /**
    * Number of concurrent sequence slots for continuous-batching (`--parallel` /
    * `n_parallel` in llama.cpp). Values `>= 2` activate the continuous-batch
-   * scheduler so multiple `run()` calls are decoded together in a single
-   * forward pass. Default `1` (sequential, batching disabled).
+   * scheduler so the prompts of a single batch-array `run()` call are decoded
+   * together across slots; separate top-level `run()` calls are not batched
+   * (only one response is active at a time). Default `1` (sequential, batching
+   * disabled).
    */
   parallel?: NumericLike
   [key: string]: string | number | boolean | string[] | undefined
@@ -196,7 +198,7 @@ export interface RunOptions {
 
 export interface BatchPrompt {
   id?: string
-  prompt: (UserTextMessage | ChatFunctionDefinition)[]
+  prompt: Message[]
   runOptions?: RunOptions
 }
 

--- a/packages/llm-llamacpp/index.js
+++ b/packages/llm-llamacpp/index.js
@@ -314,7 +314,7 @@ class LlmLlamacpp {
       }
       return this._run(() => this._runBatchInternal(prompt))
     }
-    return this._run(() => this._runInternal(prompt, runOptions || {}))
+    return this._run(() => this._runInternal(prompt, runOptions))
   }
 
   async _runBatchInternal (batchInput) {

--- a/packages/llm-llamacpp/scripts/download-unit-test-models.js
+++ b/packages/llm-llamacpp/scripts/download-unit-test-models.js
@@ -323,25 +323,6 @@ const SINGLE_FILE_MANIFEST = [
     sha256: '921dc7e259f308e5b027111fa185efcbf33db13f6e35749ddf7f5cdb60ef520b'
   },
   {
-    // Qwen2-VL uses M-RoPE (n_pos_per_embd() == 4), unlike SmolVLM (== 1), so it
-    // is the smallest reputable fixture that actually exercises per-cell
-    // llama_kv_cell_ext (x/y) preservation across GGSQ cache save/restore.
-    // linux-x64 only: it is large (~1.6GiB total) and the MTMD M-RoPE cache
-    // test GTEST_SKIPs elsewhere when the fixture is absent.
-    scope: 'ci',
-    platforms: ['linux-x64'],
-    url: 'https://huggingface.co/ggml-org/Qwen2-VL-2B-Instruct-GGUF/resolve/main/Qwen2-VL-2B-Instruct-Q4_K_M.gguf',
-    dest: 'Qwen2-VL-2B-Instruct-Q4_K_M.gguf',
-    sha256: '5745685d2e607a82a0696c1118e56a2a1ae0901da450fd9cd4f161c6b62867d7'
-  },
-  {
-    scope: 'ci',
-    platforms: ['linux-x64'],
-    url: 'https://huggingface.co/ggml-org/Qwen2-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf',
-    dest: 'mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf',
-    sha256: 'a0ad91f00a7a80dcf84d719a61b00ee2e07b71794f4ee2dfa81a254621a8c418'
-  },
-  {
     scope: 'ci',
     url: 'https://huggingface.co/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf',
     dest: 'Qwen3-0.6B-Q8_0.gguf',

--- a/packages/llm-llamacpp/scripts/download-unit-test-models.js
+++ b/packages/llm-llamacpp/scripts/download-unit-test-models.js
@@ -323,6 +323,25 @@ const SINGLE_FILE_MANIFEST = [
     sha256: '921dc7e259f308e5b027111fa185efcbf33db13f6e35749ddf7f5cdb60ef520b'
   },
   {
+    // Qwen2-VL uses M-RoPE (n_pos_per_embd() == 4), unlike SmolVLM (== 1), so it
+    // is the smallest reputable fixture that actually exercises per-cell
+    // llama_kv_cell_ext (x/y) preservation across GGSQ cache save/restore.
+    // linux-x64 only: it is large (~1.6GiB total) and the MTMD M-RoPE cache
+    // test GTEST_SKIPs elsewhere when the fixture is absent.
+    scope: 'ci',
+    platforms: ['linux-x64'],
+    url: 'https://huggingface.co/ggml-org/Qwen2-VL-2B-Instruct-GGUF/resolve/main/Qwen2-VL-2B-Instruct-Q4_K_M.gguf',
+    dest: 'Qwen2-VL-2B-Instruct-Q4_K_M.gguf',
+    sha256: '5745685d2e607a82a0696c1118e56a2a1ae0901da450fd9cd4f161c6b62867d7'
+  },
+  {
+    scope: 'ci',
+    platforms: ['linux-x64'],
+    url: 'https://huggingface.co/ggml-org/Qwen2-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf',
+    dest: 'mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf',
+    sha256: 'a0ad91f00a7a80dcf84d719a61b00ee2e07b71794f4ee2dfa81a254621a8c418'
+  },
+  {
     scope: 'ci',
     url: 'https://huggingface.co/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf',
     dest: 'Qwen3-0.6B-Q8_0.gguf',
@@ -434,8 +453,19 @@ const SHARDED_REPOS = [
   }
 ]
 
-function shouldInclude (scope, options) {
-  if (options.ciOnly) return scope === 'ci'
+function currentPlatformKey () {
+  return `${process.platform}-${process.arch}`
+}
+
+// `scope` gates by run mode (see SINGLE_FILE_MANIFEST). An optional
+// `platforms` array further restricts an entry to specific
+// `${process.platform}-${process.arch}` keys (e.g. 'linux-x64') so large,
+// platform-gated fixtures are only fetched where their tests actually run.
+function shouldInclude (entry, options) {
+  if (options.ciOnly && entry.scope !== 'ci') return false
+  if (entry.platforms && !entry.platforms.includes(currentPlatformKey())) {
+    return false
+  }
   return true
 }
 
@@ -450,14 +480,14 @@ async function ensureUnitTestModels (options = {}) {
 
   try {
     for (const entry of SINGLE_FILE_MANIFEST) {
-      if (!shouldInclude(entry.scope, opts)) continue
+      if (!shouldInclude(entry, opts)) continue
       await downloadFile(entry.url, path.join(MODEL_DIR, entry.dest), {
         sha256: entry.sha256
       })
     }
 
     for (const repo of SHARDED_REPOS) {
-      if (!shouldInclude(repo.scope, opts)) continue
+      if (!shouldInclude(repo, opts)) continue
       log(`sharded: ${repo.label}`)
       await downloadShardedRepo(repo.baseUrl, repo.files, repo.sha256)
     }

--- a/packages/llm-llamacpp/test/integration/api-behavior.test.js
+++ b/packages/llm-llamacpp/test/integration/api-behavior.test.js
@@ -141,6 +141,32 @@ safeTest('idle | run batch: returns ids, keyed chunks, ordered results', { timeo
   t.ok(toNumber(response?.stats?.avgConcurrentSeq) > 1.1, 'batch stats report concurrent sequence decoding')
 })
 
+safeTest('idle | run batch: provided falsy runOptions are rejected, not silently defaulted', { timeout: 600_000 }, async t => {
+  // Every provided-but-invalid runOptions must throw the same TypeError as the
+  // single-prompt path, instead of being coerced to {} and bypassing
+  // validation. Only undefined (property absent) is allowed to default, and
+  // that path is already exercised by the batch tests above.
+  const { model } = await setupModel(t, { parallel: '2' })
+  const prompt = [{ role: 'user', content: 'Say red.' }]
+
+  const invalidCases = [
+    { label: 'null', value: null },
+    { label: 'false', value: false },
+    { label: '0', value: 0 },
+    { label: 'empty string', value: '' },
+    { label: 'NaN', value: NaN },
+    { label: 'array', value: [] }
+  ]
+
+  for (const { label, value } of invalidCases) {
+    await t.exception.all(
+      () => model.run([{ prompt, runOptions: value }]),
+      /Run options must be an object when provided/,
+      `batch item with runOptions: ${label} rejects`
+    )
+  }
+})
+
 safeTest('idle | run batch without parallel >= 2: rejects before admission', { timeout: 600_000 }, async t => {
   // Default load (parallel = 1) leaves continuous batching inactive, so batch
   // input must be rejected up front rather than reaching the worker thread.

--- a/packages/llm-llamacpp/test/integration/continuous-batching.test.js
+++ b/packages/llm-llamacpp/test/integration/continuous-batching.test.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const test = require('brittle')
+const fs = require('bare-fs')
 const path = require('bare-path')
 const os = require('bare-os')
 const process = require('bare-process')
 const LlmLlamacpp = require('../../index.js')
-const { ensureModel, safeTest } = require('./utils')
+const { ensureModel, safeTest, getMediaPath } = require('./utils')
 const { attachSpecLogger } = require('./spec-logger')
+const { MULTIMODAL_MODEL_CONFIG } = require('./_image-common.js')
 
 const platform = os.platform()
 const arch = os.arch()
@@ -44,12 +47,44 @@ const CASES = [
   { id: 'story-saffron', story: true, expected: ['saffron'] }
 ]
 
+// Two lightweight images (~23 KB and ~38 KB) — avoid fruitPlate.png (10 MB)
+const IMAGE_CASES = [
+  {
+    id: 'elephant-animal',
+    imageFile: 'elephant.jpg',
+    prompt: 'What large animal is shown in this image? Answer with one word.',
+    expected: ['elephant', 'elephants']
+  },
+  {
+    id: 'elephant-environment',
+    imageFile: 'elephant.jpg',
+    prompt: 'Is this animal indoors or outdoors? Answer with one word.',
+    expected: ['outdoors', 'outdoor', 'outside', 'open', 'field', 'grassland', 'savanna', 'savannah', 'wild']
+  },
+  {
+    id: 'newspaper-type',
+    imageFile: 'news-paper.jpg',
+    prompt: 'What type of printed material is shown? Answer with one word.',
+    expected: ['newspaper', 'paper', 'news', 'text', 'page', 'print', 'article']
+  },
+  {
+    id: 'newspaper-content',
+    imageFile: 'news-paper.jpg',
+    prompt: 'What covers most of this page? Answer with one word.',
+    expected: ['text', 'words', 'writing', 'letters', 'printed', 'print', 'newspaper', 'article', 'content', 'storm', 'headline', 'titanic', 'ship', 'image', 'photo', 'photograph', 'picture', 'news']
+  }
+]
+
+// Interleaved: each image case followed by 4 text cases — 4 + 16 = 20 total.
+// Forces the scheduler to juggle media barriers and plain prefill in the same window.
+const MIXED_CASES = IMAGE_CASES.flatMap((img, i) => [img, ...CASES.slice(i * 4, i * 4 + 4)])
+
 function toNumber (value) {
   return typeof value === 'number' ? value : Number(value || 0)
 }
 
 function normalizeText (text) {
-  return String(text || '').toLowerCase().replace(/[^a-z]+/g, ' ').trim()
+  return String(text || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
 }
 
 function containsExpectedWord (text, expectedOptions) {
@@ -74,6 +109,52 @@ function buildPrompt (item) {
 
 function runOptionsForCase (item) {
   return { generationParams: { predict: item.story ? 96 : 64 } }
+}
+
+function buildBatchItem (item) {
+  if (item.imageFile) {
+    const imageBytes = new Uint8Array(fs.readFileSync(getMediaPath(item.imageFile)))
+    return {
+      id: item.id,
+      prompt: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', type: 'media', content: imageBytes },
+        { role: 'user', content: item.prompt }
+      ],
+      runOptions: { generationParams: { predict: 48 } }
+    }
+  }
+  return {
+    id: item.id,
+    prompt: buildPrompt(item),
+    runOptions: runOptionsForCase(item)
+  }
+}
+
+// VLM-compatible prompt builder for text-only slots in the mixed batch test.
+// BASE_SYSTEM_PROMPT and STORY_SYSTEM_PROMPT are tuned for the 1B Llama model;
+// SmolVLM2-500M needs simpler instructions to follow them correctly.
+function buildVlmBatchItem (item) {
+  if (item.imageFile) return buildBatchItem(item)
+  if (item.story) {
+    const word = Array.isArray(item.expected) ? item.expected[0] : item.expected
+    return {
+      id: item.id,
+      prompt: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: `Write one sentence of a story. Start with the word "${word}".` }
+      ],
+      runOptions: { generationParams: { predict: 48 } }
+    }
+  }
+  return {
+    id: item.id,
+    prompt: [
+      { role: 'system', content: 'Answer with one word only.' },
+      { role: 'user', content: item.user }
+    ],
+    runOptions: { generationParams: { predict: 16 } }
+  }
 }
 
 async function setupModel (t, configOverrides = {}) {
@@ -105,7 +186,45 @@ async function setupModel (t, configOverrides = {}) {
   await model.load()
 
   t.teardown(async () => {
-    await model.unload().catch(() => {})
+    await model.unload().catch(() => { })
+    specLogger.release()
+  })
+
+  return model
+}
+
+async function setupMultimodalBatchModel (t, configOverrides = {}) {
+  const [modelName, dirPath] = await ensureModel(MULTIMODAL_MODEL_CONFIG.llmModel)
+  const [projModelName] = await ensureModel(MULTIMODAL_MODEL_CONFIG.projModel)
+  const modelPath = path.join(dirPath, modelName)
+  const projModelPath = path.join(dirPath, projModelName)
+
+  // ctx_size 4096 gives each of the 4 parallel slots ~1024 tokens — enough for
+  // SmolVLM2-500M vision tokens (~256 per image) + prompt + output.
+  const config = {
+    device: useCpu ? 'cpu' : 'gpu',
+    gpu_layers: '99',
+    ctx_size: '4096',
+    temp: '0',
+    top_p: '1',
+    top_k: '1',
+    seed: '42',
+    verbosity: '2',
+    parallel: '4',
+    ...configOverrides
+  }
+  const specLogger = attachSpecLogger({ forwardToConsole: true })
+  const model = new LlmLlamacpp({
+    files: { model: [modelPath], projectionModel: projModelPath },
+    config,
+    logger: console,
+    opts: { stats: true }
+  })
+
+  await model.load()
+
+  t.teardown(async () => {
+    await model.unload().catch(() => { })
     specLogger.release()
   })
 
@@ -118,7 +237,8 @@ async function collectText (response) {
   return chunks.join('')
 }
 
-function logStreamingProgress (response) {
+function logStreamingProgress (response, tag) {
+  const logTag = tag || 'continuous-batching'
   const chunksPerLog = 8
   const progressById = new Map()
   response.onUpdate(({ id, chunk }) => {
@@ -126,7 +246,7 @@ function logStreamingProgress (response) {
     progress.chunkCount += 1
     progress.pendingText += chunk
     if (!progress.loggedFirstChunk || progress.chunkCount % chunksPerLog === 0) {
-      console.log(`[continuous-batching progress] ${id}: ${progress.pendingText.replace(/\s+/g, ' ').trim()}`)
+      console.log(`[${logTag} progress] ${id}: ${progress.pendingText.replace(/\s+/g, ' ').trim()}`)
       progress.pendingText = ''
       progress.loggedFirstChunk = true
     }
@@ -140,7 +260,7 @@ function logStreamingProgress (response) {
       for (const [id, progress] of progressById) {
         const text = progress.pendingText.replace(/\s+/g, ' ').trim()
         if (text.length > 0) {
-          console.log(`[continuous-batching progress] ${id}: ${text}`)
+          console.log(`[${logTag} progress] ${id}: ${text}`)
         }
       }
     }
@@ -222,4 +342,162 @@ safeTest('continuous batching answers 16 prompts correctly and improves Linux GP
   } else {
     t.comment('Skipping TPS assertion outside Linux GPU runtime')
   }
+})
+
+test('continuous batching MTMD: image-only batch returns correct descriptions', { timeout: 900_000, skip: skipHeavyPlatform }, async t => {
+  const model = await setupMultimodalBatchModel(t)
+
+  for (const item of IMAGE_CASES) {
+    t.ok(fs.existsSync(getMediaPath(item.imageFile)), `media file ${item.imageFile} exists`)
+  }
+
+  const batchInput = IMAGE_CASES.map(buildBatchItem)
+  const batchStartedAt = Date.now()
+  const batchResponse = await model.run(batchInput)
+  const streamingProgress = logStreamingProgress(batchResponse, 'cb-mtmd-image')
+  const batchResults = await batchResponse.await()
+  streamingProgress.flush()
+
+  t.comment(`elapsed: ${Date.now() - batchStartedAt}ms`)
+  t.comment(`native TPS: ${toNumber(batchResponse.stats.TPS)}`)
+  t.comment(`avgConcurrentSeq: ${toNumber(batchResponse.stats.avgConcurrentSeq)}`)
+
+  t.alike(batchResults.map(r => r.id), IMAGE_CASES.map(item => item.id), 'all ids reported in order')
+  t.alike(streamingProgress.ids().sort(), IMAGE_CASES.map(item => item.id).sort(), 'all ids emitted streaming chunks')
+
+  const resultsById = new Map(batchResults.map(r => [r.id, r.output]))
+  for (const item of IMAGE_CASES) {
+    const output = resultsById.get(item.id) || ''
+    console.log(`[cb-mtmd-image result] ${item.id}: ${output.trim()}`)
+    t.comment(`${item.id}: ${output.trim()}`)
+    t.ok(
+      containsExpectedWord(output, item.expected),
+      `${item.id} output includes one of [${item.expected.join(', ')}]. Full output: "${output.trim()}"`
+    )
+  }
+
+  // Match the mixed-batch bar (>1.5): serialized-on-media slots can clear 1.0
+  // even with pipelining regressed, so 1.0 is too weak a guard.
+  t.ok(
+    toNumber(batchResponse.stats.avgConcurrentSeq) > 1.5,
+    `avgConcurrentSeq (${toNumber(batchResponse.stats.avgConcurrentSeq)}) > 1.5 confirms parallel decode`
+  )
+})
+
+test('continuous batching MTMD: image batch accepts string file-path media', { timeout: 900_000, skip: skipHeavyPlatform }, async t => {
+  const model = await setupMultimodalBatchModel(t)
+
+  for (const item of IMAGE_CASES) {
+    t.ok(fs.existsSync(getMediaPath(item.imageFile)), `media file ${item.imageFile} exists`)
+  }
+
+  // Same images as the byte-mode batch test, but media is supplied as an
+  // absolute file-path string instead of Uint8Array bytes. The per-slot MTMD
+  // driver must load the file itself (mirroring the single-prompt run() path).
+  const batchInput = IMAGE_CASES.map(item => ({
+    id: item.id,
+    prompt: [
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', type: 'media', content: getMediaPath(item.imageFile) },
+      { role: 'user', content: item.prompt }
+    ],
+    runOptions: { generationParams: { predict: 48 } }
+  }))
+
+  const batchResponse = await model.run(batchInput)
+  const streamingProgress = logStreamingProgress(batchResponse, 'cb-mtmd-path')
+  const batchResults = await batchResponse.await()
+  streamingProgress.flush()
+
+  t.alike(batchResults.map(r => r.id), IMAGE_CASES.map(item => item.id), 'all ids reported in order')
+
+  const resultsById = new Map(batchResults.map(r => [r.id, r.output]))
+  for (const item of IMAGE_CASES) {
+    const output = resultsById.get(item.id) || ''
+    console.log(`[cb-mtmd-path result] ${item.id}: ${output.trim()}`)
+    t.comment(`${item.id}: ${output.trim()}`)
+    t.ok(
+      containsExpectedWord(output, item.expected),
+      `${item.id} output includes one of [${item.expected.join(', ')}]. Full output: "${output.trim()}"`
+    )
+  }
+})
+
+test('continuous batching MTMD: mixed image+text batch processes all slot types correctly', { timeout: 1_200_000, skip: skipHeavyPlatform }, async t => {
+  const model = await setupMultimodalBatchModel(t)
+
+  for (const item of IMAGE_CASES) {
+    t.ok(fs.existsSync(getMediaPath(item.imageFile)), `media file ${item.imageFile} exists`)
+  }
+
+  // Single-mode baseline: run every MIXED_CASES item sequentially to get a
+  // per-token wall-clock reference that the batch run can be compared against.
+  const singleWallTpsValues = []
+  for (const item of MIXED_CASES) {
+    const vlmItem = buildVlmBatchItem(item)
+    const startedAt = Date.now()
+    const singleResponse = await model.run(vlmItem.prompt, vlmItem.runOptions)
+    const singleText = await collectText(singleResponse)
+    const elapsedMs = Date.now() - startedAt
+    const generatedTokens = toNumber(singleResponse.stats.generatedTokens)
+    const wallTps = elapsedMs > 0 ? (generatedTokens * 1000) / elapsedMs : 0
+    singleWallTpsValues.push(wallTps)
+    t.comment(`single ${item.id} wall TPS: ${wallTps.toFixed(1)} | ${singleText.trim().slice(0, 80)}`)
+  }
+  const avgSingleWallTps = singleWallTpsValues.reduce((sum, v) => sum + v, 0) / singleWallTpsValues.length
+
+  // Batch run over MIXED_CASES (image + text-only slots interleaved).
+  const batchInput = MIXED_CASES.map(buildVlmBatchItem)
+  const batchStartedAt = Date.now()
+  const batchResponse = await model.run(batchInput)
+  const streamingProgress = logStreamingProgress(batchResponse, 'cb-mtmd-mixed')
+  const batchResults = await batchResponse.await()
+  const batchElapsedMs = Date.now() - batchStartedAt
+  streamingProgress.flush()
+
+  const batchNativeTps = toNumber(batchResponse.stats.TPS)
+  const batchGeneratedTokens = toNumber(batchResponse.stats.generatedTokens)
+  const batchWallTps = batchElapsedMs > 0 ? (batchGeneratedTokens * 1000) / batchElapsedMs : 0
+
+  const wallTpsComparison = `batch wall TPS (${batchWallTps.toFixed(1)}) vs avg single wall TPS (${avgSingleWallTps.toFixed(1)})`
+  console.log(`[cb-mtmd-mixed TPS] ${wallTpsComparison}`)
+  t.comment(wallTpsComparison)
+  t.comment(`native TPS: ${batchNativeTps}`)
+  t.comment(`elapsed: ${batchElapsedMs}ms`)
+  t.comment(`avgConcurrentSeq: ${toNumber(batchResponse.stats.avgConcurrentSeq)}`)
+
+  t.alike(batchResults.map(r => r.id), MIXED_CASES.map(item => item.id), 'all ids reported in order')
+  t.alike(streamingProgress.ids().sort(), MIXED_CASES.map(item => item.id).sort(), 'all ids emitted streaming chunks')
+
+  const resultsById = new Map(batchResults.map(r => [r.id, r.output]))
+  for (const item of MIXED_CASES) {
+    const output = resultsById.get(item.id) || ''
+    console.log(`[cb-mtmd-mixed result] ${item.id}: ${output.trim()}`)
+    t.comment(`${item.id}: ${output.trim()}`)
+    t.ok(
+      containsExpectedWord(output, item.expected),
+      `${item.id} output includes one of [${item.expected.join(', ')}]. Full output: "${output.trim()}"`
+    )
+  }
+
+  // Concurrency alone doesn't prove the text slots produced real output (loose
+  // word lists let garbage pass): require >=8 chars AND an expected-word match.
+  const MIN_TEXT_SLOT_LEN = 8
+  const textCases = MIXED_CASES.filter(item => !item.imageFile)
+  const goodTextSlots = textCases.filter(item => {
+    const output = (resultsById.get(item.id) || '').trim()
+    return output.length >= MIN_TEXT_SLOT_LEN && containsExpectedWord(output, item.expected)
+  })
+  t.ok(
+    goodTextSlots.length > 0,
+    `at least one text-only slot returned non-trivial output (>= ${MIN_TEXT_SLOT_LEN} chars) matching its expected word ` +
+    `(${goodTextSlots.length}/${textCases.length} text slots passed)`
+  )
+
+  // With 20 slots and parallel=4 the decode phases overlap significantly;
+  // text-only slots run while image slots are still waiting on a media barrier.
+  t.ok(
+    toNumber(batchResponse.stats.avgConcurrentSeq) > 1.5,
+    `avgConcurrentSeq (${toNumber(batchResponse.stats.avgConcurrentSeq)}) > 1.5 confirms concurrent scheduling across slot types`
+  )
 })

--- a/packages/llm-llamacpp/test/integration/continuous-batching.test.js
+++ b/packages/llm-llamacpp/test/integration/continuous-batching.test.js
@@ -141,8 +141,8 @@ function buildVlmBatchItem (item) {
     return {
       id: item.id,
       prompt: [
-        { role: 'system', content: 'You are a helpful assistant.' },
-        { role: 'user', content: `Write one sentence of a story. Start with the word "${word}".` }
+        { role: 'system', content: 'Follow the user instruction exactly. Do not add a preamble.' },
+        { role: 'user', content: `Write one short sentence that contains the exact word "${word}".` }
       ],
       runOptions: { generationParams: { predict: 48 } }
     }

--- a/packages/llm-llamacpp/test/unit/CMakeLists.txt
+++ b/packages/llm-llamacpp/test/unit/CMakeLists.txt
@@ -39,6 +39,10 @@ add_executable(
   test_borrow_tracked_shared_buffer.cpp
   test_continuous_batching_default.cpp
   test_continuous_batch_finalize.cpp
+  test_batch_entry_guard.cpp
+  test_slide_capable_capability.cpp
+  test_media_load_order.cpp
+  test_generation_budget_admission.cpp
   test_multi_request_batcher.cpp
   test_continuous_batching_integration.cpp
   test_kv_leak_on_admit_failure.cpp
@@ -51,6 +55,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/ContextSlider.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/GenerationParamsApply.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaModel.cpp
+  ${CMAKE_SOURCE_DIR}/addon/src/model-interface/MediaLoadOrder.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaFinetuningHelpers.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
   ${CMAKE_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp

--- a/packages/llm-llamacpp/test/unit/test_batch_entry_guard.cpp
+++ b/packages/llm-llamacpp/test/unit/test_batch_entry_guard.cpp
@@ -1,0 +1,58 @@
+// BatchEntryGuard must keep LlamaModel::activeBatchJobs_ balanced even when the
+// per-job entry validation throws. A leaked count makes cancel() believe a
+// batch is still in flight and makes the next batch entry skip the first-batch
+// cache invalidation / KV wipe (comment-3437045353).
+#include <atomic>
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/BatchEntryGuard.hpp"
+
+namespace {
+
+using qvac_lib_inference_addon_llama::batching::BatchEntryGuard;
+
+} // namespace
+
+/// A throwing validation must not leak the counter: when validation throws the
+/// guard's constructor must unwind with the count restored to its prior value.
+TEST(BatchEntryGuardTest, ThrowingValidationDoesNotLeakCounter) {
+  std::atomic<unsigned> counter{0};
+
+  EXPECT_THROW(
+      {
+        BatchEntryGuard guard(counter, [] {
+          throw std::runtime_error("entry validation failed");
+        });
+      },
+      std::runtime_error);
+
+  EXPECT_EQ(counter.load(), 0u)
+      << "COUNTER LEAK: entry validation threw, but activeBatchJobs_ stayed "
+         "positive; cancel() will think a batch is active and the next batch "
+         "entry will see a non-zero prior count and skip the KV wipe";
+}
+
+/// Happy path: the guard increments on entry, reports the prior count, and
+/// decrements on scope exit.
+TEST(BatchEntryGuardTest, BalancesCounterAcrossScope) {
+  std::atomic<unsigned> counter{0};
+  {
+    BatchEntryGuard guard(counter, [] {});
+    EXPECT_EQ(guard.prior(), 0u);
+    EXPECT_EQ(counter.load(), 1u);
+  }
+  EXPECT_EQ(counter.load(), 0u);
+}
+
+/// The prior count reflects an already-active batch job; the first job sees 0,
+/// a concurrent second job sees 1.
+TEST(BatchEntryGuardTest, PriorCountReflectsActiveJobs) {
+  std::atomic<unsigned> counter{0};
+  BatchEntryGuard first(counter, [] {});
+  EXPECT_EQ(first.prior(), 0u);
+  BatchEntryGuard second(counter, [] {});
+  EXPECT_EQ(second.prior(), 1u);
+  EXPECT_EQ(counter.load(), 2u);
+}

--- a/packages/llm-llamacpp/test/unit/test_cache_management.cpp
+++ b/packages/llm-llamacpp/test/unit/test_cache_management.cpp
@@ -1,5 +1,7 @@
 #include <any>
+#include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -1027,4 +1029,43 @@ TEST_F(CacheManagementTest, StaleCacheResidencyInvalidatedByBatchSlot) {
          "resident in seq 0 "
          "even though the batch scheduler occupied and wiped seq 0. "
          "processPrompt returned empty output.";
+}
+
+// GGSQ unification (sub-task 1): the single-prompt CacheManager path must write
+// the per-sequence state format (GGSQ), not the whole-session format (GGSN), so
+// the same on-disk cache can be read back by the batch per-sequence loader. A
+// freshly written single-prompt cache file therefore starts with the GGSQ magic
+// (0x67677371, 'ggsq'); today it starts with GGSN (0x6767736e) and this fails.
+TEST_F(CacheManagementTest, SinglePromptCacheUsesSeqStateFormat) {
+  if (!hasValidModel()) {
+    FAIL() << "Test model not found";
+  }
+
+  auto model = createModel();
+  if (!model) {
+    FAIL() << "Model failed to load";
+  }
+
+  EXPECT_NO_THROW({
+    processPromptWithCacheOptions(
+        model,
+        R"([{"role": "user", "content": "What is ethereum? Answer shortly."}])",
+        session1_path,
+        true);
+  });
+
+  ASSERT_TRUE(fs::exists(session1_path));
+
+  std::ifstream file(session1_path, std::ios::binary);
+  ASSERT_TRUE(file.is_open());
+  std::uint32_t magic = 0;
+  file.read(reinterpret_cast<char*>(&magic), sizeof(magic));
+  ASSERT_EQ(file.gcount(), static_cast<std::streamsize>(sizeof(magic)));
+
+  EXPECT_EQ(magic, static_cast<std::uint32_t>(LLAMA_STATE_SEQ_MAGIC))
+      << "single-prompt cache wrote magic 0x" << std::hex << magic
+      << " (expected GGSQ 0x"
+      << static_cast<std::uint32_t>(LLAMA_STATE_SEQ_MAGIC)
+      << "); CacheManager still uses the whole-session GGSN format instead of "
+         "the per-sequence GGSQ format shared with the batch path.";
 }

--- a/packages/llm-llamacpp/test/unit/test_continuous_batch_finalize.cpp
+++ b/packages/llm-llamacpp/test/unit/test_continuous_batch_finalize.cpp
@@ -27,14 +27,17 @@ public:
 
   [[nodiscard]] llama_pos getNPast() const override { return 0; }
   [[nodiscard]] int32_t getNSlides() const override { return 0; }
+  [[nodiscard]] bool supportsSliding() const override { return true; }
   void validatePromptPolicy(
       const std::vector<common_chat_msg>&, const std::vector<common_chat_tool>&,
       const PromptLayout&, bool) const override {}
-  std::vector<llama_token> preparePrefill(
+  PrefillPlan preparePrefill(
       const std::vector<common_chat_msg>&, const std::vector<common_chat_tool>&,
-      bool, bool) override {
+      const std::vector<std::vector<uint8_t>>&,
+      const std::vector<PlannedMedia>&, bool, bool) override {
     return {};
   }
+  llama_pos evalMediaSegment(size_t, llama_pos pos) override { return pos; }
   void onPrefillComplete(llama_pos, size_t) override {}
   void syncPosition(llama_pos) override {}
   SequenceStepResult onLogitsReady(

--- a/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
+++ b/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
@@ -2,9 +2,15 @@
 #include <atomic>
 #include <cctype>
 #include <chrono>
+#include <condition_variable>
+#include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <future>
 #include <iostream>
+#include <iterator>
+#include <mutex>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -13,10 +19,12 @@
 #include <ggml-backend.h>
 #include <gtest/gtest.h>
 #include <inference-addon-cpp/Errors.hpp>
+#include <llama.h>
 
 #include "model-interface/ContinuousBatchScheduler.hpp"
 #include "model-interface/LlamaModel.hpp"
 #include "test_common.hpp"
+#include "test_internal_peers.hpp"
 
 namespace {
 
@@ -342,6 +350,131 @@ TEST_F(
   // would average about 1.33 occupied slots. This higher threshold, plus the
   // coexistence flag above, confirms the second group joined the first.
   EXPECT_GT(avgConcurrentSeq, 1.6);
+}
+
+/// Regression for the unconditional all-sequence KV wipe at
+/// processPromptBatchImpl entry: when one batch job is already in flight, a
+/// second overlapping processPromptBatch call must NOT clear the active job's
+/// KV. The first batch is parked inside its first-token callback so its slot
+/// KV is populated (and no llama decode is running) while the main thread
+/// fires an empty overlapping batch. With the bug the empty call's entry wipe
+/// clears the active sequence; with the fix it is skipped because another
+/// batch job is active.
+TEST_F(ContinuousBatchingIntegrationTest, OverlappingBatchDoesNotWipeActiveKv) {
+  REQUIRE_MODEL(model_);
+  config_["parallel"] = "2";
+  config_["n_predict"] = "64";
+  auto model = loadModel();
+
+  std::mutex mtx;
+  std::condition_variable cv;
+  bool firstTokenSeen = false;
+  bool releaseFirst = false;
+
+  auto firstPrompt = makePrompt("List several facts about redwood forests.");
+  firstPrompt.outputCallback =
+      [&mtx, &cv, &firstTokenSeen, &releaseFirst](const std::string&) {
+        std::unique_lock<std::mutex> lk(mtx);
+        if (!firstTokenSeen) {
+          firstTokenSeen = true;
+          cv.notify_all();
+        }
+        cv.wait(lk, [&releaseFirst] { return releaseFirst; });
+      };
+
+  auto firstFuture = std::async(std::launch::async, [&model, firstPrompt] {
+    std::vector<LlamaModel::Prompt> prompts{firstPrompt};
+    return model->processPromptBatch(prompts);
+  });
+
+  {
+    std::unique_lock<std::mutex> lk(mtx);
+    ASSERT_TRUE(cv.wait_for(lk, std::chrono::seconds(60), [&firstTokenSeen] {
+      return firstTokenSeen;
+    })) << "first batch never produced a token";
+  }
+
+  llama_context* lctx = model->getContext();
+  ASSERT_NE(lctx, nullptr);
+  llama_memory_t mem = llama_get_memory(lctx);
+  ASSERT_NE(mem, nullptr);
+  const int nSeqMax = llama_n_seq_max(lctx);
+
+  llama_seq_id activeSeq = -1;
+  for (int seqId = 0; seqId < nSeqMax; seqId++) {
+    if (llama_memory_seq_pos_max(mem, static_cast<llama_seq_id>(seqId)) >= 0) {
+      activeSeq = static_cast<llama_seq_id>(seqId);
+      break;
+    }
+  }
+  ASSERT_NE(activeSeq, -1) << "first batch slot has no KV while parked";
+
+  const std::vector<LlamaModel::Prompt> emptyBatch;
+  const auto emptyOutputs = model->processPromptBatch(emptyBatch);
+  EXPECT_TRUE(emptyOutputs.empty());
+
+  const llama_pos posAfter = llama_memory_seq_pos_max(mem, activeSeq);
+
+  model->cancel();
+  {
+    std::lock_guard<std::mutex> lk(mtx);
+    releaseFirst = true;
+  }
+  cv.notify_all();
+  ASSERT_EQ(
+      firstFuture.wait_for(std::chrono::seconds(60)),
+      std::future_status::ready);
+  (void)firstFuture.get();
+
+  EXPECT_GE(posAfter, 0)
+      << "overlapping processPromptBatch wiped the active job's KV: seq "
+      << activeSeq << " pos_max=" << posAfter
+      << ". The entry-time all-sequence KV wipe must be skipped when another "
+         "batch job is already in flight.";
+}
+
+TEST_F(
+    ContinuousBatchingIntegrationTest,
+    ConcurrentBatchEntriesDoNotRaceOnKvWipe) {
+  // Reproduces comment-4742982980: two batch calls that enter
+  // processPromptBatchImpl concurrently can collide in the entry section
+  // before either has incremented activeBatchJobs_. Without a batch-entry
+  // mutex the first caller's KV wipe races with the second caller's scheduler
+  // admission, potentially clearing the second caller's sequences.
+  //
+  // The test uses an atomic counter as a rendezvous to maximise the chance
+  // that both callers execute the entry section simultaneously.
+  REQUIRE_MODEL(model_);
+  config_["parallel"] = "2";
+  config_["n_predict"] = "16";
+  auto model = loadModel();
+
+  std::atomic<int> ready{0};
+
+  auto runBatch = [&](const std::string& question) {
+    // Spin until both threads are lined up, then enter together.
+    ready.fetch_add(1);
+    while (ready.load() < 2) {
+      std::this_thread::yield();
+    }
+    std::vector<LlamaModel::Prompt> prompts{makePrompt(question)};
+    return model->processPromptBatch(prompts);
+  };
+
+  auto f1 = std::async(std::launch::async, runBatch, "What is 2+2?");
+  auto f2 = std::async(std::launch::async, runBatch, "What is 3+3?");
+
+  ASSERT_EQ(f1.wait_for(std::chrono::seconds(120)), std::future_status::ready)
+      << "first concurrent batch call timed out";
+  ASSERT_EQ(f2.wait_for(std::chrono::seconds(120)), std::future_status::ready)
+      << "second concurrent batch call timed out";
+
+  auto out1 = f1.get();
+  auto out2 = f2.get();
+  ASSERT_EQ(out1.size(), 1u);
+  ASSERT_EQ(out2.size(), 1u);
+  EXPECT_FALSE(out1[0].empty()) << "first concurrent batch returned empty";
+  EXPECT_FALSE(out2[0].empty()) << "second concurrent batch returned empty";
 }
 
 TEST_F(ContinuousBatchingIntegrationTest, FourPromptBatchReportsHigherTps) {
@@ -1055,11 +1188,11 @@ TEST_F(
   REQUIRE_MODEL(model_);
   auto model = loadModel();
 
-  auto* scheduler = model->batchSchedulerForTesting();
+  auto* scheduler = LlamaModelTestPeer::scheduler(*model);
   ASSERT_NE(scheduler, nullptr)
-      << "batchSchedulerForTesting() returned null -- is parallel >= 2?";
+      << "LlamaModelTestPeer::scheduler returned null -- is parallel >= 2?";
 
-  scheduler->setDecodeFuncForTesting(
+  ContinuousBatchSchedulerTestPeer::setDecodeFunc(*scheduler,
       [](llama_context*, llama_batch&) -> int { return 1; });
 
   std::vector<LlamaModel::Prompt> prompts{
@@ -1076,6 +1209,83 @@ TEST_F(
     EXPECT_NE(e.codeString().find("FailedToDecode"), std::string::npos)
         << "expected FailedToDecode in error code, got: " << e.codeString();
   }
+}
+
+/// Reproduce bug: A per-slot cancel that lands while `stepLocked()` has
+/// released the scheduler mutex (around media eval / llama_decode) is recorded
+/// in `pendingSlotCancels_` and only applied at the *next* worker-loop top.
+/// Before the fix, the same step then advances/samples the still-present slot,
+/// so the cancelled sequence streams one more token after cancellation. The
+/// reviewer flagged the media-eval window; the decode window shares the exact
+/// defect and is the one reachable deterministically here, since the cancel is
+/// issued from inside the injected decode stub -- which runs in that very
+/// unlock window. The RAII relock-guard fix reconciles deferred teardown on
+/// every lock reacquisition, closing both windows.
+TEST_F(
+    ContinuousBatchingIntegrationTest,
+    PerSlotCancelInUnlockWindowDoesNotStreamAfterTeardown) {
+  REQUIRE_MODEL(model_);
+  config_["parallel"] = "2";
+  config_["n_predict"] = "64";
+  auto model = loadModel();
+
+  auto* scheduler = LlamaModelTestPeer::scheduler(*model);
+  ASSERT_NE(scheduler, nullptr)
+      << "LlamaModelTestPeer::scheduler returned null -- is parallel >= 2?";
+
+  // Second admitted prompt; admission is in submission order so it owns seqId 1.
+  constexpr uint32_t kCancelSeqId = 1;
+
+  std::atomic<int> seqBTokens = 0;
+  std::atomic<bool> readyToCancel = false;
+  std::atomic<bool> cancelIssued = false;
+  std::atomic<bool> streamedAfterCancel = false;
+
+  // The stub runs while stepLocked() holds no lock -- the same window a
+  // concurrent caller's cancel() would hit. Issuing the cancel here records it
+  // as deferred teardown, then delegates to the real decode so generation
+  // continues.
+  ContinuousBatchSchedulerTestPeer::setDecodeFunc(
+      *scheduler,
+      [scheduler, &readyToCancel, &cancelIssued](
+          llama_context* ctx, llama_batch& batch) {
+        if (readyToCancel.load() && !cancelIssued.exchange(true)) {
+          scheduler->cancel(kCancelSeqId);
+        }
+        return llama_decode(ctx, batch);
+      });
+
+  auto promptA =
+      makePrompt("Write a long, detailed paragraph about redwood forests.");
+  auto promptB =
+      makePrompt("Write a long, detailed paragraph about coral reefs.");
+  // Arm the cancel only once seqId 1 is actively generating (>= 2 streamed
+  // tokens), so the step that observes the deferred cancel would otherwise
+  // sample and stream another token for it.
+  promptB.outputCallback =
+      [&seqBTokens, &readyToCancel, &cancelIssued, &streamedAfterCancel](
+          const std::string&) {
+        if (cancelIssued.load()) {
+          streamedAfterCancel.store(true);
+        }
+        if (seqBTokens.fetch_add(1) + 1 >= 2) {
+          readyToCancel.store(true);
+        }
+      };
+
+  std::vector<LlamaModel::Prompt> prompts{
+      std::move(promptA), std::move(promptB)};
+  auto outputs = model->processPromptBatch(prompts);
+
+  ASSERT_EQ(outputs.size(), 2u);
+  ASSERT_TRUE(cancelIssued.load())
+      << "test setup: seqId 1 never reached the cancel arming point";
+  EXPECT_FALSE(streamedAfterCancel.load())
+      << "DEFERRED-TEARDOWN LEAK: seqId " << kCancelSeqId
+      << " streamed a token after a cancel recorded during the decode unlock "
+         "window. stepLocked() advanced/sampled the slot before "
+         "applyDeferredTeardownLocked() ran; teardown must be reconciled on "
+         "lock reacquisition.";
 }
 
 /// A batched sequence that outgrows its per-slot window (ctx / n_parallel)
@@ -1106,10 +1316,10 @@ TEST_F(
   config_["n_discarded"] = "32";
   auto model = loadModel();
 
-  auto* scheduler = model->batchSchedulerForTesting();
+  auto* scheduler = LlamaModelTestPeer::scheduler(*model);
   ASSERT_NE(scheduler, nullptr);
   std::atomic<size_t> perSlotWindow = 0;
-  scheduler->setDecodeFuncForTesting(
+  ContinuousBatchSchedulerTestPeer::setDecodeFunc(*scheduler,
       [&perSlotWindow](llama_context* ctx, llama_batch& batch) {
         perSlotWindow.store(static_cast<size_t>(llama_n_ctx(ctx)) / kParallel);
         return llama_decode(ctx, batch);
@@ -1168,7 +1378,7 @@ public:
       qvac_lib_inference_addon_llama::batching::ContinuousBatchScheduler&
           scheduler)
       : model_(model) {
-    scheduler.setDecodeFuncForTesting(
+    ContinuousBatchSchedulerTestPeer::setDecodeFunc(scheduler,
         [this](llama_context* ctx, llama_batch& batch) {
           const int rc = llama_decode(ctx, batch);
           if (decodeCalls_.fetch_add(1) == 0) {
@@ -1234,7 +1444,7 @@ TEST_F(
     CancelSeqIsNotAppliedWhileDecodeInFlight) {
   REQUIRE_MODEL(model_);
   auto model = loadModel();
-  auto* scheduler = model->batchSchedulerForTesting();
+  auto* scheduler = LlamaModelTestPeer::scheduler(*model);
   ASSERT_NE(scheduler, nullptr);
 
   BlockedDecodeHarness harness(*model, *scheduler);
@@ -1261,7 +1471,7 @@ TEST_F(
     ContinuousBatchingIntegrationTest, ClearIsNotAppliedWhileDecodeInFlight) {
   REQUIRE_MODEL(model_);
   auto model = loadModel();
-  auto* scheduler = model->batchSchedulerForTesting();
+  auto* scheduler = LlamaModelTestPeer::scheduler(*model);
   ASSERT_NE(scheduler, nullptr);
 
   BlockedDecodeHarness harness(*model, *scheduler);
@@ -1279,4 +1489,316 @@ TEST_F(
   ASSERT_EQ(outputs.size(), 1u);
   EXPECT_EQ(scheduler->numActive(), 0u)
       << "deferred clear was never applied after the decode finished";
+}
+
+namespace {
+
+/// Reads the elephant.jpg VLM fixture from the package `media/` dir. The
+/// C++ tests run either from the package root or from build/test/unit, so
+/// both relative roots are probed (mirroring BaseTestModelPath). The batch
+/// media path takes the image as raw bytes in Prompt::media; the chat input
+/// carries a matching media marker message so tokenization lines up.
+std::vector<uint8_t> readElephantImage() {
+  for (const char* candidate :
+       {"../../../media/elephant.jpg", "media/elephant.jpg"}) {
+    std::ifstream file(candidate, std::ios::binary);
+    if (file) {
+      return {
+          std::istreambuf_iterator<char>(file),
+          std::istreambuf_iterator<char>()};
+    }
+  }
+  return {};
+}
+
+} // namespace
+
+/// A media-segment eval that throws mid-batch must fail only its own
+/// request and leave the scheduler servicing everything else.
+/// serviceNextMediaSegmentLocked wraps evalMediaSegment in try/catch and
+/// routes a throw to failSlotLocked (which fails just that slot's group);
+/// the worker loop never sees the exception, so sibling requests in other
+/// groups keep running and the scheduler stays alive.
+///
+/// Without the eval-media seam (ContinuousBatchSchedulerTestPeer::
+/// setEvalMediaFunc) this path was unverifiable: the
+/// scheduler builds its own real MtmdLlmContext drivers, so there was no
+/// seam to force one slot's evalMediaSegment to throw short of corrupting a
+/// real image. The injected throw stands in for a real mtmd encode failure.
+TEST_F(
+    ContinuousBatchingIntegrationTest, MediaEvalFailureFailsOnlyThatRequest) {
+  const std::string vlmPath = test_common::BaseTestModelPath::get(
+      "SmolVLM-500M-Instruct-Q8_0.gguf", "SmolVLM-500M-Instruct.gguf");
+  const std::string mmprojPath = test_common::BaseTestModelPath::get(
+      "mmproj-SmolVLM-500M-Instruct-Q8_0.gguf",
+      "mmproj-SmolVLM-500M-Instruct.gguf");
+  if (!fs::exists(vlmPath) || !fs::exists(mmprojPath)) {
+    GTEST_SKIP() << "SmolVLM multimodal model/projection not found";
+  }
+  const std::vector<uint8_t> image = readElephantImage();
+  ASSERT_FALSE(image.empty()) << "elephant.jpg media fixture not found";
+
+  std::string path = vlmPath;
+  std::string projection = mmprojPath;
+  auto cfg = config_;
+  // Long generation so the text slot is still decoding when the media barrier
+  // throws; widened ctx_size avoids an unrelated context-overflow stop.
+  cfg["ctx_size"] = "2048";
+  cfg["n_predict"] = "200";
+  auto model = std::make_unique<LlamaModel>(
+      std::move(path), std::move(projection), std::move(cfg));
+  model->waitForLoadInitialization();
+  ASSERT_TRUE(model->isLoaded());
+
+  auto* scheduler = LlamaModelTestPeer::scheduler(*model);
+  ASSERT_NE(scheduler, nullptr)
+      << "LlamaModelTestPeer::scheduler returned null -- is parallel >= 2?";
+
+  // Force every media eval to throw (stands in for an mtmd encode failure);
+  // capture whether the text sibling is still in flight -- the only state in
+  // which per-slot vs whole-scheduler failure is observable.
+  std::atomic<bool> textFinished = false;
+  std::atomic<bool> mediaEvalInvoked = false;
+  std::atomic<bool> textRunningAtThrow = false;
+  ContinuousBatchSchedulerTestPeer::setEvalMediaFunc(*scheduler,
+      [&](SequenceDriver&, size_t, llama_pos) -> llama_pos {
+        mediaEvalInvoked.store(true);
+        textRunningAtThrow.store(!textFinished.load());
+        throw std::runtime_error("injected media-eval failure");
+      });
+
+  // The marker message (empty content) makes formatPrompt insert a media
+  // marker into the chat without loading bytes onto the shared context; the
+  // per-slot driver loads the actual image from Prompt::media.
+  LlamaModel::Prompt mediaPrompt;
+  mediaPrompt.input = R"([{"role":"user","type":"media","content":""},)"
+                      R"({"role":"user","content":"What is in this image?"}])";
+  mediaPrompt.media.push_back(image);
+
+  // Text request (own group) started first with a head start, so it is
+  // provably in flight when the media slot's eval throws.
+  std::atomic<size_t> textPieces = 0;
+  auto textPrompt = makePrompt(
+      "Write a long, detailed essay about the history of mathematics.");
+  textPrompt.outputCallback = [&textPieces](const std::string&) {
+    textPieces.fetch_add(1);
+  };
+  auto textFuture = std::async(std::launch::async, [&] {
+    std::vector<LlamaModel::Prompt> prompts{textPrompt};
+    auto outputs = model->processPromptBatch(prompts);
+    textFinished.store(true);
+    return outputs;
+  });
+  // Wait until the text slot is actively generating before admitting the
+  // media request, so the media barrier throws mid-generation. Bounded so a
+  // text request that dies early fails the test instead of hanging it.
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  while (textPieces.load() < 2) {
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+        << "text slot never started generating; cannot exercise the "
+           "media-eval failure overlap";
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  auto mediaFuture = std::async(std::launch::async, [&] {
+    std::vector<LlamaModel::Prompt> prompts{mediaPrompt};
+    return model->processPromptBatch(prompts);
+  });
+
+  EXPECT_THROW(mediaFuture.get(), std::exception)
+      << "media-eval throw must fail the offending request";
+  ASSERT_TRUE(mediaEvalInvoked.load())
+      << "media request failed before reaching the injected eval; the "
+         "media-eval failure path was never exercised";
+
+  bool textThrew = false;
+  std::vector<std::string> textOutputs;
+  try {
+    textOutputs = textFuture.get();
+  } catch (...) {
+    textThrew = true;
+  }
+
+  // Skip loudly (not a vacuous pass) if timing ever changes so the text slot
+  // finished before the throw.
+  if (!textRunningAtThrow.load()) {
+    GTEST_SKIP() << "text slot had already stopped generating when the media "
+                    "barrier threw; overlap not established, so per-slot vs "
+                    "whole-scheduler failure is indistinguishable on this run";
+  }
+
+  // Text request (own group) must survive: failSlotLocked fails only the
+  // media group.
+  ASSERT_FALSE(textThrew)
+      << "the in-flight text request was killed by the media failure; "
+         "failSlotLocked must fail only the offending group and leave the "
+         "scheduler running";
+  ASSERT_EQ(textOutputs.size(), 1u);
+  EXPECT_FALSE(textOutputs[0].empty());
+}
+
+// GGSQ unification (sub-tasks 2 + 3): the batch multimodal path must support
+// prompt caching on GGSQ. Today MtmdLlmContext::saveCache throws, so a batched
+// media prompt with saveCacheToDisk writes no cache and this fails. The fixture
+// is Qwen2-VL (M-RoPE, n_pos_per_embd()==4) so a successful save+reload round
+// trip actually exercises per-cell llama_kv_cell_ext (x/y) restore — SmolVLM
+// (n_pos_per_embd()==1) could not. The reload pass does not just assert the
+// cache loads: it asks a follow-up that depends on the cached image and checks
+// the answer still names the image subject, so a cache that reloads but
+// restores corrupt/incomplete image KV fails. linux-x64 only; GTEST_SKIP when
+// absent.
+TEST_F(ContinuousBatchingIntegrationTest, BatchMtmdMRopeCacheRoundTrip) {
+  const std::string vlmPath = test_common::BaseTestModelPath::get(
+      "Qwen2-VL-2B-Instruct-Q4_K_M.gguf", "Qwen2-VL-2B-Instruct.gguf");
+  const std::string mmprojPath = test_common::BaseTestModelPath::get(
+      "mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf",
+      "mmproj-Qwen2-VL-2B-Instruct.gguf");
+  if (!fs::exists(vlmPath) || !fs::exists(mmprojPath)) {
+    GTEST_SKIP() << "Qwen2-VL M-RoPE fixture not found (linux-x64 only)";
+  }
+  const std::vector<uint8_t> image = readElephantImage();
+  ASSERT_FALSE(image.empty()) << "elephant.jpg media fixture not found";
+
+  const fs::path cachePath = fs::temp_directory_path() /
+                             ("qwen2vl-mrope-cache-" + uniqueTestId() + ".bin");
+
+  auto makeModel = [&] {
+    std::string path = vlmPath;
+    std::string projection = mmprojPath;
+    auto cfg = config_;
+    cfg["ctx_size"] = "2048";
+    cfg["n_predict"] = "16";
+    auto m = std::make_unique<LlamaModel>(
+        std::move(path), std::move(projection), std::move(cfg));
+    m->waitForLoadInitialization();
+    return m;
+  };
+
+  auto makeMediaPrompt = [&]() {
+    LlamaModel::Prompt p;
+    p.input = R"([{"role":"user","type":"media","content":""},)"
+              R"({"role":"user","content":"What is in this image?"}])";
+    p.media.push_back(image);
+    return p;
+  };
+
+  // Save pass: prefill the image into a slot and persist the per-slot cache.
+  auto saveModel = makeModel();
+  ASSERT_TRUE(saveModel->isLoaded());
+  auto savePrompt = makeMediaPrompt();
+  savePrompt.prefill = true;
+  savePrompt.cacheKey = cachePath.string();
+  savePrompt.saveCacheToDisk = true;
+  std::vector<LlamaModel::Prompt> savePrompts;
+  savePrompts.push_back(std::move(savePrompt));
+
+  bool saveThrew = false;
+  std::string saveErr;
+  try {
+    saveModel->processPromptBatch(savePrompts);
+  } catch (const std::exception& e) {
+    saveThrew = true;
+    saveErr = e.what();
+  } catch (...) {
+    saveThrew = true;
+    saveErr = "<non-std exception>";
+  }
+  EXPECT_FALSE(saveThrew) << "batch MTMD cache save threw: " << saveErr;
+  ASSERT_TRUE(fs::exists(cachePath))
+      << "batch MTMD path persisted no cache file";
+  EXPECT_GT(fs::file_size(cachePath), 0u);
+
+  // The persisted cache must be the per-sequence GGSQ format shared with the
+  // text path so it round-trips through the same loader.
+  {
+    std::ifstream file(cachePath, std::ios::binary);
+    ASSERT_TRUE(file.is_open());
+    std::uint32_t magic = 0;
+    file.read(reinterpret_cast<char*>(&magic), sizeof(magic));
+    EXPECT_EQ(magic, static_cast<std::uint32_t>(LLAMA_STATE_SEQ_MAGIC));
+  }
+
+  // Reload pass: a fresh model loads the cached image context, then we ask a
+  // follow-up that can ONLY be answered from the cached image -- no image is
+  // re-supplied on this turn. A non-empty reply is not enough: a corrupt
+  // M-RoPE KV (wrong per-cell kv_cell_ext x/y positions) still reloads and
+  // still generates, just garbage. So we assert the answer actually names the
+  // elephant in the fixture, proving the restored image context is
+  // semantically intact -- not merely present. If only the text context were
+  // restored (image KV missing), the model has nothing to describe and cannot
+  // produce "elephant".
+  auto reloadModel = makeModel();
+  ASSERT_TRUE(reloadModel->isLoaded());
+  auto followup =
+      makePrompt("What animal was in the image? Answer with one word.");
+  followup.cacheKey = cachePath.string();
+  std::vector<LlamaModel::Prompt> followupPrompts;
+  followupPrompts.push_back(std::move(followup));
+
+  std::vector<std::string> followupOutputs;
+  bool reloadThrew = false;
+  try {
+    followupOutputs = reloadModel->processPromptBatch(followupPrompts);
+  } catch (...) {
+    reloadThrew = true;
+  }
+  EXPECT_FALSE(reloadThrew) << "batch MTMD cache reload threw";
+  ASSERT_EQ(followupOutputs.size(), 1u);
+  ASSERT_FALSE(followupOutputs[0].empty())
+      << "reload from MTMD cache produced no output; M-RoPE KV not restored";
+  EXPECT_TRUE(containsCaseInsensitive(followupOutputs[0], "elephant"))
+      << "follow-up could not name the cached image's subject from the "
+         "reloaded cache; the M-RoPE image KV is missing or corrupt (e.g. only "
+         "text context was restored, or kv_cell_ext x/y positions are wrong). "
+         "Got: "
+      << followupOutputs[0];
+
+  std::error_code ec;
+  fs::remove(cachePath, ec);
+}
+
+// GGSQ unification (sub-task 3): four metadata fields everywhere. The
+// single-prompt CacheManager persists all four fields; the text batch path must
+// read them too, otherwise a single-prompt-saved cache cannot be resumed in
+// batch -- llama_state_seq_load_file rejects the file ("token count exceeded
+// capacity") when its four stored tokens exceed a two-field reader. This proves
+// the shared format actually round-trips across both paths.
+TEST_F(
+    ContinuousBatchingIntegrationTest,
+    BatchTextLoadsFourFieldSinglePromptCache) {
+  REQUIRE_MODEL(model_);
+  auto model = loadModel();
+  const fs::path cachePath =
+      fs::temp_directory_path() / ("xpath-cache-" + uniqueTestId() + ".bin");
+
+  // Single-prompt save -> CacheManager writes GGSQ with all four fields.
+  auto savePrompt = makePrompt("The capital of France is Paris.");
+  savePrompt.prefill = true;
+  savePrompt.cacheKey = cachePath.string();
+  savePrompt.saveCacheToDisk = true;
+  ASSERT_NO_THROW(model->processPrompt(savePrompt));
+  ASSERT_TRUE(fs::exists(cachePath));
+
+  // Batch text load of that same four-field file via the per-slot path.
+  auto loadPrompt = makePrompt("Name that capital again in one word.");
+  loadPrompt.cacheKey = cachePath.string();
+  std::vector<LlamaModel::Prompt> prompts;
+  prompts.push_back(std::move(loadPrompt));
+
+  std::vector<std::string> outputs;
+  std::string err;
+  try {
+    outputs = model->processPromptBatch(prompts);
+  } catch (const std::exception& e) {
+    err = e.what();
+  }
+  EXPECT_TRUE(err.empty())
+      << "batch text path could not load the four-field single-prompt cache: "
+      << err;
+  ASSERT_EQ(outputs.size(), 1u);
+  EXPECT_FALSE(outputs[0].empty());
+
+  std::error_code ec;
+  fs::remove(cachePath, ec);
 }

--- a/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
+++ b/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
@@ -1192,8 +1192,8 @@ TEST_F(
   ASSERT_NE(scheduler, nullptr)
       << "LlamaModelTestPeer::scheduler returned null -- is parallel >= 2?";
 
-  ContinuousBatchSchedulerTestPeer::setDecodeFunc(*scheduler,
-      [](llama_context*, llama_batch&) -> int { return 1; });
+  ContinuousBatchSchedulerTestPeer::setDecodeFunc(
+      *scheduler, [](llama_context*, llama_batch&) -> int { return 1; });
 
   std::vector<LlamaModel::Prompt> prompts{
       makePrompt("What is the capital of France? Answer in one word."),
@@ -1233,7 +1233,8 @@ TEST_F(
   ASSERT_NE(scheduler, nullptr)
       << "LlamaModelTestPeer::scheduler returned null -- is parallel >= 2?";
 
-  // Second admitted prompt; admission is in submission order so it owns seqId 1.
+  // Second admitted prompt; admission is in submission order so it owns
+  // seqId 1.
   constexpr uint32_t kCancelSeqId = 1;
 
   std::atomic<int> seqBTokens = 0;
@@ -1262,16 +1263,17 @@ TEST_F(
   // Arm the cancel only once seqId 1 is actively generating (>= 2 streamed
   // tokens), so the step that observes the deferred cancel would otherwise
   // sample and stream another token for it.
-  promptB.outputCallback =
-      [&seqBTokens, &readyToCancel, &cancelIssued, &streamedAfterCancel](
-          const std::string&) {
-        if (cancelIssued.load()) {
-          streamedAfterCancel.store(true);
-        }
-        if (seqBTokens.fetch_add(1) + 1 >= 2) {
-          readyToCancel.store(true);
-        }
-      };
+  promptB.outputCallback = [&seqBTokens,
+                            &readyToCancel,
+                            &cancelIssued,
+                            &streamedAfterCancel](const std::string&) {
+    if (cancelIssued.load()) {
+      streamedAfterCancel.store(true);
+    }
+    if (seqBTokens.fetch_add(1) + 1 >= 2) {
+      readyToCancel.store(true);
+    }
+  };
 
   std::vector<LlamaModel::Prompt> prompts{
       std::move(promptA), std::move(promptB)};
@@ -1319,8 +1321,8 @@ TEST_F(
   auto* scheduler = LlamaModelTestPeer::scheduler(*model);
   ASSERT_NE(scheduler, nullptr);
   std::atomic<size_t> perSlotWindow = 0;
-  ContinuousBatchSchedulerTestPeer::setDecodeFunc(*scheduler,
-      [&perSlotWindow](llama_context* ctx, llama_batch& batch) {
+  ContinuousBatchSchedulerTestPeer::setDecodeFunc(
+      *scheduler, [&perSlotWindow](llama_context* ctx, llama_batch& batch) {
         perSlotWindow.store(static_cast<size_t>(llama_n_ctx(ctx)) / kParallel);
         return llama_decode(ctx, batch);
       });
@@ -1378,8 +1380,8 @@ public:
       qvac_lib_inference_addon_llama::batching::ContinuousBatchScheduler&
           scheduler)
       : model_(model) {
-    ContinuousBatchSchedulerTestPeer::setDecodeFunc(scheduler,
-        [this](llama_context* ctx, llama_batch& batch) {
+    ContinuousBatchSchedulerTestPeer::setDecodeFunc(
+        scheduler, [this](llama_context* ctx, llama_batch& batch) {
           const int rc = llama_decode(ctx, batch);
           if (decodeCalls_.fetch_add(1) == 0) {
             decodeInFlight_.store(true);
@@ -1560,8 +1562,8 @@ TEST_F(
   std::atomic<bool> textFinished = false;
   std::atomic<bool> mediaEvalInvoked = false;
   std::atomic<bool> textRunningAtThrow = false;
-  ContinuousBatchSchedulerTestPeer::setEvalMediaFunc(*scheduler,
-      [&](SequenceDriver&, size_t, llama_pos) -> llama_pos {
+  ContinuousBatchSchedulerTestPeer::setEvalMediaFunc(
+      *scheduler, [&](SequenceDriver&, size_t, llama_pos) -> llama_pos {
         mediaEvalInvoked.store(true);
         textRunningAtThrow.store(!textFinished.load());
         throw std::runtime_error("injected media-eval failure");

--- a/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
+++ b/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
@@ -1316,16 +1316,20 @@ TEST_F(
   std::atomic<int> seqBTokens = 0;
   std::atomic<bool> readyToCancel = false;
   std::atomic<bool> cancelIssued = false;
+  std::atomic<bool> cancelHitOccupied = false;
 
   // Issue the cancel from inside the decode unlock window so its teardown runs
   // in the StepUnlockGuard destructor, then delegate to the real decode so the
-  // surviving sequence keeps generating.
+  // surviving sequence keeps generating. Capture cancel()'s return: it is true
+  // only when seqId 1 was still occupied, i.e. the throwing teardown actually
+  // ran. Without it the test could pass vacuously when the slot finished first
+  // and the cancel was a no-op.
   ContinuousBatchSchedulerTestPeer::setDecodeFunc(
       *scheduler,
-      [scheduler, &readyToCancel, &cancelIssued](
+      [scheduler, &readyToCancel, &cancelIssued, &cancelHitOccupied](
           llama_context* ctx, llama_batch& batch) {
         if (readyToCancel.load() && !cancelIssued.exchange(true)) {
-          scheduler->cancel(kCancelSeqId);
+          cancelHitOccupied.store(scheduler->cancel(kCancelSeqId));
         }
         return llama_decode(ctx, batch);
       });
@@ -1334,6 +1338,9 @@ TEST_F(
   // cannot open it, so TextLlmContext::saveCache throws on the cancel path.
   const fs::path unwritable = fs::temp_directory_path() /
                               ("no-such-dir-" + uniqueTestId()) / "cache.bin";
+  ASSERT_FALSE(fs::exists(unwritable.parent_path()))
+      << "precondition: the cacheKey's parent dir must be absent so saveCache "
+         "throws on the cancel path";
 
   auto promptA =
       makePrompt("Write a long, detailed paragraph about redwood forests.");
@@ -1341,11 +1348,13 @@ TEST_F(
       makePrompt("Write a long, detailed paragraph about coral reefs.");
   promptB.cacheKey = unwritable.string();
   promptB.saveCacheToDisk = true;
-  // Arm the cancel only once seqId 1 is actively generating.
+  // Arm the cancel as soon as seqId 1 streams its first token: the cancel then
+  // lands on the very next decode, leaving essentially no window for the slot
+  // to finish naturally first (which would instead hit the deliberately
+  // throwing normal-completion save path and fail the whole batch).
   promptB.outputCallback = [&seqBTokens, &readyToCancel](const std::string&) {
-    if (seqBTokens.fetch_add(1) + 1 >= 2) {
-      readyToCancel.store(true);
-    }
+    seqBTokens.fetch_add(1);
+    readyToCancel.store(true);
   };
 
   std::vector<LlamaModel::Prompt> prompts{
@@ -1357,9 +1366,10 @@ TEST_F(
   ASSERT_EQ(outputs.size(), 2u);
   ASSERT_TRUE(cancelIssued.load())
       << "test setup: seqId 1 never reached the cancel arming point";
-  EXPECT_FALSE(fs::exists(unwritable))
-      << "saveCache was expected to fail on the unwritable path, not write a "
-         "file";
+  ASSERT_TRUE(cancelHitOccupied.load())
+      << "cancel must hit the still-occupied seqId 1 so the throwing saveCache "
+         "teardown actually runs; false means the slot finished first and the "
+         "teardown path was never exercised";
   EXPECT_FALSE(outputs[0].empty())
       << "sibling sequence (seqId 0) must finish normally despite the throwing "
          "teardown on seqId 1";

--- a/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
+++ b/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
@@ -1728,34 +1728,41 @@ TEST_F(
 // GGSQ unification (sub-tasks 2 + 3): the batch multimodal path must support
 // prompt caching on GGSQ. Today MtmdLlmContext::saveCache throws, so a batched
 // media prompt with saveCacheToDisk writes no cache and this fails. The fixture
-// is Qwen2-VL (M-RoPE, n_pos_per_embd()==4) so a successful save+reload round
+// is Qwen3.5 (M-RoPE, n_pos_per_embd()==4) so a successful save+reload round
 // trip actually exercises per-cell llama_kv_cell_ext (x/y) restore — SmolVLM
-// (n_pos_per_embd()==1) could not. The reload pass does not just assert the
-// cache loads: it asks a follow-up that depends on the cached image and checks
-// the answer still names the image subject, so a cache that reloads but
-// restores corrupt/incomplete image KV fails. linux-x64 only; GTEST_SKIP when
-// absent.
+// (n_pos_per_embd()==1) could not. Its image prefill commits far more KV cells
+// (~2899) than positions (~90), so the round trip really exercises the M-RoPE
+// per-cell x/y metadata. The reload pass does not just assert the cache loads:
+// it asks a follow-up that depends on the cached image and checks the answer
+// still names the image subject, so a cache that reloads but restores
+// corrupt/incomplete image KV fails. The fixture is fetched on every platform
+// by scripts/download-unit-test-models.js; GTEST_SKIP when it is absent.
 TEST_F(ContinuousBatchingIntegrationTest, BatchMtmdMRopeCacheRoundTrip) {
-  const std::string vlmPath = test_common::BaseTestModelPath::get(
-      "Qwen2-VL-2B-Instruct-Q4_K_M.gguf", "Qwen2-VL-2B-Instruct.gguf");
-  const std::string mmprojPath = test_common::BaseTestModelPath::get(
-      "mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf",
-      "mmproj-Qwen2-VL-2B-Instruct.gguf");
+  const std::string vlmPath =
+      test_common::BaseTestModelPath::get("Qwen3.5-0.8B-Q8_0.gguf");
+  const std::string mmprojPath =
+      test_common::BaseTestModelPath::get("mmproj-Qwen3.5-0.8B-F16.gguf");
   if (!fs::exists(vlmPath) || !fs::exists(mmprojPath)) {
-    GTEST_SKIP() << "Qwen2-VL M-RoPE fixture not found (linux-x64 only)";
+    GTEST_SKIP() << "Qwen3.5 M-RoPE fixture not found";
   }
   const std::vector<uint8_t> image = readElephantImage();
   ASSERT_FALSE(image.empty()) << "elephant.jpg media fixture not found";
 
   const fs::path cachePath = fs::temp_directory_path() /
-                             ("qwen2vl-mrope-cache-" + uniqueTestId() + ".bin");
+                             ("qwen35-mrope-cache-" + uniqueTestId() + ".bin");
 
   auto makeModel = [&] {
     std::string path = vlmPath;
     std::string projection = mmprojPath;
     auto cfg = config_;
-    cfg["ctx_size"] = "2048";
-    cfg["n_predict"] = "16";
+    // Qwen3.5 image prefill commits ~2899 KV cells (M-RoPE: cells >> positions),
+    // so the round trip needs the 4096 the Qwen3.5 mtmd unit tests use.
+    cfg["ctx_size"] = "4096";
+    // Qwen3.5 is a reasoning model; without this it spends the whole n_predict
+    // budget on chain-of-thought and never reaches the one-word answer. 0
+    // disables thinking so the subject keyword fits, as the VLM perf tests do.
+    cfg["reasoning-budget"] = "0";
+    cfg["n_predict"] = "32";
     auto m = std::make_unique<LlamaModel>(
         std::move(path), std::move(projection), std::move(cfg));
     m->waitForLoadInitialization();

--- a/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
+++ b/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
@@ -1755,8 +1755,9 @@ TEST_F(ContinuousBatchingIntegrationTest, BatchMtmdMRopeCacheRoundTrip) {
     std::string path = vlmPath;
     std::string projection = mmprojPath;
     auto cfg = config_;
-    // Qwen3.5 image prefill commits ~2899 KV cells (M-RoPE: cells >> positions),
-    // so the round trip needs the 4096 the Qwen3.5 mtmd unit tests use.
+    // Qwen3.5 image prefill commits ~2899 KV cells (M-RoPE: cells >>
+    // positions), so the round trip needs the 4096 the Qwen3.5 mtmd unit tests
+    // use.
     cfg["ctx_size"] = "4096";
     // Qwen3.5 is a reasoning model; without this it spends the whole n_predict
     // budget on chain-of-thought and never reaches the one-word answer. 0

--- a/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
+++ b/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
@@ -1290,6 +1290,81 @@ TEST_F(
          "lock reacquisition.";
 }
 
+/// A per-slot cancel runs the slot's driver teardown -- onCancel + saveCache --
+/// from the noexcept StepUnlockGuard destructor (a cancel issued in the decode
+/// unlock window is applied on lock reacquisition). When saveCache throws --
+/// here forced by an unwritable cacheKey -- the throw must be swallowed in
+/// place: before the fix it escaped the noexcept destructor and
+/// std::terminate'd the whole process. The batch must instead survive: the
+/// cancelled slot is freed, its group completes, and the sibling sequence still
+/// finishes normally.
+TEST_F(
+    ContinuousBatchingIntegrationTest,
+    PerSlotCancelSwallowsThrowingDriverTeardown) {
+  REQUIRE_MODEL(model_);
+  config_["parallel"] = "2";
+  config_["n_predict"] = "64";
+  auto model = loadModel();
+
+  auto* scheduler = LlamaModelTestPeer::scheduler(*model);
+  ASSERT_NE(scheduler, nullptr)
+      << "LlamaModelTestPeer::scheduler returned null -- is parallel >= 2?";
+
+  // Admission is in submission order, so the second prompt owns seqId 1.
+  constexpr uint32_t kCancelSeqId = 1;
+
+  std::atomic<int> seqBTokens = 0;
+  std::atomic<bool> readyToCancel = false;
+  std::atomic<bool> cancelIssued = false;
+
+  // Issue the cancel from inside the decode unlock window so its teardown runs
+  // in the StepUnlockGuard destructor, then delegate to the real decode so the
+  // surviving sequence keeps generating.
+  ContinuousBatchSchedulerTestPeer::setDecodeFunc(
+      *scheduler,
+      [scheduler, &readyToCancel, &cancelIssued](
+          llama_context* ctx, llama_batch& batch) {
+        if (readyToCancel.load() && !cancelIssued.exchange(true)) {
+          scheduler->cancel(kCancelSeqId);
+        }
+        return llama_decode(ctx, batch);
+      });
+
+  // cacheKey under a directory that does not exist: llama_state_seq_save_file
+  // cannot open it, so TextLlmContext::saveCache throws on the cancel path.
+  const fs::path unwritable = fs::temp_directory_path() /
+                              ("no-such-dir-" + uniqueTestId()) / "cache.bin";
+
+  auto promptA =
+      makePrompt("Write a long, detailed paragraph about redwood forests.");
+  auto promptB =
+      makePrompt("Write a long, detailed paragraph about coral reefs.");
+  promptB.cacheKey = unwritable.string();
+  promptB.saveCacheToDisk = true;
+  // Arm the cancel only once seqId 1 is actively generating.
+  promptB.outputCallback = [&seqBTokens, &readyToCancel](const std::string&) {
+    if (seqBTokens.fetch_add(1) + 1 >= 2) {
+      readyToCancel.store(true);
+    }
+  };
+
+  std::vector<LlamaModel::Prompt> prompts{
+      std::move(promptA), std::move(promptB)};
+  // Returning from this call at all proves the throwing teardown did not
+  // std::terminate the process.
+  auto outputs = model->processPromptBatch(prompts);
+
+  ASSERT_EQ(outputs.size(), 2u);
+  ASSERT_TRUE(cancelIssued.load())
+      << "test setup: seqId 1 never reached the cancel arming point";
+  EXPECT_FALSE(fs::exists(unwritable))
+      << "saveCache was expected to fail on the unwritable path, not write a "
+         "file";
+  EXPECT_FALSE(outputs[0].empty())
+      << "sibling sequence (seqId 0) must finish normally despite the throwing "
+         "teardown on seqId 1";
+}
+
 /// A batched sequence that outgrows its per-slot window (ctx / n_parallel)
 /// must slide (`contextSlides > 0`) and keep generating, like the
 /// single-prompt path does, instead of being hard-truncated at the window.

--- a/packages/llm-llamacpp/test/unit/test_generation_budget_admission.cpp
+++ b/packages/llm-llamacpp/test/unit/test_generation_budget_admission.cpp
@@ -1,0 +1,86 @@
+// The per-sequence generation budget must be enforced against KV cells, not
+// only positions. For M-RoPE media a prompt occupies more KV cells than
+// positions (promptKvSize > promptSize), so a request can pass the
+// position-based budget (promptSize + n_predict <= cap) while its KV-cell
+// budget (promptKvSize + n_predict) overruns the per-slot KV-cache. This
+// guards the admission decision feeding ContinuousBatchScheduler::submitLocked.
+#include <gtest/gtest.h>
+
+#include "model-interface/ContinuousBatchScheduler.hpp"
+
+namespace {
+
+using qvac_lib_inference_addon_llama::batching::generationBudgetExceeded;
+
+} // namespace
+
+/// MTMD hole: a media-heavy prompt whose KV-cell span leaves no room for
+/// n_predict must be rejected, even though its position span does. With the
+/// position-only budget the request slips through and overruns the slot's
+/// KV-cache during generation.
+TEST(GenerationBudgetAdmission, KvCellBudgetRejectsMediaHeavyPrompt) {
+  constexpr unsigned perSeqMaxTokens = 100;
+  constexpr unsigned promptSize = 40;
+  constexpr unsigned promptKvSize = 95;
+  constexpr int nPredict = 16;
+
+  // Position span fits: 40 + 16 = 56 <= 100.
+  EXPECT_FALSE(generationBudgetExceeded(
+      promptSize, promptSize, nPredict, perSeqMaxTokens))
+      << "position-only budget should fit for this prompt";
+
+  // KV-cell span overruns: 95 + 16 = 111 > 100.
+  EXPECT_TRUE(generationBudgetExceeded(
+      promptSize, promptKvSize, nPredict, perSeqMaxTokens))
+      << "KV-CELL BUDGET HOLE: prompt of " << promptKvSize << " KV cells + "
+      << nPredict << " generated tokens exceeds the per-sequence cap "
+      << perSeqMaxTokens
+      << ", but the generation budget was enforced only against positions ("
+      << promptSize << " + " << nPredict << ") and admitted the request";
+}
+
+/// A text prompt (promptKvSize == promptSize) whose prompt + n_predict fits the
+/// cap is admitted; the KV-cell check must not over-reject the common case.
+TEST(GenerationBudgetAdmission, FittingPromptIsAdmitted) {
+  constexpr unsigned perSeqMaxTokens = 100;
+  constexpr unsigned promptSize = 40;
+  constexpr int nPredict = 16;
+
+  EXPECT_FALSE(generationBudgetExceeded(
+      promptSize, promptSize, nPredict, perSeqMaxTokens));
+}
+
+/// n_predict <= 0 means "no scheduler cap"; the batcher ceiling governs, so the
+/// generation budget is never exceeded regardless of prompt size.
+TEST(GenerationBudgetAdmission, NonPositiveNPredictNeverExceeds) {
+  constexpr unsigned perSeqMaxTokens = 100;
+  constexpr unsigned promptKvSize = 200;
+
+  EXPECT_FALSE(
+      generationBudgetExceeded(promptKvSize, promptKvSize, 0, perSeqMaxTokens));
+  EXPECT_FALSE(generationBudgetExceeded(
+      promptKvSize, promptKvSize, -1, perSeqMaxTokens));
+}
+
+/// Driver-side prefill admission (PR #2543 comments 3451907561 / 3451908540).
+/// A prefill-only request may exactly fill the per-slot window: it generates
+/// nothing afterward, so a fully occupied window is fine. The drivers used to
+/// reject it with a hard-coded `>= ceiling` that ignored the prefill flag,
+/// even though the scheduler admits exactly-full prefill with strict `>`.
+TEST(ContextWindowAdmission, PrefillOnlyMayExactlyFillWindow) {
+  constexpr llama_pos ceiling = 100;
+  EXPECT_FALSE(exceedsContextWindow(ceiling, ceiling, /*isPrefillOnlyRequest=*/true))
+      << "exactly-full prefill-only must be admitted (it never generates)";
+  EXPECT_TRUE(exceedsContextWindow(ceiling + 1, ceiling, /*isPrefillOnlyRequest=*/true))
+      << "strictly over the window is still rejected";
+}
+
+/// A request that will generate needs at least one free slot for the next
+/// token, so a window that is exactly full is already too many.
+TEST(ContextWindowAdmission, GenerationNeedsAFreeSlot) {
+  constexpr llama_pos ceiling = 100;
+  EXPECT_TRUE(exceedsContextWindow(ceiling, ceiling, /*isPrefillOnlyRequest=*/false))
+      << "exactly-full leaves no room to generate the next token";
+  EXPECT_FALSE(exceedsContextWindow(ceiling - 1, ceiling, /*isPrefillOnlyRequest=*/false))
+      << "one free slot is enough to start generating";
+}

--- a/packages/llm-llamacpp/test/unit/test_generation_budget_admission.cpp
+++ b/packages/llm-llamacpp/test/unit/test_generation_budget_admission.cpp
@@ -69,9 +69,11 @@ TEST(GenerationBudgetAdmission, NonPositiveNPredictNeverExceeds) {
 /// even though the scheduler admits exactly-full prefill with strict `>`.
 TEST(ContextWindowAdmission, PrefillOnlyMayExactlyFillWindow) {
   constexpr llama_pos ceiling = 100;
-  EXPECT_FALSE(exceedsContextWindow(ceiling, ceiling, /*isPrefillOnlyRequest=*/true))
+  EXPECT_FALSE(
+      exceedsContextWindow(ceiling, ceiling, /*isPrefillOnlyRequest=*/true))
       << "exactly-full prefill-only must be admitted (it never generates)";
-  EXPECT_TRUE(exceedsContextWindow(ceiling + 1, ceiling, /*isPrefillOnlyRequest=*/true))
+  EXPECT_TRUE(
+      exceedsContextWindow(ceiling + 1, ceiling, /*isPrefillOnlyRequest=*/true))
       << "strictly over the window is still rejected";
 }
 
@@ -79,8 +81,10 @@ TEST(ContextWindowAdmission, PrefillOnlyMayExactlyFillWindow) {
 /// token, so a window that is exactly full is already too many.
 TEST(ContextWindowAdmission, GenerationNeedsAFreeSlot) {
   constexpr llama_pos ceiling = 100;
-  EXPECT_TRUE(exceedsContextWindow(ceiling, ceiling, /*isPrefillOnlyRequest=*/false))
+  EXPECT_TRUE(
+      exceedsContextWindow(ceiling, ceiling, /*isPrefillOnlyRequest=*/false))
       << "exactly-full leaves no room to generate the next token";
-  EXPECT_FALSE(exceedsContextWindow(ceiling - 1, ceiling, /*isPrefillOnlyRequest=*/false))
+  EXPECT_FALSE(exceedsContextWindow(
+      ceiling - 1, ceiling, /*isPrefillOnlyRequest=*/false))
       << "one free slot is enough to start generating";
 }

--- a/packages/llm-llamacpp/test/unit/test_internal_peers.hpp
+++ b/packages/llm-llamacpp/test/unit/test_internal_peers.hpp
@@ -48,8 +48,8 @@ public:
 
   /// Override the media-segment eval used by serviceNextMediaSegmentLocked();
   /// inject a stub that throws to exercise the media-eval failure path.
-  static void setEvalMediaFunc(
-      Scheduler& scheduler, Scheduler::EvalMediaFunc fn) {
+  static void
+  setEvalMediaFunc(Scheduler& scheduler, Scheduler::EvalMediaFunc fn) {
     scheduler.evalMediaFunc_ = std::move(fn);
   }
 };

--- a/packages/llm-llamacpp/test/unit/test_internal_peers.hpp
+++ b/packages/llm-llamacpp/test/unit/test_internal_peers.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <mutex>
+#include <shared_mutex>
+#include <utility>
+
+#include "model-interface/ContinuousBatchScheduler.hpp"
+#include "model-interface/LlamaModel.hpp"
+
+// Friend test peers grant unit tests direct access to internals that are not
+// part of the production public API. The production classes befriend these
+// peers (and nothing else), so the test-only access lives here in test code
+// instead of as `*ForTesting()` accessors on the shipped surface.
+//
+// A dedicated peer is used rather than befriending the GoogleTest fixtures:
+// friendship is not inherited, and a TEST_F body lives in a generated class
+// derived from the fixture, so a `friend class Fixture;` would not grant the
+// test body access.
+
+class LlamaModelTestPeer {
+public:
+  /// The internal batch scheduler. Null when batching is inactive
+  /// (n_parallel < 2 or a multimodal model) or before the model has loaded.
+  static qvac_lib_inference_addon_llama::batching::ContinuousBatchScheduler*
+  scheduler(LlamaModel& model) {
+    std::shared_lock lock(model.stateMtx_);
+    return model.state_ ? model.state_->batchScheduler_.get() : nullptr;
+  }
+
+  /// The loaded single-prompt context, for driver-level accounting tests.
+  /// Null before the model has loaded.
+  static LlmContext* llmContext(LlamaModel& model) {
+    std::shared_lock lock(model.stateMtx_);
+    return model.state_ ? model.state_->llmContext_.get() : nullptr;
+  }
+};
+
+class ContinuousBatchSchedulerTestPeer {
+public:
+  using Scheduler =
+      qvac_lib_inference_addon_llama::batching::ContinuousBatchScheduler;
+
+  /// Override the decode function used by stepLocked(); inject a stub that
+  /// returns a non-zero rc or blocks to exercise the decode path.
+  static void setDecodeFunc(Scheduler& scheduler, Scheduler::DecodeFunc fn) {
+    scheduler.decodeFunc_ = std::move(fn);
+  }
+
+  /// Override the media-segment eval used by serviceNextMediaSegmentLocked();
+  /// inject a stub that throws to exercise the media-eval failure path.
+  static void setEvalMediaFunc(
+      Scheduler& scheduler, Scheduler::EvalMediaFunc fn) {
+    scheduler.evalMediaFunc_ = std::move(fn);
+  }
+};

--- a/packages/llm-llamacpp/test/unit/test_llama_model.cpp
+++ b/packages/llm-llamacpp/test/unit/test_llama_model.cpp
@@ -290,6 +290,34 @@ TEST_F(LlamaModelTest, ProcessBinaryInput) {
   }
 }
 
+// A media buffer supplied in `prompt.media` but NOT referenced by any media
+// marker in the prompt text must be rejected, not silently dropped. With the
+// load order built solely from the prompt's media plan, a marker-less buffer
+// produces an empty plan, so no loadMedia() ever runs and the text-only
+// rejection is never reached. This reproduces that drop on a text-only model.
+TEST_F(LlamaModelTest, RejectsUnreferencedMediaBuffer) {
+  if (!fs::exists(getValidModelPath())) {
+    FAIL() << "Test model not found at: " << getValidModelPath();
+  }
+  if (!test_projection_path.empty()) {
+    GTEST_SKIP() << "Text-only model required for this test";
+  }
+
+  LlamaModel model = createModel();
+  model.waitForLoadInitialization();
+
+  if (!model.isLoaded()) {
+    FAIL() << "Model failed to load";
+  }
+
+  std::vector<uint8_t> unreferenced_media = {0x89, 0x50, 0x4E, 0x47};
+  LlamaModel::Prompt prompt;
+  // No media marker in the prompt text — the buffer is unreferenced.
+  prompt.input = R"([{"role": "user", "content": "Describe nothing."}])";
+  prompt.media.push_back(std::move(unreferenced_media));
+  EXPECT_THROW({ model.processPrompt(prompt); }, qvac_errors::StatusError);
+}
+
 TEST_F(LlamaModelTest, ProcessEmptyInput) {
   if (!fs::exists(getValidModelPath())) {
     FAIL() << "Test model not found at: " << getValidModelPath();

--- a/packages/llm-llamacpp/test/unit/test_media_load_order.cpp
+++ b/packages/llm-llamacpp/test/unit/test_media_load_order.cpp
@@ -1,0 +1,66 @@
+// computeMediaLoadOrder must turn an ordered media plan into a load sequence
+// that preserves prompt-marker order. The single-prompt path loads hoisted
+// byte buffers and inline paths into one shared bitmap list while the MTMD
+// markers are emitted in original prompt order; if the load order diverges
+// from the plan, bitmaps bind to the wrong markers (the bug).
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/MediaLoadOrder.hpp"
+
+namespace {
+
+PlannedMedia byteBuffer() { return {MediaSource::ByteBuffer, ""}; }
+PlannedMedia path(std::string p) { return {MediaSource::Path, std::move(p)}; }
+
+} // namespace
+
+/// An interleaved plan must yield the same order, with byte buffers numbered in
+/// the sequence they appear. Plan [Path, ByteBuffer, Path, ByteBuffer] must
+/// load as Path a -> ByteBuffer#0 -> Path b -> ByteBuffer#1.
+TEST(MediaLoadOrder, PreservesInterleavedPromptOrder) {
+  const std::vector<PlannedMedia> plan = {
+      path("a.jpg"), byteBuffer(), path("b.jpg"), byteBuffer()};
+
+  const auto steps = computeMediaLoadOrder(plan);
+
+  ASSERT_EQ(steps.size(), 4u);
+
+  EXPECT_EQ(steps[0].source, MediaSource::Path);
+  EXPECT_EQ(steps[0].path, "a.jpg");
+
+  EXPECT_EQ(steps[1].source, MediaSource::ByteBuffer);
+  EXPECT_EQ(steps[1].byteIndex, 0u);
+
+  EXPECT_EQ(steps[2].source, MediaSource::Path);
+  EXPECT_EQ(steps[2].path, "b.jpg");
+
+  EXPECT_EQ(steps[3].source, MediaSource::ByteBuffer);
+  EXPECT_EQ(steps[3].byteIndex, 1u);
+}
+
+TEST(MediaLoadOrder, AllByteBuffersNumberedInOrder) {
+  const std::vector<PlannedMedia> plan = {
+      byteBuffer(), byteBuffer(), byteBuffer()};
+
+  const auto steps = computeMediaLoadOrder(plan);
+
+  ASSERT_EQ(steps.size(), 3u);
+  for (size_t i = 0; i < steps.size(); ++i) {
+    EXPECT_EQ(steps[i].source, MediaSource::ByteBuffer);
+    EXPECT_EQ(steps[i].byteIndex, i);
+  }
+}
+
+TEST(MediaLoadOrder, AllPathsCarryTheirPathInOrder) {
+  const std::vector<PlannedMedia> plan = {
+      path("a.jpg"), path("b.jpg"), path("c.jpg")};
+
+  const auto steps = computeMediaLoadOrder(plan);
+
+  ASSERT_EQ(steps.size(), 3u);
+  EXPECT_EQ(steps[0].path, "a.jpg");
+  EXPECT_EQ(steps[1].path, "b.jpg");
+  EXPECT_EQ(steps[2].path, "c.jpg");
+}

--- a/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
+++ b/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
@@ -380,9 +380,8 @@ TEST_F(MtmdLlmContextTest, Qwen35MultimodalReportsMemoryTokenCountAndPosMax) {
   const uint32_t totalCells = llama_memory_seq_token_count(mem, -1);
   const llama_pos posMax = llama_memory_seq_pos_max(mem, 0);
   SCOPED_TRACE(
-      "sequenceCells=" + std::to_string(sequenceCells) +
-      ", totalCells=" + std::to_string(totalCells) +
-      ", posMax=" + std::to_string(posMax));
+      "sequenceCells=" + std::to_string(sequenceCells) + ", totalCells=" +
+      std::to_string(totalCells) + ", posMax=" + std::to_string(posMax));
 
   EXPECT_EQ(sequenceCells, kQwen35MultimodalPrefillCells);
   EXPECT_EQ(totalCells, kQwen35MultimodalPrefillCells);
@@ -432,9 +431,8 @@ TEST_F(
   const uint32_t totalCells = llama_memory_seq_token_count(mem, -1);
   const llama_pos posMax = llama_memory_seq_pos_max(mem, 0);
   SCOPED_TRACE(
-      "sequenceCells=" + std::to_string(sequenceCells) +
-      ", totalCells=" + std::to_string(totalCells) +
-      ", posMax=" + std::to_string(posMax));
+      "sequenceCells=" + std::to_string(sequenceCells) + ", totalCells=" +
+      std::to_string(totalCells) + ", posMax=" + std::to_string(posMax));
 
   EXPECT_GT(sequenceCells, kQwen35MultimodalPrefillCells);
   EXPECT_EQ(totalCells, sequenceCells);
@@ -545,8 +543,8 @@ TEST_F(MtmdLlmContextTest, LoadCacheRollsBackRestoredKvOnPostRestoreFailure) {
       << "loadCache must reject a cache whose NPast exceeds the context size";
 
   const uint32_t leakedCells = llama_memory_seq_token_count(mem, seqId);
-  SCOPED_TRACE("sequence KV cells after failed load: " +
-               std::to_string(leakedCells));
+  SCOPED_TRACE(
+      "sequence KV cells after failed load: " + std::to_string(leakedCells));
   EXPECT_EQ(leakedCells, 0u)
       << "loadCache restored KV then threw without rolling it back: the slot "
          "leaks orphan KV cells. A ScopeGuard must clear the sequence on any "

--- a/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
+++ b/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
@@ -10,7 +10,10 @@
 #include <inference-addon-cpp/Errors.hpp>
 
 #include "model-interface/LlamaModel.hpp"
+#include "model-interface/MtmdLlmContext.hpp"
+#include "model-interface/SequenceDriver.hpp"
 #include "test_common.hpp"
+#include "test_internal_peers.hpp"
 
 using test_common::getStatValue;
 
@@ -508,6 +511,114 @@ TEST_F(MtmdLlmContextTest, NonexistentFile) {
   EXPECT_THROW({ model->processPrompt(prompt); }, qvac_errors::StatusError);
 }
 
+/// A batch prompt may carry media as a string file path (not just inline
+/// `Uint8Array` bytes). The per-slot MTMD driver must load that file itself,
+/// exactly as the single-prompt path does. With the bug the path is loaded
+/// into the shared context instead, so the per-slot driver sees a media
+/// marker with no bitmap and the batch throws.
+TEST_F(MtmdLlmContextTest, BatchLoadsPathModeMediaPerSlot) {
+  if (!hasValidModel()) {
+    FAIL() << "Multimodal model or projection file not found";
+  }
+
+  // Resolve media/ whether the test binary runs from the package root or from
+  // build/test/unit (mirrors BaseTestModelPath's two-location model lookup).
+  fs::path imagePath = "../../../media/elephant.jpg";
+  if (!fs::exists(imagePath)) {
+    imagePath = "media/elephant.jpg";
+  }
+  ASSERT_TRUE(fs::exists(imagePath))
+      << "test image missing: " << fs::absolute(imagePath).string();
+  imagePath = fs::absolute(imagePath);
+
+  auto cfg = config_files;
+  cfg["parallel"] = "2";
+  cfg["n_predict"] = "16";
+  std::string modelPath = test_model_path;
+  std::string projectionPath = test_projection_path;
+  auto model = std::make_unique<LlamaModel>(
+      std::move(modelPath), std::move(projectionPath), std::move(cfg));
+  model->waitForLoadInitialization();
+  ASSERT_TRUE(model->isLoaded());
+
+  LlamaModel::Prompt prompt;
+  prompt.input =
+      std::string(R"([{"role":"user","type":"media","content":")") +
+      imagePath.generic_string() +
+      R"("},{"role":"user","content":"What is in this image? One word."}])";
+
+  std::vector<std::string> outputs;
+  ASSERT_NO_THROW({
+    outputs =
+        model->processPromptBatch(std::vector<LlamaModel::Prompt>{prompt});
+  });
+  ASSERT_EQ(outputs.size(), 1u);
+  EXPECT_FALSE(outputs[0].empty())
+      << "batch path-mode media produced no output: the per-slot driver "
+         "never loaded the image file";
+}
+
+/// A batch prompt may interleave a string-path media item and an inline
+/// `Uint8Array` byte media item. The per-slot MTMD driver loads media via the
+/// ordered plan, so each bitmap binds to its own marker in prompt-marker order
+/// rather than bytes-then-paths. Both images decode cleanly on their own, so
+/// the mixed-mode prompt is accepted and produces output. With the bug
+/// `preparePrefill` rejected any byte+path mix instead of preserving order.
+TEST_F(MtmdLlmContextTest, BatchPreservesMixedByteAndPathMediaOrder) {
+  if (!hasValidModel()) {
+    FAIL() << "Multimodal model or projection file not found";
+  }
+
+  // Resolve media/ whether the test binary runs from the package root or from
+  // build/test/unit (mirrors BaseTestModelPath's two-location model lookup).
+  fs::path mediaDir = "../../../media";
+  if (!fs::exists(mediaDir)) {
+    mediaDir = "media";
+  }
+  const fs::path pathImage = fs::absolute(mediaDir / "elephant.jpg");
+  const fs::path byteImage = fs::absolute(mediaDir / "fruitPlate.png");
+  ASSERT_TRUE(fs::exists(pathImage)) << pathImage.string();
+  ASSERT_TRUE(fs::exists(byteImage)) << byteImage.string();
+
+  std::ifstream byteStream(byteImage, std::ios::binary);
+  ASSERT_TRUE(byteStream) << "failed to open " << byteImage.string();
+  const std::vector<uint8_t> byteData(
+      (std::istreambuf_iterator<char>(byteStream)),
+      std::istreambuf_iterator<char>());
+  ASSERT_FALSE(byteData.empty());
+
+  auto cfg = config_files;
+  cfg["parallel"] = "2";
+  cfg["n_predict"] = "16";
+  std::string modelPath = test_model_path;
+  std::string projectionPath = test_projection_path;
+  auto model = std::make_unique<LlamaModel>(
+      std::move(modelPath), std::move(projectionPath), std::move(cfg));
+  model->waitForLoadInitialization();
+  ASSERT_TRUE(model->isLoaded());
+
+  // Path media item first, then a byte placeholder (empty content marks the
+  // hoisted `Uint8Array`), so the marker order is path, byte. The driver must
+  // load the path bitmap before the byte bitmap to match that order.
+  LlamaModel::Prompt prompt;
+  prompt.input =
+      std::string(R"([{"role":"user","type":"media","content":")") +
+      pathImage.generic_string() +
+      R"("},{"role":"user","type":"media","content":""},)"
+      R"({"role":"user","content":"What is in these images? One word."}])";
+  prompt.media.push_back(byteData);
+
+  std::vector<std::string> outputs;
+  ASSERT_NO_THROW({
+    outputs =
+        model->processPromptBatch(std::vector<LlamaModel::Prompt>{prompt});
+  });
+  ASSERT_EQ(outputs.size(), 1u);
+  EXPECT_FALSE(outputs[0].empty())
+      << "batch mixed byte+path media produced no output: the per-slot driver "
+         "never bound both bitmaps in prompt-marker order";
+}
+
 TEST_F(MtmdLlmContextTest, ProcessWithTools) {
   if (!hasValidModel()) {
     FAIL() << "Multimodal model or projection file not found";
@@ -592,4 +703,82 @@ TEST_F(MtmdLlmContextTest, ProcessWithMultipleTools) {
     auto stats = model->runtimeStats();
     EXPECT_GE(stats.size(), 0);
   });
+}
+
+/// `loadCache` may only restore a multimodal session when the GGSQ header
+/// carried all four `SessionMetadataField` values. The old gate accepted any
+/// `tokenCount > 1`, so a partial header (2 or 3 fields) was restored with
+/// `cacheTokens`/`firstMsgCacheTokens` defaulted to zero — which diverges from
+/// `nPast` under M-RoPE and corrupts later cap checks. An over-long layout
+/// (`> 4`) is equally unexpected. Only an exact four-field header is complete.
+TEST(MtmdSessionMetadataGate, AcceptsOnlyTheFullFourFieldContract) {
+  EXPECT_FALSE(mtmdSessionMetadataIsComplete(0));
+  EXPECT_FALSE(mtmdSessionMetadataIsComplete(1));
+  EXPECT_FALSE(mtmdSessionMetadataIsComplete(2));
+  EXPECT_FALSE(mtmdSessionMetadataIsComplete(3));
+  EXPECT_TRUE(mtmdSessionMetadataIsComplete(SESSION_METADATA_FIELD_COUNT));
+  EXPECT_FALSE(mtmdSessionMetadataIsComplete(SESSION_METADATA_FIELD_COUNT + 1));
+}
+
+TEST_F(MtmdLlmContextTest, RejectMediaMarkerWithoutBuffer) {
+  if (!hasValidModel()) {
+    FAIL() << "Multimodal model or projection file not found";
+  }
+
+  auto model = createModel();
+  if (!model) {
+    FAIL() << "Model failed to load";
+  }
+
+  // Prompt with an empty media marker (no path) but no buffer provided.
+  // The marker will be recorded by formatPrompt as MediaSource::ByteBuffer
+  // but prompt.media is empty, so loadMedia should fail with a validation
+  // error.
+  LlamaModel::Prompt prompt;
+  prompt.input =
+      R"([{"type": "media", "content": ""}, {"role": "user", "content": "What is this?"}])";
+  // prompt.media is empty - missing the buffer that the marker expects
+
+  EXPECT_THROW({ model->processPrompt(prompt); }, qvac_errors::StatusError);
+}
+
+/// Regression for review comment #3451899281. On the continuous-batching path
+/// the scheduler decodes generated tokens itself and reconciles the driver
+/// only through syncPosition(); cacheTokens is otherwise advanced solely by
+/// prefill/media eval. Each generated token is text and consumes exactly one
+/// KV cell, so syncPosition() must advance physical KV-cell usage in lockstep
+/// with the logical position. If it advances only the position, the per-slot
+/// KV-cell cap in onLogitsReady() keeps comparing against the frozen prefill
+/// count, and an M-RoPE slot (cacheTokens > pos) can generate past its budget.
+TEST_F(MtmdLlmContextTest, SyncPositionAdvancesKvCellsForGeneratedTokens) {
+  if (!hasValidModel()) {
+    FAIL() << "Multimodal model or projection file not found";
+  }
+  auto model = createModel();
+  ASSERT_NE(model, nullptr) << "Model failed to load";
+
+  LlmContext* ctx = LlamaModelTestPeer::llmContext(*model);
+  ASSERT_NE(ctx, nullptr);
+  auto* driver = dynamic_cast<SequenceDriver*>(ctx);
+  ASSERT_NE(driver, nullptr)
+      << "MTMD context must expose the SequenceDriver interface";
+
+  // Seed an M-RoPE prefill state where physical KV cells exceed logical
+  // positions, as media does (cacheTokens > pos).
+  constexpr llama_pos prefillPos = 10;
+  constexpr llama_pos prefillCells = 20;
+  ctx->setNPast(prefillPos);
+  ctx->setCacheTokens(prefillCells);
+  ASSERT_EQ(driver->getKvCellsUsed(), prefillCells);
+
+  // The scheduler feeds three generated text tokens, advancing the logical
+  // position 10 -> 13. Generated text is one KV cell per position.
+  constexpr llama_pos generated = 3;
+  driver->syncPosition(prefillPos + generated);
+
+  EXPECT_EQ(ctx->getNPast(), prefillPos + generated);
+  EXPECT_EQ(driver->getKvCellsUsed(), prefillCells + generated)
+      << "syncPosition advanced the logical position but not physical KV-cell "
+         "usage; onLogitsReady's per-slot KV-cell cap would be checked against "
+         "a frozen prefill count";
 }

--- a/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
+++ b/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
@@ -478,6 +478,83 @@ TEST_F(MtmdLlmContextTest, ProcessWithSessionCache) {
   });
 }
 
+/// `llama_state_seq_load_file` restores the sequence's KV before `loadCache`
+/// validates it. A throw after the restore must roll those cells back: the
+/// scheduler installs its per-slot cleanup guard only once `loadCache` returns,
+/// so an unguarded throw strands orphan KV on the slot. Mirrors the text path
+/// (`TextLlmContext::loadCache`) and `CacheManager::loadCache`.
+TEST_F(MtmdLlmContextTest, LoadCacheRollsBackRestoredKvOnPostRestoreFailure) {
+  if (!hasValidModel()) {
+    FAIL() << "Multimodal model or projection file not found";
+  }
+
+  auto model = createModel();
+  if (!model) {
+    FAIL() << "Model failed to load";
+  }
+
+  auto* base = LlamaModelTestPeer::llmContext(*model);
+  ASSERT_NE(base, nullptr);
+  auto* ctx = dynamic_cast<MtmdLlmContext*>(base);
+  ASSERT_NE(ctx, nullptr) << "single-prompt context for a VLM must be MTMD";
+  auto* lctx = model->getContext();
+  ASSERT_NE(lctx, nullptr);
+  const llama_seq_id seqId = ctx->getSeqId();
+
+  // Prefill a prompt so the sequence holds real KV cells we can persist.
+  LlamaModel::Prompt prompt;
+  prompt.input = R"([{"role": "user", "content": "Hello"}])";
+  prompt.prefill = true;
+  ASSERT_NO_THROW(model->processPrompt(prompt));
+  ASSERT_GT(ctx->getNPast(), 0);
+
+  // Persist the genuine KV but with a doctored NPast that exceeds the
+  // context window. All four metadata fields are present so the
+  // completeness gate passes and execution reaches the NPast bounds check.
+  const llama_token overflowNPast =
+      static_cast<llama_token>(llama_n_ctx(lctx)) + 1;
+  const llama_token plausible = static_cast<llama_token>(ctx->getNPast());
+  const llama_token sessionTokens[SESSION_METADATA_FIELD_COUNT] = {
+      overflowNPast, plausible, plausible, plausible};
+
+  const fs::path cachePath =
+      fs::temp_directory_path() / "qvac-mtmd-loadcache-rollback.bin";
+  fs::remove(cachePath);
+  const auto savedBytes = llama_state_seq_save_file(
+      lctx,
+      cachePath.string().c_str(),
+      seqId,
+      sessionTokens,
+      SESSION_METADATA_FIELD_COUNT);
+  ASSERT_GT(savedBytes, 0u);
+
+  // Clear the sequence so restoration is observable from a clean baseline.
+  ctx->resetState(true);
+  auto* mem = llama_get_memory(lctx);
+  ASSERT_NE(mem, nullptr);
+  ASSERT_EQ(llama_memory_seq_token_count(mem, seqId), 0u)
+      << "precondition: sequence KV must be empty before the failing load";
+
+  bool threw = false;
+  try {
+    (void)ctx->loadCache(cachePath.string(), 0);
+  } catch (const qvac_errors::StatusError&) {
+    threw = true;
+  }
+  EXPECT_TRUE(threw)
+      << "loadCache must reject a cache whose NPast exceeds the context size";
+
+  const uint32_t leakedCells = llama_memory_seq_token_count(mem, seqId);
+  SCOPED_TRACE("sequence KV cells after failed load: " +
+               std::to_string(leakedCells));
+  EXPECT_EQ(leakedCells, 0u)
+      << "loadCache restored KV then threw without rolling it back: the slot "
+         "leaks orphan KV cells. A ScopeGuard must clear the sequence on any "
+         "post-restore validation failure.";
+
+  fs::remove(cachePath);
+}
+
 TEST_F(MtmdLlmContextTest, InvalidMedia) {
   if (!hasValidModel()) {
     FAIL() << "Multimodal model or projection file not found";

--- a/packages/llm-llamacpp/test/unit/test_multi_request_batcher.cpp
+++ b/packages/llm-llamacpp/test/unit/test_multi_request_batcher.cpp
@@ -887,3 +887,297 @@ TEST_F(MultiRequestBatcherTest, MarkAllFinishedWithDecodeError) {
   EXPECT_EQ(finished[0].stopReason, StopReason::DecodeError);
   EXPECT_EQ(finished[1].stopReason, StopReason::DecodeError);
 }
+
+TEST(MediaBarrierRequestTest, BarrierGatesFeedingAndCountsPositions) {
+  constexpr unsigned kMaxTokens = 100;
+  constexpr llama_pos kMediaPos = 4;
+  PrefillPlan plan{
+      .tokens = {10, 20, 30},
+      .mediaBarriers = {
+          {.afterTextTokens = 1, .mediaIndex = 7, .nPos = kMediaPos}}};
+  Request req(0, std::move(plan), kMaxTokens);
+
+  EXPECT_EQ(req.prefillTokenCount, 3u + static_cast<size_t>(kMediaPos));
+  EXPECT_FALSE(req.isAwaitingMedia());
+  EXPECT_TRUE(req.hasTokensToFeed());
+  EXPECT_EQ(req.remainingToFeed(), 1u);
+
+  req.prefillFedCount = 1;
+  req.currentPos = 1;
+  EXPECT_TRUE(req.isAwaitingMedia());
+  EXPECT_FALSE(req.hasTokensToFeed());
+  EXPECT_EQ(req.remainingToFeed(), 0u);
+  EXPECT_FALSE(req.isPrefillComplete());
+
+  // Pre-barrier chunk must never carry logits even though it drains
+  // remainingToFeed.
+  req.prefillFedCount = 0;
+  EXPECT_FALSE(req.chunkConsumesAllUnfed(1));
+}
+
+TEST(MediaBarrierRequestTest, AddRequestAtValidatesPlan) {
+  constexpr unsigned kMaxChunkSize = 8;
+  constexpr unsigned kMaxTokensPerSeq = 10;
+  constexpr size_t kBatchSize = 1;
+  MultiRequestBatcher batcher(kMaxChunkSize, kMaxTokensPerSeq, kBatchSize);
+
+  PrefillPlan unsorted{
+      .tokens = {1, 2, 3},
+      .mediaBarriers = {
+          {.afterTextTokens = 2, .mediaIndex = 0, .nPos = 2},
+          {.afterTextTokens = 1, .mediaIndex = 1, .nPos = 2}}};
+  EXPECT_EQ(
+      batcher.addRequestAt(0, std::move(unsorted)),
+      MultiRequestBatcher::AddStatus::ErrInvalidPlan);
+
+  PrefillPlan anchorPastEnd{
+      .tokens = {1, 2},
+      .mediaBarriers = {{.afterTextTokens = 3, .mediaIndex = 0, .nPos = 2}}};
+  EXPECT_EQ(
+      batcher.addRequestAt(0, std::move(anchorPastEnd)),
+      MultiRequestBatcher::AddStatus::ErrInvalidPlan);
+
+  // Media positions count against the per-sequence cap: 6 text + 5 media
+  // > 10.
+  PrefillPlan oversized{
+      .tokens = {1, 2, 3, 4, 5, 6},
+      .mediaBarriers = {{.afterTextTokens = 1, .mediaIndex = 0, .nPos = 5}}};
+  EXPECT_EQ(
+      batcher.addRequestAt(0, std::move(oversized)),
+      MultiRequestBatcher::AddStatus::ErrTokensTooLarge);
+
+  PrefillPlan fits{
+      .tokens = {1, 2, 3, 4, 5},
+      .mediaBarriers = {{.afterTextTokens = 1, .mediaIndex = 0, .nPos = 5}}};
+  EXPECT_EQ(
+      batcher.addRequestAt(0, std::move(fits)),
+      MultiRequestBatcher::AddStatus::Ok);
+}
+
+/// M-RoPE media occupies fewer positions than KV cells. A plan whose
+/// position span fits the per-sequence cap can still overrun the KV cache,
+/// so admission must reject when the KV-cell total exceeds the cap even
+/// though the position total does not.
+TEST(MediaBarrierRequestTest, AddRequestAtRejectsKvCellOverflow) {
+  constexpr unsigned kMaxChunkSize = 8;
+  constexpr unsigned kMaxTokensPerSeq = 10;
+  constexpr size_t kBatchSize = 1;
+  MultiRequestBatcher batcher(kMaxChunkSize, kMaxTokensPerSeq, kBatchSize);
+
+  // 3 text + 2 media positions = 5 <= 10, but 3 text + 9 media KV cells =
+  // 12 > 10. Positions-only admission would wrongly accept this.
+  PrefillPlan kvOverflow{
+      .tokens = {1, 2, 3},
+      .mediaBarriers = {
+          {.afterTextTokens = 1, .mediaIndex = 0, .nPos = 2, .nKvTokens = 9}}};
+  EXPECT_EQ(kvOverflow.totalPositions(), 5);
+  EXPECT_EQ(kvOverflow.totalKvTokens(), 12);
+  EXPECT_EQ(
+      batcher.addRequestAt(0, std::move(kvOverflow)),
+      MultiRequestBatcher::AddStatus::ErrTokensTooLarge);
+}
+
+/// A cache-loaded M-RoPE sequence restores more physical KV cells
+/// (`cacheTokens`) than logical positions (`nPast`). Admission must size the
+/// KV-cap check from the cell count, not the position count: a sequence whose
+/// loaded cells sit near the cap can still be wrongly admitted if the check
+/// measures from `initialPos` (comment-3437045337).
+TEST(MediaBarrierRequestTest, AddRequestAtUsesKvCellsNotPositionsForCap) {
+  constexpr unsigned kMaxChunkSize = 8;
+  constexpr unsigned kMaxTokensPerSeq = 10;
+  constexpr size_t kBatchSize = 1;
+  MultiRequestBatcher batcher(kMaxChunkSize, kMaxTokensPerSeq, kBatchSize);
+
+  // Restored cache: nPast (positions) = 2 but cacheTokens (cells) = 8.
+  // Appending 3 text tokens keeps positions at 2 + 3 = 5 <= 10, but the
+  // physical cells reach 8 + 3 = 11 > 10 and overrun the slot's KV cache.
+  PrefillPlan plan{.tokens = {1, 2, 3}};
+  EXPECT_EQ(plan.totalPositions(), 3);
+  EXPECT_EQ(plan.totalKvTokens(), 3);
+  EXPECT_EQ(
+      batcher.addRequestAt(
+          0,
+          std::move(plan),
+          /*initialPos=*/2,
+          /*slideCapable=*/false,
+          /*initialKvCells=*/8),
+      MultiRequestBatcher::AddStatus::ErrTokensTooLarge)
+      << "KV-CELL CAP HOLE: 8 loaded KV cells + 3 prompt tokens = 11 > "
+      << kMaxTokensPerSeq
+      << ", but admission sized the KV-cap check from the 2 logical positions "
+         "(2 + 3 = 5) and admitted the request";
+}
+
+/// Full prefill flow with a mid-prompt media barrier:
+/// feed text up to the barrier → slot blocks → completeMediaBarrier
+/// resumes at the helper-provided position → trailing text carries the
+/// prompt's only logits and fires onPrefillComplete.
+TEST(MediaBarrierFlowTest, BarrierBlocksThenResumesAtNewPosition) {
+  constexpr unsigned kMaxChunkSize = 8;
+  constexpr unsigned kMaxTokensPerSeq = 100;
+  constexpr size_t kBatchSize = 1;
+  constexpr llama_pos kMediaPos = 4;
+  MultiRequestBatcher batcher(kMaxChunkSize, kMaxTokensPerSeq, kBatchSize);
+  LlamaBatch batch(kMaxChunkSize, 0, kBatchSize);
+
+  PrefillPlan plan{
+      .tokens = {10, 20, 30},
+      .mediaBarriers = {
+          {.afterTextTokens = 1, .mediaIndex = 7, .nPos = kMediaPos}}};
+  ASSERT_EQ(
+      batcher.addRequestAt(0, std::move(plan)),
+      MultiRequestBatcher::AddStatus::Ok);
+
+  EXPECT_FALSE(batcher.nextAwaitingMedia().has_value());
+
+  auto result = batcher.fillBatch(batch);
+  EXPECT_EQ(result.chunkSize, 1u);
+  EXPECT_EQ(result.numActiveSequences, 1u);
+  EXPECT_EQ((*batch).token[0], 10);
+  EXPECT_EQ((*batch).logits[0], 0) << "pre-barrier token must not get logits";
+  batcher.advance(result.chunkSize);
+
+  const auto awaiting = batcher.nextAwaitingMedia();
+  ASSERT_TRUE(awaiting.has_value());
+  EXPECT_EQ(awaiting->seqId, 0u);
+  EXPECT_EQ(awaiting->mediaIndex, 7u);
+  EXPECT_EQ(awaiting->currentPos, 1);
+
+  // While awaiting media the slot must not feed.
+  result = batcher.fillBatch(batch);
+  EXPECT_EQ(result.chunkSize, 0u);
+
+  bool prefillCompleted = false;
+  EXPECT_TRUE(batcher.completeMediaBarrier(
+      0, awaiting->currentPos + kMediaPos, [&](uint32_t, llama_pos, size_t) {
+        prefillCompleted = true;
+      }));
+  EXPECT_FALSE(prefillCompleted);
+  EXPECT_FALSE(batcher.nextAwaitingMedia().has_value());
+
+  llama_pos completedPos = -1;
+  size_t completedCount = 0;
+  result = batcher.fillBatch(batch);
+  EXPECT_EQ(result.chunkSize, 2u);
+  EXPECT_EQ((*batch).token[0], 20);
+  EXPECT_EQ((*batch).token[1], 30);
+  EXPECT_EQ((*batch).pos[0], 1 + kMediaPos);
+  EXPECT_EQ((*batch).logits[1], 1) << "prompt end must carry logits";
+  batcher.advance(result.chunkSize, [&](uint32_t, llama_pos pos, size_t count) {
+    completedPos = pos;
+    completedCount = count;
+  });
+  EXPECT_EQ(completedPos, 1 + kMediaPos + 2);
+  EXPECT_EQ(completedCount, 3u + static_cast<size_t>(kMediaPos));
+}
+
+/// A media-blocked slot must not stall other slots: the text slot keeps
+/// feeding while the media slot waits for its barrier.
+TEST(MediaBarrierFlowTest, AwaitingMediaSlotDoesNotStallTextSlot) {
+  constexpr unsigned kMaxChunkSize = 8;
+  constexpr unsigned kMaxTokensPerSeq = 100;
+  constexpr size_t kBatchSize = 2;
+  MultiRequestBatcher batcher(kMaxChunkSize, kMaxTokensPerSeq, kBatchSize);
+  LlamaBatch batch(kMaxChunkSize * kBatchSize, 0, kBatchSize);
+
+  // Media-first prompt: the barrier anchors at token 0, so the slot is
+  // blocked from the start.
+  PrefillPlan mediaFirst{
+      .tokens = {50, 60},
+      .mediaBarriers = {{.afterTextTokens = 0, .mediaIndex = 0, .nPos = 3}}};
+  ASSERT_EQ(
+      batcher.addRequestAt(0, std::move(mediaFirst)),
+      MultiRequestBatcher::AddStatus::Ok);
+  ASSERT_EQ(
+      batcher.addRequestAt(1, {100, 200, 300}),
+      MultiRequestBatcher::AddStatus::Ok);
+
+  auto result = batcher.fillBatch(batch);
+  EXPECT_EQ(result.numActiveSequences, 1u)
+      << "media-blocked slot must be excluded from the fill";
+  EXPECT_EQ(result.chunkSize, 3u);
+  EXPECT_EQ((*batch).seq_id[0][0], 1);
+
+  const auto awaiting = batcher.nextAwaitingMedia();
+  ASSERT_TRUE(awaiting.has_value());
+  EXPECT_EQ(awaiting->seqId, 0u);
+  EXPECT_EQ(awaiting->currentPos, 0);
+
+  batcher.advance(result.chunkSize);
+  EXPECT_TRUE(batcher.completeMediaBarrier(0, 3));
+
+  result = batcher.fillBatch(batch);
+  EXPECT_EQ(result.numActiveSequences, 1u);
+  EXPECT_EQ(result.chunkSize, 2u);
+  EXPECT_EQ((*batch).seq_id[0][0], 0);
+  EXPECT_EQ((*batch).pos[0], 3);
+}
+
+/// A prefill that ends on a media barrier (prefill-only requests) must
+/// complete through completeMediaBarrier, not advance().
+TEST(MediaBarrierFlowTest, TrailingBarrierCompletesPrefill) {
+  constexpr unsigned kMaxChunkSize = 8;
+  constexpr unsigned kMaxTokensPerSeq = 100;
+  constexpr size_t kBatchSize = 1;
+  MultiRequestBatcher batcher(kMaxChunkSize, kMaxTokensPerSeq, kBatchSize);
+  LlamaBatch batch(kMaxChunkSize, 0, kBatchSize);
+
+  PrefillPlan plan{
+      .tokens = {10},
+      .mediaBarriers = {{.afterTextTokens = 1, .mediaIndex = 0, .nPos = 2}}};
+  ASSERT_EQ(
+      batcher.addRequestAt(0, std::move(plan)),
+      MultiRequestBatcher::AddStatus::Ok);
+
+  auto result = batcher.fillBatch(batch);
+  EXPECT_EQ(result.chunkSize, 1u);
+  batcher.advance(result.chunkSize);
+
+  bool prefillCompleted = false;
+  ASSERT_TRUE(batcher.nextAwaitingMedia().has_value());
+  EXPECT_TRUE(batcher.completeMediaBarrier(
+      0, 3, [&](uint32_t, llama_pos pos, size_t count) {
+        prefillCompleted = true;
+        EXPECT_EQ(pos, 3);
+        EXPECT_EQ(count, 3u);
+      }));
+  EXPECT_TRUE(prefillCompleted);
+
+  const Request* req = batcher.requestAt(0);
+  ASSERT_NE(req, nullptr);
+  EXPECT_TRUE(req->isPrefillComplete());
+}
+
+/// Consecutive media items (two barriers at the same anchor) are
+/// serviced one at a time, in plan order.
+TEST(MediaBarrierFlowTest, ConsecutiveBarriersServicedInOrder) {
+  constexpr unsigned kMaxChunkSize = 8;
+  constexpr unsigned kMaxTokensPerSeq = 100;
+  constexpr size_t kBatchSize = 1;
+  MultiRequestBatcher batcher(kMaxChunkSize, kMaxTokensPerSeq, kBatchSize);
+
+  PrefillPlan plan{
+      .tokens = {10},
+      .mediaBarriers = {
+          {.afterTextTokens = 0, .mediaIndex = 0, .nPos = 2},
+          {.afterTextTokens = 0, .mediaIndex = 1, .nPos = 3}}};
+  ASSERT_EQ(
+      batcher.addRequestAt(0, std::move(plan)),
+      MultiRequestBatcher::AddStatus::Ok);
+
+  auto awaiting = batcher.nextAwaitingMedia();
+  ASSERT_TRUE(awaiting.has_value());
+  EXPECT_EQ(awaiting->mediaIndex, 0u);
+  EXPECT_TRUE(batcher.completeMediaBarrier(0, 2));
+
+  awaiting = batcher.nextAwaitingMedia();
+  ASSERT_TRUE(awaiting.has_value());
+  EXPECT_EQ(awaiting->mediaIndex, 1u);
+  EXPECT_EQ(awaiting->currentPos, 2);
+  EXPECT_TRUE(batcher.completeMediaBarrier(0, 5));
+
+  EXPECT_FALSE(batcher.nextAwaitingMedia().has_value());
+  const Request* req = batcher.requestAt(0);
+  ASSERT_NE(req, nullptr);
+  EXPECT_EQ(req->remainingToFeed(), 1u);
+}

--- a/packages/llm-llamacpp/test/unit/test_runtime_stats.cpp
+++ b/packages/llm-llamacpp/test/unit/test_runtime_stats.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -120,6 +121,50 @@ TEST(RuntimeStatsAccumulate, AccumulateSlotResetClearsThinkingDiscards) {
 
   stats.reset();
   EXPECT_EQ(stats.thinkingBlockDiscards, 0);
+}
+
+// promptTokens must reflect tokens ACTUALLY prefilled, not the prompt size
+// planned at admission. Every termination path (including cancelSlotLocked)
+// funnels through accumulateSlot, so a request cancelled before any prefill
+// step ran must contribute zero prompt tokens -- otherwise the documented
+// `cacheTokens ~= promptTokens + generatedTokens` invariant breaks (cacheTokens
+// comes from the real nPast, here 0).
+TEST(RuntimeStatsAccumulate, CancelBeforePrefillCountsZeroPromptTokens) {
+  constexpr unsigned maxTokens = 256;
+  std::vector<llama_token> prompt(42, 1);
+  Request req(/*rid=*/0, std::move(prompt), maxTokens);
+  // Admission fixed the planned prompt size, but no prefill step has fed any
+  // token yet, so the request is not prefill-complete.
+  ASSERT_EQ(req.prefillTokenCount, 42U);
+  ASSERT_EQ(req.prefillFedCount, 0U);
+  ASSERT_FALSE(req.isPrefillComplete());
+
+  RuntimeStatsSnapshot stats;
+  // Same call the cancel path makes via accumulateSlotRuntimeStats: nothing
+  // was processed, so nPast and the generated vector are empty.
+  stats.accumulateSlot(/*nPast=*/0, /*nSlides=*/0, /*thinkingDiscards=*/0, req);
+
+  EXPECT_EQ(stats.promptTokens, 0);
+}
+
+// A request that completed prefill (normal completion, or a cancel after the
+// first generated token) must still report the full planned prompt: prefill
+// resets prefillFedCount to 0 once complete, so the honest count comes from
+// prefillTokenCount in that case.
+TEST(RuntimeStatsAccumulate, CompletedPrefillCountsFullPrompt) {
+  constexpr unsigned maxTokens = 256;
+  std::vector<llama_token> prompt(42, 1);
+  Request req(/*rid=*/0, std::move(prompt), maxTokens);
+  // Simulate prefill having fed every token: finishPrefillIfComplete clears the
+  // pending tokens and resets prefillFedCount to 0 once complete.
+  req.pendingPrefillTokens.clear();
+  req.prefillFedCount = 0;
+  ASSERT_TRUE(req.isPrefillComplete());
+
+  RuntimeStatsSnapshot stats;
+  stats.accumulateSlot(/*nPast=*/42, /*nSlides=*/0, /*thinkingDiscards=*/0, req);
+
+  EXPECT_EQ(stats.promptTokens, 42);
 }
 
 } // namespace

--- a/packages/llm-llamacpp/test/unit/test_runtime_stats.cpp
+++ b/packages/llm-llamacpp/test/unit/test_runtime_stats.cpp
@@ -162,7 +162,8 @@ TEST(RuntimeStatsAccumulate, CompletedPrefillCountsFullPrompt) {
   ASSERT_TRUE(req.isPrefillComplete());
 
   RuntimeStatsSnapshot stats;
-  stats.accumulateSlot(/*nPast=*/42, /*nSlides=*/0, /*thinkingDiscards=*/0, req);
+  stats.accumulateSlot(
+      /*nPast=*/42, /*nSlides=*/0, /*thinkingDiscards=*/0, req);
 
   EXPECT_EQ(stats.promptTokens, 42);
 }

--- a/packages/llm-llamacpp/test/unit/test_runtime_stats.cpp
+++ b/packages/llm-llamacpp/test/unit/test_runtime_stats.cpp
@@ -88,7 +88,8 @@ TEST(RuntimeStatsRates, ResetClearsRates) {
 // reads (`generatedTokens.size()` and `prefillTokenCount` — both zero
 // here because we're isolating the `thinkingDiscards` aggregation).
 Request makeStubRequest() {
-  return Request(/*rid=*/0, /*toks=*/{}, /*maxTokens=*/0);
+  return Request(
+      /*rid=*/0, /*toks=*/std::vector<llama_token>{}, /*maxTokens=*/0);
 }
 
 // `thinkingDiscards` is the per-slot count of compacted reasoning blocks

--- a/packages/llm-llamacpp/test/unit/test_slide_capable_capability.cpp
+++ b/packages/llm-llamacpp/test/unit/test_slide_capable_capability.cpp
@@ -1,0 +1,103 @@
+// slideCapable must be driver-aware. A multimodal slot never slides its
+// KV-cache window (it holds media cells fixed), so the scheduler must keep
+// the per-slot token cap enforced for it. A text slot slides, so it may
+// touch the cap and recover. This guards the scheduler decision feeding
+// Request::slideCapable / Request::exceededLimit.
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/ContinuousBatchScheduler.hpp"
+#include "model-interface/MultiRequestBatcher.hpp"
+#include "model-interface/SequenceDriver.hpp"
+
+namespace {
+
+using qvac_lib_inference_addon_llama::batching::computeSlideCapable;
+using qvac_lib_inference_addon_llama::batching::Request;
+
+/// SequenceDriver stub whose only meaningful behavior is supportsSliding.
+/// Every other method is an inert stub.
+class SlideCapabilityDriver : public SequenceDriver {
+public:
+  explicit SlideCapabilityDriver(bool slides) : slides_(slides) {}
+
+  [[nodiscard]] llama_pos getNPast() const override { return 0; }
+  [[nodiscard]] int32_t getNSlides() const override { return 0; }
+  [[nodiscard]] bool supportsSliding() const override { return slides_; }
+  void validatePromptPolicy(
+      const std::vector<common_chat_msg>&, const std::vector<common_chat_tool>&,
+      const PromptLayout&, bool) const override {}
+  PrefillPlan preparePrefill(
+      const std::vector<common_chat_msg>&, const std::vector<common_chat_tool>&,
+      const std::vector<std::vector<uint8_t>>&,
+      const std::vector<PlannedMedia>&, bool, bool) override {
+    return {};
+  }
+  void onPrefillComplete(llama_pos, size_t) override {}
+  void syncPosition(llama_pos) override {}
+  SequenceStepResult onLogitsReady(
+      int, unsigned, const std::function<void(const std::string&)>&,
+      LlamaBatch*) override {
+    return {};
+  }
+  void onSequenceEnd(const std::function<void(const std::string&)>&) override {}
+  void onGenerationFinished(
+      const std::function<void(const std::string&)>&) override {}
+  void onCancel(const std::function<void(const std::string&)>&) override {}
+  [[nodiscard]] bool loadCache(const std::string&, llama_pos) override {
+    return false;
+  }
+  void saveCache(const std::string&) const override {}
+
+private:
+  bool slides_;
+};
+
+/// Build a generating request that has reached its per-slot ceiling and ask
+/// exceededLimit whether the slot is capped.
+bool slotCappedAtCeiling(bool slideCapable) {
+  constexpr unsigned maxTokens = 2;
+  Request req(
+      0,
+      std::vector<llama_token>{100},
+      maxTokens,
+      /*initialPos=*/0,
+      slideCapable);
+  req.prefillFedCount = 1;
+  req.generatedTokens.push_back(200);
+  req.currentPos = static_cast<llama_pos>(maxTokens);
+  return req.exceededLimit();
+}
+
+} // namespace
+
+/// A multimodal driver does not slide, so the scheduler must NOT grant it a
+/// cap waiver even with sliding configured and a generation step. The slot
+/// must stay capped at the ceiling; otherwise its position runs away
+/// unbounded (the bug).
+TEST(SlideCapableCapability, MtmdSlotIsNotSlideCapableAndStaysCapped) {
+  SlideCapabilityDriver mtmd(/*slides=*/false);
+  const bool slideCapable =
+      computeSlideCapable(mtmd, /*slideConfigured=*/true, /*isPrefill=*/false);
+
+  EXPECT_FALSE(slideCapable)
+      << "a driver that cannot slide must not be granted a cap waiver";
+  EXPECT_TRUE(slotCappedAtCeiling(slideCapable))
+      << "a non-sliding slot at its ceiling must be capped; instead it was "
+         "left alive expecting a slide that never happens, so its position "
+         "advances past the per-slot cap unbounded";
+}
+
+/// A text driver slides, so with sliding configured during generation it may
+/// touch the cap and recover on the next step.
+TEST(SlideCapableCapability, TextSlotIsSlideCapableWhenConfigured) {
+  SlideCapabilityDriver text(/*slides=*/true);
+  const bool slideCapable =
+      computeSlideCapable(text, /*slideConfigured=*/true, /*isPrefill=*/false);
+
+  EXPECT_TRUE(slideCapable);
+  EXPECT_FALSE(slotCappedAtCeiling(slideCapable));
+}


### PR DESCRIPTION
## What this does

Extends continuous batching to multimodal (vision) models. See previous text-only PR https://github.com/tetherto/qvac/pull/2327

## Architecture

`ContinuousBatchScheduler` no longer names any concrete driver type. Driver selection moved into the model layer via `DriverFactory` (`std::function<std::unique_ptr<SequenceDriver>(const common_params&, ToolsCompactController&, uint32_t, llama_pos)>`), a required constructor argument validated at build time.

`buildDriverFactory()` in `LlamaModel.cpp` is the single decision point: if `LlmContext::visionContext()` returns a non-null `mtmd_context*`, it builds `MtmdLlmContext`; otherwise `TextLlmContext`. No `dynamic_cast`, no `isTextLlm_` check in the scheduler.

`DriverFactory` (`using DriverFactory = std::function<std::unique_ptr<SequenceDriver>(...)>`) is the seam that keeps `ContinuousBatchScheduler` decoupled from concrete context types. It is a plain `std::function` typedef — not a subclass hierarchy. At model-load time, `LlamaModel` assigns one of two lambdas: text-only models leave it empty and the scheduler fills in a default that constructs `TextLlmContext`; multimodal models assign a lambda that captures the shared `mtmd_context*` vision handle and constructs `MtmdLlmContext` per slot. The scheduler only ever calls the factory at admission time and receives a `SequenceDriver*` — the concrete type is fully hidden.


`MtmdLlmContext` gets a second constructor for per-slot use. Instead of owning its own mmproj, the per-slot variant captures the model-level `mtmd_context*` (which outlives the scheduler through `ReloadableState`'s declaration order).

Media evaluation is sequenced via `PrefillPlan` (replaces `std::vector<llama_token>` from `preparePrefill`). The plan carries text tokens plus `MediaBarrier` entries; `MultiRequestBatcher` pauses a slot at each barrier until the scheduler calls `serviceNextMediaSegmentLocked()`, which unlocks the mutex around the heavy eval. A failing eval only cancels that slot's group via `failSlotLocked()`, leaving other slots running.

Three internal refactors came with this: `clearSeqKv()` extracted from six inline lambda copies, `drainFinishedLocked()` extracted from two `stepLocked()` call sites, and `isMultiBatchActivated()` no longer gated on `isTextLlm_`.

## Testing

C++ unit tests (`test_continuous_batching_integration.cpp`): single/two/four-prompt text batches for correctness and concurrency reporting; overlapping batch submission (second batch admitted before first finishes); the `setEvalMediaFuncForTesting()` seam used to inject a throwing stub, verifying that `serviceNextMediaSegmentLocked()` catches it, cancels only the offending slot's group, and leaves other slots running; `TextLlmContext` output asserted in a mixed-slot batch.

JS integration tests (`continuous-batching.test.js`): image-only batch against SmolVLM2-500M checking correct descriptions and `avgConcurrentSeq > 1.5`; mixed image+text batch verifying all slot types complete correctly, with wall TPS measured against a single-shot baseline.

## Change-log

### Added

- Multimodal (vision) model support in continuous batching: vision models now enter the batch scheduler via a new `DriverFactory` pattern that decouples the scheduler from concrete context types. Admits multiple prompts containing images and text.
- `PrefillPlan` for sequencing media evaluation: prefill stream now carries text tokens plus `MediaBarrier` entries. The scheduler pauses slots at barriers and evaluates media between batch steps, allowing other slots to progress while vision processing is underway.
- `SequenceDriver` abstraction: `MtmdLlmContext` and `TextLlmContext` now both implement a common interface, enabling the scheduler to work with any driver type without hardcoded multimodal checks.

### Fixed

- Isolated media-evaluation failures to the offending slot's request group, preventing cascade cancellations when vision processing fails mid-batch.
- Improved KV-cell accounting for media slots in overlapping batch admissions.
- Fixed Windows path serialization in JSON by using `generic_string()` instead of `string()` (forward slashes instead of backslashes).

### Changed

- `BatchPrompt.prompt` now accepts any `Message` type (previously text-only), enabling multimodal batches.
- `ContinuousBatchScheduler` no longer imports or references concrete context types; driver selection fully delegated to the model layer.
- Consolidated sequence KV cleanup into a single `clearSeqKv()` helper, eliminating six inline copies across slot-teardown paths.

### Pull Requests

- [#2543](https://github.com/tetherto/qvac/pull/2543) - QVAC-19983: Continuous Batching (Single-job MTMD)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215365192644929