### PR TITLE
QVAC-21457 whisper addons: release whisper-cpp 1.9.1 bump (bci 0.4.0, transcription 0.11.0)

### DIFF
--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.4] - 2026-07-01
 
 ### Changed
 
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registry baseline is left unchanged; the override resolves the new version
   forward of the pinned baseline against
   [tetherto/qvac-registry-vcpkg#219](https://github.com/tetherto/qvac-registry-vcpkg/pull/219)
-  (`whisper-cpp 1.9.1` port, REF `cb91a378`). No addon version bump (QVAC-21582).
+  (`whisper-cpp 1.9.1` port, REF `cb91a378`). This release ships it as `0.3.4`.
 
 ## [0.3.3] - 2026-06-24
 

--- a/packages/bci-whispercpp/CHANGELOG.md
+++ b/packages/bci-whispercpp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.4] - 2026-07-01
+## [0.4.0] - 2026-07-01
 
 ### Changed
 
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registry baseline is left unchanged; the override resolves the new version
   forward of the pinned baseline against
   [tetherto/qvac-registry-vcpkg#219](https://github.com/tetherto/qvac-registry-vcpkg/pull/219)
-  (`whisper-cpp 1.9.1` port, REF `cb91a378`). This release ships it as `0.3.4`.
+  (`whisper-cpp 1.9.1` port, REF `cb91a378`). This release ships it as `0.4.0`.
 
 ## [0.3.3] - 2026-06-24
 

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bci-whispercpp",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Brain-Computer Interface (BCI) neural signal transcription addon for qvac, powered by whisper.cpp",
   "addon": true,
   "engines": {

--- a/packages/bci-whispercpp/package.json
+++ b/packages/bci-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/bci-whispercpp",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Brain-Computer Interface (BCI) neural signal transcription addon for qvac, powered by whisper.cpp",
   "addon": true,
   "engines": {

--- a/packages/transcription-whispercpp/CHANGELOG.md
+++ b/packages/transcription-whispercpp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.3] - 2026-07-01
+## [0.11.0] - 2026-07-01
 
 ### Changed
 
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registry baseline is left unchanged; the override resolves the new version
   forward of the pinned baseline against
   [tetherto/qvac-registry-vcpkg#219](https://github.com/tetherto/qvac-registry-vcpkg/pull/219)
-  (`whisper-cpp 1.9.1` port, REF `cb91a378`). This release ships it as `0.10.3`.
+  (`whisper-cpp 1.9.1` port, REF `cb91a378`). This release ships it as `0.11.0`.
 
 ## [0.10.2] - 2026-06-24
 

--- a/packages/transcription-whispercpp/CHANGELOG.md
+++ b/packages/transcription-whispercpp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.3] - 2026-07-01
 
 ### Changed
 
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registry baseline is left unchanged; the override resolves the new version
   forward of the pinned baseline against
   [tetherto/qvac-registry-vcpkg#219](https://github.com/tetherto/qvac-registry-vcpkg/pull/219)
-  (`whisper-cpp 1.9.1` port, REF `cb91a378`). No addon version bump (QVAC-21582).
+  (`whisper-cpp 1.9.1` port, REF `cb91a378`). This release ships it as `0.10.3`.
 
 ## [0.10.2] - 2026-06-24
 

--- a/packages/transcription-whispercpp/package.json
+++ b/packages/transcription-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/transcription-whispercpp/package.json
+++ b/packages/transcription-whispercpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/transcription-whispercpp",
-  "version": "0.10.3",
+  "version": "0.11.0",
   "description": "transcription addon for qvac",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Summary

Releases the `whisper-cpp` 1.9.1 dependency bump (pulled in under QVAC-21582)
as versioned addon releases. No source changes — this is a version + changelog
cut only.

- **`@qvac/bci-whispercpp`**: `0.3.3` → `0.4.0`
- **`@qvac/transcription-whispercpp`**: `0.10.2` → `0.11.0`

Both addons already consume the `whisper-cpp 1.9.1` vcpkg override on `main`
(upstream `ggml-org/whisper.cpp` v1.9.1 → fork `tetherto/qvac-ext-lib-whisper.cpp`
master `cb91a378`, via registry port `whisper-cpp 1.9.1`). This PR only converts
the pending `Unreleased` changelog entries into real versioned releases.

## Changes

- `packages/bci-whispercpp/package.json`: version `0.3.3` → `0.4.0`
- `packages/bci-whispercpp/CHANGELOG.md`: `Unreleased` → `[0.4.0] - 2026-07-01`
- `packages/transcription-whispercpp/package.json`: version `0.10.2` → `0.11.0`
- `packages/transcription-whispercpp/CHANGELOG.md`: `Unreleased` → `[0.11.0] - 2026-07-01`

## Context

- Ticket: QVAC-21457
- Upstream pull tracked under QVAC-21582
- Related: ext-lib [tetherto/qvac-ext-lib-whisper.cpp#73](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/73), registry [tetherto/qvac-registry-vcpkg#219](https://github.com/tetherto/qvac-registry-vcpkg/pull/219)