### PR TITLE
QVAC-22026 doc: update stale README.md across speech packages and monorepo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ node quickstart.js
 * **Completion:** LLM inference for text generation and chat via [`qvac-fabric-llm.cpp`](https://github.com/tetherto/qvac-fabric-llm.cpp).
 * **Text embeddings:** vector embedding generation for semantic search, clustering, and retrieval, via `qvac-fabric-llm.cpp`.
 * **Translation:** text-to-text neural machine translation (NMT), via `qvac-fabric-llm.cpp` and [Bergamot](https://browser.mt).
-* **Transcription:** automatic speech recognition (ASR) for speech-to-text via [`qvac-ext-lib-whisper.cpp`](https://github.com/tetherto/qvac-ext-lib-whisper.cpp) or [NVIDIA Parakeet](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2).
+* **Transcription:** automatic speech recognition (ASR) for speech-to-text via [`qvac-ext-lib-whisper.cpp`](https://github.com/tetherto/qvac-ext-lib-whisper.cpp) or [NVIDIA Parakeet](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3), plus speaker diarization via NVIDIA Sortformer.
 * **Text-to-Speech:** speech synthesis for text-to-speech (TTS) using the Chatterbox and Supertonic neural TTS models.
-* **OCR:** optical character recognition (OCR) for extracting text from images via ONNX runtime.
+* **OCR:** optical character recognition (OCR) for extracting text from images, via the ONNX Runtime or GGML backends.
 * **Image generation:** text-to-image generation via [`qvac-ext-stable-diffusion.cpp`](https://github.com/tetherto/qvac-ext-stable-diffusion.cpp).
 * **Fine-tuning:** adapting LLMs to domain-specific tasks via LoRA.
 * **Multimodal:** LLM inference over text, images, and other media within a single conversation context.
@@ -129,30 +129,39 @@ Legend:
 | Package | Description | Category |
 | :--- | :--- | :--- |
 | sdk | Main entry point to develop AI applications with QVAC | SDK |
-| lib-decoder-audio | Audio decoder library leveraging FFmpeg for efficient audio decoding as preprocessing step for other addons | Addon |
-| lib-infer-llamacpp-embed | Native C++ addon for running text embedding models to generate high-quality contextual embeddings via `qvac-fabric-llm.cpp` | Addon |
-| lib-infer-llamacpp-llm | Native C++ addon for running Large Language Models (LLMs) via `qvac-fabric-llm.cpp` | Addon |
-| diffusion-cpp | Native C++ addon for text-to-image generation via `qvac-ext-stable-diffusion.cpp` | Addon |
-| lib-infer-nmtcpp | Native C++ addon for translation using either `qvac-fabric-llm.cpp` or [Bergamot](https://browser.mt) | Addon |
-| lib-infer-onnx | Bare addon for ONNX Runtime session management | Addon |
-| tts-ggml | Text-to-Speech (TTS) library using Chatterbox and Supertonic neural TTS models via the GGML backend | Addon |
-| lib-infer-parakeet | High-performance speech-to-text inference addon using via NVIDIA/Parakeet | Addon |
-| transcription-whispercpp | Library for running Whisper transcription model for audio transcription via `qvac-ext-lib-whisper.cpp` | Addon |
-| inference-addon-cpp | Header-only C++ library providing common abstractions and infrastructure for building high-performance inference addons | Addon |
-| langdetect-text | Language detection library providing interface for detecting language of given text | Addon |
-| langdetect-text-cld2 | Language detection using CLD2 with same API as @qvac/langdetect-text | Addon |
+| bare-sdk | Bare-targeted slim assembly of the SDK; consumers install only the addons they need and register plugins explicitly | SDK |
+| ai-sdk-provider | Vercel AI SDK provider exposing the QVAC runtime (chat, embeddings, transcription, translation, speech, OCR, image) | SDK |
+| bci-whispercpp | Brain-Computer Interface (BCI) neural-signal transcription addon powered by whisper.cpp | Addon |
+| classification-ggml | Image classification addon (MobileNetV3-Small) on the GGML backend | Addon |
+| decoder-audio | Audio decoder library leveraging FFmpeg as a preprocessing step for other addons | Addon |
+| diffusion-cpp | Native C++ addon for image/video generation via `qvac-ext-stable-diffusion.cpp` | Addon |
+| embed-llamacpp | Native C++ addon for text embedding generation via `qvac-fabric-llm.cpp` | Addon |
+| langdetect-text | Language detection library providing an interface for detecting the language of given text | Addon |
+| langdetect-text-cld2 | Language detection using CLD2 with the same API as `@qvac/langdetect-text` | Addon |
+| llm-llamacpp | Native C++ addon for running Large Language Models (LLMs) via `qvac-fabric-llm.cpp` | Addon |
+| ocr-ggml | Optical Character Recognition (OCR) addon (EasyOCR pipeline) on the GGML backend | Addon |
 | ocr-onnx | Optical Character Recognition (OCR) addon using ONNX Runtime | Addon |
+| onnx | Bare addon for ONNX Runtime session management | Addon |
 | rag | JavaScript library for Retrieval-Augmented Generation (RAG) with document ingestion, vector search, and LLM integration | Addon |
-| dl-base | Base class for QVAC dataloader libraries providing common interface for loading data from various sources | Core |
-| dl-filesystem | Data loading library for loading model weights and resources from local filesystem | Core |
-| dl-hyperdrive | Data loading library for loading model weights and resources from Hyperdrive distributed file system | Core |
-| error | Standardized error handling capabilities for all QVAC libraries | Core |
-| infer-base | Base class for inference addon clients defining common lifecycle and generic methods for model interaction | Core |
-| logging | Logger wrapper that normalizes logging interface across QVAC libraries | Core |
+| transcription-parakeet | Speech-to-text (ASR) and Sortformer speaker-diarization addon using NVIDIA Parakeet models | Addon |
+| transcription-whispercpp | Whisper-based audio transcription addon via `qvac-ext-lib-whisper.cpp` | Addon |
+| translation-nmtcpp | Native C++ addon for translation using either `qvac-fabric-llm.cpp` or [Bergamot](https://browser.mt) | Addon |
+| tts-ggml | Text-to-Speech (TTS) addon wrapping the Chatterbox and Supertonic engines on the GGML backend | Addon |
+| vla-ggml | Vision-Language-Action (VLA) inference addon on the GGML backend | Addon |
+| dl-base | Base class for QVAC dataloader libraries providing a common interface for loading data from various sources | Core |
+| dl-filesystem | Data loading library for model weights and resources from the local filesystem | Core |
+| dl-hyperdrive | Data loading library for model weights and resources from the Hyperdrive distributed file system | Core |
+| error | Standardized error-handling capabilities for all QVAC libraries | Core |
+| fabric | Shared Bare addon hosting the qvac-fabric (forked llama.cpp + ggml) runtime for QVAC inference addons | Core |
+| infer-base | Base class for inference addon clients defining the common lifecycle and generic model-interaction methods | Core |
+| inference-addon-cpp | Header-only C++ library providing common abstractions and infrastructure for building inference addons | Core |
+| logging | Logger wrapper that normalizes the logging interface across QVAC libraries | Core |
 | cli | Command-line interface for the QVAC ecosystem with tooling for building, bundling, and managing QVAC-powered applications | Tool |
 | diagnostics | Diagnostic report generation library for QVAC | Tool |
-| lib-registry-server | Distributed model registry for downloading AI models for local inference and contributing new models | Tool |
+| ggml-coload-smoke | Multi-addon co-load smoke harness that loads several GGML addons into one Bare process to catch cross-addon symbol/dlopen clashes | Tool |
 | lint-cpp | Configuration files for formatting and linting C++ source files with pre-commit hooks | Tool |
+| qvac-ci | CI utilities for the QVAC monorepo | Tool |
+| registry-server | Distributed model registry server for downloading AI models and contributing new ones | Tool |
 
 ### Development
 

--- a/packages/bci-whispercpp/README.md
+++ b/packages/bci-whispercpp/README.md
@@ -222,8 +222,9 @@ const response = await bci.transcribeStream(chunkIterable, {
 
 response.onUpdate(segments => {
   // emit: 'delta' — newly-discovered tail segments since the last window.
-  //                 Each segment carries native fields (text, t0, t1, ...) plus
-  //                 windowStartTimestep so you can map back to the stream timeline.
+  //                 Each segment carries native fields (text, start, end,
+  //                 toAppend, id) plus windowStartTimestep so you can map
+  //                 back to the stream timeline.
   // emit: 'full'  — single { text } entry with the full running transcript.
   for (const s of segments) process.stdout.write(s.text)
 })
@@ -264,7 +265,7 @@ const wer = computeWER('how does it keep the cost down', 'how does it keep the c
 
 ```js
 [
-  { text: ' How does it keep the cost down?', t0: 0, t1: 280, /* ... */ }
+  { text: ' How does it keep the cost down?', start: 0, end: 280, toAppend: false, id: 0 }
 ]
 ```
 
@@ -315,7 +316,7 @@ new BCIWhispercpp(args, config)
 
 ### config.whisperConfig
 
-The convenience defaults below are surfaced explicitly. **Any other `whisper_full_params` key is forwarded untouched** to whisper.cpp — see [Advanced configuration](#advanced-configuration).
+`whisperConfig` accepts a fixed whitelist of whisper decoding parameters; unknown keys are rejected (`load()` throws `INVALID_CONFIG`). The most common ones are shown below. The full accepted set is `language`, `n_threads`, `temperature`, `detect_language`, `translate`, `duration_ms`, `no_timestamps`, `single_segment`, `suppress_blank`, `suppress_nst`, `print_special`, `print_progress`, `print_realtime`, `print_timestamps`, `greedy_best_of`, and `beam_search_beam_size` (see `index.d.ts` and [Advanced configuration](#advanced-configuration)).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -327,7 +328,7 @@ The convenience defaults below are surfaced explicitly. **Any other `whisper_ful
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `day_idx` | number | `0` | Session day index for the day-specific low-rank projection at runtime. Distinct from the conversion-time `--day-idx` flag, which bakes a positional embedding into `ggml-bci-windowed.bin`. |
+| `day_idx` | number | `0` | Session day index for the day-specific low-rank projection at runtime. `>= 0` applies the projection (out-of-range values are clamped natively); `-1` enables mel-passthrough mode, where the input buffer is treated as pre-computed 512-bin mel features (frame-major) and preprocessing is skipped — intended for parity testing against the Python reference, not production. Distinct from the conversion-time `--day-idx` flag, which bakes a positional embedding into `ggml-bci-windowed.bin`. |
 
 ### config.contextParams
 
@@ -336,7 +337,7 @@ These keys back the `whisper_context`. Changing any of them between jobs forces 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `model` | string | Optional override; usually set via `args.files.model`. |
-| `use_gpu` | boolean | Enable GPU acceleration (Metal on macOS by default). |
+| `use_gpu` | boolean | Enable GPU acceleration. Enabled by default (whisper.cpp default); set `false` to force CPU. The GPU backend is chosen per platform at build time: Metal on macOS/iOS, Vulkan on Linux/Windows, OpenCL/Vulkan on Android. |
 | `flash_attn` | boolean | Enable flash attention. |
 | `gpu_device` | number | Select a non-default GPU device. |
 
@@ -345,6 +346,12 @@ These keys back the `whisper_context`. Changing any of them between jobs forces 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `caption_enabled` | boolean | `false` | Format segments with `<\|start\|>..<\|end\|>` markers. |
+
+### config.backendsDir
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `backendsDir` | string | `<addon>/prebuilds` | **Android only.** Overrides the folder used to locate dynamically-loaded ggml backend `.so` modules; ignored on other platforms. Defaults to the in-package `prebuilds/` directory so mobile builds work out of the box (parity with `transcription-whispercpp 0.9.0`). |
 
 ### streamOpts (passed to `transcribeStream()`)
 
@@ -358,14 +365,14 @@ The encoder accepts up to ~3000 timesteps per forward pass; `MAX_WINDOW_TIMESTEP
 
 ### Advanced configuration
 
-`whisperConfig` is a thin pass-through to whisper.cpp's `whisper_full_params`. For the full surface (decoding strategy, beam search, VAD, suppression, callbacks, etc.) refer to the upstream reference:
+`whisperConfig` maps a curated subset of whisper.cpp's `whisper_full_params`; only the keys listed above are accepted, and any other key is rejected. To match the Python BrainWhisperer reference, the BCI decode path fixes several parameters natively — beam search with `beam_size` 4 (override with `beam_search_beam_size`), `length_penalty` 0.14 (not configurable), single-segment, and no-timestamps. For the meaning of each accepted parameter refer to the upstream reference:
 
 - [`whisper_full_params` in whisper.cpp](https://github.com/ggerganov/whisper.cpp/blob/master/include/whisper.h)
 - Concrete shapes used in production: see the [examples](examples) directory and [`@qvac/transcription-whispercpp`](https://github.com/tetherto/qvac/tree/main/packages/transcription-whispercpp) for richer usage patterns (VAD, chunking, live streaming).
 
 ## whisper.cpp Patches
 
-The BCI patches live in the `tetherto/qvac-ext-lib-whisper.cpp` fork (v1.8.4.2) and are consumed via the `qvac-registry-vcpkg` port:
+The BCI patches live in the `tetherto/qvac-ext-lib-whisper.cpp` fork and are consumed via the `qvac-registry-vcpkg` port (see `vcpkg.json` for the pinned version):
 
 | Feature | Description |
 |---------|-------------|
@@ -398,7 +405,7 @@ All errors thrown by this package are `QvacErrorAddonBCI` instances (extending `
 | `26016` | `INVALID_STREAM_HEADER` | Stream `[T u32, C u32]` header malformed (e.g. `C == 0`) |
 | `26017` | `WINDOW_TOO_LARGE` | `windowTimesteps` exceeds `MAX_WINDOW_TIMESTEPS` (2900) |
 
-Codes are also re-exported via `require('@qvac/bci-whispercpp/lib/error').ERR_CODES` for programmatic matching.
+Every thrown `QvacErrorAddonBCI` extends `QvacErrorBase` and carries the numeric `.code` listed above, so callers can match programmatically on `err.code` (e.g. `err.code === 26008` for `MODEL_NOT_LOADED`).
 
 ## Resources
 

--- a/packages/transcription-parakeet/README.md
+++ b/packages/transcription-parakeet/README.md
@@ -33,7 +33,7 @@ This library simplifies running NVIDIA Parakeet speech-to-text and Sortformer sp
 | Windows | x64 | 10+ | Tier 1 | Vulkan |
 
 **Dependencies:**
-- inference-addon-cpp: C++ addon framework
+- qvac-lib-inference-addon-cpp (latest): C++ addon framework
 - parakeet-cpp (latest): NVIDIA Parakeet ASR + Sortformer diarization engine
 - ggml-speech (latest): GGML flavour shared with the speech stack; library prefix `qvac-speech-` so it can coexist with the fabric/llm and diffusion ggml builds on the same Android device
 - Bare Runtime (latest): JavaScript runtime
@@ -157,14 +157,14 @@ The integration suite locates each model type via `QVAC_TEST_GGUF_DIR=<path-with
 
 The library wraps `qvac-parakeet.cpp`'s engine in the QVAC addon framework so you can transcribe audio files, run speaker diarization, or stream live mic input through the same shape: load a single `.gguf`, push audio chunks, drain segment callbacks.
 
-> **Heads up:** the package is intended to be used through `index.js`'s `TranscriptionParakeet` class. A lower-level `ParakeetInterface` (in `parakeet.js`) is also exported as an escape hatch for power users that need to drive the addon's job runner directly, but new code should default to `TranscriptionParakeet` -- it's what the bundled examples and integration tests use.
+> **Heads up:** the package is intended to be used through the default export, `index.js`'s `TranscriptionParakeet` class. A lower-level `ParakeetInterface` is available only via the dedicated `@qvac/transcription-parakeet/parakeet.js` subpath (`require('@qvac/transcription-parakeet/parakeet.js')`) as an escape hatch for power users that need to drive the addon's job runner directly, but new code should default to `TranscriptionParakeet` -- it's what the bundled examples and integration tests use.
 
 ### 1. Stage a Model
 
 The ggml backend takes a single `.gguf` per checkpoint. The standard flow is "provision a Python venv, download `.nemo` from HuggingFace, convert to `.gguf` via the in-tree converter":
 
 ```bash
-npm run setup-models                       # venv + download + convert, all 4 models, q8_0
+npm run setup-models                       # venv + download + convert, all 5 models, q8_0
 npm run setup-models -- -t tdt             # just TDT
 npm run setup-models -- -t eou -q f16      # full-precision EOU
 ```
@@ -177,9 +177,9 @@ The three underlying scripts are also flag-driven if you want to run them separa
 
 ```
 setup-venv.sh      [--python <bin>] [--venv <path>] [--force] [--help]
-download-models.sh [--type ctc|tdt|eou|sortformer|all]
+download-models.sh [--type ctc|tdt|eou|sortformer|sortformer-streaming-v2.1|all]
                    [--output <dir>] [--force] [--help]
-convert-nemo.sh    [--type ctc|tdt|eou|sortformer|all]
+convert-nemo.sh    [--type ctc|tdt|eou|sortformer|sortformer-streaming-v2.1|all]
                    [--quant f16|q8_0|q5_0|q4_0|f32]
                    [--python <bin>]
                    [--nemo-dir <dir>] [--output <dir>] [--force] [--help]
@@ -187,12 +187,13 @@ convert-nemo.sh    [--type ctc|tdt|eou|sortformer|all]
 
 #### Source repositories
 
-| Model | HuggingFace `.nemo` |
+| Model (`--type`) | HuggingFace `.nemo` |
 |-------|-----------------------------------|
-| CTC | [`nvidia/parakeet-ctc-0.6b`](https://huggingface.co/nvidia/parakeet-ctc-0.6b) |
-| TDT | [`nvidia/parakeet-tdt-0.6b-v3`](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) |
-| EOU | [`nvidia/parakeet_realtime_eou_120m-v1`](https://huggingface.co/nvidia/parakeet_realtime_eou_120m-v1) |
-| Sortformer | [`nvidia/diar_sortformer_4spk-v1`](https://huggingface.co/nvidia/diar_sortformer_4spk-v1) |
+| `ctc` | [`nvidia/parakeet-ctc-0.6b`](https://huggingface.co/nvidia/parakeet-ctc-0.6b) |
+| `tdt` | [`nvidia/parakeet-tdt-0.6b-v3`](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) |
+| `eou` | [`nvidia/parakeet_realtime_eou_120m-v1`](https://huggingface.co/nvidia/parakeet_realtime_eou_120m-v1) |
+| `sortformer` | [`nvidia/diar_sortformer_4spk-v1`](https://huggingface.co/nvidia/diar_sortformer_4spk-v1) |
+| `sortformer-streaming-v2.1` | [`nvidia/diar_streaming_sortformer_4spk-v2.1`](https://huggingface.co/nvidia/diar_streaming_sortformer_4spk-v2.1) |
 
 NVIDIA Open Model License -- see each repo's model card for terms.
 
@@ -205,7 +206,7 @@ Most users interact with the package through `index.js`. From that entrypoint we
 | Section | Key | Description |
 | --- | --- | --- |
 | `files` | `model` | Absolute or relative path to the `.gguf` checkpoint |
-| `config.parakeetConfig` | `maxThreads` | CPU threads; `0` lets the engine pick `hardware_concurrency` |
+| `config.parakeetConfig` | `maxThreads` | CPU threads (default: `4`); `0` defers to the engine's `hardware_concurrency` |
 | | `useGPU` | Enable the linked ggml GPU backend (default: `false`) |
 | | `streaming` | Open a long-lived `StreamSession` / `SortformerStreamSession` so speaker IDs stay stable across appends and EOU `<EOU>` boundaries surface as segments. Cross-append state is preserved only within a single `run()` call -- separate `run()` invocations on the same instance start a fresh session. For continuous live capture, drive a single long-running `run()` from a pushable stream, or use the duplex `runStreaming()` API which owns one streaming session for the lifetime of the call. Default: `false` (offline `transcribe_samples` / `diarize_samples`). |
 | | `streamingChunkMs` | Streaming chunk cadence in ms (default: 2000) |
@@ -296,7 +297,7 @@ try {
 
 Pass an audio stream (e.g. from `bare-fs.createReadStream` or a live PCM buffer) to either `run()` (offline / batched) or `runStreaming()` (duplex / live). Audio must be **16 kHz mono**, either Float32 or signed 16-bit little-endian PCM.
 
-> **Buffer cap (`run()` only):** the JS layer batches every chunk for a single `run()` call into one native `process()` invocation. Total buffered audio per call is capped at **500 MiB** (`MAX_BUFFERED_BYTES` in `parakeet.js`); exceeding it raises `BUFFER_LIMIT_EXCEEDED`. At 16 kHz mono int16, that's roughly 4 hours of continuous audio. For longer single-session captures, use `runStreaming()` (no per-call buffer cap -- audio is fed straight to the engine as it arrives) or split into sequential `run()` calls.
+> **Buffer cap (`run()` only):** the JS layer batches every chunk for a single `run()` call into one native `process()` invocation. Incoming audio is normalized to **Float32** (4 bytes/sample) before it is buffered, and the buffer is capped at **500 MiB** (`MAX_BUFFERED_BYTES` in `parakeet.js`); exceeding it raises `BUFFER_LIMIT_EXCEEDED`. At 16 kHz mono that's roughly 2.7 hours of continuous audio (regardless of whether the input arrived as int16 or Float32). For longer single-session captures, use `runStreaming()` (no per-call buffer cap -- audio is fed straight to the engine as it arrives) or split into sequential `run()` calls.
 
 There are three ways to receive transcription results:
 
@@ -402,6 +403,33 @@ The new lower-level entry points (`startStreaming` / `appendStreamingAudio` / `e
 
 For Sortformer GGUFs, the `Output` event carries `Speaker N: HH:MM:SS - HH:MM:SS` text per segment instead of an ASR transcript -- see `examples/diarized-transcribe.js` for offline parsing and `examples/live-mic-diarized.js` for the streaming flow.
 
+#### Backend info and runtime stats
+
+After `load()`, `getBackendInfo()` reports the compute backend the native engine actually resolved (post-fallback):
+
+```javascript
+const info = model.getBackendInfo()
+// { backendDevice: 'GPU', backendId: 3, backendName: 'Vulkan0',
+//   backendDescription: 'NVIDIA GeForce RTX 3090' }
+```
+
+It returns `null` before `load()` / after `unload()`. `backendId` follows the `BackendId` enum (`0` CPU, `1` Metal, `2` CUDA, `3` Vulkan, `4` OpenCL, `99` other; see `index.d.ts`).
+
+Once a `run()` / `runStreaming()` job settles, `response.stats` carries a `RuntimeStats` object -- pipeline timings plus the post-fallback backend truth:
+
+```javascript
+const response = await model.run(audioStream)
+await response.onUpdate(() => {}).await()
+// response.stats.backendDevice   // 0 = CPU, 1 = GPU (after any runtime fallback)
+// response.stats.backendId       // BackendId code, as above
+// response.stats.gpuUnsupported  // 1 when a GPU was present but the engine ran
+//                                //   on CPU anyway (e.g. Mali Vulkan mis-compute,
+//                                //   or a vendor/tier declined by policy)
+// response.stats.audioDurationMs, encoderMs, decoderMs, melSpecMs, totalEncodedFrames, ...
+```
+
+A CPU `backendDevice` together with `gpuUnsupported === 1` is expected on GPUs the engine declines, not a regression. See `RuntimeStats` in `index.d.ts` for the full field list.
+
 ### 6. Release Resources
 
 ```javascript
@@ -420,9 +448,10 @@ try {
 git clone https://github.com/tetherto/qvac.git
 cd qvac/packages/transcription-parakeet
 npm install
+npm run build
 ```
 
-`npm install` pulls the `parakeet-cpp` and `ggml-speech` overlay ports (the speech-stack ggml flavour, with the `qvac-speech-` library prefix) and produces `prebuilds/<platform>-<arch>/qvac__transcription-parakeet.bare`.
+`npm install` fetches the JS dependencies. `npm run build` (`bare-make generate && bare-make build && bare-make install`) is what pulls the `parakeet-cpp` and `ggml-speech` vcpkg ports (the speech-stack ggml flavour, with the `qvac-speech-` library prefix), compiles the native addon, and installs `prebuilds/<platform>-<arch>/qvac__transcription-parakeet.bare`. Published npm releases ship these prebuilds, so consumers who `npm install @qvac/transcription-parakeet` skip the build step.
 
 ### 2. Stage a model
 
@@ -442,7 +471,7 @@ bare examples/transcribe.js \
 bare examples/diarized-transcribe.js \
      --asr-model  models/parakeet-tdt-0.6b-v3.q8_0.gguf \
      --diar-model models/sortformer-4spk-v1.q8_0.gguf \
-     --audio      examples/samples/two-speakers-16k.wav
+     --audio      examples/samples/diarization-sample-16k.wav
 
 # Live mic transcription
 bare examples/live-mic.js --model models/parakeet-eou-120m-v1.q8_0.gguf --accumulate
@@ -481,13 +510,35 @@ The live-mic examples capture the default input device via `sox -d` (install: `b
 - [`examples/live-mic-diarized.js`](examples/live-mic-diarized.js) -- live mic with parallel Sortformer + ASR for speaker-tagged transcripts. Pass a v2.1 Sortformer GGUF to get AOSC speaker-cache streaming automatically.
 - [`examples/live-mic-diarized-aosc.js`](examples/live-mic-diarized-aosc.js) -- same as above but with CLI flags for the AOSC tuning knobs (`--spk-cache-len`, `--fifo-len`, `--chunk-right-context-ms`, `--spk-cache-enable`, etc.). Useful for A/B comparing AOSC vs the v1 sliding-window code path on the same v2.1 GGUF.
 - [`examples/decode-audio.js`](examples/decode-audio.js) -- decode + transcribe in one step. Same flag surface as `transcribe.js` but pipes the input through `@qvac/decoder-audio` (FFmpeg) first, so any container / codec FFmpeg supports (mp3, m4a, ogg, flac, mp4, ...) works -- not just 16 kHz mono `.wav` / raw s16le PCM.
-- [`examples/utils.js`](examples/utils.js) -- shared helpers used by the examples (`loadWeights` streaming, `Output`/`JobEnded` race resolution).
+- [`examples/utils.js`](examples/utils.js) -- shared helpers used by the examples: `setupLogger` (native-log filtering), `readFileAsStream`, `parseWavFile`, `convertRawToFloat32`, `validatePaths`, `pushableStream` (live-mic feed), and `printResults`.
 
 ## Glossary
 
 - **Bare** -- small, modular JavaScript runtime for desktop and mobile. [Learn more](https://docs.pears.com/bare-reference/overview).
 - **GGUF** -- single-file model format used by ggml-based runtimes; carries weights + tokenizer + hyperparameters in one file.
 - **QVAC** -- our open-source AI-SDK for building decentralized AI applications.
+
+## Error Range
+
+Thrown errors are `QvacErrorAddonParakeet` instances (extending `QvacErrorBase`) and carry a numeric `.code` from this package's reserved range **24001 - 25000**, so callers can match programmatically on `err.code`. The codes are re-exported as `ERR_CODES` from the `./parakeet.js` subpath (`require('@qvac/transcription-parakeet/parakeet.js').ERR_CODES`).
+
+| Code | Name | Raised when |
+|------|------|-------------|
+| 24001 | `FAILED_TO_LOAD_WEIGHTS` | Weight streaming into the engine failed. |
+| 24002 | `FAILED_TO_CANCEL` | Cancelling an in-flight job failed. |
+| 24003 | `FAILED_TO_APPEND` | Appending audio / starting a job failed. |
+| 24004 | `FAILED_TO_GET_STATUS` | Reading the wrapper state failed. |
+| 24005 | `FAILED_TO_DESTROY` | Destroying the native instance failed. |
+| 24006 | `FAILED_TO_ACTIVATE` | Activating the model for inference failed. |
+| 24007 | `FAILED_TO_RESET` | Reset / reload / `endStreaming` teardown failed. |
+| 24008 | `FAILED_TO_PAUSE` | Pausing inference failed. |
+| 24009 | `MODEL_NOT_FOUND` | The configured `.gguf` path does not exist. |
+| 24010 | `INVALID_AUDIO_FORMAT` | Audio is not 16 kHz mono. |
+| 24015 | `INVALID_CONFIG` | A configuration value was rejected. |
+| 24016 | `JOB_ALREADY_RUNNING` | A job is already set or being processed. |
+| 24017 | `BUFFER_LIMIT_EXCEEDED` | Buffered audio for one `run()` exceeded `MAX_BUFFERED_BYTES` (500 MiB). |
+| 24018 | `INSTANCE_DESTROYED` | `load()` was called on a destroyed instance. |
+| 24019 | `JOB_CANCELLED` | The active job was cancelled. |
 
 ## Resources
 

--- a/packages/transcription-whispercpp/README.md
+++ b/packages/transcription-whispercpp/README.md
@@ -33,9 +33,9 @@ This library simplifies running inference with the Whisper transcription model w
 | Windows | x64 | 10+ | ✅ Tier 1 | Vulkan |
 
 **Dependencies:**
-- qvac-lib-inference-addon-cpp (≥1.2.3): C++ addon framework
+- qvac-lib-inference-addon-cpp: C++ addon framework (vcpkg port; see `vcpkg.json` for the pinned version)
 - whisper-cpp: inference engine (vcpkg port; see `vcpkg.json` for the pinned version)
-- Bare Runtime (≥1.19.0): JavaScript runtime
+- Bare Runtime: JavaScript runtime (see `package.json` `engines.bare` for the supported version)
 - Linux requires Clang/LLVM 22 with libc++
 
 ## Installation

--- a/packages/transcription-whispercpp/README.md
+++ b/packages/transcription-whispercpp/README.md
@@ -18,7 +18,6 @@ This library simplifies running inference with the Whisper transcription model w
   - [6. Run Transcription](#6-run-transcription)
   - [7. Release Resources](#7-release-resources)
 - [Quickstart example](#quickstart-example)
-- [Model registry](#model-registry)
 - [Other examples](#other-examples)
 - [Resources](#resources)
 - [License](#license)
@@ -34,9 +33,9 @@ This library simplifies running inference with the Whisper transcription model w
 | Windows | x64 | 10+ | ✅ Tier 1 | Vulkan |
 
 **Dependencies:**
-- inference-addon-cpp (=0.12.2): C++ addon framework
-- qvac-fabric-whisper.cpp (latest): Inference engine
-- Bare Runtime (≥1.24.2): JavaScript runtime
+- qvac-lib-inference-addon-cpp (≥1.2.3): C++ addon framework
+- whisper-cpp: inference engine (vcpkg port; see `vcpkg.json` for the pinned version)
+- Bare Runtime (≥1.19.0): JavaScript runtime
 - Linux requires Clang/LLVM 22 with libc++
 
 ## Installation
@@ -48,7 +47,7 @@ Make sure [Bare](#glossary) Runtime is installed:
 npm install -g bare bare-make
 ```
 
-Note : Make sure the Bare version is `>= 1.24.2`. Check this using :
+Note : Make sure the Bare version is `>= 1.19.0`. Check this using :
 
 ```bash
 bare -v
@@ -220,15 +219,18 @@ No `bare-make generate` flag is required; just `npm run build`. CI prebuilds for
 
 After building, you can run the test suite:
 ```bash
-# Run all tests (lint + unit + integration)
+# Run the JS test suite: unit + several integration suites (does not run lint)
 npm test
 
 # Or run tests individually
 npm run test:unit
 npm run test:integration
+
+# Lint is separate from `npm test`
+npm run lint
 ```
 
-Integration tests cover both the chunked reload flow (`test/integration/audio-ctx-chunking.test.js`) and the live streaming flow (`test/integration/live-stream-simulation.test.js`), so running them is the quickest way to verify those end-to-end scenarios after changes.
+The chunked reload flow and the live streaming flow have dedicated integration scripts — `npm run test:integration:chunking` (`test/integration/audio-ctx-chunking.test.js`) and `npm run test:integration:live-stream-simultion` (`test/integration/live-stream-simulation.test.js`) — so running those is the quickest way to verify those end-to-end scenarios after changes. (`npm run test:integration` runs `test/integration/addon.test.js`.)
 
 #### Development Workflow
 
@@ -245,7 +247,7 @@ The library provides a straightforward workflow for audio transcription:
 
 ### 1. Provide Model Files
 
-The addon loads model weights directly from local file paths. Make sure the whisper model (and optional VAD model) already exist on disk — either staged manually or fetched through the [model registry](#model-registry). More info about model registry and model builds in [resources](#resources).
+The addon loads model weights directly from local file paths. Make sure the whisper model (and optional VAD model) already exist on disk — either staged manually, downloaded from HuggingFace (see [Downloading Models](#downloading-models)), or fetched through the [QVAC model registry](https://github.com/tetherto/qvac/tree/main/packages/registry-server).
 
 You pass the paths via the `files` field of the constructor arguments:
 
@@ -268,7 +270,7 @@ Most users interact with the addon exclusively through `index.js`. From that ent
 | --- | --- | --- |
 | `contextParams` | `model` | Absolute or relative path to the `.bin` whisper model |
 | | | *(all other context keys keep their defaults because changing them forces a full reload, see below)* |
-| `whisperConfig` | *(any `whisper_full_params` key)* | Forwarded untouched. We surface convenience defaults in `index.js`, but every whisper.cpp flag is accepted—see [Advanced configuration](#advanced-configuration). |
+| `whisperConfig` | *(whitelisted `whisper_full_params` keys)* | A curated whitelist of decoder/VAD keys is accepted (see `configChecker.js`); unknown keys throw. We surface convenience defaults in `index.js`—see [Advanced configuration](#advanced-configuration). |
 | | `backendsDir` | Root directory for dynamically-loaded ggml backend `.so` files (Vulkan, OpenCL, per-arch CPU variants on Android). Defaults to the package's `prebuilds/` folder; the native addon appends `<bare-target>/<module-name>` before scanning. Pass an explicit path when prebuilds live elsewhere — e.g. Android `ApplicationInfo.nativeLibraryDir` when backend libs ship inside the APK. No-op on Apple (statically linked). |
 | `miscConfig` | `caption_enabled` | Formats segments with `<\|start\|>..<\|end\|>` markers |
 
@@ -298,7 +300,7 @@ Depending on model size this can take several seconds. Everything else in `whisp
 
 #### Advanced configuration
 
-Need more than the handful of options exposed in `index.js`? The upstream whisper.cpp documentation lists every flag available through `whisper_full_params`. Rather than duplicating that matrix here, refer to:
+Need more than the handful of options surfaced by default? `whisperConfig` accepts a curated whitelist of `whisper_full_params` keys (validated in `configChecker.js`); keys outside that list are rejected. For the meaning of each accepted flag, refer to:
 
 - The official parameter reference: [`whisper_full_params`](https://github.com/ggerganov/whisper.cpp/blob/master/examples/stream/stream.cpp#L30-L96)
 - Our longer examples for concrete shapes:
@@ -323,7 +325,7 @@ const config = {
     suppress_nst: true,
     n_threads: 0,
     vad_model_path: './models/ggml-silero-v5.1.2.bin',
-    vadParams: {
+    vad_params: {
       threshold: 0.6,
       min_speech_duration_ms: 250,
       min_silence_duration_ms: 200
@@ -388,40 +390,23 @@ Note : This import changes depending on the package installed.
 
 ### 5. Load Model
 
-Load the model weights and initialize the inference engine. Optionally provide a callback for progress updates:
+Load the model weights and initialize the inference engine:
 
 ```javascript
 try {
-  // Basic usage
   await model.load()
-
-  // Advanced usage with progress tracking
-  await model.load(
-          false,  // reserved flag, kept for forwarding compatibility
-          (progress) => console.log(`Loading: ${progress.overallProgress}% complete`)
-  )
 } catch (error) {
   console.error('Failed to load model:', error)
 }
 ```
 
-**Progress Callback Data**
-
-The progress callback receives an object with the following properties:
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `action` | string | Current operation being performed |
-| `totalSize` | number | Total bytes to be loaded |
-| `totalFiles` | number | Total number of files to process |
-| `filesProcessed` | number | Number of files completed so far |
-| `currentFile` | string | Name of file currently being processed |
-| `currentFileProgress` | string | Percentage progress on current file |
-| `overallProgress` | string | Overall loading progress percentage |
+`load()` accepts two optional positional arguments (`load(closeLoader, reportProgress)`) that are kept only for forwarding compatibility — they are currently inert, so there is no load-progress reporting today. Model files must already exist on disk before calling `load()`.
 
 ### 6. Run Transcription
 
 Pass an audio stream (e.g., from `bare-fs.createReadStream`) to the `run` method. Process the transcription results asynchronously.
+
+> The snippets below assume `const fs = require('bare-fs')`.
 
 There are two ways to receive transcription results:
 
@@ -452,9 +437,9 @@ try {
 }
 ```
 
-#### Option 2: Complete Result with `iterate()`
+#### Option 2: Async iteration with `iterate()`
 
-The `iterate()` method returns all transcription segments **after the entire transcription completes**. This is useful when you need the full result before processing.
+The `iterate()` method returns an async generator that yields transcription segments **incrementally** as whisper.cpp produces them (it wakes immediately on each output/end/error event). Use it when you prefer a pull-based `for await` loop over the push-based `onUpdate()` callback.
 
 ```javascript
 try {
@@ -464,7 +449,7 @@ try {
 
   const response = await model.run(audioStream)
 
-  // Wait for complete transcription, then iterate over all segments
+  // Yields each segment incrementally as it is produced
   for await (const transcriptionChunk of response.iterate()) {
     console.log('Transcription chunk:', transcriptionChunk)
   }
@@ -477,8 +462,8 @@ try {
 ```
 
 **Key Differences:**
-- **`onUpdate()`**: Real-time streaming - segments arrive as they are generated by whisper.cpp's `new_segment_callback`
-- **`iterate()`**: Batch processing - all segments available after transcription completes
+- **`onUpdate(cb)`**: push-based — the callback fires for each segment as whisper.cpp's `new_segment_callback` emits it.
+- **`iterate()`**: pull-based — an async generator that yields each segment incrementally in a `for await` loop.
 
 #### Chunking long recordings with reload()
 
@@ -487,6 +472,27 @@ try {
 #### Live streaming a single job
 
 [`examples/example.live-transcription.js`](examples/example.live-transcription.js) feeds tiny PCM buffers into a pushable `Readable`, keeps a single `model.run(...)` open, and relies on `onUpdate()` for incremental text. `test/integration/live-stream-simulation.test.js` covers both the streaming case and a segmented loop without any `reload()` calls.
+
+#### VAD-based live streaming with `runStreaming()`
+
+`runStreaming(audioStream, opts?)` is the public VAD-segmented streaming entrypoint (part of the public API since 0.6.0). It requires a VAD model (via `files.vadModel`, `config.vadModelPath`, or `whisperConfig.vad_model_path`) and accepts the same audio input types as `run()`. Voice-activity detection splits the incoming audio into utterances and transcribes each one as it completes:
+
+```javascript
+const response = await model.runStreaming(audioStream)
+for await (const segment of response.iterate()) {
+  console.log(segment)
+}
+```
+
+Passing conversation options surfaces extra events alongside transcript segments:
+
+| Option | Description |
+|--------|-------------|
+| `emitVadEvents` / `conversationMode` | Emit `{ type: 'vad' }` state updates as speech starts and stops. |
+| `endOfTurnSilenceMs` | Emit `{ type: 'endOfTurn' }` after this much trailing silence. |
+| `vadRunIntervalMs` | How often the VAD is evaluated. |
+
+See [`examples/example.streaming-vad.js`](examples/example.streaming-vad.js) and [`examples/example.mic-conversation.js`](examples/example.mic-conversation.js).
 
 ### 7. Release Resources
 
@@ -504,8 +510,8 @@ try {
 
 ### 1. Clone the repo & Install the dependencies
 ```bash
-git clone https://github.com/tetherto/transcription-whispercpp.git
-cd transcription-whispercpp
+git clone https://github.com/tetherto/qvac.git
+cd qvac/packages/transcription-whispercpp
 npm install
 ```
 
@@ -544,6 +550,8 @@ Results are updated regularly as new model versions are released.
 -   [Model Reload](examples/example.reload.js) – Shows how to reload models with different configurations (language, temperature).
 -   [Audio ctx chunking](examples/example.audio-ctx-chunking.js) – Processes long recordings by reloading with `offset_ms`, `duration_ms`, and `audio_ctx` per chunk (mirrors the `audio-ctx-chunking` integration test).
 -   [Live transcription](examples/example.live-transcription.js) – Streams small chunks into a single job while maintaining Whisper state between updates (mirrors the `live-stream-simulation` integration test).
+-   [VAD streaming](examples/example.streaming-vad.js) – Uses `runStreaming()` for VAD-segmented live transcription.
+-   [Mic conversation](examples/example.mic-conversation.js) – Streams microphone audio through `runStreaming()` with VAD state and end-of-turn events.
 
 ## Glossary
 

--- a/packages/transcription-whispercpp/benchmarks/results/results_summary.md
+++ b/packages/transcription-whispercpp/benchmarks/results/results_summary.md
@@ -6,8 +6,8 @@ Original Model: [Whisper-Tiny](https://huggingface.co/openai/whisper-tiny)
 
 | Speaker group | Quantization | Version | Model | VAD | WER | CER | Dataset | Notes |
 |---------------|--------------|---------|-------|-----|-----|-----|---------|-------|
-| clean | whispercpp | 3.1.1 | @tetherto/transcription-whispercpp | - | 71.72 | 69.27 | Librispeech | Performed on GPU |
-| clean | whispercpp | 3.1.1 | @tetherto/transcription-whispercpp | ✓ | 62.30 | 57.87 | Librispeech | Performed on GPU |
+| clean | whispercpp | 3.1.1 | @qvac/transcription-whispercpp | - | 71.72 | 69.27 | Librispeech | Performed on GPU |
+| clean | whispercpp | 3.1.1 | @qvac/transcription-whispercpp | ✓ | 62.30 | 57.87 | Librispeech | Performed on GPU |
 
 ## Reference
 

--- a/packages/tts-ggml/README.md
+++ b/packages/tts-ggml/README.md
@@ -1,19 +1,19 @@
 # @qvac/tts-ggml
 
 Text-to-speech Bare addon backed by the [`qvac-tts.cpp`][qvac-tts-cpp]
-GGML library.  Currently ships the **Chatterbox Turbo English** model;
-additional engines will land under the same package as the upstream
-library grows.
+GGML library.  Wraps multiple engines under one package: **Chatterbox**
+(Turbo English + multilingual) and **Supertonic** (v1 English, v2, and
+v3 31-language), plus optional LavaSR neural denoise + 48 kHz
+bandwidth-extension enhancement.
 
 Runs in-process with a persistent native engine — the GGUFs, the S3Gen
 preload, the ggml backend, and any voice-conditioning tensors are
 loaded once and reused across every synthesis call.  GPU acceleration
-(Metal on macOS/iOS, Vulkan / OpenCL on Linux/Windows)
+(Metal on macOS/iOS, Vulkan on Linux/Windows, Vulkan / OpenCL on Android)
 is **opt-in** via `config: { useGPU: true }`; the default is CPU.  On
 Android `useGPU` flows through to `tts-cpp`, which picks the GPU
-backend per its own per-vendor allowlist (Supertonic on Adreno/OpenCL,
-Xclipse/Vulkan, Mali/Vulkan; Chatterbox on Adreno/Xclipse, declined to
-CPU on Mali) (see
+backend per its own per-vendor allowlist (Adreno → OpenCL,
+Xclipse/Mali → Vulkan) for both engines (see
 [Backends & GPU acceleration](#backends--gpu-acceleration)).
 
 [qvac-tts-cpp]: https://github.com/tetherto/qvac-ext-lib-whisper.cpp/tree/master/tts-cpp
@@ -69,6 +69,10 @@ supertonic.gguf            (~263 MB)
 
 # Supertonic multilingual (Supertone/supertonic-2; en/ko/es/pt/fr)
 supertonic2.gguf           (~263 MB)
+
+# Supertonic 3 (Supertone/supertonic-3; 31 languages) — published per quant
+# tier with the quant in the filename (auto-detected from modelDir)
+supertonic3-f16.gguf       (also -q8_0 / -q4_0 / -f32)
 ```
 
 The package converts these from upstream Resemble Chatterbox / Supertone
@@ -115,7 +119,7 @@ await response
   })
   .await()
 
-// pcm is Int16 mono @ 24 kHz
+// pcm is Int16 mono @ 24 kHz for Chatterbox (rate varies by engine — see data.sampleRate)
 await model.unload()
 ```
 
@@ -206,8 +210,10 @@ from `referenceAudio`.
 
 Opt-in neural post-processing that bandwidth-extends the synthesized audio to
 **48 kHz** with a synthesised high band, using the LavaSR Vocos enhancer
-(ConvNeXt backbone + ISTFT spec head) converted to a single GGUF and run on the
-CPU/GGML path. It is fully backward compatible — provide no enhancer GGUF and
+(ConvNeXt backbone + ISTFT spec head) converted to a single GGUF. It follows the
+engine's GPU intent: with `config.useGPU: true` (or `nGpuLayers`) the enhancer
+runs on the GPU (Vulkan on Linux/Windows, Metal on macOS/iOS) and falls back to
+CPU otherwise. It is fully backward compatible — provide no enhancer GGUF and
 nothing changes.
 
 Enhancement is enabled simply by supplying the enhancer GGUF; there is no
@@ -246,6 +252,8 @@ Notes:
 - The enhancer always runs at 48 kHz internally. By default the emitted audio
   is 48 kHz; set `config.outputSampleRate` to resample the enhanced output to a
   different rate (`TTSOutputChunk.sampleRate` reports the actual rate).
+- With `opts.stats`, `response.stats.enhancerBackendDevice` (`-1` none / `0` CPU
+  / `1` GPU) and `enhancerBackendId` report where the enhancer actually ran.
 
 ### Denoiser
 
@@ -268,10 +276,12 @@ const model = new TTSGgml({
 ```
 
 Convert the GGUF from the public [LavaSRcpp](https://github.com/Topping1/LavaSRcpp)
-ONNX release:
+ONNX release using the `convert-lavasr-denoiser-to-gguf.py` script shipped in the
+[`qvac-ext-lib-whisper.cpp/tts-cpp`][qvac-tts-cpp] repo (this package ships only
+the enhancer converter under `scripts/`):
 
 ```bash
-python scripts/convert-lavasr-denoiser-to-gguf.py \
+python /path/to/tts-cpp/scripts/convert-lavasr-denoiser-to-gguf.py \
   --denoiser denoiser_core_legacy_fixed63.onnx \
   --out models/lavasr/lavasr-denoiser.gguf --ftype f16   # or f32
 ```
@@ -286,8 +296,8 @@ Notes:
   synthesis, or drop the denoiser for streaming.
 - The tts-cpp UL-UNAS forward is implemented in
   [qvac-ext-lib-whisper.cpp#78](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/78)
-  (scalar CPU port, validated bit-close to the ONNX reference) and is active as of
-  the `tts-cpp` pin `2026-07-03#1` (this package's `vcpkg.json`).
+  (scalar CPU port, validated bit-close to the ONNX reference); it requires a
+  `tts-cpp` build that includes that port — see the pinned version in `vcpkg.json`.
 
 ## Backends & GPU acceleration
 
@@ -304,10 +314,9 @@ host's policy:
 | Android — Mali / others | Vulkan                                       |
 | Everything else / CPU-only build | CPU                                 |
 
-> **Chatterbox on ARM Mali** is the one exception to the table: `tts-cpp`
-> declines Mali for the Chatterbox / S3Gen graph (`allow_arm_mali=false`) and
-> runs it on CPU there (reported via `stats.gpuUnsupported`).  Supertonic runs
-> on Mali via Vulkan.
+> Both Chatterbox and Supertonic run on ARM Mali via Vulkan: `tts-cpp` sets
+> `allow_arm_mali=true` for both graphs. (Earlier `tts-cpp` builds declined
+> Mali for the Chatterbox / S3Gen graph and fell back to CPU there.)
 
 ### Android: dynamic backend loading
 
@@ -339,6 +348,10 @@ unchanged.
 | `files.modelDir`          | string     | —          | Dir containing the two GGUFs |
 | `files.t3Model`           | string     | —          | Overrides `modelDir` for T3 |
 | `files.s3genModel`        | string     | —          | Overrides `modelDir` for S3Gen |
+| `files.supertonicModel`   | string     | —          | Supertonic GGUF (overrides `modelDir`) |
+| `files.lavasrEnhancer`    | string     | —          | LavaSR enhancer GGUF — supplying it turns on 48 kHz enhancement |
+| `files.lavasrDenoiser`    | string     | —          | LavaSR denoiser GGUF — supplying it turns on denoising (batch only) |
+| `engine`                  | string     | auto       | Force `'chatterbox'` or `'supertonic'` (`TTSGgml.ENGINE_CHATTERBOX` / `ENGINE_SUPERTONIC`); auto-detected from the GGUFs present otherwise |
 | `referenceAudio`          | string     | —          | Mono wav ≥ 5 s for voice cloning |
 | `voiceDir`                | string     | —          | Pre-baked voice profile |
 | `seed`                    | number     | 42         | RNG seed (CFM noise + sampling) |
@@ -348,15 +361,21 @@ unchanged.
 | `threads`                 | number     | hw.concurrency capped at 4 | |
 | `streamChunkTokens`       | number     | 0          | **>0 enables native chunk streaming** |
 | `streamFirstChunkTokens`  | number     | = streamChunkTokens | Smaller first chunk for low first-audio-out |
-| `cfmSteps`                | number     | 2          | 1 = faster (halved CFM cost) |
+| `cfmSteps`                | number     | 2          | Chatterbox: 1 = faster (halved CFM cost) |
+| `speed`                   | number     | 1.0        | Speaking-rate multiplier, bounded `[0.25, 4.0]` (`< 1` slower, `> 1` faster). Both engines |
+| `voice` / `voiceName`     | string     | —          | Supertonic voice id (e.g. `'F1'`, `'M1'`) |
+| `steps` / `numInferenceSteps` | number | GGUF default | Supertonic vector-estimator CFM steps (`0` = GGUF default) |
+| `noiseNpyPath`            | string     | —          | Supertonic: optional fixed CFM noise `.npy` for reproducibility |
+| `mecabDictDir`            | string     | —          | Chatterbox MTL Japanese (`ja`): compiled MeCab/IPAdic dictionary directory |
+| `cangjieTsvPath`          | string     | —          | Chatterbox MTL Chinese (`zh`): `Cangjie5_TC` TSV path |
 | `backendsDir`             | string     | `path.join(__dirname, 'prebuilds')` | Root dir the addon scans for dynamically-loaded ggml backend `.so` files.  Required on Android (host should pass `path.join(__dirname, 'prebuilds')`); ignored on platforms that statically link the backend |
 | `openclCacheDir`          | string     | unset      | Android-only: directory where the OpenCL backend persists its compiled program-binary cache.  Setting it across runs avoids re-JITing the kernels on every fresh process |
 | `vulkanCacheDir`          | string     | unset      | Supertonic + `useGPU: true` only: writable directory where the Vulkan backend persists its compiled pipeline cache (`GGML_VK_PIPELINE_CACHE_DIR`).  Moves the one-time first-dispatch pipeline-compile cost (seconds on Mali) off the first `run()` — paid once per install instead of once per process — and enables a load-time pre-warm.  Fully opt-in: unset -> no cross-process cache, no pre-warm, behaviour unchanged |
 | `config.language`         | string     | `"en"`     | Chatterbox MTL accepts `es/fr/de/pt/it/zh/ja/ko/...`; turbo & Supertonic are English |
-| `config.useGPU`           | boolean    | `false`    | Set to `true` to route through Metal / Vulkan / CUDA / OpenCL if available.  Honored for both engines on GPU-capable hosts, including Android, where `tts-cpp` selects the GPU backend per its per-vendor allowlist (Chatterbox falls back to CPU on Mali) |
-| `config.outputSampleRate` | number     | 24000      | Resample native 24 kHz output |
-| `opts.stats`              | boolean    | `false`    | Populate `response.stats` with RTF, `backendDevice` (0=CPU, 1=GPU), `backendId` (0=CPU, 1=Metal, 3=Vulkan, 4=OpenCL, 99=other) etc. |
-| `opts.exclusiveRun`       | boolean    | `false`    | Serialize overlapping streaming runs |
+| `config.useGPU`           | boolean    | `false`    | Set to `true` to route through Metal / Vulkan / CUDA / OpenCL if available.  Honored for both engines on GPU-capable hosts, including Android, where `tts-cpp` selects the GPU backend per its per-vendor allowlist (see [Backends & GPU acceleration](#backends--gpu-acceleration)) |
+| `config.outputSampleRate` | number     | — (engine-native) | Resample the output to this rate (8000–192000 Hz). Omit to keep the engine-native rate (Chatterbox 24 kHz, Supertonic 44.1 kHz, enhancer 48 kHz) |
+| `opts.stats`              | boolean    | `false`    | Populate `response.stats` with RTF, `backendDevice` (0=CPU, 1=GPU), `backendId` (0=CPU, 1=Metal, 2=CUDA, 3=Vulkan, 4=OpenCL, 99=other), and — when an enhancer is active — `enhancerBackendDevice` / `enhancerBackendId` |
+| `exclusiveRun`            | boolean    | `false`    | **Top-level** option (not under `opts`): serialize overlapping streaming runs |
 
 ### Methods
 
@@ -384,8 +403,8 @@ All `run*` methods return a `QvacResponse` (from `@qvac/infer-base`):
 
 ```js
 response.onUpdate(data => {
-  data.outputArray   // Int16Array — 24 kHz mono PCM
-  data.sampleRate    // 24000
+  data.outputArray   // Int16Array — mono PCM
+  data.sampleRate    // actual rate: Chatterbox 24000, Supertonic 44100, enhancer 48000
   data.chunkIndex    // present on sentence-streaming events only
   data.sentenceChunk // present on sentence-streaming events only
 })
@@ -397,6 +416,11 @@ response.stats.realTimeFactor    // synthesis time / audio duration
 response.stats.audioDurationMs
 response.stats.totalSamples
 response.stats.tokensPerSecond
+response.stats.backendDevice     // 0=CPU, 1=GPU
+response.stats.backendId         // 0=CPU, 1=Metal, 2=CUDA, 3=Vulkan, 4=OpenCL, 99=other
+// present when a LavaSR enhancer is active:
+response.stats.enhancerBackendDevice // -1 none, 0 CPU, 1 GPU
+response.stats.enhancerBackendId
 ```
 
 ## Examples
@@ -406,10 +430,17 @@ Runnable demos under `examples/`:
 | Script | Demonstrates |
 |---|---|
 | `chatterbox-tts.js` | Batch synth + wav dump. `bare examples/chatterbox-tts.js "Hello"` |
+| `chatterbox-mtl-tts.js` | Multilingual Chatterbox synthesis |
+| `chatterbox-mtl-sweep-tts.js` | Multilingual Chatterbox sweep across languages |
+| `chatterbox-adjust-speed.js` | Speaking-rate (`speed`) control |
 | `chatterbox-sentence-stream-tts.js` | `runStreaming()` over an async iterator of sentences, with gapless streaming playback |
 | `chatterbox-chunk-stream-tts.js` | Native per-chunk PCM streaming via `streamChunkTokens`, with gapless streaming playback |
-| `supertonic-enhanced.js` | Supertonic + LavaSR 48 kHz enhancement. `bare examples/supertonic-enhanced.js "Hello"` |
 | `chatterbox-enhanced.js` | Chatterbox + LavaSR 48 kHz enhancement (batch). `bare examples/chatterbox-enhanced.js "Hello"` |
+| `supertonic-tts.js` | Supertonic batch synth. `bare examples/supertonic-tts.js "Hello"` |
+| `supertonic-mtl-tts.js` | Multilingual Supertonic synthesis |
+| `supertonic-mtl-sweep-tts.js` | Multilingual Supertonic sweep across languages |
+| `supertonic-sentence-stream-tts.js` | Supertonic sentence-level streaming |
+| `supertonic-enhanced.js` | Supertonic + LavaSR 48 kHz enhancement. `bare examples/supertonic-enhanced.js "Hello"` |
 
 The two streaming examples feed PCM into a single long-running
 `sox play` / `ffplay` process so chunks play back-to-back without any
@@ -504,9 +535,9 @@ RTF.
 **Slow-but-otherwise-fine RTF on Android** — set `config: { useGPU:
 true }` (the default is CPU; see
 [Backends & GPU acceleration](#backends--gpu-acceleration)) and confirm
-your device's GPU is on `tts-cpp`'s per-vendor allowlist.  Chatterbox is
-declined to CPU on ARM Mali, so on a Mali device that engine stays on
-CPU regardless; Supertonic runs on the GPU there.
+your device's GPU is on `tts-cpp`'s per-vendor allowlist.  Both Chatterbox
+and Supertonic run on the GPU on Adreno, Xclipse, and Mali (Adreno uses
+OpenCL; Xclipse and Mali use Vulkan).
 
 ## License
 


### PR DESCRIPTION
## Summary
- bci-whispercpp / transcription-whispercpp / tts-ggml / transcription-parakeet: correct API, config, versions, GPU/backends, examples and error-code docs to match current source.
- Root README: rebuild the Repository-layout table to the current monorepo layout (fix stale lib-infer-* names, add missing packages) and refresh AI-capability entries.

## Test plan
- Docs-only change; no code paths affected.
- Verified every claim against index.js / index.d.ts / configChecker.js / vcpkg.json / package.json / CHANGELOG / scripts / C++ sources.
- Confirmed all referenced example files and script names are tracked in git.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216426242135587