### PR TITLE
docs: add 'Where to start' routing section and quickstart expected output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@
 - **OpenAI-compatible API:** integrate with the broader AI ecosystem.
 - **Open source:** 100% free to use and modify — build on top, contribute back, be part of our community.
 
+## Where to start
+
+QVAC covers multiple capabilities. Use this table to find the right entry point for what you want to build.
+
+| Goal | Where to start |
+| :--- | :--- |
+| Run a local language model for text generation or chat | [Quickstart](#quickstart) below |
+| Use an OpenAI-compatible HTTP server with existing tools | Install `@qvac/cli`. It ships a server that follows the OpenAI API format, so tools like Open WebUI connect without changes |
+| Add speech recognition, text-to-speech, OCR, or translation | [Functionalities](#functionalities) below, then the capability pages at [docs.qvac.tether.io](https://docs.qvac.tether.io) |
+| Build semantic search or RAG (retrieval-augmented generation: answering questions from your own documents) | [Functionalities](#functionalities) below, then the RAG module docs at [docs.qvac.tether.io](https://docs.qvac.tether.io) |
+| Delegate inference to a stronger device you own over a direct P2P connection | [P2P capabilities](#p2p-capabilities) below |
+
 ## Usage
 
 QVAC is composed of JavaScript libraries and tools that converge in the JS SDK. _The SDK is the main entry point for using QVAC_. It is type-safe and exposes all QVAC capabilities through a unified interface. It runs on Node.js, [Bare runtime](https://bare.pears.com), and [Expo](https://expo.dev).
@@ -79,6 +91,8 @@ catch (error) {
 ```bash
 node quickstart.js
 ```
+
+**What you will see:** the terminal first prints model download progress (a series of percentage logs from `onProgress`). Once the download completes, the model's response streams to the terminal token by token.
 
 ### Functionalities
 


### PR DESCRIPTION
## What this changes

Adds two things to the README, both documentation-only with no SDK API impact.

**1. 'Where to start' section before Usage**

New developers arriving at the README currently have to scan past the CLI section, speech section, and key features list before knowing which path fits their use case. The new section is a five-row table that routes by goal: local LLM, OpenAI-compatible server, speech/OCR/translation, RAG, and P2P delegated inference. Each row links directly to the relevant section or doc page.

**2. Expected output note after Quickstart step 4**

After running `node quickstart.js` there is nothing on screen telling the developer what to expect. The note explains: terminal first shows model download progress (percentage logs from `onProgress`), then the response streams token by token. This removes a common first-run doubt.

## Why

Surfaced in #2790. Both gaps affect first-time evaluators most: developers who are deciding whether QVAC fits their use case before they commit to reading the full docs.

## Verified

- All five routing table destinations confirmed against the current README and docs.qvac.tether.io.
- Quickstart output description confirmed against the SDK source (`onProgress` callback and token stream).
- No SDK API changes. No new dependencies.