### PR TITLE
infra[notask]: verified label authorises only (decouple from stage selection)

### DIFF
--- a/.github/workflows/on-pr-llm-llamacpp.yml
+++ b/.github/workflows/on-pr-llm-llamacpp.yml
@@ -108,30 +108,20 @@ jobs:
           DESKTOP=false
           MOBILE=false
 
-          # `verified` is the trust gate. Per review, prebuilds / cpp-tests /
-          # desktop / mobile ALL require `verified` as well — a granular label
-          # on its own (without the trust gate) must never trigger expensive or
-          # secret-exposing jobs. So every stage below is computed inside this
-          # block; without `verified` nothing but the (empty) baseline runs.
+          # `verified` is the trust gate and ONLY the trust gate: it authorises
+          # a PR to run expensive / secret-exposing jobs, but no longer selects
+          # any stage on its own. Each heavy stage runs only when its granular
+          # label is present AND `verified` authorises it — so a granular label
+          # without `verified` never triggers anything (the security invariant),
+          # and `verified` alone runs only the baseline verified checks.
+          # cpp-tests builds the addon itself (different flag) so it does NOT
+          # depend on prebuilds; desktop + mobile DO need prebuilds.
           if [ "$HAS_VERIFIED" = "true" ]; then
             VERIFIED=true
-            if [ "$HAS_PREBUILDS" = "true" ] || [ "$HAS_CPP" = "true" ] || \
-               [ "$HAS_DESKTOP" = "true" ] || [ "$HAS_MOBILE" = "true" ]; then
-              # Selective mode: run only the explicitly requested stages.
-              # cpp-tests builds the addon itself (different flag) so it does
-              # NOT depend on prebuilds. desktop + mobile DO need prebuilds.
-              [ "$HAS_CPP" = "true" ]      && CPP_TESTS=true
-              [ "$HAS_DESKTOP" = "true" ]  && { DESKTOP=true; PREBUILDS=true; }
-              [ "$HAS_MOBILE" = "true" ]   && { MOBILE=true; PREBUILDS=true; }
-              [ "$HAS_PREBUILDS" = "true" ] && PREBUILDS=true
-            else
-              # Backward compat: `verified` alone still runs the full pipeline
-              # (kept temporarily so the rollout does not block other teams).
-              PREBUILDS=true
-              CPP_TESTS=true
-              DESKTOP=true
-              MOBILE=true
-            fi
+            [ "$HAS_CPP" = "true" ]      && CPP_TESTS=true
+            [ "$HAS_DESKTOP" = "true" ]  && { DESKTOP=true; PREBUILDS=true; }
+            [ "$HAS_MOBILE" = "true" ]   && { MOBILE=true; PREBUILDS=true; }
+            [ "$HAS_PREBUILDS" = "true" ] && PREBUILDS=true
           fi
           echo "CI Router: verified=$VERIFIED prebuilds=$PREBUILDS cpp=$CPP_TESTS desktop=$DESKTOP mobile=$MOBILE"
           echo "run_verified_checks=$VERIFIED" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What

Make the `verified` label on the LLM (`llm-llamacpp`) PR workflow **purely the trust gate**. It still authorises a PR to run expensive / secret-exposing jobs (and runs the baseline verified checks), but it no longer selects any heavy stage on its own. Each stage runs only when its granular label is present **and** `verified` authorises it:

- `run-cpp-addon-tests` → C++ tests
- `run-desktop-addon-tests` → desktop integration (+ prebuilds)
- `run-mobile-addon-tests` → mobile integration (+ prebuilds)
- `prebuilds` → prebuilds only

## Why

The original `ci-router` kept a backward-compat shortcut — explicitly marked *temporary for the initial rollout* — where `verified` **alone** ran the entire pipeline (prebuilds + cpp + desktop + mobile). Now that the rollout has settled, this removes that shortcut so a single `verified` no longer fans out into every expensive suite.

## Change

One block in the `Route CI stages` step (`.github/workflows/on-pr-llm-llamacpp.yml`): the `else` "run everything" branch is deleted and the inner `if` collapses. Net −10 lines. Nothing else changes — every downstream job's `if:` condition is untouched.

## Security invariant (unchanged)

A granular label **without** `verified` still triggers **nothing**. The trust gate (`label-gate.outputs.authorised`) that gianni's #2873 review hardened is fully intact — this PR only removes the `verified`-alone convenience, it does not change authorisation.

## Decision table

Only the `verified`-alone row changes:

| Labels | verified | prebuilds | cpp | desktop | mobile |
|---|:-:|:-:|:-:|:-:|:-:|
| *(none)* | ✗ | ✗ | ✗ | ✗ | ✗ |
| `verified` **only** | ✓ | ✗ | ✗ | ✗ | ✗ | ← changed (was all ✓) |
| `verified` + `run-cpp-addon-tests` | ✓ | ✗ | ✓ | ✗ | ✗ |
| `verified` + `run-desktop-addon-tests` | ✓ | ✓ | ✗ | ✓ | ✗ |
| `verified` + `run-mobile-addon-tests` | ✓ | ✓ | ✗ | ✗ | ✓ |
| `run-cpp-addon-tests` **without** `verified` | ✗ | ✗ | ✗ | ✗ | ✗ |

## Verification

**Local decision-table harness** (`lgci-router-harness.sh`, the route() body is a verbatim copy of the step): **21/21 pass** across the full label matrix, including every "granular-without-verified → nothing" security row.

**Live on CI** — a throwaway PR into a sandbox base ran the **new** router plus no-op stage jobs gated on the *exact same* `if:` conditions as this workflow. Labels were toggled and both the router outputs and the actual stage-job execution were captured:

| # | Labels on PR | Router decision | Stage jobs that RAN | SKIPPED | Run |
|---|---|---|---|---|---|
| 1 | *(none)* | all false | — | baseline + all 4 | [28444239612](https://github.com/tetherto/qvac/actions/runs/28444239612) |
| 2 | `verified` | verified=true, rest **false** | baseline only | **all 4 heavy stages** | [28444270055](https://github.com/tetherto/qvac/actions/runs/28444270055) |
| 3 | `verified` + `run-cpp-addon-tests` | +cpp | baseline, **cpp** | prebuilds, desktop, mobile | [28444276140](https://github.com/tetherto/qvac/actions/runs/28444276140) |
| 4 | `verified` + `run-cpp` + `run-mobile` | +cpp +mobile +prebuilds | baseline, cpp, mobile, prebuilds | desktop | [28444285242](https://github.com/tetherto/qvac/actions/runs/28444285242) |
| 5 | `run-cpp` + `run-mobile` **(no verified)** | all false | — | **all 4 stages** | [28444293524](https://github.com/tetherto/qvac/actions/runs/28444293524) |

- **Run 2** proves the change: `verified` alone runs **zero** heavy stages (baseline only).
- **Run 5** proves the security invariant holds: granular labels **without** `verified` run **nothing**.

Both match the local harness exactly.

## Heads-up for reviewers / teams

There is no longer a single-label "run everything." To run the full suite, add `verified` + all three `run-*-addon-tests` labels. (Happy to add a `run-all` convenience label if we want to keep one-click full runs.)
