### PR TITLE
chore[notask]: release sdk + bare-sdk 0.13.5 — clean up Expo RPC worker on non-iOS close

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.13.5]
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.5
+
+A patch release that fixes Expo RPC worker cleanup on Android and other
+non-iOS platforms when the SDK closes its RPC connection.
+
+## Bug Fixes
+
+### Clean up the Expo RPC worker on non-iOS close
+
+On Expo, closing the SDK RPC connection now sends the worker a shutdown
+roundtrip before dropping client-side references. On iOS the worklet can still
+be terminated safely; on Android and other non-iOS platforms the worklet cannot
+be terminated without risking a native crash, so the SDK releases addon logger
+handles and clears worklet state instead.
+
+After shutdown, the SDK also resets its worklet reference so the next RPC
+session starts with a fresh worker and a fully populated plugin registry. This
+prevents follow-up model loads from failing with "Plugin not found" when tests
+or app flows unload the last model and auto-close the RPC client between runs.
+
+The same update is mirrored into the Bare build (`@qvac/bare-sdk`), which ships
+in lockstep with `@qvac/sdk`.
+
 ## [0.13.4]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.4

--- a/packages/sdk/changelog/0.13.5/CHANGELOG.md
+++ b/packages/sdk/changelog/0.13.5/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.13.5
+
+Release Date: 2026-06-18
+
+## 🐞 Fixes
+
+- Clean up Expo RPC worker on non-iOS close. (see PR [#2639](https://github.com/tetherto/qvac/pull/2639))
+

--- a/packages/sdk/changelog/0.13.5/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.13.5/CHANGELOG_LLM.md
@@ -1,0 +1,24 @@
+# QVAC SDK v0.13.5 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.13.5
+
+A patch release that fixes Expo RPC worker cleanup on Android and other
+non-iOS platforms when the SDK closes its RPC connection.
+
+## Bug Fixes
+
+### Clean up the Expo RPC worker on non-iOS close
+
+On Expo, closing the SDK RPC connection now sends the worker a shutdown
+roundtrip before dropping client-side references. On iOS the worklet can still
+be terminated safely; on Android and other non-iOS platforms the worklet cannot
+be terminated without risking a native crash, so the SDK releases addon logger
+handles and clears worklet state instead.
+
+After shutdown, the SDK also resets its worklet reference so the next RPC
+session starts with a fresh worker and a fully populated plugin registry. This
+prevents follow-up model loads from failing with "Plugin not found" when tests
+or app flows unload the last model and auto-close the RPC client between runs.
+
+The same update is mirrored into the Bare build (`@qvac/bare-sdk`), which ships
+in lockstep with `@qvac/sdk`.

--- a/packages/sdk/client/rpc/expo-rpc-client.ts
+++ b/packages/sdk/client/rpc/expo-rpc-client.ts
@@ -195,8 +195,11 @@ export async function close(): Promise<void> {
 
     // terminate() crashes on Android (addon dlclose leaves pthread_key_t
     // destructors dangling); iOS dyld no-ops dlclose so it's safe there.
-    // Non-iOS: drop refs only -- sending __shutdown__ without a follow-up
-    // terminate would clear the worker plugin registry.
+    // Non-iOS: send the cleanup roundtrip, then drop refs without
+    // terminating. Android cannot safely terminate/dlclose the worklet
+    // here, but reset/reload still needs addon logger js_ref_t handles
+    // released before a fresh worker registers plugins in the same app
+    // process.
     let platform: string | undefined;
     try {
       platform = (await getRuntimeContext()).platform;
@@ -205,8 +208,14 @@ export async function close(): Promise<void> {
     }
 
     if (platform !== "ios") {
+      if (rpcInstance) {
+        logger.info("🧹 Requesting worker cleanup");
+        await sendShutdownMessage(rpcInstance);
+      }
       rpcInstance = null;
       rpcPromise = null;
+      workletInstance = null;
+      workletInitialized = false;
       return;
     }
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Expo apps on Android (and other non-iOS platforms) could fail to load models after the SDK auto-closed its RPC connection between runs, surfacing "Plugin not found" errors.
- The fix from #2639 is on `main` but not yet shipped in a patch release on the 0.13.x line.

## 📝 How does it solve it?

- Cherry-picks #2639 onto `release-sdk-0.13.5`: send `__shutdown__` on non-iOS `close()`, then reset worklet refs so the next RPC session registers plugins in a fresh worker.
- Bumps `@qvac/sdk` and `@qvac/bare-sdk` to `0.13.5` with generated changelog.

## 🧪 How was it tested?

- Android Expo smoke suite green after the null-worklet follow-up in #2639.
- Changelog scoped to PR #2639 only (surgical patch from 0.13.4).