### PR TITLE
[TEST cachefix] mobile cache-hit uses merged prebuilds (not @latest)

### DIFF
--- a/.github/workflows/on-pr-llm-llamacpp.yml
+++ b/.github/workflows/on-pr-llm-llamacpp.yml
@@ -1,17 +1,17 @@
 name: On PR Trigger (LLM)
 
 on:
-  pull_request_target:
+  # TEST-ONLY (throwaway branch): pull_request_target -> pull_request so the
+  # head workflow runs and ci-router reads PR labels. Base lgci-sandbox does
+  # not match main's trigger filter. NOT FOR MERGE.
+  pull_request:
     types:
       - opened
       - synchronize
       - reopened
       - labeled
     branches:
-      - main
-      - release-*
-      - feature-*
-      - tmp-*
+      - lgci-sandbox
     paths:
       - "packages/llm-llamacpp/**"
       - ".github/workflows/*llm-llamacpp*.yml"

--- a/packages/llm-llamacpp/.ci-cachefix.md
+++ b/packages/llm-llamacpp/.ci-cachefix.md
@@ -1,0 +1,1 @@
+cache-fix verification marker (JS-only, non-native)


### PR DESCRIPTION
Throwaway: verify #1 fix. Step 1 label verified+prebuilds -> build+save cache. Step 2 add run-mobile -> cache hit -> mobile must use merged prebuilds artifact, NOT npm @latest. NOT FOR MERGE.

Made with [Cursor](https://cursor.com)