### PR TITLE
chore[notask|skiplog]: release @qvac/cli 0.7.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+# QVAC CLI v0.7.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.7.0
+
+This release adds image-to-video generation and audio encoding to the OpenAI-compatible HTTP server. It also fixes token accounting and `finish_reason` reporting across all chat-category routes.
+
+## New Features
+
+### Image-to-video via POST /v1/videos
+
+`POST /v1/videos` now supports img2vid in addition to txt2vid. Supply the reference image as a multipart file field (the form the OpenAI SDK sends for `Uploadable`), as a JSON `{ image_url }` (base64 data URI or HTTP(S) URL up to 100 MB), or as a JSON `{ file_id }` referencing a previously uploaded file. Mode is inferred automatically from the presence of `input_reference`.
+
+```typescript
+import OpenAI, { toFile } from 'openai'
+import fs from 'node:fs'
+
+const client = new OpenAI({ baseURL: 'http://localhost:11434/v1' })
+
+// img2vid via local file (multipart)
+const job = await client.videos.create({
+  model: 'wan-i2v',
+  prompt: 'subject slowly turns and smiles',
+  input_reference: await toFile(fs.createReadStream('./frame.png'), 'frame.png'),
+})
+
+// img2vid via data URI (JSON)
+const job2 = await client.videos.create({
+  model: 'wan-i2v',
+  prompt: 'subject slowly turns and smiles',
+  input_reference: { image_url: 'data:image/png;base64,...' },
+})
+```
+
+### Audio encoding — mp3, opus, aac, flac
+
+`POST /v1/audio/speech` now supports `response_format: "mp3"`, `"opus"`, `"aac"`, and `"flac"` in addition to `wav` and `pcm`. Encoding is handled by `ffmpeg` on the server's `PATH`; if ffmpeg is absent, these formats return `503 transcode_unavailable`. Use `qvac doctor` to check availability.
+
+Two new discovery endpoints are also available:
+
+```
+GET /v1/audio/voices  →  list of configured TTS voices
+GET /v1/audio/models  →  list of loaded (READY) TTS models
+```
+
+## Bug Fixes
+
+### Correct finish_reason and token accounting
+
+`finish_reason: "length"` is now returned when generation is truncated by `max_tokens` or `max_completion_tokens` (previously always `"stop"`). The Responses API equivalent is `status: "incomplete"` with `incomplete_details.reason: "max_output_tokens"`. Token counts (`completion_tokens` / `output_tokens`) now consistently use the SDK's `generatedTokens` stats across `/v1/chat/completions`, `/v1/completions`, and `/v1/responses`.
+
 ## [0.6.0]
 
 Release Date: 2026-06-02

--- a/packages/cli/NOTICE
+++ b/packages/cli/NOTICE
@@ -25,11 +25,20 @@ JavaScript Dependencies
   fb-dotslash@0.5.8
     https://github.com/facebook/dotslash
 
+--- (mit AND bsd-3-clause) ---
+
+  sha.js@2.4.12
+    https://github.com/crypto-browserify/sha.js
+
 --- (mit AND cc0-1.0) ---
 
+  type-fest@0.13.1
+    https://github.com/sindresorhus/type-fest
   type-fest@0.21.3
     https://github.com/sindresorhus/type-fest
   type-fest@0.7.1
+    https://github.com/sindresorhus/type-fest
+  type-fest@1.4.0
     https://github.com/sindresorhus/type-fest
 
 --- 0bsd (Zero-Clause BSD) ---
@@ -41,45 +50,49 @@ JavaScript Dependencies
 
   @hyperswarm/secret-stream@6.9.1
     https://github.com/holepunchto/hyperswarm-secret-stream
-  @qvac/classification-ggml@0.2.1
+  @malept/cross-spawn-promise@2.0.0
+    https://github.com/malept/cross-spawn-promise
+  @qvac/bci-whispercpp@0.2.0
     https://github.com/tetherto/qvac
-  @qvac/decoder-audio@0.3.8
+  @qvac/classification-ggml@0.3.1
     https://github.com/tetherto/qvac
-  @qvac/diagnostics@0.1.1
-  @qvac/diffusion-cpp@0.9.1
+  @qvac/decoder-audio@0.4.0
     https://github.com/tetherto/qvac
-  @qvac/embed-llamacpp@0.17.1
+  @qvac/diagnostics@0.1.2
+    https://github.com/tetherto/qvac
+  @qvac/diffusion-cpp@0.11.2
+    https://github.com/tetherto/qvac
+  @qvac/embed-llamacpp@0.19.1
     https://github.com/tetherto/qvac
   @qvac/error@0.1.1
   @qvac/infer-base@0.4.1
     https://github.com/tetherto/qvac
   @qvac/langdetect-text@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/llm-llamacpp@0.22.1
+  @qvac/llm-llamacpp@0.24.0
     https://github.com/tetherto/qvac
   @qvac/logging@0.1.0
-  @qvac/ocr-onnx@0.5.1
+  @qvac/ocr-onnx@0.6.0
     https://github.com/tetherto/qvac
   @qvac/onnx@0.15.0
     https://github.com/tetherto/qvac
-  @qvac/rag@0.5.0
+  @qvac/rag@0.6.2
     https://github.com/tetherto/qvac
-  @qvac/registry-client@0.5.0
+  @qvac/registry-client@0.6.0
     https://github.com/tetherto/qvac
-  @qvac/registry-schema@0.2.0
+  @qvac/registry-schema@0.3.0
     https://github.com/tetherto/qvac
-  @qvac/response@0.1.2
-  @qvac/sdk@0.12.0
+  @qvac/sdk@0.13.1
     https://github.com/tetherto/qvac
-  @qvac/transcription-parakeet@0.6.0
+  @qvac/transcription-parakeet@0.7.2
     https://github.com/tetherto/qvac
-  @qvac/transcription-whispercpp@0.7.0
+  @qvac/transcription-whispercpp@0.9.1
     https://github.com/tetherto/qvac
-  @qvac/translation-nmtcpp@4.0.1
+  @qvac/translation-nmtcpp@5.0.2
     https://github.com/tetherto/qvac
-  @qvac/tts-ggml@0.1.2
+  @qvac/tts-ggml@0.2.2
     https://github.com/tetherto/qvac
-  @qvac/vla-ggml@0.2.1
+  @qvac/vla-ggml@0.3.2
     https://github.com/tetherto/qvac
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
@@ -95,15 +108,15 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-ansi-escapes
   bare-assert@1.2.0
     https://github.com/holepunchto/bare-assert
-  bare-buffer@3.6.0
+  bare-buffer@3.6.1
     https://github.com/holepunchto/bare-buffer
   bare-bundle@1.10.0
     https://github.com/holepunchto/bare-bundle
   bare-bundle-id@1.0.2
     https://github.com/holepunchto/bare-bundle-id
-  bare-channel@5.2.3
+  bare-channel@5.2.4
     https://github.com/holepunchto/bare-channel
-  bare-crypto@1.13.7
+  bare-crypto@1.15.3
     https://github.com/holepunchto/bare-crypto
   bare-dns@2.1.4
     https://github.com/holepunchto/bare-dns
@@ -111,21 +124,23 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-env
   bare-events@2.4.2
     https://github.com/holepunchto/bare-events
-  bare-events@2.8.3
+  bare-events@2.9.1
     https://github.com/holepunchto/bare-events
   bare-fetch@2.9.1
+    https://github.com/holepunchto/bare-fetch
+  bare-fetch@3.0.1
     https://github.com/holepunchto/bare-fetch
   bare-ffmpeg@1.2.2
     https://github.com/holepunchto/bare-ffmpeg
   bare-form-data@1.2.2
     https://github.com/holepunchto/bare-form-data
-  bare-fs@4.7.1
+  bare-fs@4.7.2
     https://github.com/holepunchto/bare-fs
   bare-hrtime@2.1.1
     https://github.com/holepunchto/bare-hrtime
-  bare-http-parser@1.1.4
+  bare-http-parser@1.1.5
     https://github.com/holepunchto/bare-http-parser
-  bare-http1@4.5.6
+  bare-http1@4.5.7
     https://github.com/holepunchto/bare-http1
   bare-https@3.0.0
     https://github.com/holepunchto/bare-https
@@ -137,35 +152,29 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-link
   bare-mime@1.0.0
     https://github.com/holepunchto/bare-mime
-  bare-module@6.2.0
-    https://github.com/holepunchto/bare-module
-  bare-module-lexer@1.4.7
+  bare-module-lexer@1.5.2
     https://github.com/holepunchto/bare-module-lexer
   bare-module-resolve@1.12.2
     https://github.com/holepunchto/bare-module-resolve
-  bare-module-traverse@2.0.2
+  bare-module-traverse@2.1.2
     https://github.com/holepunchto/bare-module-traverse
-  bare-net@2.3.1
+  bare-net@2.3.2
     https://github.com/holepunchto/bare-net
-  bare-node-stream@1.0.0
-    https://github.com/holepunchto/bare-node
-  bare-node-worker-threads@1.0.0
-    https://github.com/holepunchto/bare-node
   bare-os@3.9.1
     https://github.com/holepunchto/bare-os
-  bare-pack@2.0.1
+  bare-pack@2.1.2
     https://github.com/holepunchto/bare-pack
-  bare-path@3.0.0
+  bare-path@3.0.1
     https://github.com/holepunchto/bare-path
-  bare-pipe@4.1.5
+  bare-pipe@4.2.2
     https://github.com/holepunchto/bare-pipe
   bare-process@4.4.1
     https://github.com/holepunchto/bare-process
-  bare-rpc@1.3.2
+  bare-rpc@1.3.3
     https://github.com/holepunchto/bare-rpc
-  bare-runtime@1.28.5
+  bare-runtime@1.28.6
     https://github.com/holepunchto/bare-runtime
-  bare-runtime-darwin-arm64@1.28.5
+  bare-runtime-darwin-arm64@1.28.6
     https://github.com/holepunchto/bare-runtime
   bare-semver@1.0.3
     https://github.com/holepunchto/bare-semver
