### PR TITLE
QVAC-21775 chore: make gguf NeedMoreDataError erasable-syntax-only

### DIFF
--- a/packages/sdk/server/utils/gguf-tensor-extractor.ts
+++ b/packages/sdk/server/utils/gguf-tensor-extractor.ts
@@ -55,14 +55,16 @@ const GGUF_MAGIC_BE = 0x47475546; // "FUGG" big-endian
 // File-local error for streaming parser control flow
 // Used to signal "keep reading chunks" rather than an actual failure
 class NeedMoreDataError extends Error {
-  constructor(
-    public readonly currentOffset: number,
-    public readonly bytesNeeded: number,
-  ) {
+  readonly currentOffset: number;
+  readonly bytesNeeded: number;
+
+  constructor(currentOffset: number, bytesNeeded: number) {
     super(
       `Need more data: offset ${currentOffset} requires ${bytesNeeded} more bytes`,
     );
     this.name = "NeedMoreDataError";
+    this.currentOffset = currentOffset;
+    this.bytesNeeded = bytesNeeded;
   }
 }
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `NeedMoreDataError` in `server/utils/gguf-tensor-extractor.ts` uses constructor **parameter properties** (`constructor(public readonly currentOffset, public readonly bytesNeeded)`). Parameter properties emit runtime assignments, so they are non-erasable TypeScript.
- That blocks type-stripping loaders (e.g. the Bare runtime's stripper used by the new `@qvac/core`, which runs `.ts` directly) and is rejected by TS `erasableSyntaxOnly`. It's the one construct that stops this file from being copied into core cleanly.

## 📝 How does it solve it?

- Replace the two parameter properties with explicit `readonly` field declarations plus assignment in the constructor body. Behavior is identical (same fields, name, and message):

  ```ts
  class NeedMoreDataError extends Error {
    readonly currentOffset: number;
    readonly bytesNeeded: number;

    constructor(currentOffset: number, bytesNeeded: number) {
      super(`Need more data: offset ${currentOffset} requires ${bytesNeeded} more bytes`);
      this.name = "NeedMoreDataError";
      this.currentOffset = currentOffset;
      this.bytesNeeded = bytesNeeded;
    }
  }
  ```

## 🧪 How was it tested?

- No behavior change — the class's public shape (both `readonly` fields, `name`, and message) is unchanged; only the declaration form differs.
- SDK `lint` / `typecheck` / build are unaffected (the SDK compiles via `tsc`, which handled the parameter property fine; this change is purely to make the source erasable so the shared file strips under a type-stripping runtime).