### PR TITLE
chore: release @qvac/tts-ggml v0.4.1

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.1] - 2026-07-07
 
 ### Fixed
 

--- a/packages/tts-ggml/package.json
+++ b/packages/tts-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/tts-ggml",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Text to Speech (TTS) addon for qvac (ggml backend, wrapping the chatterbox + supertonic engines from tts-cpp)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## Release @qvac/tts-ggml v0.4.1

Cuts the release that bundles the two `[Unreleased]` fixes accumulated since **0.4.0**, both from PR [#3105](https://github.com/tetherto/qvac/pull/3105). Mirrors prior release PRs (#3044, #2881) — touches only `package.json` (version) and `CHANGELOG.md` (finalize `[Unreleased]` → `[0.4.1] - 2026-07-07`).

**Patch bump (0.4.0 → 0.4.1)** — both changes are bug fixes with zero happy-path behavior change (byte-identical direct-compute output when the GPU backend already supports every op).

### Highlights (full detail in CHANGELOG)

- **Chatterbox no longer crashes at load on Samsung S25 / Adreno GPU** — quantized OpenCL weight uploads now happen whole instead of partial/chunked (qvac-ext-lib-whisper.cpp #79).
- **T3 (Chatterbox Turbo/MTL) per-op GPU→CPU fallback** via the new shared `sched_dispatch` helper — GPU-unsupported ops no longer abort the process; also fixes a Supertonic sched graph-reuse corruption bug on natural-sched backends (Adreno) (qvac-ext-lib-whisper.cpp #81, QVAC-18632).

### Pins (already on main)

- `tts-cpp` pin = `2026-07-07` (qvac-registry-vcpkg #236) — consumed via #3105.

### Publish

On merge to `main` this publishes a `dev` build to GPR. The **npm `latest`** publish runs via `publish-npm` on a `release-*` branch push (or `workflow_dispatch tag=latest`) — a maintainer step (needs the `npm`/`release` environments) once this is merged; `release-merge-guard` validates the `0.4.1` version ↔ CHANGELOG top entry (verified locally: `grep -qE "^## \[0.4.1\]" packages/tts-ggml/CHANGELOG.md` passes).
