### PR TITLE
QVAC-21446 chore: release @qvac/tts-ggml v0.3.6 (Chatterbox Metal f16…

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.6] - 2026-06-25
 
 ### Fixed
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## What problem does this PR solve?
Version-bump-only PR for @qvac/tts-ggml, raised separately so the bump is
evident in git history (per Mathias).

## How does it solve it?
Bumps `package.json` 0.3.5 → 0.3.6 and stamps the CHANGELOG `[Unreleased]`
section as `[0.3.6] - 2026-06-25`. The actual change (Chatterbox Metal GPU
crash fix — default KV cache q8_0 → f16) landed in its functional PR
(QVAC-21401); this PR carries no code changes.

## Breaking changes
None (release/version bump only). Behavior change is documented in the
0.3.6 CHANGELOG entry from the functional PR.
