### PR TITLE
QVAC-20557 test[notask]: DO NOT MERGE main-baseline 12 kHz tone check (CPU turbo+m…

### DIFF
--- a/packages/tts-ggml/scripts/generate-mobile-integration-tests.js
+++ b/packages/tts-ggml/scripts/generate-mobile-integration-tests.js
@@ -14,14 +14,29 @@ const integrationDir = path.join(repoRoot, 'test', 'integration')
 const mobileDir = path.join(repoRoot, 'test', 'mobile')
 const outputFile = path.join(mobileDir, 'integration.auto.cjs')
 
+// QVAC-20557 DIAGNOSTIC (DO NOT MERGE): restrict the device-farm run to the
+// 12 kHz-tone diagnostic tests so each gets its own ~7.5-min module budget
+// and we get a fast, focused answer.  Empty array => run the full suite (the
+// shipped behaviour).  validate-mobile-tests.js applies the SAME filter so
+// the generated file stays in sync.  Revert to `[]` before merging.
+const MOBILE_DIAG_SUBSET = [
+  'chatterbox-tone-cpu-mtl.test.js',
+  'chatterbox-tone-cpu-turbo.test.js'
+]
+
 function getIntegrationFiles () {
   if (!fs.existsSync(integrationDir)) {
     throw new Error(`Integration directory not found: ${integrationDir}`)
   }
 
-  return fs.readdirSync(integrationDir)
+  const all = fs.readdirSync(integrationDir)
     .filter(entry => entry.endsWith('.test.js'))
     .sort()
+
+  if (MOBILE_DIAG_SUBSET.length > 0) {
+    return all.filter(entry => MOBILE_DIAG_SUBSET.includes(entry))
+  }
+  return all
 }
 
 function toFunctionName (fileName) {

--- a/packages/tts-ggml/scripts/validate-mobile-tests.js
+++ b/packages/tts-ggml/scripts/validate-mobile-tests.js
@@ -13,14 +13,28 @@ const repoRoot = path.resolve(__dirname, '..')
 const integrationDir = path.join(repoRoot, 'test', 'integration')
 const mobileAutoFile = path.join(repoRoot, 'test', 'mobile', 'integration.auto.cjs')
 
+// QVAC-20557 DIAGNOSTIC (DO NOT MERGE): mirror generate-mobile-integration-tests.js's
+// MOBILE_DIAG_SUBSET so validation expects the same restricted set.  Empty
+// array => validate against the full suite (the shipped behaviour).  Revert
+// to `[]` before merging.
+const MOBILE_DIAG_SUBSET = [
+  'chatterbox-tone-cpu-mtl.test.js',
+  'chatterbox-tone-cpu-turbo.test.js'
+]
+
 function getIntegrationTestFiles () {
   if (!fs.existsSync(integrationDir)) {
     throw new Error(`Integration directory not found: ${integrationDir}`)
   }
 
-  return fs.readdirSync(integrationDir)
+  const all = fs.readdirSync(integrationDir)
     .filter(f => f.endsWith('.test.js'))
     .sort()
+
+  if (MOBILE_DIAG_SUBSET.length > 0) {
+    return all.filter(f => MOBILE_DIAG_SUBSET.includes(f))
+  }
+  return all
 }
 
 function getGeneratedIntegrationRefs (content) {

--- a/packages/tts-ggml/test/integration/chatterbox-tone-cpu-mtl.test.js
+++ b/packages/tts-ggml/test/integration/chatterbox-tone-cpu-mtl.test.js
@@ -1,0 +1,76 @@
+'use strict'
+
+// QVAC-20557 DIAGNOSTIC (DO NOT MERGE) — main-baseline 12 kHz tone check (MTL).
+//
+// Same as chatterbox-tone-cpu-turbo.test.js but for the **mtl** variant,
+// to confirm the ~12 kHz (Nyquist) whine is variant-independent.  Runs
+// Chatterbox mtl end-to-end on the **CPU** (useGPU:false) and asserts the
+// output is tone-free.  On Mali, main runs this on the CPU (GPU declined),
+// so a red here (tonePresent=true) means main IS broken on this device.
+//
+// Detector: ../utils/toneAnalysis.js (Nyquist DFT-bin energy fraction;
+// host-validated threshold 0.1).  The `[12khz-diag]` line lands in the
+// device-farm logcat for offline reading.
+
+const os = require('bare-os')
+const path = require('bare-path')
+const test = require('brittle')
+
+const { loadChatterboxTTS, runChatterboxTTS } = require('../utils/runChatterboxTTS')
+const { ensureChatterboxMtlModels } = require('../utils/downloadModel')
+const { analyzeNyquistTone } = require('../utils/toneAnalysis')
+
+const platform = os.platform()
+const isMobile = platform === 'ios' || platform === 'android'
+const SAMPLE_RATE = 24000
+const TONE_TEXT = 'The quick brown fox jumps over the lazy dog.'
+
+function getBaseDir () {
+  return isMobile && global.testDir ? global.testDir : '.'
+}
+
+test('Chatterbox mtl CPU: output is free of the 12 kHz Nyquist tone', { timeout: 1800000 }, async (t) => {
+  const baseDir = getBaseDir()
+  const download = await ensureChatterboxMtlModels({ targetDir: path.join(baseDir, 'models') })
+  if (!download.success) {
+    t.fail('Chatterbox mtl GGUFs not available - registry fetch failed.')
+    return
+  }
+
+  // The mtl GGUFs are NOT the loadChatterboxTTS defaults (which are turbo);
+  // derive the actual filenames from the download result and pass them
+  // explicitly so the engine loads the mtl variant.
+  const names = Object.keys(download.results)
+  const t3Name = names.find(n => n.includes('t3'))
+  const s3genName = names.find(n => n.includes('s3gen'))
+  if (!t3Name || !s3genName) {
+    t.fail(`Could not resolve mtl GGUF filenames from download result: ${names.join(', ')}`)
+    return
+  }
+
+  const model = await loadChatterboxTTS({
+    modelDir: download.targetDir,
+    t3ModelPath: path.join(download.targetDir, t3Name),
+    s3genModelPath: path.join(download.targetDir, s3genName),
+    useGPU: false,
+    seed: 42
+  })
+  try {
+    const result = await runChatterboxTTS(
+      model,
+      { text: TONE_TEXT, seed: 42 },
+      { minSamples: 5000 },
+      { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox mtl CPU' }
+    )
+    t.ok(result.passed, 'mtl CPU synth produced audio within expectations')
+    t.ok(result.data.sampleCount > 0, 'mtl CPU produced audio')
+
+    const st = result.data?.stats || {}
+    const tone = analyzeNyquistTone(result.data.samples, result.data.sampleRate)
+    console.log(`[12khz-diag] variant=mtl backend=cpu backendDevice=${st.backendDevice} gpuUnsupported=${st.gpuUnsupported} n=${tone.n} rms=${tone.rms.toFixed(2)} zcr=${tone.zcr.toFixed(4)} nyquistEnergyFraction=${tone.nyquistEnergyFraction.toFixed(6)} tonePresent=${tone.tonePresent}`)
+
+    t.is(tone.tonePresent, false, 'mtl CPU output has NO 12 kHz Nyquist tone (nyquistEnergyFraction <= 0.1)')
+  } finally {
+    try { await model.unload() } catch (_e) {}
+  }
+})

--- a/packages/tts-ggml/test/integration/chatterbox-tone-cpu-turbo.test.js
+++ b/packages/tts-ggml/test/integration/chatterbox-tone-cpu-turbo.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+// QVAC-20557 DIAGNOSTIC (DO NOT MERGE) — main-baseline 12 kHz tone check.
+//
+// Runs Chatterbox **turbo** end-to-end on the **CPU** (useGPU:false) and
+// asserts the generated audio is free of the constant ~12 kHz (Nyquist)
+// whine.  On a Mali device main declines Chatterbox-on-GPU by policy, so
+// this CPU path is exactly the audio Mali users get today.  Purpose:
+// detect — without pulling the WAV off the device — whether CURRENT main
+// already emits the tone on Mali (the armv9.0 ggml-cpu conv_transpose
+// ISTFT artifact).  A red here (tonePresent=true) means main IS broken on
+// this device.
+//
+// Detector: ../utils/toneAnalysis.js (Nyquist DFT-bin energy fraction;
+// host-validated ~1e8x separation, threshold 0.1).  The `[12khz-diag]`
+// line lands in the device-farm logcat for offline reading.
+
+const os = require('bare-os')
+const path = require('bare-path')
+const test = require('brittle')
+
+const { loadChatterboxTTS, runChatterboxTTS } = require('../utils/runChatterboxTTS')
+const { ensureChatterboxModels } = require('../utils/downloadModel')
+const { analyzeNyquistTone } = require('../utils/toneAnalysis')
+
+const platform = os.platform()
+const isMobile = platform === 'ios' || platform === 'android'
+const SAMPLE_RATE = 24000
+const TONE_TEXT = 'The quick brown fox jumps over the lazy dog.'
+
+function getBaseDir () {
+  return isMobile && global.testDir ? global.testDir : '.'
+}
+
+test('Chatterbox turbo CPU: output is free of the 12 kHz Nyquist tone', { timeout: 1800000 }, async (t) => {
+  const baseDir = getBaseDir()
+  const download = await ensureChatterboxModels({ targetDir: path.join(baseDir, 'models') })
+  if (!download.success) {
+    t.fail('Chatterbox turbo GGUFs not available - registry fetch failed.')
+    return
+  }
+
+  const model = await loadChatterboxTTS({ modelDir: download.targetDir, useGPU: false, seed: 42 })
+  try {
+    const result = await runChatterboxTTS(
+      model,
+      { text: TONE_TEXT, seed: 42 },
+      { minSamples: 5000 },
+      { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox turbo CPU' }
+    )
+    t.ok(result.passed, 'turbo CPU synth produced audio within expectations')
+    t.ok(result.data.sampleCount > 0, 'turbo CPU produced audio')
+
+    const st = result.data?.stats || {}
+    const tone = analyzeNyquistTone(result.data.samples, result.data.sampleRate)
+    console.log(`[12khz-diag] variant=turbo backend=cpu backendDevice=${st.backendDevice} gpuUnsupported=${st.gpuUnsupported} n=${tone.n} rms=${tone.rms.toFixed(2)} zcr=${tone.zcr.toFixed(4)} nyquistEnergyFraction=${tone.nyquistEnergyFraction.toFixed(6)} tonePresent=${tone.tonePresent}`)
+
+    t.is(tone.tonePresent, false, 'turbo CPU output has NO 12 kHz Nyquist tone (nyquistEnergyFraction <= 0.1)')
+  } finally {
+    try { await model.unload() } catch (_e) {}
+  }
+})

--- a/packages/tts-ggml/test/mobile/integration.auto.cjs
+++ b/packages/tts-ggml/test/mobile/integration.auto.cjs
@@ -6,55 +6,15 @@ require('./integration-runtime.cjs')
 
 /* global runIntegrationModule */
 
-async function runAddonTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/addon.test.js', options)
+async function runChatterboxToneCpuMtlTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/chatterbox-tone-cpu-mtl.test.js', options)
 }
 
-async function runChatterboxJaMecabTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/chatterbox-ja-mecab.test.js', options)
-}
-
-async function runChatterboxMtlTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/chatterbox-mtl.test.js', options)
-}
-
-async function runGpuSmokeTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/gpu-smoke.test.js', options)
-}
-
-async function runMultipleRunsTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/multiple-runs.test.js', options)
-}
-
-async function runRtfBenchmarkTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/rtf-benchmark.test.js', options)
-}
-
-async function runStreamingBenchmarkTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/streaming-benchmark.test.js', options)
-}
-
-async function runSupertonicMtlTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/supertonic-mtl.test.js', options)
-}
-
-async function runSupertonicTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/supertonic.test.js', options)
-}
-
-async function runSupertonic3QuantTest (options = {}) { // eslint-disable-line no-unused-vars
-  return runIntegrationModule('../integration/supertonic3-quant.test.js', options)
+async function runChatterboxToneCpuTurboTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/chatterbox-tone-cpu-turbo.test.js', options)
 }
 
 module.exports = {
-  runAddonTest,
-  runChatterboxJaMecabTest,
-  runChatterboxMtlTest,
-  runGpuSmokeTest,
-  runMultipleRunsTest,
-  runRtfBenchmarkTest,
-  runStreamingBenchmarkTest,
-  runSupertonicMtlTest,
-  runSupertonicTest,
-  runSupertonic3QuantTest
+  runChatterboxToneCpuMtlTest,
+  runChatterboxToneCpuTurboTest
 }

