### PR TITLE
chore: release @qvac/tts-ggml v0.3.5 (QVAC-19557 S3Tokenizer host-mirror elimination)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.5] - 2026-06-24
 
 ### Changed
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
Promotes the `[Unreleased]` entry from #2833 to **`[0.3.5]`** and bumps `package.json` 0.3.4 → 0.3.5.

**Why now:** the published `@qvac/tts-ggml@0.3.4` prebuilt addon predates the S3Tokenizer host-mirror elimination (tts-cpp `2026-06-24`, PR #65). The iOS SDK e2e consumes the **published npm prebuild**, so the fix only reaches Device Farm once a release rebuilds + republishes the addon from the bumped tts-cpp pin. This release is the prerequisite for validating the `tts-chatterbox` iOS un-skip (#2834).

After merge, pushing the `release-tts-ggml-0.3.5` branch triggers the prebuild + npm publish (per the established 0.3.x release flow). Then #2834's Device Farm run picks up 0.3.5 (with the fix) — projected first-test peak ~3160 → ~2748 MB, under the iOS budget.

2-file diff (package.json + CHANGELOG).