### PR TITLE
QVAC-19908 chore[skiplog]: format @qvac/cli with prettier for the 0.8.0 publish gate

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -437,9 +437,7 @@ The wire is the new `requestId` exposed synchronously on the SDK's decorated pro
 import { sdkCompletion } from '@qvac/cli/serve/core/sdk'
 import { bindClientDisconnectCancel } from '@qvac/cli/serve/core/cancel-bridge'
 
-const run = sdkCompletion({
-  /* ... */
-})
+const run = sdkCompletion({/* ... */})
 bindClientDisconnectCancel(req, res, run.requestId, logger)
 const final = await run.final
 ```

--- a/packages/cli/changelog/0.5.0/CHANGELOG_LLM.md
+++ b/packages/cli/changelog/0.5.0/CHANGELOG_LLM.md
@@ -182,9 +182,7 @@ The wire is the new `requestId` exposed synchronously on the SDK's decorated pro
 import { sdkCompletion } from '@qvac/cli/serve/core/sdk'
 import { bindClientDisconnectCancel } from '@qvac/cli/serve/core/cancel-bridge'
 
-const run = sdkCompletion({
-  /* ... */
-})
+const run = sdkCompletion({/* ... */})
 bindClientDisconnectCancel(req, res, run.requestId, logger)
 const final = await run.final
 ```

