### PR TITLE
QVAC-21228 chore: switch @qvac/logging to Lunte and Prettier

### DIFF
--- a/packages/logging/.prettierrc
+++ b/packages/logging/.prettierrc
@@ -1,0 +1,1 @@
+"prettier-config-holepunch"

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -28,12 +28,12 @@ const log = new QvacLogger(myLogger)
 ```
 
 - **With a provided logger**:
-    1. If `logger.getLevel()` exists, its return value (case-insensitive) is used.
-    2. Else if `logger.level()` exists, its return (case-insensitive) is used.
-    3. Else if `logger.level` is a string, it’s used (case-insensitive).
-    4. If none yield a valid level, falls back to `DEFAULT_LEVEL` (`"info"`).
+  1. If `logger.getLevel()` exists, its return value (case-insensitive) is used.
+  2. Else if `logger.level()` exists, its return (case-insensitive) is used.
+  3. Else if `logger.level` is a string, it’s used (case-insensitive).
+  4. If none yield a valid level, falls back to `DEFAULT_LEVEL` (`"info"`).
 - **Without a logger**:
-    - The wrapper starts in `OFF` mode and silences all messages.
+  - The wrapper starts in `OFF` mode and silences all messages.
 
 ### Log Levels
 
@@ -67,6 +67,7 @@ Note that changing the log level on the wrapper does not change the level of the
 If you need to change the log level you need to call method on both the wrapper and the underlying logger.
 
 For example:
+
 ```js
 import * as logLevel from 'loglevel'
 import QvacLogger from '@qvac/logging'
@@ -74,16 +75,15 @@ import QvacLogger from '@qvac/logging'
 logLevel.setLevel('warn')
 const log = new QvacLogger(logLevel)
 
-console.log(log.getLevel())    // 'warn'
-log.info('Info here')          // skipped
-log.error('Critical!')         // forwarded to logLevel.error
+console.log(log.getLevel()) // 'warn'
+log.info('Info here') // skipped
+log.error('Critical!') // forwarded to logLevel.error
 
-logLevel.setLevel('debug')     // change logLevel level
-log.setLevel('debug')          // change wrapper level
-console.log(log.getLevel())    // 'debug'
-log.debug('Debugging now!')   // forwarded to logLevel.debug
+logLevel.setLevel('debug') // change logLevel level
+log.setLevel('debug') // change wrapper level
+console.log(log.getLevel()) // 'debug'
+log.debug('Debugging now!') // forwarded to logLevel.debug
 ```
-
 
 ## Quickstart Example
 
@@ -94,9 +94,9 @@ import QvacLogger from '@qvac/logging'
 logLevel.setLevel('warn')
 const log = new QvacLogger(logLevel)
 
-console.log(log.getLevel())    // 'warn'
-log.info('Info here')          // skipped
-log.error('Critical!')         // forwarded to logLevel.error
+console.log(log.getLevel()) // 'warn'
+log.info('Info here') // skipped
+log.error('Critical!') // forwarded to logLevel.error
 ```
 
 ## SDK Integration Example
@@ -109,7 +109,7 @@ import * as logLevel from 'loglevel'
 logLevel.setLevel('debug')
 const log = new QvacLogger(logLevel)
 
