### PR TITLE
QVAC-21481 feat[mod]: add LavaSR GGUF enhancer models

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -4957,6 +4957,38 @@
     "link": "https://huggingface.co/supertone/supertonic-3"
   },
   {
+    "source": "s3:///qvac_models_compiled/ggml/lavasr/2026-06-26/lavasr-enhancer-f16.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "LavaSR speech enhancer (GGUF)",
+    "quantization": "fp16",
+    "params": "",
+    "licenseId": "MIT",
+    "tags": [
+      "tts",
+      "lavasr",
+      "enhancer",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/spaces/YatharthS/LavaSR "
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/lavasr/2026-06-26/lavasr-enhancer-f32.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "LavaSR speech enhancer (GGUF)",
+    "quantization": "fp32",
+    "params": "",
+    "licenseId": "MIT",
+    "tags": [
+      "tts",
+      "lavasr",
+      "enhancer",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/spaces/YatharthS/LavaSR "
+  },
+  {
     "source": "https://huggingface.co/onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/tokenizer.json",
     "engine": "@qvac/tts",
     "description": "Supertonic tokenizer",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Makes the LavaSR GGUF speech enhancer models discoverable through the production model registry.
- Adds both fp16 and fp32 variants for @qvac/tts-ggml consumers.

## 📝 How does it solve it?

- Adds two @qvac/tts-ggml entries to packages/registry-server/data/models.prod.json.
- Points the entries at the uploaded S3 registry paths under qvac_models_compiled/ggml/lavasr/2026-06-26.
- Tags the models as tts, lavasr, enhancer, and gguf, with the source link set to https://huggingface.co/spaces/YatharthS/LavaSR.

## 📦 Models

### Added models

```
TTS_ENHANCER_LAVASR_FP16
TTS_ENHANCER_LAVASR_FP32
```

## 🧪 How was it tested?

- Verified packages/registry-server/data/models.prod.json parses as valid JSON.

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216042123586600