### PR TITLE
QVAC-19908 chore: release ai-sdk-provider 0.2.2

### DIFF
--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ---
 
+## [0.2.2]
+
+Release Date: 2026-06-16
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.2.2
+
+### Fixed
+
+- Allow managed-mode installs with either the `@qvac/cli` `0.6.x` or `0.7.x` line as the optional CLI peer, so strict package managers can resolve the provider while CLI 0.7 brings in the newer SDK runtime.
+
+---
+
 ## [0.2.1]
 
 Release Date: 2026-06-15

--- a/packages/ai-sdk-provider/changelog/0.2.2/CHANGELOG.md
+++ b/packages/ai-sdk-provider/changelog/0.2.2/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog v0.2.2
+
+## Fixed
+
+- Allow managed-mode installs with either the published `@qvac/cli` `0.6.x` line or the `0.7.x` line, so strict package managers can resolve the provider while CLI 0.7 brings in `@qvac/sdk` 0.13.x.

--- a/packages/ai-sdk-provider/changelog/0.2.2/CHANGELOG_LLM.md
+++ b/packages/ai-sdk-provider/changelog/0.2.2/CHANGELOG_LLM.md
@@ -1,0 +1,11 @@
+# QVAC AI SDK Provider v0.2.2 Release Notes
+
+Release Date: 2026-06-16
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.2.2
+
+## Managed Mode Supports CLI 0.7
+
+`@qvac/ai-sdk-provider` now accepts both the `@qvac/cli` `0.6.x` and `0.7.x` lines as its optional managed-mode CLI peer. This lets strict package managers install the provider alongside CLI 0.7, which resolves to the newer `@qvac/sdk` 0.13.x runtime.
+
+No provider API changes are included in this patch release.

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ai-sdk-provider",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Vercel AI SDK provider for the QVAC local AI runtime (chat, embeddings, transcription, translation, speech, OCR, image)",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/openai-compatible": "^2.0",
-    "@qvac/cli": "^0.6.0",
+    "@qvac/cli": "^0.6.0 || ^0.7.0",
     "ai": "^6.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/ai-sdk-provider@0.2.1` only accepts `@qvac/cli@^0.6.0` as its optional managed-mode CLI peer.
- Strict package managers reject installs that pair the provider with `@qvac/cli@0.7.x`, blocking the OpenCode release path from adopting CLI 0.7.

## 📝 How does it solve it?

- Bumps `@qvac/ai-sdk-provider` to `0.2.2` on the `release-ai-sdk-provider-0.2.2` branch.
- Widens the optional `@qvac/cli` peer dependency to `^0.6.0 || ^0.7.0`.
- Adds the 0.2.2 package changelog folder and prepends the aggregated `CHANGELOG.md` entry.
- Merging this PR into the release branch should publish the package to GPR; the follow-up backmerge PR from the release branch to `main` will publish to npm.

## 🧪 How was it tested?

- `npm run lint` in `packages/ai-sdk-provider`.
- `npm run build` in `packages/ai-sdk-provider`.
- `npm run test` in `packages/ai-sdk-provider` (75 pass, 1 skipped).
- Verified strict npm peer resolution in temp projects with the local provider package, `@qvac/cli@0.6.0`, `@qvac/cli@0.7.0`, `ai@^6.0`, and `@ai-sdk/openai-compatible@^2.0`.
- `git diff --check`.