### PR TITLE
QVAC-21396 feat: vlm-benchmark image-tiling variants (qwen3vl grid-select)

### DIFF
--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/README.md
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/README.md
@@ -244,6 +244,49 @@ Tuning lives in `config.cjs` `methodology`.
   in `mmatrix` (must exist in the Device-Farm fleet). No harness change.
 - **Tune the scorers** — `node score-check.cjs <report-or-log>` re-scores REAL predictions
   with the current scorers (no inference), so you can iterate on quality metrics offline.
+- **Compare image-tiling variants (Qwen3.5-VL grid-select)** — the catalog ships three
+  variants of the same model differing only in `image_tile_mode`: `qwen3.5-seq`
+  (sequential, default), `qwen3.5-batched` (single collapsed attention pass), and
+  `qwen3.5-tiles-off` (disabled). A model spec's `imageConfig` map (see `config.cjs`
+  `tileVariant()`) is spread into the addon config by `harness.cjs`; add
+  `image_max_tokens`/`image_min_tokens` there too. `image_max_tiles` is CLI-only today —
+  the addon doesn't parse it yet, so it can't be benchmarked without addon plumbing.
+
+## 9 · Grid-select feature runs (worked commands)
+
+The grid-select rewrite lives in a candidate build, so build the addon from your branch
+(`addon@candidate` + `-f ref=<branch>`) — the published `addon` lacks it.
+
+```bash
+# 1) tile_mode seq vs batched vs disabled, on high-MP docs (grid selection produces
+#    multiple tiles). All 3 appear in the speed/quality tables with absolute numbers;
+#    the Δ% highlight is pairwise (first two: seq vs batched).
+gh workflow run benchmark-vlm-model-comparison.yml --ref <benchmark-branch> \
+  -f matrix_mode=two-models -f matrix_preset=ocr5pages \
+  -f matrix_models=qwen3.5-seq,qwen3.5-batched,qwen3.5-tiles-off \
+  -f matrix_sources=addon@candidate -f ref=tetherto/feat/qwen3vl-grid-select-rollout \
+  -f matrix_desktop=linux-gpu,macos-gpu
+
+# 2) candidate vs baseline — net effect of the whole grid-select rewrite, same knobs.
+gh workflow run benchmark-vlm-model-comparison.yml --ref <benchmark-branch> \
+  -f matrix_mode=several-sources \
+  -f matrix_sources=addon@candidate,addon@baseline \
+  -f ref=tetherto/feat/qwen3vl-grid-select-rollout \
+  -f matrix_models=qwen3.5-0.8b-q8 -f matrix_preset=ocr5pages -f matrix_desktop=linux-gpu
+
+# 3) grid-select quality on high-res (single build, confirm no regression on multi-tile).
+gh workflow run benchmark-vlm-model-comparison.yml --ref <benchmark-branch> \
+  -f matrix_mode=two-models -f matrix_preset=ocr5pages \
+  -f matrix_models=qwen3.5-seq -f matrix_sources=addon@candidate \
+  -f ref=tetherto/feat/qwen3vl-grid-select-rollout
+```
+
+Local (desktop, against your locally-built candidate addon):
+```bash
+QVAC_VLM_MATRIX=1 QVAC_VLM_MODE=two-models QVAC_VLM_PRESET=ocr5pages \
+QVAC_VLM_MODELS=qwen3.5-seq,qwen3.5-batched,qwen3.5-tiles-off QVAC_VLM_SAMPLES=2 \
+bare test/integration/vlm-matrix.test.js
+```
 
 ---
 

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
@@ -99,6 +99,22 @@ const SOURCES_MODEL = {
     { license: 'Apache-2.0', link: 'https://huggingface.co/mradermacher/Qwen3.5-0.8B-GGUF' })
 }
 
