### PR TITLE
QVAC-22164 chore: release @qvac/cli 0.8.1

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.8.1]
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.8.1
+
+This is a maintenance release. It fixes a diagnostics gap in the OpenAI-compatible server, corrects a documentation claim about Vulkan GPU fallback behavior, and moves the CLI onto `@qvac/sdk` 0.15.0.
+
+## Other Changes
+
+Server errors are now logged with their full stack trace when a request handler throws, making failures easier to diagnose from server logs rather than only the client-facing error response. The Vulkan backend documentation now states the correct minimum required Vulkan version (1.4) and removes an inaccurate claim about CPU fallback behavior. The CLI's committed `@qvac/sdk` dependency now targets `^0.15.0`. Lint, format, and typecheck tooling was also unified across SDK-pod packages with Prettier, with no user-facing effect.
+
 ## [0.8.0]
 
 📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.8.0

--- a/packages/cli/NOTICE
+++ b/packages/cli/NOTICE
@@ -25,11 +25,6 @@ JavaScript Dependencies
   fb-dotslash@0.5.8
     https://github.com/facebook/dotslash
 
---- (mit AND bsd-3-clause) ---
-
-  sha.js@2.4.12
-    https://github.com/crypto-browserify/sha.js
-
 --- (mit AND cc0-1.0) ---
 
   type-fest@0.13.1
@@ -52,47 +47,48 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperswarm-secret-stream
   @malept/cross-spawn-promise@2.0.0
     https://github.com/malept/cross-spawn-promise
-  @qvac/bci-whispercpp@0.2.0
+  @qvac/bci-whispercpp@0.4.1
     https://github.com/tetherto/qvac
-  @qvac/classification-ggml@0.3.1
+  @qvac/classification-ggml@0.10.2
     https://github.com/tetherto/qvac
-  @qvac/decoder-audio@0.4.0
+  @qvac/decoder-audio@0.5.0
     https://github.com/tetherto/qvac
   @qvac/diagnostics@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/diffusion-cpp@0.11.2
+  @qvac/diffusion-cpp@0.13.3
     https://github.com/tetherto/qvac
-  @qvac/embed-llamacpp@0.19.1
+  @qvac/embed-llamacpp@0.26.2
     https://github.com/tetherto/qvac
   @qvac/error@0.1.1
-  @qvac/infer-base@0.4.1
+  @qvac/infer-base@0.4.2
+    https://github.com/tetherto/qvac
+  @qvac/infer-base@0.6.1
     https://github.com/tetherto/qvac
   @qvac/langdetect-text@0.1.2
     https://github.com/tetherto/qvac
-  @qvac/llm-llamacpp@0.24.0
+  @qvac/llm-llamacpp@0.36.3
     https://github.com/tetherto/qvac
-  @qvac/logging@0.1.0
-  @qvac/ocr-onnx@0.6.0
+  @qvac/logging@0.1.1
     https://github.com/tetherto/qvac
-  @qvac/onnx@0.15.0
+  @qvac/ocr-ggml@0.10.2
     https://github.com/tetherto/qvac
-  @qvac/rag@0.6.2
+  @qvac/rag@0.6.4
     https://github.com/tetherto/qvac
-  @qvac/registry-client@0.6.0
+  @qvac/registry-client@0.6.1
     https://github.com/tetherto/qvac
   @qvac/registry-schema@0.3.0
     https://github.com/tetherto/qvac
-  @qvac/sdk@0.13.1
+  @qvac/sdk@0.15.0
     https://github.com/tetherto/qvac
-  @qvac/transcription-parakeet@0.7.2
+  @qvac/transcription-parakeet@0.9.1
     https://github.com/tetherto/qvac
-  @qvac/transcription-whispercpp@0.9.1
+  @qvac/transcription-whispercpp@0.11.1
     https://github.com/tetherto/qvac
-  @qvac/translation-nmtcpp@5.0.2
+  @qvac/translation-nmtcpp@7.2.2
     https://github.com/tetherto/qvac
-  @qvac/tts-ggml@0.2.2
+  @qvac/tts-ggml@0.4.2
     https://github.com/tetherto/qvac
-  @qvac/vla-ggml@0.3.2
+  @qvac/vla-ggml@0.11.2
     https://github.com/tetherto/qvac
   adaptive-timeout@1.0.1
     https://github.com/holepunchto/adaptive-timeout
@@ -108,33 +104,27 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-ansi-escapes
   bare-assert@1.2.0
     https://github.com/holepunchto/bare-assert
-  bare-buffer@3.6.1
+  bare-buffer@3.6.2
     https://github.com/holepunchto/bare-buffer
   bare-bundle@1.10.0
     https://github.com/holepunchto/bare-bundle
   bare-bundle-id@1.0.2
     https://github.com/holepunchto/bare-bundle-id
-  bare-channel@5.2.4
-    https://github.com/holepunchto/bare-channel
   bare-crypto@1.15.3
     https://github.com/holepunchto/bare-crypto
   bare-dns@2.1.4
     https://github.com/holepunchto/bare-dns
-  bare-env@3.0.0
+  bare-env@3.0.1
     https://github.com/holepunchto/bare-env
-  bare-events@2.4.2
-    https://github.com/holepunchto/bare-events
   bare-events@2.9.1
     https://github.com/holepunchto/bare-events
-  bare-fetch@2.9.1
-    https://github.com/holepunchto/bare-fetch
   bare-fetch@3.0.1
     https://github.com/holepunchto/bare-fetch
-  bare-ffmpeg@1.2.2
+  bare-ffmpeg@1.3.0
     https://github.com/holepunchto/bare-ffmpeg
   bare-form-data@1.2.2
     https://github.com/holepunchto/bare-form-data
