### PR TITLE
QVAC-19178 feat[mod]: add Q8_0 quants for Gemma 4 E2B and Qwen3.5-2B multimodal models

### DIFF
--- a/packages/registry-server/data/models.prod.json
+++ b/packages/registry-server/data/models.prod.json
@@ -10683,6 +10683,22 @@
     "link": "https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF"
   },
   {
+    "source": "https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/b5e99bd964eaacc27ba484bb2eb3e9f6160b9143/google_gemma-4-E2B-it-Q8_0.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Gemma 4 E2B instruct multimodal model",
+    "quantization": "q8_0",
+    "params": "2B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "gemma4",
+      "instruct"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF"
+  },
+  {
     "source": "https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/b5e99bd964eaacc27ba484bb2eb3e9f6160b9143/mmproj-google_gemma-4-E2B-it-bf16.gguf",
     "engine": "@qvac/llm-llamacpp",
     "description": "Vision projector (mmproj) for Gemma 4 E2B",
@@ -10975,6 +10991,22 @@
     "engine": "@qvac/llm-llamacpp",
     "description": "Qwen 3.5 2B multimodal model",
     "quantization": "q6_k",
+    "params": "2B",
+    "licenseId": "Apache-2.0",
+    "tags": [
+      "generation",
+      "multimodal",
+      "qwen3.5",
+      "instruct"
+    ],
+    "notes": "",
+    "link": "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF"
+  },
+  {
+    "source": "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/f6d5376be1edb4d416d56da11e5397a961aca8ae/Qwen3.5-2B-Q8_0.gguf",
+    "engine": "@qvac/llm-llamacpp",
+    "description": "Qwen 3.5 2B multimodal model",
+    "quantization": "q8_0",
     "params": "2B",
     "licenseId": "Apache-2.0",
     "tags": [


### PR DESCRIPTION
## Summary

Adds the **Q8_0 main-model quants** to the QVAC Registry for the two 2B multimodal models (GEMMA4_2B_MULTIMODAL / QWEN3_5_2B_MULTIMODAL). Both models already ship Q4_K_M and Q6_K main quants plus f16/bf16/Q8_0 mmproj — only the Q8_0 **main** GGUF was missing.

Same HF repos and the **same pinned revisions** as the existing quants (no new sources introduced):

| Model | File | Size | Source |
|---|---|---|---|
| Gemma 4 E2B it | `google_gemma-4-E2B-it-Q8_0.gguf` | 4.97 GB | `bartowski/google_gemma-4-E2B-it-GGUF@b5e99bd9` |
| Qwen3.5 2B | `Qwen3.5-2B-Q8_0.gguf` | 2.01 GB | `unsloth/Qwen3.5-2B-GGUF@f6d5376b` |

Both files verified present at the pinned revisions via the HF API. Entries mirror the sibling Q4_K_M/Q6_K records exactly (engine `@qvac/llm-llamacpp`, `licenseId` Apache-2.0, tags, params `2B`). Existing entries untouched — pure addition (+32 lines).

Follow-up to #2780, which added the Q8_0 mmproj counterparts; with this PR a full Q8 main+mmproj pair is available for both VLMs.

## Validation

- `models.prod.json` parses; 734 entries, no duplicate sources
- Both sources pin a full 40-char commit SHA (CI `HF_COMMIT_PIN` rule)
- Engine matches `@qvac/<engine-name>` pattern; `Apache-2.0` present in `licenses.json` (used by the sibling entries)

After merge, `sync-models.js` uploads the blobs to staging; the SDK's `bun run update-models` can then pick up `GEMMA4_2B_MULTIMODAL_Q8_0` / `QWEN3_5_2B_MULTIMODAL_Q8_0` constants in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
