### PR TITLE
QVAC-22029 chore[skiplog]: apply prettier formatting to tts-ggml JS

### DIFF
--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -36,7 +36,7 @@ const SUPERTONIC_V3_RE = /^supertonic3(-[a-z0-9_]+)?\.gguf$/i
 // Preference when several v3 tiers share a modelDir: highest precision first.
 const SUPERTONIC_V3_QUANT_ORDER = ['f16', 'f32', 'q8_0', 'q4_0']
 
-function firstNonEmpty (...candidates) {
+function firstNonEmpty(...candidates) {
   for (let i = 0; i < candidates.length; i++) {
     const v = candidates[i]
     if (v != null && v !== '') return v
@@ -44,7 +44,7 @@ function firstNonEmpty (...candidates) {
   return undefined
 }
 
-function fileExistsSafe (p) {
+function fileExistsSafe(p) {
   if (!p) return false
   try {
     return fs.existsSync(p)
@@ -64,7 +64,7 @@ function fileExistsSafe (p) {
  * @param {string|undefined} modelDir
  * @returns {string|undefined}
  */
-function findSupertonicV3InDir (modelDir) {
+function findSupertonicV3InDir(modelDir) {
   if (!modelDir) return undefined
   let entries
   try {
@@ -96,7 +96,7 @@ function findSupertonicV3InDir (modelDir) {
  *
  * @param {Record<string, unknown>} files
  */
-function normalizeGgmlFiles (files) {
+function normalizeGgmlFiles(files) {
   if (files == null || typeof files !== 'object') {
     return {}
   }
@@ -105,11 +105,7 @@ function normalizeGgmlFiles (files) {
     modelDir: firstNonEmpty(f.modelDir),
     t3Model: firstNonEmpty(f.t3Model, f.t3ModelPath, f.t3),
     s3genModel: firstNonEmpty(f.s3genModel, f.s3genModelPath, f.s3gen),
-    supertonicModel: firstNonEmpty(
-      f.supertonicModel,
-      f.supertonicModelPath,
-      f.supertonic
-    ),
+    supertonicModel: firstNonEmpty(f.supertonicModel, f.supertonicModelPath, f.supertonic),
     voicesDir: firstNonEmpty(f.voicesDir),
     // LavaSR enhancer GGUF: single-file Vocos bandwidth extension, produced by
     // tts-cpp/scripts/convert-lavasr-enhancer-to-gguf.py. One canonical key
@@ -139,14 +135,13 @@ function normalizeGgmlFiles (files) {
  *   4. Default → Chatterbox (turbo or MTL is decided later inside the
  *      Chatterbox path resolver based on which T3 file is present).
  */
-function detectEngineType (engine, normalizedFiles) {
+function detectEngineType(engine, normalizedFiles) {
   if (engine === ENGINE_CHATTERBOX || engine === ENGINE_SUPERTONIC) {
     return engine
   }
   if (engine != null && engine !== '') {
     throw new Error(
-      "tts-ggml: 'engine' option must be 'chatterbox' or 'supertonic' " +
-        "(got '" + engine + "')"
+      "tts-ggml: 'engine' option must be 'chatterbox' or 'supertonic' " + "(got '" + engine + "')"
     )
   }
   if (normalizedFiles.t3Model || normalizedFiles.s3genModel) return ENGINE_CHATTERBOX
@@ -158,8 +153,8 @@ function detectEngineType (engine, normalizedFiles) {
     const supertonicMtl = path.join(normalizedFiles.modelDir, SUPERTONIC_MTL)
     const supertonicV3 = findSupertonicV3InDir(normalizedFiles.modelDir)
     const hasChatterbox = fileExistsSafe(turboT3) || fileExistsSafe(mtlT3)
-    const hasSupertonic = fileExistsSafe(supertonicEn) || fileExistsSafe(supertonicMtl) ||
-      !!supertonicV3
+    const hasSupertonic =
+      fileExistsSafe(supertonicEn) || fileExistsSafe(supertonicMtl) || !!supertonicV3
     if (hasChatterbox) return ENGINE_CHATTERBOX
     if (hasSupertonic) return ENGINE_SUPERTONIC
   }
@@ -173,7 +168,7 @@ function detectEngineType (engine, normalizedFiles) {
  * build when English isn't on disk.  Callers that explicitly want the
  * multilingual variant should pass `files.supertonicModel` directly.
  */
-function resolveSupertonicModelDirPath (modelDir) {
+function resolveSupertonicModelDirPath(modelDir) {
   const supertonicEn = path.join(modelDir, SUPERTONIC_DEFAULT)
   const supertonicMtl = path.join(modelDir, SUPERTONIC_MTL)
   const supertonicV3 = findSupertonicV3InDir(modelDir)
@@ -189,7 +184,7 @@ function resolveSupertonicModelDirPath (modelDir) {
  * the only state where mtl beats turbo at the file-detection layer).
  * Otherwise fall back to the turbo English layout.
  */
-function resolveChatterboxModelDirPaths (modelDir) {
+function resolveChatterboxModelDirPaths(modelDir) {
   const turboT3 = path.join(modelDir, CHATTERBOX_T3_TURBO)
   const mtlT3 = path.join(modelDir, CHATTERBOX_T3_MTL)
   const defaultS3 = path.join(modelDir, CHATTERBOX_S3GEN_DEFAULT)
@@ -212,7 +207,7 @@ function resolveChatterboxModelDirPaths (modelDir) {
  * @param {unknown} textStream
  * @returns {boolean}
  */
-function defaultAccumulateSentencesForStreamInput (textStream) {
+function defaultAccumulateSentencesForStreamInput(textStream) {
   if (textStream == null) return false
   if (typeof textStream === 'string') return false
   if (Array.isArray(textStream)) return false
@@ -220,7 +215,7 @@ function defaultAccumulateSentencesForStreamInput (textStream) {
   return false
 }
 
-function ttsOutputDebugString (data) {
+function ttsOutputDebugString(data) {
   if (!data) return ''
   if (typeof data !== 'object') return data.toString()
   // Skip the heavy fields (outputArray = Int16Array of 24 kHz PCM
@@ -251,7 +246,7 @@ function ttsOutputDebugString (data) {
  * PCM per chunk as it's produced).  See README.md for usage.
  */
 class TTSGgml {
-  constructor (options = {}) {
+  constructor(options = {}) {
     const {
       files: filesInput = {},
       config = {},
@@ -306,16 +301,17 @@ class TTSGgml {
     })
     this._runExclusive = this.exclusiveRun
       ? exclusiveRunQueue()
-      : async function runNow (fn) {
-        return fn()
-      }
+      : async function runNow(fn) {
+          return fn()
+        }
 
     const normalizedFiles = normalizeGgmlFiles(filesInput)
     this._config = { ...config }
 
-    this._lazySessionLoading = lazySessionLoading != null
-      ? lazySessionLoading
-      : (platform() === 'ios' || platform() === 'android')
+    this._lazySessionLoading =
+      lazySessionLoading != null
+        ? lazySessionLoading
+        : platform() === 'ios' || platform() === 'android'
 
     const outputSampleRate = this._config.outputSampleRate
     if (outputSampleRate != null && (outputSampleRate < 8000 || outputSampleRate > 192000)) {
@@ -338,14 +334,8 @@ class TTSGgml {
       const root = normalizedFiles.modelDir
       if (root) {
         const resolved = resolveChatterboxModelDirPaths(root)
-        this._t3ModelPath = firstNonEmpty(
-          normalizedFiles.t3Model,
-          resolved.t3
-        )
-        this._s3genModelPath = firstNonEmpty(
-          normalizedFiles.s3genModel,
-          resolved.s3
-        )
+        this._t3ModelPath = firstNonEmpty(normalizedFiles.t3Model, resolved.t3)
+        this._s3genModelPath = firstNonEmpty(normalizedFiles.s3genModel, resolved.s3)
       } else {
         this._t3ModelPath = normalizedFiles.t3Model
         this._s3genModelPath = normalizedFiles.s3genModel
@@ -357,15 +347,8 @@ class TTSGgml {
     // Accept either a top-level option or a `files.*` entry; the host
     // resolves/stages them (e.g. from the QVAC model registry) and the
     // addon forwards the local paths to tts-cpp.
-    this._mecabDictPath = firstNonEmpty(
-      mecabDictPath,
-      mecabDictDir,
-      normalizedFiles.mecabDictDir
-    )
-    this._cangjieTsvPath = firstNonEmpty(
-      cangjieTsvPath,
-      normalizedFiles.cangjieTsvPath
-    )
+    this._mecabDictPath = firstNonEmpty(mecabDictPath, mecabDictDir, normalizedFiles.mecabDictDir)
+    this._cangjieTsvPath = firstNonEmpty(cangjieTsvPath, normalizedFiles.cangjieTsvPath)
 
     this._referenceAudio = referenceAudio
     this._voiceDir = voiceDir
@@ -388,9 +371,7 @@ class TTSGgml {
     // runtime by choosing whether to pass the path). A provided `enhancer`
     // block must use the supported type so a typo can't silently disable it.
     if (enhancer != null && enhancer.type !== 'lavasr') {
-      throw new Error(
-        `tts-ggml: unknown enhancer.type '${enhancer.type}', expected 'lavasr'.`
-      )
+      throw new Error(`tts-ggml: unknown enhancer.type '${enhancer.type}', expected 'lavasr'.`)
     }
     this._enhancerGgufPath = firstNonEmpty(
       normalizedFiles.lavasrEnhancer,
@@ -407,9 +388,7 @@ class TTSGgml {
     // the ONNX reference); a supplied denoiser path activates at runtime once
     // the pinned tts-cpp version includes #78.
     if (denoiser != null && denoiser.type !== 'lavasr') {
-      throw new Error(
-        `tts-ggml: unknown denoiser.type '${denoiser.type}', expected 'lavasr'.`
-      )
+      throw new Error(`tts-ggml: unknown denoiser.type '${denoiser.type}', expected 'lavasr'.`)
     }
     this._denoiserGgufPath = firstNonEmpty(
       normalizedFiles.lavasrDenoiser,
@@ -424,18 +403,12 @@ class TTSGgml {
       this._config?.backendsDir,
       path.join(__dirname, 'prebuilds')
     )
-    this._openclCacheDir = firstNonEmpty(
-      openclCacheDir,
-      this._config?.openclCacheDir
-    )
+    this._openclCacheDir = firstNonEmpty(openclCacheDir, this._config?.openclCacheDir)
     // Persistent Vulkan pipeline cache dir. Forwarded to the addon, which
     // sets GGML_VK_PIPELINE_CACHE_DIR so the Vulkan backend's first-dispatch
     // pipeline-compile cost is paid once per install instead of once per
     // process. Host-provided (must be app-writable); empty -> no cache.
-    this._vulkanCacheDir = firstNonEmpty(
-      vulkanCacheDir,
-      this._config?.vulkanCacheDir
-    )
+    this._vulkanCacheDir = firstNonEmpty(vulkanCacheDir, this._config?.vulkanCacheDir)
 
     // Run the conflict check before any engine-specific GPU policy so a
     // caller passing { useGPU:false, nGpuLayers:99 } gets the precise
@@ -444,17 +417,17 @@ class TTSGgml {
     // `layers != 0` (rather than `layers > 0`) so a future llama.cpp-
     // style `nGpuLayers: -1` ("offload all layers") doesn't falsely
     // pass through as "wants CPU" against an explicit useGPU:true.
-    if (
-      typeof this._config.useGPU === 'boolean' &&
-      this._nGpuLayers != null
-    ) {
+    if (typeof this._config.useGPU === 'boolean' && this._nGpuLayers != null) {
       const layersWantGpu = this._nGpuLayers !== 0
       if (this._config.useGPU !== layersWantGpu) {
         throw new Error(
-          'tts-ggml: useGPU=' + this._config.useGPU +
-          ' conflicts with nGpuLayers=' + this._nGpuLayers + '. ' +
-          'Either drop one of the two, or make them agree ' +
-          '(useGPU:true + nGpuLayers!=0, or useGPU:false + nGpuLayers=0).'
+          'tts-ggml: useGPU=' +
+            this._config.useGPU +
+            ' conflicts with nGpuLayers=' +
+            this._nGpuLayers +
+            '. ' +
+            'Either drop one of the two, or make them agree ' +
+            '(useGPU:true + nGpuLayers!=0, or useGPU:false + nGpuLayers=0).'
         )
       }
     }
@@ -463,10 +436,10 @@ class TTSGgml {
       if (this._streamChunkTokens != null || this._streamFirstChunkTokens != null) {
         throw new Error(
           'tts-ggml: streamChunkTokens / streamFirstChunkTokens are Chatterbox-only ' +
-          'options (sub-sentence native streaming via the chatterbox::Engine ' +
-          'streaming chunked S3Gen+HiFT loop). Supertonic does not support sub-' +
-          'sentence native streaming; use sentence-level streaming via the engine-' +
-          'agnostic runStream() / runStreaming() / run({ streamOutput: true }) APIs.'
+            'options (sub-sentence native streaming via the chatterbox::Engine ' +
+            'streaming chunked S3Gen+HiFT loop). Supertonic does not support sub-' +
+            'sentence native streaming; use sentence-level streaming via the engine-' +
+            'agnostic runStream() / runStreaming() / run({ streamOutput: true }) APIs.'
         )
       }
     }
@@ -491,9 +464,9 @@ class TTSGgml {
     ) {
       throw new Error(
         'tts-ggml: the LavaSR denoiser is not yet supported with Chatterbox ' +
-        'native chunk streaming (streamChunkTokens / streamFirstChunkTokens). ' +
-        'Use batch synthesis, or drop the denoiser for streaming. Streaming ' +
-        'denoise is a planned follow-up (needs a stateful streaming denoiser).'
+          'native chunk streaming (streamChunkTokens / streamFirstChunkTokens). ' +
+          'Use batch synthesis, or drop the denoiser for streaming. Streaming ' +
+          'denoise is a planned follow-up (needs a stateful streaming denoiser).'
       )
     }
 
@@ -507,23 +480,21 @@ class TTSGgml {
     }
   }
 
-  getEngineType () {
+  getEngineType() {
     return this._engineType
   }
 
-  getApiDefinition () {
+  getApiDefinition() {
     const api = inferGetApiDefinition()
-    this.logger.debug(
-      `Using API definition: ${api} for platform: ${platform()}`
-    )
+    this.logger.debug(`Using API definition: ${api} for platform: ${platform()}`)
     return api
   }
 
-  getState () {
+  getState() {
     return this.state
   }
 
-  async load (..._args) {
+  async load(..._args) {
     if (this.state.destroyed) {
       throw new QvacErrorAddonTTSGgml({
         code: ERR_CODES.FAILED_TO_LOAD,
@@ -550,7 +521,7 @@ class TTSGgml {
    * @param {string} [input.locale] - BCP-47 locale for chunking when `streamOutput`
    * @param {number} [input.maxChunkScalars] - Max graphemes per chunk when `streamOutput`
    */
-  async run (input) {
+  async run(input) {
     if (input && typeof input === 'object' && input.streamOutput === true) {
       if (typeof input.input !== 'string' || input.input.trim().length === 0) {
         throw new QvacErrorAddonTTSGgml({
@@ -575,10 +546,10 @@ class TTSGgml {
   /**
    * Serialize streaming runs until the returned {@link QvacResponse} settles.
    */
-  async _enqueueExclusiveTtsResponse (runFn) {
+  async _enqueueExclusiveTtsResponse(runFn) {
     const prev = this._ttsInferenceQueueWaiter || Promise.resolve()
     let releaseSlot
-    this._ttsInferenceQueueWaiter = new Promise(resolve => {
+    this._ttsInferenceQueueWaiter = new Promise((resolve) => {
       releaseSlot = resolve
     })
     await prev
@@ -589,7 +560,12 @@ class TTSGgml {
       releaseSlot()
       throw err
     }
-    response.await().finally(() => { releaseSlot() }).catch(() => {})
+    response
+      .await()
+      .finally(() => {
+        releaseSlot()
+      })
+      .catch(() => {})
     return response
   }
 
@@ -601,7 +577,7 @@ class TTSGgml {
    * @param {string} text
    * @param {{ locale?: string, maxChunkScalars?: number }} [options]
    */
-  async runStream (text, options = {}) {
+  async runStream(text, options = {}) {
     const opts = options == null || typeof options !== 'object' ? {} : options
     return this.run({
       input: text,
@@ -630,7 +606,7 @@ class TTSGgml {
    * @param {number} [options.maxBufferScalars] - Max graphemes before hard flush (default by language).
    * @param {number} [options.flushAfterMs] - Idle flush after last fragment (default 500).
    */
-  async runStreaming (textStream, options = {}) {
+  async runStreaming(textStream, options = {}) {
     const streamOpts = this._resolveRunStreamingOptions(textStream, options)
     let normalized = this._normalizeTextStream(textStream)
     if (streamOpts.accumulateSentences) {
@@ -650,7 +626,7 @@ class TTSGgml {
     return this._runTextStreamOrchestrator(normalized)
   }
 
-  _resolveRunStreamingOptions (textStream, options) {
+  _resolveRunStreamingOptions(textStream, options) {
     const o = options == null || typeof options !== 'object' ? {} : options
     let accumulateSentences = o.accumulateSentences
     if (accumulateSentences === undefined) {
@@ -674,7 +650,7 @@ class TTSGgml {
     }
   }
 
-  _normalizeTextStream (textStream) {
+  _normalizeTextStream(textStream) {
     if (textStream == null) {
       throw new QvacErrorAddonTTSGgml({
         code: ERR_CODES.FAILED_TO_APPEND,
@@ -682,7 +658,7 @@ class TTSGgml {
       })
     }
     if (typeof textStream === 'string') {
-      async function * oneString () {
+      async function* oneString() {
         yield textStream
       }
       return oneString()
@@ -691,7 +667,7 @@ class TTSGgml {
       return textStream
     }
     if (Array.isArray(textStream)) {
-      async function * fromArray () {
+      async function* fromArray() {
         for (let i = 0; i < textStream.length; i++) {
           yield textStream[i]
         }
@@ -699,7 +675,7 @@ class TTSGgml {
       return fromArray()
     }
     if (typeof textStream[Symbol.iterator] === 'function') {
-      async function * fromIterable () {
+      async function* fromIterable() {
         for (const x of textStream) {
           yield x
         }
@@ -712,7 +688,7 @@ class TTSGgml {
     })
   }
 
-  _runTextStreamOrchestrator (asyncTextSource) {
+  _runTextStreamOrchestrator(asyncTextSource) {
     const response = this._job.start()
     this._sentenceStreamCtx = {
       textStreamMode: true,
@@ -740,7 +716,7 @@ class TTSGgml {
     return response
   }
 
-  async _sentenceStreamTextIterableDrive () {
+  async _sentenceStreamTextIterableDrive() {
     const ctx = this._sentenceStreamCtx
     if (!ctx || !ctx.textStreamMode) return
     try {
@@ -802,7 +778,7 @@ class TTSGgml {
     }
   }
 
-  _runStreamOrchestrator (text, options) {
+  _runStreamOrchestrator(text, options) {
     const chunks = splitTtsText(String(text), {
       language: this._config?.language,
       locale: options.locale,
@@ -840,7 +816,7 @@ class TTSGgml {
     return response
   }
 
-  async _sentenceStreamDriveBody () {
+  async _sentenceStreamDriveBody() {
     const ctx = this._sentenceStreamCtx
     if (!ctx || ctx.textStreamMode) return
     for (let i = 0; i < ctx.chunks.length; i++) {
@@ -857,7 +833,7 @@ class TTSGgml {
     this._sentenceStreamCtx = null
   }
 
-  async _load () {
+  async _load() {
     this.logger.info('[TTSGgml] Language:', this._config?.language || 'en')
 
     const ttsParams = this._buildTtsParams()
@@ -867,20 +843,22 @@ class TTSGgml {
     try {
       await addon.activate()
     } catch (err) {
-      try { await addon.destroyInstance() } catch (_e) {}
+      try {
+        await addon.destroyInstance()
+      } catch (_e) {}
       if (this.addon === addon) this.addon = null
       throw err
     }
   }
 
-  _buildTtsParams () {
+  _buildTtsParams() {
     if (this._engineType === ENGINE_SUPERTONIC) {
       return this._buildSupertonicParams()
     }
     return this._buildChatterboxParams()
   }
 
-  _buildChatterboxParams () {
+  _buildChatterboxParams() {
     const params = {
       engineType: ENGINE_CHATTERBOX,
       t3ModelPath: this._t3ModelPath || '',
@@ -927,7 +905,7 @@ class TTSGgml {
     return params
   }
 
-  _buildSupertonicParams () {
+  _buildSupertonicParams() {
     const params = {
       engineType: ENGINE_SUPERTONIC,
       supertonicModelPath: this._supertonicModelPath || '',
@@ -964,12 +942,12 @@ class TTSGgml {
    * @param {Function} outputCb
    * @returns {TTSInterface}
    */
-  _createAddon (configurationParams, outputCb) {
+  _createAddon(configurationParams, outputCb) {
     const binding = require('./binding')
     return new TTSInterface(binding, configurationParams, outputCb)
   }
 
-  async unload () {
+  async unload() {
     await this.cancel()
     this._failAndClearActiveResponse('Model was unloaded')
     if (this.addon) {
@@ -979,12 +957,12 @@ class TTSGgml {
     this.state.weightsLoaded = false
   }
 
-  async destroy () {
+  async destroy() {
     await this.unload()
     this.state.destroyed = true
   }
 
-  async _runInternal (input) {
+  async _runInternal(input) {
     const response = this._job.start()
     try {
       // Per-request overrides (e.g. input.outputSampleRate) are not
@@ -1005,7 +983,7 @@ class TTSGgml {
     return response
   }
 
-  _mergeSentenceStreamStats (acc, data) {
+  _mergeSentenceStreamStats(acc, data) {
     const t = typeof data.totalTime === 'number' ? data.totalTime : 0
     const a = typeof data.audioDurationMs === 'number' ? data.audioDurationMs : 0
     const s = typeof data.totalSamples === 'number' ? data.totalSamples : 0
@@ -1014,7 +992,7 @@ class TTSGgml {
     acc.totalSamples += s
   }
 
-  _addonOutputCallback (addon, event, data, error) {
+  _addonOutputCallback(addon, event, data, error) {
     if (typeof error === 'string' && error.length > 0) {
       this.logger.error(`TTS job failed with error: ${error}`)
       if (this._sentenceStreamCtx && this._sentenceStreamCtx.chunkResolver) {
@@ -1076,12 +1054,9 @@ class TTSGgml {
         if (isLast) {
           const totalChars = ctx.chunks.join('').length
           const merged = { ...ctx.acc }
-          merged.tokensPerSecond =
-            ctx.acc.totalTime > 0 ? totalChars / ctx.acc.totalTime : 0
+          merged.tokensPerSecond = ctx.acc.totalTime > 0 ? totalChars / ctx.acc.totalTime : 0
           merged.realTimeFactor =
-            ctx.acc.audioDurationMs > 0
-              ? (ctx.acc.totalTime * 1000.0) / ctx.acc.audioDurationMs
-              : 0
+            ctx.acc.audioDurationMs > 0 ? (ctx.acc.totalTime * 1000.0) / ctx.acc.audioDurationMs : 0
           if (this.opts?.stats) {
             this._job.end(merged)
           } else {
@@ -1101,13 +1076,13 @@ class TTSGgml {
     this.logger.debug(`Received TTS event: ${event}`)
   }
 
-  async cancel () {
+  async cancel() {
     if (this.addon?.cancel) {
       await this.addon.cancel()
     }
   }
 
-  _failAndClearActiveResponse (reason) {
+  _failAndClearActiveResponse(reason) {
     if (this._sentenceStreamCtx && this._sentenceStreamCtx.chunkResolver) {
       this._sentenceStreamCtx.chunkResolver.reject(
         reason instanceof Error ? reason : new Error(String(reason))
@@ -1125,12 +1100,13 @@ class TTSGgml {
    * @param {boolean} [newConfig.useGPU]
    * @param {number} [newConfig.outputSampleRate]
    */
-  async reload (newConfig = {}) {
+  async reload(newConfig = {}) {
     this.logger.debug('Reloading addon with new configuration', newConfig)
 
     if (newConfig.language !== undefined) this._config.language = newConfig.language
     if (newConfig.useGPU !== undefined) this._config.useGPU = newConfig.useGPU
-    if (newConfig.outputSampleRate !== undefined) this._outputSampleRate = newConfig.outputSampleRate
+    if (newConfig.outputSampleRate !== undefined)
+      this._outputSampleRate = newConfig.outputSampleRate
 
     const ttsParams = this._buildTtsParams()
 
@@ -1148,7 +1124,7 @@ class TTSGgml {
     noAdditionalDownload: true
   }
 
-  static getModelKey (params) {
+  static getModelKey(params) {
     return 'tts-ggml'
   }
 

--- a/packages/tts-ggml/lib/error.js
+++ b/packages/tts-ggml/lib/error.js
@@ -2,7 +2,7 @@
 
 const { QvacErrorBase, addCodes } = require('@qvac/error')
 
-class QvacErrorAddonTTSGgml extends QvacErrorBase { }
+class QvacErrorAddonTTSGgml extends QvacErrorBase {}
 
 const { name, version } = require('../package.json')
 
@@ -32,55 +32,58 @@ const ERR_CODES = Object.freeze({
   JOB_ALREADY_RUNNING: 13011
 })
 
-addCodes({
-  [ERR_CODES.FAILED_TO_ACTIVATE]: {
-    name: 'FAILED_TO_ACTIVATE',
-    message: (message) => `Failed to activate model, error: ${message}`
+addCodes(
+  {
+    [ERR_CODES.FAILED_TO_ACTIVATE]: {
+      name: 'FAILED_TO_ACTIVATE',
+      message: (message) => `Failed to activate model, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_APPEND]: {
+      name: 'FAILED_TO_APPEND',
+      message: (message) => `Failed to append data to processing queue, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_GET_STATUS]: {
+      name: 'FAILED_TO_GET_STATUS',
+      message: (message) => `Failed to get addon status, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_PAUSE]: {
+      name: 'FAILED_TO_PAUSE',
+      message: (message) => `Failed to pause inference, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_CANCEL]: {
+      name: 'FAILED_TO_CANCEL',
+      message: (message) => `Failed to cancel inference, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_DESTROY]: {
+      name: 'FAILED_TO_DESTROY',
+      message: (message) => `Failed to destroy instance, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_UNLOAD]: {
+      name: 'FAILED_TO_UNLOAD',
+      message: (message) => `Failed to unload model, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_LOAD]: {
+      name: 'FAILED_TO_LOAD',
+      message: (message) => `Failed to load model, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_RELOAD]: {
+      name: 'FAILED_TO_RELOAD',
+      message: (message) => `Failed to reload model, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_STOP]: {
+      name: 'FAILED_TO_STOP',
+      message: (message) => `Failed to stop inference, error: ${message}`
+    },
+    [ERR_CODES.JOB_ALREADY_RUNNING]: {
+      name: 'JOB_ALREADY_RUNNING',
+      message: () => 'Cannot set new job: a job is already set or being processed'
+    }
   },
-  [ERR_CODES.FAILED_TO_APPEND]: {
-    name: 'FAILED_TO_APPEND',
-    message: (message) => `Failed to append data to processing queue, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_GET_STATUS]: {
-    name: 'FAILED_TO_GET_STATUS',
-    message: (message) => `Failed to get addon status, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_PAUSE]: {
-    name: 'FAILED_TO_PAUSE',
-    message: (message) => `Failed to pause inference, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_CANCEL]: {
-    name: 'FAILED_TO_CANCEL',
-    message: (message) => `Failed to cancel inference, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_DESTROY]: {
-    name: 'FAILED_TO_DESTROY',
-    message: (message) => `Failed to destroy instance, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_UNLOAD]: {
-    name: 'FAILED_TO_UNLOAD',
-    message: (message) => `Failed to unload model, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_LOAD]: {
-    name: 'FAILED_TO_LOAD',
-    message: (message) => `Failed to load model, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_RELOAD]: {
-    name: 'FAILED_TO_RELOAD',
-    message: (message) => `Failed to reload model, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_STOP]: {
-    name: 'FAILED_TO_STOP',
-    message: (message) => `Failed to stop inference, error: ${message}`
-  },
-  [ERR_CODES.JOB_ALREADY_RUNNING]: {
-    name: 'JOB_ALREADY_RUNNING',
-    message: () => 'Cannot set new job: a job is already set or being processed'
+  {
+    name,
+    version
   }
-}, {
-  name,
-  version
-})
+)
 
 module.exports = {
   ERR_CODES,

--- a/packages/tts-ggml/lib/textChunker.js
+++ b/packages/tts-ggml/lib/textChunker.js
@@ -13,11 +13,8 @@
  * should always use {@link splitTtsText} which falls back to punctuation
  * and max-length chunking.
  */
-function intlSentenceSegmentationAvailable () {
-  return (
-    typeof Intl !== 'undefined' &&
-    typeof Intl.Segmenter === 'function'
-  )
+function intlSentenceSegmentationAvailable() {
+  return typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
 }
 
 /**
@@ -25,7 +22,7 @@ function intlSentenceSegmentationAvailable () {
  * @param {string} [locale]
  * @returns {string[]|null}
  */
-function splitByIntlSentences (text, locale) {
+function splitByIntlSentences(text, locale) {
   if (!intlSentenceSegmentationAvailable()) return null
   const trimmed = text.trim()
   if (!trimmed) return null
@@ -49,7 +46,7 @@ const SENTENCE_TERMINATORS = /([.!?。！？؟])(\s*)/gu
  * @param {string} text
  * @returns {string[]}
  */
-function splitByAsciiAndCjkPunctuation (text) {
+function splitByAsciiAndCjkPunctuation(text) {
   const parts = []
   let lastIndex = 0
   let m
@@ -68,8 +65,11 @@ function splitByAsciiAndCjkPunctuation (text) {
  * @param {string} text
  * @returns {string[]}
  */
-function splitByParagraphs (text) {
-  return text.split(/\n\s*\n/).map(p => p.trim()).filter(p => p.length > 0)
+function splitByParagraphs(text) {
+  return text
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
 }
 
 const MIN_CHUNK_GRAPHEMES = 10
@@ -78,7 +78,7 @@ const MIN_CHUNK_GRAPHEMES = 10
  * @param {string[]} chunks
  * @returns {string[]}
  */
-function mergeShortChunks (chunks) {
+function mergeShortChunks(chunks) {
   const merged = []
   let buffer = ''
 
@@ -108,7 +108,7 @@ function mergeShortChunks (chunks) {
  * @param {string} s
  * @returns {number}
  */
-function countScalars (s) {
+function countScalars(s) {
   return [...s].length
 }
 
@@ -117,7 +117,7 @@ function countScalars (s) {
  * @param {number} maxScalars
  * @returns {string[]}
  */
-function hardSplitByMaxScalars (text, maxScalars) {
+function hardSplitByMaxScalars(text, maxScalars) {
   if (maxScalars < 10) maxScalars = 10
   const g = [...text]
   if (g.length <= maxScalars) return [text]
@@ -137,7 +137,7 @@ function hardSplitByMaxScalars (text, maxScalars) {
  * @param {number} maxScalars
  * @returns {string[]}
  */
-function mergeUpToMaxScalars (pieces, maxScalars) {
+function mergeUpToMaxScalars(pieces, maxScalars) {
   const out = []
   let current = ''
 
@@ -157,7 +157,7 @@ function mergeUpToMaxScalars (pieces, maxScalars) {
   if (current.length > 0) {
     out.push(...hardSplitByMaxScalars(current, maxScalars))
   }
-  return out.filter(s => s.trim().length > 0)
+  return out.filter((s) => s.trim().length > 0)
 }
 
 /**
@@ -172,15 +172,10 @@ function mergeUpToMaxScalars (pieces, maxScalars) {
  *   mergeUpToMaxScalars pass). Default true. Useful for test harnesses that synthesize per sentence.
  * @returns {string[]}
  */
-function splitTtsText (text, options = {}) {
+function splitTtsText(text, options = {}) {
   const mergeToMaxScalars = options.mergeToMaxScalars !== false
   const language = (options.language || 'en').toLowerCase()
-  const maxScalars =
-    options.maxScalars != null
-      ? options.maxScalars
-      : language === 'ko'
-        ? 120
-        : 300
+  const maxScalars = options.maxScalars != null ? options.maxScalars : language === 'ko' ? 120 : 300
 
   const raw = text.trim()
   if (!raw) return []

--- a/packages/tts-ggml/lib/textStreamAccumulator.js
+++ b/packages/tts-ggml/lib/textStreamAccumulator.js
@@ -7,7 +7,7 @@ const { countScalars } = require('./textChunker')
  * @param {number} n
  * @returns {{ head: string, rest: string }}
  */
-function splitGraphemeHead (s, n) {
+function splitGraphemeHead(s, n) {
   const g = [...s]
   if (g.length <= n) {
     return { head: s, rest: '' }
@@ -22,10 +22,10 @@ function splitGraphemeHead (s, n) {
  * @param {{ sentenceDelimiter?: RegExp, sentenceDelimiterPreset?: string }} opts
  * @returns {(buffer: string) => boolean}
  */
-function buildSentenceEndTester (opts) {
+function buildSentenceEndTester(opts) {
   if (opts.sentenceDelimiter instanceof RegExp) {
     const re = opts.sentenceDelimiter
-    return function testCustom (buffer) {
+    return function testCustom(buffer) {
       re.lastIndex = 0
       return re.test(buffer)
     }
@@ -37,7 +37,7 @@ function buildSentenceEndTester (opts) {
     multilingual: /(?:[.!?…؟]|[。！？…])\s*$/u
   }
   const re = patterns[preset] || patterns.multilingual
-  return function testPreset (buffer) {
+  return function testPreset(buffer) {
     return re.test(buffer)
   }
 }
@@ -46,7 +46,7 @@ function buildSentenceEndTester (opts) {
  * Default `maxBufferScalars` aligned with `splitTtsText` when `maxScalars` is unset.
  * @param {string} [language]
  */
-function defaultMaxBufferScalars (language) {
+function defaultMaxBufferScalars(language) {
   const lang = (language || 'en').toLowerCase()
   return lang === 'ko' ? 120 : 300
 }
@@ -65,7 +65,7 @@ function defaultMaxBufferScalars (language) {
  * @param {number} [opts.flushAfterMs]
  * @returns {AsyncGenerator<string, void, void>}
  */
-async function * accumulateTextStream (source, opts) {
+async function* accumulateTextStream(source, opts) {
   const flushAfterMs = opts.flushAfterMs != null ? opts.flushAfterMs : 500
   const defaultMax = defaultMaxBufferScalars(opts.language)
   let maxScalars
@@ -80,7 +80,7 @@ async function * accumulateTextStream (source, opts) {
   const queue = []
   let notify = null
 
-  function push (item) {
+  function push(item) {
     queue.push(item)
     if (notify) {
       const n = notify
@@ -89,18 +89,18 @@ async function * accumulateTextStream (source, opts) {
     }
   }
 
-  ;(async function pump () {
+  ;(async function pump() {
     let buffer = ''
     let idleTimer = null
 
-    function clearIdle () {
+    function clearIdle() {
       if (idleTimer) {
         clearTimeout(idleTimer)
         idleTimer = null
       }
     }
 
-    function armIdle () {
+    function armIdle() {
       clearIdle()
       idleTimer = setTimeout(() => {
         idleTimer = null
@@ -150,7 +150,7 @@ async function * accumulateTextStream (source, opts) {
 
   while (true) {
     while (queue.length === 0) {
-      await new Promise(resolve => {
+      await new Promise((resolve) => {
         notify = resolve
       })
     }

--- a/packages/tts-ggml/test/benchmark/rtf-benchmark.test.js
+++ b/packages/tts-ggml/test/benchmark/rtf-benchmark.test.js
@@ -82,18 +82,20 @@ const isMobile = platform === 'ios' || platform === 'android'
 let _hwDevice = null
 try {
   let _subprocess = null
-  try { _subprocess = require('bare-subprocess') } catch (_) {}
+  try {
+    _subprocess = require('bare-subprocess')
+  } catch (_) {}
   const _perfBase = path.join('..', '..', '..', '..', 'scripts', 'test-utils')
   const _perfMod = require(path.join(_perfBase, 'performance-reporter'))
   _perfMod.configure({ fs, path, process, os, subprocess: _subprocess })
   _hwDevice = _perfMod.detectDevice()
 } catch (_) {}
 
-function _hwGpu () {
+function _hwGpu() {
   return _hwDevice && _hwDevice.gpu ? _hwDevice.gpu : null
 }
 
-function _hwCpu () {
+function _hwCpu() {
   return _hwDevice && _hwDevice.cpu ? _hwDevice.cpu : null
 }
 
@@ -103,7 +105,7 @@ function _hwCpu () {
 // [PERF_REPORT_START]<json>[PERF_REPORT_END] markers carrying this shape.
 // Schema must satisfy isValidReport() in extract-from-log.js (string
 // schema_version + results array).
-function buildCanonicalReport (settings, summary, backend) {
+function buildCanonicalReport(settings, summary, backend) {
   const useGPU = !!settings.useGPU
   const ep = useGPU ? 'gpu' : 'cpu'
   const engine = settings.engine
@@ -128,44 +130,51 @@ function buildCanonicalReport (settings, summary, backend) {
       cpu: _hwCpu(),
       runner: settings.runnerLabel || (isMobile ? 'device-farm' : 'github-actions')
     },
-    results: [{
-      test: testLabel,
-      execution_provider: ep,
-      metrics: {
-        real_time_factor: typeof rtf.mean === 'number' ? rtf.mean : null,
-        rtf_p50: typeof rtf.p50 === 'number' ? rtf.p50 : null,
-        rtf_p95: typeof rtf.p95 === 'number' ? rtf.p95 : null,
-        wall_time_ms: typeof wallMs.mean === 'number' ? Math.round(wallMs.mean) : null,
-        cold_rtf: typeof summary.coldRtf === 'number' ? summary.coldRtf : null,
-        model_load_ms: typeof summary.modelLoadMs === 'number' ? Math.round(summary.modelLoadMs) : null,
-        tps: typeof tps.mean === 'number' ? tps.mean : null,
-        sample_count: typeof rtf.count === 'number' ? rtf.count : null
+    results: [
+      {
+        test: testLabel,
+        execution_provider: ep,
+        metrics: {
+          real_time_factor: typeof rtf.mean === 'number' ? rtf.mean : null,
+          rtf_p50: typeof rtf.p50 === 'number' ? rtf.p50 : null,
+          rtf_p95: typeof rtf.p95 === 'number' ? rtf.p95 : null,
+          wall_time_ms: typeof wallMs.mean === 'number' ? Math.round(wallMs.mean) : null,
+          cold_rtf: typeof summary.coldRtf === 'number' ? summary.coldRtf : null,
+          model_load_ms:
+            typeof summary.modelLoadMs === 'number' ? Math.round(summary.modelLoadMs) : null,
+          tps: typeof tps.mean === 'number' ? tps.mean : null,
+          sample_count: typeof rtf.count === 'number' ? rtf.count : null
+        }
       }
-    }]
+    ]
   }
 }
 
-function getEnv (name) {
+function getEnv(name) {
   if (typeof os.getEnv === 'function') {
-    try { return os.getEnv(name) || '' } catch (_) { return '' }
+    try {
+      return os.getEnv(name) || ''
+    } catch (_) {
+      return ''
+    }
   }
   return (process.env && process.env[name]) || ''
 }
 
-function getEnvBoolean (name, fallback) {
+function getEnvBoolean(name, fallback) {
   const value = getEnv(name)
   if (value === undefined || value === '') return fallback
   return value === '1' || value.toLowerCase() === 'true' || value.toLowerCase() === 'yes'
 }
 
-function getEnvInteger (name, fallback) {
+function getEnvInteger(name, fallback) {
   const value = getEnv(name)
   if (value === undefined || value === '') return fallback
   const parsed = Number.parseInt(value, 10)
   return Number.isNaN(parsed) ? fallback : parsed
 }
 
-function sanitizeTag (value) {
+function sanitizeTag(value) {
   if (!value) return ''
   return String(value)
     .toLowerCase()
@@ -173,7 +182,7 @@ function sanitizeTag (value) {
     .replace(/^-+|-+$/g, '')
 }
 
-function getSettings () {
+function getSettings() {
   const engine = (getEnv('QVAC_TTS_GGML_BENCHMARK_ENGINE') || 'chatterbox').toLowerCase()
   if (!VALID_ENGINES.includes(engine)) {
     throw new Error(`Invalid benchmark engine: ${engine}. Valid: ${VALID_ENGINES.join(', ')}`)
@@ -186,7 +195,8 @@ function getSettings () {
 
   const numThreadsRaw = getEnv('QVAC_TTS_GGML_BENCHMARK_NUM_THREADS') || ''
   const numThreadsParsed = Number.parseInt(numThreadsRaw, 10)
-  const numThreads = Number.isFinite(numThreadsParsed) && numThreadsParsed > 0 ? numThreadsParsed : undefined
+  const numThreads =
+    Number.isFinite(numThreadsParsed) && numThreadsParsed > 0 ? numThreadsParsed : undefined
 
   return {
     engine,
@@ -216,7 +226,7 @@ function getSettings () {
 // Vulkan + OpenCL on android (see test/integration/gpu-smoke.test.js). There is
 // no CUDA in the default backend cascade today, so CUDA only appears here when
 // it is explicitly requested via the backend hint on a CUDA-capable runner.
-function resolveBackend (platformName, useGPU, backendHint) {
+function resolveBackend(platformName, useGPU, backendHint) {
   const hint = String(backendHint || '').toLowerCase()
   if (hint) return hint
   if (!useGPU) return 'cpu'
@@ -226,7 +236,7 @@ function resolveBackend (platformName, useGPU, backendHint) {
   return 'gpu'
 }
 
-function getArtifactFileName (settings) {
+function getArtifactFileName(settings) {
   const parts = [
     'rtf-benchmark',
     platformArch,
@@ -238,12 +248,12 @@ function getArtifactFileName (settings) {
   return `${parts.join('-')}.json`
 }
 
-function nowMs () {
+function nowMs() {
   const [sec, nsec] = process.hrtime()
   return sec * 1000 + nsec / 1e6
 }
 
-function percentile (sorted, p) {
+function percentile(sorted, p) {
   if (sorted.length === 0) return 0
   const idx = (p / 100) * (sorted.length - 1)
   const lo = Math.floor(idx)
@@ -252,7 +262,7 @@ function percentile (sorted, p) {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo)
 }
 
-function computeStats (values) {
+function computeStats(values) {
   if (values.length === 0) {
     return { mean: 0, min: 0, max: 0, stddev: 0, p50: 0, p95: 0, count: 0 }
   }
@@ -271,33 +281,46 @@ function computeStats (values) {
   }
 }
 
-function getRssBytes () {
+function getRssBytes() {
   if (process && typeof process.memoryUsage === 'function') {
-    try { return process.memoryUsage().rss || 0 } catch (_) { return 0 }
+    try {
+      return process.memoryUsage().rss || 0
+    } catch (_) {
+      return 0
+    }
   }
   return 0
 }
 
-function collectFilesSizeBytes (files) {
+function collectFilesSizeBytes(files) {
   let total = 0
   for (const file of files || []) {
     try {
       const stat = fs.statSync(file)
       if (stat.isFile()) total += Number(stat.size) || 0
-    } catch (_) { /* file may be absent on a soft-skip path */ }
+    } catch (_) {
+      /* file may be absent on a soft-skip path */
+    }
   }
   return total
 }
 
-function backendIdToName (id) {
+function backendIdToName(id) {
   switch (id) {
-    case 0: return 'cpu'
-    case 1: return 'metal'
-    case 2: return 'cuda'
-    case 3: return 'vulkan'
-    case 4: return 'opencl'
-    case 99: return 'other-gpu'
-    default: return ''
+    case 0:
+      return 'cpu'
+    case 1:
+      return 'metal'
+    case 2:
+      return 'cuda'
+    case 3:
+      return 'vulkan'
+    case 4:
+      return 'opencl'
+    case 99:
+      return 'other-gpu'
+    default:
+      return ''
   }
 }
 
@@ -319,19 +342,19 @@ const CORPUS_ES = [
   'Los avances en tecnologia continuan mejorando la calidad de vida de las personas en todo el mundo.'
 ]
 
-function isMultilingualEngine (engine) {
+function isMultilingualEngine(engine) {
   return engine === 'chatterbox-mtl' || engine === 'supertonic-mtl'
 }
 
-function getCorpus (engine) {
+function getCorpus(engine) {
   return isMultilingualEngine(engine) ? CORPUS_ES : CORPUS_EN
 }
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
-async function loadModelForEngine (settings) {
+async function loadModelForEngine(settings) {
   const baseDir = getBaseDir()
   const modelsDir = path.join(baseDir, 'models')
   const threadOpts = settings.numThreads !== undefined ? { threads: settings.numThreads } : {}
@@ -357,7 +380,8 @@ async function loadModelForEngine (settings) {
 
   if (settings.engine === 'chatterbox-mtl') {
     const download = await ensureChatterboxMtlModels({ targetDir: modelsDir })
-    if (!download.success) throw new Error('Chatterbox MTL GGUFs unavailable (registry fetch failed)')
+    if (!download.success)
+      throw new Error('Chatterbox MTL GGUFs unavailable (registry fetch failed)')
     const dir = download.targetDir || modelsDir
     const model = await loadChatterboxTTS({
       modelDir: dir,
@@ -378,8 +402,10 @@ async function loadModelForEngine (settings) {
 
   if (settings.engine === 'supertonic-mtl') {
     const download = await ensureSupertonicMtlModel({ targetDir: modelsDir })
-    if (!download || !download.success) throw new Error('Supertonic MTL GGUF unavailable (registry fetch failed)')
-    const supertonicPath = download.path || path.join(download.targetDir || modelsDir, 'supertonic2.gguf')
+    if (!download || !download.success)
+      throw new Error('Supertonic MTL GGUF unavailable (registry fetch failed)')
+    const supertonicPath =
+      download.path || path.join(download.targetDir || modelsDir, 'supertonic2.gguf')
     const model = await loadSupertonicTTS({
       supertonicModelPath: supertonicPath,
       voice: 'F1',
@@ -391,8 +417,10 @@ async function loadModelForEngine (settings) {
   }
 
   const download = await ensureSupertonicModel({ targetDir: modelsDir })
-  if (!download || !download.success) throw new Error('Supertonic GGUF unavailable (registry fetch failed)')
-  const supertonicPath = download.path || path.join(download.targetDir || modelsDir, 'supertonic.gguf')
+  if (!download || !download.success)
+    throw new Error('Supertonic GGUF unavailable (registry fetch failed)')
+  const supertonicPath =
+    download.path || path.join(download.targetDir || modelsDir, 'supertonic.gguf')
   const model = await loadSupertonicTTS({
     supertonicModelPath: supertonicPath,
     voice: 'F1',
@@ -403,12 +431,13 @@ async function loadModelForEngine (settings) {
   return { model, modelFiles: [supertonicPath] }
 }
 
-async function runSynthesis (engine, model, text) {
-  const runner = (engine === 'supertonic' || engine === 'supertonic-mtl') ? runSupertonicTTS : runChatterboxTTS
+async function runSynthesis(engine, model, text) {
+  const runner =
+    engine === 'supertonic' || engine === 'supertonic-mtl' ? runSupertonicTTS : runChatterboxTTS
   return runner(model, { text }, {})
 }
 
-function getUpperBound (settings) {
+function getUpperBound(settings) {
   if (!settings.requestedUpperBound) return null
   const parsed = Number.parseFloat(settings.requestedUpperBound)
   return Number.isNaN(parsed) ? null : parsed
@@ -436,7 +465,9 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
   console.log(`  Measured runs:  ${settings.numRuns}`)
   console.log(`  Corpus:         ${corpus.length} sentence(s)`)
   if (settings.correlation.githubRunId) {
-    console.log(`  GitHub run:     ${settings.correlation.githubWorkflow || ''} #${settings.correlation.githubRunId}`)
+    console.log(
+      `  GitHub run:     ${settings.correlation.githubWorkflow || ''} #${settings.correlation.githubRunId}`
+    )
   }
   console.log('='.repeat(70) + '\n')
 
@@ -456,7 +487,9 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
   const loadMs = nowMs() - loadStart
   const rssAfterLoad = getRssBytes()
   const modelSizeBytes = collectFilesSizeBytes(modelFiles)
-  console.log(`Model loaded in ${loadMs.toFixed(0)}ms (rss +${((rssAfterLoad - rssBeforeLoad) / 1024 / 1024).toFixed(1)}MB, model ${(modelSizeBytes / 1024 / 1024).toFixed(1)}MB on disk)\n`)
+  console.log(
+    `Model loaded in ${loadMs.toFixed(0)}ms (rss +${((rssAfterLoad - rssBeforeLoad) / 1024 / 1024).toFixed(1)}MB, model ${(modelSizeBytes / 1024 / 1024).toFixed(1)}MB on disk)\n`
+  )
 
   const runs = []
   const warmupRuns = []
@@ -476,8 +509,11 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
       const stats = result.data && result.data.stats
       const durationMs = (result.data && result.data.durationMs) || 0
       const rtfFromStats = stats && stats.realTimeFactor
-      const rtfFromWall = durationMs > 0 ? (wallMs / 1000) / (durationMs / 1000) : 0
-      const rtf = (rtfFromStats !== undefined && rtfFromStats !== null && rtfFromStats > 0) ? rtfFromStats : rtfFromWall
+      const rtfFromWall = durationMs > 0 ? wallMs / 1000 / (durationMs / 1000) : 0
+      const rtf =
+        rtfFromStats !== undefined && rtfFromStats !== null && rtfFromStats > 0
+          ? rtfFromStats
+          : rtfFromWall
 
       const currentRss = getRssBytes()
       if (currentRss > peakRssBytes) peakRssBytes = currentRss
@@ -492,7 +528,9 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
     }
 
     // --- Measured runs ---
-    console.log(`\nRunning ${settings.numRuns} measured iteration(s) over ${corpus.length} sentence(s)...\n`)
+    console.log(
+      `\nRunning ${settings.numRuns} measured iteration(s) over ${corpus.length} sentence(s)...\n`
+    )
     for (let i = 0; i < settings.numRuns; i++) {
       const text = corpus[i % corpus.length]
       const runStart = nowMs()
@@ -511,8 +549,11 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
       const durationMs = result.data ? result.data.durationMs : 0
       const sampleCount = result.data ? result.data.sampleCount : 0
       const rtfFromStats = stats.realTimeFactor
-      const rtfFromWall = durationMs > 0 ? (wallMs / 1000) / (durationMs / 1000) : 0
-      const rtf = (rtfFromStats !== undefined && rtfFromStats !== null && rtfFromStats > 0) ? rtfFromStats : rtfFromWall
+      const rtfFromWall = durationMs > 0 ? wallMs / 1000 / (durationMs / 1000) : 0
+      const rtf =
+        rtfFromStats !== undefined && rtfFromStats !== null && rtfFromStats > 0
+          ? rtfFromStats
+          : rtfFromWall
       if (typeof stats.backendId === 'number') observedBackendId = stats.backendId
 
       const run = {
@@ -531,12 +572,14 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
       }
       runs.push(run)
 
-      console.log(`  Run ${i + 1}/${settings.numRuns}: ` +
-        `RTF=${rtf.toFixed(4)}  ` +
-        `wall=${wallMs.toFixed(0)}ms  ` +
-        `audio=${(durationMs / 1000).toFixed(2)}s  ` +
-        `tokens/s=${(run.tokensPerSecond || 0).toFixed(1)}  ` +
-        `rss=${(currentRss / 1024 / 1024).toFixed(0)}MB`)
+      console.log(
+        `  Run ${i + 1}/${settings.numRuns}: ` +
+          `RTF=${rtf.toFixed(4)}  ` +
+          `wall=${wallMs.toFixed(0)}ms  ` +
+          `audio=${(durationMs / 1000).toFixed(2)}s  ` +
+          `tokens/s=${(run.tokensPerSecond || 0).toFixed(1)}  ` +
+          `rss=${(currentRss / 1024 / 1024).toFixed(0)}MB`
+      )
     }
 
     if (runs.length === 0) {
@@ -545,9 +588,9 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
     }
 
     // --- Aggregate stats ---
-    const rtfStats = computeStats(runs.map(r => r.rtf))
-    const wallStats = computeStats(runs.map(r => r.wallMs))
-    const tpsStats = computeStats(runs.map(r => r.tokensPerSecond).filter(v => v > 0))
+    const rtfStats = computeStats(runs.map((r) => r.rtf))
+    const wallStats = computeStats(runs.map((r) => r.wallMs))
+    const tpsStats = computeStats(runs.map((r) => r.tokensPerSecond).filter((v) => v > 0))
     const stddevOverMean = rtfStats.mean > 0 ? rtfStats.stddev / rtfStats.mean : 0
     const noisy = stddevOverMean > 0.15
     const activeBackend = observedBackendId !== null ? backendIdToName(observedBackendId) : ''
@@ -557,7 +600,9 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
     console.log('='.repeat(70))
     console.log(`  Platform:        ${platformArch}`)
     console.log(`  Engine:          ${settings.engine}`)
-    console.log(`  Backend:         ${backend}${activeBackend && activeBackend !== backend ? ` (active: ${activeBackend})` : ''}`)
+    console.log(
+      `  Backend:         ${backend}${activeBackend && activeBackend !== backend ? ` (active: ${activeBackend})` : ''}`
+    )
     console.log(`  Iterations:      ${runs.length}`)
     if (settings.numThreads !== undefined) console.log(`  numThreads:      ${settings.numThreads}`)
     console.log('')
@@ -565,7 +610,9 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
     console.log(`    Mean:   ${rtfStats.mean.toFixed(4)}`)
     console.log(`    Min:    ${rtfStats.min.toFixed(4)}`)
     console.log(`    Max:    ${rtfStats.max.toFixed(4)}`)
-    console.log(`    Stddev: ${rtfStats.stddev.toFixed(4)} (${(stddevOverMean * 100).toFixed(1)}% of mean${noisy ? ' ⚠ noisy' : ''})`)
+    console.log(
+      `    Stddev: ${rtfStats.stddev.toFixed(4)} (${(stddevOverMean * 100).toFixed(1)}% of mean${noisy ? ' ⚠ noisy' : ''})`
+    )
     console.log(`    P50:    ${rtfStats.p50.toFixed(4)}`)
     console.log(`    P95:    ${rtfStats.p95.toFixed(4)}`)
     if (coldRtf !== null) {
@@ -586,7 +633,9 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
     console.log('')
     console.log('  Memory / size:')
     console.log(`    Peak RSS:    ${(peakRssBytes / 1024 / 1024).toFixed(0)}MB`)
-    console.log(`    RSS @load:   ${(rssAfterLoad / 1024 / 1024).toFixed(0)}MB (pre-load ${(rssBeforeLoad / 1024 / 1024).toFixed(0)}MB)`)
+    console.log(
+      `    RSS @load:   ${(rssAfterLoad / 1024 / 1024).toFixed(0)}MB (pre-load ${(rssBeforeLoad / 1024 / 1024).toFixed(0)}MB)`
+    )
     console.log(`    Model size:  ${(modelSizeBytes / 1024 / 1024).toFixed(1)}MB`)
     console.log('='.repeat(70) + '\n')
 
@@ -689,18 +738,25 @@ test('RTF benchmark: GGML TTS on CI device', { timeout: 1800000 }, async (t) => 
     }
 
     // --- Assertions ---
-    t.ok(runs.length === settings.numRuns, `Completed ${settings.numRuns} benchmark runs (got ${runs.length})`)
+    t.ok(
+      runs.length === settings.numRuns,
+      `Completed ${settings.numRuns} benchmark runs (got ${runs.length})`
+    )
     t.ok(rtfStats.mean > 0, 'Mean RTF should be positive')
 
     if (upperBound !== null) {
-      t.ok(rtfStats.mean <= upperBound,
-        `Mean RTF ${rtfStats.mean.toFixed(4)} should be <= ${upperBound}`)
+      t.ok(
+        rtfStats.mean <= upperBound,
+        `Mean RTF ${rtfStats.mean.toFixed(4)} should be <= ${upperBound}`
+      )
     }
 
     console.log('RTF benchmark completed successfully.\n')
   } finally {
     if (model) {
-      try { await model.unload() } catch (_) {}
+      try {
+        await model.unload()
+      } catch (_) {}
     }
   }
 })

--- a/packages/tts-ggml/test/benchmark/streaming-benchmark.test.js
+++ b/packages/tts-ggml/test/benchmark/streaming-benchmark.test.js
@@ -62,7 +62,7 @@ const isMobile = platform === 'ios' || platform === 'android'
 // (extract-from-log.js -> aggregate.js). One result per
 // (engine, variant, backend, useGPU) configuration. Schema must satisfy
 // isValidReport() in extract-from-log.js (string schema_version + results array).
-function buildCanonicalStreamingReport (settings, summary, backend) {
+function buildCanonicalStreamingReport(settings, summary, backend) {
   const useGPU = !!settings.useGPU
   const ep = useGPU ? 'gpu' : 'cpu'
   const testLabel = `[${ep.toUpperCase()}] streaming ${settings.engine} ${settings.variant} ${backend}`
@@ -84,52 +84,63 @@ function buildCanonicalStreamingReport (settings, summary, backend) {
       arch,
       runner: settings.runnerLabel || (isMobile ? 'device-farm' : 'github-actions')
     },
-    results: [{
-      test: testLabel,
-      execution_provider: ep,
-      metrics: {
-        ttfa_ms: typeof ttfa.mean === 'number' ? Math.round(ttfa.mean) : null,
-        inter_chunk_p95_ms: typeof interChunk.p95 === 'number' ? Math.round(interChunk.p95) : null,
-        wall_time_ms: typeof totalWall.mean === 'number' ? Math.round(totalWall.mean) : null,
-        // Consumed by aggregate-tts-ggml-rtf.js expandCanonicalReport ->
-        // chunkCount.mean (the "Chunks/run" column for mobile streaming rows).
-        chunks_per_run_mean: typeof chunkCount.mean === 'number' ? Number(chunkCount.mean.toFixed(2)) : null
+    results: [
+      {
+        test: testLabel,
+        execution_provider: ep,
+        metrics: {
+          ttfa_ms: typeof ttfa.mean === 'number' ? Math.round(ttfa.mean) : null,
+          inter_chunk_p95_ms:
+            typeof interChunk.p95 === 'number' ? Math.round(interChunk.p95) : null,
+          wall_time_ms: typeof totalWall.mean === 'number' ? Math.round(totalWall.mean) : null,
+          // Consumed by aggregate-tts-ggml-rtf.js expandCanonicalReport ->
+          // chunkCount.mean (the "Chunks/run" column for mobile streaming rows).
+          chunks_per_run_mean:
+            typeof chunkCount.mean === 'number' ? Number(chunkCount.mean.toFixed(2)) : null
+        }
       }
-    }]
+    ]
   }
 }
 
-function getEnv (name) {
+function getEnv(name) {
   if (typeof os.getEnv === 'function') {
-    try { return os.getEnv(name) || '' } catch (_) { return '' }
+    try {
+      return os.getEnv(name) || ''
+    } catch (_) {
+      return ''
+    }
   }
   return (process.env && process.env[name]) || ''
 }
 
-function getEnvBoolean (name, fallback) {
+function getEnvBoolean(name, fallback) {
   const value = getEnv(name)
   if (value === undefined || value === '') return fallback
   return value === '1' || value.toLowerCase() === 'true' || value.toLowerCase() === 'yes'
 }
 
-function getEnvInteger (name, fallback) {
+function getEnvInteger(name, fallback) {
   const value = getEnv(name)
   if (value === undefined || value === '') return fallback
   const parsed = Number.parseInt(value, 10)
   return Number.isNaN(parsed) ? fallback : parsed
 }
 
-function sanitizeTag (value) {
+function sanitizeTag(value) {
   if (!value) return ''
-  return String(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
 }
 
-function nowMs () {
+function nowMs() {
   const [sec, nsec] = process.hrtime()
   return sec * 1000 + nsec / 1e6
 }
 
-function percentile (sorted, p) {
+function percentile(sorted, p) {
   if (sorted.length === 0) return 0
   const idx = (p / 100) * (sorted.length - 1)
   const lo = Math.floor(idx)
@@ -138,7 +149,7 @@ function percentile (sorted, p) {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo)
 }
 
-function computeStats (values) {
+function computeStats(values) {
   if (values.length === 0) return { mean: 0, min: 0, max: 0, stddev: 0, p50: 0, p95: 0, count: 0 }
   const sorted = [...values].sort((a, b) => a - b)
   const sum = sorted.reduce((a, b) => a + b, 0)
@@ -155,7 +166,7 @@ function computeStats (values) {
   }
 }
 
-function getSettings () {
+function getSettings() {
   const engine = (getEnv('QVAC_TTS_GGML_BENCHMARK_ENGINE') || 'chatterbox').toLowerCase()
   if (!VALID_ENGINES.includes(engine)) {
     throw new Error(`Invalid benchmark engine: ${engine}. Valid: ${VALID_ENGINES.join(', ')}`)
@@ -167,7 +178,8 @@ function getSettings () {
 
   const numThreadsRaw = getEnv('QVAC_TTS_GGML_BENCHMARK_NUM_THREADS') || ''
   const numThreadsParsed = Number.parseInt(numThreadsRaw, 10)
-  const numThreads = Number.isFinite(numThreadsParsed) && numThreadsParsed > 0 ? numThreadsParsed : undefined
+  const numThreads =
+    Number.isFinite(numThreadsParsed) && numThreadsParsed > 0 ? numThreadsParsed : undefined
 
   return {
     engine,
@@ -192,7 +204,7 @@ function getSettings () {
   }
 }
 
-function resolveBackend (platformName, useGPU, backendHint) {
+function resolveBackend(platformName, useGPU, backendHint) {
   const hint = String(backendHint || '').toLowerCase()
   if (hint) return hint
   if (!useGPU) return 'cpu'
@@ -202,7 +214,7 @@ function resolveBackend (platformName, useGPU, backendHint) {
   return 'gpu'
 }
 
-function getArtifactFileName (settings) {
+function getArtifactFileName(settings) {
   const parts = [
     'streaming-benchmark',
     platformArch,
@@ -214,15 +226,15 @@ function getArtifactFileName (settings) {
   return `${parts.join('-')}.json`
 }
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
-function isMultilingualEngine (engine) {
+function isMultilingualEngine(engine) {
   return engine === 'chatterbox-mtl' || engine === 'supertonic-mtl'
 }
 
-async function loadModelForEngine (settings) {
+async function loadModelForEngine(settings) {
   const baseDir = getBaseDir()
   const modelsDir = path.join(baseDir, 'models')
   const threadOpts = settings.numThreads !== undefined ? { threads: settings.numThreads } : {}
@@ -240,7 +252,8 @@ async function loadModelForEngine (settings) {
 
   if (settings.engine === 'chatterbox-mtl') {
     const download = await ensureChatterboxMtlModels({ targetDir: modelsDir })
-    if (!download.success) throw new Error('Chatterbox MTL GGUFs unavailable (registry fetch failed)')
+    if (!download.success)
+      throw new Error('Chatterbox MTL GGUFs unavailable (registry fetch failed)')
     const dir = download.targetDir || modelsDir
     return loadChatterboxTTS({
       modelDir: dir,
@@ -254,9 +267,11 @@ async function loadModelForEngine (settings) {
 
   if (settings.engine === 'supertonic-mtl') {
     const download = await ensureSupertonicMtlModel({ targetDir: modelsDir })
-    if (!download || !download.success) throw new Error('Supertonic MTL GGUF unavailable (registry fetch failed)')
+    if (!download || !download.success)
+      throw new Error('Supertonic MTL GGUF unavailable (registry fetch failed)')
     return loadSupertonicTTS({
-      supertonicModelPath: download.path || path.join(download.targetDir || modelsDir, 'supertonic2.gguf'),
+      supertonicModelPath:
+        download.path || path.join(download.targetDir || modelsDir, 'supertonic2.gguf'),
       voice: 'F1',
       language: 'es',
       useGPU: settings.useGPU,
@@ -265,9 +280,11 @@ async function loadModelForEngine (settings) {
   }
 
   const download = await ensureSupertonicModel({ targetDir: modelsDir })
-  if (!download || !download.success) throw new Error('Supertonic GGUF unavailable (registry fetch failed)')
+  if (!download || !download.success)
+    throw new Error('Supertonic GGUF unavailable (registry fetch failed)')
   return loadSupertonicTTS({
-    supertonicModelPath: download.path || path.join(download.targetDir || modelsDir, 'supertonic.gguf'),
+    supertonicModelPath:
+      download.path || path.join(download.targetDir || modelsDir, 'supertonic.gguf'),
     voice: 'F1',
     language: 'en',
     useGPU: settings.useGPU,
@@ -277,21 +294,23 @@ async function loadModelForEngine (settings) {
 
 // Text long enough that Chatterbox native chunking produces >=2 chunks.
 const STREAMING_CORPUS = {
-  en: 'The quick brown fox jumps over the lazy dog. ' +
-      'Artificial intelligence is transforming the world in unprecedented ways. ' +
-      'The weather forecast calls for sunny skies and temperatures around seventy degrees. ' +
-      'In a quiet village nestled between rolling hills, a young inventor dreamed of building machines that could think and learn.',
-  es: 'Hola mundo. Esta es una prueba del sistema de texto a voz. ' +
-      'El clima de hoy sera soleado con temperaturas agradables. ' +
-      'La inteligencia artificial esta transformando el mundo de maneras sin precedentes. ' +
-      'En un pequeno pueblo entre colinas, un joven inventor sonaba con construir maquinas que pudieran pensar.'
+  en:
+    'The quick brown fox jumps over the lazy dog. ' +
+    'Artificial intelligence is transforming the world in unprecedented ways. ' +
+    'The weather forecast calls for sunny skies and temperatures around seventy degrees. ' +
+    'In a quiet village nestled between rolling hills, a young inventor dreamed of building machines that could think and learn.',
+  es:
+    'Hola mundo. Esta es una prueba del sistema de texto a voz. ' +
+    'El clima de hoy sera soleado con temperaturas agradables. ' +
+    'La inteligencia artificial esta transformando el mundo de maneras sin precedentes. ' +
+    'En un pequeno pueblo entre colinas, un joven inventor sonaba con construir maquinas que pudieran pensar.'
 }
 
-function getCorpusText (engine) {
+function getCorpusText(engine) {
   return isMultilingualEngine(engine) ? STREAMING_CORPUS.es : STREAMING_CORPUS.en
 }
 
-async function measureStreamingRun (model, text) {
+async function measureStreamingRun(model, text) {
   const startMs = nowMs()
   let firstChunkAtMs = null
   const chunkTimes = []
@@ -301,7 +320,7 @@ async function measureStreamingRun (model, text) {
   const response = await model.run({ input: text, type: 'text', streamOutput: true })
 
   await response
-    .onUpdate(data => {
+    .onUpdate((data) => {
       if (data && data.outputArray) {
         const now = nowMs()
         if (firstChunkAtMs === null) firstChunkAtMs = now
@@ -334,179 +353,197 @@ async function measureStreamingRun (model, text) {
   }
 }
 
-test('Streaming benchmark: TTFA + inter-chunk latency (GGML TTS)', { timeout: 1800000 }, async (t) => {
-  const settings = getSettings()
-  const backend = resolveBackend(platform, settings.useGPU, settings.backendHint)
-  const text = getCorpusText(settings.engine)
-
-  console.log('\n' + '='.repeat(70))
-  console.log('GGML TTS STREAMING LATENCY BENCHMARK')
-  console.log('='.repeat(70))
-  console.log(`  Platform:       ${platformArch}`)
-  console.log(`  Engine:         ${settings.engine}`)
-  console.log(`  Variant:        ${settings.variant}`)
-  console.log(`  GPU requested:  ${settings.useGPU}`)
-  console.log(`  Backend:        ${backend}`)
-  if (settings.deviceLabel) console.log(`  Device label:   ${settings.deviceLabel}`)
-  if (settings.runnerLabel) console.log(`  Runner label:   ${settings.runnerLabel}`)
-  if (settings.label) console.log(`  Label:          ${settings.label}`)
-  if (settings.numThreads !== undefined) console.log(`  numThreads:     ${settings.numThreads}`)
-  console.log(`  Warmup runs:    ${settings.numWarmup}`)
-  console.log(`  Measured runs:  ${settings.numRuns}`)
-  console.log(`  Corpus chars:   ${text.length}`)
-  console.log('='.repeat(70) + '\n')
-
-  console.log(`Loading model for engine: ${settings.engine}...`)
-  const loadStart = nowMs()
-  let model
-  try {
-    model = await loadModelForEngine(settings)
-  } catch (err) {
-    t.fail(`Model load failed: ${err.message}`)
-    return
-  }
-  const loadMs = nowMs() - loadStart
-  console.log(`Model loaded in ${loadMs.toFixed(0)}ms\n`)
-
-  const runs = []
-  let observedBackendId = null
-
-  try {
-    for (let w = 0; w < settings.numWarmup; w++) {
-      console.log(`[streaming warmup ${w + 1}/${settings.numWarmup}]`)
-      const r = await measureStreamingRun(model, text)
-      if (r.backendId !== null) observedBackendId = r.backendId
-      console.log(`  ttfa=${r.ttfaMs !== null ? r.ttfaMs.toFixed(0) + 'ms' : 'n/a'}  ` +
-        `chunks=${r.chunkCount}  totalWall=${r.totalWallMs.toFixed(0)}ms`)
-    }
-
-    console.log(`\nRunning ${settings.numRuns} measured streaming iteration(s)...\n`)
-    for (let i = 0; i < settings.numRuns; i++) {
-      const r = await measureStreamingRun(model, text)
-      if (r.backendId !== null) observedBackendId = r.backendId
-      runs.push({ iteration: i + 1, ...r })
-
-      const interChunkMean = r.interChunkGapsMs.length > 0
-        ? r.interChunkGapsMs.reduce((a, b) => a + b, 0) / r.interChunkGapsMs.length
-        : 0
-      console.log(`  Run ${i + 1}/${settings.numRuns}: ` +
-        `ttfa=${r.ttfaMs !== null ? r.ttfaMs.toFixed(0) + 'ms' : 'n/a'}  ` +
-        `chunks=${r.chunkCount}  ` +
-        `interChunkMean=${interChunkMean.toFixed(0)}ms  ` +
-        `totalWall=${r.totalWallMs.toFixed(0)}ms  ` +
-        `audio=${(r.audioDurationMs / 1000).toFixed(2)}s`)
-    }
-
-    if (runs.length === 0) {
-      t.fail('No streaming benchmark runs completed')
-      return
-    }
-
-    const ttfaStats = computeStats(runs.map(r => r.ttfaMs).filter(v => v !== null && v !== undefined))
-    const totalWallStats = computeStats(runs.map(r => r.totalWallMs))
-    const chunkCountStats = computeStats(runs.map(r => r.chunkCount))
-    const interChunkAll = runs.flatMap(r => r.interChunkGapsMs)
-    const interChunkStats = computeStats(interChunkAll)
+test(
+  'Streaming benchmark: TTFA + inter-chunk latency (GGML TTS)',
+  { timeout: 1800000 },
+  async (t) => {
+    const settings = getSettings()
+    const backend = resolveBackend(platform, settings.useGPU, settings.backendHint)
+    const text = getCorpusText(settings.engine)
 
     console.log('\n' + '='.repeat(70))
-    console.log('STREAMING BENCHMARK RESULTS')
+    console.log('GGML TTS STREAMING LATENCY BENCHMARK')
     console.log('='.repeat(70))
-    console.log('  TTFA (Time To First Audio):')
-    console.log(`    Mean:   ${ttfaStats.mean.toFixed(0)}ms`)
-    console.log(`    P50:    ${ttfaStats.p50.toFixed(0)}ms`)
-    console.log(`    P95:    ${ttfaStats.p95.toFixed(0)}ms`)
-    console.log(`  Inter-chunk gap (${interChunkAll.length} samples across runs):`)
-    console.log(`    Mean:   ${interChunkStats.mean.toFixed(0)}ms`)
-    console.log(`    P95:    ${interChunkStats.p95.toFixed(0)}ms`)
-    console.log(`  Chunks per run: ${chunkCountStats.mean.toFixed(1)} (min ${chunkCountStats.min}, max ${chunkCountStats.max})`)
-    console.log(`  Total wall:     ${totalWallStats.mean.toFixed(0)}ms`)
+    console.log(`  Platform:       ${platformArch}`)
+    console.log(`  Engine:         ${settings.engine}`)
+    console.log(`  Variant:        ${settings.variant}`)
+    console.log(`  GPU requested:  ${settings.useGPU}`)
+    console.log(`  Backend:        ${backend}`)
+    if (settings.deviceLabel) console.log(`  Device label:   ${settings.deviceLabel}`)
+    if (settings.runnerLabel) console.log(`  Runner label:   ${settings.runnerLabel}`)
+    if (settings.label) console.log(`  Label:          ${settings.label}`)
+    if (settings.numThreads !== undefined) console.log(`  numThreads:     ${settings.numThreads}`)
+    console.log(`  Warmup runs:    ${settings.numWarmup}`)
+    console.log(`  Measured runs:  ${settings.numRuns}`)
+    console.log(`  Corpus chars:   ${text.length}`)
     console.log('='.repeat(70) + '\n')
 
-    const [platformName, archName] = platformArch.split('-')
-
-    const report = {
-      schemaVersion: SCHEMA_VERSION,
-      kind: 'streaming',
-      timestamp: new Date().toISOString(),
-      platform: platformArch,
-      platformName,
-      arch: archName || '',
-      isMobile,
-      engine: settings.engine,
-      model: {
-        type: settings.engine,
-        variant: settings.variant
-      },
-      labels: {
-        runner: settings.runnerLabel,
-        device: settings.deviceLabel,
-        backend,
-        requestedBackend: settings.useGPU ? 'gpu' : 'cpu',
-        label: settings.label
-      },
-      config: {
-        warmupRuns: settings.numWarmup,
-        measuredRuns: settings.numRuns,
-        useGPU: settings.useGPU,
-        variant: settings.variant,
-        modelLoadMs: loadMs,
-        numThreads: settings.numThreads !== undefined ? settings.numThreads : null
-      },
-      requested: {
-        engine: settings.engine,
-        variant: settings.variant,
-        useGPU: settings.useGPU,
-        backendHint: settings.backendHint,
-        deviceLabel: settings.deviceLabel,
-        runnerLabel: settings.runnerLabel,
-        numThreads: settings.numThreads !== undefined ? settings.numThreads : null
-      },
-      correlation: settings.correlation,
-      summary: {
-        ttfaMs: ttfaStats,
-        totalWallMs: totalWallStats,
-        chunkCount: chunkCountStats,
-        interChunkMs: interChunkStats,
-        backendId: observedBackendId
-      },
-      runs
-    }
-
-    // Keep the rich on-disk artifact unchanged — this is what
-    // `scripts/perf-report/aggregate-tts-ggml-rtf.js` consumes alongside RTF
-    // benchmark JSON files.
+    console.log(`Loading model for engine: ${settings.engine}...`)
+    const loadStart = nowMs()
+    let model
     try {
-      if (!fs.existsSync(RESULTS_DIR)) fs.mkdirSync(RESULTS_DIR, { recursive: true })
-      const outPath = path.join(RESULTS_DIR, getArtifactFileName(settings))
-      fs.writeFileSync(outPath, JSON.stringify(report, null, 2) + '\n')
-      console.log(`Results written to ${outPath}\n`)
-    } catch (writeErr) {
-      console.log(`Warning: could not write results file: ${writeErr.message}`)
+      model = await loadModelForEngine(settings)
+    } catch (err) {
+      t.fail(`Model load failed: ${err.message}`)
+      return
     }
+    const loadMs = nowMs() - loadStart
+    console.log(`Model loaded in ${loadMs.toFixed(0)}ms\n`)
 
-    // Canonical perf-report markers for the shared mobile pipeline.
-    const canonicalReport = buildCanonicalStreamingReport(settings, report.summary, backend)
-    const canonicalJson = JSON.stringify(canonicalReport)
-    console.log(`[PERF_REPORT_START]${canonicalJson}[PERF_REPORT_END]`)
+    const runs = []
+    let observedBackendId = null
 
-    if (isMobile) {
-      const CHUNK_SIZE = 400
-      const chunkCount = Math.max(1, Math.ceil(canonicalJson.length / CHUNK_SIZE))
-      const chunkId = `ttsggmlstream-${Date.now()}`
-      for (let i = 0; i < chunkCount; i++) {
-        const fragment = canonicalJson.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE)
-        console.log(`[PERF_CHUNK:${chunkId}:${i}:${chunkCount}]${fragment}`)
+    try {
+      for (let w = 0; w < settings.numWarmup; w++) {
+        console.log(`[streaming warmup ${w + 1}/${settings.numWarmup}]`)
+        const r = await measureStreamingRun(model, text)
+        if (r.backendId !== null) observedBackendId = r.backendId
+        console.log(
+          `  ttfa=${r.ttfaMs !== null ? r.ttfaMs.toFixed(0) + 'ms' : 'n/a'}  ` +
+            `chunks=${r.chunkCount}  totalWall=${r.totalWallMs.toFixed(0)}ms`
+        )
+      }
+
+      console.log(`\nRunning ${settings.numRuns} measured streaming iteration(s)...\n`)
+      for (let i = 0; i < settings.numRuns; i++) {
+        const r = await measureStreamingRun(model, text)
+        if (r.backendId !== null) observedBackendId = r.backendId
+        runs.push({ iteration: i + 1, ...r })
+
+        const interChunkMean =
+          r.interChunkGapsMs.length > 0
+            ? r.interChunkGapsMs.reduce((a, b) => a + b, 0) / r.interChunkGapsMs.length
+            : 0
+        console.log(
+          `  Run ${i + 1}/${settings.numRuns}: ` +
+            `ttfa=${r.ttfaMs !== null ? r.ttfaMs.toFixed(0) + 'ms' : 'n/a'}  ` +
+            `chunks=${r.chunkCount}  ` +
+            `interChunkMean=${interChunkMean.toFixed(0)}ms  ` +
+            `totalWall=${r.totalWallMs.toFixed(0)}ms  ` +
+            `audio=${(r.audioDurationMs / 1000).toFixed(2)}s`
+        )
+      }
+
+      if (runs.length === 0) {
+        t.fail('No streaming benchmark runs completed')
+        return
+      }
+
+      const ttfaStats = computeStats(
+        runs.map((r) => r.ttfaMs).filter((v) => v !== null && v !== undefined)
+      )
+      const totalWallStats = computeStats(runs.map((r) => r.totalWallMs))
+      const chunkCountStats = computeStats(runs.map((r) => r.chunkCount))
+      const interChunkAll = runs.flatMap((r) => r.interChunkGapsMs)
+      const interChunkStats = computeStats(interChunkAll)
+
+      console.log('\n' + '='.repeat(70))
+      console.log('STREAMING BENCHMARK RESULTS')
+      console.log('='.repeat(70))
+      console.log('  TTFA (Time To First Audio):')
+      console.log(`    Mean:   ${ttfaStats.mean.toFixed(0)}ms`)
+      console.log(`    P50:    ${ttfaStats.p50.toFixed(0)}ms`)
+      console.log(`    P95:    ${ttfaStats.p95.toFixed(0)}ms`)
+      console.log(`  Inter-chunk gap (${interChunkAll.length} samples across runs):`)
+      console.log(`    Mean:   ${interChunkStats.mean.toFixed(0)}ms`)
+      console.log(`    P95:    ${interChunkStats.p95.toFixed(0)}ms`)
+      console.log(
+        `  Chunks per run: ${chunkCountStats.mean.toFixed(1)} (min ${chunkCountStats.min}, max ${chunkCountStats.max})`
+      )
+      console.log(`  Total wall:     ${totalWallStats.mean.toFixed(0)}ms`)
+      console.log('='.repeat(70) + '\n')
+
+      const [platformName, archName] = platformArch.split('-')
+
+      const report = {
+        schemaVersion: SCHEMA_VERSION,
+        kind: 'streaming',
+        timestamp: new Date().toISOString(),
+        platform: platformArch,
+        platformName,
+        arch: archName || '',
+        isMobile,
+        engine: settings.engine,
+        model: {
+          type: settings.engine,
+          variant: settings.variant
+        },
+        labels: {
+          runner: settings.runnerLabel,
+          device: settings.deviceLabel,
+          backend,
+          requestedBackend: settings.useGPU ? 'gpu' : 'cpu',
+          label: settings.label
+        },
+        config: {
+          warmupRuns: settings.numWarmup,
+          measuredRuns: settings.numRuns,
+          useGPU: settings.useGPU,
+          variant: settings.variant,
+          modelLoadMs: loadMs,
+          numThreads: settings.numThreads !== undefined ? settings.numThreads : null
+        },
+        requested: {
+          engine: settings.engine,
+          variant: settings.variant,
+          useGPU: settings.useGPU,
+          backendHint: settings.backendHint,
+          deviceLabel: settings.deviceLabel,
+          runnerLabel: settings.runnerLabel,
+          numThreads: settings.numThreads !== undefined ? settings.numThreads : null
+        },
+        correlation: settings.correlation,
+        summary: {
+          ttfaMs: ttfaStats,
+          totalWallMs: totalWallStats,
+          chunkCount: chunkCountStats,
+          interChunkMs: interChunkStats,
+          backendId: observedBackendId
+        },
+        runs
+      }
+
+      // Keep the rich on-disk artifact unchanged — this is what
+      // `scripts/perf-report/aggregate-tts-ggml-rtf.js` consumes alongside RTF
+      // benchmark JSON files.
+      try {
+        if (!fs.existsSync(RESULTS_DIR)) fs.mkdirSync(RESULTS_DIR, { recursive: true })
+        const outPath = path.join(RESULTS_DIR, getArtifactFileName(settings))
+        fs.writeFileSync(outPath, JSON.stringify(report, null, 2) + '\n')
+        console.log(`Results written to ${outPath}\n`)
+      } catch (writeErr) {
+        console.log(`Warning: could not write results file: ${writeErr.message}`)
+      }
+
+      // Canonical perf-report markers for the shared mobile pipeline.
+      const canonicalReport = buildCanonicalStreamingReport(settings, report.summary, backend)
+      const canonicalJson = JSON.stringify(canonicalReport)
+      console.log(`[PERF_REPORT_START]${canonicalJson}[PERF_REPORT_END]`)
+
+      if (isMobile) {
+        const CHUNK_SIZE = 400
+        const chunkCount = Math.max(1, Math.ceil(canonicalJson.length / CHUNK_SIZE))
+        const chunkId = `ttsggmlstream-${Date.now()}`
+        for (let i = 0; i < chunkCount; i++) {
+          const fragment = canonicalJson.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE)
+          console.log(`[PERF_CHUNK:${chunkId}:${i}:${chunkCount}]${fragment}`)
+        }
+      }
+
+      t.ok(
+        runs.length === settings.numRuns,
+        `Completed ${settings.numRuns} streaming runs (got ${runs.length})`
+      )
+      t.ok(ttfaStats.count > 0 && ttfaStats.mean > 0, 'Mean TTFA should be positive')
+      t.ok(chunkCountStats.min >= 1, 'At least one chunk should be produced per run')
+
+      console.log('Streaming benchmark completed successfully.\n')
+    } finally {
+      if (model) {
+        try {
+          await model.unload()
+        } catch (_) {}
       }
     }
-
-    t.ok(runs.length === settings.numRuns, `Completed ${settings.numRuns} streaming runs (got ${runs.length})`)
-    t.ok(ttfaStats.count > 0 && ttfaStats.mean > 0, 'Mean TTFA should be positive')
-    t.ok(chunkCountStats.min >= 1, 'At least one chunk should be produced per run')
-
-    console.log('Streaming benchmark completed successfully.\n')
-  } finally {
-    if (model) {
-      try { await model.unload() } catch (_) {}
-    }
   }
-})
+)

--- a/packages/tts-ggml/test/integration/addon.test.js
+++ b/packages/tts-ggml/test/integration/addon.test.js
@@ -5,7 +5,13 @@ const os = require('bare-os')
 const path = require('bare-path')
 const fs = require('bare-fs')
 
-const { loadChatterboxTTS, runChatterboxTTS, runChatterboxTTSWithSplit, runChatterboxStreaming, resolveRefWavPath } = require('../utils/runChatterboxTTS')
+const {
+  loadChatterboxTTS,
+  runChatterboxTTS,
+  runChatterboxTTSWithSplit,
+  runChatterboxStreaming,
+  resolveRefWavPath
+} = require('../utils/runChatterboxTTS')
 const { ensureChatterboxModels, ensureWhisperModel } = require('../utils/downloadModel')
 const { loadWhisper, runWhisper } = require('../utils/runWhisper')
 const { recordTtsStats } = require('../utils/perf-helper')
@@ -18,7 +24,7 @@ const forceNoGpu = os.getEnv('NO_GPU') === 'true'
 const INPUT_SENTENCES = (isMobile ? 'short' : os.getEnv('INPUT_SENTENCES')) || 'short'
 const useSplit = INPUT_SENTENCES !== 'short'
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
@@ -27,343 +33,406 @@ const ENGLISH_SENTENCES_SHORT = [
   'How are you doing today?'
 ]
 
-function getEnglishSentences () {
+function getEnglishSentences() {
   if (INPUT_SENTENCES === 'short') return ENGLISH_SENTENCES_SHORT
   const { en } = require(`../data/sentences-${INPUT_SENTENCES}`)
   return en
 }
 
-test('Chatterbox TTS (ggml): English synthesis + optional WER verification', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
-  const whisperModelDir = path.join(baseDir, 'models', 'whisper')
+test(
+  'Chatterbox TTS (ggml): English synthesis + optional WER verification',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
+    const whisperModelDir = path.join(baseDir, 'models', 'whisper')
 
-  console.log('\n=== Ensuring Chatterbox GGUFs ===')
-  const download = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!download.success) {
-    console.log('Chatterbox GGUFs not available locally; see instructions above.')
-    t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-  t.ok(download.success, 'Chatterbox GGUFs should be available')
+    console.log('\n=== Ensuring Chatterbox GGUFs ===')
+    const download = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!download.success) {
+      console.log('Chatterbox GGUFs not available locally; see instructions above.')
+      t.fail(
+        'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+    t.ok(download.success, 'Chatterbox GGUFs should be available')
 
-  if (isDarwin) {
-    console.log('\n=== Ensuring Whisper model (for WER verification) ===')
-    const whisperModelPath = path.join(whisperModelDir, 'ggml-small.bin')
-    await ensureWhisperModel(whisperModelPath)
-    t.pass('Whisper model present')
-  }
-
-  const expectation = {
-    minSamples: 5000,
-    maxSamples: 5000000,
-    minDurationMs: 200,
-    maxDurationMs: 300000
-  }
-
-  const werEntries = []
-  const englishSentences = getEnglishSentences()
-
-  // `ensureChatterboxModels` may resolve to a different dir on Android
-  // (the adb-push-friendly candidate paths under /sdcard/...), so use
-  // the dir it actually found the GGUFs in.
-  const resolvedModelDir = download.targetDir
-  console.log(`\n=== English synthesis (${englishSentences.length} sentences, tier: ${INPUT_SENTENCES}, modelDir: ${resolvedModelDir}) ===`)
-  const model = await loadChatterboxTTS({
-    modelDir: resolvedModelDir,
-    language: 'en'
-  })
-  t.ok(model, 'Chatterbox (ggml) model should be loaded')
-
-  const runner = useSplit ? runChatterboxTTSWithSplit : runChatterboxTTS
-
-  for (let i = 0; i < englishSentences.length; i++) {
-    const text = englishSentences[i]
-    const preview = text.substring(0, 60) + (text.length > 60 ? '...' : '')
-    console.log(`\n--- English ${i + 1}/${englishSentences.length}: "${preview}" ---`)
-
-    const saveWav = !isMobile
-    const wavPath = saveWav ? path.join(baseDir, 'test', 'output', `chatterbox-english-${i + 1}.wav`) : undefined
-
-    const t0 = Date.now()
-    const result = await runner(model, { text, saveWav, wavOutputPath: wavPath }, expectation)
-    const wallMs = Date.now() - t0
-    console.log(result.output)
-
-    t.ok(result.passed, `English TTS ${i + 1} should pass expectations`)
-    t.ok(result.data.sampleCount > 0, `English TTS ${i + 1} should produce audio samples`)
-    t.is(result.data.reportedSampleRate, 24000, 'Sample rate should be native 24 kHz')
-
-    const st = result.data?.stats || {}
-    t.comment(recordTtsStats(
-      `chatterbox english ${i + 1}`,
-      { realTimeFactor: st.realTimeFactor, audioDurationMs: st.audioDurationMs || result.data?.durationMs, totalSamples: result.data?.sampleCount, backendDevice: st.backendDevice },
-      { wallMs, sampleCount: result.data?.sampleCount, model: 'chatterbox', output: text }
-    ))
-
-    const wavBuffer = result.data?.wavBuffer ? Buffer.from(result.data.wavBuffer) : null
-    werEntries.push({ text, lang: 'en', wavBuffer, sampleCount: result.data.sampleCount, durationMs: result.data.durationMs })
-  }
-
-  await model.unload()
-  t.pass('Chatterbox model unloaded')
-
-  console.log('\n=== WER verification ===')
-  if (!isDarwin) {
-    t.pass('WER verification skipped (non-darwin)')
-  } else if (INPUT_SENTENCES !== 'short') {
-    t.pass('WER verification skipped (non-short input)')
-  } else {
-    const whisperModel = await loadWhisper({
-      modelName: 'ggml-small.bin',
-      diskPath: whisperModelDir,
-      language: 'en'
-    })
-    t.ok(whisperModel, 'Whisper model should be loaded')
-
-    for (let i = 0; i < werEntries.length; i++) {
-      const entry = werEntries[i]
-      if (!entry.wavBuffer) {
-        console.log(`\n--- Whisper ${i + 1}/${werEntries.length}: skipped (no WAV buffer) ---`)
-        continue
-      }
-
-      console.log(`\n--- Whisper ${i + 1}/${werEntries.length}: "${entry.text.substring(0, 50)}..." ---`)
-      const whisperResult = await runWhisper(whisperModel, entry.text, entry.wavBuffer)
-      const werPct = (whisperResult.wer * 100).toFixed(1)
-      console.log(`>>> [WHISPER] [en] WER: ${werPct}%`)
-
-      const threshold = 0.4
-      t.ok(whisperResult.wer <= threshold, `WER should be ≤ ${threshold * 100}% (got ${werPct}%)`)
+    if (isDarwin) {
+      console.log('\n=== Ensuring Whisper model (for WER verification) ===')
+      const whisperModelPath = path.join(whisperModelDir, 'ggml-small.bin')
+      await ensureWhisperModel(whisperModelPath)
+      t.pass('Whisper model present')
     }
 
-    await whisperModel.unload()
-    console.log('Whisper model unloaded')
+    const expectation = {
+      minSamples: 5000,
+      maxSamples: 5000000,
+      minDurationMs: 200,
+      maxDurationMs: 300000
+    }
+
+    const werEntries = []
+    const englishSentences = getEnglishSentences()
+
+    // `ensureChatterboxModels` may resolve to a different dir on Android
+    // (the adb-push-friendly candidate paths under /sdcard/...), so use
+    // the dir it actually found the GGUFs in.
+    const resolvedModelDir = download.targetDir
+    console.log(
+      `\n=== English synthesis (${englishSentences.length} sentences, tier: ${INPUT_SENTENCES}, modelDir: ${resolvedModelDir}) ===`
+    )
+    const model = await loadChatterboxTTS({
+      modelDir: resolvedModelDir,
+      language: 'en'
+    })
+    t.ok(model, 'Chatterbox (ggml) model should be loaded')
+
+    const runner = useSplit ? runChatterboxTTSWithSplit : runChatterboxTTS
+
+    for (let i = 0; i < englishSentences.length; i++) {
+      const text = englishSentences[i]
+      const preview = text.substring(0, 60) + (text.length > 60 ? '...' : '')
+      console.log(`\n--- English ${i + 1}/${englishSentences.length}: "${preview}" ---`)
+
+      const saveWav = !isMobile
+      const wavPath = saveWav
+        ? path.join(baseDir, 'test', 'output', `chatterbox-english-${i + 1}.wav`)
+        : undefined
+
+      const t0 = Date.now()
+      const result = await runner(model, { text, saveWav, wavOutputPath: wavPath }, expectation)
+      const wallMs = Date.now() - t0
+      console.log(result.output)
+
+      t.ok(result.passed, `English TTS ${i + 1} should pass expectations`)
+      t.ok(result.data.sampleCount > 0, `English TTS ${i + 1} should produce audio samples`)
+      t.is(result.data.reportedSampleRate, 24000, 'Sample rate should be native 24 kHz')
+
+      const st = result.data?.stats || {}
+      t.comment(
+        recordTtsStats(
+          `chatterbox english ${i + 1}`,
+          {
+            realTimeFactor: st.realTimeFactor,
+            audioDurationMs: st.audioDurationMs || result.data?.durationMs,
+            totalSamples: result.data?.sampleCount,
+            backendDevice: st.backendDevice
+          },
+          { wallMs, sampleCount: result.data?.sampleCount, model: 'chatterbox', output: text }
+        )
+      )
+
+      const wavBuffer = result.data?.wavBuffer ? Buffer.from(result.data.wavBuffer) : null
+      werEntries.push({
+        text,
+        lang: 'en',
+        wavBuffer,
+        sampleCount: result.data.sampleCount,
+        durationMs: result.data.durationMs
+      })
+    }
+
+    await model.unload()
+    t.pass('Chatterbox model unloaded')
+
+    console.log('\n=== WER verification ===')
+    if (!isDarwin) {
+      t.pass('WER verification skipped (non-darwin)')
+    } else if (INPUT_SENTENCES !== 'short') {
+      t.pass('WER verification skipped (non-short input)')
+    } else {
+      const whisperModel = await loadWhisper({
+        modelName: 'ggml-small.bin',
+        diskPath: whisperModelDir,
+        language: 'en'
+      })
+      t.ok(whisperModel, 'Whisper model should be loaded')
+
+      for (let i = 0; i < werEntries.length; i++) {
+        const entry = werEntries[i]
+        if (!entry.wavBuffer) {
+          console.log(`\n--- Whisper ${i + 1}/${werEntries.length}: skipped (no WAV buffer) ---`)
+          continue
+        }
+
+        console.log(
+          `\n--- Whisper ${i + 1}/${werEntries.length}: "${entry.text.substring(0, 50)}..." ---`
+        )
+        const whisperResult = await runWhisper(whisperModel, entry.text, entry.wavBuffer)
+        const werPct = (whisperResult.wer * 100).toFixed(1)
+        console.log(`>>> [WHISPER] [en] WER: ${werPct}%`)
+
+        const threshold = 0.4
+        t.ok(whisperResult.wer <= threshold, `WER should be ≤ ${threshold * 100}% (got ${werPct}%)`)
+      }
+
+      await whisperModel.unload()
+      console.log('Whisper model unloaded')
+    }
+
+    console.log('\n' + '='.repeat(60))
+    console.log('CHATTERBOX (ggml) TEST SUMMARY')
+    console.log('='.repeat(60))
+    for (const e of werEntries) {
+      console.log(
+        `  [${e.lang}] ${e.sampleCount} samples, ${e.durationMs?.toFixed(0) || 'N/A'}ms - "${e.text.substring(0, 50)}..."`
+      )
+    }
+    console.log('='.repeat(60))
   }
+)
 
-  console.log('\n' + '='.repeat(60))
-  console.log('CHATTERBOX (ggml) TEST SUMMARY')
-  console.log('='.repeat(60))
-  for (const e of werEntries) {
-    console.log(`  [${e.lang}] ${e.sampleCount} samples, ${e.durationMs?.toFixed(0) || 'N/A'}ms - "${e.text.substring(0, 50)}..."`)
+test(
+  'Chatterbox TTS (ggml): synthesizes without referenceAudio using the built-in voice baked into the S3Gen GGUF',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
+
+    const download = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    // referenceAudio omitted on purpose: chatterbox::Engine falls back to
+    // the voice profile baked into the S3Gen GGUF (see qvac-tts.cpp's
+    // built-in voice condition).  ChatterboxModel::validateConfig only
+    // rejects referenceAudio when it's set AND the file is missing; an
+    // empty/undefined value flows through to the engine cleanly.
+    const TTSGgml = require('@qvac/tts-ggml')
+    const model = new TTSGgml({
+      files: { modelDir: download.targetDir },
+      config: { language: 'en', ...(forceNoGpu ? { useGPU: false } : {}) },
+      opts: { stats: true }
+    })
+
+    try {
+      await model.load()
+
+      const response = await model.run({
+        type: 'text',
+        input: 'Hello from the built-in voice.'
+      })
+      let samples = 0
+      let reportedSampleRate = null
+      await response
+        .onUpdate((data) => {
+          if (data && data.outputArray) samples += data.outputArray.length
+          if (data && data.sampleRate) reportedSampleRate = data.sampleRate
+        })
+        .await()
+
+      t.ok(samples > 5000, `built-in voice should produce > 5000 samples (got ${samples})`)
+      t.is(reportedSampleRate, 24000, 'built-in voice still emits at 24 kHz native rate')
+      if (response.stats) {
+        t.ok(response.stats.totalSamples > 0, 'built-in voice run reports stats')
+        t.ok(typeof response.stats.realTimeFactor === 'number', 'built-in voice run reports RTF')
+      }
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-  console.log('='.repeat(60))
-})
+)
 
-test('Chatterbox TTS (ggml): synthesizes without referenceAudio using the built-in voice baked into the S3Gen GGUF', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
+test(
+  'Chatterbox TTS (ggml): outputSampleRate option is accepted (pass-through for now)',
+  { timeout: 300000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
 
-  const download = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!download.success) {
-    t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
+    const download = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
 
-  // referenceAudio omitted on purpose: chatterbox::Engine falls back to
-  // the voice profile baked into the S3Gen GGUF (see qvac-tts.cpp's
-  // built-in voice condition).  ChatterboxModel::validateConfig only
-  // rejects referenceAudio when it's set AND the file is missing; an
-  // empty/undefined value flows through to the engine cleanly.
-  const TTSGgml = require('@qvac/tts-ggml')
-  const model = new TTSGgml({
-    files: { modelDir: download.targetDir },
-    config: { language: 'en', ...(forceNoGpu ? { useGPU: false } : {}) },
-    opts: { stats: true }
-  })
-
-  try {
+    // Native output is always 24 kHz for Chatterbox; outputSampleRate resampling
+    // is reserved for the persistent-engine milestone.  This test just verifies
+    // the option flows end-to-end without errors.  Reference audio routed
+    // through `resolveRefWavPath` so the mobile-asset path (stage-copied
+    // into `Library/Caches/jfk.wav` by the test runner) is preferred over
+    // the in-bundle `test/reference-audio/jfk.wav` that `__dirname` would
+    // resolve to (the latter is not readable from native code on iOS).
+    const TTSGgml = require('@qvac/tts-ggml')
+    const model = new TTSGgml({
+      files: { modelDir: download.targetDir },
+      referenceAudio: resolveRefWavPath({}),
+      config: { language: 'en', outputSampleRate: 16000, ...(forceNoGpu ? { useGPU: false } : {}) },
+      opts: { stats: true }
+    })
     await model.load()
 
-    const response = await model.run({
-      type: 'text',
-      input: 'Hello from the built-in voice.'
-    })
+    const response = await model.run({ type: 'text', input: 'Hello world.' })
     let samples = 0
-    let reportedSampleRate = null
     await response
-      .onUpdate(data => {
+      .onUpdate((data) => {
         if (data && data.outputArray) samples += data.outputArray.length
-        if (data && data.sampleRate) reportedSampleRate = data.sampleRate
       })
       .await()
 
-    t.ok(samples > 5000, `built-in voice should produce > 5000 samples (got ${samples})`)
-    t.is(reportedSampleRate, 24000, 'built-in voice still emits at 24 kHz native rate')
-    if (response.stats) {
-      t.ok(response.stats.totalSamples > 0, 'built-in voice run reports stats')
-      t.ok(typeof response.stats.realTimeFactor === 'number', 'built-in voice run reports RTF')
-    }
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
+    t.ok(samples > 0, 'Should produce non-empty output audio')
+    await model.unload()
 
-test('Chatterbox TTS (ggml): outputSampleRate option is accepted (pass-through for now)', { timeout: 300000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
-
-  const download = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!download.success) {
-    t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-
-  // Native output is always 24 kHz for Chatterbox; outputSampleRate resampling
-  // is reserved for the persistent-engine milestone.  This test just verifies
-  // the option flows end-to-end without errors.  Reference audio routed
-  // through `resolveRefWavPath` so the mobile-asset path (stage-copied
-  // into `Library/Caches/jfk.wav` by the test runner) is preferred over
-  // the in-bundle `test/reference-audio/jfk.wav` that `__dirname` would
-  // resolve to (the latter is not readable from native code on iOS).
-  const TTSGgml = require('@qvac/tts-ggml')
-  const model = new TTSGgml({
-    files: { modelDir: download.targetDir },
-    referenceAudio: resolveRefWavPath({}),
-    config: { language: 'en', outputSampleRate: 16000, ...(forceNoGpu ? { useGPU: false } : {}) },
-    opts: { stats: true }
-  })
-  await model.load()
-
-  const response = await model.run({ type: 'text', input: 'Hello world.' })
-  let samples = 0
-  await response
-    .onUpdate(data => {
-      if (data && data.outputArray) samples += data.outputArray.length
-    })
-    .await()
-
-  t.ok(samples > 0, 'Should produce non-empty output audio')
-  await model.unload()
-
-  if (!fs.existsSync(path.join(baseDir, 'test', 'output'))) {
-    // Just a touchpoint so CI logs show output dir; not strictly required.
-    try { fs.mkdirSync(path.join(baseDir, 'test', 'output'), { recursive: true }) } catch (e) { /* ignore */ }
-  }
-})
-
-test('Chatterbox TTS (ggml): native C++ chunk streaming via streamChunkTokens', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
-
-  const download = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!download.success) {
-    t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-
-  // streamChunkTokens > 0 activates the native Engine chunked S3Gen+HiFT
-  // loop.  The addon publishes each chunk's PCM via the outputQueue so
-  // every `onUpdate` carries a distinct chunk of audio rather than one
-  // concatenated final result.  Reference audio via `resolveRefWavPath`
-  // (see the outputSampleRate test above for the mobile-asset
-  // rationale).
-  const TTSGgml = require('@qvac/tts-ggml')
-  const model = new TTSGgml({
-    files: { modelDir: download.targetDir },
-    referenceAudio: resolveRefWavPath({}),
-    streamChunkTokens: 25,
-    streamFirstChunkTokens: 10,
-    cfmSteps: 1,
-    config: { language: 'en', ...(forceNoGpu ? { useGPU: false } : {}) },
-    opts: { stats: true }
-  })
-  await model.load()
-  t.pass('Chatterbox (ggml) model loaded with native streaming')
-
-  const response = await model.run({
-    type: 'text',
-    input: 'The quick brown fox jumps over the lazy dog. This is a slightly longer sentence to produce multiple native chunks.'
-  })
-
-  const chunkIndices = []
-  let totalSamples = 0
-  let sawIsLast = false
-  let lastSeenIsLast = null
-  await response
-    .onUpdate(data => {
-      if (data && data.outputArray) {
-        chunkIndices.push(data.chunkIndex)
-        totalSamples += data.outputArray.length
-        if (data.isLast === true) sawIsLast = true
-        lastSeenIsLast = data.isLast
+    if (!fs.existsSync(path.join(baseDir, 'test', 'output'))) {
+      // Just a touchpoint so CI logs show output dir; not strictly required.
+      try {
+        fs.mkdirSync(path.join(baseDir, 'test', 'output'), { recursive: true })
+      } catch (e) {
+        /* ignore */
       }
+    }
+  }
+)
+
+test(
+  'Chatterbox TTS (ggml): native C++ chunk streaming via streamChunkTokens',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
+
+    const download = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    // streamChunkTokens > 0 activates the native Engine chunked S3Gen+HiFT
+    // loop.  The addon publishes each chunk's PCM via the outputQueue so
+    // every `onUpdate` carries a distinct chunk of audio rather than one
+    // concatenated final result.  Reference audio via `resolveRefWavPath`
+    // (see the outputSampleRate test above for the mobile-asset
+    // rationale).
+    const TTSGgml = require('@qvac/tts-ggml')
+    const model = new TTSGgml({
+      files: { modelDir: download.targetDir },
+      referenceAudio: resolveRefWavPath({}),
+      streamChunkTokens: 25,
+      streamFirstChunkTokens: 10,
+      cfmSteps: 1,
+      config: { language: 'en', ...(forceNoGpu ? { useGPU: false } : {}) },
+      opts: { stats: true }
     })
-    .await()
+    await model.load()
+    t.pass('Chatterbox (ggml) model loaded with native streaming')
 
-  t.ok(chunkIndices.length >= 2, `native streaming should emit multiple chunks (got ${chunkIndices.length})`)
-  t.ok(totalSamples > 0, 'native streaming should produce audio samples')
-  for (let i = 0; i < chunkIndices.length; i++) {
-    t.is(chunkIndices[i], i, `chunk ${i} should carry chunkIndex=${i}`)
-  }
-  t.ok(sawIsLast, 'one of the chunks should carry isLast=true')
-  t.is(lastSeenIsLast, true, 'the final chunk should carry isLast=true')
+    const response = await model.run({
+      type: 'text',
+      input:
+        'The quick brown fox jumps over the lazy dog. This is a slightly longer sentence to produce multiple native chunks.'
+    })
 
-  await model.unload()
-  t.pass('Model unloaded after native streaming')
-})
+    const chunkIndices = []
+    let totalSamples = 0
+    let sawIsLast = false
+    let lastSeenIsLast = null
+    await response
+      .onUpdate((data) => {
+        if (data && data.outputArray) {
+          chunkIndices.push(data.chunkIndex)
+          totalSamples += data.outputArray.length
+          if (data.isLast === true) sawIsLast = true
+          lastSeenIsLast = data.isLast
+        }
+      })
+      .await()
 
-test('Chatterbox TTS (ggml): streaming input + streaming PCM output (runStreaming + onUpdate)', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
-
-  console.log('\n=== Ensuring Chatterbox GGUFs (streaming) ===')
-  const download = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!download.success) {
-    t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-  t.ok(download.success, 'Chatterbox GGUFs should be available')
-
-  const model = await loadChatterboxTTS({
-    modelDir: download.targetDir,
-    language: 'en'
-  })
-  t.ok(model, 'Chatterbox (ggml) model should be loaded')
-
-  const phrases = [
-    'First phrase arrives from the upstream text stream.',
-    'A short pause could sit between chunks.',
-    'Each yield is one discrete synthesis job.'
-  ]
-
-  const expectation = {
-    minSamples: 15000,
-    maxSamples: 5000000,
-    minDurationMs: 400,
-    maxDurationMs: 300000
-  }
-
-  const saveWav = !isMobile
-  const wavOutputPath = saveWav
-    ? path.join(baseDir, 'test', 'output', 'chatterbox-streaming.wav')
-    : undefined
-
-  console.log(`\n=== Running Chatterbox IO stream synthesis (runStreaming, ${phrases.length} phrases) ===`)
-  const result = await runChatterboxStreaming(
-    model,
-    { phrases, saveWav, wavOutputPath },
-    expectation
-  )
-  console.log(result.output)
-
-  t.ok(result.passed, 'Streaming synthesis should pass expectations')
-  t.ok(result.data.sampleCount > 0, 'Streaming should produce audio samples')
-  t.is(result.data.reportedSampleRate, 24000, 'Streaming sample rate is native 24 kHz')
-  t.is(
-    result.data.streamChunkCount,
-    phrases.length,
-    'runStreaming should emit one chunk per yielded phrase'
-  )
-  t.is(result.data.sentenceChunks.length, phrases.length)
-  for (let i = 0; i < phrases.length; i++) {
-    t.is(
-      result.data.sentenceChunks[i],
-      phrases[i],
-      `chunk ${i} sentenceChunk should match the streamed-in phrase`
+    t.ok(
+      chunkIndices.length >= 2,
+      `native streaming should emit multiple chunks (got ${chunkIndices.length})`
     )
-  }
+    t.ok(totalSamples > 0, 'native streaming should produce audio samples')
+    for (let i = 0; i < chunkIndices.length; i++) {
+      t.is(chunkIndices[i], i, `chunk ${i} should carry chunkIndex=${i}`)
+    }
+    t.ok(sawIsLast, 'one of the chunks should carry isLast=true')
+    t.is(lastSeenIsLast, true, 'the final chunk should carry isLast=true')
 
-  await model.unload()
-  t.pass('Chatterbox model unloaded')
-})
+    await model.unload()
+    t.pass('Model unloaded after native streaming')
+  }
+)
+
+test(
+  'Chatterbox TTS (ggml): streaming input + streaming PCM output (runStreaming + onUpdate)',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
+
+    console.log('\n=== Ensuring Chatterbox GGUFs (streaming) ===')
+    const download = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+    t.ok(download.success, 'Chatterbox GGUFs should be available')
+
+    const model = await loadChatterboxTTS({
+      modelDir: download.targetDir,
+      language: 'en'
+    })
+    t.ok(model, 'Chatterbox (ggml) model should be loaded')
+
+    const phrases = [
+      'First phrase arrives from the upstream text stream.',
+      'A short pause could sit between chunks.',
+      'Each yield is one discrete synthesis job.'
+    ]
+
+    const expectation = {
+      minSamples: 15000,
+      maxSamples: 5000000,
+      minDurationMs: 400,
+      maxDurationMs: 300000
+    }
+
+    const saveWav = !isMobile
+    const wavOutputPath = saveWav
+      ? path.join(baseDir, 'test', 'output', 'chatterbox-streaming.wav')
+      : undefined
+
+    console.log(
+      `\n=== Running Chatterbox IO stream synthesis (runStreaming, ${phrases.length} phrases) ===`
+    )
+    const result = await runChatterboxStreaming(
+      model,
+      { phrases, saveWav, wavOutputPath },
+      expectation
+    )
+    console.log(result.output)
+
+    t.ok(result.passed, 'Streaming synthesis should pass expectations')
+    t.ok(result.data.sampleCount > 0, 'Streaming should produce audio samples')
+    t.is(result.data.reportedSampleRate, 24000, 'Streaming sample rate is native 24 kHz')
+    t.is(
+      result.data.streamChunkCount,
+      phrases.length,
+      'runStreaming should emit one chunk per yielded phrase'
+    )
+    t.is(result.data.sentenceChunks.length, phrases.length)
+    for (let i = 0; i < phrases.length; i++) {
+      t.is(
+        result.data.sentenceChunks[i],
+        phrases[i],
+        `chunk ${i} sentenceChunk should match the streamed-in phrase`
+      )
+    }
+
+    await model.unload()
+    t.pass('Chatterbox model unloaded')
+  }
+)

--- a/packages/tts-ggml/test/integration/chatterbox-kv-cache-gpu.test.js
+++ b/packages/tts-ggml/test/integration/chatterbox-kv-cache-gpu.test.js
@@ -48,14 +48,16 @@ const LANGUAGE_FOR = { mtl: 'es', turbo: 'en' }
 
 // Load `variant` on the GPU with `kvCacheType`, synthesize once, assert it
 // completed and engaged the GPU, then unload.  Shared by every matrix entry.
-async function runGpuCase (t, variant, kvCacheType) {
+async function runGpuCase(t, variant, kvCacheType) {
   const baseDir = getBaseDir()
   const modelsDir = path.join(baseDir, 'models')
 
   const download = await ensureModelsFor(variant, modelsDir)
   if (!download.success) {
-    t.fail(`Chatterbox ${variant} GGUFs not available - registry fetch failed. ` +
-      'Run `npm run download-models:registry` or stage models locally.')
+    t.fail(
+      `Chatterbox ${variant} GGUFs not available - registry fetch failed. ` +
+        'Run `npm run download-models:registry` or stage models locally.'
+    )
     return
   }
 
@@ -84,29 +86,35 @@ async function runGpuCase (t, variant, kvCacheType) {
       allowPolicyCpu: false
     })
   } finally {
-    try { await model.unload() } catch (_e) {}
+    try {
+      await model.unload()
+    } catch (_e) {}
   }
 }
 
 // ── Headline regression: the exact cell that shipped broken ──────────────
 // MTL + useGPU=true + DEFAULT KV cache. Pre-(q8_0 default) this
 // aborts on Metal; post-fix (f16 default) it completes.
-test('Chatterbox MTL + useGPU=true + DEFAULT KV cache synthesizes to completion',
+test(
+  'Chatterbox MTL + useGPU=true + DEFAULT KV cache synthesizes to completion',
   { timeout: 600000, skip: NO_GPU },
   async (t) => {
     await runGpuCase(t, 'mtl', undefined)
-  })
+  }
+)
 
 // ── Full GPU-safe sweep: every variant × {default, f16, f32} on GPU ──────
 for (const variant of CHATTERBOX_VARIANTS) {
   for (const kvCacheType of [undefined, ...GPU_SAFE_KV_TYPES]) {
     // The MTL/default cell is the headline test above; skip the duplicate.
     if (variant === 'mtl' && kvCacheType === undefined) continue
-    test(`Chatterbox ${variant.toUpperCase()} + useGPU=true + kv=${kvLabel(kvCacheType)} synthesizes to completion`,
+    test(
+      `Chatterbox ${variant.toUpperCase()} + useGPU=true + kv=${kvLabel(kvCacheType)} synthesizes to completion`,
       { timeout: 600000, skip: NO_GPU },
       async (t) => {
         await runGpuCase(t, variant, kvCacheType)
-      })
+      }
+    )
   }
 }
 
@@ -117,9 +125,11 @@ for (const variant of CHATTERBOX_VARIANTS) {
 // follow-up once it ships (it should either complete or cleanly fall back to
 // f32 — never SIGABRT).
 for (const variant of CHATTERBOX_VARIANTS) {
-  test(`Chatterbox ${variant.toUpperCase()} + useGPU=true + kv=q8_0 does not abort (opt-in: QVAC_TTS_KV_PROBE_UNSAFE)`,
+  test(
+    `Chatterbox ${variant.toUpperCase()} + useGPU=true + kv=q8_0 does not abort (opt-in: QVAC_TTS_KV_PROBE_UNSAFE)`,
     { timeout: 600000, skip: NO_GPU || !PROBE_UNSAFE },
     async (t) => {
       await runGpuCase(t, variant, 'q8_0')
-    })
+    }
+  )
 }

--- a/packages/tts-ggml/test/integration/chatterbox-mtl.test.js
+++ b/packages/tts-ggml/test/integration/chatterbox-mtl.test.js
@@ -19,7 +19,11 @@ const test = require('brittle')
 const TTSGgml = require('@qvac/tts-ggml')
 const { runTTS } = require('../utils/runTTS')
 const { resolveRefWavPath } = require('../utils/runChatterboxTTS')
-const { ensureChatterboxMtlModels, ensureMecabDict, ensureCangjieTsv } = require('../utils/downloadModel')
+const {
+  ensureChatterboxMtlModels,
+  ensureMecabDict,
+  ensureCangjieTsv
+} = require('../utils/downloadModel')
 const { recordTtsStats } = require('../utils/perf-helper')
 
 const platform = os.platform()
@@ -29,7 +33,7 @@ const isMobile = platform === 'ios' || platform === 'android'
 // default (`useGPU: false`) rather than opting into GPU here.
 // Tests that *are* about GPU live in gpu-smoke.test.js.
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
@@ -46,7 +50,7 @@ const MTL_SENTENCES = [
 const JA_SENTENCE = '今日はいい天気ですね。'
 const ZH_SENTENCE = '敏捷的棕色狐狸跳过懒狗。'
 
-async function loadChatterboxMtlTTS (params) {
+async function loadChatterboxMtlTTS(params) {
   // Route through `resolveRefWavPath` so the mobile-asset path (staged
   // into `Library/Caches/jfk.wav` via `global.assetPaths`) is preferred
   // over the in-bundle `test/reference-audio/jfk.wav`; the bundled
@@ -77,174 +81,241 @@ async function loadChatterboxMtlTTS (params) {
   return model
 }
 
-test('Chatterbox MTL TTS (ggml): synthesizes across es/fr/de/pt/it with shared engine', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureChatterboxMtlModels({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) {
-    t.fail('Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
+test(
+  'Chatterbox MTL TTS (ggml): synthesizes across es/fr/de/pt/it with shared engine',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureChatterboxMtlModels({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
 
-  const model = await loadChatterboxMtlTTS({
-    modelDir: download.targetDir,
-    t3ModelPath: path.join(download.targetDir, 'chatterbox-t3-mtl.gguf'),
-    s3genModelPath: path.join(download.targetDir, 'chatterbox-s3gen-mtl.gguf'),
-    language: MTL_SENTENCES[0].lang
-  })
-  try {
-    for (let i = 0; i < MTL_SENTENCES.length; i++) {
-      const { lang, text } = MTL_SENTENCES[i]
-      console.log(`  [${lang}] "${text.slice(0, 50)}..."`)
-      if (i > 0) {
-        await model.reload({ language: lang })
+    const model = await loadChatterboxMtlTTS({
+      modelDir: download.targetDir,
+      t3ModelPath: path.join(download.targetDir, 'chatterbox-t3-mtl.gguf'),
+      s3genModelPath: path.join(download.targetDir, 'chatterbox-s3gen-mtl.gguf'),
+      language: MTL_SENTENCES[0].lang
+    })
+    try {
+      for (let i = 0; i < MTL_SENTENCES.length; i++) {
+        const { lang, text } = MTL_SENTENCES[i]
+        console.log(`  [${lang}] "${text.slice(0, 50)}..."`)
+        if (i > 0) {
+          await model.reload({ language: lang })
+        }
+        const t0 = Date.now()
+        const result = await runTTS(
+          model,
+          { text },
+          { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 },
+          { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox MTL' }
+        )
+        const wallMs = Date.now() - t0
+        console.log('    ' + result.output)
+
+        t.ok(result.passed, `MTL ${lang} run passes expectations`)
+        t.ok(result.data.sampleCount > 0, `MTL ${lang} produced audio`)
+        t.is(
+          result.data.reportedSampleRate || SAMPLE_RATE,
+          SAMPLE_RATE,
+          `MTL ${lang} reports 24 kHz`
+        )
+
+        const st = result.data?.stats || {}
+        t.comment(
+          recordTtsStats(
+            `chatterbox mtl ${lang}`,
+            {
+              realTimeFactor: st.realTimeFactor,
+              audioDurationMs: st.audioDurationMs || result.data?.durationMs,
+              totalSamples: st.totalSamples,
+              backendDevice: st.backendDevice
+            },
+            { wallMs, sampleCount: result.data?.sampleCount, model: 'chatterbox-mtl', output: text }
+          )
+        )
       }
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)
+
+test(
+  'Chatterbox MTL TTS (ggml): synthesizes Japanese with MeCab dictionary',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureChatterboxMtlModels({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    const mecab = await ensureMecabDict({ targetDir: path.join(baseDir, 'models', 'mecab-ipadic') })
+    if (!mecab.success) {
+      t.pass('Skipped: MeCab/IPAdic dictionary not available')
+      return
+    }
+
+    const model = await loadChatterboxMtlTTS({
+      modelDir: download.targetDir,
+      t3ModelPath: path.join(download.targetDir, 'chatterbox-t3-mtl.gguf'),
+      s3genModelPath: path.join(download.targetDir, 'chatterbox-s3gen-mtl.gguf'),
+      mecabDictDir: mecab.dir,
+      language: 'ja'
+    })
+    try {
       const t0 = Date.now()
       const result = await runTTS(
         model,
-        { text },
+        { text: JA_SENTENCE },
         { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 },
-        { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox MTL' }
+        { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox MTL JA' }
       )
       const wallMs = Date.now() - t0
       console.log('    ' + result.output)
 
-      t.ok(result.passed, `MTL ${lang} run passes expectations`)
-      t.ok(result.data.sampleCount > 0, `MTL ${lang} produced audio`)
-      t.is(result.data.reportedSampleRate || SAMPLE_RATE, SAMPLE_RATE, `MTL ${lang} reports 24 kHz`)
+      t.ok(result.passed, 'MTL ja run passes expectations')
+      t.ok(result.data.sampleCount > 0, 'MTL ja produced audio')
+      t.is(result.data.reportedSampleRate || SAMPLE_RATE, SAMPLE_RATE, 'MTL ja reports 24 kHz')
 
       const st = result.data?.stats || {}
-      t.comment(recordTtsStats(
-        `chatterbox mtl ${lang}`,
-        { realTimeFactor: st.realTimeFactor, audioDurationMs: st.audioDurationMs || result.data?.durationMs, totalSamples: st.totalSamples, backendDevice: st.backendDevice },
-        { wallMs, sampleCount: result.data?.sampleCount, model: 'chatterbox-mtl', output: text }
-      ))
+      t.comment(
+        recordTtsStats(
+          'chatterbox mtl ja',
+          {
+            realTimeFactor: st.realTimeFactor,
+            audioDurationMs: st.audioDurationMs || result.data?.durationMs,
+            totalSamples: st.totalSamples,
+            backendDevice: st.backendDevice
+          },
+          {
+            wallMs,
+            sampleCount: result.data?.sampleCount,
+            model: 'chatterbox-mtl',
+            output: JA_SENTENCE
+          }
+        )
+      )
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
     }
-  } finally {
-    try { await model.unload() } catch (_e) {}
   }
-})
+)
 
-test('Chatterbox MTL TTS (ggml): synthesizes Japanese with MeCab dictionary', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureChatterboxMtlModels({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) {
-    t.fail('Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-
-  const mecab = await ensureMecabDict({ targetDir: path.join(baseDir, 'models', 'mecab-ipadic') })
-  if (!mecab.success) {
-    t.pass('Skipped: MeCab/IPAdic dictionary not available')
-    return
-  }
-
-  const model = await loadChatterboxMtlTTS({
-    modelDir: download.targetDir,
-    t3ModelPath: path.join(download.targetDir, 'chatterbox-t3-mtl.gguf'),
-    s3genModelPath: path.join(download.targetDir, 'chatterbox-s3gen-mtl.gguf'),
-    mecabDictDir: mecab.dir,
-    language: 'ja'
-  })
-  try {
-    const t0 = Date.now()
-    const result = await runTTS(
-      model,
-      { text: JA_SENTENCE },
-      { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 },
-      { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox MTL JA' }
-    )
-    const wallMs = Date.now() - t0
-    console.log('    ' + result.output)
-
-    t.ok(result.passed, 'MTL ja run passes expectations')
-    t.ok(result.data.sampleCount > 0, 'MTL ja produced audio')
-    t.is(result.data.reportedSampleRate || SAMPLE_RATE, SAMPLE_RATE, 'MTL ja reports 24 kHz')
-
-    const st = result.data?.stats || {}
-    t.comment(recordTtsStats(
-      'chatterbox mtl ja',
-      { realTimeFactor: st.realTimeFactor, audioDurationMs: st.audioDurationMs || result.data?.durationMs, totalSamples: st.totalSamples, backendDevice: st.backendDevice },
-      { wallMs, sampleCount: result.data?.sampleCount, model: 'chatterbox-mtl', output: JA_SENTENCE }
-    ))
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Chatterbox MTL TTS (ggml): synthesizes Chinese with Cangjie table', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureChatterboxMtlModels({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) {
-    t.fail('Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-
-  const cangjie = await ensureCangjieTsv({ targetDir: path.join(baseDir, 'models') })
-  if (!cangjie.success) {
-    t.pass('Skipped: Cangjie5_TC TSV not available')
-    return
-  }
-
-  const model = await loadChatterboxMtlTTS({
-    modelDir: download.targetDir,
-    t3ModelPath: path.join(download.targetDir, 'chatterbox-t3-mtl.gguf'),
-    s3genModelPath: path.join(download.targetDir, 'chatterbox-s3gen-mtl.gguf'),
-    cangjieTsvPath: cangjie.path,
-    language: 'zh'
-  })
-  try {
-    const t0 = Date.now()
-    const result = await runTTS(
-      model,
-      { text: ZH_SENTENCE },
-      { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 },
-      { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox MTL ZH' }
-    )
-    const wallMs = Date.now() - t0
-    console.log('    ' + result.output)
-
-    t.ok(result.passed, 'MTL zh run passes expectations')
-    t.ok(result.data.sampleCount > 0, 'MTL zh produced audio')
-    t.is(result.data.reportedSampleRate || SAMPLE_RATE, SAMPLE_RATE, 'MTL zh reports 24 kHz')
-
-    const st = result.data?.stats || {}
-    t.comment(recordTtsStats(
-      'chatterbox mtl zh',
-      { realTimeFactor: st.realTimeFactor, audioDurationMs: st.audioDurationMs || result.data?.durationMs, totalSamples: st.totalSamples, backendDevice: st.backendDevice },
-      { wallMs, sampleCount: result.data?.sampleCount, model: 'chatterbox-mtl', output: ZH_SENTENCE }
-    ))
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Chatterbox MTL TTS (ggml): backendDevice + backendId surfaced in stats', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureChatterboxMtlModels({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) {
-    t.fail('Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-
-  const model = await loadChatterboxMtlTTS({
-    modelDir: download.targetDir,
-    language: 'es'
-  })
-  try {
-    const result = await runTTS(
-      model,
-      { text: 'Comprobando los datos de telemetría del backend.' },
-      { minSamples: 5000 },
-      { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox MTL' }
-    )
-    t.ok(result.passed, 'MTL run for backend telemetry passes')
-    if (result.data.stats) {
-      t.ok(typeof result.data.stats.backendDevice === 'number', 'backendDevice surfaced in stats')
-      t.ok(typeof result.data.stats.backendId === 'number', 'backendId surfaced in stats')
-    } else {
-      t.fail('expected stats from MTL run')
+test(
+  'Chatterbox MTL TTS (ggml): synthesizes Chinese with Cangjie table',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureChatterboxMtlModels({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
     }
-  } finally {
-    try { await model.unload() } catch (_e) {}
+
+    const cangjie = await ensureCangjieTsv({ targetDir: path.join(baseDir, 'models') })
+    if (!cangjie.success) {
+      t.pass('Skipped: Cangjie5_TC TSV not available')
+      return
+    }
+
+    const model = await loadChatterboxMtlTTS({
+      modelDir: download.targetDir,
+      t3ModelPath: path.join(download.targetDir, 'chatterbox-t3-mtl.gguf'),
+      s3genModelPath: path.join(download.targetDir, 'chatterbox-s3gen-mtl.gguf'),
+      cangjieTsvPath: cangjie.path,
+      language: 'zh'
+    })
+    try {
+      const t0 = Date.now()
+      const result = await runTTS(
+        model,
+        { text: ZH_SENTENCE },
+        { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 },
+        { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox MTL ZH' }
+      )
+      const wallMs = Date.now() - t0
+      console.log('    ' + result.output)
+
+      t.ok(result.passed, 'MTL zh run passes expectations')
+      t.ok(result.data.sampleCount > 0, 'MTL zh produced audio')
+      t.is(result.data.reportedSampleRate || SAMPLE_RATE, SAMPLE_RATE, 'MTL zh reports 24 kHz')
+
+      const st = result.data?.stats || {}
+      t.comment(
+        recordTtsStats(
+          'chatterbox mtl zh',
+          {
+            realTimeFactor: st.realTimeFactor,
+            audioDurationMs: st.audioDurationMs || result.data?.durationMs,
+            totalSamples: st.totalSamples,
+            backendDevice: st.backendDevice
+          },
+          {
+            wallMs,
+            sampleCount: result.data?.sampleCount,
+            model: 'chatterbox-mtl',
+            output: ZH_SENTENCE
+          }
+        )
+      )
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-})
+)
+
+test(
+  'Chatterbox MTL TTS (ggml): backendDevice + backendId surfaced in stats',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureChatterboxMtlModels({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    const model = await loadChatterboxMtlTTS({
+      modelDir: download.targetDir,
+      language: 'es'
+    })
+    try {
+      const result = await runTTS(
+        model,
+        { text: 'Comprobando los datos de telemetría del backend.' },
+        { minSamples: 5000 },
+        { sampleRate: SAMPLE_RATE, engineTag: 'Chatterbox MTL' }
+      )
+      t.ok(result.passed, 'MTL run for backend telemetry passes')
+      if (result.data.stats) {
+        t.ok(typeof result.data.stats.backendDevice === 'number', 'backendDevice surfaced in stats')
+        t.ok(typeof result.data.stats.backendId === 'number', 'backendId surfaced in stats')
+      } else {
+        t.fail('expected stats from MTL run')
+      }
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)

--- a/packages/tts-ggml/test/integration/chatterbox-speed.test.js
+++ b/packages/tts-ggml/test/integration/chatterbox-speed.test.js
@@ -12,7 +12,7 @@ const path = require('bare-path')
 const { loadChatterboxTTS, runChatterboxTTS } = require('../utils/runChatterboxTTS')
 const { ensureChatterboxModels } = require('../utils/downloadModel')
 
-function getBaseDir () {
+function getBaseDir() {
   const platform = os.platform()
   const isMobile = platform === 'ios' || platform === 'android'
   return isMobile && global.testDir ? global.testDir : '.'
@@ -27,49 +27,61 @@ const EXPECTATION = {
   maxDurationMs: 300000
 }
 
-test('Chatterbox TTS (ggml): speed config adjusts duration, preserves backward compat', { timeout: 1800000 }, async (t) => {
-  const modelsDir = path.join(getBaseDir(), 'models')
+test(
+  'Chatterbox TTS (ggml): speed config adjusts duration, preserves backward compat',
+  { timeout: 1800000 },
+  async (t) => {
+    const modelsDir = path.join(getBaseDir(), 'models')
 
-  const download = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!download.success) {
-    t.fail('Chatterbox GGUFs not available - run `npm run download-models:registry -- --group chatterbox`.')
-    return
-  }
-  const modelDir = download.targetDir
-
-  // Synthesize the same text at a given speed and return the sample count.
-  // A fixed seed (engine default) makes the un-stretched base deterministic
-  // across loads, so the only difference between runs is the speed knob.
-  async function sampleCountAt (speed) {
-    const label = speed === undefined ? 'default' : String(speed)
-    const model = await loadChatterboxTTS({ modelDir, language: 'en', speed })
-    try {
-      const r = await runChatterboxTTS(model, { text: TEXT }, EXPECTATION)
-      t.ok(r.passed, `speed=${label}: passes synthesis expectations`)
-      t.ok(r.data.sampleCount > 0, `speed=${label}: produces audio samples`)
-      t.is(r.data.reportedSampleRate, 24000, `speed=${label}: native 24 kHz`)
-      return r.data.sampleCount
-    } finally {
-      await model.unload()
+    const download = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox GGUFs not available - run `npm run download-models:registry -- --group chatterbox`.'
+      )
+      return
     }
+    const modelDir = download.targetDir
+
+    // Synthesize the same text at a given speed and return the sample count.
+    // A fixed seed (engine default) makes the un-stretched base deterministic
+    // across loads, so the only difference between runs is the speed knob.
+    async function sampleCountAt(speed) {
+      const label = speed === undefined ? 'default' : String(speed)
+      const model = await loadChatterboxTTS({ modelDir, language: 'en', speed })
+      try {
+        const r = await runChatterboxTTS(model, { text: TEXT }, EXPECTATION)
+        t.ok(r.passed, `speed=${label}: passes synthesis expectations`)
+        t.ok(r.data.sampleCount > 0, `speed=${label}: produces audio samples`)
+        t.is(r.data.reportedSampleRate, 24000, `speed=${label}: native 24 kHz`)
+        return r.data.sampleCount
+      } finally {
+        await model.unload()
+      }
+    }
+
+    // Backward compatibility: omitting `speed` must equal speed:1.0 (the raw
+    // model output) — the addon applies no default slowdown.
+    const defaultSamples = await sampleCountAt(undefined)
+    const rawSamples = await sampleCountAt(1.0)
+    t.is(defaultSamples, rawSamples, 'omitting speed == speed:1.0 (no default rate change)')
+
+    // speed < 1 slows speech down -> proportionally longer audio (~1/speed).
+    const slowSamples = await sampleCountAt(0.5)
+    const ratio = slowSamples / rawSamples
+    t.comment(`speed 0.5 / 1.0 sample-count ratio = ${ratio.toFixed(3)} (expect ~2.0)`)
+    t.ok(
+      ratio > 1.8 && ratio < 2.2,
+      `speed 0.5 yields ~2x the samples of 1.0 (got ${ratio.toFixed(3)})`
+    )
+
+    // speed > 1 speeds speech up -> shorter audio.
+    const fastSamples = await sampleCountAt(1.5)
+    t.ok(
+      fastSamples < rawSamples,
+      `speed 1.5 yields fewer samples than 1.0 (${fastSamples} < ${rawSamples})`
+    )
   }
-
-  // Backward compatibility: omitting `speed` must equal speed:1.0 (the raw
-  // model output) — the addon applies no default slowdown.
-  const defaultSamples = await sampleCountAt(undefined)
-  const rawSamples = await sampleCountAt(1.0)
-  t.is(defaultSamples, rawSamples, 'omitting speed == speed:1.0 (no default rate change)')
-
-  // speed < 1 slows speech down -> proportionally longer audio (~1/speed).
-  const slowSamples = await sampleCountAt(0.5)
-  const ratio = slowSamples / rawSamples
-  t.comment(`speed 0.5 / 1.0 sample-count ratio = ${ratio.toFixed(3)} (expect ~2.0)`)
-  t.ok(ratio > 1.8 && ratio < 2.2, `speed 0.5 yields ~2x the samples of 1.0 (got ${ratio.toFixed(3)})`)
-
-  // speed > 1 speeds speech up -> shorter audio.
-  const fastSamples = await sampleCountAt(1.5)
-  t.ok(fastSamples < rawSamples, `speed 1.5 yields fewer samples than 1.0 (${fastSamples} < ${rawSamples})`)
-})
+)
 
 test('Chatterbox TTS (ggml): out-of-range speed is rejected', { timeout: 600000 }, async (t) => {
   const modelsDir = path.join(getBaseDir(), 'models')

--- a/packages/tts-ggml/test/integration/gpu-smoke.test.js
+++ b/packages/tts-ggml/test/integration/gpu-smoke.test.js
@@ -28,9 +28,19 @@ const path = require('bare-path')
 const proc = require('bare-process')
 const test = require('brittle')
 
-const { loadChatterboxTTS, runChatterboxTTS, resolveRefWavPath } = require('../utils/runChatterboxTTS')
+const {
+  loadChatterboxTTS,
+  runChatterboxTTS,
+  resolveRefWavPath
+} = require('../utils/runChatterboxTTS')
 const { loadSupertonicTTS, runSupertonicTTS } = require('../utils/runSupertonicTTS')
-const { ensureChatterboxModels, ensureChatterboxMtlModels, ensureSupertonicModel, ensureSupertonicMtlModel, ensureSupertonic3Model } = require('../utils/downloadModel')
+const {
+  ensureChatterboxModels,
+  ensureChatterboxMtlModels,
+  ensureSupertonicModel,
+  ensureSupertonicMtlModel,
+  ensureSupertonic3Model
+} = require('../utils/downloadModel')
 const { recordTtsStats } = require('../utils/perf-helper')
 
 const platform = os.platform()
@@ -38,19 +48,26 @@ const isMobile = platform === 'ios' || platform === 'android'
 const RELAX = proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1'
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
-function backendIdToName (id) {
+function backendIdToName(id) {
   switch (id) {
-    case 0: return 'CPU'
-    case 1: return 'Metal'
-    case 2: return 'CUDA'
-    case 3: return 'Vulkan'
-    case 4: return 'OpenCL'
-    case 99: return 'other-GPU'
-    default: return `unknown(${id})`
+    case 0:
+      return 'CPU'
+    case 1:
+      return 'Metal'
+    case 2:
+      return 'CUDA'
+    case 3:
+      return 'Vulkan'
+    case 4:
+      return 'OpenCL'
+    case 99:
+      return 'other-GPU'
+    default:
+      return `unknown(${id})`
   }
 }
 
@@ -59,7 +76,7 @@ function backendIdToName (id) {
 //   - darwin / ios:        metal
 //   - linux / win32:       vulkan
 //   - android:             vulkan + opencl
-function expectsGpu () {
+function expectsGpu() {
   return (
     platform === 'darwin' ||
     platform === 'ios' ||
@@ -69,7 +86,7 @@ function expectsGpu () {
   )
 }
 
-function assertGpuBackend (t, engineTag, stats, allowPolicyCpu = false) {
+function assertGpuBackend(t, engineTag, stats, allowPolicyCpu = false) {
   if (!stats) {
     t.fail(`${engineTag}/GPU: no response.stats returned (cannot verify backend)`)
     return
@@ -80,7 +97,11 @@ function assertGpuBackend (t, engineTag, stats, allowPolicyCpu = false) {
   console.log(`[${engineTag}/GPU] backendDevice=${dev} backendId=${id} (${name})`)
 
   if (!expectsGpu()) {
-    t.is(dev, 0, `${engineTag}/${platform}: backendDevice must be 0 (CPU) on platforms with no GPU wired in`)
+    t.is(
+      dev,
+      0,
+      `${engineTag}/${platform}: backendDevice must be 0 (CPU) on platforms with no GPU wired in`
+    )
     return
   }
 
@@ -88,14 +109,17 @@ function assertGpuBackend (t, engineTag, stats, allowPolicyCpu = false) {
   // to CPU and flag stats.gpuUnsupported. Chatterbox now runs on Mali GPU, so all
   // callers assert strictly; the hatch stays for any future declined engine.
   if (allowPolicyCpu && dev === 0 && stats.gpuUnsupported) {
-    t.pass(`${engineTag}/${platform}: GPU present but declined by policy (gpuUnsupported=1); correctly using CPU`)
+    t.pass(
+      `${engineTag}/${platform}: GPU present but declined by policy (gpuUnsupported=1); correctly using CPU`
+    )
     return
   }
 
   if (dev !== 1) {
-    const msg = `${engineTag}/${platform}: expected GPU backend, got ${name} (backendDevice=${dev}, backendId=${id}). ` +
-                'useGPU=true was requested but the engine fell back to CPU. ' +
-                'Inspect addon native logs for the load-time backend init message.'
+    const msg =
+      `${engineTag}/${platform}: expected GPU backend, got ${name} (backendDevice=${dev}, backendId=${id}). ` +
+      'useGPU=true was requested but the engine fell back to CPU. ' +
+      'Inspect addon native logs for the load-time backend init message.'
     if (RELAX) {
       t.comment(`WARNING (relaxed): ${msg}`)
       t.pass(`${engineTag}/GPU smoke completed (relaxed)`)
@@ -110,7 +134,10 @@ function assertGpuBackend (t, engineTag, stats, allowPolicyCpu = false) {
   } else if (platform === 'linux' || platform === 'win32') {
     t.is(id, 3, `${engineTag}/${platform}: expected Vulkan backendId=3, got ${name}`)
   } else if (platform === 'android') {
-    t.ok(id === 3 || id === 4, `${engineTag}/${platform}: expected Vulkan(3) or OpenCL(4) backendId, got ${name}`)
+    t.ok(
+      id === 3 || id === 4,
+      `${engineTag}/${platform}: expected Vulkan(3) or OpenCL(4) backendId, got ${name}`
+    )
   }
 }
 
@@ -118,7 +145,7 @@ function assertGpuBackend (t, engineTag, stats, allowPolicyCpu = false) {
 // expect the engine to actually pick the CPU backend.  This is the gate
 // that prevents `useGPU=false` from silently still running on GPU when
 // the underlying tts-cpp library default is non-zero n_gpu_layers.
-function assertCpuBackend (t, engineTag, stats) {
+function assertCpuBackend(t, engineTag, stats) {
   if (!stats) {
     t.fail(`${engineTag}/CPU: no response.stats returned (cannot verify backend)`)
     return
@@ -137,55 +164,70 @@ function assertCpuBackend (t, engineTag, stats) {
 // GPU→CPU fallback is reported honestly. recordTtsStats also derives RTF from
 // wall time + audio duration when the addon doesn't report a positive
 // realTimeFactor.
-function recordSmoke (t, label, result, wallMs) {
+function recordSmoke(t, label, result, wallMs) {
   const st = (result && result.data && result.data.stats) || {}
-  t.comment(recordTtsStats(
-    label,
-    { realTimeFactor: st.realTimeFactor, audioDurationMs: st.audioDurationMs || (result && result.data && result.data.durationMs), totalSamples: st.totalSamples, backendDevice: st.backendDevice },
-    { wallMs, sampleCount: result && result.data && result.data.sampleCount, model: label }
-  ))
+  t.comment(
+    recordTtsStats(
+      label,
+      {
+        realTimeFactor: st.realTimeFactor,
+        audioDurationMs: st.audioDurationMs || (result && result.data && result.data.durationMs),
+        totalSamples: st.totalSamples,
+        backendDevice: st.backendDevice
+      },
+      { wallMs, sampleCount: result && result.data && result.data.sampleCount, model: label }
+    )
+  )
 }
 
-test('Chatterbox GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
+test(
+  'Chatterbox GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
 
-  const download = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!download.success) {
-    t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
+    const download = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
 
-  // Mobile-aware resolution: see multiple-runs.test.js for rationale.
-  const refWavPath = resolveRefWavPath({})
-  if (!fs.existsSync(refWavPath)) {
-    t.pass('Skipped: reference audio missing')
-    return
-  }
+    // Mobile-aware resolution: see multiple-runs.test.js for rationale.
+    const refWavPath = resolveRefWavPath({})
+    if (!fs.existsSync(refWavPath)) {
+      t.pass('Skipped: reference audio missing')
+      return
+    }
 
-  const model = await loadChatterboxTTS({
-    modelDir: download.targetDir,
-    refWavPath,
-    language: 'en',
-    useGPU: true
-  })
-  try {
-    const t0 = Date.now()
-    const result = await runChatterboxTTS(
-      model,
-      { text: 'GPU smoke check.' },
-      { minSamples: 5000 }
-    )
-    const wallMs = Date.now() - t0
-    console.log(result.output)
-    t.ok(result.passed, 'Chatterbox/GPU produced expected sample count')
-    t.ok(result.data.sampleCount > 0, 'Chatterbox/GPU produced audio')
-    assertGpuBackend(t, 'Chatterbox', result.data.stats, /* allowPolicyCpu */ false)
-    recordSmoke(t, 'chatterbox gpu-smoke', result, wallMs)
-  } finally {
-    try { await model.unload() } catch (_e) {}
+    const model = await loadChatterboxTTS({
+      modelDir: download.targetDir,
+      refWavPath,
+      language: 'en',
+      useGPU: true
+    })
+    try {
+      const t0 = Date.now()
+      const result = await runChatterboxTTS(
+        model,
+        { text: 'GPU smoke check.' },
+        { minSamples: 5000 }
+      )
+      const wallMs = Date.now() - t0
+      console.log(result.output)
+      t.ok(result.passed, 'Chatterbox/GPU produced expected sample count')
+      t.ok(result.data.sampleCount > 0, 'Chatterbox/GPU produced audio')
+      assertGpuBackend(t, 'Chatterbox', result.data.stats, /* allowPolicyCpu */ false)
+      recordSmoke(t, 'chatterbox gpu-smoke', result, wallMs)
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-})
+)
 
 // Multilingual (MTL) GPU smoke. The Chatterbox GPU smoke above loads the EN
 // Turbo model, whose step graph never CONTs the KV cache. The MULTILINGUAL
@@ -197,167 +239,198 @@ test('Chatterbox GPU smoke - useGPU=true must engage the GPU backend on GPU-capa
 // the default (f16) KV dtype, and would have aborted before the fix. Uses a
 // tier-1 non-English language so the multilingual path (tokenizer + run_t3
 // MTL dispatch) is actually exercised.
-test('Chatterbox MTL GPU smoke - multilingual model on GPU with the default (f16) KV cache', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
+test(
+  'Chatterbox MTL GPU smoke - multilingual model on GPU with the default (f16) KV cache',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
 
-  const download = await ensureChatterboxMtlModels({ targetDir: modelsDir })
-  if (!download.success) {
-    t.fail('Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
+    const download = await ensureChatterboxMtlModels({ targetDir: modelsDir })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox MTL GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    // Mobile-aware resolution: see multiple-runs.test.js for rationale.
+    const refWavPath = resolveRefWavPath({})
+    if (!fs.existsSync(refWavPath)) {
+      t.pass('Skipped: reference audio missing')
+      return
+    }
+
+    const model = await loadChatterboxTTS({
+      modelDir: download.targetDir,
+      t3ModelPath: path.join(download.targetDir, 'chatterbox-t3-mtl.gguf'),
+      s3genModelPath: path.join(download.targetDir, 'chatterbox-s3gen-mtl.gguf'),
+      refWavPath,
+      language: 'es',
+      useGPU: true
+      // kvCacheType intentionally left unset so the run uses the addon default
+      // (f16) — the whole point of this regression guard.
+    })
+    try {
+      const t0 = Date.now()
+      const result = await runChatterboxTTS(
+        model,
+        { text: 'Comprobación de la GPU multilingüe.' },
+        { minSamples: 5000 }
+      )
+      const wallMs = Date.now() - t0
+      console.log(result.output)
+      t.ok(result.passed, 'Chatterbox MTL/GPU produced expected sample count')
+      t.ok(result.data.sampleCount > 0, 'Chatterbox MTL/GPU produced audio')
+      assertGpuBackend(t, 'Chatterbox MTL', result.data.stats, /* allowPolicyCpu */ false)
+      recordSmoke(t, 'chatterbox-mtl gpu-smoke', result, wallMs)
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
+)
 
-  // Mobile-aware resolution: see multiple-runs.test.js for rationale.
-  const refWavPath = resolveRefWavPath({})
-  if (!fs.existsSync(refWavPath)) {
-    t.pass('Skipped: reference audio missing')
-    return
+test(
+  'Supertonic GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    // Supertonic GPU: Metal on Apple, Vulkan/CUDA on desktop, Vulkan/OpenCL on
+    // Android (Adreno/Xclipse/Mali, validated under tts-cpp 2026-06-18).
+    // The strict assertion runs on every GPU-capable platform including Android.
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
+
+    const download = await ensureSupertonicModel({ targetDir: modelsDir })
+    if (!download || !download.success) {
+      t.fail(
+        'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    const supertonicPath = download.path || path.join(modelsDir, 'supertonic.gguf')
+
+    const model = await loadSupertonicTTS({
+      supertonicModelPath: supertonicPath,
+      language: 'en',
+      voice: 'F1',
+      useGPU: true
+    })
+    try {
+      const t0 = Date.now()
+      const result = await runSupertonicTTS(
+        model,
+        { text: 'GPU smoke check.' },
+        { minSamples: 5000 }
+      )
+      const wallMs = Date.now() - t0
+      console.log(result.output)
+      t.ok(result.passed, 'Supertonic/GPU produced expected sample count')
+      t.ok(result.data.sampleCount > 0, 'Supertonic/GPU produced audio')
+      assertGpuBackend(t, 'Supertonic', result.data.stats)
+      recordSmoke(t, 'supertonic gpu-smoke', result, wallMs)
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-
-  const model = await loadChatterboxTTS({
-    modelDir: download.targetDir,
-    t3ModelPath: path.join(download.targetDir, 'chatterbox-t3-mtl.gguf'),
-    s3genModelPath: path.join(download.targetDir, 'chatterbox-s3gen-mtl.gguf'),
-    refWavPath,
-    language: 'es',
-    useGPU: true
-    // kvCacheType intentionally left unset so the run uses the addon default
-    // (f16) — the whole point of this regression guard.
-  })
-  try {
-    const t0 = Date.now()
-    const result = await runChatterboxTTS(
-      model,
-      { text: 'Comprobación de la GPU multilingüe.' },
-      { minSamples: 5000 }
-    )
-    const wallMs = Date.now() - t0
-    console.log(result.output)
-    t.ok(result.passed, 'Chatterbox MTL/GPU produced expected sample count')
-    t.ok(result.data.sampleCount > 0, 'Chatterbox MTL/GPU produced audio')
-    assertGpuBackend(t, 'Chatterbox MTL', result.data.stats, /* allowPolicyCpu */ false)
-    recordSmoke(t, 'chatterbox-mtl gpu-smoke', result, wallMs)
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Supertonic GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  // Supertonic GPU: Metal on Apple, Vulkan/CUDA on desktop, Vulkan/OpenCL on
-  // Android (Adreno/Xclipse/Mali, validated under tts-cpp 2026-06-18).
-  // The strict assertion runs on every GPU-capable platform including Android.
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
-
-  const download = await ensureSupertonicModel({ targetDir: modelsDir })
-  if (!download || !download.success) {
-    t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-
-  const supertonicPath = download.path ||
-    path.join(modelsDir, 'supertonic.gguf')
-
-  const model = await loadSupertonicTTS({
-    supertonicModelPath: supertonicPath,
-    language: 'en',
-    voice: 'F1',
-    useGPU: true
-  })
-  try {
-    const t0 = Date.now()
-    const result = await runSupertonicTTS(
-      model,
-      { text: 'GPU smoke check.' },
-      { minSamples: 5000 }
-    )
-    const wallMs = Date.now() - t0
-    console.log(result.output)
-    t.ok(result.passed, 'Supertonic/GPU produced expected sample count')
-    t.ok(result.data.sampleCount > 0, 'Supertonic/GPU produced audio')
-    assertGpuBackend(t, 'Supertonic', result.data.stats)
-    recordSmoke(t, 'supertonic gpu-smoke', result, wallMs)
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
+)
 
 // Supertonic 2 (multilingual) GPU smoke. The Supertonic GPU smoke above
 // loads v1; v2 ships as a separate GGUF (supertonic2.gguf) with its own
 // weights, so it needs its own GPU coverage. Strict assertion, matching the
 // v1 entry — useGPU=true must engage the GPU backend on GPU-capable platforms
 // (Metal / Vulkan / CUDA / OpenCL), no silent CPU fallback.
-test('Supertonic 2 GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
+test(
+  'Supertonic 2 GPU smoke - useGPU=true must engage the GPU backend on GPU-capable platforms',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
 
-  const download = await ensureSupertonicMtlModel({ targetDir: modelsDir })
-  if (!download || !download.success) {
-    t.fail('Supertonic 2 GGUF not available - registry fetch failed. Run `npm run download-models:registry -- --group supertonic2` or stage models locally.')
-    return
-  }
+    const download = await ensureSupertonicMtlModel({ targetDir: modelsDir })
+    if (!download || !download.success) {
+      t.fail(
+        'Supertonic 2 GGUF not available - registry fetch failed. Run `npm run download-models:registry -- --group supertonic2` or stage models locally.'
+      )
+      return
+    }
 
-  const model = await loadSupertonicTTS({
-    supertonicModelPath: download.path,
-    language: 'en',
-    voice: 'F1',
-    useGPU: true
-  })
-  try {
-    const t0 = Date.now()
-    const result = await runSupertonicTTS(
-      model,
-      { text: 'GPU smoke check for Supertonic 2.' },
-      { minSamples: 5000 }
-    )
-    const wallMs = Date.now() - t0
-    console.log(result.output)
-    t.ok(result.passed, 'Supertonic2/GPU produced expected sample count')
-    t.ok(result.data.sampleCount > 0, 'Supertonic2/GPU produced audio')
-    assertGpuBackend(t, 'Supertonic2', result.data.stats)
-    recordSmoke(t, 'supertonic2 gpu-smoke', result, wallMs)
-  } finally {
-    try { await model.unload() } catch (_e) {}
+    const model = await loadSupertonicTTS({
+      supertonicModelPath: download.path,
+      language: 'en',
+      voice: 'F1',
+      useGPU: true
+    })
+    try {
+      const t0 = Date.now()
+      const result = await runSupertonicTTS(
+        model,
+        { text: 'GPU smoke check for Supertonic 2.' },
+        { minSamples: 5000 }
+      )
+      const wallMs = Date.now() - t0
+      console.log(result.output)
+      t.ok(result.passed, 'Supertonic2/GPU produced expected sample count')
+      t.ok(result.data.sampleCount > 0, 'Supertonic2/GPU produced audio')
+      assertGpuBackend(t, 'Supertonic2', result.data.stats)
+      recordSmoke(t, 'supertonic2 gpu-smoke', result, wallMs)
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-})
+)
 
 // Supertonic 3 GPU smoke. v3 ships in multiple quant tiers (f16/f32/q8_0/q4_0);
 // the GPU smoke runs the q4_0 tier (the on-device shipping default) so the
 // quantised-weight Metal/Vulkan path is exercised — the same class of path that
 // surfaced the Chatterbox q8_0 Metal CONT abort. Strict assertion.
-test('Supertonic 3 GPU smoke (q4_0) - useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
+test(
+  'Supertonic 3 GPU smoke (q4_0) - useGPU=true must engage the GPU backend on GPU-capable platforms',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
 
-  const download = await ensureSupertonic3Model({ targetDir: modelsDir, quant: 'q4_0' })
-  if (!download || !download.success) {
-    t.fail('Supertonic 3 q4_0 GGUF not available - registry fetch failed. Run `npm run download-models:registry -- --group supertonic3` or stage models locally.')
-    return
-  }
+    const download = await ensureSupertonic3Model({ targetDir: modelsDir, quant: 'q4_0' })
+    if (!download || !download.success) {
+      t.fail(
+        'Supertonic 3 q4_0 GGUF not available - registry fetch failed. Run `npm run download-models:registry -- --group supertonic3` or stage models locally.'
+      )
+      return
+    }
 
-  const model = await loadSupertonicTTS({
-    supertonicModelPath: download.path,
-    language: 'en',
-    voice: 'F1',
-    useGPU: true
-  })
-  try {
-    const t0 = Date.now()
-    const result = await runSupertonicTTS(
-      model,
-      { text: 'GPU smoke check for Supertonic 3.' },
-      { minSamples: 5000 }
-    )
-    const wallMs = Date.now() - t0
-    console.log(result.output)
-    t.ok(result.passed, 'Supertonic3/GPU produced expected sample count')
-    t.ok(result.data.sampleCount > 0, 'Supertonic3/GPU produced audio')
-    assertGpuBackend(t, 'Supertonic3', result.data.stats)
-    recordSmoke(t, 'supertonic3 q4_0 gpu-smoke', result, wallMs)
-  } finally {
-    try { await model.unload() } catch (_e) {}
+    const model = await loadSupertonicTTS({
+      supertonicModelPath: download.path,
+      language: 'en',
+      voice: 'F1',
+      useGPU: true
+    })
+    try {
+      const t0 = Date.now()
+      const result = await runSupertonicTTS(
+        model,
+        { text: 'GPU smoke check for Supertonic 3.' },
+        { minSamples: 5000 }
+      )
+      const wallMs = Date.now() - t0
+      console.log(result.output)
+      t.ok(result.passed, 'Supertonic3/GPU produced expected sample count')
+      t.ok(result.data.sampleCount > 0, 'Supertonic3/GPU produced audio')
+      assertGpuBackend(t, 'Supertonic3', result.data.stats)
+      recordSmoke(t, 'supertonic3 q4_0 gpu-smoke', result, wallMs)
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-})
+)
 
 // CPU smoke: useGPU:false must actually pin the engine to CPU on every
 // platform (no NO_GPU skip — CPU is expected to work everywhere).  This
@@ -367,80 +440,95 @@ test('Supertonic 3 GPU smoke (q4_0) - useGPU=true must engage the GPU backend on
 // which could silently fall back to GPU.  Now that ChatterboxModel /
 // SupertonicModel translate explicit useGPU=false → n_gpu_layers=0,
 // these tests lock that contract in.
-test('Chatterbox CPU smoke - useGPU=false must run on the CPU backend', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
+test(
+  'Chatterbox CPU smoke - useGPU=false must run on the CPU backend',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
 
-  const download = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!download.success) {
-    t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
+    const download = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    // Mobile-aware resolution: see multiple-runs.test.js for rationale.
+    const refWavPath = resolveRefWavPath({})
+    if (!fs.existsSync(refWavPath)) {
+      t.pass('Skipped: reference audio missing')
+      return
+    }
+
+    const model = await loadChatterboxTTS({
+      modelDir: download.targetDir,
+      refWavPath,
+      language: 'en',
+      useGPU: false
+    })
+    try {
+      const t0 = Date.now()
+      const result = await runChatterboxTTS(
+        model,
+        { text: 'CPU smoke check.' },
+        { minSamples: 5000 }
+      )
+      const wallMs = Date.now() - t0
+      console.log(result.output)
+      t.ok(result.passed, 'Chatterbox/CPU produced expected sample count')
+      t.ok(result.data.sampleCount > 0, 'Chatterbox/CPU produced audio')
+      assertCpuBackend(t, 'Chatterbox', result.data.stats)
+      recordSmoke(t, 'chatterbox cpu-smoke', result, wallMs)
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
+)
 
-  // Mobile-aware resolution: see multiple-runs.test.js for rationale.
-  const refWavPath = resolveRefWavPath({})
-  if (!fs.existsSync(refWavPath)) {
-    t.pass('Skipped: reference audio missing')
-    return
+test(
+  'Supertonic CPU smoke - useGPU=false must run on the CPU backend',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const modelsDir = path.join(baseDir, 'models')
+
+    const download = await ensureSupertonicModel({ targetDir: modelsDir })
+    if (!download || !download.success) {
+      t.fail(
+        'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    const supertonicPath = download.path || path.join(modelsDir, 'supertonic.gguf')
+
+    const model = await loadSupertonicTTS({
+      supertonicModelPath: supertonicPath,
+      language: 'en',
+      voice: 'F1',
+      useGPU: false
+    })
+    try {
+      const t0 = Date.now()
+      const result = await runSupertonicTTS(
+        model,
+        { text: 'CPU smoke check.' },
+        { minSamples: 5000 }
+      )
+      const wallMs = Date.now() - t0
+      console.log(result.output)
+      t.ok(result.passed, 'Supertonic/CPU produced expected sample count')
+      t.ok(result.data.sampleCount > 0, 'Supertonic/CPU produced audio')
+      assertCpuBackend(t, 'Supertonic', result.data.stats)
+      recordSmoke(t, 'supertonic cpu-smoke', result, wallMs)
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-
-  const model = await loadChatterboxTTS({
-    modelDir: download.targetDir,
-    refWavPath,
-    language: 'en',
-    useGPU: false
-  })
-  try {
-    const t0 = Date.now()
-    const result = await runChatterboxTTS(
-      model,
-      { text: 'CPU smoke check.' },
-      { minSamples: 5000 }
-    )
-    const wallMs = Date.now() - t0
-    console.log(result.output)
-    t.ok(result.passed, 'Chatterbox/CPU produced expected sample count')
-    t.ok(result.data.sampleCount > 0, 'Chatterbox/CPU produced audio')
-    assertCpuBackend(t, 'Chatterbox', result.data.stats)
-    recordSmoke(t, 'chatterbox cpu-smoke', result, wallMs)
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Supertonic CPU smoke - useGPU=false must run on the CPU backend', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const modelsDir = path.join(baseDir, 'models')
-
-  const download = await ensureSupertonicModel({ targetDir: modelsDir })
-  if (!download || !download.success) {
-    t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-
-  const supertonicPath = download.path ||
-    path.join(modelsDir, 'supertonic.gguf')
-
-  const model = await loadSupertonicTTS({
-    supertonicModelPath: supertonicPath,
-    language: 'en',
-    voice: 'F1',
-    useGPU: false
-  })
-  try {
-    const t0 = Date.now()
-    const result = await runSupertonicTTS(
-      model,
-      { text: 'CPU smoke check.' },
-      { minSamples: 5000 }
-    )
-    const wallMs = Date.now() - t0
-    console.log(result.output)
-    t.ok(result.passed, 'Supertonic/CPU produced expected sample count')
-    t.ok(result.data.sampleCount > 0, 'Supertonic/CPU produced audio')
-    assertCpuBackend(t, 'Supertonic', result.data.stats)
-    recordSmoke(t, 'supertonic cpu-smoke', result, wallMs)
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
+)

--- a/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
+++ b/packages/tts-ggml/test/integration/lavasr-enhancer.test.js
@@ -36,28 +36,37 @@ const isMobile = platform === 'ios' || platform === 'android'
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 const RELAX = proc.env && proc.env.QVAC_TTS_GPU_SMOKE_RELAX === '1'
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
-function backendIdToName (id) {
+function backendIdToName(id) {
   switch (id) {
-    case 0: return 'CPU'
-    case 1: return 'Metal'
-    case 2: return 'CUDA'
-    case 3: return 'Vulkan'
-    case 4: return 'OpenCL'
-    case 99: return 'other-GPU'
-    default: return `unknown(${id})`
+    case 0:
+      return 'CPU'
+    case 1:
+      return 'Metal'
+    case 2:
+      return 'CUDA'
+    case 3:
+      return 'Vulkan'
+    case 4:
+      return 'OpenCL'
+    case 99:
+      return 'other-GPU'
+    default:
+      return `unknown(${id})`
   }
 }
 
 // Platforms that wire a GPU backend into tts-cpp's vcpkg port (default-features):
 // darwin/ios -> metal; linux/win32 -> vulkan; android -> vulkan + opencl.
-function expectsGpu () {
+function expectsGpu() {
   return (
-    platform === 'darwin' || platform === 'ios' ||
-    platform === 'linux' || platform === 'win32' ||
+    platform === 'darwin' ||
+    platform === 'ios' ||
+    platform === 'linux' ||
+    platform === 'win32' ||
     platform === 'android'
   )
 }
@@ -69,21 +78,32 @@ function expectsGpu () {
 // gpu-smoke.test.js's assertGpuBackend (which only sees the engine backend):
 // useGPU=true drives both the engine and the enhancer onto the GPU, and this
 // asserts the enhancer half actually did — the whole point of LavaSR-on-GPU.
-function assertEnhancerGpuBackend (t, stats) {
-  if (!stats) { t.fail('enhancer/GPU: no response.stats returned'); return }
+function assertEnhancerGpuBackend(t, stats) {
+  if (!stats) {
+    t.fail('enhancer/GPU: no response.stats returned')
+    return
+  }
   const dev = stats.enhancerBackendDevice
   const id = stats.enhancerBackendId
-  console.log(`[enhancer/GPU] enhancerBackendDevice=${dev} enhancerBackendId=${id} (${backendIdToName(id)})`)
+  console.log(
+    `[enhancer/GPU] enhancerBackendDevice=${dev} enhancerBackendId=${id} (${backendIdToName(id)})`
+  )
   t.not(dev, -1, 'enhancer was loaded (enhancerBackendDevice != -1)')
   if (!expectsGpu()) {
     t.is(dev, 0, `enhancer/${platform}: must be CPU (0) on platforms with no GPU wired in`)
     return
   }
   if (dev !== 1) {
-    const msg = `enhancer/${platform}: expected GPU, got ${backendIdToName(id)} ` +
+    const msg =
+      `enhancer/${platform}: expected GPU, got ${backendIdToName(id)} ` +
       `(enhancerBackendDevice=${dev}, enhancerBackendId=${id}). useGPU=true was ` +
       'requested but the LavaSR enhancer ran on the scalar CPU core.'
-    if (RELAX) { t.comment(`WARNING (relaxed): ${msg}`); t.pass('enhancer GPU (relaxed)') } else { t.fail(msg) }
+    if (RELAX) {
+      t.comment(`WARNING (relaxed): ${msg}`)
+      t.pass('enhancer GPU (relaxed)')
+    } else {
+      t.fail(msg)
+    }
     return
   }
   if (platform === 'darwin' || platform === 'ios') {
@@ -91,16 +111,19 @@ function assertEnhancerGpuBackend (t, stats) {
   } else if (platform === 'linux' || platform === 'win32') {
     t.is(id, 3, `enhancer/${platform}: expected Vulkan backendId=3, got ${backendIdToName(id)}`)
   } else if (platform === 'android') {
-    t.ok(id === 3 || id === 4, `enhancer/${platform}: expected Vulkan(3)/OpenCL(4), got ${backendIdToName(id)}`)
+    t.ok(
+      id === 3 || id === 4,
+      `enhancer/${platform}: expected Vulkan(3)/OpenCL(4), got ${backendIdToName(id)}`
+    )
   }
 }
 
-async function runAndCollect (model, text) {
+async function runAndCollect(model, text) {
   let samples = 0
   let sampleRate = null
   const response = await model.run({ input: text, type: 'text' })
   await response
-    .onUpdate(d => {
+    .onUpdate((d) => {
       if (d && d.outputArray) samples += d.outputArray.length
       if (d && d.sampleRate) sampleRate = d.sampleRate
     })
@@ -135,15 +158,16 @@ test('Chatterbox: enhancer + streamChunkTokens constructs and forwards both', (t
 
 test('enhancer with an unknown type is rejected at construction', (t) => {
   t.exception(
-    () => new TTSGgml({
-      engine: TTSGgml.ENGINE_SUPERTONIC,
-      files: {
-        supertonicModel: './models/supertonic.gguf',
-        lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
-      },
-      enhancer: { type: 'lavasr-typo' },
-      config: { language: 'en' }
-    }),
+    () =>
+      new TTSGgml({
+        engine: TTSGgml.ENGINE_SUPERTONIC,
+        files: {
+          supertonicModel: './models/supertonic.gguf',
+          lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
+        },
+        enhancer: { type: 'lavasr-typo' },
+        config: { language: 'en' }
+      }),
     /unknown enhancer\.type/,
     'a typo in enhancer.type throws instead of silently disabling enhancement'
   )
@@ -170,172 +194,265 @@ test('enhancer block with no GGUF path leaves enhancement off (no throw)', (t) =
 // switch alongside the enhancer path, for both engines.
 
 for (const [engineName, engine, files] of [
-  ['Supertonic', TTSGgml.ENGINE_SUPERTONIC, {
-    supertonicModel: './models/supertonic.gguf',
-    lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
-  }],
-  ['Chatterbox', TTSGgml.ENGINE_CHATTERBOX, {
-    t3Model: './models/chatterbox-t3-turbo.gguf',
-    s3genModel: './models/chatterbox-s3gen.gguf',
-    lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
-  }]
+  [
+    'Supertonic',
+    TTSGgml.ENGINE_SUPERTONIC,
+    {
+      supertonicModel: './models/supertonic.gguf',
+      lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
+    }
+  ],
+  [
+    'Chatterbox',
+    TTSGgml.ENGINE_CHATTERBOX,
+    {
+      t3Model: './models/chatterbox-t3-turbo.gguf',
+      s3genModel: './models/chatterbox-s3gen.gguf',
+      lavasrEnhancer: './models/lavasr/lavasr-enhancer.gguf'
+    }
+  ]
 ]) {
   test(`${engineName}: enhancer + useGPU:true forwards useGPU alongside the enhancer path`, (t) => {
     const model = new TTSGgml({ engine, files, config: { language: 'en', useGPU: true } })
     const params = model._buildTtsParams()
     t.is(params.useGPU, true, 'useGPU:true forwarded to the addon (drives EnhancerOptions.use_gpu)')
-    t.is(params.lavasrEnhancerPath, './models/lavasr/lavasr-enhancer.gguf', 'enhancer path forwarded')
+    t.is(
+      params.lavasrEnhancerPath,
+      './models/lavasr/lavasr-enhancer.gguf',
+      'enhancer path forwarded'
+    )
   })
 
   test(`${engineName}: enhancer + useGPU:false keeps the enhancer on CPU`, (t) => {
     const model = new TTSGgml({ engine, files, config: { language: 'en', useGPU: false } })
     const params = model._buildTtsParams()
-    t.is(params.useGPU, false, 'useGPU:false forwarded (enhancer runs on the ggml-CPU backend, reported as CPU)')
-    t.is(params.lavasrEnhancerPath, './models/lavasr/lavasr-enhancer.gguf', 'enhancer path forwarded')
+    t.is(
+      params.useGPU,
+      false,
+      'useGPU:false forwarded (enhancer runs on the ggml-CPU backend, reported as CPU)'
+    )
+    t.is(
+      params.lavasrEnhancerPath,
+      './models/lavasr/lavasr-enhancer.gguf',
+      'enhancer path forwarded'
+    )
   })
 
   test(`${engineName}: enhancer + nGpuLayers!=0 forwards the GPU layer count`, (t) => {
     const model = new TTSGgml({ engine, files, nGpuLayers: 99, config: { language: 'en' } })
     const params = model._buildTtsParams()
     t.is(params.nGpuLayers, 99, 'nGpuLayers forwarded (non-zero => enhancer requests the GPU)')
-    t.is(params.lavasrEnhancerPath, './models/lavasr/lavasr-enhancer.gguf', 'enhancer path forwarded')
+    t.is(
+      params.lavasrEnhancerPath,
+      './models/lavasr/lavasr-enhancer.gguf',
+      'enhancer path forwarded'
+    )
   })
 }
 
 // ---- Model-backed tests (gated on staged models) ----
 
-test('Supertonic + LavaSR enhancer reports 48 kHz enhanced output', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const enh = await ensureLavaSREnhancerGguf({ targetDir: path.join(baseDir, 'models', 'lavasr') })
-  if (!enh.success) { t.comment('LavaSR enhancer GGUF not staged; skipping.'); t.pass('skipped — no enhancer GGUF'); return }
-  const dl = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!dl.success) { t.fail('Supertonic GGUF not available — registry fetch failed.'); return }
-
-  const model = new TTSGgml({
-    engine: TTSGgml.ENGINE_SUPERTONIC,
-    files: { supertonicModel: dl.path, lavasrEnhancer: enh.path },
-    voice: 'F1',
-    config: { language: 'en', useGPU: false },
-    opts: { stats: true }
-  })
-  await model.load()
-  try {
-    const r = await runAndCollect(model, 'LavaSR neural enhancement upsamples this to forty-eight kilohertz.')
-    t.is(r.sampleRate, 48000, 'enhanced supertonic output reports 48 kHz')
-    t.ok(r.samples > 0, 'enhanced synthesis produced audio')
-    // useGPU:false -> the enhancer runs on the ggml-CPU backend (a CPU device),
-    // and the enhancer-specific backend stat must reflect that (0 = CPU, not
-    // -1 = unset; and not 1 = GPU).  The model was constructed with stats:true,
-    // so a missing stats object is itself a regression: assert it loudly instead
-    // of guarding (a guard would let a stats regression pass silently).
-    t.ok(r.stats, 'runtimeStats returned (constructed with stats:true)')
-    t.is(r.stats.enhancerBackendDevice, 0, 'useGPU:false -> enhancer on CPU (enhancerBackendDevice=0)')
-    t.is(r.stats.enhancerBackendId, 0, 'useGPU:false -> enhancer backendId=0 (CPU)')
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Supertonic without enhancer reports native 44.1 kHz (backward compat)', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const dl = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!dl.success) { t.fail('Supertonic GGUF not available — registry fetch failed.'); return }
-
-  const model = new TTSGgml({
-    engine: TTSGgml.ENGINE_SUPERTONIC,
-    files: { supertonicModel: dl.path },
-    voice: 'F1',
-    config: { language: 'en', useGPU: false },
-    opts: { stats: true }
-  })
-  await model.load()
-  try {
-    const r = await runAndCollect(model, 'No enhancement here, just the native engine output.')
-    t.is(r.sampleRate, 44100, 'un-enhanced supertonic reports 44.1 kHz')
-    t.ok(r.samples > 0, 'synthesis produced audio')
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Chatterbox + LavaSR enhancer (batch) reports 48 kHz enhanced output', { timeout: 900000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const enh = await ensureLavaSREnhancerGguf({ targetDir: path.join(baseDir, 'models', 'lavasr') })
-  if (!enh.success) { t.comment('LavaSR enhancer GGUF not staged; skipping.'); t.pass('skipped — no enhancer GGUF'); return }
-  const modelsDir = path.join(baseDir, 'models')
-  const dl = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!dl.success) { t.fail('Chatterbox GGUFs not available — registry fetch failed.'); return }
-  const dir = dl.targetDir || modelsDir
-
-  const model = new TTSGgml({
-    engine: TTSGgml.ENGINE_CHATTERBOX,
-    files: {
-      modelDir: dir,
-      t3Model: path.join(dir, 'chatterbox-t3-turbo.gguf'),
-      s3genModel: path.join(dir, 'chatterbox-s3gen.gguf'),
-      lavasrEnhancer: enh.path
-    },
-    referenceAudio: resolveRefWavPath({}),
-    config: { language: 'en', useGPU: false },
-    opts: { stats: true }
-  })
-  await model.load()
-  try {
-    const r = await runAndCollect(model, 'Chatterbox output neurally upsampled to forty-eight kilohertz.')
-    t.is(r.sampleRate, 48000, 'enhanced chatterbox output reports 48 kHz')
-    t.ok(r.samples > 0, 'enhanced synthesis produced audio')
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Chatterbox + LavaSR enhancer + native chunk streaming emits 48 kHz chunks', { timeout: 900000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const enh = await ensureLavaSREnhancerGguf({ targetDir: path.join(baseDir, 'models', 'lavasr') })
-  if (!enh.success) { t.comment('LavaSR enhancer GGUF not staged; skipping.'); t.pass('skipped — no enhancer GGUF'); return }
-  const modelsDir = path.join(baseDir, 'models')
-  const dl = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!dl.success) { t.fail('Chatterbox GGUFs not available — registry fetch failed.'); return }
-  const dir = dl.targetDir || modelsDir
-
-  const model = new TTSGgml({
-    engine: TTSGgml.ENGINE_CHATTERBOX,
-    files: {
-      modelDir: dir,
-      t3Model: path.join(dir, 'chatterbox-t3-turbo.gguf'),
-      s3genModel: path.join(dir, 'chatterbox-s3gen.gguf'),
-      lavasrEnhancer: enh.path
-    },
-    referenceAudio: resolveRefWavPath({}),
-    streamChunkTokens: 25, // native chunk streaming + enhancer (the path)
-    config: { language: 'en', useGPU: false },
-    opts: { stats: true }
-  })
-  await model.load()
-  try {
-    const updates = []
-    const response = await model.run({
-      input: 'Streaming Chatterbox audio, neurally upsampled to forty-eight kilohertz, one chunk at a time.',
-      type: 'text'
+test(
+  'Supertonic + LavaSR enhancer reports 48 kHz enhanced output',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const enh = await ensureLavaSREnhancerGguf({
+      targetDir: path.join(baseDir, 'models', 'lavasr')
     })
-    await response.onUpdate(d => { if (d && d.outputArray) updates.push(d) }).await()
-
-    const total = updates.reduce((acc, u) => acc + u.outputArray.length, 0)
-    t.ok(updates.length >= 1, 'streamed at least one chunk event')
-    t.ok(total > 0, 'streamed enhanced audio produced samples')
-    // Every chunk that carries audio must be tagged at the enhanced 48 kHz rate
-    // (not the engine's native 24 kHz) — the mislabel this feature prevents.
-    for (const u of updates) {
-      if (u.outputArray.length > 0 && u.sampleRate != null) {
-        t.is(u.sampleRate, 48000, 'streamed enhanced chunk reports 48 kHz')
-      }
+    if (!enh.success) {
+      t.comment('LavaSR enhancer GGUF not staged; skipping.')
+      t.pass('skipped — no enhancer GGUF')
+      return
     }
-    const isLastCount = updates.filter(u => u.isLast === true).length
-    t.ok(isLastCount <= 1, 'at most one isLast=true across streamed chunks')
-  } finally {
-    try { await model.unload() } catch (_e) {}
+    const dl = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!dl.success) {
+      t.fail('Supertonic GGUF not available — registry fetch failed.')
+      return
+    }
+
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_SUPERTONIC,
+      files: { supertonicModel: dl.path, lavasrEnhancer: enh.path },
+      voice: 'F1',
+      config: { language: 'en', useGPU: false },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      const r = await runAndCollect(
+        model,
+        'LavaSR neural enhancement upsamples this to forty-eight kilohertz.'
+      )
+      t.is(r.sampleRate, 48000, 'enhanced supertonic output reports 48 kHz')
+      t.ok(r.samples > 0, 'enhanced synthesis produced audio')
+      // useGPU:false -> the enhancer runs on the ggml-CPU backend (a CPU device),
+      // and the enhancer-specific backend stat must reflect that (0 = CPU, not
+      // -1 = unset; and not 1 = GPU).  The model was constructed with stats:true,
+      // so a missing stats object is itself a regression: assert it loudly instead
+      // of guarding (a guard would let a stats regression pass silently).
+      t.ok(r.stats, 'runtimeStats returned (constructed with stats:true)')
+      t.is(
+        r.stats.enhancerBackendDevice,
+        0,
+        'useGPU:false -> enhancer on CPU (enhancerBackendDevice=0)'
+      )
+      t.is(r.stats.enhancerBackendId, 0, 'useGPU:false -> enhancer backendId=0 (CPU)')
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-})
+)
+
+test(
+  'Supertonic without enhancer reports native 44.1 kHz (backward compat)',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const dl = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!dl.success) {
+      t.fail('Supertonic GGUF not available — registry fetch failed.')
+      return
+    }
+
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_SUPERTONIC,
+      files: { supertonicModel: dl.path },
+      voice: 'F1',
+      config: { language: 'en', useGPU: false },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      const r = await runAndCollect(model, 'No enhancement here, just the native engine output.')
+      t.is(r.sampleRate, 44100, 'un-enhanced supertonic reports 44.1 kHz')
+      t.ok(r.samples > 0, 'synthesis produced audio')
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)
+
+test(
+  'Chatterbox + LavaSR enhancer (batch) reports 48 kHz enhanced output',
+  { timeout: 900000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const enh = await ensureLavaSREnhancerGguf({
+      targetDir: path.join(baseDir, 'models', 'lavasr')
+    })
+    if (!enh.success) {
+      t.comment('LavaSR enhancer GGUF not staged; skipping.')
+      t.pass('skipped — no enhancer GGUF')
+      return
+    }
+    const modelsDir = path.join(baseDir, 'models')
+    const dl = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!dl.success) {
+      t.fail('Chatterbox GGUFs not available — registry fetch failed.')
+      return
+    }
+    const dir = dl.targetDir || modelsDir
+
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_CHATTERBOX,
+      files: {
+        modelDir: dir,
+        t3Model: path.join(dir, 'chatterbox-t3-turbo.gguf'),
+        s3genModel: path.join(dir, 'chatterbox-s3gen.gguf'),
+        lavasrEnhancer: enh.path
+      },
+      referenceAudio: resolveRefWavPath({}),
+      config: { language: 'en', useGPU: false },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      const r = await runAndCollect(
+        model,
+        'Chatterbox output neurally upsampled to forty-eight kilohertz.'
+      )
+      t.is(r.sampleRate, 48000, 'enhanced chatterbox output reports 48 kHz')
+      t.ok(r.samples > 0, 'enhanced synthesis produced audio')
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)
+
+test(
+  'Chatterbox + LavaSR enhancer + native chunk streaming emits 48 kHz chunks',
+  { timeout: 900000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const enh = await ensureLavaSREnhancerGguf({
+      targetDir: path.join(baseDir, 'models', 'lavasr')
+    })
+    if (!enh.success) {
+      t.comment('LavaSR enhancer GGUF not staged; skipping.')
+      t.pass('skipped — no enhancer GGUF')
+      return
+    }
+    const modelsDir = path.join(baseDir, 'models')
+    const dl = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!dl.success) {
+      t.fail('Chatterbox GGUFs not available — registry fetch failed.')
+      return
+    }
+    const dir = dl.targetDir || modelsDir
+
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_CHATTERBOX,
+      files: {
+        modelDir: dir,
+        t3Model: path.join(dir, 'chatterbox-t3-turbo.gguf'),
+        s3genModel: path.join(dir, 'chatterbox-s3gen.gguf'),
+        lavasrEnhancer: enh.path
+      },
+      referenceAudio: resolveRefWavPath({}),
+      streamChunkTokens: 25, // native chunk streaming + enhancer (the path)
+      config: { language: 'en', useGPU: false },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      const updates = []
+      const response = await model.run({
+        input:
+          'Streaming Chatterbox audio, neurally upsampled to forty-eight kilohertz, one chunk at a time.',
+        type: 'text'
+      })
+      await response
+        .onUpdate((d) => {
+          if (d && d.outputArray) updates.push(d)
+        })
+        .await()
+
+      const total = updates.reduce((acc, u) => acc + u.outputArray.length, 0)
+      t.ok(updates.length >= 1, 'streamed at least one chunk event')
+      t.ok(total > 0, 'streamed enhanced audio produced samples')
+      // Every chunk that carries audio must be tagged at the enhanced 48 kHz rate
+      // (not the engine's native 24 kHz) — the mislabel this feature prevents.
+      for (const u of updates) {
+        if (u.outputArray.length > 0 && u.sampleRate != null) {
+          t.is(u.sampleRate, 48000, 'streamed enhanced chunk reports 48 kHz')
+        }
+      }
+      const isLastCount = updates.filter((u) => u.isLast === true).length
+      t.ok(isLastCount <= 1, 'at most one isLast=true across streamed chunks')
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)
 
 // ---- GPU-backed enhancer tests (gated on staged GGUF + a real GPU) ----
 // These are the end-to-end counterpart to the C++ ggml-vs-scalar parity test
@@ -346,59 +463,95 @@ test('Chatterbox + LavaSR enhancer + native chunk streaming emits 48 kHz chunks'
 // actually ran on the GPU (enhancerBackendDevice/Id from runtimeStats). They
 // skip on NO_GPU=true (CPU-only CI) and when the enhancer GGUF isn't staged.
 
-test('Supertonic + LavaSR enhancer on GPU (useGPU:true) runs the enhancer on the GPU and reports 48 kHz', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  const baseDir = getBaseDir()
-  const enh = await ensureLavaSREnhancerGguf({ targetDir: path.join(baseDir, 'models', 'lavasr') })
-  if (!enh.success) { t.comment('LavaSR enhancer GGUF not staged; skipping.'); t.pass('skipped — no enhancer GGUF'); return }
-  const dl = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!dl.success) { t.fail('Supertonic GGUF not available — registry fetch failed.'); return }
+test(
+  'Supertonic + LavaSR enhancer on GPU (useGPU:true) runs the enhancer on the GPU and reports 48 kHz',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const enh = await ensureLavaSREnhancerGguf({
+      targetDir: path.join(baseDir, 'models', 'lavasr')
+    })
+    if (!enh.success) {
+      t.comment('LavaSR enhancer GGUF not staged; skipping.')
+      t.pass('skipped — no enhancer GGUF')
+      return
+    }
+    const dl = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!dl.success) {
+      t.fail('Supertonic GGUF not available — registry fetch failed.')
+      return
+    }
 
-  const model = new TTSGgml({
-    engine: TTSGgml.ENGINE_SUPERTONIC,
-    files: { supertonicModel: dl.path, lavasrEnhancer: enh.path },
-    voice: 'F1',
-    config: { language: 'en', useGPU: true },
-    opts: { stats: true }
-  })
-  await model.load()
-  try {
-    const r = await runAndCollect(model, 'LavaSR neural enhancement, running on the GPU, upsamples this to forty-eight kilohertz.')
-    t.is(r.sampleRate, 48000, 'GPU-enhanced supertonic output reports 48 kHz')
-    t.ok(r.samples > 0, 'GPU-enhanced synthesis produced audio')
-    assertEnhancerGpuBackend(t, r.stats)
-  } finally {
-    try { await model.unload() } catch (_e) {}
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_SUPERTONIC,
+      files: { supertonicModel: dl.path, lavasrEnhancer: enh.path },
+      voice: 'F1',
+      config: { language: 'en', useGPU: true },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      const r = await runAndCollect(
+        model,
+        'LavaSR neural enhancement, running on the GPU, upsamples this to forty-eight kilohertz.'
+      )
+      t.is(r.sampleRate, 48000, 'GPU-enhanced supertonic output reports 48 kHz')
+      t.ok(r.samples > 0, 'GPU-enhanced synthesis produced audio')
+      assertEnhancerGpuBackend(t, r.stats)
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-})
+)
 
-test('Chatterbox + LavaSR enhancer on GPU (useGPU:true, batch) runs the enhancer on the GPU and reports 48 kHz', { timeout: 900000, skip: NO_GPU }, async (t) => {
-  const baseDir = getBaseDir()
-  const enh = await ensureLavaSREnhancerGguf({ targetDir: path.join(baseDir, 'models', 'lavasr') })
-  if (!enh.success) { t.comment('LavaSR enhancer GGUF not staged; skipping.'); t.pass('skipped — no enhancer GGUF'); return }
-  const modelsDir = path.join(baseDir, 'models')
-  const dl = await ensureChatterboxModels({ targetDir: modelsDir })
-  if (!dl.success) { t.fail('Chatterbox GGUFs not available — registry fetch failed.'); return }
-  const dir = dl.targetDir || modelsDir
+test(
+  'Chatterbox + LavaSR enhancer on GPU (useGPU:true, batch) runs the enhancer on the GPU and reports 48 kHz',
+  { timeout: 900000, skip: NO_GPU },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const enh = await ensureLavaSREnhancerGguf({
+      targetDir: path.join(baseDir, 'models', 'lavasr')
+    })
+    if (!enh.success) {
+      t.comment('LavaSR enhancer GGUF not staged; skipping.')
+      t.pass('skipped — no enhancer GGUF')
+      return
+    }
+    const modelsDir = path.join(baseDir, 'models')
+    const dl = await ensureChatterboxModels({ targetDir: modelsDir })
+    if (!dl.success) {
+      t.fail('Chatterbox GGUFs not available — registry fetch failed.')
+      return
+    }
+    const dir = dl.targetDir || modelsDir
 
-  const model = new TTSGgml({
-    engine: TTSGgml.ENGINE_CHATTERBOX,
-    files: {
-      modelDir: dir,
-      t3Model: path.join(dir, 'chatterbox-t3-turbo.gguf'),
-      s3genModel: path.join(dir, 'chatterbox-s3gen.gguf'),
-      lavasrEnhancer: enh.path
-    },
-    referenceAudio: resolveRefWavPath({}),
-    config: { language: 'en', useGPU: true },
-    opts: { stats: true }
-  })
-  await model.load()
-  try {
-    const r = await runAndCollect(model, 'Chatterbox output neurally upsampled on the GPU to forty-eight kilohertz.')
-    t.is(r.sampleRate, 48000, 'GPU-enhanced chatterbox output reports 48 kHz')
-    t.ok(r.samples > 0, 'GPU-enhanced synthesis produced audio')
-    assertEnhancerGpuBackend(t, r.stats)
-  } finally {
-    try { await model.unload() } catch (_e) {}
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_CHATTERBOX,
+      files: {
+        modelDir: dir,
+        t3Model: path.join(dir, 'chatterbox-t3-turbo.gguf'),
+        s3genModel: path.join(dir, 'chatterbox-s3gen.gguf'),
+        lavasrEnhancer: enh.path
+      },
+      referenceAudio: resolveRefWavPath({}),
+      config: { language: 'en', useGPU: true },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      const r = await runAndCollect(
+        model,
+        'Chatterbox output neurally upsampled on the GPU to forty-eight kilohertz.'
+      )
+      t.is(r.sampleRate, 48000, 'GPU-enhanced chatterbox output reports 48 kHz')
+      t.ok(r.samples > 0, 'GPU-enhanced synthesis produced audio')
+      assertEnhancerGpuBackend(t, r.stats)
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-})
+)

--- a/packages/tts-ggml/test/integration/multiple-runs.test.js
+++ b/packages/tts-ggml/test/integration/multiple-runs.test.js
@@ -22,12 +22,13 @@ const os = require('bare-os')
 const path = require('bare-path')
 const test = require('brittle')
 
-const { loadChatterboxTTS, runChatterboxTTS, resolveRefWavPath } = require('../utils/runChatterboxTTS')
-const { loadSupertonicTTS, runSupertonicTTS } = require('../utils/runSupertonicTTS')
 const {
-  ensureChatterboxModels,
-  ensureSupertonicModel
-} = require('../utils/downloadModel')
+  loadChatterboxTTS,
+  runChatterboxTTS,
+  resolveRefWavPath
+} = require('../utils/runChatterboxTTS')
+const { loadSupertonicTTS, runSupertonicTTS } = require('../utils/runSupertonicTTS')
+const { ensureChatterboxModels, ensureSupertonicModel } = require('../utils/downloadModel')
 
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
@@ -36,7 +37,7 @@ const isMobile = platform === 'ios' || platform === 'android'
 // package default (`useGPU: false`) rather than opting into GPU here.
 // Tests that *are* about GPU live in gpu-smoke.test.js.
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
@@ -46,168 +47,243 @@ const PHRASES = [
   'This is the third sentence in the sequential run test.'
 ]
 
-test('Chatterbox: multiple sequential runs reuse the same engine instance', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureChatterboxModels({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
-
-  // Mobile-aware resolution: on iOS / Android the asset is staged into
-  // `Library/Caches/jfk.wav` via `global.assetPaths`; on desktop falls
-  // back to the in-tree `test/reference-audio/jfk.wav`. The bundled
-  // path is not readable from native code on iOS, which would trip
-  // `ModelFileNotFound` the moment `model.load()` reaches the C++
-  // `ChatterboxModel::validateConfig` check.
-  const refWavPath = resolveRefWavPath({})
-  if (!fs.existsSync(refWavPath)) { t.pass('Skipped: reference audio missing'); return }
-
-  const model = await loadChatterboxTTS({
-    modelDir: download.targetDir,
-    refWavPath,
-    language: 'en'
-  })
-  try {
-    const timings = []
-    for (let i = 0; i < PHRASES.length; i++) {
-      const t0 = Date.now()
-      const result = await runChatterboxTTS(
-        model,
-        { text: PHRASES[i] },
-        { minSamples: 5000 }
+test(
+  'Chatterbox: multiple sequential runs reuse the same engine instance',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureChatterboxModels({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
       )
-      const wallMs = Date.now() - t0
-      timings.push(wallMs)
-      console.log(`  run ${i + 1}/${PHRASES.length}: ${result.data.sampleCount} samples (${wallMs}ms)`)
-
-      t.ok(result.passed, `Chatterbox run ${i + 1} should pass expectations`)
-      t.ok(result.data.sampleCount > 0, `Chatterbox run ${i + 1} should produce audio`)
-      const stats = result.data.stats
-      if (stats) {
-        t.ok(typeof stats.realTimeFactor === 'number', `Chatterbox run ${i + 1} reports RTF`)
-      }
+      return
     }
 
-    const avg = timings.reduce((a, b) => a + b, 0) / timings.length
-    console.log(`  avg wall-time across ${PHRASES.length} runs: ${avg.toFixed(0)}ms`)
-    t.ok(timings.length === PHRASES.length, 'all sequential runs completed')
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Supertonic: multiple sequential runs reuse the same engine instance', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
-
-  const model = await loadSupertonicTTS({
-    supertonicModelPath: download.path,
-    voice: 'F1',
-    language: 'en',
-    useGPU: false
-  })
-  try {
-    const timings = []
-    for (let i = 0; i < PHRASES.length; i++) {
-      const t0 = Date.now()
-      const result = await runSupertonicTTS(
-        model,
-        { text: PHRASES[i] },
-        { minSamples: 5000 }
-      )
-      const wallMs = Date.now() - t0
-      timings.push(wallMs)
-      console.log(`  run ${i + 1}/${PHRASES.length}: ${result.data.sampleCount} samples (${wallMs}ms)`)
-
-      t.ok(result.passed, `Supertonic run ${i + 1} should pass expectations`)
-      t.ok(result.data.sampleCount > 0, `Supertonic run ${i + 1} should produce audio`)
-      const stats = result.data.stats
-      if (stats) {
-        t.ok(typeof stats.realTimeFactor === 'number', `Supertonic run ${i + 1} reports RTF`)
-      }
+    // Mobile-aware resolution: on iOS / Android the asset is staged into
+    // `Library/Caches/jfk.wav` via `global.assetPaths`; on desktop falls
+    // back to the in-tree `test/reference-audio/jfk.wav`. The bundled
+    // path is not readable from native code on iOS, which would trip
+    // `ModelFileNotFound` the moment `model.load()` reaches the C++
+    // `ChatterboxModel::validateConfig` check.
+    const refWavPath = resolveRefWavPath({})
+    if (!fs.existsSync(refWavPath)) {
+      t.pass('Skipped: reference audio missing')
+      return
     }
 
-    const avg = timings.reduce((a, b) => a + b, 0) / timings.length
-    console.log(`  avg wall-time across ${PHRASES.length} runs: ${avg.toFixed(0)}ms`)
-    t.ok(timings.length === PHRASES.length, 'all sequential runs completed')
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Chatterbox: fresh instance per run (app-restart simulation)', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureChatterboxModels({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
-
-  // Mobile-aware resolution: on iOS / Android the asset is staged into
-  // `Library/Caches/jfk.wav` via `global.assetPaths`; on desktop falls
-  // back to the in-tree `test/reference-audio/jfk.wav`. The bundled
-  // path is not readable from native code on iOS, which would trip
-  // `ModelFileNotFound` the moment `model.load()` reaches the C++
-  // `ChatterboxModel::validateConfig` check.
-  const refWavPath = resolveRefWavPath({})
-  if (!fs.existsSync(refWavPath)) { t.pass('Skipped: reference audio missing'); return }
-
-  const N = 2
-  const results = []
-  for (let i = 0; i < N; i++) {
-    const t0 = Date.now()
     const model = await loadChatterboxTTS({
       modelDir: download.targetDir,
       refWavPath,
       language: 'en'
     })
-    const loadMs = Date.now() - t0
     try {
-      const t1 = Date.now()
-      const r = await runChatterboxTTS(model, { text: PHRASES[i % PHRASES.length] }, { minSamples: 5000 })
-      const runMs = Date.now() - t1
-      console.log(`  instance ${i + 1}/${N}: load=${loadMs}ms run=${runMs}ms samples=${r.data.sampleCount}`)
-      results.push({ loadMs, runMs, sampleCount: r.data.sampleCount, passed: r.passed })
+      const timings = []
+      for (let i = 0; i < PHRASES.length; i++) {
+        const t0 = Date.now()
+        const result = await runChatterboxTTS(model, { text: PHRASES[i] }, { minSamples: 5000 })
+        const wallMs = Date.now() - t0
+        timings.push(wallMs)
+        console.log(
+          `  run ${i + 1}/${PHRASES.length}: ${result.data.sampleCount} samples (${wallMs}ms)`
+        )
+
+        t.ok(result.passed, `Chatterbox run ${i + 1} should pass expectations`)
+        t.ok(result.data.sampleCount > 0, `Chatterbox run ${i + 1} should produce audio`)
+        const stats = result.data.stats
+        if (stats) {
+          t.ok(typeof stats.realTimeFactor === 'number', `Chatterbox run ${i + 1} reports RTF`)
+        }
+      }
+
+      const avg = timings.reduce((a, b) => a + b, 0) / timings.length
+      console.log(`  avg wall-time across ${PHRASES.length} runs: ${avg.toFixed(0)}ms`)
+      t.ok(timings.length === PHRASES.length, 'all sequential runs completed')
     } finally {
-      try { await model.unload() } catch (_e) {}
+      try {
+        await model.unload()
+      } catch (_e) {}
     }
   }
+)
 
-  t.ok(results.every(r => r.passed), 'every fresh instance should pass expectations')
-  t.ok(results.every(r => r.sampleCount > 0), 'every fresh instance should produce audio')
-})
+test(
+  'Supertonic: multiple sequential runs reuse the same engine instance',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
 
-test('Supertonic: fresh instance per run (app-restart simulation)', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
-
-  const N = 2
-  const results = []
-  for (let i = 0; i < N; i++) {
-    const t0 = Date.now()
     const model = await loadSupertonicTTS({
       supertonicModelPath: download.path,
       voice: 'F1',
       language: 'en',
       useGPU: false
     })
-    const loadMs = Date.now() - t0
     try {
-      const t1 = Date.now()
-      const r = await runSupertonicTTS(model, { text: PHRASES[i % PHRASES.length] }, { minSamples: 5000 })
-      const runMs = Date.now() - t1
-      console.log(`  instance ${i + 1}/${N}: load=${loadMs}ms run=${runMs}ms samples=${r.data.sampleCount}`)
-      results.push({ loadMs, runMs, sampleCount: r.data.sampleCount, passed: r.passed })
+      const timings = []
+      for (let i = 0; i < PHRASES.length; i++) {
+        const t0 = Date.now()
+        const result = await runSupertonicTTS(model, { text: PHRASES[i] }, { minSamples: 5000 })
+        const wallMs = Date.now() - t0
+        timings.push(wallMs)
+        console.log(
+          `  run ${i + 1}/${PHRASES.length}: ${result.data.sampleCount} samples (${wallMs}ms)`
+        )
+
+        t.ok(result.passed, `Supertonic run ${i + 1} should pass expectations`)
+        t.ok(result.data.sampleCount > 0, `Supertonic run ${i + 1} should produce audio`)
+        const stats = result.data.stats
+        if (stats) {
+          t.ok(typeof stats.realTimeFactor === 'number', `Supertonic run ${i + 1} reports RTF`)
+        }
+      }
+
+      const avg = timings.reduce((a, b) => a + b, 0) / timings.length
+      console.log(`  avg wall-time across ${PHRASES.length} runs: ${avg.toFixed(0)}ms`)
+      t.ok(timings.length === PHRASES.length, 'all sequential runs completed')
     } finally {
-      try { await model.unload() } catch (_e) {}
+      try {
+        await model.unload()
+      } catch (_e) {}
     }
   }
+)
 
-  t.ok(results.every(r => r.passed), 'every fresh instance should pass expectations')
-  t.ok(results.every(r => r.sampleCount > 0), 'every fresh instance should produce audio')
-})
+test(
+  'Chatterbox: fresh instance per run (app-restart simulation)',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureChatterboxModels({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    // Mobile-aware resolution: on iOS / Android the asset is staged into
+    // `Library/Caches/jfk.wav` via `global.assetPaths`; on desktop falls
+    // back to the in-tree `test/reference-audio/jfk.wav`. The bundled
+    // path is not readable from native code on iOS, which would trip
+    // `ModelFileNotFound` the moment `model.load()` reaches the C++
+    // `ChatterboxModel::validateConfig` check.
+    const refWavPath = resolveRefWavPath({})
+    if (!fs.existsSync(refWavPath)) {
+      t.pass('Skipped: reference audio missing')
+      return
+    }
+
+    const N = 2
+    const results = []
+    for (let i = 0; i < N; i++) {
+      const t0 = Date.now()
+      const model = await loadChatterboxTTS({
+        modelDir: download.targetDir,
+        refWavPath,
+        language: 'en'
+      })
+      const loadMs = Date.now() - t0
+      try {
+        const t1 = Date.now()
+        const r = await runChatterboxTTS(
+          model,
+          { text: PHRASES[i % PHRASES.length] },
+          { minSamples: 5000 }
+        )
+        const runMs = Date.now() - t1
+        console.log(
+          `  instance ${i + 1}/${N}: load=${loadMs}ms run=${runMs}ms samples=${r.data.sampleCount}`
+        )
+        results.push({ loadMs, runMs, sampleCount: r.data.sampleCount, passed: r.passed })
+      } finally {
+        try {
+          await model.unload()
+        } catch (_e) {}
+      }
+    }
+
+    t.ok(
+      results.every((r) => r.passed),
+      'every fresh instance should pass expectations'
+    )
+    t.ok(
+      results.every((r) => r.sampleCount > 0),
+      'every fresh instance should produce audio'
+    )
+  }
+)
+
+test(
+  'Supertonic: fresh instance per run (app-restart simulation)',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    const N = 2
+    const results = []
+    for (let i = 0; i < N; i++) {
+      const t0 = Date.now()
+      const model = await loadSupertonicTTS({
+        supertonicModelPath: download.path,
+        voice: 'F1',
+        language: 'en',
+        useGPU: false
+      })
+      const loadMs = Date.now() - t0
+      try {
+        const t1 = Date.now()
+        const r = await runSupertonicTTS(
+          model,
+          { text: PHRASES[i % PHRASES.length] },
+          { minSamples: 5000 }
+        )
+        const runMs = Date.now() - t1
+        console.log(
+          `  instance ${i + 1}/${N}: load=${loadMs}ms run=${runMs}ms samples=${r.data.sampleCount}`
+        )
+        results.push({ loadMs, runMs, sampleCount: r.data.sampleCount, passed: r.passed })
+      } finally {
+        try {
+          await model.unload()
+        } catch (_e) {}
+      }
+    }
+
+    t.ok(
+      results.every((r) => r.passed),
+      'every fresh instance should pass expectations'
+    )
+    t.ok(
+      results.every((r) => r.sampleCount > 0),
+      'every fresh instance should produce audio'
+    )
+  }
+)
 
 test('Chatterbox: reload() between runs preserves stability', { timeout: 1800000 }, async (t) => {
   const baseDir = getBaseDir()
   const download = await ensureChatterboxModels({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
+  if (!download.success) {
+    t.fail(
+      'Chatterbox GGUFs not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+    )
+    return
+  }
 
   // Mobile-aware resolution: on iOS / Android the asset is staged into
   // `Library/Caches/jfk.wav` via `global.assetPaths`; on desktop falls
@@ -216,7 +292,10 @@ test('Chatterbox: reload() between runs preserves stability', { timeout: 1800000
   // `ModelFileNotFound` the moment `model.load()` reaches the C++
   // `ChatterboxModel::validateConfig` check.
   const refWavPath = resolveRefWavPath({})
-  if (!fs.existsSync(refWavPath)) { t.pass('Skipped: reference audio missing'); return }
+  if (!fs.existsSync(refWavPath)) {
+    t.pass('Skipped: reference audio missing')
+    return
+  }
 
   const model = await loadChatterboxTTS({
     modelDir: download.targetDir,
@@ -224,24 +303,39 @@ test('Chatterbox: reload() between runs preserves stability', { timeout: 1800000
     language: 'en'
   })
   try {
-    const r1 = await runChatterboxTTS(model, { text: 'First run before reload.' }, { minSamples: 5000 })
+    const r1 = await runChatterboxTTS(
+      model,
+      { text: 'First run before reload.' },
+      { minSamples: 5000 }
+    )
     t.ok(r1.passed, 'first run before reload should pass')
 
     await model.reload({ language: 'en' })
     t.pass('reload() resolved')
 
-    const r2 = await runChatterboxTTS(model, { text: 'Second run after reload.' }, { minSamples: 5000 })
+    const r2 = await runChatterboxTTS(
+      model,
+      { text: 'Second run after reload.' },
+      { minSamples: 5000 }
+    )
     t.ok(r2.passed, 'second run after reload should pass')
     t.ok(r2.data.sampleCount > 0, 'reloaded model produces audio')
   } finally {
-    try { await model.unload() } catch (_e) {}
+    try {
+      await model.unload()
+    } catch (_e) {}
   }
 })
 
 test('Supertonic: reload() between runs preserves stability', { timeout: 1800000 }, async (t) => {
   const baseDir = getBaseDir()
   const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
+  if (!download.success) {
+    t.fail(
+      'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+    )
+    return
+  }
 
   const model = await loadSupertonicTTS({
     supertonicModelPath: download.path,
@@ -250,50 +344,93 @@ test('Supertonic: reload() between runs preserves stability', { timeout: 1800000
     useGPU: false
   })
   try {
-    const r1 = await runSupertonicTTS(model, { text: 'First supertonic run before reload.' }, { minSamples: 5000 })
+    const r1 = await runSupertonicTTS(
+      model,
+      { text: 'First supertonic run before reload.' },
+      { minSamples: 5000 }
+    )
     t.ok(r1.passed, 'first run before reload should pass')
 
     await model.reload({ language: 'en' })
     t.pass('reload() resolved')
 
-    const r2 = await runSupertonicTTS(model, { text: 'Second supertonic run after reload.' }, { minSamples: 5000 })
+    const r2 = await runSupertonicTTS(
+      model,
+      { text: 'Second supertonic run after reload.' },
+      { minSamples: 5000 }
+    )
     t.ok(r2.passed, 'second run after reload should pass')
     t.ok(r2.data.sampleCount > 0, 'reloaded model produces audio')
   } finally {
-    try { await model.unload() } catch (_e) {}
+    try {
+      await model.unload()
+    } catch (_e) {}
   }
 })
 
-test('Engine swap: chatterbox -> supertonic -> chatterbox in separate instances', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const cb = await ensureChatterboxModels({ targetDir: path.join(baseDir, 'models') })
-  const st = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!cb.success || !st.success) { t.fail('Not all engines have models locally - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
+test(
+  'Engine swap: chatterbox -> supertonic -> chatterbox in separate instances',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const cb = await ensureChatterboxModels({ targetDir: path.join(baseDir, 'models') })
+    const st = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!cb.success || !st.success) {
+      t.fail(
+        'Not all engines have models locally - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
 
-  // Mobile-aware resolution: on iOS / Android the asset is staged into
-  // `Library/Caches/jfk.wav` via `global.assetPaths`; on desktop falls
-  // back to the in-tree `test/reference-audio/jfk.wav`. The bundled
-  // path is not readable from native code on iOS, which would trip
-  // `ModelFileNotFound` the moment `model.load()` reaches the C++
-  // `ChatterboxModel::validateConfig` check.
-  const refWavPath = resolveRefWavPath({})
-  if (!fs.existsSync(refWavPath)) { t.pass('Skipped: reference audio missing'); return }
+    // Mobile-aware resolution: on iOS / Android the asset is staged into
+    // `Library/Caches/jfk.wav` via `global.assetPaths`; on desktop falls
+    // back to the in-tree `test/reference-audio/jfk.wav`. The bundled
+    // path is not readable from native code on iOS, which would trip
+    // `ModelFileNotFound` the moment `model.load()` reaches the C++
+    // `ChatterboxModel::validateConfig` check.
+    const refWavPath = resolveRefWavPath({})
+    if (!fs.existsSync(refWavPath)) {
+      t.pass('Skipped: reference audio missing')
+      return
+    }
 
-  const c1 = await loadChatterboxTTS({ modelDir: cb.targetDir, refWavPath, language: 'en' })
-  try {
-    const r = await runChatterboxTTS(c1, { text: 'Hello from chatterbox.' }, { minSamples: 5000 })
-    t.ok(r.passed, 'first chatterbox instance OK')
-  } finally { try { await c1.unload() } catch (_e) {} }
+    const c1 = await loadChatterboxTTS({ modelDir: cb.targetDir, refWavPath, language: 'en' })
+    try {
+      const r = await runChatterboxTTS(c1, { text: 'Hello from chatterbox.' }, { minSamples: 5000 })
+      t.ok(r.passed, 'first chatterbox instance OK')
+    } finally {
+      try {
+        await c1.unload()
+      } catch (_e) {}
+    }
 
-  const s1 = await loadSupertonicTTS({ supertonicModelPath: st.path, voice: 'F1', language: 'en', useGPU: false })
-  try {
-    const r = await runSupertonicTTS(s1, { text: 'Hello from supertonic.' }, { minSamples: 5000 })
-    t.ok(r.passed, 'supertonic instance OK')
-  } finally { try { await s1.unload() } catch (_e) {} }
+    const s1 = await loadSupertonicTTS({
+      supertonicModelPath: st.path,
+      voice: 'F1',
+      language: 'en',
+      useGPU: false
+    })
+    try {
+      const r = await runSupertonicTTS(s1, { text: 'Hello from supertonic.' }, { minSamples: 5000 })
+      t.ok(r.passed, 'supertonic instance OK')
+    } finally {
+      try {
+        await s1.unload()
+      } catch (_e) {}
+    }
 
-  const c2 = await loadChatterboxTTS({ modelDir: cb.targetDir, refWavPath, language: 'en' })
-  try {
-    const r = await runChatterboxTTS(c2, { text: 'Hello from chatterbox again.' }, { minSamples: 5000 })
-    t.ok(r.passed, 'second chatterbox instance OK after supertonic swap')
-  } finally { try { await c2.unload() } catch (_e) {} }
-})
+    const c2 = await loadChatterboxTTS({ modelDir: cb.targetDir, refWavPath, language: 'en' })
+    try {
+      const r = await runChatterboxTTS(
+        c2,
+        { text: 'Hello from chatterbox again.' },
+        { minSamples: 5000 }
+      )
+      t.ok(r.passed, 'second chatterbox instance OK after supertonic swap')
+    } finally {
+      try {
+        await c2.unload()
+      } catch (_e) {}
+    }
+  }
+)

--- a/packages/tts-ggml/test/integration/output-sample-rate.test.js
+++ b/packages/tts-ggml/test/integration/output-sample-rate.test.js
@@ -15,16 +15,16 @@ const { ensureSupertonicModel } = require('../utils/downloadModel')
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
-async function collect (model, text) {
+async function collect(model, text) {
   let samples = 0
   let sampleRate = null
   const response = await model.run({ input: text, type: 'text' })
   await response
-    .onUpdate(d => {
+    .onUpdate((d) => {
       if (d && d.outputArray) samples += d.outputArray.length
       if (d && d.sampleRate) sampleRate = d.sampleRate
     })
@@ -32,44 +32,61 @@ async function collect (model, text) {
   return { samples, sampleRate }
 }
 
-test('Supertonic: outputSampleRate=16000 resamples and reports 16 kHz', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const dl = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!dl.success) { t.fail('Supertonic GGUF not available — registry fetch failed.'); return }
-
-  const text = 'Output rate selection resamples the synthesized audio.'
-
-  const native = new TTSGgml({
-    engine: TTSGgml.ENGINE_SUPERTONIC,
-    files: { supertonicModel: dl.path },
-    voice: 'F1',
-    config: { language: 'en', useGPU: false },
-    opts: { stats: true }
-  })
-  await native.load()
-  let nativeSamples
-  try {
-    const r = await collect(native, text)
-    t.is(r.sampleRate, 44100, 'native Supertonic reports 44.1 kHz')
-    nativeSamples = r.samples
-  } finally { try { await native.unload() } catch (_e) {} }
-
-  const resampled = new TTSGgml({
-    engine: TTSGgml.ENGINE_SUPERTONIC,
-    files: { supertonicModel: dl.path },
-    voice: 'F1',
-    config: { language: 'en', useGPU: false, outputSampleRate: 16000 },
-    opts: { stats: true }
-  })
-  await resampled.load()
-  try {
-    const r = await collect(resampled, text)
-    t.is(r.sampleRate, 16000, 'outputSampleRate=16000 reported on the chunk')
-    t.ok(r.samples > 0, 'resampled synthesis produced audio')
-    // 16 kHz is ~36% of 44.1 kHz, so the resampled stream is materially shorter.
-    if (nativeSamples) {
-      t.ok(r.samples < nativeSamples * 0.6,
-        `resampled sample count (${r.samples}) well below native (${nativeSamples})`)
+test(
+  'Supertonic: outputSampleRate=16000 resamples and reports 16 kHz',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const dl = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!dl.success) {
+      t.fail('Supertonic GGUF not available — registry fetch failed.')
+      return
     }
-  } finally { try { await resampled.unload() } catch (_e) {} }
-})
+
+    const text = 'Output rate selection resamples the synthesized audio.'
+
+    const native = new TTSGgml({
+      engine: TTSGgml.ENGINE_SUPERTONIC,
+      files: { supertonicModel: dl.path },
+      voice: 'F1',
+      config: { language: 'en', useGPU: false },
+      opts: { stats: true }
+    })
+    await native.load()
+    let nativeSamples
+    try {
+      const r = await collect(native, text)
+      t.is(r.sampleRate, 44100, 'native Supertonic reports 44.1 kHz')
+      nativeSamples = r.samples
+    } finally {
+      try {
+        await native.unload()
+      } catch (_e) {}
+    }
+
+    const resampled = new TTSGgml({
+      engine: TTSGgml.ENGINE_SUPERTONIC,
+      files: { supertonicModel: dl.path },
+      voice: 'F1',
+      config: { language: 'en', useGPU: false, outputSampleRate: 16000 },
+      opts: { stats: true }
+    })
+    await resampled.load()
+    try {
+      const r = await collect(resampled, text)
+      t.is(r.sampleRate, 16000, 'outputSampleRate=16000 reported on the chunk')
+      t.ok(r.samples > 0, 'resampled synthesis produced audio')
+      // 16 kHz is ~36% of 44.1 kHz, so the resampled stream is materially shorter.
+      if (nativeSamples) {
+        t.ok(
+          r.samples < nativeSamples * 0.6,
+          `resampled sample count (${r.samples}) well below native (${nativeSamples})`
+        )
+      }
+    } finally {
+      try {
+        await resampled.unload()
+      } catch (_e) {}
+    }
+  }
+)

--- a/packages/tts-ggml/test/integration/rtf-benchmark.test.js
+++ b/packages/tts-ggml/test/integration/rtf-benchmark.test.js
@@ -20,11 +20,14 @@
 
 const os = require('bare-os')
 
-const flag = typeof os.getEnv === 'function' ? (os.getEnv('QVAC_TTS_GGML_RUN_BENCHMARK_ON_MOBILE') || '') : ''
+const flag =
+  typeof os.getEnv === 'function' ? os.getEnv('QVAC_TTS_GGML_RUN_BENCHMARK_ON_MOBILE') || '' : ''
 const enabled = flag === '1' || flag.toLowerCase() === 'true' || flag.toLowerCase() === 'yes'
 
 if (enabled) {
   require('../benchmark/rtf-benchmark.test.js')
 } else {
-  console.log('[rtf-benchmark mobile shim] QVAC_TTS_GGML_RUN_BENCHMARK_ON_MOBILE not set; skipping benchmark.')
+  console.log(
+    '[rtf-benchmark mobile shim] QVAC_TTS_GGML_RUN_BENCHMARK_ON_MOBILE not set; skipping benchmark.'
+  )
 }

--- a/packages/tts-ggml/test/integration/streaming-benchmark.test.js
+++ b/packages/tts-ggml/test/integration/streaming-benchmark.test.js
@@ -8,11 +8,14 @@
 
 const os = require('bare-os')
 
-const flag = typeof os.getEnv === 'function' ? (os.getEnv('QVAC_TTS_GGML_RUN_BENCHMARK_ON_MOBILE') || '') : ''
+const flag =
+  typeof os.getEnv === 'function' ? os.getEnv('QVAC_TTS_GGML_RUN_BENCHMARK_ON_MOBILE') || '' : ''
 const enabled = flag === '1' || flag.toLowerCase() === 'true' || flag.toLowerCase() === 'yes'
 
 if (enabled) {
   require('../benchmark/streaming-benchmark.test.js')
 } else {
-  console.log('[streaming-benchmark mobile shim] QVAC_TTS_GGML_RUN_BENCHMARK_ON_MOBILE not set; skipping benchmark.')
+  console.log(
+    '[streaming-benchmark mobile shim] QVAC_TTS_GGML_RUN_BENCHMARK_ON_MOBILE not set; skipping benchmark.'
+  )
 }

--- a/packages/tts-ggml/test/integration/supertonic-mtl.test.js
+++ b/packages/tts-ggml/test/integration/supertonic-mtl.test.js
@@ -18,7 +18,7 @@ const { recordTtsStats } = require('../utils/perf-helper')
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
@@ -30,7 +30,7 @@ const MTL_SENTENCES = [
   { lang: 'pt', text: 'A raposa marrom pula sobre o cachorro preguiçoso.' }
 ]
 
-async function loadSupertonicMtlTTS (params) {
+async function loadSupertonicMtlTTS(params) {
   const model = new TTSGgml({
     engine: TTSGgml.ENGINE_SUPERTONIC,
     files: { supertonicModel: params.supertonicModelPath },
@@ -42,114 +42,151 @@ async function loadSupertonicMtlTTS (params) {
   return model
 }
 
-test('Supertonic MTL TTS (ggml): synthesizes across es/fr/pt with shared engine', { timeout: 1800000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicMtlModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) {
-    t.fail('Supertonic MTL GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
+test(
+  'Supertonic MTL TTS (ggml): synthesizes across es/fr/pt with shared engine',
+  { timeout: 1800000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicMtlModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic MTL GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
 
-  const model = await loadSupertonicMtlTTS({
-    supertonicModelPath: download.path,
-    language: MTL_SENTENCES[0].lang
-  })
-  try {
-    for (let i = 0; i < MTL_SENTENCES.length; i++) {
-      const { lang, text } = MTL_SENTENCES[i]
-      console.log(`  [${lang}] "${text.slice(0, 50)}..."`)
-      if (i > 0) {
-        await model.reload({ language: lang })
+    const model = await loadSupertonicMtlTTS({
+      supertonicModelPath: download.path,
+      language: MTL_SENTENCES[0].lang
+    })
+    try {
+      for (let i = 0; i < MTL_SENTENCES.length; i++) {
+        const { lang, text } = MTL_SENTENCES[i]
+        console.log(`  [${lang}] "${text.slice(0, 50)}..."`)
+        if (i > 0) {
+          await model.reload({ language: lang })
+        }
+        const t0 = Date.now()
+        const result = await runSupertonicTTS(
+          model,
+          { text },
+          { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 }
+        )
+        const wallMs = Date.now() - t0
+        console.log('    ' + result.output)
+
+        t.ok(result.passed, `Supertonic MTL ${lang} run passes expectations`)
+        t.ok(result.data.sampleCount > 0, `Supertonic MTL ${lang} produced audio`)
+        t.is(
+          result.data.reportedSampleRate || SAMPLE_RATE,
+          SAMPLE_RATE,
+          `Supertonic MTL ${lang} reports 44.1 kHz`
+        )
+
+        const st = result.data?.stats || {}
+        t.comment(
+          recordTtsStats(
+            `supertonic mtl ${lang}`,
+            {
+              realTimeFactor: st.realTimeFactor,
+              audioDurationMs: st.audioDurationMs || result.data?.durationMs,
+              totalSamples: st.totalSamples,
+              backendDevice: st.backendDevice
+            },
+            { wallMs, sampleCount: result.data?.sampleCount, model: 'supertonic-mtl', output: text }
+          )
+        )
       }
-      const t0 = Date.now()
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)
+
+test(
+  'Supertonic MTL TTS (ggml): unsupported language fails fast at engine load',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicMtlModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic MTL GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    // 'de' is in Chatterbox MTL's tier-1 set but NOT in Supertonic's
+    // (which only handles en/ko/es/pt/fr today; see
+    // supertonic_preprocess.cpp::is_supported_language).  The native
+    // engine should reject the run with a clear "invalid Supertonic
+    // language" error rather than silently producing garbage.
+    const model = await loadSupertonicMtlTTS({
+      supertonicModelPath: download.path,
+      language: 'de'
+    })
+    try {
+      let failed = false
+      let message = ''
+      try {
+        const response = await model.run({
+          type: 'text',
+          input: 'Der braune Fuchs springt über den faulen Hund.'
+        })
+        await response.await()
+      } catch (e) {
+        failed = true
+        message = String(e && e.message)
+      }
+      t.ok(failed, 'unsupported language should reject the synthesis call')
+      t.ok(
+        /language|Supertonic/i.test(message),
+        `error mentions language / Supertonic (got: ${message})`
+      )
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)
+
+test(
+  'Supertonic MTL TTS (ggml): backendDevice + backendId surfaced in stats',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicMtlModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic MTL GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    const model = await loadSupertonicMtlTTS({
+      supertonicModelPath: download.path,
+      language: 'es'
+    })
+    try {
       const result = await runSupertonicTTS(
         model,
-        { text },
-        { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 }
+        { text: 'Comprobando los datos de telemetría del backend.' },
+        { minSamples: 5000 }
       )
-      const wallMs = Date.now() - t0
-      console.log('    ' + result.output)
-
-      t.ok(result.passed, `Supertonic MTL ${lang} run passes expectations`)
-      t.ok(result.data.sampleCount > 0, `Supertonic MTL ${lang} produced audio`)
-      t.is(result.data.reportedSampleRate || SAMPLE_RATE, SAMPLE_RATE, `Supertonic MTL ${lang} reports 44.1 kHz`)
-
-      const st = result.data?.stats || {}
-      t.comment(recordTtsStats(
-        `supertonic mtl ${lang}`,
-        { realTimeFactor: st.realTimeFactor, audioDurationMs: st.audioDurationMs || result.data?.durationMs, totalSamples: st.totalSamples, backendDevice: st.backendDevice },
-        { wallMs, sampleCount: result.data?.sampleCount, model: 'supertonic-mtl', output: text }
-      ))
+      t.ok(result.passed, 'MTL run for backend telemetry passes')
+      if (result.data.stats) {
+        t.ok(typeof result.data.stats.backendDevice === 'number', 'backendDevice surfaced in stats')
+        t.ok(typeof result.data.stats.backendId === 'number', 'backendId surfaced in stats')
+      } else {
+        t.fail('expected stats from Supertonic MTL run')
+      }
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
     }
-  } finally {
-    try { await model.unload() } catch (_e) {}
   }
-})
-
-test('Supertonic MTL TTS (ggml): unsupported language fails fast at engine load', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicMtlModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) {
-    t.fail('Supertonic MTL GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-
-  // 'de' is in Chatterbox MTL's tier-1 set but NOT in Supertonic's
-  // (which only handles en/ko/es/pt/fr today; see
-  // supertonic_preprocess.cpp::is_supported_language).  The native
-  // engine should reject the run with a clear "invalid Supertonic
-  // language" error rather than silently producing garbage.
-  const model = await loadSupertonicMtlTTS({
-    supertonicModelPath: download.path,
-    language: 'de'
-  })
-  try {
-    let failed = false
-    let message = ''
-    try {
-      const response = await model.run({
-        type: 'text',
-        input: 'Der braune Fuchs springt über den faulen Hund.'
-      })
-      await response.await()
-    } catch (e) {
-      failed = true
-      message = String(e && e.message)
-    }
-    t.ok(failed, 'unsupported language should reject the synthesis call')
-    t.ok(/language|Supertonic/i.test(message),
-      `error mentions language / Supertonic (got: ${message})`)
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
-
-test('Supertonic MTL TTS (ggml): backendDevice + backendId surfaced in stats', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicMtlModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) {
-    t.fail('Supertonic MTL GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.')
-    return
-  }
-
-  const model = await loadSupertonicMtlTTS({
-    supertonicModelPath: download.path,
-    language: 'es'
-  })
-  try {
-    const result = await runSupertonicTTS(
-      model,
-      { text: 'Comprobando los datos de telemetría del backend.' },
-      { minSamples: 5000 }
-    )
-    t.ok(result.passed, 'MTL run for backend telemetry passes')
-    if (result.data.stats) {
-      t.ok(typeof result.data.stats.backendDevice === 'number', 'backendDevice surfaced in stats')
-      t.ok(typeof result.data.stats.backendId === 'number', 'backendId surfaced in stats')
-    } else {
-      t.fail('expected stats from Supertonic MTL run')
-    }
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
+)

--- a/packages/tts-ggml/test/integration/supertonic.test.js
+++ b/packages/tts-ggml/test/integration/supertonic.test.js
@@ -16,199 +16,287 @@ const { recordTtsStats } = require('../utils/perf-helper')
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
-test('Supertonic TTS (ggml): basic synthesis returns ~44.1 kHz audio + stats', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
-
-  const model = await loadSupertonicTTS({
-    supertonicModelPath: download.path,
-    voice: 'F1',
-    language: 'en',
-    useGPU: false
-  })
-  try {
-    const wavPath = isMobile ? undefined : path.join(baseDir, 'test', 'output', 'supertonic-en.wav')
-    const text = 'The supertonic engine produces high quality speech in real time.'
-    const t0 = Date.now()
-    const result = await runSupertonicTTS(
-      model,
-      { text, saveWav: !isMobile, wavOutputPath: wavPath },
-      { minSamples: 10000, maxSamples: 5000000, minDurationMs: 250, maxDurationMs: 300000 }
-    )
-    const wallMs = Date.now() - t0
-    console.log(result.output)
-
-    t.ok(result.passed, 'supertonic synth passes expectations')
-    t.ok(result.data.sampleCount > 0, 'supertonic produced audio')
-    t.is(result.data.reportedSampleRate, 44100, 'supertonic reports 44.1 kHz native sample rate')
-
-    const st = result.data?.stats || {}
-    t.comment(recordTtsStats(
-      'supertonic en',
-      { realTimeFactor: st.realTimeFactor, audioDurationMs: st.audioDurationMs || result.data?.durationMs, totalSamples: st.totalSamples, backendDevice: st.backendDevice },
-      { wallMs, sampleCount: result.data?.sampleCount, model: 'supertonic', output: text }
-    ))
-    if (result.data.stats) {
-      t.ok(typeof result.data.stats.realTimeFactor === 'number', 'supertonic stats include RTF')
-      t.ok(typeof result.data.stats.audioDurationMs === 'number', 'supertonic stats include audio duration')
-      t.ok(typeof result.data.stats.backendDevice === 'number', 'supertonic stats include backendDevice')
-      t.ok(typeof result.data.stats.backendId === 'number', 'supertonic stats include backendId')
+test(
+  'Supertonic TTS (ggml): basic synthesis returns ~44.1 kHz audio + stats',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
     }
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
 
-test('Supertonic TTS (ggml): cancel mid-flight rejects the response', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
-
-  const model = await loadSupertonicTTS({
-    supertonicModelPath: download.path,
-    voice: 'F1',
-    language: 'en',
-    useGPU: false
-  })
-  try {
-    const response = await model.run({ type: 'text', input: 'Cancel this synthesis call before it completes.' })
-    setTimeout(() => { response.cancel().catch(() => {}) }, 50)
-
-    let failed = false
+    const model = await loadSupertonicTTS({
+      supertonicModelPath: download.path,
+      voice: 'F1',
+      language: 'en',
+      useGPU: false
+    })
     try {
-      await response.await()
-    } catch (e) {
-      failed = true
-      console.log('  cancel rejected with: ' + e.message)
+      const wavPath = isMobile
+        ? undefined
+        : path.join(baseDir, 'test', 'output', 'supertonic-en.wav')
+      const text = 'The supertonic engine produces high quality speech in real time.'
+      const t0 = Date.now()
+      const result = await runSupertonicTTS(
+        model,
+        { text, saveWav: !isMobile, wavOutputPath: wavPath },
+        { minSamples: 10000, maxSamples: 5000000, minDurationMs: 250, maxDurationMs: 300000 }
+      )
+      const wallMs = Date.now() - t0
+      console.log(result.output)
+
+      t.ok(result.passed, 'supertonic synth passes expectations')
+      t.ok(result.data.sampleCount > 0, 'supertonic produced audio')
+      t.is(result.data.reportedSampleRate, 44100, 'supertonic reports 44.1 kHz native sample rate')
+
+      const st = result.data?.stats || {}
+      t.comment(
+        recordTtsStats(
+          'supertonic en',
+          {
+            realTimeFactor: st.realTimeFactor,
+            audioDurationMs: st.audioDurationMs || result.data?.durationMs,
+            totalSamples: st.totalSamples,
+            backendDevice: st.backendDevice
+          },
+          { wallMs, sampleCount: result.data?.sampleCount, model: 'supertonic', output: text }
+        )
+      )
+      if (result.data.stats) {
+        t.ok(typeof result.data.stats.realTimeFactor === 'number', 'supertonic stats include RTF')
+        t.ok(
+          typeof result.data.stats.audioDurationMs === 'number',
+          'supertonic stats include audio duration'
+        )
+        t.ok(
+          typeof result.data.stats.backendDevice === 'number',
+          'supertonic stats include backendDevice'
+        )
+        t.ok(typeof result.data.stats.backendId === 'number', 'supertonic stats include backendId')
+      }
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
     }
-    t.ok(failed, 'cancelled supertonic response should reject')
-  } finally {
-    try { await model.unload() } catch (_e) {}
   }
-})
+)
 
-test('Supertonic TTS (ggml): runStream emits per-sentence chunks with chunkIndex / sentenceChunk / isLast', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
+test(
+  'Supertonic TTS (ggml): cancel mid-flight rejects the response',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
 
-  const TTSGgml = require('@qvac/tts-ggml')
-  const model = new TTSGgml({
-    engine: TTSGgml.ENGINE_SUPERTONIC,
-    files: { supertonicModel: download.path },
-    voice: 'F1',
-    config: { language: 'en', useGPU: false },
-    opts: { stats: true }
-  })
-  await model.load()
-  try {
-    const text = 'First sentence. Second sentence. Third sentence here.'
-    const response = await model.runStream(text, { maxChunkScalars: 30 })
-    const chunkIndices = []
-    const sentenceChunks = []
-    const isLastFlags = []
-    let totalSamples = 0
-    let lastSampleRate = null
-    await response
-      .onUpdate(d => {
-        if (d && d.outputArray) {
-          chunkIndices.push(d.chunkIndex)
-          sentenceChunks.push(d.sentenceChunk)
-          isLastFlags.push(!!d.isLast)
-          totalSamples += d.outputArray.length
-          if (d.sampleRate) lastSampleRate = d.sampleRate
-        }
+    const model = await loadSupertonicTTS({
+      supertonicModelPath: download.path,
+      voice: 'F1',
+      language: 'en',
+      useGPU: false
+    })
+    try {
+      const response = await model.run({
+        type: 'text',
+        input: 'Cancel this synthesis call before it completes.'
       })
-      .await()
+      setTimeout(() => {
+        response.cancel().catch(() => {})
+      }, 50)
 
-    t.ok(chunkIndices.length >= 2, `runStream produced multiple chunks (got ${chunkIndices.length})`)
-    for (let i = 0; i < chunkIndices.length; i++) {
-      t.is(chunkIndices[i], i, `chunk ${i} carries chunkIndex=${i}`)
-      t.ok(typeof sentenceChunks[i] === 'string' && sentenceChunks[i].length > 0,
-        `chunk ${i} carries non-empty sentenceChunk`)
+      let failed = false
+      try {
+        await response.await()
+      } catch (e) {
+        failed = true
+        console.log('  cancel rejected with: ' + e.message)
+      }
+      t.ok(failed, 'cancelled supertonic response should reject')
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
     }
-    t.is(isLastFlags.filter(Boolean).length, 1, 'exactly one isLast=true emitted')
-    t.is(isLastFlags[isLastFlags.length - 1], true, 'final chunk carries isLast=true')
-    t.is(lastSampleRate, 44100, 'supertonic sentence-stream chunks report 44.1 kHz')
-    t.ok(totalSamples > 0, 'stream produced audio samples')
-    if (response.stats) {
-      t.ok(response.stats.totalSamples >= totalSamples * 0.95,
-        'merged stats totalSamples roughly matches concatenated chunk samples')
+  }
+)
+
+test(
+  'Supertonic TTS (ggml): runStream emits per-sentence chunks with chunkIndex / sentenceChunk / isLast',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
     }
-  } finally {
-    try { await model.unload() } catch (_e) {}
-  }
-})
 
-test('Supertonic TTS (ggml): runStreaming with async iterator emits one job per yielded sentence', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
+    const TTSGgml = require('@qvac/tts-ggml')
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_SUPERTONIC,
+      files: { supertonicModel: download.path },
+      voice: 'F1',
+      config: { language: 'en', useGPU: false },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      const text = 'First sentence. Second sentence. Third sentence here.'
+      const response = await model.runStream(text, { maxChunkScalars: 30 })
+      const chunkIndices = []
+      const sentenceChunks = []
+      const isLastFlags = []
+      let totalSamples = 0
+      let lastSampleRate = null
+      await response
+        .onUpdate((d) => {
+          if (d && d.outputArray) {
+            chunkIndices.push(d.chunkIndex)
+            sentenceChunks.push(d.sentenceChunk)
+            isLastFlags.push(!!d.isLast)
+            totalSamples += d.outputArray.length
+            if (d.sampleRate) lastSampleRate = d.sampleRate
+          }
+        })
+        .await()
 
-  const TTSGgml = require('@qvac/tts-ggml')
-  const model = new TTSGgml({
-    engine: TTSGgml.ENGINE_SUPERTONIC,
-    files: { supertonicModel: download.path },
-    voice: 'F1',
-    config: { language: 'en', useGPU: false },
-    opts: { stats: true }
-  })
-  await model.load()
-  try {
-    async function * yields () {
-      yield 'First yielded sentence.'
-      yield 'Second yielded sentence.'
-      yield 'Third yielded sentence.'
+      t.ok(
+        chunkIndices.length >= 2,
+        `runStream produced multiple chunks (got ${chunkIndices.length})`
+      )
+      for (let i = 0; i < chunkIndices.length; i++) {
+        t.is(chunkIndices[i], i, `chunk ${i} carries chunkIndex=${i}`)
+        t.ok(
+          typeof sentenceChunks[i] === 'string' && sentenceChunks[i].length > 0,
+          `chunk ${i} carries non-empty sentenceChunk`
+        )
+      }
+      t.is(isLastFlags.filter(Boolean).length, 1, 'exactly one isLast=true emitted')
+      t.is(isLastFlags[isLastFlags.length - 1], true, 'final chunk carries isLast=true')
+      t.is(lastSampleRate, 44100, 'supertonic sentence-stream chunks report 44.1 kHz')
+      t.ok(totalSamples > 0, 'stream produced audio samples')
+      if (response.stats) {
+        t.ok(
+          response.stats.totalSamples >= totalSamples * 0.95,
+          'merged stats totalSamples roughly matches concatenated chunk samples'
+        )
+      }
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
     }
-    const response = await model.runStreaming(yields())
-    const updates = []
-    await response.onUpdate(d => {
-      if (d && d.outputArray) updates.push(d)
-    }).await()
-
-    t.is(updates.length, 3, 'one chunk per yielded sentence')
-    t.is(updates[0].chunkIndex, 0, 'chunk 0 has chunkIndex=0')
-    t.is(updates[2].chunkIndex, 2, 'chunk 2 has chunkIndex=2')
-    t.ok(updates.every(u => u.isLast === undefined),
-      'isLast is undefined for async-iter mode (count not known up-front)')
-    t.ok(updates.every(u => u.sampleRate === 44100),
-      'every chunk reports 44.1 kHz native sample rate')
-  } finally {
-    try { await model.unload() } catch (_e) {}
   }
-})
+)
 
-test('Supertonic TTS (ggml): voice + steps + speed knobs survive ttsParams round-trip', { timeout: 600000 }, async (t) => {
-  const baseDir = getBaseDir()
-  const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
-  if (!download.success) { t.fail('Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'); return }
+test(
+  'Supertonic TTS (ggml): runStreaming with async iterator emits one job per yielded sentence',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
 
-  const model = await loadSupertonicTTS({
-    supertonicModelPath: download.path,
-    voice: 'F1',
-    steps: 4,
-    speed: 1.0,
-    language: 'en',
-    useGPU: false
-  })
-  try {
-    const params = model._buildTtsParams()
-    t.is(params.voice, 'F1')
-    t.is(params.steps, 4)
-    t.is(params.speed, 1)
+    const TTSGgml = require('@qvac/tts-ggml')
+    const model = new TTSGgml({
+      engine: TTSGgml.ENGINE_SUPERTONIC,
+      files: { supertonicModel: download.path },
+      voice: 'F1',
+      config: { language: 'en', useGPU: false },
+      opts: { stats: true }
+    })
+    await model.load()
+    try {
+      async function* yields() {
+        yield 'First yielded sentence.'
+        yield 'Second yielded sentence.'
+        yield 'Third yielded sentence.'
+      }
+      const response = await model.runStreaming(yields())
+      const updates = []
+      await response
+        .onUpdate((d) => {
+          if (d && d.outputArray) updates.push(d)
+        })
+        .await()
 
-    const result = await runSupertonicTTS(
-      model,
-      { text: 'Voice and steps test.' },
-      { minSamples: 5000 }
-    )
-    t.ok(result.passed, 'voice+steps run passes expectations')
-  } finally {
-    try { await model.unload() } catch (_e) {}
+      t.is(updates.length, 3, 'one chunk per yielded sentence')
+      t.is(updates[0].chunkIndex, 0, 'chunk 0 has chunkIndex=0')
+      t.is(updates[2].chunkIndex, 2, 'chunk 2 has chunkIndex=2')
+      t.ok(
+        updates.every((u) => u.isLast === undefined),
+        'isLast is undefined for async-iter mode (count not known up-front)'
+      )
+      t.ok(
+        updates.every((u) => u.sampleRate === 44100),
+        'every chunk reports 44.1 kHz native sample rate'
+      )
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
   }
-})
+)
+
+test(
+  'Supertonic TTS (ggml): voice + steps + speed knobs survive ttsParams round-trip',
+  { timeout: 600000 },
+  async (t) => {
+    const baseDir = getBaseDir()
+    const download = await ensureSupertonicModel({ targetDir: path.join(baseDir, 'models') })
+    if (!download.success) {
+      t.fail(
+        'Supertonic GGUF not available - registry fetch failed. Run `npm run download-models:registry` or stage models locally.'
+      )
+      return
+    }
+
+    const model = await loadSupertonicTTS({
+      supertonicModelPath: download.path,
+      voice: 'F1',
+      steps: 4,
+      speed: 1.0,
+      language: 'en',
+      useGPU: false
+    })
+    try {
+      const params = model._buildTtsParams()
+      t.is(params.voice, 'F1')
+      t.is(params.steps, 4)
+      t.is(params.speed, 1)
+
+      const result = await runSupertonicTTS(
+        model,
+        { text: 'Voice and steps test.' },
+        { minSamples: 5000 }
+      )
+      t.ok(result.passed, 'voice+steps run passes expectations')
+    } finally {
+      try {
+        await model.unload()
+      } catch (_e) {}
+    }
+  }
+)

--- a/packages/tts-ggml/test/integration/supertonic3-quant.test.js
+++ b/packages/tts-ggml/test/integration/supertonic3-quant.test.js
@@ -28,7 +28,7 @@ const { ensureSupertonic3Model } = require('../utils/downloadModel')
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
@@ -54,7 +54,7 @@ const SENTENCES = [
   { lang: 'nl', text: 'De snelle bruine vos springt over de luie hond.', group: 'new' }
 ]
 
-async function loadSupertonic3TTS (params) {
+async function loadSupertonic3TTS(params) {
   const model = new TTSGgml({
     engine: TTSGgml.ENGINE_SUPERTONIC,
     files: { supertonicModel: params.supertonicModelPath },
@@ -67,45 +67,59 @@ async function loadSupertonic3TTS (params) {
 }
 
 for (const quant of QUANTS) {
-  test(`Supertonic 3 (${quant}): synthesizes across existing + new languages`, { timeout: 1800000 }, async (t) => {
-    const baseDir = getBaseDir()
-    const download = await ensureSupertonic3Model({
-      targetDir: path.join(baseDir, 'models'),
-      quant
-    })
-    if (!download.success) {
-      t.fail(`supertonic3-${quant}.gguf could not be fetched from the registry. ` +
-        'All four tiers are published on the QVAC registry (S3); a fetch ' +
-        'failure is a real error (network / registry unavailable, or the ' +
-        '@qvac/registry-client devDependency is missing).')
-      return
-    }
-
-    const model = await loadSupertonic3TTS({
-      supertonicModelPath: download.path,
-      language: SENTENCES[0].lang
-    })
-    try {
-      for (let i = 0; i < SENTENCES.length; i++) {
-        const { lang, text, group } = SENTENCES[i]
-        console.log(`  [${quant}/${group}/${lang}] "${text.slice(0, 50)}..."`)
-        if (i > 0) {
-          await model.reload({ language: lang })
-        }
-        const result = await runSupertonicTTS(
-          model,
-          { text },
-          { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 }
+  test(
+    `Supertonic 3 (${quant}): synthesizes across existing + new languages`,
+    { timeout: 1800000 },
+    async (t) => {
+      const baseDir = getBaseDir()
+      const download = await ensureSupertonic3Model({
+        targetDir: path.join(baseDir, 'models'),
+        quant
+      })
+      if (!download.success) {
+        t.fail(
+          `supertonic3-${quant}.gguf could not be fetched from the registry. ` +
+            'All four tiers are published on the QVAC registry (S3); a fetch ' +
+            'failure is a real error (network / registry unavailable, or the ' +
+            '@qvac/registry-client devDependency is missing).'
         )
-        console.log('    ' + result.output)
-
-        t.ok(result.passed, `Supertonic 3 ${quant} ${lang} (${group}) run passes expectations`)
-        t.ok(result.data.sampleCount > 0, `Supertonic 3 ${quant} ${lang} (${group}) produced audio`)
-        t.is(result.data.reportedSampleRate || SAMPLE_RATE, SAMPLE_RATE,
-          `Supertonic 3 ${quant} ${lang} reports 44.1 kHz`)
+        return
       }
-    } finally {
-      try { await model.unload() } catch (_e) {}
+
+      const model = await loadSupertonic3TTS({
+        supertonicModelPath: download.path,
+        language: SENTENCES[0].lang
+      })
+      try {
+        for (let i = 0; i < SENTENCES.length; i++) {
+          const { lang, text, group } = SENTENCES[i]
+          console.log(`  [${quant}/${group}/${lang}] "${text.slice(0, 50)}..."`)
+          if (i > 0) {
+            await model.reload({ language: lang })
+          }
+          const result = await runSupertonicTTS(
+            model,
+            { text },
+            { minSamples: 5000, maxSamples: 5000000, minDurationMs: 200, maxDurationMs: 300000 }
+          )
+          console.log('    ' + result.output)
+
+          t.ok(result.passed, `Supertonic 3 ${quant} ${lang} (${group}) run passes expectations`)
+          t.ok(
+            result.data.sampleCount > 0,
+            `Supertonic 3 ${quant} ${lang} (${group}) produced audio`
+          )
+          t.is(
+            result.data.reportedSampleRate || SAMPLE_RATE,
+            SAMPLE_RATE,
+            `Supertonic 3 ${quant} ${lang} reports 44.1 kHz`
+          )
+        }
+      } finally {
+        try {
+          await model.unload()
+        } catch (_e) {}
+      }
     }
-  })
+  )
 }

--- a/packages/tts-ggml/test/mock/MockedBinding.js
+++ b/packages/tts-ggml/test/mock/MockedBinding.js
@@ -8,7 +8,7 @@ const state = Object.freeze({
 })
 
 class MockedBinding {
-  constructor ({ jobDelayMs = 10 } = {}) {
+  constructor({ jobDelayMs = 10 } = {}) {
     this._handle = null
     this._state = state.LOADING
     this.outputCb = null
@@ -17,18 +17,18 @@ class MockedBinding {
     this._jobDelayMs = jobDelayMs
   }
 
-  createInstance (interfaceType, configurationParams, outputCb) {
+  createInstance(interfaceType, configurationParams, outputCb) {
     console.log('Constructing the TTS addon')
     this.outputCb = outputCb
     this._handle = { id: Date.now() }
     return this._handle
   }
 
-  setBaseInferenceCallback (callback) {
+  setBaseInferenceCallback(callback) {
     this._baseInferenceCallback = callback
   }
 
-  _callCallbacks (event, data, error) {
+  _callCallbacks(event, data, error) {
     // addon-cpp 1.1.5 emits event, data, error only; job ownership stays in JS.
     if (this.outputCb) {
       this.outputCb(this, event, data, error)
@@ -38,18 +38,18 @@ class MockedBinding {
     }
   }
 
-  activate (handle) {
+  activate(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Activated the TTS addon')
     this._state = state.LISTENING
   }
 
-  cancel (handle) {
+  cancel(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     this._cancelRequested = true
   }
 
-  runJob (handle, data) {
+  runJob(handle, data) {
     if (handle !== this._handle) throw new Error('Invalid handle')
 
     if (this._state !== state.LISTENING) {
@@ -77,74 +77,78 @@ class MockedBinding {
       }
 
       this._callCallbacks('AudioResult', { outputArray: mockAudioSamples }, null)
-      this._callCallbacks('RuntimeStats', {
-        totalTime: 0.12,
-        tokensPerSecond: 120,
-        realTimeFactor: 0.08,
-        audioDurationMs: sampleCount / 24,
-        totalSamples: sampleCount
-      }, null)
+      this._callCallbacks(
+        'RuntimeStats',
+        {
+          totalTime: 0.12,
+          tokensPerSecond: 120,
+          realTimeFactor: 0.08,
+          audioDurationMs: sampleCount / 24,
+          totalSamples: sampleCount
+        },
+        null
+      )
       this._state = state.LISTENING
     }, this._jobDelayMs)
     return true
   }
 
-  loadWeights (handle, weightsData) {
+  loadWeights(handle, weightsData) {
     if (handle !== this._handle) throw new Error('Invalid handle')
   }
 
-  destroyInstance (handle) {
+  destroyInstance(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     this._handle = null
     this._state = state.IDLE
   }
 
-  unload (handle) {
+  unload(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     this.destroyInstance(handle)
   }
 
-  status () {
+  status() {
     return this._state
   }
 
-  pause () {
+  pause() {
     throw new Error('pause() is not supported in addon-cpp 1.x')
   }
 
-  stop () {
+  stop() {
     throw new Error('stop() is not supported in addon-cpp 1.x')
   }
 
-  load () {
+  load() {
     throw new Error('load() is not supported in addon-cpp 1.x')
   }
 
-  reload () {
+  reload() {
     throw new Error('reload() is not supported in addon-cpp 1.x')
   }
 
-  append () {
+  append() {
     throw new Error('append() is not supported in addon-cpp 1.x')
   }
 
-  unloadWeights () {
+  unloadWeights() {
     throw new Error('unloadWeights() is not supported in addon-cpp 1.x')
   }
 
-  set transitionCb (_) {
+  set transitionCb(_) {
     // no-op in addon-cpp 1.x mock
   }
 
-  get transitionCb () {
+  get transitionCb() {
     return null
   }
 
-  get state () {
+  get state() {
     return this._state
   }
 
-  set state (nextState) {
+  set state(nextState) {
     if (Object.values(state).includes(nextState)) {
       this._state = nextState
     }

--- a/packages/tts-ggml/test/mock/utils.js
+++ b/packages/tts-ggml/test/mock/utils.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // A helper function to wait a short time (to allow setImmediate callbacks to fire).
-const wait = (ms = 20) => new Promise(resolve => setTimeout(resolve, ms))
+const wait = (ms = 20) => new Promise((resolve) => setTimeout(resolve, ms))
 
 // Transition callback to log state changes.
 const transitionCb = (instance, newState) => {

--- a/packages/tts-ggml/test/unit/chatterbox-mtl.inference.test.js
+++ b/packages/tts-ggml/test/unit/chatterbox-mtl.inference.test.js
@@ -9,7 +9,7 @@ const process = require('bare-process')
 
 global.process = process
 
-function createMockedMtlModel ({
+function createMockedMtlModel({
   onOutput = () => {},
   binding,
   language = 'es',
@@ -65,10 +65,13 @@ test('Chatterbox MTL: synthesis returns audio output and stats with non-en langu
 
   const response = await model.run({ type: 'text', input: 'Bonjour le monde.' })
   const outputs = []
-  await response.onUpdate(d => outputs.push(d)).await()
+  await response.onUpdate((d) => outputs.push(d)).await()
 
   t.ok(outputs.length > 0, 'MTL run emits at least one update')
-  t.ok(outputs.some(d => d.outputArray), 'MTL output has outputArray')
+  t.ok(
+    outputs.some((d) => d.outputArray),
+    'MTL output has outputArray'
+  )
   t.ok(response.stats.totalSamples > 0, 'MTL stats include totalSamples')
   t.ok(events.length > 0, 'raw addon callback fired for MTL run')
   await model.unload()
@@ -132,7 +135,9 @@ test('Chatterbox MTL: modelDir auto-detects MTL gguf when only MTL files are pre
       'MTL s3gen wins when only MTL is present'
     )
   } finally {
-    try { fs.rmSync(tmpRoot, { recursive: true, force: true }) } catch (_e) {}
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    } catch (_e) {}
   }
 })
 
@@ -162,6 +167,8 @@ test('Chatterbox MTL: modelDir prefers turbo over MTL when both are present', as
       'turbo s3gen wins over MTL when both are on disk'
     )
   } finally {
-    try { fs.rmSync(tmpRoot, { recursive: true, force: true }) } catch (_e) {}
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    } catch (_e) {}
   }
 })

--- a/packages/tts-ggml/test/unit/chatterbox.inference.test.js
+++ b/packages/tts-ggml/test/unit/chatterbox.inference.test.js
@@ -8,8 +8,8 @@ const process = require('bare-process')
 
 global.process = process
 
-function createMockedModel ({
-  onOutput = () => { },
+function createMockedModel({
+  onOutput = () => {},
   binding = undefined,
   exclusiveRun = false
 } = {}) {
@@ -34,7 +34,7 @@ function createMockedModel ({
   return model
 }
 
-async function waitWithTimeout (promise, timeoutMs, message) {
+async function waitWithTimeout(promise, timeoutMs, message) {
   let timeoutId
   const timeoutPromise = new Promise((resolve, reject) => {
     timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs)
@@ -59,13 +59,19 @@ test('Chatterbox: run returns audio output and stats', async (t) => {
 
   const response = await model.run({ type: 'text', input: 'Hello world' })
   const outputs = []
-  await response.onUpdate(data => outputs.push(data)).await()
+  await response.onUpdate((data) => outputs.push(data)).await()
 
   t.ok(outputs.length > 0, 'Response should emit at least one update')
-  t.ok(outputs.some(d => d.outputArray), 'Response should contain outputArray payload')
+  t.ok(
+    outputs.some((d) => d.outputArray),
+    'Response should contain outputArray payload'
+  )
   t.ok(response.stats.totalSamples > 0, 'Response stats should include total samples')
   t.ok(events.length > 0, 'Raw addon callback should have been called')
-  t.ok(callbackArity.every(length => length === 4), 'Native callbacks should not include a native jobId argument')
+  t.ok(
+    callbackArity.every((length) => length === 4),
+    'Native callbacks should not include a native jobId argument'
+  )
   await model.unload()
 })
 
@@ -79,11 +85,7 @@ test('Chatterbox: exclusiveRun does not deadlock run()', async (t) => {
     'run() timed out under exclusiveRun'
   )
 
-  await waitWithTimeout(
-    response.await(),
-    1000,
-    'response.await() timed out under exclusiveRun'
-  )
+  await waitWithTimeout(response.await(), 1000, 'response.await() timed out under exclusiveRun')
 
   t.ok(response.stats.totalSamples > 0, 'Exclusive run should still produce runtime stats')
   await model.unload()
@@ -125,11 +127,7 @@ test('Chatterbox: exclusiveRun does not deadlock reload() or unload()', async (t
     'response.await() after reload timed out under exclusiveRun'
   )
 
-  await waitWithTimeout(
-    model.unload(),
-    1000,
-    'unload() timed out under exclusiveRun'
-  )
+  await waitWithTimeout(model.unload(), 1000, 'unload() timed out under exclusiveRun')
   t.pass('exclusiveRun operations complete without deadlock')
 })
 
@@ -151,7 +149,7 @@ test('Chatterbox: reload during in-flight job does not stay busy', async (t) => 
   t.ok(rejected, 'Reload should reject the in-flight response')
 
   // Let stale callbacks from the destroyed addon drain before submitting a new job.
-  await new Promise(resolve => setTimeout(resolve, 150))
+  await new Promise((resolve) => setTimeout(resolve, 150))
 
   const afterReload = await model.run({ type: 'text', input: 'hello after reload' })
   await afterReload.await()
@@ -164,7 +162,11 @@ test('Chatterbox: static methods return expected values', async (t) => {
   const modelKey = TTSGgml.getModelKey({})
   t.is(modelKey, 'tts-ggml', 'getModelKey should return "tts-ggml"')
   t.ok(TTSGgml.inferenceManagerConfig, 'inferenceManagerConfig should exist')
-  t.is(TTSGgml.inferenceManagerConfig.noAdditionalDownload, true, 'noAdditionalDownload should be true')
+  t.is(
+    TTSGgml.inferenceManagerConfig.noAdditionalDownload,
+    true,
+    'noAdditionalDownload should be true'
+  )
 })
 
 test('Chatterbox: modelDir fills in the two GGUF paths', async (t) => {
@@ -225,10 +227,17 @@ test('Chatterbox: nCtx forwards to ttsParams; omitted when unset', (t) => {
   t.is(capped._buildTtsParams().nCtx, 1024, 'explicit nCtx forwarded to the addon')
 
   const uncapped = new TTSGgml({ files, config: { language: 'en' }, nCtx: 0 })
-  t.is(uncapped._buildTtsParams().nCtx, 0, 'nCtx=0 (full GGUF context escape hatch) forwarded as-is')
+  t.is(
+    uncapped._buildTtsParams().nCtx,
+    0,
+    'nCtx=0 (full GGUF context escape hatch) forwarded as-is'
+  )
 
   const defaulted = new TTSGgml({ files, config: { language: 'en' } })
-  t.absent(defaulted._buildTtsParams().nCtx, 'nCtx omitted when unset so the addon applies its 2048 default')
+  t.absent(
+    defaulted._buildTtsParams().nCtx,
+    'nCtx omitted when unset so the addon applies its 2048 default'
+  )
 })
 
 test('Chatterbox: kvCacheType forwards to ttsParams; omitted when unset', (t) => {
@@ -241,7 +250,10 @@ test('Chatterbox: kvCacheType forwards to ttsParams; omitted when unset', (t) =>
   t.is(explicit._buildTtsParams().kvCacheType, 'f32', 'explicit kvCacheType forwarded to the addon')
 
   const defaulted = new TTSGgml({ files, config: { language: 'en' } })
-  t.absent(defaulted._buildTtsParams().kvCacheType, 'kvCacheType omitted when unset so the addon applies its f16 default')
+  t.absent(
+    defaulted._buildTtsParams().kvCacheType,
+    'kvCacheType omitted when unset so the addon applies its f16 default'
+  )
 })
 
 test('Chatterbox: enhancer GGUF path forwards lavasrEnhancerPath (no enhance flag)', (t) => {
@@ -265,15 +277,16 @@ test('Chatterbox: enhancer GGUF path forwards lavasrEnhancerPath (no enhance fla
 
 test('Chatterbox: unknown enhancer.type is rejected at construction', (t) => {
   t.exception(
-    () => new TTSGgml({
-      files: {
-        t3Model: './models/chatterbox-t3-turbo.gguf',
-        s3genModel: './models/chatterbox-s3gen.gguf',
-        lavasrEnhancer: '/abs/enh.gguf'
-      },
-      config: { language: 'en' },
-      enhancer: { type: 'nope' }
-    }),
+    () =>
+      new TTSGgml({
+        files: {
+          t3Model: './models/chatterbox-t3-turbo.gguf',
+          s3genModel: './models/chatterbox-s3gen.gguf',
+          lavasrEnhancer: '/abs/enh.gguf'
+        },
+        config: { language: 'en' },
+        enhancer: { type: 'nope' }
+      }),
     /unknown enhancer\.type/,
     'a typo in enhancer.type throws instead of silently disabling enhancement'
   )
@@ -333,15 +346,16 @@ test('Chatterbox: denoiserPath via denoiser block forwards the path', (t) => {
 
 test('Chatterbox: unknown denoiser.type is rejected at construction', (t) => {
   t.exception(
-    () => new TTSGgml({
-      files: {
-        t3Model: './models/chatterbox-t3-turbo.gguf',
-        s3genModel: './models/chatterbox-s3gen.gguf',
-        lavasrDenoiser: '/abs/den.gguf'
-      },
-      config: { language: 'en' },
-      denoiser: { type: 'nope' }
-    }),
+    () =>
+      new TTSGgml({
+        files: {
+          t3Model: './models/chatterbox-t3-turbo.gguf',
+          s3genModel: './models/chatterbox-s3gen.gguf',
+          lavasrDenoiser: '/abs/den.gguf'
+        },
+        config: { language: 'en' },
+        denoiser: { type: 'nope' }
+      }),
     /unknown denoiser\.type/,
     'a typo in denoiser.type throws instead of silently disabling denoising'
   )
@@ -349,15 +363,16 @@ test('Chatterbox: unknown denoiser.type is rejected at construction', (t) => {
 
 test('Chatterbox: denoiser + streamChunkTokens is rejected (streaming denoise is a follow-up)', (t) => {
   t.exception(
-    () => new TTSGgml({
-      files: {
-        t3Model: './models/chatterbox-t3-turbo.gguf',
-        s3genModel: './models/chatterbox-s3gen.gguf',
-        lavasrDenoiser: '/abs/den.gguf'
-      },
-      streamChunkTokens: 25,
-      config: { language: 'en' }
-    }),
+    () =>
+      new TTSGgml({
+        files: {
+          t3Model: './models/chatterbox-t3-turbo.gguf',
+          s3genModel: './models/chatterbox-s3gen.gguf',
+          lavasrDenoiser: '/abs/den.gguf'
+        },
+        streamChunkTokens: 25,
+        config: { language: 'en' }
+      }),
     /denoiser is not yet supported with Chatterbox native chunk streaming/,
     'denoiser + native chunk streaming throws (unlike the enhancer, which supports it)'
   )
@@ -385,7 +400,11 @@ test('Chatterbox: outputSampleRate forwards to ttsParams; omitted when unset', (
   }
 
   const withRate = new TTSGgml({ files, config: { language: 'en', outputSampleRate: 22050 } })
-  t.is(withRate._buildTtsParams().outputSampleRate, 22050, 'outputSampleRate forwarded to native params')
+  t.is(
+    withRate._buildTtsParams().outputSampleRate,
+    22050,
+    'outputSampleRate forwarded to native params'
+  )
 
   const noRate = new TTSGgml({ files, config: { language: 'en' } })
   t.absent(noRate._buildTtsParams().outputSampleRate, 'no outputSampleRate when unset')

--- a/packages/tts-ggml/test/unit/supertonic-mtl.inference.test.js
+++ b/packages/tts-ggml/test/unit/supertonic-mtl.inference.test.js
@@ -15,7 +15,7 @@ const process = require('bare-process')
 
 global.process = process
 
-function createMockedSupertonicMtlModel ({
+function createMockedSupertonicMtlModel({
   onOutput = () => {},
   binding,
   language = 'es',
@@ -64,10 +64,13 @@ test('Supertonic MTL: synthesis returns audio output and stats with non-en langu
 
   const response = await model.run({ type: 'text', input: 'Bonjour le monde.' })
   const outputs = []
-  await response.onUpdate(d => outputs.push(d)).await()
+  await response.onUpdate((d) => outputs.push(d)).await()
 
   t.ok(outputs.length > 0, 'MTL run emits at least one update')
-  t.ok(outputs.some(d => d.outputArray), 'MTL output has outputArray')
+  t.ok(
+    outputs.some((d) => d.outputArray),
+    'MTL output has outputArray'
+  )
   t.ok(response.stats.totalSamples > 0, 'MTL stats include totalSamples')
   t.ok(events.length > 0, 'raw addon callback fired for MTL run')
   await model.unload()

--- a/packages/tts-ggml/test/unit/supertonic.inference.test.js
+++ b/packages/tts-ggml/test/unit/supertonic.inference.test.js
@@ -9,7 +9,7 @@ const process = require('bare-process')
 
 global.process = process
 
-function createMockedSupertonicModel ({
+function createMockedSupertonicModel({
   onOutput = () => {},
   binding,
   files,
@@ -124,10 +124,13 @@ test('Supertonic: synthesis returns audio output and stats', async (t) => {
 
   const response = await model.run({ type: 'text', input: 'Hello supertonic.' })
   const outputs = []
-  await response.onUpdate(d => outputs.push(d)).await()
+  await response.onUpdate((d) => outputs.push(d)).await()
 
   t.ok(outputs.length > 0, 'supertonic emits at least one update')
-  t.ok(outputs.some(d => d.outputArray), 'supertonic output has outputArray')
+  t.ok(
+    outputs.some((d) => d.outputArray),
+    'supertonic output has outputArray'
+  )
   t.ok(response.stats.totalSamples > 0, 'supertonic stats include totalSamples')
   t.ok(events.length > 0, 'raw addon callback fired for supertonic run')
   await model.unload()
@@ -178,10 +181,7 @@ test('Supertonic: streamChunkTokens / streamFirstChunkTokens rejected at constru
       })
     } catch (e) {
       threw = true
-      t.ok(
-        /Chatterbox-only/.test(e.message),
-        `${knob} error mentions Chatterbox-only`
-      )
+      t.ok(/Chatterbox-only/.test(e.message), `${knob} error mentions Chatterbox-only`)
       t.ok(
         /runStream\(\) \/ runStreaming\(\)/.test(e.message),
         `${knob} error points at sentence-level streaming alternative`
@@ -197,13 +197,13 @@ test('Supertonic: runStream emits per-sentence chunks with chunkIndex + isLast (
   const text = 'First chunk one. Second chunk two. Third chunk three.'
   const r = await model.runStream(text, { maxChunkScalars: 18 })
   const updates = []
-  await r.onUpdate(d => updates.push(d)).await()
+  await r.onUpdate((d) => updates.push(d)).await()
 
-  const withChunk = updates.filter(u => u.chunkIndex !== undefined)
+  const withChunk = updates.filter((u) => u.chunkIndex !== undefined)
   t.ok(withChunk.length >= 2, 'supertonic runStream emits multiple chunks')
   t.is(withChunk[0].chunkIndex, 0, 'first chunkIndex is 0')
   t.ok(typeof withChunk[0].sentenceChunk === 'string', 'sentenceChunk is a string')
-  const isLastFlags = withChunk.map(u => !!u.isLast)
+  const isLastFlags = withChunk.map((u) => !!u.isLast)
   t.is(isLastFlags.filter(Boolean).length, 1, 'exactly one isLast=true on the final chunk')
   t.is(isLastFlags[isLastFlags.length - 1], true, 'final chunk carries isLast=true')
   t.is(isLastFlags[0], false, 'first chunk is not isLast (if multiple chunks)')
@@ -213,20 +213,23 @@ test('Supertonic: runStream emits per-sentence chunks with chunkIndex + isLast (
 test('Supertonic: runStreaming with async iterator drives one job per sentence (mocked)', async (t) => {
   const model = createMockedSupertonicModel()
   await model.load()
-  async function * lines () {
+  async function* lines() {
     yield 'First yielded sentence.'
     yield 'Second yielded sentence.'
     yield 'Third yielded sentence.'
   }
   const r = await model.runStreaming(lines())
   const updates = []
-  await r.onUpdate(d => updates.push(d)).await()
+  await r.onUpdate((d) => updates.push(d)).await()
 
-  const withChunk = updates.filter(u => u.chunkIndex !== undefined)
+  const withChunk = updates.filter((u) => u.chunkIndex !== undefined)
   t.is(withChunk.length, 3, 'supertonic runStreaming emits 3 chunks')
   t.is(withChunk[0].chunkIndex, 0)
   t.is(withChunk[2].chunkIndex, 2)
-  t.ok(withChunk.every(u => u.isLast === undefined), 'isLast is undefined for async-iter mode (count not known up-front)')
+  t.ok(
+    withChunk.every((u) => u.isLast === undefined),
+    'isLast is undefined for async-iter mode (count not known up-front)'
+  )
   await model.unload()
 })
 
@@ -250,7 +253,9 @@ test('Supertonic: modelDir auto-detects supertonic.gguf', async (t) => {
       'supertonic path resolved from modelDir'
     )
   } finally {
-    try { fs.rmSync(tmpRoot, { recursive: true, force: true }) } catch (_e) {}
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true })
+    } catch (_e) {}
   }
 })
 
@@ -281,13 +286,14 @@ test('Supertonic: enhancerPath via enhancer block (no files) forwards the path',
 
 test('Supertonic: unknown enhancer.type is rejected at construction', (t) => {
   t.exception(
-    () => createMockedSupertonicModel({
-      files: {
-        supertonicModel: './models/supertonic.gguf',
-        lavasrEnhancer: '/abs/enh.gguf'
-      },
-      extra: { enhancer: { type: 'bogus' } }
-    }),
+    () =>
+      createMockedSupertonicModel({
+        files: {
+          supertonicModel: './models/supertonic.gguf',
+          lavasrEnhancer: '/abs/enh.gguf'
+        },
+        extra: { enhancer: { type: 'bogus' } }
+      }),
     /unknown enhancer\.type/,
     'a typo in enhancer.type throws instead of silently disabling enhancement'
   )
@@ -335,13 +341,14 @@ test('Supertonic: denoiserPath via denoiser block (no files) forwards the path',
 
 test('Supertonic: unknown denoiser.type is rejected at construction', (t) => {
   t.exception(
-    () => createMockedSupertonicModel({
-      files: {
-        supertonicModel: './models/supertonic.gguf',
-        lavasrDenoiser: '/abs/den.gguf'
-      },
-      extra: { denoiser: { type: 'bogus' } }
-    }),
+    () =>
+      createMockedSupertonicModel({
+        files: {
+          supertonicModel: './models/supertonic.gguf',
+          lavasrDenoiser: '/abs/den.gguf'
+        },
+        extra: { denoiser: { type: 'bogus' } }
+      }),
     /unknown denoiser\.type/,
     'a typo in denoiser.type throws instead of silently disabling denoising'
   )
@@ -373,23 +380,35 @@ test('Supertonic: outputSampleRate forwards to ttsParams; omitted when unset', (
     files: { supertonicModel: './models/supertonic.gguf' },
     config: { language: 'en', outputSampleRate: 16000 }
   })
-  t.is(withRate._buildTtsParams().outputSampleRate, 16000, 'outputSampleRate forwarded to native params')
+  t.is(
+    withRate._buildTtsParams().outputSampleRate,
+    16000,
+    'outputSampleRate forwarded to native params'
+  )
 
   const noRate = new TTSGgml({
     engine: TTSGgml.ENGINE_SUPERTONIC,
     files: { supertonicModel: './models/supertonic.gguf' },
     config: { language: 'en' }
   })
-  t.absent(noRate._buildTtsParams().outputSampleRate, 'no outputSampleRate when unset (engine keeps native)')
+  t.absent(
+    noRate._buildTtsParams().outputSampleRate,
+    'no outputSampleRate when unset (engine keeps native)'
+  )
 })
 
 test('Supertonic: out-of-range outputSampleRate rejected at construction', (t) => {
   for (const bad of [999, 200000]) {
-    t.exception(() => new TTSGgml({
-      engine: TTSGgml.ENGINE_SUPERTONIC,
-      files: { supertonicModel: './models/supertonic.gguf' },
-      config: { language: 'en', outputSampleRate: bad }
-    }), /between 8000 and 192000/, `outputSampleRate=${bad} rejected`)
+    t.exception(
+      () =>
+        new TTSGgml({
+          engine: TTSGgml.ENGINE_SUPERTONIC,
+          files: { supertonicModel: './models/supertonic.gguf' },
+          config: { language: 'en', outputSampleRate: bad }
+        }),
+      /between 8000 and 192000/,
+      `outputSampleRate=${bad} rejected`
+    )
   }
 })
 

--- a/packages/tts-ggml/test/unit/tts-ggml.lifecycle.test.js
+++ b/packages/tts-ggml/test/unit/tts-ggml.lifecycle.test.js
@@ -9,7 +9,7 @@ const process = require('bare-process')
 
 global.process = process
 
-function createStubbedModel () {
+function createStubbedModel() {
   const model = new TTSGgml({
     files: {
       t3Model: './models/chatterbox-t3-turbo.gguf',

--- a/packages/tts-ggml/test/unit/tts-ggml.sentence-stream.test.js
+++ b/packages/tts-ggml/test/unit/tts-ggml.sentence-stream.test.js
@@ -9,7 +9,7 @@ const process = require('bare-process')
 
 global.process = process
 
-function createStubbedModel (opts = {}) {
+function createStubbedModel(opts = {}) {
   const model = new TTSGgml({
     files: {
       t3Model: './models/chatterbox-t3-turbo.gguf',
@@ -27,15 +27,19 @@ function createStubbedModel (opts = {}) {
 
 const origRunJob = MockedBinding.prototype.runJob
 
-function spyRunJob () {
+function spyRunJob() {
   let callCount = 0
   MockedBinding.prototype.runJob = function (...args) {
     callCount++
     return origRunJob.apply(this, args)
   }
   return {
-    get callCount () { return callCount },
-    restore () { MockedBinding.prototype.runJob = origRunJob }
+    get callCount() {
+      return callCount
+    },
+    restore() {
+      MockedBinding.prototype.runJob = origRunJob
+    }
   }
 }
 
@@ -43,16 +47,15 @@ test('runStream runs multiple native jobs and enriches output (onUpdate + await)
   const runJobSpy = spyRunJob()
   const model = createStubbedModel()
   await model.load()
-  const text =
-    'This is long text one. This is long text two. This is long text three.'
+  const text = 'This is long text one. This is long text two. This is long text three.'
   const response = await model.runStream(text, { maxChunkScalars: 18 })
   const updates = []
-  response.onUpdate(d => {
+  response.onUpdate((d) => {
     updates.push(d)
   })
   await response.await()
   t.ok(runJobSpy.callCount >= 2, 'expected multiple runJob calls')
-  const withChunk = updates.filter(u => u.chunkIndex !== undefined)
+  const withChunk = updates.filter((u) => u.chunkIndex !== undefined)
   t.ok(withChunk.length >= 2, 'expected chunk metadata on outputs')
   t.is(withChunk[0].chunkIndex, 0)
   t.ok(typeof withChunk[0].sentenceChunk === 'string')
@@ -64,20 +67,19 @@ test('run({ streamOutput: true }) matches chunked runStream behavior', async (t)
   const runJobSpy = spyRunJob()
   const model = createStubbedModel()
   await model.load()
-  const text =
-    'This is long text one. This is long text two. This is long text three.'
+  const text = 'This is long text one. This is long text two. This is long text three.'
   const response = await model.run({
     input: text,
     streamOutput: true,
     maxChunkScalars: 18
   })
   const updates = []
-  response.onUpdate(d => {
+  response.onUpdate((d) => {
     updates.push(d)
   })
   await response.await()
   t.ok(runJobSpy.callCount >= 2, 'expected multiple runJob calls')
-  const withChunk = updates.filter(u => u.chunkIndex !== undefined)
+  const withChunk = updates.filter((u) => u.chunkIndex !== undefined)
   t.ok(withChunk.length >= 2, 'expected chunk metadata on outputs')
   t.is(withChunk[0].chunkIndex, 0)
   t.ok(typeof withChunk[0].sentenceChunk === 'string')
@@ -89,7 +91,7 @@ test('runStreaming accumulate merges token stream into one job when sentence com
   const runJobSpy = spyRunJob()
   const model = createStubbedModel()
   await model.load()
-  async function * tokens () {
+  async function* tokens() {
     yield 'One '
     yield 'sentence '
     yield 'only.'
@@ -104,7 +106,7 @@ test('runStreaming accumulateSentences false runs one job per yield', async (t) 
   const runJobSpy = spyRunJob()
   const model = createStubbedModel()
   await model.load()
-  async function * tokens () {
+  async function* tokens() {
     yield 'a'
     yield 'b'
   }
@@ -118,7 +120,7 @@ test('runStreaming accumulate hard-splits when buffer exceeds maxBufferScalars',
   const runJobSpy = spyRunJob()
   const model = createStubbedModel()
   await model.load()
-  async function * oneBig () {
+  async function* oneBig() {
     yield 'a'.repeat(250)
   }
   const response = await model.runStreaming(oneBig(), { maxBufferScalars: 100 })
@@ -131,7 +133,7 @@ test('runStreaming maxBufferScalars 0 falls back to default (no infinite loop)',
   const runJobSpy = spyRunJob()
   const model = createStubbedModel()
   await model.load()
-  async function * oneBig () {
+  async function* oneBig() {
     yield 'a'.repeat(250)
   }
   const response = await model.runStreaming(oneBig(), { maxBufferScalars: 0 })
@@ -152,7 +154,7 @@ test('runStreaming custom sentenceDelimiter with /g still flushes each fragment'
   const model = createStubbedModel()
   await model.load()
   const delimiter = /[.!?]\s*$/g
-  async function * parts () {
+  async function* parts() {
     yield 'A.'
     yield 'B.'
   }
@@ -167,7 +169,7 @@ test('runStreaming yields multiple jobs from async text chunks', async (t) => {
   const model = createStubbedModel()
   await model.load()
 
-  async function * lines () {
+  async function* lines() {
     yield 'First sentence for TTS.'
     yield 'Second sentence follows.'
     yield 'Third sentence ends here.'
@@ -175,12 +177,12 @@ test('runStreaming yields multiple jobs from async text chunks', async (t) => {
 
   const response = await model.runStreaming(lines())
   const updates = []
-  response.onUpdate(d => {
+  response.onUpdate((d) => {
     updates.push(d)
   })
   await response.await()
   t.is(runJobSpy.callCount, 3, 'expected one runJob per yielded string')
-  const withChunk = updates.filter(u => u.chunkIndex !== undefined)
+  const withChunk = updates.filter((u) => u.chunkIndex !== undefined)
   t.is(withChunk.length, 3)
   t.is(withChunk[0].chunkIndex, 0)
   t.is(withChunk[2].chunkIndex, 2)
@@ -201,7 +203,7 @@ test('plain run() uses single job', async (t) => {
   }
   await response.await()
   t.is(runJobSpy.callCount, 1)
-  const withChunk = updates.filter(u => u.chunkIndex !== undefined)
+  const withChunk = updates.filter((u) => u.chunkIndex !== undefined)
   t.is(withChunk.length, 0)
   runJobSpy.restore()
 })

--- a/packages/tts-ggml/test/unit/tts.error.test.js
+++ b/packages/tts-ggml/test/unit/tts.error.test.js
@@ -4,7 +4,7 @@ const test = require('brittle')
 const { TTSInterface } = require('../../tts.js')
 const { QvacErrorAddonTTSGgml, ERR_CODES } = require('../../lib/error.js')
 
-function createErrorBinding (errorMethods = {}) {
+function createErrorBinding(errorMethods = {}) {
   return {
     createInstance: () => ({ id: 1 }),
     activate: (handle) => {
@@ -35,7 +35,10 @@ test('activate() throws QvacErrorAddonTTSGgml with FAILED_TO_ACTIVATE code', asy
     await tts.activate()
     t.fail('Should have thrown an error')
   } catch (error) {
-    t.ok(error instanceof QvacErrorAddonTTSGgml, 'Error should be instance of QvacErrorAddonTTSGgml')
+    t.ok(
+      error instanceof QvacErrorAddonTTSGgml,
+      'Error should be instance of QvacErrorAddonTTSGgml'
+    )
     t.is(error.code, ERR_CODES.FAILED_TO_ACTIVATE, 'Error code should be FAILED_TO_ACTIVATE')
     t.ok(error.message.includes(errorMessage), 'Error message should contain original error')
   }
@@ -50,7 +53,10 @@ test('runJob() throws QvacErrorAddonTTSGgml with FAILED_TO_APPEND code', async (
     await tts.runJob({ type: 'text', input: 'Hello' })
     t.fail('Should have thrown an error')
   } catch (error) {
-    t.ok(error instanceof QvacErrorAddonTTSGgml, 'Error should be instance of QvacErrorAddonTTSGgml')
+    t.ok(
+      error instanceof QvacErrorAddonTTSGgml,
+      'Error should be instance of QvacErrorAddonTTSGgml'
+    )
     t.is(error.code, ERR_CODES.FAILED_TO_APPEND, 'Error code should be FAILED_TO_APPEND')
     t.ok(error.message.includes(errorMessage), 'Error message should contain original error')
   }
@@ -65,7 +71,10 @@ test('loadWeights() throws QvacErrorAddonTTSGgml with FAILED_TO_LOAD code', asyn
     await tts.loadWeights({ filename: 'foo', contents: new Uint8Array(0) })
     t.fail('Should have thrown an error')
   } catch (error) {
-    t.ok(error instanceof QvacErrorAddonTTSGgml, 'Error should be instance of QvacErrorAddonTTSGgml')
+    t.ok(
+      error instanceof QvacErrorAddonTTSGgml,
+      'Error should be instance of QvacErrorAddonTTSGgml'
+    )
     t.is(error.code, ERR_CODES.FAILED_TO_LOAD, 'Error code should be FAILED_TO_LOAD')
     t.ok(error.message.includes(errorMessage), 'Error message should contain original error')
   }
@@ -80,7 +89,10 @@ test('cancel() throws QvacErrorAddonTTSGgml with FAILED_TO_CANCEL code', async (
     await tts.cancel()
     t.fail('Should have thrown an error')
   } catch (error) {
-    t.ok(error instanceof QvacErrorAddonTTSGgml, 'Error should be instance of QvacErrorAddonTTSGgml')
+    t.ok(
+      error instanceof QvacErrorAddonTTSGgml,
+      'Error should be instance of QvacErrorAddonTTSGgml'
+    )
     t.is(error.code, ERR_CODES.FAILED_TO_CANCEL, 'Error code should be FAILED_TO_CANCEL')
     t.ok(error.message.includes(errorMessage), 'Error message should contain original error')
   }
@@ -110,7 +122,10 @@ test('destroyInstance() throws QvacErrorAddonTTSGgml with FAILED_TO_DESTROY code
     await tts.destroyInstance()
     t.fail('Should have thrown an error')
   } catch (error) {
-    t.ok(error instanceof QvacErrorAddonTTSGgml, 'Error should be instance of QvacErrorAddonTTSGgml')
+    t.ok(
+      error instanceof QvacErrorAddonTTSGgml,
+      'Error should be instance of QvacErrorAddonTTSGgml'
+    )
     t.is(error.code, ERR_CODES.FAILED_TO_DESTROY, 'Error code should be FAILED_TO_DESTROY')
     t.ok(error.message.includes(errorMessage), 'Error message should contain original error')
   }
@@ -137,7 +152,10 @@ test('unload() delegates to destroyInstance and preserves errors', async (t) => 
     await tts.unload()
     t.fail('Should have thrown an error')
   } catch (error) {
-    t.ok(error instanceof QvacErrorAddonTTSGgml, 'Error should be instance of QvacErrorAddonTTSGgml')
+    t.ok(
+      error instanceof QvacErrorAddonTTSGgml,
+      'Error should be instance of QvacErrorAddonTTSGgml'
+    )
     t.is(error.code, ERR_CODES.FAILED_TO_DESTROY, 'Error code should be FAILED_TO_DESTROY')
     t.ok(error.message.includes(errorMessage), 'Error message should contain original error')
   }

--- a/packages/tts-ggml/test/utils/downloadModel.js
+++ b/packages/tts-ggml/test/utils/downloadModel.js
@@ -9,12 +9,12 @@ const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 
 // Returns base directory for models - uses global.testDir on mobile, current dir otherwise
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
 /** Returns true if file exists and is valid JSON; false if missing, wrong size, or invalid. */
-function isValidJsonCache (filepath) {
+function isValidJsonCache(filepath) {
   try {
     if (!fs.existsSync(filepath)) return false
     const stats = fs.statSync(filepath)
@@ -33,7 +33,7 @@ function isValidJsonCache (filepath) {
  * Mobile-friendly HTTPS download using bare-https.
  * Handles redirects and writes directly to file.
  */
-async function downloadWithHttp (url, filepath, maxRedirects = 10) {
+async function downloadWithHttp(url, filepath, maxRedirects = 10) {
   return new Promise((resolve, reject) => {
     const https = require('bare-https')
     const { URL } = require('bare-url')
@@ -69,7 +69,9 @@ async function downloadWithHttp (url, filepath, maxRedirects = 10) {
           redirectUrl = `${parsedUrl.protocol}//${parsedUrl.host}${basePath}${location}`
         }
         console.log(` [HTTPS] Redirecting to: ${redirectUrl}`)
-        downloadWithHttp(redirectUrl, filepath, maxRedirects - 1).then(resolve).catch(reject)
+        downloadWithHttp(redirectUrl, filepath, maxRedirects - 1)
+          .then(resolve)
+          .catch(reject)
         return
       }
 
@@ -90,7 +92,9 @@ async function downloadWithHttp (url, filepath, maxRedirects = 10) {
         downloadedBytes += chunk.length
         if (contentLength > 0 && downloadedBytes % (1024 * 1024) < chunk.length) {
           const percent = ((downloadedBytes / contentLength) * 100).toFixed(1)
-          console.log(` [HTTPS] Progress: ${percent}% (${downloadedBytes} / ${contentLength} bytes)`)
+          console.log(
+            ` [HTTPS] Progress: ${percent}% (${downloadedBytes} / ${contentLength} bytes)`
+          )
         }
       })
 
@@ -108,15 +112,25 @@ async function downloadWithHttp (url, filepath, maxRedirects = 10) {
   })
 }
 
-function getFileSizeFromUrl (url) {
+function getFileSizeFromUrl(url) {
   try {
     const { spawnSync } = require('bare-subprocess')
-    const result = spawnSync('curl', [
-      '-I', '-L', url,
-      '--fail', '--silent', '--show-error',
-      '--connect-timeout', '10',
-      '--max-time', '30'
-    ], { stdio: ['inherit', 'pipe', 'pipe'] })
+    const result = spawnSync(
+      'curl',
+      [
+        '-I',
+        '-L',
+        url,
+        '--fail',
+        '--silent',
+        '--show-error',
+        '--connect-timeout',
+        '10',
+        '--max-time',
+        '30'
+      ],
+      { stdio: ['inherit', 'pipe', 'pipe'] }
+    )
 
     if (result.status === 0 && result.stdout) {
       const output = result.stdout.toString()
@@ -129,13 +143,13 @@ function getFileSizeFromUrl (url) {
   return null
 }
 
-async function ensureFileDownloaded (url, filepath) {
+async function ensureFileDownloaded(url, filepath) {
   const isJson = filepath.endsWith('.json')
   const dir = path.dirname(filepath)
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
 
   const expectedSize = isMobile ? null : getFileSizeFromUrl(url)
-  const minSize = expectedSize ? Math.floor(expectedSize * 0.9) : (isJson ? 100 : 1000000)
+  const minSize = expectedSize ? Math.floor(expectedSize * 0.9) : isJson ? 100 : 1000000
 
   if (fs.existsSync(filepath)) {
     const stats = fs.statSync(filepath)
@@ -180,12 +194,21 @@ async function ensureFileDownloaded (url, filepath) {
     try {
       const { spawnSync } = require('bare-subprocess')
       if (isJson) {
-        const result = spawnSync('curl', [
-          '-L', url,
-          '--fail', '--silent', '--show-error',
-          '--connect-timeout', '30',
-          '--max-time', '300'
-        ], { stdio: ['inherit', 'pipe', 'pipe'] })
+        const result = spawnSync(
+          'curl',
+          [
+            '-L',
+            url,
+            '--fail',
+            '--silent',
+            '--show-error',
+            '--connect-timeout',
+            '30',
+            '--max-time',
+            '300'
+          ],
+          { stdio: ['inherit', 'pipe', 'pipe'] }
+        )
 
         if (result.status === 0 && result.stdout) {
           fs.writeFileSync(filepath, result.stdout)
@@ -199,12 +222,23 @@ async function ensureFileDownloaded (url, filepath) {
           console.log(` Download failed with exit code: ${result.status}`)
         }
       } else {
-        const result = spawnSync('curl', [
-          '-L', '-o', filepath, url,
-          '--fail', '--silent', '--show-error',
-          '--connect-timeout', '30',
-          '--max-time', '1800'
-        ], { stdio: ['inherit', 'inherit', 'pipe'] })
+        const result = spawnSync(
+          'curl',
+          [
+            '-L',
+            '-o',
+            filepath,
+            url,
+            '--fail',
+            '--silent',
+            '--show-error',
+            '--connect-timeout',
+            '30',
+            '--max-time',
+            '1800'
+          ],
+          { stdio: ['inherit', 'inherit', 'pipe'] }
+        )
 
         if (result.status === 0 && fs.existsSync(filepath)) {
           const stats = fs.statSync(filepath)
@@ -244,13 +278,15 @@ async function ensureFileDownloaded (url, filepath) {
 // {CHATTERBOX,SUPERTONIC}*_GGUFS entry's `registryPath` field; `source`
 // is the matching `registrySource` (today always "s3", mirroring the
 // `s3:///...` URL prefix used in registry-server/data/models.prod.json).
-async function downloadFromRegistry (registryPath, registrySource, destPath, minSize, maxSize) {
+async function downloadFromRegistry(registryPath, registrySource, destPath, minSize, maxSize) {
   let QVACRegistryClient
   try {
-    ({ QVACRegistryClient } = require('@qvac/registry-client'))
+    ;({ QVACRegistryClient } = require('@qvac/registry-client'))
   } catch (err) {
-    console.log(' Registry client (@qvac/registry-client) not installed; ' +
-      'skipping registry fetch.  Install as a devDependency to enable.')
+    console.log(
+      ' Registry client (@qvac/registry-client) not installed; ' +
+        'skipping registry fetch.  Install as a devDependency to enable.'
+    )
     return false
   }
 
@@ -279,15 +315,21 @@ async function downloadFromRegistry (registryPath, registrySource, destPath, min
       const stats = fs.statSync(result.artifact.path)
       if (stats.size < minSize) {
         console.log(` Registry download too small: ${stats.size} bytes (expected >=${minSize})`)
-        try { fs.unlinkSync(destPath) } catch (_e) {}
+        try {
+          fs.unlinkSync(destPath)
+        } catch (_e) {}
       } else if (maxSize && stats.size > maxSize) {
         // Should be impossible (the registry served a file outside the
         // declared band) but assert so a future model swap that
         // accidentally points at the wrong quant level surfaces here
         // instead of silently triggering an OOM on-device.
-        console.log(` Registry download too large: ${stats.size} bytes (expected <=${maxSize}). ` +
-          'Did the registry path flip to a different quantisation tier?')
-        try { fs.unlinkSync(destPath) } catch (_e) {}
+        console.log(
+          ` Registry download too large: ${stats.size} bytes (expected <=${maxSize}). ` +
+            'Did the registry path flip to a different quantisation tier?'
+        )
+        try {
+          fs.unlinkSync(destPath)
+        } catch (_e) {}
       } else {
         console.log(` ✓ Registry download: ${path.basename(destPath)} (${stats.size} bytes)`)
         return true
@@ -297,10 +339,14 @@ async function downloadFromRegistry (registryPath, registrySource, destPath, min
     }
   } catch (err) {
     console.log(` Registry download failed: ${err && err.message ? err.message : String(err)}`)
-    try { fs.unlinkSync(destPath) } catch (_e) {}
+    try {
+      fs.unlinkSync(destPath)
+    } catch (_e) {}
   } finally {
     if (client) {
-      try { await client.close() } catch (_e) {}
+      try {
+        await client.close()
+      } catch (_e) {}
     }
   }
 
@@ -311,7 +357,7 @@ async function downloadFromRegistry (registryPath, registrySource, destPath, min
 // Returns true iff every file ended up present at the expected size.
 // Used by the four `ensure*` helpers below as the fallback path when
 // no local candidate directory already had the GGUFs.
-async function tryFetchGgufsFromRegistry (ggufs, targetDir) {
+async function tryFetchGgufsFromRegistry(ggufs, targetDir) {
   try {
     if (!fs.existsSync(targetDir)) fs.mkdirSync(targetDir, { recursive: true })
   } catch (err) {
@@ -325,8 +371,7 @@ async function tryFetchGgufsFromRegistry (ggufs, targetDir) {
     if (fs.existsSync(dest)) {
       try {
         const stats = fs.statSync(dest)
-        const inBand = stats.size >= f.minSize &&
-          (!f.maxSize || stats.size <= f.maxSize)
+        const inBand = stats.size >= f.minSize && (!f.maxSize || stats.size <= f.maxSize)
         if (inBand) {
           console.log(` ✓ Already present at expected size: ${f.name} (${stats.size} bytes)`)
           continue
@@ -337,11 +382,17 @@ async function tryFetchGgufsFromRegistry (ggufs, targetDir) {
           // Stale cache from a previous quantisation tier (e.g. an f16
           // file lingering after the registry source flipped to q4_0).
           // Drop it and re-fetch the smaller variant.
-          console.log(` Re-fetching ${f.name} (cached ${stats.size} bytes > ${f.maxSize}; ` +
-            'likely a stale cache from a different quantisation tier)')
+          console.log(
+            ` Re-fetching ${f.name} (cached ${stats.size} bytes > ${f.maxSize}; ` +
+              'likely a stale cache from a different quantisation tier)'
+          )
         }
-        try { fs.unlinkSync(dest) } catch (_e) {}
-      } catch (_e) { /* fall through to download */ }
+        try {
+          fs.unlinkSync(dest)
+        } catch (_e) {}
+      } catch (_e) {
+        /* fall through to download */
+      }
     }
     if (!f.registryPath || !f.registrySource) {
       console.log(` ${f.name} has no registryPath/registrySource; cannot fetch.`)
@@ -350,7 +401,12 @@ async function tryFetchGgufsFromRegistry (ggufs, targetDir) {
     }
     // eslint-disable-next-line no-await-in-loop
     const ok = await downloadFromRegistry(
-      f.registryPath, f.registrySource, dest, f.minSize, f.maxSize)
+      f.registryPath,
+      f.registrySource,
+      dest,
+      f.minSize,
+      f.maxSize
+    )
     if (!ok) {
       allOk = false
       // Keep going so the user sees errors for every missing file in
@@ -363,11 +419,17 @@ async function tryFetchGgufsFromRegistry (ggufs, targetDir) {
 
 // Whisper GGML (for the transcription-WER integration check).
 const WHISPER_MODELS = {
-  'ggml-small.bin': { url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin', minSize: 460000000 },
-  'ggml-medium.bin': { url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin', minSize: 1400000000 }
+  'ggml-small.bin': {
+    url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
+    minSize: 460000000
+  },
+  'ggml-medium.bin': {
+    url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-medium.bin',
+    minSize: 1400000000
+  }
 }
 
-async function ensureWhisperModel (targetPath = null) {
+async function ensureWhisperModel(targetPath = null) {
   if (!targetPath) {
     targetPath = path.join(getBaseDir(), 'models', 'whisper', 'ggml-medium.bin')
   }
@@ -527,9 +589,9 @@ const ANDROID_CANDIDATE_DIRS = [
  *  fallback that points at chatterbox.cpp's converter output dir.
  *  Both are appended to the candidate list AFTER the caller-supplied
  *  `targetDir` so production runs remain deterministic. */
-function desktopFallbackDirs () {
+function desktopFallbackDirs() {
   const out = []
-  const env = (process && process.env) ? process.env.TTS_GGML_LOCAL_MODELS_DIR : null
+  const env = process && process.env ? process.env.TTS_GGML_LOCAL_MODELS_DIR : null
   if (env) out.push(env)
   out.push('./models')
   out.push('../../../chatterbox.cpp/models')
@@ -544,7 +606,7 @@ function desktopFallbackDirs () {
  * registry source flipped to a q4_0 variant — same name on disk, much
  * smaller payload).
  */
-function hasAllGgufsIn (dir, ggufs) {
+function hasAllGgufsIn(dir, ggufs) {
   for (const f of ggufs) {
     const p = path.join(dir, f.name)
     if (!fs.existsSync(p)) return false
@@ -559,7 +621,7 @@ function hasAllGgufsIn (dir, ggufs) {
   return true
 }
 
-function hasAllGgufs (dir) {
+function hasAllGgufs(dir) {
   return hasAllGgufsIn(dir, CHATTERBOX_GGUFS)
 }
 
@@ -582,7 +644,7 @@ function hasAllGgufs (dir) {
  * TODO: once the GGUFs land on a known HuggingFace repo, wire up the
  * download URLs here and switch the default to "fetch from HF".
  */
-async function ensureChatterboxModels (options = {}) {
+async function ensureChatterboxModels(options = {}) {
   const requestedDir = options.targetDir || path.join(getBaseDir(), 'models')
   console.log(`Ensuring Chatterbox GGUFs (requested dir: ${requestedDir})...`)
 
@@ -630,20 +692,26 @@ async function ensureChatterboxModels (options = {}) {
 
   try {
     if (!fs.existsSync(requestedDir)) fs.mkdirSync(requestedDir, { recursive: true })
-  } catch (e) { /* ignore — informational dir only */ }
+  } catch (e) {
+    /* ignore — informational dir only */
+  }
 
   const results = {}
   for (const f of CHATTERBOX_GGUFS) {
     const p = path.join(requestedDir, f.name)
     const exists = fs.existsSync(p)
     const size = exists ? fs.statSync(p).size : 0
-    console.log(` ✗ ${f.name} ${exists ? `too small (${size} bytes, expected ≥ ${f.minSize})` : `missing at ${p}`}`)
+    console.log(
+      ` ✗ ${f.name} ${exists ? `too small (${size} bytes, expected ≥ ${f.minSize})` : `missing at ${p}`}`
+    )
     results[f.name] = { success: false, path: p }
   }
   console.log('')
   if (isMobile && platform === 'android') {
-    console.log('Chatterbox GGUFs not found and registry fetch failed.  On Android, ' +
-      '`adb push` them to one of:')
+    console.log(
+      'Chatterbox GGUFs not found and registry fetch failed.  On Android, ' +
+        '`adb push` them to one of:'
+    )
     for (const d of ANDROID_CANDIDATE_DIRS) console.log(`  ${d}`)
     console.log('(or copy into the app-internal dir that testDir maps to).')
   } else {
@@ -666,7 +734,7 @@ async function ensureChatterboxModels (options = {}) {
   return { success: false, results, targetDir: requestedDir }
 }
 
-async function ensureChatterboxMtlModels (options = {}) {
+async function ensureChatterboxMtlModels(options = {}) {
   const requestedDir = options.targetDir || path.join(getBaseDir(), 'models')
   console.log(`Ensuring Chatterbox MTL GGUFs (requested dir: ${requestedDir})...`)
 
@@ -708,12 +776,14 @@ async function ensureChatterboxMtlModels (options = {}) {
 
   console.log(' Chatterbox MTL GGUFs not found locally and registry fetch failed.  Convert with:')
   console.log('   python scripts/convert-t3-mtl-to-gguf.py --out chatterbox-t3-mtl.gguf')
-  console.log('   python scripts/convert-s3gen-to-gguf.py --variant mtl --out chatterbox-s3gen-mtl.gguf')
+  console.log(
+    '   python scripts/convert-s3gen-to-gguf.py --variant mtl --out chatterbox-s3gen-mtl.gguf'
+  )
   console.log(` and place under one of: ${candidateDirs.join(', ')}`)
   return { success: false, results: {}, targetDir: requestedDir }
 }
 
-async function ensureSupertonicModel (options = {}) {
+async function ensureSupertonicModel(options = {}) {
   const requestedDir = options.targetDir || path.join(getBaseDir(), 'models')
   console.log(`Ensuring Supertonic GGUF (requested dir: ${requestedDir})...`)
 
@@ -754,12 +824,14 @@ async function ensureSupertonicModel (options = {}) {
   }
 
   console.log(' Supertonic GGUF not found locally and registry fetch failed.  Convert with:')
-  console.log('   python scripts/convert-supertonic2-to-gguf.py --arch supertonic --out supertonic.gguf')
+  console.log(
+    '   python scripts/convert-supertonic2-to-gguf.py --arch supertonic --out supertonic.gguf'
+  )
   console.log(` and place under one of: ${candidateDirs.join(', ')}`)
   return { success: false, path: null, targetDir: requestedDir }
 }
 
-async function ensureSupertonicMtlModel (options = {}) {
+async function ensureSupertonicMtlModel(options = {}) {
   const requestedDir = options.targetDir || path.join(getBaseDir(), 'models')
   console.log(`Ensuring Supertonic MTL GGUF (requested dir: ${requestedDir})...`)
 
@@ -800,7 +872,9 @@ async function ensureSupertonicMtlModel (options = {}) {
   }
 
   console.log(' Supertonic MTL GGUF not found locally and registry fetch failed.  Convert with:')
-  console.log('   python scripts/convert-supertonic2-to-gguf.py --arch supertonic2 --out supertonic2.gguf')
+  console.log(
+    '   python scripts/convert-supertonic2-to-gguf.py --arch supertonic2 --out supertonic2.gguf'
+  )
   console.log(` and place under one of: ${candidateDirs.join(', ')}`)
   return { success: false, path: null, targetDir: requestedDir }
 }
@@ -818,15 +892,14 @@ const SUPERTONIC3_REGISTRY_DATES = {
   q4_0: REGISTRY_DATE_SUPERTONIC3_QUANT
 }
 
-function supertonic3Gguf (quant) {
+function supertonic3Gguf(quant) {
   const gguf = {
     name: `supertonic3-${quant}.gguf`,
     ...SIZE_SUPERTONIC3
   }
   const date = SUPERTONIC3_REGISTRY_DATES[quant]
   if (date) {
-    gguf.registryPath =
-      `qvac_models_compiled/ggml/supertonic/${date}/supertonic3-${quant}.gguf`
+    gguf.registryPath = `qvac_models_compiled/ggml/supertonic/${date}/supertonic3-${quant}.gguf`
     gguf.registrySource = REGISTRY_SOURCE
   }
   return gguf
@@ -849,7 +922,7 @@ function supertonic3Gguf (quant) {
  * @param {string} [options.quant] - quant tier: 'q8_0' | 'q4_0' | 'f16' | 'f32'.
  * @returns {Promise<{ success: boolean, path: string|null, targetDir: string, quant: string }>}
  */
-async function ensureSupertonic3Model (options = {}) {
+async function ensureSupertonic3Model(options = {}) {
   const quant = options.quant || 'q8_0'
   const requestedDir = options.targetDir || path.join(getBaseDir(), 'models')
   const gguf = supertonic3Gguf(quant)
@@ -876,17 +949,26 @@ async function ensureSupertonic3Model (options = {}) {
   // All tiers are on the registry — fetch into the (writable) requestedDir.
   if (gguf.registryPath) {
     if (await tryFetchGgufsFromRegistry([gguf], requestedDir)) {
-      return { success: true, path: path.join(requestedDir, gguf.name), targetDir: requestedDir, quant }
+      return {
+        success: true,
+        path: path.join(requestedDir, gguf.name),
+        targetDir: requestedDir,
+        quant
+      }
     }
     console.log(` Supertonic 3 ${quant} GGUF (${gguf.name}) not staged and registry fetch failed`)
-    console.log(' (network / registry unavailable, or the @qvac/registry-client devDependency is missing).')
+    console.log(
+      ' (network / registry unavailable, or the @qvac/registry-client devDependency is missing).'
+    )
     console.log(` Expected on the registry at: ${gguf.registryPath}`)
     return { success: false, path: null, targetDir: requestedDir, quant }
   }
 
   // No registry mapping for this tier (unexpected) — every published tier has
   // one, so this only triggers on an unknown quant string.
-  console.log(` Supertonic 3 ${quant} GGUF (${gguf.name}) has no registry mapping (unknown quant tier).`)
+  console.log(
+    ` Supertonic 3 ${quant} GGUF (${gguf.name}) has no registry mapping (unknown quant tier).`
+  )
   return { success: false, path: null, targetDir: requestedDir, quant }
 }
 
@@ -905,9 +987,8 @@ async function ensureSupertonic3Model (options = {}) {
  * @param {string} [options.targetDir] - where to stage / look for the dict.
  * @returns {Promise<{ success: boolean, dir: string }>}
  */
-async function ensureMecabDict (options = {}) {
-  const targetDir = options.targetDir ||
-    path.join(getBaseDir(), 'models', MECAB_IPADIC_DIRNAME)
+async function ensureMecabDict(options = {}) {
+  const targetDir = options.targetDir || path.join(getBaseDir(), 'models', MECAB_IPADIC_DIRNAME)
   console.log(`Ensuring MeCab/IPAdic dictionary (dir: ${targetDir})...`)
 
   const candidateDirs = [targetDir]
@@ -956,7 +1037,7 @@ async function ensureMecabDict (options = {}) {
  * @param {string} [options.registryPath] - override once the GGUF is published.
  * @returns {Promise<{ success: boolean, path: string|null, targetDir: string }>}
  */
-async function ensureLavaSREnhancerGguf (options = {}) {
+async function ensureLavaSREnhancerGguf(options = {}) {
   const fileName = 'lavasr-enhancer.gguf'
   const baseDir = getBaseDir()
   const requestedDir = options.targetDir || path.join(baseDir, 'models', 'lavasr')
@@ -981,7 +1062,11 @@ async function ensureLavaSREnhancerGguf (options = {}) {
 
   // Registry fetch (once the GGUF is published — see note above).
   const gguf = options.registryPath
-    ? { name: fileName, registryPath: options.registryPath, registrySource: options.registrySource || 's3' }
+    ? {
+        name: fileName,
+        registryPath: options.registryPath,
+        registrySource: options.registrySource || 's3'
+      }
     : null
   if (gguf && typeof tryFetchGgufsFromRegistry === 'function') {
     if (await tryFetchGgufsFromRegistry([gguf], requestedDir)) {
@@ -1005,7 +1090,7 @@ const CANGJIE_TSV_MIN_BYTES = 400000
 // Cangjie5_TC.json ships as a JSON array of "<char>\t<code>" strings.  Pull
 // every JSON string literal out (regex avoids a full parse of the large blob)
 // and unescape the standard JSON escapes we care about.
-function extractCangjieEntries (raw) {
+function extractCangjieEntries(raw) {
   const str = typeof raw === 'string' ? raw : Buffer.from(raw).toString('utf8')
   const entries = []
   const re = /"([^"\\]*(?:\\.[^"\\]*)*)"/g
@@ -1026,7 +1111,7 @@ function extractCangjieEntries (raw) {
 // that tts-cpp's CangjieTable::load() (parse_tsv_line) expects: first column a
 // single-codepoint hanzi, second column the Cangjie code.  De-dupes on the
 // leading codepoint, matching tts-cpp (which keeps the first entry per char).
-function writeCangjieJsonArrayToTsv (jsonBody, tsvPath) {
+function writeCangjieJsonArrayToTsv(jsonBody, tsvPath) {
   const data = extractCangjieEntries(jsonBody)
   if (data.length === 0) {
     throw new Error('Cangjie JSON: no entries extracted')
@@ -1057,7 +1142,7 @@ function writeCangjieJsonArrayToTsv (jsonBody, tsvPath) {
  * @param {string} [options.targetDir] - preferred dir (default models/).
  * @returns {Promise<{ success: boolean, path: string|null, targetDir: string }>}
  */
-async function ensureCangjieTsv (options = {}) {
+async function ensureCangjieTsv(options = {}) {
   const baseDir = getBaseDir()
   const requestedDir = options.targetDir || path.join(baseDir, 'models')
   const fileName = 'Cangjie5_TC.tsv'

--- a/packages/tts-ggml/test/utils/kvCacheMatrix.js
+++ b/packages/tts-ggml/test/utils/kvCacheMatrix.js
@@ -68,14 +68,14 @@ const ALL_KV_TYPES = [undefined, 'f16', 'f32', 'q8_0']
 // still caught.
 const CHATTERBOX_VARIANTS = ['mtl', 'turbo']
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
 // Platforms that wire up a GPU backend in tts-cpp's vcpkg port today
 // (mirrors gpu-smoke.test.js::expectsGpu): darwin/ios -> Metal,
 // linux/win32 -> Vulkan, android -> Vulkan/OpenCL.
-function expectsGpu () {
+function expectsGpu() {
   return (
     platform === 'darwin' ||
     platform === 'ios' ||
@@ -85,19 +85,26 @@ function expectsGpu () {
   )
 }
 
-function backendIdToName (id) {
+function backendIdToName(id) {
   switch (id) {
-    case 0: return 'CPU'
-    case 1: return 'Metal'
-    case 2: return 'CUDA'
-    case 3: return 'Vulkan'
-    case 4: return 'OpenCL'
-    case 99: return 'other-GPU'
-    default: return `unknown(${id})`
+    case 0:
+      return 'CPU'
+    case 1:
+      return 'Metal'
+    case 2:
+      return 'CUDA'
+    case 3:
+      return 'Vulkan'
+    case 4:
+      return 'OpenCL'
+    case 99:
+      return 'other-GPU'
+    default:
+      return `unknown(${id})`
   }
 }
 
-function kvLabel (kvCacheType) {
+function kvLabel(kvCacheType) {
   return kvCacheType == null ? 'default' : kvCacheType
 }
 
@@ -105,7 +112,7 @@ function kvLabel (kvCacheType) {
 // EXPLICITLY (not via modelDir auto-detect) so the variant is unambiguous
 // even when both the Turbo and MTL GGUF sets live in the same models/ dir
 // (they do once both ensure* helpers have run in one CI job).
-function chatterboxFiles (variant, modelDir) {
+function chatterboxFiles(variant, modelDir) {
   if (variant === 'mtl') {
     return {
       modelDir,
@@ -120,7 +127,7 @@ function chatterboxFiles (variant, modelDir) {
   }
 }
 
-async function ensureModelsFor (variant, modelsDir) {
+async function ensureModelsFor(variant, modelsDir) {
   return variant === 'mtl'
     ? ensureChatterboxMtlModels({ targetDir: modelsDir })
     : ensureChatterboxModels({ targetDir: modelsDir })
@@ -136,11 +143,11 @@ const SAMPLE_TEXT = {
   fr: 'Le renard brun saute par-dessus le chien paresseux.'
 }
 
-function textFor (language) {
+function textFor(language) {
   return SAMPLE_TEXT[language] || SAMPLE_TEXT.en
 }
 
-async function loadChatterbox ({ variant, modelDir, refWavPath, language, useGPU, kvCacheType }) {
+async function loadChatterbox({ variant, modelDir, refWavPath, language, useGPU, kvCacheType }) {
   const options = {
     files: chatterboxFiles(variant, modelDir),
     referenceAudio: refWavPath,
@@ -161,7 +168,7 @@ async function loadChatterbox ({ variant, modelDir, refWavPath, language, useGPU
 // Mirrors gpu-smoke.test.js::assertGpuBackend; kept here so the matrix harness
 // is self-contained.  `allowPolicyCpu` would let a CPU fallback on a declined
 // vendor pass — but Chatterbox now runs on Mali GPU, so it defaults to strict.
-function assertGpuEngaged (t, tag, stats, allowPolicyCpu = false) {
+function assertGpuEngaged(t, tag, stats, allowPolicyCpu = false) {
   if (!stats) {
     t.fail(`${tag}: no response.stats returned (cannot verify backend)`)
     return
@@ -180,7 +187,8 @@ function assertGpuEngaged (t, tag, stats, allowPolicyCpu = false) {
     return
   }
   if (dev !== 1) {
-    const msg = `${tag}/${platform}: expected GPU backend, got ${name} (backendDevice=${dev}). ` +
+    const msg =
+      `${tag}/${platform}: expected GPU backend, got ${name} (backendDevice=${dev}). ` +
       'useGPU=true was requested but the engine fell back to CPU.'
     if (RELAX) {
       t.comment(`WARNING (relaxed): ${msg}`)
@@ -194,7 +202,11 @@ function assertGpuEngaged (t, tag, stats, allowPolicyCpu = false) {
 // Run one synth to completion and assert it produced audio.  Surviving this
 // call at all is the core regression signal: a q8_0 CONT abort on Metal would
 // have SIGABRT'd the process before we got here.
-async function assertSynthesisCompletes (t, model, { tag, text, language, minSamples = 2000, expectGpu = false, allowPolicyCpu = false }) {
+async function assertSynthesisCompletes(
+  t,
+  model,
+  { tag, text, language, minSamples = 2000, expectGpu = false, allowPolicyCpu = false }
+) {
   const result = await runTTS(
     model,
     { text: text || textFor(language) },

--- a/packages/tts-ggml/test/utils/pcmConcatenator.js
+++ b/packages/tts-ggml/test/utils/pcmConcatenator.js
@@ -3,7 +3,7 @@
 const DEFAULT_CROSSFADE_SAMPLES = 720
 const SILENCE_GAP_SAMPLES = 2400
 
-function applyCrossfade (prevChunk, nextChunk, crossfadeSamples) {
+function applyCrossfade(prevChunk, nextChunk, crossfadeSamples) {
   if (crossfadeSamples <= 0) return { prev: prevChunk, next: nextChunk }
   if (prevChunk.length < crossfadeSamples || nextChunk.length < crossfadeSamples) {
     return { prev: prevChunk, next: nextChunk }
@@ -14,7 +14,7 @@ function applyCrossfade (prevChunk, nextChunk, crossfadeSamples) {
   const fadeStart = prevCopy.length - crossfadeSamples
 
   for (let i = 0; i < crossfadeSamples; i++) {
-    const fadeOut = 1.0 - (i / crossfadeSamples)
+    const fadeOut = 1.0 - i / crossfadeSamples
     const fadeIn = i / crossfadeSamples
     prevCopy[fadeStart + i] = Math.round(prevCopy[fadeStart + i] * fadeOut)
     nextCopy[i] = Math.round(nextCopy[i] * fadeIn)
@@ -23,11 +23,11 @@ function applyCrossfade (prevChunk, nextChunk, crossfadeSamples) {
   return { prev: prevCopy, next: nextCopy }
 }
 
-function createSilenceGap (samples) {
+function createSilenceGap(samples) {
   return new Int16Array(samples)
 }
 
-function concatenatePcmChunks (chunks, options = {}) {
+function concatenatePcmChunks(chunks, options = {}) {
   if (chunks.length === 0) return new Int16Array(0)
   if (chunks.length === 1) return toInt16Array(chunks[0])
 
@@ -60,12 +60,12 @@ function concatenatePcmChunks (chunks, options = {}) {
   return mergeInt16Arrays(parts)
 }
 
-function toInt16Array (arr) {
+function toInt16Array(arr) {
   if (arr instanceof Int16Array) return arr
   return Int16Array.from(arr)
 }
 
-function mergeInt16Arrays (arrays) {
+function mergeInt16Arrays(arrays) {
   let totalLength = 0
   for (const arr of arrays) {
     totalLength += arr.length

--- a/packages/tts-ggml/test/utils/perf-helper.js
+++ b/packages/tts-ggml/test/utils/perf-helper.js
@@ -35,7 +35,9 @@ const isMobile = platform === 'ios' || platform === 'android'
 // _perf-helper.js. Mobile doesn't need it — the inline fallback below leaves
 // gpu null on Device Farm where the probes wouldn't work anyway.
 let _subprocess = null
-try { _subprocess = require('bare-subprocess') } catch (_) {}
+try {
+  _subprocess = require('bare-subprocess')
+} catch (_) {}
 
 let createPerformanceReporter
 const _scriptBase = path.join('..', '..', '..', '..', 'scripts', 'test-utils')
@@ -62,24 +64,27 @@ try {
     }
 
     return {
-      record (testName, metrics, extra) {
+      record(testName, metrics, extra) {
         const entry = {
           test: testName,
           execution_provider: (extra && extra.execution_provider) || null,
           model: (extra && extra.model) || null,
-          metrics: Object.assign({
-            total_time_ms: null,
-            tps: null,
-            real_time_factor: null,
-            sample_count: null,
-            audio_duration_ms: null
-          }, metrics),
+          metrics: Object.assign(
+            {
+              total_time_ms: null,
+              tps: null,
+              real_time_factor: null,
+              sample_count: null,
+              audio_duration_ms: null
+            },
+            metrics
+          ),
           input: (extra && extra.input) || null,
           output: (extra && extra.output) || null
         }
         _results.push(entry)
       },
-      toJSON () {
+      toJSON() {
         return {
           schema_version: '1.0',
           addon: _addon,
@@ -89,7 +94,7 @@ try {
           results: _results
         }
       },
-      writeReport () {
+      writeReport() {
         const json = JSON.stringify(this.toJSON())
         const dirs = []
         if (global.testDir) dirs.push(global.testDir)
@@ -101,7 +106,9 @@ try {
         dirs.push('/tmp')
         for (let di = 0; di < dirs.length; di++) {
           try {
-            try { fs.mkdirSync(dirs[di], { recursive: true }) } catch (_) {}
+            try {
+              fs.mkdirSync(dirs[di], { recursive: true })
+            } catch (_) {}
             const p = path.join(dirs[di], 'perf-report.json')
             fs.writeFileSync(p, json)
             console.log('[PERF_REPORT_PATH]' + p)
@@ -110,8 +117,8 @@ try {
           }
         }
       },
-      writeStepSummary () {},
-      writeToConsole () {
+      writeStepSummary() {},
+      writeToConsole() {
         try {
           const json = JSON.stringify(this.toJSON())
           const CHUNK = 800
@@ -121,14 +128,25 @@ try {
             const id = Date.now().toString(36)
             const n = Math.ceil(json.length / CHUNK)
             for (let i = 0; i < n; i++) {
-              console.log('[PERF_CHUNK:' + id + ':' + i + ':' + n + ']' + json.substring(i * CHUNK, (i + 1) * CHUNK))
+              console.log(
+                '[PERF_CHUNK:' +
+                  id +
+                  ':' +
+                  i +
+                  ':' +
+                  n +
+                  ']' +
+                  json.substring(i * CHUNK, (i + 1) * CHUNK)
+              )
             }
           }
         } catch (err) {
           console.log('[perf-reporter] mobile console write failed: ' + err.message)
         }
       },
-      get length () { return _results.length }
+      get length() {
+        return _results.length
+      }
     }
   }
 }
@@ -141,20 +159,26 @@ const _perfReporter = createPerformanceReporter({
 const _reportPath = path.resolve('.', 'test/results/performance-report.json')
 let _reportScheduled = false
 
-function _flushPerfReport () {
+function _flushPerfReport() {
   if (_perfReporter.length === 0) return
-  try { _perfReporter.writeReport(_reportPath) } catch (_) {}
-  try { _perfReporter.writeStepSummary() } catch (_) {}
-  try { _perfReporter.writeToConsole() } catch (_) {}
+  try {
+    _perfReporter.writeReport(_reportPath)
+  } catch (_) {}
+  try {
+    _perfReporter.writeStepSummary()
+  } catch (_) {}
+  try {
+    _perfReporter.writeToConsole()
+  } catch (_) {}
 }
 
-function _scheduleReportWrite () {
+function _scheduleReportWrite() {
   if (_reportScheduled) return
   _reportScheduled = true
   process.on('exit', _flushPerfReport)
 }
 
-function _num (v) {
+function _num(v) {
   return typeof v === 'number' && Number.isFinite(v) ? v : null
 }
 
@@ -174,7 +198,7 @@ function _num (v) {
  *                         { wallMs, sampleCount, model, output,
  *                           executionProvider }.
  */
-function recordTtsStats (label, stats, extra) {
+function recordTtsStats(label, stats, extra) {
   const s = stats || {}
   const resolvedEp = s.backendDevice === 1 ? 'gpu' : s.backendDevice === 0 ? 'cpu' : null
   const epOverride = extra && extra.executionProvider
@@ -185,11 +209,10 @@ function recordTtsStats (label, stats, extra) {
   const finalLabel = ep ? `[${ep.toUpperCase()}] ${baseLabel}` : baseLabel
 
   const rtf = _num(s.realTimeFactor)
-  const sampleCount = (extra && _num(extra.sampleCount)) != null
-    ? _num(extra.sampleCount)
-    : _num(s.totalSamples)
+  const sampleCount =
+    (extra && _num(extra.sampleCount)) != null ? _num(extra.sampleCount) : _num(s.totalSamples)
   const audioMs = _num(s.audioDurationMs) != null ? Math.round(_num(s.audioDurationMs)) : null
-  const wallMs = (extra && _num(extra.wallMs) != null) ? Math.round(_num(extra.wallMs)) : null
+  const wallMs = extra && _num(extra.wallMs) != null ? Math.round(_num(extra.wallMs)) : null
   const tps = _num(s.tokensPerSecond)
 
   // When the addon doesn't report a positive realTimeFactor (e.g. Supertonic /
@@ -202,28 +225,34 @@ function recordTtsStats (label, stats, extra) {
   // overhead that wall-RTF includes), so record rtf_source per row: anyone
   // comparing numbers across rows in a single report can see which is which.
   const usingComputeRtf = rtf != null && rtf > 0
-  const effRtf = usingComputeRtf
-    ? rtf
-    : (wallMs != null && audioMs ? wallMs / audioMs : null)
-  const rtfSource = usingComputeRtf ? 'compute' : (effRtf != null ? 'wall' : null)
+  const effRtf = usingComputeRtf ? rtf : wallMs != null && audioMs ? wallMs / audioMs : null
+  const rtfSource = usingComputeRtf ? 'compute' : effRtf != null ? 'wall' : null
 
-  _perfReporter.record(finalLabel, {
-    total_time_ms: wallMs,
-    tps,
-    real_time_factor: effRtf,
-    rtf_source: rtfSource,
-    sample_count: sampleCount,
-    audio_duration_ms: audioMs
-  }, {
-    execution_provider: ep,
-    model: (extra && extra.model) || null,
-    output: extra && extra.output ? String(extra.output) : null
-  })
+  _perfReporter.record(
+    finalLabel,
+    {
+      total_time_ms: wallMs,
+      tps,
+      real_time_factor: effRtf,
+      rtf_source: rtfSource,
+      sample_count: sampleCount,
+      audio_duration_ms: audioMs
+    },
+    {
+      execution_provider: ep,
+      model: (extra && extra.model) || null,
+      output: extra && extra.output ? String(extra.output) : null
+    }
+  )
   _scheduleReportWrite()
 
   if (isMobile) {
-    try { _perfReporter.writeReport() } catch (_) {}
-    try { _perfReporter.writeToConsole() } catch (_) {}
+    try {
+      _perfReporter.writeReport()
+    } catch (_) {}
+    try {
+      _perfReporter.writeToConsole()
+    } catch (_) {}
   }
 
   const lines = [

--- a/packages/tts-ggml/test/utils/runChatterboxTTS.js
+++ b/packages/tts-ggml/test/utils/runChatterboxTTS.js
@@ -20,7 +20,7 @@ const CHATTERBOX_SAMPLE_RATE = 24000
  * (which forwards to qvac-tts-cli's --reference-audio), so no decode /
  * resample is needed on the JS side.
  */
-function resolveRefWavPath (params) {
+function resolveRefWavPath(params) {
   if (params.refWavPath) return params.refWavPath
   if (isMobile && global.assetPaths) {
     const assetKey = '../../testAssets/jfk.wav'
@@ -31,7 +31,7 @@ function resolveRefWavPath (params) {
   return path.join(__dirname, '..', 'reference-audio', 'jfk.wav')
 }
 
-async function loadChatterboxTTS (params = {}) {
+async function loadChatterboxTTS(params = {}) {
   const baseDir = getBaseDir()
   const defaultModelDir = path.resolve(path.join(baseDir, 'models'))
   const modelDir = params.modelDir || defaultModelDir
@@ -79,29 +79,31 @@ async function loadChatterboxTTS (params = {}) {
   return model
 }
 
-async function runChatterboxTTS (model, params, expectation = {}) {
+async function runChatterboxTTS(model, params, expectation = {}) {
   return runTTS(model, params, expectation, {
     sampleRate: CHATTERBOX_SAMPLE_RATE,
     engineTag: 'Chatterbox'
   })
 }
 
-async function runChatterboxTTSWithSplit (model, params, expectation = {}) {
+async function runChatterboxTTSWithSplit(model, params, expectation = {}) {
   return runTTSWithSplit(model, params, expectation, {
     sampleRate: CHATTERBOX_SAMPLE_RATE,
     engineTag: 'Chatterbox'
   })
 }
 
-function checkExpectations (sampleCount, durationMs, expectation) {
+function checkExpectations(sampleCount, durationMs, expectation) {
   if (expectation.minSamples !== undefined && sampleCount < expectation.minSamples) return false
   if (expectation.maxSamples !== undefined && sampleCount > expectation.maxSamples) return false
-  if (expectation.minDurationMs !== undefined && durationMs < expectation.minDurationMs) return false
-  if (expectation.maxDurationMs !== undefined && durationMs > expectation.maxDurationMs) return false
+  if (expectation.minDurationMs !== undefined && durationMs < expectation.minDurationMs)
+    return false
+  if (expectation.maxDurationMs !== undefined && durationMs > expectation.maxDurationMs)
+    return false
   return true
 }
 
-function saveWavIfNeeded (params, wavBuffer, tag) {
+function saveWavIfNeeded(params, wavBuffer, tag) {
   if (params.saveWav !== true) return
   if (isMobile && !params.wavOutputPath) {
     console.log(`${tag}Skipping WAV save on mobile (no writable path provided)`)
@@ -110,7 +112,9 @@ function saveWavIfNeeded (params, wavBuffer, tag) {
   const defaultWavPath = path.join(__dirname, '../output/chatterbox-stream.wav')
   const wavPath = params.wavOutputPath || defaultWavPath
   const outputDir = path.dirname(wavPath)
-  try { fs.mkdirSync(outputDir, { recursive: true }) } catch (err) {}
+  try {
+    fs.mkdirSync(outputDir, { recursive: true })
+  } catch (err) {}
   fs.writeFileSync(wavPath, wavBuffer)
   console.log(`${tag}Saved WAV to: ${wavPath}`)
 }
@@ -120,7 +124,7 @@ function saveWavIfNeeded (params, wavBuffer, tag) {
  * collect PCM per chunk.  Mirrors `runSupertonicStreaming` in
  * @qvac/tts-onnx so downstream test shape stays consistent.
  */
-async function runChatterboxStreaming (model, params, expectation = {}) {
+async function runChatterboxStreaming(model, params, expectation = {}) {
   const sampleRate = CHATTERBOX_SAMPLE_RATE
   const tag = '[Chatterbox] '
 
@@ -136,7 +140,7 @@ async function runChatterboxStreaming (model, params, expectation = {}) {
   }
 
   try {
-    async function * textStream () {
+    async function* textStream() {
       for (let i = 0; i < phrases.length; i++) {
         yield phrases[i]
       }
@@ -154,7 +158,7 @@ async function runChatterboxStreaming (model, params, expectation = {}) {
     const textByChunk = new Map()
     let jobStats = null
 
-    response.onUpdate(data => {
+    response.onUpdate((data) => {
       if (data && data.outputArray != null && data.chunkIndex !== undefined) {
         pcmByChunk.set(data.chunkIndex, Int16Array.from(data.outputArray))
         if (typeof data.sentenceChunk === 'string') {
@@ -169,8 +173,8 @@ async function runChatterboxStreaming (model, params, expectation = {}) {
     await response.await()
 
     const indices = [...pcmByChunk.keys()].sort((a, b) => a - b)
-    const pcmChunks = indices.map(i => pcmByChunk.get(i))
-    const sentenceChunks = indices.map(i => textByChunk.get(i) || '')
+    const pcmChunks = indices.map((i) => pcmByChunk.get(i))
+    const sentenceChunks = indices.map((i) => textByChunk.get(i) || '')
     const combined = concatenatePcmChunks(pcmChunks, {
       crossfadeSamples: 0,
       silenceGapSamples: 0
@@ -179,7 +183,7 @@ async function runChatterboxStreaming (model, params, expectation = {}) {
     const durationMs =
       response.stats?.audioDurationMs ||
       jobStats?.audioDurationMs ||
-      (sampleCount / (sampleRate / 1000))
+      sampleCount / (sampleRate / 1000)
 
     const passed = checkExpectations(sampleCount, durationMs, expectation)
     const wavBuffer = createWavBuffer(Array.from(combined), sampleRate)

--- a/packages/tts-ggml/test/utils/runSupertonicTTS.js
+++ b/packages/tts-ggml/test/utils/runSupertonicTTS.js
@@ -9,12 +9,11 @@ const { createWavBuffer } = require('./wav-helper')
 
 const SUPERTONIC_SAMPLE_RATE = 44100
 
-async function loadSupertonicTTS (params = {}) {
+async function loadSupertonicTTS(params = {}) {
   const baseDir = getBaseDir()
   const defaultModelDir = path.resolve(path.join(baseDir, 'models'))
 
-  const supertonicPath =
-    params.supertonicModelPath || path.join(defaultModelDir, 'supertonic.gguf')
+  const supertonicPath = params.supertonicModelPath || path.join(defaultModelDir, 'supertonic.gguf')
 
   const config = { language: params.language || 'en' }
   if (params.useGPU !== undefined) {
@@ -39,7 +38,7 @@ async function loadSupertonicTTS (params = {}) {
   return model
 }
 
-async function runSupertonicTTS (model, params = {}, expectation = {}) {
+async function runSupertonicTTS(model, params = {}, expectation = {}) {
   const tag = '[Supertonic] '
   const sampleRate = SUPERTONIC_SAMPLE_RATE
 
@@ -56,7 +55,7 @@ async function runSupertonicTTS (model, params = {}, expectation = {}) {
     const response = await model.run({ input: params.text, type: 'text' })
 
     await response
-      .onUpdate(data => {
+      .onUpdate((data) => {
         if (data && data.outputArray) {
           outputArray = outputArray.concat(Array.from(data.outputArray))
         }
@@ -66,19 +65,23 @@ async function runSupertonicTTS (model, params = {}, expectation = {}) {
 
     const sampleCount = outputArray.length
     const stats = response.stats || null
-    const durationMs = stats?.audioDurationMs || (sampleCount / (sampleRate / 1000))
+    const durationMs = stats?.audioDurationMs || sampleCount / (sampleRate / 1000)
 
     let passed = true
     if (expectation.minSamples !== undefined && sampleCount < expectation.minSamples) passed = false
     if (expectation.maxSamples !== undefined && sampleCount > expectation.maxSamples) passed = false
-    if (expectation.minDurationMs !== undefined && durationMs < expectation.minDurationMs) passed = false
-    if (expectation.maxDurationMs !== undefined && durationMs > expectation.maxDurationMs) passed = false
+    if (expectation.minDurationMs !== undefined && durationMs < expectation.minDurationMs)
+      passed = false
+    if (expectation.maxDurationMs !== undefined && durationMs > expectation.maxDurationMs)
+      passed = false
 
     const wavBuffer = createWavBuffer(outputArray, sampleRate)
 
     if (params.saveWav === true) {
       const wavPath = params.wavOutputPath || path.join(__dirname, '../output/supertonic.wav')
-      try { fs.mkdirSync(path.dirname(wavPath), { recursive: true }) } catch (_e) {}
+      try {
+        fs.mkdirSync(path.dirname(wavPath), { recursive: true })
+      } catch (_e) {}
       if (!isMobile || params.wavOutputPath) {
         fs.writeFileSync(wavPath, wavBuffer)
       }
@@ -100,7 +103,11 @@ async function runSupertonicTTS (model, params = {}, expectation = {}) {
       }
     }
   } catch (error) {
-    return { output: `${tag}Error: ${error.message}`, passed: false, data: { error: error.message } }
+    return {
+      output: `${tag}Error: ${error.message}`,
+      passed: false,
+      data: { error: error.message }
+    }
   }
 }
 

--- a/packages/tts-ggml/test/utils/runTTS.js
+++ b/packages/tts-ggml/test/utils/runTTS.js
@@ -10,11 +10,11 @@ const { concatenatePcmChunks } = require('./pcmConcatenator')
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
-async function synthesizeChunk (model, text, tag) {
+async function synthesizeChunk(model, text, tag) {
   let outputArray = []
   let jobStats = null
   let reportedSampleRate = null
@@ -25,7 +25,7 @@ async function synthesizeChunk (model, text, tag) {
   })
 
   await response
-    .onUpdate(data => {
+    .onUpdate((data) => {
       if (data && data.outputArray) {
         const temp = Array.from(data.outputArray)
         outputArray = outputArray.concat(temp)
@@ -42,7 +42,7 @@ async function synthesizeChunk (model, text, tag) {
   return { outputArray, reportedSampleRate, jobStats, stats: response.stats || jobStats }
 }
 
-async function runTTSWithSplit (model, params, expectation = {}, options = {}) {
+async function runTTSWithSplit(model, params, expectation = {}, options = {}) {
   const sampleRate = options.sampleRate || 24000
   const engineTag = options.engineTag || ''
   const tag = engineTag ? `[${engineTag}] ` : ''
@@ -76,7 +76,9 @@ async function runTTSWithSplit (model, params, expectation = {}, options = {}) {
 
     for (let i = 0; i < chunks.length; i++) {
       const chunkText = chunks[i]
-      console.log(`${tag}  Chunk ${i + 1}/${chunks.length}: "${chunkText.substring(0, 60)}${chunkText.length > 60 ? '...' : ''}"`)
+      console.log(
+        `${tag}  Chunk ${i + 1}/${chunks.length}: "${chunkText.substring(0, 60)}${chunkText.length > 60 ? '...' : ''}"`
+      )
 
       const result = await synthesizeChunk(model, chunkText, tag)
       pcmChunks.push(Int16Array.from(result.outputArray))
@@ -113,19 +115,25 @@ async function runTTSWithSplit (model, params, expectation = {}, options = {}) {
       }
     }
   } catch (error) {
-    return { output: `${tag}Error: ${error.message}`, passed: false, data: { error: error.message } }
+    return {
+      output: `${tag}Error: ${error.message}`,
+      passed: false,
+      data: { error: error.message }
+    }
   }
 }
 
-function checkExpectations (sampleCount, durationMs, expectation) {
+function checkExpectations(sampleCount, durationMs, expectation) {
   if (expectation.minSamples !== undefined && sampleCount < expectation.minSamples) return false
   if (expectation.maxSamples !== undefined && sampleCount > expectation.maxSamples) return false
-  if (expectation.minDurationMs !== undefined && durationMs < expectation.minDurationMs) return false
-  if (expectation.maxDurationMs !== undefined && durationMs > expectation.maxDurationMs) return false
+  if (expectation.minDurationMs !== undefined && durationMs < expectation.minDurationMs)
+    return false
+  if (expectation.maxDurationMs !== undefined && durationMs > expectation.maxDurationMs)
+    return false
   return true
 }
 
-function saveWavIfNeeded (params, wavBuffer, tag) {
+function saveWavIfNeeded(params, wavBuffer, tag) {
   if (params.saveWav !== true) return
   if (isMobile && !params.wavOutputPath) {
     console.log(`${tag}Skipping WAV save on mobile (no writable path provided)`)
@@ -134,12 +142,14 @@ function saveWavIfNeeded (params, wavBuffer, tag) {
   const defaultWavPath = path.join(__dirname, '../output/test.wav')
   const wavPath = params.wavOutputPath || defaultWavPath
   const outputDir = path.dirname(wavPath)
-  try { fs.mkdirSync(outputDir, { recursive: true }) } catch (err) {}
+  try {
+    fs.mkdirSync(outputDir, { recursive: true })
+  } catch (err) {}
   fs.writeFileSync(wavPath, wavBuffer)
   console.log(`${tag}Saved WAV to: ${wavPath}`)
 }
 
-async function runTTS (model, params, expectation = {}, options = {}) {
+async function runTTS(model, params, expectation = {}, options = {}) {
   const sampleRate = options.sampleRate || 24000
   const engineTag = options.engineTag || ''
   const tag = engineTag ? `[${engineTag}] ` : ''
@@ -168,7 +178,7 @@ async function runTTS (model, params, expectation = {}, options = {}) {
     })
 
     await response
-      .onUpdate(data => {
+      .onUpdate((data) => {
         if (data && data.outputArray) {
           const temp = Array.from(data.outputArray)
           outputArray = outputArray.concat(temp)
@@ -184,7 +194,10 @@ async function runTTS (model, params, expectation = {}, options = {}) {
 
     let passed = true
     const sampleCount = outputArray.length
-    const durationMs = response.stats?.audioDurationMs || jobStats?.audioDurationMs || (sampleCount / (sampleRate / 1000))
+    const durationMs =
+      response.stats?.audioDurationMs ||
+      jobStats?.audioDurationMs ||
+      sampleCount / (sampleRate / 1000)
 
     if (expectation.minSamples !== undefined && sampleCount < expectation.minSamples) {
       passed = false
@@ -223,8 +236,12 @@ async function runTTS (model, params, expectation = {}, options = {}) {
     const roundedStats = stats
       ? {
           totalTime: stats.totalTime ? Number(stats.totalTime.toFixed(4)) : stats.totalTime,
-          tokensPerSecond: stats.tokensPerSecond ? Number(stats.tokensPerSecond.toFixed(2)) : stats.tokensPerSecond,
-          realTimeFactor: stats.realTimeFactor ? Number(stats.realTimeFactor.toFixed(5)) : stats.realTimeFactor,
+          tokensPerSecond: stats.tokensPerSecond
+            ? Number(stats.tokensPerSecond.toFixed(2))
+            : stats.tokensPerSecond,
+          realTimeFactor: stats.realTimeFactor
+            ? Number(stats.realTimeFactor.toFixed(5))
+            : stats.realTimeFactor,
           audioDurationMs: stats.audioDurationMs,
           totalSamples: stats.totalSamples,
           backendDevice: stats.backendDevice,

--- a/packages/tts-ggml/test/utils/runWhisper.js
+++ b/packages/tts-ggml/test/utils/runWhisper.js
@@ -8,11 +8,11 @@ const WHISPER_SAMPLE_RATE = 16000
 const platform = os.platform()
 const isMobile = platform === 'ios' || platform === 'android'
 
-function getBaseDir () {
+function getBaseDir() {
   return isMobile && global.testDir ? global.testDir : '.'
 }
 
-async function loadWhisper (params = {}) {
+async function loadWhisper(params = {}) {
   const defaultPath = path.join(getBaseDir(), 'models', 'whisper')
   const modelName = params.modelName || 'ggml-tiny.bin'
   const diskPath = params.diskPath || defaultPath
@@ -40,23 +40,27 @@ async function loadWhisper (params = {}) {
   return whisperModel
 }
 
-function extractWavPcm (wavBuf) {
+function extractWavPcm(wavBuf) {
   if (wavBuf.length < 44) return { raw: wavBuf, sampleRate: WHISPER_SAMPLE_RATE }
-  const isRiff = wavBuf[0] === 0x52 && wavBuf[1] === 0x49 &&
-    wavBuf[2] === 0x46 && wavBuf[3] === 0x46
+  const isRiff =
+    wavBuf[0] === 0x52 && wavBuf[1] === 0x49 && wavBuf[2] === 0x46 && wavBuf[3] === 0x46
   if (!isRiff) return { raw: wavBuf, sampleRate: WHISPER_SAMPLE_RATE }
 
-  const sampleRate = wavBuf[24] | (wavBuf[25] << 8) |
-    (wavBuf[26] << 16) | (wavBuf[27] << 24)
+  const sampleRate = wavBuf[24] | (wavBuf[25] << 8) | (wavBuf[26] << 16) | (wavBuf[27] << 24)
 
   let dataOffset = 12
   while (dataOffset + 8 <= wavBuf.length) {
     const id = String.fromCharCode(
-      wavBuf[dataOffset], wavBuf[dataOffset + 1],
-      wavBuf[dataOffset + 2], wavBuf[dataOffset + 3]
+      wavBuf[dataOffset],
+      wavBuf[dataOffset + 1],
+      wavBuf[dataOffset + 2],
+      wavBuf[dataOffset + 3]
     )
-    const chunkSize = wavBuf[dataOffset + 4] | (wavBuf[dataOffset + 5] << 8) |
-      (wavBuf[dataOffset + 6] << 16) | (wavBuf[dataOffset + 7] << 24)
+    const chunkSize =
+      wavBuf[dataOffset + 4] |
+      (wavBuf[dataOffset + 5] << 8) |
+      (wavBuf[dataOffset + 6] << 16) |
+      (wavBuf[dataOffset + 7] << 24)
     if (id === 'data') {
       const start = dataOffset + 8
       const end = Math.min(start + chunkSize, wavBuf.length)
@@ -69,7 +73,7 @@ function extractWavPcm (wavBuf) {
   return { raw: wavBuf.slice(44), sampleRate }
 }
 
-function resampleS16le (pcmBuf, fromRate, toRate) {
+function resampleS16le(pcmBuf, fromRate, toRate) {
   if (fromRate === toRate) return pcmBuf
 
   const numSamples = Math.floor(pcmBuf.length / 2)
@@ -91,12 +95,14 @@ function resampleS16le (pcmBuf, fromRate, toRate) {
   return out
 }
 
-async function runWhisper (model, text, wavBuffer) {
+async function runWhisper(model, text, wavBuffer) {
   const buf = Buffer.from(wavBuffer)
   const { raw, sampleRate } = extractWavPcm(buf)
   const pcm16k = resampleS16le(Buffer.from(raw), sampleRate, WHISPER_SAMPLE_RATE)
 
-  console.log(`>>> [WHISPER] Audio: ${sampleRate}Hz -> ${WHISPER_SAMPLE_RATE}Hz, ${pcm16k.length / 2} samples`)
+  console.log(
+    `>>> [WHISPER] Audio: ${sampleRate}Hz -> ${WHISPER_SAMPLE_RATE}Hz, ${pcm16k.length / 2} samples`
+  )
 
   const audioStream = Readable.from([pcm16k])
   const response = await model.run(audioStream)
@@ -119,36 +125,40 @@ async function runWhisper (model, text, wavBuffer) {
   return { wer }
 }
 
-async function _processResponse (response) {
+async function _processResponse(response) {
   let fullText = ''
-  await response.onUpdate((output) => {
-    if (Array.isArray(output)) {
-      for (const item of output) {
-        if (item.text) {
-          fullText += item.text
+  await response
+    .onUpdate((output) => {
+      if (Array.isArray(output)) {
+        for (const item of output) {
+          if (item.text) {
+            fullText += item.text
+          }
         }
       }
-    }
-  }).await()
+    })
+    .await()
   return fullText
 }
 
-function wordErrorRate (expected, actual) {
+function wordErrorRate(expected, actual) {
   // Normalize text for comparison
   const normalize = (text) => {
-    return text
-      .trim()
-      .toLowerCase()
-    // Remove punctuation (periods, commas, exclamation, question marks, etc.)
-      .replace(/[.,!?;:"""''„«»()[\]{}]/g, '')
-    // Normalize apostrophes (handle French contractions like l'aube -> l aube)
-      .replace(/[''ʼ]/g, ' ')
-    // Normalize hyphens (au-dessus -> au dessus)
-      .replace(/[-–—]/g, ' ')
-    // Collapse multiple spaces into one
-      .replace(/\s+/g, ' ')
-      .trim()
-      .split(/\s+/)
+    return (
+      text
+        .trim()
+        .toLowerCase()
+        // Remove punctuation (periods, commas, exclamation, question marks, etc.)
+        .replace(/[.,!?;:"""''„«»()[\]{}]/g, '')
+        // Normalize apostrophes (handle French contractions like l'aube -> l aube)
+        .replace(/[''ʼ]/g, ' ')
+        // Normalize hyphens (au-dessus -> au dessus)
+        .replace(/[-–—]/g, ' ')
+        // Collapse multiple spaces into one
+        .replace(/\s+/g, ' ')
+        .trim()
+        .split(/\s+/)
+    )
   }
 
   const r = normalize(expected)

--- a/packages/tts-ggml/test/utils/wav-helper.js
+++ b/packages/tts-ggml/test/utils/wav-helper.js
@@ -1,13 +1,13 @@
 const fs = require('bare-fs')
 
-function writeIntLE (buffer, value, offset, byteLength) {
+function writeIntLE(buffer, value, offset, byteLength) {
   for (let i = 0; i < byteLength; i++) {
     buffer[offset + i] = value & 0xff
     value >>= 8
   }
 }
 
-function readWavAsFloat32 (wavPath) {
+function readWavAsFloat32(wavPath) {
   const buf = fs.readFileSync(wavPath)
   if (buf.length < 44) throw new Error('WAV file too small')
 
@@ -32,7 +32,12 @@ function readWavAsFloat32 (wavPath) {
   let offset = 12
 
   while (offset + 8 <= buf.length) {
-    const chunkId = String.fromCharCode(buf[offset], buf[offset + 1], buf[offset + 2], buf[offset + 3])
+    const chunkId = String.fromCharCode(
+      buf[offset],
+      buf[offset + 1],
+      buf[offset + 2],
+      buf[offset + 3]
+    )
     const chunkSize = view.getUint32(offset + 4, true)
 
     if (chunkId === 'fmt ') {
@@ -59,7 +64,9 @@ function readWavAsFloat32 (wavPath) {
   const bitsPerSample = view.getUint16(fmtOff + 14, true)
 
   if (audioFormat !== 1 && audioFormat !== 3) {
-    throw new Error('Unsupported WAV audio format: ' + audioFormat + ' (only PCM=1 and IEEE_FLOAT=3 supported)')
+    throw new Error(
+      'Unsupported WAV audio format: ' + audioFormat + ' (only PCM=1 and IEEE_FLOAT=3 supported)'
+    )
   }
 
   const dataOff = dataChunk.offset
@@ -112,13 +119,15 @@ function readWavAsFloat32 (wavPath) {
       samples[i] = (buf[idx] - 128) / 128
     }
   } else {
-    throw new Error('Unsupported WAV format: audioFormat=' + audioFormat + ', bitsPerSample=' + bitsPerSample)
+    throw new Error(
+      'Unsupported WAV format: audioFormat=' + audioFormat + ', bitsPerSample=' + bitsPerSample
+    )
   }
 
   return { samples, sampleRate, numChannels }
 }
 
-function createWavBuffer (samples, sampleRate = 16000) {
+function createWavBuffer(samples, sampleRate = 16000) {
   const numChannels = 1
   const bytesPerSample = 2
   const blockAlign = numChannels * bytesPerSample
@@ -151,12 +160,12 @@ function createWavBuffer (samples, sampleRate = 16000) {
   return buffer
 }
 
-function createWav (samples, sampleRate = 16000, outputPath = 'test.wav') {
+function createWav(samples, sampleRate = 16000, outputPath = 'test.wav') {
   const buffer = createWavBuffer(samples, sampleRate)
   fs.writeFileSync(outputPath, buffer)
 }
 
-function resampleLinear (samples, fromRate, toRate) {
+function resampleLinear(samples, fromRate, toRate) {
   if (fromRate === toRate) return samples
   const ratio = fromRate / toRate
   const outputLen = Math.round(samples.length / ratio)

--- a/packages/tts-ggml/tts.js
+++ b/packages/tts-ggml/tts.js
@@ -11,7 +11,7 @@ class TTSInterface {
    * @param {Object} configuration Optional initial configuration (engine-specific model paths, language, etc.)
    * @param {Function} outputCb - To be called on inference output events
    */
-  constructor (binding, configuration = {}, outputCb = null) {
+  constructor(binding, configuration = {}, outputCb = null) {
     this._binding = binding
     this._handle = this._binding.createInstance(this, configuration, outputCb)
   }
@@ -26,7 +26,7 @@ class TTSInterface {
    * event loop.  The native call therefore returns a JS promise; awaiting
    * it here is what blocks `model.load()` until the worker finishes.
    */
-  async activate () {
+  async activate() {
     try {
       await this._binding.activate(this._handle)
     } catch (err) {
@@ -44,7 +44,7 @@ class TTSInterface {
    * @param {String} data.type
    * @param {String} data.input
    */
-  async runJob (data) {
+  async runJob(data) {
     try {
       this._binding.runJob(this._handle, data)
     } catch (err) {
@@ -56,7 +56,7 @@ class TTSInterface {
     }
   }
 
-  async loadWeights (weightsData) {
+  async loadWeights(weightsData) {
     try {
       this._binding.loadWeights(this._handle, weightsData)
     } catch (err) {
@@ -68,7 +68,7 @@ class TTSInterface {
     }
   }
 
-  async cancel () {
+  async cancel() {
     try {
       await this._binding.cancel(this._handle)
     } catch (err) {
@@ -83,7 +83,7 @@ class TTSInterface {
   /**
    * Stops addon process and clears resources (including memory).
    */
-  async destroyInstance () {
+  async destroyInstance() {
     // Already destroyed, nothing to do
     if (this._handle === null) {
       return
@@ -102,7 +102,7 @@ class TTSInterface {
     }
   }
 
-  async unload () {
+  async unload() {
     return this.destroyInstance()
   }
 }


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The JS source in `packages/tts-ggml` was not consistently formatted per the package's pinned Prettier config.
- `npm run lint` (which runs `prettier --check`) flagged JS files with code-style issues.

## 📝 How does it solve it?

- Ran `npm run format` (`prettier --write`) across `lib/`, `test/`, and top-level `*.js` to apply the canonical formatting.
- Reformatted 38 files (whitespace/style only — no functional, API, or behavioral changes).

## 🧪 How was it tested?

- Re-ran `prettier --check` → "All matched files use Prettier code style!"


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216426175394535
  - https://app.asana.com/0/0/1216426175394532