### PR TITLE
[TEST] lgci certify D — verified + run-cpp (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-certify-d.md
+++ b/packages/llm-llamacpp/zz-lgci-certify-d.md
@@ -1,0 +1,4 @@
+# lgci certify D — verified + run-cpp-addon-tests
+
+Scenario D: `verified` + `run-cpp-addon-tests` → cpp tests run; prebuild,
+desktop, mobile must skip. Throwaway; delete after.


### PR DESCRIPTION
Scenario D: verified + run-cpp-addon-tests -> cpp tests run; prebuild/desktop/mobile skip. Close after.