### PR TITLE
[TEST] lgci cache isolation — unique native (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-native-probe.cpp
+++ b/packages/llm-llamacpp/zz-lgci-native-probe.cpp
@@ -1,0 +1,6 @@
+// Throwaway native probe for caching isolation test (QVAC-21199 follow-up).
+// A UNIQUE native file → unique native_hash → unique cache key, so this run
+// cannot collide with the identical-content certification PRs. Not referenced
+// by CMake (never compiled); exists only to make native_changed=true and the
+// cache key distinct. Delete with the branch.
+int lgci_native_probe_unique_8f3a() { return 0; }


### PR DESCRIPTION
Isolation test for the prebuild-caching bug. Unique native file -> unique cache key, single uncontested run, quiet CI. Checking whether cache-save reserves+commits. Close after.