### PR TITLE
QVAC-20557 test[notask]: measure tts-ggml GPU-vs-CPU correctness on Android — DO NOT MERGE

### DIFF
--- a/packages/tts-ggml/CMakeLists.txt
+++ b/packages/tts-ggml/CMakeLists.txt
@@ -198,6 +198,14 @@ if(ANDROID)
       -Wl,-z,max-page-size=16384
       -Wl,-z,common-page-size=16384
   )
+  # DEBUG (QVAC-20557 GPU correctness bring-up, DO-NOT-MERGE):
+  # {Supertonic,Chatterbox}Model.cpp's emitDeviceDiag calls __android_log_print
+  # so the [gpu-diag] lines + canary reach the device logcat artifact. Bare
+  # modules link with `-undefined,dynamic_lookup`, so without an explicit
+  # DT_NEEDED the liblog symbol would defer to a load-time lookup that can
+  # silently fail (ADDON_NOT_FOUND). Link it explicitly. Mirrors qvac PR #2610 /
+  # qvac/packages/transcription-parakeet PR #2601.
+  target_link_libraries(${tts-ggml}_module PRIVATE log)
 endif()
 
 if(APPLE)

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -190,8 +190,10 @@ void ChatterboxModel::reload() {
 void ChatterboxModel::loadLocked() {
   if (engine_) return;
 
-  // Force useGPU to false on Android until Vulkan (Mali) and OpenCL (Adreno)
-  // stabilize for the Chatterbox graph.
+  // DEBUG (QVAC-20557, DO-NOT-MERGE): the Android GPU force-to-CPU was REMOVED
+  // here so a device-farm round can MEASURE Chatterbox GPU-vs-CPU correctness on
+  // Mali/Adreno (the original block set cfg_.useGpu=false; cfg_.nGpuLayers=0).
+  // Measurement scaffolding, NOT a ship change.
 #ifdef __ANDROID__
   {
     const bool wantsGpu =
@@ -199,12 +201,9 @@ void ChatterboxModel::loadLocked() {
         (cfg_.nGpuLayers.has_value() && *cfg_.nGpuLayers != 0);
     if (wantsGpu) {
       QLOG(logger::Priority::WARNING,
-           "Chatterbox: useGPU=true is currently ignored on Android "
-           "(GPU backends disabled at engine boundary pending Vulkan/Mali "
-           "and OpenCL/Adreno driver fixes); falling back to CPU.");
+           "Chatterbox: [QVAC-20557 DO-NOT-MERGE] Android GPU force-to-CPU "
+           "disabled — admitting GPU to measure GPU-vs-CPU correctness.");
     }
-    cfg_.useGpu     = false;
-    cfg_.nGpuLayers = 0;
   }
 #endif
 

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -5,12 +5,23 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <filesystem>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include <tts-cpp/chatterbox/engine.h>
+// DEBUG (QVAC-20557 GPU correctness bring-up, DO-NOT-MERGE): tts_cpp_log_set +
+// ggml_log_callback/ggml_log_level (pulls in ggml.h) — see ggmlLogTrampoline.
+#include <tts-cpp/log.h>
+
+#if defined(__ANDROID__)
+// DEBUG (Mali/Adreno bring-up): __android_log_print — see emitDeviceDiag.
+#include <android/log.h>
+#endif
 
 #include "addon/TTSErrors.hpp"
 #include "model-interface/BackendUtils.hpp"
@@ -26,6 +37,88 @@ using qvac_errors::StatusError;
 using qvac_errors::tts_error::TTSErrorCode;
 namespace general_error = qvac_errors::general_error;
 namespace logger = qvac_lib_inference_addon_cpp::logger;
+
+// DEBUG (QVAC-20557 GPU correctness bring-up, DO-NOT-MERGE) — native log bridge,
+// ported from QVAC PR #2610/#2601. On-device, QLOG/JsLogger rides a uv_async
+// callback that never reaches a captured sink in the embedded Bare-in-app
+// (React-Native host) runtime, and native stderr is swallowed — so native
+// diagnostics vanish (why earlier rounds were blind). Emit STRAIGHT to the
+// platform log: __android_log_print lands synchronously in the full device
+// logcat artifact (logcat_full.txt). Off-device, stderr keeps local pre-flight
+// working.
+void emitDeviceDiag(const std::string& line) {
+#if defined(__ANDROID__)
+  __android_log_print(ANDROID_LOG_INFO, "qvac-chatterbox", "%s", line.c_str());
+#else
+  std::fputs(line.c_str(), stderr);
+  std::fputc('\n', stderr);
+  std::fflush(stderr);
+#endif
+}
+
+// ggml emits log text in fragments that are not necessarily newline-terminated;
+// buffer and flush complete lines so backend-init banners, op-support warnings,
+// and unsupported-op fallbacks each reach the device log as one clean line.
+// Installed via tts_cpp_log_set, which forwards to ggml_log_set.
+void ggmlLogTrampoline(ggml_log_level /*level*/, const char* text,
+                       void* /*user_data*/) {
+  if (!text) return;
+  static std::mutex mu;
+  static std::string buf;
+  std::lock_guard<std::mutex> lk(mu);
+  buf += text;
+  std::size_t nl;
+  while ((nl = buf.find('\n')) != std::string::npos) {
+    emitDeviceDiag(buf.substr(0, nl));
+    buf.erase(0, nl + 1);
+  }
+}
+
+void installGgmlLogTrampolineOnce() {
+  static std::once_flag once;
+  std::call_once(once, [] { tts_cpp_log_set(&ggmlLogTrampoline, nullptr); });
+}
+
+// DEBUG (QVAC-20557, DO-NOT-MERGE): per-stage f32 dumps + token-pinning are
+// keyed off one dir, $TTS_CPP_GPU_DUMP_DIR (set by the gpu-smoke test to a
+// device path the device-farm pulls). Empty/unset = no dump, no pin.
+std::string gpuDumpDir() {
+  const char* d = std::getenv("TTS_CPP_GPU_DUMP_DIR");
+  return (d && *d) ? std::string(d) : std::string();
+}
+
+// DEBUG (QVAC-20557, DO-NOT-MERGE): read pre-captured T3 tokens for pinning. The
+// gpu-smoke test runs the GPU model first (which writes chatterbox_speech_tokens.i32
+// — see synthesize()), copies it to chatterbox_pinned_tokens.i32, then loads the
+// CPU model; this reads that file so CPU S3Gen decodes the SAME tokens the GPU run
+// used. Absent file = normal stochastic T3 (the GPU/first run). int32 little-endian.
+std::vector<int32_t> readPinnedTokens(const std::string& dir) {
+  std::vector<int32_t> toks;
+  if (dir.empty()) return toks;
+  const std::string path = dir + "/chatterbox_pinned_tokens.i32";
+  FILE* f = std::fopen(path.c_str(), "rb");
+  if (!f) return toks;
+  std::fseek(f, 0, SEEK_END);
+  long bytes = std::ftell(f);
+  std::fseek(f, 0, SEEK_SET);
+  if (bytes > 0) {
+    toks.resize(static_cast<size_t>(bytes) / sizeof(int32_t));
+    if (std::fread(toks.data(), sizeof(int32_t), toks.size(), f) != toks.size()) toks.clear();
+  }
+  std::fclose(f);
+  return toks;
+}
+
+// DEBUG (QVAC-20557, DO-NOT-MERGE): persist the tokens this synth used so the
+// follow-up CPU run can pin them (see readPinnedTokens).
+void writeSpeechTokens(const std::string& dir, const std::vector<int32_t>& toks) {
+  if (dir.empty() || toks.empty()) return;
+  const std::string path = dir + "/chatterbox_speech_tokens.i32";
+  FILE* f = std::fopen(path.c_str(), "wb");
+  if (!f) return;
+  std::fwrite(toks.data(), sizeof(int32_t), toks.size(), f);
+  std::fclose(f);
+}
 
 tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) {
   tts_cpp::chatterbox::EngineOptions opts;
@@ -81,6 +174,16 @@ tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) 
   // so tts-cpp keeps its character-level fallback.
   if (!cfg.mecabDictPath.empty())  opts.mecab_dict_path  = cfg.mecabDictPath;
   if (!cfg.cangjieTsvPath.empty()) opts.cangjie_tsv_path = cfg.cangjieTsvPath;
+
+  // DEBUG (QVAC-20557, DO-NOT-MERGE): route the engine's per-stage [gpu-diag]
+  // lines (input_embed/encoder_mu/cfm_mel/f0/stft/hift_wav) to the device log
+  // bridge so they reach logcat_full.txt; when $TTS_CPP_GPU_DUMP_DIR is set,
+  // also dump each S3Gen stage's raw f32 there for GPU-vs-CPU correlation; and
+  // if a pinned-tokens file is present, decode those tokens instead of running
+  // stochastic T3 (so a CPU run matches the GPU run's tokens).
+  opts.diag_sink     = &emitDeviceDiag;
+  opts.diag_dump_dir = gpuDumpDir();
+  opts.test_pinned_tokens = readPinnedTokens(opts.diag_dump_dir);
   return opts;
 }
 
