### PR TITLE
QVAC-20580 feat[api]: add `subscribeServerLogs` to capture all server logs

### DIFF
--- a/docs/website/content/docs/runtime/logging.mdx
+++ b/docs/website/content/docs/runtime/logging.mdx
@@ -6,16 +6,18 @@ schemaType: HowTo
 
 ## Overview
 
-QVAC provides two complementary logging primitives:
+QVAC provides three complementary logging primitives:
 
-- `loggingStream()`: stream real-time logs emitted by the SDK server and native addons (llamacpp, whispercpp, etc.). You decide what to do with each log line (print, persist, filter).
+- `subscribeServerLogs()`: subscribe to **every** server-side log (SDK server, all loaded models, RAG) through a single stream, without tracking individual stream IDs. Returns an unsubscribe function.
+- `loggingStream()`: stream real-time logs for a **single** source — the SDK server (`SDK_LOG_ID`) or one model (its model ID). You decide what to do with each log line (print, persist, filter).
 - `getLogger()`: create a logger for your own application code (namespaced, configurable level, optional transports).
 
 ## Functions
 
 1. [`getLogger()`](/reference/api) — create a logger
 2. [`loadModel()`](/reference/api#loadmodel) — pass logger via `logger` option
-3. [`loggingStream()`](/reference/api#loggingstream) — stream real-time logs from models or SDK server
+3. [`loggingStream()`](/reference/api#loggingstream) — stream real-time logs from a single model or the SDK server
+4. [`subscribeServerLogs()`](/reference/api#subscribeserverlogs) — stream all server-side logs through one subscription
 
 For how to use each function, see [SDK — API reference](/reference/api/).
 
@@ -33,9 +35,11 @@ For how to use each function, see [SDK — API reference](/reference/api/).
 
 ## Features
 
-* **Streaming API (`loggingStream`)** — Consume real-time logs programmatically. Stream either:
+* **Streaming API (`loggingStream`)** — Consume real-time logs from one source programmatically. Stream either:
   - SDK server logs using `SDK_LOG_ID`, or
   - per-model addon logs using the model ID returned by `loadModel()`.
+
+* **Global subscription (`subscribeServerLogs`)** — Receive every server-side log (SDK server, all models, RAG) through a single subscription, without knowing the stream IDs ahead of time. The handler is called once per log line, and each log carries its origin in `log.id` (`SDK_LOG_ID`, a model ID, or a RAG workspace key) so you can still tell the sources apart. It is built on `loggingStream` and the reserved `SDK_ALL_LOG_ID` stream that the worker fans all logs into. The call returns an `unsubscribe()` function — invoke it to stop receiving logs.
 
 * **Logger API (`getLogger`)** — Create loggers for your application code with custom transports. Console output enabled by default; set `enableConsole: false` to use only custom transports.
 
@@ -64,6 +68,26 @@ The following script shows an example of streaming logs from loaded models:
 <WrapCode>
 
 ```ts file=<rootDir>/packages/sdk/examples/logging-streaming.ts title="logging.ts" lineNumbers
+```
+</WrapCode>
+</Tab>
+</Tabs>
+
+To capture logs from every source (SDK server, all models, RAG) with a single subscription, use `subscribeServerLogs`:
+
+<Tabs>
+<Tab value="js" label="JavaScript" default>
+<WrapCode>
+
+```js file=<rootDir>/packages/sdk/dist/examples/logging-global.js title="logging-global.js" lineNumbers
+```
+</WrapCode>
+</Tab>
+
+<Tab value="ts" label="TypeScript">
+<WrapCode>
+
+```ts file=<rootDir>/packages/sdk/examples/logging-global.ts title="logging-global.ts" lineNumbers
 ```
 </WrapCode>
 </Tab>

--- a/packages/sdk/client/api/index.ts
+++ b/packages/sdk/client/api/index.ts
@@ -4,6 +4,7 @@ export { completion } from "./completion-stream";
 export { deleteCache } from "./delete-cache";
 export { unloadModel } from "./unload-model";
 export { loggingStream } from "./logging-stream";
+export { subscribeServerLogs, type ServerLogHandler } from "./subscribe-logs";
 export { heartbeat } from "./heartbeat";
 export { transcribe, transcribeStream } from "./transcribe";
 export { bciTranscribe, bciTranscribeStream } from "./bci-transcribe";

--- a/packages/sdk/client/api/subscribe-logs.ts
+++ b/packages/sdk/client/api/subscribe-logs.ts
@@ -1,0 +1,49 @@
+import { getClientLogger, SDK_ALL_LOG_ID } from "@/logging";
+import { loggingStream } from "./logging-stream";
+import type { LoggingStreamResponse } from "@/schemas/logging-stream";
+
+const logger = getClientLogger();
+
+export type ServerLogHandler = (log: LoggingStreamResponse) => void;
+
+/**
+ * Subscribes to every server-side log through a single stream: SDK server logs,
+ * per-model addon logs (llamacpp, whispercpp, …) for all loaded models, and RAG
+ * logs — without having to open a {@link loggingStream} per id.
+ *
+ * Each delivered log keeps its origin in `log.id`: `SDK_LOG_ID` for SDK server
+ * logs, the model id for model logs, or the RAG workspace key. Use it to tell the
+ * sources apart.
+ *
+ * Internally this opens a {@link loggingStream} on the reserved `SDK_ALL_LOG_ID`
+ * stream that the worker fans every log into.
+ *
+ * @param handler - called once per log line.
+ * @returns a function that stops the subscription.
+ *
+ * @example
+ * ```typescript
+ * const unsubscribe = subscribeServerLogs((log) => {
+ *   console.log(`[${log.level}] ${log.id} ${log.namespace}: ${log.message}`);
+ * });
+ * // later
+ * unsubscribe();
+ * ```
+ */
+export function subscribeServerLogs(handler: ServerLogHandler) {
+  const streamIterator = loggingStream({ id: SDK_ALL_LOG_ID });
+
+  void (async () => {
+    try {
+      for await (const log of streamIterator) {
+        handler(log);
+      }
+    } catch (error) {
+      logger.error("Server log stream error:", error);
+    }
+  })();
+
+  return () => {
+    void streamIterator.return(undefined);
+  };
+}

--- a/packages/sdk/examples/config/logging/logging.config.json
+++ b/packages/sdk/examples/config/logging/logging.config.json
@@ -1,0 +1,3 @@
+{
+  "loggerConsoleOutput": false
+}

--- a/packages/sdk/examples/logging-global.ts
+++ b/packages/sdk/examples/logging-global.ts
@@ -1,0 +1,40 @@
+// loggerConsoleOutput: false in this config disables the default console
+// transport on both the client and the worker, so the only logs printed are
+// the ones our handler below receives.
+const configDir = import.meta.dirname ?? process.cwd();
+process.env["QVAC_CONFIG_PATH"] = `${configDir}/config/logging/logging.config.json`;
+
+const { loadModel, completion, unloadModel, subscribeServerLogs, LLAMA_3_2_1B_INST_Q4_0 } =
+  await import("@qvac/sdk");
+
+try {
+  console.log("🚀 Starting global logging demo...\n");
+
+  // One subscription captures every server-side log (SDK, models, RAG, …)
+  // without having to know any stream IDs ahead of time.
+  const unsubscribe = subscribeServerLogs((log) => {
+    console.log(`[${log.level.toUpperCase()}] [${log.namespace}] ${log.message}`);
+  });
+
+  const modelId = await loadModel({
+    modelSrc: LLAMA_3_2_1B_INST_Q4_0,
+    modelConfig: { ctx_size: 2048 },
+  });
+
+  const result = completion({
+    modelId,
+    history: [{ role: "user", content: "Count from 1 to 5." }],
+    stream: true,
+  });
+
+  console.log("📝 Response:\n");
+  for await (const token of result.tokenStream) {
+    process.stdout.write(token);
+  }
+
+  await unloadModel({ modelId, clearStorage: false });
+  unsubscribe();
+} catch (error) {
+  console.error("❌ Error:", error);
+  process.exit(1);
+}

--- a/packages/sdk/index.ts
+++ b/packages/sdk/index.ts
@@ -32,6 +32,8 @@ export {
   getModelInfo,
   getLoadedModelInfo,
   loggingStream,
+  subscribeServerLogs,
+  type ServerLogHandler,
   ocr,
   invokePlugin,
   invokePluginStream,
@@ -225,7 +227,7 @@ export {
 } from "./utils/errors-client";
 
 // Logging exports
-export { getLogger, SDK_LOG_ID } from "./logging";
+export { getLogger, SDK_LOG_ID, SDK_ALL_LOG_ID } from "./logging";
 export type { Logger, LogTransport, LoggerOptions } from "./logging";
 
 // Profiler exports

--- a/packages/sdk/logging/index.ts
+++ b/packages/sdk/logging/index.ts
@@ -12,6 +12,7 @@ export type { Logger, LoggerOptions, LogTransport } from "./types";
 export {
   RAG_NAMESPACE,
   SDK_LOG_ID,
+  SDK_ALL_LOG_ID,
   SDK_SERVER_NAMESPACE,
   type AddonNamespace,
 } from "./namespaces";

--- a/packages/sdk/logging/namespaces.ts
+++ b/packages/sdk/logging/namespaces.ts
@@ -7,5 +7,8 @@ export type AddonNamespace = CanonicalModelType | typeof RAG_NAMESPACE;
 // Reserved ID for SDK server logs
 export const SDK_LOG_ID = "__sdk__";
 
+// Reserved ID for the stream that receives all server-side logs
+export const SDK_ALL_LOG_ID = "__all__";
+
 // Namespace for all SDK server logs
 export const SDK_SERVER_NAMESPACE = "sdk:server";

--- a/packages/sdk/server/bare/registry/logging-stream-registry.ts
+++ b/packages/sdk/server/bare/registry/logging-stream-registry.ts
@@ -12,11 +12,20 @@
  */
 
 import type { LogLevel } from "@qvac/logging";
+import { SDK_ALL_LOG_ID } from "@/logging/namespaces";
 
-const loggingStreams = new Map<
-  string,
-  Set<(level: LogLevel, namespace: string, message: string) => void>
->();
+// `sourceId` is the id the log was emitted under (a model id, SDK_LOG_ID, a RAG
+// workspace key, …). It usually equals the subscription id, but for the global
+// SDK_ALL_LOG_ID stream it carries the real origin so subscribers can tell which
+// model/SDK/RAG source produced each line instead of always seeing "__all__".
+type StreamHandler = (
+  level: LogLevel,
+  namespace: string,
+  message: string,
+  sourceId: string,
+) => void;
+
+const loggingStreams = new Map<string, Set<StreamHandler>>();
 
 // Buffering for logs emitted during model loading (before client subscribes)
 const MAX_BUFFERED_LOGS_PER_MODEL = 100;
@@ -27,6 +36,7 @@ interface BufferedLog {
   level: LogLevel;
   namespace: string;
   message: string;
+  sourceId: string;
   timestamp: number;
 }
 
@@ -59,10 +69,7 @@ export function stopLogBufferingWithTimeout(id: string) {
   bufferingTimeouts.set(id, timeout);
 }
 
-export function registerLoggingStream(
-  id: string,
-  streamHandler: (level: LogLevel, namespace: string, message: string) => void,
-) {
+export function registerLoggingStream(id: string, streamHandler: StreamHandler) {
   if (!loggingStreams.has(id)) {
     loggingStreams.set(id, new Set());
   }
@@ -72,7 +79,7 @@ export function registerLoggingStream(
   if (buffered && buffered.length > 0) {
     for (const log of buffered) {
       try {
-        streamHandler(log.level, log.namespace, log.message);
+        streamHandler(log.level, log.namespace, log.message, log.sourceId);
       } catch (error) {
         console.error(`Error flushing buffered log for ID ${id}:`, error); // fallback (avoid recursion)
       }
@@ -86,7 +93,7 @@ export function registerLoggingStream(
 
 export function unregisterLoggingStream(
   id: string,
-  streamHandler: (level: LogLevel, namespace: string, message: string) => void,
+  streamHandler: StreamHandler,
 ) {
   const streams = loggingStreams.get(id);
   if (streams) {
@@ -112,13 +119,28 @@ export function sendLogToStreams(
   namespace: string,
   message: string,
 ) {
+  // The originating id is preserved as `sourceId` so the global stream keeps the
+  // real origin of each log instead of reporting the subscription id.
+  deliverToStream(id, level, namespace, message, id);
+  if (id !== SDK_ALL_LOG_ID) {
+    deliverToStream(SDK_ALL_LOG_ID, level, namespace, message, id);
+  }
+}
+
+function deliverToStream(
+  id: string,
+  level: LogLevel,
+  namespace: string,
+  message: string,
+  sourceId: string,
+) {
   const streams = loggingStreams.get(id);
   const isBuffering = modelsWithBuffering.has(id);
 
   if (streams && streams.size > 0) {
     for (const streamHandler of streams) {
       try {
-        streamHandler(level, namespace, message);
+        streamHandler(level, namespace, message, sourceId);
       } catch (error) {
         console.error(`Error sending log to stream for ID ${id}:`, error); // fallback (avoid recursion)
       }
@@ -139,7 +161,7 @@ export function sendLogToStreams(
       validLogs.shift();
     }
 
-    validLogs.push({ level, namespace, message, timestamp: now });
+    validLogs.push({ level, namespace, message, sourceId, timestamp: now });
     logBuffer.set(id, validLogs);
   }
 }

--- a/packages/sdk/server/rpc/handlers/logging-stream.ts
+++ b/packages/sdk/server/rpc/handlers/logging-stream.ts
@@ -17,10 +17,13 @@ export async function* handleLoggingStream(
     level: LogLevel,
     namespace: string,
     message: string,
+    sourceId: string,
   ) => {
     const logResponse: LoggingStreamResponse = {
       type: "loggingStream",
-      id,
+      // For the global SDK_ALL_LOG_ID stream `sourceId` is the real origin of the
+      // log; for a per-id stream it equals the subscription `id`.
+      id: sourceId,
       level: level,
       namespace,
       message,

--- a/packages/sdk/server/worker-core.ts
+++ b/packages/sdk/server/worker-core.ts
@@ -12,8 +12,14 @@ import { closeRegistryClient } from "@/server/bare/registry/registry-client";
 import {
   clearAllLoggingStreams,
   startLogBuffering,
+  stopLogBufferingWithTimeout,
 } from "@/server/bare/registry/logging-stream-registry";
-import { clearAllAddonLoggers, getServerLogger, SDK_LOG_ID } from "@/logging";
+import {
+  clearAllAddonLoggers,
+  getServerLogger,
+  SDK_LOG_ID,
+  SDK_ALL_LOG_ID,
+} from "@/logging";
 import { clearPlugins } from "@/server/plugins";
 import {
   acquireWorkerLock,
@@ -68,6 +74,7 @@ export function initializeWorkerCore(): { hasRPCConfig: boolean } {
   }
 
   startLogBuffering(SDK_LOG_ID);
+  startLogBuffering(SDK_ALL_LOG_ID);
 
   const { hasRPCConfig } = initEnv();
 
@@ -109,6 +116,13 @@ export function ensureRPCSetup() {
     logger.info("Bare worker started and listening for RPC requests");
     logger.debug("Working directory:", process.cwd());
     rpcInitialized = true;
+
+    // The worker is now reachable, so a `subscribeServerLogs` client can connect.
+    // Bound the global startup buffer the same way model-load buffering is bounded:
+    // if nothing subscribes within the grace window, stop buffering so every server
+    // log doesn't keep churning that buffer for the worker's whole lifetime. A
+    // subscriber that connects in time cancels the timeout and flushes the buffer.
+    stopLogBufferingWithTimeout(SDK_ALL_LOG_ID);
   } catch (error) {
     logger.error("Worker error:", error);
     process.exit(1);

--- a/packages/sdk/test/unit/logging-stream-global.test.ts
+++ b/packages/sdk/test/unit/logging-stream-global.test.ts
@@ -1,0 +1,119 @@
+import test from "brittle";
+import { SDK_ALL_LOG_ID, SDK_LOG_ID } from "@/logging";
+import {
+  registerLoggingStream,
+  unregisterLoggingStream,
+  sendLogToStreams,
+  startLogBuffering,
+  clearAllLoggingStreams,
+} from "@/server/bare/registry/logging-stream-registry";
+
+test("global stream receives logs from every source id", (t) => {
+  clearAllLoggingStreams();
+
+  const received: string[] = [];
+  const handler = (_level: string, _ns: string, message: string) =>
+    received.push(message);
+  registerLoggingStream(SDK_ALL_LOG_ID, handler);
+
+  sendLogToStreams(SDK_LOG_ID, "info", "sdk:server", "from sdk");
+  sendLogToStreams("model-123", "debug", "llamacpp-completion", "from model");
+
+  t.alike(received, ["from sdk", "from model"], "captures logs across ids");
+
+  unregisterLoggingStream(SDK_ALL_LOG_ID, handler);
+  sendLogToStreams(SDK_LOG_ID, "info", "sdk:server", "after unsubscribe");
+  t.alike(received, ["from sdk", "from model"], "stops after unsubscribe");
+
+  clearAllLoggingStreams();
+});
+
+test("global stream preserves the originating source id per log", (t) => {
+  clearAllLoggingStreams();
+
+  const sources: string[] = [];
+  const handler = (
+    _level: string,
+    _ns: string,
+    _message: string,
+    sourceId: string,
+  ) => sources.push(sourceId);
+  registerLoggingStream(SDK_ALL_LOG_ID, handler);
+
+  sendLogToStreams(SDK_LOG_ID, "info", "sdk:server", "from sdk");
+  sendLogToStreams("model-123", "debug", "llamacpp-completion", "from model");
+
+  t.alike(
+    sources,
+    [SDK_LOG_ID, "model-123"],
+    "global subscriber sees real origin id, not __all__",
+  );
+
+  clearAllLoggingStreams();
+});
+
+test("buffered global logs preserve their source id on flush", (t) => {
+  clearAllLoggingStreams();
+  startLogBuffering(SDK_ALL_LOG_ID);
+
+  sendLogToStreams("model-123", "info", "llamacpp-completion", "early");
+
+  const sources: string[] = [];
+  registerLoggingStream(
+    SDK_ALL_LOG_ID,
+    (_l, _n, _m, sourceId) => sources.push(sourceId),
+  );
+
+  t.alike(sources, ["model-123"], "flushed buffer keeps origin id");
+
+  clearAllLoggingStreams();
+});
+
+test("per-id stream sourceId equals the subscription id", (t) => {
+  clearAllLoggingStreams();
+
+  const sources: string[] = [];
+  registerLoggingStream("model-123", (_l, _n, _m, sourceId) =>
+    sources.push(sourceId),
+  );
+
+  sendLogToStreams("model-123", "info", "llamacpp-completion", "a");
+
+  t.alike(sources, ["model-123"], "per-id stream reports its own id");
+
+  clearAllLoggingStreams();
+});
+
+test("per-id stream still receives only its own logs", (t) => {
+  clearAllLoggingStreams();
+
+  const global: string[] = [];
+  const model: string[] = [];
+  const globalHandler = (_l: string, _n: string, m: string) => global.push(m);
+  const modelHandler = (_l: string, _n: string, m: string) => model.push(m);
+
+  registerLoggingStream(SDK_ALL_LOG_ID, globalHandler);
+  registerLoggingStream("model-123", modelHandler);
+
+  sendLogToStreams("model-123", "info", "llamacpp-completion", "a");
+  sendLogToStreams("model-456", "info", "llamacpp-completion", "b");
+
+  t.alike(model, ["a"], "model stream only sees its own id");
+  t.alike(global, ["a", "b"], "global stream sees both");
+
+  clearAllLoggingStreams();
+});
+
+test("global stream flushes startup logs buffered before subscribe", (t) => {
+  clearAllLoggingStreams();
+  startLogBuffering(SDK_ALL_LOG_ID);
+
+  sendLogToStreams(SDK_LOG_ID, "info", "sdk:server", "early");
+
+  const received: string[] = [];
+  registerLoggingStream(SDK_ALL_LOG_ID, (_l, _n, m) => received.push(m));
+
+  t.alike(received, ["early"], "buffered log delivered on subscribe");
+
+  clearAllLoggingStreams();
+});


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Server-side SDK logs could only be consumed per stream ID via `loggingStream({ id })` — `SDK_LOG_ID` for SDK logs, each `modelId` for addon logs, each workspace key for RAG. There was no single mechanism to capture all server-side logs.
- Consumers (especially tests and integrations) had to open/manage multiple streams and know internal IDs ahead of time.
- Config already covered global log level and console output (`loggerLevel`, `loggerConsoleOutput`); the missing piece was a unified custom handler.

## 📝 How does it solve it?

- Adds `subscribeServerLogs(handler)` (`client/api/subscribe-logs.ts`): one subscription that receives every server-side log (SDK + all models + RAG + any future scope) and returns an `unsubscribe()`. No per-ID subscriptions, no internal IDs required.
- Introduces a reserved stream id `SDK_ALL_LOG_ID` (`"__all__"`). On the server, `sendLogToStreams(id, …)` now also fans out to the `__all__` stream (`server/bare/registry/logging-stream-registry.ts`). Because every server logger already converges on `sendLogToStreams` (via `createStreamLogger`), this captures all scopes with no per-logger wiring.
- `worker-core` buffers startup logs for `__all__` (mirroring existing `SDK_LOG_ID` buffering), so a subscriber attaching just after spawn still receives early logs.
- Exports `subscribeServerLogs`, `ServerLogHandler`, and `SDK_ALL_LOG_ID` from `@qvac/sdk`.

## 🧪 How was it tested?

- New unit test `test/unit/logging-stream-global.test.ts`: global stream receives logs across multiple source IDs, per-ID streams stay isolated, unsubscribe stops delivery, and buffered startup logs flush on subscribe. Full `bun run test:unit` passes.
- New example `examples/logging-global.ts` (+ `examples/config/logging/logging.config.json`): one handler captures all server logs end to end; verified against a live `loadModel`/`completion` run (27 server logs captured across `sdk:server` and `llamacpp-completion`).

## 🔌 API Changes

```typescript
import { subscribeServerLogs } from "@qvac/sdk";

// One handler for every server-side log — no per-ID loggingStream() calls.
const unsubscribe = subscribeServerLogs((log) => {
  console.log(`[${log.level}] [${log.namespace}] ${log.message}`);
});

// later
unsubscribe();
```