### PR TITLE
chore[skiplog|notask]: backmerge release-sdk-0.14.1 — version bump + changelog

### DIFF
--- a/packages/bare-sdk/package.json
+++ b/packages/bare-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bare-sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "Apache-2.0",
   "description": "Bare-targeted slim assembly of the QVAC SDK. Consumers install only the addon packages they need and register plugins explicitly. No addon dependencies pulled in by default.",
   "repository": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.14.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.14.1
+
+QVAC SDK 0.14.1 is a patch release that fixes `qvac bundle sdk` for projects where the SDK is installed as a symlink — the common layout under pnpm and npm/yarn workspaces.
+
+## Bug Fixes
+
+### Bundling Works for Symlinked SDK Installs
+
+Bundling the SDK worker (`qvac bundle sdk`) previously failed with a `bare-pack` error when `@qvac/sdk` was installed as a symlink rather than a plain copy — the layout produced by pnpm and by npm/yarn workspaces. The bundler looked for the SDK's low-level `bare-*` runtime dependencies relative to the symlink's location instead of where the SDK actually lives on disk, so it couldn't find them and aborted.
+
+The bundler now resolves the SDK's worker imports against the SDK's real on-disk path, so its hoisted `bare-*` dependencies are found regardless of how the package was installed. Plain (copied) installs are unaffected; symlinked installs now bundle and verify successfully.
+
 ## [0.14.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.14.0

--- a/packages/sdk/changelog/0.14.1/CHANGELOG.md
+++ b/packages/sdk/changelog/0.14.1/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog v0.14.1
+
+Release Date: 2026-06-30
+
+## 🐞 Fixes
+
+- Bundle sdk resolves the SDK's hoisted bare-* deps for symlinked installs. (see PR [#2947](https://github.com/tetherto/qvac/pull/2947))
+
+## 🧪 Tests
+
+- Skip mobile HTTP download-resilience when flaky server unreachable. (see PR [#2925](https://github.com/tetherto/qvac/pull/2925))
+

--- a/packages/sdk/changelog/0.14.1/CHANGELOG_LLM.md
+++ b/packages/sdk/changelog/0.14.1/CHANGELOG_LLM.md
@@ -1,0 +1,13 @@
+# QVAC SDK v0.14.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/sdk/v/0.14.1
+
+QVAC SDK 0.14.1 is a patch release that fixes `qvac bundle sdk` for projects where the SDK is installed as a symlink — the common layout under pnpm and npm/yarn workspaces.
+
+## Bug Fixes
+
+### Bundling Works for Symlinked SDK Installs
+
+Bundling the SDK worker (`qvac bundle sdk`) previously failed with a `bare-pack` error when `@qvac/sdk` was installed as a symlink rather than a plain copy — the layout produced by pnpm and by npm/yarn workspaces. The bundler looked for the SDK's low-level `bare-*` runtime dependencies relative to the symlink's location instead of where the SDK actually lives on disk, so it couldn't find them and aborted.
+
+The bundler now resolves the SDK's worker imports against the SDK's real on-disk path, so its hoisted `bare-*` dependencies are found regardless of how the package was installed. Plain (copied) installs are unaffected; symlinked installs now bundle and verify successfully.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Lands the `@qvac/sdk` + `@qvac/bare-sdk` 0.14.1 release metadata onto `main`. Companion release PR #2967 cuts 0.14.1 on `release-sdk-0.14.1` (publishes to GPR, then npm). Without this backmerge, `main` keeps `0.14.0` in `package.json` and would have a hole in its `CHANGELOG.md` history for the 0.14.1 line. Tagged `[skiplog]` — the 0.14.1 changelog was authored on the release branch, so `main` must not generate a second entry from this PR.

## 📝 How does it solve it?

Cherry-picks the release commit (`-x`) from `release-sdk-0.14.1` onto `main`. The diff is limited to release metadata only:

- `packages/sdk/package.json` — version `0.14.0` → `0.14.1` (version field only; dependency block untouched)
- `packages/sdk/changelog/0.14.1/CHANGELOG.md` + `CHANGELOG_LLM.md` — copied verbatim from the release branch
- `packages/sdk/CHANGELOG.md` — aggregated `## [0.14.1]` block prepended
- `packages/bare-sdk/package.json` — lockstep version `0.14.0` → `0.14.1`

## 🧪 How was it tested?

`main` had not diverged from the release branch base when 0.14.1 was cut, so a clean cherry-pick is equivalent to a hand-crafted backmerge here — no dependency divergence to reconcile. Verified `git diff --stat upstream/main..HEAD` touches **only** the five release-metadata files above (no functional or dependency changes). The shipped fix itself is covered by release PR #2967 and the merged source PR #2947.