### PR TITLE
infra: Developer ID sign + notarize darwin prebuilds to clear macOS Gatekeeper

### DIFF
--- a/.github/actions/notarize-prebuilds/action.yml
+++ b/.github/actions/notarize-prebuilds/action.yml
@@ -4,9 +4,10 @@ description: >-
   does not block the addon on first load with the "cannot verify ... is free of
   malware" dialog. Without this, prebuilt .bare modules ship only ad-hoc /
   linker-signed (Signature=adhoc, TeamIdentifier=not set), which trips
-  Gatekeeper's first-load assessment on end-user machines. Signs every
-  .bare/.dylib/.so under the workdir's prebuilds/ tree with a hardened runtime
-  and secure timestamp, then submits the bundle to Apple's notary service.
+  Gatekeeper's first-load assessment on end-user machines. Signs every Mach-O
+  object under the workdir's prebuilds/ tree (detected by content) with a
+  hardened runtime and secure timestamp, then submits the bundle to Apple's
+  notary service.
   Loose .bare dylibs cannot be stapled, so Gatekeeper resolves the notarization
   ticket online. No-op (warns) until the signing credentials are provisioned,
   so it is safe to land ahead of the secrets.
@@ -59,33 +60,60 @@ runs:
           echo "prebuilds/ does not exist; nothing to notarize"
           exit 0
         fi
-        if [ -z "$CERT_P12_BASE64" ] || [ -z "$NOTARY_KEY_BASE64" ] || [ -z "$SIGN_IDENTITY" ]; then
-          echo "::warning title=darwin prebuilds not notarized::Signing credentials not provisioned; shipping ad-hoc-signed prebuilds (Gatekeeper may warn on first load). Provide the Developer ID cert + notary key secrets to enable notarization."
+        # No-op (green) unless ALL credentials are present, so partial
+        # provisioning does not fail mid-run.
+        if [ -z "$CERT_P12_BASE64" ] || [ -z "$CERT_PASSWORD" ] || [ -z "$SIGN_IDENTITY" ] || \
+           [ -z "$NOTARY_KEY_BASE64" ] || [ -z "$NOTARY_KEY_ID" ] || [ -z "$NOTARY_ISSUER_ID" ]; then
+          echo "::warning title=darwin prebuilds not notarized::Signing credentials not fully provisioned; shipping ad-hoc-signed prebuilds (Gatekeeper may warn on first load). Provide all six MACOS_* secrets to enable notarization."
           exit 0
         fi
         set -e
         KEYCHAIN="$RUNNER_TEMP/notarize.keychain-db"
+        # Always scrub key material + the temp keychain, even on failure.
+        trap 'rm -f "$RUNNER_TEMP/devid.p12" "$RUNNER_TEMP/notary.p8"; security delete-keychain "$KEYCHAIN" 2>/dev/null || true' EXIT
         KCPASS="$(uuidgen)"
         security create-keychain -p "$KCPASS" "$KEYCHAIN"
         security set-keychain-settings -lut 21600 "$KEYCHAIN"
         security unlock-keychain -p "$KCPASS" "$KEYCHAIN"
-        echo "$CERT_P12_BASE64" | base64 -d > "$RUNNER_TEMP/devid.p12"
+        echo "$CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/devid.p12"
         security import "$RUNNER_TEMP/devid.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" -T /usr/bin/codesign
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KCPASS" "$KEYCHAIN" >/dev/null
         security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed s/\"//g)
-        # Sign every native binary in the prebuild tree with hardened runtime.
-        find prebuilds \( -name '*.bare' -o -name '*.dylib' -o -name '*.so' \) -print0 |
+        # Sign every Mach-O object in the prebuild tree (detect by content, not
+        # by suffix: notary rejects the whole zip if any Mach-O is unsigned, and
+        # addons may ship sibling dylibs / extension-less loader stubs).
+        find prebuilds -type f -print0 |
           while IFS= read -r -d '' f; do
-            echo "signing: $f"
-            codesign --force --timestamp --options runtime --sign "$SIGN_IDENTITY" "$f"
+            if file "$f" | grep -q 'Mach-O'; then
+              echo "signing: $f"
+              codesign --force --timestamp --options runtime --sign "$SIGN_IDENTITY" "$f"
+            fi
           done
