### PR TITLE
QVAC-21185 feat[api]: forward remove_thinking_from_context through serve OpenAI API

### DIFF
--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -114,7 +114,7 @@ Blocking response shape (single prompt):
 
 Same as `/v1/chat/completions`: `temperature`, `max_tokens`,
 `max_completion_tokens`, `top_p`, `seed`, `frequency_penalty`,
-`presence_penalty`, `reasoning_budget`.
+`presence_penalty`, `reasoning_budget`, `remove_thinking_from_context`.
 
 ### Ignored parameters (warning logged)
 

--- a/packages/cli/src/serve/schemas/common.ts
+++ b/packages/cli/src/serve/schemas/common.ts
@@ -75,6 +75,7 @@ export interface GenerationParams {
   presence_penalty?: number
   repeat_penalty?: number
   reasoning_budget?: -1 | 0
+  remove_thinking_from_context?: boolean
 }
 
 export type ResponseFormat =
@@ -223,6 +224,10 @@ export function extractGenerationParams (
     params.reasoning_budget = body['reasoning_budget'] ? -1 : 0
   } else if (body['reasoning_budget'] === -1 || body['reasoning_budget'] === 0) {
     params.reasoning_budget = body['reasoning_budget']
+  }
+
+  if (typeof body['remove_thinking_from_context'] === 'boolean') {
+    params.remove_thinking_from_context = body['remove_thinking_from_context']
   }
 
   return Object.keys(params).length > 0 ? params : undefined

--- a/packages/cli/test/translate.test.ts
+++ b/packages/cli/test/translate.test.ts
@@ -456,6 +456,23 @@ describe('extractGenerationParams (chat semantics)', () => {
     assert.equal(params, undefined)
   })
 
+  it('extracts remove_thinking_from_context true', () => {
+    const params = extractChat({ remove_thinking_from_context: true })
+    assert.ok(params)
+    assert.equal(params.remove_thinking_from_context, true)
+  })
+
+  it('extracts remove_thinking_from_context false', () => {
+    const params = extractChat({ remove_thinking_from_context: false })
+    assert.ok(params)
+    assert.equal(params.remove_thinking_from_context, false)
+  })
+
+  it('ignores non-boolean remove_thinking_from_context', () => {
+    const params = extractChat({ remove_thinking_from_context: 1 })
+    assert.equal(params, undefined)
+  })
+
   it('ignores non-number values', () => {
     const params = extractChat({ temperature: 'hot', max_tokens: '100' })
     assert.equal(params, undefined)


### PR DESCRIPTION
> **Draft — blocked on the SDK side.** Hold until QVAC-21185 (SDK) #2797 merges and an SDK release defining `generationParams.remove_thinking_from_context` is published. Then bump the CLI `@qvac/sdk` floor to that release and mark ready.

## 🎯 What problem does this PR solve?

- The SDK exposes a per-request `generationParams.remove_thinking_from_context` flag (QVAC-21185 / #2797) that drops a turn's reasoning block from the KV cache, but the CLI's OpenAI-compatible server (`qvac serve openai`) had no way to forward it.

## 📝 How does it solve it?

- `extractGenerationParams` reads a boolean `remove_thinking_from_context` from the chat/completions request body and carries it on the serve `GenerationParams`, so it reaches the SDK `completion()` call alongside the existing `reasoning_budget` passthrough.
- Documented in the serve OpenAI param list.

## 🧪 How was it tested?

- CLI unit suite (`npx tsx --test test/translate.test.ts`) — added extractor cases (reads `true`/`false`, ignores non-boolean); 106/106 pass.
- Typecheck clean for the touched files.

## 🔌 API Changes

```jsonc
// POST /v1/chat/completions
{ "model": "qwen3...", "messages": [...], "remove_thinking_from_context": true }
```

The SDK completion schema is strict, so this field is only accepted once an installed SDK release defines `generationParams.remove_thinking_from_context`. The `@qvac/sdk` dependency floor bump is deferred to this PR's ready-for-review pass, once that release exists.
