### PR TITLE
QVAC-19223 feat: pilot OIDC publish chain in qvac-ci via tetherto/qvac-actions@0.1.0

### DIFF
--- a/.github/workflows/trigger-reusable-lib-qvac-ci.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-ci.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
     outputs:

--- a/.github/workflows/trigger-reusable-lib-qvac-ci.yml
+++ b/.github/workflows/trigger-reusable-lib-qvac-ci.yml
@@ -68,43 +68,7 @@ jobs:
       gpr_tag: ${{ steps.logic.outputs.gpr_tag }}
     steps:
       - id: logic
-        shell: bash
-        run: |
-          set -euo pipefail
-          ref_name="${GITHUB_REF_NAME}"
-          event_name="${GITHUB_EVENT_NAME}"
-
-          publish_main="false"
-          publish_release="false"
-          publish_feature="false"
-          publish_tmp="false"
-
-          if [ "$event_name" = "push" ] || [ "$event_name" = "workflow_dispatch" ]; then
-            if [ "$ref_name" = "main" ]; then
-              publish_main="true"
-            elif [[ "$ref_name" == release-* ]]; then
-              publish_release="true"
-            elif [[ "$ref_name" == feature-* ]]; then
-              publish_feature="true"
-            elif [[ "$ref_name" == tmp-* ]]; then
-              publish_tmp="true"
-            fi
-          fi
-
-          gpr_tag="dev"
-          if [ "$ref_name" = "main" ]; then
-            gpr_tag="dev"
-          elif [[ "$ref_name" == feature-* ]]; then
-            gpr_tag="feature"
-          elif [[ "$ref_name" == tmp-* ]]; then
-            gpr_tag="temp"
-          fi
-
-          echo "publish_main=$publish_main" >> "$GITHUB_OUTPUT"
-          echo "publish_release=$publish_release" >> "$GITHUB_OUTPUT"
-          echo "publish_feature=$publish_feature" >> "$GITHUB_OUTPUT"
-          echo "publish_tmp=$publish_tmp" >> "$GITHUB_OUTPUT"
-          echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
+        uses: tetherto/qvac-actions/npm-publish-logic@0.1.0
 
   lint-and-test:
     runs-on: ubuntu-latest