-        # Notarize the bundle (loose .bare cannot be stapled -> online ticket).
-        echo "$NOTARY_KEY_BASE64" | base64 -d > "$RUNNER_TEMP/notary.p8"
+        # Notarize the bundle (loose .bare cannot be stapled -> Gatekeeper
+        # resolves the ticket online at first load).
+        echo "$NOTARY_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/notary.p8"
         ditto -c -k --keepParent prebuilds "$RUNNER_TEMP/prebuilds.zip"
+        NOTARY_OUT="$RUNNER_TEMP/notary-submit.txt"
+        set +e
         xcrun notarytool submit "$RUNNER_TEMP/prebuilds.zip" \
           --key "$RUNNER_TEMP/notary.p8" \
           --key-id "$NOTARY_KEY_ID" \
           --issuer "$NOTARY_ISSUER_ID" \
-          --wait
-        rm -f "$RUNNER_TEMP/devid.p12" "$RUNNER_TEMP/notary.p8"
-        security delete-keychain "$KEYCHAIN" || true
+          --wait 2>&1 | tee "$NOTARY_OUT"
+        NOTARY_RC=${PIPESTATUS[0]}
+        set -e
+        SUBMISSION_ID="$(awk '/id:/{print $2; exit}' "$NOTARY_OUT")"
+        # Assert the terminal status explicitly; do not trust exit code alone,
+        # and fetch the per-binary rejection log so failures are diagnosable.
+        if ! grep -qE 'status: Accepted' "$NOTARY_OUT"; then
+          echo "::error title=Notarization failed::terminal status was not Accepted (rc=$NOTARY_RC)"
+          if [ -n "$SUBMISSION_ID" ]; then
+            echo "notary log for submission $SUBMISSION_ID:"
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --key "$RUNNER_TEMP/notary.p8" \
+              --key-id "$NOTARY_KEY_ID" \
+              --issuer "$NOTARY_ISSUER_ID" || true
+          fi
+          exit 1
+        fi
+        echo "notarization accepted (submission $SUBMISSION_ID)"

--- a/.github/actions/notarize-prebuilds/action.yml
+++ b/.github/actions/notarize-prebuilds/action.yml
@@ -87,6 +87,16 @@ runs:
             if file "$f" | grep -q 'Mach-O'; then
               echo "signing: $f"
               codesign --force --timestamp --options runtime --sign "$SIGN_IDENTITY" "$f"
+              # Verify the signature landed and the root-cause state is gone:
+              # real Developer ID (Team ID present), not the shipped adhoc state.
+              codesign --verify --strict --verbose=2 "$f"
+              DESC=$(codesign -dvvv "$f" 2>&1)
+              case "$DESC" in
+                *"Signature=adhoc"*) echo "::error::$f still ad-hoc signed after codesign"; exit 1;;
+              esac
+              case "$DESC" in
+                *"TeamIdentifier=not set"*) echo "::error::$f has no Team Identifier after codesign"; exit 1;;
+              esac
             fi
           done
         # Notarize the bundle (loose .bare cannot be stapled -> Gatekeeper
@@ -99,7 +109,7 @@ runs:
           --key "$RUNNER_TEMP/notary.p8" \
           --key-id "$NOTARY_KEY_ID" \
           --issuer "$NOTARY_ISSUER_ID" \
-          --wait 2>&1 | tee "$NOTARY_OUT"
+          --wait --timeout 30m 2>&1 | tee "$NOTARY_OUT"
         NOTARY_RC=${PIPESTATUS[0]}
         set -e
         SUBMISSION_ID="$(awk '/id:/{print $2; exit}' "$NOTARY_OUT")"

