### PR TITLE
QVAC-20557 test[notask]: Chatterbox Mali fixes — combined on-device CI validation (DO-NOT-MERGE)

### DIFF
--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -60,6 +60,7 @@
     "test/utils/runSupertonicTTS.js",
     "test/utils/downloadModel.js",
     "test/utils/wav-helper.js",
+    "test/utils/toneAnalysis.js",
     "test/utils/pcmConcatenator.js",
     "test/utils/runWhisper.js",
     "test/data/sentences-medium.js",

--- a/packages/tts-ggml/ports/ggml-speech/android-vulkan-version.cmake
+++ b/packages/tts-ggml/ports/ggml-speech/android-vulkan-version.cmake
@@ -1,0 +1,37 @@
+# Detect the Vulkan version shipped with the Android NDK by parsing
+# vulkan_core.h from the NDK sysroot.  Sets `vulkan_version` in the
+# caller's scope (e.g. "1.3.275").
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from ${vulkan_core_h}")
+    endif()
+
+    # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION_COMPLETE from ${vulkan_core_h}")
+    endif()
+endfunction()

--- a/packages/tts-ggml/ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
+++ b/packages/tts-ggml/ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
@@ -1,0 +1,24 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..3d92ac5d 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -7,6 +7,7 @@ if (POLICY CMP0147)
+ endif()
+ 
+ find_package(Vulkan COMPONENTS glslc REQUIRED)
++find_package(SPIRV-Headers QUIET)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     # Parallel build object files
+@@ -87,6 +88,11 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++
++    if (TARGET SPIRV-Headers::SPIRV-Headers)
++        target_link_libraries(ggml-vulkan PRIVATE SPIRV-Headers::SPIRV-Headers)
++    endif()
++
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/packages/tts-ggml/ports/ggml-speech/portfile.cmake
+++ b/packages/tts-ggml/ports/ggml-speech/portfile.cmake
@@ -1,0 +1,174 @@
+# ggml-speech — LOCAL OVERLAY PORT (QVAC-20557 Mali-fixes CI-validation; DO NOT MERGE).
+#
+# Mirrors the registry ggml-speech port EXCEPT the pin: this overlay points at
+# tetherto/qvac-ext-ggml branch QVAC-20557-sve-vecdot-tail-fix (PR #30, the clean
+# fix-only branch off speech) = the Bug-1 fix for ggml_vec_dot_f32's SVE leftover
+# tail (svmad_f32_m -> svmla_f32_m), which removes the ~12 kHz Nyquist tone in the
+# CPU/SVE HiFT conv_transpose on Tensor/Pixel. Paired with the ports/tts-cpp
+# overlay (Bug-2 Mali-GPU fix) so ONE qvac CI-validation PR exercises both fixes
+# on the device farm. REF/SHA512 filled by ~/workstuff/overlay-bump.sh. Throwaway.
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tetherto/qvac-ext-ggml
+    REF b38a6c412c7bb042bf6bc0ca56c371b66f92cf6a
+    SHA512 1b9da6184464d60fdfb30a119be51dabe50632f7796a59b3db3561d693aa75cf50fe8d95bac70f741128d63f02c379b5954356396b04f386ca3e7ef4f4452f3f
+    HEAD_REF speech
+)
+
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+set(GGML_METAL_FUSE_MV_BIAS OFF)
+
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+
+# Off by default: the chatterbox Q-variant mul_mv + bias/residual fusion
+# produces zero tokens on parakeet's EOU q8_0 joint network. Consumers
+# whose models stay clear of that pattern can opt in for the speedup.
+if("metal-fuse-mv-bias" IN_LIST FEATURES)
+    set(GGML_METAL_FUSE_MV_BIAS ON)
+endif()
+
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+
+set(GGML_CUDA_COMPILER_OPTION "")
+
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+    find_program(NVCC_EXECUTABLE nvcc
+        PATHS /usr/local/cuda/bin /usr/local/cuda-12.8/bin
+        NO_DEFAULT_PATH
+    )
+    if(NOT NVCC_EXECUTABLE)
+        find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+    endif()
+    set(GGML_CUDA_COMPILER_OPTION "-DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}")
+    message(STATUS "CUDA compiler: ${NVCC_EXECUTABLE}")
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND "vulkan" IN_LIST FEATURES)
+    include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+    detect_ndk_vulkan_version()
+    message(STATUS "NDK Vulkan version: ${vulkan_version}")
+
+    file(DOWNLOAD
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+        "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        TLS_VERIFY ON
+    )
+    file(ARCHIVE_EXTRACT
+        INPUT "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        DESTINATION "${SOURCE_PATH}"
+        PATTERNS "*.hpp"
+    )
+    file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+         DESTINATION "${SOURCE_PATH}/src/")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+
+# Hybrid Android backend mode: GPU backends as MODULE .so loaded at runtime
+# via dlopen, CPU built as per-arch MODULE .so variants (one per ARMv8.0/
+# 8.2/8.6/9.0/9.2 feature tier) also loaded at runtime via dlopen. The
+# downstream addon installs the resulting libqvac-speech-ggml-cpu-android_armv*
+# .so files alongside the .bare binary; the per-variant scoring in
+# ggml-cpu's `ggml_backend_cpu_aarch64_score` then picks the highest tier
+# the running device supports at first use. Pairs with the speech-branch
+# `ggml-backend: android per-arch CPU variant dlopen fallback` patch
+# (commit 9562ed04) so the variant lookup also succeeds when the consumer
+# APK keeps native .so files compressed (AGP `useLegacyPackaging=false`).
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    )
+endif()
+
+# PR #13 (v0.10.2 sync) introduces an unconditional
+# `#include <spirv/unified1/spirv.hpp>` in src/ggml-vulkan/ggml-vulkan.cpp,
+# but the upstream ggml-vulkan CMakeLists.txt never finds spirv-headers nor
+# wires its include dir into the ggml-vulkan target. Apply a small patch
+# so it does (and depend on spirv-headers in vcpkg.json's vulkan feature).
+# TODO: push the equivalent fix upstream and drop this patch.
+if("vulkan" IN_LIST FEATURES)
+    vcpkg_apply_patches(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PATCHES
+            "${CMAKE_CURRENT_LIST_DIR}/patches/0001-ggml-vulkan-find-spirv-headers.patch"
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_METAL_FUSE_MV_BIAS=${GGML_METAL_FUSE_MV_BIAS}
+        -DGGML_LIB_OUTPUT_PREFIX=qvac-speech-
+        ${GGML_CUDA_COMPILER_OPTION}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Pick up the MODULE backend .so files ggml builds into the buildtree's
+# bin/ directory (Android dynamic-backend mode). cmake install() doesn't
+# move them by default.
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-speech-ggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/tts-ggml/ports/ggml-speech/usage
+++ b/packages/tts-ggml/ports/ggml-speech/usage
@@ -1,0 +1,10 @@
+The package ggml provides CMake integration:
+
+  find_package(ggml CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ggml::ggml)
+
+Available vcpkg features:
+  metal  - Metal GPU backend (macOS/iOS, auto-enabled on Apple)
+  vulkan - Vulkan GPU backend
+  cuda   - CUDA GPU backend
+  opencl - OpenCL GPU backend

--- a/packages/tts-ggml/ports/ggml-speech/vcpkg.json
+++ b/packages/tts-ggml/ports/ggml-speech/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "ggml-speech",
+  "version-date": "2026-06-15",
+  "description": "Speech-stack flavour of ggml from tetherto/qvac-ext-ggml@speech, including the ggml-org v0.10.2 sync (PR #13), the iOS Metal NULL-safety hardening from PR #10, GustavoA1604's Android per-arch CPU dlopen fallback (PR #11), the Mac M2 PAD test fix, and Adreno-aware Android OpenCL/Vulkan backend selection (PR #18, QVAC-18993): on Android the loader detects the GPU via Vulkan and only keeps OpenCL for Adreno > 700, CPU-only for Adreno 1..700, Vulkan/CPU for non-Adreno. Adds Adreno OpenCL elementwise kernels (sin/cos/abs/elu/leaky_relu) for Chatterbox S3Gen and robust Adreno-generation detection (PR #17, #19). Library filenames are prefixed libqvac-speech-ggml-* so they coexist with libqvac-ggml-* (fabric/llm) and libqvac-diffusion-ggml-* on the same Android device. Mutually exclusive with the regular ggml port in the same triplet -- pick one per build. 2026-06-15: ggml-metal drains lingering residency sets at device free instead of asserting (PR #24, QVAC-19305, fixes SIGABRT at process exit on macOS 15+ Metal teardown) plus ggml-opencl bci-whispercpp correctness on Adreno + Samsung Xclipse (PR #22).",
+  "homepage": "https://github.com/tetherto/qvac-ext-ggml/tree/speech",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU backend"
+    },
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "metal-fuse-mv-bias": {
+      "description": "Compile in the Q-variant mul_mv + ADD(bias) [+ ADD(residual)] fusion in ggml-metal. Off by default: empirically produces zero tokens on parakeet's EOU q8_0 joint network. Opt in only after Metal A/B-validating your model against the fused path."
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    }
+  }
+}