--- a/packages/tts-ggml/test/utils/toneAnalysis.js
+++ b/packages/tts-ggml/test/utils/toneAnalysis.js
@@ -1,0 +1,59 @@
+'use strict'
+
+// 12 kHz (Nyquist) tone detector for 24 kHz TTS output.
+//
+// The HiFT ISTFT in Chatterbox / CosyVoice reconstructs the waveform from
+// a real spectrogram whose Nyquist bin (f = fs/2) has the time-domain
+// basis (-1)^n.  A constant-amplitude Nyquist tone (the "whine") therefore
+// shows up as a persistent sign-alternation across the samples.  We measure
+// it with the Nyquist DFT coefficient, without a full FFT:
+//
+//   S = sum_n x[n] * (-1)^n                       // == real DFT bin X[N/2]
+//   nyquistEnergyFraction = S^2 / (N * sum_n x[n]^2)   // bounded in [0, 1]
+//
+// For a pure Nyquist tone this is 1.0; for clean speech it is ~0.  The
+// ratio is scale-invariant, so int16 vs float PCM does not matter, and it
+// is sample-rate independent (Nyquist is always the highest bin).
+//
+// Host-validated against known samples (turbo + mtl):
+//   toney (Pixel 9a Mali CPU):  nyquistEnergyFraction ~0.63-0.65, zcr ~0.86
+//   clean (Adreno CPU / dogfood): nyquistEnergyFraction ~6e-9,    zcr ~0.07
+// => threshold 0.1 separates the two classes with a >10^4x margin both
+// sides.  ZCR (sign-change rate) is reported as a corroborating signal.
+
+const NYQUIST_FRACTION_THRESHOLD = 0.1
+
+function analyzeNyquistTone (samples, sampleRate) {
+  const n = samples ? samples.length : 0
+  if (n === 0) {
+    return { n: 0, rms: 0, zcr: 0, nyquistEnergyFraction: 0, tonePresent: false, sampleRate: sampleRate || 0 }
+  }
+
+  let sumSq = 0
+  let alt = 0 // running sum of x[n] * (-1)^n
+  let sign = 1 // (-1)^n, starts at +1 for n = 0
+  let signChanges = 0
+  let prevSign = 0
+
+  for (let i = 0; i < n; i++) {
+    const v = samples[i]
+    sumSq += v * v
+    alt += sign * v
+    sign = -sign
+
+    const s = v > 0 ? 1 : (v < 0 ? -1 : 0)
+    if (s !== 0) {
+      if (prevSign !== 0 && s !== prevSign) signChanges++
+      prevSign = s
+    }
+  }
+
+  const rms = Math.sqrt(sumSq / n)
+  const zcr = signChanges / n
+  const nyquistEnergyFraction = sumSq > 0 ? (alt * alt) / (n * sumSq) : 0
+  const tonePresent = nyquistEnergyFraction > NYQUIST_FRACTION_THRESHOLD
+
+  return { n, rms, zcr, nyquistEnergyFraction, tonePresent, sampleRate: sampleRate || 0 }
+}
+
+module.exports = { analyzeNyquistTone, NYQUIST_FRACTION_THRESHOLD }


