### PR TITLE
QVAC-21396 feat[api]: bump qvac-fabric to 9341.1.4 (classification-ggml)

### DIFF
--- a/packages/classification-ggml/vcpkg.json
+++ b/packages/classification-ggml/vcpkg.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "qvac-fabric",
-      "version>=": "9341.1.3",
+      "version>=": "9341.1.4",
       "default-features": false,
       "features": [
         "gpu-backends"


### PR DESCRIPTION
Bumps qvac-fabric to 9341.1.4.

Fabric PR: https://github.com/tetherto/qvac-fabric-llm.cpp/pull/175
Registry PR: https://github.com/tetherto/qvac-registry-vcpkg/pull/231
