### PR TITLE
[DO NOT MERGE] transcription-parakeet: CI overlay → parakeet-cpp @ PR #74 (sched CPU-fallback)

### DIFF
--- a/packages/transcription-parakeet/.gitignore
+++ b/packages/transcription-parakeet/.gitignore
@@ -22,6 +22,7 @@ Makefile
 !CMakeLists.txt
 !cmake/*.cmake
 !vcpkg/**/*.cmake
+!vcpkg-overlay-ports/**/*.cmake
 compile_commands.json
 .vscode/
 .idea/

--- a/packages/transcription-parakeet/CMakeLists.txt
+++ b/packages/transcription-parakeet/CMakeLists.txt
@@ -12,6 +12,11 @@ find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/triplets;${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
 
+# TEMPORARY CI OVERLAY (do not merge): build parakeet-cpp from the PR #74 commit
+# (ggml_backend_sched per-op CPU fallback) instead of the registry port. Drop this
+# line + vcpkg-overlay-ports/ once PR #74 merges and the registry port lands.
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay-ports;${VCPKG_OVERLAY_PORTS}")
+
 set(VCPKG_INSTALL_OPTIONS --clean-after-build)
 
 project(qvac_lib_infer_parakeet

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/portfile.cmake
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/portfile.cmake
@@ -1,0 +1,80 @@
+# TEMPORARY CI OVERLAY -- do not merge.
+#
+# Mirrors the registry parakeet-cpp port verbatim except the source fetch, which
+# is repointed at the qvac-ext-lib-whisper.cpp PR #74 head commit (6420f0c0):
+# route parakeet-cpp compute through ggml_backend_sched with per-op CPU fallback
+# (cached-encoder-graph restore + Sortformer head-backend safety included).
+# This overlay validates that branch on device-farm CI ahead of merge; drop it
+# (the dir + the VCPKG_OVERLAY_PORTS line in ../../CMakeLists.txt) and bump the
+# registry version>= once PR #74 merges and the registry port lands.
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH WHISPER_CPP_SRC
+    REPO tetherto/qvac-ext-lib-whisper.cpp
+    REF 6420f0c06d35f3e0815949352eb161483be157a7
+    SHA512 7cbfb8ea945f89991719f509c0e8251ec734fe6ac7244606718775f8c53988b1de254bd37eaac9e61de02e791842fed30a40eea733c6c3a8ff7a0f8e37cd342f
+    HEAD_REF master
+)
+
+set(SOURCE_PATH "${WHISPER_CPP_SRC}/parakeet-cpp")
+if (NOT EXISTS "${SOURCE_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "parakeet-cpp: ${SOURCE_PATH}/CMakeLists.txt missing; the parakeet-cpp/ "
+        "subfolder layout in qvac-ext-lib-whisper.cpp may have changed.")
+endif()
+
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+endif()
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DPARAKEET_BUILD_LIBRARY=ON
+        -DPARAKEET_BUILD_EXECUTABLES=OFF
+        -DPARAKEET_BUILD_TESTS=OFF
+        -DPARAKEET_BUILD_EXAMPLES=OFF
+        -DPARAKEET_INSTALL=ON
+        -DPARAKEET_USE_SYSTEM_GGML=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_OPENMP=OFF
+        -DPARAKEET_OPENMP=OFF
+        -DGGML_CCACHE=OFF
+        -DPARAKEET_CCACHE=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME parakeet-cpp CONFIG_PATH share/parakeet-cpp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/portfile.cmake
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/portfile.cmake
@@ -1,9 +1,10 @@
 # TEMPORARY CI OVERLAY -- do not merge.
 #
 # Mirrors the registry parakeet-cpp port verbatim except the source fetch, which
-# is repointed at the qvac-ext-lib-whisper.cpp PR #74 head commit (6420f0c0):
-# route parakeet-cpp compute through ggml_backend_sched with per-op CPU fallback
-# (cached-encoder-graph restore + Sortformer head-backend safety included).
+# is repointed at the qvac-ext-lib-whisper.cpp PR #74 head commit (bea8c918):
+# route parakeet-cpp compute through ggml_backend_sched with per-op CPU fallback;
+# the cached encoder graph uses a persistent gallocr (Adreno OpenCL/Vulkan reuse fix)
+# with reuse-determinism + shared-sched-lifecycle regression tests.
 # This overlay validates that branch on device-farm CI ahead of merge; drop it
 # (the dir + the VCPKG_OVERLAY_PORTS line in ../../CMakeLists.txt) and bump the
 # registry version>= once PR #74 merges and the registry port lands.
@@ -14,8 +15,8 @@ set(VCPKG_BUILD_TYPE release)
 vcpkg_from_github(
     OUT_SOURCE_PATH WHISPER_CPP_SRC
     REPO tetherto/qvac-ext-lib-whisper.cpp
-    REF 6420f0c06d35f3e0815949352eb161483be157a7
-    SHA512 7cbfb8ea945f89991719f509c0e8251ec734fe6ac7244606718775f8c53988b1de254bd37eaac9e61de02e791842fed30a40eea733c6c3a8ff7a0f8e37cd342f
+    REF bea8c918fe95a191d3703dd65a77b569f6f3ea38
+    SHA512 d8cd58eb97b131e4f646cf21fbf53107f24befce02d764fe402e8720289e00ba392500990d278d5b5884b72fc937454f3a29b9efb048ebaba3cdbe5d821a03d6
     HEAD_REF master
 )
 

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "parakeet-cpp",
-  "version-date": "2026-06-30",
+  "version-date": "2026-07-01",
   "description": "Parakeet (NVIDIA FastConformer ASR + Sortformer diarization) inference in pure C++/ggml. Ships CTC, TDT, EOU and Sortformer engines under one Engine umbrella, plus the cross-engine StreamEvent API (VadStateChanged / EndOfTurn). Sourced from tetherto/qvac-ext-lib-whisper.cpp's parakeet-cpp/ subfolder; consumes the ggml-speech port. TEMPORARY CI overlay: pins the parakeet-cpp/ subfolder at the PR #74 commit (route compute through ggml_backend_sched with per-op CPU fallback) for device-farm validation ahead of merge.",
   "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/parakeet-cpp",
   "license": "MIT",

--- a/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg-overlay-ports/parakeet-cpp/vcpkg.json
@@ -1,0 +1,81 @@
+{
+  "name": "parakeet-cpp",
+  "version-date": "2026-06-30",
+  "description": "Parakeet (NVIDIA FastConformer ASR + Sortformer diarization) inference in pure C++/ggml. Ships CTC, TDT, EOU and Sortformer engines under one Engine umbrella, plus the cross-engine StreamEvent API (VadStateChanged / EndOfTurn). Sourced from tetherto/qvac-ext-lib-whisper.cpp's parakeet-cpp/ subfolder; consumes the ggml-speech port. TEMPORARY CI overlay: pins the parakeet-cpp/ subfolder at the PR #74 commit (route compute through ggml_backend_sched with per-op CPU fallback) for device-farm validation ahead of merge.",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/parakeet-cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "version>=": "2026-06-09"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "cuda"
+          ]
+        }
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal GPU acceleration (macOS / iOS)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "metal"
+          ]
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android / Adreno)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "opencl"
+          ]
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "vulkan"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
**Do not merge.** CI-only overlay PR to validate [qvac-ext-lib-whisper.cpp PR #74](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/74) on the device farm before it merges.

## What
PR #74 migrates `parakeet-cpp` from single-backend `ggml_backend_graph_compute` to `ggml_backend_sched` (per-op CPU fallback), plus the cached-encoder-graph restore and the Sortformer head-backend safety fix. It's review-approved; this PR builds the `transcription-parakeet` addon against that exact branch so AWS Device Farm (iOS + Android) and the other CI surfaces prove no regression on real hardware ahead of merge.

## How
A temporary vcpkg **overlay port** for `parakeet-cpp`, activated in CI:
- `vcpkg-overlay-ports/parakeet-cpp/{portfile.cmake,vcpkg.json}` — mirror the registry port verbatim, repointed at the PR #74 head:
  - `REF 6420f0c06d35f3e0815949352eb161483be157a7`
  - `SHA512 7cbfb8ea945f89991719f509c0e8251ec734fe6ac7244606718775f8c53988b1de254bd37eaac9e61de02e791842fed30a40eea733c6c3a8ff7a0f8e37cd342f`
- `CMakeLists.txt` — sets `VCPKG_OVERLAY_PORTS` so the overlay takes precedence over the registry on every CI platform (same pattern as the tts-onnx mecab overlay).
- `.gitignore` — exempts `vcpkg-overlay-ports/**/*.cmake` from the blanket `*.cmake` ignore.

PR #74 is **parakeet-cpp only (no ggml change)**, so no `ggml-speech` overlay and no registry PR are needed yet. The addon's `parakeet-cpp version>=` and the registry baseline are **unchanged** — the overlay overrides resolution. The new REF changes the vcpkg ABI hash, forcing a clean rebuild from the PR #74 source.

## Run CI
Apply the **`verified`** label (+ `run-*-addon-tests` / `prebuilds` as desired) to launch the gated jobs.

## After PR #74 merges (separate follow-up, not this PR)
1. Registry PR bumps the `parakeet-cpp` port (REF/SHA512 + new version-date).
2. Here: drop `vcpkg-overlay-ports/`, the `VCPKG_OVERLAY_PORTS` line, and the `.gitignore` exception; bump `parakeet-cpp version>=` to the merged registry version.
