### PR TITLE
chore: release @qvac/tts-ggml v0.3.4 (QVAC-21118 chunk-streaming CFM-step floor)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-06-23
+
+### Fixed
+
+- **Chunk-streaming saturation/clipping and per-chunk loudness "wobble" on the
+  Chatterbox Multilingual engine (QVAC-21118).** A low `cfmSteps` /
+  `streamCfmSteps` (1–2) under-integrated the model's standard 10-step CFM in
+  the chunk-streaming path, producing near-full-scale output (~99%, RMS 4–9×
+  hotter than batch) with a collapsing tail. The engine now floors the
+  streaming CFM step count to the model's `n_timesteps` for standard-CFM
+  models; Turbo's meanflow 2-step sampler and the batch step count are
+  unaffected. Consumes `tts-cpp` `2026-06-22` (`qvac-ext-lib-whisper.cpp`
+  PR #62).
+
 ## [0.3.3] - 2026-06-22
 
 ### Changed

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
> **Stacked on the wiring PR #2777** (base = `qvac-21118-tts-cpp-registry`), so this PR's diff is **only the version + CHANGELOG bump**. After #2777 merges to `main`, rebase this onto `main` (the diff stays just the bump).

## Summary

Dedicated version bump for the QVAC-21118 chunk-streaming fix — kept separate from the wiring change (#2777) so the package bump is its own clearly-labeled entry in history.

- `package.json`: `0.3.3` → **`0.3.4`** (`0.3.3` is already published on npm and on `main`).
- `CHANGELOG.md`: new **`[0.3.4]`** entry (QVAC-21118 chunk-streaming CFM-step floor), stacked above main's existing `[0.3.3]`.

## Publish (after merge to `main`)
Cut a `release-tts-ggml-0.3.4` branch → CI `publish-npm` ships `@qvac/tts-ggml@0.3.4`.

Chain: `qvac-ext-lib-whisper.cpp#62` (merged) → `qvac-registry-vcpkg#204` → `#2777` (wiring) → **this** (bump).
