### PR TITLE
QVAC-22030 chore[skiplog]: apply prettier formatting to bci-whispercpp JS

### DIFF
--- a/packages/bci-whispercpp/bci.js
+++ b/packages/bci-whispercpp/bci.js
@@ -18,7 +18,7 @@ const END_OF_INPUT = 'end of job'
 // runaway producers.
 const MAX_BUFFERED_BYTES = 500 * 1024 * 1024
 
-function nextSafeId (current) {
+function nextSafeId(current) {
   return current >= Number.MAX_SAFE_INTEGER ? 1 : current + 1
 }
 
@@ -33,7 +33,7 @@ class BCIInterface {
    * @param {Function} outputCb - callback for inference events (Output, JobEnded, Error)
    * @param {Function} [transitionCb] - callback for state changes
    */
-  constructor (binding, configurationParams, outputCb, transitionCb = null) {
+  constructor(binding, configurationParams, outputCb, transitionCb = null) {
     this._binding = binding
     this._outputCb = outputCb
     this._transitionCb = transitionCb
@@ -52,24 +52,22 @@ class BCIInterface {
     )
   }
 
-  _setState (newState) {
+  _setState(newState) {
     this._state = newState
     if (this._transitionCb) {
       this._transitionCb(this, newState)
     }
   }
 
-  _addonOutputCallback (addon, event, data, error) {
+  _addonOutputCallback(addon, event, data, error) {
     const isError = typeof error === 'string' && error.length > 0
-    const isStats = data && typeof data === 'object' && (
-      'totalTime' in data ||
-      'tokensPerSecond' in data ||
-      'totalWallMs' in data
-    )
-    const isTranscriptOutput = (
+    const isStats =
+      data &&
+      typeof data === 'object' &&
+      ('totalTime' in data || 'tokensPerSecond' in data || 'totalWallMs' in data)
+    const isTranscriptOutput =
       (Array.isArray(data) && data.length > 0) ||
       (data && typeof data === 'object' && typeof data.text === 'string')
-    )
 
     let mappedEvent = event
     if (event === 'Error' || isError || String(event).includes('Error')) {
@@ -91,10 +89,10 @@ class BCIInterface {
       this._setState(state.PROCESSING)
 
       if (this._outputCb != null) {
-        const isTranscriptArray = Array.isArray(data) && data.length > 0 &&
-          typeof data[0]?.text === 'string'
-        const isSingleTranscript = !Array.isArray(data) &&
-          data && typeof data === 'object' && typeof data.text === 'string'
+        const isTranscriptArray =
+          Array.isArray(data) && data.length > 0 && typeof data[0]?.text === 'string'
+        const isSingleTranscript =
+          !Array.isArray(data) && data && typeof data === 'object' && typeof data.text === 'string'
         if (isTranscriptArray) {
           for (const segment of data) {
             this._outputCb(addon, 'Output', jobId, [segment], null)
@@ -118,11 +116,11 @@ class BCIInterface {
     }
   }
 
-  async unload () {
+  async unload() {
     await this.destroyInstance()
   }
 
-  async load (configurationParams) {
+  async load(configurationParams) {
     checkConfig(configurationParams)
     await this.destroyInstance()
     this._handle = this._binding.createInstance(
@@ -134,7 +132,7 @@ class BCIInterface {
     this._setState(state.LOADING)
   }
 
-  async reload (configurationParams) {
+  async reload(configurationParams) {
     checkConfig(configurationParams)
     await this.cancel()
 
@@ -147,7 +145,7 @@ class BCIInterface {
     await this.load(configurationParams)
   }
 
-  async loadWeights (weightsData) {
+  async loadWeights(weightsData) {
     try {
       this._binding.loadWeights(this._handle, weightsData)
     } catch (err) {
@@ -159,11 +157,11 @@ class BCIInterface {
     }
   }
 
-  async unloadWeights () {
+  async unloadWeights() {
     return true
   }
 
-  async activate () {
+  async activate() {
     try {
       this._binding.activate(this._handle)
       this._setState(state.LISTENING)
@@ -176,7 +174,7 @@ class BCIInterface {
     }
   }
 
-  async cancel (jobId) {
+  async cancel(jobId) {
     try {
       await this._binding.cancel(this._handle, jobId)
       this._bufferedSignal = []
@@ -200,7 +198,7 @@ class BCIInterface {
    * @param {Uint8Array} [data.input] - binary neural signal data
    * @returns {number} job ID
    */
-  async append (data) {
+  async append(data) {
     try {
       if (data?.type === END_OF_INPUT) {
         if (this._bufferedSignal.length === 0) {
@@ -273,7 +271,7 @@ class BCIInterface {
    * @param {Object} data
    * @param {Uint8Array} data.input - binary neural signal data
    */
-  async runJob (data) {
+  async runJob(data) {
     if (!data || !(data.input instanceof Uint8Array)) {
       throw new QvacErrorAddonBCI({
         code: ERR_CODES.INVALID_NEURAL_INPUT,
@@ -318,11 +316,11 @@ class BCIInterface {
     return accepted
   }
 
-  async status () {
+  async status() {
     return this._state
   }
 
-  async destroyInstance () {
+  async destroyInstance() {
     if (this._handle === null) {
       return
     }
@@ -345,16 +343,14 @@ class BCIInterface {
     }
   }
 
-  _concatBufferedSignal () {
+  _concatBufferedSignal() {
     if (this._bufferedSignal.length === 0) {
       return new Uint8Array()
     }
     if (this._bufferedSignal.length === 1) {
       return this._bufferedSignal[0]
     }
-    const totalLength = this._bufferedSignal.reduce(
-      (sum, chunk) => sum + chunk.byteLength, 0
-    )
+    const totalLength = this._bufferedSignal.reduce((sum, chunk) => sum + chunk.byteLength, 0)
     const merged = new Uint8Array(totalLength)
     let offset = 0
     for (const chunk of this._bufferedSignal) {

--- a/packages/bci-whispercpp/configChecker.js
+++ b/packages/bci-whispercpp/configChecker.js
@@ -5,7 +5,7 @@
  * @param {Object} configObject
  * @returns {void} or throws if invalid
  */
-function checkConfig (configObject) {
+function checkConfig(configObject) {
   const requiredSections = ['whisperConfig', 'contextParams', 'miscConfig']
 
   for (const section of requiredSections) {
@@ -33,20 +33,11 @@ function checkConfig (configObject) {
     'beam_search_beam_size'
   ]
 
-  const validContextParams = [
-    'model',
-    'use_gpu',
-    'flash_attn',
-    'gpu_device'
-  ]
+  const validContextParams = ['model', 'use_gpu', 'flash_attn', 'gpu_device']
 
-  const validMiscParams = [
-    'caption_enabled'
-  ]
+  const validMiscParams = ['caption_enabled']
 
-  const validBCIParams = [
-    'day_idx'
-  ]
+  const validBCIParams = ['day_idx']
 
   for (const userParam of Object.keys(configObject.whisperConfig)) {
     if (!validWhisperParams.includes(userParam)) {
@@ -65,8 +56,10 @@ function checkConfig (configObject) {
       throw new Error(`${userParam} is not a valid parameter for miscConfig`)
     }
   }
-  if (configObject.miscConfig.caption_enabled !== undefined &&
-      typeof configObject.miscConfig.caption_enabled !== 'boolean') {
+  if (
+    configObject.miscConfig.caption_enabled !== undefined &&
+    typeof configObject.miscConfig.caption_enabled !== 'boolean'
+  ) {
     throw new Error('miscConfig.caption_enabled must be a boolean')
   }
 

--- a/packages/bci-whispercpp/examples/transcribe-neural.js
+++ b/packages/bci-whispercpp/examples/transcribe-neural.js
@@ -17,10 +17,11 @@ const os = require('bare-os')
 const BCIWhispercpp = require('../index')
 const { flattenSegments } = require('../lib/util')
 
-const DEFAULT_MODEL = (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
+const DEFAULT_MODEL =
+  (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
   path.join(__dirname, '..', 'models', 'ggml-bci-windowed.bin')
 
-async function main () {
+async function main() {
   const args = global.Bare ? global.Bare.argv.slice(2) : process.argv.slice(2)
   const isBatch = args[0] === '--batch'
 
@@ -45,7 +46,9 @@ async function main () {
     const manifestPath = path.join(__dirname, '..', 'test', 'fixtures', 'manifest.json')
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
 
-    console.log('=== BCI Neural Signal Transcription (Batch: ' + manifest.samples.length + ' samples) ===\n')
+    console.log(
+      '=== BCI Neural Signal Transcription (Batch: ' + manifest.samples.length + ' samples) ===\n'
+    )
 
     const startTime = Date.now()
 
@@ -60,13 +63,16 @@ async function main () {
     let sumWER = 0
 
     for (const [day, samples] of byDay) {
-      const bci = new BCIWhispercpp({
-        files: { model: modelPath, embedder: embedderPath }
-      }, {
-        whisperConfig: { language: 'en', temperature: 0.0 },
-        miscConfig: { caption_enabled: false },
-        bciConfig: day >= 0 ? { day_idx: day } : undefined
-      })
+      const bci = new BCIWhispercpp(
+        {
+          files: { model: modelPath, embedder: embedderPath }
+        },
+        {
+          whisperConfig: { language: 'en', temperature: 0.0 },
+          miscConfig: { caption_enabled: false },
+          bciConfig: day >= 0 ? { day_idx: day } : undefined
+        }
+      )
       await bci.load()
 
       try {
@@ -80,7 +86,10 @@ async function main () {
           const response = await bci.transcribeFile(samplePath)
           const output = await response.await()
           const segments = flattenSegments(output)
-          const text = segments.map(s => s.text).join('').trim()
+          const text = segments
+            .map((s) => s.text)
+            .join('')
+            .trim()
           const wer = BCIWhispercpp.computeWER(text, sample.expected_text)
 
           console.log('  [' + sample.file + '] day=' + day)
@@ -107,12 +116,15 @@ async function main () {
       return
     }
 
-    const bci = new BCIWhispercpp({
-      files: { model: modelPath, embedder: embedderPath }
-    }, {
-      whisperConfig: { language: 'en', temperature: 0.0 },
-      miscConfig: { caption_enabled: false }
-    })
+    const bci = new BCIWhispercpp(
+      {
+        files: { model: modelPath, embedder: embedderPath }
+      },
+      {
+        whisperConfig: { language: 'en', temperature: 0.0 },
+        miscConfig: { caption_enabled: false }
+      }
+    )
 
     await bci.load()
     console.log('Model loaded.\n')
@@ -125,14 +137,17 @@ async function main () {
     console.log('=== BCI Neural Signal Transcription ===')
     console.log('Signal:     ' + signalPath)
     console.log('Timesteps:  ' + T + ', Channels: ' + C)
-    console.log('Duration:   ~' + (T * 20 / 1000).toFixed(1) + 's\n')
+    console.log('Duration:   ~' + ((T * 20) / 1000).toFixed(1) + 's\n')
 
     try {
       const startTime = Date.now()
       const response = await bci.transcribeFile(signalPath)
       const output = await response.await()
       const segments = flattenSegments(output)
-      const text = segments.map(s => s.text).join('').trim()
+      const text = segments
+        .map((s) => s.text)
+        .join('')
+        .trim()
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(2)
 
       console.log('Text: "' + text + '"')

--- a/packages/bci-whispercpp/examples/transcribe-stream-neural.js
+++ b/packages/bci-whispercpp/examples/transcribe-stream-neural.js
@@ -6,16 +6,17 @@ const os = require('bare-os')
 const BCIWhispercpp = require('../index')
 const { flattenSegments } = require('../lib/util')
 
-const DEFAULT_MODEL = (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
+const DEFAULT_MODEL =
+  (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
   path.join(__dirname, '..', 'models', 'ggml-bci-windowed.bin')
 
-async function * chunkify (bytes, chunkSize) {
+async function* chunkify(bytes, chunkSize) {
   for (let i = 0; i < bytes.byteLength; i += chunkSize) {
     yield bytes.subarray(i, Math.min(i + chunkSize, bytes.byteLength))
   }
 }
 
-async function main () {
+async function main() {
   const args = global.Bare ? global.Bare.argv.slice(2) : process.argv.slice(2)
 
   if (args.length < 1) {
@@ -36,12 +37,15 @@ async function main () {
   }
   const embedderPath = path.join(path.dirname(modelPath), 'bci-embedder.bin')
 
-  const bci = new BCIWhispercpp({
-    files: { model: modelPath, embedder: embedderPath }
-  }, {
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    miscConfig: { caption_enabled: false }
-  })
+  const bci = new BCIWhispercpp(
+    {
+      files: { model: modelPath, embedder: embedderPath }
+    },
+    {
+      whisperConfig: { language: 'en', temperature: 0.0 },
+      miscConfig: { caption_enabled: false }
+    }
+  )
 
   await bci.load()
   console.log('Model loaded.\n')
@@ -62,7 +66,10 @@ async function main () {
 
     response.onUpdate((out) => {
       const segs = flattenSegments(out)
-      const piece = segs.map(s => s.text).join(' ').trim()
+      const piece = segs
+        .map((s) => s.text)
+        .join(' ')
+        .trim()
       if (piece.length > 0) {
         const elapsed = ((Date.now() - startedAt) / 1000).toFixed(2)
         console.log('[' + elapsed + 's] +' + piece)
@@ -71,7 +78,10 @@ async function main () {
 
     const output = await response.await()
     const segments = flattenSegments(output)
-    const fullText = segments.map(s => s.text).join(' ').trim()
+    const fullText = segments
+      .map((s) => s.text)
+      .join(' ')
+      .trim()
     const elapsed = ((Date.now() - startedAt) / 1000).toFixed(2)
 
     console.log('\nFinal: "' + fullText + '"')

--- a/packages/bci-whispercpp/index.js
+++ b/packages/bci-whispercpp/index.js
@@ -8,12 +8,7 @@ const { createJobHandler, exclusiveRunQueue, QvacResponse } = require('@qvac/inf
 const { BCIInterface } = require('./bci')
 const { QvacErrorAddonBCI, ERR_CODES } = require('./lib/error')
 const { computeWER } = require('./lib/wer')
-const {
-  toUint8,
-  sliceBody,
-  buildWindowBuffer,
-  stitchSegments
-} = require('./lib/stream')
+const { toUint8, sliceBody, buildWindowBuffer, stitchSegments } = require('./lib/stream')
 
 // Default prebuilds folder for dynamically-loaded ggml backend `.so`
 // files. Consumed by the native addon on Android only (no-op
@@ -68,7 +63,7 @@ class BCIWhispercpp {
    * @param {Object} [config.contextParams] - whisper context params
    * @param {Object} [config.miscConfig] - miscellaneous config
    */
-  constructor ({ files, logger = null, opts = {} }, config = {}) {
+  constructor({ files, logger = null, opts = {} }, config = {}) {
     if (!files || typeof files.model !== 'string' || files.model.length === 0) {
       throw new QvacErrorAddonBCI({
         code: ERR_CODES.MODEL_FILE_NOT_FOUND,
@@ -76,8 +71,10 @@ class BCIWhispercpp {
       })
     }
 
-    if (files.embedder !== undefined &&
-        (typeof files.embedder !== 'string' || files.embedder.length === 0)) {
+    if (
+      files.embedder !== undefined &&
+      (typeof files.embedder !== 'string' || files.embedder.length === 0)
+    ) {
       throw new QvacErrorAddonBCI({
         code: ERR_CODES.MODEL_FILE_NOT_FOUND,
         adds: 'files.embedder must be a non-empty string when provided'
@@ -121,7 +118,7 @@ class BCIWhispercpp {
    * to fully unwind (unload/destroy) should `await this._streamDriverPromise`
    * after calling this.
    */
-  _teardownActiveStream (reason) {
+  _teardownActiveStream(reason) {
     this._streamAborted = true
     this._streamWindowHandler = null
     if (this._streamWindowReject) {
@@ -136,11 +133,11 @@ class BCIWhispercpp {
     }
   }
 
-  getState () {
+  getState() {
     return this.state
   }
 
-  async load () {
+  async load() {
     if (this.state.destroyed) {
       throw new QvacErrorAddonBCI({
         code: ERR_CODES.MODEL_NOT_LOADED,
@@ -155,7 +152,7 @@ class BCIWhispercpp {
     this.state.configLoaded = true
   }
 
-  async _load () {
+  async _load() {
     if (!fs.existsSync(this._files.model)) {
       throw new QvacErrorAddonBCI({
         code: ERR_CODES.MODEL_FILE_NOT_FOUND,
@@ -192,9 +189,10 @@ class BCIWhispercpp {
       // native libs. Defaulting to the in-package prebuilds dir keeps
       // mobile builds working out of the box, parity with transcription-
       // whispercpp 0.9.0.
-      backendsDir: typeof this._config.backendsDir === 'string' && this._config.backendsDir.length > 0
-        ? this._config.backendsDir
-        : PREBUILDS_DIR
+      backendsDir:
+        typeof this._config.backendsDir === 'string' && this._config.backendsDir.length > 0
+          ? this._config.backendsDir
+          : PREBUILDS_DIR
     }
 
     if (this._config.bciConfig) {
@@ -252,7 +250,7 @@ class BCIWhispercpp {
    * @param {string} filePath - path to .bin neural signal file
    * @returns {Promise<QvacResponse>}
    */
-  async transcribeFile (filePath) {
+  async transcribeFile(filePath) {
     const data = fs.readFileSync(filePath)
     return this.transcribe(new Uint8Array(data))
   }
@@ -264,7 +262,7 @@ class BCIWhispercpp {
    * @param {Uint8Array} neuralData - binary neural signal
    * @returns {Promise<QvacResponse>}
    */
-  async transcribe (neuralData) {
+  async transcribe(neuralData) {
     this._assertReadyForInference()
     return await this._enqueueInference(async () => {
       const response = this._job.start()
@@ -331,7 +329,7 @@ class BCIWhispercpp {
    *   full running transcript ('full').
    * @returns {Promise<QvacResponse>}
    */
-  async transcribeStream (neuralStream, streamOpts = {}) {
+  async transcribeStream(neuralStream, streamOpts = {}) {
     this._assertReadyForInference()
     if (this._streamResponse !== null) {
       throw new QvacErrorAddonBCI({ code: ERR_CODES.STREAM_ALREADY_ACTIVE })
@@ -343,27 +341,31 @@ class BCIWhispercpp {
     return await this._enqueueInference(async () => {
       this._streamAborted = false
       const response = new QvacResponse({
-        cancelHandler: async () => { await this.cancel() }
+        cancelHandler: async () => {
+          await this.cancel()
+        }
       })
       this._streamResponse = response
 
-      const driver = this._runStreamDriver(iterable, opts, response).catch((err) => {
-        if (this._streamResponse === response) {
-          this._streamResponse = null
-        }
-        response.failed(err)
-      }).finally(() => {
-        if (this._streamDriverPromise === driver) {
-          this._streamDriverPromise = null
-        }
-      })
+      const driver = this._runStreamDriver(iterable, opts, response)
+        .catch((err) => {
+          if (this._streamResponse === response) {
+            this._streamResponse = null
+          }
+          response.failed(err)
+        })
+        .finally(() => {
+          if (this._streamDriverPromise === driver) {
+            this._streamDriverPromise = null
+          }
+        })
       this._streamDriverPromise = driver
 
       return response
     })
   }
 
-  async _runStreamDriver (iterable, opts, response) {
+  async _runStreamDriver(iterable, opts, response) {
     let channels = null
     let headerCarry = new Uint8Array(0)
     const body = []
@@ -442,8 +444,10 @@ class BCIWhispercpp {
         body.push(chunk)
         bodyBytes += chunk.byteLength
 
-        while (!this._streamAborted &&
-          Math.floor(bodyBytes / bytesPerTimestep) >= (windowStartTs + opts.windowTimesteps)) {
+        while (
+          !this._streamAborted &&
+          Math.floor(bodyBytes / bytesPerTimestep) >= windowStartTs + opts.windowTimesteps
+        ) {
           await decodeRange(windowStartTs, opts.windowTimesteps)
           if (this._streamAborted) return
           windowStartTs += opts.hopTimesteps
@@ -480,7 +484,7 @@ class BCIWhispercpp {
     }
   }
 
-  async _decodeWindow (windowBytes) {
+  async _decodeWindow(windowBytes) {
     return await new Promise((resolve, reject) => {
       const collected = []
       const cleanup = () => {
@@ -494,9 +498,10 @@ class BCIWhispercpp {
       this._streamWindowHandler = (event, data, error) => {
         if (event === 'Error') {
           cleanup()
-          const err = error instanceof Error
-            ? error
-            : new Error(typeof error === 'string' ? error : 'window decode failed')
+          const err =
+            error instanceof Error
+              ? error
+              : new Error(typeof error === 'string' ? error : 'window decode failed')
           reject(err)
           return
         }
@@ -516,14 +521,15 @@ class BCIWhispercpp {
         }
       }
 
-      this.addon.runJob({ input: windowBytes })
-        .then(accepted => {
+      this.addon
+        .runJob({ input: windowBytes })
+        .then((accepted) => {
           if (!accepted) {
             cleanup()
             reject(new QvacErrorAddonBCI({ code: ERR_CODES.JOB_ALREADY_RUNNING }))
           }
         })
-        .catch(err => {
+        .catch((err) => {
           cleanup()
           reject(err)
         })
@@ -536,7 +542,7 @@ class BCIWhispercpp {
    * mirroring whispercpp's `_checkParamsExists` pattern. Returns a new
    * opts object; does not mutate the caller's input.
    */
-  _validateStreamOpts (streamOpts) {
+  _validateStreamOpts(streamOpts) {
     const opts = {
       windowTimesteps: streamOpts.windowTimesteps ?? DEFAULT_WINDOW_TIMESTEPS,
       hopTimesteps: streamOpts.hopTimesteps ?? DEFAULT_HOP_TIMESTEPS,
@@ -577,7 +583,7 @@ class BCIWhispercpp {
     return opts
   }
 
-  _normalizeNeuralStream (input) {
+  _normalizeNeuralStream(input) {
     if (input == null) {
       throw new QvacErrorAddonBCI({
         code: ERR_CODES.INVALID_STREAM_INPUT,
@@ -599,10 +605,12 @@ class BCIWhispercpp {
    * response settles. Separate from _withExclusiveRun (lifecycle ops) so
    * destroy/unload can still preempt.
    */
-  async _enqueueInference (runFn) {
+  async _enqueueInference(runFn) {
     const prev = this._inferenceQueueWaiter
     let releaseSlot
-    this._inferenceQueueWaiter = new Promise(resolve => { releaseSlot = resolve })
+    this._inferenceQueueWaiter = new Promise((resolve) => {
+      releaseSlot = resolve
+    })
     await prev
     let response
     try {
@@ -611,11 +619,16 @@ class BCIWhispercpp {
       releaseSlot()
       throw err
     }
-    response.await().finally(() => { releaseSlot() }).catch(() => {})
+    response
+      .await()
+      .finally(() => {
+        releaseSlot()
+      })
+      .catch(() => {})
     return response
   }
 
-  _assertReadyForInference () {
+  _assertReadyForInference() {
     if (this.state.destroyed || !this.state.configLoaded || !this.addon) {
       throw new QvacErrorAddonBCI({
         code: ERR_CODES.MODEL_NOT_LOADED,
@@ -624,11 +637,15 @@ class BCIWhispercpp {
     }
   }
 
-  _isConfigurationError (err) {
+  _isConfigurationError(err) {
     if (err && err.code === 'ERR_ASSERTION') return true
     if (err instanceof TypeError) return true
     const msg = String(err?.message || '')
-    return msg.includes('is required') || msg.includes('is not a valid parameter') || msg.includes('must be')
+    return (
+      msg.includes('is required') ||
+      msg.includes('is not a valid parameter') ||
+      msg.includes('must be')
+    )
   }
 
   /**
@@ -640,7 +657,7 @@ class BCIWhispercpp {
    * reserved for batch `transcribe()` calls and not used while a stream
    * is active. When `_streamWindowHandler` is null the batch path runs.
    */
-  _outputCallback (addon, event, jobId, data, error) {
+  _outputCallback(addon, event, jobId, data, error) {
     if (this._streamWindowHandler) {
       this._streamWindowHandler(event, data, error)
       return
@@ -666,7 +683,7 @@ class BCIWhispercpp {
     this.logger.debug('Received event for job ' + jobId + ': ' + event)
   }
 
-  async cancel () {
+  async cancel() {
     this._teardownActiveStream('Stream cancelled')
     if (this.addon?.cancel) {
       await this.addon.cancel()
@@ -679,7 +696,7 @@ class BCIWhispercpp {
     }
   }
 
-  async unload () {
+  async unload() {
     return await this._withExclusiveRun(async () => {
       this._teardownActiveStream('Model was unloaded')
       if (this._streamDriverPromise) {
@@ -697,7 +714,7 @@ class BCIWhispercpp {
     })
   }
 
-  async destroy () {
+  async destroy() {
     return await this._withExclusiveRun(async () => {
       this._teardownActiveStream('Model was destroyed')
       if (this._streamDriverPromise) {

--- a/packages/bci-whispercpp/lib/error.js
+++ b/packages/bci-whispercpp/lib/error.js
@@ -2,7 +2,7 @@
 
 const { QvacErrorBase, addCodes } = require('@qvac/error')
 
-class QvacErrorAddonBCI extends QvacErrorBase { }
+class QvacErrorAddonBCI extends QvacErrorBase {}
 
 const { name, version } = require('../package.json')
 
@@ -32,79 +32,82 @@ const ERR_CODES = Object.freeze({
   WINDOW_TOO_LARGE: 26017
 })
 
-addCodes({
-  [ERR_CODES.FAILED_TO_LOAD_WEIGHTS]: {
-    name: 'FAILED_TO_LOAD_WEIGHTS',
-    message: (message) => `Failed to load weights, error: ${message}`
+addCodes(
+  {
+    [ERR_CODES.FAILED_TO_LOAD_WEIGHTS]: {
+      name: 'FAILED_TO_LOAD_WEIGHTS',
+      message: (message) => `Failed to load weights, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_CANCEL]: {
+      name: 'FAILED_TO_CANCEL',
+      message: (message) => `Failed to cancel inference, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_APPEND]: {
+      name: 'FAILED_TO_APPEND',
+      message: (message) => `Failed to append data to processing queue, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_DESTROY]: {
+      name: 'FAILED_TO_DESTROY',
+      message: (message) => `Failed to destroy instance, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_ACTIVATE]: {
+      name: 'FAILED_TO_ACTIVATE',
+      message: (message) => `Failed to activate model, error: ${message}`
+    },
+    [ERR_CODES.INVALID_NEURAL_INPUT]: {
+      name: 'INVALID_NEURAL_INPUT',
+      message: (message) => `Invalid neural signal input: ${message}`
+    },
+    [ERR_CODES.JOB_ALREADY_RUNNING]: {
+      name: 'JOB_ALREADY_RUNNING',
+      message: () => 'Cannot set new job: a job is already set or being processed'
+    },
+    [ERR_CODES.MODEL_NOT_LOADED]: {
+      name: 'MODEL_NOT_LOADED',
+      message: () => 'Model is not loaded'
+    },
+    [ERR_CODES.MODEL_FILE_NOT_FOUND]: {
+      name: 'MODEL_FILE_NOT_FOUND',
+      message: (modelPath) => `Model file not found at: ${modelPath}`
+    },
+    [ERR_CODES.BUFFER_LIMIT_EXCEEDED]: {
+      name: 'BUFFER_LIMIT_EXCEEDED',
+      message: (limit) => `Neural signal buffer exceeded limit of ${limit}`
+    },
+    [ERR_CODES.FAILED_TO_START_JOB]: {
+      name: 'FAILED_TO_START_JOB',
+      message: (message) => `Failed to start inference job, error: ${message}`
+    },
+    [ERR_CODES.INVALID_CONFIG]: {
+      name: 'INVALID_CONFIG',
+      message: (message) => `Invalid BCI configuration: ${message}`
+    },
+    [ERR_CODES.EMBEDDER_WEIGHTS_INVALID]: {
+      name: 'EMBEDDER_WEIGHTS_INVALID',
+      message: (message) => `BCI embedder weights are invalid: ${message}`
+    },
+    [ERR_CODES.STREAM_ALREADY_ACTIVE]: {
+      name: 'STREAM_ALREADY_ACTIVE',
+      message: () => 'A streaming transcription is already in progress'
+    },
+    [ERR_CODES.INVALID_STREAM_INPUT]: {
+      name: 'INVALID_STREAM_INPUT',
+      message: (message) => `Invalid neural signal stream input: ${message}`
+    },
+    [ERR_CODES.INVALID_STREAM_HEADER]: {
+      name: 'INVALID_STREAM_HEADER',
+      message: (message) => `Invalid neural signal stream header: ${message}`
+    },
+    [ERR_CODES.WINDOW_TOO_LARGE]: {
+      name: 'WINDOW_TOO_LARGE',
+      message: (limit) => `Stream window size exceeds encoder capacity of ${limit} timesteps`
+    }
   },
-  [ERR_CODES.FAILED_TO_CANCEL]: {
-    name: 'FAILED_TO_CANCEL',
-    message: (message) => `Failed to cancel inference, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_APPEND]: {
-    name: 'FAILED_TO_APPEND',
-    message: (message) => `Failed to append data to processing queue, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_DESTROY]: {
-    name: 'FAILED_TO_DESTROY',
-    message: (message) => `Failed to destroy instance, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_ACTIVATE]: {
-    name: 'FAILED_TO_ACTIVATE',
-    message: (message) => `Failed to activate model, error: ${message}`
-  },
-  [ERR_CODES.INVALID_NEURAL_INPUT]: {
-    name: 'INVALID_NEURAL_INPUT',
-    message: (message) => `Invalid neural signal input: ${message}`
-  },
-  [ERR_CODES.JOB_ALREADY_RUNNING]: {
-    name: 'JOB_ALREADY_RUNNING',
-    message: () => 'Cannot set new job: a job is already set or being processed'
-  },
-  [ERR_CODES.MODEL_NOT_LOADED]: {
-    name: 'MODEL_NOT_LOADED',
-    message: () => 'Model is not loaded'
-  },
-  [ERR_CODES.MODEL_FILE_NOT_FOUND]: {
-    name: 'MODEL_FILE_NOT_FOUND',
-    message: (modelPath) => `Model file not found at: ${modelPath}`
-  },
-  [ERR_CODES.BUFFER_LIMIT_EXCEEDED]: {
-    name: 'BUFFER_LIMIT_EXCEEDED',
-    message: (limit) => `Neural signal buffer exceeded limit of ${limit}`
-  },
-  [ERR_CODES.FAILED_TO_START_JOB]: {
-    name: 'FAILED_TO_START_JOB',
-    message: (message) => `Failed to start inference job, error: ${message}`
-  },
-  [ERR_CODES.INVALID_CONFIG]: {
-    name: 'INVALID_CONFIG',
-    message: (message) => `Invalid BCI configuration: ${message}`
-  },
-  [ERR_CODES.EMBEDDER_WEIGHTS_INVALID]: {
-    name: 'EMBEDDER_WEIGHTS_INVALID',
-    message: (message) => `BCI embedder weights are invalid: ${message}`
-  },
-  [ERR_CODES.STREAM_ALREADY_ACTIVE]: {
-    name: 'STREAM_ALREADY_ACTIVE',
-    message: () => 'A streaming transcription is already in progress'
-  },
-  [ERR_CODES.INVALID_STREAM_INPUT]: {
-    name: 'INVALID_STREAM_INPUT',
-    message: (message) => `Invalid neural signal stream input: ${message}`
-  },
-  [ERR_CODES.INVALID_STREAM_HEADER]: {
-    name: 'INVALID_STREAM_HEADER',
-    message: (message) => `Invalid neural signal stream header: ${message}`
-  },
-  [ERR_CODES.WINDOW_TOO_LARGE]: {
-    name: 'WINDOW_TOO_LARGE',
-    message: (limit) => `Stream window size exceeds encoder capacity of ${limit} timesteps`
+  {
+    name,
+    version
   }
-}, {
-  name,
-  version
-})
+)
 
 module.exports = {
   ERR_CODES,

--- a/packages/bci-whispercpp/lib/stream.js
+++ b/packages/bci-whispercpp/lib/stream.js
@@ -14,7 +14,7 @@ const { QvacErrorAddonBCI, ERR_CODES } = require('./error')
  * Coerce a stream chunk into a Uint8Array without copying when possible.
  * Throws INVALID_STREAM_INPUT if the chunk isn't a recognised binary form.
  */
-function toUint8 (chunk) {
+function toUint8(chunk) {
   if (chunk instanceof Uint8Array) return chunk
   if (ArrayBuffer.isView(chunk)) {
     return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
@@ -32,7 +32,7 @@ function toUint8 (chunk) {
  * (each element a Uint8Array) into a single contiguous Uint8Array.
  * The caller owns timestep→byte translation via bytesPerTimestep.
  */
-function sliceBody (bodyChunks, bytesPerTimestep, startTs, endTs, totalBytes) {
+function sliceBody(bodyChunks, bytesPerTimestep, startTs, endTs, totalBytes) {
   const startByte = startTs * bytesPerTimestep
   const endByte = Math.min(endTs * bytesPerTimestep, totalBytes)
   const out = new Uint8Array(Math.max(0, endByte - startByte))
@@ -48,7 +48,7 @@ function sliceBody (bodyChunks, bytesPerTimestep, startTs, endTs, totalBytes) {
     const from = Math.max(0, startByte - chunkStart)
     const to = Math.min(chunk.byteLength, endByte - chunkStart)
     out.set(chunk.subarray(from, to), offset)
-    offset += (to - from)
+    offset += to - from
   }
   return out
 }
@@ -57,7 +57,7 @@ function sliceBody (bodyChunks, bytesPerTimestep, startTs, endTs, totalBytes) {
  * Build an [T, C] header-prefixed buffer the addon can consume as a single
  * batch input, reusing the per-window body bytes.
  */
-function buildWindowBuffer (windowBody, channels, windowTimesteps) {
+function buildWindowBuffer(windowBody, channels, windowTimesteps) {
   const out = new Uint8Array(8 + windowBody.byteLength)
   const view = new DataView(out.buffer, out.byteOffset, out.byteLength)
   view.setUint32(0, windowTimesteps, true)
@@ -66,7 +66,7 @@ function buildWindowBuffer (windowBody, channels, windowTimesteps) {
   return out
 }
 
-function normalizeWord (w) {
+function normalizeWord(w) {
   return w.toLowerCase().replace(/[^a-z0-9']/g, '')
 }
 
@@ -92,7 +92,7 @@ function normalizeWord (w) {
  * boundary (e.g. "the the") will collapse; acceptable for v1 sliding
  * window until a segmentation model replaces this.
  */
-function stitchMerge (prevText, newText, maxWords) {
+function stitchMerge(prevText, newText, maxWords) {
   const prevWords = prevText.trim().split(/\s+/).filter(Boolean)
   const newWords = newText.trim().split(/\s+/).filter(Boolean)
 
@@ -131,13 +131,13 @@ function stitchMerge (prevText, newText, maxWords) {
  *   - merged: running transcript text (identical to stitchMerge.merged)
  *   - bestK: for inspection / tests
  */
-function stitchSegments (prevText, segments, maxWords, windowStartTimestep = 0) {
+function stitchSegments(prevText, segments, maxWords, windowStartTimestep = 0) {
   const prevWords = prevText.trim().split(/\s+/).filter(Boolean)
 
   const perSegment = []
   const newWords = []
   for (const seg of segments) {
-    const text = (seg && typeof seg.text === 'string') ? seg.text : ''
+    const text = seg && typeof seg.text === 'string' ? seg.text : ''
     const words = text.trim().split(/\s+/).filter(Boolean)
     perSegment.push({ seg, words })
     for (const w of words) newWords.push(w)
@@ -159,16 +159,18 @@ function stitchSegments (prevText, segments, maxWords, windowStartTimestep = 0) 
   const deltaSegments = []
   for (const { seg, words } of perSegment) {
     if (words.length === 0) continue
-    if (toSkip >= words.length) { toSkip -= words.length; continue }
+    if (toSkip >= words.length) {
+      toSkip -= words.length
+      continue
+    }
     if (toSkip === 0) {
       deltaSegments.push({ ...seg, windowStartTimestep })
     } else {
       const remainingWords = words.slice(toSkip)
       const hasT0 = typeof seg.t0 === 'number'
       const hasT1 = typeof seg.t1 === 'number'
-      const approxT0 = (hasT0 && hasT1)
-        ? seg.t0 + Math.round((seg.t1 - seg.t0) * (toSkip / words.length))
-        : seg.t0
+      const approxT0 =
+        hasT0 && hasT1 ? seg.t0 + Math.round((seg.t1 - seg.t0) * (toSkip / words.length)) : seg.t0
       deltaSegments.push({
         ...seg,
         text: remainingWords.join(' '),
@@ -183,14 +185,17 @@ function stitchSegments (prevText, segments, maxWords, windowStartTimestep = 0) 
   return { deltaSegments, merged, bestK }
 }
 
-function _computeBestK (prevWords, newWords, maxWords) {
+function _computeBestK(prevWords, newWords, maxWords) {
   const maxK = Math.min(prevWords.length, newWords.length, maxWords)
   for (let k = maxK; k >= 1; k--) {
     let match = true
     for (let i = 0; i < k; i++) {
       const a = normalizeWord(prevWords[prevWords.length - k + i])
       const b = normalizeWord(newWords[i])
-      if (a.length === 0 || b.length === 0 || a !== b) { match = false; break }
+      if (a.length === 0 || b.length === 0 || a !== b) {
+        match = false
+        break
+      }
     }
     if (match) return k
   }

--- a/packages/bci-whispercpp/lib/util.js
+++ b/packages/bci-whispercpp/lib/util.js
@@ -1,6 +1,6 @@
 'use strict'
 
-function flattenSegments (output) {
+function flattenSegments(output) {
   const segments = []
   for (const entry of output) {
     if (Array.isArray(entry)) {

--- a/packages/bci-whispercpp/lib/wer.js
+++ b/packages/bci-whispercpp/lib/wer.js
@@ -7,7 +7,7 @@
  * @param {string} reference
  * @returns {number} WER as a ratio (0.0 = perfect, 1.0 = 100% errors)
  */
-function computeWER (hypothesis, reference) {
+function computeWER(hypothesis, reference) {
   const hyp = hypothesis.toLowerCase().trim().split(/\s+/).filter(Boolean)
   const ref = reference.toLowerCase().trim().split(/\s+/).filter(Boolean)
 
@@ -25,11 +25,7 @@ function computeWER (hypothesis, reference) {
       if (ref[i - 1] === hyp[j - 1]) {
         dp[i][j] = dp[i - 1][j - 1]
       } else {
-        dp[i][j] = 1 + Math.min(
-          dp[i - 1][j],
-          dp[i][j - 1],
-          dp[i - 1][j - 1]
-        )
+        dp[i][j] = 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
       }
     }
   }

--- a/packages/bci-whispercpp/test/benchmark/rtf-benchmark.test.js
+++ b/packages/bci-whispercpp/test/benchmark/rtf-benchmark.test.js
@@ -33,29 +33,32 @@ const { manifest, getSamplePath } = getTestPaths()
 const RTF_RESULTS_DIR = path.resolve(__dirname, '../../benchmarks/results')
 const RESULT_MARKER = 'QVAC_BCI_RTF_REPORT::'
 
-function getEnv (name) {
+function getEnv(name) {
   return os.hasEnv(name) ? os.getEnv(name) : undefined
 }
 
-function getEnvBoolean (name, fallback) {
+function getEnvBoolean(name, fallback) {
   const value = getEnv(name)
   if (value === undefined) return fallback
   return value === '1' || value === 'true' || value === 'TRUE' || value === 'yes'
 }
 
-function getEnvInteger (name, fallback) {
+function getEnvInteger(name, fallback) {
   const value = getEnv(name)
   if (value === undefined) return fallback
   const parsed = Number.parseInt(value, 10)
   return Number.isNaN(parsed) ? fallback : parsed
 }
 
-function sanitizeTag (value) {
+function sanitizeTag(value) {
   if (!value) return ''
-  return String(value).toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '')
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
 }
 
-function getBenchmarkSettings () {
+function getBenchmarkSettings() {
   const modelFile = getEnv('QVAC_BCI_BENCHMARK_MODEL_FILE') || 'ggml-bci-windowed.bin'
   return {
     modelFile,
@@ -71,7 +74,7 @@ function getBenchmarkSettings () {
   }
 }
 
-function getRequestedBackendFamily (platform, useGPU, backendHint) {
+function getRequestedBackendFamily(platform, useGPU, backendHint) {
   if (backendHint) return backendHint
   if (!useGPU) return 'cpu'
   if (platform === 'darwin' || platform === 'ios') return 'metal'
@@ -81,18 +84,23 @@ function getRequestedBackendFamily (platform, useGPU, backendHint) {
   return 'gpu'
 }
 
-function getArtifactFileName (s) {
-  const parts = ['rtf-benchmark', platformName, sanitizeTag(s.modelFile.replace(/\.bin$/, '')), s.useGPU ? 'gpu' : 'cpu']
+function getArtifactFileName(s) {
+  const parts = [
+    'rtf-benchmark',
+    platformName,
+    sanitizeTag(s.modelFile.replace(/\.bin$/, '')),
+    s.useGPU ? 'gpu' : 'cpu'
+  ]
   if (s.label) parts.push(s.label)
   return `${parts.join('-')}.json`
 }
 
-function getTimeMs () {
+function getTimeMs() {
   const [sec, nsec] = process.hrtime()
   return sec * 1000 + nsec / 1e6
 }
 
-function percentile (sorted, p) {
+function percentile(sorted, p) {
   const idx = (p / 100) * (sorted.length - 1)
   const lo = Math.floor(idx)
   const hi = Math.ceil(idx)
@@ -100,7 +108,7 @@ function percentile (sorted, p) {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo)
 }
 
-function stats (values) {
+function stats(values) {
   const clean = values.filter((v) => typeof v === 'number' && Number.isFinite(v))
   if (clean.length === 0) {
     return { mean: null, min: null, max: null, stddev: null, p50: null, p95: null, count: 0 }
@@ -120,14 +128,17 @@ function stats (values) {
   }
 }
 
-async function runSingleBenchmark (bci, samplePath) {
+async function runSingleBenchmark(bci, samplePath) {
   const wallStart = getTimeMs()
   const response = await bci.transcribeFile(samplePath)
   const output = await response.await()
   const wallMs = getTimeMs() - wallStart
 
   const segments = flattenSegments(output)
-  const text = segments.map((s) => s.text).join('').trim()
+  const text = segments
+    .map((s) => s.text)
+    .join('')
+    .trim()
   const jobStats = response.stats || {}
 
   return {
@@ -142,126 +153,152 @@ async function runSingleBenchmark (bci, samplePath) {
   }
 }
 
-test('BCI throughput benchmark: collect runtime stats on CI device', { timeout: 600000 }, async (t) => {
-  if (isMobile) {
-    t.pass('RTF benchmark is only collected on desktop CI runners')
-    return
-  }
-
-  const s = getBenchmarkSettings()
-  const embedderPath = path.join(path.dirname(s.modelPath), 'bci-embedder.bin')
-
-  if (!fs.existsSync(s.modelPath) || !fs.existsSync(embedderPath)) {
-    t.pass('RTF benchmark skipped: model/embedder not found at ' + s.modelPath)
-    return
-  }
-  if (!manifest.samples || manifest.samples.length === 0) {
-    t.pass('RTF benchmark skipped: no fixtures in manifest')
-    return
-  }
-
-  const sample = manifest.samples[0]
-  const samplePath = getSamplePath(sample.file)
-  if (!fs.existsSync(samplePath)) {
-    t.pass('RTF benchmark skipped: fixture ' + sample.file + ' not found')
-    return
-  }
-
-  console.log('\n' + '='.repeat(70))
-  console.log('BCI THROUGHPUT BENCHMARK')
-  console.log('='.repeat(70))
-  console.log(`  Platform:       ${platformLabel}`)
-  console.log(`  Model:          ${s.modelPath}`)
-  console.log(`  GPU requested:  ${s.useGPU}`)
-  if (s.backendHint) console.log(`  Backend hint:   ${s.backendHint}`)
-  if (s.deviceLabel) console.log(`  Device label:   ${s.deviceLabel}`)
-  console.log(`  Warmup runs:    ${s.numWarmup}`)
-  console.log(`  Benchmark runs: ${s.numRuns}`)
-  console.log('='.repeat(70) + '\n')
-
-  let bci = null
-  try {
-    bci = new BCIWhispercpp({
-      files: { model: s.modelPath, embedder: embedderPath },
-      opts: { stats: true }
-    }, {
-      whisperConfig: { language: 'en', temperature: 0.0 },
-      miscConfig: { caption_enabled: false },
-      contextParams: { use_gpu: s.useGPU },
-      ...(typeof sample.day_idx === 'number' ? { bciConfig: { day_idx: sample.day_idx } } : {})
-    })
-
-    const loadStart = getTimeMs()
-    await bci.load()
-    console.log(`Model loaded in ${(getTimeMs() - loadStart).toFixed(0)}ms\n`)
-
-    for (let i = 0; i < s.numWarmup; i++) {
-      const warmup = await runSingleBenchmark(bci, samplePath)
-      console.log(`[warmup ${i + 1}/${s.numWarmup}] wall=${warmup.wallMs.toFixed(0)}ms tokens/s=${warmup.tokensPerSecond ?? 'n/a'}`)
+test(
+  'BCI throughput benchmark: collect runtime stats on CI device',
+  { timeout: 600000 },
+  async (t) => {
+    if (isMobile) {
+      t.pass('RTF benchmark is only collected on desktop CI runners')
+      return
     }
 
-    console.log(`\nRunning ${s.numRuns} benchmark iterations...\n`)
-    const allResults = []
-    for (let i = 0; i < s.numRuns; i++) {
-      const run = await runSingleBenchmark(bci, samplePath)
-      allResults.push(run)
-      console.log(`  Run ${i + 1}/${s.numRuns}: wall=${run.wallMs.toFixed(0)}ms tokens/s=${run.tokensPerSecond ?? 'n/a'} rtf=${run.realTimeFactor ?? 'n/a'}`)
+    const s = getBenchmarkSettings()
+    const embedderPath = path.join(path.dirname(s.modelPath), 'bci-embedder.bin')
+
+    if (!fs.existsSync(s.modelPath) || !fs.existsSync(embedderPath)) {
+      t.pass('RTF benchmark skipped: model/embedder not found at ' + s.modelPath)
+      return
+    }
+    if (!manifest.samples || manifest.samples.length === 0) {
+      t.pass('RTF benchmark skipped: no fixtures in manifest')
+      return
     }
 
-    const tpsStats = stats(allResults.map((r) => r.tokensPerSecond))
-    const wallStats = stats(allResults.map((r) => r.wallMs))
-    const rtfStats = stats(allResults.map((r) => r.realTimeFactor))
-    const last = allResults[allResults.length - 1]
-
-    const report = {
-      timestamp: new Date().toISOString(),
-      platform: platformLabel,
-      platformName,
-      arch: archName || '',
-      isMobile,
-      model: { name: s.modelFile, path: s.modelPath },
-      labels: {
-        runner: s.runnerLabel,
-        device: s.deviceLabel,
-        backend: getRequestedBackendFamily(platformName, s.useGPU, s.backendHint),
-        label: s.label
-      },
-      config: { warmupRuns: s.numWarmup, benchmarkRuns: s.numRuns, useGPU: s.useGPU, threads: s.threads },
-      requested: {
-        modelFile: s.modelFile,
-        useGPU: s.useGPU,
-        backendHint: s.backendHint,
-        deviceLabel: s.deviceLabel,
-        runnerLabel: s.runnerLabel
-      },
-      observed: { backendDevice: last.backendDevice, backendId: last.backendId },
-      summary: {
-        tokensPerSecond: tpsStats,
-        wallMs: wallStats,
-        rtf: rtfStats
-      },
-      runs: allResults.map((r, i) => ({ iteration: i + 1, wallMs: r.wallMs, tokensPerSecond: r.tokensPerSecond, totalTimeSec: r.totalTimeSec, realTimeFactor: r.realTimeFactor }))
+    const sample = manifest.samples[0]
+    const samplePath = getSamplePath(sample.file)
+    if (!fs.existsSync(samplePath)) {
+      t.pass('RTF benchmark skipped: fixture ' + sample.file + ' not found')
+      return
     }
 
-    if (!fs.existsSync(RTF_RESULTS_DIR)) fs.mkdirSync(RTF_RESULTS_DIR, { recursive: true })
-    const outPath = path.join(RTF_RESULTS_DIR, getArtifactFileName(s))
-    fs.writeFileSync(outPath, JSON.stringify(report, null, 2))
-    console.log(`\nResults written to ${outPath}\n`)
-    console.log(`${RESULT_MARKER}${JSON.stringify({
-      schemaVersion: 1,
-      platform: platformLabel,
-      platformName,
-      modelFile: s.modelFile,
-      useGPU: s.useGPU,
-      backendHint: getRequestedBackendFamily(platformName, s.useGPU, s.backendHint),
-      summary: report.summary
-    })}`)
+    console.log('\n' + '='.repeat(70))
+    console.log('BCI THROUGHPUT BENCHMARK')
+    console.log('='.repeat(70))
+    console.log(`  Platform:       ${platformLabel}`)
+    console.log(`  Model:          ${s.modelPath}`)
+    console.log(`  GPU requested:  ${s.useGPU}`)
+    if (s.backendHint) console.log(`  Backend hint:   ${s.backendHint}`)
+    if (s.deviceLabel) console.log(`  Device label:   ${s.deviceLabel}`)
+    console.log(`  Warmup runs:    ${s.numWarmup}`)
+    console.log(`  Benchmark runs: ${s.numRuns}`)
+    console.log('='.repeat(70) + '\n')
 
-    t.is(allResults.length, s.numRuns, `Completed ${s.numRuns} benchmark runs`)
-    t.ok(wallStats.mean > 0, 'Mean wall time should be positive')
-  } finally {
-    if (bci) {
-      try { await bci.destroy() } catch {}
+    let bci = null
+    try {
+      bci = new BCIWhispercpp(
+        {
+          files: { model: s.modelPath, embedder: embedderPath },
+          opts: { stats: true }
+        },
+        {
+          whisperConfig: { language: 'en', temperature: 0.0 },
+          miscConfig: { caption_enabled: false },
+          contextParams: { use_gpu: s.useGPU },
+          ...(typeof sample.day_idx === 'number' ? { bciConfig: { day_idx: sample.day_idx } } : {})
+        }
+      )
+
+      const loadStart = getTimeMs()
+      await bci.load()
+      console.log(`Model loaded in ${(getTimeMs() - loadStart).toFixed(0)}ms\n`)
+
+      for (let i = 0; i < s.numWarmup; i++) {
+        const warmup = await runSingleBenchmark(bci, samplePath)
+        console.log(
+          `[warmup ${i + 1}/${s.numWarmup}] wall=${warmup.wallMs.toFixed(0)}ms tokens/s=${warmup.tokensPerSecond ?? 'n/a'}`
+        )
+      }
+
+      console.log(`\nRunning ${s.numRuns} benchmark iterations...\n`)
+      const allResults = []
+      for (let i = 0; i < s.numRuns; i++) {
+        const run = await runSingleBenchmark(bci, samplePath)
+        allResults.push(run)
+        console.log(
+          `  Run ${i + 1}/${s.numRuns}: wall=${run.wallMs.toFixed(0)}ms tokens/s=${run.tokensPerSecond ?? 'n/a'} rtf=${run.realTimeFactor ?? 'n/a'}`
+        )
+      }
+
+      const tpsStats = stats(allResults.map((r) => r.tokensPerSecond))
+      const wallStats = stats(allResults.map((r) => r.wallMs))
+      const rtfStats = stats(allResults.map((r) => r.realTimeFactor))
+      const last = allResults[allResults.length - 1]
+
+      const report = {
+        timestamp: new Date().toISOString(),
+        platform: platformLabel,
+        platformName,
+        arch: archName || '',
+        isMobile,
+        model: { name: s.modelFile, path: s.modelPath },
+        labels: {
+          runner: s.runnerLabel,
+          device: s.deviceLabel,
+          backend: getRequestedBackendFamily(platformName, s.useGPU, s.backendHint),
+          label: s.label
+        },
+        config: {
+          warmupRuns: s.numWarmup,
+          benchmarkRuns: s.numRuns,
+          useGPU: s.useGPU,
+          threads: s.threads
+        },
+        requested: {
+          modelFile: s.modelFile,
+          useGPU: s.useGPU,
+          backendHint: s.backendHint,
+          deviceLabel: s.deviceLabel,
+          runnerLabel: s.runnerLabel
+        },
+        observed: { backendDevice: last.backendDevice, backendId: last.backendId },
+        summary: {
+          tokensPerSecond: tpsStats,
+          wallMs: wallStats,
+          rtf: rtfStats
+        },
+        runs: allResults.map((r, i) => ({
+          iteration: i + 1,
+          wallMs: r.wallMs,
+          tokensPerSecond: r.tokensPerSecond,
+          totalTimeSec: r.totalTimeSec,
+          realTimeFactor: r.realTimeFactor
+        }))
+      }
+
+      if (!fs.existsSync(RTF_RESULTS_DIR)) fs.mkdirSync(RTF_RESULTS_DIR, { recursive: true })
+      const outPath = path.join(RTF_RESULTS_DIR, getArtifactFileName(s))
+      fs.writeFileSync(outPath, JSON.stringify(report, null, 2))
+      console.log(`\nResults written to ${outPath}\n`)
+      console.log(
+        `${RESULT_MARKER}${JSON.stringify({
+          schemaVersion: 1,
+          platform: platformLabel,
+          platformName,
+          modelFile: s.modelFile,
+          useGPU: s.useGPU,
+          backendHint: getRequestedBackendFamily(platformName, s.useGPU, s.backendHint),
+          summary: report.summary
+        })}`
+      )
+
+      t.is(allResults.length, s.numRuns, `Completed ${s.numRuns} benchmark runs`)
+      t.ok(wallStats.mean > 0, 'Mean wall time should be positive')
+    } finally {
+      if (bci) {
+        try {
+          await bci.destroy()
+        } catch {}
+      }
     }
   }
-})
+)

--- a/packages/bci-whispercpp/test/integration/addon.test.js
+++ b/packages/bci-whispercpp/test/integration/addon.test.js
@@ -20,7 +20,8 @@ const { flattenSegments } = require('@qvac/bci-whispercpp/util')
 const platform = detectPlatform()
 const { manifest, getSamplePath } = getTestPaths()
 
-const MODEL_PATH = (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
+const MODEL_PATH =
+  (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
   getModelPath('ggml-bci-windowed.bin')
 
 // Pass the embedder path explicitly to exercise the `files.embedder`
@@ -39,257 +40,334 @@ const requireModel = os.hasEnv('BCI_REQUIRE_MODEL') && os.getEnv('BCI_REQUIRE_MO
 
 if (requireModel && !hasModel) {
   throw new Error(
-    'BCI_REQUIRE_MODEL=1 but model file was not found at ' + MODEL_PATH +
-    '. Run `npm run download-models` (or `node scripts/download-models.js`) or set WHISPER_MODEL_PATH.'
+    'BCI_REQUIRE_MODEL=1 but model file was not found at ' +
+      MODEL_PATH +
+      '. Run `npm run download-models` (or `node scripts/download-models.js`) or set WHISPER_MODEL_PATH.'
   )
 }
 
-function bciConfigFor (sample) {
+function bciConfigFor(sample) {
   return typeof sample?.day_idx === 'number' ? { day_idx: sample.day_idx } : undefined
 }
 
-test('[BCI] load and destroy via package interface', { skip: !hasModel, timeout: 120000 }, async (t) => {
-  const bci = new BCIWhispercpp({
-    files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
-  }, {
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    miscConfig: { caption_enabled: false }
-  })
+test(
+  '[BCI] load and destroy via package interface',
+  { skip: !hasModel, timeout: 120000 },
+  async (t) => {
+    const bci = new BCIWhispercpp(
+      {
+        files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
+      },
+      {
+        whisperConfig: { language: 'en', temperature: 0.0 },
+        miscConfig: { caption_enabled: false }
+      }
+    )
 
-  await bci.load()
-  t.ok(bci, 'BCIWhispercpp should be created and loaded')
-
-  await bci.destroy()
-  t.pass('BCIWhispercpp destroyed successfully')
-})
-
-test('[BCI] batch transcription from neural signal file', { skip: !hasModel, timeout: 120000 }, async (t) => {
-  t.ok(manifest.samples.length > 0, 'Manifest must contain at least one sample')
-
-  const sample = manifest.samples[0]
-  const samplePath = getSamplePath(sample.file)
-  t.ok(fs.existsSync(samplePath), 'Fixture ' + sample.file + ' must exist')
-
-  const bci = new BCIWhispercpp({
-    files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
-  }, {
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    miscConfig: { caption_enabled: false },
-    bciConfig: bciConfigFor(sample)
-  })
-
-  try {
     await bci.load()
+    t.ok(bci, 'BCIWhispercpp should be created and loaded')
 
-    const response = await bci.transcribeFile(samplePath)
-    const output = await response.await()
-    const segments = flattenSegments(output)
-    const text = segments.map(s => s.text).join('').trim()
-
-    t.comment('Expected: "' + sample.expected_text + '"')
-    t.comment('Got:      "' + text + '"')
-
-    const wer = computeWER(text, sample.expected_text)
-    t.comment('WER:      ' + (wer * 100).toFixed(1) + '%')
-
-    t.ok(typeof text === 'string' && text.length > 0, 'Should produce a transcription string')
-    t.ok(segments.length > 0, 'Should have segments')
-    t.ok(typeof wer === 'number' && wer >= 0, 'WER should be a non-negative number')
-  } finally {
     await bci.destroy()
+    t.pass('BCIWhispercpp destroyed successfully')
   }
-})
+)
 
-test('[BCI] WER measurement across all test samples', { skip: !hasModel, timeout: 180000 }, async (t) => {
-  t.ok(manifest.samples.length > 0, 'Manifest must contain at least one sample')
+test(
+  '[BCI] batch transcription from neural signal file',
+  { skip: !hasModel, timeout: 120000 },
+  async (t) => {
+    t.ok(manifest.samples.length > 0, 'Manifest must contain at least one sample')
 
-  t.comment('Platform: ' + platform.label)
-  t.comment('Model:    ' + MODEL_PATH)
+    const sample = manifest.samples[0]
+    const samplePath = getSamplePath(sample.file)
+    t.ok(fs.existsSync(samplePath), 'Fixture ' + sample.file + ' must exist')
 
-  const results = []
-
-  const byDay = new Map()
-  for (const sample of manifest.samples) {
-    const key = typeof sample.day_idx === 'number' ? sample.day_idx : -1
-    if (!byDay.has(key)) byDay.set(key, [])
-    byDay.get(key).push(sample)
-  }
-
-  for (const [day, samples] of byDay) {
-    const bci = new BCIWhispercpp({
-      files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
-    }, {
-      whisperConfig: { language: 'en', temperature: 0.0 },
-      miscConfig: { caption_enabled: false },
-      bciConfig: day >= 0 ? { day_idx: day } : undefined
-    })
+    const bci = new BCIWhispercpp(
+      {
+        files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
+      },
+      {
+        whisperConfig: { language: 'en', temperature: 0.0 },
+        miscConfig: { caption_enabled: false },
+        bciConfig: bciConfigFor(sample)
+      }
+    )
 
     try {
       await bci.load()
 
-      for (const sample of samples) {
-        const samplePath = getSamplePath(sample.file)
-        if (!fs.existsSync(samplePath)) {
-          t.fail('Fixture ' + sample.file + ' is missing')
-          continue
-        }
+      const response = await bci.transcribeFile(samplePath)
+      const output = await response.await()
+      const segments = flattenSegments(output)
+      const text = segments
+        .map((s) => s.text)
+        .join('')
+        .trim()
 
-        const response = await bci.transcribeFile(samplePath)
-        const output = await response.await()
-        const segments = flattenSegments(output)
-        const text = segments.map(s => s.text).join('').trim()
-        const wer = computeWER(text, sample.expected_text)
-        results.push({ file: sample.file, expected: sample.expected_text, got: text, wer })
+      t.comment('Expected: "' + sample.expected_text + '"')
+      t.comment('Got:      "' + text + '"')
 
-        t.comment('[' + sample.file + '] expected=' + JSON.stringify(sample.expected_text) +
-          ' got=' + JSON.stringify(text) + ' WER=' + (wer * 100).toFixed(1) + '%')
-      }
+      const wer = computeWER(text, sample.expected_text)
+      t.comment('WER:      ' + (wer * 100).toFixed(1) + '%')
+
+      t.ok(typeof text === 'string' && text.length > 0, 'Should produce a transcription string')
+      t.ok(segments.length > 0, 'Should have segments')
+      t.ok(typeof wer === 'number' && wer >= 0, 'WER should be a non-negative number')
     } finally {
       await bci.destroy()
     }
   }
+)
 
-  const avgWER = results.reduce((sum, r) => sum + r.wer, 0) / results.length
-  t.comment('Average WER: ' + (avgWER * 100).toFixed(1) + '%  (n=' + results.length + ')')
+test(
+  '[BCI] WER measurement across all test samples',
+  { skip: !hasModel, timeout: 180000 },
+  async (t) => {
+    t.ok(manifest.samples.length > 0, 'Manifest must contain at least one sample')
 
-  t.ok(results.length === manifest.samples.length, 'All manifest samples should have been evaluated')
-  t.ok(typeof avgWER === 'number' && avgWER < 0.5, 'Average WER should be below 50%')
-})
+    t.comment('Platform: ' + platform.label)
+    t.comment('Model:    ' + MODEL_PATH)
 
-test('[BCI] streaming transcription on short signal yields single-window output', { skip: !hasModel, timeout: 120000 }, async (t) => {
-  t.ok(manifest.samples.length > 0, 'Manifest must contain at least one sample')
+    const results = []
 
-  const sample = manifest.samples[0]
-  const samplePath = getSamplePath(sample.file)
-  t.ok(fs.existsSync(samplePath), 'Fixture ' + sample.file + ' must exist')
+    const byDay = new Map()
+    for (const sample of manifest.samples) {
+      const key = typeof sample.day_idx === 'number' ? sample.day_idx : -1
+      if (!byDay.has(key)) byDay.set(key, [])
+      byDay.get(key).push(sample)
+    }
 
-  const bci = new BCIWhispercpp({
-    files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
-  }, {
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    miscConfig: { caption_enabled: false },
-    bciConfig: bciConfigFor(sample)
-  })
+    for (const [day, samples] of byDay) {
+      const bci = new BCIWhispercpp(
+        {
+          files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
+        },
+        {
+          whisperConfig: { language: 'en', temperature: 0.0 },
+          miscConfig: { caption_enabled: false },
+          bciConfig: day >= 0 ? { day_idx: day } : undefined
+        }
+      )
 
-  try {
-    await bci.load()
+      try {
+        await bci.load()
 
-    const signal = readSignal(samplePath)
-    const response = await bci.transcribeStream(chunkify(signal, 4096), {
-      windowTimesteps: 1500,
-      hopTimesteps: 500
-    })
+        for (const sample of samples) {
+          const samplePath = getSamplePath(sample.file)
+          if (!fs.existsSync(samplePath)) {
+            t.fail('Fixture ' + sample.file + ' is missing')
+            continue
+          }
 
-    const updates = []
-    response.onUpdate((out) => { updates.push(out) })
+          const response = await bci.transcribeFile(samplePath)
+          const output = await response.await()
+          const segments = flattenSegments(output)
+          const text = segments
+            .map((s) => s.text)
+            .join('')
+            .trim()
+          const wer = computeWER(text, sample.expected_text)
+          results.push({ file: sample.file, expected: sample.expected_text, got: text, wer })
 
-    const output = await response.await()
-    const segments = flattenSegments(output)
-    const text = segments.map(s => s.text).join(' ').trim()
+          t.comment(
+            '[' +
+              sample.file +
+              '] expected=' +
+              JSON.stringify(sample.expected_text) +
+              ' got=' +
+              JSON.stringify(text) +
+              ' WER=' +
+              (wer * 100).toFixed(1) +
+              '%'
+          )
+        }
+      } finally {
+        await bci.destroy()
+      }
+    }
 
-    t.comment('Streamed text: "' + text + '"')
-    t.comment('Expected:      "' + sample.expected_text + '"')
-    t.comment('Update events: ' + updates.length)
+    const avgWER = results.reduce((sum, r) => sum + r.wer, 0) / results.length
+    t.comment('Average WER: ' + (avgWER * 100).toFixed(1) + '%  (n=' + results.length + ')')
 
-    t.ok(updates.length >= 1, 'At least one onUpdate should fire')
-    t.ok(typeof text === 'string' && text.length > 0, 'Should produce a non-empty transcription')
-    const wer = computeWER(text, sample.expected_text)
-    t.ok(wer < 0.5, 'Streamed WER should be below 50% (got ' + (wer * 100).toFixed(1) + '%)')
-  } finally {
-    await bci.destroy()
+    t.ok(
+      results.length === manifest.samples.length,
+      'All manifest samples should have been evaluated'
+    )
+    t.ok(typeof avgWER === 'number' && avgWER < 0.5, 'Average WER should be below 50%')
   }
-})
+)
 
-test('[BCI] streaming transcription triggers multiple sliding windows on long signal', { skip: !hasModel, timeout: 180000 }, async (t) => {
-  t.ok(manifest.samples.length > 0, 'Manifest must contain at least one sample')
+test(
+  '[BCI] streaming transcription on short signal yields single-window output',
+  { skip: !hasModel, timeout: 120000 },
+  async (t) => {
+    t.ok(manifest.samples.length > 0, 'Manifest must contain at least one sample')
 
-  const sample = manifest.samples[0]
-  const samplePath = getSamplePath(sample.file)
-  t.ok(fs.existsSync(samplePath), 'Fixture ' + sample.file + ' must exist')
+    const sample = manifest.samples[0]
+    const samplePath = getSamplePath(sample.file)
+    t.ok(fs.existsSync(samplePath), 'Fixture ' + sample.file + ' must exist')
 
-  const raw = readSignal(samplePath)
-  const { channels, body } = splitHeaderAndBody(raw)
+    const bci = new BCIWhispercpp(
+      {
+        files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
+      },
+      {
+        whisperConfig: { language: 'en', temperature: 0.0 },
+        miscConfig: { caption_enabled: false },
+        bciConfig: bciConfigFor(sample)
+      }
+    )
 
-  // Tile the fixture body twice to synthesize a signal long enough that a
-  // window=1500 / hop=500 configuration forces at least two decodes.
-  const tiled = buildSignal(channels, [body, body])
+    try {
+      await bci.load()
 
-  const bci = new BCIWhispercpp({
-    files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
-  }, {
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    miscConfig: { caption_enabled: false },
-    bciConfig: bciConfigFor(sample)
-  })
+      const signal = readSignal(samplePath)
+      const response = await bci.transcribeStream(chunkify(signal, 4096), {
+        windowTimesteps: 1500,
+        hopTimesteps: 500
+      })
 
-  try {
-    await bci.load()
+      const updates = []
+      response.onUpdate((out) => {
+        updates.push(out)
+      })
 
-    const updates = []
-    const response = await bci.transcribeStream(chunkify(tiled, 8192), {
-      windowTimesteps: 1500,
-      hopTimesteps: 500,
-      emit: 'full'
-    })
-    response.onUpdate((out) => { updates.push(out) })
+      const output = await response.await()
+      const segments = flattenSegments(output)
+      const text = segments
+        .map((s) => s.text)
+        .join(' ')
+        .trim()
 
-    const output = await response.await()
-    const segments = flattenSegments(output)
-    const text = segments.map(s => s.text).join(' ').trim()
+      t.comment('Streamed text: "' + text + '"')
+      t.comment('Expected:      "' + sample.expected_text + '"')
+      t.comment('Update events: ' + updates.length)
 
-    t.comment('Tiled stream text: "' + text + '"')
-    t.comment('Update events: ' + updates.length)
-
-    // emit:'full' fires one update per window decode regardless of seam overlap,
-    // so update count is a faithful proxy for "multiple windows ran".
-    t.ok(updates.length >= 2, 'Multiple windows should each emit an update (got ' + updates.length + ')')
-    t.ok(typeof text === 'string' && text.length > 0, 'Should produce a non-empty merged transcription')
-  } finally {
-    await bci.destroy()
+      t.ok(updates.length >= 1, 'At least one onUpdate should fire')
+      t.ok(typeof text === 'string' && text.length > 0, 'Should produce a non-empty transcription')
+      const wer = computeWER(text, sample.expected_text)
+      t.ok(wer < 0.5, 'Streamed WER should be below 50% (got ' + (wer * 100).toFixed(1) + '%)')
+    } finally {
+      await bci.destroy()
+    }
   }
-})
+)
 
-test('[BCI] streaming emits incrementally before the input ends', { skip: !hasModel, timeout: 180000 }, async (t) => {
-  const sample = manifest.samples[0]
-  const samplePath = getSamplePath(sample.file)
-  t.ok(fs.existsSync(samplePath), 'Fixture ' + sample.file + ' must exist')
+test(
+  '[BCI] streaming transcription triggers multiple sliding windows on long signal',
+  { skip: !hasModel, timeout: 180000 },
+  async (t) => {
+    t.ok(manifest.samples.length > 0, 'Manifest must contain at least one sample')
 
-  const raw = readSignal(samplePath)
-  const { channels, body } = splitHeaderAndBody(raw)
-  const tiled = buildSignal(channels, [body, body])
+    const sample = manifest.samples[0]
+    const samplePath = getSamplePath(sample.file)
+    t.ok(fs.existsSync(samplePath), 'Fixture ' + sample.file + ' must exist')
 
-  const bci = new BCIWhispercpp({
-    files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
-  }, {
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    miscConfig: { caption_enabled: false },
-    bciConfig: bciConfigFor(sample)
-  })
+    const raw = readSignal(samplePath)
+    const { channels, body } = splitHeaderAndBody(raw)
 
-  try {
-    await bci.load()
+    // Tile the fixture body twice to synthesize a signal long enough that a
+    // window=1500 / hop=500 configuration forces at least two decodes.
+    const tiled = buildSignal(channels, [body, body])
 
-    let firstUpdateAt = null
-    let streamEndedAt = null
-    const startedAt = Date.now()
+    const bci = new BCIWhispercpp(
+      {
+        files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
+      },
+      {
+        whisperConfig: { language: 'en', temperature: 0.0 },
+        miscConfig: { caption_enabled: false },
+        bciConfig: bciConfigFor(sample)
+      }
+    )
 
-    const response = await bci.transcribeStream(chunkify(tiled, 4096), {
-      windowTimesteps: 1500,
-      hopTimesteps: 500
-    })
-    response.onUpdate(() => {
-      if (firstUpdateAt === null) firstUpdateAt = Date.now()
-    })
+    try {
+      await bci.load()
 
-    await response.await()
-    streamEndedAt = Date.now()
+      const updates = []
+      const response = await bci.transcribeStream(chunkify(tiled, 8192), {
+        windowTimesteps: 1500,
+        hopTimesteps: 500,
+        emit: 'full'
+      })
+      response.onUpdate((out) => {
+        updates.push(out)
+      })
 
-    t.comment('First update after ' + (firstUpdateAt - startedAt) + 'ms')
-    t.comment('Stream ended after ' + (streamEndedAt - startedAt) + 'ms')
+      const output = await response.await()
+      const segments = flattenSegments(output)
+      const text = segments
+        .map((s) => s.text)
+        .join(' ')
+        .trim()
 
-    t.ok(firstUpdateAt !== null, 'Expected at least one update during the stream')
-    t.ok(firstUpdateAt < streamEndedAt, 'First update should arrive before stream completion')
-  } finally {
-    await bci.destroy()
+      t.comment('Tiled stream text: "' + text + '"')
+      t.comment('Update events: ' + updates.length)
+
+      // emit:'full' fires one update per window decode regardless of seam overlap,
+      // so update count is a faithful proxy for "multiple windows ran".
+      t.ok(
+        updates.length >= 2,
+        'Multiple windows should each emit an update (got ' + updates.length + ')'
+      )
+      t.ok(
+        typeof text === 'string' && text.length > 0,
+        'Should produce a non-empty merged transcription'
+      )
+    } finally {
+      await bci.destroy()
+    }
   }
-})
+)
+
+test(
+  '[BCI] streaming emits incrementally before the input ends',
+  { skip: !hasModel, timeout: 180000 },
+  async (t) => {
+    const sample = manifest.samples[0]
+    const samplePath = getSamplePath(sample.file)
+    t.ok(fs.existsSync(samplePath), 'Fixture ' + sample.file + ' must exist')
+
+    const raw = readSignal(samplePath)
+    const { channels, body } = splitHeaderAndBody(raw)
+    const tiled = buildSignal(channels, [body, body])
+
+    const bci = new BCIWhispercpp(
+      {
+        files: { model: MODEL_PATH, embedder: EMBEDDER_PATH }
+      },
+      {
+        whisperConfig: { language: 'en', temperature: 0.0 },
+        miscConfig: { caption_enabled: false },
+        bciConfig: bciConfigFor(sample)
+      }
+    )
+
+    try {
+      await bci.load()
+
+      let firstUpdateAt = null
+      let streamEndedAt = null
+      const startedAt = Date.now()
+
+      const response = await bci.transcribeStream(chunkify(tiled, 4096), {
+        windowTimesteps: 1500,
+        hopTimesteps: 500
+      })
+      response.onUpdate(() => {
+        if (firstUpdateAt === null) firstUpdateAt = Date.now()
+      })
+
+      await response.await()
+      streamEndedAt = Date.now()
+
+      t.comment('First update after ' + (firstUpdateAt - startedAt) + 'ms')
+      t.comment('Stream ended after ' + (streamEndedAt - startedAt) + 'ms')
+
+      t.ok(firstUpdateAt !== null, 'Expected at least one update during the stream')
+      t.ok(firstUpdateAt < streamEndedAt, 'First update should arrive before stream completion')
+    } finally {
+      await bci.destroy()
+    }
+  }
+)

--- a/packages/bci-whispercpp/test/integration/gpu-smoke.test.js
+++ b/packages/bci-whispercpp/test/integration/gpu-smoke.test.js
@@ -33,20 +33,28 @@ const NO_GPU = os.hasEnv('NO_GPU') && os.getEnv('NO_GPU') === 'true'
 
 const { manifest, getSamplePath } = getTestPaths()
 
-const MODEL_PATH = (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
+const MODEL_PATH =
+  (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
   getModelPath('ggml-bci-windowed.bin')
 const EMBEDDER_PATH = path.join(path.dirname(MODEL_PATH), 'bci-embedder.bin')
 const hasModel = fs.existsSync(MODEL_PATH)
 
-function backendIdToName (id) {
+function backendIdToName(id) {
   switch (id) {
-    case 0: return 'CPU'
-    case 1: return 'Metal'
-    case 2: return 'CUDA'
-    case 3: return 'Vulkan'
-    case 4: return 'OpenCL'
-    case 99: return 'other-GPU'
-    default: return `unknown(${id})`
+    case 0:
+      return 'CPU'
+    case 1:
+      return 'Metal'
+    case 2:
+      return 'CUDA'
+    case 3:
+      return 'Vulkan'
+    case 4:
+      return 'OpenCL'
+    case 99:
+      return 'other-GPU'
+    default:
+      return `unknown(${id})`
   }
 }
 
@@ -54,7 +62,7 @@ function backendIdToName (id) {
 //   - darwin / ios:   Metal
 //   - linux / win32:  CUDA or Vulkan
 //   - android:        Vulkan / OpenCL
-function expectsGpu () {
+function expectsGpu() {
   return (
     platform === 'darwin' ||
     platform === 'ios' ||
@@ -64,9 +72,11 @@ function expectsGpu () {
   )
 }
 
-function assertGpuBackend (t, stats) {
+function assertGpuBackend(t, stats) {
   if (!stats) {
-    t.fail('BCI/GPU: no response.stats returned (cannot verify backend). Did you pass opts:{stats:true}?')
+    t.fail(
+      'BCI/GPU: no response.stats returned (cannot verify backend). Did you pass opts:{stats:true}?'
+    )
     return
   }
   const dev = stats.backendDevice
@@ -80,9 +90,10 @@ function assertGpuBackend (t, stats) {
   }
 
   if (dev !== 1) {
-    const msg = `BCI/${platform}: expected GPU backend, got ${name} (backendDevice=${dev}, backendId=${id}). ` +
-                'use_gpu=true was requested but whisper fell back to CPU. ' +
-                'Inspect the addon load-time backend init log.'
+    const msg =
+      `BCI/${platform}: expected GPU backend, got ${name} (backendDevice=${dev}, backendId=${id}). ` +
+      'use_gpu=true was requested but whisper fell back to CPU. ' +
+      'Inspect the addon load-time backend init log.'
     if (RELAX) {
       t.comment(`WARNING (relaxed): ${msg}`)
       t.pass('BCI/GPU smoke completed (relaxed)')
@@ -97,71 +108,97 @@ function assertGpuBackend (t, stats) {
   if (platform === 'darwin' || platform === 'ios') {
     t.is(id, 1, `BCI/${platform}: expected Metal backendId=1, got ${name}`)
   } else if (platform === 'linux' || platform === 'win32') {
-    t.ok(id === 2 || id === 3, `BCI/${platform}: expected CUDA(2) or Vulkan(3) backendId, got ${name}`)
+    t.ok(
+      id === 2 || id === 3,
+      `BCI/${platform}: expected CUDA(2) or Vulkan(3) backendId, got ${name}`
+    )
   } else if (platform === 'android') {
-    t.ok(id === 3 || id === 4, `BCI/${platform}: expected Vulkan(3) or OpenCL(4) backendId, got ${name}`)
+    t.ok(
+      id === 3 || id === 4,
+      `BCI/${platform}: expected Vulkan(3) or OpenCL(4) backendId, got ${name}`
+    )
   }
 }
 
-function assertCpuBackend (t, stats) {
+function assertCpuBackend(t, stats) {
   if (!stats) {
-    t.fail('BCI/CPU: no response.stats returned (cannot verify backend). Did you pass opts:{stats:true}?')
+    t.fail(
+      'BCI/CPU: no response.stats returned (cannot verify backend). Did you pass opts:{stats:true}?'
+    )
     return
   }
   const dev = stats.backendDevice
   const id = stats.backendId
   console.log(`[BCI/CPU] backendDevice=${dev} backendId=${id} (${backendIdToName(id)})`)
-  t.is(dev, 0, `BCI: use_gpu:false must resolve to backendDevice=0 (CPU), got ${backendIdToName(id)}`)
+  t.is(
+    dev,
+    0,
+    `BCI: use_gpu:false must resolve to backendDevice=0 (CPU), got ${backendIdToName(id)}`
+  )
   t.is(id, 0, `BCI: use_gpu:false must resolve to backendId=0 (CPU), got ${backendIdToName(id)}`)
 }
 
-function firstSample () {
+function firstSample() {
   const sample = manifest.samples && manifest.samples[0]
   if (!sample) return null
   const samplePath = getSamplePath(sample.file)
   return fs.existsSync(samplePath) ? { sample, samplePath } : null
 }
 
-async function runBci (useGpu, samplePath, sample) {
-  const bci = new BCIWhispercpp({
-    files: { model: MODEL_PATH, embedder: EMBEDDER_PATH },
-    opts: { stats: true }
-  }, {
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    miscConfig: { caption_enabled: false },
-    contextParams: { use_gpu: useGpu },
-    ...(typeof sample?.day_idx === 'number' ? { bciConfig: { day_idx: sample.day_idx } } : {})
-  })
+async function runBci(useGpu, samplePath, sample) {
+  const bci = new BCIWhispercpp(
+    {
+      files: { model: MODEL_PATH, embedder: EMBEDDER_PATH },
+      opts: { stats: true }
+    },
+    {
+      whisperConfig: { language: 'en', temperature: 0.0 },
+      miscConfig: { caption_enabled: false },
+      contextParams: { use_gpu: useGpu },
+      ...(typeof sample?.day_idx === 'number' ? { bciConfig: { day_idx: sample.day_idx } } : {})
+    }
+  )
   await bci.load()
   try {
     const response = await bci.transcribeFile(samplePath)
     const output = await response.await()
     const segments = flattenSegments(output)
-    const text = segments.map(s => s.text).join('').trim()
+    const text = segments
+      .map((s) => s.text)
+      .join('')
+      .trim()
     return { stats: response.stats, text }
   } finally {
     await bci.destroy()
   }
 }
 
-test('[BCI] GPU smoke - use_gpu=true must engage the GPU backend on GPU-capable platforms', { timeout: 120000, skip: NO_GPU || !hasModel }, async (t) => {
-  const picked = firstSample()
-  if (!picked) {
-    t.pass('Skipped: no neural-signal fixture available')
-    return
+test(
+  '[BCI] GPU smoke - use_gpu=true must engage the GPU backend on GPU-capable platforms',
+  { timeout: 120000, skip: NO_GPU || !hasModel },
+  async (t) => {
+    const picked = firstSample()
+    if (!picked) {
+      t.pass('Skipped: no neural-signal fixture available')
+      return
+    }
+    const { stats, text } = await runBci(true, picked.samplePath, picked.sample)
+    t.ok(typeof text === 'string' && text.length > 0, 'BCI/GPU produced a transcription')
+    assertGpuBackend(t, stats)
   }
-  const { stats, text } = await runBci(true, picked.samplePath, picked.sample)
-  t.ok(typeof text === 'string' && text.length > 0, 'BCI/GPU produced a transcription')
-  assertGpuBackend(t, stats)
-})
+)
 
-test('[BCI] CPU smoke - use_gpu=false must run on the CPU backend', { timeout: 120000, skip: !hasModel }, async (t) => {
-  const picked = firstSample()
-  if (!picked) {
-    t.pass('Skipped: no neural-signal fixture available')
-    return
+test(
+  '[BCI] CPU smoke - use_gpu=false must run on the CPU backend',
+  { timeout: 120000, skip: !hasModel },
+  async (t) => {
+    const picked = firstSample()
+    if (!picked) {
+      t.pass('Skipped: no neural-signal fixture available')
+      return
+    }
+    const { stats, text } = await runBci(false, picked.samplePath, picked.sample)
+    t.ok(typeof text === 'string' && text.length > 0, 'BCI/CPU produced a transcription')
+    assertCpuBackend(t, stats)
   }
-  const { stats, text } = await runBci(false, picked.samplePath, picked.sample)
-  t.ok(typeof text === 'string' && text.length > 0, 'BCI/CPU produced a transcription')
-  assertCpuBackend(t, stats)
-})
+)

--- a/packages/bci-whispercpp/test/integration/helpers.js
+++ b/packages/bci-whispercpp/test/integration/helpers.js
@@ -43,21 +43,24 @@ try {
     }
 
     return {
-      record (testName, metrics, extra) {
+      record(testName, metrics, extra) {
         _results.push({
           test: testName,
           execution_provider: (extra && extra.execution_provider) || null,
-          metrics: Object.assign({
-            real_time_factor: null,
-            wall_time_ms: null,
-            tps: null,
-            total_time_ms: null
-          }, metrics),
+          metrics: Object.assign(
+            {
+              real_time_factor: null,
+              wall_time_ms: null,
+              tps: null,
+              total_time_ms: null
+            },
+            metrics
+          ),
           input: (extra && extra.input) || null,
           output: (extra && extra.output) || null
         })
       },
-      toJSON () {
+      toJSON() {
         return {
           schema_version: '1.0',
           addon: _addon,
@@ -67,7 +70,7 @@ try {
           results: _results
         }
       },
-      writeReport () {
+      writeReport() {
         const json = JSON.stringify(this.toJSON())
         const dirs = []
         if (global.testDir) dirs.push(global.testDir)
@@ -79,7 +82,9 @@ try {
         dirs.push('/tmp')
         for (let di = 0; di < dirs.length; di++) {
           try {
-            try { fs.mkdirSync(dirs[di], { recursive: true }) } catch (_) {}
+            try {
+              fs.mkdirSync(dirs[di], { recursive: true })
+            } catch (_) {}
             const p = path.join(dirs[di], 'perf-report.json')
             fs.writeFileSync(p, json)
             console.log('[PERF_REPORT_PATH]' + p)
@@ -88,8 +93,8 @@ try {
           }
         }
       },
-      writeStepSummary () {},
-      writeToConsole () {
+      writeStepSummary() {},
+      writeToConsole() {
         try {
           const json = JSON.stringify(this.toJSON())
           const CHUNK = 800
@@ -99,14 +104,25 @@ try {
             const id = Date.now().toString(36)
             const n = Math.ceil(json.length / CHUNK)
             for (let i = 0; i < n; i++) {
-              console.log('[PERF_CHUNK:' + id + ':' + i + ':' + n + ']' + json.substring(i * CHUNK, (i + 1) * CHUNK))
+              console.log(
+                '[PERF_CHUNK:' +
+                  id +
+                  ':' +
+                  i +
+                  ':' +
+                  n +
+                  ']' +
+                  json.substring(i * CHUNK, (i + 1) * CHUNK)
+              )
             }
           }
         } catch (err) {
           console.log('[perf-reporter] mobile console write failed: ' + err.message)
         }
       },
-      get length () { return _results.length }
+      get length() {
+        return _results.length
+      }
     }
   }
 }
@@ -115,13 +131,17 @@ const _perfReporter = createPerformanceReporter({ addon: 'bci', addonType: 'bci'
 const _reportPath = path.resolve('.', 'test/results/performance-report.json')
 let _reportScheduled = false
 
-function _flushPerfReport () {
+function _flushPerfReport() {
   if (_perfReporter.length === 0) return
-  try { _perfReporter.writeReport(_reportPath) } catch (_) {}
-  try { _perfReporter.writeToConsole() } catch (_) {}
+  try {
+    _perfReporter.writeReport(_reportPath)
+  } catch (_) {}
+  try {
+    _perfReporter.writeToConsole()
+  } catch (_) {}
 }
 
-function _scheduleReportWrite () {
+function _scheduleReportWrite() {
   if (_reportScheduled) return
   _reportScheduled = true
   process.on('exit', _flushPerfReport)
@@ -137,7 +157,7 @@ function _scheduleReportWrite () {
  *                         tokensPerSecond, totalWallMs, realTimeFactor?, ... }.
  * @param {Object} [extra] - Optional { wallMs, output, executionProvider }.
  */
-function recordBciStats (label, stats, extra) {
+function recordBciStats(label, stats, extra) {
   if (!stats || typeof stats !== 'object') return
   const epOverride = extra && extra.executionProvider
   const ep = epOverride || (/\[gpu\]/i.test(label) ? 'gpu' : /\[cpu\]/i.test(label) ? 'cpu' : null)
@@ -145,9 +165,12 @@ function recordBciStats (label, stats, extra) {
   const rtf = typeof stats.realTimeFactor === 'number' ? stats.realTimeFactor : null
   const totalTimeSec = typeof stats.totalTime === 'number' ? stats.totalTime : null
   const totalTimeMs = totalTimeSec !== null ? Math.round(totalTimeSec * 1000) : null
-  const wallMs = (extra && typeof extra.wallMs === 'number')
-    ? Math.round(extra.wallMs)
-    : (typeof stats.totalWallMs === 'number' ? Math.round(stats.totalWallMs) : totalTimeMs)
+  const wallMs =
+    extra && typeof extra.wallMs === 'number'
+      ? Math.round(extra.wallMs)
+      : typeof stats.totalWallMs === 'number'
+        ? Math.round(stats.totalWallMs)
+        : totalTimeMs
   const tps = typeof stats.tokensPerSecond === 'number' ? stats.tokensPerSecond : null
   // Active ggml backend id echoed in every stats snapshot
   // (0=CPU 1=Metal 2=CUDA 3=Vulkan 4=OpenCL 99=other). Recorded so the
@@ -155,21 +178,29 @@ function recordBciStats (label, stats, extra) {
   // platform — e.g. Adreno Android lands on OpenCL(4), Mali on Vulkan(3).
   const backendId = typeof stats.backendId === 'number' ? stats.backendId : null
 
-  _perfReporter.record(label, {
-    real_time_factor: rtf,
-    wall_time_ms: wallMs,
-    tps,
-    total_time_ms: totalTimeMs,
-    backend_id: backendId
-  }, {
-    execution_provider: ep,
-    output: extra && extra.output ? String(extra.output) : null
-  })
+  _perfReporter.record(
+    label,
+    {
+      real_time_factor: rtf,
+      wall_time_ms: wallMs,
+      tps,
+      total_time_ms: totalTimeMs,
+      backend_id: backendId
+    },
+    {
+      execution_provider: ep,
+      output: extra && extra.output ? String(extra.output) : null
+    }
+  )
   _scheduleReportWrite()
 
   if (isMobile) {
-    try { _perfReporter.writeReport() } catch (_) {}
-    try { _perfReporter.writeToConsole() } catch (_) {}
+    try {
+      _perfReporter.writeReport()
+    } catch (_) {}
+    try {
+      _perfReporter.writeToConsole()
+    } catch (_) {}
   }
 }
 
@@ -178,12 +209,12 @@ function recordBciStats (label, stats, extra) {
 // (writable scratch). Fall back to test/mobile/testAssets/ on disk so
 // the same code paths work when these tests are exercised from the
 // repo root (e.g. during local mobile dry-runs).
-function getMobileAssetsDir () {
+function getMobileAssetsDir() {
   if (typeof global !== 'undefined' && global.testDir) return global.testDir
   return path.join(__dirname, '..', 'mobile', 'testAssets')
 }
 
-function getModelPath (filename) {
+function getModelPath(filename) {
   if (isMobile) return path.join(getMobileAssetsDir(), filename)
   return path.join(__dirname, '..', '..', 'models', filename)
 }
@@ -193,7 +224,7 @@ function getModelPath (filename) {
 // and exposes each file via global.assetPaths['../../testAssets/<file>'] as a
 // file:// URL (under the app cache dir, NOT global.testDir). Falls back to the
 // testDir-based path off-mobile or when the manifest is absent.
-function getMobileAssetPath (filename) {
+function getMobileAssetPath(filename) {
   if (typeof global !== 'undefined' && global.assetPaths) {
     const key = '../../testAssets/' + filename
     if (global.assetPaths[key]) return String(global.assetPaths[key]).replace('file://', '')
@@ -201,10 +232,8 @@ function getMobileAssetPath (filename) {
   return path.join(getMobileAssetsDir(), filename)
 }
 
-function getTestPaths () {
-  const fixturesDir = isMobile
-    ? getMobileAssetsDir()
-    : path.join(__dirname, '..', 'fixtures')
+function getTestPaths() {
+  const fixturesDir = isMobile ? getMobileAssetsDir() : path.join(__dirname, '..', 'fixtures')
   const manifestPath = path.join(fixturesDir, 'manifest.json')
 
   let manifest = { samples: [] }
@@ -219,7 +248,7 @@ function getTestPaths () {
   }
 }
 
-function detectPlatform () {
+function detectPlatform() {
   const os = require('bare-os')
   const arch = os.arch()
   const platform = os.platform()
@@ -230,7 +259,7 @@ function detectPlatform () {
  * Read a .bin neural signal fixture from disk as a Uint8Array view over
  * the original buffer bytes (no copy).
  */
-function readSignal (samplePath) {
+function readSignal(samplePath) {
   const buf = fs.readFileSync(samplePath)
   return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
 }
@@ -239,7 +268,7 @@ function readSignal (samplePath) {
  * Parse the [T, C] header of a neural signal buffer and return the header
  * fields alongside a view over the body bytes.
  */
-function splitHeaderAndBody (signalBytes) {
+function splitHeaderAndBody(signalBytes) {
   const view = new DataView(signalBytes.buffer, signalBytes.byteOffset, signalBytes.byteLength)
   const timesteps = view.getUint32(0, true)
   const channels = view.getUint32(4, true)
@@ -252,7 +281,7 @@ function splitHeaderAndBody (signalBytes) {
  * fragments; used to synthesise longer fixtures (e.g. tile a fixture
  * body N times to force multi-window streaming).
  */
-function buildSignal (channels, bodies) {
+function buildSignal(channels, bodies) {
   const totalBodyBytes = bodies.reduce((sum, b) => sum + b.byteLength, 0)
   const totalTimesteps = totalBodyBytes / (channels * 4)
   const out = new Uint8Array(8 + totalBodyBytes)
@@ -271,7 +300,7 @@ function buildSignal (channels, bodies) {
  * Async generator that yields fixed-size slices of a Uint8Array; used by
  * streaming tests to simulate chunked input delivery.
  */
-async function * chunkify (bytes, chunkSize) {
+async function* chunkify(bytes, chunkSize) {
   for (let i = 0; i < bytes.byteLength; i += chunkSize) {
     yield bytes.subarray(i, Math.min(i + chunkSize, bytes.byteLength))
   }

--- a/packages/bci-whispercpp/test/integration/mobile-perf-runner.js
+++ b/packages/bci-whispercpp/test/integration/mobile-perf-runner.js
@@ -5,23 +5,18 @@ const os = require('bare-os')
 const process = require('bare-process')
 const BCIWhispercpp = require('../../index')
 const { flattenSegments } = require('@qvac/bci-whispercpp/util')
-const {
-  detectPlatform,
-  getMobileAssetPath,
-  isMobile,
-  recordBciStats
-} = require('./helpers.js')
+const { detectPlatform, getMobileAssetPath, isMobile, recordBciStats } = require('./helpers.js')
 
 const { platform } = detectPlatform()
 const NUM_TRANSCRIPTIONS = 3
 const NO_GPU = os.hasEnv('NO_GPU') && os.getEnv('NO_GPU') === 'true'
 
-function getTimeMs () {
+function getTimeMs() {
   const [sec, nsec] = process.hrtime()
   return sec * 1000 + nsec / 1e6
 }
 
-function loadManifest () {
+function loadManifest() {
   const manifestPath = getMobileAssetPath('manifest.json')
   if (!fs.existsSync(manifestPath)) return { samples: [] }
   try {
@@ -31,7 +26,7 @@ function loadManifest () {
   }
 }
 
-async function runMobilePerfCase (t, opts) {
+async function runMobilePerfCase(t, opts) {
   const modelFile = opts.modelFile || 'ggml-bci-windowed.bin'
   const useGPU = opts.useGPU
   const epLabel = useGPU ? '[GPU]' : '[CPU]'
@@ -54,7 +49,9 @@ async function runMobilePerfCase (t, opts) {
   const modelPath = getMobileAssetPath(modelFile)
   const embedderPath = getMobileAssetPath('bci-embedder.bin')
   if (!fs.existsSync(modelPath) || !fs.existsSync(embedderPath)) {
-    t.pass(modelLabel + ' ' + epLabel + ' skipped: model/embedder asset not found (' + modelPath + ')')
+    t.pass(
+      modelLabel + ' ' + epLabel + ' skipped: model/embedder asset not found (' + modelPath + ')'
+    )
     return
   }
 
@@ -81,15 +78,18 @@ async function runMobilePerfCase (t, opts) {
 
   let bci = null
   try {
-    bci = new BCIWhispercpp({
-      files: { model: modelPath, embedder: embedderPath },
-      opts: { stats: true }
-    }, {
-      whisperConfig: { language: 'en', temperature: 0.0 },
-      miscConfig: { caption_enabled: false },
-      contextParams: { use_gpu: useGPU },
-      ...(typeof sample.day_idx === 'number' ? { bciConfig: { day_idx: sample.day_idx } } : {})
-    })
+    bci = new BCIWhispercpp(
+      {
+        files: { model: modelPath, embedder: embedderPath },
+        opts: { stats: true }
+      },
+      {
+        whisperConfig: { language: 'en', temperature: 0.0 },
+        miscConfig: { caption_enabled: false },
+        contextParams: { use_gpu: useGPU },
+        ...(typeof sample.day_idx === 'number' ? { bciConfig: { day_idx: sample.day_idx } } : {})
+      }
+    )
 
     const loadStart = getTimeMs()
     await bci.load()
@@ -105,7 +105,10 @@ async function runMobilePerfCase (t, opts) {
       const runTime = getTimeMs() - runStart
 
       const segments = flattenSegments(output)
-      const text = segments.map((s) => (s && s.text) || '').join('').trim()
+      const text = segments
+        .map((s) => (s && s.text) || '')
+        .join('')
+        .trim()
       const jobStats = response.stats
 
       console.log('   Time: ' + runTime.toFixed(0) + 'ms  Text: "' + text.substring(0, 60) + '"')
@@ -125,15 +128,40 @@ async function runMobilePerfCase (t, opts) {
     // ids are logged for the report but not asserted, so a legitimate GPU->CPU
     // fallback doesn't turn the benchmark red.
     const probe = lastStats || {}
-    console.log('   Backend stats: backendDevice=' +
-      (typeof probe.backendDevice === 'number' ? probe.backendDevice : 'n/a') +
-      ' backendId=' + (typeof probe.backendId === 'number' ? probe.backendId : 'n/a'))
+    console.log(
+      '   Backend stats: backendDevice=' +
+        (typeof probe.backendDevice === 'number' ? probe.backendDevice : 'n/a') +
+        ' backendId=' +
+        (typeof probe.backendId === 'number' ? probe.backendId : 'n/a')
+    )
 
-    t.ok(statsCount > 0, modelLabel + ' ' + epLabel + ' should produce runtime stats for at least one run (got ' + statsCount + ')')
-    console.log('Mobile perf case ' + modelLabel + ' ' + epLabel + ' completed (' + statsCount + '/' + NUM_TRANSCRIPTIONS + ' runs with stats)\n')
+    t.ok(
+      statsCount > 0,
+      modelLabel +
+        ' ' +
+        epLabel +
+        ' should produce runtime stats for at least one run (got ' +
+        statsCount +
+        ')'
+    )
+    console.log(
+      'Mobile perf case ' +
+        modelLabel +
+        ' ' +
+        epLabel +
+        ' completed (' +
+        statsCount +
+        '/' +
+        NUM_TRANSCRIPTIONS +
+        ' runs with stats)\n'
+    )
   } finally {
     if (bci) {
-      try { await bci.destroy() } catch (err) { console.log('   destroy error: ' + err.message) }
+      try {
+        await bci.destroy()
+      } catch (err) {
+        console.log('   destroy error: ' + err.message)
+      }
     }
   }
 }

--- a/packages/bci-whispercpp/test/integration/vulkan-regression.test.js
+++ b/packages/bci-whispercpp/test/integration/vulkan-regression.test.js
@@ -16,7 +16,8 @@ const { flattenSegments } = require('@qvac/bci-whispercpp/util')
 const { platform, label } = detectPlatform()
 const { manifest, getSamplePath } = getTestPaths()
 
-const MODEL_PATH = (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
+const MODEL_PATH =
+  (os.hasEnv('WHISPER_MODEL_PATH') ? os.getEnv('WHISPER_MODEL_PATH') : null) ||
   getModelPath('ggml-bci-windowed.bin')
 const EMBEDDER_PATH = path.join(path.dirname(MODEL_PATH), 'bci-embedder.bin')
 const hasModel = fs.existsSync(MODEL_PATH)
@@ -26,14 +27,21 @@ const RELAX = os.hasEnv('QVAC_BCI_WER_RELAX') && os.getEnv('QVAC_BCI_WER_RELAX')
 // Tolerance for the 4-decimal bci_wer stored in the manifest.
 const WER_TOL = 1e-4
 
-function backendIdToName (id) {
-  return ({ 0: 'CPU', 1: 'Metal', 2: 'CUDA', 3: 'Vulkan', 4: 'OpenCL', 99: 'other-GPU' })[id] ||
-    ('unknown(' + id + ')')
+function backendIdToName(id) {
+  return (
+    { 0: 'CPU', 1: 'Metal', 2: 'CUDA', 3: 'Vulkan', 4: 'OpenCL', 99: 'other-GPU' }[id] ||
+    'unknown(' + id + ')'
+  )
 }
 
-function assertNoRegression (t, name, wer, bound) {
-  const msg = name + ': WER ' + (wer * 100).toFixed(2) + '% must be <= ' +
-    (bound * 100).toFixed(2) + '% (recorded good result)'
+function assertNoRegression(t, name, wer, bound) {
+  const msg =
+    name +
+    ': WER ' +
+    (wer * 100).toFixed(2) +
+    '% must be <= ' +
+    (bound * 100).toFixed(2) +
+    '% (recorded good result)'
   if (wer <= bound + WER_TOL) {
     t.pass(msg)
   } else if (RELAX) {
@@ -44,7 +52,7 @@ function assertNoRegression (t, name, wer, bound) {
   }
 }
 
-function pickTwoDistinctSamples (samples) {
+function pickTwoDistinctSamples(samples) {
   for (let i = 0; i < samples.length; i++) {
     for (let j = i + 1; j < samples.length; j++) {
       if (samples[i].expected_text !== samples[j].expected_text) {
@@ -55,29 +63,37 @@ function pickTwoDistinctSamples (samples) {
   return null
 }
 
-async function transcribeSampleOnGpu (sample) {
+async function transcribeSampleOnGpu(sample) {
   const dayIdx = typeof sample.day_idx === 'number' ? sample.day_idx : -1
-  const bci = new BCIWhispercpp({
-    files: { model: MODEL_PATH, embedder: EMBEDDER_PATH },
-    opts: { stats: true }
-  }, {
-    whisperConfig: { language: 'en', temperature: 0.0 },
-    miscConfig: { caption_enabled: false },
-    contextParams: { use_gpu: true },
-    bciConfig: dayIdx >= 0 ? { day_idx: dayIdx } : undefined
-  })
+  const bci = new BCIWhispercpp(
+    {
+      files: { model: MODEL_PATH, embedder: EMBEDDER_PATH },
+      opts: { stats: true }
+    },
+    {
+      whisperConfig: { language: 'en', temperature: 0.0 },
+      miscConfig: { caption_enabled: false },
+      contextParams: { use_gpu: true },
+      bciConfig: dayIdx >= 0 ? { day_idx: dayIdx } : undefined
+    }
+  )
   try {
     await bci.load()
     const response = await bci.transcribeFile(getSamplePath(sample.file))
     const output = await response.await()
-    return flattenSegments(output).map(s => s.text).join('').trim()
+    return flattenSegments(output)
+      .map((s) => s.text)
+      .join('')
+      .trim()
   } finally {
     await bci.destroy()
   }
 }
 
-test('[BCI][Vulkan-desktop] transcription accuracy has not regressed',
-  { skip: !hasModel, timeout: 180000 }, async (t) => {
+test(
+  '[BCI][Vulkan-desktop] transcription accuracy has not regressed',
+  { skip: !hasModel, timeout: 180000 },
+  async (t) => {
     t.ok(manifest.samples.length > 0, 'Manifest must contain at least one sample')
     t.comment('Platform: ' + label + '   Model: ' + MODEL_PATH)
 
@@ -93,15 +109,18 @@ test('[BCI][Vulkan-desktop] transcription accuracy has not regressed',
     let backendId = null
 
     for (const [day, samples] of byDay) {
-      const bci = new BCIWhispercpp({
-        files: { model: MODEL_PATH, embedder: EMBEDDER_PATH },
-        opts: { stats: true }
-      }, {
-        whisperConfig: { language: 'en', temperature: 0.0 },
-        miscConfig: { caption_enabled: false },
-        contextParams: { use_gpu: true },
-        bciConfig: day >= 0 ? { day_idx: day } : undefined
-      })
+      const bci = new BCIWhispercpp(
+        {
+          files: { model: MODEL_PATH, embedder: EMBEDDER_PATH },
+          opts: { stats: true }
+        },
+        {
+          whisperConfig: { language: 'en', temperature: 0.0 },
+          miscConfig: { caption_enabled: false },
+          contextParams: { use_gpu: true },
+          bciConfig: day >= 0 ? { day_idx: day } : undefined
+        }
+      )
 
       try {
         await bci.load()
@@ -115,14 +134,27 @@ test('[BCI][Vulkan-desktop] transcription accuracy has not regressed',
           const output = await response.await()
           if (backendId === null && response.stats) backendId = response.stats.backendId
 
-          const text = flattenSegments(output).map(s => s.text).join('').trim()
+          const text = flattenSegments(output)
+            .map((s) => s.text)
+            .join('')
+            .trim()
           const wer = computeWER(text, sample.expected_text)
           const bound = typeof sample.bci_wer === 'number' ? sample.bci_wer : 0
           results.push({ file: sample.file, wer, bound })
 
-          t.comment('[' + sample.file + '] expected=' + JSON.stringify(sample.expected_text) +
-            ' got=' + JSON.stringify(text) +
-            ' WER=' + (wer * 100).toFixed(2) + '% (bound ' + (bound * 100).toFixed(2) + '%)')
+          t.comment(
+            '[' +
+              sample.file +
+              '] expected=' +
+              JSON.stringify(sample.expected_text) +
+              ' got=' +
+              JSON.stringify(text) +
+              ' WER=' +
+              (wer * 100).toFixed(2) +
+              '% (bound ' +
+              (bound * 100).toFixed(2) +
+              '%)'
+          )
         }
       } finally {
         await bci.destroy()
@@ -134,8 +166,10 @@ test('[BCI][Vulkan-desktop] transcription accuracy has not regressed',
     // fallback. Genuine CPU fallback (backendId 0) is allowed; gpu-smoke owns
     // the "must engage GPU" gate.
     if ((platform === 'linux' || platform === 'win32') && backendId !== null && backendId !== 0) {
-      t.ok(backendId === 3 || backendId === 2,
-        'desktop GPU path should be Vulkan(3) or CUDA(2), got ' + backendIdToName(backendId))
+      t.ok(
+        backendId === 3 || backendId === 2,
+        'desktop GPU path should be Vulkan(3) or CUDA(2), got ' + backendIdToName(backendId)
+      )
     }
 
     t.is(results.length, manifest.samples.length, 'All manifest samples were evaluated')
@@ -144,17 +178,25 @@ test('[BCI][Vulkan-desktop] transcription accuracy has not regressed',
 
     const avg = results.reduce((s, r) => s + r.wer, 0) / results.length
     const refAvg = results.reduce((s, r) => s + r.bound, 0) / results.length
-    t.comment('Average WER: ' + (avg * 100).toFixed(2) + '%  (recorded reference avg ' +
-      (refAvg * 100).toFixed(2) + '%)')
+    t.comment(
+      'Average WER: ' +
+        (avg * 100).toFixed(2) +
+        '%  (recorded reference avg ' +
+        (refAvg * 100).toFixed(2) +
+        '%)'
+    )
     assertNoRegression(t, 'average', avg, refAvg)
-  })
+  }
+)
 
 // Focused guard for the neural-mel hand-off (whisper_set_mel + whisper_full with
 // zero PCM samples). A skipped injection would run whisper on an empty/stale mel
 // and produce no text; an ignored injection would collapse different inputs to
 // the same output. Both failure modes are caught here.
-test('[BCI][Vulkan-desktop] neural mel is injected and consumed by whisper',
-  { skip: !hasModel, timeout: 180000 }, async (t) => {
+test(
+  '[BCI][Vulkan-desktop] neural mel is injected and consumed by whisper',
+  { skip: !hasModel, timeout: 180000 },
+  async (t) => {
     const pair = pickTwoDistinctSamples(manifest.samples)
     t.ok(pair, 'Manifest must contain two fixtures with different expected text')
     if (!pair) return
@@ -165,8 +207,14 @@ test('[BCI][Vulkan-desktop] neural mel is injected and consumed by whisper',
     t.comment('[' + first.file + '] -> ' + JSON.stringify(firstText))
     t.comment('[' + second.file + '] -> ' + JSON.stringify(secondText))
 
-    t.ok(firstText.length > 0 && secondText.length > 0,
-      'Both fixtures produce non-empty text (mel was injected up-front)')
-    t.not(firstText, secondText,
-      'Distinct neural inputs produce distinct transcriptions (mel is consumed)')
-  })
+    t.ok(
+      firstText.length > 0 && secondText.length > 0,
+      'Both fixtures produce non-empty text (mel was injected up-front)'
+    )
+    t.not(
+      firstText,
+      secondText,
+      'Distinct neural inputs produce distinct transcriptions (mel is consumed)'
+    )
+  }
+)

--- a/packages/bci-whispercpp/test/unit/stitch.test.js
+++ b/packages/bci-whispercpp/test/unit/stitch.test.js
@@ -147,9 +147,7 @@ test('[stitchSegments] fully-overlapped leading segment is dropped; non-overlapp
 })
 
 test('[stitchSegments] partial overlap inside a single segment trims text and advances t0 proportionally', (t) => {
-  const segs = [
-    { text: 'the store today', t0: 0, t1: 300 }
-  ]
+  const segs = [{ text: 'the store today', t0: 0, t1: 300 }]
   const { deltaSegments, merged, bestK } = stitchSegments('went to the', segs, 40, 500)
   t.is(bestK, 1)
   t.is(merged, 'went to the store today')
@@ -194,7 +192,7 @@ test('[stitchSegments] punctuation-normalised overlap still preserves original c
 
 test('[normalizeWord] lowercases and strips non-alphanumeric except apostrophe', (t) => {
   t.is(normalizeWord('Hello,'), 'hello')
-  t.is(normalizeWord('Don\'t!'), 'don\'t')
+  t.is(normalizeWord("Don't!"), "don't")
   t.is(normalizeWord('...'), '')
   t.is(normalizeWord('Foo123'), 'foo123')
 })


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The JS source in `packages/bci-whispercpp` was not consistently formatted per the package's pinned Prettier config (`prettier@3.6.2` + `prettier-config-holepunch`).
- `npm run lint` (which runs `prettier --check`) flagged 16 files with code-style issues.

## 📝 How does it solve it?

- Ran `npm run format` (`prettier --write`) across `examples/`, `test/`, `lib/`, and top-level `*.js` to apply the canonical formatting.
- Reformatted 16 files (whitespace/style only — no functional, API, or behavioral changes).

## 🧪 How was it tested?

- Re-ran `prettier --check "examples/**/*.js" "test/**/*.js" "*.js" "lib/**/*.js"` → "All matched files use Prettier code style!"


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216426175394538