### PR TITLE
QVAC-17357 fix: emit npm-valid backport/prerelease dist-tag

### DIFF
--- a/.github/actions/publish-library-to-npm/action.yaml
+++ b/.github/actions/publish-library-to-npm/action.yaml
@@ -111,8 +111,16 @@ runs:
         # Auto-decide the dist-tag on release branches when the caller did not
         # pass an explicit non-"latest" tag. Backports to older release-* lines
         # (where package.json version is lower than the current published
-        # `latest`) are published under v<major>.<minor> so they never clobber
-        # the homepage pointer. The newest release line auto-promotes `latest`.
+        # `latest`) are published under release-<major>.<minor> so they never
+        # clobber the homepage pointer. The newest release line auto-promotes
+        # `latest`.
+        #
+        # The dist-tag MUST NOT be a valid SemVer range, because npm rejects
+        # such tags ("Tag name must not be a valid SemVer range"). A bare
+        # "v<major>.<minor>" (e.g. "v0.4") coerces to ">=0.4.0 <0.5.0" and is
+        # refused, so the line tag is prefixed with "release-" to keep it a
+        # plain identifier (matching the documented npm_tag override example
+        # "release-1.x" used by the addon workflows).
         #
         # Triggered when:
         #   - caller passed empty input  (EXPLICIT_TAG=false), OR
@@ -178,13 +186,13 @@ runs:
           #     otherwise win to the backport branch -- including the newest
           #     line, which is the catastrophic case (no `latest` promotion
           #     for a legitimate release).
-          #  2. IS_PRERELEASE is checked separately and FORCES v<major>.<minor>
-          #     regardless of how core() compares. npm convention is that
-          #     `npm install <pkg>` should never pull a prerelease, so even a
-          #     prerelease whose core is >= current latest must NOT take the
-          #     `latest` tag. Consumers opt in via `npm i <pkg>@v<M>.<m>`,
-          #     or operators can override with an explicit npm_tag (e.g.
-          #     "next") on workflow_dispatch.
+          #  2. IS_PRERELEASE is checked separately and FORCES
+          #     release-<major>.<minor> regardless of how core() compares. npm
+          #     convention is that `npm install <pkg>` should never pull a
+          #     prerelease, so even a prerelease whose core is >= current latest
+          #     must NOT take the `latest` tag. Consumers opt in via
+          #     `npm i <pkg>@release-<M>.<m>`, or operators can override with an
+          #     explicit npm_tag (e.g. "next") on workflow_dispatch.
           #
           # Removing either piece reintroduces a footgun. Keep both.
           IS_PRERELEASE=$(node -e 'console.log(/-/.test(process.argv[1]) ? "yes" : "no")' "$PACKAGE_VERSION")
@@ -199,13 +207,13 @@ runs:
           MAJOR_MINOR=$(echo "$PACKAGE_VERSION" | awk -F. '{print $1"."$2}')
 
           if [ "$IS_PRERELEASE" = "yes" ]; then
-            TAG="v${MAJOR_MINOR}"
+            TAG="release-${MAJOR_MINOR}"
             REASON="prerelease $PACKAGE_VERSION never auto-promotes latest (current latest=$CURRENT_LATEST)"
           elif [ "$HIGHER" = "yes" ]; then
             TAG="latest"
             REASON="package.json version $PACKAGE_VERSION >= current latest $CURRENT_LATEST"
           else
-            TAG="v${MAJOR_MINOR}"
+            TAG="release-${MAJOR_MINOR}"
             REASON="package.json version $PACKAGE_VERSION < current latest $CURRENT_LATEST (backport)"
           fi
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Publishing an older/backport version of an `@qvac/*` package from a `release-*` branch fails at `npm publish`. The action auto-decides a dist-tag of `v<major>.<minor>` (e.g. `v0.4`) for backports, but npm rejects any dist-tag that parses as a valid SemVer range — and `v0.4` coerces to `>=0.4.0 <0.5.0`. The job dies with `npm error Tag name must not be a valid SemVer range: v0.4`.

- This blocks the immediate need to publish `@qvac/infer-base@0.4.2` (required to update `bare-*` deps on the 0.4 line) and blocks **every** future backport/prerelease publish, since they all hit the same branch. Observed run: https://github.com/tetherto/qvac/actions/runs/27418353626/job/81037048529

## 📝 How does it solve it?

- In `.github/actions/publish-library-to-npm/action.yaml`, change the auto-decided line tag from `v${MAJOR_MINOR}` to `release-${MAJOR_MINOR}` (both the backport and the prerelease branches). `release-0.4` is a plain identifier npm accepts, and it matches the `release-1.x` convention already documented for the manual `npm_tag` override in the addon workflows.

- The `latest` auto-promotion path for the newest release line is untouched, so the homepage pointer (currently `0.6.1` for `infer-base`) is never at risk.

- Updated the inline comments and the `$GITHUB_STEP_SUMMARY` rationale so the on-call notes reflect the new tag format and the npm naming constraint.

## 🧪 How was it tested?

- Verified npm's rule directly against `semver@7.7.3`: `validRange('v0.4') => >=0.4.0 <0.5.0-0` (rejected by npm), `validRange('v0.4.x') => >=0.4.0 <0.5.0-0` (rejected), `validRange('release-0.4') => null` (accepted).
- Confirmed no `@qvac/*` package currently carries a `v<M>.<m>`/line dist-tag — `@qvac/infer-base` and `@qvac/llm-llamacpp` only have `latest` — so this backport path has never published successfully and there is no existing consumer contract to break.
- Change is shell-logic only; the composite action's `inputs:`/`outputs:` contract is unchanged. YAML parses cleanly.
- Post-merge validation plan: land this on `release-infer-base-0.4.2` (the workflow loads the action from the triggering ref, not `main`), then `workflow_dispatch` the infer-base pipeline. Expect dist-tag `release-0.4`, version `0.4.2`, and `latest` unchanged at `0.6.1`.
