### PR TITLE
chore: release @qvac/tts-ggml v0.4.0 (LavaSR enhancer + denoiser, output-rate, streaming enhancer)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
+## [0.4.0] - 2026-07-03
 
 ### Changed
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Release @qvac/tts-ggml v0.4.0

Cuts the release that bundles the **LavaSR** work (QVAC-16579) plus the related output-rate / streaming features accumulated in `[Unreleased]` since **0.3.6**. Mirrors prior release PRs (#2881, #2863) — touches only `package.json` (version) and `CHANGELOG.md` (finalize `[Unreleased]` → `[0.4.0] - 2026-07-03`).

**Minor bump (0.3.6 → 0.4.0)** — the batch adds two new opt-in LavaSR stages and new runtime options (backward compatible; with no LavaSR paths, output is byte-identical).

### Highlights (full detail in CHANGELOG)

- **LavaSR neural speech enhancement** — opt-in CPU/GGML post-process, bandwidth-extends to 48 kHz (qvac-ext-lib-whisper.cpp #68).
- **LavaSR denoiser** — UL-UNAS forward that cleans speech before the enhancer; runs before `enhance()`, rate-preserving (tts-cpp #78, active via the `tts-cpp 2026-07-03#1` pin).
- **Selectable output sample rate** — `outputSampleRate` (8000–192000 Hz), seam-free (#69).
- **Enhancer + Chatterbox native chunk streaming** — sliding-window enhance with look-ahead + crossfade.
- **Changed** — `qvac-lib-inference-addon-cpp` → 1.2.2; **Fixed** — Chatterbox MTL Japanese MeCab build, ARM Mali/SVE synthesis.

### Pins (already on main)

- `tts-cpp` pin = `2026-07-03#1` (qvac-registry-vcpkg #225) — ships the enhancer + denoiser + output-rate + streaming.
- Denoiser/enhancer GGUF models in the registry (#3038).

### Publish

On merge to `main` this publishes a `dev` build to GPR. The **npm `latest`** publish runs via `publish-npm` on a `release-*` branch push (or `workflow_dispatch tag=latest`) — a maintainer step (needs the `npm`/`release` environments) once this is merged; `release-merge-guard` validates the `0.4.0` version ↔ CHANGELOG top entry.

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215967101797230