### PR TITLE
fix[notask]: preserve ValidationHelpers.validate this-binding in TTS e2e executors

### DIFF
--- a/packages/sdk/e2e/tests/mobile/executors/tts-executor.ts
+++ b/packages/sdk/e2e/tests/mobile/executors/tts-executor.ts
@@ -48,14 +48,14 @@ export class MobileTtsExecutor extends ModelAssetExecutor<typeof ttsTests> {
     return makeEnhancedTtsHandler<Expectation, TestResult>({
       dependency: dep,
       ensureLoaded: (dependency) => this.resources.ensureLoaded(dependency),
-      validate: ValidationHelpers.validate
+      validate: (output, expectation) => ValidationHelpers.validate(output, expectation)
     })
   }
 
   private makeOutputSampleRateComparison() {
     return makeOutputSampleRateComparisonHandler<Expectation, TestResult>({
       ensureLoaded: (dependency) => this.resources.ensureLoaded(dependency),
-      validate: ValidationHelpers.validate
+      validate: (output, expectation) => ValidationHelpers.validate(output, expectation)
     })
   }
 

--- a/packages/sdk/e2e/tests/shared/executors/tts-executor.ts
+++ b/packages/sdk/e2e/tests/shared/executors/tts-executor.ts
@@ -38,14 +38,14 @@ export class TtsExecutor extends AbstractModelExecutor<typeof ttsTests> {
     return makeEnhancedTtsHandler<Expectation, TestResult>({
       dependency: dep,
       ensureLoaded: (dependency) => this.resources.ensureLoaded(dependency),
-      validate: ValidationHelpers.validate
+      validate: (output, expectation) => ValidationHelpers.validate(output, expectation)
     })
   }
 
   private makeOutputSampleRateComparison() {
     return makeOutputSampleRateComparisonHandler<Expectation, TestResult>({
       ensureLoaded: (dependency) => this.resources.ensureLoaded(dependency),
-      validate: ValidationHelpers.validate
+      validate: (output, expectation) => ValidationHelpers.validate(output, expectation)
     })
   }
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `tts-supertonic-output-sample-rate` and `tts-supertonic-enhanced` e2e tests fail on all platforms with `Cannot read properties of undefined (reading 'validateContainsAll')`
- Affects both desktop/electron (shared executor) and iOS/Android (mobile executor)

## 📝 How does it solve it?

- `ValidationHelpers.validate` was passed as a detached static method reference to the LavaSR helper factories, losing the class `this` binding
- Wrapped in arrow functions to preserve `this` context when the helper calls `this.validateContainsAll` internally

## 🧪 How was it tested?

- Ran `npx qvac-test run:local:desktop --filter tts` — all 12 TTS tests pass (including `output-sample-rate` and `enhanced`)
- Verified the same fix in the mobile executor (same root cause, same pattern)