### PR TITLE
QVAC-21901 bench[vcpkg][DO NOT MERGE]: Mali Gemma-4V encoder sweep (overlay -> fabric #182 + mmproj-use-gpu)

### DIFF
--- a/.github/workflows/benchmark-vlm-model-comparison.yml
+++ b/.github/workflows/benchmark-vlm-model-comparison.yml
@@ -796,7 +796,13 @@ jobs:
       device_model_operator: ${{ matrix.model_op }}
       # source_id/source_ref identify the build on this session (candidate = git:<sha>,
       # baseline = npm:<ver>); two-models legs have no matrix.source → falls back to addon.
-      device_env: "QVAC_VLM_DEVICES=${{ matrix.vlm_devices }};QVAC_VLM_MODE=${{ inputs.matrix_mode }};QVAC_VLM_PRESET=${{ inputs.matrix_preset }};QVAC_VLM_SOURCE_ID=${{ matrix.source || 'addon' }};QVAC_VLM_SOURCE_REF=${{ matrix.source == 'addon@candidate' && format('git:{0}', needs.context.outputs.head_sha) || (matrix.source == 'addon@baseline' && format('npm:{0}', needs.context.outputs.baseline_npm) || '') }}${{ inputs.matrix_samples != '' && format(';QVAC_VLM_SAMPLES={0}', inputs.matrix_samples) || '' }}${{ inputs.matrix_models != '' && format(';QVAC_VLM_MODELS=b64:{0}', needs.context.outputs.models_b64) || '' }}${{ needs.context.outputs.mobile_pertest_min != '' && format(';QVAC_VLM_TEST_TIMEOUT_MIN={0}', needs.context.outputs.mobile_pertest_min) || '' }}"
+      device_env: "QVAC_VLM_DEVICES=${{ matrix.vlm_devices }};QVAC_VLM_MODE=${{ inputs.matrix_mode }};QVAC_VLM_PRESET=${{ inputs.matrix_preset }};QVAC_VLM_SOURCE_ID=${{ matrix.source || 'addon' }};QVAC_VLM_SOURCE_REF=${{ matrix.source == 'addon@candidate' && format('git:{0}', needs.context.outputs.head_sha) || (matrix.source == 'addon@baseline' && format('npm:{0}', needs.context.outputs.baseline_npm) || '') }}${{ inputs.matrix_samples != '' && format(';QVAC_VLM_SAMPLES={0}', inputs.matrix_samples) || '' }}${{ inputs.matrix_models != '' && format(';QVAC_VLM_MODELS=b64:{0}', needs.context.outputs.models_b64) || '' }}${{ needs.context.outputs.mobile_pertest_min != '' && format(';QVAC_VLM_TEST_TIMEOUT_MIN={0}', needs.context.outputs.mobile_pertest_min) || '' }};QVAC_VLM_MMPROJ_GPU=true;QVAC_G4V_STDFOLD=1"
+      # QVAC-21901 bench (DO NOT MERGE): hardcode the projector A/B knobs on this
+      # branch. QVAC_VLM_MMPROJ_GPU=true forces the projector onto the GPU in the
+      # device=gpu cell (the device=cpu cell keeps CPU), so vision_enc_ms gpu-vs-cpu
+      # is the projector A/B. QVAC_G4V_STDFOLD toggles candidate #1 (1=on/0=off);
+      # flip between runs to isolate the fold. (dispatch-input plumbing not used
+      # because workflow_dispatch inputs are validated against the default branch.)
       # Suffix logs with the source tag (candidate/baseline) so the two sessions of a
       # build comparison upload distinct, identifiable artifacts.
       artifact_suffix: ${{ matrix.token }}${{ matrix.srctag != '' && format('-{0}', matrix.srctag) || '' }}

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/config.cjs
@@ -124,7 +124,11 @@ module.exports = {
   // two-models compares these two complete VLMs:
   models: [MODEL_1, MODEL_2],
   // several-sources runs this one VLM across the engines below:
-  sourcesModel: SOURCES_MODEL,
+  // QVAC-21901 bench (DO NOT MERGE): several-sources hardcodes the model to
+  // sourcesModel and ignores matrix_models (harness.cjs), and only several-sources
+  // routes addon@candidate to mobile — so point it at GEMMA4_Q4 to benchmark our
+  // Gemma-4V candidate build on Mali. (Upstream default is SOURCES_MODEL = qwen3.5.)
+  sourcesModel: GEMMA4_Q4,
   engines: ['addon', 'fabric-cli', 'upstream-cli'],
   engine: 'addon', //         the fixed engine for two-models
 

--- a/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
+++ b/packages/llm-llamacpp/benchmarks/vlm-benchmark/harness.cjs
@@ -105,6 +105,14 @@ const TEST_TIMEOUT_MIN = intEnv('QVAC_VLM_TEST_TIMEOUT_MIN') || 30
 const BLOCK_OVERRIDE = nonNegEnv('QVAC_VLM_BLOCK')
 const MODEL_INDEX = nonNegEnv('QVAC_VLM_MODEL_INDEX')
 const BACKENDS_DIR = env('QVAC_VLM_BACKENDS_DIR')
+// QVAC-21901 projector A/B knob: force the mmproj (vision encoder) backend.
+// '' = addon auto-default (Mali -> CPU); 'true'/'1'/'on' -> GPU; 'false'/'0'/'off' -> CPU.
+const MMPROJ_GPU = (() => {
+  const v = env('QVAC_VLM_MMPROJ_GPU').trim().toLowerCase()
+  if (v === '1' || v === 'true' || v === 'on') return 'true'
+  if (v === '0' || v === 'false' || v === 'off') return 'false'
+  return ''
+})()
 
 // Warmup passes run before the measured ones to prime weights/caches and let the
 // machine reach a steady thermal state — most important on phones, which throttle
@@ -350,6 +358,11 @@ function runModel (spec) {
           n_predict: String(nPredict),
           verbosity: '2', // surfaces `image slice encoded in N ms` on native stderr
           'reasoning-budget': '0', // disable Qwen3.5 thinking -> clean direct answers
+          // QVAC-21901 projector A/B: force the mmproj (vision encoder) backend so
+          // we can measure projector-on-CPU vs projector-on-GPU independently of the
+          // model backend. Empty = addon auto-default (Mali -> CPU). Only meaningful
+          // on the GPU model cell (device=gpu); ignored when no GPU backend.
+          ...(MMPROJ_GPU !== '' ? { 'mmproj-use-gpu': MMPROJ_GPU } : {}),
           ...(BACKENDS_DIR ? { backendsDir: BACKENDS_DIR } : {}) // candidate/baseline build swap (scheduler)
         },
         logger: console,

--- a/packages/llm-llamacpp/vcpkg-configuration.json
+++ b/packages/llm-llamacpp/vcpkg-configuration.json
@@ -1,4 +1,7 @@
 {
+  "overlay-ports": [
+    "vcpkg/ports"
+  ],
   "default-registry": {
     "kind": "git",
     "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",

--- a/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
+++ b/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/android-vulkan-version.cmake
@@ -1,0 +1,36 @@
+# Function to detect Vulkan version from NDK vulkan_core.h
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    # CMAKE_HOST_SYSTEM_PROCESSOR is unavailable here. Use a glob pattern to complete the folder instead. 
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT vulkan_core_h)
+        message(FATAL_ERROR "vulkan_core.h not found, using default version")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+
+     # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract major.minor version from vulkan_core.h, using default: ${vulkan_version}")
+    endif()
+endfunction()

--- a/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/portfile.cmake
+++ b/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/portfile.cmake
@@ -1,0 +1,250 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac-fabric-llm.cpp
+  # QVAC-21901 benchmark overlay: pin to the QVAC-21901 fabric branch HEAD
+  # (feat/QVAC-21901-close-mali-vulkan-encoder-gpu-cpu-gap) so the Mali sweep
+  # builds the candidate encoder. Repoint REF+SHA512 as new candidates land.
+  REF ec874ef0baca212e790b2d3767fcaee5ab370dba
+  SHA512 085060da5126ce5860e9eef7adecfe04f2f49becac598712ea26c37eb938ed13d03c09f1032897ffcc516d6b7b87a69e28afd59686b12162012ae1cb1ff214e3
+)
+
+# Upstream CMake options only — passed through to vcpkg_cmake_configure.
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+  FEATURES
+    force-profiler FORCE_GGML_VK_PERF_LOGGER
+    llama BUILD_LLAMA
+)
+
+# Portfile-only feature flags (drive PLATFORM_OPTIONS; not upstream cache vars).
+vcpkg_check_features(
+  OUT_FEATURE_OPTIONS _PORTFILE_FEATURE_OPTIONS
+  FEATURES
+    gpu-backends BUILD_GPU_BACKENDS
+    kleidiai BUILD_KLEIDIAI
+    openmp BUILD_OPENMP
+    hip-backend BUILD_HIP_BACKEND
+)
+
+# gpu-backends is default-on via default-features in vcpkg.json. CPU-only
+# consumers (e.g. @qvac/classification-ggml) disable it with
+# default-features:false (and re-add 'llama' if needed).
+if(NOT BUILD_GPU_BACKENDS)
+  message(STATUS "qvac-fabric: gpu-backends feature OFF — building CPU-only ggml (no Metal/Vulkan/CUDA/OpenCL)")
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  # NDK only comes with C headers.
+  # Make sure C++ header exists, it will be used by ggml tensor library.
+  # Need to determine installed vulkan version and download correct headers
+  include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+  detect_ndk_vulkan_version()
+  message(STATUS "Using Vulkan C++ wrappers from version: ${vulkan_version}")
+  file(DOWNLOAD
+    "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+    "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    TLS_VERIFY ON
+  )
+
+  file(ARCHIVE_EXTRACT
+    INPUT "${SOURCE_PATH}/vulkan-sdk-${vulkan_version}.tar.gz"
+    DESTINATION "${SOURCE_PATH}"
+    PATTERNS "*.hpp"
+  )
+
+  file(RENAME
+    "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}"
+    "${SOURCE_PATH}/ggml/src/ggml-vulkan/vulkan_cpp_wrapper"
+  )
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(NOT BUILD_GPU_BACKENDS)
+  # Force every GPU backend off explicitly, in case upstream defaults change.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_METAL=OFF
+    -DGGML_VULKAN=OFF
+    -DGGML_CUDA=OFF
+    -DGGML_OPENCL=OFF
+  )
+  if (VCPKG_TARGET_IS_IOS)
+    # Same iOS BLAS/Accelerate gating as the GPU-on path; unrelated to the
+    # CPU-vs-GPU split, an iOS-toolchain workaround for missing frameworks.
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+elseif (VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_METAL=ON)
+  if (VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+  endif()
+else()
+  list(APPEND PLATFORM_OPTIONS -DGGML_VULKAN=ON)
+endif()
+
+# Android: always build CPU variants (NEON_DOTPROD, NEON_I8MM, etc.) and CPU
+# repacking. These are CPU-only runtime optimizations selected based on the
+# device's SIMD capabilities at load time, completely orthogonal to the GPU
+# backends. Bundling them is essential for good CPU inference performance on
+# the wide range of arm64 devices the addons ship to. Requires GGML_BACKEND_DL
+# to dispatch the variants at runtime; the existing #ifdef guard around
+# `ggml_backend_load_all_from_path()` in ggml-backend-reg.cpp keeps the search
+# scoped to the consumer's own prebuilds dir.
+if(VCPKG_TARGET_IS_ANDROID OR (VCPKG_TARGET_IS_LINUX AND BUILD_GPU_BACKENDS))
+  # Desktop Linux also needs GGML_BACKEND_DL=ON so that multiple GPU backends
+  # (Vulkan + HIP/ROCm) can coexist as separately-loaded modules, the same way
+  # Android dispatches CPU variants at runtime. Without DL the Linux build links
+  # a single static GPU backend and a second one (HIP) cannot be stacked.
+  # GGML_NATIVE is incompatible with DL, so CPU variants are dispatched via
+  # GGML_CPU_ALL_VARIANTS instead. Consumers must ship the core ggml/llama libs
+  # alongside their backend modules so the dynamically-linked .bare can resolve
+  # them at load time.
+  set(DL_BACKENDS ON)
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_BACKEND_DL=ON
+    -DGGML_CPU_ALL_VARIANTS=ON
+    -DGGML_CPU_REPACK=ON)
+else()
+  set(DL_BACKENDS OFF)
+endif()
+
+# HIP/ROCm backend — opt-in via the 'hip-backend' feature (Linux + AMD only).
+# Only @qvac/vla-ggml requests it, so every other consumer builds with no HIP
+# and gains no ROCm dependency. Builds libqvac-ggml-hip.so as a standalone DL
+# module alongside Vulkan (GGML_BACKEND_DL is already ON above), so the addon
+# dlopen's whichever GPU backend BackendSelection picks at runtime. The `hip`
+# feature-dependency port forwards the system ROCm's find_package() configs.
+#
+# FAIL-SAFE: enable GGML_HIP only when a ROCm SDK is actually present. On a build
+# host without ROCm we skip HIP and build Vulkan/CPU only — the build never
+# hard-fails, and at runtime a missing HIP module just isn't loaded (the DL
+# loader skips it) so BackendSelection falls back to Vulkan/CPU. Targets gfx1151
+# (Strix Halo / Radeon 8060S); the HIP compiler + ROCM_PATH come from the build env.
+# linux-x64 only: AMD GPU hosts (Strix Halo / gfx1151) are x86_64, and the ROCm
+# dist is x64. On other arches (e.g. linux-arm64) HIP is skipped even if the
+# feature is requested — no ROCm requirement, no build break.
+if(VCPKG_TARGET_IS_LINUX AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x64" AND BUILD_GPU_BACKENDS AND BUILD_HIP_BACKEND)
+  # DETERMINISTIC: requesting hip-backend REQUIRES a ROCm SDK at build time. We
+  # must NOT silently skip when ROCm is absent — a host-dependent skip yields a
+  # no-HIP package with the SAME vcpkg ABI as a real HIP build, which the binary
+  # cache then conflates (cache poisoning: a no-ROCm build caches a no-HIP
+  # package that ROCm-equipped builds then restore). So ROCm present => HIP;
+  # ROCm absent => hard error (don't request hip-backend on a host without ROCm).
+  # The RUNTIME fail-safe is unchanged: an absent HIP module / non-AMD target is
+  # simply not loaded and BackendSelection falls back to Vulkan/CPU.
+  if(NOT (DEFINED ENV{ROCM_PATH} AND EXISTS "$ENV{ROCM_PATH}/lib/cmake/hip/hip-config.cmake"))
+    message(FATAL_ERROR "qvac-fabric: hip-backend feature requires a ROCm SDK — set ROCM_PATH to a ROCm/TheRock install containing lib/cmake/hip/hip-config.cmake. Do not request hip-backend on a host without ROCm.")
+  endif()
+  message(STATUS "qvac-fabric: hip-backend ON — building GGML_HIP (gfx1151)")
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_HIP=ON
+    -DAMDGPU_TARGETS=gfx1151
+    -DCMAKE_HIP_ARCHITECTURES=gfx1151)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_KLEIDIAI)
+  message(STATUS "qvac-fabric: kleidiai feature ON — building with ARM KleidiAI optimized kernels")
+  # ggml only vendors KleidiAI via FetchContent; registry vcpkg-cmake sets
+  # FETCHCONTENT_FULLY_DISCONNECTED=ON globally, so allow the download here.
+  list(APPEND PLATFORM_OPTIONS
+    -DGGML_CPU_KLEIDIAI=ON
+    -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+  )
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND BUILD_OPENMP)
+  message(STATUS "qvac-fabric: OpenMP for Android enabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=ON)
+else()
+  message(STATUS "qvac-fabric: OpenMP Disabled")
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENMP=OFF)
+endif()
+
+if (VCPKG_TARGET_IS_ANDROID AND BUILD_GPU_BACKENDS)
+  list(APPEND PLATFORM_OPTIONS -DGGML_OPENCL=ON)
+endif()
+
+if(BUILD_GPU_BACKENDS AND NOT VCPKG_TARGET_IS_OSX AND NOT VCPKG_TARGET_IS_IOS)
+  if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    string(APPEND VCPKG_C_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " /I${CURRENT_INSTALLED_DIR}/include")
+  else()
+    string(APPEND VCPKG_C_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+    string(APPEND VCPKG_CXX_FLAGS " -isystem ${CURRENT_INSTALLED_DIR}/include")
+  endif()
+endif()
+
+# Under GGML_BACKEND_DL the per-microarch backends ship as standalone
+# libqvac-ggml-*.so modules that the consumer dlopen's at runtime. Built with
+# -stdlib=libc++ they otherwise carry a runtime NEEDED dependency on the system
+# libc++.so.1 / libc++abi.so.1, so they silently fail to dlopen on any target
+# without libc++ installed (e.g. stock ubuntu-24.04 — no CPU backend registers,
+# inference aborts). Statically link the C++ runtime into the modules so they
+# are self-contained, matching how the addons link themselves. The module<->addon
+# boundary is the C ggml-backend ABI, so per-module libc++ copies never exchange
+# C++ objects. Linux only: Apple/iOS use Metal frameworks, Android ships
+# libc++_shared via the NDK STL, Windows uses the MSVC runtime.
+if(VCPKG_TARGET_IS_LINUX)
+  string(APPEND VCPKG_LINKER_FLAGS " -static-libstdc++")
+endif()
+
+set(LLAMA_OPTIONS)
+if("llama" IN_LIST FEATURES)
+  list(APPEND LLAMA_OPTIONS -DLLAMA_MTMD=ON)
+else()
+  list(APPEND LLAMA_OPTIONS
+    -DLLAMA_MTMD=OFF
+    -DLLAMA_BUILD_COMMON=OFF
+  )
+endif()
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DGGML_NATIVE=OFF
+    -DGGML_CCACHE=OFF
+    -DGGML_LLAMAFILE=OFF
+    -DLLAMA_CURL=OFF
+    -DLLAMA_BUILD_TESTS=OFF
+    -DLLAMA_BUILD_TOOLS=OFF
+    -DLLAMA_BUILD_EXAMPLES=OFF
+    -DLLAMA_BUILD_SERVER=OFF
+    -DLLAMA_ALL_WARNINGS=OFF
+    ${LLAMA_OPTIONS}
+    ${PLATFORM_OPTIONS}
+    ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME ggml)
+
+if(BUILD_LLAMA)
+  vcpkg_cmake_config_fixup(PACKAGE_NAME llama)
+endif()
+
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+
+if(BUILD_LLAMA)
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+  file(INSTALL "${SOURCE_PATH}/gguf-py" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/vulkan_profiling_analyzer.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/vulkan_profiling_analyzer.py")
+endif()
+
+if (NOT VCPKG_BUILD_TYPE)
+  file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/vcpkg.json
+++ b/packages/llm-llamacpp/vcpkg/ports/qvac-fabric/vcpkg.json
@@ -1,0 +1,58 @@
+{
+  "name": "qvac-fabric",
+  "version": "9341.1.3",
+  "description": "LLM inference in C/C++",
+  "homepage": "https://github.com/tetherto/qvac-fabric-llm.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "gpu-backends",
+    "llama"
+  ],
+  "features": {
+    "force-profiler": {
+      "description": "Force vk performance logging in ggml"
+    },
+    "gpu-backends": {
+      "description": "Build the GPU backends ggml ships per platform: Metal on Apple, Vulkan on Linux/Windows/Android, plus the Android backend-DL hybrid mode and OpenCL. Default-on so existing consumers (llamacpp-llm, llamacpp-embed, nmtcpp, diffusion-cpp) keep their current behaviour with default features. Disable to produce a CPU-only ggml build (useful for consumers like @qvac/classification-ggml that don't need GPU paths and want to skip the vulkan-sdk / metal / opencl build cost). Orthogonal to the 'llama' feature.",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "platform": "!osx & !ios",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    },
+    "hip-backend": {
+      "description": "Build the ROCm/HIP GPU backend (libqvac-ggml-hip.so) for AMD GPUs on Linux as a DL module alongside Vulkan. Opt-in (only @qvac/vla-ggml requests it). Fail-safe: if no ROCm SDK is present at build time the HIP backend is skipped (Vulkan/CPU only). Targets gfx1151 (Strix Halo). The 'hip' dependency forwards the system ROCm find_package configs.",
+      "dependencies": [
+        {
+          "name": "hip",
+          "platform": "linux & x64"
+        }
+      ]
+    },
+    "kleidiai": {
+      "description": "Enable ARM KleidiAI optimized kernels on Android."
+    },
+    "llama": {
+      "description": "Build llama components."
+    },
+    "openmp": {
+      "description": "Enable openmp on Android."
+    }
+  }
+}


