### PR TITLE
chore: wire in lunte and prettier-config-holepunch for ocr-onnx

### DIFF
--- a/packages/ocr-onnx/.lunteignore
+++ b/packages/ocr-onnx/.lunteignore
@@ -1,0 +1,13 @@
+node_modules
+build
+dist
+prebuilds
+coverage
+package-lock.json
+**/*.auto.cjs
+test/unit/all.js
+test/integration/all.js
+test/results
+benchmarks
+examples
+*.d.ts

--- a/packages/ocr-onnx/.lunterc
+++ b/packages/ocr-onnx/.lunterc
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "eqeqeq": "warn",
+    "no-var": "warn",
+    "curly": "warn",
+    "no-unused-vars": "warn",
+    "prefer-const": "warn"
+  }
+}

--- a/packages/ocr-onnx/.prettierignore
+++ b/packages/ocr-onnx/.prettierignore
@@ -1,0 +1,12 @@
+node_modules
+build
+dist
+prebuilds
+coverage
+package-lock.json
+**/*.auto.cjs
+test/unit/all.js
+test/integration/all.js
+test/results
+benchmarks
+examples

--- a/packages/ocr-onnx/.prettierrc
+++ b/packages/ocr-onnx/.prettierrc
@@ -1,0 +1,1 @@
+"prettier-config-holepunch"

--- a/packages/ocr-onnx/package.json
+++ b/packages/ocr-onnx/package.json
@@ -10,8 +10,8 @@
     "build": "bare-make generate && bare-make build && bare-make install",
     "build:pack": "mkdir -p dist && npm pack --pack-destination dist",
     "mobile:copy-prebuilds": "cp -r prebuilds/android-arm64 prebuilds/android-ia32 || echo 'Warning: Failed to copy prebuilds to android-ia32'; cp -r prebuilds/android-arm64 prebuilds/android-arm || echo 'Warning: Failed to copy prebuilds to android-arm'; cp -r prebuilds/android-arm64 prebuilds/android-x64 || echo 'Warning: Failed to copy prebuilds to android-x64'; cp -r prebuilds/ios-arm64 prebuilds/ios-arm64-simulator 2>/dev/null || echo 'iOS prebuilds already present'; cp -r prebuilds/ios-arm64 prebuilds/ios-x64-simulator 2>/dev/null || echo 'iOS prebuilds already present'",
-    "lint": "standard",
-    "lint:fix": "standard --fix",
+    "lint": "prettier --check \"**/*.{js,cjs,mjs}\" && lunte",
+    "format": "prettier --write \"**/*.{js,cjs,mjs}\"",
     "lint-cpp": "clang-tidy -p build $(find addon -name '*.cpp')",
     "test:unit": "brittle-bare test/unit/*.test.js",
     "test:example": "bare examples/example.fs.js",
@@ -53,12 +53,6 @@
   "license": "Apache-2.0",
   "bugs": "https://github.com/tetherto/qvac/issues",
   "homepage": "https://github.com/tetherto/qvac/tree/main/packages/ocr-onnx#readme",
-  "standard": {
-    "ignore": [
-      "benchmarks/**",
-      "examples/**"
-    ]
-  },
   "devDependencies": {
     "@qvac/registry-client": "^0.1.5",
     "@types/node": "^25.0.3",
@@ -68,7 +62,9 @@
     "brittle": "^3.16.5",
     "cmake-bare": "^1.5.0",
     "cmake-vcpkg": "^1.0.2",
-    "standard": "^17.0.0",
+    "lunte": "^1.8.0",
+    "prettier": "^3.6.2",
+    "prettier-config-holepunch": "^2.0.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Wires this package onto the in-house Holepunch tooling, replacing `standard` with `lunte` for linting and `prettier` with `prettier-config-holepunch` for formatting. Part of the repo-wide migration, done package by package.

## 📝 How does it solve it?

- `lint` now runs `prettier --check` followed by `lunte`; a new `format` script runs `prettier --write`. Scope mirrors what `standard` covered.
- Swaps the `standard` devDependency for `lunte`, `prettier`, `prettier-config-holepunch`; adds `.prettierrc`, `.prettierignore`, `.lunterc`, `.lunteignore`; removes any `standard` ignore config.
- **No reformatting is applied in this PR.** `prettier --check` (and therefore CI lint) will be red until the owning team runs `npm run format` (a single command). This is intentional, so each team applies and reviews its own formatting.
- `.lunterc` downgrades `eqeqeq`, `no-var`, `curly`, `no-unused-vars` and `prefer-const` to warnings, because `lunte` is stricter than `standard` on those (standard allows the `== null` idiom and ignores unused arguments). This keeps the tooling swap free of behavioural code edits.

## 🧪 How was it tested?

- `lunte` passes on the current code; `prettier --check` is red by design until the code is formatted with `npm run format`.
- No `standard` reference remains in the package.
