### PR TITLE
QVAC-19119 feat[api]: bump qvac-fabric to 9341.1.0 (ocr-ggml)

### DIFF
--- a/packages/ocr-ggml/vcpkg.json
+++ b/packages/ocr-ggml/vcpkg.json
@@ -20,7 +20,7 @@
     {
       "name": "qvac-fabric",
       "default-features": false,
-      "version>=": "9341.0.0",
+      "version>=": "9341.1.0",
       "features": [
         "gpu-backends"
       ]


### PR DESCRIPTION
## Summary

Phase B2 rollout of qvac-fabric 9341.1.0 (Qwen3.5-VL multi-tile batching) for ocr-ggml.

- Bump `qvac-fabric` `version>=` 9341.0.0 → 9341.1.0 (uses published registry port, overlay removed)

Fabric source: tetherto/qvac-fabric-llm.cpp#161
Registry: tetherto/qvac-registry-vcpkg#209

## Test plan

- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
