### PR TITLE
QVAC-19555 chore[skiplog]: unquarantine Wan video tests on macOS

### DIFF
--- a/packages/diffusion-cpp/test/integration/generate-video-wan.test.js
+++ b/packages/diffusion-cpp/test/integration/generate-video-wan.test.js
@@ -30,13 +30,8 @@ const { detectPlatform, setupJsLogger, ensureModelPath } = require('./utils')
 const { recordPerformance } = require('./_perf-helper')
 
 const isMobile = os.platform() === 'ios' || os.platform() === 'android'
-const isDarwin = os.platform() === 'darwin'
 const noGpu = proc.env && proc.env.NO_GPU === 'true'
-// Skip Wan tests on mobile, on any CPU-only runner (NO_GPU), and on macOS.
-// The Wan 14B I2V model OOMs the Mac mini M4 Metal GPU during diffusion compute
-// (kIOGPUCommandBufferCallbackErrorOutOfMemory), even at 256x256, so darwin is
-// excluded entirely. Wan tests continue to run on Linux/Windows GPU runners.
-const skip = isMobile || isDarwin || noGpu
+const skip = isMobile || noGpu
 
 // Log skip status for CI visibility
 console.log('[Wan Video Tests] Platform:', os.platform(), 'Arch:', os.arch(), 'NO_GPU:', noGpu, '→ Skip:', skip)


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Wan 2.1 video smoke tests (T2V + I2V) were unconditionally skipped on macOS because the older mac-mini-m4-gpu runner crashed at ~11 GB Metal GPU peak during video diffusion compute (`ggml_abort` in `ggml_metal_synchronize`)
- With the migration to macOS 26 runners (`qvac-macos26-arm64-gpu`), the Metal stability issue no longer applies and the quarantine can be lifted

## 📝 How does it solve it?

- Remove the `isDarwin` condition from the skip logic in `generate-video-wan.test.js`
- Tests now skip only on mobile and CPU-only (`NO_GPU`) runners, matching the LTX video test behavior

## 🧪 How was it tested?

- 2x macOS-only CI runs via `test-sdk.yml` (`desktop-platforms=["qvac-macos26-arm64-gpu"]`), both green:
  - https://github.com/tetherto/qvac/actions/runs/28927022894
  - https://github.com/tetherto/qvac/actions/runs/28927028102