### PR TITLE
QVAC-21281 chore: add updated Supertonic 3 q4 model

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -4941,7 +4941,7 @@
     "link": "https://huggingface.co/supertone/supertonic-3"
   },
   {
-    "source": "s3:///qvac_models_compiled/ggml/supertonic/2026-06-15/supertonic3-q4_0.gguf",
+    "source": "s3:///qvac_models_compiled/ggml/supertonic/2026-06-24/supertonic3-q4_0.gguf",
     "engine": "@qvac/tts-ggml",
     "description": "Supertonic 3 TTS (GGUF, multilingual)",
     "quantization": "q4_0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- QVAC-21281
- The existing Supertonic 3 `q4_0` GGUF model was producing unclean output.
- The SDK model update flow needs the registry to point at the corrected q4 artifact so `bun run update-models` picks up the new model.

## 📝 How does it solve it?

- Updates the existing Supertonic 3 `q4_0` entry in `packages/registry-server/data/models.prod.json`.
- Replaces the old `2026-06-15` S3 source with the re-quantized `2026-06-24` artifact:
  `s3:///qvac_models_compiled/ggml/supertonic/2026-06-24/supertonic3-q4_0.gguf`

## 🧪 How was it tested?

- Validated `packages/registry-server/data/models.prod.json` parses successfully as JSON.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215969225932067