### PR TITLE
QVAC-20692 fix: enable Metal GPU for bci-whispercpp on iOS

### DIFF
--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `bci-whispercpp`'s `vcpkg.json` now selects `whisper-cpp[metal]` on
+  **iOS** as well as macOS (QVAC-20692). The separate featureless `ios`
+  dependency entry is merged into the `osx` entry as a single
+  `"platform": "osx | ios"` block requesting `["metal"]`, so the Apple GPU
+  backend is selected declaratively on iOS for `bci-whispercpp` — at
+  parity with the same fix already landed in `transcription-whispercpp`
+  (QVAC-20687). Supersedes the `bci-whispercpp` 0.2.0 note that iOS stayed
+  CPU-only pending the upstream Metal/MTLCompiler XPC issue.
+
 ## [0.2.0]
 
 Explicit per-platform GPU backend selection (QVAC-19234). Vulkan and

--- a/packages/bci-whispercpp/vcpkg.json
+++ b/packages/bci-whispercpp/vcpkg.json
@@ -23,11 +23,7 @@
     {
       "name": "whisper-cpp",
       "features": ["metal"],
-      "platform": "osx"
-    },
-    {
-      "name": "whisper-cpp",
-      "platform": "ios"
+      "platform": "osx | ios"
     }
   ],
   "features": {


### PR DESCRIPTION
## What problem does this PR solve?

- `bci-whispercpp`'s `vcpkg.json` requested `whisper-cpp` with **no features** on iOS — the `osx` entry asked for `[metal]`, but the separate `ios` entry asked for nothing. So iOS never declaratively selected the Metal backend; GPU was opt-out on iOS for this package.
- This is the same issue QVAC-20687 just fixed for `transcription-whispercpp`, now applied to `bci-whispercpp`.

## How does it solve it?

- Merged the iOS entry into the `osx` block →
  `{ "name": "whisper-cpp", "features": ["metal"], "platform": "osx | ios" }`.
  iOS now explicitly pulls `whisper-cpp[metal]` → `ggml-speech[metal]`, at parity with `transcription-whispercpp` (QVAC-20687) and no longer relying on port default-features.
- Updated `CHANGELOG.md` (`[Unreleased]`), superseding the 0.2.0 "iOS stays CPU-only" note.

## Breaking changes

- None. Build-config-only change; no public API or behavior change for consumers.