@@ -157,17 +121,39 @@ jobs:
       - publish-logic
       - release-merge-guard
       - label-gate
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
     if: |-
       needs.label-gate.outputs.authorised == 'true' && (always() && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped'))
-    uses: ./.github/workflows/public-reusable-npm.yml
-    secrets: inherit
-    with:
-      workdir: packages/qvac-ci
-      caller_event_name: ${{ github.event_name }}
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    outputs:
+      published_version: ${{ steps.publish.outputs.npm_published_version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Determine dist-tag
+        id: dist-tag
+        uses: tetherto/qvac-actions/npm-dist-tag-determination@0.1.0
+        with:
+          workdir: ${{ env.WORKDIR }}
+
+      - name: Enable Socket Firewall Guard
+        uses: ./.github/actions/sfw-guard
+        with:
+          firewall-mode: firewall-free
+          clear-caches: "false"
+          managers: npm,pip,pip3,uv,cargo
+          workdir: ${{ env.WORKDIR }}
+
+      - name: Publish to npm
+        id: publish
+        uses: tetherto/qvac-actions/publish-library-to-npm@0.1.0
+        with:
+          workdir: ${{ env.WORKDIR }}
+          tag: ${{ steps.dist-tag.outputs.tag }}
 
   # Tag the published version (no GitHub Release; SDK-only releases policy)
   create-tag:

--- a/packages/qvac-ci/CHANGELOG.md
+++ b/packages/qvac-ci/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.2.1] - 2026-06-30
+
+### Fixed
+
+- README: remove stale GPR/`ci-mono` distribution note, correct `lib/commands/index.js` registration step (explicit import + push to commands array)
+
+## [0.2.0] - 2026-06-24
+
+### Added
+
+- `--version` / `-v` flag: prints `qvac-ci v<version>` and exits
+
+### Changed
+
+- Replace `paparam` runtime dependency with a zero-dependency internal CLI builder (`lib/cli.js`); no change to command behaviour or flags
+
 ## [0.1.0] - 2026-06-04
 
 ### Added

--- a/packages/qvac-ci/README.md
+++ b/packages/qvac-ci/README.md
@@ -1,8 +1,6 @@
 # @qvac/ci
 
-CI utilities — a modular, extensible CLI for GitHub automation. Replaces inline YAML scripts with tested, versioned Node.js commands.
-
-> **Note:** Development and feature builds are published to GitHub Packages (GPR) under the name `@qvac/ci-mono`. The unscoped `@qvac/ci` name is only available after a release-branch npm publish.
+CLI utilities for GitHub CI automation. Replaces inline YAML scripts with tested, versioned Node.js commands.
 
 ## Installation
 
@@ -20,11 +18,11 @@ npx @qvac/ci <command> [flags]
 
 ### `pending-approvals`
 
-Checks whether a PR has the required approvals from the right roles (Management, Team Lead, Member), then upserts a `## Review Status` comment on the PR summarising the current state.
+Checks whether a PR has the required approvals from the right roles (Management, Team Lead, Member) and upserts a `## Review Status` comment on the PR summarising the current state.
 
-Always exits with code `0` — this command is **informational only**. Merge enforcement is delegated to GitHub-native branch protection (CODEOWNERS + ruleset approval requirements).
+Always exits `0` — informational only. Merge enforcement is handled by GitHub-native branch protection (CODEOWNERS + ruleset requirements).
 
-> **Note:** This command is deprecated as part of the Tier 1 approval migration to native GitHub controls. It will be disabled after rollout validation.
+> **Deprecated:** This command will be removed after the Tier 1 approval migration to native GitHub controls is complete.
 
 ```bash
 qvac-ci pending-approvals \
@@ -44,15 +42,15 @@ qvac-ci pending-approvals \
 | `--team-leads-team` | GitHub team slug for Team Leads **(required)** | — |
 | `--min-approvals` | Minimum total approvals required | `2` |
 
-**Environment variables (required):**
+**Required environment variables:**
 
 | Variable | Description |
 |----------|-------------|
 | `GITHUB_TOKEN` | Token used to post the review-status comment |
-| `GITHUB_APP_ID` | GitHub App ID used for team membership resolution |
+| `GITHUB_APP_ID` | GitHub App ID for team membership resolution |
 | `GITHUB_PRIVATE_KEY` | GitHub App private key (PEM) |
 
-Secrets are env-only — there are no `--token` flags. This prevents tokens from appearing in the process list, shell history, or CI log echoes.
+Secrets are env-only — no `--token` flags — to prevent tokens from appearing in the process list or CI logs.
 
 **Example GitHub Actions step:**
 
@@ -70,29 +68,11 @@ Secrets are env-only — there are no `--token` flags. This prevents tokens from
       --min-approvals 2
 ```
 
-**Comment format:**
-
-The command upserts a single `## Review Status` comment on the PR (updates in place if one already exists):
-
-```
-## Review Status
-**Current Status: ✅ APPROVED**
-Approvals so far: Management: 1, Team Lead: 1
-```
-
-```
-## Review Status
-**Current Status: ❌ PENDING**
-Approvals so far: Member: 1
-
-Pending reviews: Needs 1 Management or Team Lead.
-```
-
 ## Adding a new command
 
 1. Create `lib/commands/<name>/index.js` — extend `Command`, implement `toCommand()` and `_run()`.
 2. Create `lib/commands/<name>/helpers.js` — domain logic. Read secrets from `process.env`; never pass them as parameters. Export a mutable `helpers` object so tests can stub methods without a mock framework.
-3. Register in `lib/commands/index.js` — `main.js` picks it up automatically.
+3. Register in `lib/commands/index.js` — add an explicit `import` and push `.toCommand()` to the `commands` array. `main.js` spreads the array.
 4. Write tests in `test/unit/<name>/index.test.js` and `test/unit/<name>/helpers.test.js`. Mock all network calls.
 
 ## Development

--- a/packages/qvac-ci/package.json
+++ b/packages/qvac-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ci",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "description": "CI utilities for the QVAC monorepo",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The `publish-release-npm` job called `public-reusable-npm.yml` (reusable workflow) which bundled a legacy non-OIDC publish path and required `contents: write` and `secrets: inherit`.
- The `publish-logic` job used a 40-line inline bash script to compute publish routing flags instead of the versioned composite action that now exists in `tetherto/qvac-actions`.
- `packages/qvac-ci/README.md` had a stale GPR/`ci-mono` distribution note and an inaccurate description of the command registration step.

## 📝 How does it solve it?

- Replaces the `publish-release-npm` reusable-workflow call with an inline job using three external composite actions from `tetherto/qvac-actions@0.1.0`: `npm-dist-tag-determination` → `sfw-guard` → `publish-library-to-npm` (OIDC provenance publish, no token required).
- Replaces the inline bash `publish-logic` script with `tetherto/qvac-actions/npm-publish-logic@0.1.0`, eliminating ~40 lines of duplicated routing logic.
- Narrows `contents: write` → `contents: read` on `publish-release-npm`; OIDC provenance only needs `id-token: write`, not write access to repo contents.
- Bumps `@qvac/ci` to `0.2.1`; backfills missing `0.2.0` CHANGELOG entry (paparam removal + `--version` flag, shipped in #2807 but not recorded).

## 🧪 How was it tested?

- Identical inline pattern pre-validated on `sidj-thr-org/npm-package-test` (`release-npm-package-test-0.36.2` branch → `publish-release-npm` CI passed, `@sidj-thr/npm-package-test@0.36.2` published to npm with OIDC provenance).
- CI triggered on `feature-QVAC-19223-pilot-qvac-ci` → `publish-logic` job resolved correctly; `publish-release-npm` skipped as expected on a `feature-*` branch.
- `release-qvac-ci-0.2.1` branch pushed to trigger end-to-end OIDC publish test for `@qvac/ci@0.2.1`.

## 🔐 Action pinning

- `actions/checkout`: new in `publish-release-npm` job — `de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2`
- `tetherto/qvac-actions/npm-dist-tag-determination@0.1.0`: first introduction (external composite action, tag-pinned)
- `tetherto/qvac-actions/npm-publish-logic@0.1.0`: first introduction (external composite action, tag-pinned)
- `tetherto/qvac-actions/publish-library-to-npm@0.1.0`: first introduction (external composite action, tag-pinned)

## 🛡️ Permissions changes

- Scope: job `publish-release-npm`
- Before: `contents: write`
- After: `contents: read`
- Justification: OIDC publish via `publish-library-to-npm` does not push tags or commits from this job; `contents: write` was an artefact of the old `public-reusable-npm.yml` reusable workflow which ran `create-tag` internally. Provenance attestation requires only `id-token: write` (unchanged).