### PR TITLE
test[notask]: prebuild-reuse flow probe

### DIFF
--- a/packages/diffusion-cpp/.ci-flow-test
+++ b/packages/diffusion-cpp/.ci-flow-test
@@ -5,3 +5,7 @@ prebuild builds the matrix, prebuild-artifact-save writes the per-PR
 reuse marker, then a subsequent non-native push reuses it (prebuild
 skipped) while tests still run. Simulates the flow Nik exercised.
 Safe to delete.
+
+Commit 2 — non-native change (simulates a js-only / merge-main push).
+Should reuse the prebuild from commit 1 and skip the prebuild matrix
+while tests still run.

--- a/packages/diffusion-cpp/.ci-flow-test
+++ b/packages/diffusion-cpp/.ci-flow-test
@@ -1,0 +1,7 @@
+CI prebuild-reuse flow test marker (throwaway) — commit 1.
+
+Purpose: validate the full diffusion-cpp CI flow end-to-end —
+prebuild builds the matrix, prebuild-artifact-save writes the per-PR
+reuse marker, then a subsequent non-native push reuses it (prebuild
+skipped) while tests still run. Simulates the flow Nik exercised.
+Safe to delete.


### PR DESCRIPTION
Throwaway PR validating the diffusion-cpp prebuild -> save -> reuse -> tests flow end-to-end (simulates Nik's flow). Commit 1 builds + saves; commit 2 (non-native) should reuse and skip prebuild while tests run. No mobile label (protects Device Farm). Safe to close + delete.

Made with [Cursor](https://cursor.com)