### PR TITLE
chore: bump llm-llamacpp to 0.36.2

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.36.2] - 2026-07-09
+
+### Changed
+
+- Android multimodal-projector (mmproj / vision encoder) auto-default narrowed: with `mmproj-use-gpu` unset the projector now defaults to the GPU **only** on positively-detected Adreno 800+ GPUs. All other Android GPU classes — Arm Mali, Adreno < 800, and any GPU whose Adreno tier can't be detected — default to CPU (the LLM layers still run on the GPU). Only Adreno 800+ was benchmarked (QVAC-21257) to encode the projector faster on the mobile GPU than on CPU, so defaulting to GPU on unbenchmarked/undetectable classes was optimistic. Desktop and iOS continue to default to GPU, and an explicit `mmproj-use-gpu` value still overrides the default in either direction.
+
+### Pull Requests
+
+- [#3168](https://github.com/tetherto/qvac/pull/3168) - fix: default Android mmproj projector to GPU only on Adreno 800+
+
 ## [0.36.1] - 2026-07-09
 
 ### Fixed

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 Problem

The Android mmproj-projector auto-default change ([#3168](https://github.com/tetherto/qvac/pull/3168)) merged to `main` without a package version bump or CHANGELOG entry, so the released `@qvac/llm-llamacpp` version does not yet reflect the new default behaviour.

## 📝 How

- Bump `packages/llm-llamacpp/package.json` `0.36.1` → `0.36.2`.
- Add a `## [0.36.2]` CHANGELOG entry under `### Changed` describing the narrowed default (GPU only on Adreno 800+; all other Android GPU classes → CPU), referencing PR #3168.

No source changes — the behaviour itself already landed in #3168.

## 🧪 Tested

Docs/metadata only; no code change. `CHANGELOG.md` and `package.json` edits verified by diff.

## ⚠️ Breaking

None. Version bump + changelog only.
