### PR TITLE
QVAC-21867 chore: bump llm-llamacpp to 0.36.0

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.36.0] - 2026-07-08
+
+### Added
+
+- `mmproj-use-gpu` config key: run the multimodal projector (mmproj / vision encoder) on the GPU (`'true'`/`'on'`/`'1'`) or CPU (`'false'`/`'off'`/`'0'`, case-insensitive). Only honoured when a GPU backend is selected — ignored with a warning on the CPU/GPU-fallback backend. When unset the projector backend is auto-selected per device class (see below).
+- Per-device-class auto-default for the projector backend on Android: Mali GPUs and Adreno < 800 default to CPU (projector encode measured slower on the Mali GPU than CPU, and sub-800 Adreno tiers are not yet benchmarked), while Adreno 800+ and other non-Mali Android GPUs default to GPU. Desktop and iOS continue to default to GPU. `BackendSelection` now surfaces Mali detection alongside the Adreno version.
+
+### Pull Requests
+
+- [#3162](https://github.com/tetherto/qvac/pull/3162) - QVAC-21867 feat[api]: auto-default the Android multimodal projector backend by GPU class
+
 ## [0.35.3] - 2026-07-08
 
 ### Changed

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.35.3",
+  "version": "0.36.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

Releases the merged QVAC-21867 change ([#3162](https://github.com/tetherto/qvac/pull/3162) — auto-default the Android multimodal projector (mmproj / vision encoder) backend by GPU class + the `mmproj-use-gpu` config key) by bumping `@qvac/llm-llamacpp` so the on-merge automation publishes it. #3162 landed without a version/changelog change (deferred to this chore PR).

## 📝 How does it solve it?

- `packages/llm-llamacpp/package.json`: `0.35.3` → `0.36.0` (minor — new `mmproj-use-gpu` API surface).
- `packages/llm-llamacpp/CHANGELOG.md`: new `[0.36.0]` section covering the `mmproj-use-gpu` config key (force the projector backend; case-insensitive `true/on/1` or `false/off/0`; honoured only on a GPU backend, otherwise warns) and the per-device-class auto-default (Android Mali and Adreno < 800 → CPU; Adreno 800+ and other non-Mali Android GPUs → GPU; desktop/iOS → GPU; `BackendSelection` surfaces Mali detection).

No code changes — changelog + version bump only.

## 🧪 How was it tested?

- #3162 was validated pre-merge: full labeled CI (cpp-tests Linux/macOS/Windows, all-platform prebuilds, Android + iOS Device Farm, `verify-fabric-lockstep`, merge-guard). Integration suite passed on a GPU-equipped machine, including the mmproj GPU auto-default leg; C++ unit tests 760 passed / 6 hardware-skipped.
- `package.json` parses; changelog follows the package's established format (read by `on-merge-llm-llamacpp.yml` via `changelog-path`).

## ⚠️ Breaking changes

None. Version + changelog only.
