### PR TITLE
QVAC-20557 feat[api]: enable Android GPU for tts-ggml (Supertonic + Chatterbox) — DO NOT MERGE (device-farm validation)

### DIFF
--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -15,7 +15,6 @@
 #include "addon/TTSErrors.hpp"
 #include "model-interface/BackendUtils.hpp"
 #include "inference-addon-cpp/Errors.hpp"
-#include "inference-addon-cpp/Logger.hpp"
 
 namespace qvac::ttsggml::chatterbox {
 
@@ -25,7 +24,6 @@ using qvac_errors::createTTSError;
 using qvac_errors::StatusError;
 using qvac_errors::tts_error::TTSErrorCode;
 namespace general_error = qvac_errors::general_error;
-namespace logger = qvac_lib_inference_addon_cpp::logger;
 
 tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) {
   tts_cpp::chatterbox::EngineOptions opts;
@@ -190,24 +188,6 @@ void ChatterboxModel::reload() {
 void ChatterboxModel::loadLocked() {
   if (engine_) return;
 
-  // Force useGPU to false on Android until Vulkan (Mali) and OpenCL (Adreno)
-  // stabilize for the Chatterbox graph.
-#ifdef __ANDROID__
-  {
-    const bool wantsGpu =
-        cfg_.useGpu.value_or(false) ||
-        (cfg_.nGpuLayers.has_value() && *cfg_.nGpuLayers != 0);
-    if (wantsGpu) {
-      QLOG(logger::Priority::WARNING,
-           "Chatterbox: useGPU=true is currently ignored on Android "
-           "(GPU backends disabled at engine boundary pending Vulkan/Mali "
-           "and OpenCL/Adreno driver fixes); falling back to CPU.");
-    }
-    cfg_.useGpu     = false;
-    cfg_.nGpuLayers = 0;
-  }
-#endif
-
   try {
     engine_ = std::make_shared<tts_cpp::chatterbox::Engine>(toEngineOptions(cfg_));
   } catch (const std::exception& e) {
@@ -217,9 +197,10 @@ void ChatterboxModel::loadLocked() {
         std::string("ChatterboxModel::load: ") + e.what());
   }
 
-  backendName_   = engine_->backend_name();
-  backendDevice_ = backendDeviceCode(engine_->backend_device());
-  backendId_     = backendIdFromName(backendName_);
+  backendName_     = engine_->backend_name();
+  backendDevice_   = backendDeviceCode(engine_->backend_device());
+  backendId_       = backendIdFromName(backendName_);
+  gpuUnsupported_  = engine_->gpu_unsupported() ? 1 : 0;
 }
 
 void ChatterboxModel::unloadLocked() {
@@ -361,6 +342,7 @@ qvac_lib_inference_addon_cpp::RuntimeStats ChatterboxModel::runtimeStats() const
   stats.emplace_back("totalSamples", totalSamples_);
   stats.emplace_back("backendDevice", static_cast<int64_t>(backendDevice_));
   stats.emplace_back("backendId",     static_cast<int64_t>(backendId_));
+  stats.emplace_back("gpuUnsupported", static_cast<int64_t>(gpuUnsupported_));
   return stats;
 }
 

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
@@ -141,6 +141,11 @@ private:
 
   int backendDevice_ = 0;
   int backendId_ = 0;
+  // 1 when useGPU was requested but the engine fell back to CPU because the
+  // device's GPU is present yet outside the validated allowlist (e.g. Mali);
+  // surfaced as the `gpuUnsupported` stat so a CPU result on such a device is
+  // not treated as a GPU-engagement regression.
+  int gpuUnsupported_ = 0;
   std::string backendName_ = "CPU";
 
   mutable std::atomic_bool cancelRequested_{false};

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicConfig.hpp
@@ -20,9 +20,7 @@ struct SupertonicConfig {
    *   - std::nullopt: unspecified, let the engine use its library default.
    *   - true:         if nGpuLayers unset, maps to nGpuLayers=99. Honored on
    *                   GPU-capable hosts (Metal on Apple, Vulkan/CUDA on
-   *                   desktop). On Android it is forced back to CPU in
-   *                   SupertonicModel::loadLocked() because Adreno
-   *                   OpenCL/Vulkan ggml graph compute is not yet stable.
+   *                   desktop, OpenCL/Vulkan on Android).
    *   - false:        if nGpuLayers unset, forces nGpuLayers=0 (CPU).
    *
    * Conflicts with nGpuLayers (true + 0, or false + !=0) are rejected

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -15,7 +15,6 @@
 #include "addon/TTSErrors.hpp"
 #include "model-interface/BackendUtils.hpp"
 #include "inference-addon-cpp/Errors.hpp"
-#include "inference-addon-cpp/Logger.hpp"
 
 namespace qvac::ttsggml::supertonic {
 
@@ -25,7 +24,6 @@ using qvac_errors::createTTSError;
 using qvac_errors::StatusError;
 using qvac_errors::tts_error::TTSErrorCode;
 namespace general_error = qvac_errors::general_error;
-namespace logger = qvac_lib_inference_addon_cpp::logger;
 
 tts_cpp::supertonic::EngineOptions toEngineOptions(const SupertonicConfig& cfg) {
   tts_cpp::supertonic::EngineOptions opts;
@@ -127,9 +125,8 @@ void SupertonicModel::validateConfig(const SupertonicConfig& cfg) {
     }
   }
   // GPU execution is honored for Supertonic on GPU-capable hosts (Metal on
-  // Apple, Vulkan/CUDA on desktop). On Android it is still forced to CPU in
-  // loadLocked() below (Adreno OpenCL/Vulkan ggml graph compute is unstable);
-  // the cross-field conflict check above is the only hard rejection here.
+  // Apple, Vulkan/CUDA on desktop, OpenCL/Vulkan on Android); the cross-field
+  // conflict check above is the only hard rejection here.
 }
 
 void SupertonicModel::load() {
@@ -151,24 +148,6 @@ void SupertonicModel::reload() {
 void SupertonicModel::loadLocked() {
   if (engine_) return;
 
-  // Force useGPU to false on Android until Vulkan (Mali) and OpenCL (Adreno)
-  // stabilize for the Supertonic graph.
-#ifdef __ANDROID__
-  {
-    const bool wantsGpu =
-        cfg_.useGpu.value_or(false) ||
-        (cfg_.nGpuLayers.has_value() && *cfg_.nGpuLayers != 0);
-    if (wantsGpu) {
-      QLOG(logger::Priority::WARNING,
-           "Supertonic: useGPU=true is currently ignored on Android "
-           "(GPU backends disabled at engine boundary pending Vulkan/Mali "
-           "and OpenCL/Adreno driver fixes); falling back to CPU.");
-    }
-    cfg_.useGpu     = false;
-    cfg_.nGpuLayers = 0;
-  }
-#endif
-
   try {
     engine_ = std::make_shared<tts_cpp::supertonic::Engine>(toEngineOptions(cfg_));
   } catch (const std::exception& e) {
@@ -178,9 +157,10 @@ void SupertonicModel::loadLocked() {
         std::string("SupertonicModel::load: ") + e.what());
   }
 
-  backendName_   = engine_->backend_name();
-  backendDevice_ = backendDeviceCode(engine_->backend_device());
-  backendId_     = backendIdFromName(backendName_);
+  backendName_     = engine_->backend_name();
+  backendDevice_   = backendDeviceCode(engine_->backend_device());
+  backendId_       = backendIdFromName(backendName_);
+  gpuUnsupported_  = engine_->gpu_unsupported() ? 1 : 0;
 }
 
 void SupertonicModel::unloadLocked() {
@@ -273,6 +253,7 @@ qvac_lib_inference_addon_cpp::RuntimeStats SupertonicModel::runtimeStats() const
   stats.emplace_back("totalSamples", totalSamples_);
   stats.emplace_back("backendDevice", static_cast<int64_t>(backendDevice_));
   stats.emplace_back("backendId",     static_cast<int64_t>(backendId_));
+  stats.emplace_back("gpuUnsupported", static_cast<int64_t>(gpuUnsupported_));
   return stats;
 }
 

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.hpp
@@ -94,6 +94,11 @@ private:
 
   int backendDevice_ = 0;
   int backendId_ = 0;
+  // 1 when useGPU was requested but the engine fell back to CPU because the
+  // device's GPU is present yet outside the validated allowlist (e.g. Mali);
+  // surfaced as the `gpuUnsupported` stat so a CPU result on such a device is
+  // not treated as a GPU-engagement regression.
+  int gpuUnsupported_ = 0;
   std::string backendName_ = "CPU";
 };
 

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -366,9 +366,7 @@ class TTSGgml {
     // Default GPU off only when neither knob is set, for every engine. A
     // caller passing nGpuLayers alone keeps it (no silent conflict with the
     // JS-side default). Supertonic GPU intent now flows through to tts-cpp on
-    // GPU-capable hosts (Metal / Vulkan / CUDA); on Android it is forced back
-    // to CPU at the native engine boundary (SupertonicModel::loadLocked) until
-    // the Adreno OpenCL/Vulkan path stabilizes.
+    // all GPU-capable hosts (Metal / Vulkan / CUDA / Android OpenCL).
     if (this._config.useGPU === undefined && this._nGpuLayers == null) {
       this._config.useGPU = false
     }

--- a/packages/tts-ggml/ports/ggml-speech/android-vulkan-version.cmake
+++ b/packages/tts-ggml/ports/ggml-speech/android-vulkan-version.cmake
@@ -1,0 +1,37 @@
+# Detect the Vulkan version shipped with the Android NDK by parsing
+# vulkan_core.h from the NDK sysroot.  Sets `vulkan_version` in the
+# caller's scope (e.g. "1.3.275").
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from ${vulkan_core_h}")
+    endif()
+
+    # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION_COMPLETE from ${vulkan_core_h}")
+    endif()
+endfunction()

--- a/packages/tts-ggml/ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
+++ b/packages/tts-ggml/ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
@@ -1,0 +1,24 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..3d92ac5d 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -7,6 +7,7 @@ if (POLICY CMP0147)
+ endif()
+ 
+ find_package(Vulkan COMPONENTS glslc REQUIRED)
++find_package(SPIRV-Headers QUIET)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     # Parallel build object files
+@@ -87,6 +88,11 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++
++    if (TARGET SPIRV-Headers::SPIRV-Headers)
++        target_link_libraries(ggml-vulkan PRIVATE SPIRV-Headers::SPIRV-Headers)
++    endif()
++
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/packages/tts-ggml/ports/ggml-speech/portfile.cmake
+++ b/packages/tts-ggml/ports/ggml-speech/portfile.cmake
@@ -1,0 +1,176 @@
+# ggml-speech: LOCAL OVERLAY PORT (Android GPU validation; DO NOT MERGE).
+#
+# Pins the published tetherto/qvac-ext-ggml@speech HEAD 44fd4817, which carries
+# the Adreno-740 Vulkan guards and the Android OpenCL-correctness fixes the
+# tts-ggml addon needs to run on the GPU on Android. Identical to the pin the
+# transcription-parakeet overlay uses; the tts-ggml Supertonic fix itself lives
+# entirely in tts-cpp, so no ggml-speech change is required here. The Android
+# backend packaging (GGML_BACKEND_DL=ON per-arch CPU variants + MODULE GPU .so)
+# is unchanged.
+#
+# TEMPORARY: remove once 44fd4817 is consumed from qvac-registry-vcpkg.
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tetherto/qvac-ext-ggml
+    REF 44fd4817dd1dc5872053927200e2824b8a0ced86
+    SHA512 7d83537e5346fc1a1470e6b7ef191c55b02459ac139a841f39d319e7a5e11aea8e3ed0178cbbb0f0b9f2016e0b79c081411d31707368ccb637940fde3496ec14
+    HEAD_REF speech
+)
+
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+set(GGML_METAL_FUSE_MV_BIAS OFF)
+
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+
+# Off by default: the chatterbox Q-variant mul_mv + bias/residual fusion
+# produces zero tokens on parakeet's EOU q8_0 joint network. Consumers
+# whose models stay clear of that pattern can opt in for the speedup.
+if("metal-fuse-mv-bias" IN_LIST FEATURES)
+    set(GGML_METAL_FUSE_MV_BIAS ON)
+endif()
+
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+
+set(GGML_CUDA_COMPILER_OPTION "")
+
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+    find_program(NVCC_EXECUTABLE nvcc
+        PATHS /usr/local/cuda/bin /usr/local/cuda-12.8/bin
+        NO_DEFAULT_PATH
+    )
+    if(NOT NVCC_EXECUTABLE)
+        find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+    endif()
+    set(GGML_CUDA_COMPILER_OPTION "-DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}")
+    message(STATUS "CUDA compiler: ${NVCC_EXECUTABLE}")
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND "vulkan" IN_LIST FEATURES)
+    include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+    detect_ndk_vulkan_version()
+    message(STATUS "NDK Vulkan version: ${vulkan_version}")
+
+    file(DOWNLOAD
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+        "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        TLS_VERIFY ON
+    )
+    file(ARCHIVE_EXTRACT
+        INPUT "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        DESTINATION "${SOURCE_PATH}"
+        PATTERNS "*.hpp"
+    )
+    file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+         DESTINATION "${SOURCE_PATH}/src/")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+
+# Hybrid Android backend mode: GPU backends as MODULE .so loaded at runtime
+# via dlopen, CPU built as per-arch MODULE .so variants (one per ARMv8.0/
+# 8.2/8.6/9.0/9.2 feature tier) also loaded at runtime via dlopen. The
+# downstream addon installs the resulting libqvac-speech-ggml-cpu-android_armv*
+# .so files alongside the .bare binary; the per-variant scoring in
+# ggml-cpu's `ggml_backend_cpu_aarch64_score` then picks the highest tier
+# the running device supports at first use. Pairs with the speech-branch
+# `ggml-backend: android per-arch CPU variant dlopen fallback` patch
+# (commit 9562ed04) so the variant lookup also succeeds when the consumer
+# APK keeps native .so files compressed (AGP `useLegacyPackaging=false`).
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    )
+endif()
+
+# PR #13 (v0.10.2 sync) introduces an unconditional
+# `#include <spirv/unified1/spirv.hpp>` in src/ggml-vulkan/ggml-vulkan.cpp,
+# but the upstream ggml-vulkan CMakeLists.txt never finds spirv-headers nor
+# wires its include dir into the ggml-vulkan target. Apply a small patch
+# so it does (and depend on spirv-headers in vcpkg.json's vulkan feature).
+# TODO: push the equivalent fix upstream and drop this patch.
+if("vulkan" IN_LIST FEATURES)
+    vcpkg_apply_patches(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PATCHES
+            "${CMAKE_CURRENT_LIST_DIR}/patches/0001-ggml-vulkan-find-spirv-headers.patch"
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_METAL_FUSE_MV_BIAS=${GGML_METAL_FUSE_MV_BIAS}
+        -DGGML_LIB_OUTPUT_PREFIX=qvac-speech-
+        ${GGML_CUDA_COMPILER_OPTION}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Pick up the MODULE backend .so files ggml builds into the buildtree's
+# bin/ directory (Android dynamic-backend mode). cmake install() doesn't
+# move them by default.
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-speech-ggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/tts-ggml/ports/ggml-speech/usage
+++ b/packages/tts-ggml/ports/ggml-speech/usage
@@ -1,0 +1,10 @@
+The package ggml provides CMake integration:
+
+  find_package(ggml CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ggml::ggml)
+
+Available vcpkg features:
+  metal  - Metal GPU backend (macOS/iOS, auto-enabled on Apple)
+  vulkan - Vulkan GPU backend
+  cuda   - CUDA GPU backend
+  opencl - OpenCL GPU backend

--- a/packages/tts-ggml/ports/ggml-speech/vcpkg.json
+++ b/packages/tts-ggml/ports/ggml-speech/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "ggml-speech",
+  "version-date": "2026-06-11",
+  "description": "Speech-stack flavour of ggml from tetherto/qvac-ext-ggml@speech, including the ggml-org v0.10.2 sync (PR #13), the iOS Metal NULL-safety hardening from PR #10, GustavoA1604's Android per-arch CPU dlopen fallback (PR #11), the Mac M2 PAD test fix, and Adreno-aware Android OpenCL/Vulkan backend selection (PR #18, QVAC-18993): on Android the loader detects the GPU via Vulkan and only keeps OpenCL for Adreno > 700, CPU-only for Adreno 1..700, Vulkan/CPU for non-Adreno. Adds Adreno OpenCL elementwise kernels (sin/cos/abs/elu/leaky_relu) for Chatterbox S3Gen and robust Adreno-generation detection (PR #17, #19). Library filenames are prefixed libqvac-speech-ggml-* so they coexist with libqvac-ggml-* (fabric/llm) and libqvac-diffusion-ggml-* on the same Android device. Mutually exclusive with the regular ggml port in the same triplet -- pick one per build.",
+  "homepage": "https://github.com/tetherto/qvac-ext-ggml/tree/speech",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU backend"
+    },
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "metal-fuse-mv-bias": {
+      "description": "Compile in the Q-variant mul_mv + ADD(bias) [+ ADD(residual)] fusion in ggml-metal. Off by default: empirically produces zero tokens on parakeet's EOU q8_0 joint network. Opt in only after Metal A/B-validating your model against the fused path."
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    }
+  }
+}