@@ -173,31 +182,27 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-signals
   bare-stdio@1.0.2
     https://github.com/holepunchto/bare-stdio
-  bare-stream@2.13.1
+  bare-stream@2.13.2
     https://github.com/holepunchto/bare-stream
   bare-structured-clone@1.5.5
     https://github.com/holepunchto/bare-structured-clone
   bare-subprocess@5.2.3
     https://github.com/holepunchto/bare-subprocess
-  bare-subprocess@6.0.0
+  bare-subprocess@6.1.0
     https://github.com/holepunchto/bare-subprocess
-  bare-tcp@2.2.13
+  bare-tcp@2.5.1
     https://github.com/holepunchto/bare-tcp
-  bare-thread@1.2.2
-    https://github.com/holepunchto/bare-thread
-  bare-tls@3.1.5
+  bare-tls@3.1.7
     https://github.com/holepunchto/bare-tls
-  bare-tty@5.1.0
+  bare-tty@5.1.1
     https://github.com/holepunchto/bare-tty
   bare-type@1.1.0
     https://github.com/holepunchto/bare-type
-  bare-url@2.4.3
+  bare-url@2.4.5
     https://github.com/holepunchto/bare-url
-  bare-worker@4.1.6
-    https://github.com/holepunchto/bare-worker
-  bare-zlib@1.3.3
+  bare-zlib@1.4.0
     https://github.com/holepunchto/bare-zlib
-  baseline-browser-mapping@2.10.32
+  baseline-browser-mapping@2.10.36
     https://github.com/web-platform-dx/baseline-browser-mapping
   blind-relay@1.6.1
     https://github.com/holepunchto/blind-relay
@@ -209,9 +214,7 @@ JavaScript Dependencies
     https://github.com/cezaraugusto/chromium-edge-launcher
   chromium-edge-launcher@0.3.0
     https://github.com/cezaraugusto/chromium-edge-launcher
-  compact-encoding@2.19.2
-    https://github.com/holepunchto/compact-encoding
-  compact-encoding@3.1.0
+  compact-encoding@3.2.0
     https://github.com/holepunchto/compact-encoding
   compact-encoding-bitfield@1.1.0
     https://github.com/compact-encoding/compact-encoding-bitfield
@@ -231,7 +234,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/fd-lock
   fs-native-extensions@1.5.0
     https://github.com/holepunchto/fs-native-extensions
-  hyperblobs@2.12.0
+  hyperblobs@2.12.1
     https://github.com/holepunchto/hyperblobs
   hypercore-errors@1.5.0
     https://github.com/holepunchto/hypercore-errors
@@ -239,9 +242,9 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore-id-encoding
   hypercore-stats@2.4.0
     https://github.com/holepunchto/hypercore-stats
-  hypercore-storage@2.9.0
+  hypercore-storage@3.1.1
     https://github.com/holepunchto/hypercore-storage
-  hyperdb@4.22.3
+  hyperdb@6.7.0
     https://github.com/holepunchto/hyperdb
   hyperdht-address@1.1.1
     https://github.com/holepunchto/hyperdht-address
@@ -253,7 +256,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperdrive
   hyperschema@1.21.0
     https://github.com/holepunchto/hyperschema
-  hyperswarm-stats@1.3.0
+  hyperswarm-stats@1.3.1
     https://github.com/holepunchto/hyperswarm-stats
   index-encoder@3.5.0
     https://github.com/holepunchto/index-encoder
@@ -279,7 +282,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/rabin-stream
   rache@1.0.0
     https://github.com/holepunchto/rache
-  react-native-bare-kit@0.14.1
+  react-native-bare-kit@0.14.3
     https://github.com/holepunchto/react-native-bare-kit
   refcounter@1.0.0
     https://github.com/holepunchto/refcounter
@@ -289,24 +292,30 @@ JavaScript Dependencies
     https://github.com/holepunchto/require-asset
   resource-on-exit@1.0.0
     https://github.com/holepunchto/bare-teardown
-  rocksdb-native@3.15.1
+  rocksdb-native@3.15.2
     https://github.com/holepunchto/rocksdb-native
   scope-lock@1.2.4
     https://github.com/holepunchto/scope-lock
   simdle-native@1.3.9
     https://github.com/holepunchto/simdle-native
+  spdx-correct@3.2.0
+    https://github.com/jslicense/spdx-correct.js
   sub-encoder@2.1.3
     https://github.com/holepunchto/sub-encoder
+  sumchecker@3.0.1
+    https://github.com/malept/sumchecker
   text-decoder@1.2.7
     https://github.com/holepunchto/text-decoder
   ts-interface-checker@0.1.13
     https://github.com/gristlabs/ts-interface-checker
   typescript@5.9.3
     https://github.com/microsoft/TypeScript
-  udx-native@1.19.2
+  udx-native@1.20.7
     https://github.com/holepunchto/udx-native
   unslab@1.3.0
     https://github.com/holepunchto/unslab
+  validate-npm-package-license@3.0.4
+    https://github.com/kemitchell/validate-npm-package-license.js
   walker@1.0.8
     https://github.com/daaku/nodejs-walker
   which-runtime@1.4.0
@@ -320,31 +329,43 @@ JavaScript Dependencies
     https://github.com/isaacs/chownr
   glob@13.0.6
     https://github.com/isaacs/node-glob
-  lru-cache@11.5.0
+  lru-cache@11.5.1
     https://github.com/isaacs/node-lru-cache
   minimatch@10.2.5
     https://github.com/isaacs/minimatch
   minipass@7.1.3
     https://github.com/isaacs/minipass
+  minipass-flush@1.0.7
+    https://github.com/isaacs/minipass-flush
   path-scurry@2.0.2
     https://github.com/isaacs/path-scurry
   sax@1.6.0
     https://github.com/isaacs/sax-js
-  tar@7.5.15
+  tar@7.5.16
     https://github.com/isaacs/node-tar
   yallist@5.0.0
     https://github.com/isaacs/yallist
 
 --- bsd-2-clause (BSD 2-Clause License) ---
 
+  @electron/osx-sign@1.3.3
+    https://github.com/electron/osx-sign
+  @electron/packager@18.4.4
+    https://github.com/electron/packager
+  @electron/windows-sign@1.2.2
+    https://github.com/electron/windows-sign
   dotenv@16.4.7
     https://github.com/motdotla/dotenv
   dotenv-expand@11.0.7
     https://github.com/motdotla/dotenv-expand
+  extract-zip@2.0.1
+    https://github.com/maxogden/extract-zip
   fontfaceobserver@2.3.0
     https://github.com/bramstein/fontfaceobserver
-  json-schema-typed@8.0.2
-    https://github.com/RemyRylan/json-schema-typed
+  http-cache-semantics@4.2.0
+    https://github.com/kornelski/http-cache-semantics
+  normalize-package-data@2.5.0
+    https://github.com/npm/normalize-package-data
   regjsparser@0.13.1
     https://github.com/jviereck/regjsparser
   terser@5.48.0
@@ -358,18 +379,20 @@ JavaScript Dependencies
     https://github.com/expo/expo-cli
   @react-native/debugger-frontend@0.81.5
     https://github.com/facebook/react-native
-  @react-native/debugger-frontend@0.85.3
+  @react-native/debugger-frontend@0.86.0
     https://github.com/facebook/react-native
   fast-uri@3.1.2
     https://github.com/fastify/fast-uri
+  global-agent@3.0.0
+    https://github.com/gajus/global-agent
   ieee754@1.2.1
     https://github.com/feross/ieee754
   light-my-request@6.6.0
     https://github.com/fastify/light-my-request
   makeerror@1.0.12
     https://github.com/daaku/nodejs-makeerror
-  qs@6.15.2
-    https://github.com/ljharb/qs
+  roarr@2.15.4
+    https://github.com/gajus/roarr
   secure-json-parse@4.1.0
     https://github.com/fastify/secure-json-parse
   source-map@0.5.7
@@ -378,13 +401,25 @@ JavaScript Dependencies
     https://github.com/mozilla/source-map
   source-map-js@1.2.1
     https://github.com/7rulnik/source-map-js
+  sprintf-js@1.1.3
+    https://github.com/alexei/sprintf.js
   tmpl@1.0.5
     https://github.com/daaku/nodejs-tmpl
 
+--- cc-by-3.0 ---
+
+  spdx-exceptions@2.5.0
+    https://github.com/kemitchell/spdx-exceptions.json
+
 --- cc-by-4.0 (Creative Commons Attribution 4.0 International) ---
 
-  caniuse-lite@1.0.30001793
+  caniuse-lite@1.0.30001799
     https://github.com/browserslist/caniuse-lite
+
+--- cc0-1.0 (Creative Commons Zero 1.0) ---
+
+  spdx-license-ids@3.0.23
+    https://github.com/jslicense/spdx-license-ids
 
 --- isc (ISC License) ---
 
@@ -392,26 +427,46 @@ JavaScript Dependencies
     https://github.com/npm/fs-minipass
   @isaacs/ttlcache@1.4.1
     https://github.com/isaacs/ttlcache
+  @npmcli/fs@2.1.2
+    https://github.com/npm/fs
   @ungap/structured-clone@1.3.1
     https://github.com/ungap/structured-clone
+  abbrev@1.1.1
+    https://github.com/isaacs/abbrev-js
+  at-least-node@1.0.0
+    https://github.com/RyanZim/at-least-node
   bits-to-bytes@1.3.0
     https://github.com/holepunchto/bits-to-bytes
+  browserify-sign@4.2.6
+    https://github.com/crypto-browserify/browserify-sign
+  cacache@16.1.3
+    https://github.com/npm/cacache
+  chownr@2.0.0
+    https://github.com/isaacs/chownr
   cliui@8.0.1
     https://github.com/yargs/cliui
-  electron-to-chromium@1.5.362
+  electron-to-chromium@1.5.372
     https://github.com/Kilian/electron-to-chromium
   fastq@1.20.1
     https://github.com/mcollina/fastq
