### PR TITLE
chore[notask]: release @qvac/rag v0.6.4

### DIFF
--- a/packages/rag/CHANGELOG.md
+++ b/packages/rag/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4]
+
+### Changed
+
+- Drop the unused `crypto-browserify` hard dependency. The package never imported it — `#crypto` resolves to `bare-crypto` (Bare) or `node:crypto` (Node), and the browser / React Native shim reads `globalThis.crypto`. Consumers needing Node-style `crypto.createHash` (e.g. HyperDB document hashing in a browser/RN runtime) should install `crypto-browserify` themselves and assign it to `globalThis.crypto`, as documented in the README.
+
 ## [0.6.3]
 
 ### Changed

--- a/packages/rag/NOTICE
+++ b/packages/rag/NOTICE
@@ -10,11 +10,6 @@ listed below.
 JavaScript Dependencies
 =========================================================================
 
---- (mit AND bsd-3-clause) ---
-
-  sha.js@2.4.12
-    https://github.com/crypto-browserify/sha.js
-
 --- apache-2.0 (Apache License 2.0) ---
 
   @hyperswarm/secret-stream@6.9.1
@@ -40,7 +35,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-events
   bare-events@2.8.3
     https://github.com/holepunchto/bare-events
-  bare-fetch@2.9.1
+  bare-fetch@3.0.1
     https://github.com/holepunchto/bare-fetch
   bare-form-data@1.2.2
     https://github.com/holepunchto/bare-form-data
@@ -141,18 +136,10 @@ JavaScript Dependencies
 
   bits-to-bytes@1.3.0
     https://github.com/holepunchto/bits-to-bytes
-  browserify-sign@4.2.6
-    https://github.com/crypto-browserify/browserify-sign
-  inherits@2.0.4
-    https://github.com/isaacs/inherits
-  minimalistic-assert@1.0.1
-    https://github.com/calvinmetcalf/minimalistic-assert
   nanoassert@2.0.0
     https://github.com/emilbayes/nanoassert
   noise-curve-ed@2.1.0
     https://github.com/chm-diederichs/noise-curve-ed
-  parse-asn1@5.1.9
-    https://github.com/crypto-browserify/parse-asn1
   quickbit-universal@2.2.0
     https://github.com/holepunchto/quickbit-universal
   simdle-universal@1.1.2
@@ -160,106 +147,24 @@ JavaScript Dependencies
 
 --- mit (MIT License) ---
 
-  asn1.js@4.10.1
-    https://github.com/indutny/asn1.js
-  available-typed-arrays@1.0.7
-    https://github.com/inspect-js/available-typed-arrays
   big-sparse-array@1.0.3
     https://github.com/mafintosh/big-sparse-array
-  bn.js@4.12.3
-    https://github.com/indutny/bn.js
-  bn.js@5.2.3
-    https://github.com/indutny/bn.js
   bogon@1.3.0
     https://github.com/mafintosh/bogon
-  brorand@1.1.0
-    https://github.com/indutny/brorand
-  browserify-aes@1.2.0
-    https://github.com/crypto-browserify/browserify-aes
-  browserify-cipher@1.0.1
-    https://github.com/crypto-browserify/browserify-cipher
-  browserify-des@1.0.2
-    https://github.com/crypto-browserify/browserify-des
-  browserify-rsa@4.1.1
-    https://github.com/crypto-browserify/browserify-rsa
-  buffer-xor@1.0.3
-    https://github.com/crypto-browserify/buffer-xor
-  call-bind@1.0.9
-    https://github.com/ljharb/call-bind
-  call-bind-apply-helpers@1.0.2
-    https://github.com/ljharb/call-bind-apply-helpers
-  call-bound@1.0.4
-    https://github.com/ljharb/call-bound
-  cipher-base@1.0.7
-    https://github.com/crypto-browserify/cipher-base
   codecs@3.1.0
     https://github.com/mafintosh/codecs
-  core-util-is@1.0.3
-    https://github.com/isaacs/core-util-is
-  create-ecdh@4.0.4
-    https://github.com/crypto-browserify/createECDH
-  create-hash@1.2.0
-    https://github.com/crypto-browserify/createHash
-  create-hmac@1.1.7
-    https://github.com/crypto-browserify/createHmac
-  crypto-browserify@3.12.1
-    https://github.com/browserify/crypto-browserify
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
-  define-data-property@1.1.4
-    https://github.com/ljharb/define-data-property
-  des.js@1.1.0
-    https://github.com/indutny/des.js
   dht-rpc@6.27.0
     https://github.com/holepunchto/dht-rpc
