### PR TITLE
chore[notask]: bump sdk diffusion-cpp to ^0.12.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -203,7 +203,7 @@
     "@qvac/bci-whispercpp": "^0.3.2",
     "@qvac/classification-ggml": "^0.6.1",
     "@qvac/decoder-audio": "^0.5.0",
-    "@qvac/diffusion-cpp": "^0.11.2",
+    "@qvac/diffusion-cpp": "^0.12.0",
     "@qvac/embed-llamacpp": "^0.22.1",
     "@qvac/error": "^0.1.1",
     "@qvac/langdetect-text": "^0.1.2",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Keeps the SDK dependency on `@qvac/diffusion-cpp` aligned with the latest addon release.
- Picks up diffusion-cpp `0.12.0`, which removes the Windows MSVC redistributable dependency from prebuilds with no public API change.

## 📝 How does it solve it?

- Updates `packages/sdk/package.json` to require `@qvac/diffusion-cpp` `^0.12.0`.
- Verified bare-sdk stays in sync because addon dependencies are intentionally excluded from `@qvac/bare-sdk`.

## 🧪 How was it tested?

- `node .cursor/skills/qv-sdk-bare-sdk-sync/scripts/sync.mjs --check`
- `bun run check:deps-vs-sdk` in `packages/bare-sdk`
- `ReadLints` on `packages/sdk/package.json`
- Attempted `npm run typecheck` in `packages/sdk`, but the fresh worktree has no installed dependencies (`tsc: command not found`).