### PR TITLE
infra[skiplog]: add bci Windows GPU + iOS benchmarks, fix real backend label

### DIFF
--- a/.github/workflows/integration-mobile-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-mobile-test-bci-whispercpp.yml
@@ -191,6 +191,11 @@ jobs:
           platform: ${{ matrix.platform }}
           step-summary-title: 'Mobile Performance: bci (${{ matrix.platform }})'
           artifact-name: perf-report-bci-whispercpp-${{ matrix.platform }}-${{ github.run_number }}
+          # iOS (and multi-device Android pools) write the PERF_REPORT markers
+          # into bare_console.log inside Customer_Artifacts.zip; unzip them so
+          # extract-from-log.js can find the per-device performance reports.
+          # Without this iOS produces no benchmark rows. Mirrors parakeet.
+          unzip-customer-artifacts: 'true'
 
       - name: Comment results on PR
         if: always() && !cancelled()

--- a/.github/workflows/integration-test-bci-whispercpp.yml
+++ b/.github/workflows/integration-test-bci-whispercpp.yml
@@ -138,7 +138,7 @@ jobs:
             runner: qvac-win25-x64-gpu
             no_gpu: 'false'
             benchmark_matrix_json: >-
-              [{"useGPU":false,"backendHint":"cpu"}]
+              [{"useGPU":false,"backendHint":"cpu"},{"useGPU":true,"backendHint":"vulkan"}]
 
     steps:
       - name: Setup Node.js
@@ -220,7 +220,13 @@ jobs:
           New-Item -ItemType Directory -Force -Path "${{ runner.temp }}\tmp" | Out-Null
           npm pack ${{ inputs.prebuild_package }} --pack-destination "${{ runner.temp }}\tmp"
           $tgz = Get-ChildItem "${{ runner.temp }}\tmp\*.tgz" | Select-Object -First 1
-          tar -xzf $tgz.FullName -C "${{ runner.temp }}\tmp"
+          # Extract from inside the temp dir with a RELATIVE archive name. The
+          # tar on PATH (Git's MSYS GNU tar) mangles absolute Windows paths — it
+          # reads the "C:" in an absolute -f/-C argument as a remote host and
+          # aborts, so the extract silently no-ops and the addon is never staged.
+          Push-Location "${{ runner.temp }}\tmp"
+          tar -xzf $tgz.Name
+          Pop-Location
           Copy-Item -Path "${{ runner.temp }}\tmp\package\prebuilds\*" -Destination prebuilds -Recurse -Force
           Get-ChildItem -Path prebuilds -Recurse -File -Filter 'tetherto__*' | ForEach-Object {
             $newName = $_.Name -replace 'tetherto__', 'qvac__'
@@ -250,8 +256,8 @@ jobs:
         working-directory: ${{ inputs.workdir }}
         shell: powershell
         run: |
-          $addon = Get-ChildItem -Recurse -Filter 'qvac__bci-whispercpp*.bare' prebuilds/ | Select-Object -First 1
-          if (-not $addon) { Write-Host "no .bare in prebuilds/"; exit 0 }
+          $addon = Get-ChildItem -Path prebuilds/win32-x64 -Recurse -Filter 'qvac__bci-whispercpp*.bare' -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $addon) { Write-Host "no win32-x64 .bare in prebuilds/"; exit 0 }
           Write-Host "addon: $($addon.FullName)"
           $dumpbin = Get-ChildItem -Path "C:\Program Files\Microsoft Visual Studio\2022" -Filter dumpbin.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
           if (-not $dumpbin) { Write-Host "dumpbin not found"; exit 0 }
@@ -261,20 +267,29 @@ jobs:
       # and its vulkan-1.dll dependency are only loaded lazily when the GPU is
       # used), bci-whispercpp statically links whisper/ggml with Vulkan, so the
       # .bare has a HARD import on vulkan-1.dll that must resolve at load time.
