### PR TITLE
QVAC-21210 fix[api]: harden Gemma4 completion drains

### DIFF
--- a/packages/cli/src/serve/schemas/common.ts
+++ b/packages/cli/src/serve/schemas/common.ts
@@ -221,6 +221,8 @@ export function extractGenerationParams (
 
   if (typeof body['reasoning_budget'] === 'boolean') {
     params.reasoning_budget = body['reasoning_budget'] ? -1 : 0
+  } else if (body['reasoning_budget'] === -1 || body['reasoning_budget'] === 0) {
+    params.reasoning_budget = body['reasoning_budget']
   }
 
   return Object.keys(params).length > 0 ? params : undefined

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -446,8 +446,13 @@ describe('extractGenerationParams (chat semantics)', () => {
     assert.equal(params.reasoning_budget, 0)
   })
 
-  it('ignores non-boolean reasoning_budget', () => {
-    const params = extractChat({ reasoning_budget: -1 })
+  it('extracts SDK-native numeric reasoning_budget', () => {
+    assert.equal(extractChat({ reasoning_budget: -1 })!.reasoning_budget, -1)
+    assert.equal(extractChat({ reasoning_budget: 0 })!.reasoning_budget, 0)
+  })
+
+  it('ignores unsupported numeric reasoning_budget values', () => {
+    const params = extractChat({ reasoning_budget: 1 })
     assert.equal(params, undefined)
   })
 

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stats.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stats.ts
@@ -1,0 +1,38 @@
+import type { CompletionStats } from "@/schemas";
+import type { LlmStats } from "@/server/bare/types/addon-responses";
+
+function finiteNumber(value: number | undefined) {
+  return value !== undefined && Number.isFinite(value) ? value : undefined;
+}
+
+export function normalizeCompletionStats(stats: LlmStats | undefined) {
+  if (!stats) return undefined;
+
+  const timeToFirstToken = finiteNumber(stats.TTFT);
+  const tokensPerSecond = finiteNumber(stats.TPS);
+  const cacheTokens = finiteNumber(stats.CacheTokens);
+  const promptTokens = finiteNumber(stats.promptTokens);
+  const generatedTokens = finiteNumber(stats.generatedTokens);
+
+  const normalized: CompletionStats = {
+    ...(timeToFirstToken !== undefined && { timeToFirstToken }),
+    ...(tokensPerSecond !== undefined && { tokensPerSecond }),
+    ...(cacheTokens !== undefined && { cacheTokens }),
+    ...(promptTokens !== undefined && { promptTokens }),
+    ...(generatedTokens !== undefined && { generatedTokens }),
+    ...(stats.backendDevice !== undefined && { backendDevice: stats.backendDevice }),
+  };
+
+  if (
+    timeToFirstToken === undefined &&
+    tokensPerSecond === undefined &&
+    cacheTokens === undefined &&
+    promptTokens === undefined &&
+    generatedTokens === undefined &&
+    stats.backendDevice === undefined
+  ) {
+    return undefined;
+  }
+
+  return normalized;
+}

--- a/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
+++ b/packages/sdk/server/bare/plugins/llamacpp-completion/ops/completion-stream.ts
@@ -45,11 +45,9 @@ import { getServerLogger } from "@/logging";
 import type { Logger } from "@/logging/types";
 import { AttachmentNotFoundError } from "@/utils/errors-server";
 import { nowMs } from "@/profiling";
-import {
-  buildStreamResult,
-  hasDefinedValues,
-} from "@/profiling/model-execution";
+import { buildStreamResult } from "@/profiling/model-execution";
 import type { LlmStats } from "@/server/bare/types/addon-responses";
+import { normalizeCompletionStats } from "@/server/bare/plugins/llamacpp-completion/ops/completion-stats";
 import fs from "bare-fs";
 
 const logger = getServerLogger();
@@ -380,32 +378,10 @@ async function* processModelResponse(
   }
 
   const responseWithStats = response as unknown as ResponseWithStats;
-  const stats: CompletionStats = {
-    ...(responseWithStats.stats?.TTFT !== undefined && {
-      timeToFirstToken: responseWithStats.stats.TTFT,
-    }),
-    ...(responseWithStats.stats?.TPS !== undefined && {
-      tokensPerSecond: responseWithStats.stats.TPS,
-    }),
-    ...(responseWithStats.stats?.CacheTokens !== undefined && {
-      cacheTokens: responseWithStats.stats.CacheTokens,
-    }),
-    ...(responseWithStats.stats?.promptTokens !== undefined && {
-      promptTokens: responseWithStats.stats.promptTokens,
-    }),
-    ...(responseWithStats.stats?.generatedTokens !== undefined && {
-      generatedTokens: responseWithStats.stats.generatedTokens,
-    }),
-    ...(responseWithStats.stats?.backendDevice !== undefined && {
-      backendDevice: responseWithStats.stats.backendDevice,
-    }),
-  };
+  const stats = normalizeCompletionStats(responseWithStats.stats);
 
   return {
-    ...buildStreamResult(
-      modelExecutionMs,
-      hasDefinedValues(stats) ? stats : undefined,
-    ),
+    ...buildStreamResult(modelExecutionMs, stats),
     toolCalls: toolCallsResult,
     responseText: accumulatedText,
     producedTokens,

--- a/packages/sdk/test/unit/completion-stats.test.ts
+++ b/packages/sdk/test/unit/completion-stats.test.ts
@@ -1,0 +1,33 @@
+import test from "brittle";
+import { completionStatsSchema } from "@/schemas";
+import { normalizeCompletionStats } from "@/server/bare/plugins/llamacpp-completion/ops/completion-stats";
+import type { LlmStats } from "@/server/bare/types/addon-responses";
+
+test("normalizeCompletionStats: drops non-finite addon numbers", (t) => {
+  const stats: LlmStats = {
+    TTFT: Number.NaN,
+    TPS: Number.POSITIVE_INFINITY,
+    CacheTokens: 12,
+    promptTokens: Number.NEGATIVE_INFINITY,
+    generatedTokens: 40,
+    backendDevice: "gpu",
+  };
+
+  const normalized = normalizeCompletionStats(stats);
+
+  t.alike(normalized, {
+    cacheTokens: 12,
+    generatedTokens: 40,
+    backendDevice: "gpu",
+  });
+  t.is(completionStatsSchema.safeParse(normalized).success, true);
+});
+
+test("normalizeCompletionStats: returns undefined when no finite stats remain", (t) => {
+  const normalized = normalizeCompletionStats({
+    TTFT: Number.NaN,
+    TPS: Number.POSITIVE_INFINITY,
+  });
+
+  t.is(normalized, undefined);
+});


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Gemma4 31B can load successfully in `qvac serve openai` but fail at completion response time after the SDK worker has already reported the request as completed. The CLI also ignored SDK-native numeric `reasoning_budget` values, which made the documented per-request mitigation hard to exercise through OpenAI-compatible routes.

## 📝 How does it solve it?

- Sanitizes llama.cpp completion stats before emitting `completionStats`, dropping non-finite numeric values that would fail completion stream schema validation.
- Keeps valid stats such as generated token counts and backend device information intact.
- Accepts numeric `reasoning_budget: -1 | 0` in CLI OpenAI-compatible request translation while preserving the existing boolean shortcut.

## 🧪 How was it tested?

- `bun run test/unit/completion-stats.test.ts` in `packages/sdk`
- `bun run test/unit/completion-normalizer.test.ts` in `packages/sdk`
- `bun test test/translate.test.ts` in `packages/cli`
- `bun run typecheck` in `packages/cli`
- `git diff --check`

Note: full SDK package typecheck still hits existing Bare stream/socket typing errors outside this change.

## 🔌 API Changes

OpenAI-compatible CLI routes now accept the SDK-native numeric form of the existing `reasoning_budget` parameter:

```json
{
  "model": "gemma4-31b",
  "messages": [{ "role": "user", "content": "The ocean is" }],
  "reasoning_budget": 0
}
```

The existing boolean form continues to work.