-  bare-fs@4.7.2
+  bare-fs@4.7.4
     https://github.com/holepunchto/bare-fs
   bare-hrtime@2.1.1
     https://github.com/holepunchto/bare-hrtime
@@ -146,63 +136,65 @@ JavaScript Dependencies
     https://github.com/holepunchto/bare-https
   bare-inspect@3.1.4
     https://github.com/holepunchto/bare-inspect
-  bare-lief@0.2.4
+  bare-lief@0.2.5
     https://github.com/holepunchto/bare-lief
-  bare-link@3.2.2
+  bare-link@3.3.0
     https://github.com/holepunchto/bare-link
   bare-mime@1.0.0
     https://github.com/holepunchto/bare-mime
-  bare-module-lexer@1.5.2
+  bare-module-lexer@1.6.2
     https://github.com/holepunchto/bare-module-lexer
   bare-module-resolve@1.12.2
     https://github.com/holepunchto/bare-module-resolve
-  bare-module-traverse@2.1.2
+  bare-module-traverse@2.4.0
     https://github.com/holepunchto/bare-module-traverse
   bare-net@2.3.2
     https://github.com/holepunchto/bare-net
-  bare-os@3.9.1
+  bare-os@3.9.3
     https://github.com/holepunchto/bare-os
-  bare-pack@2.1.2
+  bare-pack@2.2.1
     https://github.com/holepunchto/bare-pack
-  bare-path@3.0.1
+  bare-path@3.1.1
     https://github.com/holepunchto/bare-path
   bare-pipe@4.2.2
     https://github.com/holepunchto/bare-pipe
-  bare-process@4.4.1
+  bare-posix@1.0.1
+    https://github.com/holepunchto/bare-posix
+  bare-process@4.5.1
     https://github.com/holepunchto/bare-process
-  bare-rpc@1.3.3
+  bare-rpc@1.3.8
     https://github.com/holepunchto/bare-rpc
-  bare-runtime@1.28.6
+  bare-runtime@1.30.3
     https://github.com/holepunchto/bare-runtime
-  bare-runtime-darwin-arm64@1.28.6
+  bare-runtime-darwin-arm64@1.30.3
     https://github.com/holepunchto/bare-runtime
-  bare-semver@1.0.3
+  bare-semver@1.1.0
     https://github.com/holepunchto/bare-semver
   bare-signals@4.2.0
     https://github.com/holepunchto/bare-signals
-  bare-stdio@1.0.2
+  bare-signals@5.0.0
+    https://github.com/holepunchto/bare-signals
+  bare-stdio@1.0.3
     https://github.com/holepunchto/bare-stdio
-  bare-stream@2.13.2
+  bare-stream@2.13.3
     https://github.com/holepunchto/bare-stream
-  bare-structured-clone@1.5.5
+  bare-structured-clone@1.6.0
     https://github.com/holepunchto/bare-structured-clone
-  bare-subprocess@5.2.3
-    https://github.com/holepunchto/bare-subprocess
   bare-subprocess@6.1.0
     https://github.com/holepunchto/bare-subprocess
-  bare-tcp@2.5.1
+  bare-tcp@2.5.2
     https://github.com/holepunchto/bare-tcp
   bare-tls@3.1.7
     https://github.com/holepunchto/bare-tls
-  bare-tty@5.1.1
+  bare-tty@5.1.2
     https://github.com/holepunchto/bare-tty
   bare-type@1.1.0
     https://github.com/holepunchto/bare-type
   bare-url@2.4.5
     https://github.com/holepunchto/bare-url
-  bare-zlib@1.4.0
+  bare-zlib@1.4.1
     https://github.com/holepunchto/bare-zlib
-  baseline-browser-mapping@2.10.36
+  baseline-browser-mapping@2.10.43
     https://github.com/web-platform-dx/baseline-browser-mapping
   blind-relay@1.6.1
     https://github.com/holepunchto/blind-relay
@@ -214,7 +206,7 @@ JavaScript Dependencies
     https://github.com/cezaraugusto/chromium-edge-launcher
   chromium-edge-launcher@0.3.0
     https://github.com/cezaraugusto/chromium-edge-launcher
-  compact-encoding@3.2.0
+  compact-encoding@3.3.0
     https://github.com/holepunchto/compact-encoding
   compact-encoding-bitfield@1.1.0
     https://github.com/compact-encoding/compact-encoding-bitfield
@@ -230,7 +222,7 @@ JavaScript Dependencies
     https://github.com/coveooss/exponential-backoff
   fb-watchman@2.0.2
     https://github.com/facebook/watchman
-  fd-lock@2.1.1
+  fd-lock@2.2.0
     https://github.com/holepunchto/fd-lock
   fs-native-extensions@1.5.0
     https://github.com/holepunchto/fs-native-extensions
@@ -242,7 +234,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hypercore-id-encoding
   hypercore-stats@2.4.0
     https://github.com/holepunchto/hypercore-stats
-  hypercore-storage@3.1.1
+  hypercore-storage@3.1.2
     https://github.com/holepunchto/hypercore-storage
   hyperdb@6.7.0
     https://github.com/holepunchto/hyperdb
@@ -252,7 +244,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/hyperdht-stats
   hyperdispatch@1.6.0
     https://github.com/holepunchto/hyperdispatch
-  hyperdrive@13.3.2
+  hyperdrive@13.3.3
     https://github.com/holepunchto/hyperdrive
   hyperschema@1.21.0
     https://github.com/holepunchto/hyperschema
