### PR TITLE
infra[notask]: extend check-approvals trigger to release-* branches

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, labeled, synchronize]
-    branches: [main, master, release*]
+    branches: [main, master, release-*]
 
 permissions:
   contents: read

--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, labeled, synchronize]
-    branches: [main, master, release]
+    branches: [main, master, release*]
 
 permissions:
   contents: read

--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, labeled, synchronize]
-    branches: [main, master]
+    branches: [main, master, release]
 
 permissions:
   contents: read


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The `check-approvals` workflow enforces the pending-approval gate on PRs, but its `pull_request_target` trigger was scoped only to `main` and `master`. PRs opened against `release-*` branches (hotfixes, backmerges) were silently skipped — no approval check ran at all.

- This left release-branch PRs without the same approval enforcement that `main`-targeting PRs receive.

## 📝 How does it solve it?

- Extends the `pull_request_target.branches` filter from `[main, master]` to `[main, master, release-*]`, so any PR targeting a `release-` prefixed branch also triggers the approval check.

## 🧪 How was it tested?

- Branch pattern `release-*` verified against GitHub's glob matching rules — `release-0.13.3`, `release-sdk-0.13.3` both match; unrelated branch names do not.
- Two follow-up fix commits (`fix: corrected pattern for the release branches`) corrected the initial pattern — final pattern confirmed against the YAML trigger spec.
- Workflow can be validated with a test PR opened against any `release-*` branch to confirm `check-approvals` fires.