### PR TITLE
QVAC-18632 tts-ggml: consume tts-cpp 2026-07-07 (T3 sched_dispatch GPU->CPU fallback, PR #81)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Chatterbox no longer crashes at load on Samsung S25 / Adreno GPU.** The
+  multilingual model's quantized weights were uploaded to the OpenCL backend in
+  partial pieces, which the backend read past and faulted on at model load.
+  Quantized weights are now uploaded whole. Bumps the `tts-cpp` requirement to
+  `2026-07-06`.
+- **T3 (Chatterbox Turbo/MTL) now falls back to CPU per-op instead of aborting
+  when the GPU backend can't run an op.** New shared `sched_dispatch` helper
+  (mirroring the existing S3Gen/Supertonic pattern) walks the graph and only
+  engages a `ggml_backend_sched` fallback when the primary backend can't run
+  every op, so the happy-path direct-compute output is unchanged. S3Gen and
+  Supertonic converge onto the same helper, which also fixes a Supertonic
+  sched graph-reuse corruption bug on natural-sched backends (Adreno). Bumps
+  the `tts-cpp` requirement to `2026-07-07`.
+
 ## [0.4.0] - 2026-07-03
 
 ### Changed

--- a/packages/tts-ggml/vcpkg.json
+++ b/packages/tts-ggml/vcpkg.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "tts-cpp",
-      "version>=": "2026-07-03#2"
+      "version>=": "2026-07-07"
     }
   ],
   "features": {


### PR DESCRIPTION
## What

Bump `tts-ggml`'s `tts-cpp` `version>=` floor straight from `2026-07-03#2` to `2026-07-07`, consuming merged registry PR [tetherto/qvac-registry-vcpkg#236](https://github.com/tetherto/qvac-registry-vcpkg/pull/236). This addon has never picked up either of the two most recent tts-cpp fixes, so this single jump brings in both:

- **Chatterbox Samsung S25 / Adreno GPU-load crash fix** ([qvac-ext-lib-whisper.cpp#79](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/79)): the OpenCL Q4_0/Q8_0 SOA `set_tensor` path read the whole `ggml_nbytes` and ignored `(offset, size)`, so T3-MTL stacked-`wqkv` and `gguf_stream` chunked uploads over-read and SIGSEGV'd on Adreno at load; both now upload quantized weights whole.
- **T3 (Chatterbox Turbo/MTL) per-op GPU→CPU fallback via a new shared `sched_dispatch` helper** ([qvac-ext-lib-whisper.cpp#81](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/81), QVAC-18632): T3 was the last tts-cpp engine with zero per-op GPU fallback — any GPU-unsupported op aborted the host process. A `graph_fully_supported()` walk keeps the direct gallocr path byte-for-byte unchanged when the primary backend supports every op; a lazily-created `ggml_backend_sched` fallback with a pre-sched guard converts the scheduler's uncatchable `GGML_ABORT` on a pre-allocated KV-cache tensor into a graceful, catchable engine error. S3Gen and Supertonic converge onto the same helper, fixing a Supertonic sched graph-reuse corruption bug on natural-sched backends (Adreno).

**Supersedes #3083** (QVAC-19557, only bumped to `2026-07-06`/PR #79) — closing that PR in favor of this one since this is a strict superset.

## Pin

- `tts-cpp` `version>=` `2026-07-03#2` → `2026-07-07`. Manifest-only: **`default-registry.baseline` is unchanged** (`4dbe15d8c3a181d691289739c9531a09d46eae27`) — it already includes the `mecab` port, so no baseline bump is needed for this floor change to resolve.
- No `CMakeLists.txt` change needed — `tts-cpp`'s public CMake targets (`tts-cpp::tts-cpp`, `tts-cpp::tts-cpp-backend-defs`) are unchanged; all of PR #81's changes are internal to `tts-cpp`.

## Validation

- **Local**: `bare-make generate && bare-make build` green on macOS arm64 (Metal) — resolves `tts-cpp@2026-07-07` + `ggml-speech@2026-07-03` + `mecab@2019-09-25` through the real registry and compiles the addon clean.
- **Device-farm** (via temporary overlay PR [#3086](https://github.com/tetherto/qvac/pull/3086), which built `tts-cpp` from PR #81's exact head commit ahead of the registry merge — closing that PR now that the real pin is here):
  - iOS: 2/2 devices passed, 6/6 test cases passed.
  - Android Samsung S25 Ultra (Adreno): 3/3 passed, including `runChatterboxMtlTest` (460s → this run).
  - Android Google Pixel 9 (Mali): 2/3 passed. The one failure, `runChatterboxMtlTest` timing out at 20 minutes, is a **pre-existing condition, not a regression from PR #81**: [#3083](https://github.com/tetherto/qvac/pull/3083)'s device-farm run — on the *older* `2026-07-06` pin, without PR #81 — hits the identical 20-minute timeout on the same Pixel 9 test with a near-identical duration (1199876ms vs 1200482ms here). Tracked separately; not a blocker for this bump.
