### PR TITLE
DO NOT MERGE: bci-whispercpp GPU device-farm validation (OpenCL/Vulkan on Pixel 9 Mali + S25 Adreno)

### DIFF
--- a/packages/bci-whispercpp/test/integration/gpu-smoke.test.js
+++ b/packages/bci-whispercpp/test/integration/gpu-smoke.test.js
@@ -1,0 +1,223 @@
+'use strict'
+
+// DO-NOT-MERGE device-farm GPU validation for @qvac/bci-whispercpp.
+//
+// On the AWS Device Farm dual-flagship run this asserts bci engages a real GPU
+// backend and transcribes correctly on each device — naturally OpenCL on the
+// Samsung S25 Ultra (Adreno) and Vulkan on the Pixel 9 (Mali-G715) — and it
+// force-loads OpenCL even on the non-Adreno Mali GPU so the run REPORTS whether
+// OpenCL actually engages there. Expected: on Mali, OpenCL is rejected at
+// ggml_cl2_init (not an Adreno/Intel/AMD-64-wide device) and bci falls back to
+// Vulkan; the rejection reason lands in logcat. Modelled on
+// packages/tts-ggml/test/integration/gpu-smoke.test.js + bci's verify-gpu.js.
+//
+// backendDevice: 0=CPU, 1=GPU. backendId: 0=CPU,1=Metal,2=CUDA,3=Vulkan,
+// 4=OpenCL,99=other (BCIModel.cpp backendIdFromRegName). Both surface via
+// opts:{stats:true} -> response.stats.
+//
+// Env: QVAC_BCI_GPU_SMOKE_RELAX=1 downgrades the strict GPU gate to a warning
+// (host without a real GPU); NO_GPU=true skips the GPU case entirely.
+
+const fs = require('bare-fs')
+const os = require('bare-os')
+
+// OpenCL-on-Mali force-load attempt. ggml registers backends once per process
+// inside the first bci.load(), reading these via getenv — so set them at module
+// top, before any model loads. No-op on Adreno (OpenCL loads there anyway); on
+// Mali this makes ggml attempt (and log) the OpenCL device init it would
+// otherwise skip. Guarded in case the bare-os build predates setEnv.
+const HAS_SET_ENV = typeof os.setEnv === 'function'
+if (HAS_SET_ENV) {
+  os.setEnv('GGML_OPENCL_FORCE_LOAD', '1')
+  os.setEnv('GGML_OPENCL_ALLOW_UNKNOWN_GPU', '1')
+}
+
+const test = require('brittle')
+const BCIWhispercpp = require('../../index')
+const { getTestPaths, getModelPath, computeWER, detectPlatform } = require('./helpers')
+const { flattenSegments } = require('@qvac/bci-whispercpp/util')
+
+const PLAT = detectPlatform()
+const platform = PLAT.platform
+const { manifest, getSamplePath } = getTestPaths()
+
+const MODEL_PATH = (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
+  getModelPath('ggml-bci-windowed.bin')
+const hasModel = fs.existsSync(MODEL_PATH)
+const hasSamples = manifest.samples && manifest.samples.length > 0
+
+const RELAX = os.hasEnv('QVAC_BCI_GPU_SMOKE_RELAX') && os.getEnv('QVAC_BCI_GPU_SMOKE_RELAX') === '1'
+const NO_GPU = os.hasEnv('NO_GPU') && os.getEnv('NO_GPU') === 'true'
+
+// DO-NOT-MERGE validation: this exercises the AWS Device Farm Android GPUs
+// (Adreno + Mali). Skip on desktop/iOS CI (GPU-less runners would fail the
+// strict GPU assertion). Android device-farm devices always have a real GPU.
+const NOT_ON_DEVICE = platform !== 'android'
+
+function backendIdToName (id) {
+  switch (id) {
+    case 0: return 'CPU'
+    case 1: return 'Metal'
+    case 2: return 'CUDA'
+    case 3: return 'Vulkan'
+    case 4: return 'OpenCL'
+    case 99: return 'other-GPU'
+    default: return 'unknown(' + id + ')'
+  }
+}
+
+function envVal (name) {
+  return os.hasEnv(name) ? os.getEnv(name) : '(unset)'
+}
+
+// Platforms that wire up a GPU backend for bci today: android (opencl+vulkan),
+// linux/win (vulkan), darwin/ios (metal).
+function expectsGpu () {
+  return platform === 'darwin' || platform === 'ios' ||
+         platform === 'linux' || platform === 'win32' || platform === 'android'
+}
+
+function bciConfigFor (sample) {
+  return typeof sample?.day_idx === 'number' ? { day_idx: sample.day_idx } : undefined
+}
+
+function makeBci (useGpu, sample, gpuDevice) {
+  return new BCIWhispercpp({
+    files: { model: MODEL_PATH },
+    opts: { stats: true }
+  }, {
+    contextParams: { use_gpu: useGpu, gpu_device: typeof gpuDevice === 'number' ? gpuDevice : 0 },
+    whisperConfig: { language: 'en', temperature: 0.0 },
+    miscConfig: { caption_enabled: false },
+    bciConfig: bciConfigFor(sample)
+  })
+}
+
+function logEnv (t) {
+  t.comment('[BCI/setup] platform=' + PLAT.label + ' os.setEnv=' + HAS_SET_ENV)
+  t.comment('[BCI/setup] GGML_OPENCL_FORCE_LOAD=' + envVal('GGML_OPENCL_FORCE_LOAD') +
+    ' GGML_OPENCL_ALLOW_UNKNOWN_GPU=' + envVal('GGML_OPENCL_ALLOW_UNKNOWN_GPU'))
+}
+
+function logBackend (t, tag, stats, text, wer) {
+  t.comment(tag + ' backendDevice=' + stats.backendDevice + ' backendId=' + stats.backendId +
+    ' (' + backendIdToName(stats.backendId) + ')')
+  t.comment(tag + ' gpuMemTotalMb=' + stats.gpuMemTotalMb + ' gpuMemFreeMb=' + stats.gpuMemFreeMb)
+  t.comment(tag + ' WER=' + (wer * 100).toFixed(1) + '%  text="' + text + '"')
+  t.comment(tag + ' stats=' + JSON.stringify(stats))
+}
+
+test('[BCI] GPU smoke - use_gpu=true must engage a GPU backend and transcribe', {
+  timeout: 600000,
+  skip: !hasModel || !hasSamples || NO_GPU || NOT_ON_DEVICE
+}, async (t) => {
+  logEnv(t)
+  const sample = manifest.samples[0]
+  const samplePath = getSamplePath(sample.file)
+  t.ok(fs.existsSync(samplePath), 'Fixture ' + sample.file + ' must exist')
+
+  const bci = makeBci(true, sample)
+  try {
+    await bci.load()
+    const response = await bci.transcribeFile(samplePath)
+    const output = await response.await()
+    const text = flattenSegments(output).map(s => s.text).join('').trim()
+    const stats = response.stats || {}
+    const dev = stats.backendDevice
+    const id = stats.backendId
+    const name = backendIdToName(id)
+    const wer = computeWER(text, sample.expected_text)
+
+    logBackend(t, '[BCI/GPU]', stats, text, wer)
+    // The OpenCL-on-Mali answer: OpenCL(4) = engaged (expected on Adreno);
+    // anything else on android = OpenCL not engaged (expected on Mali, see logcat).
+    if (platform === 'android') {
+      t.comment(id === 4
+        ? '[BCI/OpenCL] OpenCL ENGAGED on this device (backendId=4)'
+        : '[BCI/OpenCL] OpenCL NOT engaged on this device -> ' + name + ' (force-load attempted; see logcat for the ggml_cl2_init reason)')
+    }
+
+    t.ok(typeof text === 'string' && text.length > 0, '[BCI/GPU] produced a transcription')
+    t.ok(wer < 0.5, '[BCI/GPU] WER below 50% (got ' + (wer * 100).toFixed(1) + '%)')
+
+    if (!expectsGpu()) {
+      t.is(dev, 0, '[BCI/' + platform + '] no GPU wired in -> backendDevice must be 0 (CPU)')
+      return
+    }
+    if (dev !== 1) {
+      const msg = '[BCI/' + platform + '] expected a GPU backend, got ' + name +
+        ' (backendDevice=' + dev + '). use_gpu=true was requested but it fell back to CPU.'
+      if (RELAX) {
+        t.comment('WARNING (relaxed): ' + msg)
+        t.pass('[BCI/GPU] smoke completed (relaxed)')
+      } else {
+        t.fail(msg)
+      }
+      return
+    }
+    if (platform === 'android') {
+      t.ok(id === 3 || id === 4, '[BCI/android] expected Vulkan(3) or OpenCL(4), got ' + name)
+    } else if (platform === 'darwin' || platform === 'ios') {
+      t.is(id, 1, '[BCI/' + platform + '] expected Metal(1), got ' + name)
+    } else {
+      t.is(id, 3, '[BCI/' + platform + '] expected Vulkan(3), got ' + name)
+    }
+  } finally {
+    try { await bci.destroy() } catch (_e) {}
+  }
+})
+
+// Report-only: load with each GPU device index and log the backend that
+// resolves. Reveals which GPU backends are actually REGISTERED on this device
+// (the JS-visible signal for "is OpenCL even loaded on Mali"). On Mali with
+// OpenCL rejected at init, only the Vulkan device exists, so higher indices
+// fall back to Vulkan/CPU. Never fails — diagnostics only.
+test('[BCI] GPU device enumeration (report-only) - which GPU backends are registered', {
+  timeout: 900000,
+  skip: !hasModel || !hasSamples || NO_GPU || NOT_ON_DEVICE
+}, async (t) => {
+  logEnv(t)
+  const sample = manifest.samples[0]
+  const samplePath = getSamplePath(sample.file)
+  for (let idx = 0; idx <= 2; idx++) {
+    const bci = makeBci(true, sample, idx)
+    try {
+      await bci.load()
+      const response = await bci.transcribeFile(samplePath)
+      const output = await response.await()
+      const text = flattenSegments(output).map(s => s.text).join('').trim()
+      const stats = response.stats || {}
+      t.comment('[BCI/enum] gpu_device=' + idx + ' -> backendDevice=' + stats.backendDevice +
+        ' backendId=' + stats.backendId + ' (' + backendIdToName(stats.backendId) + ')' +
+        ' gpuMemTotalMb=' + stats.gpuMemTotalMb + ' textLen=' + text.length)
+    } catch (e) {
+      t.comment('[BCI/enum] gpu_device=' + idx + ' -> error: ' + (e && e.message ? e.message : e))
+    } finally {
+      try { await bci.destroy() } catch (_e) {}
+    }
+  }
+  t.pass('[BCI/enum] enumeration complete (per-index backendId in the comments above)')
+})
+
+test('[BCI] CPU smoke - use_gpu=false must run on the CPU backend', {
+  timeout: 600000,
+  skip: !hasModel || !hasSamples || NOT_ON_DEVICE
+}, async (t) => {
+  const sample = manifest.samples[0]
+  const samplePath = getSamplePath(sample.file)
+
+  const bci = makeBci(false, sample)
+  try {
+    await bci.load()
+    const response = await bci.transcribeFile(samplePath)
+    const output = await response.await()
+    const text = flattenSegments(output).map(s => s.text).join('').trim()
+    const stats = response.stats || {}
+    t.comment('[BCI/CPU] backendDevice=' + stats.backendDevice + ' backendId=' + stats.backendId)
+    t.ok(typeof text === 'string' && text.length > 0, '[BCI/CPU] produced a transcription')
+    t.is(stats.backendDevice, 0, '[BCI/CPU] use_gpu=false must resolve to backendDevice=0 (CPU)')
+    t.is(stats.backendId, 0, '[BCI/CPU] use_gpu=false must resolve to backendId=0 (CPU)')
+  } finally {
+    try { await bci.destroy() } catch (_e) {}
+  }
+})

--- a/packages/bci-whispercpp/test/integration/helpers.js
+++ b/packages/bci-whispercpp/test/integration/helpers.js
@@ -8,25 +8,37 @@ const { computeWER } = require('@qvac/bci-whispercpp/wer')
 const isMobile = os.platform() === 'ios' || os.platform() === 'android'
 
 // On mobile, the test framework copies test/mobile/testAssets/ into the
-// app bundle and exposes the on-device asset root via global.testDir
-// (writable scratch). Fall back to test/mobile/testAssets/ on disk so
-// the same code paths work when these tests are exercised from the
-// repo root (e.g. during local mobile dry-runs).
+// app sandbox and exposes each file via global.assetPaths, a map keyed by
+// the in-project path '../../testAssets/<file>' -> 'file:///.../cache/<file>'.
+// The legacy global.testDir is never populated with these assets, so resolve
+// through global.assetPaths (mirrors transcription-whispercpp/test/
+// integration/helpers.js getAssetPath). Fall back to test/mobile/testAssets/
+// on disk so the same code paths work during local mobile dry-runs.
 function getMobileAssetsDir () {
   if (typeof global !== 'undefined' && global.testDir) return global.testDir
   return path.join(__dirname, '..', 'mobile', 'testAssets')
 }
 
+function getMobileAssetPath (filename) {
+  const projectPath = `../../testAssets/${filename}`
+  if (global.assetPaths && global.assetPaths[projectPath]) {
+    return global.assetPaths[projectPath].replace('file://', '')
+  }
+  return path.join(getMobileAssetsDir(), filename)
+}
+
 function getModelPath (filename) {
-  if (isMobile) return path.join(getMobileAssetsDir(), filename)
+  if (isMobile) return getMobileAssetPath(filename)
   return path.join(__dirname, '..', '..', 'models', filename)
 }
 
 function getTestPaths () {
+  const manifestPath = isMobile
+    ? getMobileAssetPath('manifest.json')
+    : path.join(__dirname, '..', 'fixtures', 'manifest.json')
   const fixturesDir = isMobile
-    ? getMobileAssetsDir()
+    ? path.dirname(manifestPath)
     : path.join(__dirname, '..', 'fixtures')
-  const manifestPath = path.join(fixturesDir, 'manifest.json')
 
   let manifest = { samples: [] }
   if (fs.existsSync(manifestPath)) {
@@ -36,7 +48,9 @@ function getTestPaths () {
   return {
     fixturesDir,
     manifest,
-    getSamplePath: (filename) => path.join(fixturesDir, filename)
+    getSamplePath: (filename) => isMobile
+      ? getMobileAssetPath(filename)
+      : path.join(fixturesDir, filename)
   }
 }
 

--- a/packages/bci-whispercpp/vcpkg-configuration.json
+++ b/packages/bci-whispercpp/vcpkg-configuration.json
@@ -17,5 +17,8 @@
         "spirv-headers"
       ]
     }
+  ],
+  "overlay-ports": [
+    "./vcpkg-overlay-ports"
   ]
 }

