### PR TITLE
[DO NOT MERGE] transcription-whispercpp Adreno OpenCL CI — whisper #91 + ggml #42 (QVAC-21623)

### DIFF
--- a/packages/transcription-whispercpp/CMakeLists.txt
+++ b/packages/transcription-whispercpp/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(cmake-bare REQUIRED PATHS node_modules/cmake-bare)
 find_package(cmake-vcpkg REQUIRED PATHS node_modules/cmake-vcpkg)
 
 set(VCPKG_OVERLAY_TRIPLETS "${CMAKE_CURRENT_SOURCE_DIR}/../../vcpkg-overlays/triplets;${VCPKG_OVERLAY_TRIPLETS}")
+set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay-ports;${VCPKG_OVERLAY_PORTS}")
 
 project(transcription-whispercpp CXX C)
 

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/android-vulkan-version.cmake
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/android-vulkan-version.cmake
@@ -1,0 +1,37 @@
+# Detect the Vulkan version shipped with the Android NDK by parsing
+# vulkan_core.h from the NDK sysroot.  Sets `vulkan_version` in the
+# caller's scope (e.g. "1.3.275").
+function(detect_ndk_vulkan_version)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_NAME}" host_system_name_lower)
+
+    file(GLOB host_dirs LIST_DIRECTORIES true "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_system_name_lower}-*")
+    if(host_dirs)
+        list(GET host_dirs 0 host_dir)
+        get_filename_component(host_arch "${host_dir}" NAME)
+        set(vulkan_core_h "$ENV{ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/${host_arch}/sysroot/usr/include/vulkan/vulkan_core.h")
+    else()
+        message(FATAL_ERROR "Could not find NDK host directory for ${host_system_name_lower}")
+    endif()
+
+    if(NOT EXISTS "${vulkan_core_h}")
+        message(FATAL_ERROR "vulkan_core.h not found at ${vulkan_core_h}")
+    endif()
+
+    file(READ "${vulkan_core_h}" header_content)
+    string(REGEX MATCH "VK_HEADER_VERSION ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(header_version_3 "${CMAKE_MATCH_1}")
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION from ${vulkan_core_h}")
+    endif()
+
+    # Extract major.minor version from VK_HEADER_VERSION_COMPLETE for download URL
+    string(REGEX MATCH "VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION\\(([0-9]+), ([0-9]+), ([0-9]+)" version_match "${header_content}")
+    if(version_match)
+        set(major "${CMAKE_MATCH_2}")
+        set(minor "${CMAKE_MATCH_3}")
+        set(vulkan_version "${major}.${minor}.${header_version_3}" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Could not extract VK_HEADER_VERSION_COMPLETE from ${vulkan_core_h}")
+    endif()
+endfunction()

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/patches/0001-ggml-vulkan-find-spirv-headers.patch
@@ -1,0 +1,24 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..3d92ac5d 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -7,6 +7,7 @@ if (POLICY CMP0147)
+ endif()
+ 
+ find_package(Vulkan COMPONENTS glslc REQUIRED)
++find_package(SPIRV-Headers QUIET)
+ 
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     # Parallel build object files
+@@ -87,6 +88,11 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++
++    if (TARGET SPIRV-Headers::SPIRV-Headers)
++        target_link_libraries(ggml-vulkan PRIVATE SPIRV-Headers::SPIRV-Headers)
++    endif()
++
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/portfile.cmake
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/portfile.cmake
@@ -1,0 +1,172 @@
+# ggml-speech: tetherto/qvac-ext-ggml@speech HEAD 11581cd5 (merge of PR #35,
+# ggml-vulkan: optimize parakeet/whisper Vulkan on ARM Mali). Two
+# ARM/Mali-gated changes: disable KHR_cooperative_matrix (Mali's coopmat matmul
+# is ~5x slower than the scalar path for our encoder shapes) and use the medium
+# (64x64) matmul tile instead of large (128x128) on ARM (few shader cores leave
+# tall-K/small-N GEMMs underutilized). Bumps the speech-stack ggml pin from
+# f5727c32; off ARM (desktop NVIDIA/AMD/Intel, Adreno, Apple) byte-identical.
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO tetherto/qvac-ext-ggml
+    REF 844864d310a723c5215e7f42a5ad4afd8cdb3471
+    SHA512 b91ca6c1aa2c86f24f22cc2499ef923ef54e49eaa9df220c428ca928a975c15b47b6ed6e2df99fe7259d681fdb180aab84c3732e911b5916cb275e9df45b8a27
+    HEAD_REF speech
+)
+
+set(GGML_METAL  OFF)
+set(GGML_VULKAN OFF)
+set(GGML_CUDA   OFF)
+set(GGML_OPENCL OFF)
+set(GGML_METAL_FUSE_MV_BIAS OFF)
+
+if("metal" IN_LIST FEATURES)
+    set(GGML_METAL ON)
+endif()
+
+# Off by default: the chatterbox Q-variant mul_mv + bias/residual fusion
+# produces zero tokens on parakeet's EOU q8_0 joint network. Consumers
+# whose models stay clear of that pattern can opt in for the speedup.
+if("metal-fuse-mv-bias" IN_LIST FEATURES)
+    set(GGML_METAL_FUSE_MV_BIAS ON)
+endif()
+
+if("vulkan" IN_LIST FEATURES)
+    set(GGML_VULKAN ON)
+endif()
+
+set(GGML_CUDA_COMPILER_OPTION "")
+
+if("cuda" IN_LIST FEATURES)
+    set(GGML_CUDA ON)
+    find_program(NVCC_EXECUTABLE nvcc
+        PATHS /usr/local/cuda/bin /usr/local/cuda-12.8/bin
+        NO_DEFAULT_PATH
+    )
+    if(NOT NVCC_EXECUTABLE)
+        find_program(NVCC_EXECUTABLE nvcc REQUIRED)
+    endif()
+    set(GGML_CUDA_COMPILER_OPTION "-DCMAKE_CUDA_COMPILER=${NVCC_EXECUTABLE}")
+    message(STATUS "CUDA compiler: ${NVCC_EXECUTABLE}")
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    set(GGML_OPENCL ON)
+endif()
+
+if(VCPKG_TARGET_IS_ANDROID AND "vulkan" IN_LIST FEATURES)
+    include(${CMAKE_CURRENT_LIST_DIR}/android-vulkan-version.cmake)
+    detect_ndk_vulkan_version()
+    message(STATUS "NDK Vulkan version: ${vulkan_version}")
+
+    file(DOWNLOAD
+        "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v${vulkan_version}.tar.gz"
+        "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        TLS_VERIFY ON
+    )
+    file(ARCHIVE_EXTRACT
+        INPUT "${SOURCE_PATH}/vulkan-hpp-${vulkan_version}.tar.gz"
+        DESTINATION "${SOURCE_PATH}"
+        PATTERNS "*.hpp"
+    )
+    file(COPY "${SOURCE_PATH}/Vulkan-Headers-${vulkan_version}/include/"
+         DESTINATION "${SOURCE_PATH}/src/")
+endif()
+
+set(PLATFORM_OPTIONS)
+
+if(VCPKG_TARGET_IS_IOS)
+    list(APPEND PLATFORM_OPTIONS -DGGML_BLAS=OFF -DGGML_ACCELERATE=OFF)
+endif()
+
+# Hybrid Android backend mode: GPU backends as MODULE .so loaded at runtime
+# via dlopen, CPU built as per-arch MODULE .so variants (one per ARMv8.0/
+# 8.2/8.6/9.0/9.2 feature tier) also loaded at runtime via dlopen. The
+# downstream addon installs the resulting libqvac-speech-ggml-cpu-android_armv*
+# .so files alongside the .bare binary; the per-variant scoring in
+# ggml-cpu's `ggml_backend_cpu_aarch64_score` then picks the highest tier
+# the running device supports at first use. Pairs with the speech-branch
+# `ggml-backend: android per-arch CPU variant dlopen fallback` patch
+# (commit 9562ed04) so the variant lookup also succeeds when the consumer
+# APK keeps native .so files compressed (AGP `useLegacyPackaging=false`).
+if(VCPKG_TARGET_IS_ANDROID)
+    list(APPEND PLATFORM_OPTIONS
+        -DGGML_BACKEND_DL=ON
+        -DGGML_CPU_ALL_VARIANTS=ON
+        -DGGML_CPU_REPACK=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT=ON
+        -DGGML_VULKAN_DISABLE_COOPMAT2=ON
+    )
+endif()
+
+# PR #13 (v0.10.2 sync) introduces an unconditional
+# `#include <spirv/unified1/spirv.hpp>` in src/ggml-vulkan/ggml-vulkan.cpp,
+# but the upstream ggml-vulkan CMakeLists.txt never finds spirv-headers nor
+# wires its include dir into the ggml-vulkan target. Apply a small patch
+# so it does (and depend on spirv-headers in vcpkg.json's vulkan feature).
+# TODO: push the equivalent fix upstream and drop this patch.
+if("vulkan" IN_LIST FEATURES)
+    vcpkg_apply_patches(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PATCHES
+            "${CMAKE_CURRENT_LIST_DIR}/patches/0001-ggml-vulkan-find-spirv-headers.patch"
+    )
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_SHARED_LIBS=OFF
+        -DGGML_NATIVE=OFF
+        -DGGML_CCACHE=OFF
+        -DGGML_OPENMP=OFF
+        -DGGML_LLAMAFILE=OFF
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_METAL=${GGML_METAL}
+        -DGGML_VULKAN=${GGML_VULKAN}
+        -DGGML_CUDA=${GGML_CUDA}
+        -DGGML_OPENCL=${GGML_OPENCL}
+        -DGGML_METAL_FUSE_MV_BIAS=${GGML_METAL_FUSE_MV_BIAS}
+        -DGGML_LIB_OUTPUT_PREFIX=qvac-speech-
+        ${GGML_CUDA_COMPILER_OPTION}
+        ${PLATFORM_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# Pick up the MODULE backend .so files ggml builds into the buildtree's
+# bin/ directory (Android dynamic-backend mode). cmake install() doesn't
+# move them by default.
+if(VCPKG_TARGET_IS_ANDROID)
+    file(GLOB _backend_sos
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/bin/libqvac-speech-ggml-*.so"
+    )
+    if(_backend_sos)
+        file(INSTALL ${_backend_sos} DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    endif()
+endif()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH lib/cmake/ggml)
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/ggml.pc")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc")
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig/ggml.pc"
+                "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/ggml.pc")
+endif()
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+                    "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+set(VCPKG_POLICY_MISMATCHED_NUMBER_OF_BINARIES enabled)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/usage
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/usage
@@ -1,0 +1,10 @@
+The package ggml provides CMake integration:
+
+  find_package(ggml CONFIG REQUIRED)
+  target_link_libraries(main PRIVATE ggml::ggml)
+
+Available vcpkg features:
+  metal  - Metal GPU backend (macOS/iOS, auto-enabled on Apple)
+  vulkan - Vulkan GPU backend
+  cuda   - CUDA GPU backend
+  opencl - OpenCL GPU backend

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/ggml-speech/vcpkg.json
@@ -1,0 +1,57 @@
+{
+  "name": "ggml-speech",
+  "version-date": "2026-07-14",
+  "description": "Speech-stack flavour of ggml from tetherto/qvac-ext-ggml@speech, including the ggml-org v0.10.2 sync (PR #13), the iOS Metal NULL-safety hardening from PR #10, GustavoA1604's Android per-arch CPU dlopen fallback (PR #11), the Mac M2 PAD test fix, and Adreno-aware Android OpenCL/Vulkan backend selection (PR #18): on Android the loader detects the GPU via Vulkan and only keeps OpenCL for Adreno > 700, CPU-only for Adreno 1..700, Vulkan/CPU for non-Adreno. Adds Adreno OpenCL elementwise kernels (sin/cos/abs/elu/leaky_relu) for Chatterbox S3Gen and robust Adreno-generation detection (PR #17, #19). Library filenames are prefixed libqvac-speech-ggml-* so they coexist with libqvac-ggml-* (fabric/llm) and libqvac-diffusion-ggml-* on the same Android device. Mutually exclusive with the regular ggml port in the same triplet -- pick one per build. 2026-06-15: ggml-metal drains lingering residency sets at device free instead of asserting (PR #24, fixes SIGABRT at process exit on macOS 15+ Metal teardown) plus ggml-opencl bci-whispercpp correctness on Adreno + Samsung Xclipse (PR #22). 2026-06-26: fix the SVE ggml_vec_dot_f32 leftover-tail accumulator drop (PR #30, svmad_f32_m -> svmla_f32_m) — removes the ~12 kHz Nyquist tone the SVE HiFT conv_transpose produced on Tensor/Pixel CPU; NEON/x86/RISC-V and all non-CPU backends byte-identical. 2026-07-03: ARM Mali Vulkan optimization (PR #35) — disable KHR_cooperative_matrix and use the medium matmul tile on ARM Mali; off ARM (desktop/Adreno/Apple) byte-identical.",
+  "homepage": "https://github.com/tetherto/qvac-ext-ggml/tree/speech",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    {
+      "name": "metal",
+      "platform": "osx | ios"
+    },
+    {
+      "name": "opencl",
+      "platform": "android"
+    },
+    {
+      "name": "vulkan",
+      "platform": "windows | linux | android"
+    }
+  ],
+  "features": {
+    "cuda": {
+      "description": "Enable CUDA GPU backend"
+    },
+    "metal": {
+      "description": "Enable Metal GPU backend (macOS/iOS)"
+    },
+    "metal-fuse-mv-bias": {
+      "description": "Compile in the Q-variant mul_mv + ADD(bias) [+ ADD(residual)] fusion in ggml-metal. Off by default: empirically produces zero tokens on parakeet's EOU q8_0 joint network. Opt in only after Metal A/B-validating your model against the fused path."
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU backend",
+      "dependencies": [
+        "opencl"
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU backend",
+      "dependencies": [
+        {
+          "name": "spirv-headers",
+          "version>=": "1.4.341.0"
+        }
+      ]
+    }
+  }
+}

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/patches/0001-move-gnuinstalldirs-before-add-subdirectory-src.patch
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/patches/0001-move-gnuinstalldirs-before-add-subdirectory-src.patch
@@ -1,0 +1,50 @@
+From: qvac-registry-vcpkg <none@tether.io>
+Subject: [PATCH] CMake: include(GNUInstallDirs) before add_subdirectory(src)
+
+src/CMakeLists.txt uses `${CMAKE_INSTALL_INCLUDEDIR}` in line
+`$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/whisper>` to populate
+the imported target's INTERFACE_INCLUDE_DIRECTORIES via the exported
+`whisper-targets.cmake`. The variable is only defined after
+`include(GNUInstallDirs)` runs, which is currently *after*
+`add_subdirectory(src)` in top-level CMakeLists.txt. As a result the
+generator-expression expands to just `/whisper`, and downstream
+`find_package(whisper)` consumers that rely on the install-tree
+(`WHISPER_USE_SYSTEM_GGML=ON` paths in vcpkg ports such as
+parakeet-cpp / tts-cpp / transcription-whispercpp addons) fail to
+configure with:
+
+  CMake Error in CMakeLists.txt:
+  Imported target "whisper::whisper" includes non-existent path
+    "/whisper"
+  in its INTERFACE_INCLUDE_DIRECTORIES.
+
+Move the `include(GNUInstallDirs)` call above `add_subdirectory(src)`
+so the INSTALL_INTERFACE generator-expression evaluates to the
+intended `include/whisper`. Does not change build-tree behavior
+(BUILD_INTERFACE path unaffected) and does not move any other rule
+that consumes `${CMAKE_INSTALL_*}` (those all stay after src/).
+
+Filed for upstream submission as a follow-up PR.
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -167,13 +167,14 @@
+     endif()
+     # ... otherwise assume ggml is added by a parent CMakeLists.txt
+ endif()
++include(GNUInstallDirs)
++
+ add_subdirectory(src)
+ 
+ #
+ # install
+ #
+ 
+-include(GNUInstallDirs)
+ include(CMakePackageConfigHelpers)
+ 
+ set(WHISPER_BUILD_NUMBER        ${BUILD_NUMBER})

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/portfile.cmake
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/portfile.cmake
@@ -1,11 +1,11 @@
 # whisper-cpp OVERLAY (do-not-merge) to CI-test transcription-whispercpp against the unmerged
