### PR TITLE
doc[notask]: clarify companion assets in examples

### DIFF
--- a/docs/website/content/docs/quickstart.mdx
+++ b/docs/website/content/docs/quickstart.mdx
@@ -35,6 +35,13 @@ npm i @qvac/sdk
 </Step>
 
 <Step>
+The SDK prints no logs by default. To watch its client and server logs while the quickstart runs, save this config in your workspace (any path works — `QVAC_CONFIG_PATH` points at it in the run step):
+
+```json file=<rootDir>/packages/sdk/examples/config/default/default.config.json title="qvac.config.json"
+```
+</Step>
+
+<Step>
 Create the quickstart script:
 <WrapCode>
 
@@ -44,10 +51,10 @@ Create the quickstart script:
 </Step>
 
 <Step>
-Run the quickstart script with Node.js:
+Run the quickstart script with Node.js, pointing `QVAC_CONFIG_PATH` at the config you saved (omit it to run silently):
 
 ```bash
-node quickstart.js
+QVAC_CONFIG_PATH=./qvac.config.json node quickstart.js
 ```
 
 Or with the [Bare](https://bare.pears.com) runtime. Running on Bare needs a little setup — a `process` global and plugin registration — so see [Running on Bare](#running-on-bare) below.
@@ -60,6 +67,8 @@ Or with the [Bare](https://bare.pears.com) runtime. Running on Bare needs a litt
 Follow these instructions to run any example in this documentation:
 - All examples are self-contained, runnable JavaScript scripts. Use the `qvac-examples` workspace created in this quickstart to store and run them as you explore this documentation.
 - Run each example with the indicated compatible JavaScript environment. QVAC supports multiple environments (Node.js, Bare, and Expo). The examples are written in Node style and run on Node.js or Bun directly; to run them on Bare, see [Running on Bare](#running-on-bare).
+- More examples can be found in the [SDK examples directory](https://github.com/tetherto/qvac/tree/main/packages/sdk/examples).
+- Some examples need companion files — sample audio, an image, or a config — that aren't part of the embedded code. These can be found in the same examples directory.
 - Some examples also provide a TypeScript version. If you want to run TS directly, install the required dev dependencies:
   ```bash
   npm i -D tsx typescript

--- a/packages/sdk/examples/quickstart.ts
+++ b/packages/sdk/examples/quickstart.ts
@@ -1,12 +1,12 @@
-// The SDK is silent by default. Pointing QVAC_CONFIG_PATH at a config with
-// `loggerConsoleOutput: true` prints the SDK's client and server logs to the
-// console. Drop this line (or set the flag to false) to run quietly.
-const configDir = import.meta.dirname ?? process.cwd();
-process.env["QVAC_CONFIG_PATH"] =
-  `${configDir}/config/default/default.config.json`;
-
-const { loadModel, LLAMA_3_2_1B_INST_Q4_0, completion, unloadModel } =
-  await import("@qvac/sdk");
+// The SDK prints no logs by default. To see its client and server logs, run with
+// QVAC_CONFIG_PATH pointing at a config that sets "loggerConsoleOutput": true
+// (see the Quickstart docs).
+import {
+  loadModel,
+  LLAMA_3_2_1B_INST_Q4_0,
+  completion,
+  unloadModel,
+} from "@qvac/sdk";
 
 try {
   // Load a model into memory


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The Quickstart page embeds `quickstart.js` verbatim, but the script hardcoded `QVAC_CONFIG_PATH` to a bundled `config/default/default.config.json` — a file a user copying the script into their own workspace doesn't have.
- The "Running examples" section claimed every example is self-contained, which is inaccurate: some examples need companion files (sample audio, an image, a config) that aren't part of the embedded code.

## 📝 How does it solve it?

- `examples/quickstart.ts` is now a self-contained static import with no hardcoded config path. A short comment notes that SDK logs are opt-in via `QVAC_CONFIG_PATH`.
- `quickstart.mdx` adds a step showing the config JSON to save as `qvac.config.json`, and the run commands now pass `QVAC_CONFIG_PATH=./qvac.config.json` (omit it to run silently).
- Reworked the "Running examples" list: each doc example is a runnable script; more can be found in the [SDK examples directory](https://github.com/tetherto/qvac/tree/main/packages/sdk/examples); and examples that need companion files point to that same directory.

## 🧪 How was it tested?

- `bun run lint` (eslint + typecheck) and `bun run build` pass; the emitted `dist/examples/quickstart.js` that the docs embed matches the updated source.
- Docs change is MDX only — no runtime behavior change.