### PR TITLE
[TEST] cachefix e2e (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-cachefix-native.cpp
+++ b/packages/llm-llamacpp/zz-lgci-cachefix-native.cpp
@@ -1,0 +1,5 @@
+// Throwaway unique native file for caching-FIX e2e test (QVAC-21199 follow-up).
+// Gives this PR a unique native_hash so its reuse marker is distinct. Run 1
+// builds + saves the marker; run 2 (JS-only push) must REUSE this run's
+// prebuilds artifact (prebuild skipped). Not compiled; delete with the branch.
+int lgci_cachefix_probe_5d2e() { return 0; }


### PR DESCRIPTION
E2E test of the artifact-based prebuild reuse fix. Base carries the fix so pull_request_target runs it. Run 1 builds + saves marker; run 2 (JS-only) must reuse -> prebuild skipped. Close after.