### PR TITLE
Add ubuntu 26 tests for BCI, Whisper and TTS

### DIFF
--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -94,6 +94,15 @@ jobs:
             runner: qvac-ubuntu2204-x64-gpu
             benchmark_matrix_json: >-
               [{"useGPU":false,"backendHint":"cpu"},{"useGPU":true,"backendHint":"vulkan"}]
+          # Linux x64 on the ubuntu-24.04 GPU runner: exercises the Vulkan
+          # desktop build (no_gpu unset -> NO_GPU=false -> gpu-smoke runs +
+          # asserts GPU), matching the ubuntu-24.04 leg the other packages run.
+          - os: ubuntu-24.04
+            platform: linux
+            arch: x64
+            runner: qvac-ubuntu2404-x64-gpu
+            benchmark_matrix_json: >-
+              [{"useGPU":false,"backendHint":"cpu"},{"useGPU":true,"backendHint":"vulkan"}]
           # GitHub-hosted ubuntu-26.04 CPU leg (no `runner:` -> hosted, so the
           # Manual Workspace Cleanup step auto-skips). Mirrors the parakeet
           # ubuntu-26.04 leg: forward coverage on the newest Ubuntu image,

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -94,19 +94,12 @@ jobs:
             runner: qvac-ubuntu2204-x64-gpu
             benchmark_matrix_json: >-
               [{"useGPU":false,"backendHint":"cpu"},{"useGPU":true,"backendHint":"vulkan"}]
-          # Linux x64 on the ubuntu-24.04 GPU runner: exercises the Vulkan
-          # desktop build (no_gpu unset -> NO_GPU=false -> gpu-smoke runs +
-          # asserts GPU), matching the ubuntu-24.04 leg the other packages run.
           - os: ubuntu-24.04
             platform: linux
             arch: x64
             runner: qvac-ubuntu2404-x64-gpu
             benchmark_matrix_json: >-
               [{"useGPU":false,"backendHint":"cpu"},{"useGPU":true,"backendHint":"vulkan"}]
-          # GitHub-hosted ubuntu-26.04 CPU leg (no `runner:` -> hosted, so the
-          # Manual Workspace Cleanup step auto-skips). Mirrors the parakeet
-          # ubuntu-26.04 leg: forward coverage on the newest Ubuntu image,
-          # CPU-only (no Vulkan GPU on hosted runners).
           - os: ubuntu-26.04
             platform: linux
             arch: x64

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -63,7 +63,7 @@ jobs:
     continue-on-error: true
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
-    name: ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '' || '-gpu' }}-integration-tests
+    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '' || '-gpu' }}-integration-tests
 
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -63,7 +63,7 @@ jobs:
     continue-on-error: true
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
-    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '' || '-gpu' }}-integration-tests
+    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu != 'true' && '-gpu' || '' }}-integration-tests
 
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -94,6 +94,16 @@ jobs:
             runner: qvac-ubuntu2204-x64-gpu
             benchmark_matrix_json: >-
               [{"useGPU":false,"backendHint":"cpu"},{"useGPU":true,"backendHint":"vulkan"}]
