### PR TITLE
chore[ci|notask]: add ubuntu-26.04 integration-test target for whisper

### DIFF
--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -92,6 +92,12 @@ jobs:
             no_gpu: 'true'
             benchmark_matrix_json: >-
               [{"modelFile":"ggml-tiny.bin","useGPU":false,"backendHint":"cpu"}]
+          - os: ubuntu-26.04
+            platform: linux
+            arch: x64
+            no_gpu: 'true'
+            benchmark_matrix_json: >-
+              [{"modelFile":"ggml-tiny.bin","useGPU":false,"backendHint":"cpu"}]
           - os: macos-14-xlarge
             platform: darwin
             arch: arm64


### PR DESCRIPTION
## What

Adds a GitHub-hosted `ubuntu-26.04` (x64, CPU-only) entry to the whisper integration-test matrix in `integration-test-transcription-whispercpp.yml`, so the suite runs against Ubuntu 26.04 alongside the existing 22.04 / 24.04 targets.

## Why

We want CI coverage on Ubuntu 26.04 (24.04's successor) ahead of broader adoption.

## Details

- New entry mirrors the existing GitHub-hosted `ubuntu-24.04-arm` target: no self-hosted `runner:` override (there's no 26.04 GPU box), `no_gpu: 'true'`, and a CPU-only `benchmark_matrix_json`.
- The Vulkan smoke test (`if: matrix.runner == 'qvac-ubuntu2404-x64-gpu'`) and the model-cache step (`if: runner.environment != 'github-hosted'`) both correctly skip for this target.
- No change to `reusable-prebuilds.yml`: the `linux-x64` prebuild is platform/arch-specific (not OS-version-specific), so the new job reuses the existing artifact.

> [!NOTE]
> `ubuntu-26.04` depends on GitHub having the hosted runner image generally available. If it's still in limited rollout the job would fail with "no runner matching labels".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
