### PR TITLE
infra: run parakeet macOS CI on qvac-macos26-arm64-gpu with Metal GPU

### DIFF
--- a/.github/workflows/integration-test-transcription-parakeet.yml
+++ b/.github/workflows/integration-test-transcription-parakeet.yml
@@ -87,10 +87,10 @@ jobs:
             platform: linux
             arch: arm64
             no_gpu: 'true'
-          - os: macos-14-xlarge
+          - os: macos-26
+            runner: qvac-macos26-arm64-gpu
             platform: darwin
             arch: arm64
-            no_gpu: 'true'
           - os: macos-15-large
             platform: darwin
             arch: x64
@@ -266,12 +266,18 @@ jobs:
           # quant x model-type x backend product stays readable and consistent.
           MODEL_TYPES="tdt ctc eou sortformer"
           QUANTS="f16 q8_0 q4_0"
+          # macOS GPU legs use the Metal backend; other platforms use Vulkan.
+          if [ "${{ matrix.platform }}" = "darwin" ]; then
+            GPU_BACKEND="metal"
+          else
+            GPU_BACKEND="vulkan"
+          fi
           entries=""
           for t in $MODEL_TYPES; do
             for q in $QUANTS; do
               entries="${entries}{\"modelType\":\"${t}\",\"quant\":\"${q}\",\"useGPU\":false},"
               if [ "${{ matrix.no_gpu || 'false' }}" != "true" ]; then
-                entries="${entries}{\"modelType\":\"${t}\",\"quant\":\"${q}\",\"useGPU\":true,\"backendHint\":\"vulkan\"},"
+                entries="${entries}{\"modelType\":\"${t}\",\"quant\":\"${q}\",\"useGPU\":true,\"backendHint\":\"${GPU_BACKEND}\"},"
               fi
             done
           done


### PR DESCRIPTION
## What

Switch the **arm64 macOS** integration-test leg for `@qvac/transcription-parakeet` from the CPU-only GitHub-hosted `macos-14-xlarge` runner to the self-hosted `macos-26` / `qvac-macos26-arm64-gpu` runner, so Apple Silicon actually exercises the GPU path. Mirrors the `tts-ggml` pilot (#3187).

## Changes

- **Matrix**: arm64 macOS entry now uses `os: macos-26`, `runner: qvac-macos26-arm64-gpu`, and drops `no_gpu: 'true'` (GPU legs now run there).
- **RTF benchmark matrix generator**: the GPU legs previously hardcoded `backendHint:"vulkan"`, which is wrong on macOS. A shell `GPU_BACKEND` var now resolves to `metal` when `matrix.platform == darwin`, else `vulkan`. CPU entries are unchanged.

## Notes

- The **x64** `macos-15-large` leg stays on the GitHub-hosted fleet (unchanged); the new self-hosted fleet is arm64-only.
- No job-time `brew install` steps exist in this workflow, so none were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
