### PR TITLE
QVAC-21815 chore: add LavaSR denoiser GGUF models to registry

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -4989,6 +4989,38 @@
     "link": "https://huggingface.co/spaces/YatharthS/LavaSR "
   },
   {
+    "source": "s3:///qvac_models_compiled/ggml/lavasr/2026-07-03/lavasr-denoiser-f16.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "LavaSR speech denoiser (GGUF)",
+    "quantization": "fp16",
+    "params": "",
+    "licenseId": "MIT",
+    "tags": [
+      "tts",
+      "lavasr",
+      "denoiser",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/spaces/YatharthS/LavaSR "
+  },
+  {
+    "source": "s3:///qvac_models_compiled/ggml/lavasr/2026-07-03/lavasr-denoiser-f32.gguf",
+    "engine": "@qvac/tts-ggml",
+    "description": "LavaSR speech denoiser (GGUF)",
+    "quantization": "fp32",
+    "params": "",
+    "licenseId": "MIT",
+    "tags": [
+      "tts",
+      "lavasr",
+      "denoiser",
+      "gguf"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/spaces/YatharthS/LavaSR "
+  },
+  {
     "source": "https://huggingface.co/onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/tokenizer.json",
     "engine": "@qvac/tts",
     "description": "Supertonic tokenizer",

--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -5002,7 +5002,7 @@
       "gguf"
     ],
     "notes": "",
-    "link": "https://huggingface.co/spaces/YatharthS/LavaSR "
+    "link": "https://huggingface.co/spaces/YatharthS/LavaSR"
   },
   {
     "source": "s3:///qvac_models_compiled/ggml/lavasr/2026-07-03/lavasr-denoiser-f32.gguf",
@@ -5018,7 +5018,7 @@
       "gguf"
     ],
     "notes": "",
-    "link": "https://huggingface.co/spaces/YatharthS/LavaSR "
+    "link": "https://huggingface.co/spaces/YatharthS/LavaSR"
   },
   {
     "source": "https://huggingface.co/onnx-community/Supertonic-TTS-ONNX/resolve/cff123c84b0655d9d647641f1b532c3cbb8f7faa/tokenizer.json",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The LavaSR denoiser GGUF models (uploaded to S3 under `qvac_models_compiled/ggml/lavasr/2026-07-03/`) were not yet discoverable through the registry, so consumers couldn't resolve them via `@qvac/tts-ggml`.
- Only the LavaSR *enhancer* GGUFs were registered; the *denoiser* stage of the two-stage LavaSR pipeline was missing.

## 📝 How does it solve it?

- Adds two entries to `packages/registry-server/data/models.prod.json` for the LavaSR speech denoiser (GGUF):
  - `s3:///qvac_models_compiled/ggml/lavasr/2026-07-03/lavasr-denoiser-f16.gguf` — `fp16`
  - `s3:///qvac_models_compiled/ggml/lavasr/2026-07-03/lavasr-denoiser-f32.gguf` — `fp32`
- Each entry mirrors the existing LavaSR enhancer format: `engine` `@qvac/tts-ggml`, `licenseId` `MIT`, and the same `link` (`https://huggingface.co/spaces/YatharthS/LavaSR`), with tags `tts`, `lavasr`, `denoiser`, `gguf`.

## 🧪 How was it tested?

- Validated `models.prod.json` parses as well-formed JSON after the edit.
- Confirmed the referenced S3 objects and byte sizes match the upload (`lavasr-denoiser-f16.gguf` = 505,696 bytes, `lavasr-denoiser-f32.gguf` = 722,528 bytes).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216240363036910