### PR TITLE
infra: run whisper macOS CI on qvac-macos26-arm64-gpu with Metal GPU

### DIFF
--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -102,11 +102,12 @@ jobs:
             no_gpu: 'true'
             benchmark_matrix_json: >-
               [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"}]
-          - os: macos-14-xlarge
+          - os: macos-26
+            runner: qvac-macos26-arm64-gpu
             platform: darwin
             arch: arm64
             benchmark_matrix_json: >-
-              [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-base-q5_1.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-base-q8_0.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-small.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-small-q5_1.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-small-q8_0.bin","useGPU":true,"backendHint":"coreml"}]
+              [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-base-q5_1.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-base-q8_0.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-small.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-small-q5_1.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-small-q8_0.bin","useGPU":true,"backendHint":"metal"}]
           - os: macos-15-large
             platform: darwin
             arch: x64
@@ -228,12 +229,6 @@ jobs:
           sudo apt-get update && sudo apt-get install -y mesa-vulkan-drivers
           # Add whisper.cpp dependencies for integration tests
           sudo apt-get install -y libopenblas-dev liblapack-dev libfftw3-dev
-
-      - name: macOS - install whisper dependencies
-        if: matrix.platform == 'darwin'
-        shell: bash
-        run: |
-          brew install --quiet openblas lapack fftw
 
       - if: ${{ matrix.os == 'windows-2025' }}
         name: Set Vulkan SDK Path on Windows Server 2025


### PR DESCRIPTION
## What

Runs the whisper (`transcription-whispercpp`) macOS CI on the new self-hosted Metal runner and exercises the native ggml Metal GPU backend, mirroring the validated `tts-ggml` pilot (#3187).

## Changes

- **arm64 macOS matrix entry**: `os: macos-14-xlarge` → `os: macos-26` + `runner: qvac-macos26-arm64-gpu` (the self-hosted Metal-capable runner). The x64 `macos-15-large` entry is left unchanged on the hosted runner.
- **Benchmark GPU rows**: in that entry's `benchmark_matrix_json`, every `"backendHint":"coreml"` → `"backendHint":"metal"` so the mac GPU leg runs on the native ggml Metal backend instead of CoreML. CPU rows are untouched.
- **Removed** the macOS-only `brew install --quiet openblas lapack fftw` step: openblas is preinstalled on the new runner, and job-time `brew` is forbidden on self-hosted runners.

## Risk

If the published darwin prebuild does not include the Metal backend, the new `"backendHint":"metal"` GPU rows may error at benchmark time. The dispatched validation run on this branch will confirm whether Metal is available in the prebuild. CPU rows and the x64 hosted leg are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
