### PR TITLE
[TEST] lgci certify F — prebuild caching (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-certify-f-run2.md
+++ b/packages/llm-llamacpp/zz-lgci-certify-f-run2.md
@@ -1,0 +1,5 @@
+# lgci certify F — run 2 (JS-only push)
+
+Non-native change (docs only). detect-native-changes must report
+native_changed=false, cache-restore must report cache_hit=true, and the
+prebuild matrix must be SKIPPED (restored from run-1 cache).

--- a/packages/llm-llamacpp/zz-lgci-certify-f.md
+++ b/packages/llm-llamacpp/zz-lgci-certify-f.md
@@ -1,0 +1,5 @@
+# lgci certify F — prebuild caching
+
+Scenario F (run 1): `verified` + `prebuilds` → prebuild builds + cache-save
+writes the per-PR cache. Then a JS-only push (run 2) must restore the cache
+(prebuild SKIPPED), and a native push (run 3) must rebuild. Throwaway.


### PR DESCRIPTION
Scenario F: verified + prebuilds. Run 1 builds + cache-save. Run 2 (JS-only push) restores -> prebuild skipped. Run 3 (native push) rebuilds. Close after.