### PR TITLE
QVAC-19908 chore: release sdk + bare-sdk 0.13.4 — recover Qwen hybrid tool-call frames

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.13.4]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.4
+
+A patch release that hardens tool-call parsing for Qwen models used in agentic
+workflows.
+
+## Bug Fixes
+
+### Recover malformed Qwen tool-call frames
+
+Qwen3.5/3.6 can intermittently emit a malformed tool-call frame that fuses its
+XML and JSON tool templates, embedding the `function=<name>` token as a bare
+string key inside an otherwise JSON object. Previously the parser rejected that
+frame as invalid JSON, so no structured tool call was produced and callers saw
+the raw markup as assistant text. The parser now recognizes and repairs this
+specific shape, so the tool call is recovered and dispatched correctly.
+
 ## [0.13.3]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.3

--- a/packages/sdk/changelog/0.13.4/CHANGELOG.md
+++ b/packages/sdk/changelog/0.13.4/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.13.4
+
+Release Date: 2026-06-18
+
+## 🐞 Fixes
+
+- Recover Qwen hybrid tool-call frames. (see PR [#2677](https://github.com/tetherto/qvac/pull/2677))
+

--- a/packages/sdk/changelog/0.13.4/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.13.4/CHANGELOG_LLM.md
@@ -1,0 +1,17 @@
+# QVAC SDK v0.13.4 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.4
+
+A patch release that hardens tool-call parsing for Qwen models used in agentic
+workflows.
+
+## Bug Fixes
+
+### Recover malformed Qwen tool-call frames
+
+Qwen3.5/3.6 can intermittently emit a malformed tool-call frame that fuses its
+XML and JSON tool templates, embedding the `function=<name>` token as a bare
+string key inside an otherwise JSON object. Previously the parser rejected that
+frame as invalid JSON, so no structured tool call was produced and callers saw
+the raw markup as assistant text. The parser now recognizes and repairs this
+specific shape, so the tool call is recovered and dispatched correctly.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Publishes `@qvac/sdk` + `@qvac/bare-sdk` **0.13.4**, a fix-only patch release.
It recovers malformed Qwen hybrid tool-call frames (#2677), which downstream
agentic consumers (the opencode-plugin / ai-sdk-provider path) are waiting on.

This release is intentionally scoped to **only** the tool-call fix: the branch is
based on the previous release point (`sdk-v0.13.3`) with #2677 cherry-picked on
top, so other work already merged to `main` (e.g. `subscribeServerLogs`, input
validation errors, TTS test changes) is **not** included here and will ship in a
later release.

## 📝 How does it solve it?

- Branch cut from `sdk-v0.13.3` + cherry-pick of #2677 (`-x`), so the published
  tree is `0.13.3` plus only the parser fix.
- Bumps the `version` field in `packages/sdk/package.json` and
  `packages/bare-sdk/package.json` from `0.13.3` → `0.13.4` (lockstep).
- Adds `packages/sdk/changelog/0.13.4/` (`CHANGELOG.md`, `CHANGELOG_LLM.md`) and
  prepends the aggregated `0.13.4` entry to `packages/sdk/CHANGELOG.md`.
- No dependency ranges changed, so `NOTICE` files are unchanged and were not
  regenerated.
- Merging into `release-sdk-0.13.4` triggers the GPR publish; the npm publish
  follows once the companion backmerge PR lands on `main`.

## 🧪 How was it tested?

- Changelog generated with `node scripts/sdk/generate-changelog-sdk-pod.cjs
  --package=sdk` (base tag `sdk-v0.13.3`); it resolves to exactly one PR (#2677).
- bare-sdk lockstep verified via the sync script (version-only change).
- The fix itself already passed CI on `main` as PR #2677.
