### PR TITLE
[TEST] validate merged prebuild caching (throwaway)

### DIFF
--- a/packages/llm-llamacpp/zz-lgci-cache-validate.md
+++ b/packages/llm-llamacpp/zz-lgci-cache-validate.md
@@ -1,0 +1,6 @@
+# lgci cache validation (post-merge, real workflow)
+
+Throwaway PR to confirm the merged prebuild artifact caching (#2969) actually
+reuses on `main` under pull_request_target. Run 1 (verified+prebuilds) builds
++ saves the marker; run 2 (JS-only push) must reuse -> prebuild SKIPPED.
+Delete after.

--- a/packages/llm-llamacpp/zz-lgci-cache-validate.md
+++ b/packages/llm-llamacpp/zz-lgci-cache-validate.md
@@ -4,3 +4,5 @@ Throwaway PR to confirm the merged prebuild artifact caching (#2969) actually
 reuses on `main` under pull_request_target. Run 1 (verified+prebuilds) builds
 + saves the marker; run 2 (JS-only push) must reuse -> prebuild SKIPPED.
 Delete after.
+
+run 2 (JS-only) — expect reuse hit + prebuild skipped


### PR DESCRIPTION
Post-merge validation of #2969 caching on main. verified+prebuilds -> run 1 builds + saves marker; JS-only push -> run 2 must reuse (prebuild skipped). Close after.