+  fs-minipass@2.1.0
+    https://github.com/npm/fs-minipass
   fs.realpath@1.0.0
     https://github.com/isaacs/fs.realpath
   get-caller-file@2.0.5
     https://github.com/stefanpenner/get-caller-file
   glob@7.2.3
     https://github.com/isaacs/node-glob
+  glob@8.1.0
+    https://github.com/isaacs/node-glob
   graceful-fs@4.2.11
     https://github.com/isaacs/node-graceful-fs
+  hosted-git-info@2.8.9
+    https://github.com/npm/hosted-git-info
   hosted-git-info@7.0.2
     https://github.com/npm/hosted-git-info
+  infer-owner@1.0.4
+    https://github.com/npm/infer-owner
   inflight@1.0.6
     https://github.com/npm/inflight
   inherits@2.0.4
@@ -420,33 +475,65 @@ JavaScript Dependencies
     https://github.com/isaacs/ini
   isexe@2.0.0
     https://github.com/isaacs/isexe
+  json-stringify-safe@5.0.1
+    https://github.com/isaacs/json-stringify-safe
   lru-cache@10.4.3
     https://github.com/isaacs/node-lru-cache
   lru-cache@5.1.1
     https://github.com/isaacs/node-lru-cache
+  lru-cache@7.18.3
+    https://github.com/isaacs/node-lru-cache
+  make-fetch-happen@10.2.1
+    https://github.com/npm/make-fetch-happen
+  minimalistic-assert@1.0.1
+    https://github.com/calvinmetcalf/minimalistic-assert
   minimatch@3.1.5
+    https://github.com/isaacs/minimatch
+  minimatch@5.1.9
     https://github.com/isaacs/minimatch
   minimatch@9.0.9
     https://github.com/isaacs/minimatch
+  minipass@3.3.6
+    https://github.com/isaacs/minipass
+  minipass@5.0.0
+    https://github.com/isaacs/minipass
+  minipass-collect@1.0.2
+    https://izs.me
+  minipass-pipeline@1.2.4
+    https://izs.me
+  minipass-sized@1.0.3
+    https://github.com/isaacs/minipass-sized
   nanoassert@2.0.0
     https://github.com/emilbayes/nanoassert
   noise-curve-ed@2.1.0
     https://github.com/chm-diederichs/noise-curve-ed
+  nopt@6.0.0
+    https://github.com/npm/nopt
   npm-package-arg@11.0.3
     https://github.com/npm/npm-package-arg
   once@1.4.0
     https://github.com/isaacs/once
+  parse-asn1@5.1.9
+    https://github.com/crypto-browserify/parse-asn1
   picocolors@1.1.1
     https://github.com/alexeyraspopov/picocolors
+  proc-log@2.0.1
+    https://github.com/npm/proc-log
   proc-log@4.2.0
     https://github.com/npm/proc-log
+  promise-inflight@1.0.1
+    https://github.com/iarna/promise-inflight
   quickbit-universal@2.2.0
     https://github.com/holepunchto/quickbit-universal
   rimraf@3.0.2
     https://github.com/isaacs/rimraf
+  semver@5.7.2
+    https://github.com/npm/node-semver
   semver@6.3.1
     https://github.com/npm/node-semver
-  semver@7.8.1
+  semver@7.8.2
+    https://github.com/npm/node-semver
+  semver@7.8.4
     https://github.com/npm/node-semver
   setprototypeof@1.2.0
     https://github.com/wesleytodd/setprototypeof
@@ -456,6 +543,14 @@ JavaScript Dependencies
     https://github.com/holepunchto/simdle-universal
   split2@4.2.0
     https://github.com/mcollina/split2
+  ssri@9.0.1
+    https://github.com/npm/ssri
+  tar@6.2.1
+    https://github.com/isaacs/node-tar
+  unique-filename@2.0.1
+    https://github.com/npm/unique-filename
+  unique-slug@3.0.0
+    https://github.com/npm/unique-slug
   validate-npm-package-name@5.0.1
     https://github.com/npm/validate-npm-package-name
   which@2.0.2
@@ -466,12 +561,12 @@ JavaScript Dependencies
     https://github.com/yargs/y18n
   yallist@3.1.1
     https://github.com/isaacs/yallist
+  yallist@4.0.0
+    https://github.com/isaacs/yallist
   yaml@2.9.0
     https://github.com/eemeli/yaml
   yargs-parser@21.1.1
     https://github.com/yargs/yargs-parser
-  zod-to-json-schema@3.25.2
-    https://github.com/StefanTerdell/zod-to-json-schema
 
 --- mit (MIT License) ---
 
@@ -637,9 +732,29 @@ JavaScript Dependencies
     https://github.com/babel/babel
   @babel/types@7.29.7
     https://github.com/babel/babel
+  @electron-forge/plugin-base@7.11.2
+    https://github.com/electron/forge
+  @electron-forge/shared-types@7.11.2
+    https://github.com/electron/forge
+  @electron-forge/tracer@7.11.2
+    https://github.com/electron/forge
+  @electron/asar@3.4.1
+    https://github.com/electron/asar
+  @electron/get@3.1.0
+    https://github.com/electron/get
+  @electron/node-gyp@10.2.0-electron.1
+    https://github.com/nodejs/node-gyp
+  @electron/notarize@2.5.0
+    https://github.com/electron/notarize
+  @electron/rebuild@3.7.2
+    https://github.com/electron/rebuild
+  @electron/universal@2.0.3
+    https://github.com/electron/universal
   @esbuild/darwin-arm64@0.28.0
     https://github.com/evanw/esbuild
-  @expo/cli@54.0.24
+  @esbuild/darwin-arm64@0.28.1
+    https://github.com/evanw/esbuild
+  @expo/cli@54.0.25
     https://github.com/expo/expo
   @expo/code-signing-certificates@0.0.6
     https://github.com/expo/code-signing-certificates
@@ -659,19 +774,19 @@ JavaScript Dependencies
     https://github.com/expo/expo
   @expo/image-utils@0.8.14
     https://github.com/expo/expo
-  @expo/json-file@10.0.15
+  @expo/json-file@10.0.16
     https://github.com/expo/expo
   @expo/json-file@10.2.0
     https://github.com/expo/expo
   @expo/metro@54.2.0
     https://github.com/expo/expo-metro
-  @expo/metro-config@54.0.15
+  @expo/metro-config@54.0.16
     https://github.com/expo/expo
   @expo/osascript@2.6.0
     https://github.com/expo/expo
-  @expo/package-manager@1.12.0
+  @expo/package-manager@1.12.1
     https://github.com/expo/expo
-  @expo/plist@0.4.8
+  @expo/plist@0.4.9
     https://github.com/expo/expo
   @expo/prebuild-config@54.0.8
     https://github.com/expo/expo
@@ -719,8 +834,8 @@ JavaScript Dependencies
     https://github.com/fastify/fastify-swagger
   @fastify/swagger-ui@5.2.6
     https://github.com/fastify/fastify-swagger-ui
-  @hono/node-server@1.19.14
-    https://github.com/honojs/node-server
+  @gar/promisify@1.1.3
+    https://github.com/wraithgar/gar-promisify
   @jest/schemas@29.6.3
     https://github.com/jestjs/jest
   @jest/types@29.6.3
@@ -739,11 +854,11 @@ JavaScript Dependencies
     https://github.com/jridgewell/sourcemaps
   @lukeed/ms@2.0.2
     https://github.com/lukeed/ms
-  @modelcontextprotocol/sdk@1.29.0
-    https://github.com/modelcontextprotocol/typescript-sdk
+  @npmcli/move-file@2.0.1
+    https://github.com/npm/move-file
   @pinojs/redact@0.4.0
     https://github.com/pinojs/redact
-  @react-native/assets-registry@0.85.3
+  @react-native/assets-registry@0.86.0
     https://github.com/facebook/react-native
   @react-native/babel-plugin-codegen@0.81.5
     https://github.com/facebook/react-native
@@ -751,39 +866,55 @@ JavaScript Dependencies
     https://github.com/facebook/react-native
   @react-native/codegen@0.81.5
     https://github.com/facebook/react-native
-  @react-native/codegen@0.85.3
+  @react-native/codegen@0.86.0
     https://github.com/facebook/react-native
-  @react-native/community-cli-plugin@0.85.3
+  @react-native/community-cli-plugin@0.86.0
     https://github.com/facebook/react-native
-  @react-native/debugger-shell@0.85.3
+  @react-native/debugger-shell@0.86.0
     https://github.com/facebook/react-native
   @react-native/dev-middleware@0.81.5
     https://github.com/facebook/react-native
-  @react-native/dev-middleware@0.85.3
+  @react-native/dev-middleware@0.86.0
     https://github.com/facebook/react-native
-  @react-native/gradle-plugin@0.85.3
+  @react-native/gradle-plugin@0.86.0
     https://github.com/facebook/react-native
-  @react-native/js-polyfills@0.85.3
+  @react-native/js-polyfills@0.86.0
     https://github.com/facebook/react-native
   @react-native/normalize-colors@0.81.5
     https://github.com/facebook/react-native
-  @react-native/normalize-colors@0.85.3
+  @react-native/normalize-colors@0.86.0
     https://github.com/facebook/react-native
-  @react-native/virtualized-lists@0.85.3
+  @react-native/virtualized-lists@0.86.0
     https://github.com/facebook/react-native
   @sinclair/typebox@0.27.10
     https://github.com/sinclairzx81/typebox-legacy
+  @sindresorhus/is@4.6.0
+    https://github.com/sindresorhus/is
+  @szmarczak/http-timer@4.0.6
+    https://github.com/szmarczak/http-timer
+  @tootallnate/once@2.0.1
+    https://github.com/TooTallNate/once
+  @types/cacheable-request@6.0.3
+    https://github.com/DefinitelyTyped/DefinitelyTyped
+  @types/http-cache-semantics@4.2.0
+    https://github.com/DefinitelyTyped/DefinitelyTyped
   @types/istanbul-lib-coverage@2.0.6
     https://github.com/DefinitelyTyped/DefinitelyTyped
   @types/istanbul-lib-report@3.0.3
     https://github.com/DefinitelyTyped/DefinitelyTyped
   @types/istanbul-reports@3.0.4
     https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/node@24.12.4
