### PR TITLE
QVAC-19908 chore: release sdk + bare-sdk 0.13.4 — Qwen tool-call recovery, subscribeServerLogs, validation errors

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## [0.13.4]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.4
+
+A patch release that adds two developer-experience APIs — a single subscription
+for all server logs and friendlier input-validation errors — and hardens
+tool-call parsing for Qwen models used in agentic workflows.
+
+## New APIs
+
+### Subscribe to all server logs at once
+
+You can now capture every server-side log through one subscription instead of
+wiring up a `loggingStream()` per model or request. `subscribeServerLogs`
+delivers each log entry (level, namespace, message) to a single handler and
+returns an unsubscribe function.
+
+```typescript
+import { subscribeServerLogs } from "@qvac/sdk";
+
+const unsubscribe = subscribeServerLogs((log) => {
+  console.log(`[${log.level}] [${log.namespace}] ${log.message}`);
+});
+
+// later
+unsubscribe();
+```
+
+### Field-level validation errors for user input
+
+Invalid request input now surfaces as a `RequestValidationFailedError` with a
+clear, field-level message pointing at the exact key and location that failed,
+instead of an opaque rejection. This makes it much faster to spot typos and
+unsupported options in calls like `loadModel`.
+
+```typescript
+import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
+
+try {
+  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } });
+} catch (err) {
+  if (err instanceof RequestValidationFailedError) {
+    console.error(err.message);
+    // Invalid request:
+    // ✖ Unrecognized key: "dtx_size"
+    //   → at modelConfig
+  }
+}
+```
+
+## Bug Fixes
+
+### Recover malformed Qwen tool-call frames
+
+Qwen3.5/3.6 can intermittently emit a malformed tool-call frame that fuses its
+XML and JSON tool templates, embedding the `function=<name>` token as a bare
+string key inside an otherwise JSON object. Previously the parser rejected that
+frame as invalid JSON, so no structured tool call was produced and callers saw
+the raw markup as assistant text. The parser now recognizes and repairs this
+specific shape, so the tool call is recovered and dispatched correctly.
+
 ## [0.13.3]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.3
@@ -58,15 +119,15 @@ per-platform prebuilds at install time. Both packages remain available in
 
 The bundled `@qvac/rag` dependency is updated to `^0.6.4`.
 
-## [0.13.1]
+## [0.13.1] (LLM)
 
-📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.1
+Dependency-maintenance patch. No public API changes.
 
-Dependency-maintenance patch. `@qvac/sdk` and `@qvac/bare-sdk` adopt `bare-fetch` 3.x and `@qvac/decoder-audio` 0.4.x, and move dev-only `bare-subprocess` to 6.x. This removes the deprecated `@qvac/response` and its exact `bare-events 2.4.2` pin from the dependency tree.
-
-## Maintenance
-
-Bump `bare-fetch` to `^3.0.1` (public fetch API unchanged) and dev `bare-subprocess` to `^6.1.0`. Bump `@qvac/decoder-audio` to `^0.4.0` (drops deprecated `@qvac/response`); `decoder-audio@0.4.0` returns its `QvacResponse` synchronously, so `server/utils/audio/decoder.ts` no longer `await`s `decoder.run()`. `@qvac/sdk`/`@qvac/bare-sdk` bumped in lockstep.
+- `bare-fetch` → `^3.0.1` (transitive-only major; fetch API unchanged; only 3.0.1 header validation, all SDK headers are RFC-valid).
+- dev `bare-subprocess` → `^6.1.0` (not shipped to consumers).
+- `@qvac/decoder-audio` → `^0.4.0`: removes the deprecated `@qvac/response` package (folded into `@qvac/infer-base`) from the dependency tree, eliminating its exact `bare-events 2.4.2` pin. `decoder-audio@0.4.0`'s `run()` returns `QvacResponse` synchronously; `server/utils/audio/decoder.ts` updated to not `await` it.
+- `@qvac/sdk` + `@qvac/bare-sdk` bumped in lockstep.
+- Validated by a clean install: no `@qvac/response`, no `bare-events@2.4.2`, no `bare-fetch@2.x`, no `decoder-audio@0.3.x` resolve in the tree.
 
 ## [0.13.0]
 

