### PR TITLE
QVAC-19119 feat[api]: bump qvac-fabric to 9341.1.0 + release @qvac/llm-llamacpp 0.30.0

### DIFF
--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -1030,6 +1030,32 @@ void LlamaModel::commonParamsParse(
     }
   }
 
+  // parse image-tile-mode (not in LLAMA_EXAMPLE_COMMON, must be handled
+  // manually before configVector is built)
+  for (const std::string& key : {"image-tile-mode", "image_tile_mode"}) {
+    if (auto it = configFilemap.find(key); it != configFilemap.end()) {
+      std::string val = it->second;
+      std::transform(val.begin(), val.end(), val.begin(), ::tolower);
+      if (val == "0" || val == "batched") {
+        params.image_tile_mode = COMMON_IMAGE_TILE_MODE_BATCHED;
+      } else if (val == "1" || val == "sequential") {
+        params.image_tile_mode = COMMON_IMAGE_TILE_MODE_SEQUENTIAL;
+      } else if (val == "2" || val == "disabled") {
+        params.image_tile_mode = COMMON_IMAGE_TILE_MODE_DISABLED;
+      } else {
+        throw qvac_errors::StatusError(
+            ADDON_ID,
+            qvac_errors::general_error::toString(
+                qvac_errors::general_error::InvalidArgument),
+            string_format(
+                "image-tile-mode must be 0/batched, 1/sequential, or "
+                "2/disabled, got: %s",
+                it->second.c_str()));
+      }
+      configFilemap.erase(it);
+    }
+  }
+
   // parse custom nDiscarded from config (apply only if > 0)
   if (auto iter = configFilemap.find("n_discarded");
       iter != configFilemap.end()) {

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -164,6 +164,7 @@ void MtmdLlmContext::initVisionContext() {
       params_.mmproj_backend.empty() ? nullptr : params_.mmproj_backend.c_str();
   mparams.print_timings = true;
   mparams.n_threads = params_.cpuparams.n_threads;
+  mparams.image_tile_mode = params_.image_tile_mode;
   // Forward the per-image token budget to the vision encoder. These were
   // previously dropped: the addon parsed image_min/max_tokens into
   // common_params but never copied them into mtmd_context_params, so a

--- a/packages/llm-llamacpp/vcpkg.json
+++ b/packages/llm-llamacpp/vcpkg.json
@@ -9,7 +9,7 @@
     "concurrentqueue",
     {
       "name": "qvac-fabric",
-      "version>=": "9341.0.0"
+      "version>=": "9341.1.0"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
## Summary

Phase B2 rollout of qvac-fabric 9341.1.0 (Qwen3.5-VL multi-tile batching) for llm-llamacpp.

- Bump `qvac-fabric` `version>=` 9341.0.0 → 9341.1.0 (uses published registry port, overlay removed)
- Add `--image-tile-mode` config key parsing in `LlamaModel::commonParamsParse` (0=batched, 1=sequential, 2=disabled)
- Forward `image_tile_mode` to `mtmd_context_params` in `MtmdLlmContext::initVisionContext`

Fabric source: tetherto/qvac-fabric-llm.cpp#161
Registry: tetherto/qvac-registry-vcpkg#209

## Test plan

- [ ] CI green on all platforms (darwin-arm64, linux, win32, mobile)
- [ ] `--image-tile-mode batched/sequential/disabled` accepted and forwarded to mtmd

🤖 Generated with [Claude Code](https://claude.com/claude-code)
