### PR TITLE
chore: release @qvac/tts-ggml v0.3.4 (QVAC-21118 chunk-streaming CFM-step floor)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.4] - 2026-06-23
 
 ### Added
 
@@ -25,9 +25,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `example:chatterbox-adjust-speed` npm script), C++ WSOLA unit tests, and a JS
   integration test.
 
+### Fixed
+
+- **Chunk-streaming saturation/clipping and per-chunk loudness "wobble" on the
+  Chatterbox Multilingual engine (QVAC-21118).** A low `cfmSteps` /
+  `streamCfmSteps` (1–2) under-integrated the model's standard 10-step CFM in
+  the chunk-streaming path, producing near-full-scale output (~99%, RMS 4–9×
+  hotter than batch) with a collapsing tail. The engine now floors the
+  streaming CFM step count to the model's `n_timesteps` for standard-CFM
+  models; Turbo's meanflow 2-step sampler and the batch step count are
+  unaffected. Consumes `tts-cpp` `2026-06-22` (`qvac-ext-lib-whisper.cpp`
+  PR #62).
+
 ## Pull Requests
 
 - [#2782](https://github.com/tetherto/qvac/pull/2782) - QVAC-21119: add Chatterbox speaking-rate (`speed`) control
+- [#2777](https://github.com/tetherto/qvac/pull/2777) - QVAC-21118: consume tts-cpp 2026-06-22 (chunk-streaming CFM-step floor)
 
 ## [0.3.3] - 2026-06-22
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
Dedicated **version bump** for the QVAC-21118 chunk-streaming fix, split out from the wiring change (#2777, merged) so the package bump is its own entry in git history.

## Summary
- `package.json`: `0.3.3` → **`0.3.4`**
- `CHANGELOG.md`: new **`[0.3.4]`** entry (QVAC-21118 chunk-streaming CFM-step floor), stacked above `[0.3.3]`.

## Context
- The functional change (consume `tts-cpp 2026-06-22`; floor streaming CFM steps to `n_timesteps` for standard-CFM/Multilingual) landed in **#2777** (merged) and is CI-validated: `prebuild` ×9 + GPU integration ×7 + iOS E2E all green. (The pre-existing `cpp-test-coverage` model-conversion job and a flaky Android Device-Farm device are unrelated and non-required.)
- This PR is now rebased directly on `main`; its diff is **only** the version + CHANGELOG bump.

## After merge
Cut `release-tts-ggml-0.3.4` from `main` and publish `@qvac/tts-ggml@0.3.4` to npm (`latest`).