--- a/.github/actions/notarize-prebuilds/action.yml
+++ b/.github/actions/notarize-prebuilds/action.yml
@@ -1,0 +1,91 @@
+name: Notarize darwin prebuilds
+description: >-
+  Developer ID sign + notarize the darwin native prebuilds so macOS Gatekeeper
+  does not block the addon on first load with the "cannot verify ... is free of
+  malware" dialog. Without this, prebuilt .bare modules ship only ad-hoc /
+  linker-signed (Signature=adhoc, TeamIdentifier=not set), which trips
+  Gatekeeper's first-load assessment on end-user machines. Signs every
+  .bare/.dylib/.so under the workdir's prebuilds/ tree with a hardened runtime
+  and secure timestamp, then submits the bundle to Apple's notary service.
+  Loose .bare dylibs cannot be stapled, so Gatekeeper resolves the notarization
+  ticket online. No-op (warns) until the signing credentials are provisioned,
+  so it is safe to land ahead of the secrets.
+
+inputs:
+  workdir:
+    description: Directory containing the prebuilds/ folder
+    required: true
+  sign-identity:
+    description: 'Developer ID Application identity, e.g. "Developer ID Application: Tether ... (TEAMID)"'
+    required: false
+    default: ""
+  cert-p12-base64:
+    description: base64 of the Developer ID Application certificate (.p12)
+    required: false
+    default: ""
+  cert-password:
+    description: Export password for the .p12 certificate
+    required: false
+    default: ""
+  notary-key-base64:
+    description: base64 of the App Store Connect API key (.p8)
+    required: false
+    default: ""
+  notary-key-id:
+    description: App Store Connect API key id
+    required: false
+    default: ""
+  notary-issuer-id:
+    description: App Store Connect API key issuer id
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Developer ID sign + notarize
+      shell: bash
+      working-directory: ${{ inputs.workdir }}
+      env:
+        SIGN_IDENTITY: ${{ inputs.sign-identity }}
+        CERT_P12_BASE64: ${{ inputs.cert-p12-base64 }}
+        CERT_PASSWORD: ${{ inputs.cert-password }}
+        NOTARY_KEY_BASE64: ${{ inputs.notary-key-base64 }}
+        NOTARY_KEY_ID: ${{ inputs.notary-key-id }}
+        NOTARY_ISSUER_ID: ${{ inputs.notary-issuer-id }}
+      run: |
+        set -uo pipefail
+        if [ ! -d prebuilds ]; then
+          echo "prebuilds/ does not exist; nothing to notarize"
+          exit 0
+        fi
+        if [ -z "$CERT_P12_BASE64" ] || [ -z "$NOTARY_KEY_BASE64" ] || [ -z "$SIGN_IDENTITY" ]; then
+          echo "::warning title=darwin prebuilds not notarized::Signing credentials not provisioned; shipping ad-hoc-signed prebuilds (Gatekeeper may warn on first load). Provide the Developer ID cert + notary key secrets to enable notarization."
+          exit 0
+        fi
+        set -e
+        KEYCHAIN="$RUNNER_TEMP/notarize.keychain-db"
+        KCPASS="$(uuidgen)"
+        security create-keychain -p "$KCPASS" "$KEYCHAIN"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN"
+        security unlock-keychain -p "$KCPASS" "$KEYCHAIN"
+        echo "$CERT_P12_BASE64" | base64 -d > "$RUNNER_TEMP/devid.p12"
+        security import "$RUNNER_TEMP/devid.p12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KCPASS" "$KEYCHAIN" >/dev/null
+        security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed s/\"//g)
+        # Sign every native binary in the prebuild tree with hardened runtime.
+        find prebuilds \( -name '*.bare' -o -name '*.dylib' -o -name '*.so' \) -print0 |
+          while IFS= read -r -d '' f; do
+            echo "signing: $f"
+            codesign --force --timestamp --options runtime --sign "$SIGN_IDENTITY" "$f"
+          done
+        # Notarize the bundle (loose .bare cannot be stapled -> online ticket).
+        echo "$NOTARY_KEY_BASE64" | base64 -d > "$RUNNER_TEMP/notary.p8"
+        ditto -c -k --keepParent prebuilds "$RUNNER_TEMP/prebuilds.zip"
+        xcrun notarytool submit "$RUNNER_TEMP/prebuilds.zip" \
+          --key "$RUNNER_TEMP/notary.p8" \
+          --key-id "$NOTARY_KEY_ID" \
+          --issuer "$NOTARY_ISSUER_ID" \
+          --wait
+        rm -f "$RUNNER_TEMP/devid.p12" "$RUNNER_TEMP/notary.p8"
+        security delete-keychain "$KEYCHAIN" || true

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -404,6 +404,23 @@ jobs:
           platform: ${{ matrix.platform }}
           workdir: ${{ env.WORKDIR }}
 
