### PR TITLE
QVAC-19908 chore: release ai-sdk-provider 0.3.0

### DIFF
--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,8 +1,29 @@
 # Changelog
 
-## [Unreleased]
+## [0.3.0]
 
----
+Release Date: 2026-07-03
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.3.0
+
+## Larger Agent Models in the Catalog
+
+The friendly model catalog now includes larger models aimed at agentic and coding workloads, alongside the existing families:
+
+- `gpt-oss-20b` → `GPT_OSS_20B_INST_Q4_K_M`
+- `gemma4-31b` → `GEMMA4_31B_MULTIMODAL_Q4_K_M`
+- `qwen3.6-27b` → `QWEN3_6_27B_MULTIMODAL_Q4_K_XL`
+- `qwen3.6-35b-a3b` → `QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M`
+
+These ids resolve to model constants already shipped in `@qvac/sdk` 0.14.x, so `qvac serve` can load them directly. Callers can now select these larger models by friendly id in both catalog UIs and generated serve configs.
+
+## Managed Mode Supports CLI 0.8
+
+`@qvac/ai-sdk-provider` now accepts the `@qvac/cli` `0.8.x` line as its optional managed-mode CLI peer, in addition to `0.6.x` and `0.7.x`. Installing the provider alongside CLI 0.8 resolves to the `@qvac/sdk` 0.14.x runtime, which is where the larger catalog models are available.
+
+## Compatibility
+
+External mode is unchanged and remains the default synchronous path. There are no breaking API changes in this release; the catalog additions are additive and existing model ids continue to resolve as before.
 
 ## [0.2.2]
 
@@ -10,11 +31,11 @@ Release Date: 2026-06-16
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.2.2
 
-### Fixed
+## Managed Mode Supports CLI 0.7
 
-- Allow managed-mode installs with either the `@qvac/cli` `0.6.x` or `0.7.x` line as the optional CLI peer, so strict package managers can resolve the provider while CLI 0.7 brings in the newer SDK runtime.
+`@qvac/ai-sdk-provider` now accepts both the `@qvac/cli` `0.6.x` and `0.7.x` lines as its optional managed-mode CLI peer. This lets strict package managers install the provider alongside CLI 0.7, which resolves to the newer `@qvac/sdk` 0.13.x runtime.
 
----
+No provider API changes are included in this patch release.
 
 ## [0.2.1]
 
@@ -22,11 +43,11 @@ Release Date: 2026-06-15
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.2.1
 
-### Fixed
+## Managed Mode Compatibility
 
-- Require the published `@qvac/cli` `0.6.x` line as the optional managed-mode CLI peer, so consumers can install `@qvac/ai-sdk-provider` alongside the current CLI release without strict peer-resolution failures.
+`@qvac/ai-sdk-provider` now declares the published `@qvac/cli` `0.6.x` line as its optional managed-mode CLI peer. This keeps strict package managers from rejecting installs where applications use managed mode with the current QVAC CLI release.
 
----
+No provider API changes are included in this patch release.
 
 ## [0.2.0]
 
@@ -34,12 +55,30 @@ Release Date: 2026-06-10
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.2.0
 
-### Added
+## Managed Mode
 
-- **Managed mode (`mode: 'managed'`).** `createQvac({ mode: 'managed', models, ... })` returns a `Promise<ManagedQvacProvider>` that synthesizes an ephemeral `qvac.config.json` from a model list and brings up `qvac serve openai` for you — no hand-authored config or separate CLI step. Serves are **shared** across processes via a _fleet key_ (model set + per-model config + host + binary + pinned port), owned by a **detached runner** that idle-reaps the serve once no consumer process remains for `serveIdleTimeout` (default 5 min). `close()` / `await using` detaches the calling process; a serve still in use by another consumer keeps running. Includes crash-recovery (`fetch` re-resolves and retries once on `ECONNREFUSED`) and a self-healing registry under `~/.qvac/managed-serves/`. New options: `models`, `servePort`, `serveHost`, `serveStartTimeout`, `serveBinPath`, `reuse`, `serveIdleTimeout`. New exports: `ManagedQvacProvider`, `QvacManagedOptions`, `QvacManagedModel`, `QvacExternalOptions`, and the managed error classes (`QvacManagedModeError` + subclasses) with the `QvacManagedErrorCode` union. Requires the optional `@qvac/cli` peer dependency. **External mode is unchanged**; the managed subsystem is dynamically imported only when `mode: 'managed'` is set.
-- **Refreshed model catalog.** Updated the generated provider catalog against the live QVAC registry for the 0.2.0 release, adding 17 OpenAI-compatible model constants with no removals.
+`@qvac/ai-sdk-provider` can now run `qvac serve` for local applications instead of requiring users to start a separate server first. Calling `createQvac({ mode: 'managed', models })` creates an ephemeral serve config, starts the QVAC CLI on a free local port, waits for the OpenAI-compatible endpoint to become healthy, and returns a normal AI SDK provider pointed at that serve.
 
