### PR TITLE
infra: run bci-whispercpp macOS CI on qvac-macos26-arm64-gpu with Metal GPU

### DIFF
--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -69,11 +69,14 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
       # Per-runner GPU toggle (mirrors integration-test-tts-ggml.yml): GPU
       # runners (qvac-*-gpu) leave no_gpu unset so the gpu-smoke runs and
-      # asserts the GPU backend; CPU runners and hosted macOS (where the
-      # Paravirtual Metal device crashes ggml's encoder) set no_gpu:'true' to
-      # skip it. bci ships a Vulkan desktop build (see vcpkg.json), so the Linux
-      # GPU runner exercises real desktop GPU. Mobile GPU coverage runs on
-      # Device Farm via test/mobile/integration-runtime.cjs (NO_GPU=false).
+      # asserts the GPU backend; CPU-only runners set no_gpu:'true' to skip it.
+      # The arm64 macOS leg runs on the self-hosted qvac-macos26-arm64-gpu
+      # runner, which has a real Metal GPU and so exercises the Metal backend
+      # (hosted macs' Paravirtual Metal device crashed ggml's encoder, which is
+      # why macOS was previously CPU-only). bci ships a Vulkan desktop build
+      # (see vcpkg.json), so the Linux GPU runner exercises real desktop GPU.
+      # Mobile GPU coverage runs on Device Farm via
+      # test/mobile/integration-runtime.cjs (NO_GPU=false).
       NO_GPU: ${{ matrix.no_gpu || 'false' }}
 
     permissions:
@@ -112,12 +115,12 @@ jobs:
             no_gpu: 'true'
             benchmark_matrix_json: >-
               [{"useGPU":false,"backendHint":"cpu"}]
-          - os: macos-14-xlarge
+          - os: macos-26
+            runner: qvac-macos26-arm64-gpu
             platform: darwin
             arch: arm64
-            no_gpu: 'true'
             benchmark_matrix_json: >-
-              [{"useGPU":false,"backendHint":"cpu"}]
+              [{"useGPU":false,"backendHint":"cpu"},{"useGPU":true,"backendHint":"metal"}]
           - os: macos-15-large
             platform: darwin
             arch: x64
@@ -223,12 +226,6 @@ jobs:
             $newName = $_.Name -replace 'tetherto__', 'qvac__'
             Rename-Item -Path $_.FullName -NewName $newName
           }
-
-      - name: macOS - install whisper dependencies
-        if: matrix.platform == 'darwin'
-        shell: bash
-        run: |
-          brew install --quiet openblas lapack fftw
 
       # The prebuilt Windows addon is a Vulkan build that links against the
       # Vulkan loader (vulkan-1.dll), which ships in C:\VulkanSDK\Bin on the


### PR DESCRIPTION
## What

Move the **arm64 macOS** integration/benchmark leg of `bci-whispercpp` from the hosted `macos-14-xlarge` runner to the self-hosted **`qvac-macos26-arm64-gpu`** runner and enable the Metal GPU backend. Mirrors the validated `tts-ggml` pilot (#3187).

## Changes (`.github/workflows/integration-test-bci-whispercpp.yml`)

- **arm64 mac matrix entry:** `os: macos-14-xlarge` → `os: macos-26` + `runner: qvac-macos26-arm64-gpu`; removed `no_gpu: 'true'` so the gpu-smoke runs and asserts the GPU backend.
- **benchmark matrix:** the arm64 mac `benchmark_matrix_json` now sweeps both CPU and Metal GPU: `[{"useGPU":false,"backendHint":"cpu"},{"useGPU":true,"backendHint":"metal"}]` (Metal, not Vulkan, on macOS).
- **GPU-toggle comment:** updated to reflect that the self-hosted runner has a real Metal GPU; dropped the stale "hosted mac only, Paravirtual crashes" rationale.
- **Removed** the `macOS - install whisper dependencies` step (`brew install --quiet openblas lapack fftw`): the new runner has openblas preinstalled and forbids job-time brew.
- **x64 mac (`macos-15-large`) stays hosted and CPU-only** — unchanged.

## Paravirtual-Metal context / risk

The arm64 mac leg was deliberately CPU-only (`no_gpu: 'true'`) because the hosted mac's **Paravirtual Metal device crashed ggml's encoder**. The new `qvac-macos26-arm64-gpu` runner has a **real Metal GPU**, which is expected to resolve that — but this is unverified. That's exactly what the dispatched benchmark validation run tests. If the Metal path crashes on the real GPU, we report it rather than working around it.

## Validation

Draft until the dispatched `benchmark-performance-bci-whispercpp.yml` run on this branch (include_desktop=true) is green on the arm64 mac Metal leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
