### PR TITLE
test: release-guard revalidation (DO NOT MERGE)

### DIFF
--- a/.github/actions/verify-changelog-notes/action.yml
+++ b/.github/actions/verify-changelog-notes/action.yml
@@ -1,0 +1,49 @@
+name: Verify Changelog Notes
+description: Verify a CHANGELOG contains a non-empty "## [version]" section and extract its body
+inputs:
+  changelog-path:
+    required: true
+    description: Path to the CHANGELOG.md file to inspect
+  version:
+    required: true
+    description: Version to look for (x.y.z)
+outputs:
+  release-notes-path:
+    description: Path to a file containing the extracted release-notes body
+    value: ${{ steps.extract.outputs.release_notes_path }}
+runs:
+  using: composite
+  steps:
+    - id: extract
+      shell: bash
+      env:
+        CHANGELOG_PATH: ${{ inputs.changelog-path }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        notes="${RUNNER_TEMP}/release-notes-v${VERSION}.md"
+
+        if [ ! -s "${CHANGELOG_PATH}" ]; then
+          echo "::error::Missing or empty changelog: ${CHANGELOG_PATH}"
+          exit 1
+        fi
+
+        start_line=$(awk -v version="${VERSION}" '$0 ~ "^## \\[" version "\\]" { print NR; exit }' "${CHANGELOG_PATH}")
+        if [ -z "${start_line}" ]; then
+          echo "::error::No CHANGELOG heading '## [${VERSION}]' in ${CHANGELOG_PATH}"
+          exit 1
+        fi
+
+        end_line=$(awk -v start="${start_line}" 'NR > start && /^## \[/ { print NR - 1; found=1; exit } END { if (!found) print NR }' "${CHANGELOG_PATH}")
+        if [ -z "${end_line}" ] || [ "${end_line}" -lt "${start_line}" ]; then
+          echo "::error::Invalid changelog section bounds for version ${VERSION}"
+          exit 1
+        fi
+
+        sed -n "$((start_line + 1)),${end_line}p" "${CHANGELOG_PATH}" > "${notes}"
+        if ! awk 'BEGIN { c=0 } /[^[:space:]]/ { c=1 } END { exit c ? 0 : 1 }' "${notes}"; then
+          echo "::error::Changelog section for version ${VERSION} is empty"
+          exit 1
+        fi
+
+        echo "release_notes_path=${notes}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/pr-release-guard.yml
+++ b/.github/workflows/pr-release-guard.yml
@@ -1,0 +1,114 @@
+name: PR Release Guard (SDK Pod)
+
+# Validates release PRs (base branch release-<slug>-x.y.z) before merge:
+# branch name, version bump, CHANGELOG updated, and a non-empty "## [x.y.z]"
+# section. This is the same set of checks that otherwise only run after merge
+# (release-merge-guard on push) and after npm publish (create-github-release) —
+# brought forward so a broken release fails on the PR.
+#
+# Uses pull_request (not pull_request_target): the job needs no secrets or write
+# token, only reads PR git content, so it must not run with elevated privilege.
+#
+# No trigger-level `paths:` filter on purpose: if this check is added to a branch
+# ruleset, a skipped run never reports a status and GitHub blocks the PR on
+# "waiting for status". So it runs on every release-* PR and no-ops internally
+# for non-SDK-pod release branches (mirrors pr-checks-sdk-pod.yml).
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - release-*
+
+jobs:
+  release-guard:
+    name: Release Guard (changelog/version)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Derive package from release slug
+        id: pkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_ref="${{ github.base_ref }}"
+          pods=" sdk cli rag logging error ai-sdk-provider "
+          if [[ ! "$base_ref" =~ ^release-(.+)-([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "::notice::Base '$base_ref' is not release-<slug>-x.y.z — skipping SDK-pod release guard"
+            echo "is_pod=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          slug="${BASH_REMATCH[1]}"
+          version="${BASH_REMATCH[2]}"
+          if [[ "$pods" != *" $slug "* ]]; then
+            echo "::notice::'$slug' is not an SDK pod — skipping (guarded by its own release workflow)"
+            echo "is_pod=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "is_pod=true"
+            echo "slug=$slug"
+            echo "version=$version"
+            echo "pkg_json=packages/$slug/package.json"
+            echo "changelog=packages/$slug/CHANGELOG.md"
+          } >> "$GITHUB_OUTPUT"
+
+      # Default pull_request checkout = the merge ref; fetch-depth 0 so the guard
+      # can diff base..head and read package.json/CHANGELOG at the head commit.
+      # Local actions below (uses: ./...) resolve from this checkout, i.e. from
+      # base+head — not from main. They ship in the same commit as this workflow,
+      # so any branch running this job also has them; backporting this workflow
+      # without them would fail loudly here.
+      - name: Checkout
+        if: steps.pkg.outputs.is_pod == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate release branch, version bump and changelog
+        if: steps.pkg.outputs.is_pod == 'true'
+        uses: ./.github/actions/release-merge-guard
+        with:
+          base-ref: ${{ github.base_ref }}
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          package-slug: ${{ steps.pkg.outputs.slug }}
+          package-json-path: ${{ steps.pkg.outputs.pkg_json }}
+          changelog-path: ${{ steps.pkg.outputs.changelog }}
+
+      # Read the CHANGELOG as it would be after merge (the PR head commit).
+      - name: Materialize PR-head CHANGELOG
+        if: steps.pkg.outputs.is_pod == 'true'
+        id: head_changelog
+        shell: bash
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHANGELOG: ${{ steps.pkg.outputs.changelog }}
+        run: |
+          set -euo pipefail
+          out="${RUNNER_TEMP}/changelog-head.md"
+          if ! git show "${HEAD_SHA}:${CHANGELOG}" > "${out}" 2>/dev/null; then
+            echo "::error::CHANGELOG not found at PR head: ${CHANGELOG}"
+            exit 1
+          fi
+          echo "path=${out}" >> "$GITHUB_OUTPUT"
+
+      # Same version-section check create-github-release.yml runs post-publish,
+      # brought forward to the PR so a missing/empty section fails before merge —
+      # not after the package is already on npm with no GitHub release.
+      - name: Verify CHANGELOG has release notes for this version
+        if: steps.pkg.outputs.is_pod == 'true'
+        uses: ./.github/actions/verify-changelog-notes
+        with:
+          changelog-path: ${{ steps.head_changelog.outputs.path }}
+          version: ${{ steps.pkg.outputs.version }}

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-<!-- release-guard CI validation test (do not merge) -->
+## [0.7.0]
+
+- Image-to-video generation and audio encoding for the OpenAI-compatible HTTP server.
 
 # QVAC CLI v0.7.0 Release Notes
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+<!-- release-guard CI validation test (do not merge) -->
+
 # QVAC CLI v0.7.0 Release Notes
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.7.0


### PR DESCRIPTION
Throwaway PR re-validating the revised pr-release-guard (conditional checkout + no-op gate). Expected: FAIL at version-section check (no `## [0.7.0]`). Closed after validation.