### PR TITLE
QVAC-21321 transcription-whispercpp: consume ggml-speech 2026-06-15 (whisper-cpp 1.8.5#5)

### DIFF
--- a/packages/transcription-whispercpp/CHANGELOG.md
+++ b/packages/transcription-whispercpp/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Bumped the `whisper-cpp` vcpkg override from `1.8.5#3` to `1.8.5#5`, which
+  refreshes the bundled `ggml-speech` from `2026-06-04` to `2026-06-15` (speech
+  branch tip `7bb9f229`), keeping it consistent with the other speech-stack
+  addons (`tts-cpp` already pins `ggml-speech 2026-06-15`). The `whisper-cpp`
+  C++ source is unchanged between port-versions `#3` and `#5`, so this only
+  moves `ggml-speech`. The registry baseline is left unchanged; the override
+  resolves the new port-version forward of the pinned baseline (QVAC-21321,
+  registry [tetherto/qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210)).
+
 ## [0.10.1] - 2026-06-22
 
 ### Changed

--- a/packages/transcription-whispercpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg.json
@@ -29,7 +29,7 @@
     {
       "name": "whisper-cpp",
       "version": "1.8.5",
-      "port-version": 3
+      "port-version": 5
     }
   ]
 }


### PR DESCRIPTION
## Summary

Bump the `whisper-cpp` vcpkg override from `1.8.5#3` to `1.8.5#5` so `transcription-whispercpp` bundles **`ggml-speech 2026-06-15`** (speech tip `7bb9f229`), consistent with the other speech-stack addons. `tts-cpp` already requires `ggml-speech 2026-06-15`; this brings Whisper in line.

## Scope: ggml-speech only

The `whisper-cpp` C++ source is **identical** between port-versions `#3` and `#5`:

```
git diff 128dae42..1c75d6e9 -- whisper-cpp/   # empty
```

So this moves only the bundled `ggml-speech` (`2026-06-04` → `2026-06-15`). No addon source, API, or JS change.

## Dependency / ordering

- Requires **[qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210)**, which publishes `whisper-cpp 1.8.5#5` (same REF, `ggml-speech >=2026-06-15`). That registry PR must merge first for CI here to resolve.
- The registry baseline is left unchanged; the `override` resolves `1.8.5#5` forward of the pinned `default-registry` baseline (same pattern the package already uses for `#3`). No `vcpkg-configuration.json` change.
- Verified locally with `vcpkg install --dry-run` against the registry branch: `whisper-cpp@1.8.5#5` → `ggml-speech@2026-06-15` resolves clean on `x64-linux` (vulkan).

## Not included

The `@qvac/transcription-whispercpp` version bump to `0.10.2` is released separately under **QVAC-21324** (this PR leaves the change under `## [Unreleased]`).

## Test plan

- [ ] Merge qvac-registry-vcpkg#210 first.
- [ ] `linux-x64-cpp-tests` / `cpp-lint` green once the registry version is published.

Made with [Cursor](https://cursor.com)