### PR TITLE
QVAC-21318 chore: bump llm-llamacpp to 0.31.2

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.32.0] - 2026-07-06
+
+### Added
+
+- KV-cache auto-default: when the caller does not set `cache-type-k`/`cache-type-v`, both now default to `q8_0` on Metal and Vulkan GPUs (with flash attention on) — quality-neutral vs `f16` and ~47% smaller KV cache. CPU and OpenCL (Adreno) keep the `f16` default (ARM CPU `q8_0` has a measured quality/throughput cost; quantized KV-cache shifts abort on Adreno). Skipped for finetuning, when flash attention is off, and on Adreno+Vulkan. An explicit user cache type is always respected on CPU/Vulkan/Metal.
+- Mixed/asymmetric K≠V warning: when `cache-type-k` and `cache-type-v` differ and at least one side is quantized, the addon logs a warning (asymmetric quantized K/V falls off the fused flash-attention path — a notable GPU decode penalty for no quality benefit) but proceeds.
+- Adreno 800+ Vulkan guard: quantized KV with flash attention on an Adreno Vulkan backend is rejected with a clean `StatusError` instead of a native abort (defensive — Adreno selects OpenCL by default).
+
+### Changed
+
+- OpenCL (Adreno) KV-cache rejection now carries an actionable message: only `f32`/`f16`/`bf16` are accepted, and any quantized type (`q8_0`, `q4_0`, …) throws a `StatusError` explaining that a quantized K or V cache aborts in `llama_kv_cache::update` on KV-cache shifts (ggml-opencl has no `F32→quantized` requantize kernel; CI-confirmed for both `q8_0` and `q4_0`).
+- The KV-cache guards read flash-attention state from both the `flash-attn` and `flash_attn` config keys, so the underscore variant arms the auto-default and the Adreno guard.
+- README documents the KV-cache type policy (`cache-type-k`/`cache-type-v` rows + the auto-default, OpenCL allowlist, and mixed-K/V warning).
+
+### Pull Requests
+
+- [#2921](https://github.com/tetherto/qvac/pull/2921) - QVAC-21318 feat: default KV-cache to q8_0 on GPU backends except OpenCL
+
 ## [0.31.1] - 2026-07-01
 
 ### Changed

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.31.1",
+  "version": "0.32.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Releases the merged QVAC-21318 change ([#2921](https://github.com/tetherto/qvac/pull/2921) — KV-cache q8_0 auto-default on Metal/Vulkan GPU, OpenCL quantized-KV rejection, mixed-K/V warning, Adreno 800+ Vulkan guard) by bumping `@qvac/llm-llamacpp` so the on-merge automation publishes it.

## 📝 How does it solve it?

- `packages/llm-llamacpp/package.json`: `0.31.1` → `0.31.2`.
- `packages/llm-llamacpp/CHANGELOG.md`: new `[0.31.2]` section covering the auto-default (q8_0 on Metal/Vulkan with flash attention; CPU and OpenCL keep `f16`), the OpenCL rejection of all quantized KV types with an actionable shift-crash message, the mixed/asymmetric K≠V warning, the Adreno 800+ Vulkan guard, and the `flash-attn`/`flash_attn` dual-key handling.

No code changes — changelog + version bump only.

## 🧪 How was it tested?

- #2921 was validated pre-merge: full labeled CI green (cpp-tests Linux/macOS/Windows, all prebuilds, Android S25/S26/Pixel 9 + iOS Device Farm, merge-guard), 82/82 `TuneConfigMapTest`.
- `package.json` parses; changelog follows the package's established format (read by `on-merge-llm-llamacpp.yml` via `changelog-path`).
