### PR TITLE
QVAC-21733 chore: bump SDK BCI whisper dependency

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -200,7 +200,7 @@
     "changelog:generate": "node ../../scripts/sdk/generate-changelog-sdk-pod.cjs --package=sdk && prettier --write changelog"
   },
   "dependencies": {
-    "@qvac/bci-whispercpp": "^0.3.2",
+    "@qvac/bci-whispercpp": "^0.4.0",
     "@qvac/classification-ggml": "^0.7.0",
     "@qvac/decoder-audio": "^0.5.0",
     "@qvac/diffusion-cpp": "^0.12.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- SDK consumers need the latest BCI Whisper addon release through `@qvac/sdk`.
- Keeps the SDK package aligned with the published `@qvac/bci-whispercpp` `0.4.0` release.

## 📝 How does it solve it?

- Updates the SDK dependency range for `@qvac/bci-whispercpp` from `^0.3.2` to `^0.4.0`.

## 🧪 How was it tested?

- Ran SDK/e2e locally on macOS arm64 and iOS.


Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216211571237958