--- a/packages/sdk/changelog/0.13.4/CHANGELOG.md
+++ b/packages/sdk/changelog/0.13.4/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog v0.13.4
+
+Release Date: 2026-06-18
+
+## 🔌 API
+
+- Add `subscribeServerLogs` to capture all server logs. (see PR [#2558](https://github.com/tetherto/qvac/pull/2558)) - See [API changes](./api.md)
+- Friendly, field-level validation errors for user input. (see PR [#2618](https://github.com/tetherto/qvac/pull/2618)) - See [API changes](./api.md)
+
+## 🐞 Fixes
+
+- Recover Qwen hybrid tool-call frames. (see PR [#2677](https://github.com/tetherto/qvac/pull/2677))
+
+## 🧪 Tests
+
+- Enable GPU on TTS sdk tests. (see PR [#2624](https://github.com/tetherto/qvac/pull/2624))
+

--- a/packages/sdk/changelog/0.13.4/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.13.4/CHANGELOG_LLM.md
@@ -1,0 +1,60 @@
+# QVAC SDK v0.13.4 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.4
+
+A patch release that adds two developer-experience APIs — a single subscription
+for all server logs and friendlier input-validation errors — and hardens
+tool-call parsing for Qwen models used in agentic workflows.
+
+## New APIs
+
+### Subscribe to all server logs at once
+
+You can now capture every server-side log through one subscription instead of
+wiring up a `loggingStream()` per model or request. `subscribeServerLogs`
+delivers each log entry (level, namespace, message) to a single handler and
+returns an unsubscribe function.
+
+```typescript
+import { subscribeServerLogs } from "@qvac/sdk";
+
+const unsubscribe = subscribeServerLogs((log) => {
+  console.log(`[${log.level}] [${log.namespace}] ${log.message}`);
+});
+
+// later
+unsubscribe();
+```
+
+### Field-level validation errors for user input
+
+Invalid request input now surfaces as a `RequestValidationFailedError` with a
+clear, field-level message pointing at the exact key and location that failed,
+instead of an opaque rejection. This makes it much faster to spot typos and
+unsupported options in calls like `loadModel`.
+
+```typescript
+import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
+
+try {
+  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } });
+} catch (err) {
+  if (err instanceof RequestValidationFailedError) {
+    console.error(err.message);
+    // Invalid request:
+    // ✖ Unrecognized key: "dtx_size"
+    //   → at modelConfig
+  }
+}
+```
+
+## Bug Fixes
+
+### Recover malformed Qwen tool-call frames
+
+Qwen3.5/3.6 can intermittently emit a malformed tool-call frame that fuses its
+XML and JSON tool templates, embedding the `function=<name>` token as a bare
+string key inside an otherwise JSON object. Previously the parser rejected that
+frame as invalid JSON, so no structured tool call was produced and callers saw
+the raw markup as assistant text. The parser now recognizes and repairs this
+specific shape, so the tool call is recovered and dispatched correctly.

--- a/packages/sdk/changelog/0.13.4/api.md
+++ b/packages/sdk/changelog/0.13.4/api.md
@@ -1,0 +1,41 @@
+# 🔌 API Changes v0.13.4
+
+## Add `subscribeServerLogs` to capture all server logs
+
+PR: [#2558](https://github.com/tetherto/qvac/pull/2558)
+
+```typescript
+import { subscribeServerLogs } from "@qvac/sdk";
+
+// One handler for every server-side log — no per-ID loggingStream() calls.
+const unsubscribe = subscribeServerLogs((log) => {
+  console.log(`[${log.level}] [${log.namespace}] ${log.message}`);
+});
+
+// later
+unsubscribe();
+```
+
+---
+
+## Friendly, field-level validation errors for user input
+
+PR: [#2618](https://github.com/tetherto/qvac/pull/2618)
+
+```typescript
+import { loadModel, RequestValidationFailedError, LLAMA_3_2_1B_INST_Q4_0 } from "@qvac/sdk";
+
+try {
+  await loadModel({ modelSrc: LLAMA_3_2_1B_INST_Q4_0, modelConfig: { dtx_size: 4096 } });
+} catch (err) {
+  if (err instanceof RequestValidationFailedError) {
+    console.error(err.message);
+    // Invalid request:
+    // ✖ Unrecognized key: "dtx_size"
+    //   → at modelConfig
+  }
+}
+```
+
+---
+

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Publishes `@qvac/sdk` + `@qvac/bare-sdk` **0.13.4**, a patch release batching the
SDK work merged to `main` since 0.13.3. The headline change is the recovery of
malformed Qwen hybrid tool-call frames (#2677), which downstream agentic
consumers (the opencode-plugin / ai-sdk-provider path) are waiting on; the
release also ships two already-merged developer-experience APIs and a test
infrastructure change that otherwise have no published version.

Release contents (all already on `main`):

- Recover malformed Qwen hybrid tool-call frames (#2677)
- Add `subscribeServerLogs` to capture all server logs (#2558)
- Friendly, field-level validation errors for user input (#2618)
- Enable GPU on TTS sdk tests (#2624)

## 📝 How does it solve it?

- Bumps the `version` field in `packages/sdk/package.json` and
  `packages/bare-sdk/package.json` from `0.13.3` → `0.13.4` (bare-sdk kept in
  lockstep via the sync script).
- Adds the generated `packages/sdk/changelog/0.13.4/` folder
  (`CHANGELOG.md`, `CHANGELOG_LLM.md`, `api.md`) and prepends the aggregated
  `0.13.4` entry to `packages/sdk/CHANGELOG.md`.
- No dependency ranges changed since 0.13.3, so the `NOTICE` files are unchanged
  and were intentionally not regenerated.
- Merging this PR into `release-sdk-0.13.4` triggers the GPR publish. The npm
  publish follows once the companion backmerge PR lands `release-sdk-0.13.4` on
  `main`.

## 🧪 How was it tested?

- Changelog generated deterministically with
  `node scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk` (base tag
  `sdk-v0.13.3`); root aggregate rebuilt and verified to lead with `0.13.4`.
- bare-sdk lockstep verified via the sync script (only the `version` field
  changed; no dependency drift).
- The functional changes in this release already passed CI on `main` as part of
  PRs #2677, #2558, #2618, and #2624.
