### PR TITLE
chore[notask]: release @qvac/ocr-ggml 0.3.0

### DIFF
--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this package will be documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-06-18
+
+### Added
+- **DocTR now runs end-to-end on Qualcomm Adreno GPUs via the OpenCL backend.**
+  The detection and recognition graphs use a backend-aware direct convolution
+  path (`ggml_conv_2d_direct`) on OpenCL, replacing the `im2col` f16×f16 GEMV
+  that dominated runtime on Adreno — detection drops from ~1.35 s to ~0.5–0.85 s
+  at identical accuracy (12/12 clinical-chemistry keywords; ~0.72 s warm total on
+  a Galaxy S25 / Adreno 830). Other backends keep the `im2col` path (faster on
+  Metal); the choice is resolved automatically from the compute backend, with
+  the `OCR_DOCTR_FUSED_CONV` env var as an override for A/B testing.
+
+### Changed
+- Updated the `qvac-fabric` vcpkg dependency to registry version `8828.1.2`,
+  which ships the OpenCL kernels DocTR needs to run end-to-end on Adreno instead
+  of aborting on an unsupported op: `CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, and
+  `HARDSIGMOID`.
+
 ## [0.2.2] - 2026-06-15
 
 ### Changed

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-ggml",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "GGML-backed OCR addon for qvac (EasyOCR pipeline on GGUF weights)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Release @qvac/ocr-ggml 0.3.0

Minor bump for the DocTR Adreno OpenCL work that landed on `main` in #2617.

- `package.json`: `0.2.2` → `0.3.0`
- `CHANGELOG.md`: new `## [0.3.0]` entry

### What 0.3.0 covers (from #2617)
- **DocTR runs end-to-end on Adreno via OpenCL** — backend-aware direct regular conv (`ggml_conv_2d_direct`) replaces the slow `im2col` f16×f16 GEMV on Adreno (detection ~1.35s → ~0.5–0.85s, identical accuracy, ~0.72s warm on Galaxy S25). Other backends keep `im2col`.
- **`qvac-fabric` → `8828.1.2`** — ships the OpenCL `CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, `HARDSIGMOID` kernels DocTR needs on Adreno.

Per the per-package release process (one bump PR per package). Version + changelog only — no code changes.
