### PR TITLE
[TEST] ci-router label routing via pull_request (throwaway)

### DIFF
--- a/.github/workflows/on-pr-llm-llamacpp.yml
+++ b/.github/workflows/on-pr-llm-llamacpp.yml
@@ -1,17 +1,20 @@
 name: On PR Trigger (LLM)
 
 on:
-  pull_request_target:
+  # TEST-ONLY (throwaway branch): swapped pull_request_target -> pull_request
+  # so the head's workflow runs and ci-router can read PR labels. As of
+  # 2025-12-08 pull_request_target always uses the default-branch workflow,
+  # so routing logic cannot be exercised that way pre-merge. Base branch is
+  # `lgci-sandbox` (does not match main's trigger filter) so main's
+  # pull_request_target does not double-fire. NOT FOR MERGE.
+  pull_request:
     types:
       - opened
       - synchronize
       - reopened
       - labeled
     branches:
-      - main
-      - release-*
-      - feature-*
-      - tmp-*
+      - lgci-sandbox
     paths:
       - "packages/llm-llamacpp/**"
       - ".github/workflows/*llm-llamacpp*.yml"

--- a/.github/workflows/on-pr-llm-llamacpp.yml
+++ b/.github/workflows/on-pr-llm-llamacpp.yml
@@ -331,6 +331,15 @@ jobs:
             fi
           fi
 
+          # Ensure the diff base (DIFF_FROM) is present locally. The checkout is
+          # shallow and only HEAD_SHA / BEFORE_SHA were fetched above; the PR base
+          # SHA is otherwise absent, so `git diff` would fail and force the safe
+          # rebuild-everything fallback — silently defeating the cache. BASE_SHA
+          # always lives in origin (the base repo), so a plain fetch suffices.
+          if [ -n "$DIFF_FROM" ] && ! git cat-file -e "$DIFF_FROM" 2>/dev/null; then
+            git fetch origin "$DIFF_FROM" --depth=1 2>/dev/null || true
+          fi
+
           CHANGED=false
           if [ -n "$DIFF_FROM" ] && [ -n "$HEAD_SHA" ]; then
             DIFF_FILES=$(git diff --name-only "$DIFF_FROM" "$HEAD_SHA" -- 2>&1) || {

--- a/packages/llm-llamacpp/.ci-pr-event-test.md
+++ b/packages/llm-llamacpp/.ci-pr-event-test.md
@@ -1,0 +1,1 @@
+CI pull_request-event routing test marker (JS-only). Throwaway.

--- a/packages/llm-llamacpp/.ci-pr-event-test.md
+++ b/packages/llm-llamacpp/.ci-pr-event-test.md
@@ -1,1 +1,2 @@
 CI pull_request-event routing test marker (JS-only). Throwaway.
+JS-only edit 1782476031 to trigger synchronize for cache-hit test.

--- a/packages/llm-llamacpp/CMakeLists.txt
+++ b/packages/llm-llamacpp/CMakeLists.txt
@@ -195,3 +195,4 @@ if(BUILD_TESTING)
   # Pass ENABLE_COVERAGE option to test subdirectory
   add_subdirectory(test/unit)
 endif()
+# ci cache-invalidation test marker 1782476380 (harmless comment)


### PR DESCRIPTION
Throwaway PR. Trigger swapped to pull_request so the head workflow runs and ci-router reads labels (pull_request_target uses default-branch workflow since 2025-12-08). Base lgci-sandbox avoids double-firing main's workflow. NOT FOR MERGE.

Made with [Cursor](https://cursor.com)