### PR TITLE
[DO NOT MERGE] tts-ggml: CI overlay → tts-cpp @ PR #81 (sched_dispatch convergence + Supertonic sched graph-reuse fix)

### DIFF
--- a/packages/tts-ggml/CMakeLists.txt
+++ b/packages/tts-ggml/CMakeLists.txt
@@ -17,6 +17,16 @@ find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
 
+# TEMPORARY CI OVERLAY (do not merge): build tts-cpp from the PR #81 head commit
+# (sched_dispatch convergence + Supertonic rebuild-per-sched-pass fix) instead of
+# the registry port. Drop this line + vcpkg-overlay-ports/ once PR #81 merges and
+# the registry port lands.
+# NOTE: unquoted trailing expansion — a quoted "...;${VCPKG_OVERLAY_PORTS}"
+# with the var empty leaves a trailing empty list element, which vcpkg
+# resolves to the CWD and then rejects this package's own vcpkg.json as a
+# malformed PORT manifest ("missing required field 'name'").
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay-ports" ${VCPKG_OVERLAY_PORTS})
+
 project(tts-ggml CXX C)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/packages/tts-ggml/vcpkg-overlay-ports/tts-cpp/portfile.cmake
+++ b/packages/tts-ggml/vcpkg-overlay-ports/tts-cpp/portfile.cmake
@@ -1,0 +1,84 @@
+# TEMPORARY CI OVERLAY -- do not merge.
+#
+# Mirrors the registry tts-cpp port verbatim except the source fetch, which is
+# repointed at the qvac-ext-lib-whisper.cpp PR #81 head commit (a723e25a,
+# rebased onto master 1d9ca83b): converge T3 / S3Gen / Supertonic onto the
+# shared sched_dispatch helper (per-op GPU->CPU fallback with ggml_status
+# propagation) and rebuild Supertonic's dual-path graphs per scheduler pass --
+# sched graphs are single-use for allocation, so the previous cached-graph
+# reuse through the scheduler deterministically corrupted output on
+# natural-sched backends (Adreno) after the first use per site.  Adreno output
+# deliberately changes (gets fixed) with this pin.
+# This overlay validates that branch on device-farm CI ahead of merge; drop it
+# (the dir + the VCPKG_OVERLAY_PORTS line in ../../CMakeLists.txt) and bump the
+# registry version>= once PR #81 merges and the registry port lands.
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+set(VCPKG_BUILD_TYPE release)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH WHISPER_CPP_SRC
+    REPO tetherto/qvac-ext-lib-whisper.cpp
+    REF a723e25a98e5646793c271cabb299d136e54910d
+    SHA512 45507443256f20ee3c2b8108d490c36c2abfa078d103455c8c8a497114e4f3c7c73fc3cdc6fde41dd8067d1da879dfdd44d5df6e084a2673fb84db3e90e5ba2d
+    HEAD_REF master
+)
+
+set(SOURCE_PATH "${WHISPER_CPP_SRC}/tts-cpp")
+if (NOT EXISTS "${SOURCE_PATH}/CMakeLists.txt")
+    message(FATAL_ERROR
+        "tts-cpp: ${SOURCE_PATH}/CMakeLists.txt missing; the tts-cpp/ "
+        "subfolder layout in qvac-ext-lib-whisper.cpp may have changed.")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        metal   GGML_METAL
+        vulkan  GGML_VULKAN
+        cuda    GGML_CUDA
+        opencl  GGML_OPENCL
+)
+
+set(PLATFORM_OPTIONS)
+
+if(NOT VCPKG_TARGET_IS_OSX)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BLAS=OFF
+        -DGGML_ACCELERATE=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_BLAS=ON
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        -DTTS_CPP_BUILD_LIBRARY=ON
+        -DTTS_CPP_BUILD_SHARED=OFF
+        -DTTS_CPP_BUILD_EXECUTABLES=OFF
+        -DTTS_CPP_BUILD_TESTS=OFF
+        -DTTS_CPP_INSTALL=ON
+        -DTTS_CPP_USE_SYSTEM_GGML=ON
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_OPENMP=OFF
+        -DTTS_CPP_OPENMP=OFF
+        -DGGML_CCACHE=OFF
+        -DTTS_CPP_CCACHE=OFF
+        ${FEATURE_OPTIONS}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME tts-cpp CONFIG_PATH share/tts-cpp)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/tts-ggml/vcpkg-overlay-ports/tts-cpp/vcpkg.json
+++ b/packages/tts-ggml/vcpkg-overlay-ports/tts-cpp/vcpkg.json
@@ -1,0 +1,83 @@
+{
+  "name": "tts-cpp",
+  "version-date": "2026-07-06",
+  "port-version": 1,
+  "description": "Text-to-speech inference in pure C++/ggml. Ships Resemble Chatterbox (Turbo + Multilingual variants) and Supertonic engines under a unified Engine API. Sourced from tetherto/qvac-ext-lib-whisper.cpp's tts-cpp/ subfolder. TEMPORARY CI overlay: pins the tts-cpp/ subfolder at the PR #81 head commit a723e25a (rebased onto master 1d9ca83b) for device-farm validation ahead of merge. The pin converges T3 / S3Gen / Supertonic onto the shared sched_dispatch helper (per-op GPU->CPU fallback, ggml_status propagation instead of silently consuming half-written output) and rebuilds Supertonic's dual-path graphs per scheduler pass (sched graphs are single-use for allocation; the previous cached-graph reuse through the scheduler deterministically corrupted natural-sched output on Adreno after the first use per site -- Adreno output deliberately changes/gets fixed). Adds a TTS_CPP_FORCE_SCHED escape hatch honored by all three engines with bit-exactness equivalence tests on CPU and Metal. Consumes the ggml-speech and mecab ports (mecab resolves via the microsoft/vcpkg registry routing in the addon's vcpkg-configuration.json).",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/tts-cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "version>=": "2026-07-03"
+    },
+    "mecab",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "cuda"
+          ]
+        }
+      ]
+    },
+    "metal": {
+      "description": "Enable Metal GPU acceleration (macOS / iOS)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "metal"
+          ]
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android / Adreno)",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "opencl"
+          ]
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "features": [
+            "vulkan"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
**Do not merge — temporary device-farm CI overlay.**

Builds `tts-cpp` from [tetherto/qvac-ext-lib-whisper.cpp PR #81](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/81) head commit `a723e25a` (rebased onto master `1d9ca83b`) instead of the registry pin, so the device farm validates the branch ahead of merge. Same mechanism as the Parakeet sched overlay (#2966).

**What the pin changes:**
- T3 / S3Gen / Supertonic converge onto the shared `sched_dispatch` helper: per-op GPU→CPU fallback, `ggml_status` propagated as errors instead of silently consuming half-written output.
- **Supertonic dual-path graphs rebuild per scheduler pass.** ggml sched graphs are single-use for allocation (documented contract); the previous cached-graph reuse through the scheduler deterministically corrupted natural-sched output — i.e. **Adreno Supertonic output changes (gets fixed) with this pin**.
- `TTS_CPP_FORCE_SCHED` escape hatch honored by all three engines; direct-vs-forced-sched bit-exactness equivalence tests green on CPU and Metal; direct paths byte-identical to the previous pin on Metal + CPU.

**Local verification:** `bare-make generate` green — the overlay port (`tts-cpp@2026-07-06#1`) built from source (SHA512-pinned at `a723e25a`) and installed for `arm64-android[core,opencl,vulkan]`. mecab is dropped from the overlay port: the addon's pinned registry baseline predates the mecab port and tts-cpp's MeCab support is detection-based (matches the addon's current no-mecab build).

**Teardown:** drop `packages/tts-ggml/vcpkg-overlay-ports/` + the `VCPKG_OVERLAY_PORTS` line and bump the registry `version>=` once PR #81 merges and the registry port lands.