### PR TITLE
fix: don't auto-close the bare worklet on unloadModel on Expo/Android

### DIFF
--- a/packages/sdk/client/api/unload-model.ts
+++ b/packages/sdk/client/api/unload-model.ts
@@ -1,6 +1,5 @@
-import { isBare } from "which-runtime";
 import { type UnloadModelRequest, type UnloadModelParams } from "@/schemas";
-import { send, close } from "@/client/rpc/rpc-client";
+import { send, close, autoCloseDefault } from "@/client/rpc/rpc-client";
 import { stopLoggingStreamForModel } from "@/client/logging-stream-registry";
 import {
   InvalidResponseError,
@@ -15,9 +14,16 @@ const logger = getClientLogger();
  *
  * When the last model is unloaded (no more models remain), this function
  * automatically closes the RPC connection on Node/Electron, allowing the
- * process to exit naturally without requiring manual cleanup. On Bare the
- * connection is left open by default so long-lived workers survive a routine
- * unload; pass `autoClose: true` to opt in to closing.
+ * process to exit naturally without requiring manual cleanup. On Bare and on
+ * Expo/React Native the connection is left open by default so the long-lived
+ * worker (a bare worklet on mobile) survives a routine unload and is reused by
+ * the next load; pass `autoClose: true` to opt in to closing. The per-runtime
+ * default is provided by the active RPC client as `autoCloseDefault`.
+ *
+ * NOTE (mobile): the bare worklet must NOT be auto-closed on Android — the
+ * worklet cannot be safely terminated there (addon dlclose leaves dangling
+ * pthread_key_t destructors), so closing would orphan the worklet (V8 isolate
+ * + thread + loaded model) and leak ~one worklet per load/unload cycle.
  *
  * @param params - The parameters for unloading the model
  * @param params.modelId - The unique identifier of the model to unload
@@ -43,7 +49,7 @@ export async function unloadModel(params: UnloadModelParams) {
 
   stopLoggingStreamForModel(params.modelId);
 
-  const shouldAutoClose = params.autoClose ?? !isBare;
+  const shouldAutoClose = params.autoClose ?? autoCloseDefault;
   if (
     shouldAutoClose &&
     response.hasActiveModels === false &&

--- a/packages/sdk/client/rpc/bare-client.ts
+++ b/packages/sdk/client/rpc/bare-client.ts
@@ -31,6 +31,11 @@ import {
 import { assertLifecycleAllowed } from "@/server/bare/runtime-lifecycle";
 import { ensurePluginsRegistered } from "@/client/rpc/ensure-worker-ready";
 
+// Bare hosts run the worker in-process and keep it open by default so
+// long-lived workers survive a routine unload (preserves prior `!isBare`
+// behavior); callers opt in to closing via `autoClose: true`.
+export const autoCloseDefault = false;
+
 async function ensureWorkerReady() {
   initializeWorkerCore();
   await ensurePluginsRegistered();

--- a/packages/sdk/client/rpc/expo-rpc-client.ts
+++ b/packages/sdk/client/rpc/expo-rpc-client.ts
@@ -10,6 +10,14 @@ import type { RuntimeContext } from "@/schemas";
 
 const logger = getClientLogger();
 
+// Do NOT auto-close the worklet on unload (Expo/React Native). The bare worklet
+// is long-lived and is reused across load/unload. On Android it cannot be
+// safely terminated at all (addon dlclose leaves dangling pthread_key_t
+// destructors), so auto-closing would only drop our references and orphan the
+// worklet (V8 isolate + thread + loaded model) — leaking ~one worklet per
+// load/unload cycle. See close() below, which intentionally skips terminate().
+export const autoCloseDefault = false;
+
 let rpcInstance: RPC | null = null;
 let rpcPromise: Promise<RPC> | null = null;
 let workletInstance: Worklet | null = null;

--- a/packages/sdk/client/rpc/node-rpc-client.ts
+++ b/packages/sdk/client/rpc/node-rpc-client.ts
@@ -29,6 +29,11 @@ const logger = getClientLogger();
 // worker's stderr is treated as debug.
 const workerLogger = getLogger(SDK_SERVER_NAMESPACE, { enableConsole: false });
 
+// Auto-close the worker on unload (Node/Electron): the worker is a child
+// process that can be cleanly terminated, and closing it lets the host process
+// exit naturally once the last model is unloaded.
+export const autoCloseDefault = true;
+
 let rpcInstance: RPC | null = null;
 let rpcPromise: Promise<RPC> | null = null;
 let bareWorkerProc: BareChildProcess | null = null;

--- a/packages/sdk/client/rpc/rpc-client.ts
+++ b/packages/sdk/client/rpc/rpc-client.ts
@@ -16,6 +16,10 @@ import {
   createDuplexSession,
   getWorkerLifeSignal,
 } from "#rpc";
+// Per-runtime default for whether `unloadModel` auto-closes the RPC connection
+// when the last model is unloaded. Re-exported from the active `#rpc` client so
+// callers don't need to branch on the runtime themselves.
+export { autoCloseDefault } from "#rpc";
 import {
   WorkerCrashedError,
   RequestValidationFailedError,


### PR DESCRIPTION
## Problem

On mobile (Expo/React Native + Android), repeated `loadModel`/`unloadModel`
leaks ~150 MB per cycle and eventually OOMs (observed: OCR PSS 488 → 2734 MB
over 15 cycles). It looked like a native/ggml/addon leak, but it isn't.

## Root cause

`unloadModel` auto-closes the RPC connection when the last model is unloaded:

```ts
const shouldAutoClose = params.autoClose ?? !isBare;
```

The mobile **host** runs in Hermes, not bare, so `isBare === false` → `!isBare`
is `true` → auto-close fires on every unload.

`close()` on Android **cannot terminate the bare worklet** — `terminate()`
crashes there (addon `dlclose` leaves dangling `pthread_key_t` destructors), so
the Expo client deliberately skips `terminate()` and just drops its references.
That **orphans the worklet** (its V8 isolate + `mqt_v_js` thread + the model
loaded inside it). The next `loadModel` spawns a brand-new worklet, so each
load/unload cycle leaks roughly one whole worklet (~150 MB) until OOM.

This was confirmed by reproducing the leak with a **trivial `malloc`-and-free
model** driven through the real SDK over RPC (leaks identically), while the same
model load/unload **inside a single reused worklet is flat** — i.e. the addon is
innocent; the leak is the orphaned worklets. Observed `mqt_v_js` thread count
grew to 24 and kept climbing.

## Fix

Replace the `!isBare` heuristic with a per-RPC-client `autoCloseDefault`,
re-exported through `#rpc` so callers don't branch on the runtime:

| RPC client | `autoCloseDefault` | rationale |
|---|---|---|
| expo (React Native) | `false` | worklet is long-lived + reused; un-terminable on Android |
| bare | `false` | preserves prior behavior (long-lived in-process worker) |
| node | `true` | child-process worker can be terminated so the host exits |

Node/Electron and Bare behavior is unchanged; only Expo/React Native flips from
auto-close (buggy) to reuse. The explicit `autoClose` param still overrides.

## Verification

Pixel 10 Pro XL, Android 16, OCR `loadModel`/`unloadModel` ×15:

| | before | after |
|---|---|---|
| PSS | 488 → 2734 MB | flat ~440 MB |
| `mqt_v_js` worklet threads | 24, growing | stable |

## Follow-up (out of scope here)

Longer term, bare-kit's worklet `terminate()` should be made safe on Android
(the addon `dlclose` / dangling `pthread_key_t` issue) so worklets can be torn
down when genuinely needed.
