### PR TITLE
test[notask]: ci-router label-order probe (A: stages-first)

### DIFF
--- a/packages/diffusion-cpp/.ci-label-order-test
+++ b/packages/diffusion-cpp/.ci-label-order-test
@@ -1,0 +1,5 @@
+CI label-order test marker (throwaway).
+
+This file exists only to trigger the diffusion-cpp PR workflow so we can
+observe the ci-router routing decision under different label-application
+orders. Safe to delete. PR variant: A (stage labels applied first, verified last).


### PR DESCRIPTION
Throwaway PR to verify diffusion-cpp CI stage routing is independent of label-application order. Variant A: stage labels applied first, verified last. Safe to close + delete.

Made with [Cursor](https://cursor.com)