### PR TITLE
QVAC-20772 chore: release sdk + bare-sdk 0.13.3 — bump decoder-audio to ^0.5.0

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -155,7 +155,7 @@
     "build": "rm -rf dist && bun run bundle && bun run check:no-addon-deps && bun run check:no-addon-leaks && bun run check:deps-vs-sdk"
   },
   "dependencies": {
-    "@qvac/decoder-audio": "^0.4.0",
+    "@qvac/decoder-audio": "^0.5.0",
     "@qvac/error": "^0.1.1",
     "@qvac/langdetect-text": "^0.1.2",
     "@qvac/logging": "^0.1.0",

--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.13.3]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.3
+
+A maintenance patch release that updates the bundled `@qvac/decoder-audio`
+dependency to `^0.5.0`.
+
+## Dependency Changes
+
+The bundled `@qvac/decoder-audio` audio decoder is updated to `^0.5.0`. The same
+update is mirrored into the Bare build (`@qvac/bare-sdk`), which ships in lockstep
+with `@qvac/sdk`.
+
 ## [0.13.2]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.2

--- a/packages/sdk/changelog/0.13.3/CHANGELOG.md
+++ b/packages/sdk/changelog/0.13.3/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.13.3
+
+Release Date: 2026-06-15
+
+## 🧹 Chores
+
+- Bump SDK decoder-audio to ^0.5.0. (see PR [#2608](https://github.com/tetherto/qvac/pull/2608))
+

--- a/packages/sdk/changelog/0.13.3/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.13.3/CHANGELOG_LLM.md
@@ -1,0 +1,12 @@
+# QVAC SDK v0.13.3 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.3
+
+A maintenance patch release that updates the bundled `@qvac/decoder-audio`
+dependency to `^0.5.0`.
+
+## Dependency Changes
+
+The bundled `@qvac/decoder-audio` audio decoder is updated to `^0.5.0`. The same
+update is mirrored into the Bare build (`@qvac/bare-sdk`), which ships in lockstep
+with `@qvac/sdk`.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -208,7 +208,7 @@
   "dependencies": {
     "@qvac/bci-whispercpp": "^0.2.0",
     "@qvac/classification-ggml": "^0.3.1",
-    "@qvac/decoder-audio": "^0.4.0",
+    "@qvac/decoder-audio": "^0.5.0",
     "@qvac/diffusion-cpp": "^0.11.2",
     "@qvac/embed-llamacpp": "^0.19.1",
     "@qvac/error": "^0.1.1",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Ships `@qvac/sdk` and `@qvac/bare-sdk` `0.13.3` on the release line, picking up the `@qvac/decoder-audio` `^0.5.0` upgrade.

## 📝 How does it solve it?

- Cherry-picks the decoder-audio `^0.4.0 → ^0.5.0` bump (#2608) onto `release-sdk-0.13.3`.
- Bumps `@qvac/sdk` and `@qvac/bare-sdk` to `0.13.3`, kept in lockstep (`check:deps-vs-sdk` passes).
- Adds the `0.13.3` changelog (`packages/sdk/changelog/0.13.3/`) and rebuilds the aggregate.

## 🧪 How was it tested?

- `bun run check:deps-vs-sdk` passes (bare-sdk ↔ sdk dependency parity).
- Changelog generated with `qv-sdk-changelog` and validated.
