### PR TITLE
infra[notask]: de-collide duplicate integration-test job names

### DIFF
--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -47,7 +47,7 @@ jobs:
     continue-on-error: true
     runs-on: ${{ matrix.runner }}
     environment: release
-    name: test-${{ matrix.platform }}-${{ matrix.arch }}
+    name: test-${{ matrix.os }}-${{ matrix.arch }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       WORKDIR: packages/diffusion-cpp

--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -24,7 +24,7 @@ jobs:
   run-integration-tests:
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
-    name: ${{ matrix.platform }}-${{ matrix.arch }}-integration-tests
+    name: ${{ matrix.os }}-${{ matrix.arch }}-integration-tests
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/integration-test-llm-llamacpp.yml
+++ b/.github/workflows/integration-test-llm-llamacpp.yml
@@ -59,7 +59,7 @@ jobs:
     continue-on-error: true
     runs-on: ${{ matrix.runner }}
     environment: release
-    name: test-${{ matrix.platform }}-${{ matrix.arch }}
+    name: test-${{ matrix.label }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       WORKDIR: packages/llm-llamacpp

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -28,7 +28,7 @@ jobs:
   run-integration-tests:
     runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
-    name: ${{ matrix.platform }}-${{ matrix.arch }}-integration-tests
+    name: ${{ matrix.os }}-${{ matrix.arch }}-integration-tests
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The four heavy desktop integration suites (`diffusion`, `llm`, `embed`, `vla`) name their matrix jobs by `platform`-`arch` only, but each suite has **two** matrix rows that share the same tuple — Ubuntu 22.04 + 24.04 both map to `linux-x64`, and the two arm rows both map to `linux-arm64`. Each run therefore produces two jobs with an **identical name / status-check context**.

- Duplicate check contexts are ambiguous in the PR checks UI and in run/cancel tracking, and they were part of the confusing "which `run-integration-tests / test-linux-x64` is which" picture during the recent CI-cancellation incidents.

## 📝 How does it solve it?

- `diffusion` / `embed` / `vla`: disambiguate the display name with `matrix.os` (e.g. `test-ubuntu-22.04-x64` vs `test-ubuntu-24.04-x64`).
- `llm`: reuse the existing per-row `matrix.label` (e.g. `test-linux-x64-u22-gpu`), already unique and descriptive.
- Job **keys** (`run-integration-tests`) are unchanged, so `needs:` / `combine-perf-reports` / `merge-guard` wiring is untouched — only the display / status-check name changes.
- Note: this touches the same four files as the timeout-caps PR (#3096) on nearby lines; whichever merges second may need a trivial rebase.

## 🧪 How was it tested?

- `actionlint` on all four files — no new findings versus `main`.
- Verified `matrix.label` is present on every `llm` row and `matrix.os` on every `diffusion` / `embed` / `vla` row, so no job resolves to an empty name.
- Enumerated consumers of the old names: the only repo reference is an illustrative code comment in `on-pr-llm-llamacpp.yml`; no workflow, script, or ruleset consumes these display strings. The repo's sole required status check is `Check Approvals`, so branch protection is unaffected by the rename.
