### PR TITLE
QVAC-19119 feat[api]: bump qvac-fabric to 9341.1.0 (vla-ggml)

### DIFF
--- a/packages/vla-ggml/vcpkg.json
+++ b/packages/vla-ggml/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "9341.0.0"
+      "version>=": "9341.1.0"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
## Summary

Phase B2 rollout of qvac-fabric 9341.1.0 (Qwen3.5-VL multi-tile batching) for vla-ggml.

- Bump `qvac-fabric` `version>=` 9341.0.0 → 9341.1.0 (uses published registry port, overlay removed)

Fabric source: tetherto/qvac-fabric-llm.cpp#161
Registry: tetherto/qvac-registry-vcpkg#209

## Test plan

- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
