### PR TITLE
chore[notask]: release @qvac/translation-nmtcpp 6.1.0

### DIFF
--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0] - 2026-06-18
+
+### Changed
+
+- Updated the `qvac-fabric` vcpkg dependency to registry version `8828.1.2` (adds the OpenCL DocTR ops — `CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, `HARDSIGMOID` — for the Adreno OpenCL backend; no behavioral change for this package).
+
+## Pull Requests
+
+- [#2617](https://github.com/tetherto/qvac/pull/2617) - feat[api]: DocTR Adreno OpenCL — direct regular conv (~0.72s on S25) + qvac-fabric 8828.1.2
+
 ## [6.0.1] - 2026-06-15
 
 ### Changed

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Release @qvac/translation-nmtcpp 6.1.0

Minor bump for the `qvac-fabric` `8828.1.2` dependency update that landed on `main` in #2617.

- `package.json`: `6.0.1` → `6.1.0`
- `CHANGELOG.md`: new `## [6.1.0]` entry

`8828.1.2` adds the OpenCL DocTR ops (`CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, `HARDSIGMOID`) for the Adreno OpenCL backend — no behavioral change for this package.

Per the per-package release process (one bump PR per package). Version + changelog only — no code changes.