@@ -207,6 +310,13 @@ void ChatterboxModel::loadLocked() {
   }
 #endif
 
+  // DEBUG (QVAC-20557, DO-NOT-MERGE): install the ggml log trampoline BEFORE the
+  // Engine ctor so the backend-init banner (which backend Mali/Adreno selected +
+  // its fp16/coopmat caps) is captured; emit a canary so the device-farm logcat
+  // confirms the native log pipe reaches host before trusting the rest.
+  installGgmlLogTrampolineOnce();
+  emitDeviceDiag("[gpu-diag] canary: native log reaches host (chatterbox)");
+
   try {
     engine_ = std::make_shared<tts_cpp::chatterbox::Engine>(toEngineOptions(cfg_));
   } catch (const std::exception& e) {
@@ -287,6 +397,11 @@ ChatterboxModel::SynthesizeResult ChatterboxModel::synthesize(
     throw createTTSError(TTSErrorCode::SynthesisFailed,
                          std::string("engine.synthesize: ") + e.what());
   }
+
+  // DEBUG (QVAC-20557, DO-NOT-MERGE): persist the T3 tokens this synth used so a
+  // follow-up CPU run can pin them (readPinnedTokens) for a token-matched
+  // GPU-vs-CPU per-stage comparison. No-op when $TTS_CPP_GPU_DUMP_DIR is unset.
+  writeSpeechTokens(gpuDumpDir(), result.speech_tokens);
 
   std::vector<int16_t> pcm = pcmFloatToInt16(result.pcm);
 

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -5,12 +5,23 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <filesystem>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include <tts-cpp/supertonic/engine.h>
+// DEBUG (QVAC-20557 GPU correctness bring-up, DO-NOT-MERGE): tts_cpp_log_set +
+// ggml_log_callback/ggml_log_level (pulls in ggml.h) — see ggmlLogTrampoline.
+#include <tts-cpp/log.h>
+
+#if defined(__ANDROID__)
+// DEBUG (Mali/Adreno bring-up): __android_log_print — see emitDeviceDiag.
+#include <android/log.h>
+#endif
 
 #include "addon/TTSErrors.hpp"
 #include "model-interface/BackendUtils.hpp"
@@ -26,6 +37,55 @@ using qvac_errors::StatusError;
 using qvac_errors::tts_error::TTSErrorCode;
 namespace general_error = qvac_errors::general_error;
 namespace logger = qvac_lib_inference_addon_cpp::logger;
+
+// DEBUG (QVAC-20557 GPU correctness bring-up, DO-NOT-MERGE) — native log bridge,
+// ported from QVAC PR #2610/#2601. On-device, QLOG/JsLogger rides a uv_async
+// callback that never reaches a captured sink in the embedded Bare-in-app
+// (React-Native host) runtime, and native stderr is swallowed — so native
+// diagnostics vanish. Emit STRAIGHT to the platform log: __android_log_print
+// lands synchronously in the full device logcat artifact (logcat_full.txt).
+// Off-device, stderr keeps local pre-flight working.
+void emitDeviceDiag(const std::string& line) {
+#if defined(__ANDROID__)
+  __android_log_print(ANDROID_LOG_INFO, "qvac-supertonic", "%s", line.c_str());
+#else
+  std::fputs(line.c_str(), stderr);
+  std::fputc('\n', stderr);
+  std::fflush(stderr);
+#endif
+}
+
+// ggml emits log text in fragments that are not necessarily newline-terminated;
+// buffer and flush complete lines so backend-init banners ("ggml_vulkan: …
+// Mali-G715 … fp16…"), op-support warnings, and unsupported-op fallbacks each
+// reach the device log as one clean line. Installed via tts_cpp_log_set, which
+// forwards to ggml_log_set.
+void ggmlLogTrampoline(ggml_log_level /*level*/, const char* text,
+                       void* /*user_data*/) {
+  if (!text) return;
+  static std::mutex mu;
+  static std::string buf;
+  std::lock_guard<std::mutex> lk(mu);
+  buf += text;
+  std::size_t nl;
+  while ((nl = buf.find('\n')) != std::string::npos) {
+    emitDeviceDiag(buf.substr(0, nl));
+    buf.erase(0, nl + 1);
+  }
+}
+
+void installGgmlLogTrampolineOnce() {
+  static std::once_flag once;
+  std::call_once(once, [] { tts_cpp_log_set(&ggmlLogTrampoline, nullptr); });
+}
+
+// DEBUG (QVAC-20557, DO-NOT-MERGE): per-stage f32 dumps key off one dir,
+// $TTS_CPP_GPU_DUMP_DIR (set by the gpu-smoke test to a device path the
+// device-farm pulls). Empty/unset = no dump.
+std::string gpuDumpDir() {
+  const char* d = std::getenv("TTS_CPP_GPU_DUMP_DIR");
+  return (d && *d) ? std::string(d) : std::string();
+}
 
 tts_cpp::supertonic::EngineOptions toEngineOptions(const SupertonicConfig& cfg) {
   tts_cpp::supertonic::EngineOptions opts;
@@ -59,6 +119,14 @@ tts_cpp::supertonic::EngineOptions toEngineOptions(const SupertonicConfig& cfg) 
     opts.backends_dir = backendsDirPath.string();
   }
   opts.opencl_cache_dir = cfg.openclCacheDir;
+
+  // DEBUG (QVAC-20557, DO-NOT-MERGE): route the engine's per-stage [gpu-diag]
+  // lines (latent_in/text_emb/cfm_latent/wav_full) to the device log bridge so
+  // they reach logcat_full.txt; when $TTS_CPP_GPU_DUMP_DIR is set, also dump
+  // each stage's raw f32 there for GPU-vs-CPU correlation. Supertonic is
+  // deterministic so the CPU run loads as a separate model (no token pinning).
+  opts.diag_sink     = &emitDeviceDiag;
+  opts.diag_dump_dir = gpuDumpDir();
   return opts;
 }
 
@@ -167,6 +235,13 @@ void SupertonicModel::loadLocked() {
     }
   }
 #endif
