### PR TITLE
QVAC-20682 infra: align monorepo stale-PR workflow with qvac-workbench (dry-run, concurrency)

### DIFF
--- a/.github/scripts/stale-draft-prs.mjs
+++ b/.github/scripts/stale-draft-prs.mjs
@@ -86,9 +86,17 @@ async function getStaleLabelAppliedAt (github, owner, repo, pullNumber) {
   return latest
 }
 
-export async function processStaleDraftPrs ({ github, context, core }) {
+function logDryRun (core, message) {
+  core.info(`[dry-run] ${message}`)
+}
+
+export async function processStaleDraftPrs ({ github, context, core, dryRun = false }) {
   const owner = context.repo.owner
   const repo = context.repo.repo
+
+  if (dryRun) {
+    core.info('Dry-run mode enabled: no labels, comments, or closures will be applied')
+  }
 
   const pulls = await github.paginate(github.rest.pulls.list, {
     owner,
@@ -118,13 +126,17 @@ export async function processStaleDraftPrs ({ github, context, core }) {
     if (hasStaleLabel(pull.labels)) {
       const authorCommented = await authorHasCommentedOnPr(github, owner, repo, number, authorLogin)
       if (authorCommented) {
-        core.info(`Removing stale label from PR #${number}: author has commented since opening`)
-        await github.rest.issues.removeLabel({
-          owner,
-          repo,
-          issue_number: number,
-          name: STALE_LABEL
-        })
+        if (dryRun) {
+          logDryRun(core, `Would remove stale label from PR #${number}: author has commented since opening`)
+        } else {
+          core.info(`Removing stale label from PR #${number}: author has commented since opening`)
+          await github.rest.issues.removeLabel({
+            owner,
+            repo,
+            issue_number: number,
+            name: STALE_LABEL
+          })
+        }
         continue
       }
 
@@ -135,19 +147,24 @@ export async function processStaleDraftPrs ({ github, context, core }) {
       }
 
       if (daysSince(staleLabelAppliedAt) >= DAYS_BEFORE_CLOSE) {
-        core.info(`Closing stale draft PR #${number}`)
-        await github.rest.issues.createComment({
-          owner,
-          repo,
-          issue_number: number,
-          body: CLOSE_DRAFT_MESSAGE
-        })
-        await github.rest.pulls.update({
-          owner,
-          repo,
-          pull_number: number,
-          state: 'closed'
-        })
+        if (dryRun) {
+          logDryRun(core, `Would close stale draft PR #${number}`)
+          logDryRun(core, `Would comment on PR #${number}: ${CLOSE_DRAFT_MESSAGE}`)
+        } else {
+          core.info(`Closing stale draft PR #${number}`)
+          await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: number,
+            body: CLOSE_DRAFT_MESSAGE
+          })
+          await github.rest.pulls.update({
+            owner,
+            repo,
+            pull_number: number,
+            state: 'closed'
+          })
+        }
       } else {
         core.info(`Skipping PR #${number}: stale label applied ${daysSince(staleLabelAppliedAt).toFixed(1)} day(s) ago`)
       }
@@ -165,18 +182,24 @@ export async function processStaleDraftPrs ({ github, context, core }) {
       continue
     }
 
-    core.info(`Marking draft PR #${number} as stale (no author comments since opening)`)
-    await github.rest.issues.addLabels({
-      owner,
-      repo,
-      issue_number: number,
-      labels: [STALE_LABEL]
-    })
-    await github.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: number,
-      body: STALE_DRAFT_MESSAGE
-    })
+    if (dryRun) {
+      logDryRun(core, `Would mark draft PR #${number} as stale (no author comments since opening)`)
+      logDryRun(core, `Would add label "${STALE_LABEL}" to PR #${number}`)
+      logDryRun(core, `Would comment on PR #${number}: ${STALE_DRAFT_MESSAGE}`)
+    } else {
+      core.info(`Marking draft PR #${number} as stale (no author comments since opening)`)
+      await github.rest.issues.addLabels({
+        owner,
+        repo,
+        issue_number: number,
+        labels: [STALE_LABEL]
+      })
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: number,
+        body: STALE_DRAFT_MESSAGE
+      })
+    }
   }
 }

--- a/.github/workflows/stale-pr-cleanup.yml
+++ b/.github/workflows/stale-pr-cleanup.yml
@@ -2,9 +2,25 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 12 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Log planned actions without modifying pull requests
+        required: false
+        type: boolean
+        default: false
+
 permissions:
-  actions: write
   pull-requests: write
+  contents: read
+  issues: read
+
+# This workflow mutates external state (labels, comments, closes PRs), so a
+# running instance is never cancelled. Scheduled runs share one group and
+# serialize; each dry-run dispatch gets a unique group via the run id.
+concurrency:
+  group: ${{ github.workflow }}${{ inputs.dry-run && github.run_id }}
+  cancel-in-progress: false
 
 jobs:
   stale:
