### PR TITLE
QVAC-19178 feat[mod]: add Q8_0 mmproj for Qwen3.5-2B and Qwen3.5-4B

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -12508,6 +12508,22 @@
     "link": "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF"
   },
   {
+    "source": "https://huggingface.co/mradermacher/Qwen3.5-2B-GGUF/resolve/33cc6944e40cb93e38332cd46b2a6e3c6acf081e/Qwen3.5-2B.mmproj-Q8_0.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Vision projector (mmproj) for Qwen 3.5 2B",
+    "quantization": "q8_0",
+    "params": "2B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "qwen3.5",
+      "instruct"
+    ],
+    "notes": "Q8_0 vision projector from mradermacher (the registry's unsloth Qwen3.5-2B repo ships only F16/BF16 mmproj). Same base Qwen3.5-2B model; validated compatible with the registry main, no quality regression.",
+    "link": "https://huggingface.co/mradermacher/Qwen3.5-2B-GGUF"
+  },
+  {
     "source": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/e87f176479d0855a907a41277aca2f8ee7a09523/Qwen3.5-4B-Q4_K_M.gguf",
     "engine": "@qvac/llm-llamacpp",
     "description": "Qwen 3.5 4B multimodal model",
@@ -12570,6 +12586,22 @@
     ],
     "notes": "",
     "link": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/mradermacher/Qwen3.5-4B-GGUF/resolve/1a5df2c0cba51dae8ac5888420360d8703707171/Qwen3.5-4B.mmproj-Q8_0.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Vision projector (mmproj) for Qwen 3.5 4B",
+    "quantization": "q8_0",
+    "params": "4B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "qwen3.5",
+      "instruct"
+    ],
+    "notes": "Q8_0 vision projector from mradermacher (the registry's unsloth Qwen3.5-4B repo ships only F16/BF16 mmproj). Same base Qwen3.5-4B model; validated compatible with the registry main, no quality regression.",
+    "link": "https://huggingface.co/mradermacher/Qwen3.5-4B-GGUF"
   },
   {
     "source": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/3885219b6810b007914f3a7950a8d1b469d598a5/Qwen3.5-9B-Q4_K_M.gguf",


### PR DESCRIPTION
## What

Adds **Q8_0 vision projectors (mmproj)** for the two Qwen3.5 VLMs already in the registry — the direct follow-up to #2432 (which added Q8 mmproj for Qwen3.5-0.8B + Gemma-4-E2B):

| Model | Q8 mmproj source (pinned) |
|---|---|
| **Qwen3.5-2B** | `mradermacher/Qwen3.5-2B-GGUF@33cc6944` → `Qwen3.5-2B.mmproj-Q8_0.gguf` (365 MB) |
| **Qwen3.5-4B** | `mradermacher/Qwen3.5-4B-GGUF@1a5df2c0` → `Qwen3.5-4B.mmproj-Q8_0.gguf` (367 MB) |

`licenseId: Apache-2.0`. Base models + their existing F16/BF16 mmproj are left untouched.

## Why

Each model already ships its main GGUF + **F16/BF16 mmproj**, but no Q8. A Q8 mmproj is roughly **half the size** of F16 (2B: 365 MB vs 668 MB; 4B: 367 MB vs ~720 MB) and on GPU encodes images as fast or faster than F16 with no measurable quality loss — a smaller/faster projector option for consumers.

## ⚠️ Source note (same as #2432)

The Q8 blobs come from a **different HF repo than the existing entries**, because the registry's own model repo doesn't publish a Q8 mmproj:
- `unsloth/Qwen3.5-2B-GGUF` and `unsloth/Qwen3.5-4B-GGUF` ship **only F16/BF16** mmproj.
- A Q8 mmproj exists only at **`mradermacher`** — the **same base** `Qwen3.5-2B` / `Qwen3.5-4B` models.

Validated compatible with the registry mains (the `unsloth` Q4_K_M GGUFs), no regression.

## Validation — CI (qvac `@qvac/llm-llamacpp` addon, two-models F16 vs Q8 mmproj)

Held the **registry main fixed** (`…-Q4_K_M`) and compared **registry F16 vs candidate Q8** mmproj across all desktop platforms (Linux/macOS/Windows × CPU/GPU) + mobile, `full` preset:

- **2B:** https://github.com/tetherto/qvac/actions/runs/27955889824
- **4B:** https://github.com/tetherto/qvac/actions/runs/27956460210

- **Compatibility:** all desktop cells load + run, **0 errors** — the cross-repo Q8 mmproj pairs cleanly with the registry mains on CPU and GPU.
- **Quality** (lmms-eval VQA + OCR CER/WER/BLEU): **Q8 ≈ F16** — overall % within single-sample noise on every desktop leg (2B ≈ 75%; 4B ≈ 87–91%). No regression.
- **Speed** (mmproj vision-encode): roughly a wash; Q8 faster on several CPU legs, within noise on GPU — plus the ~half-size saving.

## Files
- `packages/registry-server/data/models.prod.json` — **+2 entries** (one Q8 mmproj per model).
