### PR TITLE
QVAC-20831 infra: add packaged SDK Bare runtime smoke

### DIFF
--- a/.github/workflows/pr-checks-sdk-pod.yml
+++ b/.github/workflows/pr-checks-sdk-pod.yml
@@ -184,65 +184,12 @@ jobs:
             fi
           }
 
-          # Validates the SDK tarball installs cleanly for end consumers:
-          #   1. zero peer-dependency warnings on install
-          #   2. shared P2P packages resolve to a single copy
-          #   3. import('@qvac/sdk') resolves from a vanilla install
-          # Runs in a subshell so its directory changes do not leak.
+          # Validates the SDK tarball installs cleanly for end consumers.
+          # See packages/sdk/scripts/consumer-install-check.mjs for the
+          # vanilla install, dependency-tree, import, and runtime smoke checks.
           consumer_install_check() (
             set -eo pipefail
-            cd "$WS/packages/sdk"
-
-            # Pack the tarball produced by the preceding build step.
-            bun pm pack --destination dist/
-            tarball=$(ls dist/qvac-sdk-*.tgz | head -n1)
-            test -n "$tarball" || { echo "::error::No SDK tarball found after pack"; exit 1; }
-            tarball_abs="$(pwd)/$tarball"
-
-            check_consumer() {
-              local consumer="$1" label="$2"
-              cd "$consumer"
-
-              if grep -Eq "ERESOLVE|npm warn peer" install.log; then
-                echo "::error title=Peer dependency drift (${label})::SDK consumer install surfaced peer warnings"
-                grep -E "ERESOLVE|npm warn peer" install.log || true
-                return 1
-              fi
-              echo "::notice::[${label}] 0 peer warnings"
-
-              local f=0 tree copies
-              for pkg in corestore hyperswarm hyperdrive hyperdb hyperblobs hyperdht; do
-                tree=$(npm ls "$pkg" --all 2>&1)
-                copies=$(printf '%s\n' "$tree" | grep -E "[─ ]${pkg}@" | grep -vc "deduped" || true)
-                if [ "$copies" != "1" ]; then
-                  echo "::error::[${label}] ${pkg} resolved to ${copies} copies (expected 1)"
-                  printf '%s\n' "$tree"
-                  f=1
-                else
-                  echo "  ok  [${label}] ${pkg} = 1 copy"
-                fi
-              done
-              [ "$f" = "0" ] || return 1
-              echo "::notice::[${label}] Single-copy invariant holds for shared P2P packages"
-
-              node -e "import('@qvac/sdk').then(m => { if (Object.keys(m).length < 50) { console.error('FAIL: too few exports'); process.exit(1); } console.log('[${label}] import ok:', Object.keys(m).length, 'exports'); }).catch(e => { console.error('[${label}] FAIL:', e.message); process.exit(1); })"
-            }
-
-            # Scenario 1: default install (plug-n-play) - all optionalDependencies present.
-            consumer_default=$(mktemp -d)
-            cd "$consumer_default"
-            npm init -y > /dev/null
-            npm pkg set type=module > /dev/null
-            npm install --no-fund --no-audit --ignore-scripts --loglevel=info "$tarball_abs" 2>&1 | tee install.log
-            check_consumer "$consumer_default" "default"
-
-            # Scenario 2: lean backend install (--omit=optional) - no optionalDependencies.
-            consumer_lean=$(mktemp -d)
-            cd "$consumer_lean"
-            npm init -y > /dev/null
-            npm pkg set type=module > /dev/null
-            npm install --no-fund --no-audit --ignore-scripts --omit=optional --loglevel=info "$tarball_abs" 2>&1 | tee install.log
-            check_consumer "$consumer_lean" "lean (--omit=optional)"
+            node "$WS/packages/sdk/scripts/consumer-install-check.mjs"
           )
 
           # Install the Bare runtime once if any changed package needs it.

