### PR TITLE
infra[notask]: add concurrency group and timeout to check-approvals workflow

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -12,10 +12,15 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check-approvals:
     name: Check Approvals
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     continue-on-error: true
     if: >-
       (


### PR DESCRIPTION
## Summary

Adds a workflow-level `concurrency` group and `timeout-minutes: 30` to `check-approvals.yml`, aligning it with the pattern already in place on `qvac-workbench`.

### Changes
- `concurrency.group`: scoped to workflow + PR/issue number — prevents duplicate runs for the same PR
- `concurrency.cancel-in-progress: false`: preserves in-flight approval checks (intentional)
- `timeout-minutes: 30`: caps runaway jobs

No logic changes.