### PR TITLE
QVAC-20553 chore[skiplog]: backmerge release openclaw-plugin 0.1.0 — first release, changelog, publish workflow

### DIFF
--- a/.github/workflows/trigger-reusable-lib-openclaw-plugin.yml
+++ b/.github/workflows/trigger-reusable-lib-openclaw-plugin.yml
@@ -1,0 +1,326 @@
+name: General CI/CD (openclaw-plugin)
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+      - feature-*
+      - tmp-*
+    paths:
+      - "plugins/openclaw/**"
+  workflow_dispatch:
+    inputs:
+      npm_tag:
+        description: "Optional npm dist-tag override for release branches"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  WORKDIR: plugins/openclaw
+
+jobs:
+  label-gate:
+    name: Authorise (label-gate)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      authorised: ${{ steps.gate.outputs.authorised }}
+    steps:
+      - name: Checkout (label-gate action only)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/actions/label-gate
+          sparse-checkout-cone-mode: false
+
+      - name: Run label-gate
+        id: gate
+        uses: ./.github/actions/label-gate
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+
+  release-merge-guard:
+    name: Release Merge Guard
+    if: >-
+      github.event_name == 'push' && startsWith(github.ref_name, 'release-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/release-merge-guard
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          base-ref: ${{ github.ref_name }}
+          base-sha: ${{ github.event.before }}
+          head-sha: ${{ github.sha }}
+          package-slug: openclaw-plugin
+          package-json-path: plugins/openclaw/package.json
+          changelog-path: plugins/openclaw/CHANGELOG.md
+
+  verify-release-notes:
+    name: Verify release notes
+    if: >-
+      github.event_name == 'push' && startsWith(github.ref_name, 'release-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Verify CHANGELOG section for release version is present and non-empty
+        working-directory: ${{ env.WORKDIR }}
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          changelog_path="CHANGELOG.md"
+
+          if [ ! -s "${changelog_path}" ]; then
+            echo "::error::Missing or empty changelog: ${WORKDIR}/${changelog_path}"
+            exit 1
+          fi
+
+          start_line=$(awk -v version="${version}" '$0 ~ "^## \\[" version "\\]" { print NR; exit }' "${changelog_path}")
+          if [ -z "${start_line}" ]; then
+            echo "::error::Could not find changelog heading '## [${version}]' in ${WORKDIR}/${changelog_path}"
+            exit 1
+          fi
+
+          end_line=$(awk -v start="${start_line}" 'NR > start && /^## \[/ { print NR - 1; found=1; exit } END { if (!found) print NR }' "${changelog_path}")
+          if [ -z "${end_line}" ] || [ "${end_line}" -lt "${start_line}" ]; then
+            echo "::error::Invalid changelog section bounds for version ${version}"
+            exit 1
+          fi
+
+          if ! sed -n "$((start_line + 1)),$((end_line))p" "${changelog_path}" | awk 'BEGIN { has_content=0 } /[^[:space:]]/ { has_content=1 } END { exit has_content ? 0 : 1 }'; then
+            echo "::error::Changelog section for version ${version} is empty; GitHub Release creation would fail after npm publish"
+            exit 1
+          fi
+
+          echo "Release notes for ${version} found and non-empty."
+
+  publish-logic:
+    runs-on: ubuntu-latest
+    outputs:
+      publish_main: ${{ steps.logic.outputs.publish_main }}
+      publish_release: ${{ steps.logic.outputs.publish_release }}
+      publish_feature: ${{ steps.logic.outputs.publish_feature }}
+      publish_tmp: ${{ steps.logic.outputs.publish_tmp }}
+      gpr_tag: ${{ steps.logic.outputs.gpr_tag }}
+      npm_tag: ${{ steps.logic.outputs.npm_tag }}
+    steps:
+      - id: logic
+        shell: bash
+        env:
+          NPM_TAG_INPUT: ${{ inputs.npm_tag }}
+        run: |
+          set -euo pipefail
+          ref_name="${GITHUB_REF_NAME}"
+          event_name="${GITHUB_EVENT_NAME}"
+
+          publish_main="false"
+          publish_release="false"
+          publish_feature="false"
+          publish_tmp="false"
+
+          if [ "$event_name" = "push" ] || [ "$event_name" = "workflow_dispatch" ]; then
+            if [ "$ref_name" = "main" ]; then
+              publish_main="true"
+            elif [[ "$ref_name" == release-* ]]; then
+              publish_release="true"
+            elif [[ "$ref_name" == feature-* ]]; then
+              publish_feature="true"
+            elif [[ "$ref_name" == tmp-* ]]; then
+              publish_tmp="true"
+            fi
+          fi
+
+          gpr_tag="dev"
+          if [ "$ref_name" = "main" ]; then
+            gpr_tag="dev"
+          elif [[ "$ref_name" == feature-* ]]; then
+            gpr_tag="feature"
+          elif [[ "$ref_name" == tmp-* ]]; then
+            gpr_tag="temp"
+          fi
+
+          echo "publish_main=$publish_main" >> "$GITHUB_OUTPUT"
+          echo "publish_release=$publish_release" >> "$GITHUB_OUTPUT"
+          echo "publish_feature=$publish_feature" >> "$GITHUB_OUTPUT"
+          echo "publish_tmp=$publish_tmp" >> "$GITHUB_OUTPUT"
+          echo "gpr_tag=$gpr_tag" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=${NPM_TAG_INPUT}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        working-directory: ${{ env.WORKDIR }}
+        run: npm install
+
+      - name: Run checks
+        working-directory: ${{ env.WORKDIR }}
+        run: npm run lint
+
+      - name: Run tests
+        working-directory: ${{ env.WORKDIR }}
+        run: npm run test:unit
+
+      - name: Build package
+        working-directory: ${{ env.WORKDIR }}
+        run: npm run build
+
+      - name: Upload package dist
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # 7.0.0
+        with:
+          name: openclaw-plugin-dist
+          path: plugins/openclaw/dist
+          if-no-files-found: error
+
+  publish-main-gpr-dev:
+    needs:
+      - publish-logic
+      - label-gate
+      - build
+    if: needs.label-gate.outputs.authorised == 'true' && needs.publish-logic.outputs.publish_main == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Download package dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: openclaw-plugin-dist
+          path: plugins/openclaw/dist
+
+      - name: Publish to GitHub Packages (dev)
+        uses: ./.github/actions/publish-library-to-gpr
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          workdir: plugins/openclaw
+          name-suffix: "-mono"
+
+  publish-release-npm:
+    needs:
+      - publish-logic
+      - release-merge-guard
+      - verify-release-notes
+      - label-gate
+      - build
+    if: |-
+      needs.label-gate.outputs.authorised == 'true' && (always() && needs.publish-logic.outputs.publish_release == 'true' && (needs.release-merge-guard.result == 'success' || needs.release-merge-guard.result == 'skipped') && (needs.verify-release-notes.result == 'success' || needs.verify-release-notes.result == 'skipped'))
+    runs-on: ubuntu-latest
+    environment: npm
+    outputs:
+      published_version: ${{ steps.publish-npm.outputs.npm_published_version }}
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download package dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: openclaw-plugin-dist
+          path: plugins/openclaw/dist
+
+      - name: Publish to NPM
+        id: publish-npm
+        uses: ./.github/actions/publish-library-to-npm
+        with:
+          tag: ${{ needs.publish-logic.outputs.npm_tag }}
+          workdir: plugins/openclaw
+
+  publish-release:
+    needs: [publish-release-npm]
+    if: needs.publish-release-npm.result == 'success' && needs.publish-release-npm.outputs.published_version != ''
+    permissions:
+      contents: write
+    uses: ./.github/workflows/create-github-release.yml
+    with:
+      repo_name: "openclaw-plugin"
+      release_name: "QVAC OpenClaw Plugin"
+      published_version: ${{ needs.publish-release-npm.outputs.published_version }}
+      prev_sha: ${{ github.event.before }}
+      workdir: "plugins/openclaw"
+
+  publish-feature-gpr:
+    needs:
+      - publish-logic
+      - label-gate
+      - build
+    if: needs.label-gate.outputs.authorised == 'true' && needs.publish-logic.outputs.publish_feature == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Download package dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: openclaw-plugin-dist
+          path: plugins/openclaw/dist
+
+      - name: Publish to GitHub Packages (feature)
+        uses: ./.github/actions/publish-library-to-gpr
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          workdir: plugins/openclaw
+          name-suffix: "-mono"
+
+  publish-tmp-gpr:
+    needs:
+      - publish-logic
+      - label-gate
+      - build
+    if: needs.label-gate.outputs.authorised == 'true' && needs.publish-logic.outputs.publish_tmp == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Download package dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # 8.0.1
+        with:
+          name: openclaw-plugin-dist
+          path: plugins/openclaw/dist
+
+      - name: Publish to GitHub Packages (tmp)
+        uses: ./.github/actions/publish-library-to-gpr
+        with:
+          secret-token: ${{ secrets.GITHUB_TOKEN }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          tag: ${{ needs.publish-logic.outputs.gpr_tag }}
+          workdir: plugins/openclaw
+          name-suffix: "-mono"

--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## [0.1.0]
+
+Release Date: 2026-07-03
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.1.0
+
+The first public release of `@qvac/openclaw-plugin` — an [OpenClaw](https://openclaw.ai) provider plugin that runs a local, fully managed QVAC serve so OpenClaw works against on-device models with no separate server to start.
+
+### Added
+
+- **Local QVAC provider for OpenClaw.** Registers a `qvac` provider that OpenClaw drives through its `localService` launcher: the plugin starts `qvac serve` on a loopback port, exposes an OpenAI-compatible endpoint, waits for it to become healthy, and tears it down on OpenClaw's idle/exit lifecycle.
+- **Friendly model catalog.** Ships a static model catalog and OpenClaw wizard/model-picker entries using models.dev-style ids (e.g. `qwen3.5-9b`), with the friendly-id → QVAC constant mapping resolved through [`@qvac/ai-sdk-provider`](https://www.npmjs.com/package/@qvac/ai-sdk-provider)'s shared catalog. Defaults to `qwen3.5-9b`.
+- **Larger agent models.** The catalog includes the larger agent-oriented families in addition to the Qwen3.5 line: `qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, and `gemma4-31b`, each mapped to its `@qvac/sdk` model constant.
+- **Layered configuration.** A `configSchema` resolves options from plugin config and defaults: `model`, `host`, `port`, `baseUrl`, `apiKey`, `qvacCommand`, `cwd`, `ctxSize`, `reasoningBudget`, `tools`, `readyTimeoutMs`, `idleStopMs`, and `timeoutSeconds`.
+
+### Requirements
+
+- [`@qvac/ai-sdk-provider@^0.3.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for the shared model catalog and managed serve.
+- [`@qvac/cli@^0.8.0`](https://www.npmjs.com/package/@qvac/cli) so the local service can run `qvac serve` (SDK 0.14.x runtime).
+- [`openclaw@>=2026.6.0`](https://www.npmjs.com/package/openclaw) as the host (optional peer).

--- a/plugins/openclaw/changelog/0.1.0/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.1.0/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.1.0
+
+Release Date: 2026-07-03
+
+## ✨ Features
+
+- Add `@qvac/openclaw-plugin`: an OpenClaw provider plugin that runs a local, managed `qvac serve` so OpenClaw works against on-device QVAC models. (see PR [#2835](https://github.com/tetherto/qvac/pull/2835))
+- Add the larger agent models (`qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, `gemma4-31b`) to the plugin catalog. (see PR [#3035](https://github.com/tetherto/qvac/pull/3035))

--- a/plugins/openclaw/changelog/0.1.0/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.1.0/CHANGELOG_LLM.md
@@ -1,0 +1,19 @@
+# QVAC OpenClaw Plugin v0.1.0 Release Notes
+
+Release Date: 2026-07-03
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.1.0
+
+The first public release of `@qvac/openclaw-plugin` — an [OpenClaw](https://openclaw.ai) provider plugin that runs a local, fully managed QVAC serve so OpenClaw works against on-device models with no separate server to start.
+
+## Local QVAC Provider for OpenClaw
+
+The plugin registers a `qvac` provider that OpenClaw drives through its `localService` launcher. On use it starts `qvac serve` on a loopback port, exposes an OpenAI-compatible endpoint, waits for it to become healthy, and reaps it on OpenClaw's idle/exit lifecycle. It also contributes OpenClaw wizard and model-picker entries so QVAC can be selected like any other provider.
+
+## Model Catalog With Larger Agent Models
+
+The plugin ships a static model catalog using models.dev-style ids, resolving each friendly id to its `@qvac/sdk` model constant through `@qvac/ai-sdk-provider`'s shared catalog. Alongside the Qwen3.5 line it exposes the larger agent-oriented families — `qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, and `gemma4-31b` — which resolve to model constants shipped in `@qvac/sdk` 0.14.x. The default model is `qwen3.5-9b`.
+
+## Requirements
+
+This release targets the current agent stack: `@qvac/ai-sdk-provider` `^0.3.0` (shared catalog and managed serve), `@qvac/cli` `^0.8.0` (runs `qvac serve` on the SDK 0.14.x runtime), and `openclaw` `>=2026.6.0` as the optional host peer.

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -57,8 +57,8 @@
     "dev:link": "npm install ../../packages/ai-sdk-provider ../../packages/cli"
   },
   "dependencies": {
-    "@qvac/ai-sdk-provider": "^0.2.2",
-    "@qvac/cli": "^0.7.0"
+    "@qvac/ai-sdk-provider": "^0.3.0",
+    "@qvac/cli": "^0.8.0"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@qvac/openclaw-plugin@0.1.0` is being published from `release-openclaw-plugin-0.1.0`
(companion release PR #3048). Without this backmerge, `main` would lack the plugin's
release metadata and its publish workflow, and its changelog history would start
without the `0.1.0` entry.

Tagged `[skiplog]` — the `0.1.0` changelog is authored on the release branch, so
this backmerge must not generate another entry from `main`.

## 📝 How does it solve it?

Lands the first-release metadata for `@qvac/openclaw-plugin@0.1.0` on `main`:

- `plugins/openclaw/package.json` — dependencies `@qvac/ai-sdk-provider ^0.3.0`
  and `@qvac/cli ^0.8.0`
- `plugins/openclaw/changelog/0.1.0/` — generated changelog files
- `plugins/openclaw/CHANGELOG.md` — aggregated changelog
- `.github/workflows/trigger-reusable-lib-openclaw-plugin.yml` — the package's
  publish pipeline (needed on `main` for dev/GPR builds and future releases)

Companion release PR: #3048

## 🧪 How was it tested?

Verified on the release branch (`plugins/openclaw`): `npm run lint` (tsc),
`npm run test:unit` (16 pass), and `npm run build` all green with the local
`@qvac/ai-sdk-provider` 0.3.0 catalog linked. Metadata + workflow only; no plugin
runtime changes.

> **Backmerge ordering:** merge the provider backmerge #3047 first (it bumps the
> workspace `@qvac/ai-sdk-provider` to `0.3.0`) so `main`'s workspace satisfies
> this plugin's `^0.3.0` dependency range.