### PR TITLE
QVAC-21396 feat[api]: bump qvac-fabric to 9341.1.4 (ocr-ggml)

### DIFF
--- a/packages/ocr-ggml/vcpkg.json
+++ b/packages/ocr-ggml/vcpkg.json
@@ -20,7 +20,7 @@
     {
       "name": "qvac-fabric",
       "default-features": false,
-      "version>=": "9341.1.3",
+      "version>=": "9341.1.4",
       "features": [
         "gpu-backends"
       ]


### PR DESCRIPTION
Bumps qvac-fabric to 9341.1.4.

Fabric PR: https://github.com/tetherto/qvac-fabric-llm.cpp/pull/175
Registry PR: https://github.com/tetherto/qvac-registry-vcpkg/pull/231