--- a/packages/tts-ggml/ports/tts-cpp/portfile.cmake
+++ b/packages/tts-ggml/ports/tts-cpp/portfile.cmake
@@ -1,34 +1,23 @@
-# tts-cpp — LOCAL OVERLAY PORT (Android dlopen-fix validation).
+# tts-cpp — LOCAL OVERLAY PORT (Android GPU validation; DO NOT MERGE).
 #
-# This package-local overlay replaces the registry `tts-cpp` port so the
-# tts-ggml prebuild builds an upstream fix that is NOT yet published to
-# qvac-registry-vcpkg. It pins qvac-ext-lib-whisper.cpp@f7d4d6c — exactly
-# one commit on top of the published 2026-06-05 pin (128dae42) — which
-# reroutes Supertonic's direct CPU-backend calls that are unlinkable under
-# `GGML_BACKEND_DL=ON`:
-#   - `ggml_get_type_traits_cpu(...)->from_float` -> `ggml_quantize_chunk()`
-#     (ggml-base, always linked)
-#   - `ggml_backend_is_cpu()` -> `tts_cpp::detail::backend_is_cpu()` registry
-#     shim (the pattern Chatterbox / parakeet already use)
+# Replaces the registry tts-cpp port so the tts-ggml prebuild builds the
+# Android-GPU fixes not yet published to qvac-registry-vcpkg. Pins
+# tetherto/qvac-ext-lib-whisper.cpp @ aa2c9056 (4 commits on master ed749556):
+#   1. dlopen reroute: Supertonic's direct CPU-backend calls are unlinkable
+#      under GGML_BACKEND_DL=ON; route ggml_get_type_traits_cpu(...)->from_float
+#      to ggml_quantize_chunk() and ggml_backend_is_cpu() to the registry shim
+#      tts_cpp::detail::backend_is_cpu() (else the addon SIGABRTs at dlopen on
+#      Android, killing all Android e2e).
+#   2. keep Supertonic K/V attention F32 on OpenCL (no F32xF16 mat-vec kernel).
+#   3. explicit GPU attention when the backend can't run flash-attn (Adreno /
+#      Xclipse OpenCL route FLASH_ATTN_EXT to CPU) so the per-step CFM attention
+#      stays GPU-resident instead of going stale on a CPU bridge.
+#   4. allowlist Samsung Xclipse (Vulkan) as a 2nd Android GPU vendor + report a
+#      gpu_unsupported() policy-decline fallback (Mali stays CPU).
 #
