### PR TITLE
chore[notask]: release @qvac/embed-llamacpp 0.21.0

### DIFF
--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.21.0] - 2026-06-18
+
+### Changed
+
+- Updated the `qvac-fabric` vcpkg dependency to registry version `8828.1.2` (adds the OpenCL DocTR ops — `CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, `HARDSIGMOID` — for the Adreno OpenCL backend; no behavioral change for this package).
+
+## Pull Requests
+
+- [#2617](https://github.com/tetherto/qvac/pull/2617) - feat[api]: DocTR Adreno OpenCL — direct regular conv (~0.72s on S25) + qvac-fabric 8828.1.2
+
 ## [0.20.0] - 2026-06-12
 
 ### Changed

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Release @qvac/embed-llamacpp 0.21.0

Minor bump for the `qvac-fabric` `8828.1.2` dependency update that landed on `main` in #2617.

- `package.json`: `0.20.0` → `0.21.0`
- `CHANGELOG.md`: new `## [0.21.0]` entry

`8828.1.2` adds the OpenCL DocTR ops (`CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, `HARDSIGMOID`) for the Adreno OpenCL backend — no behavioral change for this package.

Per the per-package release process (one bump PR per package). Version + changelog only — no code changes.
