### PR TITLE
Add `IdMapIndex` Bare-addon binding (turbovec POC)

### DIFF
--- a/packages/embed-llamacpp/CMakeLists.txt
+++ b/packages/embed-llamacpp/CMakeLists.txt
@@ -17,6 +17,21 @@ find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/triplets;${VCPKG_OVERLAY_TRIPLETS}")
 
+# Local overlay-port for fabric (turbovec POC). The overlay at
+# `vcpkg/ports/qvac-fabric/` carries the POC fabric build because the public
+# `tetherto/qvac-registry-vcpkg` qvac-fabric port has no 8828.x line yet and
+# this manifest pins `>=8828.1.0`. By default the overlay fetches from
+# `dev-nid/qvac-fabric-llm.cpp` (poc/turbovec-embed branch) at a pinned
+# commit + SHA512. Drop this overlay once the registry publishes 8828.x.
+#
+# Local-iteration override: set `QVAC_FABRIC_LOCAL_PATH=/path/to/fabric` to
+# build from a working tree instead. In that mode, run
+# `./scripts/sync-fabric-overlay.sh` after each edit to bump the
+# portfile-tracked source hash (vcpkg derives ABI from portfile contents,
+# not from the source it copies in). `./scripts/rebuild-fabric.sh` chains
+# sync + generate + build + install for the inner-loop case.
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/ports;${VCPKG_OVERLAY_PORTS}")
+
 project(embed-llamacpp C CXX)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -68,6 +83,7 @@ target_sources(
   ${embed-llamacpp}
   PRIVATE
   ${PROJECT_SOURCE_DIR}/addon/src/js-interface/binding.cpp
+  ${PROJECT_SOURCE_DIR}/addon/src/js-interface/vector-index-binding.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/utils.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/AsyncWeightsLoader.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/BackendSelection.cpp
@@ -75,6 +91,7 @@ target_sources(
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/LlamaLazyInitializeBackend.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/ModelMetadata.cpp
   ${PROJECT_SOURCE_DIR}/addon/src/model-interface/BertModel.cpp
+  ${PROJECT_SOURCE_DIR}/addon/src/model-interface/VectorIndex.cpp
 )
 target_include_directories(
   ${embed-llamacpp}
@@ -82,6 +99,30 @@ target_include_directories(
     ${QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS}
     ${PROJECT_SOURCE_DIR}/addon/src
 )
+# Some fabric branches (HEAD-ish) only export the `llama` target without
+# namespacing and without exporting the `llama-common` helper lib at all.
+# The `temp-8828` branch exports the full `llama::*` namespace incl.
+# `llama::common`. Add a shim only when the expected targets are missing.
+if(TARGET llama AND NOT TARGET llama::llama)
+  add_library(llama::llama ALIAS llama)
+endif()
+if(NOT TARGET llama::common)
+  if(NOT TARGET llama-common)
+    find_library(LLAMA_COMMON_LIB
+      NAMES llama-common
+      REQUIRED
+      HINTS ${LLAMA_LIB_DIR}
+      NO_CMAKE_FIND_ROOT_PATH)
+    add_library(llama-common UNKNOWN IMPORTED)
+    set_target_properties(llama-common
+      PROPERTIES
+        IMPORTED_LOCATION "${LLAMA_COMMON_LIB}"
+        INTERFACE_INCLUDE_DIRECTORIES "${LLAMA_INCLUDE_DIR}"
+        INTERFACE_LINK_LIBRARIES "llama")
+  endif()
+  add_library(llama::common ALIAS llama-common)
+endif()
+
 target_link_libraries(
   ${embed-llamacpp}
   PRIVATE

--- a/packages/embed-llamacpp/addon/src/addon/VectorIndexErrors.hpp
+++ b/packages/embed-llamacpp/addon/src/addon/VectorIndexErrors.hpp
@@ -1,0 +1,42 @@
+#pragma once
+//
+// Maps fabric vector-index C error codes to JS-throwable messages. Mirrors
+// the layout of `BertErrors.hpp` but for the ANN index path. Kept in its own
+// header so the binding can include it without dragging in any BertModel /
+// LlamaLazyInitializeBackend symbols (lifecycle isolation requirement of
+// the POC).
+
+#include <ggml-vector-index.h>
+
+#include <string>
+
+namespace qvac_lib_infer_llamacpp_embed::vector_index_errors {
+
+constexpr const char* ADDON_ID = "IdMapIndex";
+
+inline std::string toString(int code) {
+  switch (code) {
+    case GGML_VEC_INDEX_OK:
+      return "OK";
+    case GGML_VEC_INDEX_E_INVALID_DIM:
+      return "InvalidDim";
+    case GGML_VEC_INDEX_E_INVALID_ARG:
+      return "InvalidArgument";
+    case GGML_VEC_INDEX_E_DUPLICATE:
+      return "DuplicateId";
+    case GGML_VEC_INDEX_E_IO:
+      return "IOError";
+    case GGML_VEC_INDEX_E_BAD_MAGIC:
+      return "BadMagic";
+    case GGML_VEC_INDEX_E_BAD_VERSION:
+      return "BadVersion";
+    case GGML_VEC_INDEX_E_OOM:
+      return "OutOfMemory";
+    case GGML_VEC_INDEX_E_INTERNAL:
+      return "InternalError";
+    default:
+      return "UnknownError";
+  }
+}
+
+} // namespace qvac_lib_infer_llamacpp_embed::vector_index_errors

--- a/packages/embed-llamacpp/addon/src/js-interface/binding.cpp
+++ b/packages/embed-llamacpp/addon/src/js-interface/binding.cpp
@@ -2,6 +2,15 @@
 
 #include "../addon/AddonJs.hpp"
 
+// Forward declaration for the IdMapIndex (vector-index) binding registrar.
+// The implementation lives in `vector-index-binding.cpp` and is deliberately
+// kept in its own TU so it has no symbol dependency on BertModel /
+// LlamaLazyInitializeBackend — required for the POC's lifecycle-isolation
+// invariant (constructing IdMapIndex must not boot fabric's LLM backend).
+namespace qvac_lib_inference_addon_embed::vector_index {
+void registerBindings(js_env_t* env, js_value_t* exports);
+}
+
 js_value_t*
 qvacLibInferLlamacppEmbedExports(js_env_t* env, js_value_t* exports) {
 
@@ -29,6 +38,8 @@ qvacLibInferLlamacppEmbedExports(js_env_t* env, js_value_t* exports) {
   V("releaseLogger", qvac_lib_inference_addon_cpp::JsInterface::releaseLogger)
 #undef V
 // NOLINTEND(cppcoreguidelines-macro-usage)
+
+  qvac_lib_inference_addon_embed::vector_index::registerBindings(env, exports);
 
   return exports;
 }

--- a/packages/embed-llamacpp/addon/src/js-interface/vector-index-binding.cpp
+++ b/packages/embed-llamacpp/addon/src/js-interface/vector-index-binding.cpp
@@ -1,0 +1,487 @@
+// vector-index-binding.cpp
+//
+// N-API surface for the `IdMapIndex` JS class. Registers a small set of free
+// functions on the embed-llamacpp addon's exports; the JS wrapper in
+// `idMapIndex.js` ties them into a class shape.
+//
+// Lifecycle isolation: this binding deliberately depends ONLY on the
+// VectorIndex C++ wrapper (which in turn depends only on fabric's
+// ggml-vector-index C API). It never references BertModel,
+// LlamaLazyInitializeBackend, or any other BERT-runtime symbol, so simply
+// importing the addon does not boot fabric's LLM backend. The same .bare
+// binary carries both class surfaces; the JS side decides which to construct.
+
+#include <bare.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <new>
+#include <stdexcept>
+#include <string>
+
+#include "../addon/VectorIndexErrors.hpp"
+#include "../model-interface/VectorIndex.hpp"
+
+namespace {
+
+using qvac_lib_infer_llamacpp_embed::VectorIndex;
+namespace verrors = qvac_lib_infer_llamacpp_embed::vector_index_errors;
+
+// Finalizer: invoked by the JS engine when the external handle is GC'd.
+// Tears down the native C handle via VectorIndex's RAII dtor.
+void
+finalize_vector_index(js_env_t* /*env*/, void* data, void* /*hint*/) {
+  auto* idx = static_cast<VectorIndex*>(data);
+  delete idx;
+}
+
+// Wrap an already-constructed VectorIndex into a JS external. Takes
+// ownership of `idx`; the JS engine will delete it via finalize on GC.
+js_value_t* wrap(js_env_t* env, VectorIndex* idx) {
+  js_value_t* external = nullptr;
+  if (js_create_external(env, idx, finalize_vector_index, nullptr, &external)
+      != 0) {
+    delete idx;
+    js_throw_error(env, "InternalError", "failed to create external");
+    return nullptr;
+  }
+  return external;
+}
+
+// Get a borrowed pointer out of a JS external handle. Throws and returns
+// null on failure.
+VectorIndex* unwrap(js_env_t* env, js_value_t* handle) {
+  void* data = nullptr;
+  if (js_get_value_external(env, handle, &data) != 0 || data == nullptr) {
+    js_throw_error(env, "InvalidArgument", "expected IdMapIndex handle");
+    return nullptr;
+  }
+  return static_cast<VectorIndex*>(data);
+}
+
+// Read a JS object property and parse as int32. On failure, throws and
+// returns the provided default; caller should check pending exception via
+// js_is_exception_pending or by returning nullptr from the function.
+bool read_int_prop(
+    js_env_t* env, js_value_t* obj, const char* name, int32_t* out) {
+  js_value_t* val = nullptr;
+  if (js_get_named_property(env, obj, name, &val) != 0) {
+    return false;
+  }
+  return js_get_value_int32(env, val, out) == 0;
+}
+
+void throw_status(js_env_t* env, int code) {
+  const std::string name = verrors::toString(code);
+  js_throw_error(env, name.c_str(), name.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Bindings
+// ---------------------------------------------------------------------------
+
+// idx_create({ dim, bitWidth }) -> external handle
+js_value_t* idx_create(js_env_t* env, js_callback_info_t* info) {
+  size_t argc = 1;
+  js_value_t* argv[1] = { nullptr };
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+  if (argc < 1) {
+    js_throw_type_error(env, "InvalidArgument", "expected { dim, bitWidth }");
+    return nullptr;
+  }
+  int32_t dim = 0;
+  int32_t bit_width = 32;
+  if (!read_int_prop(env, argv[0], "dim", &dim)) {
+    js_throw_type_error(env, "InvalidArgument", "missing or invalid `dim`");
+    return nullptr;
+  }
+  // bitWidth optional; default to 32 if missing.
+  (void) read_int_prop(env, argv[0], "bitWidth", &bit_width);
+
+  VectorIndex* idx = nullptr;
+  try {
+    idx = new VectorIndex(dim, bit_width);
+  } catch (const std::invalid_argument& e) {
+    js_throw_error(env, "InvalidArgument", e.what());
+    return nullptr;
+  } catch (const std::bad_alloc&) {
+    js_throw_error(env, "OutOfMemory", "allocation failure");
+    return nullptr;
+  }
+  return wrap(env, idx);
+}
+
+// idx_load(path) -> external handle (throws on file errors).
+js_value_t* idx_load(js_env_t* env, js_callback_info_t* info) {
+  size_t argc = 1;
+  js_value_t* argv[1] = { nullptr };
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+  if (argc < 1) {
+    js_throw_type_error(env, "InvalidArgument", "expected path string");
+    return nullptr;
+  }
+  size_t len = 0;
+  if (js_get_value_string_utf8(env, argv[0], nullptr, 0, &len) != 0) {
+    js_throw_type_error(env, "InvalidArgument", "path must be a string");
+    return nullptr;
+  }
+  std::string path(len, '\0');
+  size_t copied = 0;
+  if (js_get_value_string_utf8(
+          env, argv[0],
+          reinterpret_cast<utf8_t*>(path.data()), len + 1, &copied) != 0) {
+    js_throw_error(env, "InternalError", "failed to read path string");
+    return nullptr;
+  }
+  path.resize(copied);
+
+  VectorIndex loaded = VectorIndex::load(path);
+  if (!loaded.valid()) {
+    js_throw_error(env, "IOError", "ggml_vec_index_load returned null");
+    return nullptr;
+  }
+  // Move the wrapper onto the heap so we can hand JS an owning external.
+  auto* heap = new VectorIndex(std::move(loaded));
+  return wrap(env, heap);
+}
+
+// idx_add(handle, Float32Array vectors, BigUint64Array ids) -> undefined
+js_value_t* idx_add(js_env_t* env, js_callback_info_t* info) {
+  size_t argc = 3;
+  js_value_t* argv[3] = { nullptr, nullptr, nullptr };
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+  if (argc < 3) {
+    js_throw_type_error(env, "InvalidArgument",
+        "expected (handle, vectors:Float32Array, ids:BigUint64Array)");
+    return nullptr;
+  }
+  VectorIndex* idx = unwrap(env, argv[0]);
+  if (idx == nullptr) { return nullptr; }
+
+  js_typedarray_type_t vtype{};
+  void* vdata = nullptr;
+  size_t vlen = 0;
+  if (js_get_typedarray_info(
+          env, argv[1], &vtype, &vdata, &vlen, nullptr, nullptr) != 0
+      || vtype != js_float32array) {
+    js_throw_type_error(env, "InvalidArgument",
+        "vectors must be a Float32Array");
+    return nullptr;
+  }
+
+  js_typedarray_type_t itype{};
+  void* idata = nullptr;
+  size_t ilen = 0;
+  if (js_get_typedarray_info(
+          env, argv[2], &itype, &idata, &ilen, nullptr, nullptr) != 0
+      || itype != js_biguint64array) {
+    js_throw_type_error(env, "InvalidArgument",
+        "ids must be a BigUint64Array");
+    return nullptr;
+  }
+
+  const int dim = idx->dim();
+  if (dim <= 0) {
+    js_throw_error(env, "InternalError", "index has invalid dim");
+    return nullptr;
+  }
+  if (vlen != ilen * static_cast<size_t>(dim)) {
+    js_throw_range_error(env, "InvalidArgument",
+        "vectors.length must equal ids.length * dim");
+    return nullptr;
+  }
+  if (ilen > static_cast<size_t>(INT32_MAX)) {
+    js_throw_range_error(env, "InvalidArgument", "too many vectors in batch");
+    return nullptr;
+  }
+
+  const int rc = idx->add(
+      static_cast<const float*>(vdata),
+      static_cast<int>(ilen),
+      static_cast<const uint64_t*>(idata));
+  if (rc != 0) {
+    throw_status(env, rc);
+    return nullptr;
+  }
+  js_value_t* u = nullptr;
+  js_get_undefined(env, &u);
+  return u;
+}
+
+// idx_search(handle, Float32Array queries, int k)
+//   -> { scores: Float32Array(m*k), ids: BigUint64Array(m*k), m, k }
+js_value_t* idx_search(js_env_t* env, js_callback_info_t* info) {
+  size_t argc = 3;
+  js_value_t* argv[3] = { nullptr, nullptr, nullptr };
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+  if (argc < 3) {
+    js_throw_type_error(env, "InvalidArgument",
+        "expected (handle, queries:Float32Array, k:number)");
+    return nullptr;
+  }
+  VectorIndex* idx = unwrap(env, argv[0]);
+  if (idx == nullptr) { return nullptr; }
+
+  js_typedarray_type_t qtype{};
+  void* qdata = nullptr;
+  size_t qlen = 0;
+  if (js_get_typedarray_info(
+          env, argv[1], &qtype, &qdata, &qlen, nullptr, nullptr) != 0
+      || qtype != js_float32array) {
+    js_throw_type_error(env, "InvalidArgument",
+        "queries must be a Float32Array");
+    return nullptr;
+  }
+
+  int32_t k = 0;
+  if (js_get_value_int32(env, argv[2], &k) != 0 || k <= 0) {
+    js_throw_type_error(env, "InvalidArgument", "k must be a positive int");
+    return nullptr;
+  }
+
+  const int dim = idx->dim();
+  if (dim <= 0 || qlen % static_cast<size_t>(dim) != 0) {
+    js_throw_range_error(env, "InvalidArgument",
+        "queries.length must be a multiple of dim");
+    return nullptr;
+  }
+  const size_t m = qlen / static_cast<size_t>(dim);
+  if (m > static_cast<size_t>(INT32_MAX)) {
+    js_throw_range_error(env, "InvalidArgument", "too many queries");
+    return nullptr;
+  }
+
+  // Allocate output ArrayBuffers; we'll hand them to JS via typed-array
+  // views.
+  const size_t total      = m * static_cast<size_t>(k);
+  const size_t scores_b   = total * sizeof(float);
+  const size_t ids_b      = total * sizeof(uint64_t);
+
+  void* scores_data = nullptr;
+  js_value_t* scores_ab = nullptr;
+  if (js_create_arraybuffer(env, scores_b, &scores_data, &scores_ab) != 0) {
+    js_throw_error(env, "OutOfMemory", "scores arraybuffer");
+    return nullptr;
+  }
+  void* ids_data = nullptr;
+  js_value_t* ids_ab = nullptr;
+  if (js_create_arraybuffer(env, ids_b, &ids_data, &ids_ab) != 0) {
+    js_throw_error(env, "OutOfMemory", "ids arraybuffer");
+    return nullptr;
+  }
+
+  const int rc = idx->search(
+      static_cast<const float*>(qdata),
+      static_cast<int>(m),
+      k,
+      static_cast<float*>(scores_data),
+      static_cast<uint64_t*>(ids_data));
+  if (rc != 0) {
+    throw_status(env, rc);
+    return nullptr;
+  }
+
+  js_value_t* scores_ta = nullptr;
+  if (js_create_typedarray(
+          env, js_float32array, total, scores_ab, 0, &scores_ta) != 0) {
+    js_throw_error(env, "InternalError", "create scores typedarray");
+    return nullptr;
+  }
+  js_value_t* ids_ta = nullptr;
+  if (js_create_typedarray(
+          env, js_biguint64array, total, ids_ab, 0, &ids_ta) != 0) {
+    js_throw_error(env, "InternalError", "create ids typedarray");
+    return nullptr;
+  }
+
+  js_value_t* result = nullptr;
+  if (js_create_object(env, &result) != 0) {
+    js_throw_error(env, "InternalError", "create result object");
+    return nullptr;
+  }
+  if (js_set_named_property(env, result, "scores", scores_ta) != 0
+      || js_set_named_property(env, result, "ids", ids_ta) != 0) {
+    js_throw_error(env, "InternalError", "set result fields");
+    return nullptr;
+  }
+  js_value_t* m_val = nullptr;
+  js_value_t* k_val = nullptr;
+  js_create_uint32(env, static_cast<uint32_t>(m), &m_val);
+  js_create_int32(env, k, &k_val);
+  js_set_named_property(env, result, "m", m_val);
+  js_set_named_property(env, result, "k", k_val);
+  return result;
+}
+
+// idx_remove(handle, id:bigint) -> boolean
+js_value_t* idx_remove(js_env_t* env, js_callback_info_t* info) {
+  size_t argc = 2;
+  js_value_t* argv[2] = { nullptr, nullptr };
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+  if (argc < 2) {
+    js_throw_type_error(env, "InvalidArgument",
+        "expected (handle, id:bigint)");
+    return nullptr;
+  }
+  VectorIndex* idx = unwrap(env, argv[0]);
+  if (idx == nullptr) { return nullptr; }
+
+  uint64_t id = 0;
+  bool lossless = false;
+  if (js_get_value_bigint_uint64(env, argv[1], &id, &lossless) != 0
+      || !lossless) {
+    js_throw_type_error(env, "InvalidArgument",
+        "id must be an unsigned BigInt fitting in 64 bits");
+    return nullptr;
+  }
+
+  const int rc = idx->remove(id);
+  if (rc < 0) {
+    throw_status(env, rc);
+    return nullptr;
+  }
+  js_value_t* result = nullptr;
+  js_get_boolean(env, rc == 1, &result);
+  return result;
+}
+
+// idx_contains(handle, id:bigint) -> boolean
+js_value_t* idx_contains(js_env_t* env, js_callback_info_t* info) {
+  size_t argc = 2;
+  js_value_t* argv[2] = { nullptr, nullptr };
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+  if (argc < 2) {
+    js_throw_type_error(env, "InvalidArgument",
+        "expected (handle, id:bigint)");
+    return nullptr;
+  }
+  VectorIndex* idx = unwrap(env, argv[0]);
+  if (idx == nullptr) { return nullptr; }
+
+  uint64_t id = 0;
+  bool lossless = false;
+  if (js_get_value_bigint_uint64(env, argv[1], &id, &lossless) != 0
+      || !lossless) {
+    js_throw_type_error(env, "InvalidArgument",
+        "id must be an unsigned BigInt fitting in 64 bits");
+    return nullptr;
+  }
+  js_value_t* result = nullptr;
+  js_get_boolean(env, idx->contains(id), &result);
+  return result;
+}
+
+// idx_prepare(handle) -> undefined (no-op in POC).
+js_value_t* idx_prepare(js_env_t* env, js_callback_info_t* info) {
+  size_t argc = 1;
+  js_value_t* argv[1] = { nullptr };
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+  VectorIndex* idx = unwrap(env, argv[0]);
+  if (idx == nullptr) { return nullptr; }
+  idx->prepare();
+  js_value_t* u = nullptr;
+  js_get_undefined(env, &u);
+  return u;
+}
+
+// idx_write(handle, path) -> undefined; throws on IO error.
+js_value_t* idx_write(js_env_t* env, js_callback_info_t* info) {
+  size_t argc = 2;
+  js_value_t* argv[2] = { nullptr, nullptr };
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+  if (argc < 2) {
+    js_throw_type_error(env, "InvalidArgument", "expected (handle, path)");
+    return nullptr;
+  }
+  VectorIndex* idx = unwrap(env, argv[0]);
+  if (idx == nullptr) { return nullptr; }
+
+  size_t len = 0;
+  if (js_get_value_string_utf8(env, argv[1], nullptr, 0, &len) != 0) {
+    js_throw_type_error(env, "InvalidArgument", "path must be a string");
+    return nullptr;
+  }
+  std::string path(len, '\0');
+  size_t copied = 0;
+  if (js_get_value_string_utf8(
+          env, argv[1],
+          reinterpret_cast<utf8_t*>(path.data()), len + 1, &copied) != 0) {
+    js_throw_error(env, "InternalError", "failed to read path");
+    return nullptr;
+  }
+  path.resize(copied);
+
+  const int rc = idx->write(path);
+  if (rc != 0) {
+    throw_status(env, rc);
+    return nullptr;
+  }
+  js_value_t* u = nullptr;
+  js_get_undefined(env, &u);
+  return u;
+}
+
+// Generic int32 getter for len/dim/bitWidth.
+template <int (VectorIndex::*Fn)() const noexcept>
+js_value_t* idx_int_getter(js_env_t* env, js_callback_info_t* info) {
+  size_t argc = 1;
+  js_value_t* argv[1] = { nullptr };
+  if (js_get_callback_info(env, info, &argc, argv, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+  VectorIndex* idx = unwrap(env, argv[0]);
+  if (idx == nullptr) { return nullptr; }
+  js_value_t* result = nullptr;
+  js_create_int32(env, (idx->*Fn)(), &result);
+  return result;
+}
+
+} // namespace
+
+namespace qvac_lib_inference_addon_embed::vector_index {
+
+void registerBindings(js_env_t* env, js_value_t* exports) {
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+#define V(name, fn)                                                            \
+  do {                                                                         \
+    js_value_t* val = nullptr;                                                 \
+    if (js_create_function(env, name, -1, fn, nullptr, &val) != 0) {           \
+      return;                                                                  \
+    }                                                                          \
+    if (js_set_named_property(env, exports, name, val) != 0) {                 \
+      return;                                                                  \
+    }                                                                          \
+  } while (0)
+
+  V("idx_create",    idx_create);
+  V("idx_load",      idx_load);
+  V("idx_add",       idx_add);
+  V("idx_search",    idx_search);
+  V("idx_remove",    idx_remove);
+  V("idx_contains",  idx_contains);
+  V("idx_prepare",   idx_prepare);
+  V("idx_write",     idx_write);
+  V("idx_len",       (idx_int_getter<&VectorIndex::len>));
+  V("idx_dim",       (idx_int_getter<&VectorIndex::dim>));
+  V("idx_bit_width", (idx_int_getter<&VectorIndex::bitWidth>));
+#undef V
+// NOLINTEND(cppcoreguidelines-macro-usage)
+}
+
+} // namespace qvac_lib_inference_addon_embed::vector_index

--- a/packages/embed-llamacpp/addon/src/model-interface/VectorIndex.cpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/VectorIndex.cpp
@@ -1,0 +1,87 @@
+#include "VectorIndex.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace qvac_lib_infer_llamacpp_embed {
+
+VectorIndex::VectorIndex(int dim, int bitWidth)
+    : handle_(ggml_vec_index_create(dim, bitWidth)) {
+  if (handle_ == nullptr) {
+    throw std::invalid_argument(
+        "ggml_vec_index_create rejected dim/bitWidth");
+  }
+}
+
+VectorIndex::VectorIndex(ggml_vec_index_t* handle) noexcept : handle_(handle) {}
+
+VectorIndex::~VectorIndex() {
+  if (handle_ != nullptr) {
+    ggml_vec_index_free(handle_);
+    handle_ = nullptr;
+  }
+}
+
+VectorIndex::VectorIndex(VectorIndex&& other) noexcept
+    : handle_(other.handle_) {
+  other.handle_ = nullptr;
+}
+
+VectorIndex& VectorIndex::operator=(VectorIndex&& other) noexcept {
+  if (this != &other) {
+    if (handle_ != nullptr) {
+      ggml_vec_index_free(handle_);
+    }
+    handle_ = other.handle_;
+    other.handle_ = nullptr;
+  }
+  return *this;
+}
+
+int VectorIndex::add(
+    const float* vectors, int n, const uint64_t* ids) noexcept {
+  return ggml_vec_index_add(handle_, vectors, n, ids);
+}
+
+int VectorIndex::remove(uint64_t id) noexcept {
+  return ggml_vec_index_remove(handle_, id);
+}
+
+bool VectorIndex::contains(uint64_t id) const noexcept {
+  return ggml_vec_index_contains(handle_, id) != 0;
+}
+
+void VectorIndex::prepare() noexcept { ggml_vec_index_prepare(handle_); }
+
+int VectorIndex::search(
+    const float* queries,
+    int n_q,
+    int k,
+    float* outScores,
+    uint64_t* outIds) const noexcept {
+  return ggml_vec_index_search(
+      handle_, queries, n_q, k, outScores, outIds);
+}
+
+int VectorIndex::write(const std::string& path) noexcept {
+  return ggml_vec_index_write(handle_, path.c_str());
+}
+
+VectorIndex VectorIndex::load(const std::string& path) noexcept {
+  ggml_vec_index_t* raw = ggml_vec_index_load(path.c_str());
+  return VectorIndex(raw);
+}
+
+int VectorIndex::len() const noexcept {
+  return ggml_vec_index_len(handle_);
+}
+
+int VectorIndex::dim() const noexcept {
+  return ggml_vec_index_dim(handle_);
+}
+
+int VectorIndex::bitWidth() const noexcept {
+  return ggml_vec_index_bit_width(handle_);
+}
+
+} // namespace qvac_lib_infer_llamacpp_embed

--- a/packages/embed-llamacpp/addon/src/model-interface/VectorIndex.hpp
+++ b/packages/embed-llamacpp/addon/src/model-interface/VectorIndex.hpp
@@ -1,0 +1,73 @@
+#pragma once
+//
+// RAII C++ wrapper around fabric's `ggml_vec_index_t*` C handle. Provides
+// typed methods + status-aware accessors. Lifecycle isolated from
+// LlamaLazyInitializeBackend / BertModel by construction: this header
+// only depends on the ggml-base vector-index C API.
+
+#include <ggml-vector-index.h>
+
+#include <cstdint>
+#include <string>
+
+namespace qvac_lib_infer_llamacpp_embed {
+
+class VectorIndex {
+public:
+  // Construct a fresh empty index. Throws std::invalid_argument on bad
+  // dims / bit_width.
+  VectorIndex(int dim, int bitWidth);
+
+  // Adopt an already-opened native handle (used by static load).
+  explicit VectorIndex(ggml_vec_index_t* handle) noexcept;
+
+  ~VectorIndex();
+
+  VectorIndex(const VectorIndex&) = delete;
+  VectorIndex& operator=(const VectorIndex&) = delete;
+  VectorIndex(VectorIndex&& other) noexcept;
+  VectorIndex& operator=(VectorIndex&& other) noexcept;
+
+  // Returns 0 on success, ggml_vec_index_error on failure (e.g. duplicate).
+  int add(const float* vectors, int n, const uint64_t* ids) noexcept;
+
+  // Returns 1 / 0 (removed / not present), negative on error.
+  int remove(uint64_t id) noexcept;
+
+  [[nodiscard]] bool contains(uint64_t id) const noexcept;
+
+  void prepare() noexcept;
+
+  // Top-k search. Caller owns out arrays of size n_q * k.
+  int search(
+      const float* queries,
+      int n_q,
+      int k,
+      float* outScores,
+      uint64_t* outIds) const noexcept;
+
+  // Persists to disk. Returns 0 on success.
+  int write(const std::string& path) noexcept;
+
+  // Reads from disk. On failure returns a wrapper whose `valid()` is false;
+  // callers must check before using the instance.
+  static VectorIndex load(const std::string& path) noexcept;
+
+  // Stats.
+  [[nodiscard]] int len() const noexcept;
+  [[nodiscard]] int dim() const noexcept;
+  [[nodiscard]] int bitWidth() const noexcept;
+
+  // True if this instance owns a native handle (i.e. wasn't moved-from /
+  // wasn't a failed load).
+  [[nodiscard]] bool valid() const noexcept { return handle_ != nullptr; }
+
+  // Raw handle accessor for the JS binding's finalizer. Caller must not
+  // free; ownership remains with this object.
+  [[nodiscard]] ggml_vec_index_t* raw() const noexcept { return handle_; }
+
+private:
+  ggml_vec_index_t* handle_;
+};
+
+} // namespace qvac_lib_infer_llamacpp_embed

--- a/packages/embed-llamacpp/idMapIndex.js
+++ b/packages/embed-llamacpp/idMapIndex.js
@@ -1,0 +1,160 @@
+'use strict'
+
+// IdMapIndex: thin JS wrapper around the IdMapIndex N-API bindings exposed
+// by the embed-llamacpp addon (vector-index-binding.cpp). The native side
+// keeps the index in RAM as full f32 vectors for the POC; quantization,
+// SIMD, and GPU kernels are future work behind the same JS shape.
+//
+// Lifecycle isolation: constructing IdMapIndex does NOT load any BERT
+// model. It only resolves the native binding (loaded once per process)
+// and calls idx_create, which is a tiny C-API call into ggml-base. Pair
+// this with the assertion in the smoke test (no GGMLBert constructor
+// runs while exercising the index).
+
+const binding = require('./binding')
+
+const HANDLE = Symbol('IdMapIndex.handle')
+
+function ensureHandle (self) {
+  if (self[HANDLE] == null) {
+    throw new Error('IdMapIndex has been disposed')
+  }
+  return self[HANDLE]
+}
+
+/**
+ * In-memory TurboQuant-style ANN vector index. Indexes vectors of fixed
+ * dimensionality and stable external uint64 ids; supports top-k cosine /
+ * dot-product search.
+ *
+ * Scope: POC. Internals store full f32 vectors and do scalar dot products;
+ * quantization, SIMD, and GPU paths come later behind the same JS API.
+ */
+class IdMapIndex {
+  /**
+   * @param {object} opts
+   * @param {number} opts.dim - vector dimensionality (must be > 0)
+   * @param {number} [opts.bitWidth=4] - reserved for future quantization
+   */
+  constructor ({ dim, bitWidth = 4 } = {}) {
+    if (!Number.isInteger(dim) || dim <= 0) {
+      throw new TypeError('IdMapIndex: dim must be a positive integer')
+    }
+    if (!Number.isInteger(bitWidth) || bitWidth <= 0 || bitWidth > 32) {
+      throw new TypeError('IdMapIndex: bitWidth must be an integer in [1, 32]')
+    }
+    this[HANDLE] = binding.idx_create({ dim, bitWidth })
+  }
+
+  /**
+   * Load a persisted index from a .tvim file. Returns a fresh instance.
+   * @param {string} path
+   * @returns {Promise<IdMapIndex>}
+   */
+  static async load (path) {
+    if (typeof path !== 'string' || path.length === 0) {
+      throw new TypeError('IdMapIndex.load: path must be a non-empty string')
+    }
+    const instance = Object.create(IdMapIndex.prototype)
+    instance[HANDLE] = binding.idx_load(path)
+    return instance
+  }
+
+  /**
+   * Insert `n` vectors with their external ids. Throws on duplicate id or
+   * dim mismatch; partial mutation is impossible (atomic add).
+   * @param {Float32Array} vectors - length = n * dim
+   * @param {BigUint64Array} ids   - length = n
+   */
+  addWithIds (vectors, ids) {
+    if (!(vectors instanceof Float32Array)) {
+      throw new TypeError('addWithIds: vectors must be a Float32Array')
+    }
+    if (!(ids instanceof BigUint64Array)) {
+      throw new TypeError('addWithIds: ids must be a BigUint64Array')
+    }
+    if (ids.length === 0) return
+    if (vectors.length !== ids.length * this.dim) {
+      throw new RangeError(
+        `addWithIds: vectors.length (${vectors.length}) must equal ids.length (${ids.length}) * dim (${this.dim})`
+      )
+    }
+    binding.idx_add(ensureHandle(this), vectors, ids)
+  }
+
+  /**
+   * Top-k search across `m` queries packed contiguously in `queries`.
+   * Returns `{ scores, ids, m, k }` where scores/ids are typed arrays of
+   * length m*k (row-major).
+   * @param {Float32Array} queries - length = m * dim
+   * @param {number} k
+   * @returns {{ scores: Float32Array, ids: BigUint64Array, m: number, k: number }}
+   */
+  search (queries, k) {
+    if (!(queries instanceof Float32Array)) {
+      throw new TypeError('search: queries must be a Float32Array')
+    }
+    if (!Number.isInteger(k) || k <= 0) {
+      throw new TypeError('search: k must be a positive integer')
+    }
+    return binding.idx_search(ensureHandle(this), queries, k)
+  }
+
+  /**
+   * Remove an entry by external id.
+   * @param {bigint} id
+   * @returns {boolean} true if removed, false if not present
+   */
+  remove (id) {
+    if (typeof id !== 'bigint') {
+      throw new TypeError('remove: id must be a bigint')
+    }
+    return binding.idx_remove(ensureHandle(this), id)
+  }
+
+  /**
+   * @param {bigint} id
+   * @returns {boolean}
+   */
+  contains (id) {
+    if (typeof id !== 'bigint') {
+      throw new TypeError('contains: id must be a bigint')
+    }
+    return binding.idx_contains(ensureHandle(this), id)
+  }
+
+  /** No-op for the POC. Placeholder for future cache warming. */
+  prepare () {
+    binding.idx_prepare(ensureHandle(this))
+  }
+
+  /**
+   * Persist the index to disk in the .tvim v1 format.
+   * @param {string} path
+   */
+  write (path) {
+    if (typeof path !== 'string' || path.length === 0) {
+      throw new TypeError('write: path must be a non-empty string')
+    }
+    binding.idx_write(ensureHandle(this), path)
+  }
+
+  get length () { return binding.idx_len(ensureHandle(this)) }
+  get dim () { return binding.idx_dim(ensureHandle(this)) }
+  get bitWidth () { return binding.idx_bit_width(ensureHandle(this)) }
+
+  /**
+   * Mark the instance as unusable. The native handle is owned by a
+   * JS-side external whose finalizer runs at GC time; this method only
+   * drops the local reference so subsequent calls throw (`ensureHandle`).
+   * No memory is reclaimed synchronously — that requires a finalizer
+   * pass. Kept as a method for API stability; future versions may add
+   * a safe early-free path (wrapper object + sentinel) without changing
+   * the call sites.
+   */
+  async dispose () {
+    this[HANDLE] = null
+  }
+}
+
+module.exports = IdMapIndex

--- a/packages/embed-llamacpp/index.d.ts
+++ b/packages/embed-llamacpp/index.d.ts
@@ -87,3 +87,57 @@ export class BertInterface implements Addon {
 
 /** Returns the first shard (matching `-NNNNN-of-MMMMM.gguf`) or the sole entry for single-file models. */
 export function pickPrimaryGgufPath(files: string[]): string
+
+// ---------------------------------------------------------------------------
+// IdMapIndex (turbovec POC)
+// ---------------------------------------------------------------------------
+
+export interface IdMapIndexOptions {
+  /** Vector dimensionality (must be > 0). */
+  dim: number
+  /** Reserved for future quantization; POC stores full f32 internally. */
+  bitWidth?: number
+}
+
+export interface IdMapIndexSearchResult {
+  /** Row-major scores: m * k. Higher = closer. */
+  scores: Float32Array
+  /** Row-major external ids: m * k. `UINT64_MAX` padding when index is shorter than k. */
+  ids: BigUint64Array
+  /** Number of query rows. */
+  m: number
+  /** Effective k (mirrors the requested k). */
+  k: number
+}
+
+export class IdMapIndex {
+  constructor(opts: IdMapIndexOptions)
+
+  /** Open a persisted .tvim file written by `write()`. */
+  static load(path: string): Promise<IdMapIndex>
+
+  /**
+   * Insert `n` vectors with stable external ids. Throws on duplicate id or
+   * dim mismatch; mutation is atomic per call.
+   */
+  addWithIds(vectors: Float32Array, ids: BigUint64Array): void
+
+  /** Top-k search across `queries.length / dim` rows. */
+  search(queries: Float32Array, k: number): IdMapIndexSearchResult
+
+  /** Returns true if removed, false if not present. */
+  remove(id: bigint): boolean
+  contains(id: bigint): boolean
+
+  /** No-op for the POC. */
+  prepare(): void
+
+  /** Persist to disk (.tvim v1). */
+  write(path: string): void
+
+  readonly length: number
+  readonly dim: number
+  readonly bitWidth: number
+
+  dispose(): Promise<void>
+}

--- a/packages/embed-llamacpp/index.js
+++ b/packages/embed-llamacpp/index.js
@@ -217,3 +217,11 @@ class GGMLBert {
 
 module.exports = GGMLBert
 module.exports.pickPrimaryGgufPath = pickPrimaryGgufPath
+
+// IdMapIndex (turbovec POC) is also re-exported here as a named property
+// for discoverability when consumers `require('@qvac/embed-llamacpp')`.
+// Consumers that want the ANN index WITHOUT loading this file's GGMLBert /
+// addon require chain should import it directly via the package's
+// `./idMapIndex` sub-export — that path goes straight to `./binding` and
+// never touches `./addon`, satisfying the POC's lifecycle-isolation invariant.
+module.exports.IdMapIndex = require('./idMapIndex')

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -44,6 +44,7 @@
   "files": [
     "binding.js",
     "index.js",
+    "idMapIndex.js",
     "addon.js",
     "addonLogging.js",
     "addonLogging.d.ts",
@@ -80,6 +81,10 @@
     ".": {
       "types": "./index.d.ts",
       "default": "./index.js"
+    },
+    "./idMapIndex": {
+      "types": "./index.d.ts",
+      "default": "./idMapIndex.js"
     },
     "./addonLogging": {
       "types": "./addonLogging.d.ts",

--- a/packages/embed-llamacpp/scripts/rebuild-fabric.sh
+++ b/packages/embed-llamacpp/scripts/rebuild-fabric.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Inner-loop rebuild after editing fabric C++ in a LOCAL fabric checkout.
+#
+# Set QVAC_FABRIC_LOCAL_PATH (or QVAC_FABRIC_SRC_DIR) to point at a fabric
+# working tree before running. The script:
+#   1. bumps the overlay portfile's fabric-src-hash so vcpkg rebuilds the
+#      qvac-fabric port from your local source,
+#   2. regenerates CMake (which re-runs vcpkg manifest install),
+#   3. builds + installs the addon.
+#
+# If QVAC_FABRIC_LOCAL_PATH is NOT set, the overlay portfile uses its
+# pinned github fetch — there's nothing for this script to invalidate, and
+# `bare-make build` alone is enough for addon-side edits.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+package_root="$(cd "$here/.." && pwd)"
+cd "$package_root"
+
+if [ -z "${QVAC_FABRIC_LOCAL_PATH:-}${QVAC_FABRIC_SRC_DIR:-}" ]; then
+  echo "rebuild-fabric: WARNING — neither QVAC_FABRIC_LOCAL_PATH nor"
+  echo "rebuild-fabric: QVAC_FABRIC_SRC_DIR is set. The overlay is in"
+  echo "rebuild-fabric: github-fetch mode and will not pick up local edits."
+  echo "rebuild-fabric: To iterate on local fabric source set, e.g.,"
+  echo "rebuild-fabric:   export QVAC_FABRIC_LOCAL_PATH=/path/to/qvac-fabric-llm.cpp"
+fi
+
+bash "$here/sync-fabric-overlay.sh"
+bare-make generate
+bare-make build
+bare-make install
+echo "rebuild-fabric: done"

--- a/packages/embed-llamacpp/scripts/sync-fabric-overlay.sh
+++ b/packages/embed-llamacpp/scripts/sync-fabric-overlay.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Bumps the `# fabric-src-hash:` comment in the qvac-fabric overlay portfile
+# to a fresh hash of fabric source contents.
+#
+# This is ONLY needed when iterating on a local fabric checkout via the
+# `QVAC_FABRIC_LOCAL_PATH` env-var override (Phase 0 fast-edit loop). In the
+# default github-fetch mode the overlay is pinned by commit SHA + SHA512 and
+# vcpkg invalidates the cache when those change.
+#
+# Why this script exists: vcpkg derives its ABI hash from the portfile
+# contents, not from the source the portfile copies in. Without bumping a
+# portfile-tracked field, local working-tree edits to fabric won't trigger a
+# rebuild.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+package_root="$(cd "$here/.." && pwd)"
+portfile="$package_root/vcpkg/ports/qvac-fabric/portfile.cmake"
+
+if [ ! -f "$portfile" ]; then
+  echo "sync-fabric-overlay: portfile not found at $portfile" >&2
+  exit 1
+fi
+
+# Accept either QVAC_FABRIC_LOCAL_PATH (the overlay's runtime env var) or
+# QVAC_FABRIC_SRC_DIR (legacy alias).
+if [ -n "${QVAC_FABRIC_LOCAL_PATH:-}" ]; then
+  fabric_dir="$QVAC_FABRIC_LOCAL_PATH"
+elif [ -n "${QVAC_FABRIC_SRC_DIR:-}" ]; then
+  fabric_dir="$QVAC_FABRIC_SRC_DIR"
+else
+  # Best-effort default: sibling of the qvac-public checkout.
+  fabric_dir="$(cd "$package_root/../../../qvac-fabric-llm.cpp" 2>/dev/null && pwd || true)"
+fi
+
+if [ -z "$fabric_dir" ] || [ ! -d "$fabric_dir" ]; then
+  echo "sync-fabric-overlay: fabric checkout not found." >&2
+  echo "  Tried (in order):" >&2
+  echo "    QVAC_FABRIC_LOCAL_PATH=${QVAC_FABRIC_LOCAL_PATH:-<unset>}" >&2
+  echo "    QVAC_FABRIC_SRC_DIR=${QVAC_FABRIC_SRC_DIR:-<unset>}" >&2
+  echo "    default sibling: $package_root/../../../qvac-fabric-llm.cpp" >&2
+  exit 1
+fi
+
+if [ ! -f "$fabric_dir/CMakeLists.txt" ]; then
+  echo "sync-fabric-overlay: $fabric_dir does not look like a fabric checkout" >&2
+  exit 1
+fi
+
+# Hash all tracked source under fabric. `git ls-files` is preferred (fast,
+# respects .gitignore); fallback to `find` for non-git trees.
+hash=$(
+  cd "$fabric_dir" && {
+    git ls-files \
+      ':!*.gguf' ':!*.bin' ':!*.png' ':!*.jpg' \
+      2>/dev/null \
+      || find . -type f \
+           -not -path '*/.git/*' \
+           -not -path '*/build*/*' \
+           -not -path '*/node_modules/*' \
+           -not -path '*/__pycache__/*'
+  } | LC_ALL=C sort | xargs -I{} shasum "{}" 2>/dev/null | shasum | awk '{print $1}'
+)
+
+if [ -z "$hash" ] || [ "${#hash}" -lt 20 ]; then
+  echo "sync-fabric-overlay: failed to compute fabric source hash" >&2
+  exit 1
+fi
+
+tmp="$portfile.tmp.$$"
+awk -v h="$hash" '
+  /^# fabric-src-hash: / { print "# fabric-src-hash: " h; next }
+  { print }
+' "$portfile" > "$tmp"
+
+mv "$tmp" "$portfile"
+echo "sync-fabric-overlay: fabric source dir = $fabric_dir"
+echo "sync-fabric-overlay: fabric-src-hash -> $hash"
+echo "sync-fabric-overlay: portfile updated -> $portfile"

--- a/packages/embed-llamacpp/test/integration/id-map-index.test.js
+++ b/packages/embed-llamacpp/test/integration/id-map-index.test.js
@@ -1,0 +1,173 @@
+'use strict'
+//
+// Phase 2 acceptance: exercises every JS method on `IdMapIndex` end-to-end
+// without loading any BERT model. Pair-bound with the C++ test under
+// fabric's `tests/test-vector-index.cpp` (which exercises the same C API
+// directly): if both pass, the JS↔C++ binding is correct in both
+// directions.
+
+const test = require('brittle')
+const fs = require('bare-fs')
+const path = require('bare-path')
+const os = require('bare-os')
+
+// Pull IdMapIndex via the package's sub-export path. The package exports
+// `./idMapIndex` so consumers can opt into just the ANN-index class
+// without dragging the GGMLBert require chain. Loading this module must
+// NOT boot any BERT runtime. Resolved via a relative path here because
+// the integration tests run inside the package itself (no self-link).
+//
+// To catch a future regression that wires GGMLBert init back into the
+// IdMapIndex path, the first test below inspects `require.cache` and
+// asserts the GGMLBert module file was never loaded. Bare keys
+// `require.cache` by `file://` URL, so we convert the resolved paths.
+const cacheKey = (p) => 'file://' + require.resolve(p)
+const KEY_IDMAP   = cacheKey('../../idMapIndex')
+const KEY_BINDING = cacheKey('../../binding')
+const KEY_INDEX   = cacheKey('../../index.js')
+const KEY_ADDON   = cacheKey('../../addon.js')
+
+const IdMapIndex = require('../../idMapIndex')
+
+// DIM is chosen large enough that the N seed vectors below can each be a
+// distinct unit basis vector — keeps the "self-match top-1" assertion
+// well-defined.
+const DIM = 16
+const N = 10
+
+function unitVec (i) {
+  const v = new Float32Array(DIM)
+  v[i] = 1
+  return v
+}
+
+let tmpCounter = 0
+function tmpPath (name) {
+  const pid = os.pid ? os.pid() : 0
+  tmpCounter += 1
+  return path.join(os.tmpdir(),
+    `${name}-${pid}-${Date.now()}-${tmpCounter}.tvim`)
+}
+
+test('IdMapIndex sub-export does not boot the BERT runtime', (t) => {
+  // 1. Construct path: zero-arg + tiny-arg ctors must succeed without
+  //    loading any model or running addon-side BERT init.
+  const idx = new IdMapIndex({ dim: DIM, bitWidth: 4 })
+  t.is(idx.dim, DIM, 'dim getter')
+  t.is(idx.bitWidth, 4, 'bitWidth getter')
+  t.is(idx.length, 0, 'starts empty')
+  idx.dispose()
+
+  // 2. Module-cache invariant: requiring `./idMapIndex` must NOT have
+  //    transitively loaded the GGMLBert entry (`./index.js`) or the
+  //    BertInterface plumbing (`./addon.js`). If a future refactor wires
+  //    BERT init into the IdMapIndex path, one of these files will be
+  //    in the cache after the require above.
+  t.ok(require.cache[KEY_IDMAP],
+    'sub-export module loaded (sanity)')
+  t.ok(require.cache[KEY_BINDING],
+    'native binding loaded (sanity)')
+  t.absent(require.cache[KEY_INDEX],
+    'GGMLBert entry (index.js) NOT loaded by ./idMapIndex')
+  t.absent(require.cache[KEY_ADDON],
+    'BertInterface plumbing (addon.js) NOT loaded by ./idMapIndex')
+})
+
+test('IdMapIndex: add + search + remove + persistence round-trip', async (t) => {
+  const idx = new IdMapIndex({ dim: DIM, bitWidth: 4 })
+
+  const vectors = new Float32Array(N * DIM)
+  const ids = new BigUint64Array(N)
+  for (let i = 0; i < N; i++) {
+    vectors.set(unitVec(i), i * DIM)
+    // Mix non-trivial ids to flush out BigInt/uint64 round-trip bugs.
+    ids[i] = BigInt(i) + (1n << 40n) + (1n << 62n)
+  }
+
+  idx.addWithIds(vectors, ids)
+  t.is(idx.length, N, 'all 10 vectors inserted')
+  t.ok(idx.contains(ids[3]), 'contains a known id')
+  t.absent(idx.contains(999n), 'absent id missing')
+
+  // Top-1 of querying with the i-th unit vector must return that vector's id
+  // with a score very close to 1.0 (full f32, no quantization noise).
+  for (let i = 0; i < N; i++) {
+    const q = unitVec(i)
+    const out = idx.search(q, 1)
+    t.is(out.m, 1)
+    t.is(out.k, 1)
+    t.is(out.ids[0], ids[i], `query=${i} retrieves itself`)
+    t.ok(Math.abs(out.scores[0] - 1.0) < 1e-5, `score≈1.0 for self-match`)
+  }
+
+  // Top-k > length pads sentinels at the tail.
+  {
+    const out = idx.search(unitVec(0), N + 4)
+    t.is(out.ids.length, N + 4)
+    for (let i = N; i < N + 4; i++) {
+      t.is(out.ids[i], (1n << 64n) - 1n, `sentinel id at tail slot ${i}`)
+    }
+  }
+
+  // Duplicate add must throw atomically (length unchanged).
+  {
+    const dupIds = new BigUint64Array([ids[0]])
+    const dupVec = unitVec(0)
+    try {
+      idx.addWithIds(dupVec, dupIds)
+      t.fail('duplicate add should have thrown')
+    } catch (e) {
+      t.pass('duplicate add threw: ' + (e.message || e.code))
+    }
+    t.is(idx.length, N, 'length unchanged after rejected dup add')
+  }
+
+  // Remove + search: the removed id should not surface.
+  {
+    const removed = idx.remove(ids[2])
+    t.ok(removed === true, 'remove returns true on first call')
+    t.absent(idx.remove(ids[2]), 'remove returns false on second call')
+    t.absent(idx.contains(ids[2]), 'no longer contained')
+    t.is(idx.length, N - 1)
+    const out = idx.search(unitVec(2), 3)
+    for (let i = 0; i < 3; i++) {
+      t.absent(out.ids[i] === ids[2], `removed id absent from search result ${i}`)
+    }
+  }
+
+  // prepare() is a no-op but must be callable.
+  idx.prepare()
+
+  // Persist, dispose, reload, re-search.
+  const file = tmpPath('id-map-index-roundtrip')
+  try {
+    idx.write(file)
+    await idx.dispose()
+
+    const loaded = await IdMapIndex.load(file)
+    t.is(loaded.dim, DIM, 'dim restored')
+    t.is(loaded.bitWidth, 4, 'bitWidth restored')
+    t.is(loaded.length, N - 1, 'length restored (deletion persisted)')
+    t.ok(loaded.contains(ids[0]), 'kept id still there')
+    t.absent(loaded.contains(ids[2]), 'deleted id stayed deleted')
+
+    const out = loaded.search(unitVec(0), 1)
+    t.is(out.ids[0], ids[0], 'self-match after reload')
+    t.ok(Math.abs(out.scores[0] - 1.0) < 1e-5)
+
+    await loaded.dispose()
+  } finally {
+    if (fs.existsSync(file)) fs.unlinkSync(file)
+  }
+})
+
+test('IdMapIndex: BigInt id range edge cases', (t) => {
+  // 2^63 + 7 catches sign-extension bugs at the typed-array boundary.
+  const idx = new IdMapIndex({ dim: 2 })
+  const edge = (1n << 63n) + 7n
+  idx.addWithIds(new Float32Array([0.5, 0.5]), new BigUint64Array([edge]))
+  t.ok(idx.contains(edge), 'high-bit id round-trips')
+  const out = idx.search(new Float32Array([0.5, 0.5]), 1)
+  t.is(out.ids[0], edge, 'high-bit id surfaces from search')
+  idx.dispose()
+})

--- a/packages/embed-llamacpp/vcpkg.json
+++ b/packages/embed-llamacpp/vcpkg.json
@@ -1,4 +1,7 @@
 {
+  "$schema-comment": "vcpkg requires `name` + a versioning field whenever the manifest uses `version>=` constraints or overlay-ports. Both are present here because the qvac-fabric pin (>=8828.1.0) goes through an overlay (vcpkg/ports/qvac-fabric).",
+  "name": "embed-llamacpp",
+  "version-string": "0.19.1",
   "dependencies": [
     {
       "name": "opencl",

--- a/packages/embed-llamacpp/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
+++ b/packages/embed-llamacpp/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
@@ -1,0 +1,36 @@
+# Function to detect Vulkan version from NDK vulkan_core.h
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    # CMAKE_HOST_SYSTEM_PROCESSOR is unavailable here. Use a glob pattern to complete the folder instead. 
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT vulkan_core_h)
+        message(FATAL "vulkan_core.h not found, using default version")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL "Could not extract VK_HEADER_VERSION from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+
+     # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL "Could not extract major.minor version from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+endfunction()

--- a/packages/embed-llamacpp/vcpkg/ports/qvac-fabric/portfile.cmake
+++ b/packages/embed-llamacpp/vcpkg/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,229 @@
+# LOCAL OVERLAY for qvac-fabric (turbovec POC).
+#
+# Pinned by default to a commit on
+#   https://github.com/dev-nid/qvac-fabric-llm.cpp.git
+# (branch: poc/turbovec-embed)
+# which adds the new ggml-vector-index module on top of upstream
+# fabric's `v8828.1.1` (which is the highest 8828.x release tag that
+# satisfies embed-llamacpp's `qvac-fabric >= 8828.1.0` manifest pin).
+#
+# Why an overlay at all: the public `tetherto/qvac-registry-vcpkg` port
+# for qvac-fabric tops out at v7248.2.2 and has no 8828.x line yet, so
+# the manifest's >=8828.1.0 constraint cannot be satisfied by the
+# registry. This overlay closes that gap and is the single source of
+# fabric source for the POC build. Drop it once the registry publishes
+# an 8828.x port.
+#
+# Local-edit iteration (Phase 0 fast loop) — set QVAC_FABRIC_LOCAL_PATH
+# to the path of a fabric working tree. The overlay then copies that
+# directory into the vcpkg buildtree instead of fetching from github.
+# Because vcpkg's ABI hash is derived from the portfile contents (not
+# the source it copies in), use `./scripts/sync-fabric-overlay.sh` to
+# bump the `# fabric-src-hash:` comment line on each iteration so vcpkg
+# rebuilds the port.
+
+# fabric-src-hash: 0000000000000000000000000000000000000000
+
+set(FABRIC_GH_REPO "dev-nid/qvac-fabric-llm.cpp")
+set(FABRIC_GH_REF  "dd934a6d9964a718eaca6630c72dc33fe88a8892")  # poc/turbovec-embed
+set(FABRIC_GH_HEAD_REF "poc/turbovec-embed")
+set(FABRIC_GH_SHA512
+    "ad696aa0382c207ce5ca3840b9ae0b2fd7ce85b458d0a472275e2fee933bb578539244c716f07ed087b718be0de1057139837d0ec57a8ac6b0eeafabe942fae5")
+
+if(DEFINED ENV{QVAC_FABRIC_LOCAL_PATH})
+  set(FABRIC_LOCAL_PATH "$ENV{QVAC_FABRIC_LOCAL_PATH}")
+  if(NOT EXISTS "${FABRIC_LOCAL_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+      "qvac-fabric overlay: QVAC_FABRIC_LOCAL_PATH='${FABRIC_LOCAL_PATH}' "
+      "is not a fabric checkout (no CMakeLists.txt).")
+  endif()
+  message(STATUS
+    "qvac-fabric overlay: LOCAL mode — copying source from ${FABRIC_LOCAL_PATH}")
+  set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/qvac-fabric-local")
+  file(REMOVE_RECURSE "${SOURCE_PATH}")
+  file(MAKE_DIRECTORY "${SOURCE_PATH}")
+  file(COPY "${FABRIC_LOCAL_PATH}/"
+       DESTINATION "${SOURCE_PATH}"
+       PATTERN ".git" EXCLUDE
+       PATTERN "build" EXCLUDE
+       PATTERN ".cache" EXCLUDE
+       PATTERN "node_modules" EXCLUDE
+       PATTERN "__pycache__" EXCLUDE
+       PATTERN ".venv" EXCLUDE)
+else()
+  message(STATUS
+    "qvac-fabric overlay: GITHUB mode — fetching ${FABRIC_GH_REPO}@${FABRIC_GH_REF}")
+  vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ${FABRIC_GH_REPO}
+    REF ${FABRIC_GH_REF}
+    SHA512 ${FABRIC_GH_SHA512}
+    HEAD_REF ${FABRIC_GH_HEAD_REF})
+endif()
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+    llama BUILD_LLAMA
+)
+
+if (VCPKG_TARGET_IS_ANDROID)
+  include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+  detect_ndk_vulkan_version()
+  message(STATUS "Using Vulkan C++ wrappers from version: ${vulkan_version}")
+  file(DOWNLOAD
+    "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+    "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    TLS_VERIFY ON
+  )
+  file(ARCHIVE_EXTRACT
+    INPUT "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    DESTINATION "${SOURCE_PATH}"
+    PATTERNS "*.hpp"
+  )
+  file(RENAME
+    "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}"
+    "${SOURCE_PATH}/ggml/src/ggml-vulkan/vulkan_cpp_wrapper"
+  )
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID)
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_VULKAN_DISABLE_COOPMAT=ON
+    -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    -DGGML_OPENCL=ON)
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_OPENMP=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_MTMD=ON
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+# Different fabric branches install CMake configs at either
+# `lib/cmake/<pkg>` (HEAD-ish) or the upstream-standard `share/<pkg>`
+# (temp-8828 / v7248.x). Detect which is present per package so the
+# overlay works against both layouts without portfile edits.
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/ggml")
+  vcpkg_cmake_config_fixup(
+    PACKAGE_NAME ggml
+    CONFIG_PATH "lib/cmake/ggml"
+    DO_NOT_DELETE_PARENT_CONFIG_PATH)
+else()
+  vcpkg_cmake_config_fixup(PACKAGE_NAME ggml)
+endif()
+
+if(BUILD_LLAMA)
+  if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/llama")
+    vcpkg_cmake_config_fixup(PACKAGE_NAME llama CONFIG_PATH "lib/cmake/llama")
+  else()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME llama)
+  endif()
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+if(BUILD_LLAMA)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py")
+    file(RENAME
+      "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py"
+      "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+  endif()
+  if(EXISTS "${SOURCE_PATH}/gguf-py")
+    file(INSTALL "${SOURCE_PATH}/gguf-py"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  endif()
+  # Vulkan-only artifact; absent on macOS (Metal backend) and iOS.
+  if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py")
+    file(RENAME
+      "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py"
+      "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+  endif()
+endif()
+
+if (NOT VCPKG_BUILD_TYPE)
+  if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+  endif()
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Local fabric HEAD's llama-config.cmake `set_and_check`s LLAMA_BIN_DIR
+# even for static builds, so we keep an (empty) bin/ around. Upstream's
+# tagged release didn't, hence the original removal block. Preserve the
+# dirs so `find_package(llama)` succeeds.
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+
+# Fabric branches differ in where (and whether) they install the `common/`
+# headers from the llama helper library. The embed-llamacpp addon code
+# references them as both `<common/...>` and `<llama/common/...>`. To make
+# both forms resolve to the same physical file (otherwise duplicate
+# struct definitions break the build), normalize the layout:
+#   - Prefer `include/llama/common/`. The addon's `-isystem
+#     include/llama` lets `<common/...>` fall through to that path.
+#   - Remove a redundant `include/common/` if both exist (the two trees
+#     would otherwise be distinct files for the preprocessor and re-define
+#     every struct on second inclusion).
+#   - Synthesize `include/llama/common/` from source if neither is present.
+if(BUILD_LLAMA AND EXISTS "${SOURCE_PATH}/common")
+  set(_qvac_common_have_llama
+      "${CURRENT_PACKAGES_DIR}/include/llama/common/common.h")
+  set(_qvac_common_have_root
+      "${CURRENT_PACKAGES_DIR}/include/common/common.h")
+  if(EXISTS "${_qvac_common_have_llama}")
+    if(EXISTS "${_qvac_common_have_root}")
+      file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/common")
+    endif()
+  elseif(NOT EXISTS "${_qvac_common_have_root}")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/include/llama/common")
+    file(COPY "${SOURCE_PATH}/common/"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/include/llama/common"
+         FILES_MATCHING
+           PATTERN "*.h"
+           PATTERN "*.hpp"
+           PATTERN "*.inc")
+  endif()
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/embed-llamacpp/vcpkg/ports/qvac-fabric/vcpkg.json
+++ b/packages/embed-llamacpp/vcpkg/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,33 @@
+{
+  "name": "qvac-fabric",
+  "version": "8828.1.0",
+  "port-version": 9999,
+  "description": "LLM inference in C/C++ (LOCAL OVERLAY built from sibling qvac-fabric-llm.cpp source tree)",
+  "homepage": "https://github.com/tetherto/qvac-fabric-llm.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "llama"
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    },
+    "llama": {
+      "description": "Build llama components."
+    }
+  }
+}


### PR DESCRIPTION
## Context
Second of three coordinated POC PRs (fabric → embed-llamacpp → rag). Adds the Bare-addon binding + JS class for fabric's new `ggml-vector-index` C API. Strictly additive — `GGMLBert`, `BertInterface`, and the existing addon binding code are untouched.
Depends on dev-nid/qvac-fabric-llm.cpp `poc/turbovec-embed` (the fabric PR) for the C API this binding consumes.
## What was done
- **`addon/src/model-interface/VectorIndex.{hpp,cpp}`** — RAII C++ wrapper around fabric's `ggml_vec_index_t*`. Typed methods, `noexcept` throughout, `const` where the C API allows. Move-only.
- **`addon/src/addon/VectorIndexErrors.hpp`** — fabric error-code → JS error-name mapping. Mirrors the `BertErrors.hpp` pattern; lives in its own header so the binding can include it without dragging in any BertModel / LlamaLazyInitializeBackend symbols.
- **`addon/src/js-interface/vector-index-binding.cpp`** — N-API surface: `idx_create`, `idx_load`, `idx_add`, `idx_search`, `idx_remove`, `idx_contains`, `idx_prepare`, `idx_write`, plus int-getter templates for `idx_len` / `idx_dim` / `idx_bit_width`. Free functions registered onto the addon's exports next to the existing `BertInterface` plumbing. Deliberately depends only on the `VectorIndex` wrapper + fabric's C API — no `BertModel` / `LlamaLazyInitializeBackend` symbols are referenced, so importing the addon does not boot fabric's LLM backend.
- **`addon/src/js-interface/binding.cpp`** — single edit: forward-declare and call `qvac_lib_inference_addon_embed::vector_index::registerBindings(env, exports)` after the existing registrations. Keeps `vector-index-binding.cpp` in its own TU for the isolation invariant above.
- **`idMapIndex.js`** — thin JS class over the bindings. `Float32Array` vectors, `BigUint64Array` external ids. `addWithIds` is atomic. `dispose()` is documented honestly: it drops the local handle reference; the native handle is reclaimed at GC time via the JS external's finalizer (no early-free hook in the current N-API surface).
- **`index.js` + `package.json` exports** — `IdMapIndex` is re-exported as a named property on the main entry (`require('@qvac/embed-llamacpp').IdMapIndex`) for discoverability AND as a dedicated sub-export `@qvac/embed-llamacpp/idMapIndex`. The sub-export is the lifecycle-isolation path: it goes straight to `./binding` and never loads `./addon` (BertInterface) or `./index.js` (GGMLBert).
- **`index.d.ts`** — full TypeScript surface for `IdMapIndex`, `IdMapIndexOptions`, `IdMapIndexSearchResult`.
- **`test/integration/id-map-index.test.js`** — exercises every JS method end-to-end without loading any model: construct, `addWithIds` (incl. non-trivial 64-bit ids), `search` (incl. sentinel-padded tail when `k > len`), atomic duplicate rejection, `remove`, `contains`, `prepare`, `write` → `dispose` → `load` → re-search. Includes a sign-bit BigInt round-trip case (`(1n << 63n) + 7n`) and a runtime spy on `require.cache` that asserts importing the sub-export never loads `index.js` (GGMLBert) or `addon.js` (BertInterface). **73 assertions across 3 tests.**
- **`vcpkg/ports/qvac-fabric/{vcpkg.json, portfile.cmake, android-vulkan-version.cmake}`** — local overlay port. The public `tetherto/qvac-registry-vcpkg` qvac-fabric port tops out at v7248.2.2; the manifest pins `>=8828.1.0`. Default mode: `vcpkg_from_github` against `dev-nid/qvac-fabric-llm.cpp` at a pinned commit + SHA512. Override: `QVAC_FABRIC_LOCAL_PATH=/path/to/fabric` switches the portfile into local-working-tree copy mode for the Phase 0 fast-edit loop.
- **`scripts/{sync-fabric-overlay.sh,rebuild-fabric.sh}`** — helpers for the local-iteration mode. Sync rewrites the `# fabric-src-hash:` comment in the portfile (vcpkg's ABI hash is portfile-derived, so a comment bump is what trips a rebuild from a fresh working-tree copy); rebuild chains sync + generate + build + install.
- **`CMakeLists.txt`** — registers `VCPKG_OVERLAY_PORTS`; adds `llama::llama` / `llama::common` alias shims for the cases where the fabric llama-config doesn't already provide them; lists the new source files.
- **`vcpkg.json`** — adds top-level `name` + `version-string`. Required by vcpkg when the manifest uses `version>=` constraints with overlay-ports (verified empirically: removing them produces `missing required field 'name'`). Documented with a `$schema-comment`.
## Why these choices
- **Why a sibling Bare-addon class rather than extending `GGMLBert`?** `IdMapIndex` has nothing to do with model inference — it's a CPU-side vector store. Bundling it under the BERT class would force the model-init path on every consumer, contradicting the "lifecycle isolation" requirement of the POC. The same `.bare` binary carries both surfaces; the JS layer decides which to construct.
- **Why a dedicated `./idMapIndex` sub-export AND a named re-export?** Sub-export = explicit opt-in for consumers (like `@qvac/rag`'s new adapter) that want zero coupling to the GGMLBert require chain. Named re-export = ergonomic discoverability for consumers that already pull in the main entry. Both resolve to the same class.
- **Why `dispose()` as a reference-drop, not an early free?** The N-API external API doesn't expose a safe "free now, no-op the finalizer" primitive without an extra indirection layer (wrapper struct + sentinel). For POC scope, an honest reference-drop + GC-driven finalizer is the right trade-off; the JS API stays stable and can grow a real early-free later behind the same method name.
- **Why an overlay port instead of bumping the registry?** Public `qvac-registry-vcpkg` has no 8828.x port for qvac-fabric. The manifest pin is forward-looking. The overlay is intentionally temporary — drop it once the registry catches up.
- **Why pin the fabric ref by commit SHA + SHA512?** Reproducible builds. Anyone cloning the repo runs `bare-make generate` and gets the same fabric, with no need for a sibling fabric checkout. The `QVAC_FABRIC_LOCAL_PATH` override exists for the inner-loop dev case.
- **Why `llama::llama` / `llama::common` alias shims in CMakeLists?** Different fabric branches export the targets with different namespacing conventions (`temp-8828` uses `llama::`, some HEADs export plain `llama`). The shims absorb the difference so the rest of the build stays branch-agnostic.
## What's left (out of POC scope)
- **Early-free on `dispose()`**: requires a wrapper-struct + nullable sentinel inside the external so the finalizer becomes a no-op after explicit dispose. Plumbing change, not a JS-API change.
- **`const`-aware C API in fabric**: companion fabric PR is making `ggml_vec_index_contains` and `ggml_vec_index_search` take `const ggml_vec_index_t *` so the C++ wrapper's `const noexcept` methods are end-to-end const. C++ wrapper already marked accordingly; backward-compatible with the current non-const C signatures via implicit conversion.
- **Async `prepare()`** for GPU upload paths (codebook materialization, etc.). Reserved as a no-op now; future fabric work fills it in.
## Verification
- **Existing unit tests** (`npm run test:unit`): **14/14**, **27/27 asserts**. Zero regressions.
- **New integration test** (`bare test/integration/id-map-index.test.js`): **3/3**, **73/73 asserts**.
  - Sub-export does not boot the BERT runtime — incl. `require.cache` spy asserting `file://…/index.js` and `file://…/addon.js` are NOT loaded after importing the sub-export.
  - End-to-end JS lifecycle: add → search (top-1 self-match score ≈ 1.0, sentinel-padded tail when `k > len`), atomic duplicate add rejection, remove + post-remove search, persistence round-trip (write → dispose → load → re-search).
  - BigInt edge case: high-bit id `(1n << 63n) + 7n` round-trips through `BigUint64Array` ↔ `uint64_t *` cleanly.
- **Overlay loop**: `vcpkg_from_github` against the dev-nid fork at the pinned commit installs cleanly; the `ggml-vector-index.h` header lands in `build/_vcpkg/arm64-osx/include/`; the addon links against the rebuilt fabric.
- **No new dependencies** on the JS or native side beyond what fabric brings in via the overlay.
## Companion PRs
https://github.com/tetherto/qvac/pull/2589
https://github.com/tetherto/qvac-fabric-llm.cpp/pull/153