### PR TITLE
[TEST] lgci certify C — verified only (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-certify-c.md
+++ b/packages/llm-llamacpp/zz-lgci-certify-c.md
@@ -1,0 +1,4 @@
+# lgci certify C — verified only
+
+Scenario C: `verified` alone → baseline checks run, but all four heavy stages
+(prebuilds, cpp, desktop, mobile) must skip. Throwaway; delete after.


### PR DESCRIPTION
Scenario C: verified alone -> baseline runs, all heavy stages skip. Close after.