### PR TITLE
chore[ocr-ggml][mod]: bump DocTR gguf models to 2026-05-28

### DIFF
--- a/.github/workflows/benchmark-ocr-ggml.yml
+++ b/.github/workflows/benchmark-ocr-ggml.yml
@@ -31,7 +31,7 @@ on:
 env:
   PKG_DIR: packages/ocr-ggml
   EASYOCR_S3_PREFIX: qvac_models_compiled/ocr/gguf/easyocr/2026-05-14
-  DOCTR_S3_PREFIX: qvac_models_compiled/ocr/gguf/doctrf16/2026-05-15
+  DOCTR_S3_PREFIX: qvac_models_compiled/ocr/gguf/doctrf16/2026-05-28
 
 permissions:
   contents: read

--- a/.github/workflows/integration-test-ocr-ggml.yml
+++ b/.github/workflows/integration-test-ocr-ggml.yml
@@ -207,7 +207,7 @@ jobs:
             models/ \
             --recursive
           aws s3 cp \
-            "s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ocr/gguf/doctrf16/2026-05-15/" \
+            "s3://${{ secrets.MODEL_S3_BUCKET }}/qvac_models_compiled/ocr/gguf/doctrf16/2026-05-28/" \
             models/ \
             --recursive
           ls -lh models/

--- a/packages/ocr-ggml/scripts/generate-ocr-ggml-presigned-urls.sh
+++ b/packages/ocr-ggml/scripts/generate-ocr-ggml-presigned-urls.sh
@@ -13,7 +13,7 @@
 #   EASYOCR_S3_PREFIX           - S3 prefix for EasyOCR models
 #                                 (default: qvac_models_compiled/ocr/gguf/easyocr/2026-05-14)
 #   DOCTR_S3_PREFIX             - S3 prefix for DocTR models
-#                                 (default: qvac_models_compiled/ocr/gguf/doctrf16/2026-05-15)
+#                                 (default: qvac_models_compiled/ocr/gguf/doctrf16/2026-05-28)
 #   OUTPUT_DIR                  - Directory to write ocr-ggml-model-urls.json (default: .)
 #   MODEL_URL_EXPIRES_IN        - Presigned-URL lifetime in seconds (default:
 #                                 21600 = 6h). Must exceed the time between URL
@@ -37,7 +37,7 @@ set -e
 REGION="${AWS_REGION:-eu-central-1}"
 BUCKET="${MODEL_S3_BUCKET}"
 EASYOCR_PREFIX="${EASYOCR_S3_PREFIX:-qvac_models_compiled/ocr/gguf/easyocr/2026-05-14}"
-DOCTR_PREFIX="${DOCTR_S3_PREFIX:-qvac_models_compiled/ocr/gguf/doctrf16/2026-05-15}"
+DOCTR_PREFIX="${DOCTR_S3_PREFIX:-qvac_models_compiled/ocr/gguf/doctrf16/2026-05-28}"
 OUTPUT_DIR="${OUTPUT_DIR:-.}"
 JSON_FILE="${OUTPUT_DIR}/ocr-ggml-model-urls.json"
 


### PR DESCRIPTION
Bumps the DocTR f16 gguf models used by ocr-ggml tests/benchmarks from doctrf16/2026-05-15 to the newer doctrf16/2026-05-28 build in S3. The recognition model (crnn_mobilenet_v3_small.gguf) was rebuilt; the detector is unchanged. Updates integration-test-ocr-ggml.yml, benchmark-ocr-ggml.yml, and generate-ocr-ggml-presigned-urls.sh. EasyOCR stays on 2026-05-14. Opening to run the gated ocr-ggml integration + mobile suites against the new weights.