### PR TITLE
QVAC-19900 chore: release ai-sdk-provider 0.2.1

### DIFF
--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Widen the optional `@qvac/cli` peer dependency to accept the published `0.6.x` CLI line, so managed-mode consumers can install the provider alongside the current CLI without strict peer-resolution failures.
+
 ---
 
 ## [0.2.0]

--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+---
+
+## [0.2.1]
+
+Release Date: 2026-06-15
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.2.1
+
 ### Fixed
 
-- Widen the optional `@qvac/cli` peer dependency to accept the published `0.6.x` CLI line, so managed-mode consumers can install the provider alongside the current CLI without strict peer-resolution failures.
+- Require the published `@qvac/cli` `0.6.x` line as the optional managed-mode CLI peer, so consumers can install `@qvac/ai-sdk-provider` alongside the current CLI release without strict peer-resolution failures.
 
 ---
 

--- a/packages/ai-sdk-provider/changelog/0.2.1/CHANGELOG.md
+++ b/packages/ai-sdk-provider/changelog/0.2.1/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog v0.2.1
+
+## Fixed
+
+- Require the published `@qvac/cli` `0.6.x` line as the optional managed-mode CLI peer, so strict package managers can install the provider with the current CLI release.

--- a/packages/ai-sdk-provider/changelog/0.2.1/CHANGELOG_LLM.md
+++ b/packages/ai-sdk-provider/changelog/0.2.1/CHANGELOG_LLM.md
@@ -1,0 +1,11 @@
+# QVAC AI SDK Provider v0.2.1 Release Notes
+
+Release Date: 2026-06-15
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.2.1
+
+## Managed Mode Compatibility
+
+`@qvac/ai-sdk-provider` now declares the published `@qvac/cli` `0.6.x` line as its optional managed-mode CLI peer. This keeps strict package managers from rejecting installs where applications use managed mode with the current QVAC CLI release.
+
+No provider API changes are included in this patch release.

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/openai-compatible": "^2.0",
-    "@qvac/cli": "^0.5.0",
+    "@qvac/cli": "^0.5.0 || ^0.6.0",
     "ai": "^6.0"
   },
   "peerDependenciesMeta": {

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ai-sdk-provider",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Vercel AI SDK provider for the QVAC local AI runtime (chat, embeddings, transcription, translation, speech, OCR, image)",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/openai-compatible": "^2.0",
-    "@qvac/cli": "^0.5.0 || ^0.6.0",
+    "@qvac/cli": "^0.6.0",
     "ai": "^6.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/ai-sdk-provider@0.2.0` cannot be installed with the current published `@qvac/cli@0.6.0` under strict npm peer resolution.
- Managed-mode consumers need a patch release that aligns the provider's optional CLI peer with the published CLI line.

## 📝 How does it solve it?

- Bumps `@qvac/ai-sdk-provider` to `0.2.1` on the `release-ai-sdk-provider-0.2.1` branch.
- Updates the optional `@qvac/cli` peer dependency to `^0.6.0`.
- Adds the 0.2.1 package changelog folder and prepends the aggregated `CHANGELOG.md` entry.
- Merging this PR into the release branch should publish the package to GPR; the follow-up backmerge PR from the release branch to `main` will publish to npm.

## 🧪 How was it tested?

- Verified strict npm peer resolution in a temp project with the local provider package, `@qvac/cli@0.6.0`, `ai@^6.0`, and `@ai-sdk/openai-compatible@^2.0`.
- `npm run lint` in `packages/ai-sdk-provider`.
- `npm run build` in `packages/ai-sdk-provider`.
- `npm run test` in `packages/ai-sdk-provider` (75 pass, 1 skipped).