--- a/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/android-vulkan-version.cmake
+++ b/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/android-vulkan-version.cmake
@@ -1,0 +1,37 @@
+# Detect the Vulkan version shipped with the Android NDK by parsing
+# vulkan_core.h from the NDK sysroot.  Sets `vulkan_version` in the
+# caller's scope (e.g. "1.3.275").
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from ${vulkan_core_h}")
+    endif()
+
+    # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION_COMPLETE from ${vulkan_core_h}")
+    endif()
+endfunction()

--- a/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
+++ b/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
@@ -1,0 +1,24 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..3d92ac5d 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -7,6 +7,7 @@ if (POLICY CMP0147)
+ endif()
+ 
+ find_package(Vulkan COMPONENTS glslc REQUIRED)
++find_package(SPIRV-Headers QUIET)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     # Parallel build object files
+@@ -87,6 +88,11 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++
++    if (TARGET SPIRV-Headers::SPIRV-Headers)
++        target_link_libraries(ggml-vulkan PRIVATE SPIRV-Headers::SPIRV-Headers)
++    endif()
++
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/portfile.cmake
+++ b/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/portfile.cmake
@@ -1,0 +1,173 @@
+# ggml-speech: DO-NOT-MERGE device-farm validation overlay for @qvac/bci-whispercpp.
+#
+# Pins ggml to tetherto/qvac-ext-ggml PR #22, squash-merged to `speech` as
+# commit 44fd4817 — the combined Adreno FLASH_ATTN_EXT->CPU + Samsung Xclipse
+# OpenCL matmul-GEMM correctness work, which also adds the GGML_OPENCL_FORCE_LOAD
+# / GGML_OPENCL_ALLOW_UNKNOWN_GPU opt-ins used by the gpu-smoke test to attempt
+# OpenCL on a non-Adreno (Mali) GPU. (PR head da4afa34 had identical content but
+# its branch was deleted post-merge; 44fd4817 is the durable tip of `speech`.)
+# Everything else mirrors the registry ggml-speech port
+# (GGML_OPENCL_USE_ADRENO_KERNELS stays at its ON default) so the S25/Adreno
+# OpenCL path matches production. DO NOT MERGE — validation only.
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL "https://github.com/tetherto/qvac-ext-ggml"
+    REF 44fd4817dd1dc5872053927200e2824b8a0ced86
+)
+
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+set(GGML_METAL_FUSE_MV_BIAS OFF)
+
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+
+# Off by default: the chatterbox Q-variant mul_mv + bias/residual fusion
+# produces zero tokens on parakeet's EOU q8_0 joint network. Consumers
+# whose models stay clear of that pattern can opt in for the speedup.
+if("metal-fuse-mv-bias" IN_LIST FEATURES)
+    set(GGML_METAL_FUSE_MV_BIAS ON)
+endif()
+
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+
+set(GGML_CUDA_COMPILER_OPTION "")
+
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+    find_program(NVCC_EXECUTABLE nvcc
+        PATHS /usr/local/cuda/bin /usr/local/cuda-12.8/bin
+        NO_DEFAULT_PATH
+    )
+    if(NOT NVCC_EXECUTABLE)
+        find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+    endif()
+    set(GGML_CUDA_COMPILER_OPTION "-DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}")
+    message(STATUS "CUDA compiler: ${NVCC_EXECUTABLE}")
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND "vulkan" IN_LIST FEATURES)
+    include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+    detect_ndk_vulkan_version()
+    message(STATUS "NDK Vulkan version: ${vulkan_version}")
+
+    file(DOWNLOAD
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+        "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        TLS_VERIFY ON
+    )
+    file(ARCHIVE_EXTRACT
+        INPUT "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        DESTINATION "${SOURCE_PATH}"
+        PATTERNS "*.hpp"
+    )
+    file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+         DESTINATION "${SOURCE_PATH}/src/")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+
+# Hybrid Android backend mode: GPU backends as MODULE .so loaded at runtime
+# via dlopen, CPU built as per-arch MODULE .so variants (one per ARMv8.0/
+# 8.2/8.6/9.0/9.2 feature tier) also loaded at runtime via dlopen. The
+# downstream addon installs the resulting libqvac-speech-ggml-cpu-android_armv*
+# .so files alongside the .bare binary; the per-variant scoring in
+# ggml-cpu's `ggml_backend_cpu_aarch64_score` then picks the highest tier
+# the running device supports at first use. Pairs with the speech-branch
+# `ggml-backend: android per-arch CPU variant dlopen fallback` patch
+# (commit 9562ed04) so the variant lookup also succeeds when the consumer
+# APK keeps native .so files compressed (AGP `useLegacyPackaging=false`).
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    )
+endif()
+
+# PR #13 (v0.10.2 sync) introduces an unconditional
+# `#include <spirv/unified1/spirv.hpp>` in src/ggml-vulkan/ggml-vulkan.cpp,
+# but the upstream ggml-vulkan CMakeLists.txt never finds spirv-headers nor
+# wires its include dir into the ggml-vulkan target. Apply a small patch
+# so it does (and depend on spirv-headers in vcpkg.json's vulkan feature).
+# TODO: push the equivalent fix upstream and drop this patch.
+if("vulkan" IN_LIST FEATURES)
+    vcpkg_apply_patches(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PATCHES
+            "${CMAKE_CURRENT_LIST_DIR}/patches/0001-ggml-vulkan-find-spirv-headers.patch"
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_METAL_FUSE_MV_BIAS=${GGML_METAL_FUSE_MV_BIAS}
+        -DGGML_LIB_OUTPUT_PREFIX=qvac-speech-
+        ${GGML_CUDA_COMPILER_OPTION}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Pick up the MODULE backend .so files ggml builds into the buildtree's
+# bin/ directory (Android dynamic-backend mode). cmake install() doesn't
+# move them by default.
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-speech-ggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/usage
+++ b/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/usage
@@ -1,0 +1,10 @@
+The package ggml provides CMake integration:
+
+  find_package(ggml CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ggml::ggml)
+
+Available vcpkg features:
+  metal  - Metal GPU backend (macOS/iOS, auto-enabled on Apple)
+  vulkan - Vulkan GPU backend
+  cuda   - CUDA GPU backend
+  opencl - OpenCL GPU backend

--- a/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "ggml-speech",
+  "version-date": "2026-06-04",
+  "description": "Speech-stack flavour of ggml from tetherto/qvac-ext-ggml@speech, including the ggml-org v0.10.2 sync (PR #13), the iOS Metal NULL-safety hardening from PR #10, GustavoA1604's Android per-arch CPU dlopen fallback (PR #11), the Mac M2 PAD test fix, and Adreno-aware Android OpenCL/Vulkan backend selection (PR #18, QVAC-18993): on Android the loader detects the GPU via Vulkan and only keeps OpenCL for Adreno > 700, CPU-only for Adreno 1..700, Vulkan/CPU for non-Adreno. Adds Adreno OpenCL elementwise kernels (sin/cos/abs/elu/leaky_relu) for Chatterbox S3Gen and robust Adreno-generation detection (PR #17, #19). Library filenames are prefixed libqvac-speech-ggml-* so they coexist with libqvac-ggml-* (fabric/llm) and libqvac-diffusion-ggml-* on the same Android device. Mutually exclusive with the regular ggml port in the same triplet -- pick one per build.",
+  "homepage": "https://github.com/tetherto/qvac-ext-ggml/tree/speech",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU backend"
+    },
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "metal-fuse-mv-bias": {
+      "description": "Compile in the Q-variant mul_mv + ADD(bias) [+ ADD(residual)] fusion in ggml-metal. Off by default: empirically produces zero tokens on parakeet's EOU q8_0 joint network. Opt in only after Metal A/B-validating your model against the fused path."
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
> **DO NOT MERGE** — device-farm validation vehicle, modelled on #2505.

## ⚠️ Update — the first device-farm run was a FALSE PASS (now fixed)
The initial run reported green (6/6 on both devices) but was **vacuous**: every bci test reported `# SKIP`, the device run was ~0.1s, and no model was ever loaded (`test-results.json` wrapper durations were 142/384/374 ms). Root cause — bci's `test/integration/helpers.js` resolved mobile assets via the never-populated `global.testDir` instead of the framework's **`global.assetPaths`** map. The sibling addons (`transcription-whispercpp`, `transcription-parakeet`) resolve through `global.assetPaths` via `getAssetPath`; bci did not. This pre-existing bug made bci's device-farm CI vacuously green for the existing `addon.test.js` tests too.

**Fix (this revision):** `helpers.js` now resolves the model, manifest, and sample fixtures through `global.assetPaths` (`'../../testAssets/<file>' → file://…`), mirroring `transcription-whispercpp/test/integration/helpers.js`. This un-skips both the new gpu-smoke tests **and** the 6 pre-existing `addon.test.js` correctness tests on-device, so the run now actually loads the model and transcribes. **Verification is from the collected logcat** (no `# SKIP`, real seconds-scale durations + real transcription), not the pass/fail counts.

## Question this answers
Does the GPU path — and **OpenCL specifically** — work on a **Pixel 9 (Mali-G715)**?
bci-whispercpp already runs on the AWS Device Farm on both Pixel 9 (Mali) and Samsung S25 Ultra (Adreno), and the Android prebuild already bundles OpenCL + Vulkan — but the existing integration tests never enable GPU or assert which backend ran, so the device farm proves nothing about GPU today.

## What this adds
- **`test/integration/gpu-smoke.test.js`** (Android-only): runs the BCI model with `use_gpu=true`, asserts it engages a real GPU backend (`backendDevice===1`) and transcribes fixture 0 with **WER < 50%**, and logs the `backendId`. Naturally this exercises **OpenCL on S25/Adreno** and **Vulkan on Pixel 9/Mali**. A CPU smoke (`use_gpu=false → backendDevice=0`) locks the CPU contract. Gated to Android so desktop/iOS CI is unaffected.
- **OpenCL-on-Mali force-load attempt:** the test sets `GGML_OPENCL_FORCE_LOAD=1` + `GGML_OPENCL_ALLOW_UNKNOWN_GPU=1` (via `bare-os.setEnv`, before the first `bci.load()`) so ggml *attempts* the OpenCL backend even on the non-Adreno Mali GPU and the run **reports** whether it engages. The test never fails on the backend choice — only on a crash / garbage output.
- **ggml pin:** `packages/bci-whispercpp/vcpkg-overlay-ports/ggml-speech` pins ggml to **qvac-ext-ggml PR #22**, now **squash-merged to `speech`** as `44fd4817` (the PR head `da4afa34` had identical content but its branch was deleted post-merge, so the durable `speech` tip is pinned) — the Adreno `FLASH_ATTN_EXT→CPU` + Samsung Xclipse OpenCL matmul-GEMM correctness work plus the `FORCE_LOAD` opt-ins — built with the production `GGML_OPENCL_USE_ADRENO_KERNELS` default (ON) so the S25/Adreno OpenCL path matches production. Both OpenCL + Vulkan stay in the Android build. `vcpkg-configuration.json` gains the `overlay-ports` entry.

## Expected result
| Device | Backend | OpenCL-on-Mali answer |
|---|---|---|
| S25 Ultra (Adreno 830) | `backendId=4` (OpenCL), WER < 50% | OpenCL engaged ✓ |
| Pixel 9 (Mali-G715) | `backendId=3` (Vulkan), WER < 50% | OpenCL **rejected** at `ggml_cl2_init` (not Adreno/Intel/AMD-64-wide) → falls back to Vulkan; reason in logcat |

If Pixel shows `backendDevice=0` (CPU) → Vulkan regressed on Mali (a real finding). If logcat shows no OpenCL force-load attempt → the JS `setEnv` didn't take effect on-device and we switch to a `force_opencl` addon opt.

## How to run
Apply the **`verified`** label to this PR → triggers the prebuild rebuild (against the pinned ggml) and the dual-flagship device-farm run on S25 + Pixel 9. Read the per-device `backendId` from the PR comment + the collected logcat.

Closes nothing — **do not merge**; close once the data point is collected.