-  diffie-hellman@5.0.3
-    https://github.com/crypto-browserify/diffie-hellman
-  dunder-proto@1.0.1
-    https://github.com/es-shims/dunder-proto
-  elliptic@6.6.1
-    https://github.com/indutny/elliptic
-  es-define-property@1.0.1
-    https://github.com/ljharb/es-define-property
-  es-errors@1.3.0
-    https://github.com/ljharb/es-errors
-  es-object-atoms@1.1.2
-    https://github.com/ljharb/es-object-atoms
-  evp_bytestokey@1.0.3
-    https://github.com/crypto-browserify/EVP_BytesToKey
   fast-fifo@1.3.2
     https://github.com/mafintosh/fast-fifo
   flat-tree@1.13.0
     https://github.com/mafintosh/flat-tree
-  for-each@0.3.5
-    https://github.com/Raynos/for-each
-  function-bind@1.1.2
-    https://github.com/Raynos/function-bind
   generate-object-property@2.0.0
     https://github.com/mafintosh/generate-object-property
   generate-string@1.0.1
     https://github.com/mafintosh/generate-string
-  get-intrinsic@1.3.0
-    https://github.com/ljharb/get-intrinsic
-  get-proto@1.0.1
-    https://github.com/ljharb/get-proto
-  gopd@1.2.0
-    https://github.com/ljharb/gopd
-  has-property-descriptors@1.0.2
-    https://github.com/inspect-js/has-property-descriptors
-  has-symbols@1.1.0
-    https://github.com/inspect-js/has-symbols
-  has-tostringtag@1.0.2
-    https://github.com/inspect-js/has-tostringtag
-  hash-base@3.0.5
-    https://github.com/crypto-browserify/hash-base
-  hash-base@3.1.2
-    https://github.com/crypto-browserify/hash-base
-  hash.js@1.1.7
-    https://github.com/indutny/hash.js
-  hasown@2.0.3
-    https://github.com/inspect-js/hasOwn
-  hmac-drbg@1.0.1
-    https://github.com/indutny/hmac-drbg
   hyperbee@2.27.3
     https://github.com/holepunchto/hyperbee
   hypercore@11.30.2
@@ -268,72 +173,34 @@ JavaScript Dependencies
     https://github.com/mafintosh/hypercore-crypto
   hyperdht@6.32.0
     https://github.com/holepunchto/hyperdht
-  is-callable@1.2.7
-    https://github.com/inspect-js/is-callable
   is-options@1.0.2
     https://github.com/mafintosh/is-options
   is-property@1.0.2
     https://github.com/mikolalysenko/is-property
-  is-typed-array@1.1.15
-    https://github.com/inspect-js/is-typed-array
-  isarray@1.0.0
-    https://github.com/juliangruber/isarray
-  isarray@2.0.5
-    https://github.com/juliangruber/isarray
   kademlia-routing-table@1.0.6
     https://github.com/mafintosh/kademlia-routing-table
   llm-splitter@0.2.0
     https://github.com/nearform/llm-splitter
-  math-intrinsics@1.1.0
-    https://github.com/es-shims/math-intrinsics
-  md5.js@1.3.5
-    https://github.com/crypto-browserify/md5.js
-  miller-rabin@4.0.1
-    https://github.com/indutny/miller-rabin
-  minimalistic-crypto-utils@1.0.1
-    https://github.com/indutny/minimalistic-crypto-utils
   mutexify@1.4.0
     https://github.com/mafintosh/mutexify
   nat-sampler@1.0.1
     https://github.com/mafintosh/nat-sampler
-  pbkdf2@3.1.5
-    https://github.com/browserify/pbkdf2
-  possible-typed-array-names@1.1.0
-    https://github.com/ljharb/possible-typed-array-names
-  process-nextick-args@2.0.1
-    https://github.com/calvinmetcalf/process-nextick-args
   protocol-buffers-encodings@1.2.0
     https://github.com/mafintosh/protocol-buffers-encodings
   protomux@3.11.0
     https://github.com/holepunchto/protomux