--- a/packages/tts-ggml/ports/tts-cpp/portfile.cmake
+++ b/packages/tts-ggml/ports/tts-cpp/portfile.cmake
@@ -1,0 +1,80 @@
+# tts-cpp — LOCAL OVERLAY PORT (QVAC-20557 Mali-fixes CI-validation; DO NOT MERGE).
+#
+# Mirrors the registry tts-cpp port EXCEPT the pin: this overlay points at
+# tetherto/qvac-ext-lib-whisper.cpp branch QVAC-20557-chbx-mali-fix (PR #67, the
+# clean fix-only branch off master) = the Bug-2 Mali-GPU fix: allow_arm_mali=true
+# (admits Chatterbox to Mali Vulkan) + an is_arm_mali-gated unfused CFM attention
+# that fixes the f32 flash_attn_ext miscompute (the "blank+beeps"/f0->NaN break).
+# Paired with the ports/ggml-speech overlay (Bug-1 SVE vec_dot fix) so ONE qvac
+# CI-validation PR exercises both fixes on the device farm (Pixel 9 Mali + S25).
+# REF/SHA512 filled by ~/workstuff/overlay-bump.sh. Throwaway; never publish.
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH WHISPER_CPP_SRC
+    REPO tetherto/qvac-ext-lib-whisper.cpp
+    REF f2addc205e820f81723d2036bca21eed4be6ee15
+    SHA512 9710f5692036b95a0d2d46bd58f7584e52214b411b82f1fffea9cbb595c0f4ed2e7c16a9d41cac8526243d990d1651379514e6705826a66e72a627b0653bd184
+    HEAD_REF master
+)
+
+set(SOURCE_PATH "${WHISPER_CPP_SRC}/tts-cpp")
+if (NOT EXISTS "${SOURCE_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "tts-cpp: ${SOURCE_PATH}/CMakeLists.txt missing; the tts-cpp/ "
+        "subfolder layout in qvac-ext-lib-whisper.cpp may have changed.")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        metal   GGML_METAL
+        vulkan  GGML_VULKAN
+        cuda    GGML_CUDA
+        opencl  GGML_OPENCL
+)
+
+set(PLATFORM_OPTIONS)
+
+if(NOT VCPKG_TARGET_IS_OSX)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BLAS=OFF
+        -DGGML_ACCELERATE=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_BLAS=ON
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DTTS_CPP_BUILD_LIBRARY=ON
+        -DTTS_CPP_BUILD_SHARED=OFF
+        -DTTS_CPP_BUILD_EXECUTABLES=OFF
+        -DTTS_CPP_BUILD_TESTS=OFF
+        -DTTS_CPP_INSTALL=ON
+        -DTTS_CPP_USE_SYSTEM_GGML=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_OPENMP=OFF
+        -DTTS_CPP_OPENMP=OFF
+        -DGGML_CCACHE=OFF
+        -DTTS_CPP_CCACHE=OFF
+        ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME tts-cpp CONFIG_PATH share/tts-cpp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/tts-ggml/ports/tts-cpp/vcpkg.json
+++ b/packages/tts-ggml/ports/tts-cpp/vcpkg.json
@@ -1,0 +1,82 @@
+{
+  "name": "tts-cpp",
+  "version-date": "2026-06-18",
+  "port-version": 1,
+  "description": "Text-to-speech inference in pure C++/ggml. Ships Resemble Chatterbox (Turbo + Multilingual variants) and Supertonic engines under a unified Engine API. Sourced from tetherto/qvac-ext-lib-whisper.cpp's tts-cpp/ subfolder. This pin (master HEAD b95ad447) brings QVAC-20616 end-of-speech robustness (PR #53): alignment-based EOS plus a heuristic stop controller so the Chatterbox multilingual model stops at end-of-utterance instead of rambling random tokens past the text; and QVAC-20557 Supertonic Android GPU (PR #54): Adreno OpenCL + Xclipse/Mali Vulkan, which also reroutes the direct CPU-backend calls (ggml_backend_is_cpu / ggml_get_type_traits_cpu) to ggml-base + a registry shim so the addon dlopen's cleanly on Android. Consumes the ggml-speech port.",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/tts-cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "version>=": "2026-06-15"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "cuda"
+          ]
+        }
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal GPU acceleration (macOS / iOS)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "metal"
+          ]
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android / Adreno)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "opencl"
+          ]
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "vulkan"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/packages/tts-ggml/test/integration/chatterbox-audio-correctness.test.js
+++ b/packages/tts-ggml/test/integration/chatterbox-audio-correctness.test.js
@@ -1,0 +1,101 @@
+'use strict'
+
+// QVAC-20557 — on-device audio-correctness gate for the two Chatterbox Mali fixes.
+// DO-NOT-MERGE CI-validation: this branch pins both fix branches via
+// packages/tts-ggml/ports/{tts-cpp,ggml-speech} overlays, so on a Pixel 9
+// (Tensor/Mali) these assertions prove both fixes produce proper audio.
+//
+//   - Bug 1 (CPU/SVE 12 kHz tone): nyquistEnergyFraction < 0.1.
+//     Calibrated on real Pixel-9a audio: clean ~1e-8 vs the SVE tone ~0.635.
+//   - Bug 2 (Mali GPU "blank+beeps"/f0->NaN): activeFraction > 0.4.
+//     Calibrated: clean ~0.60 vs broken ~0.28. (The break carries no Nyquist
+//     energy, so nyqFrac alone misses it.)
+//
+// The GPU run on Mali exercises BOTH fixes (CFM attention on the GPU + the
+// CPU/SVE-routed HiFT conv_transpose). The CPU run exercises Bug 1 only.
+// On clean platforms (Adreno / Metal / desktop) both runs pass — no-regression
+// coverage. Metrics are emitted via t.comment so thresholds are tunable from CI.
+
+const test = require('brittle')
+const os = require('bare-os')
+const path = require('bare-path')
+
+const { loadChatterboxTTS, runChatterboxTTS } = require('../utils/runChatterboxTTS')
+const { ensureChatterboxModels } = require('../utils/downloadModel')
+const { analyzeSamples } = require('../utils/toneAnalysis')
+
+const platform = os.platform()
+const isMobile = platform === 'ios' || platform === 'android'
+
+function getBaseDir () {
+  return isMobile && global.testDir ? global.testDir : '.'
+}
+
+// A dense, run-on sentence (few long pauses) keeps the clean activeFraction high.
+const TEXT = 'The quick brown fox jumps over the lazy dog, and then it runs across the open field, past the winding river, and deep into the quiet forest well before nightfall.'
+
+// Gates calibrated on Freddy's real Pixel-9a round-1 WAVs.
+const NYQ_MAX = 0.1 // Bug-1 SVE tone: clean ~1e-8, toney ~0.635
+const ACTIVE_MIN = 0.4 // Bug-2 GPU blank+beeps: clean ~0.60, broken ~0.28
+const RMS_MIN = 0.005
+const RMS_MAX = 0.25
+
+const EXPECTATION = { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 }
+
+// result.data.samples is Int16-range PCM; normalise to [-1,1] for amplitude
+// metrics. nyquistEnergyFraction is a ratio (scale-invariant) regardless.
+function toFloat (pcm) {
+  let peak = 0
+  for (let i = 0; i < pcm.length; i++) {
+    const a = pcm[i] < 0 ? -pcm[i] : pcm[i]
+    if (a > peak) peak = a
+  }
+  const scale = peak > 1.5 ? 1 / 32768 : 1 // already float if peak <= 1.5
+  const out = new Float32Array(pcm.length)
+  for (let i = 0; i < pcm.length; i++) out[i] = pcm[i] * scale
+  return out
+}
+
+async function synthAndAnalyze (t, useGPU, label) {
+  const baseDir = getBaseDir()
+  const download = await ensureChatterboxModels({ targetDir: path.join(baseDir, 'models') })
+  if (!download.success) {
+    t.fail(`${label}: Chatterbox GGUFs not available - registry fetch failed`)
+    return null
+  }
+
+  const model = await loadChatterboxTTS({ modelDir: download.targetDir, language: 'en', useGPU })
+  t.ok(model, `${label}: Chatterbox model loaded`)
+  try {
+    const result = await runChatterboxTTS(model, { text: TEXT, saveWav: false }, EXPECTATION)
+    console.log(result.output)
+    t.ok(result.passed, `${label}: synthesis passes duration/sample expectations`)
+    if (!result.data || !result.data.samples || result.data.sampleCount <= 0) {
+      t.fail(`${label}: no audio samples returned`)
+      return null
+    }
+
+    const st = result.data.stats || {}
+    const a = analyzeSamples(toFloat(result.data.samples), result.data.reportedSampleRate || 24000)
+    t.comment(`${label}: backendDevice=${st.backendDevice} backendId=${st.backendId} gpuUnsupported=${st.gpuUnsupported} rtf=${st.realTimeFactor}`)
+    t.comment(`${label}: nyqFrac=${a.nyquistEnergyFraction.toExponential(3)} activeFrac=${a.activeFraction.toFixed(3)} rms=${a.rms.toFixed(4)} highBand=${a.highBandEnergyFraction.toExponential(3)}`)
+    return a
+  } finally {
+    try { await model.unload() } catch (_e) {}
+  }
+}
+
+test('Chatterbox audio CLEAN on CPU — Bug-1 SVE Nyquist-tone gate', { timeout: 1800000 }, async (t) => {
+  const a = await synthAndAnalyze(t, false, 'cpu')
+  if (!a) return
+  t.ok(a.nyquistEnergyFraction < NYQ_MAX, `cpu: no ~12 kHz Nyquist tone (nyqFrac ${a.nyquistEnergyFraction.toExponential(3)} < ${NYQ_MAX})`)
+  t.ok(a.rms > RMS_MIN && a.rms < RMS_MAX, `cpu: rms in [${RMS_MIN}, ${RMS_MAX}] (got ${a.rms.toFixed(4)})`)
+})
+
+test('Chatterbox audio CLEAN on GPU — Bug-1 + Bug-2 gates', { timeout: 1800000 }, async (t) => {
+  const a = await synthAndAnalyze(t, true, 'gpu')
+  if (!a) return
+  t.ok(a.nyquistEnergyFraction < NYQ_MAX, `gpu: no ~12 kHz Nyquist tone (nyqFrac ${a.nyquistEnergyFraction.toExponential(3)} < ${NYQ_MAX})`)
+  t.ok(a.activeFraction > ACTIVE_MIN, `gpu: audio not collapsed to blank+beeps (activeFrac ${a.activeFraction.toFixed(3)} > ${ACTIVE_MIN})`)
+  t.ok(a.rms > RMS_MIN && a.rms < RMS_MAX, `gpu: rms in [${RMS_MIN}, ${RMS_MAX}] (got ${a.rms.toFixed(4)})`)
+})

