### PR TITLE
QVAC-20549 feat[api]: support more Chatterbox languages

### DIFF
--- a/packages/sdk/schemas/text-to-speech.ts
+++ b/packages/sdk/schemas/text-to-speech.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { modelSrcInputSchema } from "./model-src-utils";
 
-// Chatterbox multilingual supported languages (18). The engines support
+// Chatterbox multilingual supported languages (22). The engines support
 // different language sets, so the language enum is validated per engine.
 export const TTS_CHATTERBOX_LANGUAGES = [
   "en", // English
@@ -22,6 +22,10 @@ export const TTS_CHATTERBOX_LANGUAGES = [
   "sw", // Swahili
   "ar", // Arabic
   "ko", // Korean
+  "he", // Hebrew
+  "ru", // Russian
+  "zh", // Chinese
+  "hi", // Hindi
 ] as const;
 
 // Supertonic supported languages (31, as of Supertonic 3). Earlier Supertonic
@@ -68,14 +72,12 @@ const TTS_SUPERTONIC_ONLY_LANGUAGES = [
   "bg", // Bulgarian
   "cs", // Czech
   "et", // Estonian
-  "hi", // Hindi
   "hr", // Croatian
   "hu", // Hungarian
   "id", // Indonesian
   "lt", // Lithuanian
   "lv", // Latvian
   "ro", // Romanian
-  "ru", // Russian
   "sk", // Slovak
   "sl", // Slovenian
   "uk", // Ukrainian

--- a/packages/sdk/test/unit/tts-schemas.test.ts
+++ b/packages/sdk/test/unit/tts-schemas.test.ts
@@ -82,16 +82,17 @@ test("ttsConfigSchema: accepts GGML supertonic load config", (t) => {
   t.is(r.success, true);
 });
 
-test("TTS_CHATTERBOX_LANGUAGES: exposes all 18 supported languages", (t) => {
-  t.is(TTS_CHATTERBOX_LANGUAGES.length, 18);
+test("TTS_CHATTERBOX_LANGUAGES: exposes all 22 supported languages", (t) => {
+  t.is(TTS_CHATTERBOX_LANGUAGES.length, 22);
   const expected = [
     "en", "es", "fr", "de", "it", "pt", "nl", "pl", "tr",
     "sv", "da", "fi", "no", "el", "ms", "sw", "ar", "ko",
+    "he", "ru", "zh", "hi",
   ];
   t.alike([...TTS_CHATTERBOX_LANGUAGES], expected);
 });
 
-test("ttsChatterboxRuntimeConfigSchema: accepts all 18 chatterbox languages", (t) => {
+test("ttsChatterboxRuntimeConfigSchema: accepts all 22 chatterbox languages", (t) => {
   for (const language of TTS_CHATTERBOX_LANGUAGES) {
     const r = ttsChatterboxRuntimeConfigSchema.safeParse({
       ttsEngine: "chatterbox",
@@ -133,10 +134,10 @@ test("ttsSupertonicRuntimeConfigSchema: rejects chatterbox-only languages", (t) 
 test("ttsConfigSchema: accepts a chatterbox-only language for chatterbox", (t) => {
   const r = ttsConfigSchema.safeParse({
     ttsEngine: "chatterbox",
-    language: "tr",
+    language: "he",
     s3genModelSrc: "s3:///example/s3gen.gguf",
   });
-  t.is(r.success, true, "chatterbox load config accepts 'tr'");
+  t.is(r.success, true, "chatterbox load config accepts 'he'");
 });
 
 test("ttsSupertonicRuntimeConfigSchema: strips removed ttsSupertonicMultilingual", (t) => {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Chatterbox model configs rejected `he`, `ru`, `zh`, and `hi` even though the engine supports them.
- Apps could not declare those languages through the SDK typed TTS config surface.

## 📝 How does it solve it?

- Adds `he`, `ru`, `zh`, and `hi` to `TTS_CHATTERBOX_LANGUAGES`.
- Keeps the aggregate `TTS_LANGUAGES` union deduplicated now that `ru` and `hi` are shared by Chatterbox and Supertonic.
- Updates TTS schema tests to pin the expanded 22-language Chatterbox set.

## 🧪 How was it tested?

- `bun run test/unit/tts-schemas.test.ts`
- `npm run typecheck`

## 🔌 API Changes

```typescript
import { TTS_CHATTERBOX_LANGUAGES } from "@qvac/sdk";

await loadModel({
  modelSrc: "...",
  modelConfig: {
    ttsEngine: "chatterbox",
    language: "zh",
    s3genModelSrc: "...",
  },
});

// TTS_CHATTERBOX_LANGUAGES now includes: he, ru, zh, hi
```

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215594274579701