### PR TITLE
QVAC-21319 chore[vla]: bump vla-ggml to 0.8.2 + changelog (pi05 HIP warm-path)

### DIFF
--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.8.2] - 2026-07-03
+
+### Changed
+
+- pi0.5 HIP warm-path inference optimized ~479 → 384 ms (**-18%**) on Strix Halo / gfx1151, accuracy-neutral (cos = 0.9994 vs PyTorch). Combines graph reuse across ODE steps, batched vision, flash-attention at the three attention sites (SigLIP, VLM prefill, expert block), batched AdaLN, a llama.cpp-style unified F16 KV cache, and a fused GeGLU + adaRMSNorm path. No public API change.
+
+### Added
+
+- Load-time validation on pi0.5 checkpoints: rejects non-MQA expert KV configs (`expert_n_kv_heads != 1` — the unified KV cache assumes a single K/V head so the VLM prefix is contiguous at offset 0) and validates adaRMSNorm modulation width (`3 × expert_hidden`), failing fast at load instead of silently corrupting the KV layout or reading out of bounds.
+
+## Pull Requests
+
+- [#2971](https://github.com/tetherto/qvac/pull/2971) - QVAC-21319 perf[vla]: pi05 HIP warm-path optimization (479->384ms, accuracy-neutral)
+
 ## [0.8.1] - 2026-07-01
 
 ### Changed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## What

Follow-up to #2971 (merged), which landed the pi0.5 HIP warm-path optimization plus the CI/test fixes but **without a version bump or changelog entry**. This PR adds just that:

- `@qvac/vla-ggml` `0.8.0` → `0.8.1` (patch — internal perf optimization, no public API change)
- `CHANGELOG.md` `[0.8.1]` entry documenting the warm-path work and the new load-time guards

## Why a separate PR

The version bump was authored after #2971 was already squash-merged, so it needs its own PR to reach `main`. All the code/CI/test changes it describes are already on `main` from #2971.

## Scope

Two files only:
- `packages/vla-ggml/package.json` — version
- `packages/vla-ggml/CHANGELOG.md` — `[0.8.1]` entry

No code, build, or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
