### PR TITLE
chore[QVAC-20718]: release @qvac/decoder-audio v0.5.0

### DIFF
--- a/packages/decoder-audio/CHANGELOG.md
+++ b/packages/decoder-audio/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0]
+
+This release slims the runtime dependency tree of `@qvac/decoder-audio`. Packages that were never required at runtime have been removed or moved to dev dependencies, so consumers no longer pull them into their install trees. There are no changes to `FFmpegDecoder`'s public API or behavior.
+
+## Changed
+
+### Leaner runtime dependencies
+
+The runtime `dependencies` are now limited to what `FFmpegDecoder` actually loads at runtime: `@qvac/error`, `@qvac/infer-base`, `@qvac/logging`, and `bare-ffmpeg`. The `bare-fs`, `bare-path`, and `bare-process` modules were only used by the test suite, so they have been moved to `devDependencies` — at runtime these are provided by the Bare host. Consumers that previously inherited these as transitive runtime dependencies of `@qvac/decoder-audio` will no longer do so.
+
+### Removed unused dependencies
+
+`bare-assert` and `bare-channel` were declared as runtime dependencies but were not used anywhere in the package, and have been dropped entirely.
+
+## Pull Requests
+
+- [#2159](https://github.com/tetherto/qvac/pull/2159) - remove dead deps and move dev ones to dev
+
 ## [0.4.0]
 
 This is a `[bc]` release that aligns `@qvac/decoder-audio` with the new addon shape used by the rest of the inference packages (NMT, Whisper, OCR, etc.). `FFmpegDecoder` no longer extends `BaseInference`, and the run lifecycle is now driven by `createJobHandler` from `@qvac/infer-base`.

--- a/packages/decoder-audio/package.json
+++ b/packages/decoder-audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/decoder-audio",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "",
   "license": "Apache-2.0",
   "author": "Tether",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Cuts a `0.5.0` release of `@qvac/decoder-audio`, shipping the dependency cleanup from #2159 that landed on `main` after `0.4.0` was published to npm (2026-05-07).
- Trims the runtime dependency tree so consumers stop inheriting test-only / unused packages transitively through `@qvac/decoder-audio`.

## 📝 How does it solve it?

- Bumps `packages/decoder-audio/package.json` version `0.4.0` → `0.5.0`.
- Adds the `## [0.5.0]` `CHANGELOG.md` entry documenting the dependency changes (required by the release workflow's changelog extraction).
- Net dependency effect already on `main` and now released:
  - Removed unused runtime deps: `bare-assert`, `bare-channel`.
  - Moved to `devDependencies` (provided by the Bare host at runtime): `bare-fs`, `bare-path`, `bare-process`.
  - Runtime `dependencies` now: `@qvac/error`, `@qvac/infer-base`, `@qvac/logging`, `bare-ffmpeg`.

## 🧪 How was it tested?

- No code changes; `FFmpegDecoder` public API and behavior are unchanged.
- Release-only PR (version + changelog).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215717453129303