--- a/packages/sdk/scripts/consumer-install-check.mjs
+++ b/packages/sdk/scripts/consumer-install-check.mjs
@@ -1,0 +1,183 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const sdkRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const bufferSize = 50 * 1024 * 1024;
+const p2pPackages = [
+  "corestore",
+  "hyperswarm",
+  "hyperdrive",
+  "hyperdb",
+  "hyperblobs",
+  "hyperdht",
+];
+const installArgs = [
+  "install",
+  "--no-fund",
+  "--no-audit",
+  "--ignore-scripts",
+  "--loglevel=info",
+];
+
+function run(command, args, cwd = sdkRoot, quiet = false) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: bufferSize,
+    stdio: "pipe",
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+  if (!quiet) process.stdout.write(output);
+  if (result.error) {
+    if (result.error.code === "ENOENT") {
+      throw new Error(
+        `${command} was not found on PATH. Install it before running this check.`,
+      );
+    }
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed in ${cwd}\n${output}`);
+  }
+
+  return output;
+}
+
+function packSdk() {
+  run("bun", ["pm", "pack", "--destination", "dist/"]);
+  const tarball = readdirSync(path.join(sdkRoot, "dist"))
+    .filter((name) => /^qvac-sdk-.*\.tgz$/.test(name))
+    .map((name) => path.join(sdkRoot, "dist", name))
+    .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)[0];
+
+  if (!tarball) throw new Error("No SDK tarball found after pack");
+  return tarball;
+}
+
+function makeConsumer(label, tarball, extraInstallArgs = []) {
+  const dir = mkdtempSync(path.join(tmpdir(), `qvac-sdk-${label}-`));
+  run("npm", ["init", "-y"], dir, true);
+  run("npm", ["pkg", "set", "type=module"], dir, true);
+  const installLog = run("npm", installArgs.concat(extraInstallArgs, tarball), dir);
+  writeFileSync(path.join(dir, "install.log"), installLog);
+
+  if (/ERESOLVE|npm warn peer/.test(installLog)) {
+    throw new Error(`[${label}] SDK consumer install surfaced peer warnings`);
+  }
+  console.log(`::notice::[${label}] 0 peer warnings`);
+
+  return dir;
+}
+
+function checkDependencyTree(dir, label) {
+  for (const packageName of p2pPackages) {
+    const tree = run("npm", ["ls", packageName, "--all"], dir, true);
+    const copies = tree
+      .split("\n")
+      .filter((line) => line.includes(`${packageName}@`))
+      .filter((line) => !line.includes("deduped")).length;
+
+    if (copies !== 1) {
+      throw new Error(
+        `[${label}] ${packageName} resolved to ${copies} copies (expected 1)\n${tree}`,
+      );
+    }
+    console.log(`  ok  [${label}] ${packageName} = 1 copy`);
+  }
+  console.log(
+    `::notice::[${label}] Single-copy invariant holds for shared P2P packages`,
+  );
+}
+
+function checkImport(dir, label) {
+  const source = [
+    "import('@qvac/sdk')",
+    "  .then((m) => {",
+    "    const count = Object.keys(m).length;",
+    "    if (count < 50) throw new Error(`too few exports: ${count}`);",
+    "    console.log('import ok:', count, 'exports');",
+    "  })",
+    "  .catch((error) => {",
+    "    console.error(error instanceof Error ? error.message : String(error));",
+    "    process.exit(1);",
+    "  });",
+  ].join("\n");
+
+  run(
+    "node",
+    ["-e", source],
+    dir,
+  );
+  console.log(`  ok  [${label}] import('@qvac/sdk')`);
+}
+
+function writeRuntimeSmoke(dir) {
+  const file = path.join(dir, "qvac-packaged-runtime-smoke.mjs");
+  writeFileSync(
+    file,
+    `import { close, loadModel } from "@qvac/sdk";
+
+try {
+  await loadModel({
+    modelSrc: "qvac-packaged-runtime-smoke-missing.gguf",
+    modelType: "llamacpp-completion",
+  });
+  throw new Error("Expected missing-model loadModel smoke to fail");
+} catch (error) {
+  const details = error instanceof Error
+    ? \`\${error.name}: \${error.message}\`
+    : String(error);
+
+  if (
+    details.includes("WORKER_PLUGINS_NOT_REGISTERED") ||
+    details.includes("No plugins registered")
+  ) {
+    throw error;
+  }
+
+  if (
+    !details.includes("MODEL_NOT_FOUND") &&
+    !details.includes("ModelNotFoundError") &&
+    !details.includes("Available models")
+  ) {
+    throw new Error(\`Expected missing-model failure after worker init, got \${details}\`);
+  }
+} finally {
+  await close();
+}
+`,
+  );
+  return file;
+}
+
+function checkRuntimeSmoke(dir, label) {
+  const smokeFile = writeRuntimeSmoke(dir);
+  run("node", [smokeFile], dir, true);
+  console.log(`  ok  [${label}] node packaged runtime smoke`);
+  run("bare", [smokeFile], dir, true);
+  console.log(`  ok  [${label}] bare packaged runtime smoke`);
+}
+
+function checkConsumer(dir, label) {
+  checkDependencyTree(dir, label);
+  checkImport(dir, label);
+}
+
+try {
+  const tarball = packSdk();
+
+  const defaultConsumer = makeConsumer("default", tarball);
+  checkConsumer(defaultConsumer, "default");
+  checkConsumer(
+    makeConsumer("lean", tarball, ["--omit=optional"]),
+    "lean (--omit=optional)",
+  );
+  checkRuntimeSmoke(defaultConsumer, "default");
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Packaged `@qvac/sdk` consumer checks only verified install/import, so a fresh Bare consumer could still fail on the first SDK call.
- This leaves the current `WORKER_PLUGINS_NOT_REGISTERED` regression uncovered by lightweight CI.

## 📝 How does it solve it?

- Moves the packaged consumer install checks out of the workflow bash block into `packages/sdk/scripts/consumer-install-check.mjs`.
- Keeps the existing default and `--omit=optional` install/import/dependency-tree checks.
- Adds a first-call runtime smoke for the packaged SDK under Node and Bare. The smoke uses a missing local model path, so success means the runtime initialized and reached the expected model-not-found path instead of failing during worker/plugin setup.

## 🧪 How was it tested?

- `bun run build`
- `node --check packages/sdk/scripts/consumer-install-check.mjs`
- `actionlint .github/workflows/pr-checks-sdk-pod.yml`
- `git diff --check`
- `node scripts/consumer-install-check.mjs` confirms existing install/import checks and Node runtime smoke pass.
- With a temporary Bare CLI on `PATH`, `node scripts/consumer-install-check.mjs` confirms the new Bare smoke exposes the current failure: `WORKER_PLUGINS_NOT_REGISTERED`.


Made with [Cursor](https://cursor.com)