### PR TITLE
QVAC-21396 feat[api]: bump qvac-fabric to 9341.1.4 (llm-llamacpp)

### DIFF
--- a/packages/llm-llamacpp/vcpkg.json
+++ b/packages/llm-llamacpp/vcpkg.json
@@ -9,7 +9,7 @@
     "concurrentqueue",
     {
       "name": "qvac-fabric",
-      "version>=": "9341.1.3"
+      "version>=": "9341.1.4"
     },
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
Bumps qvac-fabric to 9341.1.4.

Fabric PR: https://github.com/tetherto/qvac-fabric-llm.cpp/pull/175
Registry PR: https://github.com/tetherto/qvac-registry-vcpkg/pull/231
Overlay validation: https://github.com/tetherto/qvac/pull/2962
