### PR TITLE
doc[notask]: document granular CI-routing labels for the LLM workflow

### DIFF
--- a/docs/ci/LABELS.md
+++ b/docs/ci/LABELS.md
@@ -18,11 +18,31 @@ This is the **single** label that gates every privileged PR job in the repo. The
 | **Behaviour on `synchronize`** | When a non-trusted actor pushes new commits to a verified PR, `label-gate` strips the label automatically. A trusted actor must re-apply it after reviewing the new commits. This prevents authorisation from silently inheriting across content changes by an untrusted contributor. |
 | **Behaviour on apply by non-trusted actor** | The label is stripped immediately and the gate denies. This avoids a "look, it's verified" social signal that doesn't actually mean the PR is authorised. |
 | **Approval bot tier** | Recognised as **tier 1** by `approval-check-worker`. |
+| **Stage selection** | On `on-pr-llm-llamacpp.yml`, `verified` authorises the PR and runs the baseline verified checks (`sanity-checks`, `cpp-lint`, `ts-checks`) only — it no longer triggers the full pipeline by itself. Each expensive stage additionally needs its [granular routing label](#granular-ci-routing-labels-llm-workflow). |
 | **Implementation** | [`.github/actions/label-gate/README.md`](../../.github/actions/label-gate/README.md) — full trust model, exit policy, and test coverage. |
 
 ### When CI is blocked by `label-gate`
 
 If your PR's secret-bearing jobs are skipping with a `label-gate.outputs.authorised != 'true'` condition, ask any member of the trusted teams above to apply `verified`. There is intentionally no self-service path — the whole point of the gate is that someone other than the PR author signs off.
+
+---
+
+## Granular CI-routing labels (LLM workflow)
+
+`on-pr-llm-llamacpp.yml` uses a **`ci-router`** step that reads the PR's labels and selects which expensive stages run, so routine PRs stay cheap and a reviewer can opt a PR into the heavy matrix on demand. This scheme is currently wired into the **LLM workflow only**; other addons can adopt it by adding the same `ci-router` job and `if:` conditions.
+
+> **Security invariant** — every stage below *also* requires `verified` (the trust gate). A granular label on its own — without `verified` — triggers **nothing**, so an untrusted contributor can never self-route into a secret-bearing job. `verified` alone authorises the PR and runs the baseline verified checks (`sanity-checks`, `cpp-lint`, `ts-checks`), but no longer runs the full pipeline.
+
+| Label | Runs | Pulls in prebuilds? |
+|---|---|---|
+| `prebuilds` | The multi-platform prebuild matrix, or a cache restore when native files are unchanged (see below). | — |
+| `run-cpp-addon-tests` | C++ unit tests. Builds the addon itself, so it does **not** depend on the prebuild matrix. | No |
+| `run-desktop-addon-tests` | Desktop integration tests. | Yes (implied) |
+| `run-mobile-addon-tests` | Mobile (Android / iOS via AWS Device Farm) integration tests. | Yes (implied) |
+
+Labels combine freely — e.g. `verified` + `run-desktop-addon-tests` + `run-mobile-addon-tests` builds prebuilds once and then runs both test suites. A manual `workflow_dispatch` run bypasses routing and runs everything.
+
+> **Prebuild caching** — when a PR changes no native files (`*.cpp` / `*.hpp` / `*.c` / `*.h`, any `CMakeLists.txt`, or anything under `vcpkg/`), the prebuild matrix is skipped and binaries are restored from an `actions/cache` entry keyed `prebuilds-llm-pr-<number>-<native_hash>`. The first run on a PR always builds; any native change moves the hash and forces a fresh build.
 
 ---
 
@@ -41,6 +61,10 @@ The following labels are recognised by CI workflows but are not part of the `lab
 | Label | Purpose | Triggered by | Notes |
 |---|---|---|---|
 | `verified` | Canonical authorisation label — see the [`verified` section above](#verified--secret-bearing-ci-authorisation) for the full trust model. | `label-gate` composite action plus the `public-pr.yml`, `public-reusable-npm.yml`, `pr-test-inference-addon-cpp*.yml`, and `pr-models-validation-registry-server.yml` non-secret gates. | Replaces the legacy `verify` label, which was retired in favour of a single authorisation ceremony. |
+| `prebuilds` | LLM CI routing — run the prebuild matrix / cache restore. Requires `verified`. | `on-pr-llm-llamacpp.yml` `ci-router` | Part of the granular routing scheme — see [Granular CI-routing labels](#granular-ci-routing-labels-llm-workflow). |
+| `run-cpp-addon-tests` | LLM CI routing — run the C++ unit tests. Requires `verified`. | `on-pr-llm-llamacpp.yml` `ci-router` | Does not pull in prebuilds (the cpp-test job builds the addon itself). |
+| `run-desktop-addon-tests` | LLM CI routing — run desktop integration tests. Requires `verified`; implies `prebuilds`. | `on-pr-llm-llamacpp.yml` `ci-router` | See [Granular CI-routing labels](#granular-ci-routing-labels-llm-workflow). |
+| `run-mobile-addon-tests` | LLM CI routing — run mobile (Device Farm) integration tests. Requires `verified`; implies `prebuilds`. | `on-pr-llm-llamacpp.yml` `ci-router` | See [Granular CI-routing labels](#granular-ci-routing-labels-llm-workflow). |
 | `safe-to-test` | SDK pod security gate — reviewer has audited `packages/sdk/` package + workflow changes from a fork PR. | `pr-checks-sdk-pod.yml` | Org-wide secret authorisation is now handled by `verified`; `safe-to-test` remains in use for SDK pod check-running. |
 | `staging` | Deploys the PR to the staging environment for smoke testing. | Staging deploy workflows | Apply when a PR needs out-of-band testing on real infrastructure. |
 | `publish` | Triggers a GitHub Packages publish from the PR (pre-release / dev build). | Publish workflows | Use sparingly; consumes a published version slot. |


### PR DESCRIPTION
## What

Documents the granular CI-routing labels introduced by the label-gated CI work, which `docs/ci/LABELS.md` didn't yet cover.

- **#2873** added a `ci-router` to `on-pr-llm-llamacpp.yml` with four routing labels.
- **#2951** made `verified` authorise-only — it no longer runs the full LLM pipeline by itself.

## Changes to `docs/ci/LABELS.md`

- New **"Granular CI-routing labels (LLM workflow)"** section covering the four labels:
  | Label | Runs |
  |---|---|
  | `prebuilds` | prebuild matrix / cache restore |
  | `run-cpp-addon-tests` | C++ unit tests (no prebuild dependency) |
  | `run-desktop-addon-tests` | desktop integration tests (implies prebuilds) |
  | `run-mobile-addon-tests` | mobile / Device Farm integration tests (implies prebuilds) |
- States the **security invariant**: each stage also requires `verified`; a granular label on its own triggers nothing.
- Adds a **"Stage selection"** row to the `verified` table reflecting the authorise-only + baseline-checks behaviour.
- Documents the **prebuild cache key** (`prebuilds-llm-pr-<number>-<native_hash>`) and native-change detection.
- Adds the four labels to the quick-reference table.

## Scope / notes

- Reflects `main` today (post #2873 + #2951).
- The routing is wired into the **LLM workflow only**; noted in the doc as adoptable by other addons via the same `ci-router` + `if:` pattern.
- Docs-only change — no workflow behaviour modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