+  @types/keyv@3.1.4
+    https://github.com/DefinitelyTyped/DefinitelyTyped
+  @types/node@24.13.2
+    https://github.com/DefinitelyTyped/DefinitelyTyped
+  @types/responselike@1.0.3
     https://github.com/DefinitelyTyped/DefinitelyTyped
   @types/yargs@17.0.35
     https://github.com/DefinitelyTyped/DefinitelyTyped
   @types/yargs-parser@21.0.3
+    https://github.com/DefinitelyTyped/DefinitelyTyped
+  @types/yauzl@2.10.3
     https://github.com/DefinitelyTyped/DefinitelyTyped
   @urql/core@5.2.0
     https://github.com/urql-graphql/urql
@@ -801,10 +932,16 @@ JavaScript Dependencies
     https://github.com/jshttp/accepts
   accepts@2.0.0
     https://github.com/jshttp/accepts
-  acorn@8.16.0
+  acorn@8.17.0
     https://github.com/acornjs/acorn
+  agent-base@6.0.2
+    https://github.com/TooTallNate/node-agent-base
   agent-base@7.1.4
     https://github.com/TooTallNate/proxy-agents
+  agentkeepalive@4.6.0
+    https://github.com/node-modules/agentkeepalive
+  aggregate-error@3.1.0
+    https://github.com/sindresorhus/aggregate-error
   ajv@8.20.0
     https://github.com/ajv-validator/ajv
   ajv-formats@3.0.1
@@ -813,9 +950,13 @@ JavaScript Dependencies
     https://github.com/IonicaBizau/anser
   ansi-escapes@4.3.2
     https://github.com/sindresorhus/ansi-escapes
+  ansi-escapes@5.0.0
+    https://github.com/sindresorhus/ansi-escapes
   ansi-regex@4.1.1
     https://github.com/chalk/ansi-regex
   ansi-regex@5.0.1
+    https://github.com/chalk/ansi-regex
+  ansi-regex@6.2.2
     https://github.com/chalk/ansi-regex
   ansi-styles@3.2.1
     https://github.com/chalk/ansi-styles
@@ -823,16 +964,24 @@ JavaScript Dependencies
     https://github.com/chalk/ansi-styles
   ansi-styles@5.2.0
     https://github.com/chalk/ansi-styles
+  ansi-styles@6.2.3
+    https://github.com/chalk/ansi-styles
   any-promise@1.3.0
     https://github.com/kevinbeaty/any-promise
   arg@5.0.2
     https://github.com/vercel/arg
   asap@2.0.6
     https://github.com/kriskowal/asap
+  asn1.js@4.10.1
+    https://github.com/indutny/asn1.js
   async-limiter@1.0.1
     https://github.com/strml/async-limiter
   atomic-sleep@1.0.0
     https://github.com/davidmarkclements/atomic-sleep
+  author-regex@1.0.0
+    https://github.com/jonschlinkert/author-regex
+  available-typed-arrays@1.0.7
+    https://github.com/inspect-js/available-typed-arrays
   avvio@9.2.0
     https://github.com/fastify/avvio
   babel-plugin-polyfill-corejs2@0.4.17
@@ -847,11 +996,11 @@ JavaScript Dependencies
     https://github.com/necolas/react-native-web
   babel-plugin-syntax-hermes-parser@0.29.1
     https://github.com/facebook/hermes
-  babel-plugin-syntax-hermes-parser@0.33.3
+  babel-plugin-syntax-hermes-parser@0.36.0
     https://github.com/facebook/hermes
   babel-plugin-transform-flow-enums@0.0.2
     https://github.com/facebook/flow
-  babel-preset-expo@54.0.10
+  babel-preset-expo@54.0.11
     https://github.com/expo/expo
   balanced-match@1.0.2
     https://github.com/juliangruber/balanced-match
@@ -865,10 +1014,18 @@ JavaScript Dependencies
     https://github.com/mafintosh/big-sparse-array
   binary-stream-equals@1.0.0
     https://github.com/mafintosh/binary-stream-equals
-  body-parser@2.2.2
-    https://github.com/expressjs/body-parser
+  bl@4.1.0
+    https://github.com/rvagg/bl
+  bluebird@3.7.2
+    https://github.com/petkaantonov/bluebird
+  bn.js@4.12.3
+    https://github.com/indutny/bn.js
+  bn.js@5.2.3
+    https://github.com/indutny/bn.js
   bogon@1.3.0
     https://github.com/mafintosh/bogon
+  boolean@3.2.0
+    https://github.com/thenativeweb/boolean
   bplist-creator@0.1.0
     https://github.com/nearinfinity/node-bplist-creator
   bplist-parser@0.3.1
@@ -883,14 +1040,34 @@ JavaScript Dependencies
     https://github.com/juliangruber/brace-expansion
   braces@3.0.3
     https://github.com/micromatch/braces
+  brorand@1.1.0
+    https://github.com/indutny/brorand
+  browserify-aes@1.2.0
+    https://github.com/crypto-browserify/browserify-aes
+  browserify-cipher@1.0.1
+    https://github.com/crypto-browserify/browserify-cipher
+  browserify-des@1.0.2
+    https://github.com/crypto-browserify/browserify-des
+  browserify-rsa@4.1.1
+    https://github.com/crypto-browserify/browserify-rsa
   browserslist@4.28.2
     https://github.com/browserslist/browserslist
   buffer@5.7.1
     https://github.com/feross/buffer
+  buffer-crc32@0.2.13
+    https://github.com/brianloveswords/buffer-crc32
   buffer-from@1.1.2
     https://github.com/LinusU/buffer-from
+  buffer-xor@1.0.3
+    https://github.com/crypto-browserify/buffer-xor
   bytes@3.1.2
     https://github.com/visionmedia/bytes.js
+  cacheable-lookup@5.0.4
+    https://github.com/szmarczak/cacheable-lookup
+  cacheable-request@7.0.4
+    https://github.com/lukechilds/cacheable-request
+  call-bind@1.0.9
+    https://github.com/ljharb/call-bind
   call-bind-apply-helpers@1.0.2
     https://github.com/ljharb/call-bind-apply-helpers
   call-bound@1.0.4
@@ -901,16 +1078,30 @@ JavaScript Dependencies
     https://github.com/chalk/chalk
   chalk@4.1.2
     https://github.com/chalk/chalk
+  chrome-trace-event@1.0.4
+    https://github.com/samccone/chrome-trace-event
   ci-info@2.0.0
     https://github.com/watson/ci-info
   ci-info@3.9.0
     https://github.com/watson/ci-info
+  cipher-base@1.0.7
+    https://github.com/crypto-browserify/cipher-base
+  clean-stack@2.2.0
+    https://github.com/sindresorhus/clean-stack
   cli-cursor@2.1.0
+    https://github.com/sindresorhus/cli-cursor
+  cli-cursor@3.1.0
+    https://github.com/sindresorhus/cli-cursor
+  cli-cursor@4.0.0
     https://github.com/sindresorhus/cli-cursor
   cli-spinners@2.9.2
     https://github.com/sindresorhus/cli-spinners
+  cli-truncate@3.1.0
+    https://github.com/sindresorhus/cli-truncate
   clone@1.0.4
     https://github.com/pvorb/node-clone
+  clone-response@1.0.3
+    https://github.com/sindresorhus/clone-response
   close-with-grace@2.5.0
     https://github.com/mcollina/close-with-grace
   codecs@3.1.0
@@ -923,6 +1114,8 @@ JavaScript Dependencies
     https://github.com/dfcreative/color-name
   color-name@1.1.4
     https://github.com/colorjs/color-name
+  colorette@2.0.20
+    https://github.com/jorgebucaran/colorette
   commander@12.1.0
     https://github.com/tj/commander.js
   commander@14.0.3
@@ -931,8 +1124,14 @@ JavaScript Dependencies
     https://github.com/tj/commander.js
   commander@4.1.1
     https://github.com/tj/commander.js
+  commander@5.1.0
+    https://github.com/tj/commander.js
   commander@7.2.0
     https://github.com/tj/commander.js
+  commander@9.5.0
+    https://github.com/tj/commander.js
+  compare-version@0.1.2
+    https://github.com/kevva/compare-version
   compressible@2.0.18
     https://github.com/jshttp/compressible
   compression@1.8.1
@@ -943,26 +1142,28 @@ JavaScript Dependencies
     https://github.com/senchalabs/connect
   content-disposition@1.1.0
     https://github.com/jshttp/content-disposition
-  content-type@1.0.5
-    https://github.com/jshttp/content-type
-  content-type@2.0.0
-    https://github.com/jshttp/content-type
   convert-source-map@2.0.0
     https://github.com/thlorenz/convert-source-map
-  cookie@0.7.2
-    https://github.com/jshttp/cookie
   cookie@1.1.1
     https://github.com/jshttp/cookie
-  cookie-signature@1.2.2
-    https://github.com/visionmedia/node-cookie-signature
   core-js-compat@3.49.0
     https://github.com/zloirock/core-js
-  corestore@7.9.2
+  core-util-is@1.0.3
+    https://github.com/isaacs/core-util-is
+  corestore@7.10.1
     https://github.com/holepunchto/corestore
-  cors@2.8.6
-    https://github.com/expressjs/cors
+  create-ecdh@4.0.4
+    https://github.com/crypto-browserify/createECDH
+  create-hash@1.2.0
+    https://github.com/crypto-browserify/createHash
+  create-hmac@1.1.7
+    https://github.com/crypto-browserify/createHmac
+  cross-dirname@0.1.0
+    https://github.com/JumpLink/cross-dirname
   cross-spawn@7.0.6
     https://github.com/moxystudio/node-cross-spawn
+  crypto-browserify@3.12.1
+    https://github.com/browserify/crypto-browserify
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
   debug@2.6.9
@@ -971,34 +1172,66 @@ JavaScript Dependencies
     https://github.com/visionmedia/debug
   debug@4.4.3
     https://github.com/debug-js/debug
