### PR TITLE
fix[notask]: use S3 source for Cangjie registry asset

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -13340,7 +13340,7 @@
     "link": "https://huggingface.co/qvac/MedPsy-4B-GGUF"
   },
   {
-    "source": "https://raw.githubusercontent.com/Jackchows/Cangjie5/b76ed7fd4b8365529c056096b6a3a2ba749f5a40/Cangjie5_TC.txt",
+    "source": "s3:///qvac_models_compiled/ggml/chatterbox/2026-07-03/Cangjie5_TC.tsv",
     "engine": "@qvac/tts-ggml",
     "description": "Cangjie5 traditional Chinese input table (hanzi -> Cangjie codes) used for Chatterbox multilingual Chinese (zh) tokenization",
     "quantization": "",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Fixes the Cangjie registry source, which was mistakenly added as a GitHub raw content URL.
- Keeps the SDK registry source compatible with supported source schemes: Hugging Face and S3.

## 📝 How does it solve it?

- Updates the Cangjie model registry source to the S3-hosted TSV artifact: `s3:///qvac_models_compiled/ggml/chatterbox/2026-07-03/Cangjie5_TC.tsv`.
- Leaves the Cangjie link as the upstream project reference.

## 🧪 How was it tested?

- Confirmed the remote branch diff only changes the Cangjie source in `models.prod.json`.
- Confirmed `models.prod.json` parses as valid JSON.

Made with [Cursor](https://cursor.com)