### PR TITLE
QVAC-21544 fix: adopt inference-addon-cpp 1.2.3 (JsLogger crash fix) in translation-nmtcpp 6.3.1

### DIFF
--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.1] - 2026-07-02
+
+### Fixed
+
+- Bump `qvac-lib-inference-addon-cpp` to 1.2.3 to pick up the JsLogger teardown / re-`setLogger` crash fix (tetherto/qvac#2932, QVAC-21544): tearing down a Bare worklet or soft-reloading it while the C++→JS logger is active no longer aborts (`SIGABRT`/`SIGTRAP` in `js_delete_reference` / `GlobalHandles::Release`). Reproduced and verified on-device (Pixel 10 Pro XL, Android 16) via the translation worklet reload flow. Pinned through a local `vcpkg/overlay-ports` entry (merged commit `a3df3804`) so the registry baseline — and thus qvac-fabric/whisper/tts — stays put.
+
+## Pull Requests
+
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger (inference-addon-cpp 1.2.3)
+
 ## [6.3.0] - 2026-06-24
 
 ### Changed

--- a/packages/translation-nmtcpp/CMakeLists.txt
+++ b/packages/translation-nmtcpp/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
 find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/overlay-ports;${VCPKG_OVERLAY_PORTS}")
 set(VCPKG_INSTALL_OPTIONS --clean-after-build)
 
 # Android STL configuration must be set before project()

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/vcpkg.json
+++ b/packages/translation-nmtcpp/vcpkg.json
@@ -1,4 +1,6 @@
 {
+  "name": "qvac-translation-nmtcpp",
+  "version-string": "6.3.1",
   "dependencies": [
     {
       "name": "bergamot-translator",

--- a/packages/translation-nmtcpp/vcpkg/overlay-ports/qvac-lib-inference-addon-cpp/portfile.cmake
+++ b/packages/translation-nmtcpp/vcpkg/overlay-ports/qvac-lib-inference-addon-cpp/portfile.cmake
@@ -1,0 +1,42 @@
+# Overlay (QVAC-21544): build qvac-lib-inference-addon-cpp 1.2.3 from the merged
+# JsLogger teardown / re-setLogger crash fix (tetherto/qvac#2932, commit
+# a3df3804) without moving the registry baseline (which would drag
+# qvac-fabric/whisper/tts forward). Drop this overlay once the registry baseline
+# this package pins already carries qvac-lib-inference-addon-cpp >= 1.2.3.
+#
+# Uses vcpkg_from_github (content-addressed tarball) rather than the registry
+# port's vcpkg_from_git: the parallel per-platform prebuild jobs share the
+# self-hosted runner's vcpkg downloads dir, and concurrent vcpkg_from_git clones
+# collide on git-tmp/.git/shallow.lock. The tarball download is lock-free and
+# deduplicated by SHA512.
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac
+  REF a3df3804b237a9e933b59d24a4dd26889b5c3395
+  SHA512 ab2c985916b7b0ba5fe17b406ad4cde51b85dfe795eaec365339d35b45bf04c45cde4fa8624aadd7c7707d7e455e032633cd3b7720d68776cba3ab3e96868f96
+)
+
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    tests BUILD_TESTING
+)
+
+set(SOURCE_PATH "${SOURCE_PATH}/packages/inference-addon-cpp")
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
+
+file(
+  INSTALL "${SOURCE_PATH}/LICENSE"
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+  RENAME copyright
+)

--- a/packages/translation-nmtcpp/vcpkg/overlay-ports/qvac-lib-inference-addon-cpp/vcpkg.json
+++ b/packages/translation-nmtcpp/vcpkg/overlay-ports/qvac-lib-inference-addon-cpp/vcpkg.json
@@ -1,0 +1,26 @@
+{
+  "name": "qvac-lib-inference-addon-cpp",
+  "version": "1.2.3",
+  "dependencies": [
+    {
+      "name": "qvac-lint-cpp",
+      "version>=": "1.4.5"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Rolls the **QVAC-21544 JsLogger crash fix** onto the 6.x line of `translation-nmtcpp`, mirroring the 5.0.4 hotfix.

## What
Pins `qvac-lib-inference-addon-cpp` to the fixed **1.2.3** source (merged commit `a3df3804`, tetherto/qvac#2932) via a local **vcpkg overlay-port** — so only the addon changes and the registry baseline stays put.

- `vcpkg/overlay-ports/qvac-lib-inference-addon-cpp` → builds the addon from `a3df3804` (1.2.3)
- `CMakeLists.txt` → wire `VCPKG_OVERLAY_PORTS`
- `vcpkg.json` → add top-level `name`/`version-string` (an overlay port with a version field puts vcpkg in manifest mode, which requires a complete manifest); addon `version>=` stays `1.2.1`, the overlay supplies the 1.2.3 content
- `package.json` → `6.3.0 → 6.3.1` + changelog

## Why overlay, not a registry baseline bump
Bumping this package's registry baseline to reach 1.2.3 would drag `qvac-fabric` **8828 → 9341**, plus whisper/tts/onnx, into the 6.x build (28 registry commits). The overlay pins **only** the addon, avoiding that blast radius. Drop it once this package pins a baseline that already carries addon ≥ 1.2.3.

## Verification
The identical fix (same `a3df3804` source) shipped as the **published `@qvac/translation-nmtcpp@5.0.4`** backport and was validated on-device (Pixel 10 Pro XL, Android 16): 3× `Translate → Soft Reload`, zero crashes, correct translation each cycle. Addon binary build-id `67703c73…` carries the guard.

Ticket: QVAC-21544