+  decompress-response@6.0.0
+    https://github.com/sindresorhus/decompress-response
   deep-extend@0.6.0
     https://github.com/unclechu/node-deep-extend
   deepmerge@4.3.1
     https://github.com/TehShrike/deepmerge
   defaults@1.0.4
     https://github.com/sindresorhus/node-defaults
+  defer-to-connect@2.0.1
+    https://github.com/szmarczak/defer-to-connect
+  define-data-property@1.1.4
+    https://github.com/ljharb/define-data-property
   define-lazy-prop@2.0.0
     https://github.com/sindresorhus/define-lazy-prop
+  define-properties@1.2.1
+    https://github.com/ljharb/define-properties
   depd@2.0.0
     https://github.com/dougwilson/nodejs-depd
   dequal@2.0.3
     https://github.com/lukeed/dequal
+  des.js@1.1.0
+    https://github.com/indutny/des.js
   destroy@1.2.0
     https://github.com/stream-utils/destroy
+  detect-node@2.1.0
+    https://github.com/iliakan/detect-node
   dht-rpc@6.27.0
     https://github.com/holepunchto/dht-rpc
+  diffie-hellman@5.0.3
+    https://github.com/crypto-browserify/diffie-hellman
+  dir-compare@4.2.0
+    https://github.com/gliviu/dir-compare
   dunder-proto@1.0.1
     https://github.com/es-shims/dunder-proto
+  eastasianwidth@0.2.0
+    https://github.com/komagata/eastasianwidth
   ee-first@1.1.1
     https://github.com/jonathanong/ee-first
+  elliptic@6.6.1
+    https://github.com/indutny/elliptic
   emoji-regex@8.0.0
+    https://github.com/mathiasbynens/emoji-regex
+  emoji-regex@9.2.2
     https://github.com/mathiasbynens/emoji-regex
   encodeurl@1.0.2
     https://github.com/pillarjs/encodeurl
   encodeurl@2.0.0
     https://github.com/pillarjs/encodeurl
+  encoding@0.1.13
+    https://github.com/andris9/encoding
+  end-of-stream@1.4.5
+    https://github.com/mafintosh/end-of-stream
   env-editor@0.4.2
     https://github.com/sindresorhus/env-editor
+  env-paths@2.2.1
+    https://github.com/sindresorhus/env-paths
+  err-code@2.0.3
+    https://github.com/IndigoUnited/js-err-code
+  error-ex@1.3.4
+    https://github.com/qix-/node-error-ex
   error-stack-parser@2.1.4
     https://github.com/stacktracejs/error-stack-parser
   es-define-property@1.0.1
@@ -1007,7 +1240,11 @@ JavaScript Dependencies
     https://github.com/ljharb/es-errors
   es-object-atoms@1.1.2
     https://github.com/ljharb/es-object-atoms
+  es6-error@4.1.1
+    https://github.com/bjyoungblood/es6-error
   esbuild@0.28.0
+    https://github.com/evanw/esbuild
+  esbuild@0.28.1
     https://github.com/evanw/esbuild
   escalade@3.2.0
     https://github.com/lukeed/escalade
@@ -1021,36 +1258,30 @@ JavaScript Dependencies
     https://github.com/jshttp/etag
   event-target-shim@5.0.1
     https://github.com/mysticatea/event-target-shim
-  eventsource@3.0.7
-    git://git@github.com/EventSource/eventsource
-  eventsource-parser@3.0.8
-    https://github.com/rexxars/eventsource-parser
-  expo@54.0.34
+  eventemitter3@5.0.4
+    https://github.com/primus/eventemitter3
+  evp_bytestokey@1.0.3
+    https://github.com/crypto-browserify/EVP_BytesToKey
+  expo@54.0.35
     https://github.com/expo/expo
   expo-asset@12.0.13
-    https://github.com/expo/expo
-  expo-build-properties@0.12.5
     https://github.com/expo/expo
   expo-constants@18.0.13
     https://github.com/expo/expo
   expo-device@8.0.10
     https://github.com/expo/expo
-  expo-file-system@19.0.22
+  expo-file-system@19.0.23
     https://github.com/expo/expo
-  expo-font@14.0.11
+  expo-font@14.0.12
     https://github.com/expo/expo
   expo-keep-awake@15.0.8
     https://github.com/expo/expo
-  expo-modules-autolinking@3.0.25
+  expo-modules-autolinking@3.0.26
     https://github.com/expo/expo
   expo-modules-core@3.0.30
     https://github.com/expo/expo
-  expo-server@1.0.6
+  expo-server@1.0.7
     https://github.com/expo/expo
-  express@5.2.1
-    https://github.com/expressjs/express
-  express-rate-limit@8.5.2
-    https://github.com/express-rate-limit/express-rate-limit
   fast-decode-uri-component@1.0.1
     https://github.com/delvedor/fast-decode-uri-component
   fast-deep-equal@3.1.3
@@ -1069,32 +1300,48 @@ JavaScript Dependencies
     https://github.com/fastify/fastify-plugin
   fastify-type-provider-zod@5.1.0
     https://github.com/turkerdev/fastify-type-provider-zod
+  fd-slicer@1.1.0
+    https://github.com/andrewrk/node-fd-slicer
   fdir@6.5.0
     https://github.com/thecodrr/fdir
+  filename-reserved-regex@2.0.0
+    https://github.com/sindresorhus/filename-reserved-regex
+  filenamify@4.3.0
+    https://github.com/sindresorhus/filenamify
   fill-range@7.1.1
     https://github.com/jonschlinkert/fill-range
   finalhandler@1.1.2
     https://github.com/pillarjs/finalhandler
-  finalhandler@2.1.1
-    https://github.com/pillarjs/finalhandler
   find-my-way@9.6.0
     https://github.com/delvedor/find-my-way
+  find-up@2.1.0
+    https://github.com/sindresorhus/find-up
   flat-tree@1.13.0
     https://github.com/mafintosh/flat-tree
+  flora-colossus@2.0.0
+    https://github.com/MarshallOfSound/flora-colossus
   flow-enums-runtime@0.0.6
     https://github.com/facebook/flow
-  forwarded@0.2.0
-    https://github.com/jshttp/forwarded
+  for-each@0.3.5
+    https://github.com/Raynos/for-each
   freeport-async@2.0.0
     https://github.com/expo/freeport-async
   fresh@0.5.2
     https://github.com/jshttp/fresh
-  fresh@2.0.0
-    https://github.com/jshttp/fresh
+  fs-extra@10.1.0
+    https://github.com/jprichardson/node-fs-extra
+  fs-extra@11.3.5
+    https://github.com/jprichardson/node-fs-extra
+  fs-extra@8.1.0
+    https://github.com/jprichardson/node-fs-extra
+  fs-extra@9.1.0
+    https://github.com/jprichardson/node-fs-extra
   fsevents@2.3.3
     https://github.com/fsevents/fsevents
   function-bind@1.1.2
     https://github.com/Raynos/function-bind
+  galactus@1.0.0
+    https://github.com/marshallOfSound/galactus
   generate-object-property@2.0.0
     https://github.com/mafintosh/generate-object-property
   generate-string@1.0.1
@@ -1103,47 +1350,73 @@ JavaScript Dependencies
     https://github.com/loganfsmyth/gensync
   get-intrinsic@1.3.0
     https://github.com/ljharb/get-intrinsic
+  get-package-info@1.0.0
+    https://github.com/rahatarmanahmed/get-package-info
   get-proto@1.0.1
     https://github.com/ljharb/get-proto
+  get-stream@5.2.0
+    https://github.com/sindresorhus/get-stream
   getenv@2.0.0
     https://github.com/ctavan/node-getenv
+  globalthis@1.0.4
+    https://github.com/ljharb/System.global
   gopd@1.2.0
     https://github.com/ljharb/gopd
+  got@11.8.6
+    https://github.com/sindresorhus/got
   has-flag@3.0.0
     https://github.com/sindresorhus/has-flag
   has-flag@4.0.0
     https://github.com/sindresorhus/has-flag
+  has-property-descriptors@1.0.2
+    https://github.com/inspect-js/has-property-descriptors
   has-symbols@1.1.0
     https://github.com/inspect-js/has-symbols
-  hasown@2.0.3
+  has-tostringtag@1.0.2
+    https://github.com/inspect-js/has-tostringtag
+  hash-base@3.0.5
+    https://github.com/crypto-browserify/hash-base
+  hash-base@3.1.2
+    https://github.com/crypto-browserify/hash-base
+  hash.js@1.1.7
+    https://github.com/indutny/hash.js
+  hasown@2.0.4
     https://github.com/inspect-js/hasOwn
-  hermes-compiler@250829098.0.10
+  hermes-compiler@250829098.0.14
     https://github.com/facebook/hermes
   hermes-estree@0.29.1
     https://github.com/facebook/hermes
   hermes-estree@0.32.0
     https://github.com/facebook/hermes
-  hermes-estree@0.33.3
-    https://github.com/facebook/hermes
   hermes-estree@0.35.0
+    https://github.com/facebook/hermes
+  hermes-estree@0.36.0
     https://github.com/facebook/hermes
   hermes-parser@0.29.1
     https://github.com/facebook/hermes
   hermes-parser@0.32.0
     https://github.com/facebook/hermes
-  hermes-parser@0.33.3
-    https://github.com/facebook/hermes
   hermes-parser@0.35.0
     https://github.com/facebook/hermes
-  hono@4.12.23
-    https://github.com/honojs/hono
+  hermes-parser@0.36.0
+    https://github.com/facebook/hermes
+  hmac-drbg@1.0.1
+    https://github.com/indutny/hmac-drbg
   http-errors@2.0.1
     https://github.com/jshttp/http-errors
+  http-proxy-agent@5.0.0
+    https://github.com/TooTallNate/node-http-proxy-agent
+  http2-wrapper@1.0.3
+    https://github.com/szmarczak/http2-wrapper
+  https-proxy-agent@5.0.1
+    https://github.com/TooTallNate/node-https-proxy-agent
   https-proxy-agent@7.0.6
     https://github.com/TooTallNate/proxy-agents
