### PR TITLE
chore[notask]: release infer-base 0.6.1 — bump bare-events ^2.9.1 (pin→caret)

### DIFF
--- a/packages/infer-base/CHANGELOG.md
+++ b/packages/infer-base/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.6.1] - 2026-06-12
+
+chore: replace the exact `bare-events` pin (`2.4.2`) with caret `^2.9.1` so it resolves to the latest 2.x at install. No public API change — only the dependency version range is widened. `bare-os` is left untouched (`^3.2.0`).
+
 ## [0.6.0] - 2026-05-28
 
 Threads an optional `AbortSignal` into `QvacResponse` so addons can settle a job from external timeout / crash paths without polling.

--- a/packages/infer-base/package.json
+++ b/packages/infer-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/infer-base",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Base class for inference clients",
   "main": "index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "bare-events": "2.4.2",
+    "bare-events": "^2.9.1",
     "bare-os": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed

Bumped `@qvac/infer-base`'s `bare-events` dependency from an exact pin (`2.4.2`) to a caret range (`^2.9.1`), and bumped the package version `0.6.0 → 0.6.1`. The caret lets installs resolve the latest 2.x of `bare-events` instead of being frozen at `2.4.2`.

## Why safe

No public API impact. This is purely a dependency version-range widening — same package, exact pin → caret. The runtime/source of `infer-base` is unchanged, so no behavioral change is expected. NOTICE is unchanged because no dependency was added or removed.

## Skipped bare-* bumps

- `bare-os ^3.2.0` — already a same-major caret; install already resolves the latest 3.x (3.9.1). No edit needed.
