### PR TITLE
QVAC-21396 feat[api]: bump qvac-fabric to 9341.1.4 (vla-ggml)

### DIFF
--- a/packages/vla-ggml/vcpkg.json
+++ b/packages/vla-ggml/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "9341.1.3",
+      "version>=": "9341.1.4",
       "features": [
         "hip-backend"
       ]


### PR DESCRIPTION
Bumps qvac-fabric to 9341.1.4.

Fabric PR: https://github.com/tetherto/qvac-fabric-llm.cpp/pull/175
Registry PR: https://github.com/tetherto/qvac-registry-vcpkg/pull/231
