### PR TITLE
QVAC-21326 chore: release @qvac/bci-whispercpp 0.3.3

### DIFF
--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.3] - 2026-06-24
 
 ### Changed
 
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   moves `ggml-speech`. The registry baseline is left unchanged; the override
   resolves the new port-version forward of the pinned baseline (QVAC-21323,
   registry [tetherto/qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210)).
+
+## Pull Requests
+
+- [#2849](https://github.com/tetherto/qvac/pull/2849) - QVAC-21323 bci-whispercpp: consume ggml-speech 2026-06-15 (whisper-cpp 1.8.5#5)
 
 ## [0.3.2] - 2026-06-22
 

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bci-whispercpp",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Brain-Computer Interface (BCI) neural signal transcription addon for qvac, powered by whisper.cpp",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary

Cut the **`0.3.3`** patch release of `@qvac/bci-whispercpp`, releasing the `ggml-speech 2026-06-15` consistency bump (QVAC-21323).

- `package.json`: `0.3.2` → `0.3.3`
- `CHANGELOG.md`: promote `## [Unreleased]` → `## [0.3.3] - 2026-06-24` + `## Pull Requests` block

## Stacking / ordering (read first)

This PR is **stacked on QVAC-21323 ([#2849](https://github.com/tetherto/qvac/pull/2849))**. Until #2849 merges, this PR's diff also shows the `whisper-cpp 1.8.5#5` override change; it reduces to just the version cut once #2849 lands. Merge order:

1. [qvac-registry-vcpkg#210](https://github.com/tetherto/qvac-registry-vcpkg/pull/210) (publishes `whisper-cpp 1.8.5#5`)
2. [#2849](https://github.com/tetherto/qvac/pull/2849) (QVAC-21323 consume)
3. this PR (QVAC-21326 release)

## Test plan

- [ ] Merge #210 and #2849 first, then this rebases to a clean one-commit version cut.

Made with [Cursor](https://cursor.com)