### PR TITLE
[TEST] lgci router decouple (throwaway)

### DIFF
--- a/.github/workflows/on-pr-llm-llamacpp.yml
+++ b/.github/workflows/on-pr-llm-llamacpp.yml
@@ -108,30 +108,20 @@ jobs:
           DESKTOP=false
           MOBILE=false
 
-          # `verified` is the trust gate. Per review, prebuilds / cpp-tests /
-          # desktop / mobile ALL require `verified` as well — a granular label
-          # on its own (without the trust gate) must never trigger expensive or
-          # secret-exposing jobs. So every stage below is computed inside this
-          # block; without `verified` nothing but the (empty) baseline runs.
+          # `verified` is the trust gate and ONLY the trust gate: it authorises
+          # a PR to run expensive / secret-exposing jobs, but no longer selects
+          # any stage on its own. Each heavy stage runs only when its granular
+          # label is present AND `verified` authorises it — so a granular label
+          # without `verified` never triggers anything (the security invariant),
+          # and `verified` alone runs only the baseline verified checks.
+          # cpp-tests builds the addon itself (different flag) so it does NOT
+          # depend on prebuilds; desktop + mobile DO need prebuilds.
           if [ "$HAS_VERIFIED" = "true" ]; then
             VERIFIED=true
-            if [ "$HAS_PREBUILDS" = "true" ] || [ "$HAS_CPP" = "true" ] || \
-               [ "$HAS_DESKTOP" = "true" ] || [ "$HAS_MOBILE" = "true" ]; then
-              # Selective mode: run only the explicitly requested stages.
-              # cpp-tests builds the addon itself (different flag) so it does
-              # NOT depend on prebuilds. desktop + mobile DO need prebuilds.
-              [ "$HAS_CPP" = "true" ]      && CPP_TESTS=true
-              [ "$HAS_DESKTOP" = "true" ]  && { DESKTOP=true; PREBUILDS=true; }
-              [ "$HAS_MOBILE" = "true" ]   && { MOBILE=true; PREBUILDS=true; }
-              [ "$HAS_PREBUILDS" = "true" ] && PREBUILDS=true
-            else
-              # Backward compat: `verified` alone still runs the full pipeline
-              # (kept temporarily so the rollout does not block other teams).
-              PREBUILDS=true
-              CPP_TESTS=true
-              DESKTOP=true
-              MOBILE=true
-            fi
+            [ "$HAS_CPP" = "true" ]      && CPP_TESTS=true
+            [ "$HAS_DESKTOP" = "true" ]  && { DESKTOP=true; PREBUILDS=true; }
+            [ "$HAS_MOBILE" = "true" ]   && { MOBILE=true; PREBUILDS=true; }
+            [ "$HAS_PREBUILDS" = "true" ] && PREBUILDS=true
           fi
           echo "CI Router: verified=$VERIFIED prebuilds=$PREBUILDS cpp=$CPP_TESTS desktop=$DESKTOP mobile=$MOBILE"
           echo "run_verified_checks=$VERIFIED" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/zz-lgci-router-test.yml