-# Why this exists: tts-cpp@2026-06-05 (QVAC-19254 sched + cpu_backend
-# refactor) left `ggml_backend_is_cpu` / `ggml_get_type_traits_cpu` as
-# undefined symbols in `libqvac__tts-ggml.*.so`, so the addon fails to
-# `dlopen` on Android (per-arch CPU backends are dlopen'd lazily, not
-# linked) -> SIGABRT at bootstrap -> all Android e2e dead.
-#
-# How to verify the fix: build the Android prebuild from this overlay, then
-#   llvm-readelf --dyn-syms prebuilds/android-arm64/qvac__tts-ggml.bare \
-#     | grep -E 'UND.*(ggml_backend_is_cpu|ggml_get_type_traits_cpu)'
-# The CPU symbols should no longer appear as UND.
-#
-# TEMPORARY: remove this overlay (and the `overlay-ports` entry in
-# vcpkg-configuration.json) once the fix is published to the registry and
-# consumed via vcpkg.json. Tracked as a QVAC-19254 follow-up.
-#
-# Base pin 128dae42 brought PR #31 (supertonic_optimizations): QVAC-18605
-# Supertonic Vulkan/Metal optimisations, QVAC-19254 sched + cpu_backend
-# refactor, QVAC-19213 Adreno-generation parse fix.
+# TEMPORARY: remove this overlay (and the overlay-ports entry in
+# vcpkg-configuration.json) once the fixes are published to the registry and
+# consumed via vcpkg.json.
 
 set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
 set(VCPKG_BUILD_TYPE release)
