### PR TITLE
QVAC-21250 chore: release @qvac/llm-llamacpp v0.33.0

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.33.0] - 2026-07-07
+
+This release extends reasoning-block KV compaction to hybrid and recurrent SSM models such as Qwen3.5. It also makes reasoning compaction the default behavior for reasoning-capable models, with stricter failure handling so callers do not accidentally continue from cache state that still contains internal thinking traces.
+
+### New APIs
+
+- `generationParams.remove_thinking_from_context` now defaults to `true`. Callers that intentionally want later turns to attend to previous reasoning can still pass `false` per request.
+- Hybrid and recurrent SSM models are now supported when their reasoning close marker tokenizes to a single vocab token. The addon snapshots the sequence state at the end of prefill, restores it after generation, and replays the generated opener seed, canonical close marker, and visible answer tail so KV and recurrent state stay coherent.
+
+### Fixed
+
+- Reasoning compaction failures now surface as `StatusError` instead of silently preserving reasoning in cache. The affected sequence is rolled back or cleared before the error escapes, and batch cache saves are skipped on unsafe cancel or compaction-failure paths to preserve the last known-good on-disk cache.
+- Qwen3.5 multimodal cache metadata is verified against restored llama memory before a cache file is accepted, preventing stale or partial cache files from desynchronizing `nPast`, physical KV-cell counts, and live memory.
+- Context sliding during generation now invalidates tracked reasoning spans and recurrent boundary snapshots, so compaction hard-fails instead of using stale coordinates after the cache window shifts.
+
+### Changed
+
+- The reasoning compaction implementation was split into shared helpers for span tracking, context shifting, recurrent snapshots, rollback state, and snapshot policy. Text and multimodal generation now use the same compaction contract across single-prompt and continuous-batch paths.
+- Cache persistence for per-slot batch saves now writes through a temporary file and atomically promotes it into place, matching the single-prompt `CacheManager` behavior.
+- Runtime stats preserve user-visible prompt and generation counters across recurrent replay, so maintenance decode work does not inflate throughput or time-to-first-token measurements.
+
+### Pull Requests
+
+- [#2813](https://github.com/tetherto/qvac/pull/2813) - QVAC-21250 Support reasoning compaction on hybrid SSM models
+
 ## [0.32.0] - 2026-07-06
 
 ### Changed

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- PR #2813 landed hybrid/recurrent reasoning compaction changes for `@qvac/llm-llamacpp`, but the package release metadata still needed a follow-up bump.
- The release workflow needs a matching `CHANGELOG.md` entry for the package version that will be published.

## 📝 How does it solve it?

- Bumps `packages/llm-llamacpp/package.json` from `0.32.0` to `0.33.0`.
- Adds a `0.33.0` changelog entry covering default-on `remove_thinking_from_context`, hybrid/recurrent SSM support, stricter compaction failures, cache hardening, and the PR #2813 reference.

## 🧪 How was it tested?

- `git diff --check`
- Metadata-only change; no runtime tests were run.

Made with [Cursor](https://cursor.com)