-  public-encrypt@4.0.3
-    https://github.com/crypto-browserify/publicEncrypt
   queue-tick@1.0.1
     https://github.com/mafintosh/queue-tick
   random-array-iterator@1.0.0
     https://github.com/mafintosh/random-array-iterator
-  randombytes@2.1.0
-    https://github.com/crypto-browserify/randombytes
-  randomfill@1.0.4
-    https://github.com/crypto-browserify/randomfill
-  readable-stream@2.3.8
-    https://github.com/nodejs/readable-stream
   ready-resource@1.2.0
     https://github.com/holepunchto/ready-resource
   record-cache@1.2.0
     https://github.com/mafintosh/record-cache
   resolve-reject-promise@1.1.0
     https://github.com/mafintosh/resolve-reject-promise
-  ripemd160@2.0.3
-    https://github.com/crypto-browserify/ripemd160
-  safe-buffer@5.1.2
-    https://github.com/feross/safe-buffer
-  safe-buffer@5.2.1
-    https://github.com/feross/safe-buffer
   safety-catch@1.0.3
     https://github.com/mafintosh/safety-catch
-  set-function-length@1.2.2
-    https://github.com/ljharb/set-function-length
   signal-promise@1.0.3
     https://github.com/mafintosh/signal-promise
   signed-varint@2.0.1
@@ -346,24 +213,14 @@ JavaScript Dependencies
     https://github.com/holepunchto/sodium-universal
   streamx@2.25.0
     https://github.com/mafintosh/streamx
-  string_decoder@1.1.1
-    https://github.com/nodejs/string_decoder
   teex@1.0.1
     https://github.com/mafintosh/teex
   time-ordered-set@2.0.1
     https://github.com/mafintosh/time-ordered-set
   timeout-refresh@2.0.1
     https://github.com/mafintosh/timeout-refresh
-  to-buffer@1.2.2
-    https://github.com/browserify/to-buffer
-  typed-array-buffer@1.0.3
-    https://github.com/inspect-js/typed-array-buffer
-  util-deprecate@1.0.2
-    https://github.com/TooTallNate/util-deprecate
   varint@5.0.0
     https://github.com/chrisdickinson/varint
-  which-typed-array@1.1.20
-    https://github.com/inspect-js/which-typed-array
   xache@1.2.1
     https://github.com/mafintosh/xache
   z32@1.1.0

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/rag",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "main": "index.js",
   "scripts": {
     "lint": "standard",
@@ -71,7 +71,6 @@
     "@qvac/error": "^0.1.1",
     "bare-crypto": "^1.13.4",
     "bare-fetch": "^3.0.1",
-    "crypto-browserify": "^3.12.1",
     "hyperdb": "^6.7.0",
     "hyperdht": "^6.23.0",
     "hyperschema": "^1.13.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Release `@qvac/rag` `v0.6.4`.

- `crypto-browserify` was declared as a **hard `dependency`** but never imported, force-installing a large unused transitive tree (`browserify-sign`, `browserify-aes`, `diffie-hellman`, `pbkdf2`, `public-encrypt`, …) onto every consumer, including Bare and Node which never use it.
- The 0.5.0 release notes already described it as an *"optional peer dependency,"* so this corrects a packaging mismatch.

## 📝 How does it solve it?

- Drop `crypto-browserify` from `dependencies` (no source changes — it was never `require`d). Crypto still resolves via the `#crypto` import map: `bare-crypto` on Bare, `node:crypto` on Node, and the `globalThis.crypto`-backed shim on browser / React Native.
- Bump `@qvac/rag` `0.6.3 → 0.6.4`.
- Regenerate `NOTICE` (drops the browserify attribution tree, ~145 lines).
- Browser/RN consumers needing Node-style `crypto.createHash` (e.g. HyperDB document hashing) still install `crypto-browserify` themselves and assign it to `globalThis.crypto` — unchanged, already documented in the README.

## 🧪 How was it tested?

- Verified no source file imports `crypto-browserify` (only referenced in docs + the shim's guidance error string, intentionally kept).
- `package.json` validated: version `0.6.4`, `crypto-browserify` removed from `dependencies`.
- `NOTICE` regenerated via `qv-notice-generate` — browserify entries gone, deterministic output.
- No JS source changed, so lint / unit behavior is unaffected; `shim-crypto.test.js` still passes (its assertion checks the shim error message, which still mentions `crypto-browserify`).
