### PR TITLE
ci: remove diffusion Metal diagnostic

### DIFF
--- a/.github/workflows/integration-test-diffusion-cpp.yml
+++ b/.github/workflows/integration-test-diffusion-cpp.yml
@@ -296,33 +296,6 @@ jobs:
         shell: bash
         run: sudo apt-get update && sudo apt-get install -y mesa-vulkan-drivers
 
-      - name: macOS — Metal GPU diagnostic
-        if: matrix.platform == 'darwin'
-        shell: bash
-        run: |
-          echo "=== GPU Hardware ==="
-          system_profiler SPDisplaysDataType 2>/dev/null || echo "(system_profiler unavailable)"
-          echo ""
-          echo "=== Metal Device Check ==="
-          cat > /tmp/metal_check.m << 'OBJC'
-          #import <Metal/Metal.h>
-          #import <stdio.h>
-          int main() {
-            id<MTLDevice> dev = MTLCreateSystemDefaultDevice();
-            if (!dev) { printf("No Metal device available\n"); return 1; }
-            printf("Device    : %s\n", [[dev name] UTF8String]);
-            printf("Headless  : %s\n", dev.headless ? "yes" : "no");
-            printf("LowPower  : %s\n", dev.lowPower ? "yes" : "no");
-            printf("Apple4    : %d\n", [dev supportsFamily:MTLGPUFamilyApple4]);
-            printf("Apple7    : %d\n", [dev supportsFamily:MTLGPUFamilyApple7]);
-            printf("Metal3    : %d\n", [dev supportsFamily:MTLGPUFamilyMetal3]);
-            printf("simdgroup : %d\n", [dev supportsFamily:MTLGPUFamilyApple7]);
-            return 0;
-          }
-          OBJC
-          clang -x objective-c -framework Metal -framework Foundation \
-                -o /tmp/metal_check /tmp/metal_check.m 2>/dev/null && /tmp/metal_check || echo "(Metal check failed to compile/run)"
-
       - name: Run integration test (Linux/macOS)
         if: ${{ matrix.platform != 'win32' }}
         working-directory: ${{ env.WORKDIR }}


### PR DESCRIPTION
## Summary
- Remove the macOS Metal GPU diagnostic step from the diffusion-cpp integration workflow.
- Keep the actual Linux/macOS integration test step unchanged.

## Test plan
- Ran `git diff --check`.
- Reviewed the workflow diff; no runtime test changes.


Made with [Cursor](https://cursor.com)