### PR TITLE
QVAC-19291 chore[vla]: bump vla-ggml to 0.8.0 + changelog

### DIFF
--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.8.0] - 2026-06-30
+
+### Added
+
+- ROCm/HIP GPU backend for AMD GPUs on Linux (Strix Halo / gfx1151), built as a `GGML_BACKEND_DL` module (`libqvac-ggml-hip.so`) alongside Vulkan. `BackendSelection` prefers the ROCm device at runtime with Vulkan/CPU fallback; an unloadable HIP module or non-AMD target is skipped by the DL loader. Opt-in via the `qvac-fabric[hip-backend]` feature (linux-x64 only) — other consumers are unaffected and gain no ROCm dependency.
+
+### Changed
+
+- `default-registry` baseline raised to consume the published `qvac-fabric` `hip-backend` feature and the new `hip` port directly from the registry ([qvac-registry-vcpkg #206](https://github.com/tetherto/qvac-registry-vcpkg/pull/206)); no in-tree overlay ports.
+
+## Pull Requests
+
+- [#2781](https://github.com/tetherto/qvac/pull/2781) - QVAC-19291 feat[api]: vla-ggml ROCm/HIP backend (gfx1151, Strix Halo)
+
 ## [0.7.0] - 2026-06-24
 
 ### Changed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
Splits the version bump + changelog for the vla-ggml ROCm/HIP backend out of #2781 (merged) into its own PR.

- `@qvac/vla-ggml` `0.7.0` -> `0.8.0`
- Adds the `## [0.8.0]` changelog entry (HIP backend Added; registry/baseline Changed)

No code change — the backend itself landed in #2781.