### PR TITLE
chore[notask]: release @qvac/vla-ggml 0.5.0

### DIFF
--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.5.0] - 2026-06-18
+
+### Changed
+
+- Updated the `qvac-fabric` vcpkg dependency to registry version `8828.1.2` (adds the OpenCL DocTR ops — `CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, `HARDSIGMOID` — for the Adreno OpenCL backend; no behavioral change for this package).
+
+## Pull Requests
+
+- [#2617](https://github.com/tetherto/qvac/pull/2617) - feat[api]: DocTR Adreno OpenCL — direct regular conv (~0.72s on S25) + qvac-fabric 8828.1.2
+
 ## [0.4.0] - 2026-06-12
 
 ### Changed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Release @qvac/vla-ggml 0.5.0

Minor bump for the `qvac-fabric` `8828.1.2` dependency update that landed on `main` in #2617.

- `package.json`: `0.4.0` → `0.5.0`
- `CHANGELOG.md`: new `## [0.5.0]` entry

`8828.1.2` adds the OpenCL DocTR ops (`CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, `HARDSIGMOID`) for the Adreno OpenCL backend — no behavioral change for this package.

Per the per-package release process (one bump PR per package). Version + changelog only — no code changes.
