### PR TITLE
QVAC-19305 tts-ggml: consume ggml-speech Metal teardown fix

### DIFF
--- a/packages/tts-ggml/ports/tts-cpp/vcpkg.json
+++ b/packages/tts-ggml/ports/tts-cpp/vcpkg.json
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "ggml-speech",
-      "version>=": "2026-06-04"
+      "version>=": "2026-06-15"
     },
     {
       "name": "vcpkg-cmake",


### PR DESCRIPTION
## Summary

- Bumps the `tts-ggml` vcpkg registry baseline to `tetherto/qvac-registry-vcpkg` commit `ea080a07475ad845787f18a9244fdec444421b5b`.
- This consumes `ggml-speech@2026-06-15`, which points to `qvac-ext-ggml@speech` commit `7bb9f229`.
- That `ggml-speech` version includes the merged Metal residency-set teardown fix from `qvac-ext-ggml` PR #24.

## Why

`tts-ggml` integration tests on macOS Metal were passing all assertions but aborting at process exit with:

```text
GGML_ASSERT([rsets->data count] == 0) failed