----
+Managed serves are shared by default. If another process requests the same model fleet and config, it attaches to the existing warm serve instead of spawning another process and loading the same model into memory again. A detached runner owns the serve and reaps it after the last consumer exits and the idle timeout expires.
+
+## Lifecycle Improvements
+
+The managed serve lifecycle is designed for coding agents and other local tools that may start, restart, or crash frequently:
+
+- `close()` and `await using` detach the current consumer without killing a serve that another session is still using.
+- `closeOnParentExit` lets plugin hosts clean up when their parent tool exits.
+- Process-group shutdown ensures the serve and its inference worker are terminated together.
+- Connection-refused recovery re-resolves a serve and retries once when the backing process has disappeared before a request starts.
+
+## Friendly Model Catalog
+
+The package now exposes a small public catalog that maps models.dev-style ids, such as `qwen3.5-9b`, to the SDK constants that `qvac serve` loads. This keeps model ids consistent across catalog UIs, provider configuration, and generated serve configs while preserving support for raw SDK constants.
+
+The generated catalog was refreshed against the live QVAC registry for this release, adding 17 OpenAI-compatible model constants with no removals.
+
+## Compatibility
+
+External mode is unchanged and remains the default synchronous path. Managed mode is loaded only when `mode: 'managed'` is used and requires `@qvac/cli` as an optional peer dependency.
 
 ## [0.1.0]
 