@@ -12,6 +28,7 @@ jobs:
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
+          debug-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
           stale-pr-message: 'This PR is stale because it has been open 21 days with no activity. It is flagged for removal. Remove stale label or set the PR to Draft or this will be closed in one day.'
           close-pr-message: 'This PR was closed because it has been stalled for 22 days with no activity. You can reopen this PR later if it is still necessary.'
           days-before-pr-stale: 21
@@ -21,12 +38,13 @@ jobs:
 
   stale-draft-prs:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # 8.0.0
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
         with:
           script: |
+            const dryRun = process.env.DRY_RUN === 'true'
             const { processStaleDraftPrs } = await import(`${process.env.GITHUB_WORKSPACE}/.github/scripts/stale-draft-prs.mjs`)
-            await processStaleDraftPrs({ github, context, core })
+            await processStaleDraftPrs({ github, context, core, dryRun })

--- a/.github/workflows/stale-pr-cleanup.yml
+++ b/.github/workflows/stale-pr-cleanup.yml
@@ -16,10 +16,11 @@ permissions:
   issues: read
 
 # This workflow mutates external state (labels, comments, closes PRs), so a
-# running instance is never cancelled. Scheduled runs share one group and
-# serialize; each dry-run dispatch gets a unique group via the run id.
+# running instance is never cancelled. Real runs (scheduled or a manual
+# non-dry-run dispatch) share one group and serialize; each dry-run dispatch
+# gets a unique group via the run id so previews never block real runs.
 concurrency:
-  group: ${{ github.workflow }}${{ inputs.dry-run && github.run_id }}
+  group: ${{ github.workflow }}${{ ((github.event_name == 'workflow_dispatch' && inputs.dry-run) && format('-dry-run-{0}', github.run_id)) || '' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- [QVAC-20682](https://app.asana.com/1/45238840754660/project/1214153063536860/task/1215673353412599) — "Scheduled CI auto-close monorepo/assistant PRs". The scheduled stale-PR auto-close already runs on both the monorepo (`qvac` #2169) and the assistant (`qvac-workbench` [#87](https://github.com/tetherto/qvac-workbench/pull/87)), but the two copies have drifted.

- The `qvac-workbench` copy gained operability features — manual `dry-run`, run serialization, and `debug-only` previews — that were never backported here. This PR removes the drift so both repos run the same maintained version.

## 📝 How does it solve it?

- `.github/workflows/stale-pr-cleanup.yml`: add `workflow_dispatch` with a `dry-run` boolean input; add a `concurrency` group; add `debug-only` on `actions/stale`; thread `dry-run` into the script job via a `DRY_RUN` env var.

- `.github/scripts/stale-draft-prs.mjs`: add a `dryRun` parameter and guard every label/comment/close mutation behind it. The file is now byte-identical to the `qvac-workbench` version.

- The daily scheduled path is behaviorally unchanged (flag non-draft PRs idle 21 days, close at 22, exempt `wip` / `do-not-close` / drafts). Only the manual dry-run capability and run serialization are added.

## 🧪 How was it tested?

- `actionlint .github/workflows/stale-pr-cleanup.yml` — clean.
- `node --check .github/scripts/stale-draft-prs.mjs` — passes; `standard` clean (with `.github/` ignore override).
- Diffed `stale-draft-prs.mjs` against the `qvac-workbench` copy — identical, and that copy has run successfully on a daily cron for 12+ consecutive days.

## 🛡️ Permissions changes

- Scope: top-level workflow `permissions:` block, plus removal of the per-job block on `stale-draft-prs`.
- Before:
  ```yaml
  permissions:        # top-level
    actions: write
    pull-requests: write
  # job stale-draft-prs:
  #   permissions:
  #     pull-requests: write
  ```
- After:
  ```yaml
  permissions:        # top-level, shared by both jobs
    pull-requests: write
    contents: read
    issues: read
  ```
- Justification: `actions: write` was unused by either job and is dropped (least privilege). `contents: read` is required by `actions/checkout` in the script job; `issues: read` covers the issue-comment/issue-event reads the draft script performs; `pull-requests: write` covers labeling/commenting/closing. This matches the proven, daily-running `qvac-workbench` scope set, so the redundant per-job block is removed.

---

Note: one intentional deviation from `qvac-workbench` — `concurrency.cancel-in-progress: false` here vs. `true` there — because `.cursor/rules/devops/github-actions.mdc` mandates non-cancelling concurrency for workflows that mutate external state (this one labels/closes PRs). Worth aligning `qvac-workbench` in a follow-up.

🤖 Authored with the `qv-devops-pr-create` skill (Cursor agent) for QVAC-20682.
