### PR TITLE
QVAC-19557 tts-ggml: consume tts-cpp 2026-07-06 (Chatterbox S25/Adreno GPU-load fix)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Chatterbox no longer crashes at load on Samsung S25 / Adreno GPU.** The
+  multilingual model's quantized weights were uploaded to the OpenCL backend in
+  partial pieces, which the backend read past and faulted on at model load.
+  Quantized weights are now uploaded whole. Bumps the `tts-cpp` requirement to
+  `2026-07-06`.
+
 ## [0.4.0] - 2026-07-03
 
 ### Changed

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-07-03#2"
+      "version>=": "2026-07-06"
     }
   ],
   "features": {


### PR DESCRIPTION
Version-only bump of `tts-cpp` to `2026-07-06`, which fixes the Chatterbox Samsung S25 / Adreno GPU-load crash (`runChatterboxKvCacheGpuTest`).

**Root cause:** the OpenCL Q4_0/Q8_0 SOA `set_tensor` reads the whole `ggml_nbytes` from `data` and ignores `(offset, size)`, so the multilingual loader's partial (stacked-`wqkv`) and chunked (`gguf_stream`) quantized uploads over-read and SIGSEGV on Adreno at load. Fixed in tts-cpp by uploading quantized weights whole (qvac-ext-lib-whisper.cpp #79).

**Validation (on-device, pre-merge):** Samsung S25 Ultra 10/10, Pixel 9 Pro 10/10 — https://github.com/tetherto/qvac/actions/runs/28673004011

Baseline is unchanged (version-only, per convention); `2026-07-06` resolves from the registry version DB.

**Depends on** qvac-registry-vcpkg#232 (publishes `tts-cpp 2026-07-06`) — merge that first; this PR's CI goes green once it's on registry `main`.