-# whisper PR #91 (REF 9ac38a7b) + ggml PR #42; mirrors the registry portfile, REF/SHA512 repointed.
+# whisper PR #91 (REF 65699b26, fused-QKV repack fix) + ggml PR #42; mirrors the registry portfile.
 #
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH
   REPO tetherto/qvac-ext-lib-whisper.cpp
-  REF 9ac38a7ba62aa64aeff73fbcf84f955c674f171b
-  SHA512 21ddafc925680723eebce2b763a6b6b33aa88e77c4989da9b1c320c115cf1a6669ea304975595eaa0147a1d09f5ec16e8cfc69b1c3c63fb871db62d40a81b0af
+  REF 65699b26
+  SHA512 063afbf0cb1aafaec540ae3b1247eb5a9ea4f47412c44d04532afc1cf0c437d77d8219b4f8ffdfab7c7f440beeb8aa9497830fd3ab67d63488a6eb3df92bfe86
   HEAD_REF master
   PATCHES
     patches/0001-move-gnuinstalldirs-before-add-subdirectory-src.patch

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/portfile.cmake
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/portfile.cmake
@@ -1,0 +1,61 @@
+# whisper-cpp OVERLAY (do-not-merge) to CI-test transcription-whispercpp against the unmerged
+# whisper PR #91 (REF 9ac38a7b) + ggml PR #42; mirrors the registry portfile, REF/SHA512 repointed.
+#
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO tetherto/qvac-ext-lib-whisper.cpp
+  REF 9ac38a7ba62aa64aeff73fbcf84f955c674f171b
+  SHA512 21ddafc925680723eebce2b763a6b6b33aa88e77c4989da9b1c320c115cf1a6669ea304975595eaa0147a1d09f5ec16e8cfc69b1c3c63fb871db62d40a81b0af
+  HEAD_REF master
+  PATCHES
+    patches/0001-move-gnuinstalldirs-before-add-subdirectory-src.patch
+)
+
+# whisper-cpp consumes the system-installed ggml provided by the `ggml-speech`
+# port (same shape as the `parakeet-cpp` and `tts-cpp` ports). Backend
+# selection, Android dynamic-backend packaging, Vulkan-Headers download,
+# spirv-headers include shim, per-arch CPU variants and the
+# libqvac-speech-ggml-* filename prefix are all owned by `ggml-speech`; this
+# port only carries whisper-specific build options and links against the
+# installed ggml via `find_package(ggml)` (gated by WHISPER_USE_SYSTEM_GGML).
+#
+# Per-feature wiring lives in vcpkg.json:
+#   whisper-cpp[metal]  -> ggml-speech[metal]   (osx | ios)
+#   whisper-cpp[vulkan] -> ggml-speech[vulkan]  (linux | windows | android)
+#   whisper-cpp[opencl] -> ggml-speech[opencl]  (android)
+# so consumers express the full GPU matrix declaratively.
+
+vcpkg_cmake_configure(
+  SOURCE_PATH "${SOURCE_PATH}"
+  DISABLE_PARALLEL_CONFIGURE
+  OPTIONS
+    -DWHISPER_USE_SYSTEM_GGML=ON
+    -DWHISPER_BUILD_TESTS=OFF
+    -DWHISPER_BUILD_EXAMPLES=OFF
+    -DWHISPER_BUILD_SERVER=OFF
+    -DBUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME whisper
+  CONFIG_PATH share/whisper
+)
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# whisper-cpp itself produces no shared libraries when BUILD_SHARED_LIBS=OFF.
+# The ggml backend .so files (Android dynamic-backend mode) are installed by
+# the ggml-speech port into ${VCPKG_INSTALLED_DIR}/<triplet>/lib/, not by us.
+if (VCPKG_LIBRARY_LINKAGE MATCHES "static")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/vcpkg.json
@@ -1,0 +1,67 @@
+{
+  "name": "whisper-cpp",
+  "version": "1.9.1",
+  "port-version": 1,
+  "description": "High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model",
+  "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "ggml-speech",
+      "default-features": false,
+      "version>=": "2026-07-03"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "metal": {
+      "description": "Enable Metal GPU acceleration (Apple-only; targets macOS and iOS via the ggml-metal backend in ggml-speech). No extra package dependencies — Metal.framework is provided by the platform SDK.",
+      "supports": "osx | ios",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "default-features": false,
+          "features": [
+            "metal"
+          ],
+          "platform": "osx | ios"
+        }
+      ]
+    },
+    "opencl": {
+      "description": "Enable OpenCL GPU acceleration (Android-only; targets Adreno via the ggml-opencl backend in ggml-speech).",
+      "supports": "android",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "default-features": false,
+          "features": [
+            "opencl"
+          ],
+          "platform": "android"
+        }
+      ]
+    },
+    "vulkan": {
+      "description": "Enable Vulkan GPU acceleration (Linux/Windows/Android; macOS/iOS use the metal feature instead).",
+      "supports": "!osx & !ios",
+      "dependencies": [
+        {
+          "name": "ggml-speech",
+          "default-features": false,
+          "features": [
+            "vulkan"
+          ],
+          "platform": "!osx & !ios"
+        }
+      ]
+    }
+  }
+}

