### PR TITLE
fix[notask]: remove OpenSSL from llama addons

### DIFF
--- a/packages/embed-llamacpp/CMakeLists.txt
+++ b/packages/embed-llamacpp/CMakeLists.txt
@@ -40,10 +40,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS "inference-addon-cpp/JsInterface.hpp")
-# llama-targets.cmake transitively requires OpenSSL::SSL via cpp-httplib's
-# IMPORTED interface. Make OpenSSL discoverable before find_package(llama)
-# so the target chain resolves on local builds.
-find_package(OpenSSL)
 find_package(llama CONFIG REQUIRED)
 
 if(WIN32)

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/embed-llamacpp/vcpkg-configuration.json
+++ b/packages/embed-llamacpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "803c0d119ea002694963e89237c207ff6ecf47f6",
+    "baseline": "c056353e0253ac0cc9a1dbb067d6c811ade086f6",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [

--- a/packages/llm-llamacpp/CMakeLists.txt
+++ b/packages/llm-llamacpp/CMakeLists.txt
@@ -32,10 +32,6 @@ configure_file(${VCPKG_INSTALLED_PATH}/share/lint-cpp/.clang-tidy
 
 find_path(PICOJSON_INCLUDE_DIRS "picojson/picojson.h")
 find_path(QVAC_LIB_INFERENCE_ADDON_CPP_INCLUDE_DIRS "inference-addon-cpp/JsInterface.hpp")
-# llama-targets.cmake transitively requires OpenSSL::SSL via cpp-httplib's
-# IMPORTED interface. Make OpenSSL discoverable before find_package(llama)
-# so the target chain resolves on local builds.
-find_package(OpenSSL)
 find_package(llama CONFIG REQUIRED)
 # Required to call llama.cpp's `json_schema_to_grammar()` for per-request
 # JSON-Schema → GBNF conversion. The function signature lives in libcommon

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/llm-llamacpp/vcpkg-configuration.json
+++ b/packages/llm-llamacpp/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "c57eec31bdc37ce3a98537b312f5a366b554db6a",
+    "baseline": "c056353e0253ac0cc9a1dbb067d6c811ade086f6",
     "repository": "https://github.com/tetherto/qvac-registry-vcpkg.git"
   },
   "registries": [


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- LLM and embedding addon binaries inherit `libssl` and `libcrypto` through Fabric's exported `cpp-httplib` target.
- Builds therefore depend on whichever system OpenSSL happens to be discoverable on the build host.

## 📝 How does it solve it?

- Pin both addons to the fixed `qvac-fabric` registry revision from [qvac-registry-vcpkg#244](https://github.com/tetherto/qvac-registry-vcpkg/pull/244).
- Remove the addon-level `find_package(OpenSSL)` workaround.
- Patch-bump `@qvac/llm-llamacpp` to `0.36.4` and `@qvac/embed-llamacpp` to `0.26.3`.

## 🧪 How was it tested?

- Built both addons on macOS arm64 against the fixed Fabric overlay.
- Confirmed the installed `llama-targets.cmake` contains no OpenSSL target references.
- Confirmed `otool -L` reports neither `libssl` nor `libcrypto` for either `.bare` binary.
- Ran `git diff --check`.

## Dependency

Draft until qvac-registry-vcpkg#244 merges. The registry baseline SHA must then be refreshed to the commit reachable from `main`.

---
Authored by Cursor GPT-5.6 Sol using `qv-addon-pr-create` and `qv-qip-triage`.