+      # Developer ID sign + notarize darwin prebuilds so macOS Gatekeeper does
+      # not block the ad-hoc-signed .bare on first load ("cannot verify ... free
+      # of malware"). No-op (warns) until the signing credentials are present,
+      # so it is safe to land ahead of the secrets. Local ./ ref because the
+      # action is new and has no pinned SHA yet; pin after merge.
+      - name: Notarize darwin prebuilds
+        if: matrix.platform == 'darwin'
+        uses: ./.github/actions/notarize-prebuilds
+        with:
+          workdir: ${{ env.WORKDIR }}
+          sign-identity: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          cert-p12-base64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          cert-password: ${{ secrets.MACOS_CERT_PASSWORD }}
+          notary-key-base64: ${{ secrets.MACOS_NOTARY_KEY_BASE64 }}
+          notary-key-id: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          notary-issuer-id: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+
       # Guards against regressing the static-runtime build: addons must link the
       # static MSVC runtime, so the shipped .bare/.dll must not import the dynamic
       # Visual C++ runtime (vcruntime140.dll / msvcp140.dll / ucrtbase.dll / the

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -409,8 +409,16 @@ jobs:
       # of malware"). No-op (warns) until the signing credentials are present,
       # so it is safe to land ahead of the secrets. Local ./ ref matches the
       # existing local-action precedent in this file (see ./setup-rocm).
+      #
+      # Restricted to non-PR events. pull_request_target callers (on-pr-*.yml)
+      # reach this reusable with `secrets: inherit` while checked out at fork PR
+      # HEAD, so running the signing here would expose the Developer ID cert to
+      # untrusted PR code and sign binaries that are never published. Only the
+      # publish path (on-merge-*.yml, push/workflow_dispatch) produces shipped
+      # artifacts and should notarize. github.event_name is read from the
+      # trusted base workflow, so a PR cannot spoof it.
       - name: Notarize darwin prebuilds
-        if: matrix.platform == 'darwin'
+        if: matrix.platform == 'darwin' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
         uses: ./.github/actions/notarize-prebuilds
         with:
           workdir: ${{ env.WORKDIR }}

--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -407,8 +407,8 @@ jobs:
       # Developer ID sign + notarize darwin prebuilds so macOS Gatekeeper does
       # not block the ad-hoc-signed .bare on first load ("cannot verify ... free
       # of malware"). No-op (warns) until the signing credentials are present,
-      # so it is safe to land ahead of the secrets. Local ./ ref because the
-      # action is new and has no pinned SHA yet; pin after merge.
+      # so it is safe to land ahead of the secrets. Local ./ ref matches the
+      # existing local-action precedent in this file (see ./setup-rocm).
       - name: Notarize darwin prebuilds
         if: matrix.platform == 'darwin'
         uses: ./.github/actions/notarize-prebuilds


### PR DESCRIPTION
## 🎯 Problem

Users running the macOS quickstart hit a one-time **"cannot verify … is free of malware"** Gatekeeper dialog that blocks the addon from loading. Root cause: our darwin `.bare` prebuilds are only ad-hoc / linker-signed, never Developer ID signed or notarized. Verified on the real published `@qvac/llm-llamacpp@latest` artifact:

```
codesign -dvvv:  flags=0x20002(adhoc,linker-signed)
                 Signature=adhoc
                 TeamIdentifier=not set
spctl -a -t install:  rejected
```

That is exactly the condition macOS Gatekeeper blocks on first load. All native addons build their darwin prebuild through the shared `reusable-prebuilds.yml`, which had no signing step, so the gap is universal.

## 📝 Changes

- **New composite action** `.github/actions/notarize-prebuilds` — signs every Mach-O object under `prebuilds/` (detected by content, not by suffix) with `codesign --force --timestamp --options runtime`, then submits the zipped tree to Apple via `xcrun notarytool submit --wait`. Asserts the terminal status and fetches the per-binary notary log on failure. Key material and the temp keychain are scrubbed via an `EXIT` trap.
- **`reusable-prebuilds.yml`** — adds a `Notarize darwin prebuilds` step after "Verify prebuild symbols", gated `if: matrix.platform == 'darwin' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'`. One change covers all addons routed through the reusable.

## 🔒 Trust boundary

`on-pr-*.yml` runs on `pull_request_target` and reaches this reusable with `secrets: inherit` while checked out at fork PR HEAD. Signing there would expose the Developer ID cert to untrusted PR-HEAD code (the `./` composite action is resolved from the checkout) and sign artifacts that are never published. So notarization is gated to non-PR events — only the publish path (`on-merge-*.yml`, push/workflow_dispatch) signs. `github.event_name` is evaluated from the trusted base workflow (pull_request_target always uses base workflow definitions), so a PR cannot spoof it. This layers on the existing `release` environment approval and the all-six-secret guard. After signing, each Mach-O is verified (`codesign --verify --strict`) and asserted to no longer be adhoc / Team-ID-less before it can be uploaded.

