### PR TITLE
[TEST] lgci certify E — verified + desktop + mobile (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-certify-e.md
+++ b/packages/llm-llamacpp/zz-lgci-certify-e.md
@@ -1,0 +1,5 @@
+# lgci certify E — verified + desktop + mobile (trigger then cancel)
+
+Scenario E: `verified` + `run-desktop-addon-tests` + `run-mobile-addon-tests` →
+desktop + mobile (+ prebuilds) must trigger. Capture skipped->queued, then close
+immediately to cancel before Device Farm completes. Throwaway.


### PR DESCRIPTION
Scenario E: verified + run-desktop-addon-tests + run-mobile-addon-tests -> desktop + mobile + prebuilds trigger. Trigger-then-cancel. Close after capturing.