### PR DESCRIPTION
…tl, DO NOT MERGE)

Diagnostic to decide whether CURRENT main (registry ggml-speech + tts-cpp, NO overlay) already ships the constant ~12 kHz Nyquist whine on a Mali device. main declines Chatterbox-on-Mali-GPU, so S3Gen runs on the Mali CPU; if the armv9.0 ggml-cpu conv_transpose ISTFT artifact is pre-existing, main's Mali users already get the tone. We can't pull WAVs from CI, so we detect the tone programmatically and read it from logcat.

- test/utils/toneAnalysis.js: FFT-free Nyquist tone detector (nyquistEnergyFraction = S^2/(N*sum x^2), S = sum x[n]*(-1)^n; scale- and sample-rate-invariant). Host- AND JS-validated on known WAVs: toney ~0.63, clean ~6e-9 -> threshold 0.1 (>1e8x margin); zcr corroborates (0.86 vs 0.07).
- test/integration/chatterbox-tone-cpu-{turbo,mtl}.test.js: pure-CPU synth + emit [12khz-diag] + assert tonePresent=false (a red here = main is toney on this device).
- scripts/{generate,validate}-mobile-integration-tests.js: MOBILE_DIAG_SUBSET restricts the device farm to just these two so each gets its own ~7.5-min module budget.
- test/mobile/integration.auto.cjs: regenerated to the subset.

DO NOT MERGE — the MOBILE_DIAG_SUBSET disables the rest of the device-farm suite; revert it to [] before any real use.

<!--
Style guide for this PR description:
- Be concise; prefer bullet points.
- Delete sections that don't apply.
- Keep code examples minimal.
-->

## What problem does this PR solve?

## How does it solve it?

## Breaking changes
