### PR TITLE
tmp[validation]: chatterbox-memory SDK e2e — tts-cpp 2026-06-18 @ a7b36cbe (do not merge)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -9,18 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **QVAC-19557: Chatterbox iOS peak-memory OOM — cap the T3 context
-  (KV-cache length) at 2048 by default.** tts-cpp allocates the T3 KV
-  cache up-front, in F32, at the GGUF's full `n_ctx`; the Turbo GGUF
-  ships `n_ctx=8196`, which costs ~1.6 GB of KV
+- **QVAC-19557: Chatterbox iOS peak-memory OOM — cap the T3 context at
+  4096 and store the KV cache as q8_0 by default.** tts-cpp allocates
+  the T3 KV cache up-front at the GGUF's full `n_ctx`; the Turbo GGUF
+  ships `n_ctx=8196`, which costs ~1.6 GB of f32 KV
   (`n_embd(1024) × n_layer(24) × 8196 × 4 B × 2`) and pushed the iOS
   QVAC SDK test process to a ~3.1 GB peak footprint (jetsam kill — the
   `tts-chatterbox-*` e2e variants are currently skipped on iOS Device
   Farm for exactly this).  The addon now passes
-  `EngineOptions::n_ctx = 2048` (~400 MB of KV, ≈80 s of generated
-  audio per `synthesize()` call) unless the host overrides it via the
-  new `nCtx` constructor option.  `nCtx: 0` restores the old uncapped
-  behaviour; negative values are rejected at construction.
+  `EngineOptions::n_ctx = 4096` and `kv_cache_type = "q8_0"` (~210 MB
+  of KV for ≈160 s of generated audio per `synthesize()` call) unless
+  the host overrides them via the new `nCtx` / `kvCacheType`
+  constructor options.  `nCtx: 0` restores the uncapped context;
+  `kvCacheType: "f32"` restores the bit-exact pre-quantisation
+  behaviour; negative `nCtx` and unknown `kvCacheType` values are
+  rejected at construction.  Upstream validation
+  (qvac-ext-lib-whisper.cpp#43): Turbo greedy token sequences are
+  byte-identical across f32/f16/q8_0 on CPU and Metal, and Metal
+  decode is 20-30% faster from the KV bandwidth saving.
+
+### Changed
+
+- **`tts-cpp` pinned to `2026-06-12`** for `EngineOptions::kv_cache_type`
+  and the streamed (no host-staging) chatterbox GGUF loads.  This pin is
+  Android-safe again: the revision removes the last direct
+  `ggml_backend_is_cpu` / `ggml_get_type_traits_cpu` references from
+  tts-cpp (the unresolvable-UND-symbol dlopen crash that forced the
+  0.2.2 revert), routing them through the backend registry and
+  `ggml_quantize_chunk` (ggml-base) instead.
 
 ## [0.2.2] - 2026-06-09
 

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **QVAC-19557: Chatterbox iOS peak-memory OOM — cap the T3 context
+  (KV-cache length) at 2048 by default.** tts-cpp allocates the T3 KV
+  cache up-front, in F32, at the GGUF's full `n_ctx`; the Turbo GGUF
+  ships `n_ctx=8196`, which costs ~1.6 GB of KV
+  (`n_embd(1024) × n_layer(24) × 8196 × 4 B × 2`) and pushed the iOS
+  QVAC SDK test process to a ~3.1 GB peak footprint (jetsam kill — the
+  `tts-chatterbox-*` e2e variants are currently skipped on iOS Device
+  Farm for exactly this).  The addon now passes
+  `EngineOptions::n_ctx = 2048` (~400 MB of KV, ≈80 s of generated
+  audio per `synthesize()` call) unless the host overrides it via the
+  new `nCtx` constructor option.  `nCtx: 0` restores the old uncapped
+  behaviour; negative values are rejected at construction.
+
 ## [0.2.2] - 2026-06-09
 
 ### Fixed

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -243,7 +243,8 @@ backend persist its compiled program cache across launches.
 | `voiceDir`                | string     | —          | Pre-baked voice profile |
 | `seed`                    | number     | 42         | RNG seed (CFM noise + sampling) |
 | `nGpuLayers`              | number     | 0          | Layers offloaded to GPU (mirrors `useGPU`; pass `99` to offload all) |
-| `nCtx`                    | number     | 2048       | Cap on the T3 context (prompt + generated speech tokens; 25 tokens ≈ 1 s of audio).  The F32 KV cache is allocated up-front at this length, so it directly bounds memory: the Turbo GGUF's native `n_ctx=8196` would cost ~1.6 GB of KV vs ~400 MB at the default 2048.  Pass `0` to use the GGUF's full context |
+| `nCtx`                    | number     | 4096       | Cap on the T3 context (prompt + generated speech tokens; 25 tokens ≈ 1 s of audio).  The KV cache is allocated up-front at this length, so it directly bounds memory: the Turbo GGUF's native `n_ctx=8196` would cost ~1.6 GB of f32 KV vs ~210 MB at the defaults (4096 + `q8_0`).  Pass `0` to use the GGUF's full context |
+| `kvCacheType`             | string     | `q8_0`     | T3 KV-cache dtype: `f32` \| `f16` \| `q8_0`.  `q8_0` stores the cache at ~27% of f32 and decodes 20-30% faster on Metal; Turbo greedy decoding is byte-identical across all three (upstream-validated).  Pass `f32` for bit-exact pre-quantisation behaviour |
 | `threads`                 | number     | hw.concurrency capped at 4 | |
 | `streamChunkTokens`       | number     | 0          | **>0 enables native chunk streaming** |
 | `streamFirstChunkTokens`  | number     | = streamChunkTokens | Smaller first chunk for low first-audio-out |

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -243,6 +243,7 @@ backend persist its compiled program cache across launches.
 | `voiceDir`                | string     | —          | Pre-baked voice profile |
 | `seed`                    | number     | 42         | RNG seed (CFM noise + sampling) |
 | `nGpuLayers`              | number     | 0          | Layers offloaded to GPU (mirrors `useGPU`; pass `99` to offload all) |
+| `nCtx`                    | number     | 2048       | Cap on the T3 context (prompt + generated speech tokens; 25 tokens ≈ 1 s of audio).  The F32 KV cache is allocated up-front at this length, so it directly bounds memory: the Turbo GGUF's native `n_ctx=8196` would cost ~1.6 GB of KV vs ~400 MB at the default 2048.  Pass `0` to use the GGUF's full context |
 | `threads`                 | number     | hw.concurrency capped at 4 | |
 | `streamChunkTokens`       | number     | 0          | **>0 enables native chunk streaming** |
 | `streamFirstChunkTokens`  | number     | = streamChunkTokens | Smaller first chunk for low first-audio-out |

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
@@ -113,6 +113,7 @@ chatterbox::ChatterboxConfig JSAdapter::buildChatterboxConfig(
   cfg.seed                    = readOptionalInt(configurationParams, env, "seed");
   cfg.threads                 = readOptionalInt(configurationParams, env, "threads");
   cfg.nGpuLayers              = readOptionalInt(configurationParams, env, "nGpuLayers");
+  cfg.nCtx                    = readOptionalInt(configurationParams, env, "nCtx");
   cfg.outputSampleRate        = readOptionalInt(configurationParams, env, "outputSampleRate");
   cfg.streamChunkTokens       = readOptionalInt(configurationParams, env, "streamChunkTokens");
   cfg.streamFirstChunkTokens  = readOptionalInt(configurationParams, env, "streamFirstChunkTokens");

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
@@ -114,6 +114,7 @@ chatterbox::ChatterboxConfig JSAdapter::buildChatterboxConfig(
   cfg.threads                 = readOptionalInt(configurationParams, env, "threads");
   cfg.nGpuLayers              = readOptionalInt(configurationParams, env, "nGpuLayers");
   cfg.nCtx                    = readOptionalInt(configurationParams, env, "nCtx");
+  cfg.kvCacheType             = readOptionalString(configurationParams, env, "kvCacheType");
   cfg.outputSampleRate        = readOptionalInt(configurationParams, env, "outputSampleRate");
   cfg.streamChunkTokens       = readOptionalInt(configurationParams, env, "streamChunkTokens");
   cfg.streamFirstChunkTokens  = readOptionalInt(configurationParams, env, "streamFirstChunkTokens");

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
@@ -42,12 +42,26 @@ struct ChatterboxConfig {
    * When unset, {@link ChatterboxModel} applies kDefaultNCtx (2048,
    * ~400 MB KV on Turbo, ≈80 s of audio per synthesize() call).
    *
-   *   - unset:  kDefaultNCtx (2048)
+   *   - unset:  kDefaultNCtx (4096)
    *   - > 0:    explicit cap (prompt + generated speech tokens)
    *   - 0:      escape hatch — no cap, use the GGUF's full n_ctx
    *   - < 0:    rejected by validateConfig
    */
   std::optional<int> nCtx;
+  /**
+   * T3 KV-cache storage type, forwarded to
+   * `tts_cpp::chatterbox::EngineOptions::kv_cache_type`:
+   * "f32" | "f16" | "q8_0".  The cache is allocated up-front at nCtx,
+   * so the dtype directly scales resident memory — q8_0 stores it at
+   * ~27% of f32 (one fp16 scale per 32 values).  Upstream validation
+   * (qvac-ext-lib-whisper.cpp#43): greedy token sequences are
+   * byte-identical across all three dtypes on the Turbo model
+   * (CPU + Metal), and Metal decode gets 20-30% FASTER from the
+   * bandwidth saving.  Empty/unset -> {@link ChatterboxModel}'s
+   * kDefaultKvCacheType ("q8_0"); anything outside the three values
+   * is rejected by validateConfig.
+   */
+  std::string kvCacheType;
   /** Post-processing output sample rate.  Currently unused (engine always emits 24 kHz). */
   std::optional<int> outputSampleRate;
   /**

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
@@ -31,6 +31,23 @@ struct ChatterboxConfig {
   std::optional<int> threads;
   /** Layers to move to the GPU backend.  99 (or any large number) = all. */
   std::optional<int> nGpuLayers;
+  /**
+   * T3 context-length cap, forwarded to
+   * `tts_cpp::chatterbox::EngineOptions::n_ctx` (the engine clamps the
+   * GGUF's own n_ctx to this; it never raises it).
+   *
+   * The T3 KV cache is allocated UP-FRONT at n_ctx, in F32: the Turbo
+   * GGUF ships n_ctx=8196 which costs ~1.6 GB of KV for synthesis that
+   * rarely needs more than a few hundred tokens (QVAC-19557 iOS OOM).
+   * When unset, {@link ChatterboxModel} applies kDefaultNCtx (2048,
+   * ~400 MB KV on Turbo, ≈80 s of audio per synthesize() call).
+   *
+   *   - unset:  kDefaultNCtx (2048)
+   *   - > 0:    explicit cap (prompt + generated speech tokens)
+   *   - 0:      escape hatch — no cap, use the GGUF's full n_ctx
+   *   - < 0:    rejected by validateConfig
+   */
+  std::optional<int> nCtx;
   /** Post-processing output sample rate.  Currently unused (engine always emits 24 kHz). */
   std::optional<int> outputSampleRate;
   /**

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -27,6 +27,17 @@ using qvac_errors::tts_error::TTSErrorCode;
 namespace general_error = qvac_errors::general_error;
 namespace logger = qvac_lib_inference_addon_cpp::logger;
 
+// Default T3 context cap (EngineOptions::n_ctx) when the host doesn't pass
+// `nCtx`.  tts-cpp's library default (0 = uncapped) takes the GGUF's own
+// n_ctx, and the Turbo GGUF ships n_ctx=8196 — the F32 KV cache allocated
+// up-front at that length is n_embd(1024) x n_layer(24) x n_ctx x 4 B x 2
+// (K+V) ~= 1.6 GB, which is what pushed the iOS QVAC SDK test process to a
+// ~3.1 GB peak footprint and into jetsam (QVAC-19557).  2048 tokens keep
+// ~80 s of generated audio per synthesize() call (T3 speech tokens run at
+// 25 Hz) for ~400 MB of KV.  Hosts that need longer single-call synthesis
+// can raise the cap, or pass nCtx=0 to restore the uncapped behaviour.
+constexpr int kDefaultNCtx = 2048;
+
 tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) {
   tts_cpp::chatterbox::EngineOptions opts;
   opts.t3_gguf_path    = cfg.t3ModelPath;
@@ -36,6 +47,7 @@ tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) 
   if (!cfg.language.empty()) opts.language = cfg.language;
   if (cfg.seed.has_value())    opts.seed         = *cfg.seed;
   if (cfg.threads.has_value()) opts.n_threads    = *cfg.threads;
+  opts.n_ctx = cfg.nCtx.value_or(kDefaultNCtx);
   if (cfg.nGpuLayers.has_value()) {
     opts.n_gpu_layers = *cfg.nGpuLayers;
   } else if (cfg.useGpu.has_value()) {
@@ -134,6 +146,13 @@ void ChatterboxModel::validateConfig(const ChatterboxConfig& cfg) {
               ". Either drop one of the two, or make them agree "
               "(useGPU:true + nGpuLayers!=0, or useGPU:false + nGpuLayers=0).");
     }
+  }
+  if (cfg.nCtx.has_value() && *cfg.nCtx < 0) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "ChatterboxModel: nCtx must be >= 0 (0 = use the GGUF's full "
+        "context, > 0 = cap the T3 context / KV-cache length), got " +
+            std::to_string(*cfg.nCtx));
   }
   if (cfg.t3ModelPath.empty()) {
     throw StatusError(general_error::InvalidArgument, "t3ModelPath is required");
@@ -350,6 +369,11 @@ std::any ChatterboxModel::process(const std::any& input) {
   // reload()).
   if (result.wasStreaming) return {};
   return std::any(std::move(result.pcm));
+}
+
+tts_cpp::chatterbox::EngineOptions engineOptionsForTests(
+    const ChatterboxConfig& cfg) {
+  return toEngineOptions(cfg);
 }
 
 qvac_lib_inference_addon_cpp::RuntimeStats ChatterboxModel::runtimeStats() const {

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -32,11 +32,24 @@ namespace logger = qvac_lib_inference_addon_cpp::logger;
 // n_ctx, and the Turbo GGUF ships n_ctx=8196 — the F32 KV cache allocated
 // up-front at that length is n_embd(1024) x n_layer(24) x n_ctx x 4 B x 2
 // (K+V) ~= 1.6 GB, which is what pushed the iOS QVAC SDK test process to a
-// ~3.1 GB peak footprint and into jetsam (QVAC-19557).  2048 tokens keep
-// ~80 s of generated audio per synthesize() call (T3 speech tokens run at
-// 25 Hz) for ~400 MB of KV.  Hosts that need longer single-call synthesis
-// can raise the cap, or pass nCtx=0 to restore the uncapped behaviour.
-constexpr int kDefaultNCtx = 2048;
+// ~3.1 GB peak footprint and into jetsam (QVAC-19557).  With the q8_0
+// default KV dtype below, 4096 tokens (~160 s of generated audio per
+// synthesize() call; T3 speech tokens run at 25 Hz) cost ~210 MB of KV —
+// less memory than f32@2048 AND double the context.  Hosts that need
+// longer single-call synthesis can raise the cap, or pass nCtx=0 to
+// restore the uncapped behaviour.
+constexpr int kDefaultNCtx = 4096;
+
+// Default T3 KV-cache dtype (EngineOptions::kv_cache_type).  q8_0 stores
+// the cache at ~27% of f32.  Upstream validation on real GGUFs
+// (qvac-ext-lib-whisper.cpp#43): Turbo greedy token sequences are
+// byte-identical across f32/f16/q8_0 on CPU and Metal; the multilingual
+// variant's CFG mixing can flip a near-tie argmax (same class of
+// variation as a seed change — whisper transcribes the q8_0 output to
+// the exact input text); Metal decode is 20-30% faster from the
+// bandwidth saving.  Pass kvCacheType:"f32" for bit-exact parity with
+// the pre-quantisation behaviour.
+constexpr const char * kDefaultKvCacheType = "q8_0";
 
 tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) {
   tts_cpp::chatterbox::EngineOptions opts;
@@ -48,6 +61,8 @@ tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) 
   if (cfg.seed.has_value())    opts.seed         = *cfg.seed;
   if (cfg.threads.has_value()) opts.n_threads    = *cfg.threads;
   opts.n_ctx = cfg.nCtx.value_or(kDefaultNCtx);
+  opts.kv_cache_type =
+      cfg.kvCacheType.empty() ? kDefaultKvCacheType : cfg.kvCacheType;
   if (cfg.nGpuLayers.has_value()) {
     opts.n_gpu_layers = *cfg.nGpuLayers;
   } else if (cfg.useGpu.has_value()) {
@@ -153,6 +168,16 @@ void ChatterboxModel::validateConfig(const ChatterboxConfig& cfg) {
         "ChatterboxModel: nCtx must be >= 0 (0 = use the GGUF's full "
         "context, > 0 = cap the T3 context / KV-cache length), got " +
             std::to_string(*cfg.nCtx));
+  }
+  // Reject unknown KV dtypes at construction instead of inheriting
+  // tts-cpp's warn-and-fall-back-to-f32, which would silently change
+  // the memory profile the caller asked for.
+  if (!cfg.kvCacheType.empty() && cfg.kvCacheType != "f32" &&
+      cfg.kvCacheType != "f16" && cfg.kvCacheType != "q8_0") {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "ChatterboxModel: kvCacheType must be one of f32|f16|q8_0, got '" +
+            cfg.kvCacheType + "'");
   }
   if (cfg.t3ModelPath.empty()) {
     throw StatusError(general_error::InvalidArgument, "t3ModelPath is required");

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
@@ -17,9 +17,19 @@
 
 namespace tts_cpp::chatterbox {
 class Engine;
+struct EngineOptions;
 } // namespace tts_cpp::chatterbox
 
 namespace qvac::ttsggml::chatterbox {
+
+/**
+ * Test-only view of the ChatterboxConfig -> tts_cpp EngineOptions mapping
+ * (defaulted n_ctx cap, useGPU -> n_gpu_layers translation, ...).  The
+ * mapping itself lives in an anonymous namespace inside
+ * ChatterboxModel.cpp; production callers go through ChatterboxModel.
+ */
+tts_cpp::chatterbox::EngineOptions engineOptionsForTests(
+    const ChatterboxConfig& cfg);
 
 /**
  * IModel implementation that wraps the tts-cpp::tts-cpp static library

--- a/packages/tts-ggml/addon/tests/test_chatterbox_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_chatterbox_config.cpp
@@ -20,6 +20,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <tts-cpp/chatterbox/engine.h>
+
 #include "model-interface/chatterbox/ChatterboxConfig.hpp"
 #include "model-interface/chatterbox/ChatterboxModel.hpp"
 #include "inference-addon-cpp/Errors.hpp"
@@ -147,6 +149,40 @@ TEST(ChatterboxValidate, ConfigUseGpuDefaultIsFalse) {
   EXPECT_FALSE(cfg.threads.has_value());
   EXPECT_FALSE(cfg.nGpuLayers.has_value());
   EXPECT_FALSE(cfg.streamChunkTokens.has_value());
+  EXPECT_FALSE(cfg.nCtx.has_value());
+}
+
+TEST(ChatterboxValidate, NegativeNCtxRejected) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.nCtx = -1;
+  EXPECT_THROW(ChatterboxModel{cfg}, StatusError);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  ChatterboxConfig -> tts_cpp EngineOptions mapping.
+// ─────────────────────────────────────────────────────────────────────
+
+// The T3 KV cache is allocated up-front at n_ctx in F32 (Turbo GGUF ships
+// n_ctx=8196 ~= 1.6 GB of KV), so the addon must cap it by default rather
+// than inherit tts-cpp's uncapped library default (QVAC-19557 iOS OOM).
+TEST(ChatterboxEngineOptions, NCtxDefaultsTo2048) {
+  ChatterboxConfig cfg;
+  const auto opts = qvac::ttsggml::chatterbox::engineOptionsForTests(cfg);
+  EXPECT_EQ(opts.n_ctx, 2048);
+}
+
+TEST(ChatterboxEngineOptions, ExplicitNCtxForwarded) {
+  ChatterboxConfig cfg;
+  cfg.nCtx = 1024;
+  EXPECT_EQ(qvac::ttsggml::chatterbox::engineOptionsForTests(cfg).n_ctx, 1024);
+}
+
+TEST(ChatterboxEngineOptions, NCtxZeroMeansUncapped) {
+  // 0 is the documented escape hatch: tts-cpp treats n_ctx <= 0 as "use
+  // the GGUF's full context".
+  ChatterboxConfig cfg;
+  cfg.nCtx = 0;
+  EXPECT_EQ(qvac::ttsggml::chatterbox::engineOptionsForTests(cfg).n_ctx, 0);
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/packages/tts-ggml/addon/tests/test_chatterbox_config.cpp
+++ b/packages/tts-ggml/addon/tests/test_chatterbox_config.cpp
@@ -162,13 +162,36 @@ TEST(ChatterboxValidate, NegativeNCtxRejected) {
 //  ChatterboxConfig -> tts_cpp EngineOptions mapping.
 // ─────────────────────────────────────────────────────────────────────
 
-// The T3 KV cache is allocated up-front at n_ctx in F32 (Turbo GGUF ships
-// n_ctx=8196 ~= 1.6 GB of KV), so the addon must cap it by default rather
-// than inherit tts-cpp's uncapped library default (QVAC-19557 iOS OOM).
-TEST(ChatterboxEngineOptions, NCtxDefaultsTo2048) {
+// The T3 KV cache is allocated up-front at n_ctx (Turbo GGUF ships
+// n_ctx=8196 ~= 1.6 GB of f32 KV), so the addon must cap it by default
+// rather than inherit tts-cpp's uncapped library default (QVAC-19557 iOS
+// OOM).  4096 + the q8_0 dtype default below ~= 210 MB.
+TEST(ChatterboxEngineOptions, NCtxDefaultsTo4096) {
   ChatterboxConfig cfg;
   const auto opts = qvac::ttsggml::chatterbox::engineOptionsForTests(cfg);
-  EXPECT_EQ(opts.n_ctx, 2048);
+  EXPECT_EQ(opts.n_ctx, 4096);
+}
+
+// q8_0 KV by default: ~27% of f32's resident KV memory; Turbo greedy
+// decoding validated byte-identical across f32/f16/q8_0 upstream
+// (qvac-ext-lib-whisper.cpp#43).
+TEST(ChatterboxEngineOptions, KvCacheTypeDefaultsToQ8) {
+  ChatterboxConfig cfg;
+  EXPECT_EQ(qvac::ttsggml::chatterbox::engineOptionsForTests(cfg).kv_cache_type, "q8_0");
+}
+
+TEST(ChatterboxEngineOptions, ExplicitKvCacheTypeForwarded) {
+  ChatterboxConfig cfg;
+  cfg.kvCacheType = "f32";
+  EXPECT_EQ(qvac::ttsggml::chatterbox::engineOptionsForTests(cfg).kv_cache_type, "f32");
+  cfg.kvCacheType = "f16";
+  EXPECT_EQ(qvac::ttsggml::chatterbox::engineOptionsForTests(cfg).kv_cache_type, "f16");
+}
+
+TEST(ChatterboxValidate, UnknownKvCacheTypeRejected) {
+  auto cfg = minimallyValidStubConfig();
+  cfg.kvCacheType = "q4_0";
+  EXPECT_THROW(ChatterboxModel{cfg}, StatusError);
 }
 
 TEST(ChatterboxEngineOptions, ExplicitNCtxForwarded) {

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -70,6 +70,8 @@ declare interface TTSGgmlOptions {
   seed?: number
   /** Move N layers to the GPU backend.  Chatterbox: pass 99 to move everything.  Supertonic: must be 0 / unset (engine is CPU-only today). */
   nGpuLayers?: number
+  /** Chatterbox-only: cap on the T3 context length (prompt + generated speech tokens, 25 tokens ~= 1 s of audio).  The F32 KV cache is allocated up-front at this length, so the cap directly bounds memory: the Turbo GGUF's native n_ctx=8196 costs ~1.6 GB of KV, the default cap of 2048 (~80 s of audio per synthesis call) ~400 MB.  Pass 0 to use the GGUF's full context; negative values are rejected. */
+  nCtx?: number
   /** Override `std::thread::hardware_concurrency()`. */
   threads?: number
   /** Chatterbox-only: speech tokens per native streaming chunk (25 ~= 1 s of audio).  0 disables. */

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -70,8 +70,10 @@ declare interface TTSGgmlOptions {
   seed?: number
   /** Move N layers to the GPU backend.  Chatterbox: pass 99 to move everything.  Supertonic: must be 0 / unset (engine is CPU-only today). */
   nGpuLayers?: number
-  /** Chatterbox-only: cap on the T3 context length (prompt + generated speech tokens, 25 tokens ~= 1 s of audio).  The F32 KV cache is allocated up-front at this length, so the cap directly bounds memory: the Turbo GGUF's native n_ctx=8196 costs ~1.6 GB of KV, the default cap of 2048 (~80 s of audio per synthesis call) ~400 MB.  Pass 0 to use the GGUF's full context; negative values are rejected. */
+  /** Chatterbox-only: cap on the T3 context length (prompt + generated speech tokens, 25 tokens ~= 1 s of audio).  The KV cache is allocated up-front at this length, so the cap directly bounds memory: the Turbo GGUF's native n_ctx=8196 costs ~1.6 GB of f32 KV, while the defaults (nCtx=4096 + kvCacheType "q8_0") cost ~210 MB for ~160 s of audio per synthesis call.  Pass 0 to use the GGUF's full context; negative values are rejected. */
   nCtx?: number
+  /** Chatterbox-only: T3 KV-cache storage dtype: 'f32' | 'f16' | 'q8_0' (default 'q8_0', ~27% of f32's memory; upstream-validated byte-identical greedy decoding on Turbo, and 20-30% faster decode on Metal).  Pass 'f32' for bit-exact parity with the pre-quantisation behaviour. */
+  kvCacheType?: 'f32' | 'f16' | 'q8_0'
   /** Override `std::thread::hardware_concurrency()`. */
   threads?: number
   /** Chatterbox-only: speech tokens per native streaming chunk (25 ~= 1 s of audio).  0 disables. */

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -205,6 +205,7 @@ class TTSGgml {
       seed,
       nGpuLayers,
       nCtx,
+      kvCacheType,
       threads,
       streamChunkTokens,
       streamFirstChunkTokens,
@@ -310,6 +311,7 @@ class TTSGgml {
     this._seed = seed
     this._nGpuLayers = nGpuLayers
     this._nCtx = nCtx
+    this._kvCacheType = kvCacheType
     this._threads = threads
     this._streamChunkTokens = streamChunkTokens
     this._streamFirstChunkTokens = streamFirstChunkTokens
@@ -769,6 +771,7 @@ class TTSGgml {
     if (this._seed != null) params.seed = this._seed | 0
     if (this._nGpuLayers != null) params.nGpuLayers = this._nGpuLayers | 0
     if (this._nCtx != null) params.nCtx = this._nCtx | 0
+    if (this._kvCacheType != null) params.kvCacheType = String(this._kvCacheType)
     if (this._threads != null) params.threads = this._threads | 0
     if (this._streamChunkTokens != null) params.streamChunkTokens = this._streamChunkTokens | 0
     if (this._streamFirstChunkTokens != null) {

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -204,6 +204,7 @@ class TTSGgml {
       voiceDir,
       seed,
       nGpuLayers,
+      nCtx,
       threads,
       streamChunkTokens,
       streamFirstChunkTokens,
@@ -308,6 +309,7 @@ class TTSGgml {
     this._voiceDir = voiceDir
     this._seed = seed
     this._nGpuLayers = nGpuLayers
+    this._nCtx = nCtx
     this._threads = threads
     this._streamChunkTokens = streamChunkTokens
     this._streamFirstChunkTokens = streamFirstChunkTokens
@@ -766,6 +768,7 @@ class TTSGgml {
     }
     if (this._seed != null) params.seed = this._seed | 0
     if (this._nGpuLayers != null) params.nGpuLayers = this._nGpuLayers | 0
+    if (this._nCtx != null) params.nCtx = this._nCtx | 0
     if (this._threads != null) params.threads = this._threads | 0
     if (this._streamChunkTokens != null) params.streamChunkTokens = this._streamChunkTokens | 0
     if (this._streamFirstChunkTokens != null) {

--- a/packages/tts-ggml/test/unit/chatterbox.inference.test.js
+++ b/packages/tts-ggml/test/unit/chatterbox.inference.test.js
@@ -230,3 +230,16 @@ test('Chatterbox: nCtx forwards to ttsParams; omitted when unset (QVAC-19557)', 
   const defaulted = new TTSGgml({ files, config: { language: 'en' } })
   t.absent(defaulted._buildTtsParams().nCtx, 'nCtx omitted when unset so the addon applies its 2048 default')
 })
+
+test('Chatterbox: kvCacheType forwards to ttsParams; omitted when unset (QVAC-19557)', (t) => {
+  const files = {
+    t3Model: './models/chatterbox-t3-turbo.gguf',
+    s3genModel: './models/chatterbox-s3gen.gguf'
+  }
+
+  const explicit = new TTSGgml({ files, config: { language: 'en' }, kvCacheType: 'f32' })
+  t.is(explicit._buildTtsParams().kvCacheType, 'f32', 'explicit kvCacheType forwarded to the addon')
+
+  const defaulted = new TTSGgml({ files, config: { language: 'en' } })
+  t.absent(defaulted._buildTtsParams().kvCacheType, 'kvCacheType omitted when unset so the addon applies its q8_0 default')
+})

--- a/packages/tts-ggml/test/unit/chatterbox.inference.test.js
+++ b/packages/tts-ggml/test/unit/chatterbox.inference.test.js
@@ -214,3 +214,19 @@ test('Chatterbox: cancel propagates as job failure', async (t) => {
   t.ok(failed, 'Cancelled response should fail')
   await model.unload()
 })
+
+test('Chatterbox: nCtx forwards to ttsParams; omitted when unset (QVAC-19557)', (t) => {
+  const files = {
+    t3Model: './models/chatterbox-t3-turbo.gguf',
+    s3genModel: './models/chatterbox-s3gen.gguf'
+  }
+
+  const capped = new TTSGgml({ files, config: { language: 'en' }, nCtx: 1024 })
+  t.is(capped._buildTtsParams().nCtx, 1024, 'explicit nCtx forwarded to the addon')
+
+  const uncapped = new TTSGgml({ files, config: { language: 'en' }, nCtx: 0 })
+  t.is(uncapped._buildTtsParams().nCtx, 0, 'nCtx=0 (full GGUF context escape hatch) forwarded as-is')
+
+  const defaulted = new TTSGgml({ files, config: { language: 'en' } })
+  t.absent(defaulted._buildTtsParams().nCtx, 'nCtx omitted when unset so the addon applies its 2048 default')
+})

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$note": "default-registry temporarily tracks the tts-cpp-2026-06-12 branch (qvac-registry-vcpkg#188) so CI can resolve tts-cpp>=2026-06-12 before that PR merges; once #188 lands, drop 'reference' and move 'baseline' to the merged main commit.",
   "default-registry": {
     "kind": "git",
-    "baseline": "12e78be6cc05846865d3d1f3c53f58db04b47262",
+    "baseline": "4ace796ce463b01eb051e4219925738e7853b504",
     "reference": "tts-cpp-2026-06-12",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,8 +1,8 @@
 {
-  "$note": "default-registry temporarily tracks the tts-cpp-2026-06-12 branch (qvac-registry-vcpkg#188) so CI can resolve tts-cpp>=2026-06-12 before that PR merges; once #188 lands, drop 'reference' and move 'baseline' to the merged main commit.",
+  "$note": "default-registry temporarily tracks the tts-cpp-2026-06-12 branch (qvac-registry-vcpkg#188) so CI can resolve tts-cpp>=2026-06-18 before that PR merges; once #188 lands, drop 'reference' and move 'baseline' to the merged main commit.",
   "default-registry": {
     "kind": "git",
-    "baseline": "4ace796ce463b01eb051e4219925738e7853b504",
+    "baseline": "620f6e28cb7bf7c6319ff1b5afa9703c2ad5d7d1",
     "reference": "tts-cpp-2026-06-12",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,9 @@
 {
+  "$note": "default-registry temporarily tracks the tts-cpp-2026-06-12 branch (qvac-registry-vcpkg#188) so CI can resolve tts-cpp>=2026-06-12 before that PR merges; once #188 lands, drop 'reference' and move 'baseline' to the merged main commit.",
   "default-registry": {
     "kind": "git",
-    "baseline": "88663627cb9667b04b2b034045b7d3d65e8b8fc4",
+    "baseline": "12e78be6cc05846865d3d1f3c53f58db04b47262",
+    "reference": "tts-cpp-2026-06-12",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-06-12"
+      "version>=": "2026-06-18"
     }
   ],
   "features": {

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-06-03#1"
+      "version>=": "2026-06-12"
     }
   ],
   "features": {


### PR DESCRIPTION
## Purpose
Pre-merge **end-to-end validation** of the full (still unmerged) chatterbox iOS-memory stack via the SDK mobile e2e (iOS + Android Device Farm). **Throwaway — do not merge.**

Branched off #2527 (`feat/chatterbox-nctx-cap`), with the registry pin bumped to the latest revision so CI exercises the real code.

## What this validates
- **tts-cpp [#43](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/43)** (rebased onto master `40c95c6e`): streamed GGUF loads (no full-file host staging), selectable KV dtype (`q8_0` default) on a token-major slab, capability probe + F32 fallback, Vulkan `q8_0→f32` guard, **and the Android `GGML_BACKEND_DL` symbol fix**.
- **registry [#188](https://github.com/tetherto/qvac-registry-vcpkg/pull/188)** branch (`620f6e2`) publishing **tts-cpp `2026-06-18 @ a7b36cbe`** — consumed via the temporary `default-registry` reference in `vcpkg-configuration.json`.
- **#2527 addon**: `nCtx` + `kvCacheType` knobs; the `tts-chatterbox` mobile e2e is enabled (not skipped), so this genuinely runs Chatterbox on-device.

## Action needed
The mobile-integration (Device Farm) + integration jobs are **label-gated** (`label-gate`). Please **apply the authorising label** to run them.

## Note
Pins the unmerged stack on purpose. Once green: land #43 → re-pin & merge #188 → #2527 (re-point baseline to the merged registry main commit) → this branch is deleted.