### PR TITLE
QVAC-21322 transcription-parakeet: consume ggml-speech 2026-06-15 (parakeet-cpp 2026-06-18#1)

### DIFF
--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - New `getBackendInfo()` surfaces the active GPU hardware name. The native addon now captures `ggml_backend_dev_description()` for the resolved GPU device at `load()` (e.g. "NVIDIA GeForce RTX 3090", "Apple M2 Pro") and exposes it through `TranscriptionParakeet#getBackendInfo()` → `{ backendDevice, backendId, backendName, backendDescription }`. The RTF benchmark uses it as a fallback for `labels.gpuModel` on CI GPU runners where the host probe (nvidia-smi / procfs) can't see the device but the ggml CUDA/Vulkan/Metal backend still knows its name via `cudaGetDeviceProperties` / `VkPhysicalDeviceProperties` / `MTLDevice.name` (QVAC-21167).
+- Bumped the `parakeet-cpp` `version>=` constraint from `2026-06-18` to `2026-06-18#1`, which refreshes the bundled `ggml-speech` from `2026-06-09` to `2026-06-15` (speech branch tip `7bb9f229`), keeping it consistent with the other speech-stack addons (`tts-cpp` already pins `ggml-speech 2026-06-15`). The `parakeet-cpp` C++ source is unchanged (same `master` REF `b95ad447`), so this only moves `ggml-speech`. The registry baseline is left unchanged; `version>=` resolves the new port-version forward of the pinned baseline (QVAC-21322, registry [tetherto/qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210)).
 
 ## [0.8.1] - 2026-06-22
 

--- a/packages/transcription-parakeet/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg.json
@@ -4,19 +4,19 @@
   "dependencies": [
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-06-18",
+      "version>=": "2026-06-18#1",
       "features": ["metal"],
       "platform": "osx | ios"
     },
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-06-18",
+      "version>=": "2026-06-18#1",
       "features": ["vulkan", "opencl"],
       "platform": "android"
     },
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-06-18",
+      "version>=": "2026-06-18#1",
       "features": ["vulkan"],
       "platform": "!(osx | ios | android)"
     },


### PR DESCRIPTION
## Summary

Bump the `parakeet-cpp` `version>=` constraint (all three platform entries) from `2026-06-18` to `2026-06-18#1` so `transcription-parakeet` bundles **`ggml-speech 2026-06-15`** (speech tip `7bb9f229`), consistent with the other speech-stack addons. `tts-cpp` already requires `ggml-speech 2026-06-15`; this brings Parakeet in line (`2026-06-09` → `2026-06-15`).

## Scope: ggml-speech only

`parakeet-cpp#1` keeps the **same `master` REF `b95ad447`** as `#0` — the registry port-version bump only tightens its `ggml-speech` dependency. So this moves only the bundled `ggml-speech`. No addon source, API, or JS change.

## Dependency / ordering

- Requires **[qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210)**, which publishes `parakeet-cpp 2026-06-18#1`. That registry PR must merge first for CI here to resolve.
- The registry baseline is left unchanged; `version>=` resolves `2026-06-18#1` forward of the pinned `default-registry` baseline (same pattern the package already uses). No `vcpkg-configuration.json` change.
- Verified locally with `vcpkg install --dry-run` against the registry branch: `parakeet-cpp@2026-06-18#1` → `ggml-speech@2026-06-15` resolves clean on `x64-linux` (vulkan).

## Not included

The `@qvac/transcription-parakeet` version bump to `0.8.2` is released separately under **QVAC-21325** (this PR adds the change under the existing `## [Unreleased]`).

## Test plan

- [ ] Merge qvac-registry-vcpkg#210 first.
- [ ] `linux-x64-cpp-tests` / `cpp-lint` green once the registry version is published.

Made with [Cursor](https://cursor.com)