+  humanize-ms@1.2.1
+    https://github.com/node-modules/humanize-ms
   hyperbee@2.27.3
     https://github.com/holepunchto/hyperbee
-  hypercore@11.30.2
+  hypercore@11.33.1
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.7.0
     https://github.com/mafintosh/hypercore-crypto
@@ -1151,36 +1424,56 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperdht
   hyperswarm@4.17.0
     https://github.com/holepunchto/hyperswarm
-  iconv-lite@0.7.2
-    https://github.com/pillarjs/iconv-lite
+  iconv-lite@0.6.3
+    https://github.com/ashtuchkin/iconv-lite
   ignore@5.3.2
     https://github.com/kaelzhang/node-ignore
   image-size@1.2.1
     https://github.com/image-size/image-size
+  imurmurhash@0.1.4
+    https://github.com/jensyt/imurmurhash-js
+  indent-string@4.0.0
+    https://github.com/sindresorhus/indent-string
   invariant@2.2.4
     https://github.com/zertosh/invariant
   ip-address@10.2.0
     https://github.com/beaugunderson/ip-address
-  ipaddr.js@1.9.1
-    https://github.com/whitequark/ipaddr.js
   ipaddr.js@2.4.0
     https://github.com/whitequark/ipaddr.js
+  is-arrayish@0.2.1
+    https://github.com/qix-/node-is-arrayish
+  is-callable@1.2.7
+    https://github.com/inspect-js/is-callable
   is-core-module@2.16.2
     https://github.com/inspect-js/is-core-module
   is-docker@2.2.1
     https://github.com/sindresorhus/is-docker
   is-fullwidth-code-point@3.0.0
     https://github.com/sindresorhus/is-fullwidth-code-point
+  is-fullwidth-code-point@4.0.0
+    https://github.com/sindresorhus/is-fullwidth-code-point
+  is-interactive@1.0.0
+    https://github.com/sindresorhus/is-interactive
+  is-lambda@1.0.1
+    https://github.com/watson/is-lambda
   is-number@7.0.0
     https://github.com/jonschlinkert/is-number
   is-options@1.0.2
     https://github.com/mafintosh/is-options
-  is-promise@4.0.0
-    https://github.com/then/is-promise
   is-property@1.0.2
     https://github.com/mikolalysenko/is-property
+  is-typed-array@1.1.15
+    https://github.com/inspect-js/is-typed-array
+  is-unicode-supported@0.1.0
+    https://github.com/sindresorhus/is-unicode-supported
   is-wsl@2.2.0
     https://github.com/sindresorhus/is-wsl
+  isarray@1.0.0
+    https://github.com/juliangruber/isarray
+  isarray@2.0.5
+    https://github.com/juliangruber/isarray
+  isbinaryfile@4.0.10
+    https://github.com/gjtorikian/isBinaryFile
   jest-get-type@29.6.3
     https://github.com/jestjs/jest
   jest-util@29.7.0
@@ -1191,14 +1484,14 @@ JavaScript Dependencies
     https://github.com/jestjs/jest
   jimp-compact@0.16.1
     https://github.com/nuxt-community/jimp-compact
-  jose@6.2.3
-    https://github.com/panva/jose
   js-tokens@4.0.0
     https://github.com/lydell/js-tokens
-  js-yaml@4.1.1
+  js-yaml@4.2.0
     https://github.com/nodeca/js-yaml
   jsesc@3.1.0
     https://github.com/mathiasbynens/jsesc
+  json-buffer@3.0.1
+    https://github.com/dominictarr/json-buffer
   json-schema-ref-resolver@3.0.0
     https://github.com/fastify/json-schema-ref-resolver
   json-schema-resolver@3.0.0
@@ -1207,8 +1500,16 @@ JavaScript Dependencies
     https://github.com/epoberezkin/json-schema-traverse
   json5@2.2.3
     https://github.com/json5/json5
+  jsonfile@4.0.0
+    https://github.com/jprichardson/node-jsonfile
+  jsonfile@6.2.1
+    https://github.com/jprichardson/node-jsonfile
+  junk@3.1.0
+    https://github.com/sindresorhus/junk
   kademlia-routing-table@1.0.6
     https://github.com/mafintosh/kademlia-routing-table
+  keyv@4.5.4
+    https://github.com/jaredwray/keyv
   kleur@3.0.3
     https://github.com/lukeed/kleur
   lan-network@0.2.1
@@ -1217,24 +1518,38 @@ JavaScript Dependencies
     https://github.com/sindresorhus/leven
   lines-and-columns@1.2.4
     https://github.com/eventualbuddha/lines-and-columns
+  listr2@7.0.2
+    https://github.com/listr2/listr2
   llm-splitter@0.2.0
     https://github.com/nearform/llm-splitter
+  load-json-file@2.0.0
+    https://github.com/sindresorhus/load-json-file
+  locate-path@2.0.0
+    https://github.com/sindresorhus/locate-path
   lodash.debounce@4.0.8
+    https://github.com/lodash/lodash
+  lodash.get@4.4.2
     https://github.com/lodash/lodash
   lodash.throttle@4.1.1
     https://github.com/lodash/lodash
   log-symbols@2.2.0
     https://github.com/sindresorhus/log-symbols
+  log-symbols@4.1.0
+    https://github.com/sindresorhus/log-symbols
+  log-update@5.0.1
+    https://github.com/sindresorhus/log-update
   loose-envify@1.4.0
     https://github.com/zertosh/loose-envify
+  lowercase-keys@2.0.0
+    https://github.com/sindresorhus/lowercase-keys
+  matcher@3.0.0
+    https://github.com/sindresorhus/matcher
   math-intrinsics@1.1.0
     https://github.com/es-shims/math-intrinsics
-  media-typer@1.1.0
-    https://github.com/jshttp/media-typer
+  md5.js@1.3.5
+    https://github.com/crypto-browserify/md5.js
   memoize-one@5.2.1
     https://github.com/alexreardon/memoize-one
-  merge-descriptors@2.0.0
-    https://github.com/sindresorhus/merge-descriptors
   merge-stream@2.0.0
     https://github.com/grncdr/merge-stream
   metro@0.83.3
@@ -1295,6 +1610,8 @@ JavaScript Dependencies
     https://github.com/facebook/metro
   micromatch@4.0.8
     https://github.com/micromatch/micromatch
+  miller-rabin@4.0.1
+    https://github.com/indutny/miller-rabin
   mime@1.6.0
     https://github.com/broofa/node-mime
   mime@3.0.0
@@ -1309,8 +1626,20 @@ JavaScript Dependencies
     https://github.com/jshttp/mime-types
   mimic-fn@1.2.0
     https://github.com/sindresorhus/mimic-fn
+  mimic-fn@2.1.0
+    https://github.com/sindresorhus/mimic-fn
+  mimic-response@1.0.1
+    https://github.com/sindresorhus/mimic-response
+  mimic-response@3.1.0
+    https://github.com/sindresorhus/mimic-response
+  minimalistic-crypto-utils@1.0.1
+    https://github.com/indutny/minimalistic-crypto-utils
   minimist@1.2.8
     https://github.com/minimistjs/minimist
+  minipass-fetch@2.1.2
+    https://github.com/npm/minipass-fetch
+  minizlib@2.1.2
+    https://github.com/isaacs/minizlib
   minizlib@3.1.0
     https://github.com/isaacs/minizlib
   mkdirp@1.0.4
@@ -1335,10 +1664,16 @@ JavaScript Dependencies
     https://github.com/jshttp/negotiator
   nested-error-stacks@2.0.1
     https://github.com/mdlavin/nested-error-stacks
+  node-abi@3.92.0
+    https://github.com/electron/node-abi
+  node-api-version@0.2.1
+    https://github.com/timfish/node-api-version
   node-int64@0.4.0
     https://github.com/broofa/node-int64
-  node-releases@2.0.46
+  node-releases@2.0.47
     https://github.com/chicoxyzzy/node-releases
+  normalize-url@6.1.0
+    https://github.com/sindresorhus/normalize-url
   nullthrows@1.1.1
     https://github.com/zertosh/nullthrows
   ob1@0.83.3
@@ -1347,8 +1682,8 @@ JavaScript Dependencies
     https://github.com/facebook/metro
   object-assign@4.1.1
     https://github.com/sindresorhus/object-assign
-  object-inspect@1.13.4
-    https://github.com/inspect-js/object-inspect
+  object-keys@1.1.1
+    https://github.com/ljharb/object-keys
   on-exit-leak-free@2.1.2
     https://github.com/mcollina/on-exit-or-gc
   on-finished@2.3.0
@@ -1359,6 +1694,8 @@ JavaScript Dependencies
     https://github.com/jshttp/on-headers
   onetime@2.0.1
     https://github.com/sindresorhus/onetime
+  onetime@5.1.2
+    https://github.com/sindresorhus/onetime
   open@7.4.2
     https://github.com/sindresorhus/open
   open@8.4.2
@@ -1367,24 +1704,50 @@ JavaScript Dependencies
     https://github.com/kogosoftwarellc/open-api/tree/master/packages/openapi-types
   ora@3.4.0
     https://github.com/sindresorhus/ora
+  ora@5.4.1
+    https://github.com/sindresorhus/ora
+  p-cancelable@2.1.1
+    https://github.com/sindresorhus/p-cancelable
+  p-limit@1.3.0
+    https://github.com/sindresorhus/p-limit
   p-limit@3.1.0
     https://github.com/sindresorhus/p-limit
+  p-locate@2.0.0
+    https://github.com/sindresorhus/p-locate
+  p-map@4.0.0
+    https://github.com/sindresorhus/p-map
+  p-try@1.0.0
+    https://github.com/sindresorhus/p-try
+  parse-author@2.0.0
+    https://github.com/jonschlinkert/parse-author
+  parse-json@2.2.0
+    https://github.com/sindresorhus/parse-json
   parse-png@2.1.0
     https://github.com/kevva/parse-png
   parseurl@1.3.3
     https://github.com/pillarjs/parseurl
