### PR TITLE
infra[notask]: validate mobile test groups per OS family

### DIFF
--- a/packages/llm-llamacpp/scripts/generate-mobile-integration-tests.js
+++ b/packages/llm-llamacpp/scripts/generate-mobile-integration-tests.js
@@ -63,6 +63,14 @@ function buildFileContents (files) {
   return `${lines.join('\n')}\n`
 }
 
+// A platform's OS family is its name without the optional `Weekly` suffix, so
+// `iosWeekly` belongs to the `ios` family. Coverage is validated per family
+// (the union of its regular + weekly splits), letting the weekend-only suite
+// hold a disjoint subset of tests rather than duplicating the daily ones.
+function platformFamily (platform) {
+  return platform.replace(/Weekly$/, '')
+}
+
 function validateGroups (functionNames) {
   if (!fs.existsSync(groupsFile)) {
     console.warn('[warn] test-groups.json not found — skipping split validation')
@@ -70,24 +78,35 @@ function validateGroups (functionNames) {
   }
   const groups = JSON.parse(fs.readFileSync(groupsFile, 'utf-8'))
   const nameSet = new Set(functionNames)
+
+  const coveredByFamily = new Map()
   for (const [platform, splits] of Object.entries(groups)) {
-    const covered = new Set(Object.values(splits).flat())
+    const family = platformFamily(platform)
+    const covered = coveredByFamily.get(family) ?? new Set()
+    for (const name of Object.values(splits).flat()) {
+      covered.add(name)
+    }
+    coveredByFamily.set(family, covered)
+  }
+
+  for (const [family, covered] of coveredByFamily) {
     const missing = functionNames.filter(n => !covered.has(n))
     const extra = [...covered].filter(n => !nameSet.has(n))
     if (missing.length) {
       throw new Error(
-        '[' + platform + '] Tests not assigned to any group in test-groups.json:\n  ' +
-        missing.join('\n  ') + '\nAdd them to a group in test/mobile/test-groups.json.'
+        '[' + family + '] Tests not assigned to any group in test-groups.json:\n  ' +
+        missing.join('\n  ') +
+        `\nAdd them to a ${family} or ${family}Weekly group in test/mobile/test-groups.json.`
       )
     }
     if (extra.length) {
       throw new Error(
-        '[' + platform + '] test-groups.json references non-existent tests:\n  ' +
+        '[' + family + '] test-groups.json references non-existent tests:\n  ' +
         extra.join('\n  ') + '\nRemove them or check for typos.'
       )
     }
   }
-  console.log('Group coverage validated — all tests assigned for every platform.')
+  console.log('Group coverage validated — all tests assigned for every OS family.')
 }
 
 function main () {


### PR DESCRIPTION
## Problem

`npm run test:integration:generate` aborts on **every** platform (desktop and mobile, including `test-linux-arm64`) with:

```
Uncaught Error: [ios] Tests not assigned to any group in test-groups.json:
  runGemma4ImageElephantPerfTest
  runImageElephantTest
  runOcrPaddleTest
  ...
Error: Process completed with exit code 134.
```

`test:integration:generate` chains the mobile generator (`brittle ... && npm run test:mobile:generate`), so this kills the integration suite on all jobs before a single test runs.

Example failing https://github.com/tetherto/qvac/actions/runs/27693872114/job/81913721907?pr=2543

## Root cause

PR #2651 ("add weekend-only mobile test suite") split the heavy image/OCR/VLM-perf tests into new weekend-only `iosWeekly` / `androidWeekly` platforms in `test-groups.json`, keeping the daily tests under `ios` / `android`. The two sets are intentionally **disjoint** (21 daily + 10 weekly = 31), and the workflows consume them separately:

- the per-PR auto-detector reads only `ios` / `android`;
- `weekend-mobile-test-llm-llamacpp.yml` reads only `iosWeekly` / `androidWeekly`.

But `validateGroups()` still required **every** test to appear in **every** platform. With the split, all four platforms fail coverage (e.g. `ios` is missing the 10 weekly tests), so it throws at the first one.

## Fix

Validate coverage **per OS family** — the union of a platform and its `*Weekly` sibling — instead of per individual platform:

- `ios` ∪ `iosWeekly` must cover all tests;
- `android` ∪ `androidWeekly` must cover all tests.

This lets the daily and weekend suites hold disjoint subsets while still guaranteeing no test file is left unassigned (and still flags stale runner names). It matches the documented design intent in `weekend-mobile-test-llm-llamacpp.yml`.

## Testing

- `npm run test:mobile:generate` → `Group coverage validated — all tests assigned for every OS family.` (31 runners).
- Reverting the one-function change reproduces the exact `[ios] Tests not assigned…` failure.
- `npx standard` clean; generated `integration.auto.cjs` is unchanged.

## Notes

- Single-purpose change to `validateGroups` in `scripts/generate-mobile-integration-tests.js`.
- Bumps `@qvac/llm-llamacpp` `0.26.0 → 0.26.1` and adds a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