-const qvac = new Qvac({logger: log})
+const qvac = new Qvac({ logger: log })
 await qvac.start()
 ```
 
@@ -120,4 +120,3 @@ Run unit tests with:
 ```bash
 npm test
 ```
-

--- a/packages/logging/constants.d.ts
+++ b/packages/logging/constants.d.ts
@@ -1,16 +1,16 @@
 export interface LogLevels {
-  readonly ERROR: "error";
-  readonly WARN: "warn";
-  readonly INFO: "info";
-  readonly DEBUG: "debug";
-  readonly OFF: "off";
+  readonly ERROR: 'error'
+  readonly WARN: 'warn'
+  readonly INFO: 'info'
+  readonly DEBUG: 'debug'
+  readonly OFF: 'off'
 }
 
 export interface LevelPriorities {
-  readonly [key: string]: number;
+  readonly [key: string]: number
 }
 
-export const LOG_LEVELS: LogLevels;
-export const DEFAULT_LEVEL: string;
-export const LEVEL_PRIORITIES: LevelPriorities;
-export const ENV_LOG_LEVEL: string;
+export const LOG_LEVELS: LogLevels
+export const DEFAULT_LEVEL: string
+export const LEVEL_PRIORITIES: LevelPriorities
+export const ENV_LOG_LEVEL: string

--- a/packages/logging/index.d.ts
+++ b/packages/logging/index.d.ts
@@ -1,55 +1,55 @@
-import { LOG_LEVELS } from "./constants";
+import { LOG_LEVELS } from './constants'
 
-type LogLevel = "error" | "warn" | "info" | "debug" | "off";
+type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'off'
 
 declare interface LoggerInterface {
   /** Log an error message. */
-  error: (...args: any[]) => void;
+  error: (...args: any[]) => void
   /** Log a warn message. */
-  warn: (...args: any[]) => void;
+  warn: (...args: any[]) => void
   /** Log an info message. */
-  info: (...args: any[]) => void;
+  info: (...args: any[]) => void
   /** Log a debug message. */
-  debug: (...args: any[]) => void;
+  debug: (...args: any[]) => void
   /** Optional method to get current level. */
-  getLevel?: () => string;
+  getLevel?: () => string
   /** Optional property or method for level. */
-  level?: string | (() => string);
+  level?: string | (() => string)
 }
 
 declare class QvacLogger {
   /** Expose the available log level constants. */
-  static LOG_LEVELS: typeof LOG_LEVELS;
+  static LOG_LEVELS: typeof LOG_LEVELS
 
   /**
    * Create a new QvacLogger.
    * @param logger Underlying logger implementing LoggerInterface.
    */
-  constructor(logger?: LoggerInterface);
+  constructor(logger?: LoggerInterface)
 
   /**
    * Update the current log level.
    * @param newLevel One of the LOG_LEVELS constants.
    */
-  setLevel(newLevel: LogLevel): void;
+  setLevel(newLevel: LogLevel): void
 
   /**
    * Get the current log level.
    * @returns The active log level.
    */
-  getLevel(): LogLevel;
+  getLevel(): LogLevel
 
   /** Log an error message if level permits. */
-  error(...msgs: any[]): void;
+  error(...msgs: any[]): void
   /** Log a warning message if level permits. */
-  warn(...msgs: any[]): void;
+  warn(...msgs: any[]): void
   /** Log an informational message if level permits. */
-  info(...msgs: any[]): void;
+  info(...msgs: any[]): void
   /** Log a debug message if level permits. */
-  debug(...msgs: any[]): void;
+  debug(...msgs: any[]): void
 }
 
 declare namespace QvacLogger {
-  export { QvacLogger as default, LogLevel, LoggerInterface };
+  export { QvacLogger as default, LogLevel, LoggerInterface }
 }
-export = QvacLogger;
+export = QvacLogger

--- a/packages/logging/index.js
+++ b/packages/logging/index.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const {
-  LOG_LEVELS, LEVEL_PRIORITIES, DEFAULT_LEVEL, ENV_LOG_LEVEL
-} = require('./constants')
+const { LOG_LEVELS, LEVEL_PRIORITIES, DEFAULT_LEVEL, ENV_LOG_LEVEL } = require('./constants')
 
 const env = require('./env')
 
@@ -11,10 +9,10 @@ const env = require('./env')
  * @param {Object} logger - Logger object to validate.
  * @throws {Error} If any required logging method is missing.
  */
-function assertLoggerInterface (logger) {
+function assertLoggerInterface(logger) {
   Object.values(LOG_LEVELS)
-    .filter(level => level !== LOG_LEVELS.OFF)
-    .forEach(method => {
+    .filter((level) => level !== LOG_LEVELS.OFF)
+    .forEach((method) => {
       if (typeof logger[method] !== 'function') {
         throw new Error(`Logger must implement method: ${method}`)
       }
@@ -33,28 +31,24 @@ function assertLoggerInterface (logger) {
  * @returns {string|null}
  *   The detected log level (one of LOG_LEVELS) if found, otherwise `null`.
  */
-function getLevelFromLogger (logger) {
+function getLevelFromLogger(logger) {
   if (typeof logger.getLevel === 'function') {
     const lvl = logger.getLevel()
-    if (typeof lvl === 'string' &&
-            Object.values(LOG_LEVELS).includes(lvl.toLowerCase())
-    ) {
+    if (typeof lvl === 'string' && Object.values(LOG_LEVELS).includes(lvl.toLowerCase())) {
       return lvl
     }
   }
 
   if (typeof logger.level === 'function') {
     const lvl = logger.level()
-    if (typeof lvl === 'string' &&
-            Object.values(LOG_LEVELS).includes(lvl.toLowerCase())
-    ) {
+    if (typeof lvl === 'string' && Object.values(LOG_LEVELS).includes(lvl.toLowerCase())) {
       return lvl
     }
   }
 
   if (
     typeof logger.level === 'string' &&
-        Object.values(LOG_LEVELS).includes(logger.level.toLowerCase())
+    Object.values(LOG_LEVELS).includes(logger.level.toLowerCase())
   ) {
     return logger.level
   }
@@ -66,7 +60,7 @@ function getLevelFromLogger (logger) {
  * Check the environment variable for a log level setting.
  * @returns {null|string} Valid log level or null if not set or invalid.
  */
-function getLogLevelFromEnv () {
+function getLogLevelFromEnv() {
   const envLevel = env[ENV_LOG_LEVEL] || env[`EXPO_PUBLIC_${ENV_LOG_LEVEL}`]
   if (envLevel && Object.values(LOG_LEVELS).includes(envLevel.toLowerCase())) {
     return envLevel.toLowerCase()
@@ -80,23 +74,23 @@ function getLogLevelFromEnv () {
  */
 class QvacLogger {
   /**
-     * Expose the available log level constants.
-     * @type {Object.<string,string>}
-     * @static
-     * @memberof QvacLogger
-     */
+   * Expose the available log level constants.
+   * @type {Object.<string,string>}
+   * @static
+   * @memberof QvacLogger
+   */
   static LOG_LEVELS = LOG_LEVELS
 
   /**
-     * Create a new QvacLogger.
-     *
-     * If no `logger` is provided, defaults to `console` and starts at OFF.
-     * Otherwise, it will inherit the wrapped logger’s own level (via .getLevel()
-     * or .level), falling back to DEFAULT_LEVEL if none is found.
-     *
-     * @param {Object} [logger] - Underlying logger with the required methods.
-     */
-  constructor (logger) {
+   * Create a new QvacLogger.
+   *
+   * If no `logger` is provided, defaults to `console` and starts at OFF.
+   * Otherwise, it will inherit the wrapped logger’s own level (via .getLevel()
+   * or .level), falling back to DEFAULT_LEVEL if none is found.
+   *
+   * @param {Object} [logger] - Underlying logger with the required methods.
+   */
+  constructor(logger) {
     this._logger = logger
 
     if (!this._logger) {
@@ -111,12 +105,12 @@ class QvacLogger {
   }
 
   /**
-     * Update the current log level.
-     *
-     * @param {string} newLevel - One of the LOG_LEVELS constants.
-     * @throws {Error} If `newLevel` is not a valid level.
-     */
-  setLevel (newLevel) {
+   * Update the current log level.
+   *
+   * @param {string} newLevel - One of the LOG_LEVELS constants.
+   * @throws {Error} If `newLevel` is not a valid level.
+   */
+  setLevel(newLevel) {
     if (!Object.values(LOG_LEVELS).includes(newLevel)) {
       throw new Error(`Invalid log level: ${newLevel}`)
     }
@@ -124,42 +118,46 @@ class QvacLogger {
   }
 
   /**
-     * Get the current log level.
-     *
-     * @returns {string} The active log level.
-     */
-  getLevel () {
+   * Get the current log level.
+   *
+   * @returns {string} The active log level.
+   */
+  getLevel() {
     return this._level
   }
 
   /**
-     * Internal helper to route messages to the underlying logger
-     * if the message’s level is at-or-above the current threshold.
-     *
-     * @private
-     * @param {string} level - Level of this message.
-     * @param {...*} messages - Data or strings to log.
-     */
-  _log (level, ...messages) {
-    if (!this._logger || this._level === LOG_LEVELS.OFF || LEVEL_PRIORITIES[level] > LEVEL_PRIORITIES[this._level]) {
+   * Internal helper to route messages to the underlying logger
+   * if the message’s level is at-or-above the current threshold.
+   *
+   * @private
+   * @param {string} level - Level of this message.
+   * @param {...*} messages - Data or strings to log.
+   */
+  _log(level, ...messages) {
+    if (
+      !this._logger ||
+      this._level === LOG_LEVELS.OFF ||
+      LEVEL_PRIORITIES[level] > LEVEL_PRIORITIES[this._level]
+    ) {
       return
     }
     this._logger[level](...messages)
   }
 
-  error (...msgs) {
+  error(...msgs) {
     this._log(LOG_LEVELS.ERROR, ...msgs)
   }
 
-  warn (...msgs) {
+  warn(...msgs) {
     this._log(LOG_LEVELS.WARN, ...msgs)
   }
 
-  info (...msgs) {
+  info(...msgs) {
     this._log(LOG_LEVELS.INFO, ...msgs)
   }
 
-  debug (...msgs) {
+  debug(...msgs) {
     this._log(LOG_LEVELS.DEBUG, ...msgs)
   }
 }

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "lint": "standard",
-    "lint:fix": "standard --fix",
+    "lint": "lunte",
+    "lint:fix": "lunte --fix",
     "test": "npm run test:unit",
     "test:unit": "npm run test:unit:generate && bare test/unit/all.js",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js"
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/tetherto/qvac/tree/main/packages/logging#readme",
   "devDependencies": {
     "brittle": "^3.15.0",
-    "standard": "^17.1.2"
+    "lunte": "^1.8.1"
   },
   "imports": {
     "./env": {

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "lint": "lunte",
     "lint:fix": "lunte --fix",
-    "test": "npm run test:unit",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
+    "test": "npm run lint && npm run format && npm run test:unit",
     "test:unit": "npm run test:unit:generate && bare test/unit/all.js",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js"
   },
@@ -21,7 +23,9 @@
   "homepage": "https://github.com/tetherto/qvac/tree/main/packages/logging#readme",
   "devDependencies": {
     "brittle": "^3.15.0",
-    "lunte": "^1.8.1"
+    "lunte": "^1.8.1",
+    "prettier": "^3.8.4",
+    "prettier-config-holepunch": "^2.0.0"
   },
   "imports": {
     "./env": {

--- a/packages/logging/test/unit/QvacLogger.test.js
+++ b/packages/logging/test/unit/QvacLogger.test.js
@@ -3,14 +3,9 @@
 const test = require('brittle')
 const process = require('bare-process')
 const QvacLogger = require('../..')
-const {
-  LOG_LEVELS,
-  LEVEL_PRIORITIES,
-  DEFAULT_LEVEL,
-  ENV_LOG_LEVEL
-} = require('../../constants')
+const { LOG_LEVELS, LEVEL_PRIORITIES, DEFAULT_LEVEL, ENV_LOG_LEVEL } = require('../../constants')
 
-function createDummy () {
+function createDummy() {
   const calls = []
   const logger = {}
   for (const m of ['error', 'warn', 'info', 'debug']) {
@@ -19,19 +14,19 @@ function createDummy () {
   return { logger, calls }
 }
 
-function createWithGetLevel (level) {
+function createWithGetLevel(level) {
   const { logger, calls } = createDummy()
   logger.getLevel = () => level
   return { logger, calls }
 }
 
-function createWithLevelProp (level) {
+function createWithLevelProp(level) {
   const { logger, calls } = createDummy()
   logger.level = level
   return { logger, calls }
 }
 
-function createWithLevelFn (level) {
+function createWithLevelFn(level) {
   const { logger, calls } = createDummy()
   logger.level = () => level
   return { logger, calls }
@@ -39,12 +34,12 @@ function createWithLevelFn (level) {
 
 // ––– Tests –––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
 
-test('no-arg constructor → set log level to OFF', t => {
+test('no-arg constructor → set log level to OFF', (t) => {
   const log = new QvacLogger()
   t.is(log.getLevel(), LOG_LEVELS.OFF)
 })
 
-test('default level = DEFAULT_LEVEL when a logger is passed and level cannot be inferred', t => {
+test('default level = DEFAULT_LEVEL when a logger is passed and level cannot be inferred', (t) => {
   const { logger, calls } = createDummy()
   const log = new QvacLogger(logger)
   t.is(log.getLevel(), DEFAULT_LEVEL)
@@ -53,45 +48,45 @@ test('default level = DEFAULT_LEVEL when a logger is passed and level cannot be 
   log.warn('w')
   log.info('i')
   log.debug('d')
-  t.ok(calls.some(c => c[0] === 'error'))
-  t.ok(calls.some(c => c[0] === 'warn'))
-  t.ok(calls.some(c => c[0] === 'info'))
-  t.ok(calls.every(c => c[0] !== 'debug'))
+  t.ok(calls.some((c) => c[0] === 'error'))
+  t.ok(calls.some((c) => c[0] === 'warn'))
+  t.ok(calls.some((c) => c[0] === 'info'))
+  t.ok(calls.every((c) => c[0] !== 'debug'))
 })
 
-test('inherits level from logger.getLevel()', t => {
+test('inherits level from logger.getLevel()', (t) => {
   const { logger, calls } = createWithGetLevel(LOG_LEVELS.WARN)
   const log = new QvacLogger(logger)
   t.is(log.getLevel(), LOG_LEVELS.WARN)
   log.error('e')
   log.warn('w')
   log.info('i')
-  t.ok(calls.some(c => c[0] === 'error'))
-  t.ok(calls.some(c => c[0] === 'warn'))
-  t.ok(calls.every(c => c[0] !== 'info'))
+  t.ok(calls.some((c) => c[0] === 'error'))
+  t.ok(calls.some((c) => c[0] === 'warn'))
+  t.ok(calls.every((c) => c[0] !== 'info'))
 })
 
-test('inherits level from logger.level property', t => {
+test('inherits level from logger.level property', (t) => {
   const { logger, calls } = createWithLevelProp(LOG_LEVELS.ERROR)
   const log = new QvacLogger(logger)
   t.is(log.getLevel(), LOG_LEVELS.ERROR)
   log.error('e')
   log.warn('w')
-  t.ok(calls.some(c => c[0] === 'error'))
-  t.ok(calls.every(c => c[0] !== 'warn'))
+  t.ok(calls.some((c) => c[0] === 'error'))
+  t.ok(calls.every((c) => c[0] !== 'warn'))
 })
 
-test('inherits level from logger.level() function', t => {
+test('inherits level from logger.level() function', (t) => {
   const { logger, calls } = createWithLevelFn(LOG_LEVELS.ERROR)
   const log = new QvacLogger(logger)
   t.is(log.getLevel(), LOG_LEVELS.ERROR)
   log.error('e')
   log.warn('w')
-  t.ok(calls.some(c => c[0] === 'error'))
-  t.ok(calls.every(c => c[0] !== 'warn'))
+  t.ok(calls.some((c) => c[0] === 'error'))
+  t.ok(calls.every((c) => c[0] !== 'warn'))
 })
 
-test('getLevelReflects setLevel', t => {
+test('getLevelReflects setLevel', (t) => {
   const { logger } = createDummy()
   const log = new QvacLogger(logger)
   log.setLevel(LOG_LEVELS.DEBUG)
@@ -100,18 +95,18 @@ test('getLevelReflects setLevel', t => {
   t.is(log.getLevel(), LOG_LEVELS.ERROR)
 })
 
-test('setLevel invalid → throws', t => {
+test('setLevel invalid → throws', (t) => {
   const { logger } = createDummy()
   const log = new QvacLogger(logger)
   t.exception(() => log.setLevel('not-a-level'), /Invalid log level: not-a-level/)
 })
 
-test('constructor rejects logger missing methods', t => {
+test('constructor rejects logger missing methods', (t) => {
   // omit one or more of error/warn/info/debug
   t.exception(() => new QvacLogger({}), /Logger must implement method/)
 })
 
-test('per-level gating respects LEVEL_PRIORITIES', t => {
+test('per-level gating respects LEVEL_PRIORITIES', (t) => {
   const { logger, calls } = createDummy()
   const log = new QvacLogger(logger)
 
@@ -131,13 +126,13 @@ test('per-level gating respects LEVEL_PRIORITIES', t => {
       if (msgLevel === LOG_LEVELS.OFF) continue
 
       const shouldLog = LEVEL_PRIORITIES[msgLevel] <= LEVEL_PRIORITIES[level]
-      const found = calls.some(c => c[0] === msgLevel)
+      const found = calls.some((c) => c[0] === msgLevel)
       t.is(found, shouldLog, `at level=${level}, ${msgLevel} logged? ${shouldLog}`)
     }
   }
 })
 
-test('OFF level disables all logs', t => {
+test('OFF level disables all logs', (t) => {
   const { logger, calls } = createDummy()
   const log = new QvacLogger(logger)
   log.setLevel(LOG_LEVELS.OFF)
@@ -148,7 +143,7 @@ test('OFF level disables all logs', t => {
   t.is(calls.length, 0)
 })
 
-test('reads level from environment variable', t => {
+test('reads level from environment variable', (t) => {
   const existingLogLevel = process.env[ENV_LOG_LEVEL] ?? ''
   process.env.QVAC_LOG_LEVEL = LOG_LEVELS.DEBUG
 
@@ -157,14 +152,14 @@ test('reads level from environment variable', t => {
   t.is(log.getLevel(), LOG_LEVELS.DEBUG)
   log.info('info')
   log.debug('debug')
-  t.ok(calls.some(c => c[0] === 'info'))
-  t.ok(calls.some(c => c[0] === 'debug'))
+  t.ok(calls.some((c) => c[0] === 'info'))
+  t.ok(calls.some((c) => c[0] === 'debug'))
 
   // Restore original environment variable
   process.env.QVAC_LOG_LEVEL = existingLogLevel
 })
 
-test('environment variable takes precedence over logger level', t => {
+test('environment variable takes precedence over logger level', (t) => {
   const existingLogLevel = process.env[ENV_LOG_LEVEL] ?? ''
   process.env.QVAC_LOG_LEVEL = LOG_LEVELS.ERROR
 
@@ -173,8 +168,8 @@ test('environment variable takes precedence over logger level', t => {
   t.is(log.getLevel(), LOG_LEVELS.ERROR)
   log.info('info')
   log.error('error')
-  t.ok(calls.some(c => c[0] === 'error'))
-  t.ok(calls.every(c => c[0] !== 'info'))
+  t.ok(calls.some((c) => c[0] === 'error'))
+  t.ok(calls.every((c) => c[0] !== 'info'))
 
   // Restore original environment variable
   process.env.QVAC_LOG_LEVEL = existingLogLevel


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Replaces `standard` with Lunte for linting in `@qvac/logging`.
- Adopts Prettier with the shared `prettier-config-holepunch` config for formatting.

## 📝 How does it solve it?

- Swap the `lint`/`lint:fix` scripts and the dev dependency from `standard` to `lunte`.
- Add `prettier` + `prettier-config-holepunch` dev deps and a `.prettierrc` that extends `prettier-config-holepunch`.
- Add `format`/`format:fix` scripts and chain `lint` and `format` into `test`, so `npm test` enforces both (the package's `test` previously ran only `test:unit`).
- Reformat the package with Prettier.

## 🧪 How was it tested?

- `lunte` passes with no issues — no suppressions were needed.
- `prettier --check .` passes clean.