### PR TITLE
[TEST] lgci certify G — clean prebuild caching (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-certify-g.md
+++ b/packages/llm-llamacpp/zz-lgci-certify-g.md
@@ -1,0 +1,5 @@
+# lgci certify G — prebuild caching (clean)
+
+Controlled single-prebuild run to avoid the concurrent cache-save collision
+seen on PR F. Run 1 (verified+prebuilds) builds + saves cache cleanly; run 2
+(JS-only) must restore (prebuild SKIPPED); run 3 (native) rebuilds.


### PR DESCRIPTION
Clean caching cert. Run 1 (verified+prebuilds) builds + saves cache. Run 2 (JS-only) restores -> prebuild skipped. Run 3 (native) rebuilds. Close after.