### PR TITLE
QVAC-21325 chore: release @qvac/transcription-parakeet 0.8.2

### DIFF
--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.2] - 2026-06-24
 
 ### Changed
 
 - New `getBackendInfo()` surfaces the active GPU hardware name. The native addon now captures `ggml_backend_dev_description()` for the resolved GPU device at `load()` (e.g. "NVIDIA GeForce RTX 3090", "Apple M2 Pro") and exposes it through `TranscriptionParakeet#getBackendInfo()` → `{ backendDevice, backendId, backendName, backendDescription }`. The RTF benchmark uses it as a fallback for `labels.gpuModel` on CI GPU runners where the host probe (nvidia-smi / procfs) can't see the device but the ggml CUDA/Vulkan/Metal backend still knows its name via `cudaGetDeviceProperties` / `VkPhysicalDeviceProperties` / `MTLDevice.name` (QVAC-21167).
 - Bumped the `parakeet-cpp` `version>=` constraint from `2026-06-18` to `2026-06-18#1`, which refreshes the bundled `ggml-speech` from `2026-06-09` to `2026-06-15` (speech branch tip `7bb9f229`), keeping it consistent with the other speech-stack addons (`tts-cpp` already pins `ggml-speech 2026-06-15`). The `parakeet-cpp` C++ source is unchanged (same `master` REF `b95ad447`), so this only moves `ggml-speech`. The registry baseline is left unchanged; `version>=` resolves the new port-version forward of the pinned baseline (QVAC-21322, registry [tetherto/qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210)).
+
+## Pull Requests
+
+- [#2743](https://github.com/tetherto/qvac/pull/2743) - QVAC-21167 feat[api]: expose addon GPU device name via getBackendInfo() (parakeet)
+- [#2847](https://github.com/tetherto/qvac/pull/2847) - QVAC-21322 transcription-parakeet: consume ggml-speech 2026-06-15 (parakeet-cpp 2026-06-18#1)
 
 ## [0.8.1] - 2026-06-22
 

--- a/packages/transcription-parakeet/package.json
+++ b/packages/transcription-parakeet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-parakeet",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "High-performance speech-to-text inference addon using NVIDIA Parakeet models for Bare runtime",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary

Cut the **`0.8.2`** patch release of `@qvac/transcription-parakeet`.

- `package.json`: `0.8.1` → `0.8.2`
- `CHANGELOG.md`: promote `## [Unreleased]` → `## [0.8.2] - 2026-06-24` + `## Pull Requests` block

This release bundles the two changes that were in `## [Unreleased]`:
- **QVAC-21322** — `ggml-speech 2026-06-15` consistency bump (`parakeet-cpp 2026-06-18#1`), [#2847](https://github.com/tetherto/qvac/pull/2847)
- **QVAC-21167** — `getBackendInfo()` GPU device name (already merged, [#2743](https://github.com/tetherto/qvac/pull/2743))

## Stacking / ordering (read first)

This PR is **stacked on QVAC-21322 ([#2847](https://github.com/tetherto/qvac/pull/2847))**. Until #2847 merges, this PR's diff also shows the `parakeet-cpp 2026-06-18#1` change; it reduces to just the version cut once #2847 lands. Merge order:

1. [qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210) (publishes `parakeet-cpp 2026-06-18#1`)
2. [#2847](https://github.com/tetherto/qvac/pull/2847) (QVAC-21322 consume)
3. this PR (QVAC-21325 release)

## Test plan

- [ ] Merge #210 and #2847 first, then this rebases to a clean one-commit version cut.

Made with [Cursor](https://cursor.com)