### PR TITLE
QVAC-21324 chore: release @qvac/transcription-whispercpp 0.10.2

### DIFF
--- a/packages/transcription-whispercpp/CHANGELOG.md
+++ b/packages/transcription-whispercpp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.2] - 2026-06-24
 
 ### Changed
 
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   moves `ggml-speech`. The registry baseline is left unchanged; the override
   resolves the new port-version forward of the pinned baseline (QVAC-21321,
   registry [tetherto/qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210)).
+
+## Pull Requests
+
+- [#2845](https://github.com/tetherto/qvac/pull/2845) - QVAC-21321 transcription-whispercpp: consume ggml-speech 2026-06-15 (whisper-cpp 1.8.5#5)
 
 ## [0.10.1] - 2026-06-22
 

--- a/packages/transcription-whispercpp/package.json
+++ b/packages/transcription-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary

Cut the **`0.10.2`** patch release of `@qvac/transcription-whispercpp`, releasing the `ggml-speech 2026-06-15` consistency bump (QVAC-21321).

- `package.json`: `0.10.1` → `0.10.2`
- `CHANGELOG.md`: promote `## [Unreleased]` → `## [0.10.2] - 2026-06-24` + `## Pull Requests` block

## Stacking / ordering (read first)

This PR is **stacked on QVAC-21321 ([#2845](https://github.com/tetherto/qvac/pull/2845))**. Until #2845 merges, this PR's diff also shows the `whisper-cpp 1.8.5#5` override change; it will reduce to just the version cut once #2845 lands. Merge order:

1. [qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210) (publishes `whisper-cpp 1.8.5#5`)
2. [#2845](https://github.com/tetherto/qvac/pull/2845) (QVAC-21321 consume)
3. this PR (QVAC-21324 release)

## Test plan

- [ ] Merge #210 and #2845 first, then this rebases to a clean one-commit version cut.

Made with [Cursor](https://cursor.com)