+  path-exists@3.0.0
+    https://github.com/sindresorhus/path-exists
   path-is-absolute@1.0.1
     https://github.com/sindresorhus/path-is-absolute
   path-key@3.1.1
     https://github.com/sindresorhus/path-key
   path-parse@1.0.7
     https://github.com/jbgutierrez/path-parse
-  path-to-regexp@8.4.2
-    https://github.com/pillarjs/path-to-regexp
+  path-type@2.0.0
+    https://github.com/sindresorhus/path-type
+  pbkdf2@3.1.6
+    https://github.com/browserify/pbkdf2
+  pe-library@1.0.1
+    https://github.com/jet2jet/pe-library-js
+  pend@1.2.0
+    https://github.com/andrewrk/node-pend
   picomatch@2.3.2
     https://github.com/micromatch/picomatch
   picomatch@4.0.4
     https://github.com/micromatch/picomatch
+  pify@2.3.0
+    https://github.com/sindresorhus/pify
   pino@10.3.1
     https://github.com/pinojs/pino
   pino-abstract-transport@3.0.0
@@ -1393,18 +1756,24 @@ JavaScript Dependencies
     https://github.com/pinojs/pino-std-serializers
   pirates@4.0.7
     https://github.com/danez/pirates
-  pkce-challenge@5.0.1
-    https://github.com/crouchcd/pkce-challenge
   plist@3.1.1
     https://github.com/TooTallNate/node-plist
   pngjs@3.4.0
     https://github.com/lukeapage/pngjs2
+  possible-typed-array-names@1.1.0
+    https://github.com/ljharb/possible-typed-array-names
   postcss@8.4.49
     https://github.com/postcss/postcss
+  postject@1.0.0-alpha.6
+    https://github.com/nodejs/postject
+  prettier@3.8.4
+    https://github.com/prettier/prettier
   pretty-bytes@5.6.0
     https://github.com/sindresorhus/pretty-bytes
   pretty-format@29.7.0
     https://github.com/jestjs/jest
+  process-nextick-args@2.0.1
+    https://github.com/calvinmetcalf/process-nextick-args
   process-warning@4.0.1
     https://github.com/fastify/process-warning
   process-warning@5.0.0
@@ -1415,14 +1784,18 @@ JavaScript Dependencies
     https://github.com/mafintosh/promaphore
   promise@8.3.0
     https://github.com/then/promise
+  promise-retry@2.0.1
+    https://github.com/IndigoUnited/node-promise-retry
   prompts@2.4.2
     https://github.com/terkelg/prompts
   protocol-buffers-encodings@1.2.0
     https://github.com/mafintosh/protocol-buffers-encodings
   protomux@3.11.0
     https://github.com/holepunchto/protomux
-  proxy-addr@2.0.7
-    https://github.com/jshttp/proxy-addr
+  public-encrypt@4.0.3
+    https://github.com/crypto-browserify/publicEncrypt
+  pump@3.0.4
+    https://github.com/mafintosh/pump
   punycode@2.3.1
     https://github.com/mathiasbynens/punycode.js
   queue@6.0.2
@@ -1431,22 +1804,36 @@ JavaScript Dependencies
     https://github.com/mafintosh/queue-tick
   quick-format-unescaped@4.0.4
     https://github.com/davidmarkclements/quick-format
+  quick-lru@5.1.1
+    https://github.com/sindresorhus/quick-lru
   random-array-iterator@1.0.0
     https://github.com/mafintosh/random-array-iterator
+  randombytes@2.1.0
+    https://github.com/crypto-browserify/randombytes
+  randomfill@1.0.4
+    https://github.com/crypto-browserify/randomfill
   range-parser@1.2.1
     https://github.com/jshttp/range-parser
-  raw-body@3.0.2
-    https://github.com/stream-utils/raw-body
-  react@19.2.6
+  react@19.2.7
     https://github.com/facebook/react
   react-devtools-core@6.1.5
     https://github.com/facebook/react
   react-is@18.3.1
     https://github.com/facebook/react
-  react-native@0.85.3
+  react-native@0.86.0
     https://github.com/facebook/react-native
   react-refresh@0.14.2
     https://github.com/facebook/react
+  read-binary-file-arch@1.0.6
+    https://github.com/samuelmaddock/read-binary-file-arch
+  read-pkg@2.0.0
+    https://github.com/sindresorhus/read-pkg
+  read-pkg-up@2.0.0
+    https://github.com/sindresorhus/read-pkg-up
+  readable-stream@2.3.8
+    https://github.com/nodejs/readable-stream
+  readable-stream@3.6.2
+    https://github.com/nodejs/readable-stream
   ready-resource@1.2.0
     https://github.com/holepunchto/ready-resource
   real-require@0.2.0
@@ -1471,10 +1858,14 @@ JavaScript Dependencies
     https://github.com/floatdrop/require-from-string
   requireg@0.2.2
     https://github.com/h2non/requireg
+  resedit@2.0.3
+    https://github.com/jet2jet/resedit-js
   resolve@1.22.12
     https://github.com/browserify/resolve
   resolve@1.7.1
     https://github.com/browserify/resolve
+  resolve-alpn@1.2.1
+    https://github.com/szmarczak/resolve-alpn
   resolve-from@5.0.0
     https://github.com/sindresorhus/resolve-from
   resolve-reject-promise@1.1.0
@@ -1483,16 +1874,26 @@ JavaScript Dependencies
     https://github.com/byCedric/resolve-workspace-root
   resolve.exports@2.0.3
     https://github.com/lukeed/resolve.exports
+  responselike@2.0.1
+    https://github.com/sindresorhus/responselike
   restore-cursor@2.0.0
+    https://github.com/sindresorhus/restore-cursor
+  restore-cursor@3.1.0
+    https://github.com/sindresorhus/restore-cursor
+  restore-cursor@4.0.0
     https://github.com/sindresorhus/restore-cursor
   ret@0.5.0
     https://github.com/fent/ret.js
+  retry@0.12.0
+    https://github.com/tim-kos/node-retry
   reusify@1.1.0
     https://github.com/mcollina/reusify
   rfdc@1.4.1
     https://github.com/davidmarkclements/rfdc
-  router@2.2.0
-    https://github.com/pillarjs/router
+  ripemd160@2.0.3
+    https://github.com/crypto-browserify/ripemd160
+  safe-buffer@5.1.2
+    https://github.com/feross/safe-buffer
   safe-buffer@5.2.1
     https://github.com/feross/safe-buffer
   safe-regex2@5.1.1
@@ -1507,18 +1908,20 @@ JavaScript Dependencies
     https://github.com/mafintosh/same-data
   scheduler@0.27.0
     https://github.com/facebook/react
+  semver-compare@1.0.0
+    https://github.com/substack/semver-compare
   send@0.19.2
-    https://github.com/pillarjs/send
-  send@1.2.1
     https://github.com/pillarjs/send
   serialize-error@2.1.0
     https://github.com/sindresorhus/serialize-error
+  serialize-error@7.0.1
+    https://github.com/sindresorhus/serialize-error
   serve-static@1.16.3
-    https://github.com/expressjs/serve-static
-  serve-static@2.2.1
     https://github.com/expressjs/serve-static
   set-cookie-parser@2.7.2
     https://github.com/nfriedly/set-cookie-parser
+  set-function-length@1.2.2
+    https://github.com/ljharb/set-function-length
   shebang-command@2.0.0
     https://github.com/kevva/shebang-command
   shebang-regex@3.0.0
@@ -1527,14 +1930,6 @@ JavaScript Dependencies
     https://github.com/ljharb/shell-quote
   shuffled-priority-queue@2.1.0
     https://github.com/mafintosh/shuffled-priority-queue
-  side-channel@1.1.0
-    https://github.com/ljharb/side-channel
-  side-channel-list@1.0.1
-    https://github.com/ljharb/side-channel-list
-  side-channel-map@1.0.1
-    https://github.com/ljharb/side-channel-map
-  side-channel-weakmap@1.0.2
-    https://github.com/ljharb/side-channel-weakmap
   signal-promise@1.0.3
     https://github.com/mafintosh/signal-promise
   signed-varint@2.0.1
@@ -1545,8 +1940,16 @@ JavaScript Dependencies
     https://github.com/terkelg/sisteransi
   slash@3.0.0
     https://github.com/sindresorhus/slash
+  slice-ansi@5.0.0
+    https://github.com/chalk/slice-ansi
   slugify@1.6.9
     https://github.com/simov/slugify
+  smart-buffer@4.2.0
+    https://github.com/JoshGlazebrook/smart-buffer
+  socks@2.8.9
+    https://github.com/JoshGlazebrook/socks
+  socks-proxy-agent@7.0.0
+    https://github.com/TooTallNate/node-socks-proxy-agent
   sodium-native@5.1.0
     https://github.com/holepunchto/sodium-native
   sodium-secretstream@1.2.0
@@ -1557,6 +1960,8 @@ JavaScript Dependencies
     https://github.com/pinojs/sonic-boom
   source-map-support@0.5.21
     https://github.com/evanw/node-source-map-support
+  spdx-expression-parse@3.0.1
+    https://github.com/jslicense/spdx-expression-parse.js
   speedometer@1.1.0
     https://github.com/mafintosh/speedometer
   stackframe@1.3.4
@@ -1567,16 +1972,26 @@ JavaScript Dependencies
     https://github.com/jshttp/statuses
   statuses@2.0.2
     https://github.com/jshttp/statuses
-  streamx@2.26.0
+  streamx@2.27.0
     https://github.com/mafintosh/streamx
+  string_decoder@1.1.1
+    https://github.com/nodejs/string_decoder
   string-width@4.2.3
+    https://github.com/sindresorhus/string-width
+  string-width@5.1.2
     https://github.com/sindresorhus/string-width
   strip-ansi@5.2.0
     https://github.com/chalk/strip-ansi
   strip-ansi@6.0.1
     https://github.com/chalk/strip-ansi
+  strip-ansi@7.2.0
+    https://github.com/chalk/strip-ansi
+  strip-bom@3.0.0
+    https://github.com/sindresorhus/strip-bom
   strip-json-comments@2.0.1
     https://github.com/sindresorhus/strip-json-comments