@@ -36,8 +25,8 @@ set(VCPKG_BUILD_TYPE release)
 vcpkg_from_github(
     OUT_SOURCE_PATH WHISPER_CPP_SRC
     REPO tetherto/qvac-ext-lib-whisper.cpp
-    REF f7d4d6c18615dc0c094776db78421bbb07e90371
-    SHA512 eb4d5679db948a496282f3a73ad11da0b19efbfc63c0b27a08cb536a88c3313ad03f91aa2f875463fd9990b2cf0e2b66a063a3a84bb2ff930718926c497b435d
+    REF aa2c9056c425aec7bacab70d79ea3d66b531ba1f
+    SHA512 2fc32d81e4ce9e759fd18544d8eb1f6e900628cd8806a7a679420a80bcb980dc5b70514afacf8f3302b0d4aa67ba336e76f8e117a06ccea971a4ff4df0de8686
     HEAD_REF master
 )
 

--- a/packages/tts-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/tts-ggml/test/integration/gpu-smoke.test.js
@@ -53,6 +53,29 @@ function backendIdToName (id) {
   }
 }
 
+// Minimum RMS amplitude real synthesized speech clears by a wide margin
+// (~0.037 on the smoke sentence; samples are int16, normalised by 32768).
+// Catches a graph miscompute that emits the right sample count but silent /
+// all-zero / NaN-collapsed audio, which the sample-count-only check missed.
+const MIN_AUDIO_RMS = 0.01
+
+function audioRms (samples) {
+  if (!samples || samples.length === 0) return 0
+  let sum = 0
+  for (let i = 0; i < samples.length; i++) {
+    const v = samples[i] / 32768
+    sum += v * v
+  }
+  return Math.sqrt(sum / samples.length)
+}
+
+function assertAudibleRms (t, engineTag, samples) {
+  const r = audioRms(samples)
+  console.log(`[${engineTag}] audio rms=${r.toFixed(6)} (floor ${MIN_AUDIO_RMS})`)
+  t.ok(r > MIN_AUDIO_RMS,
+    `${engineTag}: audio rms ${r.toFixed(6)} must exceed ${MIN_AUDIO_RMS} (silent/garbage output regression)`)
+}
+
 // Which platforms wire up a GPU backend in tts-cpp's vcpkg port
 // today (default-features in qvac-registry-vcpkg/ports/tts-cpp/vcpkg.json):
 //   - darwin / ios:        metal
