### PR TITLE
infra: run tts-onnx macOS CI on qvac-macos26-arm64-gpu

### DIFF
--- a/.github/workflows/integration-test-tts-onnx.yml
+++ b/.github/workflows/integration-test-tts-onnx.yml
@@ -150,10 +150,10 @@ jobs:
           - {os: ubuntu-22.04, runner: qvac-ubuntu2204-x64-gpu, variant: q4, platform: linux, arch: x64, os_version: u22}
           - {os: ubuntu-24.04, runner: qvac-ubuntu2404-x64-gpu, variant: q4, platform: linux, arch: x64, os_version: u24}
           - {os: ubuntu-24.04-arm, variant: q4, platform: linux, arch: arm64, os_version: u24}
-          - {os: macos-14-xlarge, variant: fp32, platform: darwin, arch: arm64, os_version: m14}
-          - {os: macos-14-xlarge, variant: fp16, platform: darwin, arch: arm64, os_version: m14}
-          - {os: macos-14-xlarge, variant: q4, platform: darwin, arch: arm64, os_version: m14}
-          - {os: macos-14-xlarge, variant: q4f16, platform: darwin, arch: arm64, os_version: m14}
+          - {os: macos-14-xlarge, runner: qvac-macos26-arm64-gpu, variant: fp32, platform: darwin, arch: arm64, os_version: m14}
+          - {os: macos-14-xlarge, runner: qvac-macos26-arm64-gpu, variant: fp16, platform: darwin, arch: arm64, os_version: m14}
+          - {os: macos-14-xlarge, runner: qvac-macos26-arm64-gpu, variant: q4, platform: darwin, arch: arm64, os_version: m14}
+          - {os: macos-14-xlarge, runner: qvac-macos26-arm64-gpu, variant: q4f16, platform: darwin, arch: arm64, os_version: m14}
           - {os: macos-15-large, variant: q4, platform: darwin, arch: x64, os_version: m15}
           - {os: windows-2025, runner: qvac-win25-x64-gpu, variant: q4, platform: win32, arch: x64, os_version: w25,}
 
@@ -265,7 +265,7 @@ jobs:
   run-supertonic-desktop-benchmarks:
     if: ${{ inputs.run_supertonic_desktop_benchmarks == true }}
     continue-on-error: true
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner || matrix.os }}
     environment: release
     timeout-minutes: 180
     name: supertonic-${{ matrix.runner_label }}-${{ matrix.backend }}
@@ -323,6 +323,7 @@ jobs:
             run_python: false
             round_trip_test: true
           - os: macos-14-xlarge
+            runner: qvac-macos26-arm64-gpu
             platform: darwin
             arch: arm64
             runner_label: macos-14-xlarge
@@ -332,6 +333,7 @@ jobs:
             run_python: false
             round_trip_test: true
           - os: macos-14-xlarge
+            runner: qvac-macos26-arm64-gpu
             platform: darwin
             arch: arm64
             runner_label: macos-14-xlarge
@@ -499,12 +501,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y mesa-vulkan-drivers
-
-      - name: macOS - install benchmark client dependencies
-        if: ${{ matrix.platform == 'darwin' }}
-        shell: bash
-        run: |
-          brew install ffmpeg pkg-config
 
       - name: Install benchmark server dependencies
         working-directory: ${{ inputs.workdir }}/benchmarks/server


### PR DESCRIPTION
## What

Moves the **arm64 macOS** CI for `tts-onnx` onto the new self-hosted runner `qvac-macos26-arm64-gpu`, mirroring the already-validated `tts-ggml` pilot (#3187).

File touched: `.github/workflows/integration-test-tts-onnx.yml`.

## Changes

- **Integration matrix (`run-integration-tests`)** — added `runner: qvac-macos26-arm64-gpu` to all four arm64 `macos-14-xlarge` entries (`fp32`, `fp16`, `q4`, `q4f16`). `runs-on` already used `${{ matrix.runner || matrix.os }}`, so the key takes effect immediately.
- **Supertonic desktop matrix (`run-supertonic-desktop-benchmarks`)** — added `runner: qvac-macos26-arm64-gpu` to both arm64 `macos-14-xlarge` entries (`cpu` and `coreml`). This job's `runs-on` previously keyed on `matrix.os` **only**, so I updated it to `${{ matrix.runner || matrix.os }}` (same pattern as the integration job) so the new `runner:` key actually routes the job. The benchmark labels (`runner_label` / `device_label`) are left unchanged.
- **CoreML kept, no Metal introduced** — ONNX Runtime uses the **CoreML execution provider** for GPU/ANE on macOS. There is no Metal backend for onnx, so none was added; `backend: coreml` is preserved as-is.
- **Removed** the job-time `brew install ffmpeg pkg-config` macOS step (macOS-only, gated on `matrix.platform == 'darwin'`). ffmpeg is preinstalled on the new runner and job-time brew is forbidden.
- **x64 macOS unchanged** — `macos-15-large` (integration) stays on the GitHub-hosted fleet; the new fleet is arm64-only. Linux / Windows entries untouched.

## Notes

- **Preexisting, unrelated:** the tts-onnx Supertonic desktop matrix has been failing independently of this change. This PR does not attempt to fix that; it only changes where the arm64 mac jobs run.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` — passes.
- `actionlint` — clean (exit 0, no findings).
- Dispatch of `benchmark-performance-tts-onnx.yml` against this branch triggered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
