### PR TITLE
fix: default Android mmproj projector to GPU only on Adreno 800+

### DIFF
--- a/packages/llm-llamacpp/README.md
+++ b/packages/llm-llamacpp/README.md
@@ -191,12 +191,12 @@ For vision (VLM) models, the projector / image-encoder backend is auto-selected 
 `mmproj-use-gpu` is unset (QVAC-21867):
 
 - **Desktop & iOS:** GPU.
-- **Android, Adreno 800+ GPUs and other non-Mali Android GPUs:** GPU.
-- **Android, Arm Mali GPUs:** **CPU** — the projector encode is slower on the Mali GPU than on CPU
-  (QVAC-21257 benchmarks), so the LLM layers run on the GPU while the projector stays on CPU.
-- **Android, Adreno < 800 GPUs:** **CPU** — these weaker tiers were not covered by the QVAC-21257
-  projector-on-GPU benchmarks, so the default is conservative; this may be relaxed once they are
-  benchmarked.
+- **Android, Adreno 800+ GPUs** (e.g. Adreno 830): GPU — the only mobile GPU class
+  benchmarked (QVAC-21257) to encode the projector faster than on CPU.
+- **All other Android GPUs** — Arm Mali, Adreno < 800 (e.g. Adreno 740), and any GPU
+  whose Adreno tier can't be detected: **CPU**. The LLM layers still run on the GPU
+  while the projector stays on CPU. Mali is measurably slower on-GPU (QVAC-21257) and
+  the remaining tiers are not yet benchmarked; this may be relaxed per class once they are.
 
 An explicit `mmproj-use-gpu` value always wins over the auto-default, in either direction. When the model
 itself runs on the CPU backend (`device: "cpu"` or GPU fallback), the key is ignored with a warning and the

--- a/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlamaModel.cpp
@@ -1537,22 +1537,29 @@ void LlamaModel::commonParamsParse(
       params.mmproj_backend = chosenBackend.second;
 #ifdef __ANDROID__
       // QVAC-21867: auto-default the projector backend by GPU class.
+      // Only Adreno 800+ is benchmarked (QVAC-21257) to encode the projector
+      // faster on the mobile GPU than on CPU, so it is the only Android class
+      // that defaults to GPU. Every other Android GPU class defaults to CPU
+      // (the LLM layers still run on the GPU):
       //   - Mali: the projector encode is slower on the Mali GPU than on CPU
-      //     (QVAC-21257 benchmarks) -> CPU.
-      //   - Adreno < 800: materially weaker tiers that the QVAC-21257
-      //     projector-on-GPU benchmarks did not cover -> CPU (conservative).
-      //     Relax this once those tiers are benchmarked.
-      //   - Adreno 800+ and other Android GPUs -> GPU.
-      // The mmproj-use-gpu key overrides this either way.
+      //     (QVAC-21257 benchmarks).
+      //   - Adreno < 800: materially weaker tiers the QVAC-21257
+      //     projector-on-GPU benchmarks did not cover (conservative).
+      //   - Any GPU whose Adreno tier can't be detected: conservative default.
+      // Relax per class once those tiers are benchmarked. The mmproj-use-gpu
+      // key overrides this either way.
       constexpr int kAdrenoMmprojGpuThreshold = 800;
-      const bool adrenoBelowThreshold =
+      const bool isAdreno800Plus =
           outAdrenoVersion.has_value() &&
-          outAdrenoVersion.value() < kAdrenoMmprojGpuThreshold;
-      bool mmprojUseGpu = !isMaliGpu && !adrenoBelowThreshold;
+          outAdrenoVersion.value() >= kAdrenoMmprojGpuThreshold;
+      bool mmprojUseGpu = isAdreno800Plus;
       const char* mmprojDefaultReason =
-          isMaliGpu ? "auto-default, Mali GPU"
-                    : (adrenoBelowThreshold ? "auto-default, Adreno <800"
-                                            : "auto-default");
+          isAdreno800Plus
+              ? "auto-default, Adreno 800+"
+              : (isMaliGpu ? "auto-default, Mali GPU"
+                           : (outAdrenoVersion.has_value()
+                                  ? "auto-default, Adreno <800"
+                                  : "auto-default, non-Adreno-800+ GPU"));
 #else
       bool mmprojUseGpu = true;
       const char* mmprojDefaultReason = "auto-default";

--- a/packages/llm-llamacpp/index.d.ts
+++ b/packages/llm-llamacpp/index.d.ts
@@ -75,10 +75,10 @@ export interface LlamaConfig {
   /**
    * Run the multimodal projector (mmproj / vision encoder) on the GPU. Accepts
    * 'true'/'on'/'1' or 'false'/'off'/'0'. When unset, the backend is auto-selected
-   * per device class: GPU on desktop/iOS, Android Adreno 800+ and other non-Mali
-   * Android GPUs; CPU on Android Mali GPUs (slower on the Mali GPU than CPU) and
-   * Android Adreno <800 (weaker tiers not yet benchmarked). Only honoured when a
-   * GPU backend is selected (ignored with a warning on CPU).
+   * per device class: GPU on desktop/iOS and Android Adreno 800+; CPU on all other
+   * Android GPUs (Arm Mali, Adreno <800, and GPUs whose Adreno tier can't be
+   * detected) — the LLM layers still run on the GPU while the projector stays on
+   * CPU. Only honoured when a GPU backend is selected (ignored with a warning on CPU).
    */
   'mmproj-use-gpu'?: string
   /** Writable directory for OpenCL kernel binary cache. Required on Android for fast GPU startup. */


### PR DESCRIPTION
## 🎯 Problem

The Android multimodal-projector (mmproj / vision-encoder) auto-default introduced in QVAC-21867 enabled the **GPU** projector on Adreno 800+ **and every other non-Mali Android GPU**, only falling back to CPU on Mali and Adreno < 800.

Only **Adreno 800+** was actually benchmarked (QVAC-21257) to encode the projector faster on the mobile GPU than on CPU. Defaulting to GPU on unbenchmarked or undetectable Android GPU classes is optimistic and can regress projector-encode latency on those devices.

## 📝 How

Narrow the Android default in `LlamaModel::commonParamsParse` so the projector uses the **GPU only when an Adreno 800+ is positively detected**. Every other Android GPU class defaults to **CPU** (while the LLM layers still run on the GPU):

| Device class | Projector default |
|---|---|
| Desktop & iOS | GPU (unchanged) |
| Android — Adreno 800+ | GPU |
| Android — Arm Mali | CPU |
| Android — Adreno < 800 | CPU |
| Android — undetectable Adreno tier | CPU |

The condition flips from `!isMaliGpu && !adrenoBelowThreshold` to a positive `isAdreno800Plus` test; the decision-log reason string distinguishes each class. `BackendSelection` plumbing (Mali/Adreno detection) is unchanged. The explicit `mmproj-use-gpu` config key still overrides the default in either direction.

Docs updated to the same matrix in `README.md` and `index.d.ts`.

## 🧪 Tested

Validated via CI (no local run for this change). The desktop integration test `image-mmproj-gpu.test.js` still exercises the unchanged desktop GPU default + override paths (the `#else` branch is untouched).

The Adreno-tier branch is Android-only and is not exercised by desktop CI — on-device validation (Adreno 800+ vs Adreno < 800 / Mali) is a follow-up.

## ⚠️ Breaking

Behavioral default change only — no API signature change and no version bump. The `mmproj-use-gpu` override semantics are unaffected. Callers that relied on the implicit GPU projector default on non-Mali / non-Adreno-800+ Android GPUs will now get the CPU projector unless they set `mmproj-use-gpu: "true"`.