-      # bare's addon loader does not resolve that static import via PATH, so we
-      # place the Vulkan loader in the addon's own directory (Windows always
-      # searches the loaded module's own directory first).
+      # We copy the Vulkan loader next to the addon (Windows always searches the
+      # loaded module's own directory first) as a belt-and-suspenders fallback.
+      # The loader lives in System32 on the qvac-win25-x64-gpu runner (that is
+      # where the driver installs it and how the Vulkan device is found), not
+      # under C:\VulkanSDK, so search System32 / VULKAN_SDK\Bin first. Non-fatal:
+      # if it is not found, the default DLL search path (System32) still resolves
+      # the import, so a benchmark-only run must not be gated on the copy.
       - if: ${{ matrix.platform == 'win32' }}
         name: Windows - stage Vulkan loader next to addon
         working-directory: ${{ inputs.workdir }}
         shell: powershell
         run: |
-          $vk = Get-ChildItem -Path "C:\VulkanSDK" -Filter vulkan-1.dll -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
-          if (-not $vk) { Write-Host "vulkan-1.dll not found under C:\VulkanSDK"; exit 1 }
-          $dir = Get-ChildItem -Recurse -Filter 'qvac__bci-whispercpp*.bare' prebuilds/ | Select-Object -First 1 | ForEach-Object { $_.DirectoryName }
-          if (-not $dir) { Write-Host "no .bare dir in prebuilds/"; exit 1 }
-          Write-Host "copying $($vk.FullName) -> $dir"
-          Copy-Item -Path $vk.FullName -Destination $dir -Force
+          $vk = @("$Env:WINDIR\System32\vulkan-1.dll", "$Env:VULKAN_SDK\Bin\vulkan-1.dll") |
+            Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $vk) {
+            $found = Get-ChildItem -Path "C:\VulkanSDK" -Filter vulkan-1.dll -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($found) { $vk = $found.FullName }
+          }
+          if (-not $vk) { Write-Host "vulkan-1.dll not found; relying on the default DLL search path (System32)"; exit 0 }
+          $dir = Get-ChildItem -Path prebuilds/win32-x64 -Recurse -Filter 'qvac__bci-whispercpp*.bare' -ErrorAction SilentlyContinue | Select-Object -First 1 | ForEach-Object { $_.DirectoryName }
+          if (-not $dir) { Write-Host "no win32-x64 .bare dir in prebuilds/"; exit 0 }
+          Write-Host "copying $vk -> $dir"
+          Copy-Item -Path $vk -Destination $dir -Force
 
       - name: Download models (registry)
         working-directory: ${{ inputs.workdir }}

