### PR TITLE
fix[notask]: republish infer-base 0.4.2 with #2574 npm dist-tag fix

### DIFF
--- a/.github/actions/publish-library-to-npm/action.yaml
+++ b/.github/actions/publish-library-to-npm/action.yaml
@@ -111,8 +111,16 @@ runs:
         # Auto-decide the dist-tag on release branches when the caller did not
         # pass an explicit non-"latest" tag. Backports to older release-* lines
         # (where package.json version is lower than the current published
-        # `latest`) are published under v<major>.<minor> so they never clobber
-        # the homepage pointer. The newest release line auto-promotes `latest`.
+        # `latest`) are published under release-<major>.<minor> so they never
+        # clobber the homepage pointer. The newest release line auto-promotes
+        # `latest`.
+        #
+        # The dist-tag MUST NOT be a valid SemVer range, because npm rejects
+        # such tags ("Tag name must not be a valid SemVer range"). A bare
+        # "v<major>.<minor>" (e.g. "v0.4") coerces to ">=0.4.0 <0.5.0" and is
+        # refused, so the line tag is prefixed with "release-" to keep it a
+        # plain identifier (matching the documented npm_tag override example
+        # "release-1.x" used by the addon workflows).
         #
         # Triggered when:
         #   - caller passed empty input  (EXPLICIT_TAG=false), OR
@@ -178,13 +186,13 @@ runs:
           #     otherwise win to the backport branch -- including the newest
           #     line, which is the catastrophic case (no `latest` promotion
           #     for a legitimate release).
-          #  2. IS_PRERELEASE is checked separately and FORCES v<major>.<minor>
-          #     regardless of how core() compares. npm convention is that
-          #     `npm install <pkg>` should never pull a prerelease, so even a
-          #     prerelease whose core is >= current latest must NOT take the
-          #     `latest` tag. Consumers opt in via `npm i <pkg>@v<M>.<m>`,
-          #     or operators can override with an explicit npm_tag (e.g.
-          #     "next") on workflow_dispatch.
+          #  2. IS_PRERELEASE is checked separately and FORCES
+          #     release-<major>.<minor> regardless of how core() compares. npm
+          #     convention is that `npm install <pkg>` should never pull a
+          #     prerelease, so even a prerelease whose core is >= current latest
+          #     must NOT take the `latest` tag. Consumers opt in via
+          #     `npm i <pkg>@release-<M>.<m>`, or operators can override with an
+          #     explicit npm_tag (e.g. "next") on workflow_dispatch.
           #
           # Removing either piece reintroduces a footgun. Keep both.
           IS_PRERELEASE=$(node -e 'console.log(/-/.test(process.argv[1]) ? "yes" : "no")' "$PACKAGE_VERSION")
@@ -199,13 +207,13 @@ runs:
           MAJOR_MINOR=$(echo "$PACKAGE_VERSION" | awk -F. '{print $1"."$2}')
 
           if [ "$IS_PRERELEASE" = "yes" ]; then
-            TAG="v${MAJOR_MINOR}"
+            TAG="release-${MAJOR_MINOR}"
             REASON="prerelease $PACKAGE_VERSION never auto-promotes latest (current latest=$CURRENT_LATEST)"
           elif [ "$HIGHER" = "yes" ]; then
             TAG="latest"
             REASON="package.json version $PACKAGE_VERSION >= current latest $CURRENT_LATEST"
           else
-            TAG="v${MAJOR_MINOR}"
+            TAG="release-${MAJOR_MINOR}"
             REASON="package.json version $PACKAGE_VERSION < current latest $CURRENT_LATEST (backport)"
           fi
 

--- a/packages/infer-base/CHANGELOG.md
+++ b/packages/infer-base/CHANGELOG.md
@@ -6,6 +6,10 @@ Widen the `bare-events` dependency from the exact pin `2.4.2` to the caret `^2.9
 
 - `dependencies.bare-events`: `2.4.2` → `^2.9.1` (exact pin → caret).
 
+### Notes
+
+- Republished with the fixed `publish-library-to-npm` action (QVAC-17357 / #2574 — emit npm-valid backport dist-tag); the initial `0.4.2` publish failed on the old action's invalid `v0.4` dist-tag. Package contents unchanged.
+
 ## [0.4.1] - 2026-04-28
 
 This release drops the vestigial `@qvac/dl-hyperdrive` peer dependency from `@qvac/infer-base`'s manifest. Since the `Loader` interface moved into this package and `ready()`/`close()` became optional in `0.4.0`, the peer-dep declaration was no longer required by anything in the runtime — consumers no longer carry an `@qvac/dl-hyperdrive` peer-dep through `@qvac/infer-base` when installing it.


### PR DESCRIPTION
## What this PR does

Re-enables the `@qvac/infer-base@0.4.2` publish, which **failed** on the first attempt. `0.4.2` is **not yet on npm**, so this republishes the same version — no `0.4.3` needed.

## Why the first publish failed

The `release-infer-base-0.4.2` branch carried the **old** `.github/actions/publish-library-to-npm/action.yaml`, which emitted an npm-invalid dist-tag for backport publishes. `0.4.2` publishes under the `v0.4` backport tag (since `latest` is `0.6.1`), so it hit exactly that bug. The fix landed on `main` in **#2574** (QVAC-17357 — "emit npm-valid backport/prerelease dist-tag").

## What's in this PR

- **Brings #2574's fixed `publish-library-to-npm/action.yaml`** onto the release branch (single file, taken from `main`).
- A one-line `0.4.2` changelog note recording the republish (so `release-merge-guard` sees a changelog change on the re-push).

Deliberately a **cherry-pick of just the action fix** rather than a full `main` merge — that keeps the `0.4.1` content rewind on this branch untouched (a merge would conflict on `packages/infer-base`, where `main` is the `0.6.x` line). The package contents and version (`0.4.2`) are unchanged.

## Result on merge

Merging into `release-infer-base-0.4.2` re-fires the publish workflow with the fixed action → `@qvac/infer-base@0.4.2` publishes under `v0.4`. Addons' `^0.4.0` then resolve `0.4.2` → `bare-events ^2.9.1`, clearing the exact pin from the SDK tree.
