### PR TITLE
QVAC-22085 infra: add electron-platforms input for GUI runner on macOS

### DIFF
--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -61,6 +61,10 @@ on:
         description: "JSON array of runner labels for desktop tests"
         type: string
         default: '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu"]'
+      electron-platforms:
+        description: "JSON array of runner labels for electron tests"
+        type: string
+        default: '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu-gui"]'
       test-version:
         description: "Git ref to checkout for the tested project (branch, tag, or SHA). Defaults to current branch HEAD."
         type: string
@@ -99,6 +103,9 @@ on:
       desktop-platforms:
         type: string
         default: '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu"]'
+      electron-platforms:
+        type: string
+        default: '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu-gui"]'
       test-version:
         type: string
       cache-models:
@@ -157,7 +164,7 @@ jobs:
       consumer: electron
       project-directory: "packages/sdk"
       working-directory: "packages/sdk/e2e"
-      platforms: ${{ inputs.desktop-platforms || '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu"]' }}
+      platforms: ${{ inputs.electron-platforms || '["qvac-win25-x64-gpu", "qvac-ubuntu2204-x64-gpu", "qvac-macos26-arm64-gpu-gui"]' }}
       consumer-timeout: ${{ fromJSON(inputs.desktop-consumer-timeout || '60') }}
       filter: ${{ inputs.filter }}
       suite: ${{ needs.resolve.outputs.suite }}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Electron e2e tests on macOS fail on `qvac-macos26-arm64-gpu` because that runner is a system LaunchDaemon with no GUI/WindowServer access — Electron exits immediately with code 0 before CONNACK
- Desktop and Electron tests shared the same `desktop-platforms` input, so there was no way to route Electron to the GUI-capable runner

## 📝 How does it solve it?

- Add a separate `electron-platforms` input (both `workflow_dispatch` and `workflow_call`) defaulting to `qvac-macos26-arm64-gpu-gui` for macOS
- Wire `electron-tests` job to use `electron-platforms` instead of `desktop-platforms`
- Desktop tests remain unchanged on `qvac-macos26-arm64-gpu`

Runner mapping:

| Consumer | macOS runner |
|---|---|
| Desktop (Node) | `qvac-macos26-arm64-gpu` |
| Electron | `qvac-macos26-arm64-gpu-gui` |

## 🧪 How was it tested?

- [x] Trigger `workflow_dispatch` with `targets: electron` and verify macOS job runs on `qvac-macos26-arm64-gpu-gui`
- [x] Trigger `workflow_dispatch` with `targets: desktop` and verify macOS job runs on `qvac-macos26-arm64-gpu`
- [x] Verify Electron e2e passes on all 3 platforms (Win, Linux, macOS)
  - CI Link: https://github.com/tetherto/qvac/actions/runs/29081945847
