### PR TITLE
chore: wire in lunte and prettier-config-holepunch for tts-onnx

### DIFF
--- a/packages/tts-onnx/.lunteignore
+++ b/packages/tts-onnx/.lunteignore
@@ -1,0 +1,11 @@
+node_modules
+build
+dist
+prebuilds
+coverage
+package-lock.json
+**/*.auto.cjs
+test/unit/all.js
+test/integration/all.js
+test/results
+*.d.ts

--- a/packages/tts-onnx/.lunterc
+++ b/packages/tts-onnx/.lunterc
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "eqeqeq": "warn",
+    "no-var": "warn",
+    "curly": "warn",
+    "no-unused-vars": "warn",
+    "prefer-const": "warn"
+  }
+}

--- a/packages/tts-onnx/.prettierignore
+++ b/packages/tts-onnx/.prettierignore
@@ -1,0 +1,10 @@
+node_modules
+build
+dist
+prebuilds
+coverage
+package-lock.json
+**/*.auto.cjs
+test/unit/all.js
+test/integration/all.js
+test/results

--- a/packages/tts-onnx/.prettierrc
+++ b/packages/tts-onnx/.prettierrc
@@ -1,0 +1,1 @@
+"prettier-config-holepunch"

--- a/packages/tts-onnx/benchmarks/server/.lunteignore
+++ b/packages/tts-onnx/benchmarks/server/.lunteignore
@@ -1,0 +1,11 @@
+node_modules
+build
+dist
+prebuilds
+coverage
+package-lock.json
+**/*.auto.cjs
+test/unit/all.js
+test/integration/all.js
+test/results
+*.d.ts

--- a/packages/tts-onnx/benchmarks/server/.lunterc
+++ b/packages/tts-onnx/benchmarks/server/.lunterc
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "eqeqeq": "warn",
+    "no-var": "warn",
+    "curly": "warn",
+    "no-unused-vars": "warn",
+    "prefer-const": "warn"
+  }
+}

--- a/packages/tts-onnx/benchmarks/server/.prettierignore
+++ b/packages/tts-onnx/benchmarks/server/.prettierignore
@@ -1,0 +1,10 @@
+node_modules
+build
+dist
+prebuilds
+coverage
+package-lock.json
+**/*.auto.cjs
+test/unit/all.js
+test/integration/all.js
+test/results

--- a/packages/tts-onnx/benchmarks/server/.prettierrc
+++ b/packages/tts-onnx/benchmarks/server/.prettierrc
@@ -1,0 +1,1 @@
+"prettier-config-holepunch"

--- a/packages/tts-onnx/benchmarks/server/package.json
+++ b/packages/tts-onnx/benchmarks/server/package.json
@@ -8,8 +8,8 @@
     "setup:chatterbox": "bare chatterbox-setup.js",
     "setup:supertonic": "bare supertonic-setup.js",
     "start": "bare index.js",
-    "lint": "standard",
-    "lint:fix": "standard --fix"
+    "lint": "prettier --check \"**/*.{js,cjs,mjs}\" && lunte",
+    "format": "prettier --write \"**/*.{js,cjs,mjs}\""
   },
   "keywords": [
     "tts",
@@ -38,6 +38,8 @@
     "zod": "^3.24.4"
   },
   "devDependencies": {
-    "standard": "^17.1.2"
+    "lunte": "^1.8.0",
+    "prettier": "^3.6.2",
+    "prettier-config-holepunch": "^2.0.0"
   }
 }

--- a/packages/tts-onnx/package.json
+++ b/packages/tts-onnx/package.json
@@ -11,8 +11,8 @@
     "build:pack": "mkdir -p dist && npm pack --pack-destination dist",
     "example": "bare examples/chatterbox-tts.js english",
     "example:langdetect": "bare examples/chatterbox-langdetect-tts.js",
-    "lint": "standard \"test/**/*.js\" \"*.js\" \"lib/*.js\"",
-    "lint:fix": "standard --fix \"test/**/*.js\" \"*.js\" \"lib/*.js\"",
+    "lint": "prettier --check \"test/**/*.js\" \"*.js\" \"lib/*.js\" && lunte \"test/**/*.js\" \"*.js\" \"lib/*.js\"",
+    "format": "prettier --write \"test/**/*.js\" \"*.js\" \"lib/*.js\"",
     "test:unit": "brittle-bare test/unit/**/*.test.js",
     "test": "npm run test:unit && npm run test:integration",
     "test:integration": "brittle-bare test/integration/addon.test.js",
@@ -91,7 +91,9 @@
     "cmake-vcpkg": "^1.1.0",
     "fflate": "^0.8.2",
     "husky": "^9.1.7",
-    "standard": "^17.0.0"
+    "lunte": "^1.8.0",
+    "prettier": "^3.6.2",
+    "prettier-config-holepunch": "^2.0.0"
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Wires this package onto the in-house Holepunch tooling, replacing `standard` with `lunte` for linting and `prettier` with `prettier-config-holepunch` for formatting. Part of the repo-wide migration, done package by package.

## 📝 How does it solve it?

- `lint` now runs `prettier --check` followed by `lunte`; a new `format` script runs `prettier --write`. Scope mirrors what `standard` covered.
- Swaps the `standard` devDependency for `lunte`, `prettier`, `prettier-config-holepunch`; adds `.prettierrc`, `.prettierignore`, `.lunterc`, `.lunteignore`; removes any `standard` ignore config.
- **No reformatting is applied in this PR.** `prettier --check` (and therefore CI lint) will be red until the owning team runs `npm run format` (a single command). This is intentional, so each team applies and reviews its own formatting.
- `.lunterc` downgrades `eqeqeq`, `no-var`, `curly`, `no-unused-vars` and `prefer-const` to warnings, because `lunte` is stricter than `standard` on those (standard allows the `== null` idiom and ignores unused arguments). This keeps the tooling swap free of behavioural code edits.

## 🧪 How was it tested?

- `lunte` passes on the current code; `prettier --check` is red by design until the code is formatted with `npm run format`.
- No `standard` reference remains in the package.
