### PR TITLE
chore[skiplog|notask]: backmerge release-logging-0.2.0 — version bump, changelog

### DIFF
--- a/packages/logging/CHANGELOG.md
+++ b/packages/logging/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## [Unreleased]
+
+---
+
+## [0.2.0]
+
+Release Date: 2026-06-16
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/logging/v/0.2.0
+
+This release simplifies how `@qvac/logging` reads environment variables across Node.js and Bare runtimes. Log level detection from `QVAC_LOG_LEVEL` (and the Expo-prefixed variant) now routes through a dedicated `./env` module resolved via package import maps instead of inline runtime branching.
+
+### Bare Runtime Compatibility
+
+Environment access is delegated to `bare-env` on Bare via the package `"imports"` map, while Node.js continues to use a small `env.js` shim over `process.env`. This removes the previous try/catch chain over `process`, `bare-process`, and empty fallbacks from the main logger implementation.
+
+```json
+// packages/logging/package.json (excerpt)
+"imports": {
+  "./env": {
+    "bare": "bare-env",
+    "default": "./env.js"
+  }
+}
+```
+
+The public `QvacLogger` API is unchanged — wrap any logger, set levels on the wrapper, and read `QVAC_LOG_LEVEL` from the environment as before. Consumers do not need to change how they construct or pass loggers into the SDK.

--- a/packages/logging/changelog/0.2.0/CHANGELOG.md
+++ b/packages/logging/changelog/0.2.0/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.2.0
+
+Release Date: 2026-06-16
+
+## ✨ Features
+
+- Use bare-env and package import maps for environment access. (see PR [#2166](https://github.com/tetherto/qvac/pull/2166))

--- a/packages/logging/changelog/0.2.0/CHANGELOG_LLM.md
+++ b/packages/logging/changelog/0.2.0/CHANGELOG_LLM.md
@@ -1,0 +1,23 @@
+# QVAC Logging v0.2.0 Release Notes
+
+Release Date: 2026-06-16
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/logging/v/0.2.0
+
+This release simplifies how `@qvac/logging` reads environment variables across Node.js and Bare runtimes. Log level detection from `QVAC_LOG_LEVEL` (and the Expo-prefixed variant) now routes through a dedicated `./env` module resolved via package import maps instead of inline runtime branching.
+
+## Bare Runtime Compatibility
+
+Environment access is delegated to `bare-env` on Bare via the package `"imports"` map, while Node.js continues to use a small `env.js` shim over `process.env`. This removes the previous try/catch chain over `process`, `bare-process`, and empty fallbacks from the main logger implementation.
+
+```json
+// packages/logging/package.json (excerpt)
+"imports": {
+  "./env": {
+    "bare": "bare-env",
+    "default": "./env.js"
+  }
+}
+```
+
+The public `QvacLogger` API is unchanged — wrap any logger, set levels on the wrapper, and read `QVAC_LOG_LEVEL` from the environment as before. Consumers do not need to change how they construct or pass loggers into the SDK.

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/logging",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
## What this PR does

Lands the release metadata for `logging@0.2.0` on `main`, per [gitflow.md](../docs/gitflow.md) "Keep main aligned". No functional changes — tagged `[skiplog]` so it does not appear in future changelogs.

## Companion release PR

- https://github.com/tetherto/qvac/pull/2628

## Files

- `packages/logging/package.json` — version `0.1.0` → `0.2.0`
- `packages/logging/changelog/0.2.0/` — generated changelog files
- `packages/logging/CHANGELOG.md` — aggregated changelog