### PR TITLE
infra[skiplog]: fix whisper benchmark backend labels, Windows, and iOS perf

### DIFF
--- a/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-transcription-whispercpp.yml
@@ -178,6 +178,11 @@ jobs:
           platform: ${{ matrix.platform }}
           step-summary-title: 'Mobile Performance: whisper (${{ matrix.platform }})'
           artifact-name: perf-report-whispercpp-${{ matrix.platform }}-${{ github.run_number }}
+          # iOS (and multi-device Android pools) write the PERF_REPORT markers
+          # into bare_console.log inside Customer_Artifacts.zip; unzip them so
+          # extract-from-log.js can find the per-device performance reports.
+          # Without this iOS produces no benchmark rows. Mirrors parakeet.
+          unzip-customer-artifacts: 'true'
 
       - name: Comment results on PR
         if: always() && !cancelled()

--- a/.github/workflows/integration-test-transcription-whispercpp.yml
+++ b/.github/workflows/integration-test-transcription-whispercpp.yml
@@ -112,13 +112,13 @@ jobs:
             platform: darwin
             arch: x64
             benchmark_matrix_json: >-
-              [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-base-q5_1.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-base-q8_0.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-small.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-small-q5_1.bin","useGPU":true,"backendHint":"coreml"},{"modelFile":"ggml-small-q8_0.bin","useGPU":true,"backendHint":"coreml"}]
+              [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-base-q5_1.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-base-q8_0.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-small.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-small-q5_1.bin","useGPU":true,"backendHint":"metal"},{"modelFile":"ggml-small-q8_0.bin","useGPU":true,"backendHint":"metal"}]
           - os: windows-2025
             platform: win32
             arch: x64
             runner: qvac-win25-x64-gpu
             benchmark_matrix_json: >-
-              [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base.bin","useGPU":true,"backendHint":"directml"},{"modelFile":"ggml-base-q5_1.bin","useGPU":true,"backendHint":"directml"},{"modelFile":"ggml-base-q8_0.bin","useGPU":true,"backendHint":"directml"},{"modelFile":"ggml-small.bin","useGPU":true,"backendHint":"directml"},{"modelFile":"ggml-small-q5_1.bin","useGPU":true,"backendHint":"directml"},{"modelFile":"ggml-small-q8_0.bin","useGPU":true,"backendHint":"directml"}]
+              [{"modelFile":"ggml-base.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q5_1.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-small-q8_0.bin","useGPU":false,"backendHint":"cpu"},{"modelFile":"ggml-base.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-base-q5_1.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-base-q8_0.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-small.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-small-q5_1.bin","useGPU":true,"backendHint":"vulkan"},{"modelFile":"ggml-small-q8_0.bin","useGPU":true,"backendHint":"vulkan"}]
 
     steps:
       - name: Setup Node.js
@@ -200,7 +200,13 @@ jobs:
           New-Item -ItemType Directory -Force -Path "${{ runner.temp }}\tmp" | Out-Null
           npm pack ${{ inputs.prebuild_package }} --pack-destination "${{ runner.temp }}\tmp"
           $tgz = Get-ChildItem "${{ runner.temp }}\tmp\*.tgz" | Select-Object -First 1
-          tar -xzf $tgz.FullName -C "${{ runner.temp }}\tmp"
+          # Extract from inside the temp dir with a RELATIVE archive name. The
+          # tar on PATH (Git's MSYS GNU tar) mangles absolute Windows paths — it
+          # reads the "C:" in an absolute -f/-C argument as a remote host and
+          # aborts, so the extract silently no-ops and the addon is never staged.
+          Push-Location "${{ runner.temp }}\tmp"
+          tar -xzf $tgz.Name
+          Pop-Location
           Copy-Item -Path "${{ runner.temp }}\tmp\package\prebuilds\*" -Destination prebuilds -Recurse -Force
           Get-ChildItem -Path prebuilds -Recurse -File -Filter 'tetherto__*' | ForEach-Object {
             $newName = $_.Name -replace 'tetherto__', 'qvac__'

--- a/packages/transcription-whispercpp/test/benchmark/rtf-benchmark.test.js
+++ b/packages/transcription-whispercpp/test/benchmark/rtf-benchmark.test.js
@@ -85,10 +85,12 @@ function getUpperBound (benchmarkSettings) {
 function getRequestedBackendFamily (platformName, useGPU, backendHint) {
   if (backendHint) return backendHint
   if (!useGPU) return 'cpu'
-  if (platformName === 'darwin' || platformName === 'ios') return 'coreml'
-  if (platformName === 'win32') return 'directml'
-  if (platformName === 'linux') return 'cuda'
-  if (platformName === 'android') return 'nnapi'
+  // ggml GPU backend by platform: Metal on Apple, Vulkan on Windows (the
+  // prebuild is a Vulkan build) and Linux, Vulkan/OpenCL on Android.
+  if (platformName === 'darwin' || platformName === 'ios') return 'metal'
+  if (platformName === 'win32') return 'vulkan'
+  if (platformName === 'linux') return 'vulkan'
+  if (platformName === 'android') return 'vulkan'
   return 'gpu'
 }
 

--- a/packages/transcription-whispercpp/test/integration/helpers.js
+++ b/packages/transcription-whispercpp/test/integration/helpers.js
@@ -165,6 +165,11 @@ function recordWhisperStats (label, stats, extra) {
   const encodeMs = typeof stats.whisperEncodeMs === 'number' ? Math.round(stats.whisperEncodeMs) : null
   const decodeMs = typeof stats.whisperDecodeMs === 'number' ? Math.round(stats.whisperDecodeMs) : null
   const audioMs = typeof stats.audioDurationMs === 'number' ? Math.round(stats.audioDurationMs) : null
+  // The active ggml backend id captured once per load() and echoed in every
+  // stats snapshot (0=CPU 1=Metal 2=CUDA 3=Vulkan 4=OpenCL 99=other). Recorded
+  // so the aggregator can label the REAL backend per device instead of guessing
+  // from the platform — e.g. Adreno Android lands on OpenCL(4), Mali on Vulkan(3).
+  const backendId = typeof stats.backendId === 'number' ? stats.backendId : null
 
   _perfReporter.record(label, {
     real_time_factor: rtf,
@@ -173,7 +178,8 @@ function recordWhisperStats (label, stats, extra) {
     whisper_encode_time_ms: encodeMs,
     whisper_decode_time_ms: decodeMs,
     audio_duration_ms: audioMs,
-    total_time_ms: totalTimeMs
+    total_time_ms: totalTimeMs,
+    backend_id: backendId
   }, {
     execution_provider: ep,
     output: extra && extra.output ? String(extra.output) : null

--- a/scripts/perf-report/aggregate-whisper-rtf.js
+++ b/scripts/perf-report/aggregate-whisper-rtf.js
@@ -4,11 +4,17 @@
 const fs = require('fs')
 const path = require('path')
 
-// whisper.cpp GPU backends: the ggml cascade (Vulkan on linux/win32/android,
-// Metal on darwin/ios, OpenCL on Adreno android) plus the CoreML encoder
-// (darwin) and the DirectML path (win32) the benchmark matrix exercises.
+// whisper.cpp GPU backends: the ggml cascade — Vulkan on linux/win32/android,
+// Metal on darwin/ios, OpenCL on Adreno android. ggml has no DirectML/CoreML
+// compute backend (the Windows prebuild is a Vulkan build, macOS offloads to
+// Metal), so the set matches bci-whispercpp for consistency across packages.
 // CUDA is not supported on any platform.
-const SUPPORTED_GPU_BACKENDS = ['vulkan', 'metal', 'opencl', 'coreml', 'directml']
+const SUPPORTED_GPU_BACKENDS = ['vulkan', 'metal', 'opencl']
+
+// ggml active-backend ids reported by the addon (WhisperModel BackendId enum),
+// mapped to the backend label. Used to recover the REAL backend a mobile device
+// selected at runtime rather than guessing it from the platform family.
+const BACKEND_BY_ID = { 0: 'cpu', 1: 'metal', 2: 'cuda', 3: 'vulkan', 4: 'opencl' }
 
 function parseArgs (argv) {
   const args = {
@@ -97,9 +103,9 @@ function normalizeBackend (platformName, useGPU, backendHint) {
   switch (String(platformName || '').toLowerCase()) {
     case 'darwin':
     case 'ios':
-      return 'coreml'
+      return 'metal'
     case 'win32':
-      return 'directml'
+      return 'vulkan'
     case 'android':
       return 'vulkan'
     case 'linux':
@@ -107,6 +113,16 @@ function normalizeBackend (platformName, useGPU, backendHint) {
     default:
       return 'gpu'
   }
+}
+
+// Prefer the observed ggml backend id (per-device ground truth) over the
+// platform-family guess. Falls back to normalizeBackend when the addon did not
+// report an id (older prebuilds, or a snapshot without stats).
+function resolveMobileBackend (backendId, platformName, useGPU) {
+  if (typeof backendId === 'number' && BACKEND_BY_ID[backendId]) {
+    return BACKEND_BY_ID[backendId]
+  }
+  return normalizeBackend(platformName, useGPU)
 }
 
 function normalizeReport (report, sourceFile, source) {
@@ -226,12 +242,14 @@ function normalizeMobileRecords (report, sourceFile) {
         modelTag,
         provider,
         rtf: [],
-        wallMs: []
+        wallMs: [],
+        backendId: null
       })
     }
     const group = byModelAndProvider.get(key)
     if (typeof metrics.real_time_factor === 'number') group.rtf.push(metrics.real_time_factor)
     if (typeof metrics.wall_time_ms === 'number') group.wallMs.push(metrics.wall_time_ms)
+    if (group.backendId === null && typeof metrics.backend_id === 'number') group.backendId = metrics.backend_id
   }
 
   const records = []
@@ -244,7 +262,7 @@ function normalizeMobileRecords (report, sourceFile) {
       platformFamily: platformFamily || 'unknown',
       model: values.modelTag,
       gpu: values.provider,
-      backend: normalizeBackend(platformFamily, useGPU),
+      backend: resolveMobileBackend(values.backendId, platformFamily, useGPU),
       meanRtf: mean(values.rtf),
       stddevRtf: stddev(values.rtf),
       p50: percentile(values.rtf, 50),


### PR DESCRIPTION
## What

Fixes the whisper performance-benchmark workflow so every platform reports the real backend and Windows/iOS actually produce rows.

- **Real mobile backend**: record the ggml `backend_id` in the mobile perf report and derive the backend per device in the aggregator, so Adreno Android reports **OpenCL** and Mali reports **Vulkan** instead of a hardcoded `vulkan` for every device.
- **Windows**: the Windows prebuild-from-package extract silently no-oped because Git's MSYS tar mangles absolute `C:\` paths — extract with a relative archive name from inside the temp dir (mirrors parakeet). Windows now produces results.
- **iOS CPU+GPU**: unzip `Customer_Artifacts.zip` in the mobile perf extract step (iOS writes the PERF markers into `bare_console.log` inside the zip). iOS rows now appear.
- **CoreML→Metal / DirectML→Vulkan**: label darwin GPU rows as **Metal** and Windows GPU rows as **Vulkan** (ggml has no CoreML/DirectML compute backend); `SUPPORTED_GPU_BACKENDS` now matches bci-whispercpp.

## Validation (real CI, `benchmark-performance-transcription-whispercpp`)

- Desktop-only run 29249838405: **Windows green → 6 CPU + 6 Vulkan GPU rows**; macOS Metal, Linux Vulkan present.
- Full run 29248834447: **iOS iPhone 16 Pro + 17 Pro CPU+GPU (Metal) rows**; **Samsung S25 GPU = OpenCL**; coverage `metal, opencl, vulkan`, none missing.

Benchmark-infra only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
