### PR TITLE
QVAC-21544 doc[notask]: add release notes for the addon-cpp 1.2.3 release train

### DIFF
--- a/packages/bci-whispercpp/release-notes/v0.4.1.md
+++ b/packages/bci-whispercpp/release-notes/v0.4.1.md
@@ -1,0 +1,14 @@
+# QVAC BCI Whisper Addon v0.4.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background decoding threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/classification-ggml/release-notes/v0.10.1.md
+++ b/packages/classification-ggml/release-notes/v0.10.1.md
@@ -1,0 +1,19 @@
+# QVAC Classification Addon v0.10.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation, and picks up the qvac-fabric 9341.1.5 update.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Other
+
+The `qvac-fabric` dependency was updated from 9341.1.4 to 9341.1.5 (Mali/Vulkan GPU projector optimizations, OpenCL bidirectional-encoder attention, and Adreno vision-encoder fixes). There is no API change for this package.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#3114](https://github.com/tetherto/qvac/pull/3114) - QVAC-21300 feat[api]: bump qvac-fabric to 9341.1.5 across consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/diffusion-cpp/release-notes/v0.13.3.md
+++ b/packages/diffusion-cpp/release-notes/v0.13.3.md
@@ -1,0 +1,14 @@
+# QVAC Stable Diffusion Addon v0.13.3 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background generation threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/embed-llamacpp/release-notes/v0.26.1.md
+++ b/packages/embed-llamacpp/release-notes/v0.26.1.md
@@ -1,0 +1,19 @@
+# QVAC Embeddings Addon v0.26.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation, and picks up the qvac-fabric 9341.1.5 update.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Other
+
+The `qvac-fabric` dependency was updated from 9341.1.4 to 9341.1.5 (Mali/Vulkan GPU projector optimizations, OpenCL bidirectional-encoder attention, and Adreno vision-encoder fixes). There is no API change for this package.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#3114](https://github.com/tetherto/qvac/pull/3114) - QVAC-21300 feat[api]: bump qvac-fabric to 9341.1.5 across consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/llm-llamacpp/release-notes/v0.35.1.md
+++ b/packages/llm-llamacpp/release-notes/v0.35.1.md
@@ -1,0 +1,19 @@
+# QVAC LLM Addon v0.35.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation, and ships the qvac-fabric 9341.1.5 GPU vision-encoder optimizations.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background inference threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps (for example Keet on Android) that reload or terminate worklets while a model is loaded.
+
+## Other
+
+The `qvac-fabric` dependency was updated from 9341.1.4 to 9341.1.5, bringing Mali/Vulkan GPU projector optimizations (vendor-aware flash-attention gating, Valhall warptile tuning, layernorm fusion) that reduce GPU mmproj encode time to ~1.28× of same-device CPU on Pixel 9 Pro, plus OpenCL bidirectional-encoder attention and Adreno vision-encoder fixes. There is no API change for this package.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#3114](https://github.com/tetherto/qvac/pull/3114) - QVAC-21300 feat[api]: bump qvac-fabric to 9341.1.5 across consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/ocr-ggml/release-notes/v0.10.1.md
+++ b/packages/ocr-ggml/release-notes/v0.10.1.md
@@ -1,0 +1,19 @@
+# QVAC OCR GGML Addon v0.10.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation, and picks up the qvac-fabric 9341.1.5 update.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Other
+
+The `qvac-fabric` dependency was updated from 9341.1.4 to 9341.1.5 (Mali/Vulkan GPU projector optimizations, OpenCL bidirectional-encoder attention, and Adreno vision-encoder fixes). There is no API change for this package.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#3114](https://github.com/tetherto/qvac/pull/3114) - QVAC-21300 feat[api]: bump qvac-fabric to 9341.1.5 across consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/ocr-onnx/release-notes/v0.7.1.md
+++ b/packages/ocr-onnx/release-notes/v0.7.1.md
@@ -1,0 +1,14 @@
+# QVAC OCR Addon v0.7.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background recognition threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/transcription-parakeet/release-notes/v0.9.1.md
+++ b/packages/transcription-parakeet/release-notes/v0.9.1.md
@@ -1,0 +1,14 @@
+# QVAC Transcription Parakeet Addon v0.9.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background transcription threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/transcription-whispercpp/release-notes/v0.11.1.md
+++ b/packages/transcription-whispercpp/release-notes/v0.11.1.md
@@ -1,0 +1,14 @@
+# QVAC Transcription Whisper Addon v0.11.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background transcription threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/translation-nmtcpp/release-notes/v7.2.1.md
+++ b/packages/translation-nmtcpp/release-notes/v7.2.1.md
@@ -1,0 +1,19 @@
+# QVAC NMT Addon v7.2.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation, and picks up the qvac-fabric 9341.1.5 update.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background translation threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This was originally reproduced with this translation addon during worker reload (reload followed by re-translate no longer aborts).
+
+## Other
+
+The `qvac-fabric` dependency was updated from 9341.1.4 to 9341.1.5 (Mali/Vulkan GPU projector optimizations, OpenCL bidirectional-encoder attention, and Adreno vision-encoder fixes). There is no API change for this package.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#3114](https://github.com/tetherto/qvac/pull/3114) - QVAC-21300 feat[api]: bump qvac-fabric to 9341.1.5 across consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/tts-ggml/release-notes/v0.4.2.md
+++ b/packages/tts-ggml/release-notes/v0.4.2.md
@@ -1,0 +1,14 @@
+# QVAC TTS GGML Addon v0.4.2 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background synthesis threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger

--- a/packages/vla-ggml/release-notes/v0.11.1.md
+++ b/packages/vla-ggml/release-notes/v0.11.1.md
@@ -1,0 +1,19 @@
+# QVAC VLA Addon v0.11.1 Release Notes
+
+This release fixes native crashes during runtime teardown and logger re-installation, and picks up the qvac-fabric 9341.1.5 update.
+
+## Bug Fixes
+
+### Logger no longer crashes on worklet teardown or re-installation
+
+The C++→JS logger (`qvac-lib-inference-addon-cpp` 1.2.3) previously crashed in two lifecycle scenarios: tearing down a worker runtime while background threads were still emitting log messages aborted the process, and installing a new logger after a soft reload crashed inside V8 handle cleanup. Both paths are now safe — teardown disarms the logger before the JS context is disposed, and stale logger references from a torn-down runtime are no longer freed against the wrong environment. This matters for host apps that reload or terminate worklets while a model is loaded.
+
+## Other
+
+The `qvac-fabric` dependency was updated from 9341.1.4 to 9341.1.5 (Mali/Vulkan GPU projector optimizations, OpenCL bidirectional-encoder attention, and Adreno vision-encoder fixes). There is no API change for this package.
+
+## Pull Requests
+
+- [#3027](https://github.com/tetherto/qvac/pull/3027) - QVAC-21544 fix[api]: adopt qvac-lib-inference-addon-cpp 1.2.3 across all consumers
+- [#3114](https://github.com/tetherto/qvac/pull/3114) - QVAC-21300 feat[api]: bump qvac-fabric to 9341.1.5 across consumers
+- [#2932](https://github.com/tetherto/qvac/pull/2932) - QVAC-21544 fix[api]: fix JsLogger crashes on worklet teardown and re-setLogger


### PR DESCRIPTION
Adds release-notes/v<version>.md for all 12 addon packages whose versions were bumped in #3027 (qvac-lib-inference-addon-cpp 1.2.3 JsLogger teardown fix; the six fabric consumers also document the qvac-fabric 9341.1.5 update shipping in the same npm version). Follow-up to #3027, which merged before the notes commit landed.