### PR TITLE
chore[notask]: bump SDK decoder-audio to ^0.5.0

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -155,7 +155,7 @@
     "build": "rm -rf dist && bun run bundle && bun run check:no-addon-deps && bun run check:no-addon-leaks && bun run check:deps-vs-sdk"
   },
   "dependencies": {
-    "@qvac/decoder-audio": "^0.4.0",
+    "@qvac/decoder-audio": "^0.5.0",
     "@qvac/error": "^0.1.1",
     "@qvac/langdetect-text": "^0.1.2",
     "@qvac/logging": "^0.1.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -208,7 +208,7 @@
   "dependencies": {
     "@qvac/bci-whispercpp": "^0.2.0",
     "@qvac/classification-ggml": "^0.3.1",
-    "@qvac/decoder-audio": "^0.4.0",
+    "@qvac/decoder-audio": "^0.5.0",
     "@qvac/diffusion-cpp": "^0.11.2",
     "@qvac/embed-llamacpp": "^0.19.1",
     "@qvac/error": "^0.1.1",


### PR DESCRIPTION
## Summary
- Bumps `@qvac/decoder-audio` from `^0.4.0` to `^0.5.0` in `@qvac/sdk` after the decoder-audio 0.5.0 release in #2588.
- Mirrors the same dependency range in `@qvac/bare-sdk` to keep the bare-sdk dependency manifest in lockstep with SDK.

## Test plan
- `node packages/bare-sdk/scripts/check-deps-vs-sdk.mjs`
- `node packages/bare-sdk/scripts/check-no-addon-deps.mjs`


Made with [Cursor](https://cursor.com)