--- a/packages/tts-ggml/test/integration/chatterbox-audio-correctness.test.js
+++ b/packages/tts-ggml/test/integration/chatterbox-audio-correctness.test.js
@@ -26,6 +26,10 @@ const { analyzeSamples } = require('../utils/toneAnalysis')
 
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
+// The GPU subtest below validates the Mali/Adreno (Android) bug fixes. Skip it off
+// mobile or when NO_GPU is set: the macOS E2E job hardcodes NO_GPU=true and its
+// "Apple Paravirtual" GPU can't encode the S3-tokenizer MUL_MAT on Metal (aborts).
+const forceNoGpu = os.getEnv('NO_GPU') === 'true'
 
 function getBaseDir () {
   return isMobile && global.testDir ? global.testDir : '.'
@@ -92,7 +96,7 @@ test('Chatterbox audio CLEAN on CPU — Bug-1 SVE Nyquist-tone gate', { timeout:
   t.ok(a.rms > RMS_MIN && a.rms < RMS_MAX, `cpu: rms in [${RMS_MIN}, ${RMS_MAX}] (got ${a.rms.toFixed(4)})`)
 })
 
-test('Chatterbox audio CLEAN on GPU — Bug-1 + Bug-2 gates', { timeout: 1800000 }, async (t) => {
+test('Chatterbox audio CLEAN on GPU — Bug-1 + Bug-2 gates', { timeout: 1800000, skip: !isMobile || forceNoGpu }, async (t) => {
   const a = await synthAndAnalyze(t, true, 'gpu')
   if (!a) return
   t.ok(a.nyquistEnergyFraction < NYQ_MAX, `gpu: no ~12 kHz Nyquist tone (nyqFrac ${a.nyquistEnergyFraction.toExponential(3)} < ${NYQ_MAX})`)

--- a/packages/tts-ggml/test/mobile/integration.auto.cjs
+++ b/packages/tts-ggml/test/mobile/integration.auto.cjs
@@ -10,12 +10,20 @@ async function runAddonTest (options = {}) { // eslint-disable-line no-unused-va
   return runIntegrationModule('../integration/addon.test.js', options)
 }
 
+async function runChatterboxAudioCorrectnessTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/chatterbox-audio-correctness.test.js', options)
+}
+
 async function runChatterboxJaMecabTest (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/chatterbox-ja-mecab.test.js', options)
 }
 
 async function runChatterboxMtlTest (options = {}) { // eslint-disable-line no-unused-vars
   return runIntegrationModule('../integration/chatterbox-mtl.test.js', options)
+}
+
+async function runChatterboxSpeedTest (options = {}) { // eslint-disable-line no-unused-vars
+  return runIntegrationModule('../integration/chatterbox-speed.test.js', options)
 }
 
 async function runGpuSmokeTest (options = {}) { // eslint-disable-line no-unused-vars
@@ -48,8 +56,10 @@ async function runSupertonic3QuantTest (options = {}) { // eslint-disable-line n
 
 module.exports = {
   runAddonTest,
+  runChatterboxAudioCorrectnessTest,
   runChatterboxJaMecabTest,
   runChatterboxMtlTest,
+  runChatterboxSpeedTest,
   runGpuSmokeTest,
   runMultipleRunsTest,
   runRtfBenchmarkTest,

--- a/packages/tts-ggml/test/utils/toneAnalysis.js
+++ b/packages/tts-ggml/test/utils/toneAnalysis.js
@@ -1,0 +1,148 @@
+'use strict'
+
+// QVAC-20557 — audio-correctness metrics for the Chatterbox Mali fixes.
+// Run under `bare` (reuses wav-helper's bare-fs reader). All measures operate on
+// normalised Float32 samples in [-1, 1].
+//
+// Two device-specific bugs motivate these metrics, both calibrated on real
+// Pixel-9a audio (see chatterbox-audio-correctness.test.js):
+//   - Bug 1 (CPU/SVE): a constant ~12 kHz line = the Nyquist frequency of the
+//     24 kHz output. nyquistEnergyFraction is the decisive gate (clean ~1e-8 vs
+//     toney ~0.635).
+//   - Bug 2 (Mali GPU): the CFM miscompute collapses synthesis into "blank +
+//     beeps" (mostly silence). It carries NO Nyquist energy, so it is caught by
+//     activeFraction instead (clean ~0.60 vs broken ~0.28).
+
+const { readWavAsFloat32 } = require('./wav-helper')
+
+// Exact Nyquist-bin (f = SR/2) energy fraction, FFT-free via Parseval on the
+// alternating sum: X[N/2] = Σ s[n]·(-1)^n, energy_Nyq = (1/N)|X[N/2]|^2,
+// total = Σ s[n]^2  =>  frac = (Σ s[n]·(-1)^n)^2 / (N · Σ s[n]^2).
+// 1.0 for a pure ±A·(-1)^n tone, ~0 for DC / band-limited speech. Scale-invariant.
+function nyquistEnergyFraction (samples) {
+  if (!samples || samples.length === 0) return 0
+  let alt = 0
+  let energy = 0
+  let sign = 1
+  for (let i = 0; i < samples.length; i++) {
+    const x = samples[i]
+    alt += sign * x
+    energy += x * x
+    sign = -sign
+  }
+  if (energy <= 0) return 0
+  return (alt * alt) / (samples.length * energy)
+}
+
+// RMS amplitude of the (normalised) signal.
+function rmsEnergy (samples) {
+  if (!samples || samples.length === 0) return 0
+  let s = 0
+  for (let i = 0; i < samples.length; i++) s += samples[i] * samples[i]
+  return Math.sqrt(s / samples.length)
+}
+
+// Fraction of 20 ms frames that are "voiced/active": frame-RMS exceeds both 2% of
+// the clip peak and an absolute floor (0.005). Continuous speech is active most of
+// the time (~0.6); a "blank + beeps" collapse is active only briefly (~0.28).
+function activeFraction (samples, sampleRate) {
+  if (!samples || samples.length === 0) return 0
+  let peak = 0
+  for (let i = 0; i < samples.length; i++) {
+    const a = samples[i] < 0 ? -samples[i] : samples[i]
+    if (a > peak) peak = a
+  }
+  const frame = Math.max(1, Math.round(sampleRate * 0.02))
+  const floor = Math.max(0.005, 0.02 * peak)
+  let active = 0
+  let frames = 0
+  for (let off = 0; off + frame <= samples.length; off += frame) {
+    let s = 0
+    for (let i = 0; i < frame; i++) s += samples[off + i] * samples[off + i]
+    if (Math.sqrt(s / frame) > floor) active++
+    frames++
+  }
+  return frames > 0 ? active / frames : 0
+}
+
+// In-place iterative radix-2 Cooley–Tukey FFT (re/im, length must be a power of 2).
+function fftRadix2 (re, im) {
+  const n = re.length
+  for (let i = 1, j = 0; i < n; i++) {
+    let bit = n >> 1
+    for (; j & bit; bit >>= 1) j ^= bit
+    j ^= bit
+    if (i < j) {
+      const tr = re[i]; re[i] = re[j]; re[j] = tr
+      const ti = im[i]; im[i] = im[j]; im[j] = ti
+    }
+  }
+  for (let len = 2; len <= n; len <<= 1) {
+    const ang = -2 * Math.PI / len
+    const wr = Math.cos(ang)
+    const wi = Math.sin(ang)
+    for (let i = 0; i < n; i += len) {
+      let cr = 1
+      let ci = 0
+      for (let k = 0; k < len / 2; k++) {
+        const a = i + k
+        const b = i + k + len / 2
+        const vr = re[b] * cr - im[b] * ci
+        const vi = re[b] * ci + im[b] * cr
+        re[b] = re[a] - vr; im[b] = im[a] - vi
+        re[a] = re[a] + vr; im[a] = im[a] + vi
+        const ncr = cr * wr - ci * wi
+        ci = cr * wi + ci * wr
+        cr = ncr
+      }
+    }
+  }
+}
+
+// Fraction of spectral energy above cutoffHz, summed over non-overlapping 8192-pt
+// frames. Cross-check for the alternating-sum measure.
+function highBandEnergyFraction (samples, sampleRate, cutoffHz = 10000) {
+  const FRAME = 8192
+  if (!samples || samples.length < FRAME) return nyquistEnergyFraction(samples)
+  const binHz = sampleRate / FRAME
+  const cutBin = Math.max(1, Math.floor(cutoffHz / binHz))
+  let hi = 0
+  let tot = 0
+  for (let off = 0; off + FRAME <= samples.length; off += FRAME) {
+    const re = new Float64Array(FRAME)
+    const im = new Float64Array(FRAME)
+    for (let i = 0; i < FRAME; i++) re[i] = samples[off + i]
+    fftRadix2(re, im)
+    for (let k = 1; k <= FRAME / 2; k++) {
+      const p = re[k] * re[k] + im[k] * im[k]
+      tot += p
+      if (k >= cutBin) hi += p
+    }
+  }
+  return tot > 0 ? hi / tot : 0
+}
+
+function analyzeSamples (samples, sampleRate) {
+  return {
+    sampleRate,
+    samples: samples ? samples.length : 0,
+    nyquistEnergyFraction: nyquistEnergyFraction(samples),
+    highBandEnergyFraction: highBandEnergyFraction(samples, sampleRate, 10000),
+    rms: rmsEnergy(samples),
+    activeFraction: activeFraction(samples, sampleRate)
+  }
+}
+
+function analyzeWav (wavPath) {
+  const { samples, sampleRate } = readWavAsFloat32(wavPath)
+  return Object.assign({ wav: wavPath }, analyzeSamples(samples, sampleRate))
+}
+
+module.exports = {
+  nyquistEnergyFraction,
+  highBandEnergyFraction,
+  rmsEnergy,
+  activeFraction,
+  analyzeSamples,
+  analyzeWav
+}

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -4,6 +4,9 @@
     "baseline": "1130cabbc0bf939487cdf0f294019cc31c9ce765",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
+  "overlay-ports": [
+    "ports"
+  ],
   "registries": [
     {
       "kind": "git",


### PR DESCRIPTION
## ⚠️ DO-NOT-MERGE — CI validation only

One PR that pins **both** in-flight Chatterbox Mali fixes and adds an on-device audio-correctness test, so the AWS Device Farm CI (**Pixel 9 = Tensor/Mali**, **S25 = Adreno**) gives log evidence that both fixes produce proper audio — ready for the team to review/merge the real PRs. Throwaway scaffolding (overlay ports + a verify test); never merge.

Validates:
- **Bug-2 (GPU)** — `qvac-ext-lib-whisper.cpp` **#67** (`QVAC-20557-chbx-mali-fix`): admits Chatterbox to Mali Vulkan + is_arm_mali-gated unfused CFM attention (fixes the "blank+beeps"/f0→NaN break).
- **Bug-1 (CPU)** — `qvac-ext-ggml` **#30** (`QVAC-20557-sve-vecdot-tail-fix`, into `speech`): `ggml_vec_dot_f32` SVE leftover-tail `svmad→svmla` (fixes the ~12 kHz Nyquist tone in the CPU/SVE HiFT conv_transpose).

## How it works
- `packages/tts-ggml/ports/{tts-cpp,ggml-speech}/` — overlay ports that mirror the registry ports **verbatim** except the pin (each points at its fix-only branch). `vcpkg-configuration.json` adds `overlay-ports: ["ports"]`, so `bare-make generate` builds both fixes automatically (no CI YAML changes).
- `test/integration/chatterbox-audio-correctness.test.js` synthesizes Chatterbox on **CPU and GPU** and hard-asserts:
  - `nyquistEnergyFraction < 0.1` — Bug-1 gate (calibrated on real Pixel-9a audio: clean ~1e-8, SVE tone ~0.635).
  - `activeFraction > 0.4` (GPU run) — Bug-2 gate (clean ~0.60, blank+beeps ~0.28).
  - `rms ∈ [0.005, 0.25]` — silence/blowout sanity.
  - The GPU run on Mali exercises **both** fixes (CFM on GPU + CPU/SVE conv_transpose); the CPU run exercises Bug-1 only. Metrics are emitted via `t.comment` so thresholds are tunable from the first run.
- On clean platforms (Adreno / Metal / desktop) both subtests pass = no-regression coverage.

## How to run
Apply the **`verified`** label (authorized team member). The signal is the new test's **PASS lines on Pixel 9** + the `t.comment` nyqFrac/activeFrac metrics in the Device Farm logs. (The mobile job is `continue-on-error`, so read the logs — it isn't an auto-gate.)

## Pre-flight (local, off this branch)
- Both overlays resolve + **compose** for arm64-android (`bare-make generate` builds `ports/tts-cpp` + `ports/ggml-speech` together).
- `npm pack --dry-run` confirms `test/utils/toneAnalysis.js` ships (so the test can `require` it on-device).
- The test's in-memory analysis path reproduces the calibrated WAV metrics exactly on the real round-1 WAVs (clean passes; Bug-1 fails nyqFrac; Bug-2 fails activeFraction).

Do not merge — once both #67 and #30 merge, the fixes ship via the registry port-versions and these overlays are deleted.
