### PR TITLE
fix[notask]: keep @qvac/sdk plugin subpath resolvable after the publish rename

### DIFF
--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -13,6 +13,9 @@
     "baseUrl": ".",
     "paths": {
       "@qvac/sdk": ["./index.ts"],
+      "@qvac/sdk/llamacpp-completion/plugin": [
+        "./server/bare/plugins/llamacpp-completion/plugin.ts"
+      ],
       "@/*": ["./*"]
     },
     "outDir": "./dist",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The SDK publish build (`publish-sdk.yml`) renames the package before `bun run build` — `@qvac/sdk` → `@tetherto/sdk-mono` on `main` (and `@tetherto/sdk-<branch>` on feature/fix branches). After the rename, `tsc` can no longer self-resolve the subpath import `@qvac/sdk/llamacpp-completion/plugin` in `examples/quickstart.bare.ts`, so the build fails with `TS2307: Cannot find module '@qvac/sdk/llamacpp-completion/plugin'`. (Local builds pass because they don't rename the package.)

## 📝 How does it solve it?

- Adds one `tsconfig.json` `paths` entry mapping that subpath to its source, mirroring the existing `"@qvac/sdk": ["./index.ts"]` entry:
  ```jsonc
  "@qvac/sdk/llamacpp-completion/plugin": [
    "./server/bare/plugins/llamacpp-completion/plugin.ts"
  ]
  paths resolve by pattern and ignore the package name, so the rename can't break the import.
- Why this is needed for only this one example: quickstart.bare.ts is the only example that imports an @qvac/sdk subpath (it registers a plugin via plugins([llmPlugin])). Every other example imports the bare @qvac/sdk, which already survives the rename solely because of the pre-existing "@qvac/sdk" paths entry. This change applies that exact mechanism to the one subpath that needs it — no broader change required.

🧪 How was it tested?

- Reproduced the failure by renaming the package exactly as the publish workflow does, then running tsc --noEmit (yields the TS2307); confirmed the new paths entry clears it while the package is renamed.
- bun run build (lint + typecheck + compile) passes.