### PR TITLE
doc: sdk - fine-tuning - supported models - improve models section

### DIFF
--- a/docs/website/content/docs/ai-capabilities/fine-tuning.mdx
+++ b/docs/website/content/docs/ai-capabilities/fine-tuning.mdx
@@ -26,9 +26,18 @@ For how to use each function, see [SDK — API reference](/reference/api/).
 
 ## Models
 
-You can fine-tune any [`llama.cpp`](https://github.com/ggml-org/llama.cpp)-compatible text-generation/chat model. Base model file format: `*.gguf`.
+You can load any `llama.cpp`-compatible [text-generation/chat](/ai-capabilities/text-generation) model that meets the following criteria:
+- **File format:** `*.gguf` (or use constants)
+- **Architecture:** `qwen3`, `gemma3`, or `bitnet`
+- **Quantization:** `F32`, `F16`, `Q4_0`, `Q8_0`, `TQ1_0`, or `TQ2_0`
 
-For models available as constants, see [SDK — Models](/introduction#models).
+<Callout type="info">
+
+In QVAC, not every model compatible with text generation/chat is also compatible with fine-tuning. Only those that meet all the criteria above are.
+
+</Callout>
+
+For models available as constants, see [SDK — Models](/introduction#models). Note that not every model constant is fine-tunable: for example, many Qwen3-4B/8B constants are `Q4_K_M`. Check a model's quantization with [`getModelInfo()`](/reference/api#getmodelinfo) before training.
 
 ## Training
 


### PR DESCRIPTION
## What problem does this PR solve?

A user attempted fine-tuning by following the documentation.
Issue:
- Not every model compatible with text generation in QVAC is also compatible with fine-tuning.
- The "Fine-tuning" page states otherwise.

## How does it solve it?

Update the "Models" section of the "Fine-tuning" page to clearly indicate which models support this functionality and reiterate that not every LLM available in the SDK can be fine-tuned.