### PR TITLE
QVAC-16579 feat[api]: wire LavaSR denoiser through tts-ggml

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -34,10 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `scripts/convert-lavasr-enhancer-to-gguf.py` (f32 or f16). Examples:
   `examples/supertonic-enhanced.js`, `examples/chatterbox-enhanced.js`.
   Requires the `tts-cpp` pin that ships `tts_cpp::lavasr::Enhancer`
-  (qvac-ext-lib-whisper.cpp PR #68). The denoiser stage is wired as a scaffold
-  (see below).
+  (qvac-ext-lib-whisper.cpp PR #68). The denoiser stage is wired below.
 
-- **LavaSR denoiser wiring (scaffold).** The addon now exposes the second LavaSR
+- **LavaSR denoiser wiring.** The addon now exposes the second LavaSR
   stage — the UL-UNAS speech **denoiser**, which cleans the signal *before* the
   enhancer bandwidth-extends it — via `files.lavasrDenoiser` (or a
   `denoiser: { type: 'lavasr', denoiserPath }` block), mirroring the enhancer:
@@ -54,15 +53,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 
   The denoiser is rate-preserving and runs before the enhancer on the batch
-  path (both engines). **This is scaffold wiring:** the tts-cpp UL-UNAS forward
-  is not implemented yet (`tts_cpp::lavasr::Denoiser`, qvac-ext-lib-whisper.cpp
-  PR #76 landed only the structure/API + converter skeleton), so supplying a
-  denoiser GGUF currently fails at load with a clear *"not yet implemented"*
-  error. With no denoiser path, output is byte-identical (full backward compat).
-  Denoiser + Chatterbox native chunk streaming (`streamChunkTokens`) is rejected
-  up front — a stateful streaming denoiser is the follow-up. Requires the
-  `tts-cpp` pin `2026-07-02` (qvac-registry-vcpkg) that publishes the denoiser
-  symbols; the feature turns on with just a tts-cpp bump once the forward lands.
+  path (both engines). The tts-cpp UL-UNAS forward is implemented in
+  qvac-ext-lib-whisper.cpp PR #78 (`tts_cpp::lavasr::Denoiser`, scalar CPU port
+  validated bit-close to the ONNX reference). With no denoiser path, output is
+  byte-identical (full backward compat). Denoiser + Chatterbox native chunk
+  streaming (`streamChunkTokens`) is rejected up front — a stateful streaming
+  denoiser is the follow-up. Requires a `tts-cpp` pin (qvac-registry-vcpkg) that
+  includes PR #78; the feature activates at runtime with that version bump.
 
 - **Selectable output sample rate.** `outputSampleRate` (8000–192000 Hz,
   runtime config) now resamples the synthesized audio to the requested rate,

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -58,8 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validated bit-close to the ONNX reference). With no denoiser path, output is
   byte-identical (full backward compat). Denoiser + Chatterbox native chunk
   streaming (`streamChunkTokens`) is rejected up front — a stateful streaming
-  denoiser is the follow-up. Requires a `tts-cpp` pin (qvac-registry-vcpkg) that
-  includes PR #78; the feature activates at runtime with that version bump.
+  denoiser is the follow-up. Active as of the `tts-cpp` pin bump to
+  `2026-07-03#1` (qvac-registry-vcpkg), which ships the PR #78 UL-UNAS forward.
 
 - **Selectable output sample rate.** `outputSampleRate` (8000–192000 Hz,
   runtime config) now resamples the synthesized audio to the requested rate,

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -34,7 +34,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `scripts/convert-lavasr-enhancer-to-gguf.py` (f32 or f16). Examples:
   `examples/supertonic-enhanced.js`, `examples/chatterbox-enhanced.js`.
   Requires the `tts-cpp` pin that ships `tts_cpp::lavasr::Enhancer`
-  (qvac-ext-lib-whisper.cpp PR #68). The denoiser stage is a planned follow-up.
+  (qvac-ext-lib-whisper.cpp PR #68). The denoiser stage is wired as a scaffold
+  (see below).
+
+- **LavaSR denoiser wiring (scaffold).** The addon now exposes the second LavaSR
+  stage — the UL-UNAS speech **denoiser**, which cleans the signal *before* the
+  enhancer bandwidth-extends it — via `files.lavasrDenoiser` (or a
+  `denoiser: { type: 'lavasr', denoiserPath }` block), mirroring the enhancer:
+
+  ```js
+  new TTSGgml({
+    engine: TTSGgml.ENGINE_SUPERTONIC,
+    files: {
+      supertonicModel,
+      lavasrDenoiser: 'lavasr-denoiser.gguf', // cleaned first…
+      lavasrEnhancer: 'lavasr-enhancer.gguf'  // …then bandwidth-extended
+    }
+  })
+  ```
+
+  The denoiser is rate-preserving and runs before the enhancer on the batch
+  path (both engines). **This is scaffold wiring:** the tts-cpp UL-UNAS forward
+  is not implemented yet (`tts_cpp::lavasr::Denoiser`, qvac-ext-lib-whisper.cpp
+  PR #76 landed only the structure/API + converter skeleton), so supplying a
+  denoiser GGUF currently fails at load with a clear *"not yet implemented"*
+  error. With no denoiser path, output is byte-identical (full backward compat).
+  Denoiser + Chatterbox native chunk streaming (`streamChunkTokens`) is rejected
+  up front — a stateful streaming denoiser is the follow-up. Requires the
+  `tts-cpp` pin `2026-07-02` (qvac-registry-vcpkg) that publishes the denoiser
+  symbols; the feature turns on with just a tts-cpp bump once the forward lands.
 
 - **Selectable output sample rate.** `outputSampleRate` (8000–192000 Hz,
   runtime config) now resamples the synthesized audio to the requested rate,

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -286,8 +286,8 @@ Notes:
   synthesis, or drop the denoiser for streaming.
 - The tts-cpp UL-UNAS forward is implemented in
   [qvac-ext-lib-whisper.cpp#78](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/78)
-  (scalar CPU port, validated bit-close to the ONNX reference). It activates at
-  runtime once the `tts-cpp` pin is bumped to a version that includes #78.
+  (scalar CPU port, validated bit-close to the ONNX reference) and is active as of
+  the `tts-cpp` pin `2026-07-03#1` (this package's `vcpkg.json`).
 
 ## Backends & GPU acceleration
 

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -247,11 +247,11 @@ Notes:
   is 48 kHz; set `config.outputSampleRate` to resample the enhanced output to a
   different rate (`TTSOutputChunk.sampleRate` reports the actual rate).
 
-### Denoiser (scaffold)
+### Denoiser
 
 LavaSR's first stage — the UL-UNAS **denoiser**, which cleans the signal before
-the enhancer bandwidth-extends it — is wired through the addon as a scaffold. It
-is enabled the same way as the enhancer, via `files.lavasrDenoiser` (or a
+the enhancer bandwidth-extends it — is wired through the addon. It is enabled the
+same way as the enhancer, via `files.lavasrDenoiser` (or a
 `denoiser: { type: 'lavasr', denoiserPath }` block), and runs before the
 enhancer (rate-preserving) on the batch path for both engines:
 
@@ -267,14 +267,27 @@ const model = new TTSGgml({
 })
 ```
 
-The **tts-cpp denoiser forward is not implemented yet** (`tts_cpp::lavasr::Denoiser`,
-qvac-ext-lib-whisper.cpp PR #76 shipped only the structure/API +
-`scripts/convert-lavasr-denoiser-to-gguf.py` skeleton), so supplying a denoiser
-GGUF currently fails at load with a clear *"not yet implemented"* error; with no
-denoiser path the output is unchanged. Denoiser + Chatterbox native chunk
-streaming is rejected up front (a stateful streaming denoiser is the follow-up).
-The wiring is in place so the feature turns on with just a `tts-cpp` bump once
-the forward lands.
+Convert the GGUF from the public [LavaSRcpp](https://github.com/Topping1/LavaSRcpp)
+ONNX release:
+
+```bash
+python scripts/convert-lavasr-denoiser-to-gguf.py \
+  --denoiser denoiser_core_legacy_fixed63.onnx \
+  --out models/lavasr/lavasr-denoiser.gguf --ftype f16   # or f32
+```
+
+Notes:
+
+- The UL-UNAS forward runs at 16 kHz internally (resampled in/out), so the
+  denoiser is **rate-preserving**: the emitted audio keeps the engine's sample
+  rate. With no denoiser path the output is unchanged (full backward compat).
+- Denoiser + Chatterbox native chunk streaming (`streamChunkTokens > 0`) is
+  rejected up front — a stateful streaming denoiser is the follow-up. Use batch
+  synthesis, or drop the denoiser for streaming.
+- The tts-cpp UL-UNAS forward is implemented in
+  [qvac-ext-lib-whisper.cpp#78](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/78)
+  (scalar CPU port, validated bit-close to the ONNX reference). It activates at
+  runtime once the `tts-cpp` pin is bumped to a version that includes #78.
 
 ## Backends & GPU acceleration
 

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -245,8 +245,36 @@ Notes:
   streaming.
 - The enhancer always runs at 48 kHz internally. By default the emitted audio
   is 48 kHz; set `config.outputSampleRate` to resample the enhanced output to a
-  different rate (`TTSOutputChunk.sampleRate` reports the actual rate). The
-  LavaSR denoiser stage is a planned follow-up.
+  different rate (`TTSOutputChunk.sampleRate` reports the actual rate).
+
+### Denoiser (scaffold)
+
+LavaSR's first stage — the UL-UNAS **denoiser**, which cleans the signal before
+the enhancer bandwidth-extends it — is wired through the addon as a scaffold. It
+is enabled the same way as the enhancer, via `files.lavasrDenoiser` (or a
+`denoiser: { type: 'lavasr', denoiserPath }` block), and runs before the
+enhancer (rate-preserving) on the batch path for both engines:
+
+```js
+const model = new TTSGgml({
+  engine: TTSGgml.ENGINE_SUPERTONIC,
+  files: {
+    supertonicModel,
+    lavasrDenoiser: 'models/lavasr/lavasr-denoiser.gguf', // cleaned first…
+    lavasrEnhancer: 'models/lavasr/lavasr-enhancer.gguf'  // …then upsampled
+  },
+  config: { language: 'en' }
+})
+```
+
+The **tts-cpp denoiser forward is not implemented yet** (`tts_cpp::lavasr::Denoiser`,
+qvac-ext-lib-whisper.cpp PR #76 shipped only the structure/API +
+`scripts/convert-lavasr-denoiser-to-gguf.py` skeleton), so supplying a denoiser
+GGUF currently fails at load with a clear *"not yet implemented"* error; with no
+denoiser path the output is unchanged. Denoiser + Chatterbox native chunk
+streaming is rejected up front (a stateful streaming denoiser is the follow-up).
+The wiring is in place so the feature turns on with just a `tts-cpp` bump once
+the forward lands.
 
 ## Backends & GPU acceleration
 

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
@@ -134,8 +134,8 @@ chatterbox::ChatterboxConfig JSAdapter::buildChatterboxConfig(
   cfg.enhancerGgufPath =
       readOptionalString(configurationParams, env, "lavasrEnhancerPath");
   // LavaSR neural denoiser (runs before the enhancer): a non-empty GGUF path
-  // turns it on. SCAFFOLD — tts-cpp Denoiser::load throws until the UL-UNAS
-  // forward lands (PR #76), so a provided path currently errors at load.
+  // turns it on. The tts-cpp UL-UNAS forward is implemented in
+  // qvac-ext-lib-whisper.cpp PR #78 (activates once the pinned tts-cpp has it).
   cfg.denoiserGgufPath =
       readOptionalString(configurationParams, env, "lavasrDenoiserPath");
   return cfg;
@@ -164,8 +164,8 @@ supertonic::SupertonicConfig JSAdapter::buildSupertonicConfig(
   cfg.enhancerGgufPath =
       readOptionalString(configurationParams, env, "lavasrEnhancerPath");
   // LavaSR neural denoiser (runs before the enhancer): a non-empty GGUF path
-  // turns it on. SCAFFOLD — tts-cpp Denoiser::load throws until the UL-UNAS
-  // forward lands (PR #76), so a provided path currently errors at load.
+  // turns it on. The tts-cpp UL-UNAS forward is implemented in
+  // qvac-ext-lib-whisper.cpp PR #78 (activates once the pinned tts-cpp has it).
   cfg.denoiserGgufPath =
       readOptionalString(configurationParams, env, "lavasrDenoiserPath");
   return cfg;

--- a/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/tts-ggml/addon/src/js-interface/JSAdapter.cpp
@@ -133,6 +133,11 @@ chatterbox::ChatterboxConfig JSAdapter::buildChatterboxConfig(
   // LavaSR neural enhancement: a non-empty GGUF path turns it on.
   cfg.enhancerGgufPath =
       readOptionalString(configurationParams, env, "lavasrEnhancerPath");
+  // LavaSR neural denoiser (runs before the enhancer): a non-empty GGUF path
+  // turns it on. SCAFFOLD — tts-cpp Denoiser::load throws until the UL-UNAS
+  // forward lands (PR #76), so a provided path currently errors at load.
+  cfg.denoiserGgufPath =
+      readOptionalString(configurationParams, env, "lavasrDenoiserPath");
   return cfg;
 }
 
@@ -158,6 +163,11 @@ supertonic::SupertonicConfig JSAdapter::buildSupertonicConfig(
   // LavaSR neural enhancement: a non-empty GGUF path turns it on.
   cfg.enhancerGgufPath =
       readOptionalString(configurationParams, env, "lavasrEnhancerPath");
+  // LavaSR neural denoiser (runs before the enhancer): a non-empty GGUF path
+  // turns it on. SCAFFOLD — tts-cpp Denoiser::load throws until the UL-UNAS
+  // forward lands (PR #76), so a provided path currently errors at load.
+  cfg.denoiserGgufPath =
+      readOptionalString(configurationParams, env, "lavasrDenoiserPath");
   return cfg;
 }
 

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
@@ -156,6 +156,17 @@ struct ChatterboxConfig {
   // `outputSampleRate` is also set the enhanced signal is resampled to that
   // rate afterwards.
   std::string enhancerGgufPath;
+
+  // LavaSR neural speech denoiser (UL-UNAS). A non-empty `denoiserGgufPath` is
+  // the single switch: when set, the synthesized PCM is denoised BEFORE the
+  // enhancer (rate-preserving); empty disables it (full backward compat).
+  //
+  // SCAFFOLD: tts-cpp's Denoiser::load() throws "not yet implemented" until the
+  // UL-UNAS forward lands (qvac-ext-lib-whisper.cpp PR #76 shipped only the
+  // structure/API), so a non-empty path currently fails at load. Native chunk
+  // streaming (streamChunkTokens > 0) with a denoiser is rejected up front (a
+  // stateful streaming denoiser is the follow-up) — batch only for now.
+  std::string denoiserGgufPath;
 };
 
 } // namespace qvac::ttsggml::chatterbox

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
@@ -160,12 +160,10 @@ struct ChatterboxConfig {
   // LavaSR neural speech denoiser (UL-UNAS). A non-empty `denoiserGgufPath` is
   // the single switch: when set, the synthesized PCM is denoised BEFORE the
   // enhancer (rate-preserving); empty disables it (full backward compat).
-  //
-  // SCAFFOLD: tts-cpp's Denoiser::load() throws "not yet implemented" until the
-  // UL-UNAS forward lands (qvac-ext-lib-whisper.cpp PR #76 shipped only the
-  // structure/API), so a non-empty path currently fails at load. Native chunk
-  // streaming (streamChunkTokens > 0) with a denoiser is rejected up front (a
-  // stateful streaming denoiser is the follow-up) — batch only for now.
+  // The tts-cpp UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp PR
+  // #78; a non-empty path activates it once the pinned tts-cpp includes #78.
+  // Native chunk streaming (streamChunkTokens > 0) with a denoiser is rejected
+  // up front (a stateful streaming denoiser is the follow-up) — batch only.
   std::string denoiserGgufPath;
 };
 

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <tts-cpp/chatterbox/engine.h>
+#include <tts-cpp/lavasr/denoiser.h>
 #include <tts-cpp/lavasr/enhancer.h>
 
 #include "addon/TTSErrors.hpp"
@@ -189,6 +190,25 @@ void ChatterboxModel::validateConfig(const ChatterboxConfig& cfg) {
         TTSErrorCode::ModelFileNotFound,
         "lavasr enhancer GGUF not found: " + cfg.enhancerGgufPath);
   }
+  if (!cfg.denoiserGgufPath.empty() &&
+      !std::filesystem::exists(cfg.denoiserGgufPath)) {
+    throw createTTSError(
+        TTSErrorCode::ModelFileNotFound,
+        "lavasr denoiser GGUF not found: " + cfg.denoiserGgufPath);
+  }
+  // LavaSR denoiser + native chunk streaming is not supported yet: the UL-UNAS
+  // denoiser is causal but tts-cpp only exposes a one-shot denoise(), so a
+  // stateful streaming denoiser (à la StreamingEnhancer) is the follow-up.
+  // Reject the combo up front rather than silently dropping denoising on the
+  // streaming path. Defense-in-depth: index.js rejects it before we get here.
+  if (!cfg.denoiserGgufPath.empty() &&
+      cfg.streamChunkTokens.value_or(0) > 0) {
+    throw StatusError(
+        general_error::InvalidArgument,
+        "ChatterboxModel: the LavaSR denoiser is not yet supported with native "
+        "chunk streaming (streamChunkTokens > 0). Use batch synthesis, or drop "
+        "the denoiser for streaming (streaming denoise is a planned follow-up).");
+  }
   if (cfg.useGpu.has_value() && cfg.nGpuLayers.has_value()) {
     const bool wantsGpu = *cfg.useGpu;
     const int  layers   = *cfg.nGpuLayers;
@@ -330,11 +350,28 @@ void ChatterboxModel::loadLocked() {
   } else {
     enhancer_.reset();
   }
+
+  // LavaSR denoiser: load when a GGUF path is set (runs before the enhancer).
+  // SCAFFOLD — tts-cpp Denoiser::load throws until the UL-UNAS forward lands
+  // (PR #76), surfacing here as a clean InitializationFailed error.
+  if (!cfg_.denoiserGgufPath.empty()) {
+    try {
+      denoiser_ = tts_cpp::lavasr::Denoiser::load(cfg_.denoiserGgufPath);
+    } catch (const std::exception& e) {
+      denoiser_.reset();
+      throw createTTSError(
+          TTSErrorCode::InitializationFailed,
+          std::string("ChatterboxModel::load: lavasr denoiser: ") + e.what());
+    }
+  } else {
+    denoiser_.reset();
+  }
 }
 
 void ChatterboxModel::unloadLocked() {
   engine_.reset();
   enhancer_.reset();
+  denoiser_.reset();
 }
 
 void ChatterboxModel::cancel() const {
@@ -359,10 +396,12 @@ ChatterboxModel::SynthesizeResult ChatterboxModel::synthesize(
   // on the NEXT synthesize call.
   std::shared_ptr<tts_cpp::chatterbox::Engine> engine;
   std::shared_ptr<tts_cpp::lavasr::Enhancer> enhancer;
+  std::shared_ptr<tts_cpp::lavasr::Denoiser> denoiser;
   {
     std::lock_guard lk(engineMu_);
     engine = engine_;
     enhancer = enhancer_;
+    denoiser = denoiser_;
   }
   if (!engine) {
     throw createTTSError(TTSErrorCode::ModelNotLoaded,
@@ -487,6 +526,21 @@ ChatterboxModel::SynthesizeResult ChatterboxModel::synthesize(
   } catch (const std::exception& e) {
     throw createTTSError(TTSErrorCode::SynthesisFailed,
                          std::string("engine.synthesize: ") + e.what());
+  }
+
+  // LavaSR neural denoiser (batch path). Runs BEFORE the enhancer and preserves
+  // the sample rate. Streaming + denoiser is rejected in validateConfig (a
+  // stateful streaming denoiser is the follow-up), so this only applies on the
+  // batch path. SCAFFOLD — Denoiser::load throws at load until the UL-UNAS
+  // forward lands (PR #76), so this only runs once the tts-cpp core exists.
+  if (!wasStreaming && denoiser) {
+    try {
+      result.pcm = denoiser->denoise(result.pcm, result.sample_rate);
+    } catch (const std::exception& e) {
+      throw createTTSError(
+          TTSErrorCode::SynthesisFailed,
+          std::string("chatterbox.lavasr-denoiser: ") + e.what());
+    }
   }
 
   // LavaSR neural bandwidth extension (batch path). The streaming path enhances

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -352,8 +352,9 @@ void ChatterboxModel::loadLocked() {
   }
 
   // LavaSR denoiser: load when a GGUF path is set (runs before the enhancer).
-  // SCAFFOLD — tts-cpp Denoiser::load throws until the UL-UNAS forward lands
-  // (PR #76), surfacing here as a clean InitializationFailed error.
+  // The UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp PR #78; an
+  // older tts-cpp pin (pre-#78) makes Denoiser::load throw, surfacing here as a
+  // clean InitializationFailed error.
   if (!cfg_.denoiserGgufPath.empty()) {
     try {
       denoiser_ = tts_cpp::lavasr::Denoiser::load(cfg_.denoiserGgufPath);
@@ -531,8 +532,8 @@ ChatterboxModel::SynthesizeResult ChatterboxModel::synthesize(
   // LavaSR neural denoiser (batch path). Runs BEFORE the enhancer and preserves
   // the sample rate. Streaming + denoiser is rejected in validateConfig (a
   // stateful streaming denoiser is the follow-up), so this only applies on the
-  // batch path. SCAFFOLD — Denoiser::load throws at load until the UL-UNAS
-  // forward lands (PR #76), so this only runs once the tts-cpp core exists.
+  // batch path. The UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp
+  // PR #78; this runs whenever a denoiser was loaded.
   if (!wasStreaming && denoiser) {
     try {
       result.pcm = denoiser->denoise(result.pcm, result.sample_rate);

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -201,13 +201,13 @@ void ChatterboxModel::validateConfig(const ChatterboxConfig& cfg) {
   // stateful streaming denoiser (à la StreamingEnhancer) is the follow-up.
   // Reject the combo up front rather than silently dropping denoising on the
   // streaming path. Defense-in-depth: index.js rejects it before we get here.
-  if (!cfg.denoiserGgufPath.empty() &&
-      cfg.streamChunkTokens.value_or(0) > 0) {
+  if (!cfg.denoiserGgufPath.empty() && cfg.streamChunkTokens.value_or(0) > 0) {
     throw StatusError(
         general_error::InvalidArgument,
         "ChatterboxModel: the LavaSR denoiser is not yet supported with native "
         "chunk streaming (streamChunkTokens > 0). Use batch synthesis, or drop "
-        "the denoiser for streaming (streaming denoise is a planned follow-up).");
+        "the denoiser for streaming (streaming denoise is a planned "
+        "follow-up).");
   }
   if (cfg.useGpu.has_value() && cfg.nGpuLayers.has_value()) {
     const bool wantsGpu = *cfg.useGpu;

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
@@ -145,9 +145,9 @@ private:
   std::shared_ptr<tts_cpp::lavasr::Enhancer> enhancer_;
   // LavaSR denoiser (QVAC-16579 follow-up): runs before the enhancer
   // (rate-preserving); loaded when cfg_.denoiserGgufPath is set; null disables
-  // it. SCAFFOLD — the tts-cpp forward is unimplemented, so load() throws, and
-  // denoiser + native chunk streaming is rejected in validateConfig (batch
-  // only for now).
+  // it. The tts-cpp UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp
+  // PR #78; denoiser + native chunk streaming is rejected in validateConfig
+  // (batch only — a stateful streaming denoiser is the follow-up).
   std::shared_ptr<tts_cpp::lavasr::Denoiser> denoiser_;
 
   // Rejects concurrent `process()` invocations; the outer JobRunner also

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
@@ -21,6 +21,7 @@ struct EngineOptions;
 } // namespace tts_cpp::chatterbox
 namespace tts_cpp::lavasr {
 class Enhancer;
+class Denoiser;
 }
 
 namespace qvac::ttsggml::chatterbox {
@@ -142,6 +143,12 @@ private:
   // LavaSR enhancer (QVAC-16579): loaded alongside the engine when
   // cfg_.enhancerGgufPath is set; null disables enhancement.
   std::shared_ptr<tts_cpp::lavasr::Enhancer> enhancer_;
+  // LavaSR denoiser (QVAC-16579 follow-up): runs before the enhancer
+  // (rate-preserving); loaded when cfg_.denoiserGgufPath is set; null disables
+  // it. SCAFFOLD — the tts-cpp forward is unimplemented, so load() throws, and
+  // denoiser + native chunk streaming is rejected in validateConfig (batch
+  // only for now).
+  std::shared_ptr<tts_cpp::lavasr::Denoiser> denoiser_;
 
   // Rejects concurrent `process()` invocations; the outer JobRunner also
   // serializes jobs, but belt-and-suspenders enforcement here keeps

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicConfig.hpp
@@ -50,6 +50,15 @@ struct SupertonicConfig {
   // The enhancer always produces 48 kHz; if `outputSampleRate` is also set the
   // model resamples the enhanced signal to that rate afterwards.
   std::string enhancerGgufPath;
+
+  // LavaSR neural speech denoiser (UL-UNAS). A non-empty `denoiserGgufPath` is
+  // the single switch: when set, the model denoises the synthesized PCM BEFORE
+  // the enhancer (rate-preserving); empty disables it (full backward compat).
+  //
+  // SCAFFOLD: tts-cpp's Denoiser::load() throws "not yet implemented" until the
+  // UL-UNAS forward lands (qvac-ext-lib-whisper.cpp PR #76 shipped only the
+  // structure/API), so a non-empty path currently fails at load.
+  std::string denoiserGgufPath;
 };
 
 }

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicConfig.hpp
@@ -54,10 +54,8 @@ struct SupertonicConfig {
   // LavaSR neural speech denoiser (UL-UNAS). A non-empty `denoiserGgufPath` is
   // the single switch: when set, the model denoises the synthesized PCM BEFORE
   // the enhancer (rate-preserving); empty disables it (full backward compat).
-  //
-  // SCAFFOLD: tts-cpp's Denoiser::load() throws "not yet implemented" until the
-  // UL-UNAS forward lands (qvac-ext-lib-whisper.cpp PR #76 shipped only the
-  // structure/API), so a non-empty path currently fails at load.
+  // The tts-cpp UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp PR
+  // #78; a non-empty path activates it once the pinned tts-cpp includes #78.
   std::string denoiserGgufPath;
 };
 

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -206,8 +206,9 @@ void SupertonicModel::loadLocked() {
   }
 
   // LavaSR denoiser: load when a GGUF path is set (runs before the enhancer).
-  // SCAFFOLD — tts-cpp Denoiser::load throws until the UL-UNAS forward lands
-  // (PR #76), surfacing here as a clean InitializationFailed error.
+  // The UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp PR #78; an
+  // older tts-cpp pin (pre-#78) makes Denoiser::load throw, surfacing here as a
+  // clean InitializationFailed error.
   if (!cfg_.denoiserGgufPath.empty()) {
     try {
       denoiser_ = tts_cpp::lavasr::Denoiser::load(cfg_.denoiserGgufPath);
@@ -269,9 +270,9 @@ SupertonicModel::Output SupertonicModel::synthesize(const std::string& text) {
   }
 
   // LavaSR neural denoiser (opt-in). Runs BEFORE the enhancer and preserves the
-  // sample rate (cleans the signal, no rate change). SCAFFOLD — Denoiser::load
-  // throws at load until the UL-UNAS forward lands (PR #76), so this only runs
-  // once the tts-cpp core is implemented; the wiring is in place now.
+  // sample rate (cleans the signal, no rate change). The UL-UNAS forward is
+  // implemented in qvac-ext-lib-whisper.cpp PR #78; this runs whenever a
+  // denoiser was loaded (i.e. the pinned tts-cpp includes #78).
   if (denoiser) {
     try {
       result.pcm = denoiser->denoise(result.pcm, result.sample_rate);

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include <tts-cpp/lavasr/denoiser.h>
 #include <tts-cpp/lavasr/enhancer.h>
 #include <tts-cpp/supertonic/engine.h>
 
@@ -123,6 +124,12 @@ void SupertonicModel::validateConfig(const SupertonicConfig& cfg) {
         TTSErrorCode::ModelFileNotFound,
         "lavasr enhancer GGUF not found: " + cfg.enhancerGgufPath);
   }
+  if (!cfg.denoiserGgufPath.empty() &&
+      !std::filesystem::exists(cfg.denoiserGgufPath)) {
+    throw createTTSError(
+        TTSErrorCode::ModelFileNotFound,
+        "lavasr denoiser GGUF not found: " + cfg.denoiserGgufPath);
+  }
   // Defense-in-depth: the JS layer (index.js::_validateConfig) runs the
   // same conflict check before this method is reached, so direct C++
   // callers are the only ones who can actually trip this branch.
@@ -197,11 +204,28 @@ void SupertonicModel::loadLocked() {
   } else {
     enhancer_.reset();
   }
+
+  // LavaSR denoiser: load when a GGUF path is set (runs before the enhancer).
+  // SCAFFOLD — tts-cpp Denoiser::load throws until the UL-UNAS forward lands
+  // (PR #76), surfacing here as a clean InitializationFailed error.
+  if (!cfg_.denoiserGgufPath.empty()) {
+    try {
+      denoiser_ = tts_cpp::lavasr::Denoiser::load(cfg_.denoiserGgufPath);
+    } catch (const std::exception& e) {
+      denoiser_.reset();
+      throw createTTSError(
+          TTSErrorCode::InitializationFailed,
+          std::string("SupertonicModel::load: lavasr denoiser: ") + e.what());
+    }
+  } else {
+    denoiser_.reset();
+  }
 }
 
 void SupertonicModel::unloadLocked() {
   engine_.reset();
   enhancer_.reset();
+  denoiser_.reset();
 }
 
 void SupertonicModel::cancel() const {
@@ -217,10 +241,12 @@ void SupertonicModel::cancel() const {
 SupertonicModel::Output SupertonicModel::synthesize(const std::string& text) {
   std::shared_ptr<tts_cpp::supertonic::Engine> engine;
   std::shared_ptr<tts_cpp::lavasr::Enhancer> enhancer;
+  std::shared_ptr<tts_cpp::lavasr::Denoiser> denoiser;
   {
     std::lock_guard lk(engineMu_);
     engine = engine_;
     enhancer = enhancer_;
+    denoiser = denoiser_;
   }
   if (!engine) {
     throw createTTSError(TTSErrorCode::InitializationFailed,
@@ -240,6 +266,20 @@ SupertonicModel::Output SupertonicModel::synthesize(const std::string& text) {
   } catch (const std::exception& e) {
     throw createTTSError(TTSErrorCode::SynthesisFailed,
                          std::string("supertonic.synthesize: ") + e.what());
+  }
+
+  // LavaSR neural denoiser (opt-in). Runs BEFORE the enhancer and preserves the
+  // sample rate (cleans the signal, no rate change). SCAFFOLD — Denoiser::load
+  // throws at load until the UL-UNAS forward lands (PR #76), so this only runs
+  // once the tts-cpp core is implemented; the wiring is in place now.
+  if (denoiser) {
+    try {
+      result.pcm = denoiser->denoise(result.pcm, result.sample_rate);
+    } catch (const std::exception& e) {
+      throw createTTSError(
+          TTSErrorCode::SynthesisFailed,
+          std::string("supertonic.lavasr-denoiser: ") + e.what());
+    }
   }
 
   // LavaSR neural bandwidth extension (opt-in). Runs on the full utterance

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.hpp
@@ -18,6 +18,7 @@ class Engine;
 }
 namespace tts_cpp::lavasr {
 class Enhancer;
+class Denoiser;
 }
 
 namespace qvac::ttsggml::supertonic {
@@ -80,6 +81,11 @@ private:
   // cfg_.enhancerGgufPath is set; null disables enhancement. Holds only
   // const weights, so it is safe to share across concurrent enhance() calls.
   std::shared_ptr<tts_cpp::lavasr::Enhancer> enhancer_;
+  // LavaSR denoiser (runs before the enhancer, rate-preserving): loaded when
+  // cfg_.denoiserGgufPath is set; null disables denoising. SCAFFOLD — the
+  // tts-cpp forward is unimplemented, so load() currently throws. Holds only
+  // const weights, safe to share across concurrent denoise() calls.
+  std::shared_ptr<tts_cpp::lavasr::Denoiser> denoiser_;
 
   std::atomic_bool jobInProgress_{false};
 

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.hpp
@@ -82,9 +82,9 @@ private:
   // const weights, so it is safe to share across concurrent enhance() calls.
   std::shared_ptr<tts_cpp::lavasr::Enhancer> enhancer_;
   // LavaSR denoiser (runs before the enhancer, rate-preserving): loaded when
-  // cfg_.denoiserGgufPath is set; null disables denoising. SCAFFOLD — the
-  // tts-cpp forward is unimplemented, so load() currently throws. Holds only
-  // const weights, safe to share across concurrent denoise() calls.
+  // cfg_.denoiserGgufPath is set; null disables denoising. The tts-cpp UL-UNAS
+  // forward is implemented in qvac-ext-lib-whisper.cpp PR #78. Holds only const
+  // weights, safe to share across concurrent denoise() calls.
   std::shared_ptr<tts_cpp::lavasr::Denoiser> denoiser_;
 
   std::atomic_bool jobInProgress_{false};

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -39,10 +39,9 @@ declare interface TTSGgmlFiles {
    * enhancer and is rate-preserving (the canonical way to enable denoising;
    * `denoiser.denoiserPath` is the only alternative).
    *
-   * SCAFFOLD: the tts-cpp denoiser forward is not implemented yet
-   * (qvac-ext-lib-whisper.cpp PR #76 landed only the structure/API), so
-   * supplying this path currently fails at load with "not yet implemented".
-   * The wiring is in place so it turns on with just a tts-cpp bump.
+   * The tts-cpp UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp
+   * PR #78 (scalar CPU port, validated bit-close to the ONNX reference); it
+   * activates at runtime once the pinned tts-cpp version includes #78.
    */
   lavasrDenoiser?: string
   /** Optional directory containing baked Chatterbox voice profiles. */
@@ -99,9 +98,9 @@ declare interface LavaSREnhancerOptions {
  * no separate on/off flag. The denoiser runs BEFORE the enhancer and preserves
  * the sample rate.
  *
- * SCAFFOLD: the tts-cpp denoiser forward is not implemented yet (PR #76 landed
- * only the structure/API), so supplying a path currently fails at load with
- * "not yet implemented"; not supported with Chatterbox native chunk streaming.
+ * The tts-cpp UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp PR #78
+ * (activates once the pinned tts-cpp includes it). Not supported with Chatterbox
+ * native chunk streaming (a stateful streaming denoiser is the follow-up).
  */
 declare interface LavaSRDenoiserOptions {
   type: 'lavasr'
@@ -171,12 +170,10 @@ declare interface TTSGgmlOptions {
    * providing a GGUF path (here via `denoiserPath` or through
    * `files.lavasrDenoiser`).
    *
-   * SCAFFOLD: the tts-cpp denoiser forward is not implemented yet
-   * (qvac-ext-lib-whisper.cpp PR #76 landed only the structure/API), so
-   * supplying a path currently fails at load with "not yet implemented", and
-   * it is rejected with Chatterbox native chunk streaming (a stateful streaming
-   * denoiser is the follow-up). The wiring is in place so the feature turns on
-   * with just a tts-cpp bump once the forward lands.
+   * The tts-cpp UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp
+   * PR #78 (validated bit-close to the ONNX reference); it activates at runtime
+   * once the pinned tts-cpp version includes #78. It is rejected with Chatterbox
+   * native chunk streaming (a stateful streaming denoiser is the follow-up).
    */
   denoiser?: LavaSRDenoiserOptions
   /** Directory the addon scans for dynamically-loaded ggml backends */

--- a/packages/tts-ggml/index.d.ts
+++ b/packages/tts-ggml/index.d.ts
@@ -33,6 +33,18 @@ declare interface TTSGgmlFiles {
    * `enhancer.enhancerPath` is the only alternative).
    */
   lavasrEnhancer?: string
+  /**
+   * LavaSR denoiser GGUF: UL-UNAS speech denoiser produced by
+   * tts-cpp/scripts/convert-lavasr-denoiser-to-gguf.py. Runs BEFORE the
+   * enhancer and is rate-preserving (the canonical way to enable denoising;
+   * `denoiser.denoiserPath` is the only alternative).
+   *
+   * SCAFFOLD: the tts-cpp denoiser forward is not implemented yet
+   * (qvac-ext-lib-whisper.cpp PR #76 landed only the structure/API), so
+   * supplying this path currently fails at load with "not yet implemented".
+   * The wiring is in place so it turns on with just a tts-cpp bump.
+   */
+  lavasrDenoiser?: string
   /** Optional directory containing baked Chatterbox voice profiles. */
   voicesDir?: string
   /**
@@ -78,6 +90,23 @@ declare interface LavaSREnhancerOptions {
   type: 'lavasr'
   /** Enhancer GGUF path (alternative to `files.lavasrEnhancer`). */
   enhancerPath?: string
+}
+
+/**
+ * LavaSR denoiser config. The discriminated `type` mirrors the enhancer; v1
+ * ships `lavasr` (the UL-UNAS denoiser). Denoising is enabled by providing a
+ * GGUF path (here as `denoiserPath`, or via `files.lavasrDenoiser`) — there is
+ * no separate on/off flag. The denoiser runs BEFORE the enhancer and preserves
+ * the sample rate.
+ *
+ * SCAFFOLD: the tts-cpp denoiser forward is not implemented yet (PR #76 landed
+ * only the structure/API), so supplying a path currently fails at load with
+ * "not yet implemented"; not supported with Chatterbox native chunk streaming.
+ */
+declare interface LavaSRDenoiserOptions {
+  type: 'lavasr'
+  /** Denoiser GGUF path (alternative to `files.lavasrDenoiser`). */
+  denoiserPath?: string
 }
 
 declare interface TTSGgmlOptions {
@@ -133,10 +162,23 @@ declare interface TTSGgmlOptions {
    * `enhancerPath` or through `files.lavasrEnhancer`). Works for Supertonic and
    * Chatterbox, including Chatterbox native chunk streaming
    * (`streamChunkTokens`), where it enhances each chunk seam-free at the cost
-   * of ~0.34 s of look-ahead latency. The denoiser stage is a planned
-   * follow-up.
+   * of ~0.34 s of look-ahead latency.
    */
   enhancer?: LavaSREnhancerOptions
+  /**
+   * LavaSR neural speech denoiser (UL-UNAS). Opt-in CPU/GGML pre-processing
+   * that runs BEFORE the enhancer and preserves the sample rate; enabled by
+   * providing a GGUF path (here via `denoiserPath` or through
+   * `files.lavasrDenoiser`).
+   *
+   * SCAFFOLD: the tts-cpp denoiser forward is not implemented yet
+   * (qvac-ext-lib-whisper.cpp PR #76 landed only the structure/API), so
+   * supplying a path currently fails at load with "not yet implemented", and
+   * it is rejected with Chatterbox native chunk streaming (a stateful streaming
+   * denoiser is the follow-up). The wiring is in place so the feature turns on
+   * with just a tts-cpp bump once the forward lands.
+   */
+  denoiser?: LavaSRDenoiserOptions
   /** Directory the addon scans for dynamically-loaded ggml backends */
   backendsDir?: string
   /** Directory where ggml-opencl persists its compiled program-binary */
@@ -276,6 +318,7 @@ declare namespace TTSGgml {
     TTSGgmlFiles,
     TTSGgmlOptions,
     LavaSREnhancerOptions,
+    LavaSRDenoiserOptions,
     TTSGgmlRuntimeConfig,
     RuntimeStats,
     SentenceStreamChunkMeta,

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -115,6 +115,13 @@ function normalizeGgmlFiles (files) {
     // tts-cpp/scripts/convert-lavasr-enhancer-to-gguf.py. One canonical key
     // (the alternative is enhancer.enhancerPath on the options object).
     lavasrEnhancer: firstNonEmpty(f.lavasrEnhancer),
+    // LavaSR denoiser GGUF: UL-UNAS speech denoiser that runs BEFORE the
+    // enhancer (rate-preserving), produced by
+    // tts-cpp/scripts/convert-lavasr-denoiser-to-gguf.py. One canonical key
+    // (the alternative is denoiser.denoiserPath on the options object).
+    // SCAFFOLD: the tts-cpp denoiser forward is not implemented yet (PR #76),
+    // so supplying this path currently fails at load with "not yet implemented".
+    lavasrDenoiser: firstNonEmpty(f.lavasrDenoiser),
     // Directory of the compiled MeCab/IPAdic dictionary (Japanese) and
     // the Cangjie TSV (Chinese).  The host resolves/stages these (e.g.
     // from the QVAC model registry) and passes the local paths; the
@@ -268,6 +275,7 @@ class TTSGgml {
       speed,
       noiseNpyPath,
       enhancer,
+      denoiser,
       backendsDir,
       openclCacheDir,
       mecabDictDir,
@@ -388,6 +396,26 @@ class TTSGgml {
       enhancer ? enhancer.enhancerPath : undefined
     )
 
+    // LavaSR denoiser (opt-in, mirrors the enhancer). The denoiser runs BEFORE
+    // the enhancer and is rate-preserving; it is enabled purely by supplying a
+    // GGUF path — via files.lavasrDenoiser or denoiser.denoiserPath — so there
+    // is no separate on/off flag. A provided `denoiser` block must use the
+    // supported type so a typo can't silently disable it.
+    // SCAFFOLD: the tts-cpp UL-UNAS denoiser forward is not implemented yet
+    // (qvac-ext-lib-whisper.cpp PR #76 landed only the structure/API), so
+    // supplying a denoiser path currently fails at load with a clear
+    // "not yet implemented" error. The wiring is in place so the feature turns
+    // on with just a tts-cpp bump once the forward lands.
+    if (denoiser != null && denoiser.type !== 'lavasr') {
+      throw new Error(
+        `tts-ggml: unknown denoiser.type '${denoiser.type}', expected 'lavasr'.`
+      )
+    }
+    this._denoiserGgufPath = firstNonEmpty(
+      normalizedFiles.lavasrDenoiser,
+      denoiser ? denoiser.denoiserPath : undefined
+    )
+
     // Per-platform fallback for `backendsDir` when the host didn't
     // pass one. Mirrors the qvac/packages/llm-llamacpp +
     // transcription-parakeet resolution shape
@@ -441,6 +469,25 @@ class TTSGgml {
     // in ChatterboxModel). This adds ~0.34 s of look-ahead latency — inherent to
     // the enhancer's receptive field — so the first audio arrives a little later
     // than un-enhanced streaming.
+
+    // LavaSR denoise + native chunk streaming is NOT supported yet. The UL-UNAS
+    // denoiser is causal (streaming-friendly in principle), but tts-cpp only
+    // exposes a one-shot denoise() today — a stateful streaming denoiser (GRU
+    // hidden-state carry across chunks, à la StreamingEnhancer) is the
+    // follow-up. Reject the combo up front so it can't silently drop denoising
+    // on the streaming path; batch synthesis (run/runStream/runStreaming without
+    // streamChunkTokens) applies the denoiser normally.
+    if (
+      this._denoiserGgufPath &&
+      (this._streamChunkTokens != null || this._streamFirstChunkTokens != null)
+    ) {
+      throw new Error(
+        'tts-ggml: the LavaSR denoiser is not yet supported with Chatterbox ' +
+        'native chunk streaming (streamChunkTokens / streamFirstChunkTokens). ' +
+        'Use batch synthesis, or drop the denoiser for streaming. Streaming ' +
+        'denoise is a planned follow-up (needs a stateful streaming denoiser).'
+      )
+    }
 
     // Default GPU off only when neither knob is set, for every engine. A
     // caller passing nGpuLayers alone keeps it (no silent conflict with the
@@ -851,6 +898,9 @@ class TTSGgml {
     if (this._enhancerGgufPath) {
       params.lavasrEnhancerPath = this._enhancerGgufPath
     }
+    if (this._denoiserGgufPath) {
+      params.lavasrDenoiserPath = this._denoiserGgufPath
+    }
     // Speaking-rate multiplier (1.0 = unchanged, < 1 slower, > 1 faster).
     // Chatterbox has no native rate control, so the addon applies a
     // pitch-preserving WSOLA time-stretch post-synthesis; see
@@ -890,6 +940,9 @@ class TTSGgml {
     if (this._noiseNpyPath) params.noiseNpyPath = this._noiseNpyPath
     if (this._enhancerGgufPath) {
       params.lavasrEnhancerPath = this._enhancerGgufPath
+    }
+    if (this._denoiserGgufPath) {
+      params.lavasrDenoiserPath = this._denoiserGgufPath
     }
     if (this._backendsDir) params.backendsDir = this._backendsDir
     if (this._openclCacheDir) params.openclCacheDir = this._openclCacheDir

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -119,8 +119,8 @@ function normalizeGgmlFiles (files) {
     // enhancer (rate-preserving), produced by
     // tts-cpp/scripts/convert-lavasr-denoiser-to-gguf.py. One canonical key
     // (the alternative is denoiser.denoiserPath on the options object).
-    // SCAFFOLD: the tts-cpp denoiser forward is not implemented yet (PR #76),
-    // so supplying this path currently fails at load with "not yet implemented".
+    // The tts-cpp UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp
+    // PR #78; a provided path activates once the pinned tts-cpp includes it.
     lavasrDenoiser: firstNonEmpty(f.lavasrDenoiser),
     // Directory of the compiled MeCab/IPAdic dictionary (Japanese) and
     // the Cangjie TSV (Chinese).  The host resolves/stages these (e.g.
@@ -401,11 +401,10 @@ class TTSGgml {
     // GGUF path — via files.lavasrDenoiser or denoiser.denoiserPath — so there
     // is no separate on/off flag. A provided `denoiser` block must use the
     // supported type so a typo can't silently disable it.
-    // SCAFFOLD: the tts-cpp UL-UNAS denoiser forward is not implemented yet
-    // (qvac-ext-lib-whisper.cpp PR #76 landed only the structure/API), so
-    // supplying a denoiser path currently fails at load with a clear
-    // "not yet implemented" error. The wiring is in place so the feature turns
-    // on with just a tts-cpp bump once the forward lands.
+    // The tts-cpp UL-UNAS denoiser forward is implemented in
+    // qvac-ext-lib-whisper.cpp PR #78 (scalar CPU port, validated bit-close to
+    // the ONNX reference); a supplied denoiser path activates at runtime once
+    // the pinned tts-cpp version includes #78.
     if (denoiser != null && denoiser.type !== 'lavasr') {
       throw new Error(
         `tts-ggml: unknown denoiser.type '${denoiser.type}', expected 'lavasr'.`

--- a/packages/tts-ggml/test/unit/chatterbox.inference.test.js
+++ b/packages/tts-ggml/test/unit/chatterbox.inference.test.js
@@ -296,6 +296,88 @@ test('Chatterbox: enhancer + streamChunkTokens forwards both (streaming enhancem
   t.is(params.lavasrEnhancerPath, '/abs/enh.gguf', 'enhancer path forwarded alongside streaming')
 })
 
+// === LavaSR denoiser param forwarding (SCAFFOLD wiring) ===
+// The denoiser mirrors the enhancer: enabled purely by the presence of a GGUF
+// path, runs before the enhancer. The tts-cpp forward is not implemented yet
+// (PR #76), so at runtime a provided path errors at load — but the JS wiring
+// (path forwarding + validation) is exercised here without any model.
+
+test('Chatterbox: files.lavasrDenoiser forwards lavasrDenoiserPath', (t) => {
+  const files = {
+    t3Model: './models/chatterbox-t3-turbo.gguf',
+    s3genModel: './models/chatterbox-s3gen.gguf'
+  }
+  const denoised = new TTSGgml({
+    files: { ...files, lavasrDenoiser: '/abs/den.gguf' },
+    config: { language: 'en' }
+  })
+  const params = denoised._buildTtsParams()
+  t.is(params.engineType, TTSGgml.ENGINE_CHATTERBOX, 'routes to chatterbox')
+  t.is(params.lavasrDenoiserPath, '/abs/den.gguf', 'denoiser GGUF path forwarded')
+
+  const plain = new TTSGgml({ files, config: { language: 'en' } })
+  t.absent(plain._buildTtsParams().lavasrDenoiserPath, 'no denoiser params when absent')
+})
+
+test('Chatterbox: denoiserPath via denoiser block forwards the path', (t) => {
+  const model = new TTSGgml({
+    files: {
+      t3Model: './models/chatterbox-t3-turbo.gguf',
+      s3genModel: './models/chatterbox-s3gen.gguf'
+    },
+    config: { language: 'en' },
+    denoiser: { type: 'lavasr', denoiserPath: '/abs/den.gguf' }
+  })
+  t.is(model._buildTtsParams().lavasrDenoiserPath, '/abs/den.gguf')
+})
+
+test('Chatterbox: unknown denoiser.type is rejected at construction', (t) => {
+  t.exception(
+    () => new TTSGgml({
+      files: {
+        t3Model: './models/chatterbox-t3-turbo.gguf',
+        s3genModel: './models/chatterbox-s3gen.gguf',
+        lavasrDenoiser: '/abs/den.gguf'
+      },
+      config: { language: 'en' },
+      denoiser: { type: 'nope' }
+    }),
+    /unknown denoiser\.type/,
+    'a typo in denoiser.type throws instead of silently disabling denoising'
+  )
+})
+
+test('Chatterbox: denoiser + streamChunkTokens is rejected (streaming denoise is a follow-up)', (t) => {
+  t.exception(
+    () => new TTSGgml({
+      files: {
+        t3Model: './models/chatterbox-t3-turbo.gguf',
+        s3genModel: './models/chatterbox-s3gen.gguf',
+        lavasrDenoiser: '/abs/den.gguf'
+      },
+      streamChunkTokens: 25,
+      config: { language: 'en' }
+    }),
+    /denoiser is not yet supported with Chatterbox native chunk streaming/,
+    'denoiser + native chunk streaming throws (unlike the enhancer, which supports it)'
+  )
+})
+
+test('Chatterbox: denoiser and enhancer forward both paths (denoise before enhance)', (t) => {
+  const model = new TTSGgml({
+    files: {
+      t3Model: './models/chatterbox-t3-turbo.gguf',
+      s3genModel: './models/chatterbox-s3gen.gguf',
+      lavasrEnhancer: '/abs/enh.gguf',
+      lavasrDenoiser: '/abs/den.gguf'
+    },
+    config: { language: 'en' }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.lavasrEnhancerPath, '/abs/enh.gguf', 'enhancer path forwarded')
+  t.is(params.lavasrDenoiserPath, '/abs/den.gguf', 'denoiser path forwarded alongside enhancer')
+})
+
 test('Chatterbox: outputSampleRate forwards to ttsParams; omitted when unset', (t) => {
   const files = {
     t3Model: './models/chatterbox-t3-turbo.gguf',

--- a/packages/tts-ggml/test/unit/chatterbox.inference.test.js
+++ b/packages/tts-ggml/test/unit/chatterbox.inference.test.js
@@ -296,11 +296,11 @@ test('Chatterbox: enhancer + streamChunkTokens forwards both (streaming enhancem
   t.is(params.lavasrEnhancerPath, '/abs/enh.gguf', 'enhancer path forwarded alongside streaming')
 })
 
-// === LavaSR denoiser param forwarding (SCAFFOLD wiring) ===
+// === LavaSR denoiser param forwarding ===
 // The denoiser mirrors the enhancer: enabled purely by the presence of a GGUF
-// path, runs before the enhancer. The tts-cpp forward is not implemented yet
-// (PR #76), so at runtime a provided path errors at load — but the JS wiring
-// (path forwarding + validation) is exercised here without any model.
+// path, runs before the enhancer. The tts-cpp UL-UNAS forward is implemented in
+// qvac-ext-lib-whisper.cpp PR #78; these tests exercise the JS wiring (path
+// forwarding + validation) without loading a model.
 
 test('Chatterbox: files.lavasrDenoiser forwards lavasrDenoiserPath', (t) => {
   const files = {

--- a/packages/tts-ggml/test/unit/supertonic.inference.test.js
+++ b/packages/tts-ggml/test/unit/supertonic.inference.test.js
@@ -286,6 +286,63 @@ test('Supertonic: no enhancer -> no enhancer params (backward compat)', (t) => {
   t.absent(params.enhance, 'no enhance flag when enhancer absent')
 })
 
+// === LavaSR denoiser param forwarding (SCAFFOLD wiring) ===
+// Mirrors the enhancer: enabled purely by a GGUF path, runs before the
+// enhancer, rate-preserving. The tts-cpp forward is not implemented yet
+// (PR #76), so at runtime a provided path errors at load — the JS wiring
+// (forwarding + validation) is what's exercised here.
+
+test('Supertonic: files.lavasrDenoiser forwards lavasrDenoiserPath', (t) => {
+  const model = createMockedSupertonicModel({
+    files: {
+      supertonicModel: './models/supertonic.gguf',
+      lavasrDenoiser: './models/lavasr/lavasr-denoiser.gguf'
+    }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.lavasrDenoiserPath, './models/lavasr/lavasr-denoiser.gguf')
+})
+
+test('Supertonic: denoiserPath via denoiser block (no files) forwards the path', (t) => {
+  const model = createMockedSupertonicModel({
+    extra: { denoiser: { type: 'lavasr', denoiserPath: '/abs/den.gguf' } }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.lavasrDenoiserPath, '/abs/den.gguf')
+})
+
+test('Supertonic: unknown denoiser.type is rejected at construction', (t) => {
+  t.exception(
+    () => createMockedSupertonicModel({
+      files: {
+        supertonicModel: './models/supertonic.gguf',
+        lavasrDenoiser: '/abs/den.gguf'
+      },
+      extra: { denoiser: { type: 'bogus' } }
+    }),
+    /unknown denoiser\.type/,
+    'a typo in denoiser.type throws instead of silently disabling denoising'
+  )
+})
+
+test('Supertonic: denoiser and enhancer forward both paths (denoise before enhance)', (t) => {
+  const model = createMockedSupertonicModel({
+    files: {
+      supertonicModel: './models/supertonic.gguf',
+      lavasrEnhancer: '/abs/enh.gguf',
+      lavasrDenoiser: '/abs/den.gguf'
+    }
+  })
+  const params = model._buildTtsParams()
+  t.is(params.lavasrEnhancerPath, '/abs/enh.gguf', 'enhancer path forwarded')
+  t.is(params.lavasrDenoiserPath, '/abs/den.gguf', 'denoiser path forwarded alongside enhancer')
+})
+
+test('Supertonic: no denoiser -> no denoiser params (backward compat)', (t) => {
+  const model = createMockedSupertonicModel()
+  t.absent(model._buildTtsParams().lavasrDenoiserPath, 'no lavasrDenoiserPath when denoiser absent')
+})
+
 // === Output sample rate ===
 
 test('Supertonic: outputSampleRate forwards to ttsParams; omitted when unset', (t) => {

--- a/packages/tts-ggml/test/unit/supertonic.inference.test.js
+++ b/packages/tts-ggml/test/unit/supertonic.inference.test.js
@@ -286,11 +286,11 @@ test('Supertonic: no enhancer -> no enhancer params (backward compat)', (t) => {
   t.absent(params.enhance, 'no enhance flag when enhancer absent')
 })
 
-// === LavaSR denoiser param forwarding (SCAFFOLD wiring) ===
+// === LavaSR denoiser param forwarding ===
 // Mirrors the enhancer: enabled purely by a GGUF path, runs before the
-// enhancer, rate-preserving. The tts-cpp forward is not implemented yet
-// (PR #76), so at runtime a provided path errors at load — the JS wiring
-// (forwarding + validation) is what's exercised here.
+// enhancer, rate-preserving. The tts-cpp UL-UNAS forward is implemented in
+// qvac-ext-lib-whisper.cpp PR #78; these tests exercise the JS wiring
+// (path forwarding + validation) without loading a model.
 
 test('Supertonic: files.lavasrDenoiser forwards lavasrDenoiserPath', (t) => {
   const model = createMockedSupertonicModel({

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-06-30#1"
+      "version>=": "2026-07-02"
     }
   ],
   "features": {

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-07-02"
+      "version>=": "2026-07-03#1"
     }
   ],
   "features": {


### PR DESCRIPTION
> [!NOTE]
> **Post-merge correction (2026-07-03):** the original draft-era warnings below were stale by merge time and have been replaced with the state as merged. This PR was **not** merged as scaffold — the tts-cpp UL-UNAS denoiser *forward* landed in [qvac-ext-lib-whisper.cpp#78](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/78) and this PR pins the version that ships it, so the denoiser is **active** (not a load-time throw).

## Summary

Wires the **second LavaSR stage** — the UL-UNAS speech **denoiser**, which cleans the signal *before* the enhancer bandwidth-extends it — through the `@qvac/tts-ggml` addon, mirroring the already-shipped enhancer (#2879). Enabled purely by supplying a GGUF path via `files.lavasrDenoiser` (or a `denoiser: { type: 'lavasr', denoiserPath }` block) — no on/off flag. Runs **before** the enhancer and is **rate-preserving**, on the batch path, for both Supertonic and Chatterbox.

```js
new TTSGgml({
  engine: TTSGgml.ENGINE_SUPERTONIC,
  files: {
    supertonicModel,
    lavasrDenoiser: 'lavasr-denoiser.gguf', // cleaned first…
    lavasrEnhancer: 'lavasr-enhancer.gguf'  // …then bandwidth-extended
  }
})
```

The UL-UNAS forward is implemented and active as of the `tts-cpp` pin `2026-07-03#1`. With **no** denoiser path, output is byte-identical (full backward compat).

## Changes

**JS** (`index.js` / `index.d.ts`)
- Normalize `files.lavasrDenoiser`; accept the `denoiser` options block and **reject an unknown `denoiser.type`** (a typo can't silently disable denoising).
- Forward `lavasrDenoiserPath` in both `_buildChatterboxParams` / `_buildSupertonicParams`.
- **Reject `denoiser` + Chatterbox native chunk streaming** (`streamChunkTokens` / `streamFirstChunkTokens`) up front — tts-cpp only exposes a one-shot `denoise()`; a stateful streaming denoiser is the follow-up.

**C++**
- `denoiserGgufPath` on `ChatterboxConfig` / `SupertonicConfig`; `JSAdapter` reads `lavasrDenoiserPath`.
- Models load/reset a `shared_ptr<tts_cpp::lavasr::Denoiser>` and apply `denoise()` **before** `enhance()` (both rate-aware), capturing it under the engine lock. `ChatterboxModel::validateConfig` also rejects denoiser + streaming, and both validate the GGUF exists.

**Deps / docs**
- Bumps the `tts-cpp` pin in `packages/tts-ggml/vcpkg.json` to **`2026-07-03#1`** (published by [qvac-registry-vcpkg#225](https://github.com/tetherto/qvac-registry-vcpkg/pull/225)), which ships the `tts_cpp::lavasr::Denoiser` UL-UNAS forward from PR #78. Per the enhancer precedent, `vcpkg-configuration.json` is intentionally **not** touched (the prebuild resolves `version>=` against registry HEAD).
- CHANGELOG + README updated; JS unit tests added (both engines) for param forwarding + rejects.

## Merge order (as shipped)

1. [qvac-ext-lib-whisper.cpp#78](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/78) — UL-UNAS denoiser **forward** in tts-cpp — ✅ **merged**
2. [qvac-registry-vcpkg#225](https://github.com/tetherto/qvac-registry-vcpkg/pull/225) — publish `tts-cpp` `2026-07-03#1` (denoiser forward + Chinese support) — ✅ **merged**
3. [qvac#3038](https://github.com/tetherto/qvac/pull/3038) — LavaSR denoiser/enhancer GGUF models in the registry — ✅ **merged**
4. **This PR** — addon wiring, pinned to `2026-07-03#1` — ✅ **merged**
