### PR TITLE
[TEST] lgci certify A — no labels (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-certify-a.md
+++ b/packages/llm-llamacpp/zz-lgci-certify-a.md
@@ -1,0 +1,4 @@
+# lgci certify A — no labels
+
+Throwaway PR to certify the label-gated CI router on `main`.
+Scenario A: no labels → every stage must skip. Delete after.


### PR DESCRIPTION
Throwaway certification PR for label-gated CI. Scenario A: no labels -> every stage must skip. Close after.