--- a/packages/bci-whispercpp/test/integration/helpers.js
+++ b/packages/bci-whispercpp/test/integration/helpers.js
@@ -149,12 +149,18 @@ function recordBciStats (label, stats, extra) {
     ? Math.round(extra.wallMs)
     : (typeof stats.totalWallMs === 'number' ? Math.round(stats.totalWallMs) : totalTimeMs)
   const tps = typeof stats.tokensPerSecond === 'number' ? stats.tokensPerSecond : null
+  // Active ggml backend id echoed in every stats snapshot
+  // (0=CPU 1=Metal 2=CUDA 3=Vulkan 4=OpenCL 99=other). Recorded so the
+  // aggregator labels the REAL per-device backend instead of guessing from the
+  // platform — e.g. Adreno Android lands on OpenCL(4), Mali on Vulkan(3).
+  const backendId = typeof stats.backendId === 'number' ? stats.backendId : null
 
   _perfReporter.record(label, {
     real_time_factor: rtf,
     wall_time_ms: wallMs,
     tps,
-    total_time_ms: totalTimeMs
+    total_time_ms: totalTimeMs,
+    backend_id: backendId
   }, {
     execution_provider: ep,
     output: extra && extra.output ? String(extra.output) : null

--- a/scripts/perf-report/aggregate-bci-rtf.js
+++ b/scripts/perf-report/aggregate-bci-rtf.js
@@ -14,6 +14,11 @@ const path = require('path')
 // (Adreno android). No CoreML/DirectML path. CUDA is disabled in the build.
 const SUPPORTED_GPU_BACKENDS = ['vulkan', 'metal', 'opencl']
 
+// ggml active-backend ids reported by the addon, mapped to the backend label.
+// Used to recover the REAL backend a mobile device selected at runtime rather
+// than guessing it from the platform family (Adreno=OpenCL vs Mali=Vulkan).
+const BACKEND_BY_ID = { 0: 'cpu', 1: 'metal', 2: 'cuda', 3: 'vulkan', 4: 'opencl' }
+
 function parseArgs (argv) {
   const args = {
     input: '',
@@ -111,6 +116,15 @@ function normalizeBackend (platformName, useGPU, backendHint) {
   }
 }
 
+// Prefer the observed ggml backend id (per-device ground truth) over the
+// platform-family guess. Falls back to normalizeBackend when no id was reported.
+function resolveMobileBackend (backendId, platformName, useGPU) {
+  if (typeof backendId === 'number' && BACKEND_BY_ID[backendId]) {
+    return BACKEND_BY_ID[backendId]
+  }
+  return normalizeBackend(platformName, useGPU)
+}
+
 function num (value) {
   return typeof value === 'number' && Number.isFinite(value) ? value : NaN
 }
@@ -195,12 +209,13 @@ function normalizeMobileRecords (report, sourceFile) {
     const metrics = result.metrics || {}
     const key = `${modelTag}|${provider}`
     if (!byModelAndProvider.has(key)) {
-      byModelAndProvider.set(key, { modelTag, provider, tps: [], wallMs: [], rtf: [] })
+      byModelAndProvider.set(key, { modelTag, provider, tps: [], wallMs: [], rtf: [], backendId: null })
     }
     const group = byModelAndProvider.get(key)
     if (typeof metrics.tps === 'number') group.tps.push(metrics.tps)
     if (typeof metrics.wall_time_ms === 'number') group.wallMs.push(metrics.wall_time_ms)
     if (typeof metrics.real_time_factor === 'number') group.rtf.push(metrics.real_time_factor)
+    if (group.backendId === null && typeof metrics.backend_id === 'number') group.backendId = metrics.backend_id
   }
 
   const records = []
@@ -213,7 +228,7 @@ function normalizeMobileRecords (report, sourceFile) {
       platformFamily: platformFamily || 'unknown',
       model: values.modelTag,
       gpu: values.provider,
-      backend: normalizeBackend(platformFamily, useGPU),
+      backend: resolveMobileBackend(values.backendId, platformFamily, useGPU),
       meanTps: mean(values.tps),
       stddevTps: stddev(values.tps),
       p50Tps: percentile(values.tps, 50),


### PR DESCRIPTION
## What

Adds Windows CPU+GPU and iOS CPU+GPU coverage to the bci performance benchmark, and fixes the real backend label.

- **Real mobile backend**: record the ggml `backend_id` in the mobile perf report and derive the backend per device in the aggregator (Adreno→OpenCL, Mali→Vulkan, iOS→Metal) instead of a hardcoded platform guess.
- **iOS CPU+GPU**: unzip `Customer_Artifacts.zip` in the mobile perf extract step (iOS writes the PERF markers into `bare_console.log` inside the zip). iOS rows now appear.
- **Windows CPU+GPU**: add the Windows GPU (Vulkan) benchmark entry, plus two fixes to make the Windows leg run:
  - prebuild-from-package extract: Git's MSYS tar mangles absolute `C:\` paths — extract with a relative archive name from inside the temp dir.
  - "stage Vulkan loader" step: the loader lives in **System32** on `qvac-win25-x64-gpu` (not `C:\VulkanSDK`), it must be staged next to the **win32-x64** `.bare` (the glob was grabbing the android prebuild), and it is now non-fatal (System32 resolves the static import anyway).

## Validation (real CI, `benchmark-performance-bci-whispercpp`)

- Desktop-only run 29251290720: **Windows green → CPU + Vulkan GPU rows** (log: `copying C:\Windows\System32\vulkan-1.dll -> prebuilds\win32-x64`).
- Full run 29248839538: **iOS iPhone 16 Pro + 17 Pro CPU+GPU (Metal) rows**; coverage `metal, opencl, vulkan`, none missing.

Benchmark-infra only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
