### PR TITLE
chore[notask|skiplog]: release @qvac/logging v0.2.0

### DIFF
--- a/.github/sdk-pod-checks.json
+++ b/.github/sdk-pod-checks.json
@@ -19,7 +19,8 @@
   },
   {
     "package": "logging",
-    "path": "packages/logging"
+    "path": "packages/logging",
+    "needs_bare": true
   },
   {
     "package": "error",

--- a/packages/logging/CHANGELOG.md
+++ b/packages/logging/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## [0.2.0]
+
+Release Date: 2026-06-16
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/logging/v/0.2.0
+
+This release simplifies how `@qvac/logging` reads environment variables across Node.js and Bare runtimes. Log level detection from `QVAC_LOG_LEVEL` (and the Expo-prefixed variant) now routes through a dedicated `./env` module resolved via package import maps instead of inline runtime branching.
+
+### Bare Runtime Compatibility
+
+Environment access is delegated to `bare-env` on Bare via the package `"imports"` map, while Node.js continues to use a small `env.js` shim over `process.env`. This removes the previous try/catch chain over `process`, `bare-process`, and empty fallbacks from the main logger implementation.
+
+```json
+// packages/logging/package.json (excerpt)
+"imports": {
+  "./env": {
+    "bare": "bare-env",
+    "default": "./env.js"
+  }
+}
+```
+
+The public `QvacLogger` API is unchanged — wrap any logger, set levels on the wrapper, and read `QVAC_LOG_LEVEL` from the environment as before. Consumers do not need to change how they construct or pass loggers into the SDK.

--- a/packages/logging/NOTICE
+++ b/packages/logging/NOTICE
@@ -1,4 +1,19 @@
 @qvac/logging
 Copyright 2026 Tether Data, S.A. de C.V.
 
-This product includes software developed by Tether Data, S.A. de C.V.
+This product includes third-party components under their
+respective licenses. @qvac/logging itself is licensed under
+Apache-2.0; bundled dependencies are governed by the licenses
+listed below.
+
+=========================================================================
+JavaScript Dependencies
+=========================================================================
+
+--- apache-2.0 (Apache License 2.0) ---
+
+  bare-env@3.0.0
+    https://github.com/holepunchto/bare-env
+  bare-os@3.9.1
+    https://github.com/holepunchto/bare-os
+

--- a/packages/logging/changelog/0.2.0/CHANGELOG.md
+++ b/packages/logging/changelog/0.2.0/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.2.0
+
+Release Date: 2026-06-16
+
+## ✨ Features
+
+- Use bare-env and package import maps for environment access. (see PR [#2166](https://github.com/tetherto/qvac/pull/2166))

--- a/packages/logging/changelog/0.2.0/CHANGELOG_LLM.md
+++ b/packages/logging/changelog/0.2.0/CHANGELOG_LLM.md
@@ -1,0 +1,23 @@
+# QVAC Logging v0.2.0 Release Notes
+
+Release Date: 2026-06-16
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/logging/v/0.2.0
+
+This release simplifies how `@qvac/logging` reads environment variables across Node.js and Bare runtimes. Log level detection from `QVAC_LOG_LEVEL` (and the Expo-prefixed variant) now routes through a dedicated `./env` module resolved via package import maps instead of inline runtime branching.
+
+## Bare Runtime Compatibility
+
+Environment access is delegated to `bare-env` on Bare via the package `"imports"` map, while Node.js continues to use a small `env.js` shim over `process.env`. This removes the previous try/catch chain over `process`, `bare-process`, and empty fallbacks from the main logger implementation.
+
+```json
+// packages/logging/package.json (excerpt)
+"imports": {
+  "./env": {
+    "bare": "bare-env",
+    "default": "./env.js"
+  }
+}
+```
+
+The public `QvacLogger` API is unchanged — wrap any logger, set levels on the wrapper, and read `QVAC_LOG_LEVEL` from the environment as before. Consumers do not need to change how they construct or pass loggers into the SDK.

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/logging",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Release @qvac/logging 0.2.0

Merging this into `release-logging-0.2.0` triggers `publish-release-npm` → npm publish + `logging-v0.2.0` tag/GitHub release.

### Changes

- Version `0.1.0` → `0.2.0`.
- Changelog at `packages/logging/changelog/0.2.0/` and root `packages/logging/CHANGELOG.md` (no `[Unreleased]` stub).
- Primary change since 0.1.0: PR #2166 — route environment access through `bare-env` via package import maps (Bare) with a Node.js `env.js` shim, replacing inline `process` / `bare-process` fallback logic.
- NOTICE regenerated — lists `bare-env@3.0.0` and transitive `bare-os@3.9.1` (Apache-2.0).
- CI: set `needs_bare: true` for logging in `.github/sdk-pod-checks.json` (unit tests run via `bare`).

### Changelog notes

The SDK pod changelog generator found three PRs touching `packages/logging` since the 0.1.0 base (`8e0977ef`), but all three (#1088, #1924, #2166) predate the SDK PR title validator and were skipped automatically. The release changelog was authored manually for the user-facing item (#2166 bare-env / import maps).

### Verification (local, on this branch)

- `npm install` — clean
- `npm test` — 12/12 pass (43 asserts)

A follow-up backmerge PR lands the same metadata on `main`: #2630