@@ -282,7 +274,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/rabin-stream
   rache@1.0.0
     https://github.com/holepunchto/rache
-  react-native-bare-kit@0.14.3
+  react-native-bare-kit@0.14.5
     https://github.com/holepunchto/react-native-bare-kit
   refcounter@1.0.0
     https://github.com/holepunchto/refcounter
@@ -292,7 +284,7 @@ JavaScript Dependencies
     https://github.com/holepunchto/require-asset
   resource-on-exit@1.0.0
     https://github.com/holepunchto/bare-teardown
-  rocksdb-native@3.15.2
+  rocksdb-native@3.17.2
     https://github.com/holepunchto/rocksdb-native
   scope-lock@1.2.4
     https://github.com/holepunchto/scope-lock
@@ -329,7 +321,7 @@ JavaScript Dependencies
     https://github.com/isaacs/chownr
   glob@13.0.6
     https://github.com/isaacs/node-glob
-  lru-cache@11.5.1
+  lru-cache@11.5.2
     https://github.com/isaacs/node-lru-cache
   minimatch@10.2.5
     https://github.com/isaacs/minimatch
@@ -341,7 +333,7 @@ JavaScript Dependencies
     https://github.com/isaacs/path-scurry
   sax@1.6.0
     https://github.com/isaacs/sax-js
-  tar@7.5.16
+  tar@7.5.20
     https://github.com/isaacs/node-tar
   yallist@5.0.0
     https://github.com/isaacs/yallist
@@ -366,9 +358,9 @@ JavaScript Dependencies
     https://github.com/kornelski/http-cache-semantics
   normalize-package-data@2.5.0
     https://github.com/npm/normalize-package-data
-  regjsparser@0.13.1
+  regjsparser@0.13.2
     https://github.com/jviereck/regjsparser
-  terser@5.48.0
+  terser@5.49.0
     https://github.com/terser/terser
   webidl-conversions@5.0.0
     https://github.com/jsdom/webidl-conversions
@@ -381,7 +373,9 @@ JavaScript Dependencies
     https://github.com/facebook/react-native
   @react-native/debugger-frontend@0.86.0
     https://github.com/facebook/react-native
-  fast-uri@3.1.2
+  fast-uri@3.1.3
+    https://github.com/fastify/fast-uri
+  fast-uri@4.1.0
     https://github.com/fastify/fast-uri
   global-agent@3.0.0
     https://github.com/gajus/global-agent
@@ -413,7 +407,7 @@ JavaScript Dependencies
 
 --- cc-by-4.0 (Creative Commons Attribution 4.0 International) ---
 
-  caniuse-lite@1.0.30001799
+  caniuse-lite@1.0.30001805
     https://github.com/browserslist/caniuse-lite
 
 --- cc0-1.0 (Creative Commons Zero 1.0) ---
@@ -429,7 +423,7 @@ JavaScript Dependencies
     https://github.com/isaacs/ttlcache
   @npmcli/fs@2.1.2
     https://github.com/npm/fs
-  @ungap/structured-clone@1.3.1
+  @ungap/structured-clone@1.3.3
     https://github.com/ungap/structured-clone
   abbrev@1.1.1
     https://github.com/isaacs/abbrev-js
@@ -437,15 +431,13 @@ JavaScript Dependencies
     https://github.com/RyanZim/at-least-node
   bits-to-bytes@1.3.0
     https://github.com/holepunchto/bits-to-bytes
-  browserify-sign@4.2.6
-    https://github.com/crypto-browserify/browserify-sign
   cacache@16.1.3
     https://github.com/npm/cacache
   chownr@2.0.0
     https://github.com/isaacs/chownr
   cliui@8.0.1
     https://github.com/yargs/cliui
-  electron-to-chromium@1.5.372
+  electron-to-chromium@1.5.389
     https://github.com/Kilian/electron-to-chromium
   fastq@1.20.1
     https://github.com/mcollina/fastq
@@ -485,8 +477,6 @@ JavaScript Dependencies
     https://github.com/isaacs/node-lru-cache
   make-fetch-happen@10.2.1
     https://github.com/npm/make-fetch-happen
-  minimalistic-assert@1.0.1
-    https://github.com/calvinmetcalf/minimalistic-assert
   minimatch@3.1.5
     https://github.com/isaacs/minimatch
   minimatch@5.1.9
@@ -513,8 +503,6 @@ JavaScript Dependencies
     https://github.com/npm/npm-package-arg
   once@1.4.0
     https://github.com/isaacs/once
-  parse-asn1@5.1.9
-    https://github.com/crypto-browserify/parse-asn1
   picocolors@1.1.1
     https://github.com/alexeyraspopov/picocolors
   proc-log@2.0.1
@@ -531,9 +519,7 @@ JavaScript Dependencies
     https://github.com/npm/node-semver
   semver@6.3.1
     https://github.com/npm/node-semver
-  semver@7.8.2
-    https://github.com/npm/node-semver
-  semver@7.8.4
+  semver@7.8.5
     https://github.com/npm/node-semver
   setprototypeof@1.2.0
     https://github.com/wesleytodd/setprototypeof
@@ -570,7 +556,7 @@ JavaScript Dependencies
 
 --- mit (MIT License) ---
 
-  @0no-co/graphql.web@1.2.0
+  @0no-co/graphql.web@1.3.2
     https://github.com/0no-co/graphql.web
   @babel/code-frame@7.10.4
     https://github.com/babel/babel
@@ -750,8 +736,6 @@ JavaScript Dependencies
     https://github.com/electron/rebuild
   @electron/universal@2.0.3
     https://github.com/electron/universal
