### PR TITLE
doc: tabulate mmproj projector auto-default and reorder README

### DIFF
--- a/packages/llm-llamacpp/README.md
+++ b/packages/llm-llamacpp/README.md
@@ -185,25 +185,6 @@ const config = {
 | mmproj-use-gpu    | `"true"`/`"on"`/`"1"` or `"false"`/`"off"`/`"0"` | auto (see below)         | Run the multimodal projector (mmproj / vision encoder) on the GPU. Only honoured when a GPU backend is selected (ignored with a warning on CPU / GPU-fallback). Unset = auto-default (see mmproj backend below) |
 
 
-#### Multimodal projector (mmproj) backend & auto-default
-
-For vision (VLM) models, the projector / image-encoder backend is auto-selected per device class when
-`mmproj-use-gpu` is unset (QVAC-21867):
-
-- **Desktop & iOS:** GPU.
-- **Android, Adreno 800+ GPUs** (e.g. Adreno 830): GPU — the only mobile GPU class
-  benchmarked (QVAC-21257) to encode the projector faster than on CPU.
-- **All other Android GPUs** — Arm Mali, Adreno < 800 (e.g. Adreno 740), and any GPU
-  whose Adreno tier can't be detected: **CPU**. The LLM layers still run on the GPU
-  while the projector stays on CPU. Mali is measurably slower on-GPU (QVAC-21257) and
-  the remaining tiers are not yet benchmarked; this may be relaxed per class once they are.
-
-An explicit `mmproj-use-gpu` value always wins over the auto-default, in either direction. When the model
-itself runs on the CPU backend (`device: "cpu"` or GPU fallback), the key is ignored with a warning and the
-projector runs on CPU. The resolved choice is logged at verbosity ≥ 2 as
-`[LlamaModel] multimodal projector backend: …`.
-
-
 #### KV-cache type & auto-default
 
 The addon picks a safe KV-cache type when `cache-type-k`/`cache-type-v` are unset, and validates any explicit choice per backend:
@@ -223,6 +204,27 @@ The addon picks a safe KV-cache type when `cache-type-k`/`cache-type-v` are unse
 | System with both                | ✅ Uses dedicated GPU (preferred)     | ✅ Uses dedicated GPU               | ✅ Uses integrated GPU              |
 
 For multi-GPU setups using `split-mode` and `tensor-split`, see the **[Multi-GPU Inference guide](./docs/multi-gpu.md)**.
+
+
+#### Multimodal projector (mmproj) backend & auto-default
+
+For vision (VLM) models, the projector / image-encoder backend is auto-selected per device class when
+`mmproj-use-gpu` is unset (QVAC-21867):
+
+| Device class | Projector default | Why |
+|---|---|---|
+| Desktop & iOS | **GPU** | Metal / Vulkan projector encode is faster than CPU. |
+| Android — Adreno 800+ (e.g. Adreno 830) | **GPU** | The only mobile GPU class benchmarked (QVAC-21257) to encode the projector faster than on CPU. |
+| Android — Arm Mali | **CPU** | Projector encode measured slower on the Mali GPU than on CPU (QVAC-21257). |
+| Android — Adreno < 800 (e.g. Adreno 740) | **CPU** | Weaker tiers not yet benchmarked; conservative default (may be relaxed once benchmarked). |
+| Android — undetectable Adreno tier | **CPU** | Conservative default when the GPU's Adreno version can't be parsed. |
+
+In every Android **CPU** case above the LLM layers still run on the GPU — only the projector stays on CPU.
+
+An explicit `mmproj-use-gpu` value always wins over the auto-default, in either direction. When the model
+itself runs on the CPU backend (`device: "cpu"` or GPU fallback), the key is ignored with a warning and the
+projector runs on CPU. The resolved choice is logged at verbosity ≥ 2 as
+`[LlamaModel] multimodal projector backend: …`.
 
 ### 4. Create Model Instance
 


### PR DESCRIPTION
## 🎯 Problem

The mmproj / image-encoder auto-default (GPU only on Adreno 800+, CPU on all other Android GPU classes) was documented as a prose bullet list that was hard to scan, and it sat above the KV-cache and IGPU/GPU-selection sections rather than beside the other GPU-selection reference.

## 📝 How

- Replace the mmproj auto-default bullet list with a **device-class table** (Device class → Projector default → Why).
- Move the **Multimodal projector (mmproj) backend & auto-default** section to sit **after** the IGPU/GPU selection logic section, so both GPU-selection references are grouped together.

Docs only — no source or behaviour change.

## 🧪 Tested

README-only change; rendering verified in the diff (table + section order). No code affected.

## ⚠️ Breaking

None.
