### PR TITLE
[TEST] lgci certify B — granular no verified (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-certify-b.md
+++ b/packages/llm-llamacpp/zz-lgci-certify-b.md
@@ -1,0 +1,4 @@
+# lgci certify B — granular label, no verified
+
+Scenario B: `run-cpp-addon-tests` applied WITHOUT `verified` → every stage must
+skip (security invariant). Throwaway; delete after.


### PR DESCRIPTION
Scenario B: run-cpp-addon-tests WITHOUT verified -> everything must skip (security invariant). Close after.