-  @esbuild/darwin-arm64@0.28.0
-    https://github.com/evanw/esbuild
   @esbuild/darwin-arm64@0.28.1
     https://github.com/evanw/esbuild
   @expo/cli@54.0.25
@@ -776,15 +760,15 @@ JavaScript Dependencies
     https://github.com/expo/expo
   @expo/json-file@10.0.16
     https://github.com/expo/expo
-  @expo/json-file@10.2.0
+  @expo/json-file@11.0.0
     https://github.com/expo/expo
   @expo/metro@54.2.0
     https://github.com/expo/expo-metro
   @expo/metro-config@54.0.16
     https://github.com/expo/expo
-  @expo/osascript@2.6.0
+  @expo/osascript@2.7.0
     https://github.com/expo/expo
-  @expo/package-manager@1.12.1
+  @expo/package-manager@1.13.0
     https://github.com/expo/expo
   @expo/plist@0.4.9
     https://github.com/expo/expo
@@ -806,17 +790,17 @@ JavaScript Dependencies
     https://github.com/fastify/accept-negotiator
   @fastify/ajv-compiler@4.0.5
     https://github.com/fastify/ajv-compiler
-  @fastify/autoload@6.3.1
+  @fastify/autoload@6.4.0
     https://github.com/fastify/fastify-autoload
   @fastify/busboy@3.2.0
     https://github.com/fastify/busboy
-  @fastify/cors@11.2.0
+  @fastify/cors@11.3.0
     https://github.com/fastify/fastify-cors
   @fastify/deepmerge@3.2.1
     https://github.com/fastify/deepmerge
   @fastify/error@4.2.0
     https://github.com/fastify/fastify-error
-  @fastify/fast-json-stringify-compiler@5.0.3
+  @fastify/fast-json-stringify-compiler@5.1.0
     https://github.com/fastify/fast-json-stringify-compiler
   @fastify/forwarded@3.0.1
     https://github.com/fastify/forwarded
@@ -828,9 +812,9 @@ JavaScript Dependencies
     https://github.com/fastify/proxy-addr
   @fastify/send@4.1.0
     https://github.com/fastify/send
-  @fastify/static@9.1.3
+  @fastify/static@9.3.0
     https://github.com/fastify/fastify-static
-  @fastify/swagger@9.7.0
+  @fastify/swagger@9.8.0
     https://github.com/fastify/fastify-swagger
   @fastify/swagger-ui@5.2.6
     https://github.com/fastify/fastify-swagger-ui
@@ -906,7 +890,7 @@ JavaScript Dependencies
     https://github.com/DefinitelyTyped/DefinitelyTyped
   @types/keyv@3.1.4
     https://github.com/DefinitelyTyped/DefinitelyTyped
-  @types/node@24.13.2
+  @types/node@24.13.3
     https://github.com/DefinitelyTyped/DefinitelyTyped
   @types/responselike@1.0.3
     https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -972,16 +956,12 @@ JavaScript Dependencies
     https://github.com/vercel/arg
   asap@2.0.6
     https://github.com/kriskowal/asap
-  asn1.js@4.10.1
-    https://github.com/indutny/asn1.js
   async-limiter@1.0.1
     https://github.com/strml/async-limiter
   atomic-sleep@1.0.0
     https://github.com/davidmarkclements/atomic-sleep
   author-regex@1.0.0
     https://github.com/jonschlinkert/author-regex
-  available-typed-arrays@1.0.7
-    https://github.com/inspect-js/available-typed-arrays
   avvio@9.2.0
     https://github.com/fastify/avvio
   babel-plugin-polyfill-corejs2@0.4.17
@@ -1018,10 +998,6 @@ JavaScript Dependencies
     https://github.com/rvagg/bl
   bluebird@3.7.2
     https://github.com/petkaantonov/bluebird
-  bn.js@4.12.3
-    https://github.com/indutny/bn.js
-  bn.js@5.2.3
-    https://github.com/indutny/bn.js
   bogon@1.3.0
     https://github.com/mafintosh/bogon
   boolean@3.2.0
@@ -1032,25 +1008,15 @@ JavaScript Dependencies
     https://github.com/nearinfinity/node-bplist-parser
   bplist-parser@0.3.2
     https://github.com/nearinfinity/node-bplist-parser
-  brace-expansion@1.1.15
+  brace-expansion@1.1.16
     https://github.com/juliangruber/brace-expansion
-  brace-expansion@2.1.1
+  brace-expansion@2.1.2
     https://github.com/juliangruber/brace-expansion
-  brace-expansion@5.0.6
+  brace-expansion@5.0.7
     https://github.com/juliangruber/brace-expansion
   braces@3.0.3
     https://github.com/micromatch/braces
-  brorand@1.1.0
-    https://github.com/indutny/brorand
-  browserify-aes@1.2.0
-    https://github.com/crypto-browserify/browserify-aes
-  browserify-cipher@1.0.1
-    https://github.com/crypto-browserify/browserify-cipher
-  browserify-des@1.0.2
-    https://github.com/crypto-browserify/browserify-des
-  browserify-rsa@4.1.1
-    https://github.com/crypto-browserify/browserify-rsa
-  browserslist@4.28.2
+  browserslist@4.28.6
     https://github.com/browserslist/browserslist
   buffer@5.7.1
     https://github.com/feross/buffer
@@ -1058,20 +1024,12 @@ JavaScript Dependencies
     https://github.com/brianloveswords/buffer-crc32
   buffer-from@1.1.2
     https://github.com/LinusU/buffer-from
