### PR TITLE
QVAC-19119 chore[notask]: release package versions for qvac-fabric 9341.1.0

### DIFF
--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-06-24
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.0.0` → `9341.1.0` (Qwen3.5-VL multi-tile batching; no API change for this package).
+
+## Pull Requests
+
+- [#2838](https://github.com/tetherto/qvac/pull/2838) - QVAC-19119 feat[api]: bump qvac-fabric to 9341.1.0 (classification-ggml)
+
 ## [0.6.1] - 2026-06-22
 
 ### Changed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {

--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.23.0] - 2026-06-24
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.0.0` → `9341.1.0` (Qwen3.5-VL multi-tile batching; no API change for this package).
+
+## Pull Requests
+
+- [#2837](https://github.com/tetherto/qvac/pull/2837) - QVAC-19119 feat[api]: bump qvac-fabric to 9341.1.0 (embed-llamacpp)
+
 ## [0.22.1] - 2026-06-22
 
 ### Changed

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,4 +1,21 @@
 # Changelog
+## [0.30.0] - 2026-06-24
+
+Adds Qwen3.5-VL multi-tile batching via the `--image-tile-mode` config key, backed by `qvac-fabric` 9341.1.0.
+
+### New APIs
+
+- `image-tile-mode` / `image_tile_mode` config key: `0`/`batched`, `1`/`sequential` (default), `2`/`disabled`. Controls how multi-tile Qwen3.5-VL images are encoded.
+- OOM fallback: if batched encoding fails, encoder retries in sequential mode.
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.0.0` → `9341.1.0`.
+
+## Pull Requests
+
+- [#2836](https://github.com/tetherto/qvac/pull/2836) - QVAC-19119 feat[api]: bump qvac-fabric to 9341.1.0 (llm-llamacpp)
+
 ## [0.29.3] - 2026-06-24
 
 This release fixes per-image token budgets for multimodal (vision) contexts, which were previously parsed but never forwarded to the vision encoder, and adds a sensible default cap for Qwen-VL encoders to bound encode cost on high-resolution images.

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.29.3",
+  "version": "0.30.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this package will be documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-06-24
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.0.0` → `9341.1.0` (Qwen3.5-VL multi-tile batching; no API change for this package).
+
+## Pull Requests
+
+- [#2841](https://github.com/tetherto/qvac/pull/2841) - QVAC-19119 feat[api]: bump qvac-fabric to 9341.1.0 (ocr-ggml)
+
 ## [0.6.0] - 2026-06-22
 
 ### Changed

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-ggml",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "GGML-backed OCR addon for qvac (EasyOCR pipeline on GGUF weights)",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.0] - 2026-06-24
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.0.0` → `9341.1.0` (Qwen3.5-VL multi-tile batching; no API change for this package).
+
+## Pull Requests
+
+- [#2839](https://github.com/tetherto/qvac/pull/2839) - QVAC-19119 feat[api]: bump qvac-fabric to 9341.1.0 (translation-nmtcpp)
+
 ## [6.2.1] - 2026-06-22
 
 ### Changed

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "6.2.1",
+  "version": "6.3.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.7.0] - 2026-06-24
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.0.0` → `9341.1.0` (Qwen3.5-VL multi-tile batching; no API change for this package).
+
+## Pull Requests
+
+- [#2840](https://github.com/tetherto/qvac/pull/2840) - QVAC-19119 feat[api]: bump qvac-fabric to 9341.1.0 (vla-ggml)
+
 ## [0.6.1] - 2026-06-22
 
 ### Changed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary

- Bumps all 6 consumer package versions to track `qvac-fabric 9341.1.0` (Qwen3.5-VL multi-tile batching)
- `llm-llamacpp` 0.29.3 → 0.30.0 (new `image-tile-mode` API)
- `embed-llamacpp` 0.22.1 → 0.23.0
- `classification-ggml` 0.6.1 → 0.7.0
- `translation-nmtcpp` 6.2.1 → 6.3.0
- `vla-ggml` 0.6.1 → 0.7.0
- `ocr-ggml` 0.6.0 → 0.7.0

## Related PRs

vcpkg.json bumps (addon PRs):
- #2836 llm-llamacpp (also adds `image-tile-mode` C++ support)
- #2837 embed-llamacpp
- #2838 classification-ggml
- #2839 translation-nmtcpp
- #2840 vla-ggml
- #2841 ocr-ggml

Registry: tetherto/qvac-registry-vcpkg#209
Overlay: tetherto/qvac-overlay#161