### PR TITLE
QVAC-21379 feat: exclude release notes from llms-full.txt

### DIFF
--- a/docs/website/src/app/llms-full.txt/route.ts
+++ b/docs/website/src/app/llms-full.txt/route.ts
@@ -1,6 +1,6 @@
 import { source } from '@/lib/source';
 import { getLLMText } from '@/lib/get-llm-text';
-import { isArchivedPage } from '@/lib/docs-open-graph';
+import { isArchivedPage, isReleaseNotesPage } from '@/lib/docs-open-graph';
 
 // Resolves the response at build time so the result is written to
 // `out/llms-full.txt` as a static file under `output: 'export'`.
@@ -16,11 +16,20 @@ export const revalidate = false;
  * via `isArchivedPage` so the dump only carries the latest canonical
  * documentation — consistent with `sitemap.xml`, `llms.txt`, and per-page
  * `noindex` metadata.
+ *
+ * Additionally, the entire release-notes section (`/reference/release-notes`
+ * and its archived series) is dropped via `isReleaseNotesPage`. Release notes
+ * are historical changelogs whose bulk text inflates the dump's token count
+ * and dilutes an agent's reasoning without adding context needed for SDK
+ * usage (QVAC-21379). Unlike the archive exclusion above, this is scoped to
+ * `llms-full.txt` only: release notes stay indexed in `sitemap.xml`,
+ * `llms.txt`, and per-page `.md` so an agent can still fetch a specific
+ * release note on demand.
  */
 export async function GET() {
   const scan = source
     .getPages()
-    .filter((page) => !isArchivedPage(page))
+    .filter((page) => !isArchivedPage(page) && !isReleaseNotesPage(page))
     .map(getLLMText);
   const scanned = await Promise.all(scan);
 

--- a/docs/website/src/lib/docs-open-graph.ts
+++ b/docs/website/src/lib/docs-open-graph.ts
@@ -33,10 +33,14 @@ const VERSION_SLUG_RE = /^v\d+\.\d+\.\d+$/;
  * - **Release notes** (`RELEASE_NOTES_SECTION`) — NOT hidden. Each archive
  *   is a uniquely-valuable historical document describing what changed in
  *   a specific release. There is no duplicate-content problem (every page
- *   has distinct text), and excluding them from search/LLMs makes
+ *   has distinct text), and excluding them from search makes
  *   "what changed in v0.8.0?" undiscoverable. Each archived release-note
- *   page stays its own canonical and is included everywhere the latest
- *   release-note is.
+ *   page stays its own canonical and is indexed everywhere the latest
+ *   release-note is (sitemap, `llms.txt`, per-page `.md`). The lone
+ *   exception is `llms-full.txt`, which drops the whole release-notes
+ *   section via `isReleaseNotesPage` to shrink the dump's token footprint
+ *   (QVAC-21379) — a scope filter for that one artefact, not an indexing
+ *   decision.
  */
 const SECTIONS_HIDDEN_FROM_INDEXING: VersionedSection[] = [API_SECTION];
 
