### PR TITLE
QVAC-20553 chore: release openclaw-plugin 0.1.1

### DIFF
--- a/plugins/openclaw/CHANGELOG.md
+++ b/plugins/openclaw/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.1.1]
+
+Release Date: 2026-07-07
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.1.1
+
+The first public npm release of `@qvac/openclaw-plugin` — an [OpenClaw](https://openclaw.ai) provider plugin that runs a local, fully managed QVAC serve so OpenClaw works against on-device models with no separate server to start.
+
+### Added
+
+- **Local QVAC provider for OpenClaw.** Registers a `qvac` provider that OpenClaw drives through its `localService` launcher: the plugin starts `qvac serve` on a loopback port, exposes an OpenAI-compatible endpoint, waits for it to become healthy, and tears it down on OpenClaw's idle/exit lifecycle.
+- **Friendly model catalog.** Ships a static model catalog and OpenClaw wizard/model-picker entries using models.dev-style ids (e.g., `qwen3.5-9b`), with the friendly-id → QVAC constant mapping resolved through [`@qvac/ai-sdk-provider`](https://www.npmjs.com/package/@qvac/ai-sdk-provider)'s shared catalog. Defaults to `qwen3.5-9b`.
+- **Larger agent models.** The catalog includes the larger agent-oriented families in addition to the Qwen3.5 line: `qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, and `gemma4-31b`, each mapped to its `@qvac/sdk` model constant.
+- **Layered configuration.** A `configSchema` resolves options from plugin config and defaults: `model`, `host`, `port`, `baseUrl`, `apiKey`, `qvacCommand`, `cwd`, `ctxSize`, `reasoningBudget`, `tools`, `readyTimeoutMs`, `idleStopMs`, and `timeoutSeconds`.
+
+### Requirements
+
+- [`@qvac/ai-sdk-provider@^0.3.0`](https://www.npmjs.com/package/@qvac/ai-sdk-provider) for the shared model catalog and managed serve.
+- [`@qvac/cli@^0.8.0`](https://www.npmjs.com/package/@qvac/cli) so the local service can run `qvac serve` (SDK 0.14.x runtime).
+- [`openclaw@>=2026.6.0`](https://www.npmjs.com/package/openclaw) as the host (optional peer).
+
 ## [0.1.0]
 
 Release Date: 2026-07-03

--- a/plugins/openclaw/changelog/0.1.1/CHANGELOG.md
+++ b/plugins/openclaw/changelog/0.1.1/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog v0.1.1
+
+Release Date: 2026-07-07
+
+## ✨ Features
+
+- Publish `@qvac/openclaw-plugin`: an OpenClaw provider plugin that runs a local, managed `qvac serve` so OpenClaw works against on-device QVAC models. (see PR [#2835](https://github.com/tetherto/qvac/pull/2835))
+- Include the larger agent models (`qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, `gemma4-31b`) in the plugin catalog. (see PR [#3035](https://github.com/tetherto/qvac/pull/3035))

--- a/plugins/openclaw/changelog/0.1.1/CHANGELOG_LLM.md
+++ b/plugins/openclaw/changelog/0.1.1/CHANGELOG_LLM.md
@@ -1,0 +1,19 @@
+# QVAC OpenClaw Plugin v0.1.1 Release Notes
+
+Release Date: 2026-07-07
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/openclaw-plugin/v/0.1.1
+
+The first public npm release of `@qvac/openclaw-plugin` — an [OpenClaw](https://openclaw.ai) provider plugin that runs a local, fully managed QVAC serve so OpenClaw works against on-device models with no separate server to start.
+
+## Local QVAC Provider for OpenClaw
+
+The plugin registers a `qvac` provider that OpenClaw drives through its `localService` launcher. On use it starts `qvac serve` on a loopback port, exposes an OpenAI-compatible endpoint, waits for it to become healthy, and reaps it on OpenClaw's idle/exit lifecycle. It also contributes OpenClaw wizard and model-picker entries so QVAC can be selected like any other provider.
+
+## Model Catalog With Larger Agent Models
+
+The plugin ships a static model catalog using models.dev-style ids, resolving each friendly id to its `@qvac/sdk` model constant through `@qvac/ai-sdk-provider`'s shared catalog. Alongside the Qwen3.5 line it exposes the larger agent-oriented families — `qwen3.6-27b`, `qwen3.6-35b-a3b`, `gpt-oss-20b`, and `gemma4-31b` — which resolve to model constants shipped in `@qvac/sdk` 0.14.x. The default model is `qwen3.5-9b`.
+
+## Requirements
+
+This release targets the current agent stack: `@qvac/ai-sdk-provider` `^0.3.0` (shared catalog and managed serve), `@qvac/cli` `^0.8.0` (runs `qvac serve` on the SDK 0.14.x runtime), and `openclaw` `>=2026.6.0` as the optional host peer.

--- a/plugins/openclaw/openclaw.plugin.json
+++ b/plugins/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "qvac",
   "name": "QVAC",
   "description": "Local QVAC provider for OpenClaw",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "providers": ["qvac"],
   "modelSupport": {
     "modelPrefixes": ["qwen3.5-", "qwen3.6-", "gpt-oss-", "gemma4-"]

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/openclaw-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenClaw provider plugin that runs a local QVAC serve through OpenClaw localService",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

`@qvac/openclaw-plugin` has not had a successful public npm release yet; npm currently only has the `0.0.0` placeholder. This prepares `0.1.1` on the canonical release branch name so the release guard and publish workflow can run normally.

## 📝 How does it solve it?

- Bumps `@qvac/openclaw-plugin` from `0.1.0` to `0.1.1` in `package.json` and `openclaw.plugin.json`.
- Adds the `0.1.1` changelog (`CHANGELOG.md` + `changelog/0.1.1/`).
- Keeps the published agent stack requirements already landed on main: `@qvac/ai-sdk-provider ^0.3.0` and `@qvac/cli ^0.8.0`.

The release content is the first public npm release of the OpenClaw plugin: local managed `qvac serve`, the OpenClaw static model catalog, and the larger agent model ids from the shared QVAC catalog.

## 🧪 How was it tested?

From `plugins/openclaw`, resolving the published package chain from npm:

- `npm install --package-lock=false`
- `npm ls @qvac/ai-sdk-provider @qvac/cli` → `@qvac/ai-sdk-provider@0.3.0`, `@qvac/cli@0.8.0`
- `npm run format` — passes.
- `npm run lint` — passes.
- `npm run typecheck` — passes.
- `npm run test:unit` — 16 pass, 0 fail.
- `npm run build` — clean.

Verified npm currently exposes only `@qvac/openclaw-plugin@0.0.0`, so `0.1.1` will be the first real published release.