### PR TITLE
chore[notask]: release sdk + bare-sdk 0.13.1 — finish bare-* cleanup (bare-fetch ^3.0.1, decoder-audio ^0.4.0)

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {
@@ -155,7 +155,7 @@
     "build": "rm -rf dist && bun run bundle && bun run check:no-addon-deps && bun run check:no-addon-leaks && bun run check:deps-vs-sdk"
   },
   "dependencies": {
-    "@qvac/decoder-audio": "^0.3.7",
+    "@qvac/decoder-audio": "^0.4.0",
     "@qvac/error": "^0.1.1",
     "@qvac/langdetect-text": "^0.1.2",
     "@qvac/logging": "^0.1.0",
@@ -163,7 +163,7 @@
     "@qvac/registry-client": "^0.6.0",
     "bare-abort-controller": "^1.0.0",
     "bare-crypto": "^1.15.0",
-    "bare-fetch": "^2.9.1",
+    "bare-fetch": "^3.0.1",
     "bare-fs": "^4.5.1",
     "bare-net": "^2.3.2",
     "bare-os": "^3.6.2",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.13.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.1
+
+Dependency-maintenance patch. `@qvac/sdk` and `@qvac/bare-sdk` adopt `bare-fetch` 3.x and `@qvac/decoder-audio` 0.4.x, and move dev-only `bare-subprocess` to 6.x. This removes the deprecated `@qvac/response` and its exact `bare-events 2.4.2` pin from the dependency tree.
+
+## Maintenance
+
+Bump `bare-fetch` to `^3.0.1` (public fetch API unchanged) and dev `bare-subprocess` to `^6.1.0`. Bump `@qvac/decoder-audio` to `^0.4.0` (drops deprecated `@qvac/response`); `decoder-audio@0.4.0` returns its `QvacResponse` synchronously, so `server/utils/audio/decoder.ts` no longer `await`s `decoder.run()`. `@qvac/sdk`/`@qvac/bare-sdk` bumped in lockstep.
+
 ## [0.13.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.0

--- a/packages/sdk/changelog/0.13.1/CHANGELOG.md
+++ b/packages/sdk/changelog/0.13.1/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog v0.13.1
+
+Release Date: 2026-06-12
+
+## 🔧 Maintenance
+
+- Adopt `bare-fetch@^3.0.1` (3.x major; public `fetch` API unchanged) and move the dev-only `bare-subprocess` to `^6.1.0`.
+- Bump `@qvac/decoder-audio` to `^0.4.0`, which drops the deprecated `@qvac/response` (consolidated into `@qvac/infer-base`). `decoder-audio@0.4.0` returns its `QvacResponse` from `decoder.run()` synchronously, so the SDK audio decoder no longer `await`s that call (`server/utils/audio/decoder.ts`).
+- Net effect on the dependency tree: the exact `bare-events 2.4.2` pin and the deprecated `@qvac/response` are removed; `bare-events` resolves to `^2.9.1` (via `@qvac/infer-base@0.4.2`) and `bare-fetch` to `3.x`. `@qvac/sdk` and `@qvac/bare-sdk` are bumped in lockstep.

--- a/packages/sdk/changelog/0.13.1/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.13.1/CHANGELOG_LLM.md
@@ -1,0 +1,9 @@
+# Changelog v0.13.1 (LLM)
+
+Dependency-maintenance patch. No public API changes.
+
+- `bare-fetch` → `^3.0.1` (transitive-only major; fetch API unchanged; only 3.0.1 header validation, all SDK headers are RFC-valid).
+- dev `bare-subprocess` → `^6.1.0` (not shipped to consumers).
+- `@qvac/decoder-audio` → `^0.4.0`: removes the deprecated `@qvac/response` package (folded into `@qvac/infer-base`) from the dependency tree, eliminating its exact `bare-events 2.4.2` pin. `decoder-audio@0.4.0`'s `run()` returns `QvacResponse` synchronously; `server/utils/audio/decoder.ts` updated to not `await` it.
+- `@qvac/sdk` + `@qvac/bare-sdk` bumped in lockstep.
+- Validated by a clean install: no `@qvac/response`, no `bare-events@2.4.2`, no `bare-fetch@2.x`, no `decoder-audio@0.3.x` resolve in the tree.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -208,7 +208,7 @@
   "dependencies": {
     "@qvac/bci-whispercpp": "^0.2.0",
     "@qvac/classification-ggml": "^0.3.1",
-    "@qvac/decoder-audio": "^0.3.7",
+    "@qvac/decoder-audio": "^0.4.0",
     "@qvac/diffusion-cpp": "^0.11.2",
     "@qvac/embed-llamacpp": "^0.19.1",
     "@qvac/error": "^0.1.1",
@@ -225,7 +225,7 @@
     "@qvac/vla-ggml": "^0.3.2",
     "bare-abort-controller": "^1.0.0",
     "bare-crypto": "^1.15.0",
-    "bare-fetch": "^2.9.1",
+    "bare-fetch": "^3.0.1",
     "bare-fs": "^4.5.1",
     "bare-net": "^2.3.2",
     "bare-os": "^3.6.2",
@@ -257,7 +257,7 @@
     "@types/semver": "^7.7.1",
     "@types/tar-stream": "^3.1.4",
     "bare-readline": "^1.2.0",
-    "bare-subprocess": "^5.2.3",
+    "bare-subprocess": "^6.1.0",
     "bare-url": "^2.4.3",
     "brittle": "^4.0.0",
     "chromadb": "^3.0.14",

--- a/packages/sdk/server/utils/audio/decoder.ts
+++ b/packages/sdk/server/utils/audio/decoder.ts
@@ -28,7 +28,7 @@ export async function decodeAudioToStream(
     await decoder.load();
 
     const audioStream = fs.createReadStream(inputPath);
-    const response = await decoder.run(audioStream);
+    const response = decoder.run(audioStream);
 
     const outputStream = new Readable({
       read() {},


### PR DESCRIPTION
## What this PR does

Releases `@qvac/sdk` + `@qvac/bare-sdk` **0.13.1** (lockstep) — a dependency-maintenance patch on top of `0.13.0` that finishes the `bare-*` cleanup, removing the deprecated `@qvac/response` and the exact `bare-events 2.4.2` pin from the SDK dependency tree.

## Changes

- `bare-fetch` `^2.9.1` → `^3.0.1` (sdk + bare-sdk). Transitive-only major; public `fetch` API unchanged. The only 3.x behavior change is 3.0.1 header validation, and all SDK header construction is RFC-valid. (The `bare-tls` trust-store change already shipped at `2.x` via the lockfile.)
- `@qvac/decoder-audio` `^0.3.7` → `^0.4.0` (sdk + bare-sdk). `0.4.0` drops the deprecated `@qvac/response` (consolidated into `@qvac/infer-base`).
- **Code change:** `decoder-audio@0.4.0` returns its `QvacResponse` from `run()` **synchronously** (it was a `Promise` in `0.3.x`), so `server/utils/audio/decoder.ts` no longer `await`s `decoder.run()`.
- dev `bare-subprocess` `^5.2.3` → `^6.1.0` (sdk; not shipped to consumers).

## Validation (clean install of this tree)

- **No** `@qvac/response`, **no** `bare-events@2.4.2`, **no** `bare-fetch@2.x`, **no** `@qvac/decoder-audio@0.3.x` resolve. `bare-events` resolves `2.9.1` (via `@qvac/infer-base@0.4.2`), `bare-fetch` `3.0.1`.
- `bare-subprocess@5.x` remains only via `bare-runtime` + `brittle` (unavoidable; not an addon).
- `bun run build` (eslint + tsc) ✅, `test:unit` 10/10 ✅, desktop e2e `transcription` (decoder-audio path) ✅.
- `check:deps-vs-sdk` green (sdk ↔ bare-sdk lockstep at `0.13.1`).

## Skipped bare-* bumps

All other `bare-*` are same-major carets that resolve to latest at install (`bare-fs 4.7.2`, `bare-os 3.9.1`, `bare-crypto 1.15.3`, `bare-stream 2.13.3`, `bare-pack 2.1.3`, `bare-process 4.4.1`, `bare-zlib 1.4.0`, `bare-abort-controller`, `bare-rpc`, `bare-runtime`, `bare-readline`(dev), `bare-url`(dev)); `bare-net 2.3.2`/`bare-path 3.0.1` already latest; `bare-link >=3.0.0` peer covers `3.2.2`.

> Sequencing: this must publish **after** `0.13.0`. Do not apply the publish label until `@qvac/sdk@0.13.0` is on npm.
