### PR TITLE
test[notask]: ci-router label-order probe (B: verified-first)

### DIFF
--- a/packages/diffusion-cpp/.ci-label-order-test
+++ b/packages/diffusion-cpp/.ci-label-order-test
@@ -1,0 +1,5 @@
+CI label-order test marker (throwaway).
+
+This file exists only to trigger the diffusion-cpp PR workflow so we can
+observe the ci-router routing decision under different label-application
+orders. Safe to delete. PR variant: B (verified applied first, stage labels last).


### PR DESCRIPTION
Throwaway PR to verify diffusion-cpp CI stage routing is independent of label-application order. Variant B: verified applied first, stage labels last. Safe to close + delete.

Made with [Cursor](https://cursor.com)