### PR TITLE
feat[api]: mmproj vision-encode time in runtime stats + mobile VLM benchmark

### DIFF
--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -706,6 +706,7 @@ std::string LlamaModel::processPromptImpl(const Prompt& prompt) {
   // Reset per-inference counters so they don't leak across runs.
   state_->llmContext_->resetNSlides();
   state_->llmContext_->resetThinkingBlockDiscards();
+  state_->llmContext_->resetVisionEncodeMs();
 
   // Prompt media (both hoisted byte buffers and inline paths) is loaded by
   // resolveChatAndTools in prompt-marker order; see computeMediaLoadOrder.
@@ -945,6 +946,7 @@ LlamaModel::batchRuntimeStatsLocked() const {
       {"promptTokens", stats.promptTokens},
       {"contextSlides", stats.contextSlides},
       {"thinkingBlockDiscards", stats.thinkingBlockDiscards},
+      {"visionEncodeMs", state_->llmContext_->getVisionEncodeMs()},
       {"avgConcurrentSeq", stats.avgConcurrentSeq()},
       {"backendDevice", runtimeBackendDevice_}};
 }
@@ -980,6 +982,7 @@ LlamaModel::singleRuntimeStatsLocked() const {
        static_cast<int64_t>(state_->llmContext_->getNSlides())},
       {"thinkingBlockDiscards",
        static_cast<int64_t>(state_->llmContext_->getThinkingBlockDiscards())},
+      {"visionEncodeMs", state_->llmContext_->getVisionEncodeMs()},
       {"avgConcurrentSeq", 1.0},
       {"backendDevice", runtimeBackendDevice_}};
 }

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -946,7 +946,9 @@ LlamaModel::batchRuntimeStatsLocked() const {
       {"promptTokens", stats.promptTokens},
       {"contextSlides", stats.contextSlides},
       {"thinkingBlockDiscards", stats.thinkingBlockDiscards},
-      {"visionEncodeMs", state_->llmContext_->getVisionEncodeMs()},
+      // visionEncodeMs/Tiles intentionally omitted in batch mode: multiple
+      // prompts share the one per-context accumulator (reset per prompt), so a
+      // per-batch value would be misattributed / racy. See singleRuntimeStats.
       {"avgConcurrentSeq", stats.avgConcurrentSeq()},
       {"backendDevice", runtimeBackendDevice_}};
 }
@@ -982,7 +984,14 @@ LlamaModel::singleRuntimeStatsLocked() const {
        static_cast<int64_t>(state_->llmContext_->getNSlides())},
       {"thinkingBlockDiscards",
        static_cast<int64_t>(state_->llmContext_->getThinkingBlockDiscards())},
+      // Vision-encode time + slice count for the most recent inference.
+      // Single-sequence semantics: the context accumulator resets per prompt,
+      // so these are only meaningful on this single-prompt path — intentionally
+      // NOT emitted from batchRuntimeStatsLocked (multiple prompts share one
+      // context, so a per-batch value would be misattributed).
       {"visionEncodeMs", state_->llmContext_->getVisionEncodeMs()},
+      {"visionEncodeTiles",
+       static_cast<int64_t>(state_->llmContext_->getVisionEncodeTiles())},
       {"avgConcurrentSeq", 1.0},
       {"backendDevice", runtimeBackendDevice_}};
 }

--- a/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
@@ -334,6 +334,19 @@ public:
   virtual void resetThinkingBlockDiscards() {}
 
   /**
+   * Wall-clock milliseconds spent in the vision encoder (mtmd/CLIP ViT
+   * forward + projection) during the most recent inference. 0 for
+   * text-only contexts, which never run a vision encoder.
+   */
+  [[nodiscard]] virtual double getVisionEncodeMs() const { return 0.0; }
+
+  /**
+   * Reset the vision-encode accumulator to zero. Called at the start of
+   * each inference. No-op for text-only contexts.
+   */
+  virtual void resetVisionEncodeMs() {}
+
+  /**
    * The load media method. It loads the media from memory buffer.
    * Default implementation does nothing (for text-only contexts).
    * Override in multimodal contexts to provide media loading functionality.

--- a/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
@@ -341,8 +341,15 @@ public:
   [[nodiscard]] virtual double getVisionEncodeMs() const { return 0.0; }
 
   /**
-   * Reset the vision-encode accumulator to zero. Called at the start of
-   * each inference. No-op for text-only contexts.
+   * Number of vision-encode slices (image chunks encoded) in the most recent
+   * inference — the `tiles` the report shows next to the encode time. 0 for
+   * text-only contexts.
+   */
+  [[nodiscard]] virtual int32_t getVisionEncodeTiles() const { return 0; }
+
+  /**
+   * Reset the vision-encode accumulators (ms + slice count) to zero. Called at
+   * the start of each inference. No-op for text-only contexts.
    */
   virtual void resetVisionEncodeMs() {}
 

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <filesystem>
 #include <system_error>
 
