### PR TITLE
release(registry-client): v0.6.1

### DIFF
--- a/packages/registry-server/client/CHANGELOG.md
+++ b/packages/registry-server/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.6.1]
+
+Release Date: 2026-06-26
+
+### 🐛 Fixed
+
+- Registry model downloads now survive an app suspend/resume and a mid-download network drop: a stalled blob stream waits for the swarm to resume and a replication peer to return, then retries from the cached blocks instead of failing or re-downloading from scratch (#2864).
+- Reconnect waits are cancel-aware — a foreground cancel during the wait is honoured promptly instead of blocking until peers return (#2864).
+
 ## [0.6.0]
 
 Release Date: 2026-05-25

--- a/packages/registry-server/client/lib/client.js
+++ b/packages/registry-server/client/lib/client.js
@@ -16,6 +16,12 @@ const fs = require('#fs')
 const DEFAULT_DOWNLOAD_MAX_RETRIES = 3
 const RETRIABLE_DOWNLOAD_CODES = ['REQUEST_TIMEOUT']
 
+// While the app is backgrounded the swarm is suspended; a retry must wait for
+// resume rather than burn its (small) retry budget timing out against a dead
+// swarm. Bounded so a never-resumed runtime still fails instead of hanging.
+const RESUME_WAIT_MAX_MS = 5 * 60 * 1000
+const RESUME_WAIT_POLL_MS = 200
+
 class QVACRegistryClient extends ReadyResource {
   constructor (opts = {}) {
     super()
@@ -209,6 +215,81 @@ class QVACRegistryClient extends ReadyResource {
     return { core, blobs }
   }
 
+  /**
+   * Blocks while the swarm is suspended (app backgrounded), so a retry does not
+   * fire against a swarm that cannot connect yet and exhaust the retry budget.
+   * Bounded by RESUME_WAIT_MAX_MS; returns (and lets the retry proceed/fail) if
+   * the runtime never resumes.
+   */
+  async _waitForSwarmResumed (signal) {
+    if (!this.hyperswarm || !this.hyperswarm.suspended) return
+
+    const start = Date.now()
+    while (this.hyperswarm.suspended) {
+      if (signal && signal.aborted) throw new Error('Download cancelled')
+      if (Date.now() - start > RESUME_WAIT_MAX_MS) {
+        this.logger.warn('Swarm still suspended after resume wait; retrying anyway')
+        return
+      }
+      await new Promise(resolve => setTimeout(resolve, RESUME_WAIT_POLL_MS))
+    }
+  }
+
+  /**
+   * Blocks until at least one peer is replicating the core, so a retry after a
+   * network drop waits for the network to actually return instead of firing
+   * (and timing out) against zero peers and burning the retry budget. Bounded
+   * by RESUME_WAIT_MAX_MS. No-op when peer info is unavailable.
+   */
+  async _waitForPeers (core, signal) {
+    if (!core || !Array.isArray(core.peers)) return
+    if (core.peers.length > 0) return
+
+    const start = Date.now()
+    while (core.peers.length === 0) {
+      if (signal && signal.aborted) throw new Error('Download cancelled')
+      if (Date.now() - start > RESUME_WAIT_MAX_MS) {
+        this.logger.warn('No peers after reconnect wait; retrying anyway')
+        return
+      }
+      await new Promise(resolve => setTimeout(resolve, RESUME_WAIT_POLL_MS))
+    }
+  }
+
+  /**
+   * Re-establish peers for a blobs core before retrying a download. After the
+   * app backgrounds (or the network drops) the swarm connection for this core
+   * is gone; this waits for the swarm to resume and for a peer to be replicating
+   * the core, then re-runs the join + findingPeers + update sequence and awaits
+   * it. Resume itself is cheap: the next attempt reuses the blocks already
+   * cached in the core (the output file is re-streamed from those blocks, not
+   * appended to).
+   *
+   * Honours `signal`: a foreground cancel during the (bounded but up to
+   * RESUME_WAIT_MAX_MS) swarm/peer waits aborts promptly instead of blocking
+   * until peers return or the cap elapses.
+   */
+  async _reconnectCore (core, signal) {
+    if (!core || !this.hyperswarm) return
+    if (signal && signal.aborted) throw new Error('Download cancelled')
+
+    await this._waitForSwarmResumed(signal)
+
+    this.logger.debug('Re-establishing peers before download retry', {
+      discoveryKey: IdEnc.normalize(core.discoveryKey)
+    })
+
+    const done = core.findingPeers()
+    this.hyperswarm.join(core.discoveryKey, { client: true, server: false })
+    try {
+      await this.hyperswarm.flush()
+    } finally {
+      done()
+    }
+    await this._waitForPeers(core, signal)
+    await core.update()
+  }
+
   async downloadModel (path, source, options = {}) {
     this._validateString(path, 'path')
     this._validateString(source, 'source')
@@ -266,7 +347,11 @@ class QVACRegistryClient extends ReadyResource {
           {
             maxRetries: options.maxRetries != null ? options.maxRetries : DEFAULT_DOWNLOAD_MAX_RETRIES,
             retryCodes: RETRIABLE_DOWNLOAD_CODES,
-            onRetry: () => fs.promises.unlink(options.outputFile).catch(() => {}),
+            // Wait for the swarm to resume + reconnect peers before retrying,
+            // so the retry doesn't immediately time out again against a dead
+            // swarm (e.g. after the app backgrounded). The core's cached blocks
+            // are not cleared until success, so the retry re-streams cheaply.
+            beforeRetry: () => this._reconnectCore(core, options.signal),
             logger: this.logger
           }
         )
@@ -398,7 +483,9 @@ class QVACRegistryClient extends ReadyResource {
           {
             maxRetries: options.maxRetries != null ? options.maxRetries : DEFAULT_DOWNLOAD_MAX_RETRIES,
             retryCodes: RETRIABLE_DOWNLOAD_CODES,
-            onRetry: () => fs.promises.unlink(options.outputFile).catch(() => {}),
+            // Wait for swarm resume + peer reconnect before retrying (see
+            // downloadModel). Cached blocks are reused; the file is re-streamed.
+            beforeRetry: () => this._reconnectCore(core, options.signal),
             logger: this.logger
           }
         )

--- a/packages/registry-server/client/package.json
+++ b/packages/registry-server/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/registry-client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "QVAC Registry client library for read-only queries via Hyperswarm",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/registry-server/client/tests/unit/client.download-retry.test.js
+++ b/packages/registry-server/client/tests/unit/client.download-retry.test.js
@@ -1,0 +1,257 @@
+'use strict'
+
+const test = require('brittle')
+const tmp = require('test-tmp')
+const fs = require('#fs')
+const path = require('#path')
+const { withRetry } = require('../../utils/retry')
+
+// Builds a QVACRegistryClient instance WITHOUT running the constructor (which
+// would open a real Corestore and join a real swarm). Only the collaborators
+// that downloadModel touches are stubbed, so the real retry path runs.
+function makeClient () {
+  const QVACRegistryClient = require('../../lib/client')
+  const client = Object.create(QVACRegistryClient.prototype)
+
+  const events = []
+  client._events = events
+
+  client.logger = { info () {}, debug () {}, warn () {}, error () {} }
+
+  const core = {
+    discoveryKey: Buffer.alloc(32),
+    findingPeers () { events.push('findingPeers'); return () => {} },
+    async update () { events.push('core.update') },
+    download () { return { destroy () {} } },
+    async close () {},
+    on () {},
+    off () {}
+  }
+  const blobs = { async close () {} }
+  client._core = core
+
+  client.hyperswarm = {
+    suspended: false,
+    join () { events.push('swarm.join') },
+    async flush () {}
+  }
+
+  client._ensureMetadata = async () => {}
+  client.getModel = async () => ({
+    name: 'tiny-model',
+    blobBinding: {
+      coreKey: Buffer.alloc(32),
+      blockOffset: 0,
+      blockLength: 10,
+      byteLength: 1000
+    }
+  })
+  client._getBlobsCore = async () => ({ core, blobs })
+  client._clearBlobBlocks = async () => {}
+
+  return client
+}
+
+function requestTimeout () {
+  const err = new Error('request timed out waiting for peers')
+  err.code = 'REQUEST_TIMEOUT'
+  return err
+}
+
+const PARTIAL = Buffer.alloc(256, 1)
+const COMPLETE = Buffer.alloc(1000, 2)
+
+// The resume speedup comes from the core's cached blocks, not the output file
+// (which `_streamBlobToFile` truncates and re-streams each attempt). The real
+// invariant is that cached blocks are not cleared until the download succeeds.
+test('downloadModel keeps cached blocks across a REQUEST_TIMEOUT retry', async t => {
+  const dir = await tmp(t)
+  const outputFile = path.join(dir, 'model.gguf')
+
+  const client = makeClient()
+  let clearCalls = 0
+  let clearsBeforeRetrySucceeded = null
+  client._clearBlobBlocks = async () => { clearCalls++ }
+
+  let attempt = 0
+  client._streamBlobToFile = async (blobs, core, pointer, filePath) => {
+    attempt++
+    if (attempt === 1) throw requestTimeout()
+    clearsBeforeRetrySucceeded = clearCalls
+    await fs.promises.writeFile(filePath, COMPLETE)
+  }
+
+  await client.downloadModel('models/tiny.gguf', 's3', { outputFile, maxRetries: 3 })
+
+  t.is(attempt, 2, 'streamBlobToFile retried exactly once after REQUEST_TIMEOUT')
+  t.is(clearsBeforeRetrySucceeded, 0, 'cached blocks were not cleared before the retry')
+  t.is(clearCalls, 1, 'cached blocks cleared once, only after success')
+})
+
+test('downloadModel waits for the swarm to resume before retrying', async t => {
+  const dir = await tmp(t)
+  const outputFile = path.join(dir, 'model.gguf')
+
+  const client = makeClient()
+  // Start backgrounded; foreground shortly after the first failure.
+  let suspended = true
+  Object.defineProperty(client.hyperswarm, 'suspended', { get () { return suspended } })
+
+  let attempt = 0
+  client._streamBlobToFile = async (blobs, core, pointer, filePath) => {
+    attempt++
+    client._events.push('attempt-' + attempt)
+    if (attempt === 1) {
+      setTimeout(() => { suspended = false; client._events.push('resumed') }, 100)
+      throw requestTimeout()
+    }
+    await fs.promises.writeFile(filePath, COMPLETE)
+  }
+
+  await client.downloadModel('models/tiny.gguf', 's3', { outputFile, maxRetries: 3 })
+
+  const ev = client._events
+  t.is(attempt, 2, 'retried after the swarm resumed')
+  t.ok(ev.includes('resumed'), 'swarm resumed during the wait')
+  t.ok(
+    ev.indexOf('resumed') < ev.indexOf('attempt-2'),
+    'retry waited until the swarm resumed (did not burn the attempt while suspended)'
+  )
+})
+
+test('downloadModel waits for a replication peer before retrying', async t => {
+  const dir = await tmp(t)
+  const outputFile = path.join(dir, 'model.gguf')
+
+  const client = makeClient()
+  // No peers initially (network down); a peer shows up shortly after the failure.
+  client._core.peers = []
+
+  let attempt = 0
+  client._streamBlobToFile = async (blobs, core, pointer, filePath) => {
+    attempt++
+    client._events.push('attempt-' + attempt)
+    if (attempt === 1) {
+      setTimeout(() => { core.peers.push({}); client._events.push('peer-connected') }, 100)
+      throw requestTimeout()
+    }
+    await fs.promises.writeFile(filePath, COMPLETE)
+  }
+
+  await client.downloadModel('models/tiny.gguf', 's3', { outputFile, maxRetries: 3 })
+
+  const ev = client._events
+  t.is(attempt, 2, 'retried after a peer reconnected')
+  t.ok(ev.includes('peer-connected'), 'a peer reconnected during the wait')
+  t.ok(
+    ev.indexOf('peer-connected') < ev.indexOf('attempt-2'),
+    'retry waited until a peer was replicating the core'
+  )
+})
+
+test('downloadModel re-establishes peers before retrying after REQUEST_TIMEOUT', async t => {
+  const dir = await tmp(t)
+  const outputFile = path.join(dir, 'model.gguf')
+
+  const client = makeClient()
+  let attempt = 0
+
+  client._streamBlobToFile = async (blobs, core, pointer, filePath) => {
+    attempt++
+    client._events.push('attempt-' + attempt)
+    if (attempt === 1) {
+      await fs.promises.writeFile(filePath, PARTIAL)
+      throw requestTimeout()
+    }
+    await fs.promises.writeFile(filePath, COMPLETE)
+  }
+
+  await client.downloadModel('models/tiny.gguf', 's3', { outputFile, maxRetries: 3 })
+
+  const ev = client._events
+  const firstAttempt = ev.indexOf('attempt-1')
+  const secondAttempt = ev.indexOf('attempt-2')
+  t.ok(secondAttempt > firstAttempt, 'a second attempt happened')
+
+  const between = ev.slice(firstAttempt + 1, secondAttempt)
+  const reconnected =
+    between.includes('core.update') ||
+    between.includes('findingPeers') ||
+    between.includes('swarm.join')
+  t.ok(
+    reconnected,
+    'peer re-discovery / core re-sync runs and is awaited before the retry'
+  )
+})
+
+test('downloadModel gives up after maxRetries on persistent REQUEST_TIMEOUT', async t => {
+  const dir = await tmp(t)
+  const outputFile = path.join(dir, 'model.gguf')
+
+  const client = makeClient()
+  let attempt = 0
+
+  client._streamBlobToFile = async () => {
+    attempt++
+    throw requestTimeout()
+  }
+
+  await t.exception(
+    () => client.downloadModel('models/tiny.gguf', 's3', { outputFile, maxRetries: 2 }),
+    /request timed out/,
+    'rejects after exhausting retries'
+  )
+  t.is(attempt, 2, 'attempted exactly maxRetries times')
+})
+
+test('downloadModel aborts the reconnect wait when the signal is cancelled', async t => {
+  const dir = await tmp(t)
+  const outputFile = path.join(dir, 'model.gguf')
+
+  const client = makeClient()
+  // Swarm never resumes, so without a cancel the reconnect wait would block up
+  // to RESUME_WAIT_MAX_MS before the next attempt.
+  Object.defineProperty(client.hyperswarm, 'suspended', { get () { return true } })
+
+  const signal = { aborted: false }
+  let attempt = 0
+  client._streamBlobToFile = async (blobs, core, pointer, filePath) => {
+    attempt++
+    if (attempt === 1) {
+      // Cancel while _reconnectCore is waiting for the (never-resuming) swarm.
+      setTimeout(() => { signal.aborted = true }, 50)
+      throw requestTimeout()
+    }
+    await fs.promises.writeFile(filePath, COMPLETE)
+  }
+
+  await t.exception(
+    () => client.downloadModel('models/tiny.gguf', 's3', { outputFile, maxRetries: 3, signal }),
+    /Download cancelled/,
+    'cancel during the reconnect wait rejects promptly instead of blocking on the swarm'
+  )
+  t.is(attempt, 1, 'no second attempt started after the cancel')
+})
+
+// Locks the generic retry contract the download path relies on.
+test('withRetry retries only listed codes and stays bounded', async t => {
+  let calls = 0
+  await t.exception(
+    () => withRetry(
+      async () => { calls++; throw requestTimeout() },
+      { maxRetries: 3, retryCodes: ['REQUEST_TIMEOUT'] }
+    ),
+    /request timed out/
+  )
+  t.is(calls, 3, 'retried up to maxRetries')
+
+  let nonRetriable = 0
+  await t.exception(
+    () => withRetry(
+      async () => { nonRetriable++; const e = new Error('nope'); e.code = 'OTHER'; throw e },
+      { maxRetries: 3, retryCodes: ['REQUEST_TIMEOUT'] }
+    ),
+    /nope/
+  )
+  t.is(nonRetriable, 1, 'non-retriable error propagates immediately')
+})

--- a/packages/registry-server/client/utils/retry.js
+++ b/packages/registry-server/client/utils/retry.js
@@ -8,11 +8,14 @@
  * @param {number} [opts.maxRetries=3] - Maximum number of attempts (including the first)
  * @param {string[]} [opts.retryCodes=[]] - Error codes that trigger a retry
  * @param {() => Promise<void>} [opts.onRetry] - Called before each retry attempt (e.g. cleanup)
+ * @param {() => Promise<void>} [opts.beforeRetry] - Awaited before the next attempt runs.
+ *   Use to re-establish prerequisites (e.g. wait for peers to reconnect) so the
+ *   retry doesn't immediately fail again against a dead connection.
  * @param {{ warn: Function }} [opts.logger] - Logger instance for retry warnings
  * @returns {Promise<unknown>}
  */
 async function withRetry (fn, opts = {}) {
-  const { maxRetries = 3, retryCodes = [], onRetry, logger } = opts
+  const { maxRetries = 3, retryCodes = [], onRetry, beforeRetry, logger } = opts
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
@@ -22,6 +25,7 @@ async function withRetry (fn, opts = {}) {
       if (!isRetriable || attempt >= maxRetries) throw err
       logger && logger.warn(`Retrying after ${err.code} (attempt ${attempt}/${maxRetries}): ${err.message}`)
       if (onRetry) await onRetry()
+      if (beforeRetry) await beforeRetry()
     }
   }
 }


### PR DESCRIPTION
## Patch release `@qvac/registry-client` v0.6.1

Brings the QVAC-21225 registry-download resilience fix to the 0.6.x release line (cherry-picked from `main`, `92a31c44`).

### 🐛 Fixed
- Registry model downloads survive an app suspend/resume and a mid-download network drop: a stalled blob stream waits for the swarm to resume and a replication peer to return, then retries from the cached blocks instead of failing or re-downloading from scratch (#2864).
- Reconnect waits are cancel-aware — a foreground cancel during the wait is honoured promptly instead of blocking until peers return (#2864).

### Release metadata
- `package.json`: 0.6.0 → 0.6.1
- `CHANGELOG.md`: `## [0.6.1]`

Unit tests on the fix: 26/26 (node + bare).