-  buffer-xor@1.0.3
-    https://github.com/crypto-browserify/buffer-xor
   bytes@3.1.2
     https://github.com/visionmedia/bytes.js
   cacheable-lookup@5.0.4
     https://github.com/szmarczak/cacheable-lookup
   cacheable-request@7.0.4
     https://github.com/lukechilds/cacheable-request
-  call-bind@1.0.9
-    https://github.com/ljharb/call-bind
-  call-bind-apply-helpers@1.0.2
-    https://github.com/ljharb/call-bind-apply-helpers
-  call-bound@1.0.4
-    https://github.com/ljharb/call-bound
   camelcase@6.3.0
     https://github.com/sindresorhus/camelcase
   chalk@2.4.2
@@ -1084,8 +1042,6 @@ JavaScript Dependencies
     https://github.com/watson/ci-info
   ci-info@3.9.0
     https://github.com/watson/ci-info
-  cipher-base@1.0.7
-    https://github.com/crypto-browserify/cipher-base
   clean-stack@2.2.0
     https://github.com/sindresorhus/clean-stack
   cli-cursor@2.1.0
@@ -1148,22 +1104,12 @@ JavaScript Dependencies
     https://github.com/jshttp/cookie
   core-js-compat@3.49.0
     https://github.com/zloirock/core-js
-  core-util-is@1.0.3
-    https://github.com/isaacs/core-util-is
-  corestore@7.10.1
+  corestore@7.11.0
     https://github.com/holepunchto/corestore
-  create-ecdh@4.0.4
-    https://github.com/crypto-browserify/createECDH
-  create-hash@1.2.0
-    https://github.com/crypto-browserify/createHash
-  create-hmac@1.1.7
-    https://github.com/crypto-browserify/createHmac
   cross-dirname@0.1.0
     https://github.com/JumpLink/cross-dirname
   cross-spawn@7.0.6
     https://github.com/moxystudio/node-cross-spawn
-  crypto-browserify@3.12.1
-    https://github.com/browserify/crypto-browserify
   debounceify@1.1.0
     https://github.com/mafintosh/debounceify
   debug@2.6.9
@@ -1192,26 +1138,18 @@ JavaScript Dependencies
     https://github.com/dougwilson/nodejs-depd
   dequal@2.0.3
     https://github.com/lukeed/dequal
-  des.js@1.1.0
-    https://github.com/indutny/des.js
   destroy@1.2.0
     https://github.com/stream-utils/destroy
   detect-node@2.1.0
     https://github.com/iliakan/detect-node
   dht-rpc@6.27.0
     https://github.com/holepunchto/dht-rpc
-  diffie-hellman@5.0.3
-    https://github.com/crypto-browserify/diffie-hellman
   dir-compare@4.2.0
     https://github.com/gliviu/dir-compare
-  dunder-proto@1.0.1
-    https://github.com/es-shims/dunder-proto
   eastasianwidth@0.2.0
     https://github.com/komagata/eastasianwidth
   ee-first@1.1.1
     https://github.com/jonathanong/ee-first
-  elliptic@6.6.1
-    https://github.com/indutny/elliptic
   emoji-regex@8.0.0
     https://github.com/mathiasbynens/emoji-regex
   emoji-regex@9.2.2
@@ -1238,12 +1176,8 @@ JavaScript Dependencies
     https://github.com/ljharb/es-define-property
   es-errors@1.3.0
     https://github.com/ljharb/es-errors
-  es-object-atoms@1.1.2
-    https://github.com/ljharb/es-object-atoms
   es6-error@4.1.1
     https://github.com/bjyoungblood/es6-error
-  esbuild@0.28.0
-    https://github.com/evanw/esbuild
   esbuild@0.28.1
     https://github.com/evanw/esbuild
   escalade@3.2.0
@@ -1260,8 +1194,6 @@ JavaScript Dependencies
     https://github.com/mysticatea/event-target-shim
   eventemitter3@5.0.4
     https://github.com/primus/eventemitter3
-  evp_bytestokey@1.0.3
-    https://github.com/crypto-browserify/EVP_BytesToKey
   expo@54.0.35
     https://github.com/expo/expo
   expo-asset@12.0.13
@@ -1288,15 +1220,17 @@ JavaScript Dependencies
     https://github.com/epoberezkin/fast-deep-equal
   fast-fifo@1.3.2
     https://github.com/mafintosh/fast-fifo
-  fast-json-stringify@6.4.0
+  fast-json-stringify@7.0.1
     https://github.com/fastify/fast-json-stringify
   fast-querystring@1.1.2
     https://github.com/anonrig/fast-querystring
   fast-safe-stringify@2.1.1
     https://github.com/davidmarkclements/fast-safe-stringify
-  fastify@5.8.5
+  fastify@5.10.0
     https://github.com/fastify/fastify
   fastify-plugin@5.1.0
+    https://github.com/fastify/fastify-plugin
+  fastify-plugin@6.0.0
     https://github.com/fastify/fastify-plugin
   fastify-type-provider-zod@5.1.0
     https://github.com/turkerdev/fastify-type-provider-zod
@@ -1322,15 +1256,13 @@ JavaScript Dependencies
     https://github.com/MarshallOfSound/flora-colossus
   flow-enums-runtime@0.0.6
     https://github.com/facebook/flow
-  for-each@0.3.5
-    https://github.com/Raynos/for-each
   freeport-async@2.0.0
     https://github.com/expo/freeport-async
   fresh@0.5.2
     https://github.com/jshttp/fresh
   fs-extra@10.1.0
     https://github.com/jprichardson/node-fs-extra
