### PR TITLE
QVAC-20987 chore: bump llm-llamacpp to 0.29.0

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,4 +1,30 @@
 # Changelog
+## [0.29.0] - 2026-06-22
+
+This release makes reasoning-token budgets configurable per model load and per request, while improving how chat-template thinking markers are detected and streamed. It also tightens GPU backend validation so unsupported quantized KV-cache combinations fail early with clear errors instead of reaching backend-specific runtime failures.
+
+### Breaking Changes
+
+- TurboQuant and PolarQuant KV-cache types are now rejected during model configuration on OpenCL and Metal backends, where the required kernels are not available. Use CPU/Vulkan for TBQ/PQ KV-cache modes, or use standard KV-cache types such as `q4_0` and `q8_0` on OpenCL or Metal.
+
+### New APIs
+
+- `reasoning_budget` now accepts positive integer token caps in addition to the existing `-1` unrestricted and `0` disabled modes. Callers can set the cap at model load time or override it per request through generation params.
+
+### Changed
+
+- Reasoning-budget sampling now derives template-specific thinking start/end markers and generation prompts from the active chat template, so capped thinking output stays aligned with models that use custom `<think>`-style delimiters.
+- Flash attention now defaults on for supported non-BitNet, non-finetuning configurations, while preserving existing override behavior.
+
+### Fixed
+
+- Metal backend detection now recognizes runtime `mtl*` device names, so CPU-only Apple runs do not get treated as Metal while actual Metal devices still reject unsupported TBQ/PQ KV-cache modes.
+- Mobile and desktop LLM integration tests were adjusted for the new backend behavior and to reduce platform-specific flake in reasoning, cache, multimodal, and performance suites.
+
+## Pull Requests
+
+- [#2366](https://github.com/tetherto/qvac/pull/2366) - QVAC-20987 feat[api]: add llm reasoning budget caps
+
 ## [0.28.0] - 2026-06-22
 
 ### Changed

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Prepares the release metadata for the `@qvac/llm-llamacpp` changes in #2366.
- Keeps the package version and changelog aligned before publishing the reasoning-budget and backend-validation changes.

## 📝 How does it solve it?

- Bumps `packages/llm-llamacpp/package.json` from `0.28.0` to `0.29.0`.
- Adds a `0.29.0` changelog entry covering positive `reasoning_budget` caps, chat-template reasoning markers, flash-attention defaults, and OpenCL/Metal KV-cache validation.
- Marks this PR as dependent on #2366; merge after #2366 lands.

## 🧪 How was it tested?

- `git diff --check`
- IDE diagnostics for `packages/llm-llamacpp/package.json` and `packages/llm-llamacpp/CHANGELOG.md`

## 💥 Breaking Changes

- The release notes document that TurboQuant and PolarQuant KV-cache types are rejected on OpenCL and Metal backends. Use CPU/Vulkan for TBQ/PQ modes, or standard KV-cache types such as `q4_0` and `q8_0` on OpenCL or Metal.

## 🔌 API Changes

```typescript
await llm.run('Explain this', {
  generationParams: {
    reasoning_budget: 128
  }
})
```

Made with [Cursor](https://cursor.com)