+
+  // DEBUG (QVAC-20557, DO-NOT-MERGE): install the ggml log trampoline BEFORE the
+  // Engine ctor so the backend-init banner (which backend Mali/Adreno selected +
+  // its fp16/coopmat caps) is captured; emit a canary so the device-farm logcat
+  // confirms the native log pipe reaches host before trusting the rest.
+  installGgmlLogTrampolineOnce();
+  emitDeviceDiag("[gpu-diag] canary: native log reaches host (supertonic)");
 
   try {
     engine_ = std::make_shared<tts_cpp::supertonic::Engine>(toEngineOptions(cfg_));

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -151,8 +151,10 @@ void SupertonicModel::reload() {
 void SupertonicModel::loadLocked() {
   if (engine_) return;
 
-  // Force useGPU to false on Android until Vulkan (Mali) and OpenCL (Adreno)
-  // stabilize for the Supertonic graph.
+  // DEBUG (QVAC-20557, DO-NOT-MERGE): the Android GPU force-to-CPU was REMOVED
+  // here so a device-farm round can MEASURE Supertonic GPU-vs-CPU correctness on
+  // Mali/Adreno (the original block set cfg_.useGpu=false; cfg_.nGpuLayers=0).
+  // Measurement scaffolding, NOT a ship change.
 #ifdef __ANDROID__
   {
     const bool wantsGpu =
@@ -160,12 +162,9 @@ void SupertonicModel::loadLocked() {
         (cfg_.nGpuLayers.has_value() && *cfg_.nGpuLayers != 0);
     if (wantsGpu) {
       QLOG(logger::Priority::WARNING,
-           "Supertonic: useGPU=true is currently ignored on Android "
-           "(GPU backends disabled at engine boundary pending Vulkan/Mali "
-           "and OpenCL/Adreno driver fixes); falling back to CPU.");
+           "Supertonic: [QVAC-20557 DO-NOT-MERGE] Android GPU force-to-CPU "
+           "disabled — admitting GPU to measure GPU-vs-CPU correctness.");
     }
-    cfg_.useGpu     = false;
-    cfg_.nGpuLayers = 0;
   }
 #endif
 

--- a/packages/tts-ggml/ports/ggml-speech/android-vulkan-version.cmake
+++ b/packages/tts-ggml/ports/ggml-speech/android-vulkan-version.cmake
@@ -1,0 +1,37 @@
+# Detect the Vulkan version shipped with the Android NDK by parsing
+# vulkan_core.h from the NDK sysroot.  Sets `vulkan_version` in the
+# caller's scope (e.g. "1.3.275").
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from ${vulkan_core_h}")
+    endif()
+
+    # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION_COMPLETE from ${vulkan_core_h}")
+    endif()
+endfunction()

--- a/packages/tts-ggml/ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
+++ b/packages/tts-ggml/ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
@@ -1,0 +1,24 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..3d92ac5d 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -7,6 +7,7 @@ if (POLICY CMP0147)
+ endif()
+ 
+ find_package(Vulkan COMPONENTS glslc REQUIRED)
++find_package(SPIRV-Headers QUIET)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     # Parallel build object files
+@@ -87,6 +88,11 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++
++    if (TARGET SPIRV-Headers::SPIRV-Headers)
++        target_link_libraries(ggml-vulkan PRIVATE SPIRV-Headers::SPIRV-Headers)
++    endif()
++
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/packages/tts-ggml/ports/ggml-speech/portfile.cmake
+++ b/packages/tts-ggml/ports/ggml-speech/portfile.cmake
@@ -1,0 +1,176 @@
+# ggml-speech: LOCAL OVERLAY PORT (Android GPU validation; DO NOT MERGE).
+#
+# Pins the published tetherto/qvac-ext-ggml@speech HEAD 44fd4817, which carries
+# the Adreno-740 Vulkan guards and the Android OpenCL-correctness fixes the
+# tts-ggml addon needs to run on the GPU on Android. Identical to the pin the
+# transcription-parakeet overlay uses; the tts-ggml Supertonic fix itself lives
+# entirely in tts-cpp, so no ggml-speech change is required here. The Android
+# backend packaging (GGML_BACKEND_DL=ON per-arch CPU variants + MODULE GPU .so)
+# is unchanged.
+#
+# TEMPORARY: remove once 44fd4817 is consumed from qvac-registry-vcpkg.
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tetherto/qvac-ext-ggml
+    REF 44fd4817dd1dc5872053927200e2824b8a0ced86
+    SHA512 7d83537e5346fc1a1470e6b7ef191c55b02459ac139a841f39d319e7a5e11aea8e3ed0178cbbb0f0b9f2016e0b79c081411d31707368ccb637940fde3496ec14
+    HEAD_REF speech
+)
+
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+set(GGML_METAL_FUSE_MV_BIAS OFF)
+
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+
+# Off by default: the chatterbox Q-variant mul_mv + bias/residual fusion
+# produces zero tokens on parakeet's EOU q8_0 joint network. Consumers
+# whose models stay clear of that pattern can opt in for the speedup.
+if("metal-fuse-mv-bias" IN_LIST FEATURES)
+    set(GGML_METAL_FUSE_MV_BIAS ON)
+endif()
+
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+
+set(GGML_CUDA_COMPILER_OPTION "")
+
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+    find_program(NVCC_EXECUTABLE nvcc
+        PATHS /usr/local/cuda/bin /usr/local/cuda-12.8/bin
+        NO_DEFAULT_PATH
+    )
+    if(NOT NVCC_EXECUTABLE)
+        find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+    endif()
+    set(GGML_CUDA_COMPILER_OPTION "-DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}")
+    message(STATUS "CUDA compiler: ${NVCC_EXECUTABLE}")
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND "vulkan" IN_LIST FEATURES)
+    include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+    detect_ndk_vulkan_version()
+    message(STATUS "NDK Vulkan version: ${vulkan_version}")
+
+    file(DOWNLOAD
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+        "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        TLS_VERIFY ON
+    )
+    file(ARCHIVE_EXTRACT
+        INPUT "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        DESTINATION "${SOURCE_PATH}"
+        PATTERNS "*.hpp"
+    )
+    file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+         DESTINATION "${SOURCE_PATH}/src/")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+
+# Hybrid Android backend mode: GPU backends as MODULE .so loaded at runtime
+# via dlopen, CPU built as per-arch MODULE .so variants (one per ARMv8.0/
+# 8.2/8.6/9.0/9.2 feature tier) also loaded at runtime via dlopen. The
+# downstream addon installs the resulting libqvac-speech-ggml-cpu-android_armv*
+# .so files alongside the .bare binary; the per-variant scoring in
+# ggml-cpu's `ggml_backend_cpu_aarch64_score` then picks the highest tier
+# the running device supports at first use. Pairs with the speech-branch
+# `ggml-backend: android per-arch CPU variant dlopen fallback` patch
+# (commit 9562ed04) so the variant lookup also succeeds when the consumer
+# APK keeps native .so files compressed (AGP `useLegacyPackaging=false`).
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    )
+endif()
+
+# PR #13 (v0.10.2 sync) introduces an unconditional
+# `#include <spirv/unified1/spirv.hpp>` in src/ggml-vulkan/ggml-vulkan.cpp,
+# but the upstream ggml-vulkan CMakeLists.txt never finds spirv-headers nor
+# wires its include dir into the ggml-vulkan target. Apply a small patch
+# so it does (and depend on spirv-headers in vcpkg.json's vulkan feature).
+# TODO: push the equivalent fix upstream and drop this patch.
+if("vulkan" IN_LIST FEATURES)
+    vcpkg_apply_patches(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PATCHES
+            "${CMAKE_CURRENT_LIST_DIR}/patches/0001-ggml-vulkan-find-spirv-headers.patch"
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_METAL_FUSE_MV_BIAS=${GGML_METAL_FUSE_MV_BIAS}
+        -DGGML_LIB_OUTPUT_PREFIX=qvac-speech-
+        ${GGML_CUDA_COMPILER_OPTION}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Pick up the MODULE backend .so files ggml builds into the buildtree's
+# bin/ directory (Android dynamic-backend mode). cmake install() doesn't
+# move them by default.
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-speech-ggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/tts-ggml/ports/ggml-speech/usage
+++ b/packages/tts-ggml/ports/ggml-speech/usage
@@ -1,0 +1,10 @@
+The package ggml provides CMake integration:
+
+  find_package(ggml CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ggml::ggml)
+
+Available vcpkg features:
+  metal  - Metal GPU backend (macOS/iOS, auto-enabled on Apple)
+  vulkan - Vulkan GPU backend
+  cuda   - CUDA GPU backend
+  opencl - OpenCL GPU backend

--- a/packages/tts-ggml/ports/ggml-speech/vcpkg.json
+++ b/packages/tts-ggml/ports/ggml-speech/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "ggml-speech",
+  "version-date": "2026-06-11",
+  "description": "Speech-stack flavour of ggml from tetherto/qvac-ext-ggml@speech, including the ggml-org v0.10.2 sync (PR #13), the iOS Metal NULL-safety hardening from PR #10, GustavoA1604's Android per-arch CPU dlopen fallback (PR #11), the Mac M2 PAD test fix, and Adreno-aware Android OpenCL/Vulkan backend selection (PR #18, QVAC-18993): on Android the loader detects the GPU via Vulkan and only keeps OpenCL for Adreno > 700, CPU-only for Adreno 1..700, Vulkan/CPU for non-Adreno. Adds Adreno OpenCL elementwise kernels (sin/cos/abs/elu/leaky_relu) for Chatterbox S3Gen and robust Adreno-generation detection (PR #17, #19). Library filenames are prefixed libqvac-speech-ggml-* so they coexist with libqvac-ggml-* (fabric/llm) and libqvac-diffusion-ggml-* on the same Android device. Mutually exclusive with the regular ggml port in the same triplet -- pick one per build.",
+  "homepage": "https://github.com/tetherto/qvac-ext-ggml/tree/speech",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU backend"
+    },
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "metal-fuse-mv-bias": {
+      "description": "Compile in the Q-variant mul_mv + ADD(bias) [+ ADD(residual)] fusion in ggml-metal. Off by default: empirically produces zero tokens on parakeet's EOU q8_0 joint network. Opt in only after Metal A/B-validating your model against the fused path."
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    }
+  }
+}

