### PR TITLE
QVAC-20932 doc[skiplog]: uniform logging across examples

### DIFF
--- a/.cursor/rules/sdk/example.mdc
+++ b/.cursor/rules/sdk/example.mdc
@@ -5,10 +5,24 @@ alwaysApply: false
 ---
 - All example files should have consistent error handling using try-catch blocks with process.exit(0) on success and process.exit(1) on error
 - Use top-level await with try-catch instead of async function wrappers
-- Error messages should use: `console.error("❌ Error:", error)`
 - Examples can use plain `Error` objects (they're user-facing demos, not SDK code)
 - All example files which load models should have an unloadModel call to unload the model when done
+- Logging convention (uniform across all examples):
+  - Normal messages (status, steps, metrics, progress) use `console.log` prefixed with `▸ ` (e.g. `console.log("▸ Loading model")`)
+  - Caught errors use `console.error` prefixed with `✖ ` (e.g. `console.error("✖", error)`). Reserve `console.error` for errors only — some runtimes render it in red, which looks alarming for ordinary output
+  - Genuine results stay unprefixed so they read apart from the `▸` commentary: stream tokens via `process.stdout.write(token)`, final results via plain `console.log`
+  - Do not use other decorative emojis; only `▸` (info) and `✖` (error)
+  - No shared logging helper — each example stays standalone and copy-pasteable
+- Download progress renders as one in-place line on stderr, not a raw progress-object dump:
+  ```ts
+  onProgress: (p) => {
+    const mb = (n: number) => (n / 1e6).toFixed(1);
+    const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+    process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+    if (p.percentage >= 100) process.stderr.write("\n");
+  },
+  ```
 - Exception for continuously running services (providers, seeders, microphone recording):
   - Use `process.stdin.resume()` to keep running
-  - Include SIGINT handler for graceful shutdown: `process.on("SIGINT", () => { console.log("\n🛑 Service stopped"); process.exit(0); })`
+  - Include SIGINT handler for graceful shutdown: `process.on("SIGINT", () => { console.log("\n▸ Service stopped"); process.exit(0); })`
   

--- a/packages/sdk/examples/bci/bci-filesystem-streaming.ts
+++ b/packages/sdk/examples/bci/bci-filesystem-streaming.ts
@@ -31,11 +31,11 @@ const neuralFilePath = args[0];
 const CHUNK_SIZE = 64 * 1024;
 
 try {
-  console.log("=== BCI transcribeStream file test ===");
-  console.log(`File: ${neuralFilePath}`);
-  console.log(`Chunk size: ${CHUNK_SIZE} bytes\n`);
+  console.log("▸ BCI transcribeStream file test");
+  console.log(`▸ File: ${neuralFilePath}`);
+  console.log(`▸ Chunk size: ${CHUNK_SIZE} bytes`);
 
-  console.log("Loading model...");
+  console.log("▸ Loading model...");
   const modelId = await loadModel({
     modelSrc: BCI_WINDOWED,
     modelConfig: {
@@ -51,11 +51,10 @@ try {
       },
     },
   });
-  console.log(`Model loaded: ${modelId}\n`);
-
-  console.log("Opening live session...");
+  console.log(`▸ Model loaded: ${modelId}`);
+  console.log("▸ Opening live session...");
   const session = await bciTranscribeStream({ modelId, emit: "delta" });
-  console.log("Session open. Streaming neural signal...\n");
+  console.log("▸ Session open. Streaming neural signal...");
 
   // Drain the session concurrently with writing so the sliding-window
   // decode can make progress as chunks arrive instead of stalling.
@@ -78,20 +77,20 @@ try {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
 
-  console.log(`\n\nNeural signal streamed: ${totalBytes} bytes`);
-  console.log("Waiting for transcription to finish...\n");
+  console.log(`\n\n▸ Neural signal streamed: ${totalBytes} bytes`);
+  console.log("▸ Waiting for transcription to finish...");
   session.end();
 
   const transcript = await consume;
 
-  console.log("\n=== Results ===");
-  console.log(`Transcript: ${transcript.trim() || "(no text received)"}`);
+  console.log("\n▸ Results");
+  console.log(transcript.trim() || "(no text received)");
 
-  console.log("\nUnloading model...");
+  console.log("▸ Unloading model...");
   await unloadModel({ modelId });
-  console.log("Done.");
+  console.log("▸ Done.");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/bci/bci-filesystem.ts
+++ b/packages/sdk/examples/bci/bci-filesystem.ts
@@ -19,9 +19,9 @@ if (!args[0]) {
 const neuralFilePath = args[0];
 
 try {
-  console.log("🧠 Starting BCI transcription example...");
+  console.log("▸ Starting BCI transcription example...");
 
-  console.log("📥 Loading BCI model...");
+  console.log("▸ Loading BCI model...");
   const modelId = await loadModel({
     modelSrc: BCI_WINDOWED,
     modelConfig: {
@@ -36,21 +36,24 @@ try {
         day_idx: 1,
       },
     },
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`✅ BCI model loaded with ID: ${modelId}`);
+  console.log(`▸ BCI model loaded with ID: ${modelId}`);
 
-  console.log("🧠 Transcribing neural signal...");
+  console.log("▸ Transcribing neural signal...");
   const segments = await bciTranscribe({
     modelId,
     neuralData: neuralFilePath,
     metadata: true,
   });
 
-  console.log("📝 Transcription result:");
+  console.log("▸ Transcription result:");
   for (const segment of segments) {
     const start = (segment.startMs / 1000).toFixed(2);
     const end = (segment.endMs / 1000).toFixed(2);
@@ -59,17 +62,17 @@ try {
     );
   }
   console.log(
-    `\nFull transcript: ${segments
+    segments
       .map((s) => s.text)
       .join("")
-      .trim()}`,
+      .trim(),
   );
 
-  console.log("🧹 Unloading BCI model...");
+  console.log("▸ Unloading BCI model...");
   await unloadModel({ modelId });
-  console.log("✅ BCI model unloaded successfully");
+  console.log("▸ BCI model unloaded successfully");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/cache-management.ts
+++ b/packages/sdk/examples/cache-management.ts
@@ -3,80 +3,80 @@ import type { ModelInfo } from "@/schemas";
 import { downloadAsset, getModelInfo, loadModel, unloadModel } from "..";
 
 const printModelStatus = (info: ModelInfo, label: string) => {
-  console.log(`\n${label}`);
-  console.log(`   Model Name: ${info.name}`);
-  console.log(`   Model ID: ${info.modelId}`);
+  console.log(`\n▸ ${label}`);
+  console.log(`▸ Model Name: ${info.name}`);
+  console.log(`▸ Model ID: ${info.modelId}`);
   console.log(
-    `   Blob Core Key: ${info.blobCoreKey?.substring(0, 16) || "N/A"}...`,
+    `▸ Blob Core Key: ${info.blobCoreKey?.substring(0, 16) || "N/A"}...`,
   );
   console.log(
-    `   Expected Size: ${(info.expectedSize / 1024 / 1024).toFixed(2)} MB`,
+    `▸ Expected Size: ${(info.expectedSize / 1024 / 1024).toFixed(2)} MB`,
   );
-  console.log(`   Addon: ${info.addon}`);
-  console.log(`   Cache Files: ${info.cacheFiles.length}`);
-  console.log(`   Is Cached: ${info.isCached ? "✅" : "❌"}`);
-  console.log(`   Is Loaded: ${info.isLoaded ? "✅" : "❌"}`);
+  console.log(`▸ Addon: ${info.addon}`);
+  console.log(`▸ Cache Files: ${info.cacheFiles.length}`);
+  console.log(`▸ Is Cached: ${info.isCached ? "yes" : "no"}`);
+  console.log(`▸ Is Loaded: ${info.isLoaded ? "yes" : "no"}`);
 
   if (info.isCached) {
     if (info.cacheFiles.length === 1) {
-      console.log(`   Cache Path: ${info.cacheFiles[0]?.path}`);
+      console.log(`▸ Cache Path: ${info.cacheFiles[0]?.path}`);
     } else {
       const cachedFiles = info.cacheFiles.filter((f) => f.isCached).length;
-      console.log(`     Cached: ${cachedFiles}/${info.cacheFiles.length}`);
+      console.log(`▸ Cached: ${cachedFiles}/${info.cacheFiles.length}`);
     }
     console.log(
-      `   Actual Size: ${(info.actualSize! / 1024 / 1024).toFixed(2)} MB`,
+      `▸ Actual Size: ${(info.actualSize! / 1024 / 1024).toFixed(2)} MB`,
     );
-    console.log(`   Cached At: ${info.cachedAt?.toLocaleString()}`);
+    console.log(`▸ Cached At: ${info.cachedAt?.toLocaleString()}`);
   }
 
   if (info.loadedInstances && info.loadedInstances.length > 0) {
-    console.log(`   Loaded Instances: ${info.loadedInstances.length}`);
+    console.log(`▸ Loaded Instances: ${info.loadedInstances.length}`);
     info.loadedInstances.forEach((instance, i) => {
-      console.log(`     ${i + 1}. Registry ID: ${instance.registryId}`);
-      console.log(`        Loaded At: ${instance.loadedAt.toLocaleString()}`);
+      console.log(`▸ ${i + 1}. Registry ID: ${instance.registryId}`);
+      console.log(`▸    Loaded At: ${instance.loadedAt.toLocaleString()}`);
     });
   }
 };
 
 try {
-  console.log("=== Model Cache Management Demo ===");
+  console.log("▸ Model Cache Management Demo");
 
   // 1. Check initial status
-  console.log("\n1️⃣  INITIAL STATUS CHECK");
+  console.log("\n▸ 1. INITIAL STATUS CHECK");
   const initialInfo = await getModelInfo(WHISPER_TINY);
   printModelStatus(initialInfo, "Initial Status:");
 
   // 2. Download if not cached
   if (!initialInfo.isCached) {
-    console.log("\n2️⃣  DOWNLOADING MODEL (not cached)");
-    console.log("   Downloading from hyperdrive...");
+    console.log("\n▸ 2. DOWNLOADING MODEL (not cached)");
+    console.log("▸ Downloading from hyperdrive...");
     await downloadAsset({ assetSrc: WHISPER_TINY });
-    console.log("   ✅ Download complete!");
+    console.log("▸ Download complete!");
 
     const afterDownload = await getModelInfo(WHISPER_TINY);
     printModelStatus(afterDownload, "Status After Download:");
   } else {
-    console.log("\n2️⃣  MODEL ALREADY CACHED");
-    console.log("   Skipping download...");
+    console.log("\n▸ 2. MODEL ALREADY CACHED");
+    console.log("▸ Skipping download...");
   }
 
   // 3. Load if not loaded
-  console.log("\n3️⃣  LOADING MODEL INTO MEMORY");
+  console.log("\n▸ 3. LOADING MODEL INTO MEMORY");
   const beforeLoad = await getModelInfo(WHISPER_TINY);
 
   let modelId: string;
   if (!beforeLoad.isLoaded) {
-    console.log("   Loading model into memory...");
+    console.log("▸ Loading model into memory...");
     modelId = await loadModel({
       modelSrc: WHISPER_TINY,
     });
-    console.log(`   ✅ Model loaded! ID: ${modelId}`);
+    console.log(`▸ Model loaded! ID: ${modelId}`);
 
     const afterLoad = await getModelInfo(WHISPER_TINY);
     printModelStatus(afterLoad, "Status After Load:");
   } else {
-    console.log("   Model already loaded!");
+    console.log("▸ Model already loaded!");
     const instances = beforeLoad.loadedInstances;
     if (!instances || instances.length === 0) {
       throw new Error("Model is loaded but no instances found");
@@ -86,28 +86,28 @@ try {
       throw new Error("First instance is undefined");
     }
     modelId = firstInstance.registryId;
-    console.log(`   Using existing model ID: ${modelId}`);
+    console.log(`▸ Using existing model ID: ${modelId}`);
   }
 
   // 4. Demonstrate unload
-  console.log("\n4️⃣  UNLOADING MODEL");
-  console.log("   Unloading model from memory...");
+  console.log("\n▸ 4. UNLOADING MODEL");
+  console.log("▸ Unloading model from memory...");
   await unloadModel({ modelId });
-  console.log("   ✅ Model unloaded!");
+  console.log("▸ Model unloaded!");
 
   const afterUnload = await getModelInfo(WHISPER_TINY);
   printModelStatus(afterUnload, "Status After Unload:");
 
   // 5. Summary
-  console.log("\n5️⃣  SUMMARY");
-  console.log("   ✅ Model Info API works correctly");
-  console.log("   ✅ Cache status tracked accurately");
-  console.log("   ✅ Loaded status reflects memory state");
-  console.log("   ✅ All operations completed successfully");
+  console.log("\n▸ 5. SUMMARY");
+  console.log("▸ Model Info API works correctly");
+  console.log("▸ Cache status tracked accurately");
+  console.log("▸ Loaded status reflects memory state");
+  console.log("▸ All operations completed successfully");
 
-  console.log("\n=== Demo Complete ===\n");
+  console.log("\n▸ Demo Complete\n");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/cancel-by-request-id.ts
+++ b/packages/sdk/examples/cancel-by-request-id.ts
@@ -62,12 +62,12 @@ try {
     stream: true,
   });
 
-  console.log(`requestId: ${run.requestId}`);
+  console.log(`▸ requestId: ${run.requestId}`);
 
   // Cancel after a short delay so we exercise the cancel-mid-decode path.
   setTimeout(() => {
     void cancel({ requestId: run.requestId });
-    console.log("(cancel issued)");
+    console.log("▸ cancel issued");
   }, 250);
 
   // Channel 1: the events stream ends normally on cancel. The
@@ -84,7 +84,7 @@ try {
     }
   }
   console.log(
-    `\n\nstreamed ${tokenCount} content deltas, stopReason=${endReason}.`,
+    `\n\n▸ streamed ${tokenCount} content deltas, stopReason=${endReason}`,
   );
 
   // Channel 2: promise-aggregates reject with InferenceCancelledError
@@ -92,18 +92,18 @@ try {
   // on `err.partial`.
   try {
     const text = await run.text;
-    console.log(`completed normally (${text.length} chars).`);
+    console.log(`▸ completed normally (${text.length} chars)`);
   } catch (err) {
     if (err instanceof InferenceCancelledError) {
-      console.log(`run.text rejected: cancelled (requestId=${err.requestId})`);
-      console.log(`partial text length: ${(err.partial.text ?? "").length}`);
+      console.log(`▸ run.text rejected: cancelled (requestId=${err.requestId})`);
+      console.log(`▸ partial text length: ${(err.partial.text ?? "").length}`);
       if (err.partial.stats?.tokensPerSecond !== undefined) {
         console.log(
-          `partial stats: ${err.partial.stats.tokensPerSecond.toFixed(1)} tok/s`,
+          `▸ partial stats: ${err.partial.stats.tokensPerSecond.toFixed(1)} tok/s`,
         );
       }
       if (err.partial.toolCalls && err.partial.toolCalls.length > 0) {
-        console.log(`partial tool calls: ${err.partial.toolCalls.length}`);
+        console.log(`▸ partial tool calls: ${err.partial.toolCalls.length}`);
       }
     } else {
       throw err;
@@ -113,6 +113,6 @@ try {
   await unloadModel({ modelId });
   process.exit(0);
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/completion-events.ts
+++ b/packages/sdk/examples/completion-events.ts
@@ -27,9 +27,14 @@ try {
   const modelId = await loadModel({
     modelSrc: QWEN3_600M_INST_Q4,
     modelConfig: { ctx_size: 4096 },
-    onProgress: (p) => console.log(`Loading: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`✅ Model loaded: ${modelId}\n`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const result = completion({
     modelId,
@@ -46,25 +51,25 @@ try {
 
   const final = await result.final;
 
-  console.log("\n\n--- Final Result ---");
-  console.log(`Content: ${final.contentText}\n`);
+  console.log("\n▸ Final result");
+  console.log(`▸ Content: ${final.contentText}`);
   if (final.thinkingText) {
-    console.log(`Thinking: ${final.thinkingText}\n`);
+    console.log(`▸ Thinking: ${final.thinkingText}`);
   }
   if (final.stats) {
-    console.log(`Stats: ${final.stats.tokensPerSecond?.toFixed(1)} tok/s`);
+    console.log(`▸ ${final.stats.tokensPerSecond?.toFixed(1)} tok/s`);
   }
   if (final.toolCalls.length > 0) {
-    console.log(`Tool calls: ${final.toolCalls.map((c) => c.name).join(", ")}`);
+    console.log(`▸ Tool calls: ${final.toolCalls.map((c) => c.name).join(", ")}`);
   }
   if (final.stopReason) {
-    console.log(`Stop reason: ${final.stopReason}`);
+    console.log(`▸ Stop reason: ${final.stopReason}`);
   }
-  console.log(`Raw output length: ${final.raw.fullText.length} chars`);
+  console.log(`▸ Raw output length: ${final.raw.fullText.length} chars`);
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }
 
@@ -78,20 +83,20 @@ function handleEvent(event: CompletionEvent) {
       break;
     case "toolCall":
       console.log(
-        `\n→ Tool: ${event.call.name}(${JSON.stringify(event.call.arguments)})`,
+        `\n▸ Tool: ${event.call.name}(${JSON.stringify(event.call.arguments)})`,
       );
       break;
     case "toolError":
-      console.warn(
-        `\n⚠ Tool error [${event.error.code}]: ${event.error.message}`,
+      console.log(
+        `\n✖ Tool error [${event.error.code}]: ${event.error.message}`,
       );
       break;
     case "completionStats":
-      console.log(`\n📊 ${event.stats.tokensPerSecond?.toFixed(1)} tok/s`);
+      console.log(`\n▸ ${event.stats.tokensPerSecond?.toFixed(1)} tok/s`);
       break;
     case "completionDone":
       if (event.stopReason === "error" && "error" in event) {
-        console.error(`\n❌ ${event.error.message}`);
+        console.log(`\n✖ ${event.error.message}`);
       }
       break;
     case "rawDelta":

--- a/packages/sdk/examples/completion-stop-reason.ts
+++ b/packages/sdk/examples/completion-stop-reason.ts
@@ -33,12 +33,17 @@ try {
   const modelId = await loadModel({
     modelSrc: QWEN3_600M_INST_Q4,
     modelConfig: { ctx_size: 4096 },
-    onProgress: (p) => console.log(`Loading: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`✅ Model loaded: ${modelId}\n`);
+  console.log(`▸ Model loaded: ${modelId}\n`);
 
   // --- Case 1: natural EOS ---
-  console.log("=== Case 1: natural EOS (no predict limit) ===");
+  console.log("▸ Case 1: natural EOS (no predict limit)");
   const run1 = completion({
     modelId,
     history: [{ role: "user", content: "Say hi in one word." }],
@@ -48,10 +53,10 @@ try {
     if (event.type === "contentDelta") process.stdout.write(event.text);
   }
   const final1 = await run1.final;
-  console.log(`\nstopReason: ${final1.stopReason ?? "(undefined — natural EOS)"}`);
+  console.log(`\n▸ stopReason: ${final1.stopReason ?? "(undefined — natural EOS)"}`);
 
   // --- Case 2: predict budget exhausted → stopReason = "length" ---
-  console.log("\n=== Case 2: predict budget hit (predict: 10) ===");
+  console.log("\n▸ Case 2: predict budget hit (predict: 10)");
   const run2 = completion({
     modelId,
     history: [{ role: "user", content: "Count from 1 to 100, one number per line." }],
@@ -62,11 +67,11 @@ try {
     if (event.type === "contentDelta") process.stdout.write(event.text);
   }
   const final2 = await run2.final;
-  console.log(`\nstopReason: ${final2.stopReason}`);
+  console.log(`\n▸ stopReason: ${final2.stopReason}`);
 
   await unloadModel({ modelId, clearStorage: false });
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/concurrent-completion-collision.ts
+++ b/packages/sdk/examples/concurrent-completion-collision.ts
@@ -65,15 +65,15 @@ async function runCompletion(
 }
 
 function report(title: string, outcomes: Outcome[]): void {
-  console.log(`\n${title}`);
+  console.log(`\n▸ ${title}`);
   for (const o of outcomes) {
     if (o.ok) {
       const preview = o.text.replace(/\s+/g, " ").slice(0, 70);
-      console.log(`  ✅ ${o.label}: ${preview}${o.text.length > 70 ? "…" : ""}`);
+      console.log(`  ▸ ${o.label}: ${preview}${o.text.length > 70 ? "…" : ""}`);
     } else {
       const policy = o.code === 52420 ? " (rejected by policy)" : "";
       console.log(
-        `  ❌ ${o.label}: ${o.errorName}${o.code !== undefined ? ` [${o.code}]` : ""}${policy} — ${o.message}`,
+        `  ✖ ${o.label}: ${o.errorName}${o.code !== undefined ? ` [${o.code}]` : ""}${policy} — ${o.message}`,
       );
     }
   }
@@ -98,11 +98,11 @@ try {
   const rejected = sameModel.filter((o) => !o.ok).length;
   if (rejected === 0) {
     console.log(
-      "  → Both succeeded: the second was queued behind the first and ran when the slot freed (no 52420, no addon collision).",
+      "  ▸ Both succeeded: the second was queued behind the first and ran when the slot freed (no 52420, no addon collision).",
     );
   } else {
     console.log(
-      `  ⚠️  ${rejected}/2 failed — the FIFO admission queue should have serialized these. Check the completion policy.`,
+      `  ▸ ${rejected}/2 failed — the FIFO admission queue should have serialized these. Check the completion policy.`,
     );
   }
 
@@ -124,9 +124,9 @@ try {
   await unloadModel({ modelId: modelB, clearStorage: false });
 
   console.log(
-    `\nrejected-by-policy error available for instanceof checks: ${typeof RequestRejectedByPolicyError === "function"}`,
+    `\n▸ rejected-by-policy error available for instanceof checks: ${typeof RequestRejectedByPolicyError === "function"}`,
   );
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/config-reload.ts
+++ b/packages/sdk/examples/config-reload.ts
@@ -4,7 +4,7 @@ import { WHISPER_TINY, loadModel, transcribe, unloadModel } from "../index";
 const args = process.argv.slice(2);
 
 if (!args[0]) {
-  console.error("Usage: bun run examples/config-reload.ts <audio-file-path>");
+  console.error("✖ Usage: bun run examples/config-reload.ts <audio-file-path>");
   process.exit(1);
 }
 
@@ -12,7 +12,7 @@ const audioFilePath = args[0];
 
 try {
   // Initial load with English language
-  console.log("Loading Whisper model with English config...");
+  console.log("▸ Loading Whisper model with English config...");
   const modelId = await loadModel({
     modelSrc: WHISPER_TINY,
     modelConfig: {
@@ -21,16 +21,15 @@ try {
   });
 
   // Transcribe with English config
-  console.log("Transcribing audio with English config...");
+  console.log("▸ Transcribing audio with English config...");
   const englishText = await transcribe({
     modelId,
     audioChunk: audioFilePath,
   });
   console.log(`Transcription (EN): ${englishText}`);
-  console.log();
 
   // Hot reload config - change language and temperature
-  console.log("Hot reloading config (changing language and temperature)...");
+  console.log("▸ Hot reloading config (changing language and temperature)...");
   const reloadedId = await loadModel({
     modelId,
     modelType: "whispercpp-transcription",
@@ -38,10 +37,10 @@ try {
       language: "es", // Change to Spanish
     },
   });
-  console.log(`Config reloaded, same model ID: ${reloadedId === modelId}`);
+  console.log(`▸ Config reloaded, same model ID: ${reloadedId === modelId}`);
 
   // Transcribe again with updated config
-  console.log("Transcribing with updated config...");
+  console.log("▸ Transcribing with updated config...");
   const spanishText = await transcribe({
     modelId,
     audioChunk: audioFilePath,
@@ -50,6 +49,6 @@ try {
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/default-config-usage.ts
+++ b/packages/sdk/examples/default-config-usage.ts
@@ -20,19 +20,19 @@ const configDir = import.meta.dirname ?? process.cwd();
 process.env["QVAC_CONFIG_PATH"] =
   `${configDir}/config/default/default.config.js`;
 
-console.log(`🔍 Using config from: ${process.env["QVAC_CONFIG_PATH"]}`);
+console.log(`▸ Using config from: ${process.env["QVAC_CONFIG_PATH"]}`);
 
 const { loadModel, unloadModel, completion, LLAMA_3_2_1B_INST_Q4_0 } =
   await import("@qvac/sdk");
 
 try {
-  console.log("🚀 Loading model with configured settings...\n");
+  console.log("▸ Loading model with configured settings...");
 
   const modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
   });
 
-  console.log("\n💬 Running completion...\n");
+  console.log("▸ Running completion...");
 
   const result = completion({
     modelId,
@@ -49,6 +49,6 @@ try {
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/delegated-inference/composite.ts
+++ b/packages/sdk/examples/delegated-inference/composite.ts
@@ -37,7 +37,7 @@ function terminateProvider(provider: ChildProcess): void {
 // The provider's Hyperswarm identity (and therefore its public key) is
 // generated at startup — it can't be known ahead of time. We parse it from
 // the provider's stdout where it prints:
-//   "🆔 Provider Public Key: <hex>"
+//   "▸ Provider Public Key: <hex>"
 function waitForProviderPublicKey(provider: ChildProcess): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     let output = "";
@@ -73,42 +73,45 @@ function waitForProviderPublicKey(provider: ChildProcess): Promise<string> {
 async function runDelegatedCompletion(
   providerPublicKey: string,
 ): Promise<void> {
-  console.log("→ Loading model via delegation...");
+  console.log("▸ Loading model via delegation...");
   const modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
     delegate: {
       providerPublicKey,
       timeout: 30_000,
     },
-    onProgress: (progress) => {
-      console.log(`  Download: ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
-  console.log(`✅ Model loaded: ${modelId}\n`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
-  console.log("→ Running delegated completion (streamed)...");
+  console.log("▸ Running delegated completion (streamed)...");
   const response = completion({
     modelId,
     history: [{ role: "user", content: "Say hello in exactly 5 words." }],
     stream: true,
   });
 
-  process.stdout.write("  Response: ");
+  console.log("▸ Response:");
   for await (const token of response.tokenStream) {
     process.stdout.write(token);
   }
 
   const stats = await response.stats;
-  console.log(`\n📊 Stats: ${JSON.stringify(stats)}`);
+  console.log(`\n▸ Stats: ${JSON.stringify(stats)}`);
 }
 
 const provider = spawnProviderProcess();
 
 try {
-  console.log("🔧 Waiting for provider to start and announce its key...\n");
+  console.log("▸ Waiting for provider to start and announce its key...");
   const publicKey = await waitForProviderPublicKey(provider);
 
-  console.log(`\n📡 Provider ready — key: ${publicKey}\n`);
+  console.log(`\n▸ Provider ready — key: ${publicKey}\n`);
 
   await runDelegatedCompletion(publicKey);
   void close();

--- a/packages/sdk/examples/delegated-inference/consumer-profiled.ts
+++ b/packages/sdk/examples/delegated-inference/consumer-profiled.ts
@@ -8,17 +8,17 @@ import {
 
 const providerPublicKey = process.argv[2];
 if (!providerPublicKey) {
-  console.error("❌ Usage: bun run consumer-profiled.ts <providerPublicKey>");
+  console.error("✖ Usage: bun run consumer-profiled.ts <providerPublicKey>");
   process.exit(1);
 }
 
 try {
   profiler.enable({ mode: "verbose", includeServerBreakdown: true });
-  console.log("✓ Profiler enabled");
+  console.log("▸ Profiler enabled");
 
-  console.log(`\n🔑 Provider: ${providerPublicKey}\n`);
+  console.log(`\n▸ Provider: ${providerPublicKey}\n`);
 
-  console.log("→ Loading model (delegated, unary)...");
+  console.log("▸ Loading model (delegated, unary)...");
   const modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
     delegate: {
@@ -26,26 +26,26 @@ try {
       timeout: 60_000,
     },
   });
-  console.log(`✓ Model loaded: ${modelId}\n`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
-  console.log("→ Running completion (delegated, streamed)...");
+  console.log("▸ Running completion (delegated, streamed)...");
   const response = completion({
     modelId,
     history: [{ role: "user", content: "Say hello in exactly 5 words." }],
     stream: true,
   });
 
-  process.stdout.write("  Response: ");
+  console.log("▸ Response:");
   for await (const token of response.tokenStream) {
     process.stdout.write(token);
   }
   await response.stats;
-  console.log("\n✓ Completion done\n");
+  console.log("\n▸ Completion done\n");
 
-  console.log("=== Profiler Summary ===");
+  console.log("▸ Profiler Summary");
   console.log(profiler.exportSummary());
 
-  console.log("=== Profiler Table ===");
+  console.log("▸ Profiler Table");
   console.log(profiler.exportTable());
 
   // Look for delegation-specific metrics
@@ -55,7 +55,7 @@ try {
   );
 
   if (delegationMetrics.length > 0) {
-    console.log("=== Delegation Metrics ===");
+    console.log("▸ Delegation Metrics");
     for (const key of delegationMetrics) {
       const agg = json.aggregates[key];
       if (agg) {
@@ -63,14 +63,14 @@ try {
       }
     }
   } else {
-    console.log("⚠️  No delegation-specific metrics found");
+    console.log("▸ No delegation-specific metrics found");
     console.log("    (delegation profiling may need to be triggered)");
   }
 
   profiler.disable();
   void close();
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   profiler.disable();
   process.exit(1);
 }

--- a/packages/sdk/examples/delegated-inference/consumer.ts
+++ b/packages/sdk/examples/delegated-inference/consumer.ts
@@ -8,7 +8,7 @@ import {
 const providerPublicKey = process.argv[2];
 if (!providerPublicKey) {
   console.error(
-    "❌ Provider public key is required. Usage: node consumer.ts <provider-public-key> [consumer-seed]",
+    "✖ Provider public key is required. Usage: node consumer.ts <provider-public-key> [consumer-seed]",
   );
   process.exit(1);
 }
@@ -19,14 +19,14 @@ try {
 
   process.env["QVAC_HYPERSWARM_SEED"] = consumerSeed;
 
-  console.log(`🚀 Testing delegated inference`);
-  console.log(`🔑 Provider: ${providerPublicKey}`);
+  console.log(`▸ Testing delegated inference`);
+  console.log(`▸ Provider: ${providerPublicKey}`);
   if (consumerSeed) {
     console.log(
-      `🔑 Consumer seed: ${consumerSeed.substring(0, 16)}... (deterministic identity)`,
+      `▸ Consumer seed: ${consumerSeed.substring(0, 16)}... (deterministic identity)`,
     );
   } else {
-    console.log(`🎲 No consumer seed provided (random identity)`);
+    console.log(`▸ No consumer seed provided (random identity)`);
   }
 
   const modelId = await loadModel({
@@ -41,14 +41,15 @@ try {
       fallbackToLocal: true, // Optional: Fall back to local inference if delegation fails
       // forceNewConnection: true, // Optional: Force a new connection instead of reusing cached one
     },
-    onProgress: (progress) => {
-      console.log(
-        `📊 Download progress: ${progress.percentage.toFixed(1)}% (${progress.downloaded}/${progress.total} bytes)`,
-      );
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`✅ Delegated model registered: ${modelId}`);
+  console.log(`▸ Delegated model registered: ${modelId}`);
 
   const response = completion({
     modelId,
@@ -57,17 +58,17 @@ try {
   });
 
   for await (const token of response.tokenStream) {
-    console.log(`📨 Response: ${token}`);
+    process.stdout.write(token);
   }
 
-  console.log("🔍 Stats:", await response.stats);
+  console.log("\n▸ Stats:", await response.stats);
 
   console.log(
-    "\n🎯 Delegation infrastructure working! Server correctly detected and routed the delegated request.",
+    "▸ Delegation infrastructure working! Server correctly detected and routed the delegated request.",
   );
 
   void close();
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/delegated-inference/provider.ts
+++ b/packages/sdk/examples/delegated-inference/provider.ts
@@ -10,12 +10,12 @@ if (seed) {
 // Optional: Consumer public key for firewall (allow only this consumer)
 const allowedConsumerPublicKey: string | undefined = process.argv[3];
 
-console.log(`🚀 Starting provider service...`);
+console.log(`▸ Starting provider service...`);
 
 try {
   if (allowedConsumerPublicKey) {
     console.log(
-      `🔒 Firewall enabled: only allowing consumer ${allowedConsumerPublicKey}`,
+      `▸ Firewall enabled: only allowing consumer ${allowedConsumerPublicKey}`,
     );
   }
 
@@ -28,16 +28,16 @@ try {
       : undefined,
   });
 
-  console.log("✅ Provider service started successfully!");
-  console.log("🔗 Provider is now available for delegated inference requests");
+  console.log("▸ Provider service started successfully!");
+  console.log("▸ Provider is now available for delegated inference requests");
   console.log("");
-  console.log("📋 Connection Details:");
-  console.log(`   🆔 Provider Public Key: ${response.publicKey}`);
+  console.log("▸ Connection Details:");
+  console.log(`▸ Provider Public Key: ${response.publicKey}`);
   console.log("");
-  console.log("💡 Consumer command:");
+  console.log("▸ Consumer command:");
   console.log(`   node consumer.ts ${response.publicKey}`);
   console.log("");
-  console.log("💡 To reproduce this provider identity:");
+  console.log("▸ To reproduce this provider identity:");
   console.log(`   node provider.ts ${seed || "<random-seed>"}`);
   if (!seed) {
     console.log(
@@ -45,7 +45,7 @@ try {
     );
   }
   console.log("");
-  console.log("🔒 For firewall testing:");
+  console.log("▸ For firewall testing:");
   console.log("   1. Generate a consumer seed (64-char hex)");
   console.log(
     "   2. Get consumer public key: getConsumerPublicKey(consumerSeed)",
@@ -57,14 +57,14 @@ try {
     `   4. Run consumer with: node consumer.ts ${response.publicKey} <consumer-seed>`,
   );
 
-  console.log("📡 Provider is running... Press Ctrl+C to stop");
+  console.log("▸ Provider is running... Press Ctrl+C to stop");
   process.on("SIGINT", () => {
-    console.log("\n🛑 Provider service stopped");
+    console.log("\n▸ Provider service stopped");
     process.exit(0);
   });
 
   process.stdin.resume();
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/diffusion-esrgan-upscale.ts
+++ b/packages/sdk/examples/diffusion-esrgan-upscale.ts
@@ -27,7 +27,7 @@ const outputDir = outputDirArg ?? ".";
 const seed = 42;
 
 try {
-  console.log("Loading SD 2.1 + ESRGAN upscaler...");
+  console.log("▸ Loading SD 2.1 + ESRGAN upscaler...");
   const modelId = await loadModel({
     modelSrc: SD_V2_1_1B_Q8_0,
     modelConfig: {
@@ -38,9 +38,14 @@ try {
         tile_size: 128,
       },
     },
-    onProgress: (p) => console.log(`Loading: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   // Source size is intentionally small — each ESRGAN repeat multiplies dimensions.
   const baseParams = {
@@ -54,40 +59,38 @@ try {
     seed,
   };
 
-  console.log(`\nGenerating ESRGAN x4 upscale: "${prompt}"`);
+  console.log(`▸ Generating ESRGAN x4 upscale: "${prompt}"`);
   const single = diffusion({ ...baseParams, upscale: true });
   for await (const { step, totalSteps } of single.progressStream) {
-    process.stdout.write(`\rStep ${step}/${totalSteps}\x1b[K`);
+    console.log(`▸ step ${step}/${totalSteps}`);
   }
-  console.log();
 
   const singleBuffers = await single.outputs;
   for (let i = 0; i < singleBuffers.length; i++) {
     const out = path.join(outputDir, `sd2_esrgan_x4_seed${seed}_${i}.png`);
     fs.writeFileSync(out, singleBuffers[i]!);
-    console.log(`Saved: ${out}`);
+    console.log(`▸ Saved ${out}`);
   }
-  console.log("Stats:", await single.stats);
+  console.log("▸ Stats:", await single.stats);
 
-  console.log("\nGenerating ESRGAN two-pass x16 upscale...");
+  console.log("▸ Generating ESRGAN two-pass x16 upscale...");
   const twoPass = diffusion({ ...baseParams, upscale: { repeats: 2 } });
   for await (const { step, totalSteps } of twoPass.progressStream) {
-    process.stdout.write(`\rStep ${step}/${totalSteps}\x1b[K`);
+    console.log(`▸ step ${step}/${totalSteps}`);
   }
-  console.log();
 
   const twoPassBuffers = await twoPass.outputs;
   for (let i = 0; i < twoPassBuffers.length; i++) {
     const out = path.join(outputDir, `sd2_esrgan_x16_seed${seed}_${i}.png`);
     fs.writeFileSync(out, twoPassBuffers[i]!);
-    console.log(`Saved: ${out}`);
+    console.log(`▸ Saved ${out}`);
   }
-  console.log("Stats:", await twoPass.stats);
+  console.log("▸ Stats:", await twoPass.stats);
 
   await unloadModel({ modelId, clearStorage: false });
-  console.log("Done.");
+  console.log("▸ Done");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/diffusion-flux2-klein-img2img.ts
+++ b/packages/sdk/examples/diffusion-flux2-klein-img2img.ts
@@ -19,7 +19,7 @@ const llmModelSrc = process.argv[6] || QWEN3_4B_Q4_K_M;
 const vaeModelSrc = process.argv[7] || FLUX_2_KLEIN_4B_VAE;
 
 if (!inputPath) {
-  console.error("❌ Error: input image path is required");
+  console.error("✖ input image path is required");
   console.error(
     "Usage: bun run bare:example dist/examples/diffusion-flux2-klein-img2img.js <inputImage> [prompt] [outputDir] [diffusionModelSrc] [llmModelSrc] [vaeModelSrc]",
   );
@@ -27,7 +27,7 @@ if (!inputPath) {
 }
 
 try {
-  console.log("Loading FLUX.2 [klein] split-layout model...");
+  console.log("▸ Loading FLUX.2 [klein] split-layout model...");
   const modelId = await loadModel({
     modelSrc: diffusionModelSrc,
     modelType: "sdcpp-generation",
@@ -38,12 +38,17 @@ try {
       vaeModelSrc,
       prediction: "flux2_flow",
     },
-    onProgress: (p) => console.log(`Loading: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const init_image = new Uint8Array(fs.readFileSync(inputPath));
-  console.log(`\nTransforming "${inputPath}" with prompt: "${prompt}"`);
+  console.log(`▸ Transforming "${inputPath}" with prompt: "${prompt}"`);
 
   const { progressStream, outputs, stats } = diffusion({
     modelId,
@@ -56,22 +61,21 @@ try {
   });
 
   for await (const { step, totalSteps } of progressStream) {
-    process.stdout.write(`\rStep ${step}/${totalSteps}`);
+    console.log(`▸ step ${step}/${totalSteps}`);
   }
-  console.log();
 
   const buffers = await outputs;
   for (let i = 0; i < buffers.length; i++) {
     const outputPath = path.join(outputDir, `flux2_img2img_${i}.png`);
     fs.writeFileSync(outputPath, buffers[i]!);
-    console.log(`Saved: ${outputPath}`);
+    console.log(`▸ Saved ${outputPath}`);
   }
 
-  console.log("\nStats:", await stats);
+  console.log("▸ Stats:", await stats);
   await unloadModel({ modelId, clearStorage: false });
-  console.log("Done.");
+  console.log("▸ Done");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/diffusion-flux2-klein.ts
+++ b/packages/sdk/examples/diffusion-flux2-klein.ts
@@ -16,7 +16,7 @@ const vaeModelSrc = process.argv[4] || FLUX_2_KLEIN_4B_VAE;
 const prompt = process.argv[5] || "a futuristic city at sunset, photorealistic";
 const outputDir = process.argv[6] || ".";
 
-console.log("Loading FLUX.2 [klein] split-layout model...");
+console.log("▸ Loading FLUX.2 [klein] split-layout model...");
 
 const modelId = await loadModel({
   modelSrc: diffusionModelSrc,
@@ -27,11 +27,16 @@ const modelId = await loadModel({
     llmModelSrc,
     vaeModelSrc,
   },
-  onProgress: (p) => console.log(`Loading: ${p.percentage.toFixed(1)}%`),
+  onProgress: (p) => {
+    const mb = (n: number) => (n / 1e6).toFixed(1);
+    const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+    process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+    if (p.percentage >= 100) process.stderr.write("\n");
+  },
 });
-console.log(`Model loaded: ${modelId}`);
+console.log(`▸ Model loaded: ${modelId}`);
 
-console.log(`\nGenerating: "${prompt}"`);
+console.log(`▸ Generating: "${prompt}"`);
 
 const { progressStream, outputs, stats } = diffusion({
   modelId,
@@ -45,18 +50,17 @@ const { progressStream, outputs, stats } = diffusion({
 });
 
 for await (const { step, totalSteps } of progressStream) {
-  process.stdout.write(`\rStep ${step}/${totalSteps}`);
+  console.log(`▸ step ${step}/${totalSteps}`);
 }
-console.log();
 
 const buffers = await outputs;
 for (let i = 0; i < buffers.length; i++) {
   const outputPath = path.join(outputDir, `flux2_${i}.png`);
   fs.writeFileSync(outputPath, buffers[i]!);
-  console.log(`Saved: ${outputPath}`);
+  console.log(`▸ Saved ${outputPath}`);
 }
 
-console.log("\nStats:", await stats);
+console.log("▸ Stats:", await stats);
 await unloadModel({ modelId, clearStorage: false });
-console.log("Done.");
+console.log("▸ Done");
 process.exit(0);

--- a/packages/sdk/examples/diffusion-img2img.ts
+++ b/packages/sdk/examples/diffusion-img2img.ts
@@ -10,7 +10,7 @@ const outputDir = process.argv[4] || ".";
 const modelSrc = process.argv[5] || SD_V2_1_1B_Q8_0;
 
 if (!inputPath) {
-  console.error("❌ Error: input image path is required");
+  console.error("✖ input image path is required");
   console.error(
     "Usage: bun run bare:example dist/examples/diffusion-img2img.js <inputImage> [prompt] [outputDir] [modelSrc]",
   );
@@ -18,15 +18,15 @@ if (!inputPath) {
 }
 
 try {
-  console.log("Loading diffusion model...");
+  console.log("▸ Loading diffusion model...");
   const modelId = await loadModel({
     modelSrc,
     modelType: "sdcpp-generation",
   });
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const init_image = new Uint8Array(fs.readFileSync(inputPath));
-  console.log(`\nTransforming "${inputPath}" with prompt: "${prompt}"`);
+  console.log(`▸ Transforming "${inputPath}" with prompt: "${prompt}"`);
 
   const { progressStream, outputs, stats } = diffusion({
     modelId,
@@ -38,22 +38,21 @@ try {
   });
 
   for await (const { step, totalSteps } of progressStream) {
-    process.stdout.write(`\rStep ${step}/${totalSteps}`);
+    console.log(`▸ step ${step}/${totalSteps}`);
   }
-  console.log();
 
   const buffers = await outputs;
   for (let i = 0; i < buffers.length; i++) {
     const outputPath = path.join(outputDir, `img2img_${i}.png`);
     fs.writeFileSync(outputPath, buffers[i]!);
-    console.log(`Saved: ${outputPath}`);
+    console.log(`▸ Saved ${outputPath}`);
   }
 
-  console.log("\nStats:", await stats);
+  console.log("▸ Stats:", await stats);
   await unloadModel({ modelId, clearStorage: false });
-  console.log("Done.");
+  console.log("▸ Done");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/diffusion-img2vid.ts
+++ b/packages/sdk/examples/diffusion-img2vid.ts
@@ -25,7 +25,7 @@ const vaeModelSrc = process.argv[7] || WAN_2_1_COMFYUI_REPACKAGED_VAE;
 const clipVisionModelSrc = process.argv[8] || CLIP_VISION_H;
 
 if (!initImagePath) {
-  console.error("❌ Error: init image path is required");
+  console.error("✖ init image path is required");
   console.error(
     "Usage: bun run bare:example dist/examples/diffusion-img2vid.js " +
     "<initImagePath> [prompt] [outputDir] " +
@@ -35,7 +35,7 @@ if (!initImagePath) {
 }
 
 try {
-  console.log("Loading Wan 2.1 I2V model (diffusion + UMT5-XXL + VAE + CLIP vision)...");
+  console.log("▸ Loading Wan 2.1 I2V model (diffusion + UMT5-XXL + VAE + CLIP vision)...");
   const modelId = await loadModel({
     modelSrc: diffusionModelSrc,
     modelType: "sdcpp-generation",
@@ -51,12 +51,17 @@ try {
       vae_on_cpu: true,
       vae_tiling: true,
     },
-    onProgress: (p) => console.log(`Loading: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const init_image = new Uint8Array(fs.readFileSync(initImagePath));
-  console.log(`\nGenerating video for: "${prompt}"`);
+  console.log(`▸ Generating video for: "${prompt}"`);
 
   const { progressStream, outputs, stats } = video({
     modelId,
@@ -75,22 +80,21 @@ try {
   });
 
   for await (const { step, totalSteps } of progressStream) {
-    process.stdout.write(`\rStep ${step}/${totalSteps}`);
+    console.log(`▸ step ${step}/${totalSteps}`);
   }
-  console.log();
 
   const buffers = await outputs;
   for (let i = 0; i < buffers.length; i++) {
     const outputPath = path.join(outputDir, `wan_i2v_${i}.avi`);
     fs.writeFileSync(outputPath, buffers[i]!);
-    console.log(`Saved: ${outputPath}`);
+    console.log(`▸ Saved ${outputPath}`);
   }
 
-  console.log("\nStats:", await stats);
+  console.log("▸ Stats:", await stats);
   await unloadModel({ modelId, clearStorage: false });
-  console.log("Done.");
+  console.log("▸ Done");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/diffusion-simple.ts
+++ b/packages/sdk/examples/diffusion-simple.ts
@@ -16,7 +16,7 @@ const { outputs } = diffusion({ modelId, prompt });
 const buffers = await outputs;
 
 fs.writeFileSync("output.png", buffers[0]!);
-console.log("Saved: output.png");
+console.log("▸ Saved output.png");
 
 await unloadModel({ modelId, clearStorage: false });
 process.exit(0);

--- a/packages/sdk/examples/diffusion-txt2img.ts
+++ b/packages/sdk/examples/diffusion-txt2img.ts
@@ -16,7 +16,7 @@ const prompt =
   "a photo of a cat sitting on a windowsill, golden hour lighting";
 const outputDir = process.argv[4] || ".";
 
-console.log(`Loading diffusion model...`);
+console.log(`▸ Loading diffusion model...`);
 // FLUX.2 models require companion LLM + VAE models
 const modelId = await loadModel({
   modelSrc,
@@ -27,11 +27,16 @@ const modelId = await loadModel({
     llmModelSrc: QWEN3_4B_Q4_K_M,
     vaeModelSrc: FLUX_2_KLEIN_4B_VAE,
   },
-  onProgress: (p) => console.log(`Loading: ${p.percentage.toFixed(1)}%`),
+  onProgress: (p) => {
+    const mb = (n: number) => (n / 1e6).toFixed(1);
+    const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+    process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+    if (p.percentage >= 100) process.stderr.write("\n");
+  },
 });
-console.log(`Model loaded: ${modelId}`);
+console.log(`▸ Model loaded: ${modelId}`);
 
-console.log(`\nGenerating: "${prompt}"`);
+console.log(`▸ Generating: "${prompt}"`);
 
 const { progressStream, outputs, stats } = diffusion({
   modelId,
@@ -45,18 +50,17 @@ const { progressStream, outputs, stats } = diffusion({
 });
 
 for await (const { step, totalSteps } of progressStream) {
-  process.stdout.write(`\rStep ${step}/${totalSteps}`);
+  console.log(`▸ step ${step}/${totalSteps}`);
 }
-console.log();
 
 const buffers = await outputs;
 for (let i = 0; i < buffers.length; i++) {
   const outputPath = path.join(outputDir, `output_${i}.png`);
   fs.writeFileSync(outputPath, buffers[i]!);
-  console.log(`Saved: ${outputPath}`);
+  console.log(`▸ Saved ${outputPath}`);
 }
 
-console.log("\nStats:", await stats);
+console.log("▸ Stats:", await stats);
 await unloadModel({ modelId, clearStorage: false });
-console.log("Done.");
+console.log("▸ Done");
 process.exit(0);

--- a/packages/sdk/examples/diffusion-txt2vid.ts
+++ b/packages/sdk/examples/diffusion-txt2vid.ts
@@ -24,7 +24,7 @@ const prompt = process.argv[5] || "a colorful bird flapping its wings";
 const outputDir = process.argv[6] || ".";
 
 try {
-  console.log("Loading Wan 2.1 T2V model (diffusion + UMT5-XXL + VAE)...");
+  console.log("▸ Loading Wan 2.1 T2V model (diffusion + UMT5-XXL + VAE)...");
   const modelId = await loadModel({
     modelSrc: diffusionModelSrc,
     modelType: "sdcpp-generation",
@@ -39,11 +39,16 @@ try {
       vae_on_cpu: true,
       vae_tiling: true,
     },
-    onProgress: (p) => console.log(`Loading: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
-  console.log(`\nGenerating video for: "${prompt}"`);
+  console.log(`\n▸ Generating video for: "${prompt}"`);
 
   const { progressStream, outputs, stats } = video({
     modelId,
@@ -73,22 +78,21 @@ try {
   });
 
   for await (const { step, totalSteps } of progressStream) {
-    process.stdout.write(`\rStep ${step}/${totalSteps}`);
+    console.log(`▸ step ${step}/${totalSteps}`);
   }
-  console.log();
 
   const buffers = await outputs;
   for (let i = 0; i < buffers.length; i++) {
     const outputPath = path.join(outputDir, `wan_t2v_${i}.avi`);
     fs.writeFileSync(outputPath, buffers[i]!);
-    console.log(`Saved: ${outputPath}`);
+    console.log(`▸ Saved ${outputPath}`);
   }
 
-  console.log("\nStats:", await stats);
+  console.log("\n▸ Stats:", await stats);
   await unloadModel({ modelId, clearStorage: false });
-  console.log("Done.");
+  console.log("▸ Done.");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/download-with-blind-relays.ts
+++ b/packages/sdk/examples/download-with-blind-relays.ts
@@ -16,7 +16,7 @@ import {
   unloadModel,
 } from "@qvac/sdk";
 
-console.log(`🚀 Download with Blind Relays Example`);
+console.log(`▸ Download with Blind Relays Example`);
 console.log(`${"=".repeat(60)}\n`);
 
 try {
@@ -24,53 +24,41 @@ try {
   // The config contains swarmRelays - an array of Hyperswarm relay public keys
   // These relays help with NAT traversal and firewall bypassing for P2P downloads
 
-  console.log(`📥 Starting model download from Hyperdrive...\n`);
-
-  const startTime = Date.now();
+  console.log(`▸ Starting model download from Hyperdrive...\n`);
 
   const modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
   });
 
-  console.log(`Model loaded with ID: ${modelId}`);
+  console.log(`▸ Model loaded with ID: ${modelId}`);
 
   const firstStatus = await getModelInfo(LLAMA_3_2_1B_INST_Q4_0);
 
-  console.log(`First status: ${JSON.stringify(firstStatus)}`);
+  console.log(`▸ First status: ${JSON.stringify(firstStatus)}`);
 
   await unloadModel({ modelId });
 
   // Download model with progress tracking
   await downloadAsset({
     assetSrc: LLAMA_3_2_1B_INST_Q4_0,
-    onProgress: (progress: ModelProgressUpdate) => {
-      const downloadedMB = (progress.downloaded / 1024 / 1024).toFixed(2);
-      const totalMB = (progress.total / 1024 / 1024).toFixed(2);
-      const percentage = progress.percentage.toFixed(1);
-      const elapsedSeconds = (Date.now() - startTime) / 1000;
-      const speedMBps = (
-        progress.downloaded /
-        1024 /
-        1024 /
-        elapsedSeconds
-      ).toFixed(2);
-
-      console.log(
-        `📊 ${percentage}% - ${downloadedMB}MB / ${totalMB}MB (${speedMBps} MB/s)`,
-      );
+    onProgress: (p: ModelProgressUpdate) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`\n✅ Model downloaded successfully using blind relays!`);
+  console.log(`\n▸ Model downloaded successfully using blind relays!`);
   console.log(
-    `Blind relays helped establish peer connections through NAT/firewalls\n`,
+    `▸ Blind relays helped establish peer connections through NAT/firewalls\n`,
   );
 
   await close();
 } catch (error) {
-  console.error("❌ Error:", error);
-  console.log(`\nIf download failed, check the relay public keys in:`);
-  console.log(`   examples/config/qvac.config.json`);
-  console.log(`   (Mock keys in this example won't work in practice!)`);
+  console.error("✖", error);
+  console.log(`\n▸ If download failed, check the relay public keys in:`);
+  console.log(`▸ examples/config/qvac.config.json`);
+  console.log(`▸ (Mock keys in this example won't work in practice!)`);
   process.exit(1);
 }

--- a/packages/sdk/examples/download-with-cancel.ts
+++ b/packages/sdk/examples/download-with-cancel.ts
@@ -5,9 +5,9 @@ import {
   LLAMA_3_2_1B_INST_Q4_0,
 } from "@qvac/sdk";
 
-console.log(`🚀 Starting download with pause/resume example`);
+console.log(`▸ Starting download with pause/resume example`);
 console.log(
-  `\n💡 Press Ctrl+C to pause the download (it will resume on restart)\n`,
+  `\n▸ Press Ctrl+C to pause the download (it will resume on restart)\n`,
 );
 
 let modelId: string | undefined;
@@ -20,22 +20,15 @@ try {
   // synchronous `requestId` field so we can cancel before it settles.
   const download = downloadAsset({
     assetSrc: LLAMA_3_2_1B_INST_Q4_0,
-    onProgress: (progress) => {
-      const downloadedMB = (progress.downloaded / 1024 / 1024).toFixed(2);
-      const totalMB = (progress.total / 1024 / 1024).toFixed(2);
-      const percentage = progress.percentage.toFixed(1);
-
-      console.log(
-        `📊 Progress: ${percentage}% (${downloadedMB}MB / ${totalMB}MB)`,
-      );
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
 
       // Example: Stops at 10% (or use Ctrl+C for manual stop)
-      if (parseFloat(percentage) >= 10 && !cancelled) {
-        console.log("\n🚫 Auto-cancelling at 10% for demo purposes...,");
-        console.log(
-          `📊 Progress: ${percentage}% (${downloadedMB}MB / ${totalMB}MB)`,
-        );
-        console.log(progress);
+      if (p.percentage >= 10 && !cancelled) {
+        console.log("\n▸ Auto-cancelling at 10% for demo purposes...");
         cancelled = true;
 
         void cancel({
@@ -45,17 +38,17 @@ try {
       }
     },
   });
-  await download;
+  modelId = await download;
 
-  console.log(`\n✅ Model downloaded successfully! Model ID: ${modelId}`);
-  console.log("🎯 Download completed without interruption");
+  console.log(`\n▸ Model downloaded successfully! Model ID: ${modelId}`);
+  console.log("▸ Download completed without interruption");
   void close();
 } catch (error) {
   if (error instanceof Error && error.message.includes("cancelled")) {
-    console.log("✅ Download was successfully cancelled");
+    console.log("▸ Download was successfully cancelled");
     void close();
   } else {
-    console.error("❌ Error:", error);
+    console.error("✖", error);
     process.exit(1);
   }
 }

--- a/packages/sdk/examples/embed-multi-gpu.ts
+++ b/packages/sdk/examples/embed-multi-gpu.ts
@@ -39,11 +39,10 @@ try {
 
   for (const text of texts) {
     const { embedding, stats } = await embed({ modelId, text });
-    console.log(`Embedded ${text.slice(0, 50)}...`);
-    console.log(`  Dimensions: ${embedding.length}`);
+    console.log(`${embedding.length} dims  ${text.slice(0, 50)}...`);
     if (stats) {
       console.log(
-        `  Backend: ${stats.backendDevice}, TPS: ${stats.tokensPerSecond?.toFixed(1)}`,
+        `▸ ${stats.backendDevice}  ${stats.tokensPerSecond?.toFixed(1)} tok/s`,
       );
     }
   }
@@ -51,6 +50,6 @@ try {
   await unloadModel({ modelId, clearStorage: false });
   process.exit(0);
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/embed-p2p.ts
+++ b/packages/sdk/examples/embed-p2p.ts
@@ -11,8 +11,11 @@ function cosineSimilarity(vecA: number[], vecB: number[]) {
 try {
   const modelId = await loadModel({
     modelSrc: GTE_LARGE_FP16,
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
     modelConfig: {
       gpuLayers: 99,
@@ -20,7 +23,7 @@ try {
     },
   });
 
-  console.log("\n📝 Example 1: Single Text Embedding");
+  console.log("\n▸ Example 1: Single Text Embedding");
   console.log("=".repeat(50));
 
   const { embedding: singleEmbedding } = await embed({
@@ -32,7 +35,7 @@ try {
   console.log("Embedding dimensions:", singleEmbedding.length);
   console.log("First 10 values:", singleEmbedding.slice(0, 10));
 
-  console.log("\n📝 Example 2: Batch Text Embeddings");
+  console.log("\n▸ Example 2: Batch Text Embeddings");
   console.log("=".repeat(50));
 
   const texts = [
@@ -54,7 +57,7 @@ try {
 
   console.log("Each embedding dimensions:", emb1.length);
 
-  console.log("\n🔍 Similarity Analysis");
+  console.log("\n▸ Similarity Analysis");
   console.log("=".repeat(50));
 
   const similarity1 = cosineSimilarity(emb1, emb2);
@@ -68,10 +71,10 @@ try {
     "Similarity between texts 1 and 3 (different topics):",
     similarity2.toFixed(4),
   );
-  console.log("\n💡 Higher values indicate more similar meanings");
+  console.log("\n▸ Higher values indicate more similar meanings");
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/finetune/llamacpp-finetune.ts
+++ b/packages/sdk/examples/finetune/llamacpp-finetune.ts
@@ -20,7 +20,7 @@ async function readProgress(
   for await (const tick of handle.progressStream) {
     const phase = tick.is_train ? "train" : "val";
     console.log(
-      `epoch=${tick.current_epoch + 1} step=${tick.global_steps} batch=${tick.current_batch}/${tick.total_batches} ${phase} loss=${tick.loss?.toFixed(4)} acc=${tick.accuracy?.toFixed(4)} eta=${Math.round(tick.eta_ms / 1000)}s`,
+      `▸ epoch=${tick.current_epoch + 1} step=${tick.global_steps} batch=${tick.current_batch}/${tick.total_batches} ${phase} loss=${tick.loss?.toFixed(4)} acc=${tick.accuracy?.toFixed(4)} eta=${Math.round(tick.eta_ms / 1000)}s`,
     );
 
     onTick(tick.global_steps);
@@ -36,7 +36,7 @@ try {
     },
   });
 
-  console.log(`✅ Model loaded with ID: ${modelId}`);
+  console.log(`▸ Model loaded with ID: ${modelId}`);
   const loadedModelId = modelId;
 
   const finetuneParams: FinetuneRunParams = {
@@ -65,7 +65,7 @@ try {
   const progressTask = readProgress(handle, (globalSteps) => {
     if (pauseResumeEnabled && !pauseRequested && globalSteps >= 10) {
       pauseRequested = true;
-      console.log("⏸️ Requesting a pause so the run can be resumed...");
+      console.log("▸ Requesting a pause so the run can be resumed...");
       pauseResultPromise = finetune({
         modelId: loadedModelId,
         operation: "pause",
@@ -80,10 +80,10 @@ try {
     await pauseResultPromise;
   }
 
-  console.log("📦 Initial finetune result:", initialResult);
+  console.log("▸ Initial finetune result:", initialResult);
 
   if (pauseResumeEnabled && initialResult.status === "PAUSED") {
-    console.log("▶️ Resuming from the saved checkpoint...");
+    console.log("▸ Resuming from the saved checkpoint...");
 
     const resumedHandle = finetune({
       ...finetuneParams,
@@ -94,10 +94,10 @@ try {
     const resumedResult = await resumedHandle.result;
     await resumedProgressTask;
 
-    console.log("✅ Resumed finetune result:", resumedResult);
+    console.log("▸ Resumed finetune result:", resumedResult);
   }
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   exitCode = 1;
 } finally {
   if (modelId) {

--- a/packages/sdk/examples/kv-cache-cleanup.ts
+++ b/packages/sdk/examples/kv-cache-cleanup.ts
@@ -8,9 +8,9 @@ import {
 } from "@qvac/sdk";
 
 try {
-  console.log("🧹 KV Cache Cleanup Demo\n");
-  console.log("Cache structure: {kvCacheKey}/{modelId}/{configHash}.bin\n");
-  console.log("=".repeat(70) + "\n");
+  console.log("▸ KV Cache Cleanup Demo\n");
+  console.log("▸ Cache structure: {kvCacheKey}/{modelId}/{configHash}.bin\n");
+  console.log("▸ " + "=".repeat(70) + "\n");
 
   const modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
@@ -25,7 +25,7 @@ try {
   const cacheKey1 = "user-alice-session";
   const cacheKey2 = "user-bob-session";
 
-  console.log(`📝 Creating cache for key: "${cacheKey1}"`);
+  console.log(`▸ Creating cache for key: "${cacheKey1}"`);
   const result1 = completion({
     modelId,
     history: [{ role: "user", content: "Hello, I'm Alice!" }],
@@ -36,9 +36,9 @@ try {
   for await (const token of result1.tokenStream) {
     process.stdout.write(token);
   }
-  console.log("\n✅ Cache created\n");
+  console.log("\n▸ Cache created\n");
 
-  console.log(`📝 Creating cache for key: "${cacheKey2}"`);
+  console.log(`▸ Creating cache for key: "${cacheKey2}"`);
   const result2 = completion({
     modelId,
     history: [{ role: "user", content: "Hello, I'm Bob!" }],
@@ -49,63 +49,63 @@ try {
   for await (const token of result2.tokenStream) {
     process.stdout.write(token);
   }
-  console.log("\n✅ Cache created\n");
+  console.log("\n▸ Cache created\n");
 
   // Now cleanup specific cache key
-  console.log("=".repeat(70));
-  console.log(`\n🗑️  Deleting cache key: "${cacheKey1}"`);
+  console.log("▸ " + "=".repeat(70));
+  console.log(`\n▸ Deleting cache key: "${cacheKey1}"`);
   const deleteResult1 = await deleteCache({ kvCacheKey: cacheKey1 });
 
   if (deleteResult1.success) {
-    console.log(`✅ Deleted all caches for key "${cacheKey1}"`);
-    console.log(`   (Removed: ${cacheKey1}/{modelId}/{configHash}.bin)`);
+    console.log(`▸ Deleted all caches for key "${cacheKey1}"`);
+    console.log(`▸   (Removed: ${cacheKey1}/{modelId}/{configHash}.bin)`);
   }
 
   // Delete specific model within a cache key
-  console.log(`\n🗑️  Deleting specific model in cache key: "${cacheKey2}"`);
+  console.log(`\n▸ Deleting specific model in cache key: "${cacheKey2}"`);
   const deleteResult2 = await deleteCache({
     kvCacheKey: cacheKey2,
     modelId: modelId,
   });
 
   if (deleteResult2.success) {
-    console.log(`✅ Deleted model "${modelId}" from cache key "${cacheKey2}"`);
-    console.log(`   (Removed: ${cacheKey2}/${modelId}/)`);
+    console.log(`▸ Deleted model "${modelId}" from cache key "${cacheKey2}"`);
+    console.log(`▸   (Removed: ${cacheKey2}/${modelId}/)`);
   }
 
   // Try to delete non-existent cache key (should succeed silently)
-  console.log(`\n🗑️  Deleting non-existent cache key: "non-existent"`);
+  console.log(`\n▸ Deleting non-existent cache key: "non-existent"`);
   const deleteResult3 = await deleteCache({ kvCacheKey: "non-existent" });
 
   if (deleteResult3.success) {
-    console.log("✅ Delete succeeded (cache key didn't exist)");
+    console.log("▸ Delete succeeded (cache key didn't exist)");
   }
 
-  console.log("\n" + "=".repeat(70));
-  console.log("\n✅ CLEANUP OPTIONS:");
-  console.log("-".repeat(70));
-  console.log("\n1️⃣  Delete entire cache key (all models):");
-  console.log('   await deleteCache({ kvCacheKey: "my-session" })');
-  console.log("   └─ Removes: my-session/ (entire directory)");
-  console.log("\n2️⃣  Delete specific model within cache key:");
+  console.log("\n▸ " + "=".repeat(70));
+  console.log("\n▸ CLEANUP OPTIONS:");
+  console.log("▸ " + "-".repeat(70));
+  console.log("\n▸ 1. Delete entire cache key (all models):");
+  console.log('▸    await deleteCache({ kvCacheKey: "my-session" })');
+  console.log("▸    └─ Removes: my-session/ (entire directory)");
+  console.log("\n▸ 2. Delete specific model within cache key:");
   console.log(
-    '   await deleteCache({ kvCacheKey: "my-session", modelId: "model-abc" })',
+    '▸    await deleteCache({ kvCacheKey: "my-session", modelId: "model-abc" })',
   );
   console.log(
-    "   └─ Removes: my-session/model-abc/ (specific model directory)",
+    "▸    └─ Removes: my-session/model-abc/ (specific model directory)",
   );
-  console.log("\n3️⃣  Delete ALL caches (entire cache folder):");
-  console.log("   await deleteCache({ all: true })");
-  console.log("   └─ Removes: ALL cache files from all sessions and models");
-  console.log("\n💡 Use Cases:");
-  console.log("   - User logout → Delete user's cache key");
-  console.log("   - Model updated → Delete old model caches");
-  console.log("   - Disk space cleanup → Delete old cache keys or all caches");
-  console.log("   - Privacy → Clear conversation history");
-  console.log("   - App reset → Delete all caches with { all: true }");
+  console.log("\n▸ 3. Delete ALL caches (entire cache folder):");
+  console.log("▸    await deleteCache({ all: true })");
+  console.log("▸    └─ Removes: ALL cache files from all sessions and models");
+  console.log("\n▸ Use Cases:");
+  console.log("▸    - User logout → Delete user's cache key");
+  console.log("▸    - Model updated → Delete old model caches");
+  console.log("▸    - Disk space cleanup → Delete old cache keys or all caches");
+  console.log("▸    - Privacy → Clear conversation history");
+  console.log("▸    - App reset → Delete all caches with { all: true }");
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/kv-cache-custom-key.ts
+++ b/packages/sdk/examples/kv-cache-custom-key.ts
@@ -15,7 +15,7 @@ const systemPromptMessage = {
   `,
 };
 try {
-  console.log("🧪 Simple KV Cache Demo: Same vs Different Cache Keys\n");
+  console.log("▸ Simple KV Cache Demo: Same vs Different Cache Keys\n");
 
   const modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
@@ -27,8 +27,8 @@ try {
   });
 
   // Prompt 1 with cache key "session-a" (first time - no cache exists)
-  console.log('📝 Prompt 1: "What is 2+2?" with cache key "session-a"');
-  console.log("   Status: Creating NEW cache (first time)\n");
+  console.log('▸ Prompt 1: "What is 2+2?" with cache key "session-a"');
+  console.log("▸   Status: Creating NEW cache (first time)\n");
 
   const result1 = completion({
     modelId,
@@ -37,7 +37,7 @@ try {
     kvCache: "session-a",
   });
 
-  console.log("   Response: ");
+  console.log("▸ Response: ");
   let response1 = "";
   for await (const token of result1.tokenStream) {
     response1 += token;
@@ -46,16 +46,16 @@ try {
 
   const stats1 = await result1.stats;
   console.log(
-    `\n   Stats: TTFT=${stats1?.timeToFirstToken}ms, CacheTokens=${stats1?.cacheTokens}\n`,
+    `\n▸ Stats: TTFT=${stats1?.timeToFirstToken}ms, CacheTokens=${stats1?.cacheTokens}\n`,
   );
 
   // Prompt 2 with SAME cache key "session-a" (cache exists - optimized!)
   // This continues the conversation - asking about the previous answer
   console.log(
-    '\n📝 Prompt 2: "Now multiply that result by 3" with cache key "session-a" (SAME)',
+    '\n▸ Prompt 2: "Now multiply that result by 3" with cache key "session-a" (SAME)',
   );
   console.log(
-    "   Status: REUSING existing cache (only last message sent, but context remembered!)\n",
+    "▸   Status: REUSING existing cache (only last message sent, but context remembered!)\n",
   );
 
   const result2 = completion({
@@ -70,22 +70,22 @@ try {
     kvCache: "session-a", // Same cache key!
   });
 
-  console.log("   Response: ");
+  console.log("▸ Response: ");
   for await (const token of result2.tokenStream) {
     process.stdout.write(token);
   }
 
   const stats2 = await result2.stats;
   console.log(
-    `\n   Stats: TTFT=${stats2?.timeToFirstToken}ms, CacheTokens=${stats2?.cacheTokens}\n`,
+    `\n▸ Stats: TTFT=${stats2?.timeToFirstToken}ms, CacheTokens=${stats2?.cacheTokens}\n`,
   );
 
   // Prompt 3 with DIFFERENT cache key "session-b" (new cache)
   console.log(
-    '\n📝 Prompt 3: "What is 10+10?" with cache key "session-b" (DIFFERENT)',
+    '\n▸ Prompt 3: "What is 10+10?" with cache key "session-b" (DIFFERENT)',
   );
   console.log(
-    "   Status: Creating NEW cache (different key = isolated cache)\n",
+    "▸   Status: Creating NEW cache (different key = isolated cache)\n",
   );
 
   const result3 = completion({
@@ -95,7 +95,7 @@ try {
     kvCache: "session-b", // Different cache key!
   });
 
-  console.log("   Response: ");
+  console.log("▸ Response: ");
   for await (const token of result3.tokenStream) {
     process.stdout.write(token);
   }
@@ -103,15 +103,15 @@ try {
   const stats3 = await result3.stats;
 
   console.log(
-    `\n   Stats: TTFT=${stats3?.timeToFirstToken}ms, CacheTokens=${stats3?.cacheTokens}\n`,
+    `\n▸ Stats: TTFT=${stats3?.timeToFirstToken}ms, CacheTokens=${stats3?.cacheTokens}\n`,
   );
 
   // Prompt 4: Go back to session-a to trigger flush of session-b
   console.log(
-    '\n📝 Prompt 4: "What is 5+5?" with cache key "session-a" (BACK TO FIRST)',
+    '\n▸ Prompt 4: "What is 5+5?" with cache key "session-a" (BACK TO FIRST)',
   );
   console.log(
-    "   Status: This should trigger session-b to be flushed to disk\n",
+    "▸   Status: This should trigger session-b to be flushed to disk\n",
   );
 
   const result4 = completion({
@@ -121,38 +121,38 @@ try {
     kvCache: "session-a", // Back to session-a!
   });
 
-  console.log("   Response: ");
+  console.log("▸ Response: ");
   for await (const token of result4.tokenStream) {
     process.stdout.write(token);
   }
 
   const stats4 = await result4.stats;
   console.log(
-    `\n   Stats: TTFT=${stats4?.timeToFirstToken}ms, CacheTokens=${stats4?.cacheTokens}\n`,
+    `\n▸ Stats: TTFT=${stats4?.timeToFirstToken}ms, CacheTokens=${stats4?.cacheTokens}\n`,
   );
 
   // Summary
-  console.log("\n✅ Summary:");
+  console.log("\n▸ Summary:");
   console.log(
-    '   - Prompts 1 & 2 share cache key "session-a" → same cache file',
+    '▸   - Prompts 1 & 2 share cache key "session-a" → same cache file',
   );
   console.log(
-    "   - Prompt 2 built on Prompt 1's context (model remembered the answer!)",
+    "▸   - Prompt 2 built on Prompt 1's context (model remembered the answer!)",
   );
   console.log(
-    "   - Only the last message was sent, but full conversation context maintained",
+    "▸   - Only the last message was sent, but full conversation context maintained",
   );
   console.log(
-    '   - Prompt 3 uses cache key "session-b" → separate cache file (isolated)',
+    '▸   - Prompt 3 uses cache key "session-b" → separate cache file (isolated)',
   );
   console.log(
-    "   - Different cache keys provide complete isolation between sessions",
+    "▸   - Different cache keys provide complete isolation between sessions",
   );
 
   await deleteCache({ all: true });
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/kv-cache-example.ts
+++ b/packages/sdk/examples/kv-cache-example.ts
@@ -17,10 +17,10 @@ try {
     },
   });
 
-  console.log("🧠 Testing KV Cache functionality...\n");
+  console.log("▸ Testing KV Cache functionality...\n");
 
   // First conversation with auto-keyed cache enabled
-  console.log("📝 First conversation (building cache for the next turn):");
+  console.log("▸ First conversation (building cache for the next turn):");
   const history1 = [
     { role: "user", content: "What is the capital of France?" },
   ];
@@ -38,10 +38,10 @@ try {
 
   const final1 = await result1.final;
   const stats1 = final1.stats;
-  console.log(`\n⏱️  First completion stats: ${JSON.stringify(stats1)}\n`);
+  console.log(`\n▸ First completion stats: ${JSON.stringify(stats1)}\n`);
 
   // Continue conversation (should reuse the completed first-turn cache).
-  console.log("🔄 Continuing conversation (reusing previous turn cache):");
+  console.log("▸ Continuing conversation (reusing previous turn cache):");
   const history2 = [
     { role: "user", content: "What is the capital of France?" },
     {
@@ -67,10 +67,10 @@ try {
   }
 
   const stats2 = await result2.stats;
-  console.log(`\n⏱️  Second completion stats: ${JSON.stringify(stats2)}\n`);
+  console.log(`\n▸ Second completion stats: ${JSON.stringify(stats2)}\n`);
 
   // Compare with non-cached version
-  console.log("🚀 Same conversation without cache:");
+  console.log("▸ Same conversation without cache:");
   const result3 = completion({
     modelId,
     history: history2,
@@ -83,12 +83,12 @@ try {
   }
 
   const stats3 = await result3.stats;
-  console.log(`\n⏱️  Non-cached completion stats: ${JSON.stringify(stats3)}\n`);
+  console.log(`\n▸ Non-cached completion stats: ${JSON.stringify(stats3)}\n`);
 
-  console.log("✅ KV Cache test completed!");
+  console.log("▸ KV Cache test completed!");
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/llamacpp-cache.ts
+++ b/packages/sdk/examples/llamacpp-cache.ts
@@ -23,7 +23,7 @@ const systemPrompt = {
 };
 
 function printStats(stats: CompletionStats | undefined) {
-  console.log("\nPerformance Stats:", {
+  console.log("\n▸ Performance Stats:", {
     timeToFirstToken: stats?.timeToFirstToken,
     tokensPerSecond: stats?.tokensPerSecond,
     cacheTokens: stats?.cacheTokens,
@@ -36,9 +36,9 @@ async function runCachedCompletion(params: {
   history: ChatMessage[];
   kvCache?: string | boolean;
 }) {
-  console.log(`\n=== ${params.label} ===`);
-  console.log(`Cache key: ${params.kvCache || "disabled"}`);
-  console.log("AI Response:");
+  console.log(`\n▸ ${params.label}`);
+  console.log(`▸ Cache key: ${params.kvCache || "disabled"}`);
+  console.log("▸ AI Response:");
 
   const result = completion({
     modelId: params.modelId,
@@ -62,7 +62,7 @@ async function runCachedCompletion(params: {
 let modelId: string | undefined;
 
 try {
-  console.log("Loading llama.cpp model with cache support...");
+  console.log("▸ Loading llama.cpp model with cache support...");
 
   modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
@@ -70,12 +70,15 @@ try {
       ctx_size: 4096,
       verbosity: VERBOSITY.ERROR,
     },
-    onProgress: (progress) => {
-      console.log(`Loading: ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`Model loaded successfully. Model ID: ${modelId}`);
+  console.log(`▸ Model loaded successfully. Model ID: ${modelId}`);
 
   await deleteCache({ kvCacheKey: sharedCacheKey });
   await deleteCache({ kvCacheKey: isolatedCacheKey });
@@ -123,15 +126,15 @@ try {
     ],
   });
 
-  console.log("\nSummary:");
+  console.log("\n▸ Summary:");
   console.log(
-    `- Reusing "${sharedCacheKey}" keeps conversation context across turns.`,
+    `▸ - Reusing "${sharedCacheKey}" keeps conversation context across turns.`,
   );
   console.log(
-    `- Switching to "${isolatedCacheKey}" starts a separate cache session.`,
+    `▸ - Switching to "${isolatedCacheKey}" starts a separate cache session.`,
   );
   console.log(
-    '- Use deleteCache({ kvCacheKey: "your-session" }) to clear a saved session.',
+    '▸ - Use deleteCache({ kvCacheKey: "your-session" }) to clear a saved session.',
   );
 
   await deleteCache({ kvCacheKey: sharedCacheKey });
@@ -144,10 +147,10 @@ try {
     try {
       await unloadModel({ modelId, clearStorage: false });
     } catch (cleanupError) {
-      console.warn("⚠️ cleanup failed:", cleanupError);
+      console.warn("✖ cleanup failed:", cleanupError);
     }
   }
 
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/llamacpp-dynamic-tools.ts
+++ b/packages/sdk/examples/llamacpp-dynamic-tools.ts
@@ -101,7 +101,7 @@ async function chatTurn({ modelId, kvCache, history, tools }: ChatTurnParams) {
   const toolEventsTask = (async () => {
     for await (const evt of result.toolCallStream) {
       console.log(
-        `\n→ tool call: ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
+        `\n▸ tool call: ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
       );
     }
   })();
@@ -121,7 +121,7 @@ async function chatTurn({ modelId, kvCache, history, tools }: ChatTurnParams) {
     if (schema) {
       const parsed = schema.safeParse(call.arguments);
       if (!parsed.success) {
-        console.warn(`   ✗ validation failed for ${call.name}:`, parsed.error);
+        console.log(`✖ validation failed for ${call.name}:`, parsed.error);
       }
     }
   }
@@ -143,10 +143,14 @@ async function main() {
       tools: true,
       toolsMode: "dynamic",
     },
-    onProgress: (progress) =>
-      console.log(`Loading: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`✅ Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const kvCache = `dynamic-tools-${Date.now()}`;
   const history: Array<{ role: string; content: string }> = [
@@ -160,7 +164,7 @@ async function main() {
 
   // Turn 1 — only weather tools available.
   history.push({ role: "user", content: "What's the weather in Tokyo?" });
-  console.log("\n🤖 Turn 1 (tools=weather):\n");
+  console.log("\n▸ Turn 1 (tools=weather):\n");
   await chatTurn({ modelId, kvCache, history, tools: weatherTools });
 
   // Turn 2 — same session, swap to horoscope tools. Dynamic mode lets the
@@ -169,19 +173,19 @@ async function main() {
     role: "user",
     content: "Now check my horoscope for Aquarius.",
   });
-  console.log("\n\n🤖 Turn 2 (tools=horoscope):\n");
+  console.log("\n\n▸ Turn 2 (tools=horoscope):\n");
   await chatTurn({ modelId, kvCache, history, tools: horoscopeTools });
 
   // Turn 3 — swap to a parameterless tool to confirm empty-arg flows work.
   history.push({ role: "user", content: "What's today's date?" });
-  console.log("\n\n🤖 Turn 3 (tools=date):\n");
+  console.log("\n\n▸ Turn 3 (tools=date):\n");
   await chatTurn({ modelId, kvCache, history, tools: dateTools });
 
-  console.log("\n\n🎉 Done.");
+  console.log("\n\n▸ Done.");
   await unloadModel({ modelId, clearStorage: false });
 }
 
 main().catch((err) => {
-  console.error("❌ Error:", err);
+  console.error("✖", err);
   process.exit(1);
 });

--- a/packages/sdk/examples/llamacpp-filesystem.ts
+++ b/packages/sdk/examples/llamacpp-filesystem.ts
@@ -5,15 +5,15 @@ const ggufPath = process.argv[2];
 
 if (!ggufPath) {
   console.error(
-    "❌ Error: Please provide the path to a GGUF file as the first argument",
+    "✖ Please provide the path to a GGUF file as the first argument",
   );
   console.error(
-    "Usage: bun run examples/llamacpp-filesystem.ts <path-to-gguf-file>",
+    "✖ Usage: bun run examples/llamacpp-filesystem.ts <path-to-gguf-file>",
   );
   process.exit(1);
 }
 
-console.log(`🚀 Loading GGUF model from: ${ggufPath}`);
+console.log(`▸ Loading GGUF model from: ${ggufPath}`);
 
 try {
   // Load model from provided file path
@@ -23,17 +23,21 @@ try {
     modelConfig: {
       ctx_size: 4096,
     },
-    onProgress: (progress) =>
-      console.log(`Loading: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`✅ Model loaded successfully! Model ID: ${modelId}`);
+  console.log(`▸ Model loaded successfully! Model ID: ${modelId}`);
 
   // Create conversation history
   const history = [
     { role: "user", content: "Explain Bitcoin in 3 key points" },
   ];
 
-  console.log("\n🤖 AI Response:");
+  console.log("\n▸ AI Response:");
   process.stdout.write(""); // Start response on new line
 
   // Stream completion
@@ -44,12 +48,12 @@ try {
   }
 
   const stats = await result.stats;
-  console.log("\n📊 Performance Stats:", stats);
+  console.log("\n▸ Performance Stats:", stats);
 
-  console.log("\n\n🎉 Completed!");
+  console.log("\n\n▸ Completed!");
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/llamacpp-http.ts
+++ b/packages/sdk/examples/llamacpp-http.ts
@@ -5,7 +5,7 @@ const httpUrl =
   process.argv[2] ||
   "https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_0.gguf";
 
-console.log(`🚀 Loading GGUF model from HTTP: ${httpUrl}`);
+console.log(`▸ Loading GGUF model from HTTP: ${httpUrl}`);
 
 try {
   // Load model from HTTP URL
@@ -15,22 +15,21 @@ try {
     modelConfig: {
       ctx_size: 4096,
     },
-    onProgress: (progress) => {
-      const downloadedMB = (progress.downloaded / 1024 / 1024).toFixed(2);
-      const totalMB = (progress.total / 1024 / 1024).toFixed(2);
-      console.log(
-        `Loading: ${progress.percentage.toFixed(1)}% (${downloadedMB}MB / ${totalMB}MB)`,
-      );
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
-  console.log(`✅ Model loaded successfully! Model ID: ${modelId}`);
+  console.log(`▸ Model loaded successfully! Model ID: ${modelId}`);
 
   // Create conversation history
   const history = [
     { role: "user", content: "Explain quantum computing in 3 key points" },
   ];
 
-  console.log("\n🤖 AI Response:");
+  console.log("\n▸ AI Response:");
   process.stdout.write(""); // Start response on new line
 
   // Stream completion
@@ -41,11 +40,11 @@ try {
   }
 
   const stats = await result.stats;
-  console.log("\n📊 Performance Stats:", stats);
-  console.log("\n\n🎉 Completed!");
+  console.log("\n▸ Performance Stats:", stats);
+  console.log("\n\n▸ Completed!");
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/llamacpp-multi-gpu.ts
+++ b/packages/sdk/examples/llamacpp-multi-gpu.ts
@@ -38,11 +38,11 @@ try {
       if (progress.shardInfo) {
         const { shardInfo } = progress;
         console.log(
-          `Downloading ${shardInfo.shardName} (${shardInfo.currentShard}/${shardInfo.totalShards}) ` +
+          `▸ Downloading ${shardInfo.shardName} (${shardInfo.currentShard}/${shardInfo.totalShards}) ` +
             `— overall: ${shardInfo.overallPercentage.toFixed(1)}%`,
         );
       } else {
-        console.log(`Downloading: ${progress.percentage.toFixed(1)}%`);
+        console.log(`▸ Downloading: ${progress.percentage.toFixed(1)}%`);
       }
     },
   });
@@ -62,11 +62,11 @@ try {
   }
 
   const stats = await result.stats;
-  console.log("\n\nStats:", stats);
+  console.log("\n\n▸ Stats:", stats);
 
   await unloadModel({ modelId, clearStorage: false });
   process.exit(0);
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/llamacpp-multimodal.ts
+++ b/packages/sdk/examples/llamacpp-multimodal.ts
@@ -8,7 +8,7 @@ import {
 
 if (process.argv.length < 3) {
   console.error(
-    `Specify an image file path as the first argument and a second image file path as the second (optional) argument`,
+    `▸ Specify an image file path as the first argument and a second image file path as the second (optional) argument`,
   );
   process.exit(1);
 }
@@ -24,8 +24,11 @@ try {
       ctx_size: 1024,
       projectionModelSrc: MMPROJ_SMOLVLM2_500M_MULTIMODAL_Q8_0,
     },
-    onProgress: (progress) => {
-      console.log(`Loading: ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
@@ -45,13 +48,13 @@ try {
 
   const stats = await result.stats;
 
-  console.log("\n📊 Performance Stats:", stats);
+  console.log("\n▸ Performance Stats:", stats);
 
-  console.log("--------------------------------");
+  console.log("▸ --------------------------------");
 
   //Using multiple media
   if (process.argv.length < 4) {
-    console.log(`Only one image provided, terminating`);
+    console.log(`▸ Only one image provided, terminating`);
     process.exit(0);
   }
 
@@ -73,12 +76,12 @@ try {
 
   const stats2 = await result2.stats;
 
-  console.log("\n📊 Performance Stats:", stats2);
+  console.log("\n▸ Performance Stats:", stats2);
 
-  console.log("--------------------------------");
+  console.log("▸ --------------------------------");
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/llamacpp-p2p.ts
+++ b/packages/sdk/examples/llamacpp-p2p.ts
@@ -11,8 +11,11 @@ try {
   // First just cache the model
   await downloadAsset({
     assetSrc: LLAMA_3_2_1B_INST_Q4_0,
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
@@ -40,11 +43,11 @@ try {
   }
 
   const stats = await result.stats;
-  console.log("\n📊 Performance Stats:", stats);
+  console.log("\n▸ Performance Stats:", stats);
 
   // Change `clearStorage: true` to delete cached model files
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/llamacpp-sharded.ts
+++ b/packages/sdk/examples/llamacpp-sharded.ts
@@ -25,14 +25,14 @@ try {
         const { shardInfo } = progress;
 
         console.log(
-          `📥 Downloading ${shardInfo.shardName} (${shardInfo.currentShard}/${shardInfo.totalShards})\n` +
+          `▸ Downloading ${shardInfo.shardName} (${shardInfo.currentShard}/${shardInfo.totalShards})\n` +
             `   File: ${progress.percentage.toFixed(1)}% (${(progress.downloaded / 1024 / 1024).toFixed(2)}MB / ${(progress.total / 1024 / 1024).toFixed(2)}MB)\n` +
             `   Overall: ${shardInfo.overallPercentage.toFixed(1)}% (${(shardInfo.overallDownloaded / 1024 / 1024).toFixed(2)}MB / ${(shardInfo.overallTotal / 1024 / 1024).toFixed(2)}MB)`,
         );
       } else {
         // For archive-based shards
         console.log(
-          `📥 Progress: ${progress.percentage.toFixed(1)}% ` +
+          `▸ Progress: ${progress.percentage.toFixed(1)}% ` +
             `(${(progress.downloaded / 1024 / 1024).toFixed(2)}MB / ${(progress.total / 1024 / 1024).toFixed(2)}MB)`,
         );
       }
@@ -49,17 +49,17 @@ try {
 
   const result = completion({ modelId, history, stream: true });
 
-  console.log("\n🤖 Model response:");
+  console.log("\n▸ Model response:");
   for await (const token of result.tokenStream) {
     process.stdout.write(token);
   }
 
   const stats = await result.stats;
-  console.log("\n\n📊 Performance Stats:", stats);
+  console.log("\n\n▸ Performance Stats:", stats);
 
   await unloadModel({ modelId, clearStorage: false });
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/llamacpp-structured-output.ts
+++ b/packages/sdk/examples/llamacpp-structured-output.ts
@@ -72,12 +72,16 @@ async function runToContent(
 try {
   const modelId = await loadModel({
     modelSrc: QWEN3_600M_INST_Q4,
-    onProgress: (p) =>
-      process.stdout.write(`\rLoading: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`\nModel loaded: ${modelId}\n`);
+  console.log(`\n▸ Model loaded: ${modelId}\n`);
 
-  console.log("--- 1. responseFormat: text (baseline, free-form) ---");
+  console.log("▸ --- 1. responseFormat: text (baseline, free-form) ---");
   await runToContent(
     completion({
       modelId,
@@ -87,7 +91,7 @@ try {
     }),
   );
 
-  console.log("\n--- 2. responseFormat: json_object (any valid JSON) ---");
+  console.log("\n▸ --- 2. responseFormat: json_object (any valid JSON) ---");
   const jsonObjectOut = await runToContent(
     completion({
       modelId,
@@ -96,9 +100,9 @@ try {
       responseFormat: { type: "json_object" },
     }),
   );
-  console.log("parsed:", JSON.parse(jsonObjectOut.trim()));
+  console.log("▸ parsed:", JSON.parse(jsonObjectOut.trim()));
 
-  console.log("\n--- 3. responseFormat: json_schema (strict shape) ---");
+  console.log("\n▸ --- 3. responseFormat: json_schema (strict shape) ---");
   const jsonSchemaOut = await runToContent(
     completion({
       modelId,
@@ -120,9 +124,9 @@ try {
     age: number;
     occupation: string;
   };
-  console.log("parsed:", parsed);
+  console.log("▸ parsed:", parsed);
   console.log(
-    "schema-valid:",
+    "▸ schema-valid:",
     typeof parsed.name === "string" &&
       Number.isInteger(parsed.age) &&
       typeof parsed.occupation === "string" &&
@@ -131,6 +135,6 @@ try {
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/logging-file-transport.ts
+++ b/packages/sdk/examples/logging-file-transport.ts
@@ -70,9 +70,9 @@ try {
   logger.info("Model unloaded successfully");
 
   // Show user where logs were saved
-  console.log(`\n📄 All logs (including model internals) saved to: ${logFile}`);
-  console.log("You can inspect the file to see detailed model operation logs!");
+  console.log(`▸ Logs saved to ${logFile}`);
+  console.log("▸ Inspect it to see detailed model operation logs");
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/logging-global.ts
+++ b/packages/sdk/examples/logging-global.ts
@@ -8,12 +8,12 @@ const { loadModel, completion, unloadModel, subscribeServerLogs, LLAMA_3_2_1B_IN
   await import("@qvac/sdk");
 
 try {
-  console.log("🚀 Starting global logging demo...\n");
+  console.log("▸ Starting global logging demo...\n");
 
   // One subscription captures every server-side log (SDK, models, RAG, …)
   // without having to know any stream IDs ahead of time.
   const unsubscribe = subscribeServerLogs((log) => {
-    console.log(`[${log.level.toUpperCase()}] [${log.namespace}] ${log.message}`);
+    console.log(`[SDK] [${log.level.toUpperCase()}] [${log.namespace}] ${log.message}`);
   });
 
   const modelId = await loadModel({
@@ -27,7 +27,7 @@ try {
     stream: true,
   });
 
-  console.log("📝 Response:\n");
+  console.log("▸ Response:\n");
   for await (const token of result.tokenStream) {
     process.stdout.write(token);
   }
@@ -35,6 +35,6 @@ try {
   await unloadModel({ modelId, clearStorage: false });
   unsubscribe();
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/logging-streaming.ts
+++ b/packages/sdk/examples/logging-streaming.ts
@@ -11,13 +11,13 @@ import {
 } from "@qvac/sdk";
 
 try {
-  console.log("🚀 Starting log streaming demo...\n");
+  console.log("▸ Streaming SDK and model logs");
 
   // Note: To configure logging (level and console output), use config file:
   // { "loggerLevel": "debug", "loggerConsoleOutput": false } in qvac.config.json/js/ts
 
   // Subscribe to SDK server logs in background
-  console.log("📡 Starting SDK server log stream...\n");
+  console.log("▸ Subscribing to SDK server logs");
   (async () => {
     for await (const log of loggingStream({ id: SDK_LOG_ID })) {
       console.log(
@@ -29,7 +29,7 @@ try {
   });
 
   // Load models
-  console.log("📥 Loading models (watch SDK logs above)...\n");
+  console.log("▸ Loading models");
   const llmModelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
     modelConfig: {
@@ -43,7 +43,7 @@ try {
     modelSrc: GTE_LARGE_FP16,
   });
 
-  console.log("📡 Starting model-specific log streams...\n");
+  console.log("▸ Subscribing to model logs");
   (async () => {
     for await (const log of loggingStream({ id: llmModelId })) {
       const timestamp = new Date(log.timestamp).toISOString();
@@ -79,7 +79,7 @@ try {
     text: messages[0]?.content ?? "Hello, world!",
   });
 
-  console.log("📝 Response:\n");
+  console.log("▸ Response");
   for await (const token of result.tokenStream) {
     process.stdout.write(token);
   }
@@ -88,15 +88,12 @@ try {
   console.log("Embeddings length", embedding.length);
 
   console.log(
-    "\n💡 Notice three log streams running:\n" +
-      "   - [SDK] = SDK server operations\n" +
-      "   - [LLM] = LLM model inference logs\n" +
-      "   - [EMBED] = Embedding model logs\n",
+    "▸ Three streams running: [SDK] server, [LLM] inference, [EMBED] embedding",
   );
 
   await unloadModel({ modelId: llmModelId, clearStorage: false });
   await unloadModel({ modelId: embedModelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/mcp-websearch.ts
+++ b/packages/sdk/examples/mcp-websearch.ts
@@ -86,12 +86,12 @@ function parseSearchResults(mcpResult: unknown): string {
 let mcpClient: Client | null = null;
 
 try {
-  console.log("🦆 MCP DuckDuckGo Search Example\n");
+  console.log("▸ MCP DuckDuckGo Search Example\n");
 
   // ============================================================
   // STEP 1: Connect to DuckDuckGo MCP server
   // ============================================================
-  console.log("1️⃣  Starting DuckDuckGo MCP server...");
+  console.log("▸ Starting DuckDuckGo MCP server...");
 
   mcpClient = new Client({
     name: "qvac-ddg-example",
@@ -104,22 +104,26 @@ try {
   });
 
   await mcpClient.connect(transport);
-  console.log("   ✓ MCP server connected\n");
+  console.log("▸ MCP server connected\n");
 
   // ============================================================
   // STEP 2: Load model
   // ============================================================
-  console.log("2️⃣  Loading model...");
+  console.log("▸ Loading model...");
   const modelId = await loadModel({
     modelSrc: QWEN3_1_7B_INST_Q4,
     modelConfig: {
       ctx_size: 4096,
       tools: true,
     },
-    onProgress: (progress) =>
-      process.stdout.write(`\r   Loading: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`\n   ✓ Model loaded\n`);
+  console.log(`\n▸ Model loaded\n`);
 
   // ============================================================
   // STEP 3: Ask AI to search the web (with MCP client)
@@ -137,8 +141,8 @@ Always cite your sources with the URL.`,
     },
   ];
 
-  console.log("3️⃣  Asking AI to search the web...\n");
-  console.log("🤖 AI Response:");
+  console.log("▸ Asking AI to search the web...\n");
+  console.log("▸ AI Response:");
 
   // Pass MCP client directly to completion - tools are adapted internally!
   const result = completion({
@@ -159,15 +163,17 @@ Always cite your sources with the URL.`,
   // STEP 4: Execute tool calls using call() - automatic MCP routing!
   // ============================================================
   if (toolCalls.length > 0) {
-    console.log("4️⃣  Executing search...\n");
+    console.log("▸ Executing search...\n");
 
     const toolResults: Array<{ id: string; result: string }> = [];
 
     for (const toolCall of toolCalls) {
-      console.log(`🔍 ${toolCall.name}(${JSON.stringify(toolCall.arguments)})`);
+      console.log(
+        `▸ ${toolCall.name}(${JSON.stringify(toolCall.arguments)})`,
+      );
 
       if (!toolCall.invoke) {
-        console.log(`   ⚠️ No handler found for tool "${toolCall.name}"`);
+        console.log(`▸ No handler found for tool "${toolCall.name}"`);
         continue;
       }
 
@@ -177,7 +183,7 @@ Always cite your sources with the URL.`,
       // Parse and clean up the search results
       const cleanResult = parseSearchResults(mcpResult);
 
-      console.log(`   ✓ Got search results:`);
+      console.log(`▸ Got search results:`);
       console.log(
         cleanResult
           .split("\n")
@@ -192,7 +198,7 @@ Always cite your sources with the URL.`,
     // ============================================================
     // STEP 5: Continue with search results
     // ============================================================
-    console.log("5️⃣  Getting AI response with search results...\n");
+    console.log("▸ Getting AI response with search results...\n");
 
     history.push({
       role: "assistant",
@@ -206,7 +212,7 @@ Always cite your sources with the URL.`,
       });
     }
 
-    console.log("🤖 Final Response:");
+    console.log("▸ Final Response:");
     const finalResult = completion({
       modelId,
       history,
@@ -223,14 +229,14 @@ Always cite your sources with the URL.`,
   // ============================================================
   // Cleanup
   // ============================================================
-  console.log("6️⃣  Cleaning up...");
+  console.log("▸ Cleaning up...");
   await unloadModel({ modelId, clearStorage: false });
-  console.log("   ✓ Done\n");
+  console.log("▸ Done\n");
 
-  console.log("🎉 Example completed!");
+  console.log("▸ Example completed!");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 } finally {
   if (mcpClient) {

--- a/packages/sdk/examples/multi-model-demo.ts
+++ b/packages/sdk/examples/multi-model-demo.ts
@@ -18,8 +18,12 @@ try {
     modelConfig: {
       ctx_size: 4096,
     },
-    onProgress: (progress) =>
-      console.log(`Loading Bob: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
 
   const aliceHistory = [
@@ -36,7 +40,7 @@ try {
     },
   ];
 
-  console.log("🙋🏻‍♂️ Bob: ", "What is Bitcoin?");
+  console.log("Bob: ", "What is Bitcoin?");
 
   const aliceResponse = completion({
     modelId: alice,
@@ -46,8 +50,8 @@ try {
   const aliceText = await aliceResponse.text;
   aliceHistory.push({ role: "assistant", content: aliceText });
 
-  console.log("🙋🏻‍♀️ Alice: ", aliceText);
-  console.log("📊 Alice Stats: ", await aliceResponse.stats);
+  console.log("Alice: ", aliceText);
+  console.log("▸ Alice Stats: ", await aliceResponse.stats);
 
   const bobResponse = completion({
     modelId: bob,
@@ -57,8 +61,8 @@ try {
   const bobText = await bobResponse.text;
   bobHistory.push({ role: "assistant", content: bobText });
 
-  console.log("🙋🏻‍♂️ Bob: ", bobText);
-  console.log("📊 Bob Stats: ", await bobResponse.stats);
+  console.log("Bob: ", bobText);
+  console.log("▸ Bob Stats: ", await bobResponse.stats);
 
   const aliceResponse2 = completion({
     modelId: alice,
@@ -68,8 +72,8 @@ try {
   const aliceText2 = await aliceResponse2.text;
   aliceHistory.push({ role: "assistant", content: aliceText2 });
 
-  console.log("🙋🏻‍♀️ Alice: ", aliceText2);
-  console.log("📊 Alice Stats: ", await aliceResponse2.stats);
+  console.log("Alice: ", aliceText2);
+  console.log("▸ Alice Stats: ", await aliceResponse2.stats);
 
   const bobResponse2 = completion({
     modelId: bob,
@@ -79,12 +83,12 @@ try {
   const bobText2 = await bobResponse2.text;
   bobHistory.push({ role: "assistant", content: bobText2 });
 
-  console.log("🙋🏻‍♂️ Bob: ", bobText2);
-  console.log("📊 Bob Stats: ", await bobResponse2.stats);
+  console.log("Bob: ", bobText2);
+  console.log("▸ Bob Stats: ", await bobResponse2.stats);
 
   await unloadModel({ modelId: alice, clearStorage: false });
   await unloadModel({ modelId: bob, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/ocr-fasttext.ts
+++ b/packages/sdk/examples/ocr-fasttext.ts
@@ -24,7 +24,7 @@ const imagePath =
   process.argv[2] || path.join(__dirname, "image/basic_test.bmp");
 
 try {
-  console.log("🚀 Loading OCR model...");
+  console.log("▸ Loading OCR model...");
   const modelId = await loadModel({
     modelSrc: OCR_LATIN_RECOGNIZER_1,
     modelConfig: {
@@ -38,9 +38,9 @@ try {
       recognizerBatchSize: 1,
     },
   });
-  console.log(`✅ Model loaded successfully! Model ID: ${modelId}`);
+  console.log(`▸ Model loaded successfully! Model ID: ${modelId}`);
 
-  console.log(`\n🔍 Running OCR on: ${imagePath}`);
+  console.log(`\n▸ Running OCR on: ${imagePath}`);
   const { blocks } = ocr({
     modelId,
     image: imagePath,
@@ -51,23 +51,23 @@ try {
 
   const result = await blocks;
 
-  console.log("\n📝 OCR Results:");
-  console.log("================================");
+  console.log("\n▸ OCR Results:");
+  console.log("▸ ================================");
   for (const block of result) {
-    console.log(`\n📄 Text: ${block.text}`);
+    console.log(block.text);
     if (block.bbox) {
-      console.log(`   📍 BBox: [${block.bbox.join(", ")}]`);
+      console.log(`▸ BBox: [${block.bbox.join(", ")}]`);
     }
     if (block.confidence !== undefined) {
-      console.log(`   ✓ Confidence: ${block.confidence}`);
+      console.log(`▸ Confidence: ${block.confidence}`);
     }
   }
-  console.log("\n================================");
-  console.log("\n🔄 Unloading model...");
+  console.log("\n▸ ================================");
+  console.log("\n▸ Unloading model...");
   await unloadModel({ modelId, clearStorage: false });
-  console.log("✅ Model unloaded successfully.");
+  console.log("▸ Model unloaded successfully.");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error during OCR processing:", error);
+  console.error("✖", error);
   await close();
 }

--- a/packages/sdk/examples/parallel-download.ts
+++ b/packages/sdk/examples/parallel-download.ts
@@ -23,7 +23,7 @@ const timers: Record<
   { start: number; firstProgress?: number; end?: number }
 > = {};
 
-console.log(`\n=== Parallel Download (${assets.length} assets) ===\n`);
+console.log(`\n▸ Parallel Download (${assets.length} assets)\n`);
 const wallStart = now();
 
 try {
@@ -37,13 +37,13 @@ try {
         if (t.firstProgress == null) {
           t.firstProgress = now();
           console.log(
-            `[${asset.name}] first progress at ${((t.firstProgress - wallStart) / 1000).toFixed(1)}s — ${progress.percentage}%`,
+            `▸ [${asset.name}] first progress at ${((t.firstProgress - wallStart) / 1000).toFixed(1)}s — ${progress.percentage}%`,
           );
         }
         if (progress.percentage === 100 && t.end == null) {
           t.end = now();
           console.log(
-            `[${asset.name}] done at ${((t.end - wallStart) / 1000).toFixed(1)}s`,
+            `▸ [${asset.name}] done at ${((t.end - wallStart) / 1000).toFixed(1)}s`,
           );
         }
       },
@@ -53,7 +53,7 @@ try {
   const results = await Promise.allSettled(promises);
   const wallEnd = now();
 
-  console.log(`\n=== Results ===\n`);
+  console.log(`\n▸ Results\n`);
 
   for (let i = 0; i < assets.length; i++) {
     const asset = assets[i]!;
@@ -70,14 +70,14 @@ try {
       t.end != null ? `${((t.end - t.start) / 1000).toFixed(1)}s` : "N/A";
 
     console.log(
-      `${status} ${asset.name}: first-progress=${timeToFirst}, total=${total}${reason}`,
+      `▸ ${status} ${asset.name}: first-progress=${timeToFirst}, total=${total}${reason}`,
     );
   }
 
-  console.log(`\nWall time: ${((wallEnd - wallStart) / 1000).toFixed(1)}s`);
+  console.log(`\n▸ Wall time: ${((wallEnd - wallStart) / 1000).toFixed(1)}s`);
 
   void close();
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/plugins.ts
+++ b/packages/sdk/examples/plugins.ts
@@ -22,20 +22,20 @@ const qvacOutputDir = path.join(projectRoot, "qvac");
 
 // ─── Generate the worker bundle from the plugins config ─────────────────────
 
-console.log(`🔍 Config: ${configPath}`);
+console.log(`▸ Config: ${configPath}`);
 console.log(
-  `⚠️  This example will generate a worker bundle in ${qvacOutputDir} and delete it on exit.`,
+  `▸ This example will generate a worker bundle in ${qvacOutputDir} and delete it on exit.`,
 );
 console.log(
-  "   If you have an existing qvac/ folder with bundled files, they will be overwritten and removed.\n",
+  "▸ If you have an existing qvac/ folder with bundled files, they will be overwritten and removed.\n",
 );
-console.log("🔨 Generating worker bundle from plugins config...\n");
+console.log("▸ Generating worker bundle from plugins config...\n");
 
 try {
   await bundleSdk({ projectRoot, configPath, quiet: true });
 } catch (error) {
-  console.error("❌ Failed to generate worker bundle.");
-  console.error("❌ Error:", error);
+  console.error("✖ Failed to generate worker bundle.");
+  console.error("✖", error);
   process.exit(1);
 }
 
@@ -45,7 +45,7 @@ console.log("");
 function cleanup() {
   if (existsSync(qvacOutputDir)) {
     rmSync(qvacOutputDir, { recursive: true, force: true });
-    console.log(`\n🧹 Cleaned up ${qvacOutputDir}`);
+    console.log(`\n▸ Cleaned up ${qvacOutputDir}`);
   }
 }
 process.on("exit", cleanup);
@@ -65,20 +65,24 @@ const {
   GTE_LARGE_FP16,
 } = await import("@qvac/sdk");
 
-console.log("1. LLM Completion (llamacpp-completion plugin)");
+console.log("▸ 1. LLM Completion (llamacpp-completion plugin)");
 
 try {
   const llmModelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
     modelConfig: { ctx_size: 2048 },
-    onProgress: (p) =>
-      console.log(`   Loading LLM: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
 
-  console.log(`   Model loaded: ${llmModelId}`);
+  console.log(`▸ Model loaded: ${llmModelId}`);
 
   const question = "What is 2 + 2? Answer in one word.";
-  console.log(`   Question: ${question}`);
+  console.log(`▸ Question: ${question}`);
 
   const result = completion({
     modelId: llmModelId,
@@ -86,20 +90,20 @@ try {
     stream: true,
   });
 
-  process.stdout.write("   Response: ");
+  console.log("▸ Response:");
   for await (const token of result.tokenStream) {
     process.stdout.write(token);
   }
-  console.log("\n");
+  console.log("");
 
   await unloadModel({ modelId: llmModelId });
-  console.log("   ✅ LLM unloaded\n");
+  console.log("▸ LLM unloaded\n");
 } catch (error) {
-  console.error("   ❌ LLM failed:", error);
+  console.error("✖ LLM failed:", error);
   process.exit(1);
 }
 
-console.log("2. Translation (nmtcpp-translation plugin)");
+console.log("▸ 2. Translation (nmtcpp-translation plugin)");
 
 try {
   const nmtModelId = await loadModel({
@@ -109,11 +113,15 @@ try {
       from: "en",
       to: "es",
     },
-    onProgress: (p) =>
-      console.log(`   Loading NMT: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
 
-  console.log(`   Model loaded: ${nmtModelId}`);
+  console.log(`▸ Model loaded: ${nmtModelId}`);
 
   const text = "Hello, how are you?";
   const result = translate({
@@ -124,17 +132,17 @@ try {
   });
 
   const translated = await result.text;
-  console.log(`   "${text}" -> "${translated}"\n`);
+  console.log(`"${text}" -> "${translated}"`);
 
   await unloadModel({ modelId: nmtModelId });
-  console.log("   ✅ NMT unloaded\n");
+  console.log("▸ NMT unloaded\n");
 } catch (error) {
-  console.error("   ❌ Translation failed:", error);
+  console.error("✖ Translation failed:", error);
   process.exit(1);
 }
 
-console.log("3. Embeddings (llamacpp-embedding plugin NOT in config)");
-console.log("   Attempting to load an embeddings model...\n");
+console.log("▸ 3. Embeddings (llamacpp-embedding plugin NOT in config)");
+console.log("▸ Attempting to load an embeddings model...\n");
 
 try {
   const embedModelId = await loadModel({
@@ -143,18 +151,18 @@ try {
 
   await embed({ modelId: embedModelId, text: "test" });
 
-  console.error("   ❌ Unexpected: embed succeeded without the plugin!");
+  console.error("✖ Unexpected: embed succeeded without the plugin!");
   process.exit(1);
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
 
   if (message.includes("Plugin not found")) {
-    console.log("   ✅ Expected PLUGIN_NOT_FOUND error:");
-    console.log(`   ${message}\n`);
+    console.log("▸ Expected PLUGIN_NOT_FOUND error:");
+    console.log(`▸ ${message}\n`);
   } else {
-    console.error("   ❌ Unexpected error:", error);
+    console.error("✖ Unexpected error:", error);
     process.exit(1);
   }
 }
 
-console.log("Done! Only the selected plugins were available.");
+console.log("▸ Done! Only the selected plugins were available.");

--- a/packages/sdk/examples/profiling/basic.ts
+++ b/packages/sdk/examples/profiling/basic.ts
@@ -12,15 +12,20 @@ try {
     mode: "verbose",
     includeServerBreakdown: true,
   });
-  console.log("Profiler enabled:", profiler.isEnabled());
+  console.log("▸ Profiler enabled:", profiler.isEnabled());
 
   const modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-    onProgress: (p) => console.log(`  ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log("Model loaded:", modelId);
+  console.log("▸ Model loaded:", modelId);
 
-  console.log("\n→ Running completion...");
+  console.log("\n▸ Running completion...");
   const result = completion({
     modelId,
     history: [{ role: "user", content: "Say hello in one sentence." }],
@@ -35,14 +40,14 @@ try {
   await unloadModel({ modelId });
 
   // Export profiling data
-  console.log("\n=== Profiler Summary ===");
+  console.log("\n▸ Profiler Summary");
   console.log(profiler.exportSummary());
 
-  console.log("\n=== Profiler Table ===");
+  console.log("\n▸ Profiler Table");
   console.log(profiler.exportTable());
 
   const json = profiler.exportJSON();
-  console.log("\n=== Load Model Metrics ===");
+  console.log("\n▸ Load Model Metrics");
   // Filter for operation-level event (kind: "handler"), not RPC phase events
   const loadModelEvent = json.recentEvents?.find(
     (e) => e.op === "loadModel" && e.kind === "handler",
@@ -91,15 +96,15 @@ try {
     console.log("  Available ops:", ops.join(", "));
   }
 
-  console.log("\n=== Profiler JSON (structure) ===");
+  console.log("\n▸ Profiler JSON (structure)");
   console.log("  aggregates:", Object.keys(json.aggregates).length, "metrics");
   console.log("  recentEvents:", json.recentEvents?.length ?? 0, "events");
   console.log("  config:", json.config);
 
   // Disable profiling
   profiler.disable();
-  console.log("\nProfiler disabled:", !profiler.isEnabled());
+  console.log("\n▸ Profiler disabled:", !profiler.isEnabled());
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/profiling/per-call.ts
+++ b/packages/sdk/examples/profiling/per-call.ts
@@ -8,40 +8,45 @@ import {
 
 try {
   profiler.disable();
-  console.log("Profiler globally enabled:", profiler.isEnabled());
+  console.log("▸ Profiler globally enabled:", profiler.isEnabled());
 
   const modelId = await loadModel({
     modelSrc: GTE_LARGE_FP16,
-    onProgress: (p) => console.log(`  ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log("Model loaded:", modelId);
+  console.log("▸ Model loaded:", modelId);
 
-  console.log("\n=== Embed with per-call profiling ===");
+  console.log("\n▸ Embed with per-call profiling");
   const { embedding: embedding1 } = await embed(
     { modelId, text: "Profile this specific call" },
     { profiling: { enabled: true, includeServerBreakdown: true } },
   );
-  console.log("Embedding dimensions:", embedding1.length);
+  console.log("▸ Embedding dimensions:", embedding1.length);
 
-  console.log("\n=== Embed without profiling ===");
+  console.log("\n▸ Embed without profiling");
   const { embedding: embedding2 } = await embed({
     modelId,
     text: "This call is not profiled",
   });
-  console.log("Embedding dimensions:", embedding2.length);
+  console.log("▸ Embedding dimensions:", embedding2.length);
 
-  console.log("\n=== Embed with profiling explicitly disabled ===");
+  console.log("\n▸ Embed with profiling explicitly disabled");
   const { embedding: embedding3 } = await embed(
     { modelId, text: "Profiling explicitly disabled for this call" },
     { profiling: { enabled: false } },
   );
-  console.log("Embedding dimensions:", embedding3.length);
+  console.log("▸ Embedding dimensions:", embedding3.length);
 
   await unloadModel({ modelId });
 
-  console.log("\n=== Profiler Summary (per-call data only) ===");
+  console.log("\n▸ Profiler Summary (per-call data only)");
   console.log(profiler.exportSummary());
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/quickstart.ts
+++ b/packages/sdk/examples/quickstart.ts
@@ -12,8 +12,11 @@ try {
   // Load a model into memory
   const modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
@@ -32,6 +35,6 @@ try {
   // Unload model to free up system resources
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/rag/rag-chromadb.ts
+++ b/packages/sdk/examples/rag/rag-chromadb.ts
@@ -4,7 +4,7 @@ import { ChromaClient } from "chromadb";
 
 // Setup instructions for ChromaDB server
 const CHROMADB_SETUP_INSTRUCTIONS = `
-🚀 To run this example, you need a ChromaDB server running locally.
+▸ To run this example, you need a ChromaDB server running locally.
 
 Setup options:
 
@@ -24,11 +24,11 @@ async function initializeChromaClient() {
 
   try {
     await client.heartbeat();
-    console.log("✅ Connected to ChromaDB server");
+    console.log("▸ Connected to ChromaDB server");
     return client;
   } catch {
-    console.error("❌ Failed to connect to ChromaDB server");
-    console.error("Please ensure the server is running on localhost:8000");
+    console.error("✖ Failed to connect to ChromaDB server");
+    console.error("▸ Please ensure the server is running on localhost:8000");
     console.error(CHROMADB_SETUP_INSTRUCTIONS);
     process.exit(1);
   }
@@ -37,14 +37,18 @@ async function initializeChromaClient() {
 try {
   // Get query from command line or use default
   const query = process.argv[2] || "machine learning algorithms";
-  console.log(`🔍 Query: "${query}"`);
+  console.log(`▸ Query: "${query}"`);
 
   const client = await initializeChromaClient();
 
   const modelId = await loadModel({
     modelSrc: GTE_LARGE_FP16,
-    onProgress: (p) =>
-      console.log(`Loading model... ${Math.round(p.percentage)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
 
   // Sample corpus
@@ -88,7 +92,7 @@ try {
   try {
     await client.deleteCollection({ name: collectionName });
   } catch (e) {
-    console.warn(`Collection didn't exist, no need to delete: ${String(e)}`);
+    console.warn(`▸ Collection didn't exist, no need to delete: ${String(e)}`);
   }
   const collection = await client.createCollection({
     name: collectionName,
@@ -96,7 +100,7 @@ try {
   });
 
   // Embed and add documents (we're bringing our own embeddings)
-  console.log("📚 Embedding documents...");
+  console.log("▸ Embedding documents...");
   const ids: string[] = [];
   const documents: string[] = [];
   const embeddings: number[][] = [];
@@ -113,7 +117,7 @@ try {
     embeddings,
   });
 
-  console.log("🔎 Searching for similar documents...");
+  console.log("▸ Searching for similar documents...");
   const { embedding: queryEmbedding } = await embed({ modelId, text: query });
 
   // Query top 3 by vector similarity and include distances
@@ -123,19 +127,17 @@ try {
     include: ["documents", "distances"],
   });
 
-  console.log("\n📋 Top 3 most similar documents:");
+  console.log("▸ Top 3 most similar documents:");
   const docs = res.documents?.[0] ?? [];
   const dists = res.distances?.[0] ?? [];
   for (let i = 0; i < docs.length; i++) {
-    console.log("=".repeat(50) + " Top result:");
-    console.log(`\n${i + 1}. (Score: ${dists[i]?.toFixed(4)})`);
+    console.log(`${i + 1}. (Score: ${dists[i]?.toFixed(4)})`);
     console.log(`   ${docs[i]}`);
-    console.log("=".repeat(100));
     console.log();
   }
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/rag/rag-hyperdb/cancellation.ts
+++ b/packages/sdk/examples/rag/rag-hyperdb/cancellation.ts
@@ -26,21 +26,24 @@ function generateDocuments(count: number): string[] {
 }
 
 try {
-  console.log("RAG Cancellation Example\n");
+  console.log("▸ RAG Cancellation Example");
 
   // Load embedding model
-  console.log("Loading embedding model...");
+  console.log("▸ Loading embedding model...");
   const modelId = await loadModel({
     modelSrc: GTE_LARGE_FP16,
-    onProgress: (progress) => {
-      process.stdout.write(`\r   ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
-  console.log("\n✅ Model loaded\n");
+  console.log("▸ Model loaded");
 
   // Generate documents
   const documents = generateDocuments(200);
-  console.log(`📄 Processing ${documents.length} documents...\n`);
+  console.log(`▸ Processing ${documents.length} documents...`);
 
   let progressCount = 0;
   let cancelled = false;
@@ -55,11 +58,10 @@ try {
     progressInterval: 50,
     onProgress: (stage, current, total) => {
       progressCount++;
-      const pct = total > 0 ? Math.round((current / total) * 100) : 0;
-      console.log(`   [${stage}] ${current}/${total} (${pct}%)`);
+      console.log(`▸ ${stage} ${current}/${total}`);
 
       if (!cancelled && stage === "embedding" && current > 10) {
-        console.log("\n🛑 Triggering cancellation...\n");
+        console.log("▸ Triggering cancellation...");
         cancelled = true;
         void cancel({ requestId: ingest.requestId });
       }
@@ -68,9 +70,7 @@ try {
 
   try {
     await ingest;
-    console.log(
-      "\n⚠️  Ingest completed (cancellation didn't interrupt in time)",
-    );
+    console.log("▸ Ingest completed (cancellation didn't interrupt in time)");
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     const wasCancelled =
@@ -78,8 +78,8 @@ try {
       msg.toLowerCase().includes("abort");
 
     if (wasCancelled) {
-      console.log("✅ Operation cancelled successfully!");
-      console.log(`   Progress updates received: ${progressCount}`);
+      console.log("▸ Operation cancelled successfully!");
+      console.log(`▸ Progress updates received: ${progressCount}`);
     } else {
       throw error;
     }
@@ -92,9 +92,9 @@ try {
 
   await unloadModel({ modelId });
 
-  console.log("✅ Done");
+  console.log("▸ Done");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/rag/rag-hyperdb/ingest.ts
+++ b/packages/sdk/examples/rag/rag-hyperdb/ingest.ts
@@ -12,11 +12,14 @@ try {
   const query = process.argv[2] || "machine learning algorithms";
   const workspace = "ingest-example";
 
-  console.log(`🔍 Query: "${query}"`);
+  console.log(`▸ Query: "${query}"`);
   const modelId = await loadModel({
     modelSrc: GTE_LARGE_FP16,
-    onProgress: (progress) => {
-      console.log(`Loading model... ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
@@ -31,16 +34,16 @@ try {
     "Cybersecurity protects digital systems, networks, and data from malicious attacks, unauthorized access, and various forms of cyber threats through multiple layers of defense.",
   ];
 
-  console.log("📚 Ingesting documents...");
+  console.log("▸ Ingesting documents...");
   const result = await ragIngest({
     modelId,
     workspace,
     documents: samples,
     chunk: false,
   });
-  console.log(`✅ Ingested ${result.processed.length} documents`);
+  console.log(`▸ Ingested ${result.processed.length} documents`);
 
-  console.log("🔎 Searching for similar documents...");
+  console.log("▸ Searching for similar documents...");
   const results = await ragSearch({
     modelId,
     workspace,
@@ -48,21 +51,19 @@ try {
     topK: 3,
   });
 
-  console.log("\n📋 Top 3 most similar documents:");
+  console.log("▸ Top 3 most similar documents:");
   results.forEach((result, index) => {
-    console.log("=".repeat(50) + " Top result:");
-    console.log(`\n${index + 1}. (Score: ${result.score})`);
+    console.log(`${index + 1}. (Score: ${result.score})`);
     console.log(`   ${result.content}`);
-    console.log("=".repeat(100));
     console.log();
   });
 
   // Cleanup: close and delete workspace
   await ragCloseWorkspace({ workspace, deleteOnClose: true });
-  console.log(`\n🗑️  Deleted '${workspace}' workspace`);
+  console.log(`▸ Deleted '${workspace}' workspace`);
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/rag/rag-hyperdb/pipeline.ts
+++ b/packages/sdk/examples/rag/rag-hyperdb/pipeline.ts
@@ -14,14 +14,17 @@ try {
   // Get query from command line or use default
   const query = process.argv[2] || "machine learning algorithms";
 
-  console.log("🔧 RAG Pipeline Example (Segregated Flow)\n");
-  console.log(`🔍 Query: "${query}"`);
+  console.log("▸ RAG Pipeline Example (Segregated Flow)");
+  console.log(`▸ Query: "${query}"`);
   const workspace = "pipeline-example";
 
   const modelId = await loadModel({
     modelSrc: GTE_LARGE_FP16,
-    onProgress: (progress) => {
-      console.log(`Loading model... ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
@@ -36,7 +39,7 @@ try {
     "Cybersecurity protects digital systems, networks, and data from malicious attacks, unauthorized access, and various forms of cyber threats through multiple layers of defense.",
   ];
 
-  console.log("\n📝 Step 1: Chunking documents...");
+  console.log("▸ Step 1: Chunking documents...");
   const chunks = await ragChunk({
     documents: samples,
     chunkOpts: {
@@ -44,9 +47,9 @@ try {
       chunkOverlap: 20,
     },
   });
-  console.log(`   Created ${chunks.length} chunks`);
+  console.log(`▸ Created ${chunks.length} chunks`);
 
-  console.log("\n🧠 Step 2: Generating embeddings (batch)...");
+  console.log("▸ Step 2: Generating embeddings (batch)...");
   const texts = chunks.map((chunk) => chunk.content);
   const { embedding: embeddings } = await embed({ modelId, text: texts });
 
@@ -56,17 +59,17 @@ try {
     embedding: embeddings[i],
     embeddingModelId: modelId,
   })) as RagEmbeddedDoc[];
-  console.log(`   Generated ${embeddedDocs.length} embeddings`);
+  console.log(`▸ Generated ${embeddedDocs.length} embeddings`);
 
-  console.log("\n💾 Step 3: Saving to vector database...");
+  console.log("▸ Step 3: Saving to vector database...");
   const saveResult = await ragSaveEmbeddings({
     workspace,
     documents: embeddedDocs,
   });
   const saved = saveResult.filter((r) => r.status === "fulfilled").length;
-  console.log(`   Saved ${saved}/${saveResult.length} documents`);
+  console.log(`▸ Saved ${saved}/${saveResult.length} documents`);
 
-  console.log("\n🔎 Step 4: Searching...");
+  console.log("▸ Step 4: Searching...");
   const results = await ragSearch({
     workspace,
     modelId,
@@ -74,21 +77,19 @@ try {
     topK: 3,
   });
 
-  console.log("\n📋 Top 3 most similar documents:");
+  console.log("▸ Top 3 most similar documents:");
   results.forEach((result, index) => {
-    console.log("=".repeat(50) + " Top result:");
-    console.log(`\n${index + 1}. (Score: ${result.score})`);
+    console.log(`${index + 1}. (Score: ${result.score})`);
     console.log(`   ${result.content}`);
-    console.log("=".repeat(100));
     console.log();
   });
 
   // Cleanup: close and delete workspace
   await ragCloseWorkspace({ workspace, deleteOnClose: true });
-  console.log(`🗑️  Deleted '${workspace}' workspace`);
+  console.log(`▸ Deleted '${workspace}' workspace`);
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/rag/rag-hyperdb/workspaces.ts
+++ b/packages/sdk/examples/rag/rag-hyperdb/workspaces.ts
@@ -11,15 +11,18 @@ import {
 } from "@qvac/sdk";
 
 try {
-  console.log("🚀 RAG Workspaces with Chunking Example\n");
+  console.log("▸ RAG Workspaces with Chunking Example");
 
   // Load model
   const modelId = await loadModel({
     modelSrc: GTE_LARGE_FP16,
-    onProgress: (p) =>
-      process.stdout.write(`\rLoading: ${Math.round(p.percentage * 100)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log("\n");
 
   // Medical articles (will be chunked)
   const medicalArticles = [
@@ -87,7 +90,7 @@ try {
   ];
 
   // Ingest medical articles with chunking
-  console.log("📚 Ingesting medical articles with chunking...");
+  console.log("▸ Ingesting medical articles with chunking...");
   const medicalResult = await ragIngest({
     modelId,
     workspace: "medical",
@@ -101,18 +104,18 @@ try {
     },
   });
   console.log(
-    `✅ Created ${medicalResult.processed.length} chunks from medical articles`,
+    `▸ Created ${medicalResult.processed.length} chunks from medical articles`,
   );
 
   // Ingest tech docs without chunking
-  console.log("\n📚 Ingesting tech documents...");
+  console.log("\n▸ Ingesting tech documents...");
   const techResult = await ragIngest({
     modelId,
     workspace: "technology",
     documents: techDocs,
     chunk: false,
   });
-  console.log(`✅ Ingested ${techResult.processed.length} tech documents`);
+  console.log(`▸ Ingested ${techResult.processed.length} tech documents`);
 
   // Test searches
   const searches = [
@@ -122,20 +125,20 @@ try {
     { workspace: "technology", query: "COVID", label: "Tech (isolation test)" },
   ];
 
-  console.log("\n🔍 Running searches:");
+  console.log("\n▸ Running searches:");
   for (const { workspace, query, label } of searches) {
     const results = await ragSearch({ modelId, workspace, query, topK: 1 });
     console.log(`\n${label}: "${query}"`);
     if (results.length > 0 && results[0]) {
-      console.log(`  ✓ Score: ${results[0].score.toFixed(3)}`);
-      console.log(`  ✓ Match: ${results[0].content.substring(0, 80)}...`);
+      console.log(`  Score: ${results[0].score.toFixed(3)}`);
+      console.log(`  Match: ${results[0].content.substring(0, 80)}...`);
     } else {
-      console.log(`  ✗ No results (workspace isolation working correctly)`);
+      console.log(`  ▸ No results (workspace isolation working correctly)`);
     }
   }
 
   // Test a third workspace
-  console.log("\n📁 Testing 'general' workspace...");
+  console.log("\n▸ Testing 'general' workspace...");
   await ragIngest({
     modelId,
     workspace: "general",
@@ -149,24 +152,23 @@ try {
     query: "general workspace",
   });
   console.log(
-    `General workspace: ${generalSearch?.[0]?.content === "General workspace content for testing" ? "✅ Working" : "❌ Failed"}`,
+    `▸ General workspace: ${generalSearch?.[0]?.content === "General workspace content for testing" ? "Working" : "Failed"}`,
   );
 
   // Reindexing - regenerate embeddings for an existing workspace
-  console.log("\n🔄 Reindexing medical workspace...");
+  console.log("\n▸ Reindexing medical workspace...");
   const reindexResult = await ragReindex({
     workspace: "medical",
     modelId,
     onProgress: (stage, current, total) => {
-      const pct = total > 0 ? Math.round((current / total) * 100) : 0;
-      console.log(`   [${stage}] ${current}/${total} (${pct}%)`);
+      console.log(`▸ ${stage} ${current}/${total}`);
     },
   });
   console.log(
-    `${reindexResult.reindexed ? "✅ Reindex completed" : "⚠️  Reindex returned false"} for medical workspace`,
+    `▸ ${reindexResult.reindexed ? "Reindex completed" : "Reindex returned false"} for medical workspace`,
   );
   if (reindexResult.details) {
-    console.log("   Details:", reindexResult.details);
+    console.log("▸ Details:", reindexResult.details);
   }
 
   // Verify reindexed data still works
@@ -177,7 +179,7 @@ try {
     topK: 1,
   });
   console.log(
-    `   Verification search: ${reindexVerify.length > 0 ? "✅ Working" : "❌ Failed"}`,
+    `▸ Verification search: ${reindexVerify.length > 0 ? "Working" : "Failed"}`,
   );
 
   // Cleanup example
@@ -189,27 +191,27 @@ try {
       workspace: "medical",
       ids: [firstChunk.id],
     });
-    console.log("\n🗑️  Deleted one medical chunk");
+    console.log("\n▸ Deleted one medical chunk");
   }
 
   // List all workspaces
-  console.log("\n📂 Listing workspaces...");
+  console.log("\n▸ Listing workspaces...");
   const workspaces = await ragListWorkspaces();
   workspaces.forEach((ws) => {
-    console.log(`  • ${ws.name} (${ws.open ? "open" : "closed"})`);
+    console.log(`▸ ${ws.name} (${ws.open ? "open" : "closed"})`);
   });
 
   // Close and delete all workspaces created in this example
-  console.log("\n🗑️  Closing and deleting workspaces...");
+  console.log("\n▸ Closing and deleting workspaces...");
   await ragCloseWorkspace({ workspace: "medical", deleteOnClose: true });
-  console.log("Deleted 'medical' workspace");
+  console.log("▸ Deleted 'medical' workspace");
   await ragCloseWorkspace({ workspace: "technology", deleteOnClose: true });
-  console.log("Deleted 'technology' workspace");
+  console.log("▸ Deleted 'technology' workspace");
   await ragCloseWorkspace({ workspace: "general", deleteOnClose: true });
-  console.log("Deleted 'general' workspace");
+  console.log("▸ Deleted 'general' workspace");
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/rag/rag-lancedb.ts
+++ b/packages/sdk/examples/rag/rag-lancedb.ts
@@ -6,13 +6,16 @@ try {
   // Get query from command line or use default
   const query = process.argv[2] || "machine learning algorithms";
 
-  console.log(`🔍 Query: "${query}"`);
+  console.log(`▸ Query: "${query}"`);
 
   const db = await lancedb.connect(".rag-lancedb");
   const modelId = await loadModel({
     modelSrc: GTE_LARGE_FP16,
-    onProgress: (progress) => {
-      console.log(`Loading model... ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
@@ -64,12 +67,12 @@ try {
   try {
     await db.dropTable("documents");
   } catch (e) {
-    console.warn(`Table doesn't exist, no need to drop: ${String(e)}`);
+    console.warn(`▸ Table doesn't exist, no need to drop: ${String(e)}`);
   }
 
   const documentsTable = await db.createEmptyTable("documents", schema);
 
-  console.log("📚 Embedding documents...");
+  console.log("▸ Embedding documents...");
   const documents = [];
   for (const sample of samples) {
     const { embedding } = await embed({ modelId, text: sample.text });
@@ -83,7 +86,7 @@ try {
 
   await documentsTable.add(documents);
 
-  console.log("🔎 Searching for similar documents...");
+  console.log("▸ Searching for similar documents...");
   const { embedding: queryEmbedding } = await embed({ modelId, text: query });
   const results = (await documentsTable
     .vectorSearch(queryEmbedding)
@@ -95,7 +98,7 @@ try {
     _distance: number;
   }[];
 
-  console.log("\n📋 Top 3 most similar documents:");
+  console.log("\n▸ Top 3 most similar documents:");
   results.forEach((result, index) => {
     console.log("=".repeat(50) + " Top result:");
     console.log(`\n${index + 1}. (Score: ${result._distance?.toFixed(4)})`);
@@ -106,6 +109,6 @@ try {
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/rag/rag-sqlite.ts
+++ b/packages/sdk/examples/rag/rag-sqlite.ts
@@ -4,7 +4,7 @@ import sqlite3InitModule from "@sqliteai/sqlite-wasm";
 try {
   // Get query from command line or use default
   const query = process.argv[2] || "machine learning algorithms";
-  console.log(`🔍 Query: "${query}"`);
+  console.log(`▸ Query: "${query}"`);
 
   // Initialize SQLite with vector extension
   const sqlite3 = await sqlite3InitModule();
@@ -12,8 +12,11 @@ try {
 
   const modelId = await loadModel({
     modelSrc: GTE_LARGE_FP16,
-    onProgress: (progress) => {
-      console.log(`Loading model... ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
@@ -61,7 +64,7 @@ try {
   )
 `);
 
-  console.log("📚 Embedding documents...");
+  console.log("▸ Embedding documents...");
   for (const sample of samples) {
     const { embedding } = await embed({ modelId, text: sample.text });
     db.exec({
@@ -82,7 +85,7 @@ try {
   db.exec(`SELECT vector_quantize_preload('documents', 'embedding')`);
 
   // Search for similar documents
-  console.log("🔎 Searching for similar documents...");
+  console.log("▸ Searching for similar documents...");
   const { embedding: queryEmbedding } = await embed({ modelId, text: query });
 
   const results: Array<{
@@ -107,7 +110,7 @@ try {
     },
   });
 
-  console.log("\n📋 Top 3 most similar documents:");
+  console.log("\n▸ Top 3 most similar documents:");
   results.forEach((result, index) => {
     console.log("=".repeat(50) + " Top result:");
     console.log(
@@ -121,6 +124,6 @@ try {
   await unloadModel({ modelId });
   db.close();
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/registry-query.ts
+++ b/packages/sdk/examples/registry-query.ts
@@ -8,15 +8,15 @@ import {
 } from "@qvac/sdk";
 
 try {
-  console.log("QVAC Model Registry Query Examples\n");
+  console.log("▸ QVAC Model Registry Query Examples\n");
 
   // List all available models
-  console.log("Listing all models in QVAC model registry...");
+  console.log("▸ Listing all models in QVAC model registry...");
   const allModels = await modelRegistryList();
-  console.log(`   Found ${allModels.length} models in registry\n`);
+  console.log(`▸ Found ${allModels.length} models in registry\n`);
 
   // Show first 5 models as sample
-  console.log("   Sample models:");
+  console.log("▸ Sample models:");
   allModels.slice(0, 5).forEach((model) => {
     console.log(
       `   - ${model.name} (${model.addon}, ${model.engine}, ${formatSize(model.expectedSize)})`,
@@ -25,48 +25,48 @@ try {
   console.log();
 
   // Search with text filter
-  console.log('Searching for "whisper" models...');
+  console.log('▸ Searching for "whisper" models...');
   const whisperModels = await modelRegistrySearch({ filter: "whisper" });
-  console.log(`   Found ${whisperModels.length} whisper-related models\n`);
+  console.log(`▸ Found ${whisperModels.length} whisper-related models\n`);
 
   // Search by engine (using canonical ModelType enum)
-  console.log(`Searching by engine (${ModelType.llamacppEmbedding})...`);
+  console.log(`▸ Searching by engine (${ModelType.llamacppEmbedding})...`);
   const embedModels = await modelRegistrySearch({
     engine: ModelType.llamacppEmbedding,
   });
-  console.log(`   Found ${embedModels.length} embedding models`);
+  console.log(`▸ Found ${embedModels.length} embedding models`);
   embedModels.slice(0, 3).forEach((model) => {
     console.log(`   - ${model.name} (${model.quantization})`);
   });
   console.log();
 
   // Search by quantization
-  console.log("Searching for Q4 quantized models...");
+  console.log("▸ Searching for Q4 quantized models...");
   const q4Models = await modelRegistrySearch({ quantization: "q4" });
-  console.log(`   Found ${q4Models.length} Q4 quantized models`);
+  console.log(`▸ Found ${q4Models.length} Q4 quantized models`);
   q4Models.slice(0, 3).forEach((model) => {
     console.log(`   - ${model.name}`);
   });
   console.log();
 
   // Search by addon/model type
-  console.log("Searching for transcription models...");
+  console.log("▸ Searching for transcription models...");
   const transcriptionModels = await modelRegistrySearch({
     addon: "whisper",
   });
-  console.log(`   Found ${transcriptionModels.length} transcription models`);
+  console.log(`▸ Found ${transcriptionModels.length} transcription models`);
   transcriptionModels.slice(0, 3).forEach((model: ModelRegistryEntry) => {
     console.log(`   - ${model.name}`);
   });
   console.log();
 
   // Combined search: engine + quantization
-  console.log("Searching for Q4 LLM models...");
+  console.log("▸ Searching for Q4 LLM models...");
   const q4LlmModels = await modelRegistrySearch({
     engine: ModelType.llamacppCompletion,
     quantization: "q4",
   });
-  console.log(`   Found ${q4LlmModels.length} Q4 LLM models`);
+  console.log(`▸ Found ${q4LlmModels.length} Q4 LLM models`);
   q4LlmModels.slice(0, 3).forEach((model: ModelRegistryEntry) => {
     console.log(`   - ${model.name} (${model.quantization})`);
   });
@@ -76,7 +76,7 @@ try {
   const sampleModel = allModels[0];
   if (sampleModel) {
     console.log(
-      `Getting specific model: ${sampleModel.registrySource}/${sampleModel.registryPath}`,
+      `▸ Getting specific model: ${sampleModel.registrySource}/${sampleModel.registryPath}`,
     );
     const model = await modelRegistryGetModel(
       sampleModel.registryPath,
@@ -92,12 +92,12 @@ try {
     console.log();
   }
 
-  console.log("QVAC model registry query examples completed successfully!");
+  console.log("▸ QVAC model registry query examples completed successfully!");
 
   void close();
   process.exit(0);
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }
 

--- a/packages/sdk/examples/seed-p2p.ts
+++ b/packages/sdk/examples/seed-p2p.ts
@@ -3,21 +3,24 @@ import { LLAMA_3_2_1B_INST_Q4_0, downloadAsset } from "@qvac/sdk";
 await downloadAsset({
   assetSrc: LLAMA_3_2_1B_INST_Q4_0,
   seed: true,
-  onProgress: (progress) => {
-    console.log(progress);
+  onProgress: (p) => {
+    const mb = (n: number) => (n / 1e6).toFixed(1);
+    const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+    process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+    if (p.percentage >= 100) process.stderr.write("\n");
   },
 })
   .then(() => {
-    console.log("✅ Model loaded and seeding started!");
-    console.log("📡 Seeding service is running... Press Ctrl+C to stop");
+    console.log("▸ Model loaded and seeding started!");
+    console.log("▸ Seeding service is running... Press Ctrl+C to stop");
   })
   .catch((error) => {
-    console.error("❌ Error:", error);
+    console.error("✖", error);
     process.exit(1);
   });
 
 process.on("SIGINT", () => {
-  console.log("\n🛑 Seeding service stopped");
+  console.log("\n▸ Seeding service stopped");
   process.exit(0);
 });
 

--- a/packages/sdk/examples/suspend-resume.ts
+++ b/packages/sdk/examples/suspend-resume.ts
@@ -12,17 +12,20 @@ try {
   // Load a model
   const modelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log("✅ Model loaded\n");
+  console.log("▸ Model loaded\n");
 
-  console.log(`📊 Lifecycle state: ${await state()}\n`);
+  console.log(`▸ Lifecycle state: ${await state()}\n`);
 
   // Run a completion before suspending
-  console.log("--- Completion before suspend ---");
+  console.log("▸ Completion before suspend");
   const result1 = completion({
     modelId,
     history: [{ role: "user", content: "Say hello in one word" }],
@@ -31,12 +34,12 @@ try {
   for await (const token of result1.tokenStream) {
     process.stdout.write(token);
   }
-  console.log("\n");
+  console.log("");
 
   // Suspend all networking and storage (e.g. app going to background)
-  console.log("⏸️  Suspending...");
+  console.log("▸ Suspending...");
   await suspend();
-  console.log(`📊 Lifecycle state: ${await state()}\n`);
+  console.log(`▸ Lifecycle state: ${await state()}\n`);
 
   try {
     await completion({
@@ -47,23 +50,23 @@ try {
   } catch (error: unknown) {
     const name = (error as { name?: string }).name;
     if (name === "LIFECYCLE_OPERATION_BLOCKED") {
-      console.log(`🚫 Operation blocked while suspended (${name})`);
+      console.log(`▸ Operation blocked while suspended (${name})`);
     } else {
       throw error;
     }
   }
 
   // Simulate time in background
-  console.log("\n💤 Simulating 3 seconds in background...");
+  console.log("\n▸ Simulating 3 seconds in background...");
   await new Promise((resolve) => setTimeout(resolve, 3000));
 
   // Resume when returning to foreground
-  console.log("▶️  Resuming...");
+  console.log("▸ Resuming...");
   await resume();
-  console.log(`📊 Lifecycle state: ${await state()}\n`);
+  console.log(`▸ Lifecycle state: ${await state()}\n`);
 
   // Run another completion after resuming
-  console.log("--- Completion after resume ---");
+  console.log("▸ Completion after resume");
   const result2 = completion({
     modelId,
     history: [{ role: "user", content: "Say goodbye in one word" }],
@@ -72,12 +75,12 @@ try {
   for await (const token of result2.tokenStream) {
     process.stdout.write(token);
   }
-  console.log("\n");
+  console.log("");
 
   await unloadModel({ modelId });
-  console.log("✅ Model unloaded");
+  console.log("▸ Model unloaded");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/tools/llamacpp-native-tools.ts
+++ b/packages/sdk/examples/tools/llamacpp-native-tools.ts
@@ -15,10 +15,14 @@ try {
       ctx_size: 4096,
       tools: true,
     },
-    onProgress: (progress) =>
-      console.log(`Loading: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`✅ Model loaded successfully! Model ID: ${modelId}`);
+  console.log(`▸ Model loaded successfully! Model ID: ${modelId}`);
 
   const history = [
     {
@@ -32,8 +36,8 @@ try {
     },
   ];
 
-  console.log("\n🤖 AI Response:");
-  console.log("(Streaming with tool definitions in prompt)\n");
+  console.log("\n▸ AI Response:");
+  console.log("▸ (Streaming with tool definitions in prompt)\n");
 
   const result = completion({ modelId, history, stream: true, tools });
 
@@ -46,9 +50,9 @@ try {
   const toolsTask = (async () => {
     for await (const evt of result.toolCallStream) {
       console.log(
-        `\n\n→ Tool Call Detected: ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
+        `\n\n▸ Tool Call Detected: ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
       );
-      console.log(`   ID: ${evt.call.id}`);
+      console.log(`▸ ID: ${evt.call.id}`);
     }
   })();
 
@@ -57,33 +61,33 @@ try {
   const stats: CompletionStats | undefined = await result.stats;
   const toolCalls: ToolCall[] = await result.toolCalls;
 
-  console.log("\n\n📋 Parsed Tool Calls:");
+  console.log("\n\n▸ Parsed Tool Calls:");
   if (toolCalls.length > 0) {
     for (const call of toolCalls) {
-      console.log(`  - ${call.name}(${JSON.stringify(call.arguments)})`);
+      console.log(`▸ ${call.name}(${JSON.stringify(call.arguments)})`);
 
       const schema = toolSchemas[call.name as keyof typeof toolSchemas];
       if (schema) {
         const validated = schema.safeParse(call.arguments);
         if (validated.success) {
-          console.log(`    ✓ Arguments validated with Zod`);
+          console.log(`▸ Arguments validated with Zod`);
         } else {
-          console.log(`    ✗ Validation failed:`, validated.error);
+          console.log(`✖ Validation failed:`, validated.error);
         }
       }
     }
   } else {
-    console.log("  No tool calls detected in response");
+    console.log("▸ No tool calls detected in response");
   }
 
-  console.log("\n📊 Performance Stats:", stats);
+  console.log("\n▸ Performance Stats:", stats);
 
   if (toolCalls.length > 0) {
-    console.log("\n\n🔧 Simulating Tool Execution...");
+    console.log("\n\n▸ Simulating Tool Execution...");
 
     const toolResults = toolCalls.map((call) => {
       const result = mockExecute(call.name, call.arguments);
-      console.log(`  ✓ ${call.name}: ${result}`);
+      console.log(`▸ ${call.name}: ${result}`);
       return { toolCallId: call.id, result };
     });
 
@@ -99,7 +103,7 @@ try {
       });
     }
 
-    console.log("\n\n🤖 Follow-up Response with Tool Results:");
+    console.log("\n\n▸ Follow-up Response with Tool Results:");
     const followUpResult = completion({
       modelId,
       history,
@@ -112,12 +116,12 @@ try {
     }
 
     const followUpStats = await followUpResult.stats;
-    console.log("\n\n📊 Follow-up Stats:", followUpStats);
+    console.log("\n\n▸ Follow-up Stats:", followUpStats);
   }
 
-  console.log("\n\n🎉 Completed!");
+  console.log("\n\n▸ Completed!");
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/tools/llamacpp-tools-gemma4.ts
+++ b/packages/sdk/examples/tools/llamacpp-tools-gemma4.ts
@@ -32,10 +32,14 @@ try {
     modelSrc,
     modelType: "llamacpp-completion",
     modelConfig: { ctx_size: 4096, tools: true },
-    onProgress: (progress) =>
-      console.log(`Loading: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const history = [
     {
@@ -61,7 +65,7 @@ try {
     for await (const evt of result.toolCallStream) {
       if (evt.type === "toolCall") {
         console.log(
-          `\n-> ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
+          `\n▸ ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
         );
       }
     }
@@ -71,20 +75,20 @@ try {
 
   const toolCalls: ToolCall[] = await result.toolCalls;
 
-  console.log("\n\nFinal tool calls:");
+  console.log("\n\n▸ Final tool calls:");
   if (toolCalls.length > 0) {
     for (const call of toolCalls) {
-      console.log(`  - ${call.name}(${JSON.stringify(call.arguments)})`);
+      console.log(`▸ ${call.name}(${JSON.stringify(call.arguments)})`);
       const toolResult = mockExecute(call.name, call.arguments);
-      console.log(`    result: ${toolResult}`);
+      console.log(`▸ result: ${toolResult}`);
     }
   } else {
-    console.log("  (none)");
+    console.log("▸ (none)");
   }
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   if (modelId)
     await unloadModel({ modelId, clearStorage: false }).catch(() => {});
   process.exit(1);

--- a/packages/sdk/examples/tools/llamacpp-tools-harmony-multiturn.ts
+++ b/packages/sdk/examples/tools/llamacpp-tools-harmony-multiturn.ts
@@ -22,10 +22,14 @@ try {
   modelId = await loadModel({
     modelSrc: GPT_OSS_20B_INST_Q4_K_M,
     modelConfig: { ctx_size: 4096, tools: true },
-    onProgress: (progress) =>
-      console.log(`Loading: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`✅ Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const history: Array<{ role: string; content: string }> = [
     {
@@ -40,7 +44,7 @@ try {
   ];
 
   for (let turn = 1; turn <= MAX_TURNS; turn++) {
-    console.log(`\n========== TURN ${turn} ==========`);
+    console.log(`\n▸ ========== TURN ${turn} ==========`);
     const result = completion({ modelId, history, tools, stream: true });
 
     for await (const token of result.tokenStream) {
@@ -49,14 +53,14 @@ try {
     console.log();
 
     const final = await result.final;
-    console.log(`\n--- TURN ${turn} SUMMARY ---`);
-    console.log(`[sdk toolCalls] ${final.toolCalls.length}`);
+    console.log(`\n▸ --- TURN ${turn} SUMMARY ---`);
+    console.log(`▸ [sdk toolCalls] ${final.toolCalls.length}`);
     for (const call of final.toolCalls) {
-      console.log(`  → ${call.name}(${JSON.stringify(call.arguments)})`);
+      console.log(`▸   ${call.name}(${JSON.stringify(call.arguments)})`);
     }
 
     if (final.toolCalls.length === 0) {
-      console.log(`\n🎉 Final response received — exiting loop.`);
+      console.log(`\n▸ Final response received — exiting loop.`);
       break;
     }
 
@@ -67,32 +71,32 @@ try {
 
     for (const call of final.toolCalls) {
       const toolResult = mockExecute(call.name, call.arguments);
-      console.log(`  ✓ mock-executed ${call.name}: ${toolResult}`);
+      console.log(`▸   mock-executed ${call.name}: ${toolResult}`);
       history.push({ role: "tool", content: toolResult });
     }
 
     if (turn === MAX_TURNS) {
-      console.log(`\n⚠️  MAX_TURNS (${MAX_TURNS}) reached — stopping.`);
+      console.log(`\n▸ MAX_TURNS (${MAX_TURNS}) reached — stopping.`);
     }
   }
 
-  console.log(`\n========== HISTORY ==========`);
+  console.log(`\n▸ ========== HISTORY ==========`);
   for (const msg of history) {
     const preview = msg.content.slice(0, 120).replace(/\n/g, "\\n");
     console.log(
-      `[${msg.role}] ${preview}${msg.content.length > 120 ? "…" : ""}`,
+      `▸ [${msg.role}] ${preview}${msg.content.length > 120 ? "…" : ""}`,
     );
   }
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 } finally {
   if (modelId) {
     try {
       await unloadModel({ modelId, clearStorage: false });
-      console.log(`\n[unload] done`);
+      console.log(`\n▸ [unload] done`);
     } catch (unloadError) {
-      console.error("[unload] failed:", unloadError);
+      console.error("✖ [unload] failed:", unloadError);
     }
   }
 }

--- a/packages/sdk/examples/tools/llamacpp-tools-pythonic.ts
+++ b/packages/sdk/examples/tools/llamacpp-tools-pythonic.ts
@@ -9,10 +9,14 @@ try {
     modelSrc: LFM_TOOL_HF,
     modelType: "llamacpp-completion",
     modelConfig: { ctx_size: 4096, tools: true },
-    onProgress: (progress) =>
-      console.log(`Loading: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`✅ Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const history = [
     {
@@ -26,7 +30,7 @@ try {
     },
   ];
 
-  console.log("\n🤖 Streaming...\n");
+  console.log("\n▸ Streaming...\n");
 
   const result = completion({ modelId, history, stream: true, tools });
 
@@ -39,7 +43,7 @@ try {
   const toolsTask = (async () => {
     for await (const evt of result.toolCallStream) {
       console.log(
-        `\n→ ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
+        `\n▸ ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
       );
     }
   })();
@@ -48,17 +52,17 @@ try {
 
   const toolCalls: ToolCall[] = await result.toolCalls;
 
-  console.log("\n\n📋 Final tool calls:");
+  console.log("\n\n▸ Final tool calls:");
   if (toolCalls.length > 0) {
     for (const call of toolCalls) {
-      console.log(`  - ${call.name}(${JSON.stringify(call.arguments)})`);
+      console.log(`▸ ${call.name}(${JSON.stringify(call.arguments)})`);
     }
   } else {
-    console.log("  (none)");
+    console.log("▸ (none)");
   }
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/tools/llamacpp-tools-qwen35.ts
+++ b/packages/sdk/examples/tools/llamacpp-tools-qwen35.ts
@@ -28,10 +28,14 @@ try {
     modelSrc,
     modelType: "llamacpp-completion",
     modelConfig: { ctx_size: 4096, tools: true },
-    onProgress: (progress) =>
-      console.log(`Loading: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const history = [
     {
@@ -57,7 +61,7 @@ try {
     for await (const evt of result.toolCallStream) {
       if (evt.type === "toolCall") {
         console.log(
-          `\n-> ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
+          `\n▸ ${evt.call.name}(${JSON.stringify(evt.call.arguments)})`,
         );
       }
     }
@@ -67,20 +71,20 @@ try {
 
   const toolCalls: ToolCall[] = await result.toolCalls;
 
-  console.log("\n\nFinal tool calls:");
+  console.log("\n\n▸ Final tool calls:");
   if (toolCalls.length > 0) {
     for (const call of toolCalls) {
-      console.log(`  - ${call.name}(${JSON.stringify(call.arguments)})`);
+      console.log(`▸ ${call.name}(${JSON.stringify(call.arguments)})`);
       const toolResult = mockExecute(call.name, call.arguments);
-      console.log(`    result: ${toolResult}`);
+      console.log(`▸ result: ${toolResult}`);
     }
   } else {
-    console.log("  (none)");
+    console.log("▸ (none)");
   }
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   if (modelId)
     await unloadModel({ modelId, clearStorage: false }).catch(() => {});
   process.exit(1);

--- a/packages/sdk/examples/transcription/parakeet-ctc-filesystem.ts
+++ b/packages/sdk/examples/transcription/parakeet-ctc-filesystem.ts
@@ -34,27 +34,29 @@ const audioFilePath = args[0];
 const parakeetModelSrc = args[1] ?? PARAKEET_CTC_0_6B_Q8_0;
 
 try {
-  console.log("Loading Parakeet CTC model...");
+  console.log("▸ Loading Parakeet CTC model...");
   const modelId = await loadModel({
     modelSrc: parakeetModelSrc,
     modelType: "parakeet-transcription",
-    onProgress: (progress) => {
-      console.log(`Download progress: ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`Parakeet CTC model loaded with ID: ${modelId}`);
+  console.log(`▸ Parakeet CTC model loaded with ID: ${modelId}`);
 
-  console.log("Transcribing audio...");
+  console.log("▸ Transcribing audio...");
   const text = await transcribe({ modelId, audioChunk: audioFilePath });
 
-  console.log("Transcription result:");
   console.log(text);
 
-  console.log("Unloading model...");
+  console.log("▸ Unloading model...");
   await unloadModel({ modelId });
-  console.log("Done");
+  console.log("▸ Done");
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/transcription/parakeet-microphone-record.ts
+++ b/packages/sdk/examples/transcription/parakeet-microphone-record.ts
@@ -29,16 +29,21 @@ try {
   const r = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" });
   if (r.error || r.status !== 0) throw new Error("FFmpeg not found");
 } catch {
-  console.error("FFmpeg is required. Install it and try again.");
+  console.error("✖ FFmpeg is required. Install it and try again.");
   process.exit(1);
 }
 
-console.log("Loading Parakeet model...");
+console.log("▸ Loading Parakeet model...");
 const modelId = await loadModel({
   modelSrc: PARAKEET_TDT_0_6B_V3_Q8_0,
-  onProgress: (p) => console.log(`Download: ${p.percentage.toFixed(1)}%`),
+  onProgress: (p) => {
+    const mb = (n: number) => (n / 1e6).toFixed(1);
+    const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+    process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+    if (p.percentage >= 100) process.stderr.write("\n");
+  },
 });
-console.log("Model loaded.\n");
+console.log("▸ Model loaded.");
 
 const ffmpeg = startMicrophone({
   sampleRate: SAMPLE_RATE,
@@ -48,7 +53,7 @@ const ffmpeg = startMicrophone({
 let buffer = Buffer.alloc(0);
 let processing = false;
 
-console.log("Listening... speak and pause to see transcriptions.\n");
+console.log("▸ Listening... speak and pause to see transcriptions.");
 
 ffmpeg.stdout.on("data", (chunk: Buffer) => {
   buffer = Buffer.concat([buffer, chunk]);
@@ -62,13 +67,10 @@ ffmpeg.stdout.on("data", (chunk: Buffer) => {
       try {
         const text = await transcribe({ modelId, audioChunk });
         if (text.trim() && !text.includes("[No speech detected]")) {
-          console.log(`> ${text.trim()}`);
+          console.log(text.trim());
         }
       } catch (err) {
-        console.error(
-          "Transcription error:",
-          err instanceof Error ? err.message : err,
-        );
+        console.error("✖", err instanceof Error ? err.message : err);
       } finally {
         processing = false;
       }
@@ -77,10 +79,10 @@ ffmpeg.stdout.on("data", (chunk: Buffer) => {
 });
 
 async function cleanup() {
-  console.log("\n\nStopping...");
+  console.log("\n▸ Stopping...");
   ffmpeg.kill();
   await unloadModel({ modelId });
-  console.log("Done.");
+  console.log("▸ Done.");
 }
 
 process.on("SIGINT", () => void cleanup());

--- a/packages/sdk/examples/transcription/parakeet-microphone-stream.ts
+++ b/packages/sdk/examples/transcription/parakeet-microphone-stream.ts
@@ -26,7 +26,7 @@ try {
   const r = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" });
   if (r.error || r.status !== 0) throw new Error("FFmpeg not found");
 } catch {
-  console.error("Error: FFmpeg is required. Install it and try again.");
+  console.error("✖ FFmpeg is required. Install it and try again.");
   process.exit(1);
 }
 
@@ -34,10 +34,10 @@ let modelId: string | null = null;
 let ffmpeg: ReturnType<typeof startMicrophone> | null = null;
 
 async function cleanup() {
-  console.log("\n\nStopping...");
+  console.log("\n▸ Stopping...");
   ffmpeg?.kill();
   if (modelId) await unloadModel({ modelId });
-  console.log("Done.");
+  console.log("▸ Done.");
 }
 
 process.on("SIGINT", () => {
@@ -48,12 +48,17 @@ process.on("SIGTERM", () => {
 });
 
 try {
-  console.log("Loading Parakeet (EOU) streaming model...");
+  console.log("▸ Loading Parakeet (EOU) streaming model...");
   modelId = await loadModel({
     modelSrc: PARAKEET_EOU_120M_V1_Q8_0,
-    onProgress: (p) => console.log(`Download: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log("Model loaded.\n");
+  console.log("▸ Model loaded.");
 
   ffmpeg = startMicrophone({ sampleRate: SAMPLE_RATE, format: "s16le" });
 
@@ -68,7 +73,7 @@ try {
   ffmpeg.stdout.on("data", (chunk: Buffer) => session.write(chunk));
 
   console.log(
-    "Listening... speak and pause to see transcripts. End-of-turn boundaries fire when the EOU model emits an <EOU> token.\n",
+    "▸ Listening... speak and pause to see transcripts. End-of-turn boundaries fire when the EOU model emits an <EOU> token.",
   );
 
   for await (const event of session) {
@@ -79,14 +84,14 @@ try {
         }
         break;
       case "endOfTurn":
-        console.log("\n[endOfTurn] turn boundary detected\n");
+        console.log("\n▸ [endOfTurn] turn boundary detected");
         break;
     }
   }
   await cleanup();
   process.exit(0);
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   await cleanup();
   process.exit(1);
 }

--- a/packages/sdk/examples/transcription/parakeet-sortformer-streaming.ts
+++ b/packages/sdk/examples/transcription/parakeet-sortformer-streaming.ts
@@ -96,7 +96,12 @@ function readS16leFromWav(wavPath: string): Promise<Uint8Array> {
 const loadOptions: LoadModelOptions = {
   modelType: "parakeet-transcription",
   modelConfig: { ...SORTFORMER_V21_AOSC_LOAD_CONFIG },
-  onProgress: (p) => console.log(`Download: ${p.percentage.toFixed(1)}%`),
+  onProgress: (p) => {
+    const mb = (n: number) => (n / 1e6).toFixed(1);
+    const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+    process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+    if (p.percentage >= 100) process.stderr.write("\n");
+  },
   ...(sortformerOverride
     ? { modelSrc: sortformerOverride }
     : { modelSrc: PARAKEET_SORTFORMER_4SPK_V2_1_Q8_0 }),
@@ -104,10 +109,10 @@ const loadOptions: LoadModelOptions = {
 
 try {
   console.log(
-    "Loading Sortformer v2.1 with streaming + AOSC (load-time config)...",
+    "▸ Loading Sortformer v2.1 with streaming + AOSC (load-time config)...",
   );
   modelId = await loadModel(loadOptions);
-  console.log(`Model loaded: ${modelId}\n`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const session = await transcribeStream({
     modelId,
@@ -115,7 +120,7 @@ try {
   });
 
   console.log(
-    `Streaming ${audioFilePath} in ${STREAM_CHUNK_MS}ms chunks (wall-clock paced)...\n`,
+    `▸ Streaming ${audioFilePath} in ${STREAM_CHUNK_MS}ms chunks (wall-clock paced)...`,
   );
 
   const pcm = await readS16leFromWav(audioFilePath);
@@ -150,13 +155,13 @@ try {
     }
   }
 
-  console.log("\n=== Streaming diarization transcript ===");
+  console.log("\n▸ Streaming diarization transcript");
   console.log(lines.join("\n") || "(no speaker lines emitted)");
 
   await cleanup();
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   await cleanup();
   process.exit(1);
 }

--- a/packages/sdk/examples/transcription/parakeet-sortformer.ts
+++ b/packages/sdk/examples/transcription/parakeet-sortformer.ts
@@ -93,18 +93,16 @@ try {
 
   const merged = mergeSpeakers(results);
 
-  console.log("\n=== DIARIZED TRANSCRIPTION ===");
-  console.log("=".repeat(60));
+  console.log("\n▸ Diarized transcription");
   for (const entry of merged) {
     console.log(
       `Speaker ${entry.speaker} (${entry.start.toFixed(2)}s - ${entry.end.toFixed(2)}s):`,
     );
     console.log(`  ${entry.text}\n`);
   }
-  console.log("=".repeat(60));
-  console.log("\nDone!");
+  console.log("▸ Done");
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }
 

--- a/packages/sdk/examples/transcription/parakeet-tdt-filesystem.ts
+++ b/packages/sdk/examples/transcription/parakeet-tdt-filesystem.ts
@@ -34,29 +34,31 @@ const audioFilePath = args[0];
 const parakeetModelSrc = args[1] ?? PARAKEET_TDT_0_6B_V3_Q8_0;
 
 try {
-  console.log("Starting Parakeet transcription example...");
+  console.log("▸ Starting Parakeet transcription example...");
 
-  console.log("Loading Parakeet model...");
+  console.log("▸ Loading Parakeet model...");
   const modelId = await loadModel({
     modelSrc: parakeetModelSrc,
     modelType: "parakeet-transcription",
-    onProgress: (progress) => {
-      console.log(`Download progress: ${progress.percentage.toFixed(1)}%`);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`Parakeet model loaded with ID: ${modelId}`);
+  console.log(`▸ Parakeet model loaded with ID: ${modelId}`);
 
-  console.log("Transcribing audio...");
+  console.log("▸ Transcribing audio...");
   const text = await transcribe({ modelId, audioChunk: audioFilePath });
 
-  console.log("Transcription result:");
   console.log(text);
 
-  console.log("Unloading Parakeet model...");
+  console.log("▸ Unloading Parakeet model...");
   await unloadModel({ modelId });
-  console.log("Parakeet model unloaded successfully");
+  console.log("▸ Parakeet model unloaded successfully");
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/transcription/whispercpp-filesystem-streaming.ts
+++ b/packages/sdk/examples/transcription/whispercpp-filesystem-streaming.ts
@@ -36,11 +36,11 @@ const BYTES_PER_SAMPLE = 4; // f32le
 const CHUNK_SIZE = Math.floor(0.1 * SAMPLE_RATE) * BYTES_PER_SAMPLE; // 100ms chunks
 
 try {
-  console.log("=== transcribeStream file test ===");
-  console.log(`File: ${SAMPLE_FILE}`);
-  console.log(`Chunk size: ${CHUNK_SIZE} bytes (100ms)\n`);
+  console.log("▸ transcribeStream file test");
+  console.log(`▸ File: ${SAMPLE_FILE}`);
+  console.log(`▸ Chunk size: ${CHUNK_SIZE} bytes (100ms)`);
 
-  console.log("Loading model...");
+  console.log("▸ Loading model...");
   const modelId = await loadModel({
     modelSrc: WHISPER_TINY,
     modelConfig: {
@@ -62,11 +62,11 @@ try {
       },
     },
   });
-  console.log(`Model loaded: ${modelId}\n`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
-  console.log("Opening live session...");
+  console.log("▸ Opening live session...");
   const session = await transcribeStream({ modelId, metadata: true });
-  console.log("Session open. Streaming audio...\n");
+  console.log("▸ Session open. Streaming audio...");
 
   const ffmpeg = spawn(
     "ffmpeg",
@@ -99,9 +99,9 @@ try {
   ffmpeg.on("close", () => {
     const durationSec = totalBytes / (SAMPLE_RATE * BYTES_PER_SAMPLE);
     console.log(
-      `Audio streamed: ${totalBytes} bytes (~${durationSec.toFixed(1)}s)`,
+      `▸ Audio streamed: ${totalBytes} bytes (~${durationSec.toFixed(1)}s)`,
     );
-    console.log("Waiting for transcription...\n");
+    console.log("▸ Waiting for transcription...");
     session.end();
   });
 
@@ -111,23 +111,22 @@ try {
     const start = (segment.startMs / 1000).toFixed(2);
     const end = (segment.endMs / 1000).toFixed(2);
     console.log(
-      `  [${segments.length}] [${start}s → ${end}s] (id=${segment.id}, append=${segment.append}) ${segment.text.trim()}`,
+      `▸ [${segments.length}] [${start}s → ${end}s] (id=${segment.id}, append=${segment.append}) ${segment.text.trim()}`,
     );
   }
 
-  console.log("\n=== Results ===");
-  console.log(`Segments: ${segments.length}`);
+  console.log(`\n▸ Segments: ${segments.length}`);
   if (segments.length > 0) {
-    console.log(`Transcript: ${segments.map((s) => s.text.trim()).join(" ")}`);
+    console.log(segments.map((s) => s.text.trim()).join(" "));
   } else {
-    console.log("WARNING: No transcription segments received!");
+    console.log("▸ No transcription segments received!");
   }
 
-  console.log("\nUnloading model...");
+  console.log("▸ Unloading model...");
   await unloadModel({ modelId });
-  console.log("Done.");
+  console.log("▸ Done.");
   process.exit(0);
 } catch (error) {
-  console.error("Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/transcription/whispercpp-filesystem.ts
+++ b/packages/sdk/examples/transcription/whispercpp-filesystem.ts
@@ -13,10 +13,10 @@ if (!args[0]) {
 const audioFilePath = args[0];
 
 try {
-  console.log("🎤 Starting Whisper transcription example...");
+  console.log("▸ Starting Whisper transcription example...");
 
   // Load the Whisper model
-  console.log("📥 Loading Whisper model...");
+  console.log("▸ Loading Whisper model...");
   const modelId = await loadModel({
     modelSrc: WHISPER_TINY,
     modelConfig: {
@@ -54,22 +54,25 @@ try {
         gpu_device: 0,
       },
     },
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`✅ Whisper model loaded with ID: ${modelId}`);
+  console.log(`▸ Whisper model loaded with ID: ${modelId}`);
 
   // Perform transcription with per-segment metadata
-  console.log("🎧 Transcribing audio...");
+  console.log("▸ Transcribing audio...");
   const segments = await transcribe({
     modelId,
     audioChunk: audioFilePath,
     metadata: true,
   });
 
-  console.log("📝 Transcription result:");
+  console.log("▸ Transcription result:");
   for (const segment of segments) {
     const start = (segment.startMs / 1000).toFixed(2);
     const end = (segment.endMs / 1000).toFixed(2);
@@ -85,10 +88,10 @@ try {
   );
 
   // Unload the model when done
-  console.log("🧹 Unloading Whisper model...");
+  console.log("▸ Unloading Whisper model...");
   await unloadModel({ modelId });
-  console.log("✅ Whisper model unloaded successfully");
+  console.log("▸ Whisper model unloaded successfully");
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/transcription/whispercpp-microphone-conversation.ts
+++ b/packages/sdk/examples/transcription/whispercpp-microphone-conversation.ts
@@ -32,7 +32,7 @@ try {
   const r = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" });
   if (r.error || r.status !== 0) throw new Error("FFmpeg not found");
 } catch {
-  console.error("❌ Error: FFmpeg is required. Install it and try again.");
+  console.error("✖ FFmpeg is required. Install it and try again.");
   process.exit(1);
 }
 
@@ -40,10 +40,10 @@ let modelId: string | null = null;
 let ffmpeg: ReturnType<typeof startMicrophone> | null = null;
 
 async function cleanup() {
-  console.log("\n\nStopping...");
+  console.log("\n\n▸ Stopping...");
   ffmpeg?.kill();
   if (modelId) await unloadModel({ modelId });
-  console.log("Done.");
+  console.log("▸ Done.");
 }
 
 process.on("SIGINT", () => {
@@ -54,7 +54,7 @@ process.on("SIGTERM", () => {
 });
 
 try {
-  console.log("Loading model (whisper-tiny + Silero VAD)...");
+  console.log("▸ Loading model (whisper-tiny + Silero VAD)...");
   modelId = await loadModel({
     modelSrc: WHISPER_TINY,
     modelConfig: {
@@ -76,7 +76,7 @@ try {
       },
     },
   });
-  console.log("Model loaded.\n");
+  console.log("▸ Model loaded.\n");
 
   ffmpeg = startMicrophone({ sampleRate: SAMPLE_RATE, format: "f32le" });
 
@@ -89,7 +89,7 @@ try {
   ffmpeg.stdout.on("data", (chunk: Buffer) => session.write(chunk));
 
   console.log(
-    "Listening... speak and pause to see transcripts, VAD events, and end-of-turn signals.\n",
+    "▸ Listening... speak and pause to see transcripts, VAD events, and end-of-turn signals.\n",
   );
 
   let lastSpeaking = false;
@@ -101,7 +101,7 @@ try {
       case "vad":
         if (event.speaking !== lastSpeaking) {
           console.log(
-            `[vad] speaking=${event.speaking} probability=${event.probability.toFixed(2)}`,
+            `▸ [vad] speaking=${event.speaking} probability=${event.probability.toFixed(2)}`,
           );
           lastSpeaking = event.speaking;
         }
@@ -109,16 +109,16 @@ try {
       case "endOfTurn":
         if (event.source === "whisper") {
           console.log(
-            `[endOfTurn] silence ${event.silenceDurationMs}ms — turn complete\n`,
+            `▸ [endOfTurn] silence ${event.silenceDurationMs}ms — turn complete\n`,
           );
         } else {
-          console.log(`[endOfTurn] turn complete (token-driven EOU)\n`);
+          console.log(`▸ [endOfTurn] turn complete (token-driven EOU)\n`);
         }
         break;
     }
   }
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   await cleanup();
   process.exit(1);
 }

--- a/packages/sdk/examples/transcription/whispercpp-microphone-record.ts
+++ b/packages/sdk/examples/transcription/whispercpp-microphone-record.ts
@@ -26,11 +26,11 @@ try {
   const r = spawnSync("ffmpeg", ["-version"], { stdio: "ignore" });
   if (r.error || r.status !== 0) throw new Error("FFmpeg not found");
 } catch {
-  console.error("FFmpeg is required. Install it and try again.");
+  console.error("✖ FFmpeg is required. Install it and try again.");
   process.exit(1);
 }
 
-console.log("Loading model (whisper-tiny + Silero VAD)...");
+console.log("▸ Loading model (whisper-tiny + Silero VAD)...");
 const modelId = await loadModel({
   modelSrc: WHISPER_TINY,
   modelConfig: {
@@ -52,7 +52,7 @@ const modelId = await loadModel({
     },
   },
 });
-console.log("Model loaded.\n");
+console.log("▸ Model loaded.\n");
 
 const ffmpeg = startMicrophone({
   sampleRate: SAMPLE_RATE,
@@ -63,17 +63,17 @@ const session = await transcribeStream({ modelId });
 
 ffmpeg.stdout.on("data", (chunk: Buffer) => session.write(chunk));
 
-console.log("Listening... speak and pause to see transcriptions.\n");
+console.log("▸ Listening... speak and pause to see transcriptions.\n");
 
 for await (const text of session) {
   console.log(`> ${text.trim()}`);
 }
 
 async function cleanup() {
-  console.log("\n\nStopping...");
+  console.log("\n\n▸ Stopping...");
   ffmpeg.kill();
   await unloadModel({ modelId });
-  console.log("Done.");
+  console.log("▸ Done.");
 }
 
 process.on("SIGINT", () => void cleanup());

--- a/packages/sdk/examples/transcription/whispercpp-prompt.ts
+++ b/packages/sdk/examples/transcription/whispercpp-prompt.ts
@@ -12,10 +12,10 @@
 import { loadModel, unloadModel, transcribe, WHISPER_TINY } from "@qvac/sdk";
 
 try {
-  console.log("🎤 Starting Whisper transcription with prompt example...");
+  console.log("▸ Starting Whisper transcription with prompt example...");
 
   // Load the Whisper model
-  console.log("📥 Loading Whisper model...");
+  console.log("▸ Loading Whisper model...");
   const modelId = await loadModel({
     modelSrc: WHISPER_TINY,
     modelConfig: {
@@ -53,15 +53,18 @@ try {
         gpu_device: 0,
       },
     },
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`✅ Whisper model loaded with ID: ${modelId}`);
+  console.log(`▸ Whisper model loaded with ID: ${modelId}`);
 
   // Perform transcription
-  console.log("🎧 Transcribing audio...");
+  console.log("▸ Transcribing audio...");
   const text = await transcribe({
     modelId,
     audioChunk: "examples/audio/sample-16khz.wav",
@@ -69,15 +72,15 @@ try {
       "This is a test recording with clear speech and proper punctuation.",
   });
 
-  console.log("📝 Transcription result:");
+  console.log("▸ Transcription result:");
   console.log(text);
 
   // Unload the model when done
-  console.log("🧹 Unloading Whisper model...");
+  console.log("▸ Unloading Whisper model...");
   await unloadModel({ modelId });
-  console.log("✅ Whisper model unloaded successfully");
+  console.log("▸ Whisper model unloaded successfully");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/translation/translation-bergamot-batch.ts
+++ b/packages/sdk/examples/translation/translation-bergamot-batch.ts
@@ -13,12 +13,15 @@ try {
       norepeatngramsize: 3,
       lengthpenalty: 1.2,
     },
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`✅ Bergamot model loaded: ${modelId}`);
+  console.log(`▸ Bergamot model loaded: ${modelId}`);
 
   // Test with array of texts for batch processing
   const texts = [
@@ -28,8 +31,8 @@ try {
     "The weather is nice",
   ];
 
-  console.log("\n📝 Translating batch of texts:");
-  texts.forEach((text, i) => console.log(`  ${i + 1}. ${text}`));
+  console.log("▸ Translating batch of texts:");
+  texts.forEach((text, i) => console.log(`▸   ${i + 1}. ${text}`));
 
   const result = translate({
     modelId,
@@ -41,7 +44,7 @@ try {
   const translatedText = await result.text;
   const translations = translatedText.split("\n");
 
-  console.log("\n✅ Translations:");
+  console.log("▸ Translations:");
   translations.forEach((translation, i) => {
     if (i < texts.length) {
       console.log(`  ${i + 1}. ${texts[i]} -> "${translation}"`);
@@ -50,6 +53,6 @@ try {
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/translation/translation-bergamot-pivot.ts
+++ b/packages/sdk/examples/translation/translation-bergamot-pivot.ts
@@ -44,21 +44,24 @@ try {
         lengthpenalty: 1.2,
       },
     },
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`✅ Pivot translation model loaded: ${modelId}`);
-  console.log("   Primary: Spanish → English");
-  console.log("   Pivot: English → Italian");
+  console.log(`▸ Pivot translation model loaded: ${modelId}`);
+  console.log("▸ Primary: Spanish → English");
+  console.log("▸ Pivot: English → Italian");
 
   // Spanish text to translate
   const spanishText = `Era una mañana soleada cuando María decidió visitar el mercado local.
   Compró frutas frescas, verduras y flores para su casa.
   El vendedor le recomendó las mejores manzanas de la temporada.`;
 
-  console.log("\n📝 Original Spanish text:");
+  console.log("▸ Original Spanish text:");
   console.log(spanishText);
 
   // Translate Spanish → English → Italian
@@ -71,7 +74,7 @@ try {
 
   const italianText = await result.text;
 
-  console.log("\n🇮🇹 Translated to Italian (via English):");
+  console.log("▸ Translated to Italian (via English):");
   console.log(italianText);
 
   // Expected output (approximate):
@@ -80,8 +83,8 @@ try {
   //  Il venditore ha consigliato le migliori mele della stagione."
 
   await unloadModel({ modelId });
-  console.log("\n✅ Model unloaded successfully");
+  console.log("▸ Model unloaded successfully");
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/translation/translation-bergamot.ts
+++ b/packages/sdk/examples/translation/translation-bergamot.ts
@@ -18,12 +18,15 @@ try {
       norepeatngramsize: 3,
       lengthpenalty: 1.2,
     },
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`✅ Bergamot model loaded: ${modelId}`);
+  console.log(`▸ Bergamot model loaded: ${modelId}`);
 
   const text = "This is a test of the Bergamot translation model.";
   const result = translate({
@@ -38,6 +41,6 @@ try {
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/translation/translation-indic.ts
+++ b/packages/sdk/examples/translation/translation-indic.ts
@@ -12,8 +12,11 @@ import {
 try {
   const modelId = await loadModel({
     modelSrc: MARIAN_EN_HI_INDIC_1B_Q4_0,
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
     modelConfig: {
       engine: "IndicTrans",
@@ -22,7 +25,7 @@ try {
     },
   });
 
-  console.log(`✅ Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const text = "Hello, how are you today?";
   const result = translate({
@@ -37,6 +40,6 @@ try {
 
   await unloadModel({ modelId });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/translation/translation-llm-afriquegemma.ts
+++ b/packages/sdk/examples/translation/translation-llm-afriquegemma.ts
@@ -8,8 +8,11 @@ import {
 try {
   const modelId = await loadModel({
     modelSrc: AFRICAN_4B_TRANSLATION_Q4_K_M,
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
     // IMPORTANT: these parameters are validated to be optimal
     modelConfig: {
@@ -42,6 +45,6 @@ try {
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/translation/translation-llm-context.ts
+++ b/packages/sdk/examples/translation/translation-llm-context.ts
@@ -8,12 +8,15 @@ import {
 try {
   const modelId = await loadModel({
     modelSrc: SALAMANDRATA_2B_INST_Q8,
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`✅ Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   // With explicit source language
   const engText = "bank";
@@ -33,6 +36,6 @@ try {
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/translation/translation-llm.ts
+++ b/packages/sdk/examples/translation/translation-llm.ts
@@ -8,8 +8,11 @@ import {
 try {
   const modelId = await loadModel({
     modelSrc: SALAMANDRATA_2B_INST_Q4,
-    onProgress: (progress) => {
-      console.log(progress);
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
@@ -45,6 +48,6 @@ try {
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/translation/translation-stream.ts
+++ b/packages/sdk/examples/translation/translation-stream.ts
@@ -10,12 +10,12 @@ try {
     },
   });
 
-  console.log(`✅ Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const text =
     "Hello, how are you today? I hope you are having a wonderful day!";
 
-  console.log("\n--- Streaming Translation ---");
+  console.log("▸ Streaming Translation");
   const streamResult = translate({
     modelId,
     text,
@@ -31,11 +31,11 @@ try {
 
   const stats = await streamResult.stats;
   if (stats) {
-    console.log(`Processing stats:`, stats);
+    console.log(`▸ Processing stats:`, stats);
   }
 
   await unloadModel({ modelId, clearStorage: false });
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/tts/chatterbox.ts
+++ b/packages/sdk/examples/tts/chatterbox.ts
@@ -29,14 +29,17 @@ try {
       s3genModelSrc: TTS_S3GEN_EN_CHATTERBOX.src,
       ...(referenceAudioSrc ? { referenceAudioSrc } : {}),
     },
-    onProgress: (progress: ModelProgressUpdate) => {
-      console.log(progress);
+    onProgress: (p: ModelProgressUpdate) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
-  console.log("🎵 Testing Text-to-Speech...");
+  console.log("▸ Testing Text-to-Speech...");
   const result = textToSpeech({
     modelId,
     text: `QVAC SDK is the canonical entry point to QVAC. Written in TypeScript, it provides all QVAC capabilities through a unified interface while also abstracting away the complexity of running your application in a JS environment other than Bare. Supported JS environments include Bare, Node.js, Expo and Bun.`,
@@ -45,25 +48,25 @@ try {
   });
 
   const audioBuffer = await result.buffer;
-  console.log(`TTS complete. Total bytes: ${audioBuffer.length}`);
+  console.log(`▸ TTS complete. Total bytes: ${audioBuffer.length}`);
 
-  console.log("💾 Saving audio to file...");
+  console.log("▸ Saving audio to file...");
   createWav(audioBuffer, CHATTERBOX_SAMPLE_RATE, "tts-output.wav");
-  console.log("✅ Audio saved to tts-output.wav");
+  console.log("▸ Audio saved to tts-output.wav");
 
-  console.log("🔊 Playing audio...");
+  console.log("▸ Playing audio...");
   const audioData = int16ArrayToBuffer(audioBuffer);
   const wavBuffer = Buffer.concat([
     createWavHeader(audioData.length, CHATTERBOX_SAMPLE_RATE),
     audioData,
   ]);
   playAudio(wavBuffer);
-  console.log("✅ Audio playback complete");
+  console.log("▸ Audio playback complete");
 
   await unloadModel({ modelId });
-  console.log("Model unloaded");
+  console.log("▸ Model unloaded");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/tts/llm-to-tts-streaming.ts
+++ b/packages/sdk/examples/tts/llm-to-tts-streaming.ts
@@ -70,18 +70,22 @@ function appendPcmSamples(target: number[], chunk: number[]) {
 }
 
 try {
-  console.log(`Loading LLM from registry: ${LLAMA_3_2_1B_INST_Q4_0.name}`);
+  console.log(`▸ Loading LLM from registry: ${LLAMA_3_2_1B_INST_Q4_0.name}`);
   const llmModelId = await loadModel({
     modelSrc: LLAMA_3_2_1B_INST_Q4_0,
     modelConfig: {
       ctx_size: 2048,
     },
-    onProgress: (progress: ModelProgressUpdate) =>
-      console.log(`LLM load: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p: ModelProgressUpdate) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`LLM ready: ${llmModelId}`);
+  console.log(`▸ LLM ready: ${llmModelId}`);
 
-  console.log("Loading Supertonic TTS (registry)…");
+  console.log("▸ Loading Supertonic TTS (registry)…");
   const ttsModelId = await loadModel({
     modelSrc: TTS_EN_SUPERTONIC_Q8_0,
     modelConfig: {
@@ -91,14 +95,19 @@ try {
       ttsSpeed: 1.05,
       ttsNumInferenceSteps: 10,
     },
-    onProgress: (progress: ModelProgressUpdate) =>
-      console.log(`TTS load: ${progress.percentage.toFixed(1)}%`),
+    onProgress: (p: ModelProgressUpdate) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  console.log(`TTS ready: ${ttsModelId}`);
+  console.log(`▸ TTS ready: ${ttsModelId}`);
 
   const prompt = "What is a constellation?";
 
-  console.log(`\nUser: ${prompt}\nAssistant (streaming):`);
+  console.log(`▸ User: ${prompt}`);
+  console.log("▸ Assistant (streaming):");
 
   const result = completion({
     modelId: llmModelId,
@@ -127,7 +136,7 @@ try {
             ? m.sentenceChunk.replace(/\s+/g, " ").trim().slice(0, 72)
             : "";
         console.log(
-          `\n[TTS phrase ${phraseIndex}] ${m.buffer.length} samples${preview ? ` — "${preview}${preview.length >= 72 ? "..." : ""}"` : ""}`,
+          `\n▸ [TTS phrase ${phraseIndex}] ${m.buffer.length} samples${preview ? ` — "${preview}${preview.length >= 72 ? "..." : ""}"` : ""}`,
         );
         await playPcmInt16Chunk(m.buffer, SUPERTONIC_SAMPLE_RATE);
       }
@@ -146,20 +155,20 @@ try {
 
   const stats = await result.stats;
   if (stats) {
-    console.log("\nLLM stats:", stats);
+    console.log("\n▸ LLM stats:", stats);
   }
 
   const outWav = "llm-to-tts-streaming-output.wav";
   console.log(
-    `\nWriting ${combinedPcm.length} samples to ${outWav} (full utterance; phrases were already played above).`,
+    `\n▸ Writing ${combinedPcm.length} samples to ${outWav} (full utterance; phrases were already played above).`,
   );
   createWav(combinedPcm, SUPERTONIC_SAMPLE_RATE, outWav);
 
   await unloadModel({ modelId: llmModelId, clearStorage: false });
   await unloadModel({ modelId: ttsModelId, clearStorage: false });
-  console.log("Models unloaded.");
+  console.log("▸ Models unloaded.");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/tts/supertonic-multilingual.ts
+++ b/packages/sdk/examples/tts/supertonic-multilingual.ts
@@ -25,14 +25,17 @@ try {
       ttsSpeed: 1.05,
       ttsNumInferenceSteps: 5,
     },
-    onProgress: (progress: ModelProgressUpdate) => {
-      console.log(progress);
+    onProgress: (p: ModelProgressUpdate) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
-  console.log("🎵 Testing Text-to-Speech...");
+  console.log("▸ Testing Text-to-Speech...");
   const result = textToSpeech({
     modelId,
     text: `Hola mundo. Esta es una demostración de síntesis de voz con Supertonic en español.`,
@@ -41,29 +44,29 @@ try {
   });
 
   const audioBuffer = await result.buffer;
-  console.log(`TTS complete. Total samples: ${audioBuffer.length}`);
+  console.log(`▸ TTS complete. Total samples: ${audioBuffer.length}`);
 
-  console.log("💾 Saving audio to file...");
+  console.log("▸ Saving audio to file...");
   createWav(
     audioBuffer,
     SUPERTONIC_SAMPLE_RATE,
     "supertonic-multilingual-output.wav",
   );
-  console.log("✅ Audio saved to supertonic-multilingual-output.wav");
+  console.log("▸ Audio saved to supertonic-multilingual-output.wav");
 
-  console.log("🔊 Playing audio...");
+  console.log("▸ Playing audio...");
   const audioData = int16ArrayToBuffer(audioBuffer);
   const wavBuffer = Buffer.concat([
     createWavHeader(audioData.length, SUPERTONIC_SAMPLE_RATE),
     audioData,
   ]);
   playAudio(wavBuffer);
-  console.log("✅ Audio playback complete");
+  console.log("▸ Audio playback complete");
 
   await unloadModel({ modelId });
-  console.log("Model unloaded");
+  console.log("▸ Model unloaded");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/tts/supertonic.ts
+++ b/packages/sdk/examples/tts/supertonic.ts
@@ -26,14 +26,17 @@ try {
       ttsSpeed: 1.05,
       ttsNumInferenceSteps: 5,
     },
-    onProgress: (progress: ModelProgressUpdate) => {
-      console.log(progress);
+    onProgress: (p: ModelProgressUpdate) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
     },
   });
 
-  console.log(`Model loaded: ${modelId}`);
+  console.log(`▸ Model loaded: ${modelId}`);
 
-  console.log("🎵 Testing Text-to-Speech...");
+  console.log("▸ Testing Text-to-Speech...");
   const result = textToSpeech({
     modelId,
     text: `QVAC SDK is the canonical entry point to QVAC. Written in TypeScript, it provides all QVAC capabilities through a unified interface while also abstracting away the complexity of running your application in a JS environment other than Bare. Supported JS environments include Bare, Node.js, Expo and Bun.`,
@@ -42,25 +45,25 @@ try {
   });
 
   const audioBuffer = await result.buffer;
-  console.log(`TTS complete. Total samples: ${audioBuffer.length}`);
+  console.log(`▸ TTS complete. Total samples: ${audioBuffer.length}`);
 
-  console.log("💾 Saving audio to file...");
+  console.log("▸ Saving audio to file...");
   createWav(audioBuffer, SUPERTONIC_SAMPLE_RATE, "supertonic-output.wav");
-  console.log("✅ Audio saved to supertonic-output.wav");
+  console.log("▸ Audio saved to supertonic-output.wav");
 
-  console.log("🔊 Playing audio...");
+  console.log("▸ Playing audio...");
   const audioData = int16ArrayToBuffer(audioBuffer);
   const wavBuffer = Buffer.concat([
     createWavHeader(audioData.length, SUPERTONIC_SAMPLE_RATE),
     audioData,
   ]);
   playAudio(wavBuffer);
-  console.log("✅ Audio playback complete");
+  console.log("▸ Audio playback complete");
 
   await unloadModel({ modelId });
-  console.log("Model unloaded");
+  console.log("▸ Model unloaded");
   process.exit(0);
 } catch (error) {
-  console.error("❌ Error:", error);
+  console.error("✖", error);
   process.exit(1);
 }

--- a/packages/sdk/examples/tts/utils.ts
+++ b/packages/sdk/examples/tts/utils.ts
@@ -62,7 +62,7 @@ export function createWav(
   const wavFile = Buffer.concat([wavHeader, audioData]);
 
   writeFileSync(filename, wavFile);
-  console.log(`WAV file saved as: ${filename}`);
+  console.log(`▸ WAV file saved as: ${filename}`);
 }
 
 /**

--- a/packages/sdk/examples/vla-pi05.ts
+++ b/packages/sdk/examples/vla-pi05.ts
@@ -32,22 +32,24 @@ const modelSrcOverride = process.argv[2];
 const modelSrc = modelSrcOverride ?? PI05_BASE_Q_AGGRESSIVE;
 
 try {
-  console.log("Loading π₀.₅ (pi05) model...");
+  console.log("▸ Loading π₀.₅ (pi05) model...");
   const modelId = await loadModel({
     modelSrc,
     modelType: "ggml-vla",
     modelConfig: { backend: "cpu" },
-    onProgress: (p) =>
-      typeof modelSrc === "string"
-        ? undefined
-        : process.stdout.write(`\rDownloading: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  if (typeof modelSrc !== "string") process.stdout.write("\n");
-  console.log(`Model loaded: ${modelId}`);
+  if (typeof modelSrc !== "string") process.stderr.write("\n");
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const { hparams, backendName } = await vlaHparams({ modelId });
-  console.log(`Backend: ${backendName ?? "(unknown)"}`);
-  console.log("Hparams:", hparams);
+  console.log(`▸ Backend: ${backendName ?? "(unknown)"}`);
+  console.log("▸ Hparams:", hparams);
 
   // Build synthetic inputs sized to the model's expectations. A real
   // consumer would: read camera frames, tokenize the instruction with the
@@ -71,7 +73,7 @@ try {
   const state = new Float32Array(0);
   const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim);
 
-  console.log("Running VLA inference...");
+  console.log("▸ Running VLA inference...");
   const { actions, actionDim, chunkSize, stats } = await vla({
     modelId,
     images,
@@ -83,11 +85,11 @@ try {
     noise,
   });
 
-  console.log(`Got ${chunkSize} action steps of dim ${actionDim}.`);
-  console.log("First step:", Array.from(actions.subarray(0, actionDim)));
+  console.log(`▸ Got ${chunkSize} action steps of dim ${actionDim}.`);
+  console.log(Array.from(actions.subarray(0, actionDim)));
   if (stats) {
     console.log(
-      `Timing: vision=${stats.vision_ms?.toFixed(0)}ms ` +
+      `▸ Timing: vision=${stats.vision_ms?.toFixed(0)}ms ` +
         `prefill=${stats.prefill_total_ms?.toFixed(0)}ms ` +
         `ode=${stats.ode_ms?.toFixed(0)}ms ` +
         `total=${stats.total_ms?.toFixed(0)}ms`,
@@ -95,10 +97,10 @@ try {
   }
 
   await unloadModel({ modelId, clearStorage: false });
-  console.log("Model unloaded.");
+  console.log("▸ Model unloaded.");
   process.exit(0);
 } catch (error) {
-  console.error("π₀.₅ example failed:", error);
+  console.error("✖", error);
   await close();
   process.exit(1);
 }

--- a/packages/sdk/examples/vla-smolvla.ts
+++ b/packages/sdk/examples/vla-smolvla.ts
@@ -27,22 +27,24 @@ const modelSrcOverride = process.argv[2];
 const modelSrc = modelSrcOverride ?? SMOLVLA_LIBERO_VISION_Q8;
 
 try {
-  console.log("Loading SmolVLA model...");
+  console.log("▸ Loading SmolVLA model...");
   const modelId = await loadModel({
     modelSrc,
     modelType: "ggml-vla",
     modelConfig: { backend: "cpu" },
-    onProgress: (p) =>
-      typeof modelSrc === "string"
-        ? undefined
-        : process.stdout.write(`\rDownloading: ${p.percentage.toFixed(1)}%`),
+    onProgress: (p) => {
+      const mb = (n: number) => (n / 1e6).toFixed(1);
+      const line = `▸ Downloading ${p.percentage.toFixed(0)}% (${mb(p.downloaded)}/${mb(p.total)} MB)`;
+      process.stderr.write(process.stderr.isTTY ? `\r${line}` : `${line}\n`);
+      if (p.percentage >= 100) process.stderr.write("\n");
+    },
   });
-  if (typeof modelSrc !== "string") process.stdout.write("\n");
-  console.log(`Model loaded: ${modelId}`);
+  if (typeof modelSrc !== "string") process.stderr.write("\n");
+  console.log(`▸ Model loaded: ${modelId}`);
 
   const { hparams, backendName } = await vlaHparams({ modelId });
-  console.log(`Backend: ${backendName ?? "(unknown)"}`);
-  console.log("Hparams:", hparams);
+  console.log(`▸ Backend: ${backendName ?? "(unknown)"}`);
+  console.log("▸ Hparams:", hparams);
 
   // Build synthetic inputs sized to the model's expectations. A real
   // consumer would: read camera frames, tokenize the instruction with the
@@ -61,7 +63,7 @@ try {
   const state = vlaPadState([0, 0, 0, 0, 0, 0], hparams.maxStateDim);
   const noise = new Float32Array(hparams.chunkSize * hparams.maxActionDim);
 
-  console.log("Running VLA inference...");
+  console.log("▸ Running VLA inference...");
   const { actions, actionDim, chunkSize, stats } = await vla({
     modelId,
     images: [front, wrist],
@@ -73,11 +75,11 @@ try {
     noise,
   });
 
-  console.log(`Got ${chunkSize} action steps of dim ${actionDim}.`);
-  console.log("First step:", Array.from(actions.subarray(0, actionDim)));
+  console.log(`▸ Got ${chunkSize} action steps of dim ${actionDim}.`);
+  console.log(Array.from(actions.subarray(0, actionDim)));
   if (stats) {
     console.log(
-      `Timing: vision=${stats.vision_ms?.toFixed(0)}ms ` +
+      `▸ Timing: vision=${stats.vision_ms?.toFixed(0)}ms ` +
         `smollm2=${stats.smollm2_total_ms?.toFixed(0)}ms ` +
         `ode=${stats.ode_ms?.toFixed(0)}ms ` +
         `total=${stats.total_ms?.toFixed(0)}ms`,
@@ -85,10 +87,10 @@ try {
   }
 
   await unloadModel({ modelId, clearStorage: false });
-  console.log("Model unloaded.");
+  console.log("▸ Model unloaded.");
   process.exit(0);
 } catch (error) {
-  console.error("VLA example failed:", error);
+  console.error("✖", error);
   await close();
   process.exit(1);
 }

--- a/packages/sdk/examples/voice-assistant/voice-assistant.ts
+++ b/packages/sdk/examples/voice-assistant/voice-assistant.ts
@@ -86,13 +86,13 @@ for (const tool of ["ffmpeg", "ffplay"]) {
   const r = spawnSync(tool, ["-version"], { stdio: "ignore" });
   if (r.error || r.status !== 0) {
     console.error(
-      `${tool} not found on PATH. Install ffmpeg (ffplay ships with it) and retry.`,
+      `✖ ${tool} not found on PATH. Install ffmpeg (ffplay ships with it) and retry.`,
     );
     process.exit(1);
   }
 }
 
-console.log("Loading whisper-tiny + Silero VAD...");
+console.log("▸ Loading whisper-tiny + Silero VAD...");
 const asrModelId = await loadModel({
   modelSrc: WHISPER_TINY,
   modelConfig: {
@@ -109,7 +109,7 @@ const asrModelId = await loadModel({
   },
 });
 
-console.log("Loading Llama 3.2 1B...");
+console.log("▸ Loading Llama 3.2 1B...");
 const llmModelId = await loadModel({
   modelSrc: LLAMA_3_2_1B_INST_Q4_0,
   modelConfig: {
@@ -117,7 +117,7 @@ const llmModelId = await loadModel({
   },
 });
 
-console.log("Loading Supertonic TTS...");
+console.log("▸ Loading Supertonic TTS...");
 const ttsModelId = await loadModel({
   modelSrc: TTS_EN_SUPERTONIC_Q8_0,
   modelConfig: {
@@ -129,7 +129,7 @@ const ttsModelId = await loadModel({
   },
 });
 
-console.log("All models loaded.\n");
+console.log("▸ All models loaded.\n");
 
 const ffmpeg = startMicrophone({
   sampleRate: MIC_SAMPLE_RATE,
@@ -157,7 +157,7 @@ let shuttingDown = false;
 async function cleanup() {
   if (shuttingDown) return;
   shuttingDown = true;
-  console.log("\n\nStopping...");
+  console.log("\n\n▸ Stopping...");
   ffmpeg.kill();
   try {
     session.end();
@@ -167,25 +167,25 @@ async function cleanup() {
   await unloadModel({ modelId: ttsModelId }).catch(() => {});
   await unloadModel({ modelId: llmModelId }).catch(() => {});
   await unloadModel({ modelId: asrModelId }).catch(() => {});
-  console.log("Done.");
+  console.log("▸ Done.");
   process.exit(0);
 }
 
 process.on("SIGINT", () => void cleanup());
 process.on("SIGTERM", () => void cleanup());
 
-console.log("🎙️  Listening. Speak a question and pause. Ctrl+C to quit.\n");
+console.log("▸ Listening. Speak a question and pause. Ctrl+C to quit.\n");
 
 for await (const rawText of session) {
   if (!isMeaningfulTranscript(rawText)) continue;
   const userText = rawText.trim();
 
-  console.log(`🗣️  You: ${userText}`);
+  console.log(`▸ You: ${userText}`);
   history.push({ role: "user", content: userText });
 
   isSpeaking = true;
   try {
-    process.stdout.write("🤖 Assistant: ");
+    console.log("▸ Assistant:");
     const llmResult = completion({
       modelId: llmModelId,
       history,
@@ -220,11 +220,11 @@ for await (const rawText of session) {
     }
   } catch (turnError) {
     console.error(
-      "\n⚠️  Turn failed:",
+      "\n✖ Turn failed:",
       turnError instanceof Error ? turnError.message : turnError,
     );
   } finally {
     isSpeaking = false;
-    console.log("\n🎙️  Listening...\n");
+    console.log("\n▸ Listening...\n");
   }
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Example output was inconsistent: scattered, ad-hoc emojis (✅ 📥 📡 📊 🚀 …), raw progress-object dumps, and no clear separation between the result and the running commentary.
- Readers running an example couldn't tell the genuine output from the script's own status messages.

## 📝 How does it solve it?

One uniform convention across every example:

- Normal messages (status, steps, metrics, progress) → `console.log` with a single `▸ ` prefix.
- Caught errors → `console.error` with a `✖ ` prefix — `console.error` is reserved for errors only, since some runtimes render it in red, which looks alarming for ordinary output.
- Genuine results stay unprefixed (streamed tokens via `process.stdout.write`; final results via plain `console.log`), so the result reads cleanly apart from the `▸` commentary.
- Download progress renders as one friendly, in-place line (`▸ Downloading 45% (12.3/27.1 MB)`, carriage-return on a TTY) instead of dumping the raw progress object.
- Only the `▸` (info) and `✖` (error) markers are used; the scattered decorative emojis are gone.
- No shared helper module — each example stays standalone and copy-pasteable.

A few examples keep their own shape where required: RAG progress uses its `(stage, current, total)` callback, profiler tables print to stdout as the result, and `delegated-inference/` keeps the provider's public-key line on stdout because a sibling process reads it.

## 🧪 How was it tested?

- `bun run build` (lint + typecheck + compile) passes across all examples.
- Verified no old patterns remain (raw progress dumps, `Loading: x%`, decorative emojis) via grep; spot-checked converted files for consistency.
- Manually running a few examples.