### PR TITLE
QVAC-19908 chore: release @qvac/cli 0.7.1 — pull in @qvac/sdk 0.13.4 tool-call fix

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+# QVAC CLI v0.7.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.7.1
+
+A patch release that pulls in the `@qvac/sdk` 0.13.4 tool-call parsing fix so the
+OpenAI-compatible server recovers malformed Qwen tool-call frames.
+
+## Bug Fixes
+
+### Recover malformed Qwen tool-call frames
+
+`qvac serve` delegates tool-call parsing to `@qvac/sdk`. Qwen3.5/3.6 can
+intermittently emit a malformed tool-call frame that fuses its XML and JSON tool
+templates, embedding the `function=<name>` token as a bare string key inside an
+otherwise JSON object. The SDK previously rejected that frame as invalid JSON, so
+no structured tool call was produced and callers saw the raw markup as assistant
+text. This release raises the `@qvac/sdk` floor to `^0.13.4`, which recognizes and
+repairs that specific shape so the tool call is recovered and dispatched correctly.
+
 # QVAC CLI v0.7.0 Release Notes
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.7.0

--- a/packages/cli/changelog/0.7.1/CHANGELOG.md
+++ b/packages/cli/changelog/0.7.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.7.1
+
+Release Date: 2026-06-18
+
+## 🐛 Bug Fixes
+
+- Recover malformed Qwen tool-call frames in `qvac serve` by raising the `@qvac/sdk` floor to `^0.13.4`.

--- a/packages/cli/changelog/0.7.1/CHANGELOG_LLM.md
+++ b/packages/cli/changelog/0.7.1/CHANGELOG_LLM.md
@@ -1,0 +1,18 @@
+# QVAC CLI v0.7.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.7.1
+
+A patch release that pulls in the `@qvac/sdk` 0.13.4 tool-call parsing fix so the
+OpenAI-compatible server recovers malformed Qwen tool-call frames.
+
+## Bug Fixes
+
+### Recover malformed Qwen tool-call frames
+
+`qvac serve` delegates tool-call parsing to `@qvac/sdk`. Qwen3.5/3.6 can
+intermittently emit a malformed tool-call frame that fuses its XML and JSON tool
+templates, embedding the `function=<name>` token as a bare string key inside an
+otherwise JSON object. The SDK previously rejected that frame as invalid JSON, so
+no structured tool call was produced and callers saw the raw markup as assistant
+text. This release raises the `@qvac/sdk` floor to `^0.13.4`, which recognizes and
+repairs that specific shape so the tool call is recovered and dispatched correctly.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -55,7 +55,7 @@
     "@fastify/multipart": "^9.0.0",
     "@fastify/swagger": "^9.0.0",
     "@fastify/swagger-ui": "^5.0.0",
-    "@qvac/sdk": "^0.13.1",
+    "@qvac/sdk": "^0.13.4",
     "close-with-grace": "^2.1.0",
     "commander": "^14.0.3",
     "fastify": "^5.0.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@qvac/cli`'s `serve` command delegates tool-call parsing to `@qvac/sdk`. The published `0.7.0` floors `@qvac/sdk` at `^0.13.1`, which does not *guarantee* the Qwen tool-call recovery fix shipped in `@qvac/sdk` `0.13.4`. Downstream consumers (`@qvac/ai-sdk-provider`, `@qvac/opencode-plugin`) reach the SDK only through this package, so that fix cannot be guaranteed to them until cli raises its floor.

## 📝 How does it solve it?

Patch release cut from the `0.7.0` release point (so it excludes unrelated unreleased cli work currently on `main`):

- `packages/cli/package.json`: version `0.7.0 → 0.7.1`, `@qvac/sdk` floor `^0.13.1 → ^0.13.4`.
- `packages/cli/changelog/0.7.1/` (`CHANGELOG.md` + `CHANGELOG_LLM.md`) documenting the fix propagation.
- `packages/cli/CHANGELOG.md`: prepend the `0.7.1` entry; older entries left byte-for-byte unchanged.

Merging triggers the GPR publish; the npm publish follows from the backmerge into `main`.

## 🧪 How was it tested?

- `@qvac/sdk` `0.13.3` and `0.13.4` declare **identical** dependency sets, so cli's third-party attribution tree is unchanged — `NOTICE` is unaffected and intentionally not regenerated.
- Diff is limited to the version bump, the `^0.13.4` floor, and changelog files (4 files); no source changes.