### PR TITLE
QVAC-19557 tts-ggml: consume tts-cpp 2026-06-24 (S3Tokenizer host-mirror elimination)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Bump the `tts-cpp` pin to `2026-06-24`** (`qvac-ext-lib-whisper.cpp` master
+  `46921668`, PR #65), consumed from `qvac-registry-vcpkg`. Brings QVAC-19557
+  **S3TokenizerV2 host-mirror elimination**: the Chatterbox voice-conditioning
+  bake no longer holds the ~458 MB S3Tokenizer encoder weights in a host
+  `std::vector` mirror *and* the backend (Metal) weight buffer simultaneously —
+  `build_encoder_ctx` now streams each encoder tensor straight from the GGUF
+  into its backend tensor (8 MiB chunks, no host mirror). This drops the
+  ~900 MB dual-residency that dominated the Chatterbox first-`synthesize()`
+  peak; on-device (iPhone 17 Pro Max) the first-test peak falls from ~3184 MB to
+  ~2772 MB (under the ~3 GB iOS jetsam budget), warm synthesis unchanged, and
+  the produced audio is bit-identical (same tensor names/shapes/dtypes). The
+  `default-registry` baseline advances to `1130cabb` so the new pin resolves.
+
 ## [0.3.4] - 2026-06-23
 
 ### Added

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "233c2d41bf10d7a3c4150a0a7a515333b1437ad1",
+    "baseline": "1130cabbc0bf939487cdf0f294019cc31c9ce765",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-06-22"
+      "version>=": "2026-06-24"
     }
   ],
   "features": {


### PR DESCRIPTION
Bumps the `tts-cpp` pin to **`2026-06-24`** (qvac-ext-lib-whisper.cpp master `46921668`, PR #65) and advances the `default-registry` baseline to `1130cabb` so it resolves.

**What it brings:** QVAC-19557 **S3TokenizerV2 host-mirror elimination** — the Chatterbox voice-conditioning bake no longer holds the ~458 MB tokenizer encoder weights in both a host mirror and the backend buffer (~900 MB dual-resident). On-device (iPhone 17 Pro Max) the Chatterbox first-`synthesize()` peak drops **~3184 → ~2772 MB** (under the ~3 GB iOS jetsam budget); warm synthesis unchanged; audio bit-identical.

CHANGELOG entry is under **`[Unreleased]`** — the package version release is a separate follow-up. No `package.json` version bump here.

**Separate follow-up PR** un-skips the iOS `tts-chatterbox` SDK e2e (now that the peak clears budget); this PR is just the dependency bump + changelog.