### PR TITLE
infra[notask]: migrate inference-addon-cpp native test workflow to self-hosted runners

### DIFF
--- a/.github/workflows/pr-test-inference-addon-cpp.yml
+++ b/.github/workflows/pr-test-inference-addon-cpp.yml
@@ -106,20 +106,6 @@ jobs:
         with:
           workdir: ${{ env.PKG_DIR }}
 
-      - if: ${{ matrix.os == 'ubuntu-22.04' }}
-        name: Maximize build space
-        run: |
-          sudo docker image prune --all --force
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/share/dotnet
-
-      - if: ${{ matrix.os == 'ubuntu-22.04' && matrix.arch == 'arm64' }}
-        name: Install tooling for cross compilation - ubuntu arm64
-        run: |
-          sudo apt update
-          sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross lld
-
       - if: ${{ matrix.os == 'windows-2025' }}
         name: setup cmake windows
         run: |


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `Test pipeline for PRs (Inference-addon-cpp)` fails on every real run whenever the native build matrix executes on our self-hosted Ubuntu runners (`qvac-ubuntu2204-x64`). The `Maximize build space` step calls `sudo`, but the self-hosted runner user is unprivileged (no passwordless sudo), so it dies immediately with `sudo: a password is required` — failing the `linux-x64` and `android-arm64` jobs before any build runs (e.g. runs `28671541000` and `28780150302` on PR #2990).

- The workflow was never migrated to the self-hosted runner pattern its sibling `pr-test-inference-addon-cpp-js.yml` (same runner) and the `integration-test-*` / `cpp-tests-*` workflows already follow — it still carries GitHub-hosted-only idioms that are dead/harmful on bare metal.

## 📝 How does it solve it?

- Removes the two `sudo`-based steps that only ever target the self-hosted `qvac-ubuntu2204-x64` runner (this workflow's matrix has no GitHub-hosted Ubuntu entry, so neither step had a valid execution path):
  - `Maximize build space` — a GitHub-hosted disk-freeing hack (`sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL`, docker prune). Meaningless on the bare-metal Hetzner boxes, where those paths don't exist and disk is ample.
  - `Install tooling for cross compilation - ubuntu arm64` — `sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross lld`. These are already baked into the runner image at provisioning time, so the job-time install is redundant.

- Mirrors the already-migrated JS twin, which runs on the same runner with no `sudo` and guards its self-hosted-only cleanup with `runner.environment != 'github-hosted'`. No runner reconfiguration and no granting of `sudo` (which would regress the unprivileged-runner security model).

## 🧪 How was it tested?

- `actionlint` on the modified workflow: finding count unchanged vs `main` (24 → 24; all pre-existing shellcheck notes on the untouched Windows/macOS PowerShell steps). No new findings introduced, none removed.
- Verified the removed apt packages (`gcc-aarch64-linux-gnu`, `g++-aarch64-linux-gnu`, `libc6-dev-arm64-cross`, `lld`) are pre-installed by the runner provisioning script (`gh-self-hosted-runners/runners_scripts/install-runner-tools-2204.sh`, lines 27–28), so cross-compilation still resolves.
- Confirmed no `sudo` remains in the workflow and that job/step names are unchanged, so branch-protection required status checks (`linux-x64`, `android-arm64`, …) are unaffected.
- Final gate: this PR's own CI — the `linux-x64` and `android-arm64` native jobs should now proceed past setup into build/test on the self-hosted runners.

Made with [Cursor](https://cursor.com)