### PR TITLE
transcription-parakeet: consume parakeet-cpp 2026-07-13 (EOU GPU decode)

### DIFF
--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Bumped the `parakeet-cpp` `version>=` floors from `2026-07-07` to `2026-07-13`,
+  consuming merged registry PR
+  [tetherto/qvac-registry-vcpkg#245](https://github.com/tetherto/qvac-registry-vcpkg/pull/245)
+  (qvac-ext-lib-whisper.cpp
+  [PR #85](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/85)). The EOU
+  RNN-T decoder now runs as ggml graphs on the active GPU backend
+  (Metal / CUDA / Vulkan) instead of scalar host code: span-batched joint
+  (16 frames per launch), persistent LSTM/pred state and full-window
+  enc-projection on device, on-device argmax and `<EOU>` state reset. Scalar
+  host decode remains for CPU and ggml-opencl. RTX 4000 Vulkan (q8_0, 20 s
+  file): EOU RTF `0.0052` → `0.0031`, decoder ~54 → ~14.5 ms; CTC / TDT /
+  Sortformer unchanged. No addon API changes; the GPU decode engages
+  automatically under `useGPU`. Manifest-only: `default-registry.baseline` is
+  unchanged.
+
 ## [0.9.1] - 2026-07-08
 
 ### Fixed

--- a/packages/transcription-parakeet/vcpkg-configuration.json
+++ b/packages/transcription-parakeet/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "d7cae6dc8c556247bc239c7677dc3a979135bc4a",
+    "baseline": "74d2dfd03d1c2c0767bac6d892ec43a2a0e29c10",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/transcription-parakeet/vcpkg-configuration.json
+++ b/packages/transcription-parakeet/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "74d2dfd03d1c2c0767bac6d892ec43a2a0e29c10",
+    "baseline": "d7cae6dc8c556247bc239c7677dc3a979135bc4a",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/transcription-parakeet/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg.json
@@ -4,19 +4,19 @@
   "dependencies": [
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-07-07",
+      "version>=": "2026-07-13",
       "features": ["metal"],
       "platform": "osx | ios"
     },
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-07-07",
+      "version>=": "2026-07-13",
       "features": ["vulkan", "opencl"],
       "platform": "android"
     },
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-07-07",
+      "version>=": "2026-07-13",
       "features": ["vulkan"],
       "platform": "!(osx | ios | android)"
     },


### PR DESCRIPTION
Bumps `packages/transcription-parakeet` to `parakeet-cpp` **2026-07-13** (qvac-ext-lib-whisper.cpp master `ecac5bb7`, [PR #85](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/85)): the EOU RNN-T decoder now runs as ggml graphs on the active GPU backend (Metal / CUDA / Vulkan) — span-batched joint, persistent LSTM state on device, on-device argmax and `<EOU>` reset. Scalar host decode remains for CPU and OpenCL. No addon code changes needed — the Engine API is unchanged and the GPU decode engages automatically under `useGPU`.

**Expected impact** (RTX 4000, q8_0, 20 s file): EOU Vulkan RTF 0.0052 → **0.0031**, decoder ~54 → ~14.5 ms; CTC/TDT/Sortformer unchanged. Same-content pin already validated end-to-end:
- RTF benchmark: https://github.com/tetherto/qvac/actions/runs/29008861968
- Full validation (prebuild + integration + mobile e2e): https://github.com/tetherto/qvac/actions/runs/29016334322

Registry side landed as [qvac-registry-vcpkg#245](https://github.com/tetherto/qvac-registry-vcpkg/pull/245); this PR is the conventional `version>=` bump only — no baseline change needed (vcpkg reads the registry version database from the registry's main HEAD, and `version>=` resolves above the baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