+          # GitHub-hosted ubuntu-26.04 CPU leg (no `runner:` -> hosted, so the
+          # Manual Workspace Cleanup step auto-skips). Mirrors the parakeet
+          # ubuntu-26.04 leg: forward coverage on the newest Ubuntu image,
+          # CPU-only (no Vulkan GPU on hosted runners).
+          - os: ubuntu-26.04
+            platform: linux
+            arch: x64
+            no_gpu: 'true'
+            benchmark_matrix_json: >-
+              [{"useGPU":false,"backendHint":"cpu"}]
           - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -86,11 +86,6 @@ jobs:
             runner: qvac-ubuntu2404-x64-gpu
             benchmark_matrix_json: >-
               [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-base-q5_1.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-base-q8_0.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-small.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-small-q5_1.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-small-q8_0.bin","useGPU":true,"backendHint":"vulkan"}]
-          # GitHub-hosted ubuntu-26.04 CPU leg (no `runner:` -> hosted, so the
-          # Manual Workspace Cleanup + cache-models steps auto-skip and models
-          # download fresh). Mirrors the parakeet ubuntu-26.04 leg: forward
-          # coverage on the newest Ubuntu image, CPU-only (no Vulkan GPU on
-          # hosted runners).
           - os: ubuntu-26.04
             platform: linux
             arch: x64

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -59,7 +59,7 @@ jobs:
     continue-on-error: true
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
-    name: ${{ matrix.platform }}-${{ matrix.arch }}-integration-tests
+    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '' || '-gpu' }}-integration-tests
 
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -86,6 +86,17 @@ jobs:
             runner: qvac-ubuntu2404-x64-gpu
             benchmark_matrix_json: >-
               [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-base-q5_1.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-base-q8_0.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-small.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-small-q5_1.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-small-q8_0.bin","useGPU":true,"backendHint":"vulkan"}]
+          # GitHub-hosted ubuntu-26.04 CPU leg (no `runner:` -> hosted, so the
+          # Manual Workspace Cleanup + cache-models steps auto-skip and models
+          # download fresh). Mirrors the parakeet ubuntu-26.04 leg: forward
+          # coverage on the newest Ubuntu image, CPU-only (no Vulkan GPU on
+          # hosted runners).
+          - os: ubuntu-26.04
+            platform: linux
+            arch: x64
+            no_gpu: 'true'
+            benchmark_matrix_json: >-
+              [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"}]
           - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -59,7 +59,7 @@ jobs:
     continue-on-error: true
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
-    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '' || '-gpu' }}-integration-tests
+    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu != 'true' && '-gpu' || '' }}-integration-tests
 
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -91,6 +91,14 @@ jobs:
             platform: linux
             arch: x64
             runner: qvac-ubuntu2404-x64-gpu
+          # GitHub-hosted ubuntu-26.04 CPU leg (no `runner:` -> hosted, so the
+          # Manual Workspace Cleanup + cache-models steps auto-skip and models
+          # download fresh). Mirrors the parakeet ubuntu-26.04 leg: forward
+          # coverage on the newest Ubuntu image, CPU-only.
+          - os: ubuntu-26.04
+            platform: linux
+            arch: x64
+            no_gpu: 'true'
           - os: ubuntu-24.04-arm
             platform: linux
             arch: arm64

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -110,11 +110,6 @@ jobs:
           - os: windows-2025
             platform: win32
             arch: x64
-            runner: qvac-win25-x64
-            no_gpu: 'true'
-          - os: windows-2025
-            platform: win32
-            arch: x64
             runner: qvac-win25-x64-gpu
 
     steps:

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -72,7 +72,7 @@ jobs:
     continue-on-error: true
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
-    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu == 'true' && '' || '-gpu' }}-integration-tests
+    name: ${{ matrix.os }}-${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.no_gpu != 'true' && '-gpu' || '' }}-integration-tests
     env:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
       NO_GPU: ${{ matrix.no_gpu || 'false' }}

--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -91,10 +91,6 @@ jobs:
             platform: linux
             arch: x64
             runner: qvac-ubuntu2404-x64-gpu
-          # GitHub-hosted ubuntu-26.04 CPU leg (no `runner:` -> hosted, so the
-          # Manual Workspace Cleanup + cache-models steps auto-skip and models
-          # download fresh). Mirrors the parakeet ubuntu-26.04 leg: forward
-          # coverage on the newest Ubuntu image, CPU-only.
           - os: ubuntu-26.04
             platform: linux
             arch: x64


### PR DESCRIPTION
## What problem does this PR solve?
Only parakeet has the ubuntu-26 tests running

## How does it solve it?
Expand it to other packages of speech team

## Breaking changes
None

## How was it tested?
[TTS](https://github.com/tetherto/qvac/actions/runs/28520358007)
[BCI](https://github.com/tetherto/qvac/actions/runs/28520820306/job/84544226086)
[Whisper](https://github.com/tetherto/qvac/actions/runs/28520839008)