### PR TITLE
QVAC-19908 chore[skiplog]: backmerge release-cli-0.7.1 — version bump + changelog

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+# QVAC CLI v0.7.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.7.1
+
+A patch release that pulls in the `@qvac/sdk` 0.13.4 tool-call parsing fix so the
+OpenAI-compatible server recovers malformed Qwen tool-call frames.
+
+## Bug Fixes
+
+### Recover malformed Qwen tool-call frames
+
+`qvac serve` delegates tool-call parsing to `@qvac/sdk`. Qwen3.5/3.6 can
+intermittently emit a malformed tool-call frame that fuses its XML and JSON tool
+templates, embedding the `function=<name>` token as a bare string key inside an
+otherwise JSON object. The SDK previously rejected that frame as invalid JSON, so
+no structured tool call was produced and callers saw the raw markup as assistant
+text. This release raises the `@qvac/sdk` floor to `^0.13.4`, which recognizes and
+repairs that specific shape so the tool call is recovered and dispatched correctly.
+
 # QVAC CLI v0.7.0 Release Notes
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.7.0

--- a/packages/cli/changelog/0.7.1/CHANGELOG.md
+++ b/packages/cli/changelog/0.7.1/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog v0.7.1
+
+Release Date: 2026-06-18
+
+## 🐛 Bug Fixes
+
+- Recover malformed Qwen tool-call frames in `qvac serve` by raising the `@qvac/sdk` floor to `^0.13.4`.

--- a/packages/cli/changelog/0.7.1/CHANGELOG_LLM.md
+++ b/packages/cli/changelog/0.7.1/CHANGELOG_LLM.md
@@ -1,0 +1,18 @@
+# QVAC CLI v0.7.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.7.1
+
+A patch release that pulls in the `@qvac/sdk` 0.13.4 tool-call parsing fix so the
+OpenAI-compatible server recovers malformed Qwen tool-call frames.
+
+## Bug Fixes
+
+### Recover malformed Qwen tool-call frames
+
+`qvac serve` delegates tool-call parsing to `@qvac/sdk`. Qwen3.5/3.6 can
+intermittently emit a malformed tool-call frame that fuses its XML and JSON tool
+templates, embedding the `function=<name>` token as a bare string key inside an
+otherwise JSON object. The SDK previously rejected that frame as invalid JSON, so
+no structured tool call was produced and callers saw the raw markup as assistant
+text. This release raises the `@qvac/sdk` floor to `^0.13.4`, which recognizes and
+repairs that specific shape so the tool call is recovered and dispatched correctly.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -55,7 +55,7 @@
     "@fastify/multipart": "^9.0.0",
     "@fastify/swagger": "^9.0.0",
     "@fastify/swagger-ui": "^5.0.0",
-    "@qvac/sdk": "^0.13.1",
+    "@qvac/sdk": "^0.13.4",
     "close-with-grace": "^2.1.0",
     "commander": "^14.0.3",
     "fastify": "^5.0.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Lands the `@qvac/cli` `0.7.1` release metadata (release PR #2698) onto `main` and triggers the npm publish. Without this, `main` would be a published version behind and its changelog history would have a hole at `0.7.1`.

## 📝 How does it solve it?

Hand-crafted backmerge (cherry-pick of the release commit), so it touches only the release artifacts and leaves `main`'s unreleased cli work intact:

- `packages/cli/package.json`: `version 0.7.0 → 0.7.1`, `@qvac/sdk` floor `^0.13.1 → ^0.13.4`.
- `packages/cli/changelog/0.7.1/` added; `packages/cli/CHANGELOG.md` gets the `0.7.1` entry prepended (older entries unchanged).

`main`'s already-merged-but-unreleased cli work (e.g. `image_url` content support, #2459) is preserved — a literal merge was avoided so nothing on `main` is regressed.

Merge **after** #2698 lands on `release-cli-0.7.1` (GPR publish); merging this into `main` triggers the npm publish of `@qvac/cli 0.7.1`.

## 🧪 How was it tested?

- Diff is exactly the 4 release-artifact files; `git log` confirms `#2459` and other `main` advances remain in history.
- `@qvac/sdk` `0.13.3`/`0.13.4` have identical dependency sets, so cli's `NOTICE` is unchanged and intentionally not regenerated.