### PR TITLE
QVAC-21906 feat(tts-ggml): document + convert quantized LavaSR enhancer GGUFs (q4_0/q5_0/q8_0)

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged — `q4_0` is ~15 % of the F32 GGUF (8.5 MB vs 55.9 MB) and `q8_0` is
   near-lossless at ~half the F16 size. Covered by the new always-on
   `test-lavasr-enhancer-quant` unit test (QVAC-21906).
+- **K-quant LavaSR enhancer GGUFs (`q6_K` / `q5_K` / `q4_K`).** The loader's
+  dequant-at-load path is generic, so K-quants load with no code change; the
+  Python `gguf` lib can't *emit* them, so a C++ producer (`lavasr-requantize` in
+  tts-cpp, via `ggml_quantize_chunk`) quantizes the same 17 matmul tensors.
+  `q6_K` (12.0 MB, 21 % of F32, ~0.97 cos vs F32) is the recommended small tier;
+  `q8_0` remains near-lossless. 4-bit (`q4_K`/`q4_0`) is quite lossy on this
+  enhancer (~0.6 cos — the spec-head `exp()` amplifies low-bit error), so a
+  sub-`q8_0` tier should get a real-audio A/B before shipping. The README quant
+  table has the full size/fidelity ladder (QVAC-21906).
 
 ## [0.4.2] - 2026-07-08
 

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Supertonic models now report `enhancerBackendDevice` (`-1` none / `0` CPU /
   `1` GPU) and `enhancerBackendId` (the ggml backend id, e.g. `3` for Vulkan),
   so hosts can confirm where the enhancer actually ran.