+  strip-outer@1.0.1
+    https://github.com/sindresorhus/strip-outer
   structured-headers@0.4.1
     https://github.com/evert/structured-header
   sucrase@3.35.1
@@ -1611,25 +2026,29 @@ JavaScript Dependencies
     https://github.com/mafintosh/timeout-refresh
   tiny-byte-size@1.1.0
     https://github.com/mafintosh/tiny-byte-size
-  tinyglobby@0.2.16
+  tinyglobby@0.2.17
     https://github.com/SuperchupuDev/tinyglobby
   tinyld@1.3.4
     https://github.com/komodojp/tinyld
+  to-buffer@1.2.2
+    https://github.com/browserify/to-buffer
   to-regex-range@5.0.1
     https://github.com/micromatch/to-regex-range
   toad-cache@3.7.1
     https://github.com/kibertoad/toad-cache
   toidentifier@1.0.1
     https://github.com/component/toidentifier
-  tsx@4.22.3
+  trim-repeated@1.0.0
+    https://github.com/sindresorhus/trim-repeated
+  tsx@4.22.4
     https://github.com/privatenumber/tsx
-  type-is@2.1.0
-    https://github.com/jshttp/type-is
+  typed-array-buffer@1.0.3
+    https://github.com/inspect-js/typed-array-buffer
   ua-parser-js@0.7.41
     https://github.com/faisalman/ua-parser-js
   undici@6.26.0
     https://github.com/nodejs/undici
-  undici-types@7.16.0
+  undici-types@7.18.2
     https://github.com/nodejs/undici
   unicode-canonical-property-names-ecmascript@2.0.1
     https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript
@@ -1639,6 +2058,10 @@ JavaScript Dependencies
     https://github.com/mathiasbynens/unicode-match-property-value-ecmascript
   unicode-property-aliases-ecmascript@2.2.0
     https://github.com/mathiasbynens/unicode-property-aliases-ecmascript
+  universalify@0.1.2
+    https://github.com/RyanZim/universalify
+  universalify@2.0.1
+    https://github.com/RyanZim/universalify
   unix-path-resolve@1.0.2
     https://github.com/mafintosh/unix-path-resolve
   unordered-set@2.0.1
@@ -1647,6 +2070,8 @@ JavaScript Dependencies
     https://github.com/stream-utils/unpipe
   update-browserslist-db@1.2.3
     https://github.com/browserslist/update-db
+  util-deprecate@1.0.2
+    https://github.com/TooTallNate/util-deprecate
   utils-merge@1.0.1
     https://github.com/jaredhanson/utils-merge
   uuid@7.0.3
@@ -1663,9 +2088,13 @@ JavaScript Dependencies
     https://github.com/github/fetch
   whatwg-url-without-unicode@8.0.0-3
     https://github.com/charpeni/whatwg-url
+  which-typed-array@1.1.22
+    https://github.com/inspect-js/which-typed-array
   wonka@6.3.6
     https://github.com/0no-co/wonka
   wrap-ansi@7.0.0
+    https://github.com/chalk/wrap-ansi
+  wrap-ansi@8.1.0
     https://github.com/chalk/wrap-ansi
   ws@6.2.4
     https://github.com/websockets/ws
@@ -1683,6 +2112,8 @@ JavaScript Dependencies
     https://github.com/oozcitak/xmlbuilder-js
   yargs@17.7.2
     https://github.com/yargs/yargs
+  yauzl@2.10.0
+    https://github.com/thejoshwolfe/yauzl
   yocto-queue@0.1.0
     https://github.com/sindresorhus/yocto-queue
   z32@1.1.0

--- a/packages/cli/changelog/0.7.0/CHANGELOG.md
+++ b/packages/cli/changelog/0.7.0/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog v0.7.0
+
+Release Date: 2026-06-15
+
+## 🔌 API
+
+- Ffmpeg-backed mp3/opus/aac/flac encoding for POST /v1/audio/speech. (see PR [#2451](https://github.com/tetherto/qvac/pull/2451)) - See [API changes](./api.md)
+- Finish_reason=length + unified token accounting across chat-category routes. (see PR [#2477](https://github.com/tetherto/qvac/pull/2477)) - See [API changes](./api.md)
+- Img2vid for POST /v1/videos. (see PR [#2481](https://github.com/tetherto/qvac/pull/2481)) - See [API changes](./api.md)
+
+## ⚙️ Infrastructure
+
+- Test CLI against in-repo and published SDK in SDK Pod Checks. (see PR [#2541](https://github.com/tetherto/qvac/pull/2541))
+

--- a/packages/cli/changelog/0.7.0/CHANGELOG_LLM.md
+++ b/packages/cli/changelog/0.7.0/CHANGELOG_LLM.md
@@ -1,0 +1,49 @@
+# QVAC CLI v0.7.0 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.7.0
+
+This release adds image-to-video generation and audio encoding to the OpenAI-compatible HTTP server. It also fixes token accounting and `finish_reason` reporting across all chat-category routes.
+
+## New Features
+
+### Image-to-video via POST /v1/videos
+
+`POST /v1/videos` now supports img2vid in addition to txt2vid. Supply the reference image as a multipart file field (the form the OpenAI SDK sends for `Uploadable`), as a JSON `{ image_url }` (base64 data URI or HTTP(S) URL up to 100 MB), or as a JSON `{ file_id }` referencing a previously uploaded file. Mode is inferred automatically from the presence of `input_reference`.
+
+```typescript
+import OpenAI, { toFile } from 'openai'
+import fs from 'node:fs'
+
+const client = new OpenAI({ baseURL: 'http://localhost:11434/v1' })
+
+// img2vid via local file (multipart)
+const job = await client.videos.create({
+  model: 'wan-i2v',
+  prompt: 'subject slowly turns and smiles',
+  input_reference: await toFile(fs.createReadStream('./frame.png'), 'frame.png'),
+})
+
+// img2vid via data URI (JSON)
+const job2 = await client.videos.create({
+  model: 'wan-i2v',
+  prompt: 'subject slowly turns and smiles',
+  input_reference: { image_url: 'data:image/png;base64,...' },
+})
+```
+
+### Audio encoding — mp3, opus, aac, flac
+
+`POST /v1/audio/speech` now supports `response_format: "mp3"`, `"opus"`, `"aac"`, and `"flac"` in addition to `wav` and `pcm`. Encoding is handled by `ffmpeg` on the server's `PATH`; if ffmpeg is absent, these formats return `503 transcode_unavailable`. Use `qvac doctor` to check availability.
+
+Two new discovery endpoints are also available:
+
+```
+GET /v1/audio/voices  →  list of configured TTS voices
+GET /v1/audio/models  →  list of loaded (READY) TTS models
+```
+
+## Bug Fixes
+
+### Correct finish_reason and token accounting
+
+`finish_reason: "length"` is now returned when generation is truncated by `max_tokens` or `max_completion_tokens` (previously always `"stop"`). The Responses API equivalent is `status: "incomplete"` with `incomplete_details.reason: "max_output_tokens"`. Token counts (`completion_tokens` / `output_tokens`) now consistently use the SDK's `generatedTokens` stats across `/v1/chat/completions`, `/v1/completions`, and `/v1/responses`.

--- a/packages/cli/changelog/0.7.0/api.md
+++ b/packages/cli/changelog/0.7.0/api.md
@@ -1,0 +1,59 @@
+# 🔌 API Changes v0.7.0
+
+## Ffmpeg-backed mp3/opus/aac/flac encoding for POST /v1/audio/speech
+
+PR: [#2451](https://github.com/tetherto/qvac/pull/2451)
+
+```
+GET /v1/audio/voices  →  { object: "list", voices: string[], data: [{ id, object: "audio.voice", model }] }
+GET /v1/audio/models  →  { object: "list", data: [{ id, object: "model", created, owned_by }] }
+```
+
+---
+
+## Finish_reason=length + unified token accounting across chat-category routes
+
+PR: [#2477](https://github.com/tetherto/qvac/pull/2477)
+
+```typescript
+// finish_reason now reflects truncation
+{ finish_reason: "length" }  // when max_tokens cuts generation short (was always "stop")
+
+// Responses API — length truncation (blocking)
+{ status: "incomplete", incomplete_details: { reason: "max_output_tokens" } }
+// Responses API — length truncation (streaming)
+{ type: "response.incomplete" }  // was "response.completed"
+
+// completion_tokens: now consistently uses stats.generatedTokens (with whitespace-split fallback)
+// across /v1/chat/completions, /v1/completions, and /v1/responses
+```
+
+---
+
+## Img2vid for POST /v1/videos
+
+PR: [#2481](https://github.com/tetherto/qvac/pull/2481)
+
+```typescript
+import OpenAI, { toFile } from 'openai'
+import fs from 'node:fs'
+
+const client = new OpenAI({ baseURL: 'http://localhost:11434/v1' })
+
+const job = await client.videos.create({
+  model: 'wan-i2v',
+  prompt: 'subject slowly turns and smiles',
+  input_reference: await toFile(fs.createReadStream('./frame.png'), 'frame.png'),
+})
+```
+
+```typescript
+const job = await client.videos.create({
+  model: 'wan-i2v',
+  prompt: 'subject slowly turns and smiles',
+  input_reference: { image_url: 'data:image/png;base64,...' },
+})
+```
+
+---
+

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Release @qvac/cli 0.7.0

Merging this into `release-cli-0.7.0` triggers `publish-release-npm` → npm publish + `cli-v0.7.0` tag/GitHub release.

### Changes

- Version `0.6.0` → `0.7.0`.
- `@qvac/sdk` bumped to `^0.13.1`.
- Changelog generated at `packages/cli/changelog/0.7.0/` and folded into `packages/cli/CHANGELOG.md` (covers PRs #2451, #2477, #2481).
- NOTICE regenerated to reflect the updated dependency tree.

### Verification (local, on this branch)

- `npm install` → resolves `@qvac/sdk@^0.13.1`
- `npm run build` — clean
- `npm run test:unit` — 400 pass
- `npm run test:e2e` — 139 pass

A follow-up backmerge PR (#2599) lands the same version + changelog + NOTICE on `main`.