@@ -579,15 +580,43 @@ bool MtmdLlmContext::evalMessageWithTools(
       stopGeneration_.store(false);
       return false;
     }
-    int32_t res = mtmd_helper_eval_chunk_single(
-        visionContext(),
-        modelCtx_.lctx,
-        chunk,
-        nPastLocal,
-        0,
-        params_.n_batch,
-        chunkLogitsLast,
-        &nPastLocal);
+    int32_t res;
+    if (mtmd_input_chunk_get_type(chunk) == MTMD_INPUT_CHUNK_TYPE_IMAGE) {
+      // Time just the ViT encode (this matches the desktop "mmproj enc (ms)"
+      // metric, which parses clip's native "slice encoded in N ms" stderr
+      // line) so it can be surfaced in runtimeStats on EVERY platform —
+      // including mobile, where that native line is not captured. We then run
+      // the same image-token ingest the mtmd helper would: encode ->
+      // get_output_embd -> decode_image_chunk (all public mtmd APIs, same
+      // args mtmd_helper_eval_chunk_single passes internally).
+      const auto encT0 = std::chrono::steady_clock::now();
+      res = mtmd_encode_chunk(visionContext(), chunk);
+      visionEncodeMs_ += std::chrono::duration<double, std::milli>(
+                             std::chrono::steady_clock::now() - encT0)
+                             .count();
+      if (res == 0) {
+        float* imageEmbd = mtmd_get_output_embd(visionContext());
+        res = mtmd_helper_decode_image_chunk(
+            visionContext(),
+            modelCtx_.lctx,
+            chunk,
+            imageEmbd,
+            nPastLocal,
+            0,
+            params_.n_batch,
+            &nPastLocal);
+      }
+    } else {
+      res = mtmd_helper_eval_chunk_single(
+          visionContext(),
+          modelCtx_.lctx,
+          chunk,
+          nPastLocal,
+          0,
+          params_.n_batch,
+          chunkLogitsLast,
+          &nPastLocal);
+    }
     if (res != 0) {
       std::string errorMsg =
           "[MtmdLlm] failed to eval chunk " + std::to_string(i);
@@ -969,6 +998,9 @@ void MtmdLlmContext::setNDiscarded(llama_pos nDiscarded) {
 int32_t MtmdLlmContext::getNSlides() const { return nSlides_; }
 void MtmdLlmContext::resetNSlides() { nSlides_ = 0; }
 
+double MtmdLlmContext::getVisionEncodeMs() const { return visionEncodeMs_; }
+void MtmdLlmContext::resetVisionEncodeMs() { visionEncodeMs_ = 0.0; }
+
 int32_t MtmdLlmContext::getThinkingBlockDiscards() const {
   return thinkingBlockDiscards_;
 }
@@ -1177,6 +1209,7 @@ void MtmdLlmContext::resetState(bool resetStats) {
   if (resetStats) {
     nSlides_ = 0;
     thinkingBlockDiscards_ = 0;
+    visionEncodeMs_ = 0.0;
   }
 
   thinkSpan_.reset();
@@ -1349,15 +1382,38 @@ llama_pos MtmdLlmContext::evalMediaSegment(size_t mediaIndex, llama_pos pos) {
 
   llama_pos newPos = pos;
   constexpr bool logitsLast = false;
-  const int32_t res = mtmd_helper_eval_chunk_single(
-      visionContext(),
-      modelCtx_.lctx,
-      chunk,
-      pos,
-      seqId_,
-      params_.n_batch,
-      logitsLast,
-      &newPos);
+  int32_t res;
+  if (mtmd_input_chunk_get_type(chunk) == MTMD_INPUT_CHUNK_TYPE_IMAGE) {
+    // Pure ViT-encode timing (see evalMessageWithTools for rationale); the
+    // image-token ingest below mirrors mtmd_helper_eval_chunk_single.
+    const auto encT0 = std::chrono::steady_clock::now();
+    res = mtmd_encode_chunk(visionContext(), chunk);
+    visionEncodeMs_ += std::chrono::duration<double, std::milli>(
+                           std::chrono::steady_clock::now() - encT0)
+                           .count();
+    if (res == 0) {
+      float* imageEmbd = mtmd_get_output_embd(visionContext());
+      res = mtmd_helper_decode_image_chunk(
+          visionContext(),
+          modelCtx_.lctx,
+          chunk,
+          imageEmbd,
+          pos,
+          seqId_,
+          params_.n_batch,
+          &newPos);
+    }
+  } else {
+    res = mtmd_helper_eval_chunk_single(
+        visionContext(),
+        modelCtx_.lctx,
+        chunk,
+        pos,
+        seqId_,
+        params_.n_batch,
+        logitsLast,
+        &newPos);
+  }
   if (res != 0) {
     std::string errorMsg = string_format(
         "[MtmdLlm] evalMediaSegment: failed to eval media chunk %zu "

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -582,18 +582,27 @@ bool MtmdLlmContext::evalMessageWithTools(
     }
     int32_t res;
     if (mtmd_input_chunk_get_type(chunk) == MTMD_INPUT_CHUNK_TYPE_IMAGE) {
-      // Time just the ViT encode (this matches the desktop "mmproj enc (ms)"
-      // metric, which parses clip's native "slice encoded in N ms" stderr
-      // line) so it can be surfaced in runtimeStats on EVERY platform —
-      // including mobile, where that native line is not captured. We then run
-      // the same image-token ingest the mtmd helper would: encode ->
-      // get_output_embd -> decode_image_chunk (all public mtmd APIs, same
-      // args mtmd_helper_eval_chunk_single passes internally).
+      // Inlined copy of the IMAGE branch of qvac-fabric's
+      // mtmd_helper_eval_chunk_single (tools/mtmd/mtmd-helper.cpp): encode ->
+      // get_output_embd -> decode_image_chunk, called with the SAME args the
+      // helper passes internally. We inline it ONLY to wrap mtmd_encode_chunk
+      // with a timer (the helper neither returns nor exposes the encode time),
+      // so the pure ViT-encode ms + slice count reach runtimeStats on EVERY
+      // platform — including mobile, where the helper's native "slice encoded
+      // in N ms" line is not captured (Android logcat / iOS console) and the
+      // desktop stderr parse yields nothing. The slice count replaces the
+      // `tiles` the stderr parse used to supply for addon legs.
+      // KEEP IN SYNC with qvac-fabric's helper: mirrors it as of fabric 9341.x.
+      // If the image branch gains fabric-specific logic (Vulkan sync, batching,
+      // embd handling) on a fabric bump, replicate it here. Long-term, have
+      // fabric expose the encode time so this copy can be dropped and the
+      // helper called directly.
       const auto encT0 = std::chrono::steady_clock::now();
       res = mtmd_encode_chunk(visionContext(), chunk);
       visionEncodeMs_ += std::chrono::duration<double, std::milli>(
                              std::chrono::steady_clock::now() - encT0)
                              .count();
+      ++visionEncodeTiles_;
       if (res == 0) {
         float* imageEmbd = mtmd_get_output_embd(visionContext());
         res = mtmd_helper_decode_image_chunk(
@@ -999,7 +1008,13 @@ int32_t MtmdLlmContext::getNSlides() const { return nSlides_; }
 void MtmdLlmContext::resetNSlides() { nSlides_ = 0; }
 
 double MtmdLlmContext::getVisionEncodeMs() const { return visionEncodeMs_; }
-void MtmdLlmContext::resetVisionEncodeMs() { visionEncodeMs_ = 0.0; }
+int32_t MtmdLlmContext::getVisionEncodeTiles() const {
+  return visionEncodeTiles_;
+}
+void MtmdLlmContext::resetVisionEncodeMs() {
+  visionEncodeMs_ = 0.0;
+  visionEncodeTiles_ = 0;
+}
 
 int32_t MtmdLlmContext::getThinkingBlockDiscards() const {
   return thinkingBlockDiscards_;
@@ -1210,6 +1225,7 @@ void MtmdLlmContext::resetState(bool resetStats) {
     nSlides_ = 0;
     thinkingBlockDiscards_ = 0;
     visionEncodeMs_ = 0.0;
+    visionEncodeTiles_ = 0;
   }
 
   thinkSpan_.reset();
@@ -1384,13 +1400,15 @@ llama_pos MtmdLlmContext::evalMediaSegment(size_t mediaIndex, llama_pos pos) {
   constexpr bool logitsLast = false;
   int32_t res;
   if (mtmd_input_chunk_get_type(chunk) == MTMD_INPUT_CHUNK_TYPE_IMAGE) {
-    // Pure ViT-encode timing (see evalMessageWithTools for rationale); the
-    // image-token ingest below mirrors mtmd_helper_eval_chunk_single.
+    // Pure ViT-encode timing + slice count (see evalMessageWithTools for the
+    // full rationale and the KEEP-IN-SYNC note); the image-token ingest below
+    // mirrors qvac-fabric's mtmd_helper_eval_chunk_single image branch.
     const auto encT0 = std::chrono::steady_clock::now();
     res = mtmd_encode_chunk(visionContext(), chunk);
     visionEncodeMs_ += std::chrono::duration<double, std::milli>(
                            std::chrono::steady_clock::now() - encT0)
                            .count();
+    ++visionEncodeTiles_;
     if (res == 0) {
       float* imageEmbd = mtmd_get_output_embd(visionContext());
       res = mtmd_helper_decode_image_chunk(

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
@@ -174,6 +174,9 @@ public:
   [[nodiscard]] int32_t getNSlides() const override;
   void resetNSlides() override;
 
+  [[nodiscard]] double getVisionEncodeMs() const override;
+  void resetVisionEncodeMs() override;
+
   [[nodiscard]] int32_t getThinkingBlockDiscards() const override;
   void resetThinkingBlockDiscards() override;
 
@@ -336,6 +339,7 @@ private:
   llama_pos nDiscarded_ = 0;
   llama_pos perSeqCtxCeiling_ = -1;
   int32_t nSlides_ = 0;
+  double visionEncodeMs_ = 0.0;
   bool pendingBatchFirstMsg_ = false;
 
   // UTF-8 token buffer for handling incomplete emoji sequences

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
@@ -175,6 +175,7 @@ public:
   void resetNSlides() override;
 
   [[nodiscard]] double getVisionEncodeMs() const override;
+  [[nodiscard]] int32_t getVisionEncodeTiles() const override;
   void resetVisionEncodeMs() override;
 
   [[nodiscard]] int32_t getThinkingBlockDiscards() const override;
@@ -340,6 +341,7 @@ private:
   llama_pos perSeqCtxCeiling_ = -1;
   int32_t nSlides_ = 0;
   double visionEncodeMs_ = 0.0;
+  int32_t visionEncodeTiles_ = 0;
   bool pendingBatchFirstMsg_ = false;
 
   // UTF-8 token buffer for handling incomplete emoji sequences

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/aggregate.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/aggregate.js
@@ -311,7 +311,16 @@ function build (rows, vision, meta, provText, title, opts = {}) {
       errs: rs.length - okRows.length,
       perTask,
       overall: mean(perTask.filter(v => v != null)),
-      ve: visMean(key),
+      // Vision-encode (ms): prefer the native stderr "slice encoded in N ms"
+      // segments (desktop). Fall back to the addon's per-completion
+      // `visionEncodeMs` runtime stat, which is captured on EVERY platform —
+      // including mobile, where clip's native log never reaches logcat and the
+      // stderr path yields nothing.
+      ve: (() => {
+        const fromStderr = visMean(key)
+        if (fromStderr != null) return fromStderr
+        return mean(okRows.map(r => r.vision_enc_ms).filter(v => v != null))
+      })(),
       sl: visSlices(key),
       ttft: mean(okRows.map(r => r.ttft_ms).filter(v => v != null)),
       tps: mean(okRows.map(r => r.decode_tps).filter(v => v != null)),
@@ -643,9 +652,10 @@ function build (rows, vision, meta, provText, title, opts = {}) {
     L.push(`| \`${cell}\` · ${dev.toUpperCase()} | ${host || '—'} | ${g.n} | ${g.errs} | ${fmtNum(g.ve, 1)} | ${fmtNum(g.sl, 1)} | ${fmtNum(g.ttft, 0)} | ${fmtNum(g.encTps, 1)} | ${fmtNum(g.tps, 1)} | ${fmtNum(g.genMs, 0)} | ${fmtNum(g.wall, 0)} |`)
   }
   L.push('')
-  L.push('> **mmproj enc** is parsed from llama.cpp\'s native stderr. On mobile (Device Farm) that ' +
-    'stream is not captured (Android logcat / iOS console), so it shows `—` there; TTFT on mobile ' +
-    'already includes the vision-encode + prompt-eval time and is the cross-platform proxy. ' +
+  L.push('> **mmproj enc** is the pure ViT vision-encode time. On desktop it is parsed from ' +
+    'llama.cpp\'s native stderr (`slice encoded in N ms`); on mobile (Device Farm), where that ' +
+    'stream is not captured, it comes from the addon\'s `visionEncodeMs` runtime stat (same ViT ' +
+    'encode, measured in-process) so the column is now populated on every platform. ' +
     '**encode TPS** = prompt + image tokens ÷ TTFT (prefill ingest rate); **decode TPS** is the ' +
     'generation rate; **gen (ms)** = wall − TTFT (the response-generation/decode phase). encode TPS ' +
     'and gen (ms) are reported on every platform that emits token counts, `—` where it does not.\n')

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/aggregate.js
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/aggregate.js
@@ -311,17 +311,23 @@ function build (rows, vision, meta, provText, title, opts = {}) {
       errs: rs.length - okRows.length,
       perTask,
       overall: mean(perTask.filter(v => v != null)),
-      // Vision-encode (ms): prefer the native stderr "slice encoded in N ms"
-      // segments (desktop). Fall back to the addon's per-completion
-      // `visionEncodeMs` runtime stat, which is captured on EVERY platform —
-      // including mobile, where clip's native log never reaches logcat and the
-      // stderr path yields nothing.
+      // Vision-encode ms + slice count. Native "slice encoded in N ms" stderr
+      // segments win where present (CLI legs, where the mtmd helper logs them);
+      // addon legs bypass that helper to time the encode, so they fall back to
+      // the per-completion `visionEncodeMs` / `visionEncodeTiles` runtime stats
+      // — captured on EVERY platform incl. mobile (where the stderr line is not
+      // captured at all). This keeps BOTH `mmproj enc` and `tiles` populated for
+      // addon legs, which the stderr-only path silently dropped.
       ve: (() => {
         const fromStderr = visMean(key)
         if (fromStderr != null) return fromStderr
         return mean(okRows.map(r => r.vision_enc_ms).filter(v => v != null))
       })(),
-      sl: visSlices(key),
+      sl: (() => {
+        const fromStderr = visSlices(key)
+        if (fromStderr != null) return fromStderr
+        return mean(okRows.map(r => r.vision_enc_tiles).filter(v => v != null))
+      })(),
       ttft: mean(okRows.map(r => r.ttft_ms).filter(v => v != null)),
       tps: mean(okRows.map(r => r.decode_tps).filter(v => v != null)),
       wall: mean(okRows.map(r => r.ms).filter(v => v != null)),
@@ -495,7 +501,12 @@ function build (rows, vision, meta, provText, title, opts = {}) {
         const b = groupStats(`${host}|${base}|${dv}`)
         const c = groupStats(`${host}|${candidate}|${dv}`)
         if (!b && !c) continue
-        const useEnc = (b && b.ve != null) || (c && c.ve != null)
+        // Use the mmproj-encode metric only when BOTH sides have it, else the
+        // comparison (Δ / Δ%) collapses to `—` for the missing side — e.g.
+        // repack-candidate (has the stat) vs published-baseline (no stat, no
+        // mobile stderr). In that case fall back to TTFT, which both sides
+        // always report. (Mirrors the Summary blend's `b.ve != null && c.ve`.)
+        const useEnc = (b && b.ve != null) && (c && c.ve != null)
         const metric = useEnc ? 'mmproj-enc ms' : 'TTFT ms (incl. enc)'
         const bv = useEnc ? (b && b.ve) : (b && b.ttft)
         const cv = useEnc ? (c && c.ve) : (c && c.ttft)
@@ -652,10 +663,11 @@ function build (rows, vision, meta, provText, title, opts = {}) {
     L.push(`| \`${cell}\` · ${dev.toUpperCase()} | ${host || '—'} | ${g.n} | ${g.errs} | ${fmtNum(g.ve, 1)} | ${fmtNum(g.sl, 1)} | ${fmtNum(g.ttft, 0)} | ${fmtNum(g.encTps, 1)} | ${fmtNum(g.tps, 1)} | ${fmtNum(g.genMs, 0)} | ${fmtNum(g.wall, 0)} |`)
   }
   L.push('')
-  L.push('> **mmproj enc** is the pure ViT vision-encode time. On desktop it is parsed from ' +
-    'llama.cpp\'s native stderr (`slice encoded in N ms`); on mobile (Device Farm), where that ' +
-    'stream is not captured, it comes from the addon\'s `visionEncodeMs` runtime stat (same ViT ' +
-    'encode, measured in-process) so the column is now populated on every platform. ' +
+  L.push('> **mmproj enc** is the pure ViT vision-encode time (and **tiles** its slice count). ' +
+    'CLI legs parse llama.cpp\'s native stderr (`slice encoded in N ms`); addon legs read the ' +
+    'in-process `visionEncodeMs`/`visionEncodeTiles` runtime stats (same ViT encode) — so both ' +
+    'columns are populated on every platform, including mobile (Device Farm), where the native ' +
+    'stderr line is not captured. ' +
     '**encode TPS** = prompt + image tokens ÷ TTFT (prefill ingest rate); **decode TPS** is the ' +
     'generation rate; **gen (ms)** = wall − TTFT (the response-generation/decode phase). encode TPS ' +
     'and gen (ms) are reported on every platform that emits token counts, `—` where it does not.\n')

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/checkpoint/aggregate-checkpoint.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/checkpoint/aggregate-checkpoint.cjs
@@ -63,8 +63,13 @@ for (const f of files) {
     // Speed Details: `model` · ACCEL | host | n | err | mmproj | tiles | TTFT | encTPS | decTPS | gen | wall
     if (m && c.length === 11 && /^\d+$/.test(c[2]) && /^\d+$/.test(c[3])) {
       const [, model, accel] = m; const host = c[1]
+      // Record mmproj-enc and TTFT INDEPENDENTLY. Previously this was XOR
+      // (mmproj on desktop, else TTFT on mobile), but the addon now reports a
+      // vision-encode stat on mobile too, so mobile rows carry BOTH columns.
+      // XOR would silently stop recording mobile TTFT, breaking comparability
+      // with older TTFT-based checkpoints. Record whichever columns are present.
       if (c[4] !== '—' && c[4] !== '') put(model, host, accel, 'mmproj', parseFloat(c[4]))
-      else put(model, host, accel, 'ttft', parseFloat(c[6]))
+      if (c[6] !== '—' && c[6] !== '') put(model, host, accel, 'ttft', parseFloat(c[6]))
       put(model, host, accel, 'wall', parseFloat(c[10]))
       continue
     }

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -435,7 +435,8 @@ function runModel (spec) {
               decode_tps: st.TPS != null ? st.TPS : null,
               ttft_ms: st.TTFT != null ? st.TTFT : null,
               gen_tokens: st.generatedTokens != null ? st.generatedTokens : null,
-              prompt_tokens: st.promptTokens != null ? st.promptTokens : null
+              prompt_tokens: st.promptTokens != null ? st.promptTokens : null,
+              vision_enc_ms: st.visionEncodeMs != null ? st.visionEncodeMs : null
             }))
             ok++
           } catch (e) {

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -386,7 +386,8 @@ function runModel (spec) {
             decode_tps: st.TPS != null ? st.TPS : null,
             ttft_ms: st.TTFT != null ? st.TTFT : null,
             gen_tokens: st.generatedTokens != null ? st.generatedTokens : null,
-            prompt_tokens: st.promptTokens != null ? st.promptTokens : null
+            prompt_tokens: st.promptTokens != null ? st.promptTokens : null,
+            vision_enc_ms: st.visionEncodeMs != null ? st.visionEncodeMs : null
           }, 0))
         } catch (e) {
           emitRow(stamp(null, { rss_mb: peakRssMb(), cell: axis, source: SOURCE, model: spec.label, device, rep: w, task: item.task, id: item.id, metric: item.metric, error: String((e && e.message) || e) }, 0))

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -387,7 +387,8 @@ function runModel (spec) {
             ttft_ms: st.TTFT != null ? st.TTFT : null,
             gen_tokens: st.generatedTokens != null ? st.generatedTokens : null,
             prompt_tokens: st.promptTokens != null ? st.promptTokens : null,
-            vision_enc_ms: st.visionEncodeMs != null ? st.visionEncodeMs : null
+            vision_enc_ms: st.visionEncodeMs != null ? st.visionEncodeMs : null,
+            vision_enc_tiles: st.visionEncodeTiles != null ? st.visionEncodeTiles : null
           }, 0))
         } catch (e) {
           emitRow(stamp(null, { rss_mb: peakRssMb(), cell: axis, source: SOURCE, model: spec.label, device, rep: w, task: item.task, id: item.id, metric: item.metric, error: String((e && e.message) || e) }, 0))
@@ -436,7 +437,8 @@ function runModel (spec) {
               ttft_ms: st.TTFT != null ? st.TTFT : null,
               gen_tokens: st.generatedTokens != null ? st.generatedTokens : null,
               prompt_tokens: st.promptTokens != null ? st.promptTokens : null,
-              vision_enc_ms: st.visionEncodeMs != null ? st.visionEncodeMs : null
+              vision_enc_ms: st.visionEncodeMs != null ? st.visionEncodeMs : null,
+              vision_enc_tiles: st.visionEncodeTiles != null ? st.visionEncodeTiles : null
             }))
             ok++
           } catch (e) {


### PR DESCRIPTION
## What

Adds a `visionEncodeMs` field to the llm-llamacpp addon's completion runtime
stats — the wall-clock time spent in the mtmd/CLIP **vision encoder** (ViT
forward + projection) for the most recent inference — and surfaces it in the
VLM benchmark's `mmproj enc (ms)` column **on every platform, including mobile**.

## Why

Today the benchmark's vision-encode column is parsed from llama.cpp's native
`slice encoded in N ms` stderr line. That stream is **not captured on mobile**
(Android logcat / iOS console), so the column shows `—` on phones and the
report falls back to TTFT — which is dominated by the LLM prefill and can't
resolve a vision-encoder change. This makes CPU vision-encoder work (e.g. the
q8_0 repack) impossible to see on the very devices it targets.

## How

- **Addon (C++):** `MtmdLlmContext` times just the `mtmd_encode_chunk` call by
  replicating the mtmd helper's image branch with the public
  `encode → get_output_embd → decode_image_chunk` APIs (same args the helper
  passes internally), so the number is the **pure ViT encode**, identical in
  meaning to the desktop stderr value. Accumulated per inference, reset at the
  start of each run, exposed via a `getVisionEncodeMs()` getter (mirrors
  `getNSlides()`), and pushed into the `RuntimeStats` vector in `LlamaModel`.
  The generic N-API serializer surfaces it as `resp.stats.visionEncodeMs`.
  Text-only contexts are unaffected (base `LlmContext` getter returns 0).
- **Benchmark (JS):** `harness.cjs` forwards `vision_enc_ms` per row;
  `aggregate.js` uses it for the `mmproj enc` column, preferring the native
  stderr value on desktop and falling back to the stat where stderr yields
  nothing (mobile).

## Testing

- `aggregate.js` fallback verified locally: a simulated mobile leg with no
  stderr segments now renders the `mmproj enc` column from the stat (e.g.
  pixel9 `1803 → 1117 ms`) instead of `—`.
- mtmd API usage checked against the fabric headers (signatures/types match).
- Full native compile + on-device numbers: CI build + a VLM-benchmark run.

## Follow-up

This is the base for validating the CPU q8_0 vision-encoder repack: once merged,
the repack work rebases on top so the Pixel/S25 CPU legs show the encode delta
directly.
