### PR TITLE
Update decoder version to 0.5.0 in parakeet and whisper

### DIFF
--- a/packages/transcription-parakeet/package.json
+++ b/packages/transcription-parakeet/package.json
@@ -74,7 +74,7 @@
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://github.com/tetherto/qvac/tree/main/packages/transcription-parakeet#readme",
   "devDependencies": {
-    "@qvac/decoder-audio": "^0.3.3",
+    "@qvac/decoder-audio": "^0.5.0",
     "@qvac/registry-client": "^0.4.0",
     "bare-process": "^4.2.2",
     "bare-subprocess": "^6.0.0",

--- a/packages/transcription-whispercpp/package.json
+++ b/packages/transcription-whispercpp/package.json
@@ -67,7 +67,7 @@
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://github.com/tetherto/qvac/tree/main/packages/transcription-whispercpp#readme",
   "devDependencies": {
-    "@qvac/decoder-audio": "^0.3.3",
+    "@qvac/decoder-audio": "^0.5.0",
     "@qvac/dl-base": "^0.1.0",
     "@qvac/dl-filesystem": "^0.1.0",
     "@types/node": "^22",


### PR DESCRIPTION
## What problem does this PR solve?
Whisper and parakeet use out-of-date decoder-audio version

## How does it solve it?
Update decoder version to 0.5.0 in parakeet and whisper

## Breaking changes
None