--- a/packages/ai-sdk-provider/changelog/0.3.0/CHANGELOG.md
+++ b/packages/ai-sdk-provider/changelog/0.3.0/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog v0.3.0
+
+Release Date: 2026-07-03
+
+## 📦 Models
+
+- Add larger agent models to QVAC catalog. (see PR [#3035](https://github.com/tetherto/qvac/pull/3035)) - See [model changes](./models.md)
+  Added: qwen3.6-27b -> QWEN3_6_27B_MULTIMODAL_Q4_K_XL, qwen3.6-35b-a3b -> QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M, gpt-oss-20b -> GPT_OSS_20B_INST_Q4_K_M, gemma4-31b -> GEMMA4_31B_MULTIMODAL_Q4_K_M
+
+## 📘 Docs
+
+- Update npm package homepage metadata. (see PR [#2810](https://github.com/tetherto/qvac/pull/2810))
+
+## 🧪 Tests
+
+- Add ai-sdk-provider managed integration script. (see PR [#2825](https://github.com/tetherto/qvac/pull/2825))
+
+## 🧹 Chores
+
+- Switch @qvac/ai-sdk-provider to Lunte and Prettier. (see PR [#2816](https://github.com/tetherto/qvac/pull/2816))

--- a/packages/ai-sdk-provider/changelog/0.3.0/CHANGELOG_LLM.md
+++ b/packages/ai-sdk-provider/changelog/0.3.0/CHANGELOG_LLM.md
@@ -1,0 +1,24 @@
+# QVAC AI SDK Provider v0.3.0 Release Notes
+
+Release Date: 2026-07-03
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/ai-sdk-provider/v/0.3.0
+
+## Larger Agent Models in the Catalog
+
+The friendly model catalog now includes larger models aimed at agentic and coding workloads, alongside the existing families:
+
+- `gpt-oss-20b` → `GPT_OSS_20B_INST_Q4_K_M`
+- `gemma4-31b` → `GEMMA4_31B_MULTIMODAL_Q4_K_M`
+- `qwen3.6-27b` → `QWEN3_6_27B_MULTIMODAL_Q4_K_XL`
+- `qwen3.6-35b-a3b` → `QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M`
+
+These ids resolve to model constants already shipped in `@qvac/sdk` 0.14.x, so `qvac serve` can load them directly. Callers can now select these larger models by friendly id in both catalog UIs and generated serve configs.
+
+## Managed Mode Supports CLI 0.8
+
+`@qvac/ai-sdk-provider` now accepts the `@qvac/cli` `0.8.x` line as its optional managed-mode CLI peer, in addition to `0.6.x` and `0.7.x`. Installing the provider alongside CLI 0.8 resolves to the `@qvac/sdk` 0.14.x runtime, which is where the larger catalog models are available.
+
+## Compatibility
+
+External mode is unchanged and remains the default synchronous path. There are no breaking API changes in this release; the catalog additions are additive and existing model ids continue to resolve as before.

--- a/packages/ai-sdk-provider/changelog/0.3.0/models.md
+++ b/packages/ai-sdk-provider/changelog/0.3.0/models.md
@@ -1,0 +1,16 @@
+# 📦 Model Changes v0.3.0
+
+## Added Models
+
+```
+gemma4-31b -> GEMMA4_31B_MULTIMODAL_Q4_K_M
+gpt-oss-20b -> GPT_OSS_20B_INST_Q4_K_M
+qwen3.6-27b -> QWEN3_6_27B_MULTIMODAL_Q4_K_XL
+qwen3.6-35b-a3b -> QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M
+```
+
+---
+
+### Related PRs
+
+- [#3035](https://github.com/tetherto/qvac/pull/3035) - Add larger agent models to QVAC catalog

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ai-sdk-provider",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Vercel AI SDK provider for the QVAC local AI runtime (chat, embeddings, transcription, translation, speech, OCR, image)",
   "author": "Tether",
   "license": "Apache-2.0",
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "@ai-sdk/openai-compatible": "^2.0",
-    "@qvac/cli": "^0.6.0 || ^0.7.0",
+    "@qvac/cli": "^0.6.0 || ^0.7.0 || ^0.8.0",
     "ai": "^6.0"
   },
   "peerDependenciesMeta": {

--- a/packages/ai-sdk-provider/test/managed-integration.test.ts
+++ b/packages/ai-sdk-provider/test/managed-integration.test.ts
@@ -15,7 +15,7 @@ import type { ManagedQvacProvider, QvacManagedOptions } from '../src/types.js'
 const integration = process.env['QVAC_INTEGRATION_TEST'] === '1'
 const MODEL = process.env['QVAC_INTEGRATION_MODEL'] ?? 'QWEN3_600M_INST_Q4'
 
-function managedOptions (): QvacManagedOptions {
+function managedOptions(): QvacManagedOptions {
   return {
     mode: 'managed',
     models: [MODEL],
@@ -24,42 +24,50 @@ function managedOptions (): QvacManagedOptions {
   }
 }
 
-test('managed mode runs an end-to-end chat completion and tears down', { skip: !integration }, async () => {
-  const provider = await createQvac(managedOptions())
+test(
+  'managed mode runs an end-to-end chat completion and tears down',
+  { skip: !integration },
+  async () => {
+    const provider = await createQvac(managedOptions())
 
-  try {
-    assert.ok(provider.port > 0)
-    assert.ok(provider.pid > 0)
+    try {
+      assert.ok(provider.port > 0)
+      assert.ok(provider.pid > 0)
 
-    const { generateText } = await import('ai')
-    const { text } = await generateText({
-      model: provider.chatModel(MODEL),
-      prompt: 'Reply with the single word: pong'
-    })
+      const { generateText } = await import('ai')
+      const { text } = await generateText({
+        model: provider.chatModel(MODEL),
+        prompt: 'Reply with the single word: pong'
+      })
 
-    assert.equal(typeof text, 'string')
-    assert.ok(text.length > 0, 'expected a non-empty completion')
-  } finally {
-    await provider.close()
-  }
-})
-
-test('managed mode reuses a real serve for matching providers', { skip: !integration }, async () => {
-  const providers: ManagedQvacProvider[] = []
-
-  try {
-    const first = await createQvac(managedOptions())
-    providers.push(first)
-
-    const second = await createQvac(managedOptions())
-    providers.push(second)
-
-    assert.equal(second.pid, first.pid)
-    assert.equal(second.port, first.port)
-    assert.equal(second.baseURL, first.baseURL)
-  } finally {
-    for (const provider of providers.reverse()) {
+      assert.equal(typeof text, 'string')
+      assert.ok(text.length > 0, 'expected a non-empty completion')
+    } finally {
       await provider.close()
     }
   }
-})
+)
+
+test(
+  'managed mode reuses a real serve for matching providers',
+  { skip: !integration },
+  async () => {
+    const providers: ManagedQvacProvider[] = []
+
+    try {
+      const first = await createQvac(managedOptions())
+      providers.push(first)
+
+      const second = await createQvac(managedOptions())
+      providers.push(second)
+
+      assert.equal(second.pid, first.pid)
+      assert.equal(second.port, first.port)
+      assert.equal(second.baseURL, first.baseURL)
+    } finally {
+      for (const provider of providers.reverse()) {
+        await provider.close()
+      }
+    }
+  }
+)

--- a/scripts/sdk/generate-changelog-sdk-pod.cjs
+++ b/scripts/sdk/generate-changelog-sdk-pod.cjs
@@ -925,7 +925,7 @@ function rebuildRootChangelog(packageName) {
     let content = fs.readFileSync(versionFile, "utf8").trim();
     // Transform version headers to "## [X.Y.Z]" for aggregated file
     content = content.replace(/^# Changelog v(\d+\.\d+\.\d+)/, "## [$1]");
-    content = content.replace(/^# QVAC SDK v(\d+\.\d+\.\d+) Release Notes/, "## [$1]");
+    content = content.replace(/^# QVAC .+? v(\d+\.\d+\.\d+) Release Notes/, "## [$1]");
     // Rewrite relative links: ./file.md -> ./changelog/VERSION/file.md
     content = content.replace(
       /\(\.\/([^)]+\.md)\)/g,


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@qvac/ai-sdk-provider@0.2.2` predates `@qvac/cli` 0.8.0 and does not expose the
larger agent models that were added to the shared friendly catalog. Managed-mode
users on the CLI 0.8 / SDK 0.14.x runtime cannot install the provider cleanly
(its optional `@qvac/cli` peer only allows `^0.6.0 || ^0.7.0`), and cannot select
the new large models by friendly id. This release publishes both.

## 📝 How does it solve it?

- Bumps `packages/ai-sdk-provider/package.json` version `0.2.2 → 0.3.0`.
- Extends the optional managed-mode peer `@qvac/cli` to `^0.6.0 || ^0.7.0 || ^0.8.0`,
  so strict package managers resolve the provider alongside CLI 0.8 (SDK 0.14.x).
- Ships the `0.3.0` changelog. The friendly catalog now maps four larger models to
  their SDK 0.14.x constants: `gpt-oss-20b → GPT_OSS_20B_INST_Q4_K_M`,
  `gemma4-31b → GEMMA4_31B_MULTIMODAL_Q4_K_M`,
  `qwen3.6-27b → QWEN3_6_27B_MULTIMODAL_Q4_K_XL`,
  `qwen3.6-35b-a3b → QWEN3_6_35B_A3B_MULTIMODAL_Q4_K_M`.
- Generalizes the aggregate `CHANGELOG.md` heading transform so non-SDK pod release
  notes render as `## [x.y.z]` (the form the release-notes verifier requires).
- Applies Prettier to `test/managed-integration.test.ts` so the package passes
  `prettier --check` in the publish build.

The catalog additions are additive; there are no breaking or public API changes in
this release.

## 🧪 How was it tested?

From `packages/ai-sdk-provider` on the release branch:

- `npm run check` — lint (lunte), `prettier --check .`, and typecheck all pass.
- `npm run build` — clean.
- `npm run test:unit` — 77 pass, 2 skipped, 0 fail.
- Verified the built `qvacCatalog` resolves all four new friendly ids
  (`gpt-oss-20b`, `gemma4-31b`, `qwen3.6-27b`, `qwen3.6-35b-a3b`) to their SDK
  model constants.