### PR TITLE
chore[notask]: release @qvac/classification-ggml 0.5.0

### DIFF
--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-18
+
+### Changed
+
+- Updated the `qvac-fabric` vcpkg dependency to registry version `8828.1.2` (adds the OpenCL DocTR ops — `CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, `HARDSIGMOID` — for the Adreno OpenCL backend; no behavioral change for this package).
+
+## Pull Requests
+
+- [#2617](https://github.com/tetherto/qvac/pull/2617) - feat[api]: DocTR Adreno OpenCL — direct regular conv (~0.72s on S25) + qvac-fabric 8828.1.2
+
 ## [0.4.0] - 2026-06-12
 
 ### Changed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## Release @qvac/classification-ggml 0.5.0

Minor bump for the `qvac-fabric` `8828.1.2` dependency update that landed on `main` in #2617.

- `package.json`: `0.4.0` → `0.5.0`
- `CHANGELOG.md`: new `## [0.5.0]` entry

`8828.1.2` adds the OpenCL DocTR ops (`CONV_2D_DW`, `POOL_2D`, `HARDSWISH`, `HARDSIGMOID`) for the Adreno OpenCL backend — no behavioral change for this package.

Per the per-package release process (one bump PR per package). Version + changelog only — no code changes.
