### PR TITLE
infra: run tts-ggml macOS CI on qvac-macos26-arm64-gpu with Metal GPU

### DIFF
--- a/.github/workflows/integration-test-tts-ggml.yml
+++ b/.github/workflows/integration-test-tts-ggml.yml
@@ -103,10 +103,10 @@ jobs:
             platform: linux
             arch: arm64
             no_gpu: 'true'
-          - os: macos-14-xlarge
+          - os: macos-26
+            runner: qvac-macos26-arm64-gpu
             platform: darwin
             arch: arm64
-            no_gpu: 'true'
           - os: macos-15-large
             platform: darwin
             arch: x64
@@ -253,6 +253,10 @@ jobs:
             export QVAC_TTS_GGML_BENCHMARK_MATRIX_JSON="$QVAC_TTS_GGML_BENCHMARK_MATRIX_OVERRIDE"
           elif [ "${{ matrix.no_gpu || 'false' }}" = "true" ]; then
             export QVAC_TTS_GGML_BENCHMARK_MATRIX_JSON='[{"engine":"chatterbox","useGPU":false,"backendHint":"cpu"},{"engine":"chatterbox-mtl","useGPU":false,"backendHint":"cpu"},{"engine":"supertonic","useGPU":false,"backendHint":"cpu"},{"engine":"supertonic-mtl","useGPU":false,"backendHint":"cpu"}]'
+          elif [ "${{ matrix.platform }}" = "darwin" ]; then
+            # macOS GPU backend is Metal, not Vulkan. Needs a Metal-capable
+            # runner (qvac-macos26-arm64-gpu); hosted macs stay CPU-only via no_gpu.
+            export QVAC_TTS_GGML_BENCHMARK_MATRIX_JSON='[{"engine":"chatterbox","useGPU":false,"backendHint":"cpu"},{"engine":"chatterbox-mtl","useGPU":false,"backendHint":"cpu"},{"engine":"supertonic","useGPU":false,"backendHint":"cpu"},{"engine":"supertonic-mtl","useGPU":false,"backendHint":"cpu"},{"engine":"chatterbox","useGPU":true,"backendHint":"metal"},{"engine":"chatterbox-mtl","useGPU":true,"backendHint":"metal"},{"engine":"supertonic","useGPU":true,"backendHint":"metal"},{"engine":"supertonic-mtl","useGPU":true,"backendHint":"metal"}]'
           else
             export QVAC_TTS_GGML_BENCHMARK_MATRIX_JSON='[{"engine":"chatterbox","useGPU":false,"backendHint":"cpu"},{"engine":"chatterbox-mtl","useGPU":false,"backendHint":"cpu"},{"engine":"supertonic","useGPU":false,"backendHint":"cpu"},{"engine":"supertonic-mtl","useGPU":false,"backendHint":"cpu"},{"engine":"chatterbox","useGPU":true,"backendHint":"vulkan"},{"engine":"chatterbox-mtl","useGPU":true,"backendHint":"vulkan"},{"engine":"supertonic","useGPU":true,"backendHint":"vulkan"},{"engine":"supertonic-mtl","useGPU":true,"backendHint":"vulkan"}]'
           fi


### PR DESCRIPTION
## What problem does this PR solve?

The tts-ggml macOS integration-test + benchmark matrix ran on the GitHub-hosted
macs (`macos-14-xlarge`) **CPU-only** (`no_gpu: 'true'`), so the addon was never
exercised on the Metal GPU on macOS, and the benchmark had no macOS GPU numbers.

## How does it solve it?

Adopts the new self-hosted Apple-Silicon runner (`qvac-macos26-arm64-gpu`, Metal
GPU, Xcode 26.5) for the arm64 macOS leg:

- point the arm64 macOS matrix entry at `runner: qvac-macos26-arm64-gpu` and drop
  `no_gpu: 'true'`, so functional integration tests **and** the RTF benchmark run
  on the Metal GPU instead of CPU-only;
- add a `platform == darwin` branch to the benchmark-matrix generator that emits
  `backendHint: "metal"` GPU entries (the generic GPU branch hardcoded `vulkan`,
  which is wrong on macOS).

The x64 `macos-15-large` entry stays GitHub-hosted (the new fleet is Apple
Silicon only). No macOS toolchain steps needed changing (tts-ggml's only installs
are Linux apt, already guarded to `arch==arm64 && linux`).

## Validation

Dispatched `benchmark-performance-tts-ggml.yml` on this branch
(run 29021793685, `prebuild_package=@qvac/tts-ggml@0.4.2`, desktop): the
`macos-26-darwin-arm64-gpu` job ran on the new runner and produced `metal` RTF
rows for all four engines, far faster than the old hosted-mac CPU:

| engine | hosted mac CPU | qvac-macos26 Metal |
|---|---|---|
| chatterbox | 1.2936 | 0.1517 |
| chatterbox-mtl | 4.3645 | 0.2886 |
| supertonic | 0.0973 | 0.0135 |
| supertonic-mtl | 0.0893 | 0.0101 |

Note: `desktop-benchmarks` downloads a published prebuild, so this validates
*running* on Metal; the Xcode-26.5 *build* lives in the separate
`reusable-prebuilds` workflow and is unchanged here.

## Breaking changes

None. Only the arm64 macOS runner target and its bench backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)