-  fs-extra@11.3.5
+  fs-extra@11.3.6
     https://github.com/jprichardson/node-fs-extra
   fs-extra@8.1.0
     https://github.com/jprichardson/node-fs-extra
@@ -1348,12 +1280,8 @@ JavaScript Dependencies
     https://github.com/mafintosh/generate-string
   gensync@1.0.0-beta.2
     https://github.com/loganfsmyth/gensync
-  get-intrinsic@1.3.0
-    https://github.com/ljharb/get-intrinsic
   get-package-info@1.0.0
     https://github.com/rahatarmanahmed/get-package-info
-  get-proto@1.0.1
-    https://github.com/ljharb/get-proto
   get-stream@5.2.0
     https://github.com/sindresorhus/get-stream
   getenv@2.0.0
@@ -1370,16 +1298,6 @@ JavaScript Dependencies
     https://github.com/sindresorhus/has-flag
   has-property-descriptors@1.0.2
     https://github.com/inspect-js/has-property-descriptors
-  has-symbols@1.1.0
-    https://github.com/inspect-js/has-symbols
-  has-tostringtag@1.0.2
-    https://github.com/inspect-js/has-tostringtag
-  hash-base@3.0.5
-    https://github.com/crypto-browserify/hash-base
-  hash-base@3.1.2
-    https://github.com/crypto-browserify/hash-base
-  hash.js@1.1.7
-    https://github.com/indutny/hash.js
   hasown@2.0.4
     https://github.com/inspect-js/hasOwn
   hermes-compiler@250829098.0.14
@@ -1400,8 +1318,6 @@ JavaScript Dependencies
     https://github.com/facebook/hermes
   hermes-parser@0.36.0
     https://github.com/facebook/hermes
-  hmac-drbg@1.0.1
-    https://github.com/indutny/hmac-drbg
   http-errors@2.0.1
     https://github.com/jshttp/http-errors
   http-proxy-agent@5.0.0
@@ -1416,11 +1332,11 @@ JavaScript Dependencies
     https://github.com/node-modules/humanize-ms
   hyperbee@2.27.3
     https://github.com/holepunchto/hyperbee
-  hypercore@11.33.1
+  hypercore@11.33.5
     https://github.com/holepunchto/hypercore
   hypercore-crypto@3.7.0
     https://github.com/mafintosh/hypercore-crypto
-  hyperdht@6.32.0
+  hyperdht@6.33.0
     https://github.com/holepunchto/hyperdht
   hyperswarm@4.17.0
     https://github.com/holepunchto/hyperswarm
@@ -1442,8 +1358,6 @@ JavaScript Dependencies
     https://github.com/whitequark/ipaddr.js
   is-arrayish@0.2.1
     https://github.com/qix-/node-is-arrayish
-  is-callable@1.2.7
-    https://github.com/inspect-js/is-callable
   is-core-module@2.16.2
     https://github.com/inspect-js/is-core-module
   is-docker@2.2.1
@@ -1462,16 +1376,10 @@ JavaScript Dependencies
     https://github.com/mafintosh/is-options
   is-property@1.0.2
     https://github.com/mikolalysenko/is-property
-  is-typed-array@1.1.15
-    https://github.com/inspect-js/is-typed-array
   is-unicode-supported@0.1.0
     https://github.com/sindresorhus/is-unicode-supported
   is-wsl@2.2.0
     https://github.com/sindresorhus/is-wsl
-  isarray@1.0.0
-    https://github.com/juliangruber/isarray
-  isarray@2.0.5
-    https://github.com/juliangruber/isarray
   isbinaryfile@4.0.10
     https://github.com/gjtorikian/isBinaryFile
   jest-get-type@29.6.3
@@ -1486,7 +1394,7 @@ JavaScript Dependencies
     https://github.com/nuxt-community/jimp-compact
   js-tokens@4.0.0
     https://github.com/lydell/js-tokens
-  js-yaml@4.2.0
+  js-yaml@4.3.0
     https://github.com/nodeca/js-yaml
   jsesc@3.1.0
     https://github.com/mathiasbynens/jsesc
@@ -1544,10 +1452,6 @@ JavaScript Dependencies
     https://github.com/sindresorhus/lowercase-keys
   matcher@3.0.0
     https://github.com/sindresorhus/matcher
-  math-intrinsics@1.1.0
-    https://github.com/es-shims/math-intrinsics
-  md5.js@1.3.5
-    https://github.com/crypto-browserify/md5.js
   memoize-one@5.2.1
     https://github.com/alexreardon/memoize-one
   merge-stream@2.0.0
@@ -1610,8 +1514,6 @@ JavaScript Dependencies
     https://github.com/facebook/metro
   micromatch@4.0.8
     https://github.com/micromatch/micromatch
-  miller-rabin@4.0.1
-    https://github.com/indutny/miller-rabin
   mime@1.6.0
     https://github.com/broofa/node-mime
   mime@3.0.0
@@ -1632,8 +1534,6 @@ JavaScript Dependencies
     https://github.com/sindresorhus/mimic-response
   mimic-response@3.1.0
     https://github.com/sindresorhus/mimic-response
-  minimalistic-crypto-utils@1.0.1
-    https://github.com/indutny/minimalistic-crypto-utils
   minimist@1.2.8
     https://github.com/minimistjs/minimist
   minipass-fetch@2.1.2
@@ -1652,7 +1552,7 @@ JavaScript Dependencies
     https://github.com/mafintosh/mutexify
   mz@2.7.0
     https://github.com/normalize/mz
-  nanoid@3.3.12
+  nanoid@3.3.16
     https://github.com/ai/nanoid
   nat-sampler@1.0.1
     https://github.com/mafintosh/nat-sampler