--- a/packages/tts-ggml/ports/tts-cpp/portfile.cmake
+++ b/packages/tts-ggml/ports/tts-cpp/portfile.cmake
@@ -1,0 +1,92 @@
+# tts-cpp — LOCAL OVERLAY PORT (Android GPU CORRECTNESS MEASUREMENT; DO NOT MERGE).
+#
+# Replaces the registry tts-cpp port so the tts-ggml prebuild builds the
+# QVAC-20557 GPU-correctness measurement instrumentation not (and never to be)
+# published to qvac-registry-vcpkg. Pins
+# tetherto/qvac-ext-lib-whisper.cpp @ b9f9268c (branch
+# QVAC-20557-chatterbox-mali-gpu, off PR #54 master b95ad447):
+#   - shared detail::diag_stats(): bit-pattern NaN/Inf (fast-math safe) +
+#     rms/min/max, emitting one `[gpu-diag] <name> ...` line per stage.
+#   - Supertonic + Chatterbox: per-stage [gpu-diag] dumps tagged by backend reg
+#     name, emitted on BOTH GPU and CPU runs (gated on $TTS_CPP_GPU_TRACE) so the
+#     device-farm logcat can be diffed GPU-vs-CPU to localize the first stage a
+#     GPU backend miscomputes.
+#   - allow_arm_mali flipped false->true for Chatterbox T3 + S3Gen to ADMIT
+#     Chatterbox onto ARM Mali Vulkan FOR MEASUREMENT (not a ship decision):
+#     this round MEASURES whether Chatterbox is GPU-correct on Mali rather than
+#     assuming it miscomputes. Supertonic already shipped allow_arm_mali=true.
+# Paired with test/utils/correlation-helper.js + gpu-smoke.test.js GPU-vs-CPU
+# correlation gate. ggml-speech overlay unchanged.
+#
+# TEMPORARY: this entire overlay (and the overlay-ports entry in
+# vcpkg-configuration.json) is throwaway measurement scaffolding — never merge.
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH WHISPER_CPP_SRC
+    REPO tetherto/qvac-ext-lib-whisper.cpp
+    REF b9f9268cf82467b1b5e98516f114278f64c39023
+    SHA512 8503421fab81b3213e6da2528da4f2761343b879b5d9ebd80c8e6466e64ab2d0345de369d26dc5e81662d1444dbe52f808fb927e2f2e4a45c47f0b6d920f3023
+    HEAD_REF master
+)
+
+set(SOURCE_PATH "${WHISPER_CPP_SRC}/tts-cpp")
+if (NOT EXISTS "${SOURCE_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "tts-cpp: ${SOURCE_PATH}/CMakeLists.txt missing; the tts-cpp/ "
+        "subfolder layout in qvac-ext-lib-whisper.cpp may have changed.")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        metal   GGML_METAL
+        vulkan  GGML_VULKAN
+        cuda    GGML_CUDA
+        opencl  GGML_OPENCL
+)
+
+set(PLATFORM_OPTIONS)
+
+if(NOT VCPKG_TARGET_IS_OSX)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BLAS=OFF
+        -DGGML_ACCELERATE=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_BLAS=ON
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DTTS_CPP_BUILD_LIBRARY=ON
+        -DTTS_CPP_BUILD_SHARED=OFF
+        -DTTS_CPP_BUILD_EXECUTABLES=OFF
+        -DTTS_CPP_BUILD_TESTS=OFF
+        -DTTS_CPP_INSTALL=ON
+        -DTTS_CPP_USE_SYSTEM_GGML=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_OPENMP=OFF
+        -DTTS_CPP_OPENMP=OFF
+        -DGGML_CCACHE=OFF
+        -DTTS_CPP_CCACHE=OFF
+        ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME tts-cpp CONFIG_PATH share/tts-cpp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/tts-ggml/ports/tts-cpp/portfile.cmake
+++ b/packages/tts-ggml/ports/tts-cpp/portfile.cmake
@@ -3,18 +3,21 @@
 # Replaces the registry tts-cpp port so the tts-ggml prebuild builds the
 # QVAC-20557 GPU-correctness measurement instrumentation not (and never to be)
 # published to qvac-registry-vcpkg. Pins
-# tetherto/qvac-ext-lib-whisper.cpp @ b9f9268c (branch
+# tetherto/qvac-ext-lib-whisper.cpp @ d8752687 (branch
 # QVAC-20557-chatterbox-mali-gpu, off PR #54 master b95ad447):
-#   - shared detail::diag_stats(): bit-pattern NaN/Inf (fast-math safe) +
-#     rms/min/max, emitting one `[gpu-diag] <name> ...` line per stage.
-#   - Supertonic + Chatterbox: per-stage [gpu-diag] dumps tagged by backend reg
-#     name, emitted on BOTH GPU and CPU runs (gated on $TTS_CPP_GPU_TRACE) so the
-#     device-farm logcat can be diffed GPU-vs-CPU to localize the first stage a
-#     GPU backend miscomputes.
-#   - allow_arm_mali flipped false->true for Chatterbox T3 + S3Gen to ADMIT
-#     Chatterbox onto ARM Mali Vulkan FOR MEASUREMENT (not a ship decision):
-#     this round MEASURES whether Chatterbox is GPU-correct on Mali rather than
-#     assuming it miscomputes. Supertonic already shipped allow_arm_mali=true.
+#   - shared detail::diag_stats() + diag_dump(): bit-pattern NaN/Inf (fast-math
+#     safe) + rms/min/max one `[gpu-diag] <name> ...` line per stage, AND a raw
+#     f32 dump of each stage to <diag_dump_dir>/<model>_<backend>_<stage>.f32.
+#   - PUBLIC EngineOptions.diag_sink + diag_dump_dir (round 2): the addon injects
+#     a sink that calls __android_log_print — the ONLY native sink that reaches
+#     the device-farm logcat (fprintf(stderr) is swallowed by the bare/RN-host
+#     runtime, which is why round 1 emitted ZERO lines). Per-stage dumps power a
+#     GPU-vs-CPU Pearson gate; raw buffers are read back in the JS test.
+#   - Chatterbox token-pinning (test-only): EngineOptions.test_pinned_tokens +
+#     SynthesisResult.speech_tokens bypass the stochastic T3 decode so GPU and
+#     CPU S3Gen runs decode IDENTICAL tokens (hard corr gate).
+#   - allow_arm_mali=true for Chatterbox T3 + S3Gen to ADMIT Chatterbox onto ARM
+#     Mali Vulkan FOR MEASUREMENT (Supertonic already shipped allow_arm_mali=true).
 # Paired with test/utils/correlation-helper.js + gpu-smoke.test.js GPU-vs-CPU
 # correlation gate. ggml-speech overlay unchanged.
 #
