### PR TITLE
QVAC-20686 chore: add quantised Supertonic 3 models to registry

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -4865,6 +4865,38 @@
     "link": "https://huggingface.co/supertone/supertonic-3"
   },
   {
+    "source": "s3:///qvac_models_compiled/ggml/supertonic/2026-06-15/supertonic3-q8_0.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Supertonic 3 TTS (GGUF, multilingual)",
+    "quantization": "q8_0",
+    "params": "",
+    "licenseId": "openrail",
+    "tags": [
+      "tts",
+      "supertonic3",
+      "multilingual",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/supertone/supertonic-3"
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/supertonic/2026-06-15/supertonic3-q4_0.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "Supertonic 3 TTS (GGUF, multilingual)",
+    "quantization": "q4_0",
+    "params": "",
+    "licenseId": "openrail",
+    "tags": [
+      "tts",
+      "supertonic3",
+      "multilingual",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/supertone/supertonic-3"
+  },
+  {
     "source": "https://huggingface.co/onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/tokenizer.json",
     "engine": "@qvac/tts",
     "description": "Supertonic tokenizer",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The newly compiled q8_0 and q4_0 quantisations of Supertonic 3 TTS were not yet discoverable through the model registry, so consumers could only access the f16/f32 variants.

## 📝 How does it solve it?

- Adds two new GGUF entries to `packages/registry-server/data/models.prod.json` for the `2026-06-15` build of Supertonic 3:
  - `supertonic3-q8_0.gguf` (`quantization: q8_0`)
  - `supertonic3-q4_0.gguf` (`quantization: q4_0`)
- Both reuse the existing Supertonic 3 metadata (`engine: @qvac/tts-ggml`, `licenseId: openrail`, `tts`/`supertonic3`/`multilingual`/`gguf` tags, HF `link`) and follow the existing `s3:///qvac_models_compiled/...` convention with the bucket name stripped.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215660484503462