--- a/packages/cli/changelog/0.8.0/CHANGELOG.md
+++ b/packages/cli/changelog/0.8.0/CHANGELOG.md
@@ -22,4 +22,3 @@ Release Date: 2026-06-29
 ## 🧹 Chores
 
 - Switch @qvac/cli to Lunte and Prettier. (see PR [#2829](https://github.com/tetherto/qvac/pull/2829))
-

--- a/packages/cli/changelog/0.8.0/api.md
+++ b/packages/cli/changelog/0.8.0/api.md
@@ -34,8 +34,8 @@ PR: [#2797](https://github.com/tetherto/qvac/pull/2797)
 // SDK — drop this turn's reasoning block from the KV cache after generation
 await model.completion({
   history,
-  generationParams: { remove_thinking_from_context: true },
-});
+  generationParams: { remove_thinking_from_context: true }
+})
 ```
 
 ```jsonc
@@ -58,4 +58,3 @@ PR: [#2802](https://github.com/tetherto/qvac/pull/2802)
 ```
 
 ---
-

--- a/packages/cli/docs/serve-openai.md
+++ b/packages/cli/docs/serve-openai.md
@@ -199,22 +199,22 @@ Both routes require an alias whose **endpoint category** is `image`. Built-in SD
 
 This server is intentionally **loud** about every OpenAI image-API field it cannot honor without producing the wrong bytes. Every case below is a `400` with a stable `error.code` so an agent can branch on it instead of silently shipping the wrong output to a user.
 
-| HTTP | `error.code`                                         | Trigger                                                                                                                                                                                                        |
+| HTTP | `error.code` | Trigger |
 | ---- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ----------------------------------------------- |
-| 400  | `mask_not_supported`                                 | `/v1/images/edits` received a `mask` / `mask[]` field. The diffusion engine has no mask channel, so masked inpainting cannot be honored — it would silently re-render the entire image. Resend without `mask`. |
-| 400  | `unsupported_response_format`                        | `response_format=url` was requested but the server is not configured with `--public-base-url` (no way to mint a downloadable URL — see below). Use `response_format=b64_json`.                                 |
-| 400  | `invalid_response_format`                            | Anything other than `b64_json` / `url`.                                                                                                                                                                        |
-| 400  | `unsupported_output_format`                          | `output_format` other than `png`. The server only emits PNG.                                                                                                                                                   |
-| 400  | `unsupported_output_compression`                     | `output_compression` is set. Only meaningful with jpeg/webp, which we do not emit.                                                                                                                             |
-| 400  | `unsupported_background`                             | `background=transparent                                                                                                                                                                                        | opaque | auto`. The server has no alpha-channel control. |
-| 400  | `invalid_strength`                                   | `/v1/images/edits` received a `strength` outside `[0, 1]` or a non-numeric value.                                                                                                                              |
-| 400  | `missing_prompt` / `missing_model` / `missing_image` | Required fields absent.                                                                                                                                                                                        |
-| 400  | `invalid_size`                                       | `size` is not `"WIDTHxHEIGHT"` (multiples of 8) or `"auto"`.                                                                                                                                                   |
-| 400  | `invalid_n`                                          | `n` is not a positive integer.                                                                                                                                                                                 |
-| 404  | `model_not_found`                                    | Unknown alias.                                                                                                                                                                                                 |
-| 400  | `invalid_model_type`                                 | Alias is not an `image` model.                                                                                                                                                                                 |
-| 503  | `model_not_ready`                                    | Model not loaded yet.                                                                                                                                                                                          |
-| 500  | `image_generation_error` / `image_edit_error`        | SDK / engine failure.                                                                                                                                                                                          |
+| 400 | `mask_not_supported` | `/v1/images/edits` received a `mask` / `mask[]` field. The diffusion engine has no mask channel, so masked inpainting cannot be honored — it would silently re-render the entire image. Resend without `mask`. |
+| 400 | `unsupported_response_format` | `response_format=url` was requested but the server is not configured with `--public-base-url` (no way to mint a downloadable URL — see below). Use `response_format=b64_json`. |
+| 400 | `invalid_response_format` | Anything other than `b64_json` / `url`. |
+| 400 | `unsupported_output_format` | `output_format` other than `png`. The server only emits PNG. |
+| 400 | `unsupported_output_compression` | `output_compression` is set. Only meaningful with jpeg/webp, which we do not emit. |
+| 400 | `unsupported_background` | `background=transparent                                                                                                                                                                                        | opaque | auto`. The server has no alpha-channel control. |
+| 400 | `invalid_strength` | `/v1/images/edits` received a `strength` outside `[0, 1]` or a non-numeric value. |
+| 400 | `missing_prompt` / `missing_model` / `missing_image` | Required fields absent. |
+| 400 | `invalid_size` | `size` is not `"WIDTHxHEIGHT"` (multiples of 8) or `"auto"`. |
+| 400 | `invalid_n` | `n` is not a positive integer. |
+| 404 | `model_not_found` | Unknown alias. |
+| 400 | `invalid_model_type` | Alias is not an `image` model. |
+| 503 | `model_not_ready` | Model not loaded yet. |
+| 500 | `image_generation_error` / `image_edit_error` | SDK / engine failure. |
 
 The following OpenAI fields are **accepted and silently ignored** (a warning is logged) because they are advisory and would not change the bytes returned: `quality`, `style`, `moderation`, `partial_images`, `user`, `input_fidelity`.
 

--- a/packages/cli/src/serve/adapters/openai/chat-shapes.ts
+++ b/packages/cli/src/serve/adapters/openai/chat-shapes.ts
@@ -69,11 +69,13 @@ interface ChatCompletionChunk {
   usage?: ChatCompletionUsage
 }
 
-export function chatCompletionResponse (params: ChatCompletionResponseParams): ChatCompletionResponse {
+export function chatCompletionResponse(
+  params: ChatCompletionResponseParams
+): ChatCompletionResponse {
   const hasToolCalls = params.toolCalls.length > 0
   const message: ChatCompletionMessage = {
     role: 'assistant',
-    content: hasToolCalls ? null : (params.text || null)
+    content: hasToolCalls ? null : params.text || null
   }
 
   if (hasToolCalls) {
@@ -94,7 +96,7 @@ export function chatCompletionResponse (params: ChatCompletionResponseParams): C
   }
 }
 
-export function chatCompletionChunk (params: ChatCompletionChunkParams): ChatCompletionChunk {
+export function chatCompletionChunk(params: ChatCompletionChunkParams): ChatCompletionChunk {
   return {
     id: params.id,
     object: 'chat.completion.chunk',

--- a/packages/cli/src/serve/plugins/error-handler.ts
+++ b/packages/cli/src/serve/plugins/error-handler.ts
@@ -34,8 +34,7 @@ const plugin: FastifyPluginAsync = async (app) => {
 
     if (hasZodFastifySchemaValidationErrors(err)) {
       const issue = err.validation[0] as
-        | { instancePath?: string; message?: string; keyword?: string }
-        | undefined
+        { instancePath?: string; message?: string; keyword?: string } | undefined
       const head = headFromInstancePath(issue?.instancePath)
       const code = head in ZOD_PATH_TO_CODE ? ZOD_PATH_TO_CODE[head]! : 'invalid_request'
       const detail = issue?.message ?? 'Request body failed validation.'

--- a/packages/cli/src/serve/routes/chat.ts
+++ b/packages/cli/src/serve/routes/chat.ts
@@ -147,15 +147,17 @@ async function runBlocking(
       `  completion done tokens=${completionTokens} finish=${finishReason}`
     )
 
-    reply.send(chatCompletionResponse({
-      id: `chatcmpl-${randomId()}`,
-      created: Math.floor(Date.now() / 1000),
-      model: p.modelAlias,
-      text,
-      toolCalls,
-      completionTokens,
-      finishReason
-    }))
+    reply.send(
+      chatCompletionResponse({
+        id: `chatcmpl-${randomId()}`,
+        created: Math.floor(Date.now() / 1000),
+        model: p.modelAlias,
+        text,
+        toolCalls,
+        completionTokens,
+        finishReason
+      })
+    )
   } finally {
     await Promise.all(tmpPaths.map((path) => unlink(path).catch(() => undefined)))
   }
@@ -188,14 +190,15 @@ async function runStreaming(
       delta: ChatCompletionDelta,
       finishReason: OpenAiFinishReason | null,
       usage?: ChatCompletionUsage
-    ) => chatCompletionChunk({
-      id,
-      created,
-      model: p.modelAlias,
-      delta,
-      finishReason,
-      ...(usage !== undefined ? { usage } : {})
-    })
+    ) =>
+      chatCompletionChunk({
+        id,
+        created,
+        model: p.modelAlias,
+        delta,
+        finishReason,
+        ...(usage !== undefined ? { usage } : {})
+      })
 
     sendSSE(raw, chunk({ role: 'assistant', content: '' }, null))
 
@@ -213,11 +216,14 @@ async function runStreaming(
       sendSSE(raw, chunk({ tool_calls: openaiToolCalls }, null))
       sendSSE(raw, chunk({}, 'tool_calls'))
     } else {
-      sendSSE(raw, chunk({}, finishReason, {
-        prompt_tokens: 0,
-        completion_tokens: completionTokens,
-        total_tokens: completionTokens
-      }))
+      sendSSE(
+        raw,
+        chunk({}, finishReason, {
+          prompt_tokens: 0,
+          completion_tokens: completionTokens,
+          total_tokens: completionTokens
+        })
+      )
     }
 
     endSSE(raw)

--- a/packages/cli/test/AGENT_STACK_E2E.md
+++ b/packages/cli/test/AGENT_STACK_E2E.md
@@ -6,14 +6,14 @@ The SDK e2e suite should stay focused on SDK consumer behavior. Agent-stack test
 
 ## Test Buckets
 
-| Layer | Location | Owns |
-| --- | --- | --- |
-| SDK e2e | `packages/sdk/e2e` | Public SDK consumer/device behavior, including `loadModel()`, inference, download, lifecycle, and mobile/desktop coverage through the test-suite framework. |
-| CLI TypeScript contract tests | `packages/cli/test/*.test.ts` | OpenAI-compatible adapter and helper contracts, structured JSON assertions, SSE parsing, content-parts handling, tool-call payloads, and deterministic model-free behavior that does not need a Fastify request. |
-| CLI in-process HTTP e2e | `packages/cli/test/e2e/http` | Modelless wire-level validation through `useServer` / `app.inject`, including status codes, error codes, routing, CORS, multipart parsing, and OpenAI-compatible endpoint validation. |
-| CLI spawned-binary e2e | `packages/cli/test/e2e/cli` and `packages/cli/test/e2e/model` | Built CLI startup, real `qvac serve openai` process smoke, model-load checks, network-bound endpoint smoke, logs, diagnostics, and process cleanup. |
-| ai-sdk-provider integration | `packages/ai-sdk-provider/test/managed-integration.test.ts` | Vercel AI SDK calls through managed `qvac serve`, real managed serve reuse, close behavior, and opt-in real-model integration checks. |
-| Plugin integration | `plugins/opencode` and future tool plugins such as `plugins/openclaw` | Tool-specific host, proxy, config, readiness, request-shaping, and shutdown behavior. |
+| Layer                         | Location                                                              | Owns                                                                                                                                                                                                             |
+| ----------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SDK e2e                       | `packages/sdk/e2e`                                                    | Public SDK consumer/device behavior, including `loadModel()`, inference, download, lifecycle, and mobile/desktop coverage through the test-suite framework.                                                      |
+| CLI TypeScript contract tests | `packages/cli/test/*.test.ts`                                         | OpenAI-compatible adapter and helper contracts, structured JSON assertions, SSE parsing, content-parts handling, tool-call payloads, and deterministic model-free behavior that does not need a Fastify request. |
+| CLI in-process HTTP e2e       | `packages/cli/test/e2e/http`                                          | Modelless wire-level validation through `useServer` / `app.inject`, including status codes, error codes, routing, CORS, multipart parsing, and OpenAI-compatible endpoint validation.                            |
+| CLI spawned-binary e2e        | `packages/cli/test/e2e/cli` and `packages/cli/test/e2e/model`         | Built CLI startup, real `qvac serve openai` process smoke, model-load checks, network-bound endpoint smoke, logs, diagnostics, and process cleanup.                                                              |
+| ai-sdk-provider integration   | `packages/ai-sdk-provider/test/managed-integration.test.ts`           | Vercel AI SDK calls through managed `qvac serve`, real managed serve reuse, close behavior, and opt-in real-model integration checks.                                                                            |
+| Plugin integration            | `plugins/opencode` and future tool plugins such as `plugins/openclaw` | Tool-specific host, proxy, config, readiness, request-shaping, and shutdown behavior.                                                                                                                            |
 
 ## Decision Rules
 

--- a/packages/cli/test/chat-agent-shapes.test.ts
+++ b/packages/cli/test/chat-agent-shapes.test.ts
@@ -30,9 +30,10 @@ describe('chat agent OpenAI shapes', () => {
   })
 
   it('emits JSON-serializable streaming tool-call deltas', () => {
-    const deltas = sdkToolCallsToOpenaiDeltas([
-      { id: 'call_weather', name: 'get_weather', arguments: { location: 'Tokyo' } }
-    ]) ?? []
+    const deltas =
+      sdkToolCallsToOpenaiDeltas([
+        { id: 'call_weather', name: 'get_weather', arguments: { location: 'Tokyo' } }
+      ]) ?? []
     const toolChunk = chatCompletionChunk({
       id: 'chatcmpl_stream',
       created: 100,
@@ -48,7 +49,9 @@ describe('chat agent OpenAI shapes', () => {
       finishReason: 'tool_calls'
     })
 
-    const serialized = [toolChunk, doneChunk].map((chunk) => JSON.parse(JSON.stringify(chunk)) as typeof chunk)
+    const serialized = [toolChunk, doneChunk].map(
+      (chunk) => JSON.parse(JSON.stringify(chunk)) as typeof chunk
+    )
     const toolCall = serialized[0]!.choices[0]!.delta.tool_calls![0]!
 
     assert.equal(serialized[0]!.object, 'chat.completion.chunk')


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

The `@qvac/cli` 0.8.0 publish build failed at `npm run check` → `prettier --check .` with style issues in 10 files ([run](https://github.com/tetherto/qvac/actions/runs/28602876699/job/84815413751)), which skipped the npm publish. The CLI adopted Prettier in 0.8.0 (#2829), but the PR-level `SDK Pod Checks` only run `lint` (lunte), not `prettier --check`, so pre-existing formatting violations reached the release branch and only surfaced in the publish build's format gate. The same files are unformatted on `main`.

## 📝 How does it solve it?

Ran `prettier --write` across `packages/cli`. Whitespace/style only — no behavior change. Affected files:

- `CHANGELOG.md`, `changelog/0.5.0/CHANGELOG_LLM.md`, `changelog/0.8.0/CHANGELOG.md`, `changelog/0.8.0/api.md`
- `docs/serve-openai.md`
- `src/serve/adapters/openai/chat-shapes.ts`, `src/serve/plugins/error-handler.ts`, `src/serve/routes/chat.ts`
- `test/AGENT_STACK_E2E.md`, `test/chat-agent-shapes.test.ts`

Tagged `[skiplog]` — formatting only, no changelog entry. Merging this into `release-cli-0.8.0` retriggers the publish workflow so the 0.8.0 npm publish can proceed.

## 🧪 How was it tested?

`npm run check` (the exact publish gate: `lint` + `prettier --check .`) now passes locally — "No issues found" + "All matched files use Prettier code style!". Verified the 0.8.0 changelog still references `@qvac/sdk` 0.14.1 after formatting.