### PR TITLE
chore[notask][skiplog]: clarify llm logging comment

### DIFF
--- a/packages/llm-llamacpp/addon/src/utils/BackendSelection.cpp
+++ b/packages/llm-llamacpp/addon/src/utils/BackendSelection.cpp
@@ -224,7 +224,7 @@ backend_selection::parseMainGpu(const std::string& mainGpuStr) {
     return std::nullopt;
   }
 
-  // Try to parse as integer first
+  // Try parsing as an integer first
   try {
     int deviceIndex = std::stoi(mainGpuStr);
     return MainGpu(deviceIndex);

--- a/packages/llm-llamacpp/addon/src/utils/ChatTemplateUtils.cpp
+++ b/packages/llm-llamacpp/addon/src/utils/ChatTemplateUtils.cpp
@@ -283,7 +283,7 @@ std::string getPrompt(
     exportParams(params);
     return params.prompt;
   } catch (const std::exception& e) {
-    // Catching known issue when a model does not support tools
+    // Handle the known case where a model does not support tools
     QLOG_IF(
         Priority::ERROR,
         string_format(

--- a/packages/llm-llamacpp/addon/src/utils/LoggingMacros.cpp
+++ b/packages/llm-llamacpp/addon/src/utils/LoggingMacros.cpp
@@ -6,7 +6,7 @@ using namespace qvac_lib_inference_addon_cpp::logger;
 
 namespace qvac_lib_inference_addon_llama {
 namespace logging {
-// Global verbosity level - initialized to ERROR as safe default
+// Global verbosity level - initialized to ERROR as a safe default
 // This ensures that if llamaLogCallback is triggered before verbosity is set,
 // only ERROR messages will be shown, preventing log spam
 Priority g_verbosityLevel = Priority::ERROR;

--- a/packages/llm-llamacpp/addon/src/utils/ReasoningUtils.cpp
+++ b/packages/llm-llamacpp/addon/src/utils/ReasoningUtils.cpp
@@ -10,7 +10,7 @@ namespace utils {
 
 namespace {
 
-// Returns true iff the first piece in `tokens` has a CONTROL or
+// Returns true if and only if the first piece in `tokens` has a CONTROL or
 // USER_DEFINED attribute. That attribute is a BPE-merge barrier under
 // `parse_special=true`, so a prior context token cannot absorb the start
 // of the marker — which is what the span-start math


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Corrects a minor grammar issue in an `llm-llamacpp` C++ comment.

## 📝 How does it solve it?

- Adds the missing article in the logging default description.
- Makes no runtime or API changes.

## 🧪 How was it tested?

- Not run (comment-only change).

---
Generated by GPT-5.6 Sol using `qv-addon-pr-create`.