@@ -76,7 +99,16 @@ function assertGpuBackend (t, engineTag, stats) {
   const dev = stats.backendDevice
   const id = stats.backendId
   const name = backendIdToName(id)
-  console.log(`[${engineTag}/GPU] backendDevice=${dev} backendId=${id} (${name})`)
+  console.log(`[${engineTag}/GPU] backendDevice=${dev} backendId=${id} (${name}) gpuUnsupported=${stats.gpuUnsupported}`)
+
+  // On Android the GPU is engaged only on validated vendors (Adreno → OpenCL,
+  // Samsung Xclipse → Vulkan). Other Android GPUs (e.g. ARM Mali) are routed to
+  // CPU by the tts-cpp allowlist — a correct fallback, not a regression — and
+  // the engine flags it via stats.gpuUnsupported. Accept that CPU result.
+  if (platform === 'android' && dev === 0 && stats.gpuUnsupported) {
+    t.pass(`${engineTag}/android: GPU present but unsupported vendor (e.g. Mali); correctly using CPU`)
+    return
+  }
 
   if (!expectsGpu()) {
     t.is(dev, 0, `${engineTag}/${platform}: backendDevice must be 0 (CPU) on platforms with no GPU wired in`)
@@ -123,10 +155,6 @@ function assertCpuBackend (t, engineTag, stats) {
 }
 
 test('Chatterbox GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  if (platform === 'android') {
-    t.pass('Android: GPU disabled at engine boundary pending Vulkan/Mali + OpenCL/Adreno upstream fixes')
-    return
-  }
   const baseDir = getBaseDir()
   const modelsDir = path.join(baseDir, 'models')
 
@@ -159,21 +187,16 @@ test('Chatterbox GPU smoke - useGPU=true must engage the GPU backend on GPU-capa
     t.ok(result.passed, 'Chatterbox/GPU produced expected sample count')
     t.ok(result.data.sampleCount > 0, 'Chatterbox/GPU produced audio')
     assertGpuBackend(t, 'Chatterbox', result.data.stats)
+    assertAudibleRms(t, 'Chatterbox/GPU', result.data.samples)
   } finally {
     try { await model.unload() } catch (_e) {}
   }
 })
 
 test('Supertonic GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  // QVAC-19255 re-land: Supertonic GPU (Metal on Apple, Vulkan/CUDA on desktop)
-  // is consumed via tts-cpp@2026-06-05 (f7d4d6c overlay). Android (Adreno) is
-  // intentionally kept CPU-only at the engine boundary
-  // (SupertonicModel::loadLocked) because Adreno Vulkan/OpenCL ggml graph
-  // compute still aborts, so skip the GPU assertion there (mirrors Chatterbox).
-  if (platform === 'android') {
-    t.pass('Android: Supertonic GPU disabled at engine boundary pending Adreno Vulkan/OpenCL ggml fixes')
-    return
-  }
+  // Android GPU is enabled for both engines (the loadLocked __ANDROID__ guards
+  // are removed). Adreno auto-selects OpenCL(4); Mali/Xclipse auto-select
+  // Vulkan(3) — assertGpuBackend accepts either.
   const baseDir = getBaseDir()
   const modelsDir = path.join(baseDir, 'models')
 
@@ -202,6 +225,7 @@ test('Supertonic GPU smoke - useGPU=true must engage the GPU backend on GPU-capa
     t.ok(result.passed, 'Supertonic/GPU produced expected sample count')
     t.ok(result.data.sampleCount > 0, 'Supertonic/GPU produced audio')
     assertGpuBackend(t, 'Supertonic', result.data.stats)
+    assertAudibleRms(t, 'Supertonic/GPU', result.data.samples)
   } finally {
     try { await model.unload() } catch (_e) {}
   }
@@ -248,6 +272,7 @@ test('Chatterbox CPU smoke - useGPU=false must run on the CPU backend', { timeou
     t.ok(result.passed, 'Chatterbox/CPU produced expected sample count')
     t.ok(result.data.sampleCount > 0, 'Chatterbox/CPU produced audio')
     assertCpuBackend(t, 'Chatterbox', result.data.stats)
+    assertAudibleRms(t, 'Chatterbox/CPU', result.data.samples)
   } finally {
     try { await model.unload() } catch (_e) {}
   }
@@ -282,6 +307,7 @@ test('Supertonic CPU smoke - useGPU=false must run on the CPU backend', { timeou
     t.ok(result.passed, 'Supertonic/CPU produced expected sample count')
     t.ok(result.data.sampleCount > 0, 'Supertonic/CPU produced audio')
     assertCpuBackend(t, 'Supertonic', result.data.stats)
+    assertAudibleRms(t, 'Supertonic/CPU', result.data.samples)
   } finally {
     try { await model.unload() } catch (_e) {}
   }

--- a/packages/tts-ggml/test/utils/runTTS.js
+++ b/packages/tts-ggml/test/utils/runTTS.js
@@ -228,7 +228,8 @@ async function runTTS (model, params, expectation = {}, options = {}) {
           audioDurationMs: stats.audioDurationMs,
           totalSamples: stats.totalSamples,
           backendDevice: stats.backendDevice,
-          backendId: stats.backendId
+          backendId: stats.backendId,
+          gpuUnsupported: stats.gpuUnsupported
         }
       : null
 


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — device-farm validation only

Validates enabling **Android GPU** for `tts-ggml` (Supertonic + Chatterbox) on real hardware before the production merge. Uses temporary in-package vcpkg overlays to pin upstream fixes not yet in `qvac-registry-vcpkg`. The real merge consumes the fixes from the registry and deletes `packages/tts-ggml/ports/`.

## What this enables

`#2506` forced `useGPU=false` on Android for both TTS engines (the `loadLocked` `#ifdef __ANDROID__` guards) because Supertonic miscomputed on the Adreno GPU. This PR removes those guards. Validated Android GPU vendors:

- **Qualcomm Adreno** → OpenCL (700+) / Vulkan
- **Samsung Xclipse** → Vulkan (2nd vendor, added this PR)
- **Other (e.g. ARM Mali)** → intentionally CPU (their drivers abort the host from inside graph compute); the engine flags this via the new `gpuUnsupported` stat so it's treated as a correct fallback, not a regression.

## Root cause & fix (tts-cpp)

`ggml-opencl` force-routes `FLASH_ATTN_EXT` to CPU on Adreno/Xclipse (the fused FA kernel miscomputes). Under the scheduler that bridges Supertonic's CFM text-attention across CPU↔GPU; the GPU-side copy goes **stale when the per-step CFM graph is reused across the 4 denoise steps**, corrupting every step after the first (silent output on the addon). **Fix:** when `ggml_backend_supports_op` reports the backend won't run flash-attn, compute attention with explicit GPU ops (`mul_mat QKᵀ → soft_max → mul_mat·V`) — mathematically identical, GPU-resident, no bridge. `supports_op`-gated, not a backend-name check.

## On-device verification

| Device / GPU | Backend | Supertonic | Chatterbox |
|---|---|---|---|
| Adreno 740 | OpenCL (auto) | ✓ rms 0.0374 (== CPU) | ✓ |
| Adreno 740 | Vulkan | ✓ | ✓ |
| Xclipse 920 (SM-S711B) | Vulkan (auto) | ✓ rms 0.0376 | ✓ rms 0.0455 |
| CPU | — | ✓ | ✓ |

OpenCL trace-diff matches CPU to `maxdiff=0.00000` across all CFM steps. Xclipse OpenCL is *not* used (ggml-opencl drops the device; Vulkan is the Xclipse path).

## Overlays pinned (temporary)

- `ports/tts-cpp` → `tetherto/qvac-ext-lib-whisper.cpp@aa2c9056` (dlopen reroute + F32-only OpenCL K/V + explicit attention + Xclipse allowlist + `gpu_unsupported()`) — branch `QVAC-20557-supertonic-opencl-attn`
- `ports/ggml-speech` → published `tetherto/qvac-ext-ggml@speech 44fd4817`

## Tests

`gpu-smoke.test.js`: un-skip Android on both GPU tests; assert the device-correct backend (Adreno OpenCL / Xclipse·Mali Vulkan); add an **audio RMS floor** (catches silent/garbage — the failure the old sample-count-only assertion missed); accept the CPU fallback on a non-validated Android GPU via `gpuUnsupported`.

## How to run device-farm CI

Apply the **`verified`** label. Expected: **S25 Ultra / Adreno → OpenCL** (GPU, correct audio), **Pixel 9 / Mali → CPU** (`gpuUnsupported`, correct audio — accepted). Check Device Farm console logs for no `# SKIP`, real synthesis, correct `backendId`, and RMS floor passing.

## Follow-ups (not in this PR)

- Companion tts-cpp source PR to `qvac-ext-lib-whisper.cpp` (branch `QVAC-20557-supertonic-opencl-attn`), coordinated with PR #43 (defect-A overlap — do not rebase onto it).
- Publish to `qvac-registry-vcpkg`, then a clean merge PR that drops `ports/`.