@@ -27,8 +30,8 @@ set(VCPKG_BUILD_TYPE release)
 vcpkg_from_github(
     OUT_SOURCE_PATH WHISPER_CPP_SRC
     REPO tetherto/qvac-ext-lib-whisper.cpp
-    REF b9f9268cf82467b1b5e98516f114278f64c39023
-    SHA512 8503421fab81b3213e6da2528da4f2761343b879b5d9ebd80c8e6466e64ab2d0345de369d26dc5e81662d1444dbe52f808fb927e2f2e4a45c47f0b6d920f3023
+    REF d8752687e315a7a2024e6c6750f37d370f35b968
+    SHA512 30abc983213f381ebdbeb17ae6121e6df0eaf4337e83d8051ca62c842021d5bdf1b90525989887fe6c9acb2c9303c77aec4aafa49ee496f895e7762f2fff1964
     HEAD_REF master
 )
 

--- a/packages/tts-ggml/ports/tts-cpp/vcpkg.json
+++ b/packages/tts-ggml/ports/tts-cpp/vcpkg.json
@@ -1,0 +1,82 @@
+{
+  "name": "tts-cpp",
+  "version-date": "2026-06-19",
+  "port-version": 0,
+  "description": "LOCAL OVERLAY (DO NOT MERGE) of tts-cpp pinned at qvac-ext-lib-whisper.cpp@b9f9268c (branch QVAC-20557-chatterbox-mali-gpu, off PR #54 master b95ad447). QVAC-20557 GPU-correctness MEASUREMENT build: shared bit-pattern diag_stats + per-stage [gpu-diag] dumps for Supertonic + Chatterbox (gated on $TTS_CPP_GPU_TRACE, emitted on both GPU and CPU, tagged by backend), and allow_arm_mali flipped true to ADMIT Chatterbox onto ARM Mali Vulkan for measurement. Paired with the gpu-smoke GPU-vs-CPU correlation gate. Throwaway; never publish to the registry.",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/tts-cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "version>=": "2026-06-04"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "cuda"
+          ]
+        }
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal GPU acceleration (macOS / iOS)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "metal"
+          ]
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android / Adreno)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "opencl"
+          ]
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "vulkan"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/tts-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/tts-ggml/test/integration/gpu-smoke.test.js
@@ -32,7 +32,8 @@ const { loadChatterboxTTS, runChatterboxTTS, resolveRefWavPath } = require('../u
 const { loadSupertonicTTS, runSupertonicTTS } = require('../utils/runSupertonicTTS')
 const { ensureChatterboxModels, ensureSupertonicModel } = require('../utils/downloadModel')
 const { recordTtsStats } = require('../utils/perf-helper')
-const { assertSampleCorrelation } = require('../utils/correlation-helper')
+const { assertSampleCorrelation, pearson } = require('../utils/correlation-helper')
+const { createWavBuffer } = require('../utils/wav-helper')
 
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
@@ -329,6 +330,82 @@ test('Supertonic CPU smoke - useGPU=false must run on the CPU backend', { timeou
 // is the native [gpu-diag] trace in logcat_full.txt.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// DEBUG (QVAC-20557, DO-NOT-MERGE): per-stage GPU-vs-CPU correlation + artifacts.
+// The native engine dumps each stage's raw f32 to $TTS_CPP_GPU_DUMP_DIR as
+// <model>_<backend>_<stage>.f32 (set by ensureDumpDir before any model loads);
+// we read GPU vs CPU back here and Pearson-correlate per stage to localize the
+// FIRST diverging stage, and write the generated GPU/CPU WAVs so the device farm
+// can pull them for offline inspection. Stage lists mirror the native dg() order.
+// ---------------------------------------------------------------------------
+const SUPERTONIC_STAGES = ['latent_in', 'text_emb', 'cfm_latent', 'wav_full']
+const CHATTERBOX_STAGES = ['input_embed', 'encoder_mu', 'cfm_mel', 'f0', 'stft', 'hift_wav']
+
+function ensureDumpDir () {
+  const dir = path.join(getBaseDir(), 'gpu-diag')
+  try { fs.mkdirSync(dir, { recursive: true }) } catch (_e) {
+    try { fs.mkdirSync(dir) } catch (_e2) {}
+  }
+  if (proc.env) proc.env.TTS_CPP_GPU_DUMP_DIR = dir
+  // The pinned-tokens file gates the Chatterbox T3 bypass; clear any stale one so
+  // the GPU/first run decodes real (stochastic) tokens.
+  try { fs.unlinkSync(path.join(dir, 'chatterbox_pinned_tokens.i32')) } catch (_e) {}
+  return dir
+}
+
+function readF32 (filePath) {
+  const buf = fs.readFileSync(filePath)
+  const n = buf.length >>> 2
+  const out = new Float32Array(n)
+  const dv = new DataView(buf.buffer, buf.byteOffset, buf.length)
+  for (let i = 0; i < n; i++) out[i] = dv.getFloat32(i * 4, true)
+  return out
+}
+
+// Read GPU+CPU stage dumps and Pearson-correlate each stage. Logs every number
+// (so it lands in the device-farm console log) and, when hard, gates each stage.
+function assertPerStageCorrelation (t, model, gpuBtag, stages, dir, opts = {}) {
+  const hard = opts.hard === true
+  const threshold = opts.threshold !== undefined ? opts.threshold : CORR_THRESHOLD
+  for (const stage of stages) {
+    const gpuPath = path.join(dir, `${model}_${gpuBtag}_${stage}.f32`)
+    const cpuPath = path.join(dir, `${model}_CPU_${stage}.f32`)
+    const haveG = fs.existsSync(gpuPath)
+    const haveC = fs.existsSync(cpuPath)
+    if (!haveG || !haveC) {
+      const msg = `[${model}/${stage}/corr] MISSING dump (gpu=${haveG} cpu=${haveC})`
+      console.log(msg)
+      if (hard) t.fail(msg + ' — native per-stage f32 dump did not land; observability broken')
+      continue
+    }
+    const g = readF32(gpuPath)
+    const c = readF32(cpuPath)
+    const { corr, n, reason } = pearson(g, c)
+    const corrStr = Number.isFinite(corr) ? corr.toFixed(6) : String(corr)
+    console.log(`[${model}/${stage}/corr] ${gpuBtag}-vs-CPU gpu_n=${g.length} cpu_n=${c.length} aligned_n=${n} corr=${corrStr}${reason ? ' reason=' + reason : ''}`)
+    if (hard) {
+      t.ok(Number.isFinite(corr) && corr >= threshold,
+        `${model}/${stage}: per-stage GPU-vs-CPU corr ${corrStr} must be >= ${threshold}${reason ? ' (' + reason + ')' : ''}`)
+    }
+  }
+}
+
+function writeDumpWav (dir, name, samples, sampleRate) {
+  try {
+    const buf = createWavBuffer(samples, sampleRate)
+    fs.writeFileSync(path.join(dir, name), buf)
+    console.log(`[wav] wrote ${name} (${samples.length} samples @ ${sampleRate} Hz)`)
+  } catch (e) {
+    console.log(`[wav] failed to write ${name}: ${e && e.message}`)
+  }
+}
+
+function rms16 (samples) {
+  let s = 0
+  for (let i = 0; i < samples.length; i++) { const v = samples[i] / 32768; s += v * v }
+  return samples.length ? Math.sqrt(s / samples.length) : 0
+}
+
 async function runSupertonicOn (useGPU, supertonicPath) {
   const model = await loadSupertonicTTS({
     supertonicModelPath: supertonicPath, language: 'en', voice: 'F1', useGPU, seed: 42
@@ -343,6 +420,7 @@ async function runSupertonicOn (useGPU, supertonicPath) {
 
 test('Supertonic GPU-vs-CPU correctness - output must correlate with CPU', { timeout: 600000, skip: NO_GPU }, async (t) => {
   if (!expectsGpu()) { t.pass('Supertonic corr: no GPU wired on this platform'); return }
+  const dumpDir = ensureDumpDir()
   const baseDir = getBaseDir()
   const modelsDir = path.join(baseDir, 'models')
   const download = await ensureSupertonicModel({ targetDir: modelsDir })
@@ -359,9 +437,20 @@ test('Supertonic GPU-vs-CPU correctness - output must correlate with CPU', { tim
     return
   }
   const cpu = await runSupertonicOn(false, supertonicPath)
-  assertSampleCorrelation(t, `Supertonic/${backendIdToName(gpu.stats.backendId)}`, gpu.samples, cpu.samples, {
+  const gpuBtag = backendIdToName(gpu.stats.backendId)
+  // Supertonic is deterministic (fixed seed) → both end-to-end and per-stage
+  // GPU-vs-CPU correlation are HARD gates.
+  assertSampleCorrelation(t, `Supertonic/${gpuBtag}`, gpu.samples, cpu.samples, {
     threshold: CORR_THRESHOLD, minSamples: 1000, minLenRatio: 0.90
   })
+  assertPerStageCorrelation(t, 'supertonic', gpuBtag, SUPERTONIC_STAGES, dumpDir, { hard: true })
+  // Audio artifacts (pulled by the device farm) + an audible-RMS floor that
+  // catches a silent/NaN GPU independently of the correlation maths.
+  writeDumpWav(dumpDir, `supertonic_${gpuBtag}.wav`, gpu.samples, 44100)
+  writeDumpWav(dumpDir, 'supertonic_CPU.wav', cpu.samples, 44100)
+  const r = rms16(gpu.samples)
+  console.log(`[Supertonic/${gpuBtag}/rms] ${r.toFixed(5)}`)
+  t.ok(r > 0.001, `Supertonic/${gpuBtag}: GPU audio must be audible (rms ${r.toFixed(5)} > 0.001)`)
 })
 
 async function runChatterboxOn (useGPU, modelDir, refWavPath) {
@@ -374,8 +463,9 @@ async function runChatterboxOn (useGPU, modelDir, refWavPath) {
   }
 }
 
-test('Chatterbox GPU-vs-CPU correctness - GPU output must be finite (corr informational)', { timeout: 600000, skip: NO_GPU }, async (t) => {
+test('Chatterbox GPU-vs-CPU correctness - token-pinned per-stage + end-to-end', { timeout: 600000, skip: NO_GPU }, async (t) => {
   if (!expectsGpu()) { t.pass('Chatterbox corr: no GPU wired on this platform'); return }
+  const dumpDir = ensureDumpDir()
   const baseDir = getBaseDir()
   const modelsDir = path.join(baseDir, 'models')
   const download = await ensureChatterboxModels({ targetDir: modelsDir })
@@ -386,15 +476,41 @@ test('Chatterbox GPU-vs-CPU correctness - GPU output must be finite (corr inform
   const refWavPath = resolveRefWavPath({})
   if (!fs.existsSync(refWavPath)) { t.pass('Skipped: reference audio missing'); return }
 
+  // GPU run: real (stochastic) T3 → S3Gen. The native side writes the tokens it
+  // used to chatterbox_speech_tokens.i32 and dumps chatterbox_<gpu>_*.f32 stages.
   const gpu = await runChatterboxOn(true, download.targetDir, refWavPath)
   if (!gpu.stats || gpu.stats.backendDevice !== 1) {
     t.comment(`Chatterbox corr: GPU did not engage (backendDevice=${gpu.stats && gpu.stats.backendDevice}); per-stage [gpu-diag] trace still emitted`)
     return
   }
+  const gpuBtag = backendIdToName(gpu.stats.backendId)
+
+  // Pin the GPU run's tokens for the CPU run so both S3Gen runs decode IDENTICAL
+  // tokens — removes T3 stochasticity from the comparison and makes it a HARD
+  // gate. If the capture file is missing (observability gap), fall back to soft.
+  const tokSrc = path.join(dumpDir, 'chatterbox_speech_tokens.i32')
+  const tokPin = path.join(dumpDir, 'chatterbox_pinned_tokens.i32')
+  let pinned = false
+  if (fs.existsSync(tokSrc)) {
+    try { fs.writeFileSync(tokPin, fs.readFileSync(tokSrc)); pinned = true } catch (_e) {}
+  }
+  if (!pinned) {
+    t.comment('Chatterbox corr: token capture file missing — comparison is informational (T3 not pinned)')
+  }
+
   const cpu = await runChatterboxOn(false, download.targetDir, refWavPath)
-  // soft: T3 stochasticity makes the magnitude informational; the hard signal
-  // here is finite-ness (silent/NaN GPU fails) + the per-stage [gpu-diag] trace.
-  assertSampleCorrelation(t, `Chatterbox/${backendIdToName(gpu.stats.backendId)}`, gpu.samples, cpu.samples, {
-    threshold: CORR_THRESHOLD, soft: true, minSamples: 1000, minLenRatio: 0.0
+  // Remove the pin so it can't leak into a later test run on the same device.
+  try { fs.unlinkSync(tokPin) } catch (_e) {}
+
+  // With pinned tokens + fixed seed the S3Gen comparison is deterministic → HARD
+  // (end-to-end AND per-stage). Without pinning, end-to-end stays informational.
+  assertSampleCorrelation(t, `Chatterbox/${gpuBtag}`, gpu.samples, cpu.samples, {
+    threshold: CORR_THRESHOLD, soft: !pinned, minSamples: 1000, minLenRatio: pinned ? 0.90 : 0.0
   })
+  assertPerStageCorrelation(t, 'chatterbox', gpuBtag, CHATTERBOX_STAGES, dumpDir, { hard: pinned })
+  writeDumpWav(dumpDir, `chatterbox_${gpuBtag}.wav`, gpu.samples, 24000)
+  writeDumpWav(dumpDir, 'chatterbox_CPU.wav', cpu.samples, 24000)
+  const r = rms16(gpu.samples)
+  console.log(`[Chatterbox/${gpuBtag}/rms] ${r.toFixed(5)}`)
+  t.ok(r > 0.001, `Chatterbox/${gpuBtag}: GPU audio must be audible (rms ${r.toFixed(5)} > 0.001)`)
 })

--- a/packages/tts-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/tts-ggml/test/integration/gpu-smoke.test.js
@@ -32,11 +32,22 @@ const { loadChatterboxTTS, runChatterboxTTS, resolveRefWavPath } = require('../u
 const { loadSupertonicTTS, runSupertonicTTS } = require('../utils/runSupertonicTTS')
 const { ensureChatterboxModels, ensureSupertonicModel } = require('../utils/downloadModel')
 const { recordTtsStats } = require('../utils/perf-helper')
+const { assertSampleCorrelation } = require('../utils/correlation-helper')
 
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 const RELAX = proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1'
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
+
+// DEBUG (QVAC-20557, DO-NOT-MERGE): enable the native per-stage [gpu-diag] trace
+// so a device-farm round carries per-stage GPU-vs-CPU stats (rms/nan/inf/min/max)
+// in logcat_full.txt, localizing the first stage a GPU backend miscomputes. Set
+// before any Engine construction (native getenv runs at load()).
+if (proc.env) proc.env.TTS_CPP_GPU_TRACE = '1'
+
+// GPU-vs-CPU correlation threshold. GPU and CPU load the SAME gguf — only the
+// compute backend differs — so a correct backend correlates ~0.999+.
+const CORR_THRESHOLD = 0.99
 
 function getBaseDir () {
   return isMobile && global.testDir ? global.testDir : '.'
@@ -139,10 +150,8 @@ function recordSmoke (t, label, result, wallMs) {
 }
 
 test('Chatterbox GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  if (platform === 'android') {
-    t.pass('Android: GPU disabled at engine boundary pending Vulkan/Mali + OpenCL/Adreno upstream fixes')
-    return
-  }
+  // DEBUG (QVAC-20557, DO-NOT-MERGE): Android skip REMOVED so the device-farm
+  // round runs Chatterbox on Mali/Adreno GPU and measures correctness.
   const baseDir = getBaseDir()
   const modelsDir = path.join(baseDir, 'models')
 
@@ -184,15 +193,8 @@ test('Chatterbox GPU smoke - useGPU=true must engage the GPU backend on GPU-capa
 })
 
 test('Supertonic GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  // QVAC-19255 re-land: Supertonic GPU (Metal on Apple, Vulkan/CUDA on desktop)
-  // is consumed via tts-cpp@2026-06-05 (f7d4d6c overlay). Android (Adreno) is
-  // intentionally kept CPU-only at the engine boundary
-  // (SupertonicModel::loadLocked) because Adreno Vulkan/OpenCL ggml graph
-  // compute still aborts, so skip the GPU assertion there (mirrors Chatterbox).
-  if (platform === 'android') {
-    t.pass('Android: Supertonic GPU disabled at engine boundary pending Adreno Vulkan/OpenCL ggml fixes')
-    return
-  }
+  // DEBUG (QVAC-20557, DO-NOT-MERGE): Android skip REMOVED so the device-farm
+  // round runs Supertonic on Mali/Adreno GPU and measures correctness.
   const baseDir = getBaseDir()
   const modelsDir = path.join(baseDir, 'models')
 
@@ -313,4 +315,86 @@ test('Supertonic CPU smoke - useGPU=false must run on the CPU backend', { timeou
   } finally {
     try { await model.unload() } catch (_e) {}
   }
+})
+
+// ---------------------------------------------------------------------------
+// GPU-vs-CPU correctness gate (QVAC-20557, DO-NOT-MERGE measurement).
+//
+// The smoke tests above only prove the GPU is *engaged*. These prove its OUTPUT
+// matches CPU — the signal missing when a GPU could mis-compute yet still emit
+// non-silent audio. Supertonic is deterministic for a fixed seed → HARD corr
+// gate. Chatterbox's T3 is autoregressive + stochastic → identical seeds do NOT
+// give identical tokens across backends, so its end-to-end corr is informational
+// (still HARD-fails on a silent/NaN GPU); its real per-stage correctness signal
+// is the native [gpu-diag] trace in logcat_full.txt.
+// ---------------------------------------------------------------------------
+
+async function runSupertonicOn (useGPU, supertonicPath) {
+  const model = await loadSupertonicTTS({
+    supertonicModelPath: supertonicPath, language: 'en', voice: 'F1', useGPU, seed: 42
+  })
+  try {
+    const r = await runSupertonicTTS(model, { text: 'GPU versus CPU correctness check.' }, { minSamples: 5000 })
+    return { samples: r.data.samples, stats: r.data.stats }
+  } finally {
+    try { await model.unload() } catch (_e) {}
+  }
+}
+
+test('Supertonic GPU-vs-CPU correctness - output must correlate with CPU', { timeout: 600000, skip: NO_GPU }, async (t) => {
+  if (!expectsGpu()) { t.pass('Supertonic corr: no GPU wired on this platform'); return }
+  const baseDir = getBaseDir()
+  const modelsDir = path.join(baseDir, 'models')
+  const download = await ensureSupertonicModel({ targetDir: modelsDir })
+  if (!download || !download.success) {
+    t.fail('Supertonic GGUF not available - registry fetch failed.')
+    return
+  }
+  const supertonicPath = download.path || path.join(modelsDir, 'supertonic.gguf')
+
+  const gpu = await runSupertonicOn(true, supertonicPath)
+  if (!gpu.stats || gpu.stats.backendDevice !== 1) {
+    const msg = `Supertonic corr: GPU did not engage (backendDevice=${gpu.stats && gpu.stats.backendDevice}); engagement is asserted by the smoke test above`
+    if (RELAX) { t.pass(msg + ' (relaxed)') } else { t.comment(msg) }
+    return
+  }
+  const cpu = await runSupertonicOn(false, supertonicPath)
+  assertSampleCorrelation(t, `Supertonic/${backendIdToName(gpu.stats.backendId)}`, gpu.samples, cpu.samples, {
+    threshold: CORR_THRESHOLD, minSamples: 1000, minLenRatio: 0.90
+  })
+})
+
+async function runChatterboxOn (useGPU, modelDir, refWavPath) {
+  const model = await loadChatterboxTTS({ modelDir, refWavPath, language: 'en', useGPU, seed: 42 })
+  try {
+    const r = await runChatterboxTTS(model, { text: 'GPU versus CPU correctness check.' }, { minSamples: 5000 })
+    return { samples: r.data.samples, stats: r.data.stats }
+  } finally {
+    try { await model.unload() } catch (_e) {}
+  }
+}
+
+test('Chatterbox GPU-vs-CPU correctness - GPU output must be finite (corr informational)', { timeout: 600000, skip: NO_GPU }, async (t) => {
+  if (!expectsGpu()) { t.pass('Chatterbox corr: no GPU wired on this platform'); return }
+  const baseDir = getBaseDir()
+  const modelsDir = path.join(baseDir, 'models')
+  const download = await ensureChatterboxModels({ targetDir: modelsDir })
+  if (!download.success) {
+    t.fail('Chatterbox GGUFs not available - registry fetch failed.')
+    return
+  }
+  const refWavPath = resolveRefWavPath({})
+  if (!fs.existsSync(refWavPath)) { t.pass('Skipped: reference audio missing'); return }
+
+  const gpu = await runChatterboxOn(true, download.targetDir, refWavPath)
+  if (!gpu.stats || gpu.stats.backendDevice !== 1) {
+    t.comment(`Chatterbox corr: GPU did not engage (backendDevice=${gpu.stats && gpu.stats.backendDevice}); per-stage [gpu-diag] trace still emitted`)
+    return
+  }
+  const cpu = await runChatterboxOn(false, download.targetDir, refWavPath)
+  // soft: T3 stochasticity makes the magnitude informational; the hard signal
+  // here is finite-ness (silent/NaN GPU fails) + the per-stage [gpu-diag] trace.
+  assertSampleCorrelation(t, `Chatterbox/${backendIdToName(gpu.stats.backendId)}`, gpu.samples, cpu.samples, {
+    threshold: CORR_THRESHOLD, soft: true, minSamples: 1000, minLenRatio: 0.0
+  })
 })

--- a/packages/tts-ggml/test/utils/correlation-helper.js
+++ b/packages/tts-ggml/test/utils/correlation-helper.js
@@ -1,0 +1,115 @@
+'use strict'
+
+// GPU-vs-CPU output correlation gate (QVAC-20557).
+//
+// Reuses the Pearson metric from tts-cpp/scripts/validate-precision-parity.sh
+// (corr = corrcoef(gpu, cpu) on min-length-aligned PCM): a correct GPU backend
+// matches CPU at corr ~0.999+, while the ARM Mali Valhall mul_mat miscompute
+// produces garbage/NaN/silence at corr ~0.003 (or undefined). This is the
+// correctness signal the shipped gpu-smoke test lacked — it only proved the GPU
+// was *engaged* (backendDevice/backendId), never that its output matched CPU.
+//
+// Always logs the number so every model×device correlation is visible in
+// bare_console.log on the device farm (which does NOT export the WAV).
+//
+// NOTE on determinism: deterministic engines (Supertonic) can be HARD-gated.
+// Chatterbox's T3 is autoregressive + stochastic (temp>0, sampled per token),
+// so identical seeds do NOT yield identical tokens across backends — its
+// end-to-end corr is informational only (soft); its real per-stage correctness
+// signal is the native `[gpu-diag]` trace in logcat_full.txt.
+
+function toFloat (samples) {
+  const n = samples.length
+  const out = new Float64Array(n)
+  // int16 PCM → [-1, 1]. Correlation is scale-invariant so the exact divisor
+  // does not matter, but normalising keeps the intermediate sums well-scaled.
+  for (let i = 0; i < n; i++) out[i] = samples[i] / 32768
+  return out
+}
+
+// Pearson correlation over the min-length prefix of two PCM arrays. Returns
+// corr=NaN with a reason when one side is constant (silence / NaN-collapsed
+// output) — that is itself a hard failure, never a pass.
+function pearson (a, b) {
+  const n = Math.min(a ? a.length : 0, b ? b.length : 0)
+  if (n === 0) return { corr: NaN, n: 0, reason: 'empty' }
+  const fa = toFloat(a)
+  const fb = toFloat(b)
+  let ma = 0
+  let mb = 0
+  for (let i = 0; i < n; i++) { ma += fa[i]; mb += fb[i] }
+  ma /= n
+  mb /= n
+  let cov = 0
+  let va = 0
+  let vb = 0
+  for (let i = 0; i < n; i++) {
+    const da = fa[i] - ma
+    const db = fb[i] - mb
+    cov += da * db
+    va += da * da
+    vb += db * db
+  }
+  if (va === 0 || vb === 0) {
+    return { corr: NaN, n, reason: va === 0 ? 'gpu-constant(silent/NaN)' : 'cpu-constant(silent/NaN)' }
+  }
+  return { corr: cov / Math.sqrt(va * vb), n, reason: null }
+}
+
+// Length + sample-count sanity around pearson(). minLenRatio guards against a
+// mid-synthesis crash (one side much shorter); minSamples mirrors the existing
+// gpu-smoke floor.
+function compareSamples (gpu, cpu, opts = {}) {
+  const minSamples = opts.minSamples || 1000
+  const minLenRatio = opts.minLenRatio || 0.90
+  const lg = gpu ? gpu.length : 0
+  const lc = cpu ? cpu.length : 0
+  if (lg < minSamples || lc < minSamples) {
+    return { ok: false, corr: NaN, n: Math.min(lg, lc), lenRatio: 0, reason: `too-few-samples (gpu=${lg} cpu=${lc} min=${minSamples})` }
+  }
+  const lenRatio = Math.min(lg, lc) / Math.max(lg, lc)
+  const { corr, n, reason } = pearson(gpu, cpu)
+  if (reason) return { ok: false, corr, n, lenRatio, reason }
+  const lenOk = lenRatio >= minLenRatio
+  return { ok: lenOk, corr, n, lenRatio, reason: lenOk ? null : `len-ratio ${lenRatio.toFixed(3)} < ${minLenRatio}` }
+}
+
+// Assert GPU output correlates with CPU.
+//   opts.threshold : minimum acceptable corr (default 0.99)
+//   opts.soft      : informational mode (Chatterbox/stochastic) — still HARD-fails
+//                    on undefined corr (silent/NaN GPU), but only WARNS on a low
+//                    magnitude (expected when T3 sampled different tokens).
+// Always logs the number. Returns the compareSamples result.
+function assertSampleCorrelation (t, engineTag, gpu, cpu, opts = {}) {
+  const threshold = opts.threshold !== undefined ? opts.threshold : 0.99
+  const soft = opts.soft === true
+  const res = compareSamples(gpu, cpu, opts)
+  const corrStr = Number.isFinite(res.corr) ? res.corr.toFixed(6) : String(res.corr)
+  console.log(
+    `[${engineTag}/corr] gpu_n=${gpu ? gpu.length : 0} cpu_n=${cpu ? cpu.length : 0} ` +
+    `aligned_n=${res.n} lenRatio=${(res.lenRatio || 0).toFixed(3)} corr=${corrStr} ` +
+    `threshold=${threshold} mode=${soft ? 'soft(informational)' : 'hard'}` +
+    `${res.reason ? ' reason=' + res.reason : ''}`
+  )
+
+  // Undefined correlation (silent / NaN / collapsed GPU output) is a hard
+  // failure in BOTH modes — it is the Valhall garbage signature, token-independent.
+  if (!Number.isFinite(res.corr)) {
+    t.fail(`${engineTag}: GPU-vs-CPU correlation undefined (${res.reason}) — GPU output is silent/NaN/garbage`)
+    return res
+  }
+
+  if (soft) {
+    t.pass(`${engineTag}: GPU output finite; corr=${corrStr} (informational — T3 stochastic, see [gpu-diag] per-stage trace)`)
+    if (res.corr < threshold) {
+      t.comment(`${engineTag}: corr ${corrStr} < ${threshold} — expected for stochastic T3; verify via [gpu-diag] per-stage trace, not this number`)
+    }
+    return res
+  }
+
+  t.ok(res.corr >= threshold && res.ok,
+    `${engineTag}: GPU-vs-CPU correlation ${corrStr} must be >= ${threshold} (length/quality ok=${res.ok}${res.reason ? ', ' + res.reason : ''})`)
+  return res
+}
+
+module.exports = { pearson, compareSamples, assertSampleCorrelation }

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -4,6 +4,9 @@
     "baseline": "e55f10fb73332e2f126437cc0380fe7449f19596",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
+  "overlay-ports": [
+    "ports"
+  ],
   "registries": [
     {
       "kind": "git",


### PR DESCRIPTION
## DO NOT MERGE — QVAC-20557 device-farm measurement

Throwaway measurement scaffolding to answer one question with **data**, not assumptions:
**is every tts-cpp model GPU-correct on Adreno + Mali, and if not, exactly which stage diverges?**

Fresh off `main` (single commit). Pairs with tts-cpp branch `QVAC-20557-chatterbox-mali-gpu` @ `b9f9268c`.

### What it does
- **Overlay** (`ports/`): pins tts-cpp to `b9f9268c` — per-stage `[gpu-diag]` dumps (bit-pattern NaN/Inf + rms/min/max, emitted on **both** GPU and CPU runs, tagged by backend) and `allow_arm_mali=true` so Chatterbox is admitted onto ARM Mali Vulkan. `ggml-speech` overlay carried unchanged; baseline kept at `main`'s.
- **Addon** (`ChatterboxModel.cpp` / `SupertonicModel.cpp`): remove the Android GPU→CPU force-at-engine-boundary so the round actually runs on Mali/Adreno GPU.
- **Correctness gate** (`correlation-helper.js` + `gpu-smoke.test.js`): Pearson GPU-vs-CPU correlation on the in-memory PCM (device farm doesn't export WAV). **Supertonic** is HARD-gated (deterministic, `corr ≥ 0.99`); **Chatterbox** is soft + finite-gated (T3 sampling is stochastic across backends, so its end-to-end magnitude is informational — its real per-stage signal is the `[gpu-diag]` trace in `logcat_full.txt`). The shipped smoke only proved GPU *engagement*; this proves output *correctness*.

### How to read the result
- `bare_console.log`: `[<engine>/corr] ... corr=…` per model × device.
- `logcat_full.txt`: `[gpu-diag] <backend>.<model>.<stage> rms=.. nan=.. inf=.. min=.. max=..` — diff GPU vs CPU per stage to localize the first diverging stage.

Trigger the device farm (Pixel 9 / Mali + S25 / Adreno) with the `verified` label.
