### PR TITLE
QVAC-21618 fix: enable Windows GPU in transcription-parakeet benchmark

### DIFF
--- a/.github/workflows/integration-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-test-transcription-parakeet.yml
@@ -91,8 +91,7 @@ jobs:
           - os: windows-2025
             platform: win32
             arch: x64
-            runner: qvac-win25-x64
-            no_gpu: 'true'
+            runner: qvac-win25-x64-gpu
 
     steps:
       - name: Setup Node.js
@@ -160,6 +159,12 @@ jobs:
       - if: ${{ matrix.os == 'windows-2025' }}
         name: Set Vulkan SDK Path on Windows Server 2025
         run: echo "VULKAN_SDK=C:\VulkanSDK" >> $Env:GITHUB_ENV
+
+      # Runner enumerates the Intel iGPU at index 0 and the NVIDIA card at
+      # index 1; pin ggml to the NVIDIA device (re-check if the image changes).
+      - if: ${{ matrix.os == 'windows-2025' }}
+        name: Pin ggml Vulkan to the NVIDIA GPU on Windows
+        run: echo "GGML_VK_VISIBLE_DEVICES=1" >> $Env:GITHUB_ENV
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # 6.0.0


### PR DESCRIPTION
## What problem does this PR solve?

The transcription-parakeet RTF benchmark ran **CPU-only on Windows**. Its
`windows-2025` matrix entry targeted the non-GPU runner (`qvac-win25-x64`)
and carried `no_gpu: 'true'`, so the RTF benchmark step skipped the Vulkan
GPU legs entirely. Windows was the only desktop platform missing GPU numbers.

This mirrors the gap already fixed for TTS-GGML in #2989.

## How does it solve it?

Aligns the parakeet workflow's Windows leg with the tts-ggml one:

- Switch the `windows-2025` matrix entry to the GPU-capable runner
  `qvac-win25-x64-gpu` and drop `no_gpu: 'true'`, so the benchmark step
  takes the branch that includes the `useGPU: true, backendHint: "vulkan"`
  combos.
- Add a step pinning `GGML_VK_VISIBLE_DEVICES=1` on Windows. The
  windows-2025 image enumerates the Intel iGPU at Vulkan index 0 and the
  NVIDIA card at index 1; without the pin, ggml selects the iGPU and GPU
  numbers come out ≈ CPU (the same issue #2989 addressed).

The `-gpu` artifact suffix and `NO_GPU=false` now resolve correctly for
the Windows leg with no further changes.

## Breaking changes

None. CI-only workflow change.
