### PR TITLE
QVAC-20843 chore: release @qvac/transcription-whispercpp 0.10.0

### DIFF
--- a/packages/transcription-whispercpp/CHANGELOG.md
+++ b/packages/transcription-whispercpp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0]
 
 ### Changed
 

--- a/packages/transcription-whispercpp/package.json
+++ b/packages/transcription-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## What problem does this PR solve?

- The Whisper 0.10.0 epic is merged on `main`, but the package isn't versioned for release: `package.json` is still `0.9.1` and the release notes sit under `[Unreleased]`. Publishing requires `package.json` and `CHANGELOG.md` to agree on `0.10.0`.

## How does it solve it?

- Bumps `@qvac/transcription-whispercpp` `package.json` `0.9.1` → `0.10.0`.
- Promotes the CHANGELOG `[Unreleased]` section to `[0.10.0]`, covering the 0.10.0 epic:
  - iOS Metal GPU for whisper transcription — `whisper-cpp[metal]` on `osx | ios` + the iOS `backendId` device-farm assertion (QVAC-20687).
  - `@qvac/infer-base` runtime dependency bumped `^0.4.0` → `^0.6.0` (#2638).
- Version/changelog only — no source or behavior change. Unblocks the `release-transcription-whispercpp-0.10.0` branch + NPM publish (QVAC-20843).

## Breaking changes

- None. Release metadata only; no API or runtime change.
