### PR TITLE
QVAC-21347 infra: backport pinned verify-prebuild-symbols gate to release-translation-nmtcpp-5.0.4

### DIFF
--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -377,6 +377,17 @@ jobs:
           platform: ${{ matrix.platform }}
           workdir: ${{ env.WORKDIR }}
 
+      # Static guard: fail the prebuild if the addon module is left with
+      # unresolvable engine symbols (the @qvac/tts-ggml@0.2.1 ggml_backend_is_cpu
+      # dlopen crash) -- caught here, off the artifact, before any device run.
+      # Pinned to a fixed, self-contained action so the verify step does not
+      # depend on this release branch's tree (QVAC-21347 / #2844).
+      - name: Verify prebuild symbols
+        uses: tetherto/qvac/.github/actions/verify-prebuild-symbols@f8e9a76e3c4336c044775857f1eca8ca2f663741
+        with:
+          platform: ${{ matrix.platform }}
+          workdir: ${{ env.WORKDIR }}
+
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
         with:
           name: ${{ inputs.artifact-name-prefix }}${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- This release line publishes via `reusable-prebuilds.yml`, which currently has **no symbol-verification gate** (it predates the gate added to `main` in #2548). The gate (`verify-prebuild-symbols`) catches the `@qvac/tts-ggml@0.2.1` dlopen-on-device crash class (unresolvable engine symbols) straight off the prebuild artifacts.
- On `main` the gate was wired with a branch-relative `uses: ./.github/actions/verify-prebuild-symbols` + a `$GITHUB_WORKSPACE` script, which is why syncing it onto older release branches broke publishing with `Can't find 'action.yml'` (the desync fixed for `main` in #2844 / QVAC-21347).

## 📝 How does it solve it?

- Adds the verify step to this branch's `reusable-prebuilds.yml`, pinned to the **self-contained, SHA-pinned** action `tetherto/qvac/.github/actions/verify-prebuild-symbols@f8e9a76e3…`. The action bundles its own script and resolves it via `$GITHUB_ACTION_PATH`, so the step does **not** depend on this release branch carrying the action/script files — exactly like the other pinned actions in the file (e.g. `strip-prebuilds`).
- No action `inputs`/`outputs` or workflow `workflow_call` contract changes; only a new step is inserted between "Strip debug symbols" and artifact upload.

## 🧪 How was it tested?

- `actionlint` clean on the edited `reusable-prebuilds.yml`.
- The pinned action + bundled script were validated on the `main`-side change (#2844): `node verify-prebuild-symbols.mjs --help` runs, and `actionlint` is clean.
- The gate now executes on this branch's prebuild matrix; a hard failure here would indicate a genuine unresolved-engine-symbol regression in this addon's prebuilds (which the gate is designed to catch before publish).

## 🔐 Action pinning

- `verify-prebuild-symbols` (first-party) added: `uses: tetherto/qvac/.github/actions/verify-prebuild-symbols@f8e9a76e3c4336c044775857f1eca8ca2f663741`.
  - Pinned to the commit on PR #2844 that introduces the self-contained action. Per [`.cursor/rules/devops/github-actions.mdc`](.cursor/rules/devops/github-actions.mdc), first-party actions consumed by a workflow that may run on a different ref MUST be SHA-pinned.
  - **Note:** once #2844 lands on `main`, this pin can be bumped to the landed `main` SHA.

---
Ticket: QVAC-21347. Backport of the prebuild symbol-verify gate to this release line. Generated with the `qv-devops-pr-create` skill.