--- a/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg-overlay-ports/whisper-cpp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "whisper-cpp",
   "version": "1.9.1",
-  "port-version": 1,
+  "port-version": 2,
   "description": "High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model",
   "homepage": "https://github.com/tetherto/qvac-ext-lib-whisper.cpp",
   "license": "MIT",

--- a/packages/transcription-whispercpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg.json
@@ -31,7 +31,7 @@
     {
       "name": "whisper-cpp",
       "version": "1.9.1",
-      "port-version": 1
+      "port-version": 2
     }
   ]
 }

--- a/packages/transcription-whispercpp/vcpkg.json
+++ b/packages/transcription-whispercpp/vcpkg.json
@@ -1,4 +1,6 @@
 {
+  "name": "transcription-whispercpp",
+  "version": "0.12.0",
   "dependencies": [
     {
       "name": "qvac-lib-inference-addon-cpp",


### PR DESCRIPTION
**[DO NOT MERGE]** — throwaway overlay-CI PR to build/test **transcription-whispercpp** on the
device farm against the unmerged QVAC-21623 Adreno OpenCL source PRs, reusing this PR's existing
`verified` + `run-mobile-addon-tests` labels.

## Source PRs under test
- whisper: **tetherto/qvac-ext-lib-whisper.cpp#91** (decoder QKV fusion + vocab-logits slice) — REF `9ac38a7b`
- ggml: **tetherto/qvac-ext-ggml#42** (Adreno FLASH_ATTN fix + q8_0 SOA get_rows + decode speedups) — REF `844864d3`

## What this PR does
- Adds `packages/transcription-whispercpp/vcpkg-overlay-ports/{whisper-cpp,ggml-speech}` — the registry
  portfiles with `REF`/`SHA512` repointed to the two branch tips (ggml-speech `version-date` bumped to
  `2026-07-14` to bust the CI prebuild-artifact cache so the native build actually reruns).
- Wires `VCPKG_OVERLAY_PORTS` into `packages/transcription-whispercpp/CMakeLists.txt`.

Forked fresh from the current `origin/main`; only `packages/transcription-whispercpp/**` changes.

## Local verification
`vcpkg install whisper-cpp[metal] --overlay-ports=…/vcpkg-overlay-ports` resolves both overlays
(whisper-cpp `1.9.1#1` via the addon override, ggml-speech `2026-07-14`), downloads + SHA512-validates
both REFs, applies the whisper-cpp patch, and builds both ports clean. On-device (Adreno 740) the
opencl path is WER 0% vs CPU on multilingual base/small q8_0 (verified in the source PRs).

Do not merge — delete after the device-farm run is green.
