### PR TITLE
chore[notask]: bump qvac-lib-inference-addon-cpp to 1.2.2 in tts-onnx

### DIFF
--- a/packages/tts-onnx/CHANGELOG.md
+++ b/packages/tts-onnx/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-07-01
+
+### Changed
+
+- Bumped the `qvac-lib-inference-addon-cpp` vcpkg dependency to `1.2.2` (self-pin fix for safe `Worklet.terminate()` on Android).
+
 ## [0.10.0] - 2026-06-22
 
 ### Changed

--- a/packages/tts-onnx/package.json
+++ b/packages/tts-onnx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-onnx",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Text to Speech (TTS) addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/tts-onnx/vcpkg.json
+++ b/packages/tts-onnx/vcpkg.json
@@ -4,7 +4,7 @@
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",
-      "version>=": "1.2.1"
+      "version>=": "1.2.2"
     },
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- On Android, bare `Worklet.terminate()` SIGSEGVs because `dlclose()` unmaps the addon's code while its `pthread_key`/thread-local destructors still point into it. This forces the SDK to skip `terminate()` on non-iOS, leaking worklet memory between loads.
- `qvac-lib-inference-addon-cpp 1.2.2` (released in #2972, published in [qvac-registry-vcpkg#220](https://github.com/tetherto/qvac-registry-vcpkg/pull/220)) carries the self-pin fix (`Pin.hpp` / `pinAddon`, #2906), but `tts-onnx` still pins `>= 1.2.1` and can't pick it up.

## 📝 How does it solve it?

- Bump the `qvac-lib-inference-addon-cpp` vcpkg dependency `version>=` from `1.2.1` to `1.2.2` so the addon links against the self-pinned build (`RTLD_NODELETE`), keeping addon code mapped for the process lifetime and making `Worklet.terminate()` safe on Android.
- Patch-bump the package `0.10.0 → 0.10.1` and add a CHANGELOG entry.

## 🧪 How was it tested?

- CI addon build/test pipeline on this branch (vcpkg resolves `qvac-lib-inference-addon-cpp 1.2.2` from the published registry).
