### PR TITLE
infra[notask]: bootstrap fresh vcpkg per job on Windows runners

### DIFF
--- a/.github/actions/setup-vcpkg/action.yml
+++ b/.github/actions/setup-vcpkg/action.yml
@@ -1,7 +1,7 @@
 name: Setup vcpkg
 description: >-
-  Point VCPKG_ROOT at the runner's pre-installed vcpkg (Linux, Windows) or do
-  a shallow blobless sparse bootstrap (macOS), pin policy env vars
+  Point VCPKG_ROOT at the runner's pre-installed vcpkg (Linux) or do a
+  shallow blobless sparse bootstrap (macOS, Windows), pin policy env vars
   (VCPKG_BUILD_TYPE=release to skip debug libs, --no-parallel-configure to
   stabilize Visual Studio / Apple toolchain configuration), and enable the
   shared S3-backed binary cache.
@@ -47,16 +47,26 @@ runs:
       run: echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> "$GITHUB_ENV"
 
     - if: ${{ runner.os == 'Windows' }}
-      name: Configure vcpkg on Windows
+      name: Bootstrap vcpkg on Windows
       shell: powershell
       run: |
-        if (-not $env:VCPKG_INSTALLATION_ROOT -or -not (Test-Path $env:VCPKG_INSTALLATION_ROOT)) {
-          Write-Error "VCPKG_INSTALLATION_ROOT is not set or does not exist; expected a pre-installed vcpkg on the runner"
-          exit 1
-        }
-        $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT -replace '\\', '/'
+        # The pre-installed vcpkg on the self-hosted Windows runners predates
+        # Visual Studio 2026: its bundled CMake does not know the
+        # "Visual Studio 18 2026" generator (needed by MSBuild-based ports
+        # such as mecab) and it cannot compute binary-cache ABIs for the
+        # v145 toolset. Bootstrap a current vcpkg per job instead, mirroring
+        # the macOS step above.
+        if (Test-Path vcpkg) { Remove-Item -Recurse -Force vcpkg }
+        git clone --depth=1 --filter=blob:none --sparse https://github.com/microsoft/vcpkg.git
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        cd vcpkg
+        git sparse-checkout set --no-cone '/*' '!/ports' '!/versions'
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        .\bootstrap-vcpkg.bat -disableMetrics
+        if ($LASTEXITCODE -ne 0) { exit 1 }
+        $vcpkgRoot = (Get-Location).Path -replace '\\', '/'
         echo "VCPKG_ROOT=$vcpkgRoot" >> $env:GITHUB_ENV
-        echo $vcpkgRoot >> $env:GITHUB_PATH
+        echo (Get-Location).Path >> $env:GITHUB_PATH
 
     - name: Export vcpkg policy env
       shell: bash


### PR DESCRIPTION
## Problem

Every `tts-ggml` (and `tts-onnx`) win32-x64 prebuild has been failing since 2026-07-03, on PRs and on `main`, with:

```
CMake Error: Could not create named generator Visual Studio 18 2026
error: building mecab:x64-windows failed with: BUILD_FAILED
```

Root cause: the pre-installed vcpkg on the self-hosted `qvac-win25-x64-*` Windows runners predates Visual Studio 2026. Its bundled CMake 3.31.10 does not know the `Visual Studio 18 2026` generator required by MSBuild-based ports (mecab is the only such port in our dependency trees), and it cannot compute binary-cache ABI hashes for the v145 toolset — so mecab can neither be restored from the S3 cache (no cache key) nor built from source. Passing runs before 2026-07-03 were binary-cache hits served under a key that only one runner's vcpkg could still compute; whether a job passed depended on which runner picked it up.

## Fix

Bootstrap a current vcpkg per job on Windows (shallow blobless sparse clone + `bootstrap-vcpkg.bat`), mirroring what the macOS step already does, instead of pointing `VCPKG_ROOT` at per-machine pre-installed state. A current vcpkg fetches CMake 4.3.x, which drives VS 2026 fine and hashes the v145 toolset, so ports get cache keys and the S3 cache works again. This also removes the dependency on per-runner vcpkg freshness entirely.

Setup cost is ~1 minute per Windows job (few-MB clone; ports/ and versions/ are excluded since the project registries and S3 cache provide everything).

## Validation

Verified via `workflow_dispatch` of `On PR Trigger (TTS GGML)` on a branch carrying this change: the win32-x64 prebuild bootstrapped vcpkg, downloaded CMake 4.3.3, computed a package ABI for mecab, built it in 27s under VS 2026, and went green — first green tts-ggml win32 prebuild since 2026-07-03. Run: https://github.com/tetherto/qvac/actions/runs/28799596139

The mecab binary is now in the S3 cache, so once this is live, win32 jobs restore it in milliseconds.

## Note for reviewers

`reusable-prebuilds.yml` pins this action by commit SHA (`setup-vcpkg@98990f3d…`). A one-line follow-up PR must bump that pin to this PR's merge commit once merged — until then the fix is inert (`pull_request_target` workflows always resolve from `main`, which is also why this could only be validated via `workflow_dispatch`).

Expect a one-time cache repopulation: the new vcpkg computes different ABI hashes, so the first Windows job per package rebuilds its ports and reseeds the S3 cache (tts-ggml is already seeded).
