### PR TITLE
QVAC-22027 chore[skiplog]: apply prettier formatting to transcription-whispercpp JS

### DIFF
--- a/packages/transcription-whispercpp/configChecker.js
+++ b/packages/transcription-whispercpp/configChecker.js
@@ -1,22 +1,18 @@
 /*
  * @param {Object} configObject - the configuration object to check
-*
-* all objects most contain structure like this
-* {
-*   whisperConfig:{
-*    vadParams:{},
-*   },
-*    contextParams:{}
-*    miscConfig:{}
+ *
+ * all objects most contain structure like this
+ * {
+ *   whisperConfig:{
+ *    vadParams:{},
+ *   },
+ *    contextParams:{}
+ *    miscConfig:{}
  * }
  * @returns {void} or throws an error if the config object is invalid
  */
-function checkConfig (configObject) {
-  const listOfConfigs = [
-    'whisperConfig',
-    'contextParams',
-    'miscConfig'
-  ]
+function checkConfig(configObject) {
+  const listOfConfigs = ['whisperConfig', 'contextParams', 'miscConfig']
 
   for (const config of listOfConfigs) {
     if (!configObject[config]) {
@@ -74,12 +70,7 @@ function checkConfig (configObject) {
     'samples_overlap'
   ]
 
-  const listOfContextParams = [
-    'model',
-    'use_gpu',
-    'flash_attn',
-    'gpu_device'
-  ]
+  const listOfContextParams = ['model', 'use_gpu', 'flash_attn', 'gpu_device']
 
   const listOfMiscParams = [
     'caption_enabled',
@@ -117,7 +108,7 @@ function checkConfig (configObject) {
   if (typeof configObject.whisperConfig.suppress_regex === 'string') {
     _validateSuppressRegex(configObject.whisperConfig.suppress_regex)
   }
-};
+}
 
 const MAX_SUPPRESS_REGEX_LENGTH = 512
 
@@ -125,7 +116,7 @@ const MAX_SUPPRESS_REGEX_LENGTH = 512
 // Reject grouping constructs entirely to prevent nested quantifier patterns like (a+)+.
 const SAFE_SUPPRESS_REGEX = /^[^()]*$/
 
-function _validateSuppressRegex (pattern) {
+function _validateSuppressRegex(pattern) {
   if (pattern.length > MAX_SUPPRESS_REGEX_LENGTH) {
     throw new Error(
       'suppress_regex exceeds maximum length of ' + MAX_SUPPRESS_REGEX_LENGTH + ' characters'

--- a/packages/transcription-whispercpp/examples/example.audio-ctx-chunking.js
+++ b/packages/transcription-whispercpp/examples/example.audio-ctx-chunking.js
@@ -17,7 +17,7 @@ const TranscriptionWhispercpp = require('../index.js')
 /**
  * Download model if not present
  */
-async function downloadRealModel (url, filepath, minSize = 1000000) {
+async function downloadRealModel(url, filepath, minSize = 1000000) {
   if (fs.existsSync(filepath)) {
     const stats = fs.statSync(filepath)
     if (stats.size >= minSize) {
@@ -32,12 +32,23 @@ async function downloadRealModel (url, filepath, minSize = 1000000) {
   console.log(`⬇ Downloading model: ${filepath}...`)
   try {
     const { spawnSync } = require('bare-subprocess')
-    const result = spawnSync('curl', [
-      '-L', '-o', filepath, url,
-      '--fail', '--silent', '--show-error',
-      '--connect-timeout', '30',
-      '--max-time', '300'
-    ], { stdio: ['inherit', 'inherit', 'pipe'] })
+    const result = spawnSync(
+      'curl',
+      [
+        '-L',
+        '-o',
+        filepath,
+        url,
+        '--fail',
+        '--silent',
+        '--show-error',
+        '--connect-timeout',
+        '30',
+        '--max-time',
+        '300'
+      ],
+      { stdio: ['inherit', 'inherit', 'pipe'] }
+    )
 
     if (result.status === 0 && fs.existsSync(filepath)) {
       const stats = fs.statSync(filepath)
@@ -56,7 +67,7 @@ async function downloadRealModel (url, filepath, minSize = 1000000) {
 /**
  * Transcribe audio with specific offset, duration and audio_ctx
  */
-async function transcribeChunk (model, audioStream, offsetMs, durationMs, audioCtx) {
+async function transcribeChunk(model, audioStream, offsetMs, durationMs, audioCtx) {
   await model.reload({
     whisperConfig: {
       offset_ms: offsetMs,
@@ -77,10 +88,10 @@ async function transcribeChunk (model, audioStream, offsetMs, durationMs, audioC
   return results
 }
 
-function createFullAudioStream (audioBuffer) {
+function createFullAudioStream(audioBuffer) {
   const { Readable } = require('streamx')
   return new Readable({
-    read (cb) {
+    read(cb) {
       this.push(audioBuffer)
       this.push(null)
       cb(null)
@@ -88,7 +99,7 @@ function createFullAudioStream (audioBuffer) {
   })
 }
 
-async function main () {
+async function main() {
   const modelsDir = path.join(__dirname, '..', 'models')
   const modelPath = path.join(modelsDir, 'ggml-tiny.bin')
   const audioPath = path.join(__dirname, 'samples', '10min-16k-s16le.raw')
@@ -137,11 +148,13 @@ async function main () {
   // Calculate audio duration and chunks
   const WHISPER_SAMPLE_RATE = 16000
   const BYTES_PER_SAMPLE = 2
-  const totalDurationSeconds = (audioStats.size / BYTES_PER_SAMPLE) / WHISPER_SAMPLE_RATE
+  const totalDurationSeconds = audioStats.size / BYTES_PER_SAMPLE / WHISPER_SAMPLE_RATE
   const CHUNK_SIZE_SECONDS = 30
   const chunksToProcess = Math.ceil(totalDurationSeconds / CHUNK_SIZE_SECONDS)
 
-  console.log(`Audio: ${totalDurationSeconds.toFixed(1)}s, Chunks: ${chunksToProcess} x ${CHUNK_SIZE_SECONDS}s`)
+  console.log(
+    `Audio: ${totalDurationSeconds.toFixed(1)}s, Chunks: ${chunksToProcess} x ${CHUNK_SIZE_SECONDS}s`
+  )
   console.log('Processing all chunks\n')
 
   const allResults = []
@@ -152,7 +165,9 @@ async function main () {
     const chunkDuration = Math.min(CHUNK_SIZE_SECONDS, totalDurationSeconds - offsetSeconds)
     const audioCtx = i === 0 ? 0 : Math.min(Math.floor(50 * chunkDuration + 1), 1500)
 
-    console.log(`[${i + 1}/${chunksToProcess}] offset=${offsetSeconds.toFixed(1)}s duration=${chunkDuration.toFixed(1)}s audio_ctx=${audioCtx}`)
+    console.log(
+      `[${i + 1}/${chunksToProcess}] offset=${offsetSeconds.toFixed(1)}s duration=${chunkDuration.toFixed(1)}s audio_ctx=${audioCtx}`
+    )
 
     const audioStream = createFullAudioStream(fullAudioBuffer)
     const startTime = Date.now()
@@ -167,7 +182,11 @@ async function main () {
     totalProcessingTime += Date.now() - startTime
 
     if (results.length > 0) {
-      const text = results.map(s => s.text).join(' ').replace(/\s+/g, ' ').trim()
+      const text = results
+        .map((s) => s.text)
+        .join(' ')
+        .replace(/\s+/g, ' ')
+        .trim()
       console.log(`  → ${text}\n`)
       allResults.push(...results)
     } else {
@@ -175,9 +194,15 @@ async function main () {
     }
   }
 
-  console.log(`Processing completed: ${(totalProcessingTime / 1000).toFixed(1)}s, ${allResults.length} segments`)
+  console.log(
+    `Processing completed: ${(totalProcessingTime / 1000).toFixed(1)}s, ${allResults.length} segments`
+  )
 
-  const fullText = allResults.map(s => s.text).join(' ').replace(/\s+/g, ' ').trim()
+  const fullText = allResults
+    .map((s) => s.text)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim()
   if (fullText.length) {
     console.log('\n=== FULL TRANSCRIPTION ===')
     console.log(fullText)
@@ -191,7 +216,7 @@ async function main () {
   await model.destroy()
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Error:', err)
   console.error(err.stack)
   process.exit(1)

--- a/packages/transcription-whispercpp/examples/example.decoder.js
+++ b/packages/transcription-whispercpp/examples/example.decoder.js
@@ -7,7 +7,7 @@ const path = require('bare-path')
 /**
  * Example demonstrating how to use FFmpegDecoder for audio processing and write output to a file
  */
-async function main () {
+async function main() {
   console.log('FFmpegDecoder Example')
   console.log('====================')
 
@@ -42,9 +42,17 @@ async function main () {
       // Handle the response
       response.on('output', (data) => {
         // Write the decoded chunk (S16LE) to output file
-        outputFileStream.write(Buffer.from(data.outputArray.buffer, data.outputArray.byteOffset, data.outputArray.byteLength))
+        outputFileStream.write(
+          Buffer.from(
+            data.outputArray.buffer,
+            data.outputArray.byteOffset,
+            data.outputArray.byteLength
+          )
+        )
         writtenBytes += data.outputArray.byteLength
-        console.log(`Received decoded audio chunk: ${data.outputArray.length} bytes, total written: ${writtenBytes} bytes`)
+        console.log(
+          `Received decoded audio chunk: ${data.outputArray.length} bytes, total written: ${writtenBytes} bytes`
+        )
       })
 
       response.on('end', () => {
@@ -65,7 +73,9 @@ async function main () {
       })
     } else {
       console.log('⚠ Sample audio file not found, skipping file processing example')
-      console.log('   To test with a real file, place a LastQuestion_long_EN.mp3 in the examples directory')
+      console.log(
+        '   To test with a real file, place a LastQuestion_long_EN.mp3 in the examples directory'
+      )
     }
   } catch (error) {
     console.error('Example failed:', error)

--- a/packages/transcription-whispercpp/examples/example.live-transcription.js
+++ b/packages/transcription-whispercpp/examples/example.live-transcription.js
@@ -21,7 +21,7 @@ const TranscriptionWhispercpp = require('../index.js')
 /**
  * Download model if not present
  */
-async function downloadRealModel (url, filepath, minSize = 1000000) {
+async function downloadRealModel(url, filepath, minSize = 1000000) {
   if (fs.existsSync(filepath)) {
     const stats = fs.statSync(filepath)
     if (stats.size >= minSize) {
@@ -36,12 +36,23 @@ async function downloadRealModel (url, filepath, minSize = 1000000) {
   console.log(`⬇ Downloading model: ${filepath}...`)
   try {
     const { spawnSync } = require('bare-subprocess')
-    const result = spawnSync('curl', [
-      '-L', '-o', filepath, url,
-      '--fail', '--silent', '--show-error',
-      '--connect-timeout', '30',
-      '--max-time', '300'
-    ], { stdio: ['inherit', 'inherit', 'pipe'] })
+    const result = spawnSync(
+      'curl',
+      [
+        '-L',
+        '-o',
+        filepath,
+        url,
+        '--fail',
+        '--silent',
+        '--show-error',
+        '--connect-timeout',
+        '30',
+        '--max-time',
+        '300'
+      ],
+      { stdio: ['inherit', 'inherit', 'pipe'] }
+    )
 
     if (result.status === 0 && fs.existsSync(filepath)) {
       const stats = fs.statSync(filepath)
@@ -60,7 +71,7 @@ async function downloadRealModel (url, filepath, minSize = 1000000) {
 /**
  * Split audio buffer into small chunks for live transcription simulation
  */
-function splitAudioIntoChunks (audioBuffer, chunkSizeSeconds, sampleRate, bytesPerSample) {
+function splitAudioIntoChunks(audioBuffer, chunkSizeSeconds, sampleRate, bytesPerSample) {
   const chunkSizeBytes = chunkSizeSeconds * sampleRate * bytesPerSample
   const chunks = []
 
@@ -75,7 +86,7 @@ function splitAudioIntoChunks (audioBuffer, chunkSizeSeconds, sampleRate, bytesP
 /**
  * Simulate live transcription by sending small audio chunks sequentially
  */
-async function transcribeLiveStream (model, audioChunks, audioCtx) {
+async function transcribeLiveStream(model, audioChunks, audioCtx) {
   const startTime = Date.now()
 
   const results = []
@@ -84,7 +95,9 @@ async function transcribeLiveStream (model, audioChunks, audioCtx) {
   console.log(`\nSending ${audioChunks.length} chunks sequentially...\n`)
 
   const liveReadable = new Readable({
-    read (cb) { cb(null) }
+    read(cb) {
+      cb(null)
+    }
   })
 
   const response = await model.run(liveReadable)
@@ -94,7 +107,10 @@ async function transcribeLiveStream (model, audioChunks, audioCtx) {
     results.push(...items)
     segmentCount += items.length
 
-    const latestText = items.map(i => i.text).join(' ').trim()
+    const latestText = items
+      .map((i) => i.text)
+      .join(' ')
+      .trim()
     if (latestText) {
       process.stdout.write(`\r[${segmentCount} segments] Latest: ${latestText.substring(0, 60)}...`)
     }
@@ -111,7 +127,7 @@ async function transcribeLiveStream (model, audioChunks, audioCtx) {
     }
 
     if (chunkDelayMs > 0) {
-      await new Promise(resolve => setTimeout(resolve, chunkDelayMs))
+      await new Promise((resolve) => setTimeout(resolve, chunkDelayMs))
     }
   }
   liveReadable.push(null)
@@ -141,7 +157,7 @@ async function transcribeLiveStream (model, audioChunks, audioCtx) {
   return { results, processingTime }
 }
 
-async function main () {
+async function main() {
   const modelsDir = path.join(__dirname, '..', 'models')
   const modelPath = path.join(modelsDir, 'ggml-tiny.bin')
   const audioPath = path.join(__dirname, 'samples', '10min-16k-s16le.raw')
@@ -189,13 +205,15 @@ async function main () {
   // Calculate audio duration and chunks
   const WHISPER_SAMPLE_RATE = 16000
   const BYTES_PER_SAMPLE = 2
-  const totalDurationSeconds = (audioStats.size / BYTES_PER_SAMPLE) / WHISPER_SAMPLE_RATE
+  const totalDurationSeconds = audioStats.size / BYTES_PER_SAMPLE / WHISPER_SAMPLE_RATE
   const CHUNK_SIZE_SECONDS = 3
   const audioCtx = 1500
 
   console.log(`Audio file: ${audioPath}`)
   console.log(`File size: ${(audioStats.size / 1024 / 1024).toFixed(2)} MB`)
-  console.log(`Duration: ${totalDurationSeconds.toFixed(1)}s (~${(totalDurationSeconds / 60).toFixed(1)} minutes)`)
+  console.log(
+    `Duration: ${totalDurationSeconds.toFixed(1)}s (~${(totalDurationSeconds / 60).toFixed(1)} minutes)`
+  )
   console.log(`Chunk size: ${CHUNK_SIZE_SECONDS}s`)
   console.log(`Audio context: ${audioCtx}ms`)
   console.log(`Model: ${modelPath}\n`)
@@ -213,11 +231,7 @@ async function main () {
 
   console.log(`Created ${audioChunks.length} chunks of ~${CHUNK_SIZE_SECONDS}s each\n`)
 
-  const { results, processingTime } = await transcribeLiveStream(
-    model,
-    audioChunks,
-    audioCtx
-  )
+  const { results, processingTime } = await transcribeLiveStream(model, audioChunks, audioCtx)
 
   console.log('\n=== RESULTS ===')
   console.log(`Total segments: ${results.length}`)
@@ -227,8 +241,8 @@ async function main () {
 
   // Build full transcription
   const fullTranscription = results
-    .map(s => s.text.trim())
-    .filter(t => t.length > 0)
+    .map((s) => s.text.trim())
+    .filter((t) => t.length > 0)
     .join(' ')
     .replace(/\s+/g, ' ')
     .trim()
@@ -246,7 +260,7 @@ async function main () {
   await model.destroy()
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Error:', err)
   console.error(err.stack)
   process.exit(1)

--- a/packages/transcription-whispercpp/examples/example.mic-conversation.js
+++ b/packages/transcription-whispercpp/examples/example.mic-conversation.js
@@ -22,7 +22,7 @@ const DEFAULT_DURATION_SECONDS = 30
  * Use durationSeconds=0 to run until Ctrl+C.
  */
 
-function getAudioInputArgs () {
+function getAudioInputArgs() {
   switch (os.platform()) {
     case 'darwin':
       return ['-f', 'avfoundation', '-i', ':0']
@@ -33,29 +33,38 @@ function getAudioInputArgs () {
   }
 }
 
-function ensureFfmpeg () {
+function ensureFfmpeg() {
   const result = spawnSync('ffmpeg', ['-version'], { stdio: ['ignore', 'ignore', 'ignore'] })
   if (result.status !== 0) {
     throw new Error('ffmpeg is required for microphone capture')
   }
 }
 
-function startMicStream () {
-  return spawn('ffmpeg', [
-    '-hide_banner',
-    '-loglevel', 'error',
-    ...getAudioInputArgs(),
-    '-ar', String(SAMPLE_RATE),
-    '-ac', '1',
-    '-sample_fmt', 's16',
-    '-f', 's16le',
-    'pipe:1'
-  ], {
-    stdio: ['ignore', 'pipe', 'pipe']
-  })
+function startMicStream() {
+  return spawn(
+    'ffmpeg',
+    [
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      ...getAudioInputArgs(),
+      '-ar',
+      String(SAMPLE_RATE),
+      '-ac',
+      '1',
+      '-sample_fmt',
+      's16',
+      '-f',
+      's16le',
+      'pipe:1'
+    ],
+    {
+      stdio: ['ignore', 'pipe', 'pipe']
+    }
+  )
 }
 
-function parseArgs () {
+function parseArgs() {
   const args = process.argv.slice(2)
   const modelsDir = path.join(__dirname, '..', 'models')
   const durationSeconds = Number.parseInt(args[0] || String(DEFAULT_DURATION_SECONDS), 10)
@@ -67,13 +76,13 @@ function parseArgs () {
   }
 }
 
-function assertFileExists (filePath, label) {
+function assertFileExists(filePath, label) {
   if (!fs.existsSync(filePath)) {
     throw new Error(`${label} not found at ${filePath}`)
   }
 }
 
-async function main () {
+async function main() {
   ensureFfmpeg()
 
   const { durationSeconds, modelPath, vadModelPath } = parseArgs()
@@ -118,7 +127,7 @@ async function main () {
   let response
   let timeout = null
 
-  ffmpeg.stderr.on('data', data => {
+  ffmpeg.stderr.on('data', (data) => {
     const message = data.toString().trim()
     if (message) console.error(`[ffmpeg] ${message}`)
   })
@@ -142,7 +151,7 @@ async function main () {
       vadRunIntervalMs: 300
     })
 
-    response.onUpdate(data => {
+    response.onUpdate((data) => {
       if (data?.type === 'vad') {
         console.log(`[vad] speaking=${data.speaking} probability=${data.probability}`)
         return
@@ -174,7 +183,7 @@ async function main () {
   console.log('\nMicrophone conversation example complete.')
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error(err)
   process.exit(1)
 })

--- a/packages/transcription-whispercpp/examples/example.reload.js
+++ b/packages/transcription-whispercpp/examples/example.reload.js
@@ -9,7 +9,7 @@ const TranscriptionWhispercpp = require('../index.js')
 // Demonstrates reloading the model with different configurations
 // This example transcribes the same audio twice with different language settings
 
-async function main () {
+async function main() {
   const args = process.argv.slice(2)
   const [audioPathArg, modelPathArg] = args
 
@@ -18,7 +18,9 @@ async function main () {
   const modelPath = modelPathArg || path.join(modelsDir, 'ggml-tiny.bin')
 
   if (!fs.existsSync(modelPath)) {
-    console.error(`Model file not found at ${modelPath}. Download or provide a path as the second argument.`)
+    console.error(
+      `Model file not found at ${modelPath}. Download or provide a path as the second argument.`
+    )
     process.exit(1)
   }
   if (!fs.existsSync(audioFilePath)) {
@@ -143,7 +145,7 @@ async function main () {
   console.log('='.repeat(60))
 }
 
-async function transcribeAudio (model, audioFilePath) {
+async function transcribeAudio(model, audioFilePath) {
   const bitRate = 128000
   const bytesPerSecond = bitRate / 8
   const audioStream = fs.createReadStream(audioFilePath, { highWaterMark: bytesPerSecond })
@@ -167,13 +169,16 @@ async function transcribeAudio (model, audioFilePath) {
   }
 
   if (full.length) {
-    return full.map(s => s.text).join(' ').trim()
+    return full
+      .map((s) => s.text)
+      .join(' ')
+      .trim()
   } else {
     return '(No transcription output received)'
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('❌ Error:', err)
   process.exit(1)
 })

--- a/packages/transcription-whispercpp/examples/example.streaming-vad.js
+++ b/packages/transcription-whispercpp/examples/example.streaming-vad.js
@@ -27,7 +27,7 @@ binding.setLogger((priority, message) => {
  * Usage: bare examples/example.streaming-vad.js [audioPath] [modelPath] [vadModelPath]
  */
 
-async function main () {
+async function main() {
   const args = process.argv.slice(2)
   const modelsDir = path.join(__dirname, '..', 'models')
   const audioFilePath = args[0] || path.join(__dirname, 'samples', 'sample.raw')
@@ -89,7 +89,7 @@ async function main () {
   })
 
   const { size: fileSize } = fs.statSync(audioFilePath)
-  const totalDurationS = (fileSize / BYTES_PER_SAMPLE) / SAMPLE_RATE
+  const totalDurationS = fileSize / BYTES_PER_SAMPLE / SAMPLE_RATE
   console.log(`Audio duration: ${totalDurationS.toFixed(1)}s\n`)
 
   const segments = []
@@ -105,7 +105,9 @@ async function main () {
       segments.push(item)
       const text = (item.text || '').trim()
       if (text) {
-        console.log(`[segment ${segmentCount}] [${item.start.toFixed(1)}s - ${item.end.toFixed(1)}s] ${text}`)
+        console.log(
+          `[segment ${segmentCount}] [${item.start.toFixed(1)}s - ${item.end.toFixed(1)}s] ${text}`
+        )
       }
     }
   })
@@ -119,8 +121,8 @@ async function main () {
     console.log(`Audio duration: ${totalDurationS.toFixed(1)}s`)
 
     const fullText = segments
-      .map(s => (s.text || '').trim())
-      .filter(t => t.length > 0)
+      .map((s) => (s.text || '').trim())
+      .filter((t) => t.length > 0)
       .join(' ')
       .replace(/\s+/g, ' ')
       .trim()
@@ -140,7 +142,7 @@ async function main () {
   binding.releaseLogger()
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error(err)
   binding.releaseLogger()
   process.exit(1)

--- a/packages/transcription-whispercpp/examples/ffmpeg.js
+++ b/packages/transcription-whispercpp/examples/ffmpeg.js
@@ -42,7 +42,7 @@ const OUTPUT_CHANNEL_LAYOUT = ffmpeg.constants.channelLayouts.MONO
 // 13. Repeat till out input has packets.
 // 14. Get the remaining data out of resampler.
 // 15. By concatenating all the output data, we get decoded audio.
-function decodeAudio (audio) {
+function decodeAudio(audio) {
   const io = new ffmpeg.IOContext(audio)
   const format = new ffmpeg.InputFormatContext(io)
 
@@ -92,8 +92,7 @@ function decodeAudio (audio) {
         // `bytesPerSample` * `samplesPerChannel` * `channelsPerSample` gives
         // total amount of bytes.
         const count = resampler.convert(raw, output)
-        const length =
-          OUTPUT_FORMAT_BYTE_LENGTH * count * output.channelLayout.nbChannels
+        const length = OUTPUT_FORMAT_BYTE_LENGTH * count * output.channelLayout.nbChannels
         const buf = Buffer.from(samples.data.subarray(0, length))
         buffers.push(buf)
       }

--- a/packages/transcription-whispercpp/examples/quickstart.js
+++ b/packages/transcription-whispercpp/examples/quickstart.js
@@ -16,9 +16,9 @@ binding.setLogger((priority, message) => {
 // Usage: node examples/quickstart.js [audioDir] [modelPath] [vadModelPath]
 // Defaults stream ./examples/sample.raw through a tiny model in ./examples
 
-async function main () {
+async function main() {
   const args = process.argv.slice(2)
-  const [,, vadModelPathArg, audioPathArg] = args
+  const [, , vadModelPathArg, audioPathArg] = args
 
   const modelsDir = path.join(__dirname, '..', 'models')
   const audioFilePath = audioPathArg || path.join(__dirname, 'samples', 'sample.raw')
@@ -26,11 +26,15 @@ async function main () {
   // ignore optional vadModelPathArg to keep API stable
 
   if (!fs.existsSync(modelPath)) {
-    console.error(`Model file not found at ${modelPath}. Download or provide a path as the second argument.`)
+    console.error(
+      `Model file not found at ${modelPath}. Download or provide a path as the second argument.`
+    )
     process.exit(1)
   }
   if (!fs.existsSync(audioFilePath)) {
-    console.error(`Audio file not found at ${audioFilePath}. Provide a directory containing sample.raw as the first argument.`)
+    console.error(
+      `Audio file not found at ${audioFilePath}. Provide a directory containing sample.raw as the first argument.`
+    )
     process.exit(1)
   }
 
@@ -95,7 +99,10 @@ async function main () {
   console.log('[JS] iterate() chunks received:', full.length)
 
   if (full.length) {
-    const text = full.map(s => s.text).join(' ').trim()
+    const text = full
+      .map((s) => s.text)
+      .join(' ')
+      .trim()
     console.log('\n=== TRANSCRIPTION (from run/iterate) ===')
     console.log(text)
     console.log('=======================================\n')
@@ -107,7 +114,7 @@ async function main () {
   binding.releaseLogger()
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error(err)
   binding.releaseLogger()
   process.exit(1)

--- a/packages/transcription-whispercpp/index.js
+++ b/packages/transcription-whispercpp/index.js
@@ -28,12 +28,12 @@ class TranscriptionWhispercpp {
    * @param {string} [args.files.vadModel] - optional path to the Silero VAD model
    * @param {Object} config - environment-specific inference setup configuration
    */
-  constructor (
-    { files, logger = null, exclusiveRun = true, ...args },
-    config
-  ) {
+  constructor({ files, logger = null, exclusiveRun = true, ...args }, config) {
     if (!files || typeof files.model !== 'string' || files.model.length === 0) {
-      throw new QvacErrorAddonWhisper({ code: ERR_CODES.MODEL_REQUIRED, adds: 'files.model is required' })
+      throw new QvacErrorAddonWhisper({
+        code: ERR_CODES.MODEL_REQUIRED,
+        adds: 'files.model is required'
+      })
     }
 
     const { opts = {}, ...passThrough } = { logger, exclusiveRun, ...args }
@@ -48,9 +48,7 @@ class TranscriptionWhispercpp {
     }
 
     const vadModel =
-      typeof files.vadModel === 'string' && files.vadModel.length > 0
-        ? files.vadModel
-        : null
+      typeof files.vadModel === 'string' && files.vadModel.length > 0 ? files.vadModel : null
 
     this._files = { model: files.model, vadModel }
     this._config = config
@@ -77,11 +75,11 @@ class TranscriptionWhispercpp {
     this.validateModelFiles()
   }
 
-  getState () {
+  getState() {
     return this.state
   }
 
-  async load (...loadArgs) {
+  async load(...loadArgs) {
     if (this.state.destroyed) {
       throw new QvacErrorAddonWhisper({
         code: ERR_CODES.FAILED_TO_LOAD_WEIGHTS,
@@ -98,35 +96,47 @@ class TranscriptionWhispercpp {
     this.state.weightsLoaded = true
   }
 
-  async pause () {
+  async pause() {
     if (!this.addon?.pause) {
-      throw new QvacErrorAddonWhisper({ code: ERR_CODES.FAILED_TO_PAUSE, adds: 'pause not supported' })
+      throw new QvacErrorAddonWhisper({
+        code: ERR_CODES.FAILED_TO_PAUSE,
+        adds: 'pause not supported'
+      })
     }
     await this.addon.pause()
   }
 
-  async unpause () {
+  async unpause() {
     if (!this.addon?.activate) {
-      throw new QvacErrorAddonWhisper({ code: ERR_CODES.FAILED_TO_ACTIVATE, adds: 'activate not supported' })
+      throw new QvacErrorAddonWhisper({
+        code: ERR_CODES.FAILED_TO_ACTIVATE,
+        adds: 'activate not supported'
+      })
     }
     await this.addon.activate()
   }
 
-  async stop () {
+  async stop() {
     if (!this.addon?.stop) {
-      throw new QvacErrorAddonWhisper({ code: ERR_CODES.FAILED_TO_STOP, adds: 'stop not supported' })
+      throw new QvacErrorAddonWhisper({
+        code: ERR_CODES.FAILED_TO_STOP,
+        adds: 'stop not supported'
+      })
     }
     await this.addon.stop()
   }
 
-  async status () {
+  async status() {
     if (!this.addon?.status) {
-      throw new QvacErrorAddonWhisper({ code: ERR_CODES.FAILED_TO_GET_STATUS, adds: 'status not supported' })
+      throw new QvacErrorAddonWhisper({
+        code: ERR_CODES.FAILED_TO_GET_STATUS,
+        adds: 'status not supported'
+      })
     }
     return await this.addon.status()
   }
 
-  _resolveVadModelPath () {
+  _resolveVadModelPath() {
     if (this._config.vadModelPath) {
       return this._config.vadModelPath
     }
@@ -144,7 +154,7 @@ class TranscriptionWhispercpp {
    * @param {boolean} [_closeLoader=false] - Unused; kept for `load(...args)` forwarding compatibility.
    * @param {Function} [_reportProgressCallback] - Unused; kept for `load(...args)` forwarding compatibility.
    */
-  async _load (_closeLoader = false, _reportProgressCallback) {
+  async _load(_closeLoader = false, _reportProgressCallback) {
     this.logger.debug('TranscriptionWhispercpp _load (local model files)')
 
     const whisperConfig = {
@@ -194,7 +204,7 @@ class TranscriptionWhispercpp {
     this.logger.debug('Addon activated')
   }
 
-  _getModelFilePath () {
+  _getModelFilePath() {
     return this._files.model
   }
 
@@ -202,10 +212,12 @@ class TranscriptionWhispercpp {
    * Serialize inference until the returned response settles (replaces `_hasActiveResponse`).
    * Uses a dedicated waiter so `destroy` / `reload` (`_runQueueWaiter`) can still preempt.
    */
-  async _enqueueExclusiveRunResponse (runFn) {
+  async _enqueueExclusiveRunResponse(runFn) {
     const prev = this._inferenceQueueWaiter || Promise.resolve()
     let releaseSlot
-    this._inferenceQueueWaiter = new Promise(resolve => { releaseSlot = resolve })
+    this._inferenceQueueWaiter = new Promise((resolve) => {
+      releaseSlot = resolve
+    })
     await prev
     let response
     try {
@@ -214,18 +226,23 @@ class TranscriptionWhispercpp {
       releaseSlot()
       throw err
     }
-    response.await().finally(() => { releaseSlot() }).catch(() => {})
+    response
+      .await()
+      .finally(() => {
+        releaseSlot()
+      })
+      .catch(() => {})
     return response
   }
 
-  async run (input) {
+  async run(input) {
     if (this.exclusiveRun) {
       return await this._enqueueExclusiveRunResponse(() => this._runInternal(input))
     }
     return await this._runInternal(input)
   }
 
-  async runStreaming (audioStream, opts = {}) {
+  async runStreaming(audioStream, opts = {}) {
     if (this.exclusiveRun) {
       return await this._enqueueExclusiveRunResponse(() =>
         this._runInternal(audioStream, { ...opts, streaming: true })
@@ -234,7 +251,7 @@ class TranscriptionWhispercpp {
     return await this._runInternal(audioStream, { ...opts, streaming: true })
   }
 
-  async _runInternal (audioStream, opts = {}) {
+  async _runInternal(audioStream, opts = {}) {
     const normalizedAudioStream = this._normalizeAudioStream(audioStream)
 
     if (opts.streaming) {
@@ -245,7 +262,7 @@ class TranscriptionWhispercpp {
   }
 
   /** Batch runJob path: `_job` / response setup; audio via {@link #_handleAudioStream}. */
-  async _runBatchTranscription (normalizedAudioStream) {
+  async _runBatchTranscription(normalizedAudioStream) {
     this._pendingWhisperJobId = await this.addon.append({
       type: 'audio',
       input: new Uint8Array()
@@ -263,7 +280,7 @@ class TranscriptionWhispercpp {
     return response
   }
 
-  async _runStreaming (audioStream, streamingOpts = {}) {
+  async _runStreaming(audioStream, streamingOpts = {}) {
     const vadModelPath = this._resolveVadModelPath()
     if (!vadModelPath) {
       throw new QvacErrorAddonWhisper({
@@ -307,7 +324,7 @@ class TranscriptionWhispercpp {
   }
 
   /** Append-only path to the native addon; job lifecycle lives in callers / `_outputCallback`. */
-  async _handleAudioStream (audioStream) {
+  async _handleAudioStream(audioStream) {
     this.logger.debug('Start handling audio stream', {
       modelPath: this._getModelFilePath()
     })
@@ -322,7 +339,7 @@ class TranscriptionWhispercpp {
     await this.addon.append({ type: END_OF_INPUT })
   }
 
-  async _handleStreamingAudio (audioStream) {
+  async _handleStreamingAudio(audioStream) {
     this.logger.debug('Start handling streaming audio')
     for await (const chunk of audioStream) {
       this.addon.appendStreamingAudio({
@@ -333,7 +350,7 @@ class TranscriptionWhispercpp {
     this.addon.endStreaming()
   }
 
-  _normalizeAudioStream (audioStream) {
+  _normalizeAudioStream(audioStream) {
     if (!audioStream) {
       throw new QvacErrorAddonWhisper({
         code: ERR_CODES.INVALID_AUDIO_INPUT,
@@ -371,7 +388,7 @@ class TranscriptionWhispercpp {
    * @param {Object} [newConfig.miscConfig] - Miscellaneous configuration
    * @param {string} [newConfig.audio_format] - Audio format (defaults to 's16le')
    */
-  async reload (newConfig = {}) {
+  async reload(newConfig = {}) {
     return await this._withExclusiveRun(async () => {
       this.logger.debug('Reloading addon with new configuration', newConfig)
 
@@ -384,7 +401,9 @@ class TranscriptionWhispercpp {
         ...this.params,
         ...newConfig.whisperConfig,
         language: newConfig.whisperConfig?.language || this.params.language || 'en',
-        duration_ms: newConfig.whisperConfig?.duration_ms ?? (this.params.max_seconds ? this.params.max_seconds * 1000 : 0),
+        duration_ms:
+          newConfig.whisperConfig?.duration_ms ??
+          (this.params.max_seconds ? this.params.max_seconds * 1000 : 0),
         temperature: newConfig.whisperConfig?.temperature ?? this.params.temperature ?? 0.0,
         suppress_nst: newConfig.whisperConfig?.suppress_nst ?? this.params.suppress_nst ?? true,
         n_threads: newConfig.whisperConfig?.n_threads ?? this.params.n_threads ?? 0
@@ -402,7 +421,8 @@ class TranscriptionWhispercpp {
       const vadModelPath = this._resolveVadModelPath()
       if (vadModelPath) {
         whisperConfig.vad_model_path = vadModelPath
-        whisperConfig.vadParams = newConfig.whisperConfig?.vad_params || this.params.vad_params || { threshold: 0.6 }
+        whisperConfig.vadParams = newConfig.whisperConfig?.vad_params ||
+          this.params.vad_params || { threshold: 0.6 }
       }
 
       const configurationParams = {
@@ -439,11 +459,8 @@ class TranscriptionWhispercpp {
    * @param {string} [configurationParams.backendsDir] - root of the per-arch ggml backend `.so` modules (Android only)
    * @returns {Addon} The instantiated addon interface
    */
-  _createAddon (configurationParams) {
-    this.logger.info(
-      'Creating Whisper interface with configuration:',
-      configurationParams
-    )
+  _createAddon(configurationParams) {
+    this.logger.info('Creating Whisper interface with configuration:', configurationParams)
     const binding = require('./binding')
     return new WhisperInterface(
       binding,
@@ -453,7 +470,7 @@ class TranscriptionWhispercpp {
     )
   }
 
-  _outputCallback (addon, event, jobId, data, error) {
+  _outputCallback(addon, event, jobId, data, error) {
     if (event === 'Error') {
       this.logger.error(`Job failed with error: ${error}`)
       this._pendingWhisperJobId = null
@@ -492,7 +509,7 @@ class TranscriptionWhispercpp {
    * Override unload to also call destroyInstance for proper cleanup
    * This ensures the process can exit cleanly by closing the uv_async handle
    */
-  async unload () {
+  async unload() {
     return await this._withExclusiveRun(async () => {
       this._pendingWhisperJobId = null
       if (this._job.active) {
@@ -507,7 +524,7 @@ class TranscriptionWhispercpp {
     })
   }
 
-  async cancel () {
+  async cancel() {
     if (this.addon?.cancel) {
       await this.addon.cancel()
     }
@@ -517,7 +534,7 @@ class TranscriptionWhispercpp {
     }
   }
 
-  async destroy () {
+  async destroy() {
     return await this._withExclusiveRun(async () => {
       this._pendingWhisperJobId = null
       if (this._job.active) {
@@ -533,14 +550,12 @@ class TranscriptionWhispercpp {
     })
   }
 
-  validateModelFiles () {
+  validateModelFiles() {
     const modelPath = this._config.path || this._getModelFilePath()
     if (!modelPath || !fs.existsSync(modelPath)) {
       this.logger.error('Model file not found', { path: modelPath })
       throw new Error(
-        modelPath
-          ? `Model file doesn't exist: ${modelPath}`
-          : "Model file doesn't exist"
+        modelPath ? `Model file doesn't exist: ${modelPath}` : "Model file doesn't exist"
       )
     }
 
@@ -552,7 +567,7 @@ class TranscriptionWhispercpp {
   }
 }
 
-function dataAsStringWhisper (data) {
+function dataAsStringWhisper(data) {
   if (!data) return ''
   if (typeof data === 'object') {
     return JSON.stringify(data)
@@ -560,7 +575,7 @@ function dataAsStringWhisper (data) {
   return data.toString()
 }
 
-function _checkParamsExists (params) {
+function _checkParamsExists(params) {
   // Use the centralized config validation from configChecker.js
   checkConfig(params)
 }

--- a/packages/transcription-whispercpp/test/benchmark/rtf-benchmark.test.js
+++ b/packages/transcription-whispercpp/test/benchmark/rtf-benchmark.test.js
@@ -41,20 +41,20 @@ const SAMPLE_RATE = 16000
 const RTF_RESULTS_DIR = path.resolve(__dirname, '../../benchmarks/results')
 const RESULT_MARKER = 'QVAC_RTF_REPORT::'
 
-function getEnvBoolean (name, fallback) {
+function getEnvBoolean(name, fallback) {
   const value = process.env[name]
   if (value === undefined) return fallback
   return value === '1' || value === 'true' || value === 'TRUE' || value === 'yes'
 }
 
-function getEnvInteger (name, fallback) {
+function getEnvInteger(name, fallback) {
   const value = process.env[name]
   if (value === undefined) return fallback
   const parsed = Number.parseInt(value, 10)
   return Number.isNaN(parsed) ? fallback : parsed
 }
 
-function sanitizeTag (value) {
+function sanitizeTag(value) {
   if (!value) return ''
   return String(value)
     .toLowerCase()
@@ -62,7 +62,7 @@ function sanitizeTag (value) {
     .replace(/^-+|-+$/g, '')
 }
 
-function getBenchmarkSettings () {
+function getBenchmarkSettings() {
   const modelFile = process.env.QVAC_WHISPER_BENCHMARK_MODEL_FILE || 'ggml-tiny.bin'
   const label = sanitizeTag(process.env.QVAC_WHISPER_BENCHMARK_LABEL || '')
   const backendHint = process.env.QVAC_WHISPER_BENCHMARK_BACKEND || ''
@@ -85,13 +85,13 @@ function getBenchmarkSettings () {
   }
 }
 
-function getUpperBound (benchmarkSettings) {
+function getUpperBound(benchmarkSettings) {
   if (benchmarkSettings.requestedUpperBound === undefined) return null
   const parsed = Number.parseFloat(benchmarkSettings.requestedUpperBound)
   return Number.isNaN(parsed) ? null : parsed
 }
 
-function getRequestedBackendFamily (platformName, useGPU, backendHint) {
+function getRequestedBackendFamily(platformName, useGPU, backendHint) {
   if (backendHint) return backendHint
   if (!useGPU) return 'cpu'
   // ggml GPU backend by platform: Metal on Apple, Vulkan on Windows (the
@@ -103,7 +103,7 @@ function getRequestedBackendFamily (platformName, useGPU, backendHint) {
   return 'gpu'
 }
 
-function getArtifactFileName (benchmarkSettings) {
+function getArtifactFileName(benchmarkSettings) {
   const parts = [
     'rtf-benchmark',
     platform,
@@ -118,12 +118,12 @@ function getArtifactFileName (benchmarkSettings) {
   return `${parts.join('-')}.json`
 }
 
-function getTimeMs () {
+function getTimeMs() {
   const [sec, nsec] = process.hrtime()
   return sec * 1000 + nsec / 1e6
 }
 
-function percentile (sorted, p) {
+function percentile(sorted, p) {
   const idx = (p / 100) * (sorted.length - 1)
   const lo = Math.floor(idx)
   const hi = Math.ceil(idx)
@@ -131,7 +131,7 @@ function percentile (sorted, p) {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo)
 }
 
-function stats (values) {
+function stats(values) {
   const sorted = [...values].sort((a, b) => a - b)
   const sum = sorted.reduce((a, b) => a + b, 0)
   const mean = sum / sorted.length
@@ -148,12 +148,12 @@ function stats (values) {
   }
 }
 
-function getAudioDurationSec (samplePath) {
+function getAudioDurationSec(samplePath) {
   const rawBuffer = fs.readFileSync(samplePath)
   return rawBuffer.length / 2 / SAMPLE_RATE
 }
 
-async function runSingleBenchmark (model, samplePath) {
+async function runSingleBenchmark(model, samplePath) {
   const audioStream = createAudioStream(samplePath)
   const sampler = createMemorySampler()
   const wallStart = getTimeMs()
@@ -191,18 +191,25 @@ async function runSingleBenchmark (model, samplePath) {
   }
 }
 
-async function reclaimAfterUnload (model) {
-  try { await model.unload() } catch {}
+async function reclaimAfterUnload(model) {
+  try {
+    await model.unload()
+  } catch {}
   if (typeof global.gc === 'function') {
-    try { global.gc() } catch {}
+    try {
+      global.gc()
+    } catch {}
   }
-  await new Promise(resolve => setTimeout(resolve, RECLAIM_SETTLE_MS))
+  await new Promise((resolve) => setTimeout(resolve, RECLAIM_SETTLE_MS))
   return readRssBytes()
 }
 
-async function measureMemory (model, allResults, rssBeforeLoad, rssAfterLoad) {
-  const avgRssBytes = meanOfPositive(allResults.map(result => result.avgRssBytes)) || rssAfterLoad
-  const peakRssBytes = maxOfPositive(allResults.map(result => result.peakRssBytes), rssAfterLoad)
+async function measureMemory(model, allResults, rssBeforeLoad, rssAfterLoad) {
+  const avgRssBytes = meanOfPositive(allResults.map((result) => result.avgRssBytes)) || rssAfterLoad
+  const peakRssBytes = maxOfPositive(
+    allResults.map((result) => result.peakRssBytes),
+    rssAfterLoad
+  )
   const sampleCount = allResults.reduce((sum, result) => sum + (result.rssSampleCount || 0), 0)
   const lastResult = allResults[allResults.length - 1] || {}
   const rssAfterUnload = await reclaimAfterUnload(model)
@@ -215,254 +222,288 @@ async function measureMemory (model, allResults, rssBeforeLoad, rssAfterLoad) {
     rssAfterUnloadBytes: rssAfterUnload,
     sampleCount
   })
-  summary.gpuMemTotalMb = typeof lastResult.gpuMemTotalMb === 'number' ? lastResult.gpuMemTotalMb : -1
+  summary.gpuMemTotalMb =
+    typeof lastResult.gpuMemTotalMb === 'number' ? lastResult.gpuMemTotalMb : -1
   summary.gpuMemFreeMb = typeof lastResult.gpuMemFreeMb === 'number' ? lastResult.gpuMemFreeMb : -1
   return summary
 }
 
-test('RTF benchmark: collect whisper real-time factor on CI device', { timeout: 600000 }, async (t) => {
-  if (isMobile) {
-    t.pass('RTF benchmark is only collected on desktop CI runners')
-    return
-  }
-
-  const benchmarkSettings = getBenchmarkSettings()
-  const upperBound = getUpperBound(benchmarkSettings)
-  const [platformName, archName] = platform.split('-')
-  const loggerBinding = setupJsLogger(binding)
-  let model = null
-
-  try {
-    console.log('\n' + '='.repeat(70))
-    console.log('WHISPER RTF BENCHMARK')
-    console.log('='.repeat(70))
-    console.log(`  Platform:       ${platform}`)
-    console.log(`  Model path:     ${benchmarkSettings.modelPath}`)
-    console.log(`  GPU requested:  ${benchmarkSettings.useGPU}`)
-    if (benchmarkSettings.backendHint) console.log(`  Backend hint:   ${benchmarkSettings.backendHint}`)
-    if (benchmarkSettings.deviceLabel) console.log(`  Device label:   ${benchmarkSettings.deviceLabel}`)
-    if (benchmarkSettings.runnerLabel) console.log(`  Runner label:   ${benchmarkSettings.runnerLabel}`)
-    console.log(`  Warmup runs:    ${benchmarkSettings.numWarmup}`)
-    console.log(`  Benchmark runs: ${benchmarkSettings.numRuns}`)
-    console.log('='.repeat(70) + '\n')
-
-    await ensureWhisperModel(benchmarkSettings.modelPath)
-
-    let samplePath = path.join(samplesDir, 'sample.raw')
-    if (!fs.existsSync(samplePath)) {
-      samplePath = generateTestAudio(audioPath)
-      console.log(`Using generated benchmark audio: ${samplePath}`)
-    }
-
-    if (!fs.existsSync(samplePath)) {
-      t.pass('RTF benchmark skipped because no audio sample is available')
+test(
+  'RTF benchmark: collect whisper real-time factor on CI device',
+  { timeout: 600000 },
+  async (t) => {
+    if (isMobile) {
+      t.pass('RTF benchmark is only collected on desktop CI runners')
       return
     }
 
-    const audioDurationSec = getAudioDurationSec(samplePath)
-    console.log(`  Audio path:     ${samplePath}`)
-    console.log(`  Audio duration: ${audioDurationSec.toFixed(2)}s\n`)
+    const benchmarkSettings = getBenchmarkSettings()
+    const upperBound = getUpperBound(benchmarkSettings)
+    const [platformName, archName] = platform.split('-')
+    const loggerBinding = setupJsLogger(binding)
+    let model = null
 
-    const constructorArgs = {
-      files: {
-        model: benchmarkSettings.modelPath
-      },
-      opts: { stats: true }
-    }
+    try {
+      console.log('\n' + '='.repeat(70))
+      console.log('WHISPER RTF BENCHMARK')
+      console.log('='.repeat(70))
+      console.log(`  Platform:       ${platform}`)
+      console.log(`  Model path:     ${benchmarkSettings.modelPath}`)
+      console.log(`  GPU requested:  ${benchmarkSettings.useGPU}`)
+      if (benchmarkSettings.backendHint)
+        console.log(`  Backend hint:   ${benchmarkSettings.backendHint}`)
+      if (benchmarkSettings.deviceLabel)
+        console.log(`  Device label:   ${benchmarkSettings.deviceLabel}`)
+      if (benchmarkSettings.runnerLabel)
+        console.log(`  Runner label:   ${benchmarkSettings.runnerLabel}`)
+      console.log(`  Warmup runs:    ${benchmarkSettings.numWarmup}`)
+      console.log(`  Benchmark runs: ${benchmarkSettings.numRuns}`)
+      console.log('='.repeat(70) + '\n')
 
-    const config = {
-      path: benchmarkSettings.modelPath,
-      contextParams: {
-        use_gpu: benchmarkSettings.useGPU,
-        gpu_device: benchmarkSettings.gpuDevice
-      },
-      whisperConfig: {
-        language: 'en',
-        audio_format: 's16le',
-        temperature: 0.0,
-        n_threads: benchmarkSettings.threads
-      }
-    }
+      await ensureWhisperModel(benchmarkSettings.modelPath)
 
-    console.log('Loading model...')
-    const rssBeforeLoad = readRssBytes()
-    const loadStart = getTimeMs()
-    model = new TranscriptionWhispercpp(constructorArgs, config)
-    await model._load()
-    const loadMs = getTimeMs() - loadStart
-    const rssAfterLoad = readRssBytes()
-    console.log(`Model loaded in ${loadMs.toFixed(0)}ms (RSS ${bytesToMb(rssAfterLoad, 1)}MB)\n`)
-
-    for (let i = 0; i < benchmarkSettings.numWarmup; i++) {
-      console.log(`[warmup ${i + 1}/${benchmarkSettings.numWarmup}]`)
-      const warmup = await runSingleBenchmark(model, samplePath)
-      console.log(
-        `  RTF=${warmup.rtf.toFixed(4)}  ` +
-        `wall=${warmup.wallMs.toFixed(0)}ms  ` +
-        `tokens/s=${warmup.tokensPerSecond.toFixed(1)}`
-      )
-    }
-
-    console.log(`\nRunning ${benchmarkSettings.numRuns} benchmark iterations...\n`)
-
-    const allResults = []
-    for (let i = 0; i < benchmarkSettings.numRuns; i++) {
-      const run = await runSingleBenchmark(model, samplePath)
-      const result = {
-        iteration: i + 1,
-        requestedUseGPU: benchmarkSettings.useGPU,
-        requestedBackend: benchmarkSettings.backendHint,
-        ...run
+      let samplePath = path.join(samplesDir, 'sample.raw')
+      if (!fs.existsSync(samplePath)) {
+        samplePath = generateTestAudio(audioPath)
+        console.log(`Using generated benchmark audio: ${samplePath}`)
       }
 
-      allResults.push(result)
+      if (!fs.existsSync(samplePath)) {
+        t.pass('RTF benchmark skipped because no audio sample is available')
+        return
+      }
 
+      const audioDurationSec = getAudioDurationSec(samplePath)
+      console.log(`  Audio path:     ${samplePath}`)
+      console.log(`  Audio duration: ${audioDurationSec.toFixed(2)}s\n`)
+
+      const constructorArgs = {
+        files: {
+          model: benchmarkSettings.modelPath
+        },
+        opts: { stats: true }
+      }
+
+      const config = {
+        path: benchmarkSettings.modelPath,
+        contextParams: {
+          use_gpu: benchmarkSettings.useGPU,
+          gpu_device: benchmarkSettings.gpuDevice
+        },
+        whisperConfig: {
+          language: 'en',
+          audio_format: 's16le',
+          temperature: 0.0,
+          n_threads: benchmarkSettings.threads
+        }
+      }
+
+      console.log('Loading model...')
+      const rssBeforeLoad = readRssBytes()
+      const loadStart = getTimeMs()
+      model = new TranscriptionWhispercpp(constructorArgs, config)
+      await model._load()
+      const loadMs = getTimeMs() - loadStart
+      const rssAfterLoad = readRssBytes()
+      console.log(`Model loaded in ${loadMs.toFixed(0)}ms (RSS ${bytesToMb(rssAfterLoad, 1)}MB)\n`)
+
+      for (let i = 0; i < benchmarkSettings.numWarmup; i++) {
+        console.log(`[warmup ${i + 1}/${benchmarkSettings.numWarmup}]`)
+        const warmup = await runSingleBenchmark(model, samplePath)
+        console.log(
+          `  RTF=${warmup.rtf.toFixed(4)}  ` +
+            `wall=${warmup.wallMs.toFixed(0)}ms  ` +
+            `tokens/s=${warmup.tokensPerSecond.toFixed(1)}`
+        )
+      }
+
+      console.log(`\nRunning ${benchmarkSettings.numRuns} benchmark iterations...\n`)
+
+      const allResults = []
+      for (let i = 0; i < benchmarkSettings.numRuns; i++) {
+        const run = await runSingleBenchmark(model, samplePath)
+        const result = {
+          iteration: i + 1,
+          requestedUseGPU: benchmarkSettings.useGPU,
+          requestedBackend: benchmarkSettings.backendHint,
+          ...run
+        }
+
+        allResults.push(result)
+
+        console.log(
+          `  Run ${i + 1}/${benchmarkSettings.numRuns}: ` +
+            `RTF=${result.rtf.toFixed(4)}  ` +
+            `wall=${result.wallMs.toFixed(0)}ms  ` +
+            `tokens/s=${result.tokensPerSecond.toFixed(1)}  ` +
+            `encode=${result.whisperEncodeMs.toFixed(0)}ms  ` +
+            `decode=${result.whisperDecodeMs.toFixed(0)}ms`
+        )
+      }
+
+      const rtfStats = stats(allResults.map((result) => result.rtf))
+      const wallStats = stats(allResults.map((result) => result.wallMs))
+      const tpsStats = stats(allResults.map((result) => result.tokensPerSecond))
+      const encodeStats = stats(allResults.map((result) => result.whisperEncodeMs))
+      const decodeStats = stats(allResults.map((result) => result.whisperDecodeMs))
+
+      const memorySummary = await measureMemory(model, allResults, rssBeforeLoad, rssAfterLoad)
+      model = null
+
+      console.log('\n' + '='.repeat(70))
+      console.log('WHISPER RTF BENCHMARK RESULTS')
+      console.log('='.repeat(70))
+      console.log(`\n  Platform:        ${platform}`)
+      console.log(`  Audio duration:  ${audioDurationSec.toFixed(2)}s`)
+      console.log(`  Iterations:      ${allResults.length}`)
+      console.log('')
+      console.log('  Real-Time Factor (RTF):')
+      console.log(`    Mean:   ${rtfStats.mean.toFixed(4)}`)
+      console.log(`    Min:    ${rtfStats.min.toFixed(4)}`)
+      console.log(`    Max:    ${rtfStats.max.toFixed(4)}`)
+      console.log(`    Stddev: ${rtfStats.stddev.toFixed(4)}`)
+      console.log(`    P50:    ${rtfStats.p50.toFixed(4)}`)
+      console.log(`    P95:    ${rtfStats.p95.toFixed(4)}`)
+      console.log('')
+      console.log('  Wall Time (ms):')
+      console.log(`    Mean:   ${wallStats.mean.toFixed(0)}`)
+      console.log(`    P50:    ${wallStats.p50.toFixed(0)}`)
+      console.log(`    P95:    ${wallStats.p95.toFixed(0)}`)
+      console.log('')
+      console.log('  Tokens/Second:')
+      console.log(`    Mean:   ${tpsStats.mean.toFixed(1)}`)
+      console.log(`    P50:    ${tpsStats.p50.toFixed(1)}`)
+      console.log('')
+      console.log('  Encode (ms):')
+      console.log(`    Mean:   ${encodeStats.mean.toFixed(0)}`)
+      console.log(`    P50:    ${encodeStats.p50.toFixed(0)}`)
+      console.log('')
+      console.log('  Decode (ms):')
+      console.log(`    Mean:   ${decodeStats.mean.toFixed(0)}`)
+      console.log(`    P50:    ${decodeStats.p50.toFixed(0)}`)
+      console.log('')
+      console.log('  Memory (RSS, MB):')
+      console.log(`    Average:   ${memorySummary.avgRssMb.toFixed(2)}`)
+      console.log(`    Peak:      ${memorySummary.peakRssMb.toFixed(2)}`)
+      console.log(`    After load:${memorySummary.rssAfterLoadMb.toFixed(2)}`)
+      console.log(`    After unload: ${memorySummary.rssAfterUnloadMb.toFixed(2)}`)
+      console.log(`    Reclaimed: ${memorySummary.reclaimedMb.toFixed(2)}`)
+      if (memorySummary.gpuMemTotalMb >= 0) {
+        console.log(
+          `    GPU total: ${memorySummary.gpuMemTotalMb}  GPU free: ${memorySummary.gpuMemFreeMb}`
+        )
+      }
+      console.log('')
+      console.log('='.repeat(70) + '\n')
+
+      const report = {
+        timestamp: new Date().toISOString(),
+        platform,
+        platformName,
+        arch: archName || '',
+        isMobile,
+        model: {
+          name: path.basename(benchmarkSettings.modelPath),
+          path: benchmarkSettings.modelPath
+        },
+        labels: {
+          runner: benchmarkSettings.runnerLabel,
+          device: benchmarkSettings.deviceLabel,
+          backend: getRequestedBackendFamily(
+            platformName,
+            benchmarkSettings.useGPU,
+            benchmarkSettings.backendHint
+          ),
+          label: benchmarkSettings.label
+        },
+        audio: {
+          path: samplePath,
+          durationSec: audioDurationSec,
+          sampleRate: SAMPLE_RATE
+        },
+        config: {
+          warmupRuns: benchmarkSettings.numWarmup,
+          benchmarkRuns: benchmarkSettings.numRuns,
+          useGPU: benchmarkSettings.useGPU,
+          threads: benchmarkSettings.threads
+        },
+        requested: {
+          modelFile: benchmarkSettings.modelFile,
+          useGPU: benchmarkSettings.useGPU,
+          gpuDevice: benchmarkSettings.gpuDevice,
+          backendHint: benchmarkSettings.backendHint,
+          deviceLabel: benchmarkSettings.deviceLabel,
+          runnerLabel: benchmarkSettings.runnerLabel
+        },
+        observed: {
+          runtimeStatsKeys: allResults.length > 0 ? Object.keys(allResults[0]).sort() : []
+        },
+        summary: {
+          rtf: rtfStats,
+          wallMs: wallStats,
+          tokensPerSecond: tpsStats,
+          whisperEncodeMs: encodeStats,
+          whisperDecodeMs: decodeStats,
+          memory: memorySummary
+        },
+        runs: allResults
+      }
+
+      if (!fs.existsSync(RTF_RESULTS_DIR)) {
+        fs.mkdirSync(RTF_RESULTS_DIR, { recursive: true })
+      }
+
+      const outPath = path.join(RTF_RESULTS_DIR, getArtifactFileName(benchmarkSettings))
+      fs.writeFileSync(outPath, JSON.stringify(report, null, 2))
+      console.log(`Results written to ${outPath}\n`)
       console.log(
-        `  Run ${i + 1}/${benchmarkSettings.numRuns}: ` +
-        `RTF=${result.rtf.toFixed(4)}  ` +
-        `wall=${result.wallMs.toFixed(0)}ms  ` +
-        `tokens/s=${result.tokensPerSecond.toFixed(1)}  ` +
-        `encode=${result.whisperEncodeMs.toFixed(0)}ms  ` +
-        `decode=${result.whisperDecodeMs.toFixed(0)}ms`
+        `${RESULT_MARKER}${JSON.stringify({
+          schemaVersion: 1,
+          platform,
+          platformName,
+          arch: archName || '',
+          modelFile: benchmarkSettings.modelFile,
+          useGPU: benchmarkSettings.useGPU,
+          backendHint: getRequestedBackendFamily(
+            platformName,
+            benchmarkSettings.useGPU,
+            benchmarkSettings.backendHint
+          ),
+          deviceLabel: benchmarkSettings.deviceLabel,
+          runnerLabel: benchmarkSettings.runnerLabel,
+          summary: report.summary
+        })}`
       )
+
+      t.is(
+        allResults.length,
+        benchmarkSettings.numRuns,
+        `Completed ${benchmarkSettings.numRuns} benchmark runs`
+      )
+      t.ok(rtfStats.mean > 0, 'Mean RTF should be positive')
+      if (upperBound !== null) {
+        t.ok(
+          rtfStats.mean <= upperBound,
+          `Mean RTF ${rtfStats.mean.toFixed(4)} should be <= ${upperBound}`
+        )
+      }
+      t.ok(tpsStats.mean > 0, 'Tokens/second should be positive')
+      t.ok(memorySummary.peakRssMb > 0, 'Peak memory (RSS) should be positive')
+      t.ok(memorySummary.avgRssMb > 0, 'Average memory (RSS) should be positive')
+      t.ok(
+        memorySummary.peakRssMb >= memorySummary.avgRssMb,
+        'Peak memory should be >= average memory'
+      )
+      t.ok(memorySummary.reclaimedMb >= 0, 'Reclaimed memory should be non-negative')
+    } finally {
+      if (model) {
+        try {
+          await model.unload()
+        } catch {}
+      }
+      try {
+        loggerBinding.releaseLogger()
+      } catch {}
     }
-
-    const rtfStats = stats(allResults.map(result => result.rtf))
-    const wallStats = stats(allResults.map(result => result.wallMs))
-    const tpsStats = stats(allResults.map(result => result.tokensPerSecond))
-    const encodeStats = stats(allResults.map(result => result.whisperEncodeMs))
-    const decodeStats = stats(allResults.map(result => result.whisperDecodeMs))
-
-    const memorySummary = await measureMemory(model, allResults, rssBeforeLoad, rssAfterLoad)
-    model = null
-
-    console.log('\n' + '='.repeat(70))
-    console.log('WHISPER RTF BENCHMARK RESULTS')
-    console.log('='.repeat(70))
-    console.log(`\n  Platform:        ${platform}`)
-    console.log(`  Audio duration:  ${audioDurationSec.toFixed(2)}s`)
-    console.log(`  Iterations:      ${allResults.length}`)
-    console.log('')
-    console.log('  Real-Time Factor (RTF):')
-    console.log(`    Mean:   ${rtfStats.mean.toFixed(4)}`)
-    console.log(`    Min:    ${rtfStats.min.toFixed(4)}`)
-    console.log(`    Max:    ${rtfStats.max.toFixed(4)}`)
-    console.log(`    Stddev: ${rtfStats.stddev.toFixed(4)}`)
-    console.log(`    P50:    ${rtfStats.p50.toFixed(4)}`)
-    console.log(`    P95:    ${rtfStats.p95.toFixed(4)}`)
-    console.log('')
-    console.log('  Wall Time (ms):')
-    console.log(`    Mean:   ${wallStats.mean.toFixed(0)}`)
-    console.log(`    P50:    ${wallStats.p50.toFixed(0)}`)
-    console.log(`    P95:    ${wallStats.p95.toFixed(0)}`)
-    console.log('')
-    console.log('  Tokens/Second:')
-    console.log(`    Mean:   ${tpsStats.mean.toFixed(1)}`)
-    console.log(`    P50:    ${tpsStats.p50.toFixed(1)}`)
-    console.log('')
-    console.log('  Encode (ms):')
-    console.log(`    Mean:   ${encodeStats.mean.toFixed(0)}`)
-    console.log(`    P50:    ${encodeStats.p50.toFixed(0)}`)
-    console.log('')
-    console.log('  Decode (ms):')
-    console.log(`    Mean:   ${decodeStats.mean.toFixed(0)}`)
-    console.log(`    P50:    ${decodeStats.p50.toFixed(0)}`)
-    console.log('')
-    console.log('  Memory (RSS, MB):')
-    console.log(`    Average:   ${memorySummary.avgRssMb.toFixed(2)}`)
-    console.log(`    Peak:      ${memorySummary.peakRssMb.toFixed(2)}`)
-    console.log(`    After load:${memorySummary.rssAfterLoadMb.toFixed(2)}`)
-    console.log(`    After unload: ${memorySummary.rssAfterUnloadMb.toFixed(2)}`)
-    console.log(`    Reclaimed: ${memorySummary.reclaimedMb.toFixed(2)}`)
-    if (memorySummary.gpuMemTotalMb >= 0) {
-      console.log(`    GPU total: ${memorySummary.gpuMemTotalMb}  GPU free: ${memorySummary.gpuMemFreeMb}`)
-    }
-    console.log('')
-    console.log('='.repeat(70) + '\n')
-
-    const report = {
-      timestamp: new Date().toISOString(),
-      platform,
-      platformName,
-      arch: archName || '',
-      isMobile,
-      model: {
-        name: path.basename(benchmarkSettings.modelPath),
-        path: benchmarkSettings.modelPath
-      },
-      labels: {
-        runner: benchmarkSettings.runnerLabel,
-        device: benchmarkSettings.deviceLabel,
-        backend: getRequestedBackendFamily(platformName, benchmarkSettings.useGPU, benchmarkSettings.backendHint),
-        label: benchmarkSettings.label
-      },
-      audio: {
-        path: samplePath,
-        durationSec: audioDurationSec,
-        sampleRate: SAMPLE_RATE
-      },
-      config: {
-        warmupRuns: benchmarkSettings.numWarmup,
-        benchmarkRuns: benchmarkSettings.numRuns,
-        useGPU: benchmarkSettings.useGPU,
-        threads: benchmarkSettings.threads
-      },
-      requested: {
-        modelFile: benchmarkSettings.modelFile,
-        useGPU: benchmarkSettings.useGPU,
-        gpuDevice: benchmarkSettings.gpuDevice,
-        backendHint: benchmarkSettings.backendHint,
-        deviceLabel: benchmarkSettings.deviceLabel,
-        runnerLabel: benchmarkSettings.runnerLabel
-      },
-      observed: {
-        runtimeStatsKeys: allResults.length > 0 ? Object.keys(allResults[0]).sort() : []
-      },
-      summary: {
-        rtf: rtfStats,
-        wallMs: wallStats,
-        tokensPerSecond: tpsStats,
-        whisperEncodeMs: encodeStats,
-        whisperDecodeMs: decodeStats,
-        memory: memorySummary
-      },
-      runs: allResults
-    }
-
-    if (!fs.existsSync(RTF_RESULTS_DIR)) {
-      fs.mkdirSync(RTF_RESULTS_DIR, { recursive: true })
-    }
-
-    const outPath = path.join(RTF_RESULTS_DIR, getArtifactFileName(benchmarkSettings))
-    fs.writeFileSync(outPath, JSON.stringify(report, null, 2))
-    console.log(`Results written to ${outPath}\n`)
-    console.log(`${RESULT_MARKER}${JSON.stringify({
-      schemaVersion: 1,
-      platform,
-      platformName,
-      arch: archName || '',
-      modelFile: benchmarkSettings.modelFile,
-      useGPU: benchmarkSettings.useGPU,
-      backendHint: getRequestedBackendFamily(platformName, benchmarkSettings.useGPU, benchmarkSettings.backendHint),
-      deviceLabel: benchmarkSettings.deviceLabel,
-      runnerLabel: benchmarkSettings.runnerLabel,
-      summary: report.summary
-    })}`)
-
-    t.is(allResults.length, benchmarkSettings.numRuns, `Completed ${benchmarkSettings.numRuns} benchmark runs`)
-    t.ok(rtfStats.mean > 0, 'Mean RTF should be positive')
-    if (upperBound !== null) {
-      t.ok(rtfStats.mean <= upperBound, `Mean RTF ${rtfStats.mean.toFixed(4)} should be <= ${upperBound}`)
-    }
-    t.ok(tpsStats.mean > 0, 'Tokens/second should be positive')
-    t.ok(memorySummary.peakRssMb > 0, 'Peak memory (RSS) should be positive')
-    t.ok(memorySummary.avgRssMb > 0, 'Average memory (RSS) should be positive')
-    t.ok(memorySummary.peakRssMb >= memorySummary.avgRssMb, 'Peak memory should be >= average memory')
-    t.ok(memorySummary.reclaimedMb >= 0, 'Reclaimed memory should be non-negative')
-  } finally {
-    if (model) {
-      try { await model.unload() } catch {}
-    }
-    try { loggerBinding.releaseLogger() } catch {}
   }
-})
+)

--- a/packages/transcription-whispercpp/test/integration/accuracy-multilang.test.js
+++ b/packages/transcription-whispercpp/test/integration/accuracy-multilang.test.js
@@ -20,25 +20,29 @@ const LANGUAGE_TESTS = {
     name: 'English',
     code: 'en',
     sampleFile: 'sample.raw',
-    expected: 'Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do. Once or twice she had peeped into the book her sister was reading but it had no pictures or conversations in it. And what is the use of a book thought Alice without pictures or conversations?'
+    expected:
+      'Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do. Once or twice she had peeped into the book her sister was reading but it had no pictures or conversations in it. And what is the use of a book thought Alice without pictures or conversations?'
   },
   es: {
     name: 'Spanish',
     code: 'es',
     sampleFile: 'sample_es.raw',
-    expected: 'se recomienda enfáticamente a los viajeros que se informen sobre cualquier riesgo de clima extremo en el área que visitan dado que ello puede afectar sus planes de viaje'
+    expected:
+      'se recomienda enfáticamente a los viajeros que se informen sobre cualquier riesgo de clima extremo en el área que visitan dado que ello puede afectar sus planes de viaje'
   },
   de: {
     name: 'German',
     code: 'de',
     sampleFile: 'sample_de.raw',
-    expected: 'für die besten aussichten auf hongkong sollten sie die insel verlassen und zum gegenüberliegenden ufer von kowloon fahren'
+    expected:
+      'für die besten aussichten auf hongkong sollten sie die insel verlassen und zum gegenüberliegenden ufer von kowloon fahren'
   },
   fr: {
     name: 'French',
     code: 'fr',
     sampleFile: 'sample_fr.raw',
-    expected: "l'accident a eu lieu en terrain montagneux et il semblerait que cela ait été causé par un incendie malveillant",
+    expected:
+      "l'accident a eu lieu en terrain montagneux et il semblerait que cela ait été causé par un incendie malveillant",
     // Keep greedy decoding for realtime parity; tiny model French output is
     // slightly noisier, so we allow a small threshold bump to reduce CI flake.
     werThreshold: 0.35
@@ -47,25 +51,29 @@ const LANGUAGE_TESTS = {
     name: 'Portuguese',
     code: 'pt',
     sampleFile: 'sample_pt.raw',
-    expected: 'segundo informações ele estava na casa dos 20 anos em uma declaração bieber disse que embora eu não estivesse presente nem diretamente envolvido neste trágico incidente meus pensamentos e orações estão com a família da vítima'
+    expected:
+      'segundo informações ele estava na casa dos 20 anos em uma declaração bieber disse que embora eu não estivesse presente nem diretamente envolvido neste trágico incidente meus pensamentos e orações estão com a família da vítima'
   },
   it: {
     name: 'Italian',
     code: 'it',
     sampleFile: 'sample_it.raw',
-    expected: "il blog è uno strumento che si prefigge di incoraggiare la collaborazione e sviluppare l'apprendimento degli studenti ben oltre la giornata scolastica normale"
+    expected:
+      "il blog è uno strumento che si prefigge di incoraggiare la collaborazione e sviluppare l'apprendimento degli studenti ben oltre la giornata scolastica normale"
   },
   ru: {
     name: 'Russian',
     code: 'ru',
     sampleFile: 'sample_ru.raw',
-    expected: 'в древнем китае использовали уникальный способ обозначения периодов времени каждый этап китая или каждая семья находившаяся у власти были особой династией'
+    expected:
+      'в древнем китае использовали уникальный способ обозначения периодов времени каждый этап китая или каждая семья находившаяся у власти были особой династией'
   },
   ja: {
     name: 'Japanese',
     code: 'ja',
     sampleFile: 'sample_ja.raw',
-    expected: 'インターネットで 敵対的環境コース について検索すると おそらく現地企業の住所が出てくるでしょう'
+    expected:
+      'インターネットで 敵対的環境コース について検索すると おそらく現地企業の住所が出てくるでしょう'
   },
   auto: {
     name: 'Auto-detect',
@@ -75,13 +83,14 @@ const LANGUAGE_TESTS = {
     // the language AND transcribe. A regression where detect_language is forced
     // true would only detect the language and return zero segments, so this
     // case guards against empty output as well as accuracy.
-    expected: 'Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do. Once or twice she had peeped into the book her sister was reading but it had no pictures or conversations in it. And what is the use of a book thought Alice without pictures or conversations?'
+    expected:
+      'Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do. Once or twice she had peeped into the book her sister was reading but it had no pictures or conversations in it. And what is the use of a book thought Alice without pictures or conversations?'
   }
 }
 
-const WER_THRESHOLD = 0.30
+const WER_THRESHOLD = 0.3
 
-async function runLanguageAccuracyTest (t, langConfig) {
+async function runLanguageAccuracyTest(t, langConfig) {
   let loggerBinding = null
   let samplePath
   try {
@@ -98,7 +107,9 @@ async function runLanguageAccuracyTest (t, langConfig) {
     return { skipped: true, reason: 'sample_not_found' }
   }
 
-  const diskPath = isMobile ? (global.testDir || os.tmpdir()) : require('bare-path').dirname(modelPath)
+  const diskPath = isMobile
+    ? global.testDir || os.tmpdir()
+    : require('bare-path').dirname(modelPath)
   const actualModelPath = require('bare-path').join(diskPath, 'ggml-tiny.bin')
 
   if (!isMobile) {
@@ -147,7 +158,10 @@ async function runLanguageAccuracyTest (t, langConfig) {
       console.log(`   WER:      ${accuracy.werPercent} (threshold: ${werThreshold * 100}%)`)
       console.log(`   Status:   ${accuracy.passed ? '✅ PASSED' : '❌ FAILED'}`)
 
-      t.ok(accuracy.passed, `${langConfig.name} WER should be below ${werThreshold * 100}%, got ${accuracy.werPercent}`)
+      t.ok(
+        accuracy.passed,
+        `${langConfig.name} WER should be below ${werThreshold * 100}%, got ${accuracy.werPercent}`
+      )
       return { skipped: false, passed: accuracy.passed, wer: accuracy.wer, actualText }
     } else {
       t.ok(actualText.length > 0, `${langConfig.name} should produce non-empty transcription`)
@@ -160,7 +174,9 @@ async function runLanguageAccuracyTest (t, langConfig) {
     return { skipped: false, passed: false, error: error.message }
   } finally {
     if (loggerBinding) {
-      try { loggerBinding.releaseLogger() } catch {}
+      try {
+        loggerBinding.releaseLogger()
+      } catch {}
     }
   }
 }
@@ -200,7 +216,9 @@ test('Accuracy test - Japanese', { timeout: 300000 }, async (t) => {
 test('Accuracy test - Auto language detection', { timeout: 300000 }, async (t) => {
   const result = await runLanguageAccuracyTest(t, LANGUAGE_TESTS.auto)
   if (!result.skipped) {
-    t.ok(result.actualText && result.actualText.length > 0,
-      'Auto-detect should produce a non-empty transcription, not just detect the language')
+    t.ok(
+      result.actualText && result.actualText.length > 0,
+      'Auto-detect should produce a non-empty transcription, not just detect the language'
+    )
   }
 })

--- a/packages/transcription-whispercpp/test/integration/addon.test.js
+++ b/packages/transcription-whispercpp/test/integration/addon.test.js
@@ -92,19 +92,23 @@ test('[low level] Real C++ addon bindings work correctly', async (t) => {
 
     const sawJobEnded = await Promise.race([
       jobEndedPromise.then(() => true),
-      new Promise(resolve => setTimeout(() => resolve(false), 5000))
+      new Promise((resolve) => setTimeout(() => resolve(false), 5000))
     ])
     t.ok(sawJobEnded, 'JobEnded should be emitted for low-level run')
 
     // destroyInstance() performs native cancellation/cleanup internally.
-    try { await model.destroyInstance() } catch {}
+    try {
+      await model.destroyInstance()
+    } catch {}
 
     console.log('All tests passed!')
   } catch (error) {
     console.error('Unexpected error in addon bindings test:', error.message)
     throw error
   } finally {
-    try { if (model) await model.destroyInstance() } catch {}
+    try {
+      if (model) await model.destroyInstance()
+    } catch {}
   }
 })
 
@@ -168,7 +172,9 @@ test('[low level] Real addon state transitions work correctly', async (t) => {
     await model.destroyInstance()
     t.pass('State transitions test completed')
   } finally {
-    try { if (model) await model.destroyInstance() } catch {}
+    try {
+      if (model) await model.destroyInstance()
+    } catch {}
   }
 })
 
@@ -181,19 +187,17 @@ test('Real addon can handle multiple audio chunks', { timeout: 120000 }, async (
   ]
 
   try {
-    const result = await runTranscription(
-      {
-        audioInput: chunks,
-        modelPath,
-        whisperConfig: {
-          language: 'en',
-          temperature: 0.0,
-          vadParams: {
-            threshold: 0.6
-          }
+    const result = await runTranscription({
+      audioInput: chunks,
+      modelPath,
+      whisperConfig: {
+        language: 'en',
+        temperature: 0.0,
+        vadParams: {
+          threshold: 0.6
         }
       }
-    )
+    })
 
     if (result.passed) {
       t.pass('Multiple chunks test completed')
@@ -218,7 +222,9 @@ test('Real addon with downloaded models - success case', { timeout: 120000 }, as
   t.ok(fs.existsSync(audioPath), 'Test audio should exist')
 
   if (whisperResult.isReal) {
-    console.log(' Testing with REAL whisper model (VAD disabled) - expecting successful transcription')
+    console.log(
+      ' Testing with REAL whisper model (VAD disabled) - expecting successful transcription'
+    )
 
     const result = await runTranscription(
       {
@@ -253,19 +259,17 @@ test('Real addon with downloaded models - success case', { timeout: 120000 }, as
   } else {
     console.log(' Could not download real models - testing with placeholder models instead')
 
-    const result = await runTranscription(
-      {
-        audioInput: audioPath,
-        modelPath,
-        whisperConfig: {
-          language: 'en',
-          temperature: 0.0,
-          vadParams: {
-            threshold: 0.6
-          }
+    const result = await runTranscription({
+      audioInput: audioPath,
+      modelPath,
+      whisperConfig: {
+        language: 'en',
+        temperature: 0.0,
+        vadParams: {
+          threshold: 0.6
         }
       }
-    )
+    })
 
     if (result.data.error) {
       t.pass(' Correctly handled placeholder models with expected errors')
@@ -316,7 +320,9 @@ test('Runtime stats are populated when opts.stats=true', { timeout: 120000 }, as
     t.is(typeof response.stats.totalSamples, 'number', 'totalSamples should be a number')
     t.ok(response.stats.totalSamples > 0, 'totalSamples should be > 0')
   } finally {
-    try { await model.unload() } catch {}
+    try {
+      await model.unload()
+    } catch {}
   }
 })
 
@@ -350,7 +356,10 @@ test('Real addon with VAD enabled - advanced case', { timeout: 120000 }, async (
 
     console.log(`VAD+Whisper Transcription result: ${result.output}`)
     if (result.data.segmentCount > 0) {
-      console.log('VAD+Whisper Transcription [segments]:', JSON.stringify(result.data.segments.slice(0, 3), null, 2))
+      console.log(
+        'VAD+Whisper Transcription [segments]:',
+        JSON.stringify(result.data.segments.slice(0, 3), null, 2)
+      )
     }
 
     if (result.passed && result.data.segmentCount > 0) {
@@ -370,19 +379,17 @@ test('Real addon error handling - failure cases', { timeout: 120000 }, async (t)
 
   // Test 1: Invalid model path
   t.test('Invalid model path handling', async (t) => {
-    const result = await runTranscription(
-      {
-        audioInput: new Uint8Array([1, 2, 3, 4, 5]),
-        modelPath: '/nonexistent/path/model.bin',
-        whisperConfig: {
-          language: 'en',
-          temperature: 0.0,
-          vadParams: {
-            threshold: 0.6
-          }
+    const result = await runTranscription({
+      audioInput: new Uint8Array([1, 2, 3, 4, 5]),
+      modelPath: '/nonexistent/path/model.bin',
+      whisperConfig: {
+        language: 'en',
+        temperature: 0.0,
+        vadParams: {
+          threshold: 0.6
         }
       }
-    )
+    })
 
     if (result.data.error) {
       console.log(' Expected error caught:', result.data.error)
@@ -437,13 +444,11 @@ test('Real addon error handling - failure cases', { timeout: 120000 }, async (t)
 
     for (const testCase of invalidConfigs) {
       console.log(` Testing ${testCase.name}...`)
-      const result = await runTranscription(
-        {
-          whisperConfig: testCase.whisperConfig,
-          modelPath
-          // No audioInput - we're just testing config validation
-        }
-      )
+      const result = await runTranscription({
+        whisperConfig: testCase.whisperConfig,
+        modelPath
+        // No audioInput - we're just testing config validation
+      })
 
       // Config validation should fail during _load() via checkConfig()
       if (result.passed) {
@@ -465,19 +470,17 @@ test('Real addon error handling - failure cases', { timeout: 120000 }, async (t)
       makePcmNoise(128) // more noise
     ]
 
-    const result = await runTranscription(
-      {
-        audioInput: chunks,
-        modelPath,
-        whisperConfig: {
-          language: 'en',
-          temperature: 0.0,
-          vadParams: {
-            threshold: 0.6
-          }
+    const result = await runTranscription({
+      audioInput: chunks,
+      modelPath,
+      whisperConfig: {
+        language: 'en',
+        temperature: 0.0,
+        vadParams: {
+          threshold: 0.6
         }
       }
-    )
+    })
 
     if (result.data.error) {
       console.log('Exception handling for noisy/silent data:', result.data.error)
@@ -500,17 +503,15 @@ test('Caption mode transcription (VAD disabled)', { timeout: 120000 }, async (t)
   t.ok(fs.existsSync(audioPath), 'Test audio should exist')
 
   try {
-    const result = await runTranscription(
-      {
-        audioInput: audioPath,
-        modelPath,
-        whisperConfig: {
-          language: 'en',
-          temperature: 0.0,
-          audio_format: 's16le'
-        }
+    const result = await runTranscription({
+      audioInput: audioPath,
+      modelPath,
+      whisperConfig: {
+        language: 'en',
+        temperature: 0.0,
+        audio_format: 's16le'
       }
-    )
+    })
 
     console.log(' Caption Output:', result.output)
     if (whisperResult.isReal) {
@@ -531,7 +532,9 @@ test('Caption mode transcription (VAD disabled)', { timeout: 120000 }, async (t)
     console.log(` Caption mode test error: ${error.message}`)
     t.pass('Caption mode handled error gracefully')
   } finally {
-    try { loggerBinding.releaseLogger() } catch {}
+    try {
+      loggerBinding.releaseLogger()
+    } catch {}
   }
 })
 
@@ -550,26 +553,24 @@ test('Caption mode transcription (VAD enabled)', { timeout: 120000 }, async (t) 
   generateTestAudio(audioPath)
 
   try {
-    const result = await runTranscription(
-      {
-        audioInput: audioPath,
-        modelPath,
-        vadModelPath,
-        whisperConfig: {
-          language: 'en',
-          temperature: 0.0,
-          audio_format: 's16le',
-          vadParams: {
-            threshold: 0.6,
-            min_speech_duration_ms: 300,
-            min_silence_duration_ms: 200,
-            max_speech_duration_s: 30.0,
-            speech_pad_ms: 50,
-            samples_overlap: 0.15
-          }
+    const result = await runTranscription({
+      audioInput: audioPath,
+      modelPath,
+      vadModelPath,
+      whisperConfig: {
+        language: 'en',
+        temperature: 0.0,
+        audio_format: 's16le',
+        vadParams: {
+          threshold: 0.6,
+          min_speech_duration_ms: 300,
+          min_silence_duration_ms: 200,
+          max_speech_duration_s: 30.0,
+          speech_pad_ms: 50,
+          samples_overlap: 0.15
         }
       }
-    )
+    })
 
     console.log(' Caption+VAD Output:', result.output)
     if (result.data.error) {
@@ -579,13 +580,17 @@ test('Caption mode transcription (VAD enabled)', { timeout: 120000 }, async (t) 
       t.pass('Successfully received transcription output in caption mode with VAD')
     } else {
       t.ok(result.data.segmentCount >= 0, 'Should receive some result in caption mode with VAD')
-      t.pass('Caption+VAD mode handled without transcription output (may be expected with test audio)')
+      t.pass(
+        'Caption+VAD mode handled without transcription output (may be expected with test audio)'
+      )
     }
   } catch (error) {
     console.log(` Caption+VAD mode test error: ${error.message}`)
     t.pass('Caption+VAD mode handled error gracefully')
   } finally {
-    try { loggerBinding.releaseLogger() } catch {}
+    try {
+      loggerBinding.releaseLogger()
+    } catch {}
   }
 })
 
@@ -594,7 +599,7 @@ test('Audio format transcription tests (s16le and f32le)', { timeout: 120000 }, 
   console.log('==================================')
 
   // Helper function to test a specific audio format using runTranscription
-  async function testAudioFormat (audioFile, audioFormat, description) {
+  async function testAudioFormat(audioFile, audioFormat, description) {
     console.log(`\n=== Testing ${description} ===`)
     console.log(`Audio file: ${audioFile}`)
     console.log(`Audio format: ${audioFormat}`)
@@ -659,11 +664,7 @@ test('Audio format transcription tests (s16le and f32le)', { timeout: 120000 }, 
     return
   }
 
-  const s16leResult = await testAudioFormat(
-    s16leFile,
-    's16le',
-    's16le format (sample.raw)'
-  )
+  const s16leResult = await testAudioFormat(s16leFile, 's16le', 's16le format (sample.raw)')
 
   const f32leResult = await testAudioFormat(
     f32leFile,

--- a/packages/transcription-whispercpp/test/integration/audio-ctx-chunking.test.js
+++ b/packages/transcription-whispercpp/test/integration/audio-ctx-chunking.test.js
@@ -5,7 +5,7 @@ const test = require('brittle')
 const TranscriptionWhispercpp = require('../../index.js')
 const { ensureWhisperModel, getTestPaths, createAudioStream, isMobile } = require('./helpers.js')
 
-async function transcribeChunk (model, audioStream, offsetMs, durationMs, audioCtx) {
+async function transcribeChunk(model, audioStream, offsetMs, durationMs, audioCtx) {
   await model.reload({
     whisperConfig: {
       offset_ms: offsetMs,
@@ -34,165 +34,183 @@ async function transcribeChunk (model, audioStream, offsetMs, durationMs, audioC
 const { modelPath } = getTestPaths()
 
 // Skip on mobile - requires 10min audio file (~19MB) which is too large to bundle
-test('Audio context chunking - 10 minute audio file with 30s chunks', { skip: isMobile }, async (t) => {
-  // Increase timeout as we process ~30 chunks from disk with model reloads
-  t.timeout(180000)
-  console.log('\n=== Audio Context Chunking Integration Test ===\n')
+test(
+  'Audio context chunking - 10 minute audio file with 30s chunks',
+  { skip: isMobile },
+  async (t) => {
+    // Increase timeout as we process ~30 chunks from disk with model reloads
+    t.timeout(180000)
+    console.log('\n=== Audio Context Chunking Integration Test ===\n')
 
-  // Ensure whisper model is available
-  const whisperResult = await ensureWhisperModel(modelPath)
+    // Ensure whisper model is available
+    const whisperResult = await ensureWhisperModel(modelPath)
 
-  if (!whisperResult.success && !whisperResult.isReal) {
-    console.log('Whisper model not available - skipping audio chunking test')
-    t.pass('Audio chunking test skipped (model not available)')
-    return
-  }
-
-  // Check if 10-minute test audio file exists
-  const audioFile = path.resolve(__dirname, '../../examples/samples/10min-16k-s16le.raw')
-
-  if (!fs.existsSync(audioFile)) {
-    console.log(`Test audio file not found: ${audioFile}`)
-    t.pass('Audio chunking test skipped (10min-16k-s16le.raw not found)')
-    return
-  }
-
-  // Get file size
-  const stats = fs.statSync(audioFile)
-  const fileSizeBytes = stats.size
-  const WHISPER_SAMPLE_RATE = 16000
-  const BYTES_PER_SAMPLE = 2 // s16le = 2 bytes per sample
-  const totalDurationSeconds = (fileSizeBytes / BYTES_PER_SAMPLE) / WHISPER_SAMPLE_RATE
-
-  console.log(`Audio file: ${path.basename(audioFile)}`)
-  console.log(`File size: ${(fileSizeBytes / 1024 / 1024).toFixed(2)} MB`)
-  console.log(`Duration: ${totalDurationSeconds.toFixed(1)}s (~${(totalDurationSeconds / 60).toFixed(1)} minutes)`)
-  console.log(`Model: ${path.basename(modelPath)}\n`)
-
-  // Configuration
-  const CHUNK_SIZE_SECONDS = 30
-  const totalChunks = Math.ceil(totalDurationSeconds / CHUNK_SIZE_SECONDS)
-
-  const constructorArgs = {
-    files: {
-      model: modelPath
-    }
-  }
-
-  const config = {
-    path: modelPath,
-    whisperConfig: {
-      language: 'en',
-      audio_format: 's16le',
-      temperature: 0.0,
-      suppress_nst: true
-    }
-  }
-
-  let model
-  try {
-    model = new TranscriptionWhispercpp(constructorArgs, config)
-    await model._load()
-
-    console.log('Reading full audio file into memory...')
-    const fullAudioBuffer = fs.readFileSync(audioFile)
-
-    console.log(`Processing ${totalChunks} chunks of ${CHUNK_SIZE_SECONDS}s each...\n`)
-    const allResults = []
-    let errorCount = 0
-    let chunksWithSegments = 0
-    let batchedDeliveryCount = 0
-
-    // Process each chunk - always pass full audio, only change offset_ms, duration_ms, audio_ctx
-    let currentOffsetSeconds = 0
-    for (let i = 0; i < totalChunks; i++) {
-      const chunkDuration = Math.min(CHUNK_SIZE_SECONDS, totalDurationSeconds - currentOffsetSeconds)
-      const audioCtx = i === 0 ? 0 : Math.min(Math.floor(50 * chunkDuration + 1), 1500)
-
-      console.log(`[${i + 1}/${totalChunks}] offset=${currentOffsetSeconds.toFixed(1)}s duration=${chunkDuration.toFixed(1)}s audio_ctx=${audioCtx}`)
-
-      const fullAudioStream = createAudioStream(fullAudioBuffer)
-
-      let chunk = { results: [], updateCallCount: 0, maxBatchSize: 0 }
-      try {
-        chunk = await transcribeChunk(
-          model,
-          fullAudioStream,
-          currentOffsetSeconds * 1000,
-          chunkDuration * 1000,
-          audioCtx
-        )
-      } catch (err) {
-        errorCount++
-        console.error(`Chunk ${i + 1} failed:`, err)
-      }
-
-      currentOffsetSeconds += chunkDuration
-
-      if (chunk.results.length > 0) {
-        const text = chunk.results.map(s => s.text).join(' ').replace(/\s+/g, ' ').trim()
-        console.log(`  → segments=${chunk.results.length} updates=${chunk.updateCallCount} maxBatch=${chunk.maxBatchSize}`)
-        console.log(`  → ${text}\n`)
-        allResults.push(...chunk.results)
-        chunksWithSegments++
-
-        if (chunk.results.length > 1 && chunk.updateCallCount === 1) {
-          batchedDeliveryCount++
-        }
-      } else {
-        console.log('  → [no output]\n')
-      }
+    if (!whisperResult.success && !whisperResult.isReal) {
+      console.log('Whisper model not available - skipping audio chunking test')
+      t.pass('Audio chunking test skipped (model not available)')
+      return
     }
 
-    console.log('\n=== RESULTS ===')
-    console.log(`Total segments: ${allResults.length}`)
-    console.log(`Total chunks processed: ${totalChunks}`)
-    console.log(`Chunks with segments: ${chunksWithSegments}`)
-    console.log(`Chunk errors: ${errorCount}`)
-    console.log(`Batched deliveries (regression): ${batchedDeliveryCount}`)
-    console.log(`Duration processed: ${totalDurationSeconds.toFixed(1)}s`)
+    // Check if 10-minute test audio file exists
+    const audioFile = path.resolve(__dirname, '../../examples/samples/10min-16k-s16le.raw')
 
-    // Assertions
-    t.ok(allResults.length > 0, 'Should produce transcription segments')
-    t.is(chunksWithSegments, totalChunks, 'Should transcribe exactly totalChunks chunks')
-    t.is(errorCount, 0, 'No chunk errors or exceptions')
+    if (!fs.existsSync(audioFile)) {
+      console.log(`Test audio file not found: ${audioFile}`)
+      t.pass('Audio chunking test skipped (10min-16k-s16le.raw not found)')
+      return
+    }
 
-    t.is(
-      batchedDeliveryCount, 0,
-      'Segments must be streamed incrementally (not all batched into a single onUpdate call)'
+    // Get file size
+    const stats = fs.statSync(audioFile)
+    const fileSizeBytes = stats.size
+    const WHISPER_SAMPLE_RATE = 16000
+    const BYTES_PER_SAMPLE = 2 // s16le = 2 bytes per sample
+    const totalDurationSeconds = fileSizeBytes / BYTES_PER_SAMPLE / WHISPER_SAMPLE_RATE
+
+    console.log(`Audio file: ${path.basename(audioFile)}`)
+    console.log(`File size: ${(fileSizeBytes / 1024 / 1024).toFixed(2)} MB`)
+    console.log(
+      `Duration: ${totalDurationSeconds.toFixed(1)}s (~${(totalDurationSeconds / 60).toFixed(1)} minutes)`
     )
+    console.log(`Model: ${path.basename(modelPath)}\n`)
 
-    // Verify segments have required properties
-    if (allResults.length > 0) {
-      const firstSegment = allResults[0]
-      t.ok(firstSegment.text, 'Segments should have text')
-      t.ok(typeof firstSegment.start === 'number', 'Segments should have start time')
-      t.ok(typeof firstSegment.end === 'number', 'Segments should have end time')
+    // Configuration
+    const CHUNK_SIZE_SECONDS = 30
+    const totalChunks = Math.ceil(totalDurationSeconds / CHUNK_SIZE_SECONDS)
+
+    const constructorArgs = {
+      files: {
+        model: modelPath
+      }
     }
 
-    // Build full transcription
-    const fullTranscription = allResults
-      .map(s => s.text.trim())
-      .filter(text => text.length > 0)
-      .join(' ')
-
-    console.log(`\nTranscription length: ${fullTranscription.length} characters`)
-
-    if (fullTranscription.length > 0) {
-      console.log('\n=== FULL TRANSCRIPTION (test) ===')
-      console.log(fullTranscription)
-      console.log('=== END FULL TRANSCRIPTION ===\n')
+    const config = {
+      path: modelPath,
+      whisperConfig: {
+        language: 'en',
+        audio_format: 's16le',
+        temperature: 0.0,
+        suppress_nst: true
+      }
     }
 
-    t.ok(fullTranscription.length > 0, 'Should produce non-empty transcription')
+    let model
+    try {
+      model = new TranscriptionWhispercpp(constructorArgs, config)
+      await model._load()
 
-    console.log('✅ Audio context chunking test completed successfully!\n')
-  } catch (error) {
-    console.error('Test failed with error:', error)
-    t.fail(error.message)
-  } finally {
-    if (model) {
-      await model.destroy()
+      console.log('Reading full audio file into memory...')
+      const fullAudioBuffer = fs.readFileSync(audioFile)
+
+      console.log(`Processing ${totalChunks} chunks of ${CHUNK_SIZE_SECONDS}s each...\n`)
+      const allResults = []
+      let errorCount = 0
+      let chunksWithSegments = 0
+      let batchedDeliveryCount = 0
+
+      // Process each chunk - always pass full audio, only change offset_ms, duration_ms, audio_ctx
+      let currentOffsetSeconds = 0
+      for (let i = 0; i < totalChunks; i++) {
+        const chunkDuration = Math.min(
+          CHUNK_SIZE_SECONDS,
+          totalDurationSeconds - currentOffsetSeconds
+        )
+        const audioCtx = i === 0 ? 0 : Math.min(Math.floor(50 * chunkDuration + 1), 1500)
+
+        console.log(
+          `[${i + 1}/${totalChunks}] offset=${currentOffsetSeconds.toFixed(1)}s duration=${chunkDuration.toFixed(1)}s audio_ctx=${audioCtx}`
+        )
+
+        const fullAudioStream = createAudioStream(fullAudioBuffer)
+
+        let chunk = { results: [], updateCallCount: 0, maxBatchSize: 0 }
+        try {
+          chunk = await transcribeChunk(
+            model,
+            fullAudioStream,
+            currentOffsetSeconds * 1000,
+            chunkDuration * 1000,
+            audioCtx
+          )
+        } catch (err) {
+          errorCount++
+          console.error(`Chunk ${i + 1} failed:`, err)
+        }
+
+        currentOffsetSeconds += chunkDuration
+
+        if (chunk.results.length > 0) {
+          const text = chunk.results
+            .map((s) => s.text)
+            .join(' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+          console.log(
+            `  → segments=${chunk.results.length} updates=${chunk.updateCallCount} maxBatch=${chunk.maxBatchSize}`
+          )
+          console.log(`  → ${text}\n`)
+          allResults.push(...chunk.results)
+          chunksWithSegments++
+
+          if (chunk.results.length > 1 && chunk.updateCallCount === 1) {
+            batchedDeliveryCount++
+          }
+        } else {
+          console.log('  → [no output]\n')
+        }
+      }
+
+      console.log('\n=== RESULTS ===')
+      console.log(`Total segments: ${allResults.length}`)
+      console.log(`Total chunks processed: ${totalChunks}`)
+      console.log(`Chunks with segments: ${chunksWithSegments}`)
+      console.log(`Chunk errors: ${errorCount}`)
+      console.log(`Batched deliveries (regression): ${batchedDeliveryCount}`)
+      console.log(`Duration processed: ${totalDurationSeconds.toFixed(1)}s`)
+
+      // Assertions
+      t.ok(allResults.length > 0, 'Should produce transcription segments')
+      t.is(chunksWithSegments, totalChunks, 'Should transcribe exactly totalChunks chunks')
+      t.is(errorCount, 0, 'No chunk errors or exceptions')
+
+      t.is(
+        batchedDeliveryCount,
+        0,
+        'Segments must be streamed incrementally (not all batched into a single onUpdate call)'
+      )
+
+      // Verify segments have required properties
+      if (allResults.length > 0) {
+        const firstSegment = allResults[0]
+        t.ok(firstSegment.text, 'Segments should have text')
+        t.ok(typeof firstSegment.start === 'number', 'Segments should have start time')
+        t.ok(typeof firstSegment.end === 'number', 'Segments should have end time')
+      }
+
+      // Build full transcription
+      const fullTranscription = allResults
+        .map((s) => s.text.trim())
+        .filter((text) => text.length > 0)
+        .join(' ')
+
+      console.log(`\nTranscription length: ${fullTranscription.length} characters`)
+
+      if (fullTranscription.length > 0) {
+        console.log('\n=== FULL TRANSCRIPTION (test) ===')
+        console.log(fullTranscription)
+        console.log('=== END FULL TRANSCRIPTION ===\n')
+      }
+
+      t.ok(fullTranscription.length > 0, 'Should produce non-empty transcription')
+
+      console.log('✅ Audio context chunking test completed successfully!\n')
+    } catch (error) {
+      console.error('Test failed with error:', error)
+      t.fail(error.message)
+    } finally {
+      if (model) {
+        await model.destroy()
+      }
     }
   }
-})
+)

--- a/packages/transcription-whispercpp/test/integration/cold-start-timing.test.js
+++ b/packages/transcription-whispercpp/test/integration/cold-start-timing.test.js
@@ -20,9 +20,11 @@ const process = require('bare-process')
 const TranscriptionWhispercpp = require('../../index.js')
 const { ensureWhisperModel, ensureVADModel, getAssetPath, isMobile } = require('./helpers.js')
 
-async function getModelPaths () {
+async function getModelPaths() {
   // Use writable directory for models
-  const modelsDir = isMobile ? path.join(global.testDir || os.tmpdir(), 'models') : path.resolve(__dirname, '../../models')
+  const modelsDir = isMobile
+    ? path.join(global.testDir || os.tmpdir(), 'models')
+    : path.resolve(__dirname, '../../models')
 
   if (!fs.existsSync(modelsDir)) {
     fs.mkdirSync(modelsDir, { recursive: true })
@@ -55,7 +57,7 @@ async function getModelPaths () {
 /**
  * High-resolution timer using hrtime (works in Bare)
  */
-function getTimeMs () {
+function getTimeMs() {
   const [sec, nsec] = process.hrtime()
   return sec * 1000 + nsec / 1e6
 }
@@ -63,7 +65,7 @@ function getTimeMs () {
 /**
  * Run a single transcription and return timing info
  */
-async function runTimedTranscription (model, audioPath) {
+async function runTimedTranscription(model, audioPath) {
   const startTime = getTimeMs()
   let firstSegmentTime = null
 
@@ -87,143 +89,158 @@ async function runTimedTranscription (model, audioPath) {
     totalTime: endTime - startTime,
     timeToFirstSegment: firstSegmentTime ? firstSegmentTime - startTime : null,
     segmentCount: segments.length,
-    text: segments.map(s => s?.text || '').join(' ').trim()
+    text: segments
+      .map((s) => s?.text || '')
+      .join(' ')
+      .trim()
   }
 }
 
 // Works on both mobile and desktop - fewer runs on mobile
-test('Cold start timing: measure first vs subsequent transcription times', { timeout: 300000 }, async (t) => {
-  const paths = await getModelPaths()
+test(
+  'Cold start timing: measure first vs subsequent transcription times',
+  { timeout: 300000 },
+  async (t) => {
+    const paths = await getModelPaths()
 
-  const NUM_RUNS = 5
-  const ACCEPTABLE_PENALTY_THRESHOLD = 100 // 100% = 2x slower is acceptable
+    const NUM_RUNS = 5
+    const ACCEPTABLE_PENALTY_THRESHOLD = 100 // 100% = 2x slower is acceptable
 
-  console.log('\n' + '='.repeat(60))
-  console.log('COLD START TIMING TEST')
-  console.log('='.repeat(60))
-  console.log(`Model: ${path.basename(paths.modelPath)}`)
-  console.log(`VAD Model: ${paths.vadModelPath ? path.basename(paths.vadModelPath) : 'none'}`)
-  console.log(`Audio: ${path.basename(paths.audioPath)}`)
-  console.log(`Platform: ${isMobile ? 'mobile' : 'desktop'}`)
-  console.log(`Runs: ${NUM_RUNS}`)
-  console.log('='.repeat(60) + '\n')
-
-  // Verify files exist
-  if (!fs.existsSync(paths.modelPath)) {
-    console.log(`⚠️ Model not found: ${paths.modelPath}`)
-    t.pass('Test skipped - model not found')
-    return
-  }
-  if (!fs.existsSync(paths.audioPath)) {
-    console.log(`⚠️ Audio not found: ${paths.audioPath}`)
-    t.pass('Test skipped - audio not found')
-    return
-  }
-
-  const config = {
-    path: paths.modelPath,
-    vadModelPath: paths.vadModelPath,
-    whisperConfig: {
-      language: 'en',
-      audio_format: 's16le',
-      temperature: 0.0,
-      suppress_nst: true
-    }
-  }
-
-  if (paths.vadModelPath && fs.existsSync(paths.vadModelPath)) {
-    config.whisperConfig.vad_model_path = paths.vadModelPath
-    config.whisperConfig.vad_params = {
-      threshold: 0.5,
-      min_speech_duration_ms: 100,
-      min_silence_duration_ms: 100
-    }
-  }
-
-  let model
-  try {
-    // Create model instance
-    console.log('📦 Creating model instance...')
-    const loadStartTime = getTimeMs()
-
-    const ctorFiles = { model: paths.modelPath }
-    if (paths.vadModelPath) {
-      ctorFiles.vadModel = paths.vadModelPath
-    }
-    model = new TranscriptionWhispercpp({
-      files: ctorFiles
-    }, config)
-
-    // Load model (this should trigger warmup)
-    console.log('🔄 Loading model (with warmup)...')
-    await model._load()
-
-    const loadEndTime = getTimeMs()
-    console.log(`✅ Model loaded in ${(loadEndTime - loadStartTime).toFixed(0)}ms\n`)
-
-    // Run multiple transcriptions
-    const results = []
-
-    console.log(`🎤 Running ${NUM_RUNS} consecutive transcriptions...\n`)
-
-    for (let i = 0; i < NUM_RUNS; i++) {
-      console.log(`--- Run ${i + 1}/${NUM_RUNS} ---`)
-
-      const result = await runTimedTranscription(model, paths.audioPath)
-      results.push(result)
-
-      console.log(`  Total time: ${result.totalTime.toFixed(0)}ms`)
-      if (result.timeToFirstSegment) {
-        console.log(`  Time to first segment: ${result.timeToFirstSegment.toFixed(0)}ms`)
-      }
-      console.log(`  Segments: ${result.segmentCount}`)
-      console.log(`  Text preview: "${result.text.substring(0, 50)}${result.text.length > 50 ? '...' : ''}"\n`)
-
-      // Small delay on mobile to allow memory cleanup
-      if (isMobile) {
-        await new Promise(resolve => setTimeout(resolve, 200))
-      }
-    }
-
-    // Calculate statistics
+    console.log('\n' + '='.repeat(60))
+    console.log('COLD START TIMING TEST')
     console.log('='.repeat(60))
-    console.log('📊 TIMING SUMMARY')
-    console.log('='.repeat(60))
+    console.log(`Model: ${path.basename(paths.modelPath)}`)
+    console.log(`VAD Model: ${paths.vadModelPath ? path.basename(paths.vadModelPath) : 'none'}`)
+    console.log(`Audio: ${path.basename(paths.audioPath)}`)
+    console.log(`Platform: ${isMobile ? 'mobile' : 'desktop'}`)
+    console.log(`Runs: ${NUM_RUNS}`)
+    console.log('='.repeat(60) + '\n')
 
-    const times = results.map(r => r.totalTime)
-    const firstRunTime = times[0]
-    const subsequentTimes = times.slice(1)
-    const avgSubsequent = subsequentTimes.reduce((a, b) => a + b, 0) / subsequentTimes.length
+    // Verify files exist
+    if (!fs.existsSync(paths.modelPath)) {
+      console.log(`⚠️ Model not found: ${paths.modelPath}`)
+      t.pass('Test skipped - model not found')
+      return
+    }
+    if (!fs.existsSync(paths.audioPath)) {
+      console.log(`⚠️ Audio not found: ${paths.audioPath}`)
+      t.pass('Test skipped - audio not found')
+      return
+    }
 
-    console.log('\n  Run times:')
-    times.forEach((time, i) => {
-      const marker = i === 0 ? ' (FIRST)' : ''
-      console.log(`    Run ${i + 1}: ${time.toFixed(0)}ms${marker}`)
-    })
+    const config = {
+      path: paths.modelPath,
+      vadModelPath: paths.vadModelPath,
+      whisperConfig: {
+        language: 'en',
+        audio_format: 's16le',
+        temperature: 0.0,
+        suppress_nst: true
+      }
+    }
 
-    console.log('\n  Statistics:')
-    console.log(`    First run: ${firstRunTime.toFixed(0)}ms`)
-    console.log(`    Average of runs 2-${NUM_RUNS}: ${avgSubsequent.toFixed(0)}ms`)
+    if (paths.vadModelPath && fs.existsSync(paths.vadModelPath)) {
+      config.whisperConfig.vad_model_path = paths.vadModelPath
+      config.whisperConfig.vad_params = {
+        threshold: 0.5,
+        min_speech_duration_ms: 100,
+        min_silence_duration_ms: 100
+      }
+    }
 
-    const coldStartPenalty = ((firstRunTime - avgSubsequent) / avgSubsequent) * 100
-    console.log(`    Cold start penalty: ${coldStartPenalty.toFixed(1)}%`)
+    let model
+    try {
+      // Create model instance
+      console.log('📦 Creating model instance...')
+      const loadStartTime = getTimeMs()
 
-    console.log('\n' + '='.repeat(60) + '\n')
+      const ctorFiles = { model: paths.modelPath }
+      if (paths.vadModelPath) {
+        ctorFiles.vadModel = paths.vadModelPath
+      }
+      model = new TranscriptionWhispercpp(
+        {
+          files: ctorFiles
+        },
+        config
+      )
 
-    // Assertions
-    t.ok(results.length === NUM_RUNS, `Completed ${NUM_RUNS} transcription runs`)
-    t.ok(coldStartPenalty <= ACCEPTABLE_PENALTY_THRESHOLD, `Cold start penalty ${coldStartPenalty.toFixed(1)}% should be <= ${ACCEPTABLE_PENALTY_THRESHOLD}%`)
-  } finally {
-    // Cleanup
-    if (model) {
-      try {
-        await model.unload()
-      } catch (e) {
-        // ignore
+      // Load model (this should trigger warmup)
+      console.log('🔄 Loading model (with warmup)...')
+      await model._load()
+
+      const loadEndTime = getTimeMs()
+      console.log(`✅ Model loaded in ${(loadEndTime - loadStartTime).toFixed(0)}ms\n`)
+
+      // Run multiple transcriptions
+      const results = []
+
+      console.log(`🎤 Running ${NUM_RUNS} consecutive transcriptions...\n`)
+
+      for (let i = 0; i < NUM_RUNS; i++) {
+        console.log(`--- Run ${i + 1}/${NUM_RUNS} ---`)
+
+        const result = await runTimedTranscription(model, paths.audioPath)
+        results.push(result)
+
+        console.log(`  Total time: ${result.totalTime.toFixed(0)}ms`)
+        if (result.timeToFirstSegment) {
+          console.log(`  Time to first segment: ${result.timeToFirstSegment.toFixed(0)}ms`)
+        }
+        console.log(`  Segments: ${result.segmentCount}`)
+        console.log(
+          `  Text preview: "${result.text.substring(0, 50)}${result.text.length > 50 ? '...' : ''}"\n`
+        )
+
+        // Small delay on mobile to allow memory cleanup
+        if (isMobile) {
+          await new Promise((resolve) => setTimeout(resolve, 200))
+        }
+      }
+
+      // Calculate statistics
+      console.log('='.repeat(60))
+      console.log('📊 TIMING SUMMARY')
+      console.log('='.repeat(60))
+
+      const times = results.map((r) => r.totalTime)
+      const firstRunTime = times[0]
+      const subsequentTimes = times.slice(1)
+      const avgSubsequent = subsequentTimes.reduce((a, b) => a + b, 0) / subsequentTimes.length
+
+      console.log('\n  Run times:')
+      times.forEach((time, i) => {
+        const marker = i === 0 ? ' (FIRST)' : ''
+        console.log(`    Run ${i + 1}: ${time.toFixed(0)}ms${marker}`)
+      })
+
+      console.log('\n  Statistics:')
+      console.log(`    First run: ${firstRunTime.toFixed(0)}ms`)
+      console.log(`    Average of runs 2-${NUM_RUNS}: ${avgSubsequent.toFixed(0)}ms`)
+
+      const coldStartPenalty = ((firstRunTime - avgSubsequent) / avgSubsequent) * 100
+      console.log(`    Cold start penalty: ${coldStartPenalty.toFixed(1)}%`)
+
+      console.log('\n' + '='.repeat(60) + '\n')
+
+      // Assertions
+      t.ok(results.length === NUM_RUNS, `Completed ${NUM_RUNS} transcription runs`)
+      t.ok(
+        coldStartPenalty <= ACCEPTABLE_PENALTY_THRESHOLD,
+        `Cold start penalty ${coldStartPenalty.toFixed(1)}% should be <= ${ACCEPTABLE_PENALTY_THRESHOLD}%`
+      )
+    } finally {
+      // Cleanup
+      if (model) {
+        try {
+          await model.unload()
+        } catch (e) {
+          // ignore
+        }
       }
     }
   }
-})
+)
 
 // Fresh instance test - fewer runs on mobile
 test('Cold start: fresh model instance per transcription', { timeout: 300000 }, async (t) => {
@@ -269,9 +286,12 @@ test('Cold start: fresh model instance per transcription', { timeout: 300000 }, 
       if (paths.vadModelPath) {
         ctorFiles.vadModel = paths.vadModelPath
       }
-      model = new TranscriptionWhispercpp({
-        files: ctorFiles
-      }, config)
+      model = new TranscriptionWhispercpp(
+        {
+          files: ctorFiles
+        },
+        config
+      )
 
       await model._load()
 
@@ -304,7 +324,7 @@ test('Cold start: fresh model instance per transcription', { timeout: 300000 }, 
 
     // Delay between instances on mobile
     if (isMobile) {
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await new Promise((resolve) => setTimeout(resolve, 500))
     }
   }
 

--- a/packages/transcription-whispercpp/test/integration/corrupted-model.test.js
+++ b/packages/transcription-whispercpp/test/integration/corrupted-model.test.js
@@ -11,7 +11,7 @@ const { setupJsLogger, ensureWhisperModel, isMobile } = require('./helpers.js')
 /**
  * Helper function to test that corrupted model files throw exceptions
  */
-async function testCorruptedModelFile (t, { corruptedFilePath, constructorArgs, config }) {
+async function testCorruptedModelFile(t, { corruptedFilePath, constructorArgs, config }) {
   let loggerBinding = null
   if (!isMobile) {
     loggerBinding = setupJsLogger()
@@ -25,7 +25,7 @@ async function testCorruptedModelFile (t, { corruptedFilePath, constructorArgs, 
 
     const audioData = new Uint8Array(1600)
     const audioStream = new Readable({
-      read () {
+      read() {
         this.push(Buffer.from(audioData))
         this.push(null)
       }
@@ -66,7 +66,7 @@ async function testCorruptedModelFile (t, { corruptedFilePath, constructorArgs, 
       try {
         loggerBinding.releaseLogger()
       } catch (e) {
-      // ignore
+        // ignore
       }
     }
   }
@@ -79,7 +79,9 @@ async function testCorruptedModelFile (t, { corruptedFilePath, constructorArgs, 
  * Works on both mobile and desktop
  */
 test('Corrupted model file should throw exception to JavaScript', { timeout: 30000 }, async (t) => {
-  const testDir = isMobile ? path.join(global.testDir || os.tmpdir(), '.test-models') : path.join(__dirname, '../.test-models')
+  const testDir = isMobile
+    ? path.join(global.testDir || os.tmpdir(), '.test-models')
+    : path.join(__dirname, '../.test-models')
   const corruptedModelPath = path.join(testDir, 'corrupted-model.bin')
 
   if (!fs.existsSync(testDir)) {
@@ -108,45 +110,53 @@ test('Corrupted model file should throw exception to JavaScript', { timeout: 300
  * Test corrupted VAD model file
  * Works on both mobile and desktop
  */
-test('Corrupted VAD model file should throw exception to JavaScript', { timeout: 180000 }, async (t) => {
-  const testDir = isMobile ? path.join(global.testDir || os.tmpdir(), '.test-models') : path.join(__dirname, '../.test-models')
-  const corruptedVadPath = path.join(testDir, 'corrupted-vad-model.bin')
+test(
+  'Corrupted VAD model file should throw exception to JavaScript',
+  { timeout: 180000 },
+  async (t) => {
+    const testDir = isMobile
+      ? path.join(global.testDir || os.tmpdir(), '.test-models')
+      : path.join(__dirname, '../.test-models')
+    const corruptedVadPath = path.join(testDir, 'corrupted-vad-model.bin')
 
-  // Ensure we have a valid whisper model
-  const modelsDir = isMobile ? path.join(global.testDir || os.tmpdir(), 'models') : path.resolve(__dirname, '../../models')
-  const validModelPath = path.join(modelsDir, 'ggml-tiny.bin')
+    // Ensure we have a valid whisper model
+    const modelsDir = isMobile
+      ? path.join(global.testDir || os.tmpdir(), 'models')
+      : path.resolve(__dirname, '../../models')
+    const validModelPath = path.join(modelsDir, 'ggml-tiny.bin')
 
-  // Download the model if needed
-  const modelResult = await ensureWhisperModel(validModelPath)
-  if (!modelResult.success) {
-    console.log('⚠️ Could not download model, skipping test')
-    t.pass('Test skipped - model not available')
-    return
-  }
-
-  t.ok(fs.existsSync(validModelPath), 'Valid whisper model should exist')
-
-  if (!fs.existsSync(testDir)) {
-    fs.mkdirSync(testDir, { recursive: true })
-  }
-
-  fs.writeFileSync(corruptedVadPath, 'This is not a valid VAD model file')
-  t.ok(fs.existsSync(corruptedVadPath), 'Corrupted VAD model file should exist')
-
-  await testCorruptedModelFile(t, {
-    corruptedFilePath: corruptedVadPath,
-    constructorArgs: {
-      files: {
-        model: validModelPath
-      }
-    },
-    config: {
-      whisperConfig: {
-        language: 'en',
-        vad_model_path: corruptedVadPath
-      },
-      contextParams: { model: validModelPath },
-      miscConfig: { caption_enabled: false }
+    // Download the model if needed
+    const modelResult = await ensureWhisperModel(validModelPath)
+    if (!modelResult.success) {
+      console.log('⚠️ Could not download model, skipping test')
+      t.pass('Test skipped - model not available')
+      return
     }
-  })
-})
+
+    t.ok(fs.existsSync(validModelPath), 'Valid whisper model should exist')
+
+    if (!fs.existsSync(testDir)) {
+      fs.mkdirSync(testDir, { recursive: true })
+    }
+
+    fs.writeFileSync(corruptedVadPath, 'This is not a valid VAD model file')
+    t.ok(fs.existsSync(corruptedVadPath), 'Corrupted VAD model file should exist')
+
+    await testCorruptedModelFile(t, {
+      corruptedFilePath: corruptedVadPath,
+      constructorArgs: {
+        files: {
+          model: validModelPath
+        }
+      },
+      config: {
+        whisperConfig: {
+          language: 'en',
+          vad_model_path: corruptedVadPath
+        },
+        contextParams: { model: validModelPath },
+        miscConfig: { caption_enabled: false }
+      }
+    })
+  }
+)

--- a/packages/transcription-whispercpp/test/integration/gpu.test.js
+++ b/packages/transcription-whispercpp/test/integration/gpu.test.js
@@ -39,33 +39,42 @@ const NO_GPU = process.env && process.env.NO_GPU === 'true'
 
 const SAMPLE_AUDIO_NAME = 'sample.raw'
 
-function backendIdToName (id) {
+function backendIdToName(id) {
   switch (id) {
-    case 0: return 'CPU'
-    case 1: return 'Metal'
-    case 2: return 'CUDA'
-    case 3: return 'Vulkan'
-    case 4: return 'OpenCL'
-    case 99: return 'other-GPU'
-    default: return `unknown(${id})`
+    case 0:
+      return 'CPU'
+    case 1:
+      return 'Metal'
+    case 2:
+      return 'CUDA'
+    case 3:
+      return 'Vulkan'
+    case 4:
+      return 'OpenCL'
+    case 99:
+      return 'other-GPU'
+    default:
+      return `unknown(${id})`
   }
 }
 
-function locateSampleAudio () {
+function locateSampleAudio() {
   try {
     const samplePath = getAssetPath(SAMPLE_AUDIO_NAME)
     if (samplePath && fs.existsSync(samplePath)) return samplePath
-  } catch (_) { /* asset manifest may not contain the sample on mobile */ }
+  } catch (_) {
+    /* asset manifest may not contain the sample on mobile */
+  }
   return null
 }
 
-async function ensureTinyModel () {
+async function ensureTinyModel() {
   const { modelPath } = getTestPaths()
   const result = await ensureWhisperModel(modelPath)
   return result && result.success ? modelPath : null
 }
 
-function buildConfig (useGpu) {
+function buildConfig(useGpu) {
   return {
     contextParams: {
       use_gpu: !!useGpu,
@@ -80,7 +89,7 @@ function buildConfig (useGpu) {
   }
 }
 
-async function loadAndTranscribe ({ modelPath, samplePath, useGpu }) {
+async function loadAndTranscribe({ modelPath, samplePath, useGpu }) {
   const constructorArgs = {
     files: { model: modelPath },
     opts: { stats: true }
@@ -95,20 +104,26 @@ async function loadAndTranscribe ({ modelPath, samplePath, useGpu }) {
     const response = await model.run(audioStream)
 
     const segments = []
-    await response.onUpdate((out) => {
-      const items = Array.isArray(out) ? out : [out]
-      for (const seg of items) {
-        if (seg && typeof seg.text === 'string') segments.push(seg)
-      }
-    }).await()
+    await response
+      .onUpdate((out) => {
+        const items = Array.isArray(out) ? out : [out]
+        for (const seg of items) {
+          if (seg && typeof seg.text === 'string') segments.push(seg)
+        }
+      })
+      .await()
 
     return { segments, stats: response.stats || null }
   } finally {
-    try { await model.destroy() } catch (_) { /* ignore */ }
+    try {
+      await model.destroy()
+    } catch (_) {
+      /* ignore */
+    }
   }
 }
 
-function assertStatsShape (t, label, stats) {
+function assertStatsShape(t, label, stats) {
   t.ok(stats, `${label}: response.stats must be present (opts.stats=true was set)`)
   if (!stats) return
   t.ok(
@@ -123,17 +138,11 @@ function assertStatsShape (t, label, stats) {
     typeof stats.realTimeFactor === 'number' && stats.realTimeFactor >= 0,
     `${label}: stats.realTimeFactor must be a non-negative number`
   )
-  t.ok(
-    typeof stats.backendDevice === 'number',
-    `${label}: stats.backendDevice must be a number`
-  )
-  t.ok(
-    typeof stats.backendId === 'number',
-    `${label}: stats.backendId must be a number`
-  )
+  t.ok(typeof stats.backendDevice === 'number', `${label}: stats.backendDevice must be a number`)
+  t.ok(typeof stats.backendId === 'number', `${label}: stats.backendId must be a number`)
 }
 
-function assertGpuBackend (t, label, stats) {
+function assertGpuBackend(t, label, stats) {
   if (!stats) {
     t.fail(`${label}: no response.stats returned (cannot verify backend)`)
     return
@@ -144,11 +153,12 @@ function assertGpuBackend (t, label, stats) {
   console.log(`[${label}] backendDevice=${dev} backendId=${id} (${name})`)
 
   if (dev !== 1) {
-    const msg = `${label}/${platform}: expected GPU backend, got ${name} ` +
-                `(backendDevice=${dev}, backendId=${id}). ` +
-                'use_gpu=true was requested but the engine fell back to CPU. ' +
-                'Set QVAC_WHISPER_GPU_RELAX=1 to downgrade this to a warning ' +
-                'on hosts without a usable GPU.'
+    const msg =
+      `${label}/${platform}: expected GPU backend, got ${name} ` +
+      `(backendDevice=${dev}, backendId=${id}). ` +
+      'use_gpu=true was requested but the engine fell back to CPU. ' +
+      'Set QVAC_WHISPER_GPU_RELAX=1 to downgrade this to a warning ' +
+      'on hosts without a usable GPU.'
     if (RELAX) {
       t.comment(`WARNING (relaxed): ${msg}`)
       t.pass(`${label}: GPU smoke completed (relaxed)`)
@@ -163,12 +173,14 @@ function assertGpuBackend (t, label, stats) {
   } else if (platform === 'linux' || platform === 'win32') {
     t.is(id, 3, `${label}/${platform}: expected Vulkan backendId=3, got ${name}`)
   } else if (platform === 'android') {
-    t.ok(id === 3 || id === 4,
-      `${label}/${platform}: expected Vulkan(3) or OpenCL(4) backendId, got ${name}`)
+    t.ok(
+      id === 3 || id === 4,
+      `${label}/${platform}: expected Vulkan(3) or OpenCL(4) backendId, got ${name}`
+    )
   }
 }
 
-function assertCpuBackend (t, label, stats) {
+function assertCpuBackend(t, label, stats) {
   if (!stats) {
     t.fail(`${label}: no response.stats returned (cannot verify backend)`)
     return
@@ -176,16 +188,25 @@ function assertCpuBackend (t, label, stats) {
   const dev = stats.backendDevice
   const id = stats.backendId
   console.log(`[${label}] backendDevice=${dev} backendId=${id} (${backendIdToName(id)})`)
-  t.is(dev, 0,
+  t.is(
+    dev,
+    0,
     `${label}: use_gpu=false must pin the engine to CPU (backendDevice=0), ` +
-    `got backendDevice=${dev} (${backendIdToName(id)})`)
+      `got backendDevice=${dev} (${backendIdToName(id)})`
+  )
 }
 
-async function runCase (t, { useGpu, label }) {
+async function runCase(t, { useGpu, label }) {
   const modelPath = await ensureTinyModel()
-  if (!modelPath) { t.pass(`${label}: skipped — ggml-tiny.bin not available locally`); return null }
+  if (!modelPath) {
+    t.pass(`${label}: skipped — ggml-tiny.bin not available locally`)
+    return null
+  }
   const samplePath = locateSampleAudio()
-  if (!samplePath) { t.pass(`${label}: skipped — ${SAMPLE_AUDIO_NAME} not available locally`); return null }
+  if (!samplePath) {
+    t.pass(`${label}: skipped — ${SAMPLE_AUDIO_NAME} not available locally`)
+    return null
+  }
 
   const result = await loadAndTranscribe({ modelPath, samplePath, useGpu })
   console.log(`[${label}] segments=${result.segments.length}`)
@@ -202,7 +223,9 @@ test(
   { timeout: 600000, skip: NO_GPU },
   async (t) => {
     if (platform === 'android') {
-      t.pass('Android: Whisper GPU test quarantined pending teardown crash investigation (see mobile-perf-tiny-gpu.test.js)')
+      t.pass(
+        'Android: Whisper GPU test quarantined pending teardown crash investigation (see mobile-perf-tiny-gpu.test.js)'
+      )
       return
     }
     const gpuRun = await runCase(t, { useGpu: true, label: 'GPU' })

--- a/packages/transcription-whispercpp/test/integration/helpers.js
+++ b/packages/transcription-whispercpp/test/integration/helpers.js
@@ -46,28 +46,31 @@ try {
     }
 
     return {
-      record (testName, metrics, extra) {
+      record(testName, metrics, extra) {
         const entry = {
           test: testName,
           execution_provider: (extra && extra.execution_provider) || null,
-          metrics: Object.assign({
-            real_time_factor: null,
-            wall_time_ms: null,
-            tps: null,
-            whisper_encode_time_ms: null,
-            whisper_decode_time_ms: null,
-            audio_duration_ms: null,
-            total_time_ms: null,
-            avg_rss_mb: null,
-            peak_rss_mb: null,
-            reclaimed_mb: null
-          }, metrics),
+          metrics: Object.assign(
+            {
+              real_time_factor: null,
+              wall_time_ms: null,
+              tps: null,
+              whisper_encode_time_ms: null,
+              whisper_decode_time_ms: null,
+              audio_duration_ms: null,
+              total_time_ms: null,
+              avg_rss_mb: null,
+              peak_rss_mb: null,
+              reclaimed_mb: null
+            },
+            metrics
+          ),
           input: (extra && extra.input) || null,
           output: (extra && extra.output) || null
         }
         _results.push(entry)
       },
-      toJSON () {
+      toJSON() {
         return {
           schema_version: '1.0',
           addon: _addon,
@@ -77,7 +80,7 @@ try {
           results: _results
         }
       },
-      writeReport () {
+      writeReport() {
         const json = JSON.stringify(this.toJSON())
         const dirs = []
         if (global.testDir) dirs.push(global.testDir)
@@ -89,7 +92,9 @@ try {
         dirs.push('/tmp')
         for (let di = 0; di < dirs.length; di++) {
           try {
-            try { fs.mkdirSync(dirs[di], { recursive: true }) } catch (_) {}
+            try {
+              fs.mkdirSync(dirs[di], { recursive: true })
+            } catch (_) {}
             const p = path.join(dirs[di], 'perf-report.json')
             fs.writeFileSync(p, json)
             console.log('[PERF_REPORT_PATH]' + p)
@@ -98,8 +103,8 @@ try {
           }
         }
       },
-      writeStepSummary () {},
-      writeToConsole () {
+      writeStepSummary() {},
+      writeToConsole() {
         try {
           const json = JSON.stringify(this.toJSON())
           const CHUNK = 800
@@ -109,14 +114,25 @@ try {
             const id = Date.now().toString(36)
             const n = Math.ceil(json.length / CHUNK)
             for (let i = 0; i < n; i++) {
-              console.log('[PERF_CHUNK:' + id + ':' + i + ':' + n + ']' + json.substring(i * CHUNK, (i + 1) * CHUNK))
+              console.log(
+                '[PERF_CHUNK:' +
+                  id +
+                  ':' +
+                  i +
+                  ':' +
+                  n +
+                  ']' +
+                  json.substring(i * CHUNK, (i + 1) * CHUNK)
+              )
             }
           }
         } catch (err) {
           console.log('[perf-reporter] mobile console write failed: ' + err.message)
         }
       },
-      get length () { return _results.length }
+      get length() {
+        return _results.length
+      }
     }
   }
 }
@@ -129,19 +145,23 @@ const _perfReporter = createPerformanceReporter({
 const _reportPath = path.resolve('.', 'test/results/performance-report.json')
 let _reportScheduled = false
 
-function _flushPerfReport () {
+function _flushPerfReport() {
   if (_perfReporter.length === 0) return
-  try { _perfReporter.writeReport(_reportPath) } catch (_) {}
-  try { _perfReporter.writeToConsole() } catch (_) {}
+  try {
+    _perfReporter.writeReport(_reportPath)
+  } catch (_) {}
+  try {
+    _perfReporter.writeToConsole()
+  } catch (_) {}
 }
 
-function _scheduleReportWrite () {
+function _scheduleReportWrite() {
   if (_reportScheduled) return
   _reportScheduled = true
   process.on('exit', _flushPerfReport)
 }
 
-function roundToTwo (value) {
+function roundToTwo(value) {
   return typeof value === 'number' && Number.isFinite(value) ? roundTo(value, 2) : null
 }
 
@@ -158,7 +178,7 @@ function roundToTwo (value) {
  * @param {Object} [extra] - Optional { wallMs, output, executionProvider,
  *                            avgRssMb, peakRssMb, reclaimedMb } overrides.
  */
-function recordWhisperStats (label, stats, extra) {
+function recordWhisperStats(label, stats, extra) {
   if (!stats || typeof stats !== 'object') return
   const epOverride = extra && extra.executionProvider
   const ep = epOverride || (/\[gpu\]/i.test(label) ? 'gpu' : /\[cpu\]/i.test(label) ? 'cpu' : null)
@@ -166,48 +186,62 @@ function recordWhisperStats (label, stats, extra) {
   const rtf = typeof stats.realTimeFactor === 'number' ? stats.realTimeFactor : null
   const totalTimeSec = typeof stats.totalTime === 'number' ? stats.totalTime : null
   const totalTimeMs = totalTimeSec !== null ? Math.round(totalTimeSec * 1000) : null
-  const wallMs = (extra && typeof extra.wallMs === 'number')
-    ? Math.round(extra.wallMs)
-    : (typeof stats.totalWallMs === 'number' ? Math.round(stats.totalWallMs) : totalTimeMs)
+  const wallMs =
+    extra && typeof extra.wallMs === 'number'
+      ? Math.round(extra.wallMs)
+      : typeof stats.totalWallMs === 'number'
+        ? Math.round(stats.totalWallMs)
+        : totalTimeMs
   const tps = typeof stats.tokensPerSecond === 'number' ? stats.tokensPerSecond : null
-  const encodeMs = typeof stats.whisperEncodeMs === 'number' ? Math.round(stats.whisperEncodeMs) : null
-  const decodeMs = typeof stats.whisperDecodeMs === 'number' ? Math.round(stats.whisperDecodeMs) : null
-  const audioMs = typeof stats.audioDurationMs === 'number' ? Math.round(stats.audioDurationMs) : null
+  const encodeMs =
+    typeof stats.whisperEncodeMs === 'number' ? Math.round(stats.whisperEncodeMs) : null
+  const decodeMs =
+    typeof stats.whisperDecodeMs === 'number' ? Math.round(stats.whisperDecodeMs) : null
+  const audioMs =
+    typeof stats.audioDurationMs === 'number' ? Math.round(stats.audioDurationMs) : null
   // The active ggml backend id captured once per load() and echoed in every
   // stats snapshot (0=CPU 1=Metal 2=CUDA 3=Vulkan 4=OpenCL 99=other). Recorded
   // so the aggregator can label the REAL backend per device instead of guessing
   // from the platform — e.g. Adreno Android lands on OpenCL(4), Mali on Vulkan(3).
   const backendId = typeof stats.backendId === 'number' ? stats.backendId : null
 
-  _perfReporter.record(label, {
-    real_time_factor: rtf,
-    wall_time_ms: wallMs,
-    tps,
-    whisper_encode_time_ms: encodeMs,
-    whisper_decode_time_ms: decodeMs,
-    audio_duration_ms: audioMs,
-    total_time_ms: totalTimeMs,
-    avg_rss_mb: roundToTwo(extra && extra.avgRssMb),
-    peak_rss_mb: roundToTwo(extra && extra.peakRssMb),
-    reclaimed_mb: roundToTwo(extra && extra.reclaimedMb),
-    backend_id: backendId
-  }, {
-    execution_provider: ep,
-    output: extra && extra.output ? String(extra.output) : null
-  })
+  _perfReporter.record(
+    label,
+    {
+      real_time_factor: rtf,
+      wall_time_ms: wallMs,
+      tps,
+      whisper_encode_time_ms: encodeMs,
+      whisper_decode_time_ms: decodeMs,
+      audio_duration_ms: audioMs,
+      total_time_ms: totalTimeMs,
+      avg_rss_mb: roundToTwo(extra && extra.avgRssMb),
+      peak_rss_mb: roundToTwo(extra && extra.peakRssMb),
+      reclaimed_mb: roundToTwo(extra && extra.reclaimedMb),
+      backend_id: backendId
+    },
+    {
+      execution_provider: ep,
+      output: extra && extra.output ? String(extra.output) : null
+    }
+  )
   _scheduleReportWrite()
 
   if (isMobile) {
-    try { _perfReporter.writeReport() } catch (_) {}
-    try { _perfReporter.writeToConsole() } catch (_) {}
+    try {
+      _perfReporter.writeReport()
+    } catch (_) {}
+    try {
+      _perfReporter.writeToConsole()
+    } catch (_) {}
   }
 }
 
-function detectPlatform () {
+function detectPlatform() {
   return `${platform}-${arch}`
 }
 
-async function downloadWithHttp (url, destPath, maxRedirects = 10) {
+async function downloadWithHttp(url, destPath, maxRedirects = 10) {
   const https = require('bare-https')
   const { URL } = require('bare-url')
 
@@ -286,11 +320,11 @@ async function downloadWithHttp (url, destPath, maxRedirects = 10) {
   })
 }
 
-async function downloadFile (url, destPath) {
+async function downloadFile(url, destPath) {
   return downloadWithHttp(url, destPath)
 }
 
-async function ensureWhisperModel (modelPath) {
+async function ensureWhisperModel(modelPath) {
   const modelName = path.basename(modelPath)
   const diskPath = path.dirname(modelPath)
 
@@ -328,14 +362,16 @@ async function ensureWhisperModel (modelPath) {
   }
 }
 
-async function ensureVADModel (vadModelPath) {
+async function ensureVADModel(vadModelPath) {
   const modelName = path.basename(vadModelPath)
   const diskPath = path.dirname(vadModelPath)
 
   if (fs.existsSync(vadModelPath)) {
     const stats = fs.statSync(vadModelPath)
     if (stats.size > 500000) {
-      console.log(`Using cached VAD model: ${modelName} (${(stats.size / 1024 / 1024).toFixed(1)}MB)`)
+      console.log(
+        `Using cached VAD model: ${modelName} (${(stats.size / 1024 / 1024).toFixed(1)}MB)`
+      )
       return true
     }
   }
@@ -353,7 +389,9 @@ async function ensureVADModel (vadModelPath) {
     if (fs.existsSync(vadModelPath)) {
       const stats = fs.statSync(vadModelPath)
       if (stats.size > 500000) {
-        console.log(`Downloaded VAD model: ${modelName} (${(stats.size / 1024 / 1024).toFixed(1)}MB)`)
+        console.log(
+          `Downloaded VAD model: ${modelName} (${(stats.size / 1024 / 1024).toFixed(1)}MB)`
+        )
         return true
       }
     }
@@ -366,14 +404,14 @@ async function ensureVADModel (vadModelPath) {
   }
 }
 
-async function waitUntilIdle (model, maxMs = 30000) {
+async function waitUntilIdle(model, maxMs = 30000) {
   const start = Date.now()
   while (Date.now() - start < maxMs) {
     try {
       const s = await model.status()
       if (s === 'IDLE') return true
     } catch {}
-    await new Promise(resolve => setTimeout(resolve, 500))
+    await new Promise((resolve) => setTimeout(resolve, 500))
   }
   return false
 }
@@ -383,7 +421,7 @@ async function waitUntilIdle (model, maxMs = 30000) {
  * @param {string|Buffer|Uint8Array|Array|Readable} audioInput - Audio input in various formats
  * @returns {Readable} Readable stream
  */
-function createAudioStream (audioInput) {
+function createAudioStream(audioInput) {
   if (typeof audioInput === 'string') {
     const audioBuffer = fs.readFileSync(audioInput)
     // Create stream from Buffer with chunking to simulate streaming behavior
@@ -416,7 +454,7 @@ function createAudioStream (audioInput) {
  * @param {number} sampleRate - Sample rate in Hz (default: 16000)
  * @returns {number} Duration in milliseconds
  */
-function calculateAudioDuration (audioBuffer, audioFormat = 's16le', sampleRate = 16000) {
+function calculateAudioDuration(audioBuffer, audioFormat = 's16le', sampleRate = 16000) {
   let bytesPerSample
   if (audioFormat === 's16le') {
     bytesPerSample = 2
@@ -441,12 +479,18 @@ function calculateAudioDuration (audioBuffer, audioFormat = 's16le', sampleRate 
  * @param {number} [amplitude=0.3] - Amplitude (0-1)
  * @returns {string} The filepath of the generated audio file
  */
-function generateTestAudio (filepath, sampleRate = 16000, duration = 3, frequency = 440, amplitude = 0.3) {
+function generateTestAudio(
+  filepath,
+  sampleRate = 16000,
+  duration = 3,
+  frequency = 440,
+  amplitude = 0.3
+) {
   if (fs.existsSync(filepath)) return filepath
   const samples = sampleRate * duration
   const buffer = Buffer.alloc(samples * 2)
   for (let i = 0; i < samples; i++) {
-    const sample = Math.sin(2 * Math.PI * frequency * i / sampleRate) * amplitude
+    const sample = Math.sin((2 * Math.PI * frequency * i) / sampleRate) * amplitude
     buffer.writeInt16LE(Math.round(sample * 32767), i * 2)
   }
   fs.writeFileSync(filepath, buffer)
@@ -459,7 +503,7 @@ function generateTestAudio (filepath, sampleRate = 16000, duration = 3, frequenc
  * @param {number} [amplitude=1000] - Maximum amplitude of noise
  * @returns {Uint8Array} PCM noise data as Uint8Array
  */
-function makePcmNoise (numSamples, amplitude = 1000) {
+function makePcmNoise(numSamples, amplitude = 1000) {
   const buf = Buffer.alloc(numSamples * 2)
   for (let i = 0; i < numSamples; i++) {
     const sample = Math.floor((Math.random() * 2 - 1) * amplitude)
@@ -473,7 +517,7 @@ function makePcmNoise (numSamples, amplitude = 1000) {
  * @param {Object} [binding] - Optional binding instance (will require if not provided)
  * @returns {Object} The binding instance with logger configured
  */
-function setupJsLogger (binding = null) {
+function setupJsLogger(binding = null) {
   const actualBinding = binding || require('../../binding')
   const LOG_PRIORITIES = ['ERROR', 'WARNING', 'INFO', 'DEBUG']
   actualBinding.setLogger((priority, message) => {
@@ -490,12 +534,21 @@ function setupJsLogger (binding = null) {
  * @param {string} actual - Actual/hypothesis transcription
  * @returns {number} WER as a decimal (0.0 = perfect, 1.0 = 100% error)
  */
-function wordErrorRate (expected, actual) {
+function wordErrorRate(expected, actual) {
   // Normalize text: lowercase, collapse whitespace, trim
-  const normalize = (text) => text.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim()
+  const normalize = (text) =>
+    text
+      .toLowerCase()
+      .replace(/[^\w\s]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
 
-  const r = normalize(expected).split(/\s+/).filter(w => w.length > 0)
-  const h = normalize(actual).split(/\s+/).filter(w => w.length > 0)
+  const r = normalize(expected)
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+  const h = normalize(actual)
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
 
   if (r.length === 0) {
     return h.length === 0 ? 0 : 1
@@ -533,7 +586,7 @@ function wordErrorRate (expected, actual) {
  * @param {number} [threshold=0.3] - Maximum acceptable WER (default 30%)
  * @returns {Object} Validation result with wer, passed, and details
  */
-function validateAccuracy (expected, actual, threshold = 0.3) {
+function validateAccuracy(expected, actual, threshold = 0.3) {
   const wer = wordErrorRate(expected, actual)
   const passed = wer <= threshold
 
@@ -558,7 +611,7 @@ function validateAccuracy (expected, actual, threshold = 0.3) {
  * @param {string} options.desktopDir - Directory to look in on desktop (default: 'examples/samples')
  * @returns {string} - Full path to the asset file
  */
-function getAssetPath (filename, options = {}) {
+function getAssetPath(filename, options = {}) {
   const { desktopDir = 'examples/samples' } = options
 
   // Mobile environment - use asset loading from testAssets
@@ -570,7 +623,9 @@ function getAssetPath (filename, options = {}) {
       return resolvedPath
     }
     // Asset not found in manifest
-    throw new Error(`Asset not found in testAssets: ${filename}. Make sure ${filename} is in test/mobile/testAssets/ directory and rebuild the app.`)
+    throw new Error(
+      `Asset not found in testAssets: ${filename}. Make sure ${filename} is in test/mobile/testAssets/ directory and rebuild the app.`
+    )
   }
 
   // Desktop environment - check multiple locations
@@ -597,7 +652,7 @@ function getAssetPath (filename, options = {}) {
  * @param {string} [modelsDir] - Optional models directory (defaults to '../../models')
  * @returns {Object} Object with modelsDir, samplesDir, modelPath, vadModelPath, and audioPath
  */
-function getTestPaths (modelsDir = null) {
+function getTestPaths(modelsDir = null) {
   // On mobile, use global.testDir if available (set by mobile test framework)
   const writableRoot = global.testDir || (isMobile ? os.tmpdir() : null)
 
@@ -650,7 +705,7 @@ function getTestPaths (modelsDir = null) {
  * @param {Function} [params.onUpdate] - Optional callback for real-time updates: (outputArr) => void
  * @returns {Promise<Object>} Result object with passed, output, and data
  */
-async function runTranscription (params, expectation = {}) {
+async function runTranscription(params, expectation = {}) {
   if (!params) {
     return {
       output: 'Error: Missing required parameter: params',
@@ -778,8 +833,8 @@ async function runTranscription (params, expectation = {}) {
     }
 
     const fullText = segments
-      .map(s => (s && s.text) ? s.text : '')
-      .filter(t => t.trim().length > 0)
+      .map((s) => (s && s.text ? s.text : ''))
+      .filter((t) => t.trim().length > 0)
       .join(' ')
       .trim()
       .replace(/\s+/g, ' ')
@@ -831,9 +886,15 @@ async function runTranscription (params, expectation = {}) {
     // Round stats for readability
     const roundedStats = jobStats
       ? {
-          totalTime: jobStats.totalTime ? Number(jobStats.totalTime.toFixed(4)) : jobStats.totalTime,
-          tokensPerSecond: jobStats.tokensPerSecond ? Number(jobStats.tokensPerSecond.toFixed(2)) : jobStats.tokensPerSecond,
-          realTimeFactor: jobStats.realTimeFactor ? Number(jobStats.realTimeFactor.toFixed(5)) : jobStats.realTimeFactor,
+          totalTime: jobStats.totalTime
+            ? Number(jobStats.totalTime.toFixed(4))
+            : jobStats.totalTime,
+          tokensPerSecond: jobStats.tokensPerSecond
+            ? Number(jobStats.tokensPerSecond.toFixed(2))
+            : jobStats.tokensPerSecond,
+          realTimeFactor: jobStats.realTimeFactor
+            ? Number(jobStats.realTimeFactor.toFixed(5))
+            : jobStats.realTimeFactor,
           audioDurationMs: jobStats.audioDurationMs,
           totalSamples: jobStats.totalSamples
         }
@@ -844,11 +905,12 @@ async function runTranscription (params, expectation = {}) {
       ? `duration: ${durationMs.toFixed(0)}ms, RTF: ${jobStats.realTimeFactor?.toFixed(4) || 'N/A'}`
       : `duration: ${durationMs.toFixed(0)}ms (calculated)`
 
-    const audioInputPreview = typeof params.audioInput === 'string'
-      ? path.basename(params.audioInput)
-      : (Buffer.isBuffer(params.audioInput) || params.audioInput instanceof Uint8Array
+    const audioInputPreview =
+      typeof params.audioInput === 'string'
+        ? path.basename(params.audioInput)
+        : Buffer.isBuffer(params.audioInput) || params.audioInput instanceof Uint8Array
           ? `${(params.audioInput.length / 1024).toFixed(1)}KB`
-          : 'stream')
+          : 'stream'
 
     const output = `Transcribed ${segmentCount} segments (${statsInfo}) from audio: "${audioInputPreview}"`
 

--- a/packages/transcription-whispercpp/test/integration/live-stream-simulation.test.js
+++ b/packages/transcription-whispercpp/test/integration/live-stream-simulation.test.js
@@ -6,18 +6,26 @@ const test = require('brittle')
 const { Readable } = require('streamx')
 
 const TranscriptionWhispercpp = require('../../index.js')
-const { ensureWhisperModel, ensureVADModel, getTestPaths, createAudioStream, isMobile } = require('./helpers.js')
+const {
+  ensureWhisperModel,
+  ensureVADModel,
+  getTestPaths,
+  createAudioStream,
+  isMobile
+} = require('./helpers.js')
 
 // Create a pushable Readable to simulate a live input source.
-function createLiveReadable () {
+function createLiveReadable() {
   const r = new Readable({
-    read (cb) { cb(null) }
+    read(cb) {
+      cb(null)
+    }
   })
   return r
 }
 
 // Paces pushing chunks at a given bytes-per-second rate.
-async function feedStreamLive ({ readable, filePath, chunkBytes, bytesPerSecond }) {
+async function feedStreamLive({ readable, filePath, chunkBytes, bytesPerSecond }) {
   const fileStream = fs.createReadStream(filePath, { highWaterMark: chunkBytes })
   const delayPerChunkMs = Math.max(1, Math.round(1000 * (chunkBytes / Math.max(1, bytesPerSecond))))
   let idx = 0
@@ -28,7 +36,7 @@ async function feedStreamLive ({ readable, filePath, chunkBytes, bytesPerSecond 
     total += view.byteLength
     console.log(`[feed] chunk #${idx} bytes=${view.byteLength} total=${total}`) // eslint-disable-line
     readable.push(view)
-    await new Promise(resolve => setTimeout(resolve, delayPerChunkMs))
+    await new Promise((resolve) => setTimeout(resolve, delayPerChunkMs))
     idx++
   }
   readable.push(null) // End of stream
@@ -36,270 +44,296 @@ async function feedStreamLive ({ readable, filePath, chunkBytes, bytesPerSecond 
 }
 
 // Skip on mobile - requires 10min audio file (~19MB) which is too large to bundle
-test('Live stream simulation using pushable Readable with model.run()', { timeout: 180000, skip: isMobile }, async (t) => {
-  // Use standardized test paths from helpers
-  const { modelPath } = getTestPaths()
-  // Use the 10-minute s16le sample from examples (provided by repo)
-  const audioPath = path.resolve(__dirname, '../../examples/samples/10min-16k-s16le.raw')
+test(
+  'Live stream simulation using pushable Readable with model.run()',
+  { timeout: 180000, skip: isMobile },
+  async (t) => {
+    // Use standardized test paths from helpers
+    const { modelPath } = getTestPaths()
+    // Use the 10-minute s16le sample from examples (provided by repo)
+    const audioPath = path.resolve(__dirname, '../../examples/samples/10min-16k-s16le.raw')
 
-  const whisperResult = await ensureWhisperModel(modelPath)
+    const whisperResult = await ensureWhisperModel(modelPath)
 
-  // Verify test audio exists; skip if not present in repo checkout
-  if (!fs.existsSync(audioPath)) {
-    console.log(` Live stream test skipped: audio file not found at ${audioPath}`) // eslint-disable-line
-    t.pass('Live stream simulation skipped (10min audio not available)')
-    return
-  }
-
-  const constructorArgs = {
-    files: {
-      model: modelPath
+    // Verify test audio exists; skip if not present in repo checkout
+    if (!fs.existsSync(audioPath)) {
+      console.log(` Live stream test skipped: audio file not found at ${audioPath}`) // eslint-disable-line
+      t.pass('Live stream simulation skipped (10min audio not available)')
+      return
     }
-  }
 
-  const config = {
-    path: modelPath,
-    whisperConfig: {
-      language: 'en',
-      audio_format: 's16le',
-      temperature: 0.0,
-      suppress_nst: true,
-      // the no_context = false is important because it allows maintaining the context in live transcription
-      // to provide better output quality
-      no_context: false
-    }
-  }
-
-  let model
-  try {
-    model = new TranscriptionWhispercpp(constructorArgs, config)
-    await model._load()
-
-    const liveReadable = createLiveReadable()
-
-    // Start model run first with an "empty" stream that will be fed
-    const response = await model.run(liveReadable)
-    const segments = []
-    let firstUpdateAt = null
-    response.onUpdate((outputArr) => {
-      const items = Array.isArray(outputArr) ? outputArr : [outputArr]
-      // Print each segment as it arrives to verify live output delivery
-      for (const seg of items) {
-        if (seg && typeof seg === 'object') {
-          const txt = typeof seg.text === 'string' ? seg.text : JSON.stringify(seg)
-          console.log(`[onUpdate] segment:`, txt) // eslint-disable-line
-        } else {
-          console.log(`[onUpdate] raw:`, seg) // eslint-disable-line
-        }
+    const constructorArgs = {
+      files: {
+        model: modelPath
       }
-      if (firstUpdateAt === null) firstUpdateAt = Date.now()
-      segments.push(...items)
-    })
-
-    // Feed audio in pseudo real-time (accelerated) with 3-second chunks.
-    // s16le@16kHz → 32000 B/s; 3s chunk = 96000 bytes.
-    const chunkBytes = 96000 // ~3s per chunk at 16k s16le
-    const bytesPerSecond = chunkBytes * 1000 // keep ~1ms delay per chunk for fast tests
-    const feedStart = Date.now()
-    const feedStats = await feedStreamLive({ readable: liveReadable, filePath: audioPath, chunkBytes, bytesPerSecond })
-    const feedEnd = Date.now()
-
-    // Wait for completion
-    await response.await()
-
-    // Timing diagnostics to understand if updates came before feed completion
-    if (firstUpdateAt) {
-      console.log(`[timing] first update after ${(firstUpdateAt - feedStart)} ms from start feeding`) // eslint-disable-line
-      console.log(`[timing] feed duration ${(feedEnd - feedStart)} ms; time to first update vs end: ${(firstUpdateAt - feedEnd)} ms`) // eslint-disable-line
-    } else {
-      console.log('[timing] no onUpdate received during/after feed') // eslint-disable-line
     }
 
-    // Asserts: el feed debe haber empujado al menos 1 chunk y >0 bytes
-    t.ok(feedStats.chunksProcessed > 0, 'Se han enviado chunks al stream (chunksProcessed > 0)')
-    t.ok(feedStats.totalBytes > 0, 'Se han enviado bytes al stream (totalBytes > 0)')
-
-    // Assertions (lenient to allow placeholder/real model paths)
-    if (whisperResult.isReal) {
-      t.ok(segments.length >= 1, 'Se recibió al menos un segmento en onUpdate con modelo real')
-    } else {
-      // With placeholder, we still expect no crashes and completion
-      t.pass('Live run completed (placeholder model)')
+    const config = {
+      path: modelPath,
+      whisperConfig: {
+        language: 'en',
+        audio_format: 's16le',
+        temperature: 0.0,
+        suppress_nst: true,
+        // the no_context = false is important because it allows maintaining the context in live transcription
+        // to provide better output quality
+        no_context: false
+      }
     }
-  } catch (err) {
-    console.error('Live stream simulation failed:', err)
-    t.fail(err.message)
-  } finally {
-    if (model) {
-      await model.destroy()
-    }
-  }
-})
 
-// Skip on mobile - requires 10min audio file (~19MB) which is too large to bundle
-test('Live segmented loop: repeated model.run per 3s chunk (no model teardown until end)', { timeout: 180000, skip: isMobile }, async (t) => {
-  // Use standardized test paths from helpers
-  const { modelPath } = getTestPaths()
-  const audioPath = path.resolve(__dirname, '../../examples/samples/10min-16k-s16le.raw')
+    let model
+    try {
+      model = new TranscriptionWhispercpp(constructorArgs, config)
+      await model._load()
 
-  const whisperResult = await ensureWhisperModel(modelPath)
+      const liveReadable = createLiveReadable()
 
-  if (!fs.existsSync(audioPath)) {
-    console.log(` Segmented-live test skipped: audio file not found at ${audioPath}`) // eslint-disable-line
-    t.pass('Segmented-live skipped (audio not available)')
-    return
-  }
-
-  const constructorArgs = {
-    files: {
-      model: modelPath
-    }
-  }
-
-  const config = {
-    path: modelPath,
-    whisperConfig: {
-      language: 'en',
-      audio_format: 's16le',
-      temperature: 0.0,
-      suppress_nst: true
-    }
-  }
-
-  let model
-  try {
-    model = new TranscriptionWhispercpp(constructorArgs, config)
-    await model._load()
-
-    // 3-second chunks (s16le@16kHz → 96000 bytes per chunk)
-    const chunkBytes = 96000
-    const fileStream = fs.createReadStream(audioPath, { highWaterMark: chunkBytes })
-
-    let idx = 0
-    const MAX_CHUNKS = 5 // keep test fast; adjust as needed
-    const allSegments = []
-    let runsCompleted = 0
-    let updatesCount = 0
-
-    for await (const buf of fileStream) {
-      // Use createAudioStream from helpers - it handles Buffer/Uint8Array inputs correctly
-      // Create a proper Uint8Array view to avoid byteOffset issues
-      const view = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
-      const chunkReadable = createAudioStream(view)
-
-      console.log(`[segmented] running chunk #${idx} size=${view.byteLength}`) // eslint-disable-line
-      const response = await model.run(chunkReadable)
+      // Start model run first with an "empty" stream that will be fed
+      const response = await model.run(liveReadable)
+      const segments = []
+      let firstUpdateAt = null
       response.onUpdate((outputArr) => {
         const items = Array.isArray(outputArr) ? outputArr : [outputArr]
+        // Print each segment as it arrives to verify live output delivery
         for (const seg of items) {
-          const txt = seg && typeof seg.text === 'string' ? seg.text : JSON.stringify(seg)
-          console.log(`[segmented:onUpdate] #${idx} ->`, txt) // eslint-disable-line
+          if (seg && typeof seg === 'object') {
+            const txt = typeof seg.text === 'string' ? seg.text : JSON.stringify(seg)
+            console.log(`[onUpdate] segment:`, txt) // eslint-disable-line
+          } else {
+            console.log(`[onUpdate] raw:`, seg) // eslint-disable-line
+          }
         }
-        allSegments.push(...items)
-        updatesCount += items.length
+        if (firstUpdateAt === null) firstUpdateAt = Date.now()
+        segments.push(...items)
       })
+
+      // Feed audio in pseudo real-time (accelerated) with 3-second chunks.
+      // s16le@16kHz → 32000 B/s; 3s chunk = 96000 bytes.
+      const chunkBytes = 96000 // ~3s per chunk at 16k s16le
+      const bytesPerSecond = chunkBytes * 1000 // keep ~1ms delay per chunk for fast tests
+      const feedStart = Date.now()
+      const feedStats = await feedStreamLive({
+        readable: liveReadable,
+        filePath: audioPath,
+        chunkBytes,
+        bytesPerSecond
+      })
+      const feedEnd = Date.now()
+
+      // Wait for completion
       await response.await()
-      runsCompleted++
 
-      idx++
-      if (idx >= MAX_CHUNKS) break
-    }
-
-    // Asserts básicos del bucle segmentado
-    t.is(runsCompleted, idx, 'Each model.run() per chunk must complete (runsCompleted == idx)')
-    t.ok(idx > 0, 'At least one chunk should have been processed in segmented mode (idx > 0)')
-
-    if (whisperResult.isReal) {
-      t.ok(updatesCount >= 1, 'With real model, at least one update should be received in segmented mode')
-    } else {
-      t.pass('Segmented live run completed (placeholder model)')
-    }
-  } catch (err) {
-    console.error('Segmented live simulation failed:', err)
-    t.fail(err.message)
-  } finally {
-    if (model) {
-      await model.destroy()
-    }
-  }
-})
-
-test('Conversation mode streaming emits VAD events with transcript output', { timeout: 180000, skip: isMobile }, async (t) => {
-  const { modelPath, vadModelPath } = getTestPaths()
-  const audioPath = path.resolve(__dirname, '../../examples/samples/sample.raw')
-
-  const whisperResult = await ensureWhisperModel(modelPath)
-  const hasVadModel = await ensureVADModel(vadModelPath)
-
-  if (!fs.existsSync(audioPath)) {
-    console.log(` Conversation stream test skipped: audio file not found at ${audioPath}`) // eslint-disable-line
-    t.pass('Conversation stream skipped (audio not available)')
-    return
-  }
-
-  if (!whisperResult.isReal || !hasVadModel) {
-    t.pass('Conversation stream skipped (model or VAD unavailable)')
-    return
-  }
-
-  const constructorArgs = {
-    files: {
-      model: modelPath,
-      vadModel: vadModelPath
-    }
-  }
-
-  const config = {
-    path: modelPath,
-    whisperConfig: {
-      language: 'en',
-      audio_format: 's16le',
-      temperature: 0.0,
-      suppress_nst: true,
-      vad_params: {
-        threshold: 0.5,
-        min_silence_duration_ms: 300,
-        min_speech_duration_ms: 250,
-        max_speech_duration_s: 30,
-        speech_pad_ms: 30,
-        samples_overlap: 0.1
+      // Timing diagnostics to understand if updates came before feed completion
+      if (firstUpdateAt) {
+        console.log(
+          `[timing] first update after ${firstUpdateAt - feedStart} ms from start feeding`
+        ) // eslint-disable-line
+        console.log(
+          `[timing] feed duration ${feedEnd - feedStart} ms; time to first update vs end: ${firstUpdateAt - feedEnd} ms`
+        ) // eslint-disable-line
+      } else {
+        console.log('[timing] no onUpdate received during/after feed') // eslint-disable-line
       }
-    },
-    vadModelPath
-  }
 
-  let model
-  try {
-    model = new TranscriptionWhispercpp(constructorArgs, config)
-    await model._load()
+      // Asserts: el feed debe haber empujado al menos 1 chunk y >0 bytes
+      t.ok(feedStats.chunksProcessed > 0, 'Se han enviado chunks al stream (chunksProcessed > 0)')
+      t.ok(feedStats.totalBytes > 0, 'Se han enviado bytes al stream (totalBytes > 0)')
 
-    const response = await model.runStreaming(createAudioStream(audioPath), {
-      emitVadEvents: true,
-      endOfTurnSilenceMs: 750,
-      vadRunIntervalMs: 300
-    })
-
-    const updates = []
-    response.onUpdate((data) => {
-      updates.push(data)
-    })
-
-    await response.await()
-
-    const vadEvents = updates.filter(data => data?.type === 'vad')
-    const transcriptOutputs = updates.flatMap(data => {
-      if (data?.type === 'vad' || data?.type === 'endOfTurn') return []
-      return Array.isArray(data) ? data : [data]
-    }).filter(item => typeof item?.text === 'string' && item.text.trim().length > 0)
-
-    t.ok(vadEvents.length > 0, 'Conversation stream should emit VAD events')
-    t.ok(transcriptOutputs.length > 0, 'Conversation stream should emit transcript output')
-  } catch (err) {
-    console.error('Conversation stream simulation failed:', err)
-    t.fail(err.message)
-  } finally {
-    if (model) {
-      await model.destroy()
+      // Assertions (lenient to allow placeholder/real model paths)
+      if (whisperResult.isReal) {
+        t.ok(segments.length >= 1, 'Se recibió al menos un segmento en onUpdate con modelo real')
+      } else {
+        // With placeholder, we still expect no crashes and completion
+        t.pass('Live run completed (placeholder model)')
+      }
+    } catch (err) {
+      console.error('Live stream simulation failed:', err)
+      t.fail(err.message)
+    } finally {
+      if (model) {
+        await model.destroy()
+      }
     }
   }
-})
+)
+
+// Skip on mobile - requires 10min audio file (~19MB) which is too large to bundle
+test(
+  'Live segmented loop: repeated model.run per 3s chunk (no model teardown until end)',
+  { timeout: 180000, skip: isMobile },
+  async (t) => {
+    // Use standardized test paths from helpers
+    const { modelPath } = getTestPaths()
+    const audioPath = path.resolve(__dirname, '../../examples/samples/10min-16k-s16le.raw')
+
+    const whisperResult = await ensureWhisperModel(modelPath)
+
+    if (!fs.existsSync(audioPath)) {
+      console.log(` Segmented-live test skipped: audio file not found at ${audioPath}`) // eslint-disable-line
+      t.pass('Segmented-live skipped (audio not available)')
+      return
+    }
+
+    const constructorArgs = {
+      files: {
+        model: modelPath
+      }
+    }
+
+    const config = {
+      path: modelPath,
+      whisperConfig: {
+        language: 'en',
+        audio_format: 's16le',
+        temperature: 0.0,
+        suppress_nst: true
+      }
+    }
+
+    let model
+    try {
+      model = new TranscriptionWhispercpp(constructorArgs, config)
+      await model._load()
+
+      // 3-second chunks (s16le@16kHz → 96000 bytes per chunk)
+      const chunkBytes = 96000
+      const fileStream = fs.createReadStream(audioPath, { highWaterMark: chunkBytes })
+
+      let idx = 0
+      const MAX_CHUNKS = 5 // keep test fast; adjust as needed
+      const allSegments = []
+      let runsCompleted = 0
+      let updatesCount = 0
+
+      for await (const buf of fileStream) {
+        // Use createAudioStream from helpers - it handles Buffer/Uint8Array inputs correctly
+        // Create a proper Uint8Array view to avoid byteOffset issues
+        const view = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength)
+        const chunkReadable = createAudioStream(view)
+
+        console.log(`[segmented] running chunk #${idx} size=${view.byteLength}`) // eslint-disable-line
+        const response = await model.run(chunkReadable)
+        response.onUpdate((outputArr) => {
+          const items = Array.isArray(outputArr) ? outputArr : [outputArr]
+          for (const seg of items) {
+            const txt = seg && typeof seg.text === 'string' ? seg.text : JSON.stringify(seg)
+            console.log(`[segmented:onUpdate] #${idx} ->`, txt) // eslint-disable-line
+          }
+          allSegments.push(...items)
+          updatesCount += items.length
+        })
+        await response.await()
+        runsCompleted++
+
+        idx++
+        if (idx >= MAX_CHUNKS) break
+      }
+
+      // Asserts básicos del bucle segmentado
+      t.is(runsCompleted, idx, 'Each model.run() per chunk must complete (runsCompleted == idx)')
+      t.ok(idx > 0, 'At least one chunk should have been processed in segmented mode (idx > 0)')
+
+      if (whisperResult.isReal) {
+        t.ok(
+          updatesCount >= 1,
+          'With real model, at least one update should be received in segmented mode'
+        )
+      } else {
+        t.pass('Segmented live run completed (placeholder model)')
+      }
+    } catch (err) {
+      console.error('Segmented live simulation failed:', err)
+      t.fail(err.message)
+    } finally {
+      if (model) {
+        await model.destroy()
+      }
+    }
+  }
+)
+
+test(
+  'Conversation mode streaming emits VAD events with transcript output',
+  { timeout: 180000, skip: isMobile },
+  async (t) => {
+    const { modelPath, vadModelPath } = getTestPaths()
+    const audioPath = path.resolve(__dirname, '../../examples/samples/sample.raw')
+
+    const whisperResult = await ensureWhisperModel(modelPath)
+    const hasVadModel = await ensureVADModel(vadModelPath)
+
+    if (!fs.existsSync(audioPath)) {
+      console.log(` Conversation stream test skipped: audio file not found at ${audioPath}`) // eslint-disable-line
+      t.pass('Conversation stream skipped (audio not available)')
+      return
+    }
+
+    if (!whisperResult.isReal || !hasVadModel) {
+      t.pass('Conversation stream skipped (model or VAD unavailable)')
+      return
+    }
+
+    const constructorArgs = {
+      files: {
+        model: modelPath,
+        vadModel: vadModelPath
+      }
+    }
+
+    const config = {
+      path: modelPath,
+      whisperConfig: {
+        language: 'en',
+        audio_format: 's16le',
+        temperature: 0.0,
+        suppress_nst: true,
+        vad_params: {
+          threshold: 0.5,
+          min_silence_duration_ms: 300,
+          min_speech_duration_ms: 250,
+          max_speech_duration_s: 30,
+          speech_pad_ms: 30,
+          samples_overlap: 0.1
+        }
+      },
+      vadModelPath
+    }
+
+    let model
+    try {
+      model = new TranscriptionWhispercpp(constructorArgs, config)
+      await model._load()
+
+      const response = await model.runStreaming(createAudioStream(audioPath), {
+        emitVadEvents: true,
+        endOfTurnSilenceMs: 750,
+        vadRunIntervalMs: 300
+      })
+
+      const updates = []
+      response.onUpdate((data) => {
+        updates.push(data)
+      })
+
+      await response.await()
+
+      const vadEvents = updates.filter((data) => data?.type === 'vad')
+      const transcriptOutputs = updates
+        .flatMap((data) => {
+          if (data?.type === 'vad' || data?.type === 'endOfTurn') return []
+          return Array.isArray(data) ? data : [data]
+        })
+        .filter((item) => typeof item?.text === 'string' && item.text.trim().length > 0)
+
+      t.ok(vadEvents.length > 0, 'Conversation stream should emit VAD events')
+      t.ok(transcriptOutputs.length > 0, 'Conversation stream should emit transcript output')
+    } catch (err) {
+      console.error('Conversation stream simulation failed:', err)
+      t.fail(err.message)
+    } finally {
+      if (model) {
+        await model.destroy()
+      }
+    }
+  }
+)

--- a/packages/transcription-whispercpp/test/integration/longES.test.js
+++ b/packages/transcription-whispercpp/test/integration/longES.test.js
@@ -3,133 +3,149 @@ const fs = require('bare-fs')
 const path = require('bare-path')
 const os = require('bare-os')
 const test = require('brittle')
-const { detectPlatform, ensureWhisperModel, runTranscription, getAssetPath, isMobile } = require('./helpers.js')
+const {
+  detectPlatform,
+  ensureWhisperModel,
+  runTranscription,
+  getAssetPath,
+  isMobile
+} = require('./helpers.js')
 
 const platform = detectPlatform()
 
 // Works on both mobile and desktop - skips gracefully if audio not available
-test('Spanish audio transcription - LastQuestion_long_ES.raw with real-time output', { timeout: 300000 }, async (t) => {
-  // Get model path - use writable directory for models
-  const modelsDir = isMobile ? path.join(global.testDir || os.tmpdir(), 'models') : path.resolve(__dirname, '../../models')
-  const modelPath = path.join(modelsDir, 'ggml-tiny.bin')
+test(
+  'Spanish audio transcription - LastQuestion_long_ES.raw with real-time output',
+  { timeout: 300000 },
+  async (t) => {
+    // Get model path - use writable directory for models
+    const modelsDir = isMobile
+      ? path.join(global.testDir || os.tmpdir(), 'models')
+      : path.resolve(__dirname, '../../models')
+    const modelPath = path.join(modelsDir, 'ggml-tiny.bin')
 
-  // Get audio path - try getAssetPath first (for mobile testAssets)
-  let audioPath
-  try {
-    audioPath = getAssetPath('LastQuestion_long_ES.raw')
-  } catch (e) {
-    // Try desktop path
-    audioPath = path.resolve(__dirname, '../../examples/samples/LastQuestion_long_ES.raw')
-  }
+    // Get audio path - try getAssetPath first (for mobile testAssets)
+    let audioPath
+    try {
+      audioPath = getAssetPath('LastQuestion_long_ES.raw')
+    } catch (e) {
+      // Try desktop path
+      audioPath = path.resolve(__dirname, '../../examples/samples/LastQuestion_long_ES.raw')
+    }
 
-  console.log(` Running Spanish audio test on platform: ${platform}`)
-  console.log(` Audio file: ${path.basename(audioPath)}`)
-  console.log(` Model path: ${modelPath}`)
-  console.log(` Platform: ${isMobile ? 'mobile' : 'desktop'}`)
+    console.log(` Running Spanish audio test on platform: ${platform}`)
+    console.log(` Audio file: ${path.basename(audioPath)}`)
+    console.log(` Model path: ${modelPath}`)
+    console.log(` Platform: ${isMobile ? 'mobile' : 'desktop'}`)
 
-  // Ensure model is downloaded
-  const modelResult = await ensureWhisperModel(modelPath)
-  if (!modelResult.success) {
-    console.log('⚠️ Could not download model, skipping test')
-    t.pass('Test skipped - model not available')
-    return
-  }
+    // Ensure model is downloaded
+    const modelResult = await ensureWhisperModel(modelPath)
+    if (!modelResult.success) {
+      console.log('⚠️ Could not download model, skipping test')
+      t.pass('Test skipped - model not available')
+      return
+    }
 
-  // Check if audio file exists - skip gracefully if not
-  if (!fs.existsSync(audioPath)) {
-    console.log(`⚠️ Spanish audio file not found: ${audioPath}`)
-    console.log('   This is expected on mobile if file is not in testAssets/')
-    t.pass('Test skipped - audio file not available')
-    return
-  }
+    // Check if audio file exists - skip gracefully if not
+    if (!fs.existsSync(audioPath)) {
+      console.log(`⚠️ Spanish audio file not found: ${audioPath}`)
+      console.log('   This is expected on mobile if file is not in testAssets/')
+      t.pass('Test skipped - audio file not available')
+      return
+    }
 
-  const audioStats = fs.statSync(audioPath)
-  console.log(` Audio file size: ${audioStats.size} bytes`)
-  console.log(` Audio duration (estimated): ${(audioStats.size / (16000 * 2)).toFixed(2)} seconds`)
-
-  t.ok(fs.existsSync(audioPath), 'Spanish audio file should exist')
-  t.ok(fs.existsSync(modelPath), 'Whisper model file should exist')
-
-  // Track real-time updates
-  const segments = []
-  const jobStartTime = Date.now()
-  let transcriptionReceived = false
-
-  // Real-time output callback for onUpdate
-  const onUpdate = (outputArr) => {
-    const items = Array.isArray(outputArr) ? outputArr : [outputArr]
-    const elapsed = ((Date.now() - jobStartTime) / 1000).toFixed(2)
-
-    items.forEach((segment) => {
-      if (segment && segment.text) {
-        console.log(`📝 [${elapsed}s] "${segment.text}"`)
-        if (segment.start !== undefined && segment.end !== undefined) {
-          console.log(`   ⏱️  ${segment.start.toFixed(2)}s - ${segment.end.toFixed(2)}s\n`)
-        }
-        transcriptionReceived = true
-      }
-    })
-
-    segments.push(...items)
-  }
-
-  try {
-    console.log('\n🎵 Starting transcription with real-time output...')
-    console.log('   Watch for real-time transcription output below:\n')
-
-    const result = await runTranscription(
-      {
-        audioInput: audioPath,
-        modelPath,
-        whisperConfig: {
-          language: 'es',
-          duration_ms: 0, // 0 means no duration limit
-          temperature: 0.0,
-          vadParams: {
-            threshold: 0.6
-          }
-        },
-        onUpdate // Real-time update callback
-      },
-      {
-        minSegments: 0 // At least 0 segments (may be 0 with test audio)
-      }
+    const audioStats = fs.statSync(audioPath)
+    console.log(` Audio file size: ${audioStats.size} bytes`)
+    console.log(
+      ` Audio duration (estimated): ${(audioStats.size / (16000 * 2)).toFixed(2)} seconds`
     )
 
-    const totalTime = ((Date.now() - jobStartTime) / 1000).toFixed(2)
-    console.log(`\n✅ Transcription completed in ${totalTime}s`)
+    t.ok(fs.existsSync(audioPath), 'Spanish audio file should exist')
+    t.ok(fs.existsSync(modelPath), 'Whisper model file should exist')
 
-    // Display stats if available
-    if (result.data.stats) {
-      console.log('   Stats:', JSON.stringify(result.data.stats, null, 2))
-    }
+    // Track real-time updates
+    const segments = []
+    const jobStartTime = Date.now()
+    let transcriptionReceived = false
 
-    // Validate and summarize results
-    console.log('\n📊 Test Results Summary:')
-    console.log(`   Total segments received: ${segments.length}`)
-    console.log(`   Transcription result: ${result.passed ? 'SUCCESS' : 'FAILED'}`)
-    console.log(`   Segments: ${result.data.segmentCount}`)
-    console.log(`   Text length: ${result.data.textLength}`)
+    // Real-time output callback for onUpdate
+    const onUpdate = (outputArr) => {
+      const items = Array.isArray(outputArr) ? outputArr : [outputArr]
+      const elapsed = ((Date.now() - jobStartTime) / 1000).toFixed(2)
 
-    if (transcriptionReceived && segments.length > 0) {
-      console.log('\n🎉 SUCCESS: Spanish audio transcription completed!')
-      console.log('\n📝 Final Transcription:')
-      segments.forEach((segment, idx) => {
+      items.forEach((segment) => {
         if (segment && segment.text) {
-          console.log(`   [${idx + 1}] "${segment.text}" (${segment.start?.toFixed(2) || '?'}s-${segment.end?.toFixed(2) || '?'}s)`)
+          console.log(`📝 [${elapsed}s] "${segment.text}"`)
+          if (segment.start !== undefined && segment.end !== undefined) {
+            console.log(`   ⏱️  ${segment.start.toFixed(2)}s - ${segment.end.toFixed(2)}s\n`)
+          }
+          transcriptionReceived = true
         }
       })
-      t.pass('Successfully transcribed Spanish audio with real-time output')
-    } else if (result.data.error) {
-      console.log('\n⚠️  Model loaded but transcription had issues')
-      console.log(`   Error: ${result.data.error}`)
-      t.pass('Model loaded but transcription had issues (may be expected)')
-    } else {
-      t.ok(result.passed, 'Should pass expectations even if no transcription segments')
+
+      segments.push(...items)
     }
-  } catch (error) {
-    console.log(`\n❌ Test error: ${error.message}`)
-    console.log(`   Stack: ${error.stack}`)
-    t.pass('Test handled error gracefully')
+
+    try {
+      console.log('\n🎵 Starting transcription with real-time output...')
+      console.log('   Watch for real-time transcription output below:\n')
+
+      const result = await runTranscription(
+        {
+          audioInput: audioPath,
+          modelPath,
+          whisperConfig: {
+            language: 'es',
+            duration_ms: 0, // 0 means no duration limit
+            temperature: 0.0,
+            vadParams: {
+              threshold: 0.6
+            }
+          },
+          onUpdate // Real-time update callback
+        },
+        {
+          minSegments: 0 // At least 0 segments (may be 0 with test audio)
+        }
+      )
+
+      const totalTime = ((Date.now() - jobStartTime) / 1000).toFixed(2)
+      console.log(`\n✅ Transcription completed in ${totalTime}s`)
+
+      // Display stats if available
+      if (result.data.stats) {
+        console.log('   Stats:', JSON.stringify(result.data.stats, null, 2))
+      }
+
+      // Validate and summarize results
+      console.log('\n📊 Test Results Summary:')
+      console.log(`   Total segments received: ${segments.length}`)
+      console.log(`   Transcription result: ${result.passed ? 'SUCCESS' : 'FAILED'}`)
+      console.log(`   Segments: ${result.data.segmentCount}`)
+      console.log(`   Text length: ${result.data.textLength}`)
+
+      if (transcriptionReceived && segments.length > 0) {
+        console.log('\n🎉 SUCCESS: Spanish audio transcription completed!')
+        console.log('\n📝 Final Transcription:')
+        segments.forEach((segment, idx) => {
+          if (segment && segment.text) {
+            console.log(
+              `   [${idx + 1}] "${segment.text}" (${segment.start?.toFixed(2) || '?'}s-${segment.end?.toFixed(2) || '?'}s)`
+            )
+          }
+        })
+        t.pass('Successfully transcribed Spanish audio with real-time output')
+      } else if (result.data.error) {
+        console.log('\n⚠️  Model loaded but transcription had issues')
+        console.log(`   Error: ${result.data.error}`)
+        t.pass('Model loaded but transcription had issues (may be expected)')
+      } else {
+        t.ok(result.passed, 'Should pass expectations even if no transcription segments')
+      }
+    } catch (error) {
+      console.log(`\n❌ Test error: ${error.message}`)
+      console.log(`   Stack: ${error.stack}`)
+      t.pass('Test handled error gracefully')
+    }
   }
-})
+)

--- a/packages/transcription-whispercpp/test/integration/memory-usage.js
+++ b/packages/transcription-whispercpp/test/integration/memory-usage.js
@@ -10,11 +10,11 @@ const DEFAULT_SAMPLE_INTERVAL_MS = 25
 // chance to return freed pages to the OS.
 const RECLAIM_SETTLE_MS = 250
 
-function isPositiveNumber (value) {
+function isPositiveNumber(value) {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
 }
 
-function readRssFromBareOs () {
+function readRssFromBareOs() {
   try {
     const usage = require('bare-os').memoryUsage()
     return usage && isPositiveNumber(usage.rss) ? usage.rss : 0
@@ -23,7 +23,7 @@ function readRssFromBareOs () {
   }
 }
 
-function resolveProcess () {
+function resolveProcess() {
   if (globalThis.process && typeof globalThis.process.memoryUsage === 'function') {
     return globalThis.process
   }
@@ -35,7 +35,7 @@ function resolveProcess () {
   }
 }
 
-function readRssFromProcess () {
+function readRssFromProcess() {
   try {
     const proc = resolveProcess()
     const usage = proc && proc.memoryUsage()
@@ -45,27 +45,27 @@ function readRssFromProcess () {
   }
 }
 
-function readRssBytes () {
+function readRssBytes() {
   return readRssFromBareOs() || readRssFromProcess()
 }
 
-function filterPositive (samples) {
+function filterPositive(samples) {
   return (Array.isArray(samples) ? samples : []).filter(isPositiveNumber)
 }
 
-function sumValues (values) {
+function sumValues(values) {
   return values.reduce((total, value) => total + value, 0)
 }
 
-function maxValue (values) {
+function maxValue(values) {
   return values.reduce((current, value) => (value > current ? value : current), values[0])
 }
 
-function minValue (values) {
+function minValue(values) {
   return values.reduce((current, value) => (value < current ? value : current), values[0])
 }
 
-function summarizeSamples (samples) {
+function summarizeSamples(samples) {
   const values = filterPositive(samples)
   if (values.length === 0) {
     return { count: 0, avgBytes: 0, peakBytes: 0, minBytes: 0 }
@@ -78,18 +78,18 @@ function summarizeSamples (samples) {
   }
 }
 
-function meanOfPositive (values) {
+function meanOfPositive(values) {
   const positives = filterPositive(values)
   if (positives.length === 0) return 0
   return sumValues(positives) / positives.length
 }
 
-function maxOfPositive (values, floor) {
+function maxOfPositive(values, floor) {
   const list = Array.isArray(values) ? values : []
   return list.reduce((current, value) => (value > current ? value : current), floor || 0)
 }
 
-function scheduleSample (state) {
+function scheduleSample(state) {
   state.timer = setTimeout(() => {
     if (!state.running) return
     collectSample(state)
@@ -100,20 +100,20 @@ function scheduleSample (state) {
   }
 }
 
-function collectSample (state) {
+function collectSample(state) {
   const rss = readRssBytes()
   if (rss > 0) state.samples.push(rss)
   return rss
 }
 
-function startSampler (state) {
+function startSampler(state) {
   if (state.running) return
   state.running = true
   collectSample(state)
   scheduleSample(state)
 }
 
-function stopSampler (state) {
+function stopSampler(state) {
   state.running = false
   if (state.timer) {
     clearTimeout(state.timer)
@@ -123,7 +123,7 @@ function stopSampler (state) {
   return summarizeSamples(state.samples)
 }
 
-function createMemorySampler (options) {
+function createMemorySampler(options) {
   const state = {
     intervalMs: (options && options.intervalMs) || DEFAULT_SAMPLE_INTERVAL_MS,
     samples: [],
@@ -134,15 +134,17 @@ function createMemorySampler (options) {
     start: () => startSampler(state),
     stop: () => stopSampler(state),
     sampleOnce: () => collectSample(state),
-    get samples () { return state.samples }
+    get samples() {
+      return state.samples
+    }
   }
 }
 
-function toBytes (value) {
+function toBytes(value) {
   return isPositiveNumber(value) ? value : 0
 }
 
-function computeReclaim (input) {
+function computeReclaim(input) {
   const afterLoad = toBytes(input && input.rssAfterLoadBytes)
   const peak = toBytes(input && input.peakRssBytes)
   const afterUnload = toBytes(input && input.rssAfterUnloadBytes)
@@ -154,18 +156,18 @@ function computeReclaim (input) {
   }
 }
 
-function roundTo (value, digits) {
+function roundTo(value, digits) {
   const factor = 10 ** digits
   return Math.round(value * factor) / factor
 }
 
-function bytesToMb (bytes, digits) {
+function bytesToMb(bytes, digits) {
   if (!isPositiveNumber(bytes)) return 0
   const mb = bytes / BYTES_PER_MB
   return typeof digits === 'number' ? roundTo(mb, digits) : mb
 }
 
-function buildMemorySummary (input) {
+function buildMemorySummary(input) {
   const source = input || {}
   const rssAfterLoadBytes = toBytes(source.rssAfterLoadBytes)
   const peakRssBytes = Math.max(toBytes(source.peakRssBytes), rssAfterLoadBytes)

--- a/packages/transcription-whispercpp/test/integration/mobile-perf-runner.js
+++ b/packages/transcription-whispercpp/test/integration/mobile-perf-runner.js
@@ -29,28 +29,34 @@ const NUM_TRANSCRIPTIONS = 3
 const SAMPLE_RATE = 16000
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 
-async function recordReclaimAfterUnload (modelLabel, epLabel, rssAfterLoadBytes, peakRssBytes) {
+async function recordReclaimAfterUnload(modelLabel, epLabel, rssAfterLoadBytes, peakRssBytes) {
   if (typeof global.gc === 'function') {
-    try { global.gc() } catch (_) {}
+    try {
+      global.gc()
+    } catch (_) {}
   }
-  await new Promise(resolve => setTimeout(resolve, RECLAIM_SETTLE_MS))
+  await new Promise((resolve) => setTimeout(resolve, RECLAIM_SETTLE_MS))
   const summary = buildMemorySummary({
     rssAfterLoadBytes,
     peakRssBytes,
     rssAfterUnloadBytes: readRssBytes()
   })
-  recordWhisperStats(modelLabel + ' ' + epLabel + ' mobile-perf teardown', {}, {
-    reclaimedMb: summary.reclaimedMb
-  })
+  recordWhisperStats(
+    modelLabel + ' ' + epLabel + ' mobile-perf teardown',
+    {},
+    {
+      reclaimedMb: summary.reclaimedMb
+    }
+  )
   console.log('   Reclaimed after unload: ' + summary.reclaimedMb + 'MB')
 }
 
-function getTimeMs () {
+function getTimeMs() {
   const [sec, nsec] = proc.hrtime()
   return sec * 1000 + nsec / 1e6
 }
 
-function locateSampleAudio () {
+function locateSampleAudio() {
   const candidates = ['sample.raw', 'short_en.raw']
   for (const name of candidates) {
     try {
@@ -63,7 +69,7 @@ function locateSampleAudio () {
   return null
 }
 
-async function ensureMobileModel (t, modelFile) {
+async function ensureMobileModel(t, modelFile) {
   const modelPath = path.join(modelsDir, modelFile)
   const result = await ensureWhisperModel(modelPath)
   if (result && result.success) return modelPath
@@ -71,7 +77,7 @@ async function ensureMobileModel (t, modelFile) {
   return null
 }
 
-async function runMobilePerfCase (t, opts) {
+async function runMobilePerfCase(t, opts) {
   const modelFile = opts.modelFile || 'ggml-tiny.bin'
   const useGPU = opts.useGPU
   const epLabel = useGPU ? '[GPU]' : '[CPU]'
@@ -139,7 +145,13 @@ async function runMobilePerfCase (t, opts) {
     await model._load()
     rssAfterLoadBytes = readRssBytes()
     peakRssBytes = rssAfterLoadBytes
-    console.log('   Model loaded in ' + (getTimeMs() - loadStart).toFixed(0) + 'ms (RSS ' + bytesToMb(rssAfterLoadBytes, 1) + 'MB)\n')
+    console.log(
+      '   Model loaded in ' +
+        (getTimeMs() - loadStart).toFixed(0) +
+        'ms (RSS ' +
+        bytesToMb(rssAfterLoadBytes, 1) +
+        'MB)\n'
+    )
 
     const timings = []
     let statsCount = 0
@@ -161,12 +173,23 @@ async function runMobilePerfCase (t, opts) {
 
       const jobStats = response.stats
       const segments = Array.isArray(response.segments) ? response.segments : []
-      const runText = segments.map(s => (s && s.text) || '').join(' ').trim()
+      const runText = segments
+        .map((s) => (s && s.text) || '')
+        .join(' ')
+        .trim()
 
       console.log('   Time: ' + runTime.toFixed(0) + 'ms')
       console.log('   Segments: ' + segments.length)
-      console.log('   Memory: avg ' + bytesToMb(runMemory.avgBytes, 1) + 'MB, peak ' + bytesToMb(runMemory.peakBytes, 1) + 'MB')
-      console.log('   Text preview: "' + runText.substring(0, 80) + (runText.length > 80 ? '...' : '') + '"')
+      console.log(
+        '   Memory: avg ' +
+          bytesToMb(runMemory.avgBytes, 1) +
+          'MB, peak ' +
+          bytesToMb(runMemory.peakBytes, 1) +
+          'MB'
+      )
+      console.log(
+        '   Text preview: "' + runText.substring(0, 80) + (runText.length > 80 ? '...' : '') + '"'
+      )
 
       if (jobStats) {
         statsCount++
@@ -184,8 +207,21 @@ async function runMobilePerfCase (t, opts) {
       console.log('')
     }
 
-    t.ok(statsCount >= NUM_TRANSCRIPTIONS, modelLabel + ' ' + epLabel + ' should receive stats for every run (got ' + statsCount + ')')
-    t.ok(timings.length === NUM_TRANSCRIPTIONS, modelLabel + ' ' + epLabel + ' should complete ' + NUM_TRANSCRIPTIONS + ' transcriptions (got ' + timings.length + ')')
+    t.ok(
+      statsCount >= NUM_TRANSCRIPTIONS,
+      modelLabel + ' ' + epLabel + ' should receive stats for every run (got ' + statsCount + ')'
+    )
+    t.ok(
+      timings.length === NUM_TRANSCRIPTIONS,
+      modelLabel +
+        ' ' +
+        epLabel +
+        ' should complete ' +
+        NUM_TRANSCRIPTIONS +
+        ' transcriptions (got ' +
+        timings.length +
+        ')'
+    )
 
     // Backend identity assertions. `backendDevice` (0=CPU / 1=GPU) and
     // `backendId` (BackendId enum) are populated once per load() by
@@ -200,15 +236,25 @@ async function runMobilePerfCase (t, opts) {
     const backendId = typeof probe.backendId === 'number' ? probe.backendId : null
     const gpuMemTotalMb = typeof probe.gpuMemTotalMb === 'number' ? probe.gpuMemTotalMb : -1
     const gpuMemFreeMb = typeof probe.gpuMemFreeMb === 'number' ? probe.gpuMemFreeMb : -1
-    console.log('   Backend stats: backendDevice=' + backendDevice +
-                ' backendId=' + backendId +
-                ' gpuMemTotalMb=' + gpuMemTotalMb +
-                ' gpuMemFreeMb=' + gpuMemFreeMb)
+    console.log(
+      '   Backend stats: backendDevice=' +
+        backendDevice +
+        ' backendId=' +
+        backendId +
+        ' gpuMemTotalMb=' +
+        gpuMemTotalMb +
+        ' gpuMemFreeMb=' +
+        gpuMemFreeMb
+    )
 
-    t.ok(backendDevice !== null,
-      modelLabel + ' ' + epLabel + ' should report backendDevice in runtimeStats')
-    t.ok(backendId !== null,
-      modelLabel + ' ' + epLabel + ' should report backendId in runtimeStats')
+    t.ok(
+      backendDevice !== null,
+      modelLabel + ' ' + epLabel + ' should report backendDevice in runtimeStats'
+    )
+    t.ok(
+      backendId !== null,
+      modelLabel + ' ' + epLabel + ' should report backendId in runtimeStats'
+    )
 
     if (useGPU && platform.startsWith('android')) {
       // On Android with use_gpu=true we expect ggml to have registered
@@ -222,8 +268,14 @@ async function runMobilePerfCase (t, opts) {
       // capability that distinguishes Pixel from Samsung lives in the
       // wdio config, not in the spec body). Per-device QLOG output
       // is in the device-farm logcat capture for review.
-      t.ok(backendId === 3 || backendId === 4,
-        modelLabel + ' ' + epLabel + ' Android with use_gpu=true should select a GPU backend (Vulkan=3 or OpenCL=4); got ' + backendId)
+      t.ok(
+        backendId === 3 || backendId === 4,
+        modelLabel +
+          ' ' +
+          epLabel +
+          ' Android with use_gpu=true should select a GPU backend (Vulkan=3 or OpenCL=4); got ' +
+          backendId
+      )
     } else if (useGPU && platform.startsWith('ios')) {
       // On iOS with use_gpu=true we expect ggml to have registered the
       // Metal backend (backendId 1). Metal ships inside the statically
@@ -234,8 +286,15 @@ async function runMobilePerfCase (t, opts) {
       // device-farm guard that iOS actually offloads to Metal (and that
       // the historical MTLCompiler XPC init crash has not regressed)
       // rather than silently falling back to CPU.
-      t.is(backendId, 1,
-        modelLabel + ' ' + epLabel + ' iOS with use_gpu=true should select the Metal backend (backendId=1); got ' + backendId)
+      t.is(
+        backendId,
+        1,
+        modelLabel +
+          ' ' +
+          epLabel +
+          ' iOS with use_gpu=true should select the Metal backend (backendId=1); got ' +
+          backendId
+      )
     }
 
     console.log('Mobile perf case ' + modelLabel + ' ' + epLabel + ' completed successfully!\n')

--- a/packages/transcription-whispercpp/test/integration/mobile-perf-sweep-cpu.test.js
+++ b/packages/transcription-whispercpp/test/integration/mobile-perf-sweep-cpu.test.js
@@ -19,10 +19,14 @@ const CPU_SWEEP = [
 ]
 
 for (const modelFile of CPU_SWEEP) {
-  test('Mobile perf ' + modelFile.replace(/\.bin$/, '') + ' CPU', { timeout: 600000 }, async (t) => {
-    await runMobilePerfCase(t, {
-      modelFile,
-      useGPU: false
-    })
-  })
+  test(
+    'Mobile perf ' + modelFile.replace(/\.bin$/, '') + ' CPU',
+    { timeout: 600000 },
+    async (t) => {
+      await runMobilePerfCase(t, {
+        modelFile,
+        useGPU: false
+      })
+    }
+  )
 }

--- a/packages/transcription-whispercpp/test/integration/mobile-perf-sweep-gpu.test.js
+++ b/packages/transcription-whispercpp/test/integration/mobile-perf-sweep-gpu.test.js
@@ -21,10 +21,14 @@ const GPU_SWEEP = [
 ]
 
 for (const modelFile of GPU_SWEEP) {
-  test('Mobile perf ' + modelFile.replace(/\.bin$/, '') + ' GPU', { timeout: 600000 }, async (t) => {
-    await runMobilePerfCase(t, {
-      modelFile,
-      useGPU: true
-    })
-  })
+  test(
+    'Mobile perf ' + modelFile.replace(/\.bin$/, '') + ' GPU',
+    { timeout: 600000 },
+    async (t) => {
+      await runMobilePerfCase(t, {
+        modelFile,
+        useGPU: true
+      })
+    }
+  )
 }

--- a/packages/transcription-whispercpp/test/integration/model-file-validation.test.js
+++ b/packages/transcription-whispercpp/test/integration/model-file-validation.test.js
@@ -6,13 +6,13 @@ const path = require('bare-path')
 const os = require('bare-os')
 const { ensureWhisperModel, ensureVADModel, isMobile } = require('./helpers.js')
 
-const tmpDir = isMobile ? (global.testDir || os.tmpdir()) : os.tmpdir()
+const tmpDir = isMobile ? global.testDir || os.tmpdir() : os.tmpdir()
 const testModelPath = path.join(tmpDir, 'qvac-test-models', 'ggml-tiny.bin')
 const testVadPath = path.join(tmpDir, 'qvac-test-models', 'ggml-silero-v5.1.2.bin')
 
 let modelsReady = false
 
-async function ensureModelsDownloaded () {
+async function ensureModelsDownloaded() {
   if (modelsReady) return
 
   await ensureWhisperModel(testModelPath)
@@ -73,8 +73,14 @@ test('Should throw error when model file does not exist', { timeout: 60000 }, as
     new TranscriptionWhispercpp(args, config) // eslint-disable-line no-new
     t.fail('Should have thrown an error for non-existent model file')
   } catch (error) {
-    t.ok(error.message.includes('Model file doesn\'t exist'), 'Error message should mention model file doesn\'t exist')
-    t.ok(error.message.includes('non-existent-model.bin'), 'Error message should include the model filename')
+    t.ok(
+      error.message.includes("Model file doesn't exist"),
+      "Error message should mention model file doesn't exist"
+    )
+    t.ok(
+      error.message.includes('non-existent-model.bin'),
+      'Error message should include the model filename'
+    )
   }
 })
 
@@ -108,8 +114,14 @@ test('Should throw error when VAD model file does not exist', { timeout: 180000 
     new TranscriptionWhispercpp(args, config) // eslint-disable-line no-new
     t.fail('Should have thrown an error for non-existent VAD model file')
   } catch (error) {
-    t.ok(error.message.includes('VAD model file not found'), 'Error message should mention VAD model file doesn\'t exist')
-    t.ok(error.message.includes('non-existent-vad-model.bin'), 'Error message should include the VAD model filename')
+    t.ok(
+      error.message.includes('VAD model file not found'),
+      "Error message should mention VAD model file doesn't exist"
+    )
+    t.ok(
+      error.message.includes('non-existent-vad-model.bin'),
+      'Error message should include the VAD model filename'
+    )
   }
 })
 
@@ -117,69 +129,77 @@ test('Should throw error when VAD model file does not exist', { timeout: 180000 
  * Test 4: If model path is valid and VAD path is not provided, no exception should be thrown
  * Works on both mobile and desktop
  */
-test('Should not throw error when model file exists and VAD is not specified', { timeout: 180000 }, async (t) => {
-  // Ensure model is downloaded
-  await ensureModelsDownloaded()
+test(
+  'Should not throw error when model file exists and VAD is not specified',
+  { timeout: 180000 },
+  async (t) => {
+    // Ensure model is downloaded
+    await ensureModelsDownloaded()
 
-  const args = {
-    files: {
-      model: testModelPath
+    const args = {
+      files: {
+        model: testModelPath
+      }
+    }
+    const config = {
+      whisperConfig: {
+        language: 'en'
+        // No vad_model_path specified
+      },
+      contextParams: {
+        model: testModelPath
+      },
+      miscConfig: {
+        caption_enabled: false
+      }
+    }
+
+    try {
+      const model = new TranscriptionWhispercpp(args, config)
+      t.ok(model, 'Model should be created successfully')
+      t.pass('No exception thrown when model file exists and VAD is not specified')
+    } catch (error) {
+      t.fail('Should not have thrown an error: ' + error.message)
     }
   }
-  const config = {
-    whisperConfig: {
-      language: 'en'
-      // No vad_model_path specified
-    },
-    contextParams: {
-      model: testModelPath
-    },
-    miscConfig: {
-      caption_enabled: false
-    }
-  }
-
-  try {
-    const model = new TranscriptionWhispercpp(args, config)
-    t.ok(model, 'Model should be created successfully')
-    t.pass('No exception thrown when model file exists and VAD is not specified')
-  } catch (error) {
-    t.fail('Should not have thrown an error: ' + error.message)
-  }
-})
+)
 
 /**
  * Test 5: If both model path and VAD model path are valid, no exception should be thrown
  * Works on both mobile and desktop
  */
-test('Should not throw error when both model and VAD model files exist', { timeout: 180000 }, async (t) => {
-  // Ensure models are downloaded
-  await ensureModelsDownloaded()
+test(
+  'Should not throw error when both model and VAD model files exist',
+  { timeout: 180000 },
+  async (t) => {
+    // Ensure models are downloaded
+    await ensureModelsDownloaded()
 
-  const args = {
-    files: {
-      model: testModelPath,
-      vadModel: testVadPath
+    const args = {
+      files: {
+        model: testModelPath,
+        vadModel: testVadPath
+      }
+    }
+    const config = {
+      whisperConfig: {
+        language: 'en',
+        vad_model_path: testVadPath
+      },
+      contextParams: {
+        model: testModelPath
+      },
+      miscConfig: {
+        caption_enabled: false
+      }
+    }
+
+    try {
+      const model = new TranscriptionWhispercpp(args, config)
+      t.ok(model, 'Model should be created successfully')
+      t.pass('No exception thrown when both model and VAD model files exist')
+    } catch (error) {
+      t.fail('Should not have thrown an error: ' + error.message)
     }
   }
-  const config = {
-    whisperConfig: {
-      language: 'en',
-      vad_model_path: testVadPath
-    },
-    contextParams: {
-      model: testModelPath
-    },
-    miscConfig: {
-      caption_enabled: false
-    }
-  }
-
-  try {
-    const model = new TranscriptionWhispercpp(args, config)
-    t.ok(model, 'Model should be created successfully')
-    t.pass('No exception thrown when both model and VAD model files exist')
-  } catch (error) {
-    t.fail('Should not have thrown an error: ' + error.message)
-  }
-})
+)

--- a/packages/transcription-whispercpp/test/integration/multiple-transcriptions.test.js
+++ b/packages/transcription-whispercpp/test/integration/multiple-transcriptions.test.js
@@ -8,111 +8,121 @@ const TranscriptionWhispercpp = require('../../index')
 const { ensureWhisperModel, getAssetPath, createAudioStream, isMobile } = require('./helpers.js')
 
 // On mobile, runs fewer transcriptions to avoid memory pressure
-test('Multiple consecutive transcriptions should work without errors', { timeout: 300000 }, async (t) => {
-  const numTranscriptions = 3
+test(
+  'Multiple consecutive transcriptions should work without errors',
+  { timeout: 300000 },
+  async (t) => {
+    const numTranscriptions = 3
 
-  t.plan(3)
+    t.plan(3)
 
-  const modelsDir = isMobile ? path.join(global.testDir || os.tmpdir(), 'models') : path.resolve(__dirname, '../../models')
-  const modelPath = path.join(modelsDir, 'ggml-tiny.bin')
+    const modelsDir = isMobile
+      ? path.join(global.testDir || os.tmpdir(), 'models')
+      : path.resolve(__dirname, '../../models')
+    const modelPath = path.join(modelsDir, 'ggml-tiny.bin')
 
-  // Create models directory if needed
-  if (!fs.existsSync(modelsDir)) {
-    fs.mkdirSync(modelsDir, { recursive: true })
-  }
-
-  const modelResult = await ensureWhisperModel(modelPath)
-  if (!modelResult.success) {
-    console.log('⚠️ Model not available, skipping test')
-    t.pass('Model not available')
-    t.pass('Skipped')
-    t.pass('Skipped')
-    return
-  }
-
-  // Get audio path - uses getAssetPath for mobile compatibility
-  let audioPath
-  try {
-    audioPath = getAssetPath('sample.raw')
-  } catch (e) {
-    console.log('⚠️ Audio file not available, skipping test')
-    t.pass('Audio not available')
-    t.pass('Skipped')
-    t.pass('Skipped')
-    return
-  }
-
-  t.ok(fs.existsSync(modelPath), 'Model file should exist')
-  t.ok(fs.existsSync(audioPath), 'Audio file should exist')
-
-  const args = {
-    files: {
-      model: modelPath
-    },
-    logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
-  }
-
-  const config = {
-    path: modelPath,
-    whisperConfig: {
-      language: 'en'
+    // Create models directory if needed
+    if (!fs.existsSync(modelsDir)) {
+      fs.mkdirSync(modelsDir, { recursive: true })
     }
-  }
 
-  let model
-  try {
-    model = new TranscriptionWhispercpp(args, config)
-    await model.load()
+    const modelResult = await ensureWhisperModel(modelPath)
+    if (!modelResult.success) {
+      console.log('⚠️ Model not available, skipping test')
+      t.pass('Model not available')
+      t.pass('Skipped')
+      t.pass('Skipped')
+      return
+    }
 
-    console.log(`\n=== Starting ${numTranscriptions} consecutive transcriptions (${isMobile ? 'mobile' : 'desktop'}) ===\n`)
+    // Get audio path - uses getAssetPath for mobile compatibility
+    let audioPath
+    try {
+      audioPath = getAssetPath('sample.raw')
+    } catch (e) {
+      console.log('⚠️ Audio file not available, skipping test')
+      t.pass('Audio not available')
+      t.pass('Skipped')
+      t.pass('Skipped')
+      return
+    }
 
-    for (let i = 0; i < numTranscriptions; i++) {
-      console.log(`\n--- Transcription ${i + 1}/${numTranscriptions} ---`)
+    t.ok(fs.existsSync(modelPath), 'Model file should exist')
+    t.ok(fs.existsSync(audioPath), 'Audio file should exist')
 
-      // Use createAudioStream helper to avoid fs.createReadStream bug
-      const audioStream = createAudioStream(audioPath)
+    const args = {
+      files: {
+        model: modelPath
+      },
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
+    }
 
-      const response = await model.run(audioStream)
+    const config = {
+      path: modelPath,
+      whisperConfig: {
+        language: 'en'
+      }
+    }
 
-      let transcriptText = ''
-      await response.onUpdate((output) => {
-        console.log('Transcription onUpdate:', output)
-        if (Array.isArray(output)) {
-          for (const segment of output) {
-            if (segment.text) {
-              transcriptText += segment.text
+    let model
+    try {
+      model = new TranscriptionWhispercpp(args, config)
+      await model.load()
+
+      console.log(
+        `\n=== Starting ${numTranscriptions} consecutive transcriptions (${isMobile ? 'mobile' : 'desktop'}) ===\n`
+      )
+
+      for (let i = 0; i < numTranscriptions; i++) {
+        console.log(`\n--- Transcription ${i + 1}/${numTranscriptions} ---`)
+
+        // Use createAudioStream helper to avoid fs.createReadStream bug
+        const audioStream = createAudioStream(audioPath)
+
+        const response = await model.run(audioStream)
+
+        let transcriptText = ''
+        await response
+          .onUpdate((output) => {
+            console.log('Transcription onUpdate:', output)
+            if (Array.isArray(output)) {
+              for (const segment of output) {
+                if (segment.text) {
+                  transcriptText += segment.text
+                }
+              }
             }
-          }
+          })
+          .await()
+
+        console.log(`Transcription ${i + 1} completed`)
+        console.log(`Text length: ${transcriptText.length}`)
+
+        // Small delay between runs to allow memory cleanup
+        await new Promise((resolve) => setTimeout(resolve, 200))
+      }
+
+      console.log(`\n=== All ${numTranscriptions} transcriptions completed ===\n`)
+      t.ok(true, 'All transcriptions completed without errors')
+    } finally {
+      if (model) {
+        console.log('Calling model.unload()...')
+        try {
+          await model.unload()
+          console.log('model.unload() completed')
+        } catch (e) {
+          console.log('model.unload() error:', e.message)
         }
-      }).await()
 
-      console.log(`Transcription ${i + 1} completed`)
-      console.log(`Text length: ${transcriptText.length}`)
-
-      // Small delay between runs to allow memory cleanup
-      await new Promise(resolve => setTimeout(resolve, 200))
-    }
-
-    console.log(`\n=== All ${numTranscriptions} transcriptions completed ===\n`)
-    t.ok(true, 'All transcriptions completed without errors')
-  } finally {
-    if (model) {
-      console.log('Calling model.unload()...')
-      try {
-        await model.unload()
-        console.log('model.unload() completed')
-      } catch (e) {
-        console.log('model.unload() error:', e.message)
+        console.log('Calling model.destroy()...')
+        try {
+          await model.destroy()
+          console.log('model.destroy() completed')
+        } catch (e) {
+          console.log('model.destroy() error:', e.message)
+        }
       }
-
-      console.log('Calling model.destroy()...')
-      try {
-        await model.destroy()
-        console.log('model.destroy() completed')
-      } catch (e) {
-        console.log('model.destroy() error:', e.message)
-      }
+      console.log('Test finished')
     }
-    console.log('Test finished')
   }
-})
+)

--- a/packages/transcription-whispercpp/test/mocks/MockedBinding.js
+++ b/packages/transcription-whispercpp/test/mocks/MockedBinding.js
@@ -8,7 +8,7 @@ const state = Object.freeze({
 })
 
 class MockedBinding {
-  constructor () {
+  constructor() {
     this._handle = null
     this._state = state.LOADING
     this.isVadTest = false
@@ -24,23 +24,23 @@ class MockedBinding {
     this.lastStreamingConfig = null
   }
 
-  enableVadTestMode () {
+  enableVadTestMode() {
     this.isVadTest = true
   }
 
-  setScriptedOutputs (outputs) {
+  setScriptedOutputs(outputs) {
     this._scriptedOutputs = Array.isArray(outputs) ? outputs : null
   }
 
-  setJobDelayMs (delayMs) {
+  setJobDelayMs(delayMs) {
     this._jobDelayMs = Number.isFinite(delayMs) ? Math.max(0, delayMs) : 0
   }
 
-  setStreamingErrorOnSegment (segmentIndex) {
+  setStreamingErrorOnSegment(segmentIndex) {
     this._streamingErrorOnSegment = segmentIndex
   }
 
-  createInstance (interfaceType, configurationParams, outputCb, transitionCb = null) {
+  createInstance(interfaceType, configurationParams, outputCb, transitionCb = null) {
     console.log('Constructing the whisper addon')
     this._interfaceType = interfaceType
     this.outputCb = outputCb
@@ -50,18 +50,18 @@ class MockedBinding {
   }
 
   // Legacy no-op kept so older tests can still call it.
-  setBaseInferenceCallback (callback) {
+  setBaseInferenceCallback(callback) {
     this._baseInferenceCallback = callback
   }
 
   // Mimic addon-cpp 1.1.5 callback shape: no trailing native job id.
-  _callCallbacks (event, output, error) {
+  _callCallbacks(event, output, error) {
     if (this.outputCb) {
       this.outputCb(this._interfaceType, event, output, error)
     }
   }
 
-  loadWeights (handle, data) {
+  loadWeights(handle, data) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log(`Loading weights: ${data.filename || data}`)
     // After creating the addon, we allow weights to be loaded. The loadWeights
@@ -70,7 +70,7 @@ class MockedBinding {
     return true
   }
 
-  activate (handle) {
+  activate(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Activated the addon')
     this._state = state.LISTENING
@@ -86,7 +86,7 @@ class MockedBinding {
     // Will be in IDLE status while waiting for next job
   }
 
-  reload (handle, configurationParams) {
+  reload(handle, configurationParams) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     this._configurationParams = configurationParams
     this._state = state.LOADING
@@ -95,7 +95,7 @@ class MockedBinding {
     }
   }
 
-  cancel (handle, jobId) {
+  cancel(handle, jobId) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log(`Cancel job id: ${jobId}`)
     this._runToken += 1
@@ -109,14 +109,14 @@ class MockedBinding {
     }
   }
 
-  status (handle) {
+  status(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     return this._state
     // Returns whether the plugin status is LOADING, PROCESSING, LISTENING, IDLE,
     // STOPPED, or PAUSED
   }
 
-  runJob (handle, data) {
+  runJob(handle, data) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     if (this._busy) {
       return false
@@ -138,9 +138,16 @@ class MockedBinding {
           this._callCallbacks('Output', output, null, jobId)
         }
       } else if (this.isVadTest) {
-        const mockTranscription = data.input.length > 0
-          ? { text: `Mock transcription for ${data.input.length} bytes of audio`, toAppend: false, start: 0, end: 1, id: 0 }
-          : { text: 'Silent audio detected', toAppend: false, start: 0, end: 1, id: 0 }
+        const mockTranscription =
+          data.input.length > 0
+            ? {
+                text: `Mock transcription for ${data.input.length} bytes of audio`,
+                toAppend: false,
+                start: 0,
+                end: 1,
+                id: 0
+              }
+            : { text: 'Silent audio detected', toAppend: false, start: 0, end: 1, id: 0 }
         this._callCallbacks('Output', mockTranscription, null, jobId)
       } else {
         this._callCallbacks('Output', { data: data.input.length }, null, jobId)
@@ -149,7 +156,12 @@ class MockedBinding {
       if (!this._busy || runToken !== this._runToken) {
         return
       }
-      this._callCallbacks('JobEnded', { totalTime: 0.01, audioDurationMs: data.input.length, totalSamples: data.input.length }, null, jobId)
+      this._callCallbacks(
+        'JobEnded',
+        { totalTime: 0.01, audioDurationMs: data.input.length, totalSamples: data.input.length },
+        null,
+        jobId
+      )
       this._busy = false
       this._currentJobId = null
       this._state = state.LISTENING
@@ -164,7 +176,7 @@ class MockedBinding {
     return true
   }
 
-  append (handle, data) {
+  append(handle, data) {
     // Legacy API for compatibility in older tests.
     if (data.type !== 'audio') {
       return 1
@@ -172,19 +184,19 @@ class MockedBinding {
     return this.runJob(handle, data) ? 1 : 0
   }
 
-  setLogger (handle, logger) {
+  setLogger(handle, logger) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Set logger:', logger)
     // Mock implementation - just log that it was called
   }
 
-  releaseLogger (handle) {
+  releaseLogger(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Released logger')
     // Mock implementation - just log that it was called
   }
 
-  startStreaming (handle, config) {
+  startStreaming(handle, config) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     if (this._streaming) throw new Error('Streaming session already active')
     this.lastStreamingConfig = config
@@ -200,13 +212,13 @@ class MockedBinding {
     if (this.transitionCb) this.transitionCb(this, this._state)
   }
 
-  appendStreamingAudio (handle, data) {
+  appendStreamingAudio(handle, data) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     if (!this._streaming) throw new Error('No active streaming session')
     this._streamingChunks.push(data)
   }
 
-  endStreaming (handle) {
+  endStreaming(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     if (!this._streaming) return false
     this._streaming = false
@@ -216,7 +228,8 @@ class MockedBinding {
     this._streamingChunks = []
 
     const emitStreamResults = () => {
-      const hasError = this._streamingErrorOnSegment >= 0 &&
+      const hasError =
+        this._streamingErrorOnSegment >= 0 &&
         this._scriptedOutputs &&
         this._streamingErrorOnSegment < this._scriptedOutputs.length
 
@@ -228,15 +241,23 @@ class MockedBinding {
       }
 
       if (hasError) {
-        this._callCallbacks('Error', null, new Error('One or more segments failed during processing'))
+        this._callCallbacks(
+          'Error',
+          null,
+          new Error('One or more segments failed during processing')
+        )
       } else {
         const totalSamples = chunks.reduce((sum, c) => sum + (c.input?.length || 0), 0)
-        this._callCallbacks('JobEnded', {
-          totalTime: 0.01 * Math.max(1, chunks.length),
-          audioDurationMs: totalSamples,
-          totalSamples,
-          processCalls: chunks.length
-        }, null)
+        this._callCallbacks(
+          'JobEnded',
+          {
+            totalTime: 0.01 * Math.max(1, chunks.length),
+            audioDurationMs: totalSamples,
+            totalSamples,
+            processCalls: chunks.length
+          },
+          null
+        )
       }
 
       this._currentJobId = null
@@ -248,7 +269,7 @@ class MockedBinding {
     return true
   }
 
-  destroyInstance (handle) {
+  destroyInstance(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     this._runToken += 1
     this._busy = false

--- a/packages/transcription-whispercpp/test/mocks/loader.fake.js
+++ b/packages/transcription-whispercpp/test/mocks/loader.fake.js
@@ -17,24 +17,24 @@ const files = {
 // Standalone loader mock. Intentionally does not depend on @qvac/dl-* so the
 // dl- packages can be deprecated and removed from the monorepo.
 class FakeDL {
-  constructor (opts = {}) {
+  constructor(opts = {}) {
     this.opts = opts
   }
 
-  async ready () { }
+  async ready() {}
 
-  async close () { }
+  async close() {}
 
-  async list (path) {
+  async list(path) {
     return Object.keys(files)
   }
 
-  async getStream (filepath) {
+  async getStream(filepath) {
     const name = path.basename(filepath)
     return Readable.from(Buffer.from(files[name]))
   }
 
-  async download (filepath, destPath) {
+  async download(filepath, destPath) {
     const name = path.basename(filepath)
     const content = files[name]
     if (!content) {

--- a/packages/transcription-whispercpp/test/mocks/utils.js
+++ b/packages/transcription-whispercpp/test/mocks/utils.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // A helper function to wait a short time (to allow setImmediate callbacks to fire).
-const wait = (ms = 20) => new Promise(resolve => setTimeout(resolve, ms))
+const wait = (ms = 20) => new Promise((resolve) => setTimeout(resolve, ms))
 
 // Transition callback to log state changes.
 const transitionCb = (instance, newState) => {

--- a/packages/transcription-whispercpp/test/stand-alone/addon.reload.esraw.test.js
+++ b/packages/transcription-whispercpp/test/stand-alone/addon.reload.esraw.test.js
@@ -11,7 +11,7 @@ const samplesDir = path.resolve(__dirname, '../../examples/samples')
 const modelPath = path.join(modelsDir, 'ggml-tiny.bin')
 const audioPath = path.join(samplesDir, 'LastQuestion_long_ES.raw')
 
-function chunkBuffer (buf, size) {
+function chunkBuffer(buf, size) {
   const chunks = []
   for (let i = 0; i < buf.length; i += size) chunks.push(buf.slice(i, i + size))
   return chunks
@@ -38,7 +38,9 @@ test('Addon reload: French → Spanish transcription of LastQuestion_long_ES.raw
     switch (event) {
       case 'JobStarted':
         jobStartTime = Date.now()
-        console.log(`\n🚀 [${timestamp}] Job ${jobId} started (Language: ${currentLanguage.toUpperCase()})`)
+        console.log(
+          `\n🚀 [${timestamp}] Job ${jobId} started (Language: ${currentLanguage.toUpperCase()})`
+        )
         break
 
       case 'Output': {
@@ -115,10 +117,12 @@ test('Addon reload: French → Spanish transcription of LastQuestion_long_ES.raw
   const startTime1 = Date.now()
   // eslint-disable-next-line no-unmodified-loop-condition
   while (jobEndedCount < 1 && Date.now() - startTime1 < 30000) {
-    await new Promise(resolve => setTimeout(resolve, 100))
+    await new Promise((resolve) => setTimeout(resolve, 100))
   }
 
-  const job1Events = events.filter(e => e.jobId === events.find(e => e.event === 'JobStarted')?.jobId)
+  const job1Events = events.filter(
+    (e) => e.jobId === events.find((e) => e.event === 'JobStarted')?.jobId
+  )
   console.log(`\n📊 First job summary: ${job1Events.length} events`)
 
   // Now reload with Spanish config
@@ -154,7 +158,7 @@ test('Addon reload: French → Spanish transcription of LastQuestion_long_ES.raw
   const startTime2 = Date.now()
   // eslint-disable-next-line no-unmodified-loop-condition
   while (jobEndedCount < 2 && Date.now() - startTime2 < 30000) {
-    await new Promise(resolve => setTimeout(resolve, 100))
+    await new Promise((resolve) => setTimeout(resolve, 100))
   }
 
   console.log(`\n${'='.repeat(55)}`)
@@ -162,10 +166,10 @@ test('Addon reload: French → Spanish transcription of LastQuestion_long_ES.raw
   console.log(`${'='.repeat(55)}`)
 
   // Analyze results
-  const outputEvents = events.filter(e => e.event === 'Output')
-  const jobEndedEvents = events.filter(e => e.event === 'JobEnded')
-  const frenchOutputs = events.filter(e => e.event === 'Output' && e.language === 'fr')
-  const spanishOutputs = events.filter(e => e.event === 'Output' && e.language === 'es')
+  const outputEvents = events.filter((e) => e.event === 'Output')
+  const jobEndedEvents = events.filter((e) => e.event === 'JobEnded')
+  const frenchOutputs = events.filter((e) => e.event === 'Output' && e.language === 'fr')
+  const spanishOutputs = events.filter((e) => e.event === 'Output' && e.language === 'es')
 
   console.log(`\n📊 Total events received: ${events.length}`)
   console.log(`   - Output events: ${outputEvents.length}`)
@@ -176,7 +180,7 @@ test('Addon reload: French → Spanish transcription of LastQuestion_long_ES.raw
   console.log(`\n📝 French Transcription (${frenchOutputs.length} segments):`)
   frenchOutputs.forEach((event, idx) => {
     if (Array.isArray(event.output)) {
-      event.output.forEach(segment => {
+      event.output.forEach((segment) => {
         if (segment && segment.text) {
           console.log(`   [${idx + 1}] "${segment.text}"`)
         }
@@ -187,7 +191,7 @@ test('Addon reload: French → Spanish transcription of LastQuestion_long_ES.raw
   console.log(`\n📝 Spanish Transcription (${spanishOutputs.length} segments):`)
   spanishOutputs.forEach((event, idx) => {
     if (Array.isArray(event.output)) {
-      event.output.forEach(segment => {
+      event.output.forEach((segment) => {
         if (segment && segment.text) {
           console.log(`   [${idx + 1}] "${segment.text}"`)
         }

--- a/packages/transcription-whispercpp/test/stand-alone/seed-vulkan-gpu-speed.test.js
+++ b/packages/transcription-whispercpp/test/stand-alone/seed-vulkan-gpu-speed.test.js
@@ -13,20 +13,30 @@ const spanishAudioPath = path.join(samplesDir, 'LastQuestion_long_ES.raw')
 const spanishAudioShortPath = path.join(samplesDir, 'LastQuestion_short_ES.raw')
 
 // Download model if needed
-async function ensureModel () {
+async function ensureModel() {
   if (fs.existsSync(modelPath) && fs.statSync(modelPath).size > 400000000) {
     return modelPath
   }
 
   console.log('Downloading test model...')
   const { spawnSync } = require('bare-subprocess')
-  const result = spawnSync('curl', [
-    '-L', '-o', modelPath,
-    'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
-    '--fail', '--silent', '--show-error',
-    '--connect-timeout', '30',
-    '--max-time', '1800'
-  ], { stdio: ['inherit', 'inherit', 'pipe'] })
+  const result = spawnSync(
+    'curl',
+    [
+      '-L',
+      '-o',
+      modelPath,
+      'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
+      '--fail',
+      '--silent',
+      '--show-error',
+      '--connect-timeout',
+      '30',
+      '--max-time',
+      '1800'
+    ],
+    { stdio: ['inherit', 'inherit', 'pipe'] }
+  )
 
   if (result.status === 0 && fs.existsSync(modelPath) && fs.statSync(modelPath).size > 400000000) {
     return modelPath
@@ -35,7 +45,7 @@ async function ensureModel () {
 }
 
 // Check if GPU/Vulkan is available
-async function checkVulkanAvailable () {
+async function checkVulkanAvailable() {
   try {
     const args = {
       files: {
@@ -66,21 +76,28 @@ async function checkVulkanAvailable () {
 }
 
 // Monitor GPU usage with nvidia-smi
-function startGPUMonitoring () {
+function startGPUMonitoring() {
   const samples = []
 
   // Start nvidia-smi in dmon mode (monitoring mode)
   // -s u: utilization metrics
   // -d 1: 1 second intervals
   // -c 10000: large sample count (will be killed before reaching this)
-  const monitor = spawn('nvidia-smi', [
-    'dmon',
-    '-s', 'u', // utilization
-    '-d', '1', // 1 second intervals
-    '-c', '10000' // large count (will be killed before reaching this)
-  ], {
-    stdio: ['ignore', 'pipe', 'pipe']
-  })
+  const monitor = spawn(
+    'nvidia-smi',
+    [
+      'dmon',
+      '-s',
+      'u', // utilization
+      '-d',
+      '1', // 1 second intervals
+      '-c',
+      '10000' // large count (will be killed before reaching this)
+    ],
+    {
+      stdio: ['ignore', 'pipe', 'pipe']
+    }
+  )
 
   // Parse output
   let buffer = ''
@@ -126,12 +143,16 @@ function startGPUMonitoring () {
 }
 
 // Get GPU stats snapshot
-function getGPUSnapshot () {
+function getGPUSnapshot() {
   try {
-    const result = spawnSync('nvidia-smi', [
-      '--query-gpu=utilization.gpu,utilization.memory,memory.used,memory.total,temperature.gpu',
-      '--format=csv,noheader,nounits'
-    ], { encoding: 'utf8', timeout: 5000 })
+    const result = spawnSync(
+      'nvidia-smi',
+      [
+        '--query-gpu=utilization.gpu,utilization.memory,memory.used,memory.total,temperature.gpu',
+        '--format=csv,noheader,nounits'
+      ],
+      { encoding: 'utf8', timeout: 5000 }
+    )
 
     if (result.status === 0 && result.stdout) {
       const line = result.stdout.trim()
@@ -155,7 +176,7 @@ function getGPUSnapshot () {
 }
 
 // Run transcription and measure time
-async function runTranscription (args, config, description, monitorGPU = false) {
+async function runTranscription(args, config, description, monitorGPU = false) {
   const start = Date.now()
   let gpuMonitor = null
   let gpuStatsBefore = null
@@ -183,13 +204,18 @@ async function runTranscription (args, config, description, monitorGPU = false) 
     let wordCount = 0
     let segmentCount = 0
 
-    await response.onUpdate((outputChunk) => {
-      const items = Array.isArray(outputChunk) ? outputChunk : [outputChunk]
-      const text = items.map(s => s.text).join(' ')
-      output += text
-      wordCount += text.trim().split(/\s+/).filter(w => w.length > 0).length
-      segmentCount += items.length
-    }).await()
+    await response
+      .onUpdate((outputChunk) => {
+        const items = Array.isArray(outputChunk) ? outputChunk : [outputChunk]
+        const text = items.map((s) => s.text).join(' ')
+        output += text
+        wordCount += text
+          .trim()
+          .split(/\s+/)
+          .filter((w) => w.length > 0).length
+        segmentCount += items.length
+      })
+      .await()
 
     console.log(`  Transcription complete: ${segmentCount} segments, ${wordCount} words`)
 
@@ -200,12 +226,16 @@ async function runTranscription (args, config, description, monitorGPU = false) 
 
       if (samples.length > 0) {
         const avgGpuUtil = samples.reduce((sum, s) => sum + s.gpuUtil, 0) / samples.length
-        const maxGpuUtil = Math.max(...samples.map(s => s.gpuUtil))
+        const maxGpuUtil = Math.max(...samples.map((s) => s.gpuUtil))
         const avgMemUtil = samples.reduce((sum, s) => sum + s.memUtil, 0) / samples.length
-        const maxMemUtil = Math.max(...samples.map(s => s.memUtil))
+        const maxMemUtil = Math.max(...samples.map((s) => s.memUtil))
 
-        console.log(`  GPU utilization during run: avg=${avgGpuUtil.toFixed(1)}%, max=${maxGpuUtil}%`)
-        console.log(`  Memory utilization during run: avg=${avgMemUtil.toFixed(1)}%, max=${maxMemUtil}%`)
+        console.log(
+          `  GPU utilization during run: avg=${avgGpuUtil.toFixed(1)}%, max=${maxGpuUtil}%`
+        )
+        console.log(
+          `  Memory utilization during run: avg=${avgMemUtil.toFixed(1)}%, max=${maxMemUtil}%`
+        )
         console.log(`  Samples collected: ${samples.length}`)
       } else {
         console.log('  ⚠️  No GPU samples collected - monitoring may have failed')
@@ -244,123 +274,137 @@ async function runTranscription (args, config, description, monitorGPU = false) 
   }
 }
 
-test('GPU performance test with Spanish audio (LastQuestion_long_ES.raw)', { timeout: 300000 }, async (t) => {
-  // Check if audio file exists
-  if (!fs.existsSync(spanishAudioPath)) {
-    t.pass('Spanish audio file not found, skipping')
-    return
-  }
-
-  const audioSize = fs.statSync(spanishAudioPath).size
-  const audioSizeMB = (audioSize / 1024 / 1024).toFixed(2)
-  console.log('\n=== GPU/Vulkan Performance Test ===')
-  console.log('Audio file: LastQuestion_long_ES.raw')
-  console.log(`File size: ${audioSizeMB} MB`)
-  console.log('Model: ggml-small.bin (466 MiB)')
-  console.log('Language: Spanish (es)')
-  console.log('\n✅ Using \'small\' model (466MB) to demonstrate GPU acceleration benefits.\n')
-  console.log('Note: CPU comparison skipped (would take 5-10+ minutes with this model/audio size)')
-
-  await ensureModel()
-
-  const args = {
-    files: {
-      model: modelPath
+test(
+  'GPU performance test with Spanish audio (LastQuestion_long_ES.raw)',
+  { timeout: 300000 },
+  async (t) => {
+    // Check if audio file exists
+    if (!fs.existsSync(spanishAudioPath)) {
+      t.pass('Spanish audio file not found, skipping')
+      return
     }
-  }
 
-  const baseConfig = {
-    path: modelPath,
-    whisperConfig: {
-      language: 'es',
-      temperature: 0.5,
-      duration_ms: 0,
-      seed: 1234 // Use seed for reproducibility
-    },
-    miscConfig: {}
-  }
+    const audioSize = fs.statSync(spanishAudioPath).size
+    const audioSizeMB = (audioSize / 1024 / 1024).toFixed(2)
+    console.log('\n=== GPU/Vulkan Performance Test ===')
+    console.log('Audio file: LastQuestion_long_ES.raw')
+    console.log(`File size: ${audioSizeMB} MB`)
+    console.log('Model: ggml-small.bin (466 MiB)')
+    console.log('Language: Spanish (es)')
+    console.log("\n✅ Using 'small' model (466MB) to demonstrate GPU acceleration benefits.\n")
+    console.log(
+      'Note: CPU comparison skipped (would take 5-10+ minutes with this model/audio size)'
+    )
 
-  // CPU Configuration (skipped for performance)
-  // const cpuConfig = {
-  //   ...baseConfig,
-  //   contextParams: {
-  //     use_gpu: false
-  //   }
-  // }
+    await ensureModel()
 
-  // GPU Configuration
-  const gpuConfig = {
-    ...baseConfig,
-    contextParams: {
-      use_gpu: true,
-      gpu_device: 0
+    const args = {
+      files: {
+        model: modelPath
+      }
     }
-  }
 
-  // Check if GPU is available
-  const vulkanAvailable = await checkVulkanAvailable()
+    const baseConfig = {
+      path: modelPath,
+      whisperConfig: {
+        language: 'es',
+        temperature: 0.5,
+        duration_ms: 0,
+        seed: 1234 // Use seed for reproducibility
+      },
+      miscConfig: {}
+    }
 
-  // Run CPU test - SKIPPED for large model/long audio (would take 5-10+ minutes)
-  const cpuResult = null
-  console.log('\n⚠️  Skipping CPU test (ggml-small with 360s audio takes too long on CPU)')
-  console.log('   This test focuses on GPU/Vulkan performance verification')
+    // CPU Configuration (skipped for performance)
+    // const cpuConfig = {
+    //   ...baseConfig,
+    //   contextParams: {
+    //     use_gpu: false
+    //   }
+    // }
 
-  // Run GPU test if available
-  let gpuResult = null
-  if (vulkanAvailable) {
-    console.log('\nRunning GPU transcription with monitoring...')
-    gpuResult = await runTranscription(args, gpuConfig, 'GPU', true)
-    console.log(`✅ GPU completed in ${gpuResult.timeSec.toFixed(2)}s (${gpuResult.timeMs.toFixed(0)}ms)`)
-    console.log(`   Output: ${gpuResult.charCount} chars, ${gpuResult.wordCount} words`)
-  } else {
-    console.log('\n⚠️  GPU/Vulkan not available, skipping GPU test')
-    t.pass('GPU/Vulkan not available, skipping')
-    return
-  }
+    // GPU Configuration
+    const gpuConfig = {
+      ...baseConfig,
+      contextParams: {
+        use_gpu: true,
+        gpu_device: 0
+      }
+    }
 
-  // Print results
-  console.log('\n=== GPU Performance Results ===')
-  if (gpuResult) {
-    console.log(`GPU Time: ${gpuResult.timeSec.toFixed(2)}s (${gpuResult.timeMs.toFixed(0)}ms)`)
-    console.log(`GPU output: ${gpuResult.charCount} chars, ${gpuResult.wordCount} words`)
+    // Check if GPU is available
+    const vulkanAvailable = await checkVulkanAvailable()
 
-    // Calculate throughput
-    const gpuThroughput = (audioSizeMB / gpuResult.timeSec).toFixed(2)
-    console.log(`Throughput: ${gpuThroughput} MB/s`)
+    // Run CPU test - SKIPPED for large model/long audio (would take 5-10+ minutes)
+    const cpuResult = null
+    console.log('\n⚠️  Skipping CPU test (ggml-small with 360s audio takes too long on CPU)')
+    console.log('   This test focuses on GPU/Vulkan performance verification')
 
-    // Show sample output
-    console.log('\nSample Output (first 200 chars):')
-    console.log(`  ${gpuResult.output.substring(0, 200)}...`)
-  }
-
-  // GPU monitoring summary
-  if (gpuResult && gpuResult.gpuSamples && gpuResult.gpuSamples.length > 0) {
-    const samples = gpuResult.gpuSamples
-    const avgGpuUtil = samples.reduce((sum, s) => sum + s.gpuUtil, 0) / samples.length
-    const maxGpuUtil = Math.max(...samples.map(s => s.gpuUtil))
-    const avgMemUtil = samples.reduce((sum, s) => sum + s.memUtil, 0) / samples.length
-    const maxMemUtil = Math.max(...samples.map(s => s.memUtil))
-
-    console.log('\n=== GPU Usage Summary ===')
-    console.log(`Average GPU Utilization: ${avgGpuUtil.toFixed(1)}%`)
-    console.log(`Peak GPU Utilization: ${maxGpuUtil}%`)
-    console.log(`Average Memory Utilization: ${avgMemUtil.toFixed(1)}%`)
-    console.log(`Peak Memory Utilization: ${maxMemUtil}%`)
-    if (avgGpuUtil < 10) {
-      console.log('⚠️  WARNING: Low GPU utilization suggests GPU may not be actively used')
-    } else if (avgGpuUtil > 50) {
-      console.log('✅ GPU is actively being used')
+    // Run GPU test if available
+    let gpuResult = null
+    if (vulkanAvailable) {
+      console.log('\nRunning GPU transcription with monitoring...')
+      gpuResult = await runTranscription(args, gpuConfig, 'GPU', true)
+      console.log(
+        `✅ GPU completed in ${gpuResult.timeSec.toFixed(2)}s (${gpuResult.timeMs.toFixed(0)}ms)`
+      )
+      console.log(`   Output: ${gpuResult.charCount} chars, ${gpuResult.wordCount} words`)
     } else {
-      console.log('⚠️  GPU utilization is moderate - may indicate partial GPU usage')
+      console.log('\n⚠️  GPU/Vulkan not available, skipping GPU test')
+      t.pass('GPU/Vulkan not available, skipping')
+      return
     }
-  }
 
-  // Verify we got meaningful output (prefer GPU result, fallback to CPU if available)
-  const result = gpuResult || cpuResult
-  t.ok(result, 'Should have completed at least one transcription (CPU or GPU)')
-  t.ok(result.wordCount > 100, `Should produce meaningful transcription (got ${result.wordCount} words)`)
-  t.ok(result.charCount > 1000, `Should produce substantial output (got ${result.charCount} chars)`)
-})
+    // Print results
+    console.log('\n=== GPU Performance Results ===')
+    if (gpuResult) {
+      console.log(`GPU Time: ${gpuResult.timeSec.toFixed(2)}s (${gpuResult.timeMs.toFixed(0)}ms)`)
+      console.log(`GPU output: ${gpuResult.charCount} chars, ${gpuResult.wordCount} words`)
+
+      // Calculate throughput
+      const gpuThroughput = (audioSizeMB / gpuResult.timeSec).toFixed(2)
+      console.log(`Throughput: ${gpuThroughput} MB/s`)
+
+      // Show sample output
+      console.log('\nSample Output (first 200 chars):')
+      console.log(`  ${gpuResult.output.substring(0, 200)}...`)
+    }
+
+    // GPU monitoring summary
+    if (gpuResult && gpuResult.gpuSamples && gpuResult.gpuSamples.length > 0) {
+      const samples = gpuResult.gpuSamples
+      const avgGpuUtil = samples.reduce((sum, s) => sum + s.gpuUtil, 0) / samples.length
+      const maxGpuUtil = Math.max(...samples.map((s) => s.gpuUtil))
+      const avgMemUtil = samples.reduce((sum, s) => sum + s.memUtil, 0) / samples.length
+      const maxMemUtil = Math.max(...samples.map((s) => s.memUtil))
+
+      console.log('\n=== GPU Usage Summary ===')
+      console.log(`Average GPU Utilization: ${avgGpuUtil.toFixed(1)}%`)
+      console.log(`Peak GPU Utilization: ${maxGpuUtil}%`)
+      console.log(`Average Memory Utilization: ${avgMemUtil.toFixed(1)}%`)
+      console.log(`Peak Memory Utilization: ${maxMemUtil}%`)
+      if (avgGpuUtil < 10) {
+        console.log('⚠️  WARNING: Low GPU utilization suggests GPU may not be actively used')
+      } else if (avgGpuUtil > 50) {
+        console.log('✅ GPU is actively being used')
+      } else {
+        console.log('⚠️  GPU utilization is moderate - may indicate partial GPU usage')
+      }
+    }
+
+    // Verify we got meaningful output (prefer GPU result, fallback to CPU if available)
+    const result = gpuResult || cpuResult
+    t.ok(result, 'Should have completed at least one transcription (CPU or GPU)')
+    t.ok(
+      result.wordCount > 100,
+      `Should produce meaningful transcription (got ${result.wordCount} words)`
+    )
+    t.ok(
+      result.charCount > 1000,
+      `Should produce substantial output (got ${result.charCount} chars)`
+    )
+  }
+)
 
 test('Multiple GPU runs with seed for consistency check', { timeout: 120000 }, async (t) => {
   if (!fs.existsSync(spanishAudioPath)) {
@@ -417,181 +461,206 @@ test('Multiple GPU runs with seed for consistency check', { timeout: 120000 }, a
 
   console.log('\n=== Consistency Results ===')
   console.log(`All ${results.length} runs produced identical output`)
-  console.log(`Average time: ${(results.reduce((sum, r) => sum + r.timeMs, 0) / results.length).toFixed(0)}ms`)
+  console.log(
+    `Average time: ${(results.reduce((sum, r) => sum + r.timeMs, 0) / results.length).toFixed(0)}ms`
+  )
   console.log(`Output: ${results[0].charCount} chars, ${results[0].wordCount} words`)
 })
 
-test('CPU vs GPU speed comparison with SHORT audio (30s sample)', { timeout: 300000 }, async (t) => {
-  // Check if short audio file exists
-  if (!fs.existsSync(spanishAudioShortPath)) {
-    t.pass('Short Spanish audio file not found')
-    return
-  }
-
-  const audioSize = fs.statSync(spanishAudioShortPath).size
-  const audioSizeMB = (audioSize / 1024 / 1024).toFixed(2)
-  const audioDurationSec = (audioSize / (16000 * 2)).toFixed(1) // s16le at 16kHz
-
-  console.log('\n=== CPU vs GPU Speed Comparison (Short Audio) ===')
-  console.log('Audio file: LastQuestion_short_ES.raw')
-  console.log(`File size: ${audioSizeMB} MB (~${audioDurationSec}s audio)`)
-  console.log('Model: ggml-small.bin (466 MiB)')
-  console.log('Language: Spanish (es)')
-  console.log('\n✅ Using shorter audio to enable practical CPU vs GPU comparison\n')
-
-  await ensureModel()
-
-  const args = {
-    files: {
-      model: modelPath
+test(
+  'CPU vs GPU speed comparison with SHORT audio (30s sample)',
+  { timeout: 300000 },
+  async (t) => {
+    // Check if short audio file exists
+    if (!fs.existsSync(spanishAudioShortPath)) {
+      t.pass('Short Spanish audio file not found')
+      return
     }
-  }
 
-  const baseConfig = {
-    path: modelPath,
-    whisperConfig: {
-      language: 'es',
-      temperature: 0.5,
-      duration_ms: 0,
-      seed: 1234,
-      n_threads: 8 // Use 8 threads for CPU
-    },
-    miscConfig: {}
-  }
+    const audioSize = fs.statSync(spanishAudioShortPath).size
+    const audioSizeMB = (audioSize / 1024 / 1024).toFixed(2)
+    const audioDurationSec = (audioSize / (16000 * 2)).toFixed(1) // s16le at 16kHz
 
-  // CPU Configuration
-  const cpuConfig = {
-    ...baseConfig,
-    contextParams: {
-      use_gpu: false
-    }
-  }
+    console.log('\n=== CPU vs GPU Speed Comparison (Short Audio) ===')
+    console.log('Audio file: LastQuestion_short_ES.raw')
+    console.log(`File size: ${audioSizeMB} MB (~${audioDurationSec}s audio)`)
+    console.log('Model: ggml-small.bin (466 MiB)')
+    console.log('Language: Spanish (es)')
+    console.log('\n✅ Using shorter audio to enable practical CPU vs GPU comparison\n')
 
-  // GPU Configuration
-  const gpuConfig = {
-    ...baseConfig,
-    contextParams: {
-      use_gpu: true,
-      gpu_device: 0
-    }
-  }
+    await ensureModel()
 
-  // Check if GPU is available
-  const vulkanAvailable = await checkVulkanAvailable()
-  if (!vulkanAvailable) {
-    t.pass('GPU/Vulkan not available on this system')
-    return
-  }
-
-  // Helper function for short audio
-  async function runShortTranscription (config, description, monitorGPU = false) {
-    const start = Date.now()
-    let gpuMonitor = null
-    let model = null
-
-    try {
-      if (monitorGPU) {
-        gpuMonitor = startGPUMonitoring()
-      }
-
-      model = new TranscriptionWhispercpp(args, config)
-      console.log(`  Loading ${description} model...`)
-      await model._load()
-
-      const audioStream = fs.createReadStream(spanishAudioShortPath, {
-        highWaterMark: 16384
-      })
-
-      const response = await model.run(audioStream)
-      let output = ''
-      let wordCount = 0
-      let segmentCount = 0
-
-      await response.onUpdate((outputChunk) => {
-        const items = Array.isArray(outputChunk) ? outputChunk : [outputChunk]
-        const text = items.map(s => s.text).join(' ')
-        output += text
-        wordCount += text.trim().split(/\s+/).filter(w => w.length > 0).length
-        segmentCount += items.length
-      }).await()
-
-      const timeMs = Date.now() - start
-      const timeSec = timeMs / 1000
-
-      let gpuSamples = null
-      if (gpuMonitor) {
-        gpuSamples = await gpuMonitor.stop()
-      }
-
-      return {
-        output: output.trim(),
-        timeMs,
-        timeSec,
-        wordCount,
-        charCount: output.trim().length,
-        segmentCount,
-        gpuSamples
-      }
-    } finally {
-      if (model) {
-        await model.destroy()
+    const args = {
+      files: {
+        model: modelPath
       }
     }
+
+    const baseConfig = {
+      path: modelPath,
+      whisperConfig: {
+        language: 'es',
+        temperature: 0.5,
+        duration_ms: 0,
+        seed: 1234,
+        n_threads: 8 // Use 8 threads for CPU
+      },
+      miscConfig: {}
+    }
+
+    // CPU Configuration
+    const cpuConfig = {
+      ...baseConfig,
+      contextParams: {
+        use_gpu: false
+      }
+    }
+
+    // GPU Configuration
+    const gpuConfig = {
+      ...baseConfig,
+      contextParams: {
+        use_gpu: true,
+        gpu_device: 0
+      }
+    }
+
+    // Check if GPU is available
+    const vulkanAvailable = await checkVulkanAvailable()
+    if (!vulkanAvailable) {
+      t.pass('GPU/Vulkan not available on this system')
+      return
+    }
+
+    // Helper function for short audio
+    async function runShortTranscription(config, description, monitorGPU = false) {
+      const start = Date.now()
+      let gpuMonitor = null
+      let model = null
+
+      try {
+        if (monitorGPU) {
+          gpuMonitor = startGPUMonitoring()
+        }
+
+        model = new TranscriptionWhispercpp(args, config)
+        console.log(`  Loading ${description} model...`)
+        await model._load()
+
+        const audioStream = fs.createReadStream(spanishAudioShortPath, {
+          highWaterMark: 16384
+        })
+
+        const response = await model.run(audioStream)
+        let output = ''
+        let wordCount = 0
+        let segmentCount = 0
+
+        await response
+          .onUpdate((outputChunk) => {
+            const items = Array.isArray(outputChunk) ? outputChunk : [outputChunk]
+            const text = items.map((s) => s.text).join(' ')
+            output += text
+            wordCount += text
+              .trim()
+              .split(/\s+/)
+              .filter((w) => w.length > 0).length
+            segmentCount += items.length
+          })
+          .await()
+
+        const timeMs = Date.now() - start
+        const timeSec = timeMs / 1000
+
+        let gpuSamples = null
+        if (gpuMonitor) {
+          gpuSamples = await gpuMonitor.stop()
+        }
+
+        return {
+          output: output.trim(),
+          timeMs,
+          timeSec,
+          wordCount,
+          charCount: output.trim().length,
+          segmentCount,
+          gpuSamples
+        }
+      } finally {
+        if (model) {
+          await model.destroy()
+        }
+      }
+    }
+
+    // Run CPU test
+    console.log('\nRunning CPU transcription...')
+    const cpuResult = await runShortTranscription(cpuConfig, 'CPU', false)
+    console.log(`✅ CPU completed in ${cpuResult.timeSec.toFixed(2)}s`)
+    console.log(
+      `   Output: ${cpuResult.charCount} chars, ${cpuResult.wordCount} words, ${cpuResult.segmentCount} segments`
+    )
+
+    // Run GPU test
+    console.log('\nRunning GPU transcription...')
+    const gpuResult = await runShortTranscription(gpuConfig, 'GPU', true)
+    console.log(`✅ GPU completed in ${gpuResult.timeSec.toFixed(2)}s`)
+    console.log(
+      `   Output: ${gpuResult.charCount} chars, ${gpuResult.wordCount} words, ${gpuResult.segmentCount} segments`
+    )
+
+    // Print comparison
+    console.log('\n=== Performance Comparison ===')
+    console.log(`CPU Time: ${cpuResult.timeSec.toFixed(2)}s`)
+    console.log(`GPU Time: ${gpuResult.timeSec.toFixed(2)}s`)
+
+    const speedup = cpuResult.timeMs / gpuResult.timeMs
+    const improvement = (((cpuResult.timeMs - gpuResult.timeMs) / cpuResult.timeMs) * 100).toFixed(
+      1
+    )
+
+    console.log(`\n🚀 Speedup: ${speedup.toFixed(2)}x faster with GPU`)
+    console.log(`   Improvement: ${improvement}% time reduction`)
+    console.log(`   Time saved: ${((cpuResult.timeMs - gpuResult.timeMs) / 1000).toFixed(2)}s`)
+
+    // Calculate throughput
+    const cpuThroughput = (audioSizeMB / cpuResult.timeSec).toFixed(3)
+    const gpuThroughput = (audioSizeMB / gpuResult.timeSec).toFixed(3)
+    console.log('\n📊 Throughput:')
+    console.log(`   CPU: ${cpuThroughput} MB/s`)
+    console.log(`   GPU: ${gpuThroughput} MB/s`)
+
+    // Verify outputs are similar
+    const wordDiff = Math.abs(cpuResult.wordCount - gpuResult.wordCount)
+    console.log('\n📝 Output Comparison:')
+    console.log(`   CPU: ${cpuResult.wordCount} words, ${cpuResult.segmentCount} segments`)
+    console.log(`   GPU: ${gpuResult.wordCount} words, ${gpuResult.segmentCount} segments`)
+    console.log(`   Difference: ${wordDiff} words`)
+
+    // GPU monitoring summary
+    if (gpuResult.gpuSamples && gpuResult.gpuSamples.length > 0) {
+      const samples = gpuResult.gpuSamples
+      const avgGpuUtil = samples.reduce((sum, s) => sum + s.gpuUtil, 0) / samples.length
+      const maxGpuUtil = Math.max(...samples.map((s) => s.gpuUtil))
+
+      console.log('\n🎮 GPU Usage:')
+      console.log(`   Average: ${avgGpuUtil.toFixed(1)}%`)
+      console.log(`   Peak: ${maxGpuUtil}%`)
+    }
+
+    // Assertions
+    t.ok(
+      cpuResult.wordCount > 50,
+      `CPU should produce meaningful output (got ${cpuResult.wordCount} words)`
+    )
+    t.ok(
+      gpuResult.wordCount > 50,
+      `GPU should produce meaningful output (got ${gpuResult.wordCount} words)`
+    )
+    t.ok(speedup > 1.5, `GPU should be faster than CPU (speedup: ${speedup.toFixed(2)}x)`)
+    t.ok(
+      Math.abs(cpuResult.wordCount - gpuResult.wordCount) <= 20,
+      `CPU and GPU outputs should be similar (word diff: ${wordDiff})`
+    )
   }
-
-  // Run CPU test
-  console.log('\nRunning CPU transcription...')
-  const cpuResult = await runShortTranscription(cpuConfig, 'CPU', false)
-  console.log(`✅ CPU completed in ${cpuResult.timeSec.toFixed(2)}s`)
-  console.log(`   Output: ${cpuResult.charCount} chars, ${cpuResult.wordCount} words, ${cpuResult.segmentCount} segments`)
-
-  // Run GPU test
-  console.log('\nRunning GPU transcription...')
-  const gpuResult = await runShortTranscription(gpuConfig, 'GPU', true)
-  console.log(`✅ GPU completed in ${gpuResult.timeSec.toFixed(2)}s`)
-  console.log(`   Output: ${gpuResult.charCount} chars, ${gpuResult.wordCount} words, ${gpuResult.segmentCount} segments`)
-
-  // Print comparison
-  console.log('\n=== Performance Comparison ===')
-  console.log(`CPU Time: ${cpuResult.timeSec.toFixed(2)}s`)
-  console.log(`GPU Time: ${gpuResult.timeSec.toFixed(2)}s`)
-
-  const speedup = cpuResult.timeMs / gpuResult.timeMs
-  const improvement = ((cpuResult.timeMs - gpuResult.timeMs) / cpuResult.timeMs * 100).toFixed(1)
-
-  console.log(`\n🚀 Speedup: ${speedup.toFixed(2)}x faster with GPU`)
-  console.log(`   Improvement: ${improvement}% time reduction`)
-  console.log(`   Time saved: ${((cpuResult.timeMs - gpuResult.timeMs) / 1000).toFixed(2)}s`)
-
-  // Calculate throughput
-  const cpuThroughput = (audioSizeMB / cpuResult.timeSec).toFixed(3)
-  const gpuThroughput = (audioSizeMB / gpuResult.timeSec).toFixed(3)
-  console.log('\n📊 Throughput:')
-  console.log(`   CPU: ${cpuThroughput} MB/s`)
-  console.log(`   GPU: ${gpuThroughput} MB/s`)
-
-  // Verify outputs are similar
-  const wordDiff = Math.abs(cpuResult.wordCount - gpuResult.wordCount)
-  console.log('\n📝 Output Comparison:')
-  console.log(`   CPU: ${cpuResult.wordCount} words, ${cpuResult.segmentCount} segments`)
-  console.log(`   GPU: ${gpuResult.wordCount} words, ${gpuResult.segmentCount} segments`)
-  console.log(`   Difference: ${wordDiff} words`)
-
-  // GPU monitoring summary
-  if (gpuResult.gpuSamples && gpuResult.gpuSamples.length > 0) {
-    const samples = gpuResult.gpuSamples
-    const avgGpuUtil = samples.reduce((sum, s) => sum + s.gpuUtil, 0) / samples.length
-    const maxGpuUtil = Math.max(...samples.map(s => s.gpuUtil))
-
-    console.log('\n🎮 GPU Usage:')
-    console.log(`   Average: ${avgGpuUtil.toFixed(1)}%`)
-    console.log(`   Peak: ${maxGpuUtil}%`)
-  }
-
-  // Assertions
-  t.ok(cpuResult.wordCount > 50, `CPU should produce meaningful output (got ${cpuResult.wordCount} words)`)
-  t.ok(gpuResult.wordCount > 50, `GPU should produce meaningful output (got ${gpuResult.wordCount} words)`)
-  t.ok(speedup > 1.5, `GPU should be faster than CPU (speedup: ${speedup.toFixed(2)}x)`)
-  t.ok(Math.abs(cpuResult.wordCount - gpuResult.wordCount) <= 20,
-    `CPU and GPU outputs should be similar (word diff: ${wordDiff})`)
-})
+)

--- a/packages/transcription-whispercpp/test/unit/addon.inference.test.js
+++ b/packages/transcription-whispercpp/test/unit/addon.inference.test.js
@@ -10,7 +10,7 @@ const { WhisperInterface } = require('../../whisper')
 const process = require('bare-process')
 global.process = process
 
-function createMockedModel ({ onOutput = () => { }, binding = undefined } = {}) {
+function createMockedModel({ onOutput = () => {}, binding = undefined } = {}) {
   TranscriptionWhispercpp.prototype.validateModelFiles = () => undefined
 
   const args = {
@@ -38,12 +38,17 @@ function createMockedModel ({ onOutput = () => { }, binding = undefined } = {}) 
   }
   const model = new TranscriptionWhispercpp(args, config)
 
-  model._createAddon = configurationParams => {
+  model._createAddon = (configurationParams) => {
     const _binding = binding || new MockedBinding()
-    const addon = new WhisperInterface(_binding, configurationParams, (addon, event, jobId, output, error) => {
-      onOutput(addon, event, jobId, output, error)
-      model._outputCallback(addon, event, jobId, output, error)
-    }, transitionCb)
+    const addon = new WhisperInterface(
+      _binding,
+      configurationParams,
+      (addon, event, jobId, output, error) => {
+        onOutput(addon, event, jobId, output, error)
+        model._outputCallback(addon, event, jobId, output, error)
+      },
+      transitionCb
+    )
 
     return addon
   }
@@ -78,13 +83,17 @@ test('Inference returns correct output for audio input', async (t) => {
   await wait()
 
   // Check that we received an Output event for the audio chunk.
-  const outputEvent = events.find(e => e.event === 'Output' && e.jobId === 1)
+  const outputEvent = events.find((e) => e.event === 'Output' && e.jobId === 1)
   t.ok(outputEvent, 'Should receive an Output event for the audio chunk')
   t.ok(outputEvent.output, 'Output event should have output property')
-  t.is(outputEvent.output.data, sampleChunk.length, 'Output data should equal the audio chunk length')
+  t.is(
+    outputEvent.output.data,
+    sampleChunk.length,
+    'Output data should equal the audio chunk length'
+  )
 
   // Check that we received a JobEnded event.
-  const jobEndedEvent = events.find(e => e.event === 'JobEnded' && e.jobId === 1)
+  const jobEndedEvent = events.find((e) => e.event === 'JobEnded' && e.jobId === 1)
   t.ok(jobEndedEvent, 'Should receive a JobEnded event for job 1')
 })
 
@@ -108,14 +117,14 @@ test('Streaming transcript output preserves segment ordering', async (t) => {
   await model.addon.append({ type: 'end of job' })
   await wait()
 
-  const outputEvents = events.filter(e => e.event === 'Output' && e.jobId === 1)
+  const outputEvents = events.filter((e) => e.event === 'Output' && e.jobId === 1)
   t.alike(
-    outputEvents.map(e => e.output[0].text),
+    outputEvents.map((e) => e.output[0].text),
     ['segment-0', 'segment-1', 'segment-2'],
     'Output segments should keep original ordering'
   )
 
-  const jobEndedIndex = events.findIndex(e => e.event === 'JobEnded' && e.jobId === 1)
+  const jobEndedIndex = events.findIndex((e) => e.event === 'JobEnded' && e.jobId === 1)
   const lastOutputIndex = events.reduce((idx, evt, i) => {
     return evt.event === 'Output' && evt.jobId === 1 ? i : idx
   }, -1)
@@ -139,7 +148,7 @@ test('Cancel clears in-flight job and allows a new run', async (t) => {
   await wait(60)
 
   t.is(
-    events.find(e => e.jobId === 1 && (e.event === 'Output' || e.event === 'JobEnded')),
+    events.find((e) => e.jobId === 1 && (e.event === 'Output' || e.event === 'JobEnded')),
     undefined,
     'Cancelled job should not emit output or completion events'
   )
@@ -149,26 +158,30 @@ test('Cancel clears in-flight job and allows a new run', async (t) => {
   await wait(60)
 
   t.ok(
-    events.find(e => e.jobId === 2 && e.event === 'JobEnded'),
+    events.find((e) => e.jobId === 2 && e.event === 'JobEnded'),
     'A new job should complete successfully after cancel'
   )
 })
 
 test('WhisperInterface runJob preserves active job when native rejects new job', async (t) => {
   const binding = new MockedBinding()
-  const addon = new WhisperInterface(binding, {
-    contextParams: {
-      model: 'ggml-tiny.bin'
+  const addon = new WhisperInterface(
+    binding,
+    {
+      contextParams: {
+        model: 'ggml-tiny.bin'
+      },
+      whisperConfig: {
+        language: 'en',
+        duration_ms: 0,
+        temperature: 0.0
+      },
+      miscConfig: {
+        caption_enabled: false
+      }
     },
-    whisperConfig: {
-      language: 'en',
-      duration_ms: 0,
-      temperature: 0.0
-    },
-    miscConfig: {
-      caption_enabled: false
-    }
-  }, () => {})
+    () => {}
+  )
 
   addon._activeJobId = 42
   addon._nextJobId = 43
@@ -183,24 +196,32 @@ test('WhisperInterface runJob preserves active job when native rejects new job',
   t.is(accepted, false, 'runJob should report rejected when native side is busy')
   t.is(addon._activeJobId, 42, 'Current active job ID should remain unchanged')
   t.is(addon._nextJobId, 43, 'Next job counter should not advance on rejection')
-  t.is(await addon.status(), 'processing', 'State should remain unchanged for the current active job')
+  t.is(
+    await addon.status(),
+    'processing',
+    'State should remain unchanged for the current active job'
+  )
 })
 
 test('WhisperInterface cancel clears active job only after cancel resolves', async (t) => {
   const binding = new MockedBinding()
-  const addon = new WhisperInterface(binding, {
-    contextParams: {
-      model: 'ggml-tiny.bin'
+  const addon = new WhisperInterface(
+    binding,
+    {
+      contextParams: {
+        model: 'ggml-tiny.bin'
+      },
+      whisperConfig: {
+        language: 'en',
+        duration_ms: 0,
+        temperature: 0.0
+      },
+      miscConfig: {
+        caption_enabled: false
+      }
     },
-    whisperConfig: {
-      language: 'en',
-      duration_ms: 0,
-      temperature: 0.0
-    },
-    miscConfig: {
-      caption_enabled: false
-    }
-  }, () => {})
+    () => {}
+  )
 
   addon._activeJobId = 7
   addon._setState('processing')
@@ -222,21 +243,25 @@ test('WhisperInterface cancel clears active job only after cancel resolves', asy
 test('WhisperInterface cancels buffered job before native run starts', async (t) => {
   const events = []
   const binding = new MockedBinding()
-  const addon = new WhisperInterface(binding, {
-    contextParams: {
-      model: 'ggml-tiny.bin'
+  const addon = new WhisperInterface(
+    binding,
+    {
+      contextParams: {
+        model: 'ggml-tiny.bin'
+      },
+      whisperConfig: {
+        language: 'en',
+        duration_ms: 0,
+        temperature: 0.0
+      },
+      miscConfig: {
+        caption_enabled: false
+      }
     },
-    whisperConfig: {
-      language: 'en',
-      duration_ms: 0,
-      temperature: 0.0
-    },
-    miscConfig: {
-      caption_enabled: false
+    (handle, event, jobId, output, error) => {
+      events.push({ event, jobId, output, error })
     }
-  }, (handle, event, jobId, output, error) => {
-    events.push({ event, jobId, output, error })
-  })
+  )
 
   const pendingJobId = await addon.append({
     type: 'audio',
@@ -249,26 +274,32 @@ test('WhisperInterface cancels buffered job before native run starts', async (t)
   t.is(addon._bufferedAudio.length, 0, 'Buffered cancel should clear queued audio')
   t.is(await addon.status(), 'listening', 'Buffered cancel should return to listening state')
   t.ok(
-    events.find(e => e.event === 'Error' && e.jobId === pendingJobId && e.error === 'Job cancelled'),
+    events.find(
+      (e) => e.event === 'Error' && e.jobId === pendingJobId && e.error === 'Job cancelled'
+    ),
     'Buffered cancel should fail the pending JS-owned job'
   )
 })
 
 test('WhisperInterface ignores stale wrapper job ids when cancelling', async (t) => {
   const binding = new MockedBinding()
-  const addon = new WhisperInterface(binding, {
-    contextParams: {
-      model: 'ggml-tiny.bin'
+  const addon = new WhisperInterface(
+    binding,
+    {
+      contextParams: {
+        model: 'ggml-tiny.bin'
+      },
+      whisperConfig: {
+        language: 'en',
+        duration_ms: 0,
+        temperature: 0.0
+      },
+      miscConfig: {
+        caption_enabled: false
+      }
     },
-    whisperConfig: {
-      language: 'en',
-      duration_ms: 0,
-      temperature: 0.0
-    },
-    miscConfig: {
-      caption_enabled: false
-    }
-  }, () => {})
+    () => {}
+  )
 
   addon._activeJobId = 2
   addon._nextJobId = 3
@@ -320,7 +351,11 @@ test('Orphan native callbacks are ignored when no active job exists', async (t) 
   await model.load()
 
   binding._callCallbacks('Output', { data: 99 }, null)
-  binding._callCallbacks('JobEnded', { totalTime: 0.01, audioDurationMs: 99, totalSamples: 99 }, null)
+  binding._callCallbacks(
+    'JobEnded',
+    { totalTime: 0.01, audioDurationMs: 99, totalSamples: 99 },
+    null
+  )
 
   t.is(events.length, 0, 'Callbacks without an active job should be ignored')
 })
@@ -339,7 +374,7 @@ test('Model state transitions are handled correctly', async (t) => {
   const response = await model.run(new Uint8Array([10, 19, 30, 40, 50]))
   await response._finishPromise
 
-  t.ok(await model.status() === 'listening', 'Status: Model should be listening')
+  t.ok((await model.status()) === 'listening', 'Status: Model should be listening')
 
   try {
     await model.pause()
@@ -350,16 +385,19 @@ test('Model state transitions are handled correctly', async (t) => {
       'Pause should explicitly reject in runJob mode'
     )
   }
-  t.ok(await model.status() === 'listening', 'Status: Model should remain listening after unsupported pause')
+  t.ok(
+    (await model.status()) === 'listening',
+    'Status: Model should remain listening after unsupported pause'
+  )
 
   await model.unpause()
-  t.ok(await model.status() === 'listening', 'Status: Model should be listening')
+  t.ok((await model.status()) === 'listening', 'Status: Model should be listening')
 
   await model.addon.activate()
-  t.ok(await model.status() === 'listening', 'Status: Model should be listening')
+  t.ok((await model.status()) === 'listening', 'Status: Model should be listening')
 
   await model.addon.destroyInstance()
-  t.ok(await model.status() === 'idle', 'Status: Model should be idle')
+  t.ok((await model.status()) === 'idle', 'Status: Model should be idle')
 })
 
 /**
@@ -371,13 +409,15 @@ test('Model emits error events when an error occurs during processing', async (t
   // Create a custom binding that throws an error on append
   const binding = {
     createInstance: () => ({ id: 1 }),
-    runJob: () => { throw new Error('Forced error for testing') },
-    loadWeights: () => { },
-    activate: () => { },
-    cancel: () => { },
-    destroyInstance: () => { },
-    setLogger: () => { },
-    releaseLogger: () => { }
+    runJob: () => {
+      throw new Error('Forced error for testing')
+    },
+    loadWeights: () => {},
+    activate: () => {},
+    cancel: () => {},
+    destroyInstance: () => {},
+    setLogger: () => {},
+    releaseLogger: () => {}
   }
   const model = createMockedModel({ binding })
 
@@ -389,10 +429,16 @@ test('Model emits error events when an error occurs during processing', async (t
     t.fail('Should have failed the response')
   } catch (error) {
     // The error should be a QvacErrorAddonWhisper
-    t.ok(error.constructor.name === 'QvacErrorAddonWhisper', 'Error should be a QvacErrorAddonWhisper')
+    t.ok(
+      error.constructor.name === 'QvacErrorAddonWhisper',
+      'Error should be a QvacErrorAddonWhisper'
+    )
     // The test is mainly about ensuring errors are caught and wrapped properly
     // The specific error code is less important than the error handling mechanism
-    t.ok(error.message.includes('Forced error') || typeof error.code === 'number', 'Error should contain forced error message or have error code')
+    t.ok(
+      error.message.includes('Forced error') || typeof error.code === 'number',
+      'Error should contain forced error message or have error code'
+    )
   }
 })
 
@@ -407,7 +453,7 @@ test('FakeDL returns correct file list and data streams', async (t) => {
 
   const fileList = await fakeDL.list('/')
   t.ok(
-    ['0.bin', '1.bin', '2.bin', '3.bin', 'conf.json'].every(f => fileList.includes(f)),
+    ['0.bin', '1.bin', '2.bin', '3.bin', 'conf.json'].every((f) => fileList.includes(f)),
     'File list should match expected files'
   )
 
@@ -434,19 +480,24 @@ test('AddonInterface full sequence: status, append, and job boundaries', async (
   }
 
   const binding = new MockedBinding()
-  const addon = new WhisperInterface(binding, {
-    contextParams: {
-      model: 'ggml-tiny.bin'
+  const addon = new WhisperInterface(
+    binding,
+    {
+      contextParams: {
+        model: 'ggml-tiny.bin'
+      },
+      whisperConfig: {
+        language: 'en',
+        duration_ms: 0,
+        temperature: 0.0
+      },
+      miscConfig: {
+        caption_enabled: false
+      }
     },
-    whisperConfig: {
-      language: 'en',
-      duration_ms: 0,
-      temperature: 0.0
-    },
-    miscConfig: {
-      caption_enabled: false
-    }
-  }, onOutput, transitionCb)
+    onOutput,
+    transitionCb
+  )
 
   let status = await addon.status()
   t.ok(status === 'loading', 'Initial addon status should be "loading"')
@@ -468,7 +519,13 @@ test('AddonInterface full sequence: status, append, and job boundaries', async (
   await wait()
   console.log(JSON.stringify(events))
   t.ok(
-    events.find(e => e.event === 'JobEnded' && e.jobId === 1 && e.output && typeof e.output.totalTime === 'number'),
+    events.find(
+      (e) =>
+        e.event === 'JobEnded' &&
+        e.jobId === 1 &&
+        e.output &&
+        typeof e.output.totalTime === 'number'
+    ),
     'JobEnded callback should be emitted for job 1'
   )
 
@@ -488,11 +545,11 @@ test('AddonInterface full sequence: status, append, and job boundaries', async (
   t.ok(appendResult5 === 2, 'Job ID should be 2 for the end-of-job signal of job 2')
   await wait()
   t.ok(
-    events.find(e => e.event === 'Output' && e.jobId === 2 && e.output.data === 6),
+    events.find((e) => e.event === 'Output' && e.jobId === 2 && e.output.data === 6),
     'Output callback should report merged audio length for job 2'
   )
   t.ok(
-    events.find(e => e.event === 'JobEnded' && e.jobId === 2),
+    events.find((e) => e.event === 'JobEnded' && e.jobId === 2),
     'JobEnded callback should be emitted for job 2'
   )
 
@@ -501,7 +558,7 @@ test('AddonInterface full sequence: status, append, and job boundaries', async (
   t.ok(appendResult6 === 3, 'Job ID should increment to 3 for a redundant end-of-job signal')
   await wait()
   t.ok(
-    events.find(e => e.event === 'JobEnded' && e.jobId === 3),
+    events.find((e) => e.event === 'JobEnded' && e.jobId === 3),
     'JobEnded callback should be emitted for job 3'
   )
 

--- a/packages/transcription-whispercpp/test/unit/addon.reload.test.js
+++ b/packages/transcription-whispercpp/test/unit/addon.reload.test.js
@@ -9,7 +9,7 @@ const { WhisperInterface } = require('../../whisper')
 const process = require('bare-process')
 global.process = process
 
-function createTestModel ({ onOutput = () => { }, binding = undefined } = {}) {
+function createTestModel({ onOutput = () => {}, binding = undefined } = {}) {
   TranscriptionWhispercpp.prototype.validateModelFiles = () => undefined
 
   const args = {
@@ -25,8 +25,10 @@ function createTestModel ({ onOutput = () => { }, binding = undefined } = {}) {
   }
   const model = new TranscriptionWhispercpp(args, config)
   let capturedConfigResolve
-  const capturedConfig = new Promise(resolve => { capturedConfigResolve = resolve })
-  model._createAddon = configurationParams => {
+  const capturedConfig = new Promise((resolve) => {
+    capturedConfigResolve = resolve
+  })
+  model._createAddon = (configurationParams) => {
     capturedConfigResolve(configurationParams)
     const _binding = binding || new MockedBinding()
     return new WhisperInterface(_binding, configurationParams, onOutput, transitionCb)
@@ -101,7 +103,7 @@ test('Reload method handles configuration changes correctly', async (t) => {
   await wait()
 
   // Verify initial processing worked
-  const initialOutputEvents = events.filter(e => e.event === 'Output' && e.jobId === 1)
+  const initialOutputEvents = events.filter((e) => e.event === 'Output' && e.jobId === 1)
   t.ok(initialOutputEvents.length > 0, 'Should receive Output events before reload')
 
   // Clear events for reload test
@@ -136,7 +138,7 @@ test('Reload method handles configuration changes correctly', async (t) => {
   await wait()
 
   // Verify processing still works after reload
-  const reloadOutputEvents = events.filter(e => e.event === 'Output' && e.jobId === 2)
+  const reloadOutputEvents = events.filter((e) => e.event === 'Output' && e.jobId === 2)
   t.ok(reloadOutputEvents.length > 0, 'Should receive Output events after reload')
 })
 
@@ -210,7 +212,10 @@ test('Reload method handles multiple reloads correctly', async (t) => {
 
   await model.addon.reload(config1)
   let status = await model.addon.status()
-  t.ok(status === 'idle' || status === 'loading', 'Status should be idle or loading after first reload')
+  t.ok(
+    status === 'idle' || status === 'loading',
+    'Status should be idle or loading after first reload'
+  )
 
   await model.addon.activate()
   status = await model.addon.status()
@@ -225,7 +230,10 @@ test('Reload method handles multiple reloads correctly', async (t) => {
 
   await model.addon.reload(config2)
   status = await model.addon.status()
-  t.ok(status === 'idle' || status === 'loading', 'Status should be idle or loading after second reload')
+  t.ok(
+    status === 'idle' || status === 'loading',
+    'Status should be idle or loading after second reload'
+  )
 
   await model.addon.activate()
   status = await model.addon.status()
@@ -277,6 +285,6 @@ test('Reload method works with different language settings', async (t) => {
   await wait()
 
   // Verify processing works with different language
-  const outputEvents = events.filter(e => e.event === 'Output' && e.jobId === 2)
+  const outputEvents = events.filter((e) => e.event === 'Output' && e.jobId === 2)
   t.ok(outputEvents.length > 0, 'Should process audio with Spanish configuration')
 })

--- a/packages/transcription-whispercpp/test/unit/streaming.test.js
+++ b/packages/transcription-whispercpp/test/unit/streaming.test.js
@@ -9,7 +9,7 @@ const { WhisperInterface } = require('../../whisper')
 const process = require('bare-process')
 global.process = process
 
-function createMockedModel ({ onOutput = () => { }, binding = undefined } = {}) {
+function createMockedModel({ onOutput = () => {}, binding = undefined } = {}) {
   TranscriptionWhispercpp.prototype.validateModelFiles = () => undefined
 
   const args = {
@@ -32,12 +32,17 @@ function createMockedModel ({ onOutput = () => { }, binding = undefined } = {}) 
   }
   const model = new TranscriptionWhispercpp(args, config)
 
-  model._createAddon = configurationParams => {
+  model._createAddon = (configurationParams) => {
     const _binding = binding || new MockedBinding()
-    const addon = new WhisperInterface(_binding, configurationParams, (addon, event, jobId, output, error) => {
-      onOutput(addon, event, jobId, output, error)
-      model._outputCallback(addon, event, jobId, output, error)
-    }, transitionCb)
+    const addon = new WhisperInterface(
+      _binding,
+      configurationParams,
+      (addon, event, jobId, output, error) => {
+        onOutput(addon, event, jobId, output, error)
+        model._outputCallback(addon, event, jobId, output, error)
+      },
+      transitionCb
+    )
 
     return addon
   }
@@ -45,12 +50,12 @@ function createMockedModel ({ onOutput = () => { }, binding = undefined } = {}) 
   return model
 }
 
-function makeAudioChunks (count, size) {
+function makeAudioChunks(count, size) {
   const chunks = []
   for (let i = 0; i < count; i++) {
     const chunk = new Uint8Array(size)
     for (let j = 0; j < size; j++) {
-      chunk[j] = (i * size + j) & 0xFF
+      chunk[j] = (i * size + j) & 0xff
     }
     chunks.push(chunk)
   }
@@ -85,7 +90,7 @@ test('runStreaming completes and delivers transcription output', async (t) => {
 
   t.ok(results.length > 0, 'Should receive transcription output from streaming')
   t.ok(
-    events.find(e => e.event === 'JobEnded'),
+    events.find((e) => e.event === 'JobEnded'),
     'JobEnded should be emitted after streaming completes'
   )
 })
@@ -99,18 +104,19 @@ test('runStreaming passes conversation config to native streaming', async (t) =>
   const model = createMockedModel({ binding })
   await model.load()
 
-  const response = await model.runStreaming(
-    makeAudioChunks(1, 16000),
-    {
-      emitVadEvents: true,
-      endOfTurnSilenceMs: 750,
-      vadRunIntervalMs: 125
-    }
-  )
+  const response = await model.runStreaming(makeAudioChunks(1, 16000), {
+    emitVadEvents: true,
+    endOfTurnSilenceMs: 750,
+    vadRunIntervalMs: 125
+  })
   await response.await()
 
   t.ok(binding.lastStreamingConfig.emitVadEvents, 'emitVadEvents should be forwarded')
-  t.is(binding.lastStreamingConfig.endOfTurnSilenceMs, 750, 'end-of-turn threshold should be forwarded')
+  t.is(
+    binding.lastStreamingConfig.endOfTurnSilenceMs,
+    750,
+    'end-of-turn threshold should be forwarded'
+  )
   t.is(binding.lastStreamingConfig.vadRunIntervalMs, 125, 'VAD interval should be forwarded')
 })
 
@@ -130,10 +136,10 @@ test('runStreaming forwards VAD and end-of-turn events without ending the job', 
   const model = createMockedModel({ onOutput, binding })
   await model.load()
 
-  const response = await model.runStreaming(
-    makeAudioChunks(2, 16000),
-    { emitVadEvents: true, endOfTurnSilenceMs: 900 }
-  )
+  const response = await model.runStreaming(makeAudioChunks(2, 16000), {
+    emitVadEvents: true,
+    endOfTurnSilenceMs: 900
+  })
 
   const updates = []
   response.onUpdate((data) => {
@@ -142,12 +148,30 @@ test('runStreaming forwards VAD and end-of-turn events without ending the job', 
 
   await response.await()
 
-  t.ok(events.find(e => e.event === 'VadState'), 'VadState event should be forwarded')
-  t.ok(events.find(e => e.event === 'EndOfTurn'), 'EndOfTurn event should be forwarded')
-  t.ok(events.find(e => e.event === 'JobEnded'), 'JobEnded should still complete the stream')
-  t.ok(updates.find(data => data?.type === 'vad'), 'VAD event should reach response output')
-  t.ok(updates.find(data => data?.type === 'endOfTurn'), 'EndOfTurn event should reach response output')
-  t.ok(updates.find(data => Array.isArray(data) && data[0]?.text === 'hello world'), 'Transcript output should still be delivered')
+  t.ok(
+    events.find((e) => e.event === 'VadState'),
+    'VadState event should be forwarded'
+  )
+  t.ok(
+    events.find((e) => e.event === 'EndOfTurn'),
+    'EndOfTurn event should be forwarded'
+  )
+  t.ok(
+    events.find((e) => e.event === 'JobEnded'),
+    'JobEnded should still complete the stream'
+  )
+  t.ok(
+    updates.find((data) => data?.type === 'vad'),
+    'VAD event should reach response output'
+  )
+  t.ok(
+    updates.find((data) => data?.type === 'endOfTurn'),
+    'EndOfTurn event should reach response output'
+  )
+  t.ok(
+    updates.find((data) => Array.isArray(data) && data[0]?.text === 'hello world'),
+    'Transcript output should still be delivered'
+  )
 })
 
 test('runStreaming delivers accumulated stats across segments', async (t) => {
@@ -169,7 +193,7 @@ test('runStreaming delivers accumulated stats across segments', async (t) => {
   const response = await model.runStreaming(audioChunks)
   await response.await()
 
-  const jobEnded = events.find(e => e.event === 'JobEnded')
+  const jobEnded = events.find((e) => e.event === 'JobEnded')
   t.ok(jobEnded, 'JobEnded should be emitted')
   t.ok(jobEnded.output.processCalls === 4, 'processCalls should reflect total chunk count')
   t.ok(jobEnded.output.totalSamples > 0, 'totalSamples should be > 0 for accumulated stats')
@@ -186,9 +210,9 @@ test('Cancel stops an active streaming session', async (t) => {
   await model.load()
 
   const slowStream = {
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       yield new Uint8Array([1, 2, 3, 4])
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise((resolve) => setTimeout(resolve, 100))
       yield new Uint8Array([5, 6, 7, 8])
     }
   }
@@ -203,7 +227,10 @@ test('Cancel stops an active streaming session', async (t) => {
     t.fail('Response should not resolve after cancel')
   } catch (error) {
     t.ok(
-      error.message.includes('cancel') || error.message.includes('Cancel') || error.message.includes('failed') || error.message.includes('No active'),
+      error.message.includes('cancel') ||
+        error.message.includes('Cancel') ||
+        error.message.includes('failed') ||
+        error.message.includes('No active'),
       'Response should fail with a cancellation-related error'
     )
   }
@@ -219,9 +246,9 @@ test('Destroy cleans up active streaming session', async (t) => {
   await model.load()
 
   const slowStream = {
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       yield new Uint8Array([10, 20, 30])
-      await new Promise(resolve => setTimeout(resolve, 200))
+      await new Promise((resolve) => setTimeout(resolve, 200))
       yield new Uint8Array([40, 50, 60])
     }
   }
@@ -235,7 +262,10 @@ test('Destroy cleans up active streaming session', async (t) => {
     t.fail('Response should fail when model is destroyed mid-stream')
   } catch (error) {
     t.ok(
-      error.message.includes('destroyed') || error.message.includes('Destroy') || error.message.includes('cancel') || error.message.includes('No active'),
+      error.message.includes('destroyed') ||
+        error.message.includes('Destroy') ||
+        error.message.includes('cancel') ||
+        error.message.includes('No active'),
       'Streaming response should fail on destroy'
     )
   }
@@ -267,10 +297,10 @@ test('Streaming error propagation surfaces to response', async (t) => {
     t.ok(error, 'Response should reject with an error when segments fail')
   }
 
-  const goodOutputs = events.filter(e => e.event === 'Output' && e.output !== null)
+  const goodOutputs = events.filter((e) => e.event === 'Output' && e.output !== null)
   t.ok(goodOutputs.length > 0, 'Successful segments should still deliver output')
 
-  const errorEvents = events.filter(e => e.event === 'Error')
+  const errorEvents = events.filter((e) => e.event === 'Error')
   t.ok(errorEvents.length > 0, 'Error event should be emitted for failed processing')
 })
 
@@ -280,9 +310,9 @@ test('Second streaming session waits on exclusive queue until first completes', 
   await model.load()
 
   const slowStream = {
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       yield new Uint8Array([1, 2])
-      await new Promise(resolve => setTimeout(resolve, 500))
+      await new Promise((resolve) => setTimeout(resolve, 500))
       yield new Uint8Array([3, 4])
     }
   }

--- a/packages/transcription-whispercpp/test/unit/vad.test.js
+++ b/packages/transcription-whispercpp/test/unit/vad.test.js
@@ -9,7 +9,7 @@ const { WhisperInterface } = require('../../whisper')
 const process = require('bare-process')
 global.process = process
 
-function createTestModel ({ onOutput = () => { }, vadModelPath = 'ggml-silero-v5.1.2.bin' } = {}) {
+function createTestModel({ onOutput = () => {}, vadModelPath = 'ggml-silero-v5.1.2.bin' } = {}) {
   TranscriptionWhispercpp.prototype.validateModelFiles = () => undefined
 
   const args = {
@@ -24,8 +24,10 @@ function createTestModel ({ onOutput = () => { }, vadModelPath = 'ggml-silero-v5
   }
   const model = new TranscriptionWhispercpp(args, config)
   let capturedConfigResolve
-  const capturedConfig = new Promise(resolve => { capturedConfigResolve = resolve })
-  model._createAddon = configurationParams => {
+  const capturedConfig = new Promise((resolve) => {
+    capturedConfigResolve = resolve
+  })
+  model._createAddon = (configurationParams) => {
     capturedConfigResolve(configurationParams)
     const binding = new MockedBinding()
     binding.enableVadTestMode()
@@ -66,20 +68,22 @@ test('VAD mode processes audio with voice activity detection', async (t) => {
 
   // Check that we received Output events with stronger assertions
   console.log(events)
-  const outputEvents = events.filter(e => e.event === 'Output' && e.jobId === 1)
+  const outputEvents = events.filter((e) => e.event === 'Output' && e.jobId === 1)
   t.ok(outputEvents.length > 0, 'Should receive Output events for VAD processing')
 
   if (outputEvents.length > 0) {
     t.ok(outputEvents[0].output, 'Should have transcription output')
     t.ok(Array.isArray(outputEvents[0].output), 'Output should be wrapped in array')
     const transcript = outputEvents[0].output[0]
-    t.ok(transcript.text.includes('Mock transcription') ||
-      transcript.text.includes('Silent audio detected'),
-    'Should contain mock transcription or silence detection text')
+    t.ok(
+      transcript.text.includes('Mock transcription') ||
+        transcript.text.includes('Silent audio detected'),
+      'Should contain mock transcription or silence detection text'
+    )
   }
 
   // Check that we received a JobEnded event
-  const jobEndedEvent = events.find(e => e.event === 'JobEnded' && e.jobId === 1)
+  const jobEndedEvent = events.find((e) => e.event === 'JobEnded' && e.jobId === 1)
   t.ok(jobEndedEvent, 'Should receive a JobEnded event for job 1')
 })
 
@@ -93,8 +97,16 @@ test('VAD model path is correctly configured', async (t) => {
   const capturedConfig = await capturedConfigFut
 
   t.ok(capturedConfig, 'Configuration should be captured')
-  t.is(capturedConfig.whisperConfig.vad_model_path, 'ggml-silero-v5.1.2.bin', 'VAD model path should be correctly passed')
-  t.is(capturedConfig.contextParams.model, 'ggml-tiny.bin', 'Model filename should be correctly passed')
+  t.is(
+    capturedConfig.whisperConfig.vad_model_path,
+    'ggml-silero-v5.1.2.bin',
+    'VAD model path should be correctly passed'
+  )
+  t.is(
+    capturedConfig.contextParams.model,
+    'ggml-tiny.bin',
+    'Model filename should be correctly passed'
+  )
 })
 
 test('VAD handles invalid audio input gracefully', async (t) => {
@@ -124,6 +136,6 @@ test('VAD handles invalid audio input gracefully', async (t) => {
 
   await wait()
 
-  const outputEvents = events.filter(e => e.event === 'Output')
+  const outputEvents = events.filter((e) => e.event === 'Output')
   t.ok(outputEvents.length > 0, 'Should still process valid audio after errors')
 })

--- a/packages/transcription-whispercpp/whisper.js
+++ b/packages/transcription-whispercpp/whisper.js
@@ -12,7 +12,7 @@ const state = Object.freeze({
 
 const END_OF_INPUT = 'end of job'
 
-function nextSafeId (current) {
+function nextSafeId(current) {
   return current >= Number.MAX_SAFE_INTEGER ? 1 : current + 1
 }
 
@@ -30,7 +30,7 @@ class WhisperInterface {
    * @param {Function} outputCb - to be called on any inference event ( started, new output, error, etc )
    * @param {Function} transitionCb - to be called on addon state changes (LISTENING, IDLE, STOPPED, etc )
    */
-  constructor (binding, configurationParams, outputCb, transitionCb = null) {
+  constructor(binding, configurationParams, outputCb, transitionCb = null) {
     this._binding = binding
     this._outputCb = outputCb
     this._transitionCb = transitionCb
@@ -51,24 +51,22 @@ class WhisperInterface {
     )
   }
 
-  _setState (newState) {
+  _setState(newState) {
     this._state = newState
     if (this._transitionCb) {
       this._transitionCb(this, newState)
     }
   }
 
-  _addonOutputCallback (addon, event, data, error) {
+  _addonOutputCallback(addon, event, data, error) {
     const isError = typeof error === 'string' && error.length > 0
-    const isStats = data && typeof data === 'object' && (
-      'totalTime' in data ||
-      'audioDurationMs' in data ||
-      'totalSamples' in data
-    )
-    const isTranscriptOutput = (
+    const isStats =
+      data &&
+      typeof data === 'object' &&
+      ('totalTime' in data || 'audioDurationMs' in data || 'totalSamples' in data)
+    const isTranscriptOutput =
       (Array.isArray(data) && data.length > 0) ||
       (data && typeof data === 'object' && typeof data.text === 'string')
-    )
     const isVadEvent = data && typeof data === 'object' && data.type === 'vad'
     const isEndOfTurnEvent = data && typeof data === 'object' && data.type === 'endOfTurn'
 
@@ -97,10 +95,10 @@ class WhisperInterface {
     if (mappedEvent === 'Output') {
       this._setState(state.PROCESSING)
       if (this._outputCb != null) {
-        const isTranscriptArray = Array.isArray(data) && data.length > 0 &&
-          typeof data[0]?.text === 'string'
-        const isSingleTranscript = !Array.isArray(data) &&
-          data && typeof data === 'object' && typeof data.text === 'string'
+        const isTranscriptArray =
+          Array.isArray(data) && data.length > 0 && typeof data[0]?.text === 'string'
+        const isSingleTranscript =
+          !Array.isArray(data) && data && typeof data === 'object' && typeof data.text === 'string'
         if (isTranscriptArray) {
           for (const segment of data) {
             this._outputCb(addon, 'Output', jobId, [segment], null)
@@ -115,13 +113,7 @@ class WhisperInterface {
     }
 
     if (this._outputCb != null) {
-      this._outputCb(
-        addon,
-        mappedEvent,
-        jobId,
-        data,
-        isError ? error : null
-      )
+      this._outputCb(addon, mappedEvent, jobId, data, isError ? error : null)
     }
 
     if (mappedEvent === 'Error' || mappedEvent === 'JobEnded') {
@@ -130,7 +122,7 @@ class WhisperInterface {
     }
   }
 
-  _emitSyntheticError (jobId, error) {
+  _emitSyntheticError(jobId, error) {
     if (this._outputCb == null) {
       return
     }
@@ -142,7 +134,7 @@ class WhisperInterface {
    * frees memory allocated for configuration and weights,
    * and moves addon to the UNLOADED state.
    */
-  async unload () {
+  async unload() {
     await this.destroyInstance()
   }
 
@@ -151,7 +143,7 @@ class WhisperInterface {
    * Can only be invoked after unload()
    * @param {Object} configurationParams - all the required configuration for inference setup
    */
-  async load (configurationParams) {
+  async load(configurationParams) {
     checkConfig(configurationParams)
     this._audioFormat = configurationParams?.audio_format || this._audioFormat
     await this.destroyInstance()
@@ -171,7 +163,7 @@ class WhisperInterface {
    * and moves addon to the LOADING state.
    * @param {Object} configurationParams - all the required configuration for inference setup
    */
-  async reload (configurationParams) {
+  async reload(configurationParams) {
     checkConfig(configurationParams)
     this._audioFormat = configurationParams?.audio_format || this._audioFormat
     await this.cancel()
@@ -197,7 +189,7 @@ class WhisperInterface {
    * @param {Uint8Array} weightsData.contents
    * @param {Boolean} weightsData.completed
    */
-  async loadWeights (weightsData) {
+  async loadWeights(weightsData) {
     try {
       this._binding.loadWeights(this._handle, weightsData)
     } catch (err) {
@@ -213,7 +205,7 @@ class WhisperInterface {
    * Unloads weights for the model.
    * Can only be invoked after instance has loaded weights
    */
-  async unloadWeights () {
+  async unloadWeights() {
     // Whisper bundles weights in the model file; keep API compatibility.
     return true
   }
@@ -221,7 +213,7 @@ class WhisperInterface {
   /**
    * Moves addon to the LISTENING state after all the initialization is done
    */
-  async activate () {
+  async activate() {
     try {
       this._binding.activate(this._handle)
       this._setState(state.LISTENING)
@@ -237,7 +229,7 @@ class WhisperInterface {
   /**
    * Pauses current inference process
    */
-  async pause () {
+  async pause() {
     throw new QvacErrorAddonWhisper({
       code: ERR_CODES.FAILED_TO_PAUSE,
       adds: 'pause is not supported in runJob mode'
@@ -247,7 +239,7 @@ class WhisperInterface {
   /**
    * Stops current inference process
    */
-  async stop () {
+  async stop() {
     throw new QvacErrorAddonWhisper({
       code: ERR_CODES.FAILED_TO_RESET,
       adds: 'stop is not supported in runJob mode'
@@ -257,7 +249,7 @@ class WhisperInterface {
   /**
    * Cancel a inference process by jobId, if no jobId is provided it cancel the whole queue
    */
-  async cancel (jobId) {
+  async cancel(jobId) {
     try {
       const pendingJobId = this._bufferedAudio.length > 0 ? this._nextJobId : null
       const targetJobId = jobId ?? this._activeJobId ?? pendingJobId
@@ -300,7 +292,7 @@ class WhisperInterface {
    * @param {String} data.input
    * @returns {Number} - job ID
    */
-  async append (data) {
+  async append(data) {
     try {
       if (data?.type === END_OF_INPUT) {
         const currentJobId = this._nextJobId
@@ -363,7 +355,7 @@ class WhisperInterface {
    * Addon process status
    * @returns {String}
    */
-  async status () {
+  async status() {
     try {
       return this._state
     } catch (err) {
@@ -378,7 +370,7 @@ class WhisperInterface {
   /**
    * Stops addon process and clears resources (including memory).
    */
-  async destroyInstance () {
+  async destroyInstance() {
     // Already destroyed, nothing to do
     if (this._handle === null) {
       return
@@ -405,7 +397,7 @@ class WhisperInterface {
     }
   }
 
-  async runJob (data) {
+  async runJob(data) {
     const currentJobId = this._nextJobId
     const previousJobId = this._activeJobId
     const previousState = this._state
@@ -434,7 +426,7 @@ class WhisperInterface {
     }
   }
 
-  startStreaming (config = {}) {
+  startStreaming(config = {}) {
     try {
       this._activeJobId = this._nextJobId
       this._nextJobId = nextSafeId(this._nextJobId)
@@ -454,7 +446,7 @@ class WhisperInterface {
     }
   }
 
-  appendStreamingAudio (data) {
+  appendStreamingAudio(data) {
     try {
       if (!(data.input instanceof Uint8Array)) {
         throw new Error('Audio input must be Uint8Array')
@@ -473,7 +465,7 @@ class WhisperInterface {
     }
   }
 
-  endStreaming () {
+  endStreaming() {
     try {
       this._binding.endStreaming(this._handle)
     } catch (err) {
@@ -485,17 +477,14 @@ class WhisperInterface {
     }
   }
 
-  _concatBufferedAudio () {
+  _concatBufferedAudio() {
     if (this._bufferedAudio.length === 0) {
       return new Uint8Array()
     }
     if (this._bufferedAudio.length === 1) {
       return this._bufferedAudio[0]
     }
-    const totalLength = this._bufferedAudio.reduce(
-      (sum, chunk) => sum + chunk.byteLength,
-      0
-    )
+    const totalLength = this._bufferedAudio.reduce((sum, chunk) => sum + chunk.byteLength, 0)
     const merged = new Uint8Array(totalLength)
     let offset = 0
     for (const chunk of this._bufferedAudio) {


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The JS source in `packages/transcription-whispercpp` was not consistently formatted per the package's pinned Prettier config.
- `npm run lint` (which runs `prettier --check`) flagged JS files with code-style issues.

## 📝 How does it solve it?

- Ran `npm run format` (`prettier --write`) across `examples/`, `test/`, and top-level `*.js` to apply the canonical formatting.
- Reformatted 36 files (whitespace/style only — no functional, API, or behavioral changes).

## 🧪 How was it tested?

- Re-ran `prettier --check` → "All matched files use Prettier code style!"


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216426242135592