### PR TITLE
chore[notask]: release @qvac/sdk + bare-sdk 0.14.1

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.14.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.14.1
+
+QVAC SDK 0.14.1 is a patch release that fixes `qvac bundle sdk` for projects where the SDK is installed as a symlink — the common layout under pnpm and npm/yarn workspaces.
+
+## Bug Fixes
+
+### Bundling Works for Symlinked SDK Installs
+
+Bundling the SDK worker (`qvac bundle sdk`) previously failed with a `bare-pack` error when `@qvac/sdk` was installed as a symlink rather than a plain copy — the layout produced by pnpm and by npm/yarn workspaces. The bundler looked for the SDK's low-level `bare-*` runtime dependencies relative to the symlink's location instead of where the SDK actually lives on disk, so it couldn't find them and aborted.
+
+The bundler now resolves the SDK's worker imports against the SDK's real on-disk path, so its hoisted `bare-*` dependencies are found regardless of how the package was installed. Plain (copied) installs are unaffected; symlinked installs now bundle and verify successfully.
+
 ## [0.14.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.14.0

--- a/packages/sdk/changelog/0.14.1/CHANGELOG.md
+++ b/packages/sdk/changelog/0.14.1/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.14.1
+
+Release Date: 2026-06-30
+
+## 🐞 Fixes
+
+- Bundle sdk resolves the SDK's hoisted bare-* deps for symlinked installs. (see PR [#2947](https://github.com/tetherto/qvac/pull/2947))
+
+## 🧪 Tests
+
+- Skip mobile HTTP download-resilience when flaky server unreachable. (see PR [#2925](https://github.com/tetherto/qvac/pull/2925))
+

--- a/packages/sdk/changelog/0.14.1/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.14.1/CHANGELOG_LLM.md
@@ -1,0 +1,13 @@
+# QVAC SDK v0.14.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.14.1
+
+QVAC SDK 0.14.1 is a patch release that fixes `qvac bundle sdk` for projects where the SDK is installed as a symlink — the common layout under pnpm and npm/yarn workspaces.
+
+## Bug Fixes
+
+### Bundling Works for Symlinked SDK Installs
+
+Bundling the SDK worker (`qvac bundle sdk`) previously failed with a `bare-pack` error when `@qvac/sdk` was installed as a symlink rather than a plain copy — the layout produced by pnpm and by npm/yarn workspaces. The bundler looked for the SDK's low-level `bare-*` runtime dependencies relative to the symlink's location instead of where the SDK actually lives on disk, so it couldn't find them and aborted.
+
+The bundler now resolves the SDK's worker imports against the SDK's real on-disk path, so its hoisted `bare-*` dependencies are found regardless of how the package was installed. Plain (copied) installs are unaffected; symlinked installs now bundle and verify successfully.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`qvac bundle sdk` fails with a `bare-pack` error whenever `@qvac/sdk` is installed as a **symlink** — the layout produced by pnpm and by npm/yarn workspaces. The bundler resolved the SDK worker's low-level `bare-*` runtime dependencies (e.g. `bare-os`) relative to the symlink's location instead of where the SDK actually lives on disk, so it couldn't find them and aborted. This is the failure that gates the `@qvac/cli` 0.8.0 release (#2939): the CLI's `bundle-verify` published-leg e2e installs the published SDK and exercises exactly this path. The fix is already on `main` (#2947) but unreleased; this PR cuts the patch so it reaches npm.

## 📝 How does it solve it?

This release ships the bundler fix from #2947 (already merged to `main`):

- `packages/sdk/package.json` — version `0.14.0` → `0.14.1`
- `packages/sdk/changelog/0.14.1/` — new `CHANGELOG.md` + `CHANGELOG_LLM.md`
- `packages/sdk/CHANGELOG.md` — aggregated `## [0.14.1]` entry prepended
- `packages/bare-sdk/package.json` — lockstep version bump `0.14.0` → `0.14.1`

No dependency changes vs `sdk-v0.14.0` (the only `package.json` delta is the version field), so NOTICE files are unchanged for both `sdk` and `bare-sdk`. Merging this PR into `release-sdk-0.14.1` publishes to GPR; the follow-up backmerge to `main` publishes 0.14.1 to npm.

## 🧪 How was it tested?

The fix itself was verified in true published mode — pack the SDK to a tarball, install it like a real consumer (real dir + hoisted `bare-*`), symlink it into a project (the failing layout), then run `bundleSdk` + `verifyBundle` from the installed tarball:

- Fixed SDK → bundle + verify **pass**.
- Published `@qvac/sdk@0.14.0` (no fix) → **fails** with the same `bare-pack exited with code 1`.

Release prep checks:
- `bun run check:deps-vs-sdk` for `bare-sdk` → OK (dependencies=27).
- Changelog regenerated idempotently; aggregate carries the `## [0.14.1]` heading the Release Guard requires.