@@ -1664,13 +1564,13 @@ JavaScript Dependencies
     https://github.com/jshttp/negotiator
   nested-error-stacks@2.0.1
     https://github.com/mdlavin/nested-error-stacks
-  node-abi@3.92.0
+  node-abi@3.94.0
     https://github.com/electron/node-abi
   node-api-version@0.2.1
     https://github.com/timfish/node-api-version
   node-int64@0.4.0
     https://github.com/broofa/node-int64
-  node-releases@2.0.47
+  node-releases@2.0.51
     https://github.com/chicoxyzzy/node-releases
   normalize-url@6.1.0
     https://github.com/sindresorhus/normalize-url
@@ -1736,15 +1636,13 @@ JavaScript Dependencies
     https://github.com/jbgutierrez/path-parse
   path-type@2.0.0
     https://github.com/sindresorhus/path-type
-  pbkdf2@3.1.6
-    https://github.com/browserify/pbkdf2
   pe-library@1.0.1
     https://github.com/jet2jet/pe-library-js
   pend@1.2.0
     https://github.com/andrewrk/node-pend
   picomatch@2.3.2
     https://github.com/micromatch/picomatch
-  picomatch@4.0.4
+  picomatch@4.0.5
     https://github.com/micromatch/picomatch
   pify@2.3.0
     https://github.com/sindresorhus/pify
@@ -1760,20 +1658,16 @@ JavaScript Dependencies
     https://github.com/TooTallNate/node-plist
   pngjs@3.4.0
     https://github.com/lukeapage/pngjs2
-  possible-typed-array-names@1.1.0
-    https://github.com/ljharb/possible-typed-array-names
   postcss@8.4.49
     https://github.com/postcss/postcss
   postject@1.0.0-alpha.6
     https://github.com/nodejs/postject
-  prettier@3.8.4
+  prettier@3.9.5
     https://github.com/prettier/prettier
   pretty-bytes@5.6.0
     https://github.com/sindresorhus/pretty-bytes
   pretty-format@29.7.0
     https://github.com/jestjs/jest
-  process-nextick-args@2.0.1
-    https://github.com/calvinmetcalf/process-nextick-args
   process-warning@4.0.1
     https://github.com/fastify/process-warning
   process-warning@5.0.0
@@ -1792,8 +1686,6 @@ JavaScript Dependencies
     https://github.com/mafintosh/protocol-buffers-encodings
   protomux@3.11.0
     https://github.com/holepunchto/protomux
-  public-encrypt@4.0.3
-    https://github.com/crypto-browserify/publicEncrypt
   pump@3.0.4
     https://github.com/mafintosh/pump
   punycode@2.3.1
@@ -1808,10 +1700,6 @@ JavaScript Dependencies
     https://github.com/sindresorhus/quick-lru
   random-array-iterator@1.0.0
     https://github.com/mafintosh/random-array-iterator
-  randombytes@2.1.0
-    https://github.com/crypto-browserify/randombytes
-  randomfill@1.0.4
-    https://github.com/crypto-browserify/randomfill
   range-parser@1.2.1
     https://github.com/jshttp/range-parser
   react@19.2.7
@@ -1830,8 +1718,6 @@ JavaScript Dependencies
     https://github.com/sindresorhus/read-pkg
   read-pkg-up@2.0.0
     https://github.com/sindresorhus/read-pkg-up
-  readable-stream@2.3.8
-    https://github.com/nodejs/readable-stream
   readable-stream@3.6.2
     https://github.com/nodejs/readable-stream
   ready-resource@1.2.0
@@ -1890,10 +1776,6 @@ JavaScript Dependencies
     https://github.com/mcollina/reusify
   rfdc@1.4.1
     https://github.com/davidmarkclements/rfdc
-  ripemd160@2.0.3
-    https://github.com/crypto-browserify/ripemd160
-  safe-buffer@5.1.2
-    https://github.com/feross/safe-buffer
   safe-buffer@5.2.1
     https://github.com/feross/safe-buffer
   safe-regex2@5.1.1
@@ -1920,13 +1802,11 @@ JavaScript Dependencies
     https://github.com/expressjs/serve-static
   set-cookie-parser@2.7.2
     https://github.com/nfriedly/set-cookie-parser
-  set-function-length@1.2.2
-    https://github.com/ljharb/set-function-length
   shebang-command@2.0.0
     https://github.com/kevva/shebang-command
   shebang-regex@3.0.0
     https://github.com/sindresorhus/shebang-regex
-  shell-quote@1.8.4
+  shell-quote@1.10.0
     https://github.com/ljharb/shell-quote
   shuffled-priority-queue@2.1.0
     https://github.com/mafintosh/shuffled-priority-queue
@@ -1972,9 +1852,9 @@ JavaScript Dependencies
     https://github.com/jshttp/statuses
   statuses@2.0.2
     https://github.com/jshttp/statuses
-  streamx@2.27.0
+  streamx@2.28.0
     https://github.com/mafintosh/streamx
-  string_decoder@1.1.1
+  string_decoder@1.3.0
     https://github.com/nodejs/string_decoder
   string-width@4.2.3
     https://github.com/sindresorhus/string-width
@@ -2030,23 +1910,19 @@ JavaScript Dependencies
     https://github.com/SuperchupuDev/tinyglobby
   tinyld@1.3.4
     https://github.com/komodojp/tinyld
-  to-buffer@1.2.2
-    https://github.com/browserify/to-buffer
   to-regex-range@5.0.1
     https://github.com/micromatch/to-regex-range