@@ -109,7 +113,9 @@ export interface ArchivePageRef {
  *
  * Returns `false` for archived snapshots of sections that we intentionally
  * keep indexed (e.g. release-notes back-versions): those pages are visible
- * to crawlers and listed in the sitemap / llms.txt / llms-full.txt.
+ * to crawlers and listed in the sitemap and llms.txt. (They are still kept
+ * out of the `llms-full.txt` bulk dump — but by the separate
+ * `isReleaseNotesPage` filter, not by this function; see QVAC-21379.)
  *
  * Also returns `true` for legacy bundle-style URLs (`/vX.Y.Z/...` with the
  * version slug as the first segment), as a defensive fallback against any
@@ -118,6 +124,27 @@ export interface ArchivePageRef {
 export function isArchivedPage(page: ArchivePageRef): boolean {
   if (HIDDEN_ARCHIVED_PAGE_TO_SECTION.has(page.url)) return true;
   return isLegacyBundleSlug(page.slugs);
+}
+
+/**
+ * True when the page belongs to the release-notes section — its latest
+ * (`/reference/release-notes`) or any archived series
+ * (`/reference/release-notes/vX.Y.x`).
+ *
+ * Used exclusively by `llms-full.txt` to keep release notes out of the
+ * full-documentation dump (QVAC-21379): each release note is a historical
+ * changelog whose bulk text bloats the agent's token budget and dilutes its
+ * reasoning without adding context it needs for day-to-day SDK usage. Release
+ * notes stay indexed and discoverable everywhere else (sitemap, `llms.txt`,
+ * per-page `.md`); an agent that specifically needs "what changed in vX.Y?"
+ * can still fetch the individual page on demand.
+ *
+ * Deliberately separate from `isArchivedPage`: this is a scope-reduction
+ * filter for one artefact, not the "hidden near-duplicate archive" policy.
+ */
+export function isReleaseNotesPage(page: ArchivePageRef): boolean {
+  const base = RELEASE_NOTES_SECTION.basePath;
+  return page.url === base || page.url.startsWith(base + '/');
 }
 
 function isLegacyBundleSlug(slugs: string[] | undefined): boolean {

--- a/docs/website/tests/docs-open-graph.test.ts
+++ b/docs/website/tests/docs-open-graph.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isArchivedPage,
   isArchivedVersionSlug,
+  isReleaseNotesPage,
   buildCanonicalDocsUrl,
   buildPageCanonicalUrl,
   DOCS_SITE_ORIGIN,
@@ -44,8 +45,10 @@ describe('isArchivedPage', () => {
     // Each archived release-notes series is a unique historical document
     // describing what changed in that minor line — no duplicate-content
     // problem, and excluding them would make "what changed in v0.8.x?"
-    // undiscoverable. Kept in sitemap.xml, llms.txt, and llms-full.txt.
-    // (Per-page `.md` is no longer gated by `isArchivedPage` — see
+    // undiscoverable. Kept in sitemap.xml and llms.txt. (They ARE dropped
+    // from the llms-full.txt bulk dump, but via the separate
+    // `isReleaseNotesPage` filter — see QVAC-21379 — not by `isArchivedPage`.
+    // Per-page `.md` is likewise no longer gated by `isArchivedPage` — see
     // `src/app/llm-md-manifest.json/route.ts` for the rationale.)
     expect(isArchivedPage(page('/reference/release-notes/v0.10.x'))).toBe(false);
     expect(isArchivedPage(page('/reference/release-notes/v0.8.x'))).toBe(false);
@@ -90,6 +93,30 @@ describe('isArchivedVersionSlug', () => {
   it('returns true for legacy bundle slugs', () => {
     expect(isArchivedVersionSlug(['v0.7.0'])).toBe(true);
     expect(isArchivedVersionSlug(['v0.7.0', 'anything'])).toBe(true);
+  });
+});
+
+describe('isReleaseNotesPage', () => {
+  it('returns true for the latest release-notes page', () => {
+    expect(isReleaseNotesPage(page('/reference/release-notes'))).toBe(true);
+  });
+
+  it('returns true for archived release-notes series', () => {
+    // These are excluded from the llms-full.txt bulk dump to reduce token
+    // consumption (QVAC-21379), while staying indexed elsewhere.
+    expect(isReleaseNotesPage(page('/reference/release-notes/v0.13.x'))).toBe(true);
+    expect(isReleaseNotesPage(page('/reference/release-notes/v0.8.x'))).toBe(true);
+  });
+
+  it('returns false for non-release-notes pages', () => {
+    expect(isReleaseNotesPage(page('/'))).toBe(false);
+    expect(isReleaseNotesPage(page('/quickstart'))).toBe(false);
+    expect(isReleaseNotesPage(page('/reference/api'))).toBe(false);
+    expect(isReleaseNotesPage(page('/reference/api/v0.10.x'))).toBe(false);
+  });
+
+  it('does not match a look-alike sibling path (prefix guard)', () => {
+    expect(isReleaseNotesPage(page('/reference/release-notes-guide'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `llms-full.txt` (the single-file docs dump AI agents ingest) carried the entire release-notes history — a large volume of changelog text that isn't needed for day-to-day SDK usage.
- That surplus content inflates token consumption and dilutes agent reasoning/response quality. The dump should provide the context an agent needs, and no more (QVAC-21379).

## 📝 How does it solve it?

- Adds an `isReleaseNotesPage` predicate in `docs-open-graph.ts` that matches the release-notes section — `/reference/release-notes` and its archived series (`.../vX.Y.x`) — reusing `RELEASE_NOTES_SECTION.basePath` (with a `+ '/'` prefix guard so look-alikes like `/reference/release-notes-guide` don't match).
- Filters those pages out of the `llms-full.txt` route, in addition to the existing archived-page filter.
- Scope is intentionally limited to `llms-full.txt`: release notes remain indexed and discoverable in `llms.txt`, `sitemap.xml`, and per-page `.md`, so an agent can still fetch a specific release note on demand. Comments in `docs-open-graph.ts` and the route were updated to reflect this one-artefact exception.

## 🧪 How was it tested?

- Unit tests added for `isReleaseNotesPage` (latest page, archived series, negatives, and the `/reference/release-notes-guide` prefix-guard case); `docs-open-graph.test.ts` passes 25/25 and the rest of the suite is unaffected.
- Ran a full `next build` and inspected the generated `out/llms-full.txt`:
  - 0 release-notes pages present.
  - `llms.txt` still lists all 7 release-notes pages (latest `v0.14.x` + archived `v0.8.x`–`v0.13.x`).
  - Page math: `llms.txt` reports 58 non-archived pages; `llms-full.txt` retains 51 → `51 + 7 = 58`, confirming exactly the release-notes pages were dropped and nothing else.

---
<sub>PR description generated with the `qv-sdk-pr-create` skill.</sub>


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216009592269166