### PR TITLE
ci(llm): run C++ tests on macos-15-xlarge runner

### DIFF
--- a/.github/workflows/cpp-tests-llm.yml
+++ b/.github/workflows/cpp-tests-llm.yml
@@ -37,9 +37,10 @@ jobs:
             platform: linux
             runner: qvac-ubuntu2404-x64
             arch: x64
-          - os: macos-14
+          - os: macos-15-xlarge
             platform: darwin
             arch: arm64
+            runner: macos-15-xlarge
           - os: windows-2025
             platform: windows
             runner: qvac-win25-x64


### PR DESCRIPTION
## Summary
- Update the darwin matrix leg in `cpp-tests-llm.yml` from `macos-14` to `macos-15-xlarge`
- Explicitly set the `runner` label to match other llm-llamacpp CI workflows (e.g. `integration-test-llm-llamacpp.yml`)

## Test plan
- [ ] Verify the `CPP Tests (LLM)` workflow picks up the new runner on PR CI
- [ ] Confirm darwin arm64 C++ tests build and run successfully on `macos-15-xlarge`


Made with [Cursor](https://cursor.com)