-  toad-cache@3.7.1
+  toad-cache@3.7.4
     https://github.com/kibertoad/toad-cache
   toidentifier@1.0.1
     https://github.com/component/toidentifier
   trim-repeated@1.0.0
     https://github.com/sindresorhus/trim-repeated
-  tsx@4.22.4
+  tsx@4.23.1
     https://github.com/privatenumber/tsx
-  typed-array-buffer@1.0.3
-    https://github.com/inspect-js/typed-array-buffer
   ua-parser-js@0.7.41
     https://github.com/faisalman/ua-parser-js
-  undici@6.26.0
+  undici@6.27.0
     https://github.com/nodejs/undici
   undici-types@7.18.2
     https://github.com/nodejs/undici
@@ -2088,8 +1964,6 @@ JavaScript Dependencies
     https://github.com/github/fetch
   whatwg-url-without-unicode@8.0.0-3
     https://github.com/charpeni/whatwg-url
-  which-typed-array@1.1.22
-    https://github.com/inspect-js/which-typed-array
   wonka@6.3.6
     https://github.com/0no-co/wonka
   wrap-ansi@7.0.0
@@ -2110,7 +1984,7 @@ JavaScript Dependencies
     https://github.com/oozcitak/xmlbuilder-js
   xmlbuilder@15.1.1
     https://github.com/oozcitak/xmlbuilder-js
-  yargs@17.7.2
+  yargs@17.7.3
     https://github.com/yargs/yargs
   yauzl@2.10.0
     https://github.com/thejoshwolfe/yauzl

--- a/packages/cli/changelog/0.8.1/CHANGELOG.md
+++ b/packages/cli/changelog/0.8.1/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog v0.8.1
+
+Release Date: 2026-07-13
+
+## 🐞 Fixes
+
+- Log CLI server error stack traces. (see PR [#3184](https://github.com/tetherto/qvac/pull/3184))
+
+## 📘 Docs
+
+- Document Vulkan 1.4 minimum and correct the CPU-fallback claim. (see PR [#3118](https://github.com/tetherto/qvac/pull/3118))
+
+## 🧹 Chores
+
+- Adopt Prettier across SDK-pod packages. (see PR [#3039](https://github.com/tetherto/qvac/pull/3039))
+- Unify lint/format/typecheck across SDK-pod packages. (see PR [#3040](https://github.com/tetherto/qvac/pull/3040))
+

--- a/packages/cli/changelog/0.8.1/CHANGELOG.md
+++ b/packages/cli/changelog/0.8.1/CHANGELOG.md
@@ -14,4 +14,3 @@ Release Date: 2026-07-13
 
 - Adopt Prettier across SDK-pod packages. (see PR [#3039](https://github.com/tetherto/qvac/pull/3039))
 - Unify lint/format/typecheck across SDK-pod packages. (see PR [#3040](https://github.com/tetherto/qvac/pull/3040))
-

--- a/packages/cli/changelog/0.8.1/CHANGELOG_LLM.md
+++ b/packages/cli/changelog/0.8.1/CHANGELOG_LLM.md
@@ -1,0 +1,9 @@
+# QVAC CLI v0.8.1 Release Notes
+
+📦 **NPM:** https://www.npmjs.com/package/@qvac/cli/v/0.8.1
+
+This is a maintenance release. It fixes a diagnostics gap in the OpenAI-compatible server, corrects a documentation claim about Vulkan GPU fallback behavior, and moves the CLI onto `@qvac/sdk` 0.15.0.
+
+## Other Changes
+
+Server errors are now logged with their full stack trace when a request handler throws, making failures easier to diagnose from server logs rather than only the client-facing error response. The Vulkan backend documentation now states the correct minimum required Vulkan version (1.4) and removes an inaccurate claim about CPU fallback behavior. The CLI's committed `@qvac/sdk` dependency now targets `^0.15.0`. Lint, format, and typecheck tooling was also unified across SDK-pod packages with Prettier, with no user-facing effect.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "@fastify/multipart": "^9.0.0",
     "@fastify/swagger": "^9.0.0",
     "@fastify/swagger-ui": "^5.0.0",
-    "@qvac/sdk": "^0.14.1",
+    "@qvac/sdk": "^0.15.0",
     "close-with-grace": "^2.1.0",
     "commander": "^14.0.3",
     "fastify": "^5.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Command-line interface for the QVAC ecosystem",
   "author": "Tether",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- Cuts the `@qvac/cli` 0.8.1 release: bumps the CLI's `@qvac/sdk` dependency to `0.15.0` and ships a couple of accumulated fixes/docs since 0.8.0.

## 📝 How does it solve it?

- Bumps `packages/cli/package.json` `dependencies["@qvac/sdk"]` from `^0.14.1` to `^0.15.0` (separate commit).
- Bumps `packages/cli/package.json` version to `0.8.1`.
- Generates `changelog/0.8.1/{CHANGELOG.md,CHANGELOG_LLM.md}` and folds them into the root `CHANGELOG.md` via `scripts/sdk/generate-changelog-sdk-pod.cjs`.
- Regenerates `NOTICE` against the bumped dependency tree.

## 🧪 How was it tested?

- Built `@qvac/sdk` from source (`npm run sdk-source:workspace`) and ran against it locally, since `@qvac/sdk` 0.15.0 was still unpublished at the time of this work (now confirmed live on npm).
- `npm run typecheck`, `npm run lint`, `npm run format` — all clean.
- `npm run test:unit` — 413/413 passing.
- `npm run test:e2e` — 176/176 passing (JS + model suites).
- `node packages/cli/scripts/check-publish-ready.cjs` — exits 0.
