### PR TITLE
QVAC-20772 chore[skiplog]: backmerge release-sdk-0.13.3 — version bump + changelog

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.13.3]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.3
+
+A maintenance patch release that updates the bundled `@qvac/decoder-audio`
+dependency to `^0.5.0`.
+
+## Dependency Changes
+
+The bundled `@qvac/decoder-audio` audio decoder is updated to `^0.5.0`. The same
+update is mirrored into the Bare build (`@qvac/bare-sdk`), which ships in lockstep
+with `@qvac/sdk`.
+
 ## [0.13.2]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.2

--- a/packages/sdk/changelog/0.13.3/CHANGELOG.md
+++ b/packages/sdk/changelog/0.13.3/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.13.3
+
+Release Date: 2026-06-15
+
+## 🧹 Chores
+
+- Bump SDK decoder-audio to ^0.5.0. (see PR [#2608](https://github.com/tetherto/qvac/pull/2608))
+

--- a/packages/sdk/changelog/0.13.3/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.13.3/CHANGELOG_LLM.md
@@ -1,0 +1,12 @@
+# QVAC SDK v0.13.3 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.3
+
+A maintenance patch release that updates the bundled `@qvac/decoder-audio`
+dependency to `^0.5.0`.
+
+## Dependency Changes
+
+The bundled `@qvac/decoder-audio` audio decoder is updated to `^0.5.0`. The same
+update is mirrored into the Bare build (`@qvac/bare-sdk`), which ships in lockstep
+with `@qvac/sdk`.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `@qvac/sdk` + `@qvac/bare-sdk` `0.13.3` on `main`, per [gitflow](../blob/main/docs/gitflow.md) "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs. (The decoder-audio `^0.5.0` bump itself already landed on `main` via #2608.)

## Companion release PR

- https://github.com/tetherto/qvac/pull/2612

## Files

- `packages/sdk/package.json` — version `0.13.2` → `0.13.3`
- `packages/bare-sdk/package.json` — version `0.13.2` → `0.13.3`
- `packages/sdk/changelog/0.13.3/` — generated changelog files
- `packages/sdk/CHANGELOG.md` — aggregated changelog

---
🤖 Generated with Cursor (qv-sdk-backmerge skill).
