### PR TITLE
docs[ocr-ggml]: correct stale OpenCL POOL_2D comments

### DIFF
--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -77,9 +77,9 @@ struct MatchingDevice {
 //
 // The defect is specific to Adreno's *Vulkan* path, so the check is scoped to
 // the Vulkan backend rather than the GPU name alone: Adreno's OpenCL backend is
-// numerically sound and is the supported OpenCL path for Adreno (QVAC-19798), so
-// an Adreno-via-OpenCL device must NOT be rejected here. Apple Metal devices are
-// never Adreno, so the Metal path is unaffected.
+// numerically sound and is the supported OpenCL path for Adreno (QVAC-19798),
+// so an Adreno-via-OpenCL device must NOT be rejected here. Apple Metal devices
+// are never Adreno, so the Metal path is unaffected.
 bool isBrokenGpuDevice(ggml_backend_dev_t dev) {
   const char* descRaw = ggml_backend_dev_description(dev);
   if (descRaw == nullptr ||
@@ -245,17 +245,17 @@ namespace {
 // the selected backend does not implement — so a GPU backend that cannot run a
 // required op must be rejected here, in favour of CPU, rather than crashing at
 // inference time. This originally guarded ggml's OpenCL backend, which lacked
-// POOL_2D and aborted on the CRAFT detector (QVAC-19798); the OpenCL backend now
-// implements POOL_2D (and the other OCR vision ops) as of qvac-fabric 8828.1.2,
-// so it passes this probe and runs OCR end-to-end. The probe remains a safety
-// net for any current or future backend that is missing a required op.
+// POOL_2D and aborted on the CRAFT detector (QVAC-19798); the OpenCL backend
+// now implements POOL_2D (and the other OCR vision ops) as of qvac-fabric
+// 8828.1.2, so it passes this probe and runs OCR end-to-end. The probe remains
+// a safety net for any current or future backend that is missing a required op.
 //
 // POOL_2D is a reliable representative probe: it is used by every OCR graph
 // (EasyOCR CRAFT max-pools, CRNN max/avg-pools, DocTR DBNet / recognizer SE
 // avg-pools) and was historically the op ggml's OpenCL backend was missing,
-// while the full-featured Vulkan/Metal backends support it. The probe op mirrors
-// the production call in `easyocr/craft.cpp` (`maxpool_2x2`) so a device that
-// runs OCR for real is never falsely rejected.
+// while the full-featured Vulkan/Metal backends support it. The probe op
+// mirrors the production call in `easyocr/craft.cpp` (`maxpool_2x2`) so a
+// device that runs OCR for real is never falsely rejected.
 bool deviceSupportsRequiredOcrOps(ggml_backend_dev_t dev) {
   if (dev == nullptr) {
     return false;

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -77,8 +77,8 @@ struct MatchingDevice {
 //
 // The defect is specific to Adreno's *Vulkan* path, so the check is scoped to
 // the Vulkan backend rather than the GPU name alone: Adreno's OpenCL backend is
-// numerically sound, and OpenCL support for Adreno is planned, so an
-// Adreno-via-OpenCL device must NOT be rejected here. Apple Metal devices are
+// numerically sound and is the supported OpenCL path for Adreno (QVAC-19798), so
+// an Adreno-via-OpenCL device must NOT be rejected here. Apple Metal devices are
 // never Adreno, so the Metal path is unaffected.
 bool isBrokenGpuDevice(ggml_backend_dev_t dev) {
   const char* descRaw = ggml_backend_dev_description(dev);
@@ -244,15 +244,18 @@ namespace {
 // hard-aborts (GGML_ASSERT in the backend) when a compute graph contains an op
 // the selected backend does not implement — so a GPU backend that cannot run a
 // required op must be rejected here, in favour of CPU, rather than crashing at
-// inference time (QVAC-19798: ggml's OpenCL backend lacks POOL_2D and aborts on
-// the CRAFT detector).
+// inference time. This originally guarded ggml's OpenCL backend, which lacked
+// POOL_2D and aborted on the CRAFT detector (QVAC-19798); the OpenCL backend now
+// implements POOL_2D (and the other OCR vision ops) as of qvac-fabric 8828.1.2,
+// so it passes this probe and runs OCR end-to-end. The probe remains a safety
+// net for any current or future backend that is missing a required op.
 //
 // POOL_2D is a reliable representative probe: it is used by every OCR graph
 // (EasyOCR CRAFT max-pools, CRNN max/avg-pools, DocTR DBNet / recognizer SE
-// avg-pools) and is exactly the op ggml's OpenCL backend is missing, while the
-// full-featured Vulkan/Metal backends support it. The probe op mirrors the
-// production call in `easyocr/craft.cpp` (`maxpool_2x2`) so a device that runs
-// OCR for real is never falsely rejected.
+// avg-pools) and was historically the op ggml's OpenCL backend was missing,
+// while the full-featured Vulkan/Metal backends support it. The probe op mirrors
+// the production call in `easyocr/craft.cpp` (`maxpool_2x2`) so a device that
+// runs OCR for real is never falsely rejected.
 bool deviceSupportsRequiredOcrOps(ggml_backend_dev_t dev) {
   if (dev == nullptr) {
     return false;
@@ -366,10 +369,11 @@ bool trySelectGpu(
 
   const MatchingDevice& md = candidates[*chosen];
 
-  // Guard against backends that match the request but cannot run the OCR ops
-  // (e.g. ggml's OpenCL backend selects on Adreno but lacks POOL_2D and would
-  // GGML_ABORT at inference). Reject here and fall back to CPU with a clear
-  // reason instead of crashing. Full-featured Vulkan/Metal devices pass.
+  // Guard against backends that match the request but cannot run the OCR ops:
+  // any backend missing a required op (such as POOL_2D) would GGML_ABORT at
+  // inference. Reject here and fall back to CPU with a clear reason instead of
+  // crashing. Full-featured Vulkan/Metal/OpenCL devices pass (ggml's OpenCL
+  // backend implements POOL_2D as of qvac-fabric 8828.1.2; see QVAC-19798).
   if (!deviceSupportsRequiredOcrOps(md.dev)) {
     sel.fallbackReason =
         std::string(label) + " backend '" +

--- a/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
+++ b/packages/ocr-ggml/addon/src/model-interface/OcrBackendSelection.cpp
@@ -77,9 +77,9 @@ struct MatchingDevice {
 //
 // The defect is specific to Adreno's *Vulkan* path, so the check is scoped to
 // the Vulkan backend rather than the GPU name alone: Adreno's OpenCL backend is
-// numerically sound and is the supported OpenCL path for Adreno (QVAC-19798),
-// so an Adreno-via-OpenCL device must NOT be rejected here. Apple Metal devices
-// are never Adreno, so the Metal path is unaffected.
+// numerically sound and is the supported OpenCL path for Adreno, so an
+// Adreno-via-OpenCL device must NOT be rejected here. Apple Metal devices are
+// never Adreno, so the Metal path is unaffected.
 bool isBrokenGpuDevice(ggml_backend_dev_t dev) {
   const char* descRaw = ggml_backend_dev_description(dev);
   if (descRaw == nullptr ||
@@ -245,10 +245,10 @@ namespace {
 // the selected backend does not implement — so a GPU backend that cannot run a
 // required op must be rejected here, in favour of CPU, rather than crashing at
 // inference time. This originally guarded ggml's OpenCL backend, which lacked
-// POOL_2D and aborted on the CRAFT detector (QVAC-19798); the OpenCL backend
-// now implements POOL_2D (and the other OCR vision ops) as of qvac-fabric
-// 8828.1.2, so it passes this probe and runs OCR end-to-end. The probe remains
-// a safety net for any current or future backend that is missing a required op.
+// POOL_2D and aborted on the CRAFT detector; the OpenCL backend now implements
+// POOL_2D (and the other OCR vision ops) as of qvac-fabric 8828.1.2, so it
+// passes this probe and runs OCR end-to-end. The probe remains a safety net
+// for any current or future backend that is missing a required op.
 //
 // POOL_2D is a reliable representative probe: it is used by every OCR graph
 // (EasyOCR CRAFT max-pools, CRNN max/avg-pools, DocTR DBNet / recognizer SE
@@ -373,7 +373,7 @@ bool trySelectGpu(
   // any backend missing a required op (such as POOL_2D) would GGML_ABORT at
   // inference. Reject here and fall back to CPU with a clear reason instead of
   // crashing. Full-featured Vulkan/Metal/OpenCL devices pass (ggml's OpenCL
-  // backend implements POOL_2D as of qvac-fabric 8828.1.2; see QVAC-19798).
+  // backend implements POOL_2D as of qvac-fabric 8828.1.2).
   if (!deviceSupportsRequiredOcrOps(md.dev)) {
     sel.fallbackReason =
         std::string(label) + " backend '" +

--- a/packages/ocr-ggml/addon/src/model-interface/easyocr/kernel_precision.hpp
+++ b/packages/ocr-ggml/addon/src/model-interface/easyocr/kernel_precision.hpp
@@ -117,9 +117,8 @@ inline bool ocr_kernels_use_f16(
 // fragile (cos-sim ~0.73 vs reference; a regularB test regressed on a Galaxy
 // S25 Ultra / Adreno when mul_mat ran there), and OcrBackendSelection already
 // auto-skips Adreno Vulkan to CPU. The exclusion is keyed on the backend *API*,
-// not the chip, so a future Adreno-OpenCL backend (QVAC-19798) is NOT blocked
-// and can adopt mul_mat once validated. The env overrides below take
-// precedence.
+// not the chip, so the Adreno-OpenCL backend (QVAC-19798) is NOT blocked and
+// uses mul_mat like any other GPU. The env overrides below take precedence.
 inline bool ocr_conv1x1_mulmat_default(ggml_backend_t backend) {
   ggml_backend_dev_t dev =
       (backend != nullptr) ? ggml_backend_get_device(backend) : nullptr;

--- a/packages/ocr-ggml/addon/src/model-interface/easyocr/kernel_precision.hpp
+++ b/packages/ocr-ggml/addon/src/model-interface/easyocr/kernel_precision.hpp
@@ -117,8 +117,8 @@ inline bool ocr_kernels_use_f16(
 // fragile (cos-sim ~0.73 vs reference; a regularB test regressed on a Galaxy
 // S25 Ultra / Adreno when mul_mat ran there), and OcrBackendSelection already
 // auto-skips Adreno Vulkan to CPU. The exclusion is keyed on the backend *API*,
-// not the chip, so the Adreno-OpenCL backend (QVAC-19798) is NOT blocked and
-// uses mul_mat like any other GPU. The env overrides below take precedence.
+// not the chip, so the Adreno-OpenCL backend is NOT blocked and uses mul_mat
+// like any other GPU. The env overrides below take precedence.
 inline bool ocr_conv1x1_mulmat_default(ggml_backend_t backend) {
   ggml_backend_dev_t dev =
       (backend != nullptr) ? ggml_backend_get_device(backend) : nullptr;


### PR DESCRIPTION
## Summary
- ggml's OpenCL backend now implements `POOL_2D` (plus the other OCR vision ops: `CONV_2D_DW`, `HARDSWISH`, `HARDSIGMOID`) as of `qvac-fabric` `8828.1.2` (QVAC-19798 / fabric PR [#160](https://github.com/tetherto/qvac-fabric-llm.cpp/pull/160)). Several code comments in `ocr-ggml` still claimed the opposite — that OpenCL "lacks POOL_2D and aborts on the CRAFT detector" — which is no longer true and is misleading.
- This corrects those stale comments. **Comment-only change; no behavior change.**

### What changed
- `addon/src/model-interface/OcrBackendSelection.cpp`
  - Reframe the `deviceSupportsRequiredOcrOps` (POOL_2D) probe docs as a general safety net for *any* backend missing a required op, and note that OpenCL now passes it and runs OCR end-to-end.
  - Update the Adreno-OpenCL reference from "OpenCL support for Adreno is planned" to the supported/shipped path.
  - Update the in-function reject-guard comment so it no longer asserts OpenCL lacks POOL_2D.
- `addon/src/model-interface/easyocr/kernel_precision.hpp`
  - Update the "a future Adreno-OpenCL backend" wording to present tense.

### Context
Verified on CI run #601 (`main`, `b44d461`): on a Samsung Galaxy S25 Ultra, requesting `backendDevice: 'opencl'` resolves to `GPUOpenCL` (Adreno 830) with no fallback (`backendIsGpu: 1`), the op-support probe passes, and CRAFT detection runs ~5x faster than CPU. The README and CHANGELOG already reflect this; only the inline code comments were stale.

## Test plan
- [ ] No functional change — comment-only. Existing `ocr-ggml` integration/mobile tests (incl. `opencl-backend` / `android-opencl`) should remain green.

Made with [Cursor](https://cursor.com)