### PR TITLE
[TEST] post-merge routing validation (embed)

### DIFF
--- a/packages/embed-llamacpp/zz-ci-validate.md
+++ b/packages/embed-llamacpp/zz-ci-validate.md
@@ -1,0 +1,4 @@
+# CI validation (throwaway)
+
+Post-merge check that the migrated on-pr-embed-llamacpp.yml routes correctly on
+main. Delete after.


### PR DESCRIPTION
throwaway — confirm the merged on-pr-embed routes correctly (verified-only => baseline runs, heavy skips). close after.