+- **Quantized LavaSR enhancer GGUFs (`q8_0` / `q5_0` / `q4_0`).**
+  `convert-lavasr-enhancer-to-gguf.py --ftype` now accepts the block-quant tiers
+  in addition to `f32`/`f16`, block-quantizing only the large ConvNeXt
+  `pwconv1`/`pwconv2` and spec-head matmul weights via the shared
+  `should_quantize` policy (so it can't drift from `requantize-gguf.py`). The
+  loader dequantizes to F32 at load (dequant-at-load), so the forward math is
+  unchanged — `q4_0` is ~15 % of the F32 GGUF (8.5 MB vs 55.9 MB) and `q8_0` is
+  near-lossless at ~half the F16 size. Covered by the new always-on
+  `test-lavasr-enhancer-quant` unit test (QVAC-21906).
 
 ## [0.4.2] - 2026-07-08
 

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -231,8 +231,39 @@ public [LavaSRcpp](https://github.com/Topping1/LavaSRcpp) ONNX release:
 ```bash
 python scripts/convert-lavasr-enhancer-to-gguf.py \
   --backbone enhancer_backbone.onnx --spec-head enhancer_spec_head.onnx \
-  --out models/lavasr/lavasr-enhancer.gguf --ftype f16   # or f32
+  --out models/lavasr/lavasr-enhancer.gguf \
+  --ftype f16   # f32 | f16 | q8_0 | q5_0 | q4_0
 ```
+
+#### Quantization
+
+`--ftype` accepts `f32`, `f16` and the block-quant tiers `q8_0` / `q5_0` /
+`q4_0`. Only the enhancer supports quantization (the denoiser is already
+<1 MB). Quantization is **dequant-at-load**: the block-quant tiers shrink the
+*file on disk*, but `enhancer_gguf.cpp` dequantizes every tensor back to F32 in
+RAM, so the CPU/GGML forward math is byte-for-byte the same code path as F32 —
+there is no quantized-kernel graph to maintain. Only the 17 large 2-D matmul
+weights (the 8 ConvNeXt blocks' `pwconv1`/`pwconv2` and the spec-head `Linear`,
+~97 % of the parameters) are block-quantized; they route through the same
+`should_quantize` policy `requantize-gguf.py` uses, so the one-step converter
+and the requantizer can't drift. The K=7 conv kernels (not block-aligned) stay
+F16, and all LayerNorm scales, biases and per-block layer-scale `gamma` stay
+F32.
+
+| `--ftype` | GGUF size | vs F32 | vs F16 | fidelity vs F32 (cosine, real/imag) |
+| --------- | --------- | ------ | ------ | ----------------------------------- |
+| `f32`     | 55.9 MB   | 100 %  | 200 %  | 1.0 / 1.0 (baseline)                |
+| `f16`     | 28.1 MB   | 50 %   | 100 %  | ≈1.0 / ≈1.0                         |
+| `q8_0`    | 15.3 MB   | 27 %   | 54 %   | ≈0.9996 / ≈0.9994 (near-lossless)   |
+| `q4_0`    | 8.5 MB    | 15 %   | 30 %   | ≈0.90 / ≈0.88                       |
+
+(Sizes are exact for the current enhancer; f32/f16 GGUFs are byte-identical to
+the published registry artifacts. Fidelity is a synthetic-input sanity check —
+cosine similarity of the real/imag spectra vs the F32 GGUF, measured end-to-end
+mel → backbone → spec head. `q8_0` is effectively lossless at ~half the F16
+size; `q4_0` is the smallest and preserves the spectral shape but is the least
+faithful; `q5_0` sits between the two.) The GGUF-load round-trip is covered by
+the always-on `test-lavasr-enhancer-quant` C++ unit test.
 
 Notes:
 

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -237,33 +237,49 @@ python scripts/convert-lavasr-enhancer-to-gguf.py \
 
 #### Quantization
 
-`--ftype` accepts `f32`, `f16` and the block-quant tiers `q8_0` / `q5_0` /
-`q4_0`. Only the enhancer supports quantization (the denoiser is already
-<1 MB). Quantization is **dequant-at-load**: the block-quant tiers shrink the
-*file on disk*, but `enhancer_gguf.cpp` dequantizes every tensor back to F32 in
-RAM, so the CPU/GGML forward math is byte-for-byte the same code path as F32 —
-there is no quantized-kernel graph to maintain. Only the 17 large 2-D matmul
-weights (the 8 ConvNeXt blocks' `pwconv1`/`pwconv2` and the spec-head `Linear`,
-~97 % of the parameters) are block-quantized; they route through the same
-`should_quantize` policy `requantize-gguf.py` uses, so the one-step converter
-and the requantizer can't drift. The K=7 conv kernels (not block-aligned) stay
-F16, and all LayerNorm scales, biases and per-block layer-scale `gamma` stay
-F32.
+Only the enhancer supports quantization (the denoiser is already <1 MB).
+Quantization is **dequant-at-load**: the block-quant tiers shrink the *file on
+disk*, but `enhancer_gguf.cpp` dequantizes every tensor back to F32 in RAM, so
+the CPU/GGML forward math is byte-for-byte the same code path as F32 — there is
+no quantized-kernel graph to maintain. Only the 17 large 2-D matmul weights (the
+8 ConvNeXt blocks' `pwconv1`/`pwconv2` and the spec-head `Linear`, ~97 % of the
+parameters) are quantized; the K=7 conv kernels stay F16, and all LayerNorm
+scales, biases and per-block layer-scale `gamma` stay F32.
 
-| `--ftype` | GGUF size | vs F32 | vs F16 | fidelity vs F32 (cosine, real/imag) |
-| --------- | --------- | ------ | ------ | ----------------------------------- |
-| `f32`     | 55.9 MB   | 100 %  | 200 %  | 1.0 / 1.0 (baseline)                |
-| `f16`     | 28.1 MB   | 50 %   | 100 %  | ≈1.0 / ≈1.0                         |
-| `q8_0`    | 15.3 MB   | 27 %   | 54 %   | ≈0.9996 / ≈0.9994 (near-lossless)   |
-| `q4_0`    | 8.5 MB    | 15 %   | 30 %   | ≈0.90 / ≈0.88                       |
+Two producers, because the Python `gguf` library can only *emit* the legacy
+tiers:
 
-(Sizes are exact for the current enhancer; f32/f16 GGUFs are byte-identical to
-the published registry artifacts. Fidelity is a synthetic-input sanity check —
-cosine similarity of the real/imag spectra vs the F32 GGUF, measured end-to-end
-mel → backbone → spec head. `q8_0` is effectively lossless at ~half the F16
-size; `q4_0` is the smallest and preserves the spectral shape but is the least
-faithful; `q5_0` sits between the two.) The GGUF-load round-trip is covered by
-the always-on `test-lavasr-enhancer-quant` C++ unit test.
+- **Legacy tiers `q8_0` / `q5_0` / `q4_0`** — pass `--ftype` to the converter
+  above, or requantize an existing GGUF with `scripts/requantize-gguf.py`. Both
+  share one `should_quantize` policy so they can't drift.
+- **K-quants `q6_K` / `q5_K` / `q4_K`** — the Python lib can't quantize these,
+  so use the C++ tool from tts-cpp (`lavasr-requantize <in.gguf> <out.gguf>
+  <q6_K|q5_K|q4_K>`), which quantizes the same 17 tensors via
+  `ggml_quantize_chunk`. The loader reads them with no code change (its
+  dequant-at-load path is generic over any ggml quant type).
+
+| tier   | GGUF size | vs F32 | vs F16 | bits/wt | cos vs F32 (real / imag) |
+| ------ | --------- | ------ | ------ | ------- | ------------------------ |
+| `f32`  | 55.9 MB   | 100 %  | 199 %  | 32      | 1.000 / 1.000 (baseline) |
+| `f16`  | 28.1 MB   | 50 %   | 100 %  | 16      | ≈1.000 / ≈1.000          |
+| `q8_0` | 15.3 MB   | 27 %   | 54 %   | 8.5     | 0.998 / 0.997            |
+| `q6_K` | 12.0 MB   | 21 %   | 43 %   | 6.6     | 0.969 / 0.967            |
+| `q5_K` | 10.2 MB   | 18 %   | 36 %   | 5.5     | 0.889 / 0.897            |
+| `q4_K` | 8.5 MB    | 15 %   | 30 %   | 4.5     | 0.621 / 0.601            |
+| `q4_0` | 8.5 MB    | 15 %   | 30 %   | 4.5     | 0.612 / 0.593            |
+
+Sizes are exact for the current enhancer; f32/f16 GGUFs are byte-identical to
+the published registry artifacts. Fidelity is the cosine similarity of the
+real/imag spectra vs the F32 GGUF on a realistic log-mel (T=512), i.e. pure
+quantization error (the F32/F16/`q8_0` GGUFs also match the ONNX golden in
+`test-lavasr-enhancer-gguf`). **Guidance:** `q8_0` is near-lossless; **`q6_K`
+is the sweet spot** below it (≈43 % of F16, still 0.97 cos); `q5_K` is
+noticeably degraded; and **4-bit (`q4_K`/`q4_0`) is quite lossy on this model**
+— the spec-head `exp()` reconstruction amplifies low-bit error, and at 4 bits
+the K-quant super-block scaling barely helps (same 8.5 MB as `q4_0`). Don't ship
+a sub-`q8_0` tier without a real-audio A/B; `q6_K` is the recommended small tier.
+The GGUF-load round-trip for every tier (incl. the K-quants) is covered by the
+always-on `test-lavasr-enhancer-quant` C++ unit test.
 
 Notes:
 

--- a/packages/tts-ggml/scripts/convert-lavasr-enhancer-to-gguf.py
+++ b/packages/tts-ggml/scripts/convert-lavasr-enhancer-to-gguf.py
@@ -20,22 +20,61 @@ Linear (MatMul) weights are stored ONNX-side as [in,out]; we transpose them to
 [out,in] (PyTorch convention) so the C++ loader reads ggml ne=[in,out] and runs
 ggml_mul_mat(W, x) directly.  Conv weights are stored as ONNX [out,in,k].
 
+Quantization (--ftype q4_0 / q5_0 / q8_0): the block-quant tiers reuse the
+shared policy in requantize-gguf.py (should_quantize), so the one-step ONNX->
+GGUF converter and the requantize-an-existing-GGUF path can never drift (the
+drift between them is exactly what broke S3Gen conversion in QVAC-21203). Only
+the big 2-D matmul weights qualify: the 8x ConvNeXt pwconv1/pwconv2 (512<->1536)
+and the spec-head Linear (512->2050), i.e. 17 tensors and ~97% of the weights.
+The K=7 conv kernels (embed + depthwise) are not block-aligned so they stay F16;
+LayerNorm scales, all biases and the per-block layer-scale gamma stay F32. The
+C++ loader (enhancer_gguf.cpp) dequantizes every tensor to F32 at load, so the
+forward math is identical to F32 — the win is a smaller GGUF (Q4_0 ~= 15% of the
+F32 GGUF / ~30% of F16).
+
 Usage:
   python convert-lavasr-enhancer-to-gguf.py \
       --backbone  enhancer_backbone.onnx \
       --spec-head enhancer_spec_head.onnx \
       --out       lavasr-enhancer.gguf \
-      --ftype     f32            # or f16
+      --ftype     f32            # or f16 / q8_0 / q5_0 / q4_0
 """
 import argparse
+import importlib.util
+import os
 import sys
 
+import gguf
 import numpy as np
 import onnx
 from gguf import GGUFWriter
 from onnx import numpy_helper
 
 ARCH = "lavasr-enhancer"
+
+# Map the --ftype quant tiers onto gguf quant types. F32/F16 are handled inline
+# by store(); these are the block-quant tiers that route through should_quantize.
+_QUANT_TYPE = {
+    "q8_0": gguf.GGMLQuantizationType.Q8_0,
+    "q5_0": gguf.GGMLQuantizationType.Q5_0,
+    "q4_0": gguf.GGMLQuantizationType.Q4_0,
+}
+
+
+def _load_should_quantize():
+    """Import should_quantize() from the sibling requantize-gguf.py so the
+    converter and the requantizer share ONE quant policy (name deny-list +
+    block-size gates). The hyphen in the filename blocks a plain import, so
+    load it by path."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(here, "requantize-gguf.py")
+    spec = importlib.util.spec_from_file_location("requantize_gguf", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.should_quantize
+
+
+should_quantize = _load_should_quantize()
 
 # Mel / STFT params (must match src/lavasr/dsp + the @qvac/tts-onnx enhancer).
 N_MELS = 80
@@ -82,6 +121,32 @@ def find_matmul_weight(graph, inits, by_out, bias_name):
 
 def store(writer, name, arr, ftype, allow_f16=True):
     arr = np.ascontiguousarray(arr)
+
+    # Block-quant tiers (q4_0 / q5_0 / q8_0): defer the per-tensor keep/quant
+    # decision to the shared should_quantize policy so this one-step converter
+    # and requantize-gguf.py stay consistent. Only the big 2-D matmul weights
+    # (pwconv1/pwconv2/spec_head.out) clear the block-size gate; the K=7 conv
+    # kernels, LayerNorm scales, biases and gamma fall through to the F16/F32
+    # keep path below (matching requantize-gguf.py's "kept at source dtype").
+    if ftype in _QUANT_TYPE:
+        qtype = _QUANT_TYPE[ftype]
+        if arr.dtype == np.float32 and should_quantize(name, tuple(arr.shape), qtype):
+            qdata = gguf.quants.quantize(arr, qtype)
+            # raw_shape is the BYTE shape (gguf-0.18+ add_tensor_info treats a
+            # uint8 raw tensor's inner dim as bytes/row); raw_dtype=Q* carries
+            # the element dims. qdata.shape already encodes it — same call
+            # requantize-gguf.py uses.
+            writer.add_tensor(name, qdata, raw_shape=qdata.shape, raw_dtype=qtype)
+            print(f"  {name:42s} {qtype.name:8s} {list(arr.shape)}")
+            return
+        if allow_f16 and arr.ndim >= 2 and arr.dtype == np.float32:
+            arr = arr.astype(np.float16)
+        elif arr.dtype != np.float32 and arr.dtype != np.float16:
+            arr = arr.astype(np.float32)
+        writer.add_tensor(name, arr)
+        print(f"  {name:42s} {str(arr.dtype):8s} {list(arr.shape)}")
+        return
+
     if ftype == "f16" and allow_f16 and arr.ndim >= 2 and arr.dtype == np.float32:
         arr = arr.astype(np.float16)
     elif arr.dtype != np.float32 and arr.dtype != np.float16:
@@ -95,7 +160,8 @@ def main():
     ap.add_argument("--backbone", required=True)
     ap.add_argument("--spec-head", required=True)
     ap.add_argument("--out", required=True)
-    ap.add_argument("--ftype", choices=["f32", "f16"], default="f32")
+    ap.add_argument("--ftype", choices=["f32", "f16", "q8_0", "q5_0", "q4_0"],
+                    default="f32")
     args = ap.parse_args()
 
     bb = onnx.load(args.backbone, load_external_data=True).graph

--- a/packages/tts-ggml/scripts/requantize-gguf.py
+++ b/packages/tts-ggml/scripts/requantize-gguf.py
@@ -12,6 +12,11 @@ builtin voice conditioning) at their source dtype.
 Works for both models because the deny-list covers the union of
 patterns that either side uses for "keep-as-F32/F16".
 
+Only the legacy block-quant tiers (Q8_0 / Q5_0 / Q4_0) are reachable here: the
+Python `gguf` library can quantize those but not the K-quants (Q4_K / Q5_K /
+Q6_K).  K-quants need ggml's own quantizer — for the LavaSR enhancer use the C++
+`lavasr-requantize` tool in tts-cpp; the enhancer loader reads either.
+
 Usage:
 
     # T3 Q8_0


### PR DESCRIPTION
## Summary

Addon-package (`@qvac/tts-ggml`) docs + converter for quantized LavaSR enhancer support. The C++ loader/producer live in **tts-cpp** (tetherto/qvac-ext-lib-whisper.cpp#84); this PR adds the converter option and documents what we support. Two commits.

**1. Legacy tiers `q4_0` / `q5_0` / `q8_0`**
- `scripts/convert-lavasr-enhancer-to-gguf.py --ftype`: block-quantizes only the big `pwconv`/spec-head matmul weights via the shared `should_quantize()` policy (kept in sync with the tts-cpp copy).
- README "Quantization" section + CHANGELOG.

**2. K-quants `q4_K` / `q5_K` / `q6_K`**
- The tts-cpp loader reads K-quants unchanged (dequant-at-load is generic), but the Python `gguf` lib can't emit them, so they're produced by the C++ `lavasr-requantize` tool in tts-cpp. README documents the two-producer split and the full size/fidelity ladder.

### Size / fidelity ladder (current enhancer)

Fidelity = cosine vs the F32 GGUF on a realistic log-mel (T=512). f32/f16 GGUFs are **byte-identical** (SHA-256) to the published registry artifacts.

| tier   | size    | vs F32 | vs F16 | bits/wt | cos vs F32 (real / imag) |
| ------ | ------- | ------ | ------ | ------- | ------------------------ |
| f32    | 55.9 MB | 100%   | 199%   | 32      | 1.000 / 1.000 |
| f16    | 28.1 MB | 50%    | 100%   | 16      | ≈1.000 / ≈1.000 |
| q8_0   | 15.3 MB | 27%    | 54%    | 8.5     | 0.998 / 0.997 |
| q6_K   | 12.0 MB | 21%    | 43%    | 6.6     | 0.969 / 0.967 |
| q5_K   | 10.2 MB | 18%    | 36%    | 5.5     | 0.889 / 0.897 |
| q4_K   | 8.5 MB  | 15%    | 30%    | 4.5     | 0.621 / 0.601 |
| q4_0   | 8.5 MB  | 15%    | 30%    | 4.5     | 0.612 / 0.593 |

**Guidance:** `q8_0` near-lossless; **`q6_K` is the recommended small tier**; 4-bit is quite lossy on this model (spec-head `exp()` amplifies low-bit error). This also **corrects the earlier `q4_0` figure** — on realistic input it's ~0.61 cos, not the ~0.90 first published (that came from an over-gentle synthetic input).

## Test plan

- [x] Converter regenerates all `--ftype` GGUFs; f32/f16 SHA-256 match the registry artifacts.
- [x] Round-trip (incl. K-quants) covered by the always-on `test-lavasr-enhancer-quant` C++ unit test (tts-cpp PR #84).
- [ ] Docs render check.

## Notes / follow-up

- Depends on tts-cpp PR #84 (loader + `lavasr-requantize`) landing + a `tts-cpp` version bump.
- Publishing a quantized enhancer to the **model registry** is a separate infra step: `models.ts` is auto-generated by `update-models` (scans the remote registry), so the artifact must be built + uploaded first.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216355185018360