### PR TITLE
QVAC-21732 chore: bump SDK whisper dependency to 0.11.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -213,7 +213,7 @@
     "@qvac/rag": "^0.6.4",
     "@qvac/registry-client": "^0.6.1",
     "@qvac/transcription-parakeet": "^0.8.1",
-    "@qvac/transcription-whispercpp": "^0.10.0",
+    "@qvac/transcription-whispercpp": "^0.11.0",
     "@qvac/translation-nmtcpp": "^6.3.0",
     "@qvac/tts-ggml": "^0.3.1",
     "@qvac/vla-ggml": "^0.7.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- SDK consumers should resolve the latest transcription Whisper addon release through `@qvac/sdk`.
- The SDK dependency range was still pinned to `@qvac/transcription-whispercpp` `^0.10.0`, missing the 0.11.0 release.

## 📝 How does it solve it?

- Updates `packages/sdk` to depend on `@qvac/transcription-whispercpp` `^0.11.0`.
- Keeps the change scoped to the SDK package dependency graph; no SDK API surface changes.

## 🧪 How was it tested?

- Tested local e2e run on desktop macOS.
- Tested local e2e run on mobile platforms.

---
Generated by Cursor agent via `qv-sdk-pr-create`.

Reminder: sdk deps changed but bare-sdk was not synced for this PR per author direction; sync is expected during the SDK release branch flow.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216211571237952