### PR TITLE
chore: wire in lunte and prettier-config-holepunch for diagnostics

### DIFF
--- a/packages/diagnostics/.lunteignore
+++ b/packages/diagnostics/.lunteignore
@@ -1,0 +1,11 @@
+node_modules
+build
+dist
+prebuilds
+coverage
+package-lock.json
+**/*.auto.cjs
+test/unit/all.js
+test/integration/all.js
+test/results
+*.d.ts

--- a/packages/diagnostics/.lunterc
+++ b/packages/diagnostics/.lunterc
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "eqeqeq": "warn",
+    "no-var": "warn",
+    "curly": "warn",
+    "no-unused-vars": "warn",
+    "prefer-const": "warn"
+  }
+}

--- a/packages/diagnostics/.prettierignore
+++ b/packages/diagnostics/.prettierignore
@@ -1,0 +1,10 @@
+node_modules
+build
+dist
+prebuilds
+coverage
+package-lock.json
+**/*.auto.cjs
+test/unit/all.js
+test/integration/all.js
+test/results

--- a/packages/diagnostics/.prettierrc
+++ b/packages/diagnostics/.prettierrc
@@ -1,0 +1,1 @@
+"prettier-config-holepunch"

--- a/packages/diagnostics/package.json
+++ b/packages/diagnostics/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "lint": "standard",
-    "lint:fix": "standard --fix",
+    "lint": "prettier --check \"**/*.{js,cjs,mjs}\" && lunte",
+    "format": "prettier --write \"**/*.{js,cjs,mjs}\"",
     "build:types": "tsc",
     "test:unit": "npm run test:unit:generate && bare test/unit/all.js",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js",
@@ -44,7 +44,9 @@
   },
   "devDependencies": {
     "brittle": "^3.10.1",
-    "standard": "17.1.0",
+    "lunte": "^1.8.0",
+    "prettier": "^3.6.2",
+    "prettier-config-holepunch": "^2.0.0",
     "typescript": "^5.9.3"
   },
   "files": [


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Wires this package onto the in-house Holepunch tooling, replacing `standard` with `lunte` for linting and `prettier` with `prettier-config-holepunch` for formatting. Part of the repo-wide migration, done package by package.

## 📝 How does it solve it?

- `lint` now runs `prettier --check` followed by `lunte`; a new `format` script runs `prettier --write`. Scope mirrors what `standard` covered.
- Swaps the `standard` devDependency for `lunte`, `prettier`, `prettier-config-holepunch`; adds `.prettierrc`, `.prettierignore`, `.lunterc`, `.lunteignore`; removes any `standard` ignore config.
- **No reformatting is applied in this PR.** `prettier --check` (and therefore CI lint) will be red until the owning team runs `npm run format` (a single command). This is intentional, so each team applies and reviews its own formatting.
- `.lunterc` downgrades `eqeqeq`, `no-var`, `curly`, `no-unused-vars` and `prefer-const` to warnings, because `lunte` is stricter than `standard` on those (standard allows the `== null` idiom and ignores unused arguments). This keeps the tooling swap free of behavioural code edits.

## 🧪 How was it tested?

- `lunte` passes on the current code; `prettier --check` is red by design until the code is formatted with `npm run format`.
- No `standard` reference remains in the package.
