### PR TITLE
chore[notask]: bump @qvac/ocr-ggml ^0.6.0 and diffusion-cpp ^0.12.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -203,7 +203,7 @@
     "@qvac/bci-whispercpp": "^0.3.2",
     "@qvac/classification-ggml": "^0.6.1",
     "@qvac/decoder-audio": "^0.5.0",
-    "@qvac/diffusion-cpp": "^0.11.2",
+    "@qvac/diffusion-cpp": "^0.12.0",
     "@qvac/embed-llamacpp": "^0.22.1",
     "@qvac/error": "^0.1.1",
     "@qvac/langdetect-text": "^0.1.2",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -209,7 +209,7 @@
     "@qvac/langdetect-text": "^0.1.2",
     "@qvac/llm-llamacpp": "^0.29.2",
     "@qvac/logging": "^0.1.0",
-    "@qvac/ocr-ggml": "^0.4.0",
+    "@qvac/ocr-ggml": "^0.6.0",
     "@qvac/rag": "^0.6.4",
     "@qvac/registry-client": "^0.6.0",
     "@qvac/transcription-parakeet": "^0.8.1",


### PR DESCRIPTION
## Summary

Bumps the SDK dependency on `@qvac/ocr-ggml` from `^0.4.0` to `^0.6.0`, matching the latest version published to npm.

## Changes

- `packages/sdk/package.json`: `@qvac/ocr-ggml` `^0.4.0` -> `^0.6.0`

## Notes

Dependency version bump only - no code changes.