### PR TITLE
doc[skiplog]: note why LLM benchmark workflow secrets: inherit is bounded

### DIFF
--- a/.github/workflows/benchmark-perf-llm-llamacpp.yml
+++ b/.github/workflows/benchmark-perf-llm-llamacpp.yml
@@ -166,6 +166,8 @@ jobs:
       pull-requests: write
       id-token: write
     uses: ./.github/workflows/prebuilds-llm-llamacpp.yml
+    # Bounded: prebuild needs the GPR/signing secrets; no repository input, and the
+    # release environment + label-gate keep this to trusted in-repo refs.
     secrets: inherit
     with:
       repository: ${{ github.repository }}
@@ -313,6 +315,8 @@ jobs:
           - cache: pq4_0
             groups: '[{"name":"BenchmarkPerf08bQ40Pq40","grep":"runBenchmarkPerf08bQ40Pq40Test"},{"name":"BenchmarkPerf08bQ41Pq40","grep":"runBenchmarkPerf08bQ41Pq40Test"},{"name":"BenchmarkPerf08bQ4KMPq40","grep":"runBenchmarkPerf08bQ4KMPq40Test"},{"name":"BenchmarkPerf08bQ6KPq40","grep":"runBenchmarkPerf08bQ6KPq40Test"},{"name":"BenchmarkPerf08bQ80Pq40","grep":"runBenchmarkPerf08bQ80Pq40Test"},{"name":"BenchmarkPerf2bQ40Pq40","grep":"runBenchmarkPerf2bQ40Pq40Test"},{"name":"BenchmarkPerf2bQ41Pq40","grep":"runBenchmarkPerf2bQ41Pq40Test"},{"name":"BenchmarkPerf2bQ4KMPq40","grep":"runBenchmarkPerf2bQ4KMPq40Test"},{"name":"BenchmarkPerf2bQ6KPq40","grep":"runBenchmarkPerf2bQ6KPq40Test"},{"name":"BenchmarkPerf2bQ80Pq40","grep":"runBenchmarkPerf2bQ80Pq40Test"}]'
     uses: ./.github/workflows/integration-mobile-test-llm-llamacpp.yml
+    # Bounded: Device Farm needs the AWS/Apple/pool secrets; no repository input, and
+    # the release environment + label-gate keep this to trusted in-repo refs.
     secrets: inherit
     with:
       repository: ${{ github.repository }}


### PR DESCRIPTION
## 🎯 What

Adds a two-line inline comment at the two `secrets: inherit` call sites in `benchmark-perf-llm-llamacpp.yml` (the `prebuild` and `mobile` jobs), recording why they are safe. Comment-only, no behaviour change.

## 📝 Why

The security question — a manual dispatcher picks a `ref`, so can secret-bearing jobs run untrusted code — was reviewed and accepted on #2382, but nothing in the workflow records that, so it keeps getting re-derived (most recently on the embed twin, #2658).

The note captures the invariant: there is no `repository` input, so the ref is always within `tetherto/qvac`, and the only two `secrets: inherit` jobs (prebuild publish, Device Farm) run solely under the `release` environment plus label-gate — reachable only from trusted in-repo refs. Desktop, which needs no secrets, carries none.

Decision of record: https://github.com/tetherto/qvac/pull/2382#issuecomment-4604807101

## 💥 Impact

None. Comment-only change to one workflow file. The identical comment was added to the embed twin in #2658.
