### PR TITLE
QVAC-20553 chore[skiplog]: backmerge release openclaw-plugin 0.1.0

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## [0.1.0]
+
+Release Date: 2026-07-03
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.1.0
+
+The first public release of `@qvac/openclaw-plugin` — an [OpenClaw](https://openclaw.ai) provider plugin that runs a local, fully managed QVAC serve so OpenClaw works against on-device models with no separate server to start.
+
+### Added
+
+- **Local QVAC provider for OpenClaw.** Registers a `qvac` provider that OpenClaw drives through its `localService` launcher: the plugin starts `qvac serve` on a loopback port, exposes an OpenAI-compatible endpoint, waits for it to become healthy, and tears it down on OpenClaw's idle/exit lifecycle.
+- **Friendly model catalog.** Ships a static model catalog and OpenClaw wizard/model-picker entries using models.dev-style ids (e.g. `qwen3.5-9b`), with the friendly-id → QVAC constant mapping resolved through [`@qvac/ai-sdk-provider`](https://www.npmjs.com/package/@qvac/ai-sdk-provider)'s shared catalog. Defaults to `qwen3.5-9b`.
+- **Larger agent models.** The catalog includes the larger agent-oriented families in addition to the Qwen3.5 line: `qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, and `gemma4-31b`, each mapped to its `@qvac/sdk` model constant.
+- **Layered configuration.** A `configSchema` resolves options from plugin config and defaults: `model`, `host`, `port`, `baseUrl`, `apiKey`, `qvacCommand`, `cwd`, `ctxSize`, `reasoningBudget`, `tools`, `readyTimeoutMs`, `idleStopMs`, and `timeoutSeconds`.
+
+### Requirements
+
+- [`@qvac/ai-sdk-provider@^0.3.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for the shared model catalog and managed serve.
+- [`@qvac/cli@^0.8.0`](https://www.npmjs.com/package/@qvac/cli) so the local service can run `qvac serve` (SDK 0.14.x runtime).
+- [`openclaw@>=2026.6.0`](https://www.npmjs.com/package/openclaw) as the host (optional peer).

--- a/plugins/openclaw/changelog/0.1.0/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.1.0/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.1.0
+
+Release Date: 2026-07-03
+
+## ✨ Features
+
+- Add `@qvac/openclaw-plugin`: an OpenClaw provider plugin that runs a local, managed `qvac serve` so OpenClaw works against on-device QVAC models. (see PR [#2835](https://github.com/tetherto/qvac/pull/2835))
+- Add the larger agent models (`qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, `gemma4-31b`) to the plugin catalog. (see PR [#3035](https://github.com/tetherto/qvac/pull/3035))

--- a/plugins/openclaw/changelog/0.1.0/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.1.0/CHANGELOG_LLM.md
@@ -1,0 +1,19 @@
+# QVAC OpenClaw Plugin v0.1.0 Release Notes
+
+Release Date: 2026-07-03
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.1.0
+
+The first public release of `@qvac/openclaw-plugin` — an [OpenClaw](https://openclaw.ai) provider plugin that runs a local, fully managed QVAC serve so OpenClaw works against on-device models with no separate server to start.
+
+## Local QVAC Provider for OpenClaw
+
+The plugin registers a `qvac` provider that OpenClaw drives through its `localService` launcher. On use it starts `qvac serve` on a loopback port, exposes an OpenAI-compatible endpoint, waits for it to become healthy, and reaps it on OpenClaw's idle/exit lifecycle. It also contributes OpenClaw wizard and model-picker entries so QVAC can be selected like any other provider.
+
+## Model Catalog With Larger Agent Models
+
+The plugin ships a static model catalog using models.dev-style ids, resolving each friendly id to its `@qvac/sdk` model constant through `@qvac/ai-sdk-provider`'s shared catalog. Alongside the Qwen3.5 line it exposes the larger agent-oriented families — `qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, and `gemma4-31b` — which resolve to model constants shipped in `@qvac/sdk` 0.14.x. The default model is `qwen3.5-9b`.
+
+## Requirements
+
+This release targets the current agent stack: `@qvac/ai-sdk-provider` `^0.3.0` (shared catalog and managed serve), `@qvac/cli` `^0.8.0` (runs `qvac serve` on the SDK 0.14.x runtime), and `openclaw` `>=2026.6.0` as the optional host peer.

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -60,8 +60,8 @@
     "dev:link": "npm install ../../packages/ai-sdk-provider ../../packages/cli"
   },
   "dependencies": {
-    "@qvac/ai-sdk-provider": "^0.2.2",
-    "@qvac/cli": "^0.7.0"
+    "@qvac/ai-sdk-provider": "^0.3.0",
+    "@qvac/cli": "^0.8.0"
   },
   "devDependencies": {
     "@types/node": "^24.2.1",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@qvac/openclaw-plugin` 0.1.0 is being released from the companion release branch. `main` needs the same release metadata so future work sees the published dependency requirements and changelog history.

## 📝 How does it solve it?

This backmerges the OpenClaw release metadata from #3092:

- `plugins/openclaw/package.json` updates the runtime package dependencies to `@qvac/ai-sdk-provider ^0.3.0` and `@qvac/cli ^0.8.0`.
- `plugins/openclaw/CHANGELOG.md` adds the aggregate 0.1.0 release entry.
- `plugins/openclaw/changelog/0.1.0/` adds the per-version release notes.

The PR is tagged `[skiplog]` because it only lands release metadata already represented by the release PR.

## 🧪 How was it tested?

The companion release branch was verified from `plugins/openclaw` with the published package chain from npm:

- `npm install --package-lock=false`
- `npm ls @qvac/ai-sdk-provider @qvac/cli` → `@qvac/ai-sdk-provider@0.3.0`, `@qvac/cli@0.8.0`
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit` — 16 pass, 0 fail.
- `npm run build`

This backmerge diff touches only the same four release metadata files as #3092.