### PR TITLE
fix[notask]: revert expo non-ios close worker teardown (#2639)

### DIFF
--- a/packages/sdk/client/rpc/expo-rpc-client.ts
+++ b/packages/sdk/client/rpc/expo-rpc-client.ts
@@ -195,11 +195,8 @@ export async function close(): Promise<void> {
 
     // terminate() crashes on Android (addon dlclose leaves pthread_key_t
     // destructors dangling); iOS dyld no-ops dlclose so it's safe there.
-    // Non-iOS: send the cleanup roundtrip, then drop refs without
-    // terminating. Android cannot safely terminate/dlclose the worklet
-    // here, but reset/reload still needs addon logger js_ref_t handles
-    // released before a fresh worker registers plugins in the same app
-    // process.
+    // Non-iOS: drop refs only -- sending __shutdown__ without a follow-up
+    // terminate would clear the worker plugin registry.
     let platform: string | undefined;
     try {
       platform = (await getRuntimeContext()).platform;
@@ -208,14 +205,8 @@ export async function close(): Promise<void> {
     }
 
     if (platform !== "ios") {
-      if (rpcInstance) {
-        logger.info("🧹 Requesting worker cleanup");
-        await sendShutdownMessage(rpcInstance);
-      }
       rpcInstance = null;
       rpcPromise = null;
-      workletInstance = null;
-      workletInitialized = false;
       return;
     }
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- On Android the bare worklet can't be `terminate()`d, so #2639's `__shutdown__`-on-close plus `workletInstance = null` orphaned a whole worklet (V8 isolate + `mqt_v_js` thread + loaded model) on every auto-close (i.e. every last `unloadModel`), leaking ~one worklet per load/unload cycle until OOM.
- The full Android e2e suite hit **270/449 failures** with the device OOMing mid-run (~4.7 GB PSS, consumer marked dead), versus **2/449** without the orphaning.

## 📝 How does it solve it?

- Reverts #2639, restoring the prior #1797 non-iOS `close()` behavior: drop RPC refs only (`rpcInstance` / `rpcPromise`) and keep + reuse the worklet on the next `getRPC()`.
- Sending `__shutdown__` on close guts the worker's plugin registry, which is the only reason the worklet had to be dropped. Not sending it keeps the worker reusable, so memory stays flat across load/unload cycles.
- iOS path is unchanged (still pre-terminate cleanup + `terminate()`).

## 🧪 How was it tested?

- Change is the exact inverse of #2639 (single-file blob revert of `expo-rpc-client.ts`).
- Lint/typecheck not run locally (SDK deps not installed in this checkout). Recommend running the Android e2e job on this branch to confirm flat memory and the 270 → ~2 failure delta.

---

Temporary measure: this also removes #2639's addon logger `js_ref_t` release on reset/reload. Follow-ups: (1) root-cause fix for the addon logger ref so reset is safe without dropping the worklet, (2) the upstream bare Android `terminate()` fix (`RTLD_NODELETE`) so worklets can be torn down at all on Android.