+// ════════════════════ IMAGE-TILING VARIANTS (Qwen3.5-VL grid-select) ════════════════════
+// Same model (SOURCES_MODEL blobs), differing ONLY in the image_tile_mode knob, so
+// two-models mode compares the grid-select multi-tile encode paths head-to-head
+// (Δ% speed + quality). image_tile_mode: 'sequential' (default) encodes tiles one at
+// a time; 'batched' collapses them into one attention pass; 'disabled' turns off
+// multi-tile splitting. Run these on a high-MP preset (ocr5pages) so grid selection
+// actually produces multiple tiles. Requires the candidate build (grid-select code):
+//   -f matrix_models=qwen3.5-seq,qwen3.5-batched -f matrix_preset=ocr5pages
+// and, to test the branch, build it as the addon (see §candidate dispatch in README).
+function tileVariant (label, name, tileMode) {
+  return { ...SOURCES_MODEL, label, name, imageConfig: { image_tile_mode: tileMode } }
+}
+const QWEN_TILE_SEQ = tileVariant('qwen3.5-seq', 'Qwen3.5-0.8B · tile=sequential', 'sequential')
+const QWEN_TILE_BATCHED = tileVariant('qwen3.5-batched', 'Qwen3.5-0.8B · tile=batched', 'batched')
+const QWEN_TILE_OFF = tileVariant('qwen3.5-tiles-off', 'Qwen3.5-0.8B · tile=disabled', 'disabled')
+
 // Scenario definitions (the workload axis — which fixture tasks run, how they
 // are scored) live in their own file (scenarios.cjs). The task lists live there too.
 const SCENARIOS = require('./scenarios.cjs')
@@ -129,7 +145,11 @@ module.exports = {
     'qwen3.5-f16': MODEL_1,
     'qwen3.5-q8': MODEL_2,
     'qwen3.5-0.8b-q8': SOURCES_MODEL,
-    'gemma4-q4': GEMMA4_Q4
+    'gemma4-q4': GEMMA4_Q4,
+    // Image-tiling variants (grid-select): same model, differ only in image_tile_mode.
+    'qwen3.5-seq': QWEN_TILE_SEQ,
+    'qwen3.5-batched': QWEN_TILE_BATCHED,
+    'qwen3.5-tiles-off': QWEN_TILE_OFF
   },
   // What runs when matrix_models is empty (two-models mode).
   defaultModels: ['qwen3.5-f16', 'qwen3.5-q8'],

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -350,6 +350,12 @@ function runModel (spec) {
           n_predict: String(nPredict),
           verbosity: '2', // surfaces `image slice encoded in N ms` on native stderr
           'reasoning-budget': '0', // disable Qwen3.5 thinking -> clean direct answers
+          // Per-model image-tiling knobs (Qwen3.5-VL). A model spec may carry an
+          // `imageConfig` map (e.g. { image_tile_mode: 'sequential' | 'batched' |
+          // 'disabled', image_max_tokens, image_min_tokens }); it is spread into the
+          // addon config so two catalog variants differing ONLY in tiling can be
+          // compared in two-models mode (grid-select rewrite: seq vs batched encode).
+          ...(spec.imageConfig || {}),
           ...(BACKENDS_DIR ? { backendsDir: BACKENDS_DIR } : {}) // candidate/baseline build swap (scheduler)
         },
         logger: console,


### PR DESCRIPTION
## Summary

Adds an image-tiling comparison axis to the VLM benchmark so the Qwen3.5-VL grid-select rewrite (fabric PR #175 / add-on PR #2962) can be measured head-to-head.

- **`harness.cjs`** — spreads a model spec's optional `imageConfig` map into the addon config (`image_tile_mode` / `image_max_tokens` / `image_min_tokens`), so two catalog variants differing only in tiling are comparable in two-models mode.
- **`config.cjs`** — `tileVariant()` + three catalog entries (same Qwen q8 model, differ only in `image_tile_mode`): `qwen3.5-seq` (sequential, default), `qwen3.5-batched` (collapsed attention), `qwen3.5-tiles-off` (disabled).
- **`README.md`** — §9 worked dispatch commands (tile-mode compare, candidate-vs-baseline, high-res quality) + local run. Notes `image_max_tiles` is CLI-only (no addon plumbing yet).

No behavior change to existing runs — defaults and existing catalog entries untouched; variants are opt-in via `matrix_models`.

## Test plan

- [ ] `node run-desktop.cjs --selfcheck` (config/contract wiring)
- [ ] Dispatch: `-f matrix_models=qwen3.5-seq,qwen3.5-batched,qwen3.5-tiles-off -f matrix_preset=ocr5pages -f matrix_sources=addon@candidate -f ref=tetherto/feat/qwen3vl-grid-select-rollout`
