### PR TITLE
chore[notask]: release rag 0.6.3 — bump bare-fetch ^3.0.1

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3]
+
+### Changed
+
+- Bump `bare-fetch` to `^3.0.1` (adopt the 3.x major; public fetch API unchanged).
+
 ## [0.6.2]
 
 ### Fixed

--- a/packages/rag/changelog/0.6.3/CHANGELOG.md
+++ b/packages/rag/changelog/0.6.3/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.6.3
+
+Release Date: 2026-06-12
+
+## 🔧 Changed
+
+- Bump `bare-fetch` to `^3.0.1` (adopt the 3.x major; public fetch API unchanged).

--- a/packages/rag/changelog/0.6.3/CHANGELOG_LLM.md
+++ b/packages/rag/changelog/0.6.3/CHANGELOG_LLM.md
@@ -1,0 +1,13 @@
+# QVAC RAG v0.6.3 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/rag/v/0.6.3
+
+This patch bumps the production `bare-fetch` dependency across the 2→3 major to `^3.0.1`.
+
+---
+
+## 🔧 Changed
+
+### `bare-fetch` bumped to `^3.0.1`
+
+The 2→3 transition is transitive-only — the public fetch API is unchanged. The only behavioral change in 3.x is the header validation added in 3.0.1, and RAG only constructs RFC-valid headers, so no code change is required. The bare-tls trust-store change already shipped within the 2.x line via `bun.lock`.

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "index.js",
   "scripts": {
     "lint": "standard",
@@ -70,7 +70,7 @@
   "dependencies": {
     "@qvac/error": "^0.1.1",
     "bare-crypto": "^1.13.4",
-    "bare-fetch": "^2.5.0",
+    "bare-fetch": "^3.0.1",
     "crypto-browserify": "^3.12.1",
     "hyperdb": "^6.7.0",
     "hyperdht": "^6.23.0",


### PR DESCRIPTION
## What changed

Bumps `@qvac/rag`'s production `bare-fetch` dependency across the 2→3 major to `^3.0.1` and releases it as patch `0.6.3`.

- `package.json`: `bare-fetch` `^2.5.0` → `^3.0.1`; `version` `0.6.2` → `0.6.3`.
- Changelog: added `packages/rag/changelog/0.6.3/` (`CHANGELOG.md`, `CHANGELOG_LLM.md`) and a `## [0.6.3]` section in the aggregated `packages/rag/CHANGELOG.md`.

## Migration note

`bare-fetch` 2→3 is a transitive-only major for RAG: the public fetch API is unchanged. The only API-affecting change in the 3.x line is the header validation introduced in `3.0.1`, and RAG only constructs RFC-valid headers, so no code change is required. The `bare-tls` trust-store change already shipped within the 2.x line via `bun.lock`, so it is not part of this bump.

## Skipped bare-* bumps

These dependencies use carets that already resolve to the latest within their major at install time, so no edit is needed:

- `bare-crypto` `^1.13.4` (dep) — same-major caret, resolves to 1.15.3.
- `bare-fs` `^4.1.6` (devDep) — caret, resolves to 4.7.2.
- `bare-path` `^3.0.0` (devDep) — caret, resolves to 3.0.1.
