### PR TITLE
TEST (do not merge): validate ggml OpenCL SOA-serialize fix on S25 Adreno

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Chatterbox multilingual `q8_0` KV cache now runs on the Metal GPU — the real
+  fix for the 0.3.6 crash mitigation.** Bumps the `tts-cpp` pin to `2026-06-29#1`
+  (`qvac-ext-lib-whisper.cpp` PR #71 `12749a05`, one commit ahead of the LavaSR
+  `4c8767a2`), consumed from `qvac-registry-vcpkg` (#216); the `default-registry`
+  baseline advances to `bf8d9a92` so the new pin resolves. 0.3.6 dodged the
+  multilingual Metal SIGABRT (`unsupported op 'CONT'`) by defaulting the KV cache
+  to `f16`; the root cause was the per-(layer,head) alignment probe `ggml_cont`'ing
+  a strided view of the `q8_0` K cache, which ggml-metal can't encode (no
+  quantized CONT kernel). The probe now dequantizes that slice via
+  `ggml_cast(->f32)` (Metal-supported), so a `q8_0` KV cache runs on the GPU
+  again — `chatterbox_mtl_resolve_kv_type` probes the cast per-backend and falls
+  back to f32 only where the backend can't encode it. Validated on macOS Metal
+  and on-device iOS (iPhone 17 Pro Max, A19 Pro). (QVAC-19557)
 - **Chatterbox now synthesizes correctly on both ARM CPU and the ARM Mali Vulkan
   GPU.** Bumps the `tts-cpp` pin to `2026-06-26` (`qvac-ext-lib-whisper.cpp`
   master `586268bf`, PR #67), consumed from `qvac-registry-vcpkg` (#214), which

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "b433b2013fcf6115b6298cce72567f8effa015bb",
+    "baseline": "b43e1a3d25adce90986323cf2f04bb2b4798e78d",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
     "reference": "test/ggml-speech-opencl-soa-fix"
   },

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,8 +1,9 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "f04e244701f462c4c8fead7b50bcaffa52c052ac",
-    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
+    "baseline": "b433b2013fcf6115b6298cce72567f8effa015bb",
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
+    "reference": "test/ggml-speech-opencl-soa-fix"
   },
   "registries": [
     {

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "2d57e9ebf9502e2658ae1569c98330a53fd80fde",
+    "baseline": "a0ee7ca36d7797a2a196e1d40887bcfbc2b4be64",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
     "reference": "test/ggml-speech-opencl-soa-fix"
   },

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "162f8f7c3b85750554c461dc1030e23178309db8",
+    "baseline": "bf8d9a9290db4a85e1d72d4210b1e65098714968",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,9 +1,8 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "84724b00ad8bcb6cef9320ac467fe30f9d288fe0",
-    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
-    "reference": "feat/qvac-19557-tts-cpp-mtl-q8-gpu"
+    "baseline": "f04e244701f462c4c8fead7b50bcaffa52c052ac",
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [
     {

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "4fdb29905bcc6573b715796ce92424b11e01548c",
+    "baseline": "2d57e9ebf9502e2658ae1569c98330a53fd80fde",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
     "reference": "test/ggml-speech-opencl-soa-fix"
   },

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "ffa4c3d567241fe34c5aa8b8d57392ec232500e3",
+    "baseline": "4fdb29905bcc6573b715796ce92424b11e01548c",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
     "reference": "test/ggml-speech-opencl-soa-fix"
   },

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -2,7 +2,8 @@
   "default-registry": {
     "kind": "git",
     "baseline": "bf8d9a9290db4a85e1d72d4210b1e65098714968",
-    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
+    "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
+    "reference": "feat/qvac-19557-tts-cpp-mtl-q8-gpu"
   },
   "registries": [
     {

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "b43e1a3d25adce90986323cf2f04bb2b4798e78d",
+    "baseline": "ffa4c3d567241fe34c5aa8b8d57392ec232500e3",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
     "reference": "test/ggml-speech-opencl-soa-fix"
   },

--- a/packages/tts-ggml/vcpkg-configuration.json
+++ b/packages/tts-ggml/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "bf8d9a9290db4a85e1d72d4210b1e65098714968",
+    "baseline": "84724b00ad8bcb6cef9320ac467fe30f9d288fe0",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git",
     "reference": "feat/qvac-19557-tts-cpp-mtl-q8-gpu"
   },

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-06-26"
+      "version>=": "2026-06-29"
     }
   ],
   "features": {

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-06-29"
+      "version>=": "2026-07-03"
     }
   ],
   "features": {


### PR DESCRIPTION
Throwaway test PR to validate whether qvac-ext-ggml `72e38153` (serialize OpenCL SOA quantized uploads) clears the Samsung S25 Ultra chatterbox-mtl load SIGSEGV. Pins base tts-cpp 2026-06-29#0 + ggml-speech 2026-06-26#1 (fixed). Do not merge.