### PR TITLE
infra[notask]: wire performance-reporter into diffusion-cpp integration tests & CI

### DIFF
--- a/.github/workflows/benchmark-performance-diffusion-cpp.yml
+++ b/.github/workflows/benchmark-performance-diffusion-cpp.yml
@@ -1,0 +1,210 @@
+name: Benchmark Performance (Diffusion CPP)
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Repository to benchmark"
+        required: false
+        type: string
+      ref:
+        description: "Git ref (branch/tag/SHA) to benchmark"
+        required: false
+        type: string
+      qvac_perf_runs:
+        description: "QVAC_PERF_RUNS — counted iterations per perf test"
+        required: false
+        type: string
+        default: "3"
+      qvac_perf_warmup_runs:
+        description: "QVAC_PERF_WARMUP_RUNS — warmup iterations before measurement"
+        required: false
+        type: string
+        default: "1"
+      run_desktop:
+        description: "Run desktop matrix (Linux / macOS / Windows)"
+        required: false
+        type: boolean
+        default: true
+      run_mobile:
+        description: "Run mobile matrix (Android / iOS via Device Farm)"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: read
+  id-token: write
+
+jobs:
+  label-gate:
+    name: Authorise (label-gate)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      authorised: ${{ steps.gate.outputs.authorised }}
+    steps:
+      - name: Checkout (label-gate action only)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/actions/label-gate
+          sparse-checkout-cone-mode: false
+      - name: Run label-gate
+        id: gate
+        uses: ./.github/actions/label-gate
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+
+  context:
+    runs-on: ubuntu-latest
+    outputs:
+      repository: ${{ steps.ctx.outputs.repository }}
+      ref: ${{ steps.ctx.outputs.ref }}
+    steps:
+      - id: ctx
+        shell: bash
+        env:
+          INPUT_REPO: ${{ inputs.repository }}
+          INPUT_REF: ${{ inputs.ref }}
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          repo="${INPUT_REPO:-$REPO}"
+          ref="${INPUT_REF:-$REF_NAME}"
+          echo "repository=$repo" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+  prebuild:
+    needs:
+      - context
+      - label-gate
+    if: needs.label-gate.outputs.authorised == 'true'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
+    uses: ./.github/workflows/prebuilds-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      repository: ${{ needs.context.outputs.repository }}
+      ref: ${{ needs.context.outputs.ref }}
+
+  desktop-benchmarks:
+    needs:
+      - context
+      - prebuild
+      - label-gate
+    if: needs.label-gate.outputs.authorised == 'true' && inputs.run_desktop
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+    uses: ./.github/workflows/integration-test-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      repository: ${{ needs.context.outputs.repository }}
+      ref: ${{ needs.context.outputs.ref }}
+      qvac_perf_runs: ${{ inputs.qvac_perf_runs }}
+      qvac_perf_warmup_runs: ${{ inputs.qvac_perf_warmup_runs }}
+
+  mobile-benchmarks:
+    needs:
+      - context
+      - prebuild
+      - label-gate
+    if: needs.label-gate.outputs.authorised == 'true' && inputs.run_mobile
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+      id-token: write
+    uses: ./.github/workflows/integration-mobile-test-diffusion-cpp.yml
+    secrets: inherit
+    with:
+      repository: ${{ needs.context.outputs.repository }}
+      ref: ${{ needs.context.outputs.ref }}
+
+  summarize:
+    needs:
+      - context
+      - desktop-benchmarks
+      - mobile-benchmarks
+      - label-gate
+    if: needs.label-gate.outputs.authorised == 'true' && (always() && needs.context.result == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          repository: ${{ needs.context.outputs.repository }}
+          ref: ${{ needs.context.outputs.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
+          sparse-checkout: |
+            scripts/perf-report
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: lts/*
+
+      - name: Download all perf report artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          pattern: perf-report-diffusion-cpp-*-${{ github.run_number }}
+          path: combined-reports
+        continue-on-error: true
+
+      - name: Generate consolidated benchmark report
+        run: |
+          if ! find combined-reports -name "performance-report.json" -type f 2>/dev/null | grep -q .; then
+            echo "No performance reports found."
+            exit 0
+          fi
+
+          mkdir -p benchmark-artifacts
+
+          node scripts/perf-report/aggregate.js \
+            --dir combined-reports \
+            --addon-type diffusion \
+            --device-details \
+            --output-html benchmark-artifacts/diffusion-cpp-performance-findings.html \
+            --output-json benchmark-artifacts/diffusion-cpp-performance-findings.json \
+            --output benchmark-artifacts/diffusion-cpp-performance-findings.md
+
+      - name: Add summary
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          MD_FILE="benchmark-artifacts/diffusion-cpp-performance-findings.md"
+          {
+            echo "## Diffusion CPP Benchmark Report"
+            echo ""
+            echo "> \`QVAC_PERF_RUNS=${{ inputs.qvac_perf_runs }}\`, \`QVAC_PERF_WARMUP_RUNS=${{ inputs.qvac_perf_warmup_runs }}\`."
+            echo ""
+            if [ -f "$MD_FILE" ]; then
+              cat "$MD_FILE"
+            else
+              echo "No combined performance report available."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload consolidated benchmark report
+        if: always()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
+        with:
+          name: diffusion-cpp-performance-findings
+          path: |
+            benchmark-artifacts/diffusion-cpp-performance-findings.md
+            benchmark-artifacts/diffusion-cpp-performance-findings.json
+            benchmark-artifacts/diffusion-cpp-performance-findings.html
+          retention-days: 30
+          if-no-files-found: ignore

--- a/.github/workflows/integration-mobile-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-mobile-test-diffusion-cpp.yml
@@ -129,7 +129,7 @@ jobs:
           app-name: ${{ steps.build.outputs.app-name }}
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           device-farm-project-arn: ${{ secrets.LLM_AWS_DEVICE_FARM_PROJECT_ARN }}
-          enables-perf: 'false'
+          enables-perf: 'true'
           after-hook-pulls: '[{"device_path":"tests/artifacts","artifact_name":"generated-images"}]'
 
       - name: Schedule Device Farm test run
@@ -165,9 +165,17 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           addon-npm-name: '@qvac/diffusion-cpp'
-          enables-perf: 'false'
+          enables-perf: 'true'
           aws-role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           run-arns: ${{ steps.schedule.outputs.run-arns }}
+
+      - name: Extract & upload addon perf report (Diffusion CPP)
+        if: always() && !cancelled()
+        uses: ./.github/actions/run-mobile-integration-tests/extract-addon-perf
+        with:
+          platform: ${{ matrix.platform }}
+          addon-npm-name: '@qvac/diffusion-cpp'
+          artifact-name: perf-report-diffusion-cpp-${{ matrix.platform }}-${{ github.run_number }}
 
       - name: Comment results on PR
         if: always() && !cancelled()

--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -8,6 +8,16 @@ on:
         type: string
       repository:
         type: string
+      qvac_perf_runs:
+        description: "Number of measured perf iterations per test (default 3)"
+        type: string
+        required: false
+        default: '3'
+      qvac_perf_warmup_runs:
+        description: "Number of warmup iterations before perf measurement (default 0)"
+        type: string
+        required: false
+        default: '0'
 
   workflow_dispatch:
     inputs:
@@ -20,6 +30,16 @@ on:
         description: "NPM package containing prebuilds (e.g. @qvac/diffusion-cpp@0.1.0)"
         type: string
         required: true
+      qvac_perf_runs:
+        description: "Number of measured perf iterations per test (default 3)"
+        type: string
+        required: false
+        default: '3'
+      qvac_perf_warmup_runs:
+        description: "Number of warmup iterations before perf measurement (default 0)"
+        type: string
+        required: false
+        default: '0'
 
 jobs:
   run-integration-tests:
@@ -298,6 +318,8 @@ jobs:
         shell: bash
         env:
           QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
+          QVAC_PERF_RUNS: ${{ inputs.qvac_perf_runs || '3' }}
+          QVAC_PERF_WARMUP_RUNS: ${{ inputs.qvac_perf_warmup_runs || '0' }}
 
       - name: Run integration test (Windows)
         if: ${{ matrix.platform == 'win32' }}
@@ -308,6 +330,29 @@ jobs:
         shell: powershell
         env:
           QASE_API_TOKEN: ${{ secrets.QASE_API_TOKEN }}
+          QVAC_PERF_RUNS: ${{ inputs.qvac_perf_runs || '3' }}
+          QVAC_PERF_WARMUP_RUNS: ${{ inputs.qvac_perf_warmup_runs || '0' }}
+
+      - name: Generate HTML performance report
+        if: always() && !cancelled()
+        working-directory: ${{ env.WORKDIR }}
+        shell: bash
+        run: |
+          if [ -f test/results/performance-report.json ]; then
+            node ../../scripts/perf-report/aggregate.js --dir test/results || true
+          else
+            echo "No performance-report.json found — skipping aggregation"
+          fi
+        continue-on-error: true
+
+      - name: Upload performance report
+        if: always() && !cancelled()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: perf-report-diffusion-cpp-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.run_number }}
+          path: ${{ env.WORKDIR }}/test/results/performance-report.json
+          if-no-files-found: ignore
+          retention-days: 90
 
       - name: List generated images
         if: always() && !cancelled()

--- a/.github/workflows/on-pr-diffusion-cpp.yml
+++ b/.github/workflows/on-pr-diffusion-cpp.yml
@@ -193,8 +193,36 @@ jobs:
       repository: ${{ github.event.pull_request.head.repo.full_name }}
       ref: ${{ github.event.pull_request.head.ref }}
 
+  combine-perf-reports:
+    name: Combined Performance Report
+    needs: [authorize, run-integration-tests, run-mobile-integration-tests]
+    if: always() && needs.authorize.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository (base branch for action code)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.ref || github.ref }}
+          sparse-checkout: |
+            .github/actions
+            scripts/perf-report
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Combine performance reports
+        uses: ./.github/actions/run-mobile-integration-tests/combine-perf-reports
+        with:
+          artifact-pattern: perf-report-diffusion-cpp-*-${{ github.run_number }}
+          report-title: 'Diffusion Performance Report (All Platforms)'
+
   merge-guard:
-    needs: [authorize, run-integration-tests, run-mobile-integration-tests, sanity-checks, prebuild, cpp-tests, cpp-lint, ts-checks]
+    needs: [authorize, run-integration-tests, run-mobile-integration-tests, combine-perf-reports, sanity-checks, prebuild, cpp-tests, cpp-lint, ts-checks]
     if: always() && !cancelled()
     uses: ./.github/workflows/public-pr.yml
     permissions:

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -16,6 +16,7 @@ on:
           - vlm
           - onnx-tts
           - parakeet
+          - diffusion-cpp
       workflow_name:
         description: "Integration test workflow name to query"
         type: choice
@@ -29,6 +30,8 @@ on:
           - "Integration Tests (TTS)"
           - "Mobile Integration Tests (TTS)"
           - "Mobile Integration Tests (Parakeet)"
+          - "Integration Tests (Stable Diffusion)"
+          - "Mobile Integration Tests (Diffusion CPP)"
       runs:
         description: "Number of recent runs to aggregate"
         type: number
@@ -184,6 +187,24 @@ jobs:
             --output reports/parakeet-mobile-performance.md \
             --output-json reports/parakeet-mobile-performance.json \
             --output-html reports/parakeet-mobile-performance.html || true
+
+          echo "=== Diffusion (Desktop) ==="
+          node scripts/perf-report/aggregate.js \
+            --addon diffusion-cpp \
+            --workflow "Integration Tests (Stable Diffusion)" \
+            --runs 6 \
+            --output reports/diffusion-cpp-performance.md \
+            --output-json reports/diffusion-cpp-performance.json \
+            --output-html reports/diffusion-cpp-performance.html || true
+
+          echo "=== Diffusion (Mobile) ==="
+          node scripts/perf-report/aggregate.js \
+            --addon diffusion-cpp \
+            --workflow "Mobile Integration Tests (Diffusion CPP)" \
+            --runs 6 \
+            --output reports/diffusion-cpp-mobile-performance.md \
+            --output-json reports/diffusion-cpp-mobile-performance.json \
+            --output-html reports/diffusion-cpp-mobile-performance.html || true
 
       # ─── Phase B: COMET quality scoring for NMT (weekly aggregate only) ───
       # Runs only on the Monday scheduled trigger, or on workflow_dispatch

--- a/packages/diffusion-cpp/.gitignore
+++ b/packages/diffusion-cpp/.gitignore
@@ -28,5 +28,6 @@ temp/
 !assets/**
 *.png
 test/model/
+test/results/
 test/integration/all.js
 test/unit/all.js

--- a/packages/diffusion-cpp/test/integration/_perf-helper.js
+++ b/packages/diffusion-cpp/test/integration/_perf-helper.js
@@ -1,0 +1,275 @@
+'use strict'
+// Shared performance-recording helper for the diffusion-cpp addon's
+// integration tests. Holds the singleton perf-reporter, the mobile-safe
+// inline fallback, and the `recordPerformance()` wrapper that turns an
+// addon `response.stats` (RuntimeStats / EsrganRuntimeStats / VideoRuntimeStats)
+// payload into a perf row.
+//
+// This file intentionally does NOT end in `.test.js` so it is not
+// picked up by the mobile test generator or the brittle test runner.
+
+const fs = require('bare-fs')
+const path = require('bare-path')
+const os = require('bare-os')
+const process = require('bare-process')
+let _subprocess = null
+try { _subprocess = require('bare-subprocess') } catch (_) {}
+
+const platform = os.platform()
+const arch = os.arch()
+const platformLabel = `${platform}-${arch}`
+const isDarwinX64 = platform === 'darwin' && arch === 'x64'
+const isLinuxArm64 = platform === 'linux' && arch === 'arm64'
+const isMobile = platform === 'ios' || platform === 'android'
+
+function _getEnv (name) {
+  if (typeof os.getEnv === 'function') {
+    try { return os.getEnv(name) || '' } catch (_) { return '' }
+  }
+  return (process.env && process.env[name]) || ''
+}
+
+const PERF_RUNS = parseInt(_getEnv('QVAC_PERF_RUNS') || '1', 10)
+const WARMUP_RUNS = parseInt(_getEnv('QVAC_PERF_WARMUP_RUNS') || '0', 10)
+
+let createPerformanceReporter
+const _scriptBase = path.join('..', '..', '..', '..', 'scripts', 'test-utils')
+try {
+  const perfReporterMod = require(path.join(_scriptBase, 'performance-reporter'))
+  perfReporterMod.configure({ fs, path, process, os, subprocess: _subprocess })
+  createPerformanceReporter = perfReporterMod.createPerformanceReporter
+} catch (_) {
+  const OUTPUT_CAP_CHARS = 400
+
+  createPerformanceReporter = function (opts) {
+    const _results = []
+    const _startedAt = new Date().toISOString()
+    const _addon = (opts && opts.addon) || 'unknown'
+    const _addonType = (opts && opts.addonType) || 'generic'
+    const _device = {
+      name: platform,
+      platform,
+      os_version: '',
+      arch: os.arch ? os.arch() : '',
+      gpu: null,
+      runner: 'device-farm'
+    }
+
+    function _trim (text) {
+      if (text == null) return null
+      const s = String(text)
+      if (s.length <= OUTPUT_CAP_CHARS) return s
+      return s.substring(0, OUTPUT_CAP_CHARS) + '...[truncated ' +
+        (s.length - OUTPUT_CAP_CHARS) + 'c]'
+    }
+
+    return {
+      record (testName, metrics, extra) {
+        const entry = {
+          test: testName,
+          scenario: (extra && extra.scenario) || 'default',
+          model: (extra && extra.model) || null,
+          execution_provider: (extra && extra.execution_provider) || null,
+          metrics: Object.assign({
+            model_load_ms: null,
+            generation_ms: null,
+            ttfb_ms: null,
+            total_steps: null,
+            steps_per_second: null,
+            megapixels_per_second: null,
+            width: null,
+            height: null
+          }, metrics),
+          input: (extra && extra.input) || null,
+          output: _trim(extra && extra.output)
+        }
+        _results.push(entry)
+      },
+      toJSON () {
+        return {
+          schema_version: '1.0',
+          addon: _addon,
+          addon_type: _addonType,
+          timestamp: _startedAt,
+          device: _device,
+          results: _results
+        }
+      },
+      writeReport () {
+        const json = JSON.stringify(this.toJSON())
+        let written = false
+        const dirs = []
+        if (global.testDir) dirs.push(global.testDir)
+        if (platform === 'android') {
+          dirs.push('/sdcard/Android/data/io.tether.test.qvac/files')
+          dirs.push('/storage/emulated/0/Android/data/io.tether.test.qvac/files')
+          dirs.push('/data/local/tmp')
+        }
+        dirs.push('/tmp')
+        for (let di = 0; di < dirs.length; di++) {
+          try {
+            try { fs.mkdirSync(dirs[di], { recursive: true }) } catch (_) {}
+            const p = path.join(dirs[di], 'perf-report.json')
+            fs.writeFileSync(p, json)
+            console.log('[PERF_REPORT_PATH]' + p)
+            written = true
+          } catch (e) {
+            console.log('[perf-reporter] write to ' + dirs[di] + ' failed: ' + e.message)
+          }
+        }
+        if (!written) {
+          console.log('[perf-reporter] all write locations failed')
+        }
+      },
+      writeStepSummary () {},
+      writeToConsole (consoleOpts) {
+        try {
+          const data = this.toJSON()
+          const lightweight = consoleOpts && consoleOpts.lightweight
+          const delta = consoleOpts && consoleOpts.delta
+          let rows = data.results
+          if (delta && rows.length > 0) rows = [rows[rows.length - 1]]
+          data.results = rows.map(r => ({
+            test: r.test,
+            scenario: r.scenario || 'default',
+            model: r.model || null,
+            execution_provider: r.execution_provider,
+            metrics: r.metrics,
+            output: lightweight ? null : r.output
+          }))
+          const json = JSON.stringify(data)
+          const CHUNK = 800
+          if (json.length <= CHUNK) {
+            console.log('[PERF_REPORT_START]' + json + '[PERF_REPORT_END]')
+          } else {
+            const id = Date.now().toString(36)
+            const n = Math.ceil(json.length / CHUNK)
+            for (let i = 0; i < n; i++) {
+              console.log('[PERF_CHUNK:' + id + ':' + i + ':' + n + ']' + json.substring(i * CHUNK, (i + 1) * CHUNK))
+            }
+          }
+        } catch (err) {
+          console.log('[perf-reporter] mobile console write failed: ' + err.message)
+        }
+      },
+      get length () { return _results.length }
+    }
+  }
+}
+
+const _perfReporter = createPerformanceReporter({
+  addon: 'diffusion-cpp',
+  addonType: 'diffusion'
+})
+
+const _reportPath = path.resolve('.', 'test/results/performance-report.json')
+let _exitHookInstalled = false
+
+function _installExitHook () {
+  if (_exitHookInstalled) return
+  _exitHookInstalled = true
+  process.on('exit', () => {
+    if (_perfReporter.length > 0) {
+      try { _perfReporter.writeReport(_reportPath) } catch (_) {}
+      try { _perfReporter.writeStepSummary() } catch (_) {}
+    }
+  })
+}
+
+function _num (v) {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+
+function resolveBackend (device) {
+  if (!device || device === 'cpu') return 'cpu'
+  if (platform === 'darwin' || platform === 'ios') return 'metal'
+  if (platform === 'android') {
+    const override = _getEnv('QVAC_GPU_BACKEND')
+    return String(override || 'vulkan').toLowerCase()
+  }
+  if (platform === 'linux' || platform === 'win32') return 'vulkan'
+  return 'gpu'
+}
+
+/**
+ * Records perf metrics for a single diffusion generation / upscale call.
+ *
+ * @param {string} label    Test row identifier (e.g. "[SD2.1 Q8_0 txt2img 712x712] [GPU]").
+ * @param {Object} stats    response.stats from the addon (RuntimeStats / EsrganRuntimeStats / VideoRuntimeStats).
+ * @param {Object} extra
+ * @param {string} [extra.scenario]            'txt2img' | 'img2img' | 'upscale' | 'txt2vid' | 'img2vid'
+ * @param {string} [extra.model]               Model id (e.g. 'stable-diffusion-v2-1-Q8_0')
+ * @param {string} [extra.execution_provider]  'cpu' | 'gpu'
+ * @param {number} [extra.ttfbMs]              Time from run() to first onUpdate event (ms)
+ */
+function recordPerformance (label, stats, extra) {
+  if (!stats) return '[perf] no stats available'
+
+  const isEsrgan = stats.upscaleMs != null
+  const genMs = isEsrgan ? _num(stats.upscaleMs) : _num(stats.generationMs)
+  const modelLoadMs = _num(stats.modelLoadMs)
+  const totalSteps = _num(stats.totalSteps)
+  const w = _num(stats.width)
+  const h = _num(stats.height)
+  const ttfbMs = (extra && extra.ttfbMs != null) ? _num(extra.ttfbMs) : null
+
+  let stepsPerSecond = null
+  if (totalSteps && genMs && genMs > 0) {
+    stepsPerSecond = Number((totalSteps / (genMs / 1000)).toFixed(2))
+  }
+
+  let megapixelsPerSecond = null
+  if (w && h && genMs && genMs > 0) {
+    megapixelsPerSecond = Number(((w * h / 1e6) / (genMs / 1000)).toFixed(4))
+  }
+
+  const labelDevice = /\[gpu\]/i.test(label) ? 'gpu' : /\[cpu\]/i.test(label) ? 'cpu' : null
+  const effectiveDevice = (extra && extra.execution_provider) || labelDevice || 'gpu'
+  const backend = resolveBackend(effectiveDevice)
+
+  _perfReporter.record(label, {
+    model_load_ms: modelLoadMs,
+    generation_ms: genMs,
+    ttfb_ms: ttfbMs,
+    total_steps: totalSteps,
+    steps_per_second: stepsPerSecond,
+    megapixels_per_second: megapixelsPerSecond,
+    width: w,
+    height: h
+  }, {
+    scenario: (extra && extra.scenario) || 'default',
+    model: (extra && extra.model) || null,
+    execution_provider: effectiveDevice
+  })
+
+  _installExitHook()
+
+  if (isMobile) {
+    if (typeof _perfReporter.writeToConsole === 'function') {
+      _perfReporter.writeToConsole({ lightweight: true, delta: true })
+    }
+  }
+
+  const lines = [
+    `${label} Performance (backend=${backend}, platform=${platformLabel}):`,
+    `    - Model load: ${modelLoadMs != null ? modelLoadMs + 'ms' : 'n/a'}`,
+    `    - Generation: ${genMs != null ? genMs + 'ms' : 'n/a'}`,
+    `    - TTFB: ${ttfbMs != null ? Math.round(ttfbMs) + 'ms' : 'n/a'}`,
+    `    - Steps: ${totalSteps || 'n/a'} (${stepsPerSecond != null ? stepsPerSecond + ' steps/sec' : 'n/a'})`,
+    `    - Resolution: ${w || '?'}x${h || '?'} (${megapixelsPerSecond != null ? megapixelsPerSecond + ' MP/sec' : 'n/a'})`
+  ]
+  return lines.join('\n')
+}
+
+module.exports = {
+  platform,
+  arch,
+  platformLabel,
+  isDarwinX64,
+  isLinuxArm64,
+  isMobile,
+  resolveBackend,
+  recordPerformance,
+  PERF_RUNS,
+  WARMUP_RUNS
+}

--- a/packages/diffusion-cpp/test/integration/api-behavior.test.js
+++ b/packages/diffusion-cpp/test/integration/api-behavior.test.js
@@ -11,6 +11,7 @@ const {
   setupJsLogger,
   safeTest
 } = require('./utils')
+const { recordPerformance } = require('./_perf-helper')
 
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
 const isLinuxArm64 = os.platform() === 'linux' && os.arch() === 'arm64'
@@ -90,6 +91,8 @@ function saveGeneratedImages (modelDir, filenameSuffix, images) {
 
 safeTest('idle | run: allowed, returns QvacResponse', { timeout: testTimeout }, async t => {
   const { model, modelDir } = await setupModel(t)
+  const tGen = Date.now()
+  let ttfbMs = null
   const response = await model.run(SHORT_PARAMS)
   t.ok(response, 'run() returns a response')
   t.ok(typeof response.onUpdate === 'function', 'response has onUpdate')
@@ -97,11 +100,19 @@ safeTest('idle | run: allowed, returns QvacResponse', { timeout: testTimeout }, 
 
   const images = []
   await response.onUpdate(data => {
+    if (ttfbMs === null) ttfbMs = Date.now() - tGen
     if (data instanceof Uint8Array) images.push(data)
   }).await()
 
   t.ok(images.length > 0, 'run produces at least one image')
   saveGeneratedImages(modelDir, 'idle-run', images)
+
+  t.comment(recordPerformance('[SD2.1 Q4_0 txt2img 256x256] [' + (useCpu ? 'CPU' : 'GPU') + ']', response.stats, {
+    scenario: 'txt2img',
+    model: 'stable-diffusion-v2-1-Q4_0',
+    execution_provider: useCpu ? 'cpu' : 'gpu',
+    ttfbMs
+  }))
 })
 
 safeTest('idle | cancel: allowed, no-op', { timeout: testTimeout }, async t => {

--- a/packages/diffusion-cpp/test/integration/esrgan-backend-device.test.js
+++ b/packages/diffusion-cpp/test/integration/esrgan-backend-device.test.js
@@ -9,6 +9,7 @@ const test = require('brittle')
 const binding = require('../../binding')
 const { EsrganUpscaler } = require('../../index')
 const { ensureModel, setupJsLogger } = require('./utils')
+const { recordPerformance } = require('./_perf-helper')
 
 const noGpu = proc.env && proc.env.NO_GPU === 'true'
 const isAndroid = os.platform() === 'android'
@@ -115,6 +116,12 @@ test(
         expected,
         'native CPU path maps to stats'
       )
+
+      t.comment(recordPerformance('[ESRGAN 4x upscale 16x16] [CPU]', response.stats, {
+        scenario: 'upscale',
+        model: 'RealESRGAN_x4plus_anime_6B',
+        execution_provider: 'cpu'
+      }))
     } finally {
       await upscaler.unload().catch(() => {})
       try {
@@ -171,6 +178,12 @@ test(
           'or cpu when runtime falls back (e.g. GPU/OpenCL init failure); ' +
           'native policy hint=' + expected + ', actual=' + actual
       )
+
+      t.comment(recordPerformance('[ESRGAN 4x upscale 16x16] [' + (actual || 'GPU') + ']', response.stats, {
+        scenario: 'upscale',
+        model: 'RealESRGAN_x4plus_anime_6B',
+        execution_provider: actual || 'gpu'
+      }))
     } finally {
       await upscaler.unload().catch(() => {})
       try {

--- a/packages/diffusion-cpp/test/integration/generate-image-esrgan-upscale.test.js
+++ b/packages/diffusion-cpp/test/integration/generate-image-esrgan-upscale.test.js
@@ -16,6 +16,7 @@ const {
   setupJsLogger,
   isPng
 } = require('./utils')
+const { recordPerformance } = require('./_perf-helper')
 
 const platform = detectPlatform()
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
@@ -309,6 +310,12 @@ test('ESRGAN post-generation upscale — emits expected PNG dimensions', { timeo
         `generate-image--sd2-esrgan-${runCase.repeats}x-repeat.png`,
         images[0]
       )
+
+      t.comment(recordPerformance(
+        '[ESRGAN 4x post-gen upscale repeats=' + runCase.repeats + '] [' + (useCpu ? 'CPU' : 'GPU') + ']',
+        response.stats,
+        { scenario: 'upscale', model: 'RealESRGAN_x4plus_anime_6B' }
+      ))
     }
   } finally {
     await model.unload().catch(() => {})
@@ -364,6 +371,12 @@ test('ESRGAN standalone upscale — emits expected PNG dimensions', { timeout: t
         `generate-image--standalone-esrgan-${runCase.repeats}x-repeat.png`,
         images[0]
       )
+
+      t.comment(recordPerformance(
+        '[ESRGAN 4x standalone upscale repeats=' + runCase.repeats + '] [' + (useCpu ? 'CPU' : 'GPU') + ']',
+        response.stats,
+        { scenario: 'upscale', model: 'RealESRGAN_x4plus_anime_6B' }
+      ))
     }
   } finally {
     await upscaler.unload().catch(() => {})

--- a/packages/diffusion-cpp/test/integration/generate-image-flux2-i2i.test.js
+++ b/packages/diffusion-cpp/test/integration/generate-image-flux2-i2i.test.js
@@ -13,6 +13,7 @@ const {
   safeTest
 } = require('./utils')
 const { readImageDimensions } = require('../../addon')
+const { recordPerformance, PERF_RUNS, WARMUP_RUNS } = require('./_perf-helper')
 
 const proc = require('bare-process')
 
@@ -112,45 +113,64 @@ safeTest('FLUX2-klein img2img — transforms an input image', { timeout: 1800000
     const initImage = fs.readFileSync(initImagePath)
     console.log(`\nLoaded init image: ${initImage.length} bytes`)
 
-    // ── Generate (img2img) ────────────────────────────────────────────────────
-    console.log('\n=== Generating image (img2img) ===')
-    console.log(`  Steps    : ${STEPS}`)
-    console.log(`  Guidance : ${GUIDANCE}`)
-    console.log(`  Seed     : ${SEED}`)
+    // ── Generate (perf loop) ───────────────────────────────────────────────────
+    const totalIterations = WARMUP_RUNS + PERF_RUNS
+    for (let iteration = 0; iteration < totalIterations; iteration++) {
+      const isWarmup = iteration < WARMUP_RUNS
+      const runLabel = isWarmup ? `warmup ${iteration + 1}` : `run ${iteration - WARMUP_RUNS + 1}/${PERF_RUNS}`
+      console.log(`\n=== Generating image (img2img ${runLabel}) ===`)
+      console.log(`  Steps    : ${STEPS}`)
+      console.log(`  Guidance : ${GUIDANCE}`)
+      console.log(`  Seed     : ${SEED + iteration}`)
 
-    const tGen = Date.now()
+      const tGen = Date.now()
+      let ttfbMs = null
 
-    const response = await model.run({
-      prompt: 'same person, color photograph, modern tech CEO of this version, wearing a gray zip up vest, black studio background',
-      negative_prompt: 'blurry, low quality, NSFW, distorted, different person, different face',
-      init_image: initImage,
-      cfg_scale: 1.0,
-      steps: STEPS,
-      guidance: GUIDANCE,
-      seed: SEED,
-      width: 624,
-      height: 624
-    })
+      images.length = 0
+      progressTicks.length = 0
 
-    await response
-      .onUpdate((data) => {
-        if (data instanceof Uint8Array) {
-          images.push(data)
-        } else if (typeof data === 'string') {
-          try {
-            const tick = JSON.parse(data)
-            if ('step' in tick && 'total' in tick) {
-              progressTicks.push(tick)
-            }
-          } catch (_) {}
-        }
+      const response = await model.run({
+        prompt: 'same person, color photograph, modern tech CEO of this version, wearing a gray zip up vest, black studio background',
+        negative_prompt: 'blurry, low quality, NSFW, distorted, different person, different face',
+        init_image: initImage,
+        cfg_scale: 1.0,
+        steps: STEPS,
+        guidance: GUIDANCE,
+        seed: SEED + iteration,
+        width: 624,
+        height: 624
       })
-      .await()
 
-    const genMs = Date.now() - tGen
-    console.log(`\nGenerated in ${(genMs / 1000).toFixed(1)}s`)
+      await response
+        .onUpdate((data) => {
+          if (ttfbMs === null) ttfbMs = Date.now() - tGen
+          if (data instanceof Uint8Array) {
+            images.push(data)
+          } else if (typeof data === 'string') {
+            try {
+              const tick = JSON.parse(data)
+              if ('step' in tick && 'total' in tick) {
+                progressTicks.push(tick)
+              }
+            } catch (_) {}
+          }
+        })
+        .await()
 
-    // ── Assertions ────────────────────────────────────────────────────────────
+      const genMs = Date.now() - tGen
+      console.log(`Generated in ${(genMs / 1000).toFixed(1)}s (TTFB: ${ttfbMs}ms)`)
+
+      if (!isWarmup) {
+        t.comment(recordPerformance('[FLUX.2 klein img2img] [' + (useCpu ? 'CPU' : 'GPU') + ']', response.stats, {
+          scenario: 'img2img',
+          model: 'flux-2-klein-4b-Q8_0',
+          execution_provider: useCpu ? 'cpu' : 'gpu',
+          ttfbMs
+        }))
+      }
+    }
+
+    // ── Assertions (on last iteration) ──────────────────────────────────────
     t.ok(progressTicks.length > 0, `Received progress ticks (got ${progressTicks.length})`)
     t.is(progressTicks[progressTicks.length - 1].total, STEPS, `Final progress tick reports ${STEPS} total steps`)
 
@@ -165,21 +185,9 @@ safeTest('FLUX2-klein img2img — transforms an input image', { timeout: 1800000
     t.is(dims.width, 624, 'Output width matches requested 624')
     t.is(dims.height, 624, 'Output height matches requested 624')
 
-    // Saved to modelDir so mobile has write permission to the same path
     const outPath = path.join(modelDir, 'generate-image--flux2-i2i-seed42.png')
     fs.writeFileSync(outPath, img)
     console.log(`\nSaved → ${outPath}`)
-
-    // ── Summary ───────────────────────────────────────────────────────────────
-    console.log('\n' + '='.repeat(60))
-    console.log('TEST SUMMARY')
-    console.log('='.repeat(60))
-    console.log(` Load time   : ${(loadMs / 1000).toFixed(1)}s`)
-    console.log(` Gen time    : ${(genMs / 1000).toFixed(1)}s`)
-    console.log(` Steps ticks : ${progressTicks.length}`)
-    console.log(` Image size  : ${img.length} bytes`)
-    console.log(' PNG valid   : true')
-    console.log('='.repeat(60))
   } finally {
     console.log('\n=== Cleanup ===')
     if (model) await model.unload().catch(() => {})

--- a/packages/diffusion-cpp/test/integration/generate-image-flux2.test.js
+++ b/packages/diffusion-cpp/test/integration/generate-image-flux2.test.js
@@ -12,6 +12,7 @@ const {
   isPng,
   safeTest
 } = require('./utils')
+const { recordPerformance, PERF_RUNS, WARMUP_RUNS } = require('./_perf-helper')
 
 const proc = require('bare-process')
 
@@ -100,38 +101,57 @@ safeTest('FLUX.2 klein txt2img — generates a valid PNG image', { timeout: 1800
     console.log(`Loaded in ${(loadMs / 1000).toFixed(1)}s`)
     t.ok(loadMs < 120000, `Model loaded within 120s (took ${(loadMs / 1000).toFixed(1)}s)`)
 
-    // ── Generate ──────────────────────────────────────────────────────────────
-    console.log('\n=== Generating image ===')
-    const tGen = Date.now()
+    // ── Generate (perf loop) ───────────────────────────────────────────────────
+    const totalIterations = WARMUP_RUNS + PERF_RUNS
+    for (let iteration = 0; iteration < totalIterations; iteration++) {
+      const isWarmup = iteration < WARMUP_RUNS
+      const runLabel = isWarmup ? `warmup ${iteration + 1}` : `run ${iteration - WARMUP_RUNS + 1}/${PERF_RUNS}`
+      console.log(`\n=== Generating image (${runLabel}) ===`)
+      const tGen = Date.now()
+      let ttfbMs = null
 
-    const response = await model.run({
-      prompt: 'a red fox in a snowy forest, laying on a rock with a santa hat, cartoon, watercolor',
-      steps: 10,
-      width: 512,
-      height: 512,
-      guidance: 3.5,
-      seed: 1000
-    })
+      images.length = 0
+      progressTicks.length = 0
 
-    await response
-      .onUpdate((data) => {
-        if (data instanceof Uint8Array) {
-          images.push(data)
-        } else if (typeof data === 'string') {
-          try {
-            const tick = JSON.parse(data)
-            if ('step' in tick && 'total' in tick) {
-              progressTicks.push(tick)
-            }
-          } catch (_) {}
-        }
+      const response = await model.run({
+        prompt: 'a red fox in a snowy forest, laying on a rock with a santa hat, cartoon, watercolor',
+        steps: 10,
+        width: 512,
+        height: 512,
+        guidance: 3.5,
+        seed: 1000 + iteration
       })
-      .await()
 
-    const genMs = Date.now() - tGen
-    console.log(`\nGenerated in ${(genMs / 1000).toFixed(1)}s`)
+      await response
+        .onUpdate((data) => {
+          if (ttfbMs === null) ttfbMs = Date.now() - tGen
+          if (data instanceof Uint8Array) {
+            images.push(data)
+          } else if (typeof data === 'string') {
+            try {
+              const tick = JSON.parse(data)
+              if ('step' in tick && 'total' in tick) {
+                progressTicks.push(tick)
+              }
+            } catch (_) {}
+          }
+        })
+        .await()
 
-    // ── Assertions ────────────────────────────────────────────────────────────
+      const genMs = Date.now() - tGen
+      console.log(`Generated in ${(genMs / 1000).toFixed(1)}s (TTFB: ${ttfbMs}ms)`)
+
+      if (!isWarmup) {
+        t.comment(recordPerformance('[FLUX.2 klein Q8_0 txt2img 512x512] [' + (useCpu ? 'CPU' : 'GPU') + ']', response.stats, {
+          scenario: 'txt2img',
+          model: 'flux-2-klein-4b-Q8_0',
+          execution_provider: useCpu ? 'cpu' : 'gpu',
+          ttfbMs
+        }))
+      }
+    }
+
+    // ── Assertions (on last iteration) ──────────────────────────────────────
     t.ok(progressTicks.length > 0, `Received progress ticks (got ${progressTicks.length})`)
     t.is(progressTicks[progressTicks.length - 1].total, 10, 'Final progress tick reports 10 total steps')
 
@@ -145,17 +165,6 @@ safeTest('FLUX.2 klein txt2img — generates a valid PNG image', { timeout: 1800
     const outPath = path.join(modelDir, 'generate-image--flux2-txt2img-seed42.png')
     fs.writeFileSync(outPath, img)
     console.log(`\nSaved → ${outPath}`)
-
-    // ── Summary ───────────────────────────────────────────────────────────────
-    console.log('\n' + '='.repeat(60))
-    console.log('TEST SUMMARY')
-    console.log('='.repeat(60))
-    console.log(` Load time   : ${(loadMs / 1000).toFixed(1)}s`)
-    console.log(` Gen time    : ${(genMs / 1000).toFixed(1)}s`)
-    console.log(` Steps ticks : ${progressTicks.length}`)
-    console.log(` Image size  : ${img.length} bytes`)
-    console.log(' PNG valid   : true')
-    console.log('='.repeat(60))
   } finally {
     console.log('\n=== Cleanup ===')
     if (model) await model.unload().catch(() => {})

--- a/packages/diffusion-cpp/test/integration/generate-image-sd3-i2i.test.js
+++ b/packages/diffusion-cpp/test/integration/generate-image-sd3-i2i.test.js
@@ -12,6 +12,7 @@ const {
   isPng,
   safeTest
 } = require('./utils')
+const { recordPerformance, PERF_RUNS, WARMUP_RUNS } = require('./_perf-helper')
 
 const proc = require('bare-process')
 
@@ -90,45 +91,64 @@ safeTest('SD3 Medium img2img — transforms an input image', { timeout: 1800000,
     const initImage = fs.readFileSync(initImagePath)
     console.log(`\nLoaded init image: ${initImage.length} bytes`)
 
-    // ── Generate (img2img) ────────────────────────────────────────────────────
-    console.log('\n=== Generating image (img2img) ===')
-    console.log(`  Steps    : ${STEPS}`)
-    console.log(`  CFG Scale: ${CFG_SCALE}`)
-    console.log(`  Strength : ${STRENGTH}`)
-    console.log(`  Seed     : ${SEED}`)
+    // ── Generate (perf loop) ───────────────────────────────────────────────────
+    const totalIterations = WARMUP_RUNS + PERF_RUNS
+    for (let iteration = 0; iteration < totalIterations; iteration++) {
+      const isWarmup = iteration < WARMUP_RUNS
+      const runLabel = isWarmup ? `warmup ${iteration + 1}` : `run ${iteration - WARMUP_RUNS + 1}/${PERF_RUNS}`
+      console.log(`\n=== Generating image (img2img ${runLabel}) ===`)
+      console.log(`  Steps    : ${STEPS}`)
+      console.log(`  CFG Scale: ${CFG_SCALE}`)
+      console.log(`  Strength : ${STRENGTH}`)
+      console.log(`  Seed     : ${SEED + iteration}`)
 
-    const tGen = Date.now()
+      const tGen = Date.now()
+      let ttfbMs = null
 
-    const response = await model.run({
-      prompt: 'anime portrait, scientist, same pose, comic-book style, professional illustration',
-      negative_prompt: 'photorealistic, blurry, low quality, 3d render, deformed, different person',
-      init_image: initImage,
-      cfg_scale: CFG_SCALE,
-      steps: STEPS,
-      strength: STRENGTH,
-      sampling_method: 'euler',
-      seed: SEED
-    })
+      images.length = 0
+      progressTicks.length = 0
 
-    await response
-      .onUpdate((data) => {
-        if (data instanceof Uint8Array) {
-          images.push(data)
-        } else if (typeof data === 'string') {
-          try {
-            const tick = JSON.parse(data)
-            if ('step' in tick && 'total' in tick) {
-              progressTicks.push(tick)
-            }
-          } catch (_) {}
-        }
+      const response = await model.run({
+        prompt: 'anime portrait, scientist, same pose, comic-book style, professional illustration',
+        negative_prompt: 'photorealistic, blurry, low quality, 3d render, deformed, different person',
+        init_image: initImage,
+        cfg_scale: CFG_SCALE,
+        steps: STEPS,
+        strength: STRENGTH,
+        sampling_method: 'euler',
+        seed: SEED + iteration
       })
-      .await()
 
-    const genMs = Date.now() - tGen
-    console.log(`\nGenerated in ${(genMs / 1000).toFixed(1)}s`)
+      await response
+        .onUpdate((data) => {
+          if (ttfbMs === null) ttfbMs = Date.now() - tGen
+          if (data instanceof Uint8Array) {
+            images.push(data)
+          } else if (typeof data === 'string') {
+            try {
+              const tick = JSON.parse(data)
+              if ('step' in tick && 'total' in tick) {
+                progressTicks.push(tick)
+              }
+            } catch (_) {}
+          }
+        })
+        .await()
 
-    // ── Assertions ────────────────────────────────────────────────────────────
+      const genMs = Date.now() - tGen
+      console.log(`Generated in ${(genMs / 1000).toFixed(1)}s (TTFB: ${ttfbMs}ms)`)
+
+      if (!isWarmup) {
+        t.comment(recordPerformance('[SD3 img2img] [' + (useCpu ? 'CPU' : 'GPU') + ']', response.stats, {
+          scenario: 'img2img',
+          model: 'sd3_medium_incl_clips',
+          execution_provider: useCpu ? 'cpu' : 'gpu',
+          ttfbMs
+        }))
+      }
+    }
+
+    // ── Assertions (on last iteration) ──────────────────────────────────────
     t.ok(progressTicks.length > 0, `Received progress ticks (got ${progressTicks.length})`)
 
     t.is(images.length, 1, 'Received exactly 1 image')
@@ -146,17 +166,6 @@ safeTest('SD3 Medium img2img — transforms an input image', { timeout: 1800000,
     const outPath = path.join(modelDir, 'generate-image--sd3-i2i-seed3.png')
     fs.writeFileSync(outPath, img)
     console.log(`\nSaved → ${outPath}`)
-
-    // ── Summary ───────────────────────────────────────────────────────────────
-    console.log('\n' + '='.repeat(60))
-    console.log('TEST SUMMARY')
-    console.log('='.repeat(60))
-    console.log(` Load time   : ${(loadMs / 1000).toFixed(1)}s`)
-    console.log(` Gen time    : ${(genMs / 1000).toFixed(1)}s`)
-    console.log(` Steps ticks : ${progressTicks.length}`)
-    console.log(` Image size  : ${img.length} bytes`)
-    console.log(' PNG valid   : true')
-    console.log('='.repeat(60))
   } finally {
     console.log('\n=== Cleanup ===')
     if (model) await model.unload().catch(() => {})

--- a/packages/diffusion-cpp/test/integration/generate-image-sd3.test.js
+++ b/packages/diffusion-cpp/test/integration/generate-image-sd3.test.js
@@ -12,6 +12,7 @@ const {
   isPng,
   safeTest
 } = require('./utils')
+const { recordPerformance, PERF_RUNS, WARMUP_RUNS } = require('./_perf-helper')
 
 const proc = require('bare-process')
 
@@ -75,40 +76,59 @@ safeTest('SD3 Medium txt2img — generates a valid PNG image', { timeout: 900000
     console.log(`Loaded in ${(loadMs / 1000).toFixed(1)}s`)
     t.ok(loadMs < 120000, `Model loaded within 120s (took ${(loadMs / 1000).toFixed(1)}s)`)
 
-    // ── Generate ──────────────────────────────────────────────────────────────
-    console.log('\n=== Generating image ===')
-    const tGen = Date.now()
+    // ── Generate (perf loop) ───────────────────────────────────────────────────
+    const totalIterations = WARMUP_RUNS + PERF_RUNS
+    for (let iteration = 0; iteration < totalIterations; iteration++) {
+      const isWarmup = iteration < WARMUP_RUNS
+      const runLabel = isWarmup ? `warmup ${iteration + 1}` : `run ${iteration - WARMUP_RUNS + 1}/${PERF_RUNS}`
+      console.log(`\n=== Generating image (${runLabel}) ===`)
+      const tGen = Date.now()
+      let ttfbMs = null
 
-    const response = await model.run({
-      prompt: 'a red fox in a snowy forest, photorealistic',
-      negative_prompt: 'blurry, low quality, watermark',
-      steps: 10,
-      width: 512,
-      height: 512,
-      cfg_scale: 5.0,
-      sampling_method: 'euler',
-      seed: 42
-    })
+      images.length = 0
+      progressTicks.length = 0
 
-    await response
-      .onUpdate((data) => {
-        if (data instanceof Uint8Array) {
-          images.push(data)
-        } else if (typeof data === 'string') {
-          try {
-            const tick = JSON.parse(data)
-            if ('step' in tick && 'total' in tick) {
-              progressTicks.push(tick)
-            }
-          } catch (_) {}
-        }
+      const response = await model.run({
+        prompt: 'a red fox in a snowy forest, photorealistic',
+        negative_prompt: 'blurry, low quality, watermark',
+        steps: 10,
+        width: 512,
+        height: 512,
+        cfg_scale: 5.0,
+        sampling_method: 'euler',
+        seed: 42 + iteration
       })
-      .await()
 
-    const genMs = Date.now() - tGen
-    console.log(`\nGenerated in ${(genMs / 1000).toFixed(1)}s`)
+      await response
+        .onUpdate((data) => {
+          if (ttfbMs === null) ttfbMs = Date.now() - tGen
+          if (data instanceof Uint8Array) {
+            images.push(data)
+          } else if (typeof data === 'string') {
+            try {
+              const tick = JSON.parse(data)
+              if ('step' in tick && 'total' in tick) {
+                progressTicks.push(tick)
+              }
+            } catch (_) {}
+          }
+        })
+        .await()
 
-    // ── Assertions ────────────────────────────────────────────────────────────
+      const genMs = Date.now() - tGen
+      console.log(`Generated in ${(genMs / 1000).toFixed(1)}s (TTFB: ${ttfbMs}ms)`)
+
+      if (!isWarmup) {
+        t.comment(recordPerformance('[SD3 txt2img] [' + (useCpu ? 'CPU' : 'GPU') + ']', response.stats, {
+          scenario: 'txt2img',
+          model: 'sd3_medium_incl_clips',
+          execution_provider: useCpu ? 'cpu' : 'gpu',
+          ttfbMs
+        }))
+      }
+    }
+
+    // ── Assertions (on last iteration) ──────────────────────────────────────
     t.ok(progressTicks.length > 0, `Received progress ticks (got ${progressTicks.length})`)
     t.is(progressTicks[progressTicks.length - 1].total, 10, 'Final progress tick reports 10 total steps')
 
@@ -122,17 +142,6 @@ safeTest('SD3 Medium txt2img — generates a valid PNG image', { timeout: 900000
     const outPath = path.join(modelDir, 'generate-image--sd3-txt2img-seed42.png')
     fs.writeFileSync(outPath, img)
     console.log(`\nSaved → ${outPath}`)
-
-    // ── Summary ───────────────────────────────────────────────────────────────
-    console.log('\n' + '='.repeat(60))
-    console.log('TEST SUMMARY')
-    console.log('='.repeat(60))
-    console.log(` Load time   : ${(loadMs / 1000).toFixed(1)}s`)
-    console.log(` Gen time    : ${(genMs / 1000).toFixed(1)}s`)
-    console.log(` Steps ticks : ${progressTicks.length}`)
-    console.log(` Image size  : ${img.length} bytes`)
-    console.log(' PNG valid   : true')
-    console.log('='.repeat(60))
   } finally {
     console.log('\n=== Cleanup ===')
     if (model) await model.unload().catch(() => {})

--- a/packages/diffusion-cpp/test/integration/generate-image-sdxl.test.js
+++ b/packages/diffusion-cpp/test/integration/generate-image-sdxl.test.js
@@ -12,6 +12,7 @@ const {
   isPng,
   safeTest
 } = require('./utils')
+const { recordPerformance, PERF_RUNS, WARMUP_RUNS } = require('./_perf-helper')
 
 const proc = require('bare-process')
 
@@ -72,39 +73,58 @@ safeTest('SDXL txt2img — generates a valid PNG image', { timeout: 900000, skip
     console.log(`Loaded in ${(loadMs / 1000).toFixed(1)}s`)
     t.ok(loadMs < 120000, `Model loaded within 120s (took ${(loadMs / 1000).toFixed(1)}s)`)
 
-    // ── Generate ──────────────────────────────────────────────────────────────
-    console.log('\n=== Generating image ===')
-    const tGen = Date.now()
+    // ── Generate (perf loop) ───────────────────────────────────────────────────
+    const totalIterations = WARMUP_RUNS + PERF_RUNS
+    for (let iteration = 0; iteration < totalIterations; iteration++) {
+      const isWarmup = iteration < WARMUP_RUNS
+      const runLabel = isWarmup ? `warmup ${iteration + 1}` : `run ${iteration - WARMUP_RUNS + 1}/${PERF_RUNS}`
+      console.log(`\n=== Generating image (${runLabel}) ===`)
+      const tGen = Date.now()
+      let ttfbMs = null
 
-    const response = await model.run({
-      prompt: 'a red fox in a snowy forest, photorealistic',
-      negative_prompt: 'blurry, low quality, watermark',
-      steps: 10,
-      width: 1024,
-      height: 1024,
-      cfg_scale: 6.5,
-      seed: 15
-    })
+      images.length = 0
+      progressTicks.length = 0
 
-    await response
-      .onUpdate((data) => {
-        if (data instanceof Uint8Array) {
-          images.push(data)
-        } else if (typeof data === 'string') {
-          try {
-            const tick = JSON.parse(data)
-            if ('step' in tick && 'total' in tick) {
-              progressTicks.push(tick)
-            }
-          } catch (_) {}
-        }
+      const response = await model.run({
+        prompt: 'a red fox in a snowy forest, photorealistic',
+        negative_prompt: 'blurry, low quality, watermark',
+        steps: 10,
+        width: 1024,
+        height: 1024,
+        cfg_scale: 6.5,
+        seed: 15 + iteration
       })
-      .await()
 
-    const genMs = Date.now() - tGen
-    console.log(`\nGenerated in ${(genMs / 1000).toFixed(1)}s`)
+      await response
+        .onUpdate((data) => {
+          if (ttfbMs === null) ttfbMs = Date.now() - tGen
+          if (data instanceof Uint8Array) {
+            images.push(data)
+          } else if (typeof data === 'string') {
+            try {
+              const tick = JSON.parse(data)
+              if ('step' in tick && 'total' in tick) {
+                progressTicks.push(tick)
+              }
+            } catch (_) {}
+          }
+        })
+        .await()
 
-    // ── Assertions ────────────────────────────────────────────────────────────
+      const genMs = Date.now() - tGen
+      console.log(`Generated in ${(genMs / 1000).toFixed(1)}s (TTFB: ${ttfbMs}ms)`)
+
+      if (!isWarmup) {
+        t.comment(recordPerformance('[SDXL txt2img] [' + (useCpu ? 'CPU' : 'GPU') + ']', response.stats, {
+          scenario: 'txt2img',
+          model: 'stable-diffusion-xl-base-1.0-Q4_0',
+          execution_provider: useCpu ? 'cpu' : 'gpu',
+          ttfbMs
+        }))
+      }
+    }
+
+    // ── Assertions (on last iteration) ──────────────────────────────────────
     t.ok(progressTicks.length > 0, `Received progress ticks (got ${progressTicks.length})`)
     t.is(progressTicks[progressTicks.length - 1].total, 10, 'Final progress tick reports 10 total steps')
 
@@ -118,17 +138,6 @@ safeTest('SDXL txt2img — generates a valid PNG image', { timeout: 900000, skip
     const outPath = path.join(modelDir, 'generate-image--sdxl-txt2img-seed15.png')
     fs.writeFileSync(outPath, img)
     console.log(`\nSaved → ${outPath}`)
-
-    // ── Summary ───────────────────────────────────────────────────────────────
-    console.log('\n' + '='.repeat(60))
-    console.log('TEST SUMMARY')
-    console.log('='.repeat(60))
-    console.log(` Load time   : ${(loadMs / 1000).toFixed(1)}s`)
-    console.log(` Gen time    : ${(genMs / 1000).toFixed(1)}s`)
-    console.log(` Steps ticks : ${progressTicks.length}`)
-    console.log(` Image size  : ${img.length} bytes`)
-    console.log(' PNG valid   : true')
-    console.log('='.repeat(60))
   } finally {
     console.log('\n=== Cleanup ===')
     if (model) await model.unload().catch(() => {})

--- a/packages/diffusion-cpp/test/integration/generate-image.test.js
+++ b/packages/diffusion-cpp/test/integration/generate-image.test.js
@@ -13,6 +13,7 @@ const {
   isPng,
   safeTest
 } = require('./utils')
+const { recordPerformance, PERF_RUNS, WARMUP_RUNS } = require('./_perf-helper')
 
 const platform = detectPlatform()
 const isDarwinX64 = os.platform() === 'darwin' && os.arch() === 'x64'
@@ -76,39 +77,58 @@ safeTest('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000, ski
     console.log(`Loaded in ${(loadMs / 1000).toFixed(1)}s`)
     t.ok(loadMs < 120000, `Model loaded within 120s (took ${(loadMs / 1000).toFixed(1)}s)`)
 
-    // ── Generate ──────────────────────────────────────────────────────────────
-    console.log('\n=== Generating image ===')
-    const tGen = Date.now()
+    // ── Generate (perf loop) ───────────────────────────────────────────────────
+    const totalIterations = WARMUP_RUNS + PERF_RUNS
+    for (let iteration = 0; iteration < totalIterations; iteration++) {
+      const isWarmup = iteration < WARMUP_RUNS
+      const runLabel = isWarmup ? `warmup ${iteration + 1}` : `run ${iteration - WARMUP_RUNS + 1}/${PERF_RUNS}`
+      console.log(`\n=== Generating image (${runLabel}) ===`)
+      const tGen = Date.now()
+      let ttfbMs = null
 
-    const response = await model.run({
-      prompt: 'a red fox in a snowy forest, photorealistic',
-      negative_prompt: 'blurry, low quality, watermark',
-      steps: 10,
-      width: 712,
-      height: 712,
-      cfg_scale: 7.5,
-      seed: 42 // fixed seed for reproducibility
-    })
+      images.length = 0
+      progressTicks.length = 0
 
-    await response
-      .onUpdate((data) => {
-        if (data instanceof Uint8Array) {
-          images.push(data)
-        } else if (typeof data === 'string') {
-          try {
-            const tick = JSON.parse(data)
-            if ('step' in tick && 'total' in tick) {
-              progressTicks.push(tick)
-            }
-          } catch (_) {}
-        }
+      const response = await model.run({
+        prompt: 'a red fox in a snowy forest, photorealistic',
+        negative_prompt: 'blurry, low quality, watermark',
+        steps: 10,
+        width: 712,
+        height: 712,
+        cfg_scale: 7.5,
+        seed: 42 + iteration
       })
-      .await()
 
-    const genMs = Date.now() - tGen
-    console.log(`\nGenerated in ${(genMs / 1000).toFixed(1)}s`)
+      await response
+        .onUpdate((data) => {
+          if (ttfbMs === null) ttfbMs = Date.now() - tGen
+          if (data instanceof Uint8Array) {
+            images.push(data)
+          } else if (typeof data === 'string') {
+            try {
+              const tick = JSON.parse(data)
+              if ('step' in tick && 'total' in tick) {
+                progressTicks.push(tick)
+              }
+            } catch (_) {}
+          }
+        })
+        .await()
 
-    // ── Assertions ────────────────────────────────────────────────────────────
+      const genMs = Date.now() - tGen
+      console.log(`Generated in ${(genMs / 1000).toFixed(1)}s (TTFB: ${ttfbMs}ms)`)
+
+      if (!isWarmup) {
+        t.comment(recordPerformance('[SD2.1 Q8_0 txt2img 712x712] [' + (useCpu ? 'CPU' : 'GPU') + ']', response.stats, {
+          scenario: 'txt2img',
+          model: 'stable-diffusion-v2-1-Q8_0',
+          execution_provider: useCpu ? 'cpu' : 'gpu',
+          ttfbMs
+        }))
+      }
+    }
+
+    // ── Assertions (on last iteration) ──────────────────────────────────────
     t.ok(progressTicks.length > 0, `Received progress ticks (got ${progressTicks.length})`)
     t.is(progressTicks[progressTicks.length - 1].total, 10, 'Final progress tick reports 10 total steps')
 
@@ -119,22 +139,9 @@ safeTest('SD2.1 txt2img — generates a valid PNG image', { timeout: 600000, ski
     t.ok(img.length > 0, `Image is non-empty (${img.length} bytes)`)
     t.ok(isPng(img), 'Image has valid PNG magic bytes')
 
-    // Save output for CI artifact upload — filename encodes test origin
-    // Saved to modelDir so mobile has write permission to the same path
     const outPath = path.join(modelDir, 'generate-image--sd2-txt2img-seed42.png')
     fs.writeFileSync(outPath, img)
     console.log(`\nSaved → ${outPath}`)
-
-    // ── Summary ───────────────────────────────────────────────────────────────
-    console.log('\n' + '='.repeat(60))
-    console.log('TEST SUMMARY')
-    console.log('='.repeat(60))
-    console.log(` Load time   : ${(loadMs / 1000).toFixed(1)}s`)
-    console.log(` Gen time    : ${(genMs / 1000).toFixed(1)}s`)
-    console.log(` Steps ticks : ${progressTicks.length}`)
-    console.log(` Image size  : ${img.length} bytes`)
-    console.log(' PNG valid   : true')
-    console.log('='.repeat(60))
   } finally {
     console.log('\n=== Cleanup ===')
     if (model) await model.unload().catch(() => {})

--- a/packages/diffusion-cpp/test/integration/generate-video-wan.test.js
+++ b/packages/diffusion-cpp/test/integration/generate-video-wan.test.js
@@ -27,6 +27,7 @@ const test = require('brittle')
 const binding = require('../../binding')
 const VideoStableDiffusion = require('@qvac/diffusion-cpp/video')
 const { detectPlatform, setupJsLogger, ensureModelPath } = require('./utils')
+const { recordPerformance } = require('./_perf-helper')
 
 const isMobile = os.platform() === 'ios' || os.platform() === 'android'
 const isDarwin = os.platform() === 'darwin'
@@ -212,6 +213,7 @@ test('Wan 2.1 T2V — smoke (txt2vid) generates a structurally valid AVI',
     })
 
     let avi = null
+    let ttfbMs = null
     const progressTicks = []
     const stringDataPayloads = []
 
@@ -242,6 +244,7 @@ test('Wan 2.1 T2V — smoke (txt2vid) generates a structurally valid AVI',
 
       await response
         .onUpdate((data) => {
+          if (ttfbMs === null) ttfbMs = Date.now() - tGen
           if (data instanceof Uint8Array) {
             avi = data
           } else if (typeof data === 'string') {
@@ -258,6 +261,17 @@ test('Wan 2.1 T2V — smoke (txt2vid) generates a structurally valid AVI',
 
       const genMs = Date.now() - tGen
       console.log(`\nGenerated in ${(genMs / 1000).toFixed(1)}s`)
+
+      t.comment(recordPerformance(
+        '[Wan 2.1 txt2vid] [GPU]',
+        response.stats,
+        {
+          scenario: 'txt2vid',
+          model: 'wan2.1_t2v_1.3B_fp16',
+          execution_provider: (proc.env && proc.env.WAN_DEVICE) || 'gpu',
+          ttfbMs
+        }
+      ))
 
       // ── Progress assertions ─────────────────────────────────────────────
       // Wan generation is multi-phase (text encode, denoise loop, VAE
@@ -394,6 +408,7 @@ test('Wan 2.1 I2V — smoke (img2vid) generates a structurally valid AVI',
     })
 
     let avi = null
+    let ttfbMs = null
     const progressTicks = []
 
     try {
@@ -422,6 +437,7 @@ test('Wan 2.1 I2V — smoke (img2vid) generates a structurally valid AVI',
 
       await response
         .onUpdate((data) => {
+          if (ttfbMs === null) ttfbMs = Date.now() - tGen
           if (data instanceof Uint8Array) {
             avi = data
           } else if (typeof data === 'string') {
@@ -437,6 +453,17 @@ test('Wan 2.1 I2V — smoke (img2vid) generates a structurally valid AVI',
 
       const genMs = Date.now() - tGen
       console.log(`\nGenerated in ${(genMs / 1000).toFixed(1)}s`)
+
+      t.comment(recordPerformance(
+        '[Wan 2.1 img2vid] [GPU]',
+        response.stats,
+        {
+          scenario: 'img2vid',
+          model: 'wan2.1-i2v-14b-480p-Q4_K_M',
+          execution_provider: (proc.env && proc.env.WAN_DEVICE) || 'gpu',
+          ttfbMs
+        }
+      ))
 
       // ── Progress assertions ─────────────────────────────────────────────
       t.ok(progressTicks.length > 0,

--- a/scripts/test-utils/performance-reporter.js
+++ b/scripts/test-utils/performance-reporter.js
@@ -511,6 +511,16 @@ const METRIC_COLUMNS = {
     { key: 'ttfa_ms', label: 'TTFA (ms)' },
     { key: 'inter_chunk_p95_ms', label: 'Inter-chunk P95 (ms)' }
   ],
+  diffusion: [
+    { key: 'model_load_ms', label: 'Load (ms)' },
+    { key: 'generation_ms', label: 'Gen (ms)' },
+    { key: 'ttfb_ms', label: 'TTFB (ms)' },
+    { key: 'total_steps', label: 'Steps' },
+    { key: 'steps_per_second', label: 'Steps/sec' },
+    { key: 'megapixels_per_second', label: 'MP/sec' },
+    { key: 'width', label: 'Width' },
+    { key: 'height', label: 'Height' }
+  ],
   generic: [
     { key: 'total_time_ms', label: 'Total Time (ms)' },
     { key: 'tps', label: 'TPS' }
@@ -593,6 +603,14 @@ function createPerformanceReporter (opts) {
           ode_time_ms: null,
           backend: null,
           platform: null,
+          model_load_ms: null,
+          generation_ms: null,
+          ttfb_ms: null,
+          total_steps: null,
+          steps_per_second: null,
+          megapixels_per_second: null,
+          width: null,
+          height: null,
           ...metrics
         },
         input: (extra && extra.input) || null,


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- No automated performance regression detection for `@qvac/diffusion-cpp` — the v0.11.0 regression (12.8x slower TTFB, 2.4x slower generation from a `keep_clip_on_cpu` ifdef) was caught manually by comparing SDK e2e wall-clock times.
- Missing perf data in CI: no `performance-report.json` artifacts, no Step Summary table, no weekly trend tracking for diffusion.

## 📝 How does it solve it?

- Add `diffusion` addonType to `METRIC_COLUMNS` in `performance-reporter.js` (Load, Gen, TTFB, Steps, Steps/sec, MP/sec, Width, Height)
- New `_perf-helper.js` singleton with mobile inline fallback, `PERF_RUNS`/`WARMUP_RUNS` loop exports
- Wire `recordPerformance()` + TTFB measurement into all existing generation tests (SD2, FLUX, SDXL, SD3, img2img variants, ESRGAN, Wan video)
- Wire `recordPerformance()` into mobile tests (`api-behavior.test.js`, `esrgan-backend-device.test.js`)
- Desktop CI: upload `performance-report.json` artifact, set `QVAC_PERF_RUNS=3`
- Mobile CI: `enables-perf: 'true'` + `extract-addon-perf` step
- On-PR: `combine-perf-reports` job → cross-platform GitHub Step Summary
- New `benchmark-performance-diffusion-cpp.yml` (on-demand, configurable iterations)
- Add diffusion-cpp to `perf-report.yml` weekly schedule

## 🧪 How was it tested?

- Simulated `recordPerformance()` output with real Device Farm timing data (iOS iPhone 17: 8.19s gen, Android Pixel 9 Pro: 273s first-run gen)
- Verified all metrics compute correctly: steps/sec, MP/sec, TTFB from JS timing
- Confirmed v0.11.0 regression would be immediately visible (TTFB 1.14s→14.59s = 12.8x in Step Summary)
- Manual workflow_dispatch trigger of on-pr-diffusion-cpp.yml
- [ ] Verify desktop integration tests pass with PERF_RUNS=3
- [ ] Verify `performance-report.json` artifact is uploaded per matrix leg
- [ ] Verify mobile Device Farm logs contain `[PERF_REPORT_START]...[PERF_REPORT_END]` markers
- [ ] Verify `combine-perf-reports` job produces a Step Summary table