### PR TITLE
infra[notask]: install bare runtime for logging SDK pod checks

### DIFF
--- a/.github/sdk-pod-checks.json
+++ b/.github/sdk-pod-checks.json
@@ -19,7 +19,8 @@
   },
   {
     "package": "logging",
-    "path": "packages/logging"
+    "path": "packages/logging",
+    "needs_bare": true
   },
   {
     "package": "error",


### PR DESCRIPTION
## What problem does this PR solve?

SDK Pod Checks fail for any PR touching `packages/logging` because unit tests run via `bare test/unit/all.js`, but logging was missing `"needs_bare": true` in `.github/sdk-pod-checks.json`. CI never installs the Bare runtime, so the job exits with `sh: bare: not found`.

`@qvac/error` already has this flag; logging uses the same test runner pattern.

## How does it solve it?

Add `"needs_bare": true` for the logging entry in `.github/sdk-pod-checks.json`. The SDK pod checks workflow installs Bare globally when any changed package requires it.

No runtime or package changes — CI wiring only.

## How was it tested?

Local verification on current `@qvac/logging@0.1.0`:

```bash
cd packages/logging
npm install
npm run lint          # pass
npm run test:unit     # 12/12 pass
```