+++ b/.github/workflows/zz-lgci-router-test.yml
@@ -1,0 +1,99 @@
+name: '[TEST] lgci router decouple'
+
+# THROWAWAY validation for the "verified authorises only" change.
+# Runs the NEW ci-router logic on a regular pull_request (so the head's file
+# runs) into lgci-sandbox, then has no-op stage jobs gated on EXACTLY the same
+# `if:` conditions the real workflow uses. Toggling labels on the PR shows which
+# stages run vs skip end-to-end — proving `verified` alone runs nothing heavy
+# and a granular label without `verified` stays gated. Delete after.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [lgci-sandbox]
+
+permissions:
+  contents: read
+
+jobs:
+  router:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      run_verified_checks: ${{ steps.route.outputs.run_verified_checks }}
+      run_prebuilds: ${{ steps.route.outputs.run_prebuilds }}
+      run_cpp_tests: ${{ steps.route.outputs.run_cpp_tests }}
+      run_desktop: ${{ steps.route.outputs.run_desktop }}
+      run_mobile: ${{ steps.route.outputs.run_mobile }}
+    steps:
+      - name: Route CI stages (NEW logic)
+        id: route
+        env:
+          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          HAS_VERIFIED=false
+          HAS_PREBUILDS=false
+          HAS_CPP=false
+          HAS_DESKTOP=false
+          HAS_MOBILE=false
+          if [ -n "$PR_LABELS_JSON" ] && [ "$PR_LABELS_JSON" != "null" ]; then
+            for label in $(echo "$PR_LABELS_JSON" | jq -r '.[]' 2>/dev/null); do
+              case "$label" in
+                verified)                 HAS_VERIFIED=true ;;
+                prebuilds)                HAS_PREBUILDS=true ;;
+                run-cpp-addon-tests)      HAS_CPP=true ;;
+                run-desktop-addon-tests)  HAS_DESKTOP=true ;;
+                run-mobile-addon-tests)   HAS_MOBILE=true ;;
+              esac
+            done
+          fi
+
+          VERIFIED=false
+          PREBUILDS=false
+          CPP_TESTS=false
+          DESKTOP=false
+          MOBILE=false
+          if [ "$HAS_VERIFIED" = "true" ]; then
+            VERIFIED=true
+            [ "$HAS_CPP" = "true" ]      && CPP_TESTS=true
+            [ "$HAS_DESKTOP" = "true" ]  && { DESKTOP=true; PREBUILDS=true; }
+            [ "$HAS_MOBILE" = "true" ]   && { MOBILE=true; PREBUILDS=true; }
+            [ "$HAS_PREBUILDS" = "true" ] && PREBUILDS=true
+          fi
+
+          echo "ROUTER labels=$PR_LABELS_JSON => verified=$VERIFIED prebuilds=$PREBUILDS cpp=$CPP_TESTS desktop=$DESKTOP mobile=$MOBILE"
+          echo "run_verified_checks=$VERIFIED" >> "$GITHUB_OUTPUT"
+          echo "run_prebuilds=$PREBUILDS" >> "$GITHUB_OUTPUT"
+          echo "run_cpp_tests=$CPP_TESTS" >> "$GITHUB_OUTPUT"
+          echo "run_desktop=$DESKTOP" >> "$GITHUB_OUTPUT"
+          echo "run_mobile=$MOBILE" >> "$GITHUB_OUTPUT"
+
+  baseline:
+    needs: router
+    if: needs.router.outputs.run_verified_checks == 'true'
+    runs-on: ubuntu-latest
+    steps: [{ name: ran, run: 'echo "RAN baseline (verified checks)"' }]
+
+  stage-prebuilds:
+    needs: router
+    if: needs.router.outputs.run_prebuilds == 'true'
+    runs-on: ubuntu-latest
+    steps: [{ name: ran, run: 'echo "RAN prebuilds"' }]
+
+  stage-cpp:
+    needs: router
+    if: needs.router.outputs.run_cpp_tests == 'true'
+    runs-on: ubuntu-latest
+    steps: [{ name: ran, run: 'echo "RAN cpp-tests"' }]
+
+  stage-desktop:
+    needs: router
+    if: needs.router.outputs.run_desktop == 'true'
+    runs-on: ubuntu-latest
+    steps: [{ name: ran, run: 'echo "RAN desktop"' }]
+
+  stage-mobile:
+    needs: router
+    if: needs.router.outputs.run_mobile == 'true'
+    runs-on: ubuntu-latest
+    steps: [{ name: ran, run: 'echo "RAN mobile"' }]


### PR DESCRIPTION
Throwaway: proves verified-authorise-only routing live by toggling labels and watching stage jobs run vs skip. Delete after.