## 🔌 Rollout

The step is a **no-op that stays green until all six credentials are provisioned** (it warns and exits 0 otherwise), so this can merge safely ahead of the secrets. It activates automatically once these exist in the `release` environment (where the prebuild job already runs):

`MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`, `MACOS_SIGN_IDENTITY`, `MACOS_NOTARY_KEY_BASE64`, `MACOS_NOTARY_KEY_ID`, `MACOS_NOTARY_ISSUER_ID`

Needs the Tether Apple Developer org's real Developer ID Application cert + an App Store Connect API key (Developer role) for notarytool.

## 🧪 Testing

- **Reproduced the actual block on a real Mac** (Mac Studio, macOS 15.5, Apple Silicon) against the published `@qvac/llm-llamacpp@0.31.0`. With the quarantine bit applied, loading the `.bare` under Bare is blocked:
  ```
  dlopen(qvac__llm-llamacpp.bare): code signature not valid for use in process:
  library load disallowed by system policy
  ```
  The same binary with the quarantine bit removed loads cleanly, confirming the block is exactly (ad-hoc/un-notarized signature) × (the `com.apple.quarantine` xattr). (Run over SSH, so the load error rather than the GUI dialog; same underlying Gatekeeper verdict.)
- Root-cause signature state confirmed on the shipped artifact: `Signature=adhoc`, `TeamIdentifier=not set`, `spctl` rejected.
- No-op-safe merge verified: with no secrets the step warns and the darwin leg stays green.
- Signing / keychain / notarytool sequence reviewed; `bash -n` clean.

## 🔍 Evidence: not a version regression, and it's the addon that's flagged

**Not a regression, and not the latest addon update.** Swept the addon's published history — every version that ships a darwin prebuild, from `0.28.0` through the current `latest` (`0.35.1`), is identical: all ad-hoc, all blocked under quarantine.

| Version | Signature | Quarantined load |
|---|---|---|
| `0.28.0` | `adhoc`, `TeamIdentifier=not set` | `exit 134` · blocked |
| `0.29.3` | `adhoc`, `TeamIdentifier=not set` | `exit 134` · blocked |
| `0.30.1` | `adhoc`, `TeamIdentifier=not set` | `exit 134` · blocked |
| `0.31.0` | `adhoc`, `TeamIdentifier=not set` | `exit 134` · blocked |
| `0.35.1` (current latest) | `adhoc`, `TeamIdentifier=not set` | `exit 134` · blocked |

Nothing changed in the signing across versions. The trigger is a Gatekeeper quarantine-class xattr on the user's machine (reproduced directly with `com.apple.quarantine`; affected boxes such as Simone's macOS 26 machine show `com.apple.provenance`), which the OS/MDM applies and npm install does not — hence environment-dependent.

**The block is on the addon library, not the runtime — so signing the Bare runtime alone would not fix it.** In a normal npm setup the `bare` command is a small Node launcher (node shebang) that `spawn`s the native Bare binary, so the process that actually `dlopen`s the addon is the native Bare runtime. Tested against that runtime (`v1.30.3`, itself only ad-hoc signed / `spctl` rejected):

| Runtime (the process that dlopens the addon) | Addon quarantined | Addon un-quarantined |
|---|---|---|
| Native Bare `v1.30.3` (ad-hoc) | `exit 134` · blocked (`library load disallowed by system policy`) | `exit 0` · loads |

The same runtime loads the same addon once the addon's quarantine bit is removed, so the verdict tracks the **addon's** own quarantine + notarization state, not the runtime's. macOS assesses each quarantined Mach-O independently, so notarizing the runtime would not clear the addon's block — the addon `.bare` itself must be notarized (this PR). The direct positive proof (a notarized addon loading under the same runtime *with* the quarantine bit present) lands once the cert is provisioned.

## 💥 Limitations

- Loose `.bare` dylibs cannot be stapled, so Gatekeeper resolves the notarization ticket **online** at first load.
- Still to validate once the cert lands: the notarized-positive case (the signed + notarized `.bare` loading *with* the quarantine bit) and the literal GUI dialog (needs a desktop session; the CI runner is headless and the Mac repro above was over SSH).
- No user-facing API change; CI-only. No package version bump or CHANGELOG.
