### PR TITLE
chore[notask]: trim DevOps pod member list

### DIFF
--- a/.github/teams/devops.json
+++ b/.github/teams/devops.json
@@ -2,11 +2,8 @@
   "name": "DevOps Pod",
   "leads": ["Proletter"],
   "members": [
-    "darkynt",
     "GSServita",
-    "sidj-thr",
-    "tamer-hassan-tether",
-    "yauhenipankratovich-web"
+    "sidj-thr"
   ],
   "ownedPaths": [
     ".github/workflows/",


### PR DESCRIPTION
## Summary

- Trim the DevOps pod member list in `.github/teams/devops.json`.
- Keep only Proletter (lead), GSServita (Giacomo), and sidj-thr (Sidd).
- Remove `darkynt`, `tamer-hassan-tether`, and `yauhenipankratovich-web`.

## Test plan

- [ ] Confirm `.github/teams/devops.json` remains valid JSON.
- [ ] Confirm the intended members are the only entries.
