### PR TITLE
QVAC-19119 chore[notask]: release package version for llm-llamacpp 0.32.1

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.34.1] - 2026-07-08
+
+### Fixed
+
+- `test/mobile/integration.auto.cjs` was stale since `qwen3-5-image-tile-mode-tokens.test.js` was added (#2887, 2026-06-29) — the generated dispatch file was never regenerated, so `runQwen35ImageTileModeTokensTest` silently never ran on Android or iOS despite being listed in `test-groups.json`. Regenerated via `npm run test:mobile:generate`; desktop CI was unaffected (it regenerates its own runner list fresh every run).
+
 ## [0.34.0] - 2026-07-06
 
 ### Changed

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
Version bump + changelog for the stale mobile test dispatch fix.

Code PR: https://github.com/tetherto/qvac/pull/3111