### PR DESCRIPTION
## Purpose — DO NOT MERGE
Benchmark/overlay branch to run the **QVAC-21901** Mali Gemma-4V vision-encoder sweep on the Pixel 9 Device Farm. Not for merge — mirrors the QVAC-21361 overlay-validation flow (#2979).

## What it stacks
- **QVAC-21257** base (`feat/QVAC-21257-mmproj-gpu-config`) — provides the `mmproj-use-gpu` config key that removes the Android CPU hard-pin, so the projector can run on the **Mali GPU** (required to measure a GPU cell at all).
- **vcpkg overlay** (`packages/llm-llamacpp/vcpkg/ports/qvac-fabric`) pinning `qvac-fabric` → **QVAC-21901 fabric HEAD `ec874ef0`** (fabric draft PR tetherto/qvac-fabric-llm.cpp#182, candidate #1: `gemma4v` std-norm fold). SHA512 `085060da…`.

## How to run (once QVAC-21257 is available)
```
gh workflow run benchmark-vlm-model-comparison.yml --repo tetherto/qvac \
  --ref bench/QVAC-21901-mali-gemma4v-sweep \
  -f matrix_mobile=pixel9 -f matrix_models=gemma4-q4 -f matrix_preset=cognitive
```
Sweep axes (keep winners, QVAC-21361-style): `mmproj-use-gpu` false vs true (CPU vs GPU projector) × `QVAC_G4V_STDFOLD` on vs off. Correctness via quality-identity; perf via encode-ms A/B.

## Depends on
- tetherto/qvac-fabric-llm.cpp#182 (QVAC-21901 fabric candidates)
- QVAC-21257 (Android mmproj CPU hard-pin removal)

Made with [Cursor](https://cursor.com)