### PR TITLE
QVAC-21614 fix: parakeet perf report — GPU name on CPU rows, Windows GPU detection, mobile RTF

### DIFF
--- a/scripts/perf-report/__tests__/aggregate-parakeet-rtf.test.js
+++ b/scripts/perf-report/__tests__/aggregate-parakeet-rtf.test.js
@@ -1,0 +1,74 @@
+'use strict'
+
+/**
+ * Unit tests for the parakeet perf-report normalizers in
+ * scripts/perf-report/aggregate-parakeet-rtf.js (QVAC-21618).
+ *
+ * Covers three reporting fixes:
+ *   1. CPU-only rows must not be attributed a GPU model.
+ *   2. GPU rows keep the probed GPU model.
+ *   3. Mobile rows derive RTF from wall/audio when real_time_factor is null,
+ *      so Android/iOS rows are populated instead of rendering all n/a.
+ *
+ * Pure-function code paths only — no fixtures on disk.
+ *
+ * Run locally:
+ *   node --test scripts/perf-report/__tests__/aggregate-parakeet-rtf.test.js
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  normalizeDesktopRecord,
+  normalizeMobileRecords
+} = require('../aggregate-parakeet-rtf')
+
+function desktopReport (useGPU) {
+  return {
+    platform: 'win32-x64',
+    platformName: 'win32',
+    addonVersion: '0.8.2',
+    model: { type: 'tdt', quant: 'q8_0' },
+    requested: { useGPU },
+    labels: { device: 'qvac-win25-x64-gpu', backend: useGPU ? 'vulkan' : 'cpu' },
+    device: { gpu: 'NVIDIA RTX 4000 SFF Ada Generation' },
+    summary: { rtf: { mean: 0.005, p50: 0.005, p95: 0.006, stddev: 0.0002 }, wallMs: { mean: 99 } }
+  }
+}
+
+test('CPU desktop row is not attributed a GPU model', () => {
+  const record = normalizeDesktopRecord(desktopReport(false), 'rtf-benchmark-win32-x64-tdt-q8_0-cpu.json')
+  assert.equal(record.gpu, 'cpu')
+  assert.equal(record.gpuModel, null)
+})
+
+test('GPU desktop row keeps the probed GPU model', () => {
+  const record = normalizeDesktopRecord(desktopReport(true), 'rtf-benchmark-win32-x64-tdt-q8_0-gpu.json')
+  assert.equal(record.gpu, 'gpu')
+  assert.equal(record.gpuModel, 'NVIDIA RTX 4000 SFF Ada Generation')
+})
+
+test('mobile RTF is derived from wall/audio when real_time_factor is null', () => {
+  const report = {
+    addon: 'parakeet',
+    addon_type: 'parakeet',
+    addonVersion: '0.8.2',
+    device: { name: 'Apple iPhone 16 Pro', platform: 'ios' },
+    results: [
+      {
+        test: '[tdt] [q8_0] [CPU] mobile-perf run 1',
+        execution_provider: 'cpu',
+        metrics: { real_time_factor: null, wall_time_ms: 1000, audio_duration_ms: 20000 }
+      }
+    ]
+  }
+  const records = normalizeMobileRecords(report, '/x/Apple_iPhone_16_Pro/performance-report.json')
+  assert.equal(records.length, 1)
+  const [row] = records
+  assert.equal(row.platformFamily, 'ios')
+  // 1000ms / 20000ms = 0.05
+  assert.ok(Math.abs(row.meanRtf - 0.05) < 1e-9, `expected ~0.05, got ${row.meanRtf}`)
+  assert.ok(Number.isFinite(row.p95))
+  assert.equal(row.gpuModel, null)
+})

--- a/scripts/perf-report/aggregate-parakeet-rtf.js
+++ b/scripts/perf-report/aggregate-parakeet-rtf.js
@@ -159,7 +159,12 @@ function normalizeDesktopRecord (report, sourceFile) {
     quant,
     gpu: useGPU ? 'gpu' : 'cpu',
     backend,
-    gpuModel: (report.labels && report.labels.gpuModel) || (report.device && report.device.gpu) || null,
+    // CPU-only rows never ran on the GPU, so don't attribute the host's GPU
+    // to them — the probe stamps the GPU name onto every report regardless of
+    // whether that run used it (QVAC-21618).
+    gpuModel: useGPU
+      ? ((report.labels && report.labels.gpuModel) || (report.device && report.device.gpu) || null)
+      : null,
     version: report.addonVersion || '',
     meanRtf: Number(rtf.mean),
     stddev: Number(rtf.stddev),
@@ -187,7 +192,7 @@ function normalizeManualRecord (record, sourceFile) {
     quant: record.quant || quantFromName(record.dirName) || '',
     gpu: useGPU ? 'gpu' : 'cpu',
     backend: normalizeBackend(platformFamily, useGPU, record.backend),
-    gpuModel: record.gpuModel || record.gpu_model || null,
+    gpuModel: useGPU ? (record.gpuModel || record.gpu_model || null) : null,
     version: record.version || '',
     meanRtf: Number(record.meanRtf),
     stddev: Number(record.stddev),
@@ -265,7 +270,18 @@ function normalizeMobileRecords (report, sourceFile) {
       })
     }
     const group = byModelAndProvider.get(key)
-    if (typeof metrics.real_time_factor === 'number') group.rtf.push(metrics.real_time_factor)
+    // Mobile runs report real_time_factor as null (the mobile inference stats
+    // don't carry it), so the RTF/P50/P95 columns rendered empty and the
+    // Android/iOS rows looked unpopulated. Derive RTF from the wall time over
+    // the audio duration when the explicit value is missing (QVAC-21618).
+    const rtf = typeof metrics.real_time_factor === 'number'
+      ? metrics.real_time_factor
+      : (typeof metrics.wall_time_ms === 'number' &&
+         typeof metrics.audio_duration_ms === 'number' &&
+         metrics.audio_duration_ms > 0
+          ? metrics.wall_time_ms / metrics.audio_duration_ms
+          : null)
+    if (typeof rtf === 'number' && Number.isFinite(rtf)) group.rtf.push(rtf)
     if (typeof metrics.wall_time_ms === 'number') group.wallMs.push(metrics.wall_time_ms)
   }
 
@@ -281,7 +297,7 @@ function normalizeMobileRecords (report, sourceFile) {
       quant: values.quant || '',
       gpu: values.provider,
       backend: normalizeBackend(platformFamily, useGPU),
-      gpuModel: device.gpu || null,
+      gpuModel: useGPU ? (device.gpu || null) : null,
       version: report.addonVersion || '',
       meanRtf: mean(values.rtf),
       stddev: stddev(values.rtf),
@@ -618,4 +634,12 @@ function main () {
   process.stdout.write(markdown)
 }
 
-main()
+if (require.main === module) {
+  main()
+}
+
+module.exports = {
+  normalizeDesktopRecord,
+  normalizeManualRecord,
+  normalizeMobileRecords
+}

--- a/scripts/test-utils/performance-reporter.js
+++ b/scripts/test-utils/performance-reporter.js
@@ -99,10 +99,24 @@ function _detectGpu (platform) {
     : null
   if (!nodeExecSync && !bareSpawnSync) return null
 
+  // Accepts either a flat string command (split on whitespace) or an explicit
+  // argv array. Use the array form when a single argument must retain spaces or
+  // shell metacharacters — e.g. PowerShell's `-Command "<expr>"`, where the `|`
+  // is parsed by PowerShell itself, not by an OS shell. Splitting such a command
+  // on whitespace shattered the pipeline, so PowerShell echoed the literal query
+  // back and it surfaced as the Windows "GPU name" in perf reports (QVAC-21618).
   function _safeExec (cmd) {
+    const argv = Array.isArray(cmd) ? cmd.filter(Boolean) : null
+
     if (nodeExecSync) {
+      // Node's execSync runs through a shell, so a flat string works as-is. For
+      // the argv form, quote any argument containing whitespace so the shell
+      // keeps it as a single token (and does not interpret the inner `|`).
+      const cmdStr = argv
+        ? argv.map(part => /\s/.test(part) ? `"${part}"` : part).join(' ')
+        : cmd
       try {
-        return nodeExecSync(cmd, {
+        return nodeExecSync(cmdStr, {
           encoding: 'utf-8',
           stdio: ['pipe', 'pipe', 'pipe'],
           timeout: 5000
@@ -111,11 +125,11 @@ function _detectGpu (platform) {
         return null
       }
     }
-    // Bare path: spawnSync takes (bin, args[]). All commands we shell
-    // out to here are flat (no shell metacharacters, no quoting) so a
-    // simple split-on-whitespace is safe.
+    // Bare path: spawnSync takes (bin, args[]) with no shell, so an explicit
+    // argv array passes metacharacters through untouched. Flat strings (which
+    // carry no shell metacharacters) are split on whitespace as before.
     try {
-      const parts = cmd.split(/\s+/).filter(Boolean)
+      const parts = argv || cmd.split(/\s+/).filter(Boolean)
       if (!parts.length) return null
       const res = bareSpawnSync(parts[0], parts.slice(1), {
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -261,7 +275,7 @@ function _detectGpu (platform) {
     // PowerShell CIM: `wmic` was removed in Windows 11 24H2 / Server 2025, so it
     // is absent on the windows-2025 runner. Try CIM first, keep wmic for older
     // Windows images. QVAC-20684.
-    const ps = _safeExec('powershell -NoProfile -Command "Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name"')
+    const ps = _safeExec(['powershell', '-NoProfile', '-Command', 'Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name'])
     if (ps) {
       const lines = ps.split('\n').map(l => l.trim()).filter(Boolean)
       if (lines.length) return lines[0]


### PR DESCRIPTION
## What problem does this PR solve?

Three defects in the parakeet benchmark summary table (seen in
[run 27968071657](https://github.com/tetherto/qvac/actions/runs/27968071657)):

1. **GPU name shown on CPU rows.** The hardware probe stamps the host GPU
   onto every report, so CPU-only rows displayed a GPU model
   (e.g. `Apple M2 Pro (Virtual)`).
2. **Windows GPU name was the literal probe command** —
   `Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name`
   instead of the actual GPU.
3. **Android / iOS rows unpopulated.** Mobile rows rendered every metric as
   `n/a`.

## How does it solve it?

1. **CPU rows:** gate `gpuModel` on `useGPU` in all three normalizers
   (desktop / manual / mobile). CPU rows → `null`; GPU rows keep the probed
   name.
2. **Windows detection:** the Bare `_safeExec` split commands on whitespace,
   which shattered the piped PowerShell probe so PowerShell echoed the query
   text back. `_safeExec` now accepts an explicit argv array, passing the
   `-Command` expression (pipe included) as one intact argument for
   PowerShell to parse itself — no OS shell involved.
3. **Mobile RTF:** the mobile report emits `real_time_factor: null` (only
   `wall_time_ms` / `audio_duration_ms` are populated), so RTF/P50/P95 were
   blank. The aggregator now derives RTF as `wall_time_ms / audio_duration_ms`
   when the explicit value is missing, which also populates P50/P95/stddev.

Verified against the run's real artifacts: 14/14 mobile rows now carry a
numeric RTF, 0 CPU rows carry a GPU model, and desktop GPU rows still show
`NVIDIA RTX 4000 SFF Ada Generation`. Added a `node:test` unit test
(`__tests__/aggregate-parakeet-rtf.test.js`) covering all three; `standard`
lint clean.

## Breaking changes

None. Reporting/CI-only changes.
