### PR TITLE
QVAC-22028 chore[skiplog]: apply prettier formatting to transcription-parakeet JS

### DIFF
--- a/packages/transcription-parakeet/examples/decode-audio.js
+++ b/packages/transcription-parakeet/examples/decode-audio.js
@@ -24,7 +24,7 @@ const { setupLogger, validatePaths, printResults } = require('./utils.js')
 
 const SAMPLE_RATE = 16000
 
-function parseArgs () {
+function parseArgs() {
   const args = { model: null, audio: null }
   const argv = Bare.argv.slice(2)
   for (let i = 0; i < argv.length; i++) {
@@ -36,10 +36,13 @@ function parseArgs () {
 }
 
 const silentLogger = {
-  debug () {}, info () {}, warn () {}, error () {}
+  debug() {},
+  info() {},
+  warn() {},
+  error() {}
 }
 
-async function decodeToFloat32 (audioPath) {
+async function decodeToFloat32(audioPath) {
   const decoder = new FFmpegDecoder({
     config: { streamIndex: 0 },
     logger: silentLogger
@@ -52,9 +55,11 @@ async function decodeToFloat32 (audioPath) {
     const response = await decoder.run(audioStream)
 
     response.on('output', (data) => {
-      const view = new DataView(data.outputArray.buffer,
+      const view = new DataView(
+        data.outputArray.buffer,
         data.outputArray.byteOffset,
-        data.outputArray.byteLength)
+        data.outputArray.byteLength
+      )
       const n = Math.floor(data.outputArray.byteLength / 2)
       const f32 = new Float32Array(n)
       for (let i = 0; i < n; i++) {
@@ -81,7 +86,7 @@ async function decodeToFloat32 (audioPath) {
   }
 }
 
-async function main () {
+async function main() {
   const args = parseArgs()
   if (!args.model || !args.audio) {
     console.error('Usage: bare examples/decode-audio.js --model <gguf> --audio <file>')
@@ -110,7 +115,7 @@ async function main () {
   const segments = []
   const response = await model.run(audioData)
   await response
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const s of items) {
         if (s && s.text && s.toAppend) segments.push(s)
@@ -123,7 +128,7 @@ async function main () {
   addonLogging.releaseLogger()
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Error:', err)
   addonLogging.releaseLogger()
   process.exit(1)

--- a/packages/transcription-parakeet/examples/diarized-transcribe.js
+++ b/packages/transcription-parakeet/examples/diarized-transcribe.js
@@ -36,7 +36,7 @@ const {
 
 const SAMPLE_RATE = 16000
 
-function parseArgs () {
+function parseArgs() {
   const args = { asrModel: null, diarModel: null, audio: null }
   const argv = Bare.argv.slice(2)
   for (let i = 0; i < argv.length; i++) {
@@ -48,14 +48,14 @@ function parseArgs () {
   return args
 }
 
-async function loadAudio (audioPath) {
+async function loadAudio(audioPath) {
   const ext = path.extname(audioPath).toLowerCase()
   if (ext === '.wav') return parseWavFile(audioPath)
   const rawBuffer = await readFileAsStream(audioPath)
   return convertRawToFloat32(rawBuffer)
 }
 
-function parseSpeakerSegments (sortformerText) {
+function parseSpeakerSegments(sortformerText) {
   const segments = []
   for (const line of sortformerText.split('\n')) {
     const m = line.match(/Speaker\s+(\d+)\s*:\s*([\d.:]+)\s*-\s*([\d.:]+)/)
@@ -76,14 +76,14 @@ function parseSpeakerSegments (sortformerText) {
   return segments
 }
 
-function sliceAudio (audioData, startS, endS) {
+function sliceAudio(audioData, startS, endS) {
   const i0 = Math.max(0, Math.floor(startS * SAMPLE_RATE))
   const i1 = Math.min(audioData.length, Math.ceil(endS * SAMPLE_RATE))
   if (i1 <= i0) return null
   return audioData.slice(i0, i1)
 }
 
-async function transcribeSegments (asrModel, audioData, segments) {
+async function transcribeSegments(asrModel, audioData, segments) {
   const results = []
   for (const seg of segments) {
     const slice = sliceAudio(audioData, seg.start, seg.end)
@@ -94,23 +94,28 @@ async function transcribeSegments (asrModel, audioData, segments) {
     const segments = []
     const response = await asrModel.run(slice)
     await response
-      .onUpdate(out => {
+      .onUpdate((out) => {
         const items = Array.isArray(out) ? out : [out]
         for (const s of items) {
           if (s && s.text && s.toAppend) segments.push(s)
         }
       })
       .await()
-    const text = segments.map(s => s.text).join(' ').trim()
+    const text = segments
+      .map((s) => s.text)
+      .join(' ')
+      .trim()
     results.push({ speaker: seg.speaker, text: text || '[no speech]' })
   }
   return results
 }
 
-async function main () {
+async function main() {
   const args = parseArgs()
   if (!args.asrModel || !args.diarModel || !args.audio) {
-    console.error('Usage: bare examples/diarized-transcribe.js --asr-model <gguf> --diar-model <gguf> --audio <file>')
+    console.error(
+      'Usage: bare examples/diarized-transcribe.js --asr-model <gguf> --diar-model <gguf> --audio <file>'
+    )
     process.exit(1)
   }
 
@@ -140,7 +145,7 @@ async function main () {
   const sortformerSegments = []
   const diarResponse = await diarModel.run(audioData)
   await diarResponse
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const s of items) {
         if (s && s.text) sortformerSegments.push(s)
@@ -149,7 +154,10 @@ async function main () {
     .await()
   await diarModel.unload()
 
-  const sfText = sortformerSegments.map(s => s.text).join(' ').trim()
+  const sfText = sortformerSegments
+    .map((s) => s.text)
+    .join(' ')
+    .trim()
   const segments = parseSpeakerSegments(sfText)
   if (segments.length === 0) {
     console.log('No speakers detected.')
@@ -169,7 +177,7 @@ async function main () {
   addonLogging.releaseLogger()
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Error:', err)
   addonLogging.releaseLogger()
   process.exit(1)

--- a/packages/transcription-parakeet/examples/live-mic-diarized-aosc.js
+++ b/packages/transcription-parakeet/examples/live-mic-diarized-aosc.js
@@ -77,11 +77,11 @@ const SILENCE_SENTINELS = new Set([
   '[No speakers detected]'
 ])
 
-function isSilenceText (text) {
+function isSilenceText(text) {
   return text.length === 0 || SILENCE_SENTINELS.has(text)
 }
 
-function buildSegmentText (items) {
+function buildSegmentText(items) {
   let text = ''
   let firstStartsWord = true
   let isFirst = true
@@ -99,14 +99,12 @@ function buildSegmentText (items) {
   return { text: text.replace(/\s+/g, ' '), firstStartsWord }
 }
 
-function parseSortformerSpeakerId (text) {
-  const m = typeof text === 'string'
-    ? text.match(/Speaker\s+(\d+)/)
-    : null
+function parseSortformerSpeakerId(text) {
+  const m = typeof text === 'string' ? text.match(/Speaker\s+(\d+)/) : null
   return m ? parseInt(m[1], 10) : -1
 }
 
-function parseBoolFlag (value) {
+function parseBoolFlag(value) {
   if (value === undefined || value === null) return undefined
   const normalised = String(value).toLowerCase()
   if (normalised === 'true' || normalised === '1' || normalised === 'yes') return true
@@ -114,17 +112,17 @@ function parseBoolFlag (value) {
   return undefined
 }
 
-function parsePositiveInt (value) {
+function parsePositiveInt(value) {
   const n = parseInt(value, 10)
   return Number.isFinite(n) && n > 0 ? n : null
 }
 
-function parseNonNegativeInt (value) {
+function parseNonNegativeInt(value) {
   const n = parseInt(value, 10)
   return Number.isFinite(n) && n >= 0 ? n : null
 }
 
-function parseArgs () {
+function parseArgs() {
   const args = {
     asrModel: null,
     diarModel: null,
@@ -153,14 +151,17 @@ function parseArgs () {
       if (v !== undefined) args.spkCacheEnable = v
     } else if (a === '--spk-cache-len') args.spkCacheLen = parsePositiveInt(argv[++i])
     else if (a === '--fifo-len') args.fifoLen = parsePositiveInt(argv[++i])
-    else if (a === '--chunk-left-context-ms') args.chunkLeftContextMs = parseNonNegativeInt(argv[++i])
-    else if (a === '--chunk-right-context-ms') args.chunkRightContextMs = parseNonNegativeInt(argv[++i])
-    else if (a === '--spk-cache-update-period') args.spkCacheUpdatePeriod = parsePositiveInt(argv[++i])
+    else if (a === '--chunk-left-context-ms')
+      args.chunkLeftContextMs = parseNonNegativeInt(argv[++i])
+    else if (a === '--chunk-right-context-ms')
+      args.chunkRightContextMs = parseNonNegativeInt(argv[++i])
+    else if (a === '--spk-cache-update-period')
+      args.spkCacheUpdatePeriod = parsePositiveInt(argv[++i])
   }
   return args
 }
 
-function buildDiarConfig (args) {
+function buildDiarConfig(args) {
   const config = {
     streaming: true,
     streamingChunkMs: args.chunkMs ?? 2000,
@@ -170,26 +171,34 @@ function buildDiarConfig (args) {
   if (args.spkCacheLen !== null) config.streamingSpkCacheLen = args.spkCacheLen
   if (args.fifoLen !== null) config.streamingFifoLen = args.fifoLen
   if (args.chunkLeftContextMs !== null) config.streamingChunkLeftContextMs = args.chunkLeftContextMs
-  if (args.chunkRightContextMs !== null) config.streamingChunkRightContextMs = args.chunkRightContextMs
-  if (args.spkCacheUpdatePeriod !== null) config.streamingSpkCacheUpdatePeriod = args.spkCacheUpdatePeriod
+  if (args.chunkRightContextMs !== null)
+    config.streamingChunkRightContextMs = args.chunkRightContextMs
+  if (args.spkCacheUpdatePeriod !== null)
+    config.streamingSpkCacheUpdatePeriod = args.spkCacheUpdatePeriod
   return config
 }
 
-function describeAoscConfig (config) {
+function describeAoscConfig(config) {
   const parts = []
-  if ('streamingSpkCacheEnable' in config) parts.push(`spkCacheEnable=${config.streamingSpkCacheEnable}`)
+  if ('streamingSpkCacheEnable' in config)
+    parts.push(`spkCacheEnable=${config.streamingSpkCacheEnable}`)
   if ('streamingSpkCacheLen' in config) parts.push(`spkCacheLen=${config.streamingSpkCacheLen}`)
   if ('streamingFifoLen' in config) parts.push(`fifoLen=${config.streamingFifoLen}`)
-  if ('streamingChunkLeftContextMs' in config) parts.push(`chunkLeftContextMs=${config.streamingChunkLeftContextMs}`)
-  if ('streamingChunkRightContextMs' in config) parts.push(`chunkRightContextMs=${config.streamingChunkRightContextMs}`)
-  if ('streamingSpkCacheUpdatePeriod' in config) parts.push(`spkCacheUpdatePeriod=${config.streamingSpkCacheUpdatePeriod}`)
+  if ('streamingChunkLeftContextMs' in config)
+    parts.push(`chunkLeftContextMs=${config.streamingChunkLeftContextMs}`)
+  if ('streamingChunkRightContextMs' in config)
+    parts.push(`chunkRightContextMs=${config.streamingChunkRightContextMs}`)
+  if ('streamingSpkCacheUpdatePeriod' in config)
+    parts.push(`spkCacheUpdatePeriod=${config.streamingSpkCacheUpdatePeriod}`)
   return parts.length === 0 ? '(all AOSC defaults)' : parts.join(' ')
 }
 
-async function main () {
+async function main() {
   const args = parseArgs()
   if (!args.asrModel || !args.diarModel) {
-    console.error('Usage: bare examples/live-mic-diarized-aosc.js --asr-model <gguf> --diar-model <v2.1-gguf> [--accumulate] [--chunk-ms <ms>] [--capture "<sox cmd>"] [--spk-cache-enable {true|false}] [--spk-cache-len <rows>] [--fifo-len <rows>] [--chunk-left-context-ms <ms>] [--chunk-right-context-ms <ms>] [--spk-cache-update-period <count>]')
+    console.error(
+      'Usage: bare examples/live-mic-diarized-aosc.js --asr-model <gguf> --diar-model <v2.1-gguf> [--accumulate] [--chunk-ms <ms>] [--capture "<sox cmd>"] [--spk-cache-enable {true|false}] [--spk-cache-len <rows>] [--fifo-len <rows>] [--chunk-left-context-ms <ms>] [--chunk-right-context-ms <ms>] [--spk-cache-update-period <count>]'
+    )
     process.exit(1)
   }
 
@@ -198,8 +207,14 @@ async function main () {
 
   const asrPath = path.resolve(args.asrModel)
   const diarPath = path.resolve(args.diarModel)
-  if (!validatePaths({ model: asrPath })) { addonLogging.releaseLogger(); process.exit(1) }
-  if (!validatePaths({ model: diarPath })) { addonLogging.releaseLogger(); process.exit(1) }
+  if (!validatePaths({ model: asrPath })) {
+    addonLogging.releaseLogger()
+    process.exit(1)
+  }
+  if (!validatePaths({ model: diarPath })) {
+    addonLogging.releaseLogger()
+    process.exit(1)
+  }
 
   console.log(`Loading ASR: ${asrPath}`)
   console.log(`Loading DIAR: ${diarPath}`)
@@ -230,12 +245,13 @@ async function main () {
   const [captureBin, ...captureArgs] = captureCmd.split(' ')
   let child
   try {
-    child = subprocess.spawn(captureBin, captureArgs,
-      { stdio: ['ignore', 'pipe', 'pipe'] })
+    child = subprocess.spawn(captureBin, captureArgs, { stdio: ['ignore', 'pipe', 'pipe'] })
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       console.error(`\n'${captureBin}' not found on PATH.`)
-      console.error('Install sox (brew install sox / apt install sox / choco install sox / winget install ChrisBagwell.SoX).')
+      console.error(
+        'Install sox (brew install sox / apt install sox / choco install sox / winget install ChrisBagwell.SoX).'
+      )
     } else {
       console.error(`\nFailed to spawn capture command: ${err.message}`)
     }
@@ -258,14 +274,14 @@ async function main () {
   let lineSpeaker = null
   let lastSpeaker = -1
 
-  function flushLine () {
+  function flushLine() {
     if (lineOpen) {
       process.stdout.write('\n')
       lineOpen = false
       lineSpeaker = null
     }
   }
-  function emitTranscript (speaker, text, firstStartsWord) {
+  function emitTranscript(speaker, text, firstStartsWord) {
     if (isSilenceText(text)) {
       if (args.accumulate) flushLine()
       return
@@ -301,7 +317,7 @@ async function main () {
   const diarRunPromise = (async () => {
     const response = await diar.runStreaming(diarStream, streamingConfig)
     await response
-      .onUpdate(out => {
+      .onUpdate((out) => {
         const items = Array.isArray(out) ? out : [out]
         for (let i = items.length - 1; i >= 0; i--) {
           const s = items[i]
@@ -319,7 +335,7 @@ async function main () {
   const asrRunPromise = (async () => {
     const response = await asr.runStreaming(asrStream, streamingConfig)
     await response
-      .onUpdate(out => {
+      .onUpdate((out) => {
         const items = Array.isArray(out) ? out : [out]
         const { text, firstStartsWord } = buildSegmentText(items)
         emitTranscript(lastSpeaker, text.trim(), firstStartsWord)
@@ -327,17 +343,33 @@ async function main () {
       .await()
   })()
 
-  async function shutdown () {
+  async function shutdown() {
     if (stopping) return
     stopping = true
     console.log('\nStopping...')
-    try { child.kill('SIGTERM') } catch (e) { /* ignore */ }
+    try {
+      child.kill('SIGTERM')
+    } catch (e) {
+      /* ignore */
+    }
     asrStream.end()
     diarStream.end()
-    try { await Promise.all([asrRunPromise, diarRunPromise]) } catch (e) { /* swallow */ }
+    try {
+      await Promise.all([asrRunPromise, diarRunPromise])
+    } catch (e) {
+      /* swallow */
+    }
     flushLine()
-    try { await asr.unload() } catch (e) { /* ignore */ }
-    try { await diar.unload() } catch (e) { /* ignore */ }
+    try {
+      await asr.unload()
+    } catch (e) {
+      /* ignore */
+    }
+    try {
+      await diar.unload()
+    } catch (e) {
+      /* ignore */
+    }
     addonLogging.releaseLogger()
     process.exit(0)
   }
@@ -346,7 +378,9 @@ async function main () {
   process.once('SIGTERM', shutdown)
   child.on('exit', (code, signal) => {
     if (!firstAudioSeen && !stopping) {
-      console.error(`\nCapture command exited before producing audio (code=${code}, signal=${signal}).`)
+      console.error(
+        `\nCapture command exited before producing audio (code=${code}, signal=${signal}).`
+      )
       const tail = stderrBuf.trim()
       if (tail) {
         console.error('--- sox stderr ---')
@@ -354,15 +388,21 @@ async function main () {
         console.error('------------------')
       }
       console.error('Hints:')
-      console.error('  - On Windows, try: --capture "sox -t waveaudio default -t raw -r 16000 -b 16 -c 1 -e signed-integer -L -"')
-      console.error('  - Verify a default recording device exists (Settings -> System -> Sound -> Input).')
-      console.error('  - Confirm SoX can list audio devices: sox -V6 -d -t raw -r 16000 -c 1 -e signed-integer -b 16 -L - 2>&1 | head')
+      console.error(
+        '  - On Windows, try: --capture "sox -t waveaudio default -t raw -r 16000 -b 16 -c 1 -e signed-integer -L -"'
+      )
+      console.error(
+        '  - Verify a default recording device exists (Settings -> System -> Sound -> Input).'
+      )
+      console.error(
+        '  - Confirm SoX can list audio devices: sox -V6 -d -t raw -r 16000 -c 1 -e signed-integer -b 16 -L - 2>&1 | head'
+      )
     }
     shutdown()
   })
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Error:', err)
   addonLogging.releaseLogger()
   process.exit(1)

--- a/packages/transcription-parakeet/examples/live-mic-diarized.js
+++ b/packages/transcription-parakeet/examples/live-mic-diarized.js
@@ -58,7 +58,7 @@ const SILENCE_SENTINELS = new Set([
   '[No speakers detected]'
 ])
 
-function isSilenceText (text) {
+function isSilenceText(text) {
   return text.length === 0 || SILENCE_SENTINELS.has(text)
 }
 
@@ -67,7 +67,7 @@ function isSilenceText (text) {
 // flag we use to gate the inserted separator so "see" + "if" stays
 // "see if" while "pun" + "ctuation" rejoins into "punctuation". See
 // live-mic.js for full rationale.
-function buildSegmentText (items) {
+function buildSegmentText(items) {
   let text = ''
   let firstStartsWord = true
   let isFirst = true
@@ -85,7 +85,7 @@ function buildSegmentText (items) {
   return { text: text.replace(/\s+/g, ' '), firstStartsWord }
 }
 
-function parseArgs () {
+function parseArgs() {
   const args = {
     asrModel: null,
     diarModel: null,
@@ -122,17 +122,17 @@ const STREAMING_HISTORY_MS = 30000
 // Pull the Sortformer speaker_id out of the addon's segment text
 // ("Speaker N: HH:MM:SS.fff - HH:MM:SS.fff"). Returns -1 if the text
 // doesn't match the expected format.
-function parseSortformerSpeakerId (text) {
-  const m = typeof text === 'string'
-    ? text.match(/Speaker\s+(\d+)/)
-    : null
+function parseSortformerSpeakerId(text) {
+  const m = typeof text === 'string' ? text.match(/Speaker\s+(\d+)/) : null
   return m ? parseInt(m[1], 10) : -1
 }
 
-async function main () {
+async function main() {
   const args = parseArgs()
   if (!args.asrModel || !args.diarModel) {
-    console.error('Usage: bare examples/live-mic-diarized.js --asr-model <gguf> --diar-model <gguf> [--accumulate] [--chunk-ms <ms>] [--capture "<sox cmd>"]')
+    console.error(
+      'Usage: bare examples/live-mic-diarized.js --asr-model <gguf> --diar-model <gguf> [--accumulate] [--chunk-ms <ms>] [--capture "<sox cmd>"]'
+    )
     process.exit(1)
   }
 
@@ -141,8 +141,14 @@ async function main () {
 
   const asrPath = path.resolve(args.asrModel)
   const diarPath = path.resolve(args.diarModel)
-  if (!validatePaths({ model: asrPath })) { addonLogging.releaseLogger(); process.exit(1) }
-  if (!validatePaths({ model: diarPath })) { addonLogging.releaseLogger(); process.exit(1) }
+  if (!validatePaths({ model: asrPath })) {
+    addonLogging.releaseLogger()
+    process.exit(1)
+  }
+  if (!validatePaths({ model: diarPath })) {
+    addonLogging.releaseLogger()
+    process.exit(1)
+  }
 
   console.log(`Loading ${asrPath}...`)
   console.log(`Loading ${diarPath}...`)
@@ -177,12 +183,13 @@ async function main () {
   const [captureBin, ...captureArgs] = captureCmd.split(' ')
   let child
   try {
-    child = subprocess.spawn(captureBin, captureArgs,
-      { stdio: ['ignore', 'pipe', 'pipe'] })
+    child = subprocess.spawn(captureBin, captureArgs, { stdio: ['ignore', 'pipe', 'pipe'] })
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       console.error(`\n'${captureBin}' not found on PATH.`)
-      console.error('Install sox (brew install sox / apt install sox / choco install sox / winget install ChrisBagwell.SoX).')
+      console.error(
+        'Install sox (brew install sox / apt install sox / choco install sox / winget install ChrisBagwell.SoX).'
+      )
     } else {
       console.error(`\nFailed to spawn capture command: ${err.message}`)
     }
@@ -205,14 +212,14 @@ async function main () {
   let lineSpeaker = null
   let lastSpeaker = -1
 
-  function flushLine () {
+  function flushLine() {
     if (lineOpen) {
       process.stdout.write('\n')
       lineOpen = false
       lineSpeaker = null
     }
   }
-  function emitTranscript (speaker, text, firstStartsWord) {
+  function emitTranscript(speaker, text, firstStartsWord) {
     if (isSilenceText(text)) {
       if (args.accumulate) flushLine()
       return
@@ -248,7 +255,7 @@ async function main () {
   const diarRunPromise = (async () => {
     const response = await diar.runStreaming(diarStream, streamingConfig)
     await response
-      .onUpdate(out => {
+      .onUpdate((out) => {
         const items = Array.isArray(out) ? out : [out]
         // Update lastSpeaker from the latest non-silence segment in
         // the batch. We tag the ASR transcript with whatever ID
@@ -270,7 +277,7 @@ async function main () {
   const asrRunPromise = (async () => {
     const response = await asr.runStreaming(asrStream, streamingConfig)
     await response
-      .onUpdate(out => {
+      .onUpdate((out) => {
         const items = Array.isArray(out) ? out : [out]
         const { text, firstStartsWord } = buildSegmentText(items)
         emitTranscript(lastSpeaker, text.trim(), firstStartsWord)
@@ -278,17 +285,33 @@ async function main () {
       .await()
   })()
 
-  async function shutdown () {
+  async function shutdown() {
     if (stopping) return
     stopping = true
     console.log('\nStopping...')
-    try { child.kill('SIGTERM') } catch (e) { /* ignore */ }
+    try {
+      child.kill('SIGTERM')
+    } catch (e) {
+      /* ignore */
+    }
     asrStream.end()
     diarStream.end()
-    try { await Promise.all([asrRunPromise, diarRunPromise]) } catch (e) { /* swallow */ }
+    try {
+      await Promise.all([asrRunPromise, diarRunPromise])
+    } catch (e) {
+      /* swallow */
+    }
     flushLine()
-    try { await asr.unload() } catch (e) { /* ignore */ }
-    try { await diar.unload() } catch (e) { /* ignore */ }
+    try {
+      await asr.unload()
+    } catch (e) {
+      /* ignore */
+    }
+    try {
+      await diar.unload()
+    } catch (e) {
+      /* ignore */
+    }
     addonLogging.releaseLogger()
     process.exit(0)
   }
@@ -297,7 +320,9 @@ async function main () {
   process.once('SIGTERM', shutdown)
   child.on('exit', (code, signal) => {
     if (!firstAudioSeen && !stopping) {
-      console.error(`\nCapture command exited before producing audio (code=${code}, signal=${signal}).`)
+      console.error(
+        `\nCapture command exited before producing audio (code=${code}, signal=${signal}).`
+      )
       const tail = stderrBuf.trim()
       if (tail) {
         console.error('--- sox stderr ---')
@@ -305,15 +330,21 @@ async function main () {
         console.error('------------------')
       }
       console.error('Hints:')
-      console.error('  - On Windows, try: --capture "sox -t waveaudio default -t raw -r 16000 -b 16 -c 1 -e signed-integer -L -"')
-      console.error('  - Verify a default recording device exists (Settings -> System -> Sound -> Input).')
-      console.error('  - Confirm SoX can list audio devices: sox -V6 -d -t raw -r 16000 -c 1 -e signed-integer -b 16 -L - 2>&1 | head')
+      console.error(
+        '  - On Windows, try: --capture "sox -t waveaudio default -t raw -r 16000 -b 16 -c 1 -e signed-integer -L -"'
+      )
+      console.error(
+        '  - Verify a default recording device exists (Settings -> System -> Sound -> Input).'
+      )
+      console.error(
+        '  - Confirm SoX can list audio devices: sox -V6 -d -t raw -r 16000 -c 1 -e signed-integer -b 16 -L - 2>&1 | head'
+      )
     }
     shutdown()
   })
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Error:', err)
   addonLogging.releaseLogger()
   process.exit(1)

--- a/packages/transcription-parakeet/examples/live-mic.js
+++ b/packages/transcription-parakeet/examples/live-mic.js
@@ -40,7 +40,7 @@ const SILENCE_SENTINELS = new Set([
   '[Model not ready]'
 ])
 
-function isSilenceText (text) {
+function isSilenceText(text) {
   return text.length === 0 || SILENCE_SENTINELS.has(text)
 }
 
@@ -54,7 +54,7 @@ function isSilenceText (text) {
 // Returns { text, firstStartsWord }: `firstStartsWord` mirrors the
 // flag of the first emitted segment so the cross-update accumulator
 // knows whether to prepend a space.
-function buildSegmentText (items) {
+function buildSegmentText(items) {
   let text = ''
   let firstStartsWord = true
   let isFirst = true
@@ -72,7 +72,7 @@ function buildSegmentText (items) {
   return { text: text.replace(/\s+/g, ' '), firstStartsWord }
 }
 
-function parseArgs () {
+function parseArgs() {
   const args = {
     model: null,
     accumulate: false,
@@ -93,10 +93,12 @@ function parseArgs () {
   return args
 }
 
-async function main () {
+async function main() {
   const args = parseArgs()
   if (!args.model) {
-    console.error('Usage: bare examples/live-mic.js --model <gguf> [--accumulate] [--chunk-ms <ms>] [--capture "<sox cmd>"]')
+    console.error(
+      'Usage: bare examples/live-mic.js --model <gguf> [--accumulate] [--chunk-ms <ms>] [--capture "<sox cmd>"]'
+    )
     process.exit(1)
   }
 
@@ -128,12 +130,13 @@ async function main () {
   const [captureBin, ...captureArgs] = captureCmd.split(' ')
   let child
   try {
-    child = subprocess.spawn(captureBin, captureArgs,
-      { stdio: ['ignore', 'pipe', 'pipe'] })
+    child = subprocess.spawn(captureBin, captureArgs, { stdio: ['ignore', 'pipe', 'pipe'] })
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       console.error(`\n'${captureBin}' not found on PATH.`)
-      console.error('Install sox (brew install sox / apt install sox / choco install sox / winget install ChrisBagwell.SoX).')
+      console.error(
+        'Install sox (brew install sox / apt install sox / choco install sox / winget install ChrisBagwell.SoX).'
+      )
     } else {
       console.error(`\nFailed to spawn capture command: ${err.message}`)
     }
@@ -153,13 +156,13 @@ async function main () {
   })
 
   let lineOpen = false
-  function flushLine () {
+  function flushLine() {
     if (lineOpen) {
       process.stdout.write('\n')
       lineOpen = false
     }
   }
-  function emitTranscript (text, firstStartsWord) {
+  function emitTranscript(text, firstStartsWord) {
     if (isSilenceText(text)) {
       if (args.accumulate) flushLine()
       return
@@ -189,7 +192,7 @@ async function main () {
   const runPromise = (async () => {
     const response = await model.runStreaming(audioStream, streamingConfig)
     await response
-      .onUpdate(out => {
+      .onUpdate((out) => {
         const items = Array.isArray(out) ? out : [out]
         const { text, firstStartsWord } = buildSegmentText(items)
         emitTranscript(text.trim(), firstStartsWord)
@@ -197,15 +200,27 @@ async function main () {
       .await()
   })()
 
-  async function shutdown () {
+  async function shutdown() {
     if (stopping) return
     stopping = true
     console.log('\nStopping...')
-    try { child.kill('SIGTERM') } catch (e) { /* ignore */ }
+    try {
+      child.kill('SIGTERM')
+    } catch (e) {
+      /* ignore */
+    }
     audioStream.end()
-    try { await runPromise } catch (e) { /* swallow */ }
+    try {
+      await runPromise
+    } catch (e) {
+      /* swallow */
+    }
     flushLine()
-    try { await model.unload() } catch (e) { /* ignore */ }
+    try {
+      await model.unload()
+    } catch (e) {
+      /* ignore */
+    }
     addonLogging.releaseLogger()
     process.exit(0)
   }
@@ -214,7 +229,9 @@ async function main () {
   process.once('SIGTERM', shutdown)
   child.on('exit', (code, signal) => {
     if (!firstAudioSeen && !stopping) {
-      console.error(`\nCapture command exited before producing audio (code=${code}, signal=${signal}).`)
+      console.error(
+        `\nCapture command exited before producing audio (code=${code}, signal=${signal}).`
+      )
       const tail = stderrBuf.trim()
       if (tail) {
         console.error('--- sox stderr ---')
@@ -222,15 +239,21 @@ async function main () {
         console.error('------------------')
       }
       console.error('Hints:')
-      console.error('  - On Windows, try: --capture "sox -t waveaudio default -t raw -r 16000 -b 16 -c 1 -e signed-integer -L -"')
-      console.error('  - Verify a default recording device exists (Settings -> System -> Sound -> Input).')
-      console.error('  - Confirm SoX can list audio devices: sox -V6 -d -t raw -r 16000 -c 1 -e signed-integer -b 16 -L - 2>&1 | head')
+      console.error(
+        '  - On Windows, try: --capture "sox -t waveaudio default -t raw -r 16000 -b 16 -c 1 -e signed-integer -L -"'
+      )
+      console.error(
+        '  - Verify a default recording device exists (Settings -> System -> Sound -> Input).'
+      )
+      console.error(
+        '  - Confirm SoX can list audio devices: sox -V6 -d -t raw -r 16000 -c 1 -e signed-integer -b 16 -L - 2>&1 | head'
+      )
     }
     shutdown()
   })
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Error:', err)
   addonLogging.releaseLogger()
   process.exit(1)

--- a/packages/transcription-parakeet/examples/transcribe.js
+++ b/packages/transcription-parakeet/examples/transcribe.js
@@ -26,7 +26,7 @@ const {
   printResults
 } = require('./utils.js')
 
-function parseArgs () {
+function parseArgs() {
   const args = { model: null, audio: null }
   const argv = Bare.argv.slice(2)
   for (let i = 0; i < argv.length; i++) {
@@ -37,14 +37,14 @@ function parseArgs () {
   return args
 }
 
-async function loadAudio (audioPath) {
+async function loadAudio(audioPath) {
   const ext = path.extname(audioPath).toLowerCase()
   if (ext === '.wav') return parseWavFile(audioPath)
   const rawBuffer = await readFileAsStream(audioPath)
   return convertRawToFloat32(rawBuffer)
 }
 
-async function main () {
+async function main() {
   const args = parseArgs()
   if (!args.model || !args.audio) {
     console.error('Usage: bare examples/transcribe.js --model <gguf> --audio <file>')
@@ -74,7 +74,7 @@ async function main () {
   const segments = []
   const response = await model.run(audioData)
   await response
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const s of items) {
         if (s && s.text && s.toAppend) segments.push(s)
@@ -87,7 +87,7 @@ async function main () {
   addonLogging.releaseLogger()
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.error('Error:', err)
   addonLogging.releaseLogger()
   process.exit(1)

--- a/packages/transcription-parakeet/examples/utils.js
+++ b/packages/transcription-parakeet/examples/utils.js
@@ -24,7 +24,7 @@ const NATIVE_MIN_PRIORITY = 1 // WARNING
  *
  * @param {Object} loggerBinding
  */
-function setupLogger (loggerBinding) {
+function setupLogger(loggerBinding) {
   if (loggerBinding.__qvacExampleLoggerSet) return
   loggerBinding.setLogger((priority, message) => {
     if (priority > NATIVE_MIN_PRIORITY) return
@@ -37,11 +37,11 @@ function setupLogger (loggerBinding) {
 /**
  * Read a file using streams to handle large GGUFs (>2 GiB).
  */
-function readFileAsStream (filePath) {
+function readFileAsStream(filePath) {
   return new Promise((resolve, reject) => {
     const chunks = []
     const stream = fs.createReadStream(filePath)
-    stream.on('data', chunk => chunks.push(chunk))
+    stream.on('data', (chunk) => chunks.push(chunk))
     stream.on('end', () => resolve(Buffer.concat(chunks)))
     stream.on('error', reject)
   })
@@ -51,7 +51,7 @@ function readFileAsStream (filePath) {
  * Parse a WAV file (RIFF/PCM int16 mono) into a Float32Array of
  * normalised samples. Skips non-`data` chunks.
  */
-function parseWavFile (wavPath) {
+function parseWavFile(wavPath) {
   const buffer = fs.readFileSync(wavPath)
   if (buffer.toString('utf8', 0, 4) !== 'RIFF') throw new Error('Not a valid WAV file')
   if (buffer.toString('utf8', 8, 12) !== 'WAVE') throw new Error('Not a valid WAV file')
@@ -77,7 +77,7 @@ function parseWavFile (wavPath) {
  * Convert a raw int16 little-endian PCM buffer to a normalised
  * Float32Array. Used for `.raw` audio fixtures.
  */
-function convertRawToFloat32 (rawBuffer) {
+function convertRawToFloat32(rawBuffer) {
   const view = new Int16Array(rawBuffer.buffer, rawBuffer.byteOffset, rawBuffer.length / 2)
   const out = new Float32Array(view.length)
   for (let i = 0; i < view.length; i++) out[i] = view[i] / 32768
@@ -87,7 +87,7 @@ function convertRawToFloat32 (rawBuffer) {
 /**
  * Validate that required paths exist on disk.
  */
-function validatePaths (paths) {
+function validatePaths(paths) {
   if (!fs.existsSync(paths.model)) {
     console.error(`Model not found: ${paths.model}`)
     console.error("Run 'npm run setup-models' or pass --model </path/to/model.gguf>.")
@@ -108,12 +108,12 @@ function validatePaths (paths) {
  * path) without buffering the entire stream. Also accepted by the
  * batched `run()` path; both consumers iterate it lazily.
  */
-function pushableStream () {
+function pushableStream() {
   const queue = []
   let waiter = null
   let ended = false
 
-  function push (chunk) {
+  function push(chunk) {
     if (ended) return
     queue.push(chunk)
     if (waiter) {
@@ -123,7 +123,7 @@ function pushableStream () {
     }
   }
 
-  function end () {
+  function end() {
     ended = true
     if (waiter) {
       const w = waiter
@@ -135,14 +135,16 @@ function pushableStream () {
   return {
     push,
     end,
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       while (true) {
         if (queue.length > 0) {
           yield queue.shift()
           continue
         }
         if (ended) return
-        await new Promise(resolve => { waiter = resolve })
+        await new Promise((resolve) => {
+          waiter = resolve
+        })
       }
     }
   }
@@ -151,11 +153,15 @@ function pushableStream () {
 /**
  * Print transcription segments to stdout in a uniform banner block.
  */
-function printResults (segments) {
+function printResults(segments) {
   console.log('\n=== RESULT ===')
   console.log('='.repeat(50))
   if (segments.length > 0) {
-    const text = segments.map(s => s.text).join(' ').trim().replace(/\s+/g, ' ')
+    const text = segments
+      .map((s) => s.text)
+      .join(' ')
+      .trim()
+      .replace(/\s+/g, ' ')
     console.log(text)
   } else {
     console.log('[No speech detected]')

--- a/packages/transcription-parakeet/index.js
+++ b/packages/transcription-parakeet/index.js
@@ -66,7 +66,7 @@ class TranscriptionParakeet {
    * @param {Object} [opts.logger=null] - Optional structured logger
    * @param {boolean} [opts.exclusiveRun=true] - Whether to run exclusively
    */
-  constructor ({ files = {}, config = {}, logger = null, exclusiveRun = true }) {
+  constructor({ files = {}, config = {}, logger = null, exclusiveRun = true }) {
     this.logger = new QvacLogger(logger)
     this.exclusiveRun = !!exclusiveRun
     this._runQueueWaiter = Promise.resolve()
@@ -93,7 +93,7 @@ class TranscriptionParakeet {
    * so callers can pre-stage the file asynchronously between
    * construction and `load()`.
    */
-  validateModelFiles () {
+  validateModelFiles() {
     const modelPath = this._config.modelPath
     if (modelPath && !fs.existsSync(modelPath)) {
       this.logger.warn('Model file not found', { path: modelPath })
@@ -105,7 +105,7 @@ class TranscriptionParakeet {
    * @returns {Object} configurationParams for createInstance / reload / activate
    * @private
    */
-  _buildConfigurationParams () {
+  _buildConfigurationParams() {
     // modelType is intentionally not passed: the binding reads
     // `parakeet.model.type` from the GGUF metadata at load() time and
     // overrides cfg_.modelType so the right dispatch (ASR vs
@@ -149,11 +149,11 @@ class TranscriptionParakeet {
     }
   }
 
-  getState () {
+  getState() {
     return this.state
   }
 
-  async load () {
+  async load() {
     if (this.state.destroyed) {
       throw new QvacErrorAddonParakeet(ERR_CODES.INSTANCE_DESTROYED)
     }
@@ -166,7 +166,7 @@ class TranscriptionParakeet {
     this.state.weightsLoaded = true
   }
 
-  async run (input) {
+  async run(input) {
     if (this.exclusiveRun) {
       return await this._withExclusiveRun(() => this._runInternal(input))
     }
@@ -199,19 +199,21 @@ class TranscriptionParakeet {
    * @returns {Promise<QvacResponse>} - response object exposing
    *   `onUpdate(seg => ...).await()`
    */
-  async runStreaming (audioStream, streamingConfig = {}) {
+  async runStreaming(audioStream, streamingConfig = {}) {
     if (this.exclusiveRun) {
-      return await this._withExclusiveRun(
-        () => this._runStreamingInternal(audioStream, streamingConfig)
+      return await this._withExclusiveRun(() =>
+        this._runStreamingInternal(audioStream, streamingConfig)
       )
     }
     return await this._runStreamingInternal(audioStream, streamingConfig)
   }
 
-  async _withExclusiveRun (fn) {
+  async _withExclusiveRun(fn) {
     const prev = this._runQueueWaiter || Promise.resolve()
     let release
-    this._runQueueWaiter = new Promise(resolve => { release = resolve })
+    this._runQueueWaiter = new Promise((resolve) => {
+      release = resolve
+    })
     await prev
     try {
       return await fn()
@@ -223,7 +225,7 @@ class TranscriptionParakeet {
   /**
    * Load model and activate addon.
    */
-  async _load () {
+  async _load() {
     const configurationParams = this._buildConfigurationParams()
 
     this.logger.info('Creating Parakeet addon with configuration:', configurationParams)
@@ -238,7 +240,7 @@ class TranscriptionParakeet {
    * @param {AsyncIterable<Buffer>} audioStream - Stream of audio data (16kHz mono, Float32 or s16le)
    * @returns {Promise<QvacResponse>} - Response object for tracking the transcription job
    */
-  async _runInternal (audioStream) {
+  async _runInternal(audioStream) {
     const response = this._job.start()
 
     let normalized
@@ -256,7 +258,7 @@ class TranscriptionParakeet {
     return response
   }
 
-  async _runStreamingInternal (audioStream, streamingConfig) {
+  async _runStreamingInternal(audioStream, streamingConfig) {
     const normalized = this._normalizeAudioStream(audioStream)
     const response = this._job.start()
 
@@ -275,7 +277,7 @@ class TranscriptionParakeet {
     return response
   }
 
-  async _pumpStreamingAudio (audioStream) {
+  async _pumpStreamingAudio(audioStream) {
     this.logger.debug('Start pumping audio into duplex streaming session')
     for await (const chunk of audioStream) {
       let audioData
@@ -300,7 +302,7 @@ class TranscriptionParakeet {
    * @param {AsyncIterable<Buffer>} audioStream - Audio data stream
    * @private
    */
-  async _handleAudioStream (audioStream) {
+  async _handleAudioStream(audioStream) {
     this.logger.debug('Start handling audio stream')
     for await (const chunk of audioStream) {
       this.logger.debug('Appending audio chunk', { chunkLength: chunk.length })
@@ -327,7 +329,7 @@ class TranscriptionParakeet {
     await this.addon.append({ type: END_OF_INPUT })
   }
 
-  _normalizeAudioStream (audioStream) {
+  _normalizeAudioStream(audioStream) {
     if (!audioStream) {
       throw new Error('audioStream is required')
     }
@@ -351,7 +353,7 @@ class TranscriptionParakeet {
     throw new Error('Unsupported audio input. Expected stream, TypedArray, or chunk array.')
   }
 
-  _outputCallback (addon, event, jobId, data, error) {
+  _outputCallback(addon, event, jobId, data, error) {
     if (event === 'Error') {
       this._job.fail(error instanceof Error ? error : new Error(String(error)))
     } else if (event === 'Output') {
@@ -367,7 +369,7 @@ class TranscriptionParakeet {
    * @param {Object} [newConfig={}] - New configuration parameters
    * @param {Object} [newConfig.parakeetConfig] - Parakeet-specific settings
    */
-  async reload (newConfig = {}) {
+  async reload(newConfig = {}) {
     return await this._withExclusiveRun(async () => {
       this.logger.debug('Reloading addon with new configuration', newConfig)
 
@@ -392,7 +394,7 @@ class TranscriptionParakeet {
    * @returns {ParakeetInterface} The instantiated addon interface
    * @private
    */
-  _createAddon (configurationParams) {
+  _createAddon(configurationParams) {
     this.logger.info('Creating Parakeet interface with configuration:', configurationParams)
     const binding = require('./binding')
     return new ParakeetInterface(
@@ -406,7 +408,7 @@ class TranscriptionParakeet {
   /**
    * Override unload to call destroyInstance for proper cleanup.
    */
-  async unload () {
+  async unload() {
     return await this._withExclusiveRun(async () => {
       await this.cancel()
       this._job.fail(new Error('Model was unloaded'))
@@ -418,7 +420,7 @@ class TranscriptionParakeet {
     })
   }
 
-  async cancel (jobId) {
+  async cancel(jobId) {
     if (this.addon?.cancel) {
       await this.addon.cancel(jobId)
     }
@@ -427,7 +429,7 @@ class TranscriptionParakeet {
     }
   }
 
-  async status () {
+  async status() {
     return this.addon?.status()
   }
 
@@ -439,19 +441,19 @@ class TranscriptionParakeet {
    * `null` before load / after unload.
    * @returns {{ backendDevice: string, backendId: number, backendName: string, backendDescription: string }|null}
    */
-  getBackendInfo () {
+  getBackendInfo() {
     return this.addon?.getBackendInfo?.() ?? null
   }
 
-  async pause () {
+  async pause() {
     await this.addon?.pause()
   }
 
-  async unpause () {
+  async unpause() {
     await this.addon?.activate()
   }
 
-  async destroy () {
+  async destroy() {
     return await this._withExclusiveRun(async () => {
       await this.cancel()
       this._job.fail(new Error('Model was destroyed'))

--- a/packages/transcription-parakeet/lib/error.js
+++ b/packages/transcription-parakeet/lib/error.js
@@ -2,7 +2,7 @@
 
 const { QvacErrorBase, addCodes } = require('@qvac/error')
 
-class QvacErrorAddonParakeet extends QvacErrorBase { }
+class QvacErrorAddonParakeet extends QvacErrorBase {}
 
 const { name, version } = require('../package.json')
 
@@ -25,71 +25,74 @@ const ERR_CODES = Object.freeze({
   JOB_CANCELLED: 24019
 })
 
-addCodes({
-  [ERR_CODES.FAILED_TO_LOAD_WEIGHTS]: {
-    name: 'FAILED_TO_LOAD_WEIGHTS',
-    message: (message) => `Failed to load weights, error: ${message}`
+addCodes(
+  {
+    [ERR_CODES.FAILED_TO_LOAD_WEIGHTS]: {
+      name: 'FAILED_TO_LOAD_WEIGHTS',
+      message: (message) => `Failed to load weights, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_CANCEL]: {
+      name: 'FAILED_TO_CANCEL',
+      message: (message) => `Failed to cancel inference, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_APPEND]: {
+      name: 'FAILED_TO_APPEND',
+      message: (message) => `Failed to append audio data to processing queue, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_GET_STATUS]: {
+      name: 'FAILED_TO_GET_STATUS',
+      message: (message) => `Failed to get addon status, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_DESTROY]: {
+      name: 'FAILED_TO_DESTROY',
+      message: (message) => `Failed to destroy instance, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_ACTIVATE]: {
+      name: 'FAILED_TO_ACTIVATE',
+      message: (message) => `Failed to activate model, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_RESET]: {
+      name: 'FAILED_TO_RESET',
+      message: (message) => `Failed to reset model state, error: ${message}`
+    },
+    [ERR_CODES.FAILED_TO_PAUSE]: {
+      name: 'FAILED_TO_PAUSE',
+      message: (message) => `Failed to pause inference, error: ${message}`
+    },
+    [ERR_CODES.MODEL_NOT_FOUND]: {
+      name: 'MODEL_NOT_FOUND',
+      message: (path) => `Model not found at path: ${path}`
+    },
+    [ERR_CODES.INVALID_AUDIO_FORMAT]: {
+      name: 'INVALID_AUDIO_FORMAT',
+      message: (format) => `Invalid audio format: ${format}. Expected 16kHz mono audio.`
+    },
+    [ERR_CODES.INVALID_CONFIG]: {
+      name: 'INVALID_CONFIG',
+      message: (message) => `Invalid configuration: ${message}`
+    },
+    [ERR_CODES.JOB_ALREADY_RUNNING]: {
+      name: 'JOB_ALREADY_RUNNING',
+      message: () => 'Cannot set new job: a job is already set or being processed'
+    },
+    [ERR_CODES.BUFFER_LIMIT_EXCEEDED]: {
+      name: 'BUFFER_LIMIT_EXCEEDED',
+      message: (message) => `Audio buffer size limit exceeded: ${message}`
+    },
+    [ERR_CODES.INSTANCE_DESTROYED]: {
+      name: 'INSTANCE_DESTROYED',
+      message: () => 'Cannot load: instance has been destroyed'
+    },
+    [ERR_CODES.JOB_CANCELLED]: {
+      name: 'JOB_CANCELLED',
+      message: () => 'Job cancelled'
+    }
   },
-  [ERR_CODES.FAILED_TO_CANCEL]: {
-    name: 'FAILED_TO_CANCEL',
-    message: (message) => `Failed to cancel inference, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_APPEND]: {
-    name: 'FAILED_TO_APPEND',
-    message: (message) => `Failed to append audio data to processing queue, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_GET_STATUS]: {
-    name: 'FAILED_TO_GET_STATUS',
-    message: (message) => `Failed to get addon status, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_DESTROY]: {
-    name: 'FAILED_TO_DESTROY',
-    message: (message) => `Failed to destroy instance, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_ACTIVATE]: {
-    name: 'FAILED_TO_ACTIVATE',
-    message: (message) => `Failed to activate model, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_RESET]: {
-    name: 'FAILED_TO_RESET',
-    message: (message) => `Failed to reset model state, error: ${message}`
-  },
-  [ERR_CODES.FAILED_TO_PAUSE]: {
-    name: 'FAILED_TO_PAUSE',
-    message: (message) => `Failed to pause inference, error: ${message}`
-  },
-  [ERR_CODES.MODEL_NOT_FOUND]: {
-    name: 'MODEL_NOT_FOUND',
-    message: (path) => `Model not found at path: ${path}`
-  },
-  [ERR_CODES.INVALID_AUDIO_FORMAT]: {
-    name: 'INVALID_AUDIO_FORMAT',
-    message: (format) => `Invalid audio format: ${format}. Expected 16kHz mono audio.`
-  },
-  [ERR_CODES.INVALID_CONFIG]: {
-    name: 'INVALID_CONFIG',
-    message: (message) => `Invalid configuration: ${message}`
-  },
-  [ERR_CODES.JOB_ALREADY_RUNNING]: {
-    name: 'JOB_ALREADY_RUNNING',
-    message: () => 'Cannot set new job: a job is already set or being processed'
-  },
-  [ERR_CODES.BUFFER_LIMIT_EXCEEDED]: {
-    name: 'BUFFER_LIMIT_EXCEEDED',
-    message: (message) => `Audio buffer size limit exceeded: ${message}`
-  },
-  [ERR_CODES.INSTANCE_DESTROYED]: {
-    name: 'INSTANCE_DESTROYED',
-    message: () => 'Cannot load: instance has been destroyed'
-  },
-  [ERR_CODES.JOB_CANCELLED]: {
-    name: 'JOB_CANCELLED',
-    message: () => 'Job cancelled'
+  {
+    name,
+    version
   }
-}, {
-  name,
-  version
-})
+)
 
 const END_OF_INPUT = 'end of job'
 

--- a/packages/transcription-parakeet/parakeet.js
+++ b/packages/transcription-parakeet/parakeet.js
@@ -2,11 +2,7 @@
 
 const path = require('bare-path')
 
-const {
-  QvacErrorAddonParakeet,
-  ERR_CODES,
-  END_OF_INPUT
-} = require('./lib/error')
+const { QvacErrorAddonParakeet, ERR_CODES, END_OF_INPUT } = require('./lib/error')
 
 const state = Object.freeze({
   LOADING: 'loading',
@@ -17,14 +13,14 @@ const state = Object.freeze({
   STOPPED: 'stopped'
 })
 
-function nextSafeId (current) {
+function nextSafeId(current) {
   return current >= Number.MAX_SAFE_INTEGER ? 1 : current + 1
 }
 
 // 500 MB — ~2.7 hours of 16 kHz f32le mono audio
 const MAX_BUFFERED_BYTES = 500 * 1024 * 1024
 
-function createParakeetError (code, message, cause = undefined) {
+function createParakeetError(code, message, cause = undefined) {
   return new QvacErrorAddonParakeet({ code, adds: message, cause })
 }
 
@@ -93,7 +89,7 @@ class ParakeetInterface {
    * @param {Function} outputCallback - callback for transcription output events
    * @param {Function} [stateCallback] - callback for state transitions
    */
-  constructor (binding, configurationParams, outputCallback, stateCallback = null) {
+  constructor(binding, configurationParams, outputCallback, stateCallback = null) {
     this._binding = binding
     this._outputCallback = outputCallback
     this._stateCallback = stateCallback
@@ -123,7 +119,7 @@ class ParakeetInterface {
    * CMakeLists.txt.
    * @private
    */
-  _applyDefaults (configurationParams) {
+  _applyDefaults(configurationParams) {
     const out = { ...configurationParams }
     if (!out.backendsDir) {
       out.backendsDir = path.join(__dirname, 'prebuilds')
@@ -131,14 +127,14 @@ class ParakeetInterface {
     return out
   }
 
-  _setState (newState) {
+  _setState(newState) {
     this._state = newState
     if (this._stateCallback) {
       this._stateCallback(this, newState)
     }
   }
 
-  _createNativeInstance (configurationParams) {
+  _createNativeInstance(configurationParams) {
     this._config = configurationParams
     // Wrapper job ids are owned in JS, so recreating the native instance only
     // clears native state and buffered audio.
@@ -154,7 +150,7 @@ class ParakeetInterface {
     )
   }
 
-  _addonOutputCallback (addon, event, data, error) {
+  _addonOutputCallback(addon, event, data, error) {
     const isError = typeof error === 'string' && error.length > 0
     const eventStr = typeof event === 'string' ? event : String(event)
 
@@ -168,15 +164,12 @@ class ParakeetInterface {
     } else if (eventStr.includes('Output')) {
       mappedEvent = 'Output'
     } else {
-      const isStats = data && typeof data === 'object' && (
-        'totalTime' in data ||
-        'audioDurationMs' in data ||
-        'totalSamples' in data
-      )
-      const isTranscriptOutput = (
-        Array.isArray(data) ||
-        (data && typeof data === 'object' && typeof data.text === 'string')
-      )
+      const isStats =
+        data &&
+        typeof data === 'object' &&
+        ('totalTime' in data || 'audioDurationMs' in data || 'totalSamples' in data)
+      const isTranscriptOutput =
+        Array.isArray(data) || (data && typeof data === 'object' && typeof data.text === 'string')
       if (isStats) mappedEvent = 'JobEnded'
       else if (isTranscriptOutput) mappedEvent = 'Output'
     }
@@ -214,7 +207,7 @@ class ParakeetInterface {
     }
   }
 
-  _emitSyntheticError (jobId, error) {
+  _emitSyntheticError(jobId, error) {
     if (!this._outputCallback) {
       return
     }
@@ -231,7 +224,7 @@ class ParakeetInterface {
    * @param {number} [weightsData.size] - total file size in bytes
    * @returns {Promise<boolean>}
    */
-  async loadWeights (weightsData) {
+  async loadWeights(weightsData) {
     try {
       return this._binding.loadWeights(this._handle, weightsData)
     } catch (error) {
@@ -243,7 +236,7 @@ class ParakeetInterface {
    * Activate the model for inference
    * @returns {Promise<void>}
    */
-  async activate () {
+  async activate() {
     try {
       this._binding.activate(this._handle)
       this._setState(state.LISTENING)
@@ -260,7 +253,7 @@ class ParakeetInterface {
    * Returns `null` before the instance exists / after destroy.
    * @returns {{ backendDevice: string, backendId: number, backendName: string, backendDescription: string }|null}
    */
-  getBackendInfo () {
+  getBackendInfo() {
     if (this._handle == null) return null
     return this._binding.getBackendInfo(this._handle)
   }
@@ -272,7 +265,7 @@ class ParakeetInterface {
    * @param {ArrayBuffer} [data.data] - audio data buffer (Float32, 16kHz mono)
    * @returns {Promise<number>} - job ID
    */
-  async append (data) {
+  async append(data) {
     try {
       if (data?.type === END_OF_INPUT) {
         const currentJobId = this._nextJobId
@@ -328,7 +321,7 @@ class ParakeetInterface {
    * `stopped` / `loading`).
    * @returns {Promise<string>} - 'loading', 'listening', 'processing', 'idle', 'paused', 'stopped'
    */
-  async status () {
+  async status() {
     try {
       return this._state
     } catch (error) {
@@ -345,7 +338,7 @@ class ParakeetInterface {
    * the active inference call to actually abort.
    * @returns {Promise<void>}
    */
-  async pause () {
+  async pause() {
     try {
       this._setState(state.PAUSED)
     } catch (error) {
@@ -357,12 +350,12 @@ class ParakeetInterface {
    * Stop processing and discard current job
    * @returns {Promise<void>}
    */
-  async stop () {
+  async stop() {
     try {
       this._bufferedAudio = []
       this._bufferedBytes = 0
       if (this._activeJobId !== null) {
-        const cancelComplete = new Promise(resolve => {
+        const cancelComplete = new Promise((resolve) => {
           this._onCancelComplete = resolve
         })
         this._activeJobId = null
@@ -380,7 +373,7 @@ class ParakeetInterface {
    * @param {number} jobId - job ID to cancel
    * @returns {Promise<void>}
    */
-  async cancel (jobId) {
+  async cancel(jobId) {
     try {
       const pendingJobId = this._bufferedAudio.length > 0 ? this._nextJobId : null
       const targetJobId = jobId ?? this._activeJobId ?? pendingJobId
@@ -393,7 +386,7 @@ class ParakeetInterface {
       }
 
       if (this._activeJobId === targetJobId) {
-        const cancelComplete = new Promise(resolve => {
+        const cancelComplete = new Promise((resolve) => {
           this._onCancelComplete = resolve
         })
         await this._binding.cancel(this._handle)
@@ -421,7 +414,7 @@ class ParakeetInterface {
    * @param {Object} configurationParams - new configuration
    * @returns {Promise<void>}
    */
-  async reload (configurationParams) {
+  async reload(configurationParams) {
     try {
       await this.cancel()
       await this.destroyInstance()
@@ -436,14 +429,14 @@ class ParakeetInterface {
    * Unload model weights from memory
    * @returns {Promise<void>}
    */
-  async unloadWeights () {
+  async unloadWeights() {
     throw createParakeetError(
       ERR_CODES.FAILED_TO_RESET,
       'unloadWeights is not supported by this package. Use unload() or destroyInstance().'
     )
   }
 
-  async load (configurationParams) {
+  async load(configurationParams) {
     try {
       await this.destroyInstance()
       this._createNativeInstance(configurationParams)
@@ -453,7 +446,7 @@ class ParakeetInterface {
     }
   }
 
-  async unload () {
+  async unload() {
     await this.destroyInstance()
   }
 
@@ -461,7 +454,7 @@ class ParakeetInterface {
    * Destroy the addon instance and free resources
    * @returns {Promise<void>}
    */
-  async destroyInstance () {
+  async destroyInstance() {
     try {
       if (this._handle === null) {
         return
@@ -482,7 +475,7 @@ class ParakeetInterface {
     }
   }
 
-  async runJob (data) {
+  async runJob(data) {
     const currentJobId = this._nextJobId
     const previousJobId = this._activeJobId
     const previousState = this._state
@@ -529,12 +522,10 @@ class ParakeetInterface {
    * @param {number} [config.spkCacheUpdatePeriod] - AOSC: FIFO-overflow pop-out count (overrides cfg.streamingSpkCacheUpdatePeriod)
    * @returns {Promise<number>} jobId assigned to the streaming session
    */
-  async startStreaming (config = {}) {
+  async startStreaming(config = {}) {
     try {
       if (this._activeJobId !== null) {
-        throw new Error(
-          'Cannot start streaming: a job is already active. Call cancel() first.'
-        )
+        throw new Error('Cannot start streaming: a job is already active. Call cancel() first.')
       }
       const currentJobId = this._nextJobId
       this._activeJobId = currentJobId
@@ -557,7 +548,7 @@ class ParakeetInterface {
    * @param {Float32Array|Int16Array|ArrayBuffer|TypedArray} data - audio samples
    * @returns {Promise<boolean>} true if the chunk was accepted
    */
-  async appendStreamingAudio (data) {
+  async appendStreamingAudio(data) {
     try {
       if (this._activeJobId === null) {
         throw new Error('No active streaming session; call startStreaming() first.')
@@ -579,7 +570,7 @@ class ParakeetInterface {
    * response chain (`onUpdate().await()`) resolves cleanly.
    * @returns {Promise<void>}
    */
-  async endStreaming () {
+  async endStreaming() {
     try {
       if (this._activeJobId === null) return
       const jobId = this._activeJobId
@@ -600,11 +591,18 @@ class ParakeetInterface {
       this._activeJobId = null
       this._setState(state.LISTENING)
       if (this._outputCallback) {
-        this._outputCallback(this, 'JobEnded', jobId, {
-          totalTime: 0,
-          audioDurationMs: typeof teardown.audioDurationMs === 'number' ? teardown.audioDurationMs : 0,
-          totalSamples: typeof teardown.totalSamples === 'number' ? teardown.totalSamples : 0
-        }, null)
+        this._outputCallback(
+          this,
+          'JobEnded',
+          jobId,
+          {
+            totalTime: 0,
+            audioDurationMs:
+              typeof teardown.audioDurationMs === 'number' ? teardown.audioDurationMs : 0,
+            totalSamples: typeof teardown.totalSamples === 'number' ? teardown.totalSamples : 0
+          },
+          null
+        )
       }
     } catch (error) {
       throw createParakeetError(ERR_CODES.FAILED_TO_RESET, error.message, error)
@@ -618,11 +616,11 @@ class ParakeetInterface {
    * and falls through to the framework's regular cancel.
    * @returns {Promise<void>}
    */
-  async cancelStreaming () {
+  async cancelStreaming() {
     return this.cancel()
   }
 
-  _normalizeAudioInput (data) {
+  _normalizeAudioInput(data) {
     if (!data) {
       throw new Error('Audio input is required')
     }
@@ -645,7 +643,7 @@ class ParakeetInterface {
     throw new Error('Unsupported audio input format')
   }
 
-  _concatBufferedAudio () {
+  _concatBufferedAudio() {
     if (this._bufferedAudio.length === 0) {
       return new Float32Array(0)
     }

--- a/packages/transcription-parakeet/test/benchmark/rtf-benchmark.test.js
+++ b/packages/transcription-parakeet/test/benchmark/rtf-benchmark.test.js
@@ -62,31 +62,33 @@ const RESULT_MARKER = 'QVAC_RTF_REPORT::'
 let _hwDevice = null
 try {
   let _subprocess = null
-  try { _subprocess = require('bare-subprocess') } catch (_) {}
+  try {
+    _subprocess = require('bare-subprocess')
+  } catch (_) {}
   const _perfBase = path.join('..', '..', '..', '..', 'scripts', 'test-utils')
   const _perfMod = require(path.join(_perfBase, 'performance-reporter'))
   _perfMod.configure({ fs, path, process, os, subprocess: _subprocess })
   _hwDevice = _perfMod.detectDevice()
 } catch (_) {}
 
-function _hwGpu () {
+function _hwGpu() {
   return _hwDevice && _hwDevice.gpu ? _hwDevice.gpu : null
 }
 
-function getEnvBoolean (name, fallback) {
+function getEnvBoolean(name, fallback) {
   const value = process.env[name]
   if (value === undefined) return fallback
   return value === '1' || value === 'true' || value === 'TRUE' || value === 'yes'
 }
 
-function getEnvInteger (name, fallback) {
+function getEnvInteger(name, fallback) {
   const value = process.env[name]
   if (value === undefined) return fallback
   const parsed = Number.parseInt(value, 10)
   return Number.isNaN(parsed) ? fallback : parsed
 }
 
-function sanitizeTag (value) {
+function sanitizeTag(value) {
   if (!value) return ''
   return value
     .toLowerCase()
@@ -95,7 +97,7 @@ function sanitizeTag (value) {
     .replace(/-+$/, '')
 }
 
-function getBenchmarkSettings () {
+function getBenchmarkSettings() {
   const requestedModelType = (process.env.QVAC_PARAKEET_BENCHMARK_MODEL_TYPE || 'tdt').toLowerCase()
   if (!VALID_MODEL_TYPES.includes(requestedModelType)) {
     throw new Error(`Invalid benchmark model type: ${requestedModelType}`)
@@ -111,7 +113,9 @@ function getBenchmarkSettings () {
   // can sweep q8_0 vs q4_0.
   const requestedQuant = (process.env.QVAC_PARAKEET_BENCHMARK_QUANT || '').toLowerCase()
   if (requestedQuant && !VALID_QUANTS.includes(requestedQuant)) {
-    throw new Error(`Invalid benchmark quant: ${requestedQuant} (expected one of ${VALID_QUANTS.join(', ')})`)
+    throw new Error(
+      `Invalid benchmark quant: ${requestedQuant} (expected one of ${VALID_QUANTS.join(', ')})`
+    )
   }
 
   return {
@@ -129,7 +133,7 @@ function getBenchmarkSettings () {
   }
 }
 
-async function resolveModelPath (benchmarkSettings) {
+async function resolveModelPath(benchmarkSettings) {
   const modelPath = await ensureGgufForType(
     benchmarkSettings.modelType,
     null,
@@ -143,7 +147,7 @@ async function resolveModelPath (benchmarkSettings) {
   return modelPath
 }
 
-function getUpperBound (benchmarkSettings) {
+function getUpperBound(benchmarkSettings) {
   if (benchmarkSettings.requestedUpperBound !== undefined) {
     const parsed = Number.parseFloat(benchmarkSettings.requestedUpperBound)
     if (!Number.isNaN(parsed)) return parsed
@@ -158,7 +162,7 @@ function getUpperBound (benchmarkSettings) {
 //   - android:        Vulkan (Adreno: OpenCL fallback)
 // (The previous coreml/nnapi/auto-gpu names were ONNX-era and never matched
 // the GGML runtime, which reports the real backend via stats.backendId.)
-function getRequestedBackendFamily (platformName, useGPU, backendHint) {
+function getRequestedBackendFamily(platformName, useGPU, backendHint) {
   if (backendHint) return backendHint
   if (!useGPU) return 'cpu'
   if (platformName === 'darwin' || platformName === 'ios') return 'metal'
@@ -169,24 +173,27 @@ function getRequestedBackendFamily (platformName, useGPU, backendHint) {
 
 // Maps stats.backendId (surfaced by ParakeetModel::runtimeStats() after
 // Engine::backend_name()) to the GGML backend family that actually ran.
-function backendIdToName (id) {
+function backendIdToName(id) {
   switch (id) {
-    case 0: return 'cpu'
-    case 1: return 'metal'
-    case 2: return 'cuda'
-    case 3: return 'vulkan'
-    case 4: return 'opencl'
-    case 99: return 'other-gpu'
-    default: return ''
+    case 0:
+      return 'cpu'
+    case 1:
+      return 'metal'
+    case 2:
+      return 'cuda'
+    case 3:
+      return 'vulkan'
+    case 4:
+      return 'opencl'
+    case 99:
+      return 'other-gpu'
+    default:
+      return ''
   }
 }
 
-function getArtifactFileName (benchmarkSettings) {
-  const parts = [
-    'rtf-benchmark',
-    platform,
-    benchmarkSettings.modelType
-  ]
+function getArtifactFileName(benchmarkSettings) {
+  const parts = ['rtf-benchmark', platform, benchmarkSettings.modelType]
 
   // Quant goes between model type and device so multi-quant sweeps on the
   // same runner don't clobber each other's artifacts.
@@ -203,7 +210,7 @@ function getArtifactFileName (benchmarkSettings) {
   return `${parts.join('-')}.json`
 }
 
-function getTimeMs () {
+function getTimeMs() {
   const [sec, nsec] = process.hrtime()
   return sec * 1000 + nsec / 1e6
 }
@@ -212,7 +219,7 @@ function getTimeMs () {
 // label which build produced the numbers (matches the version-stamping the
 // LLM benchmark suite does). Read from package.json via bare-fs because bare
 // does not support require()-ing JSON.
-function getAddonVersion () {
+function getAddonVersion() {
   try {
     const pkgPath = path.resolve(__dirname, '../../package.json')
     return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version || ''
@@ -221,7 +228,7 @@ function getAddonVersion () {
   }
 }
 
-function percentile (sorted, p) {
+function percentile(sorted, p) {
   const idx = (p / 100) * (sorted.length - 1)
   const lo = Math.floor(idx)
   const hi = Math.ceil(idx)
@@ -229,7 +236,7 @@ function percentile (sorted, p) {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo)
 }
 
-function stats (values) {
+function stats(values) {
   const sorted = [...values].sort((a, b) => a - b)
   const sum = sorted.reduce((a, b) => a + b, 0)
   const mean = sum / sorted.length
@@ -245,16 +252,24 @@ function stats (values) {
   }
 }
 
-async function reclaimAfterUnload (model) {
-  try { await model.unload() } catch (_) { /* ignore */ }
-  if (typeof global.gc === 'function') {
-    try { global.gc() } catch (_) { /* ignore */ }
+async function reclaimAfterUnload(model) {
+  try {
+    await model.unload()
+  } catch (_) {
+    /* ignore */
   }
-  await new Promise(resolve => setTimeout(resolve, RECLAIM_SETTLE_MS))
+  if (typeof global.gc === 'function') {
+    try {
+      global.gc()
+    } catch (_) {
+      /* ignore */
+    }
+  }
+  await new Promise((resolve) => setTimeout(resolve, RECLAIM_SETTLE_MS))
   return readRssBytes()
 }
 
-async function measureMemory (model, allResults, rssBeforeLoad, rssAfterLoad) {
+async function measureMemory(model, allResults, rssBeforeLoad, rssAfterLoad) {
   const rssAfterUnload = await reclaimAfterUnload(model)
   return summarizeRunMemory(allResults, {
     rssBeforeLoadBytes: rssBeforeLoad,
@@ -281,9 +296,12 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
   console.log(`  Model type:     ${benchmarkSettings.modelType}`)
   console.log(`  Quant:          ${benchmarkSettings.resolvedQuant || 'default'}`)
   console.log(`  GPU requested:  ${benchmarkSettings.useGPU}`)
-  if (benchmarkSettings.backendHint) console.log(`  Backend hint:   ${benchmarkSettings.backendHint}`)
-  if (benchmarkSettings.deviceLabel) console.log(`  Device label:   ${benchmarkSettings.deviceLabel}`)
-  if (benchmarkSettings.runnerLabel) console.log(`  Runner label:   ${benchmarkSettings.runnerLabel}`)
+  if (benchmarkSettings.backendHint)
+    console.log(`  Backend hint:   ${benchmarkSettings.backendHint}`)
+  if (benchmarkSettings.deviceLabel)
+    console.log(`  Device label:   ${benchmarkSettings.deviceLabel}`)
+  if (benchmarkSettings.runnerLabel)
+    console.log(`  Runner label:   ${benchmarkSettings.runnerLabel}`)
   console.log(`  Mobile:         ${isMobile}`)
   console.log(`  Warmup runs:    ${benchmarkSettings.numWarmup}`)
   console.log(`  Benchmark runs: ${benchmarkSettings.numRuns}`)
@@ -321,9 +339,13 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
     }
   })
 
-  async function runOnce (audio) {
+  async function runOnce(audio) {
     const response = await model.run(audio)
-    await response.onUpdate(() => { /* discard segments here -- we only need stats */ }).await()
+    await response
+      .onUpdate(() => {
+        /* discard segments here -- we only need stats */
+      })
+      .await()
     return response.stats || null
   }
 
@@ -342,7 +364,9 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
       if (info && info.backendDevice === 'GPU' && info.backendDescription) {
         backendGpuModel = info.backendDescription
       }
-    } catch (_) { /* best-effort enrichment */ }
+    } catch (_) {
+      /* best-effort enrichment */
+    }
 
     // Warmup with silent audio to trigger full model initialisation.
     const silentAudio = new Float32Array(SAMPLE_RATE).fill(0)
@@ -350,7 +374,9 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
 
     const loadMs = getTimeMs() - loadStart
     const rssAfterLoad = readRssBytes()
-    console.log(`Model loaded and initialised in ${loadMs.toFixed(0)}ms (RSS ${bytesToMb(rssAfterLoad, 1)}MB)\n`)
+    console.log(
+      `Model loaded and initialised in ${loadMs.toFixed(0)}ms (RSS ${bytesToMb(rssAfterLoad, 1)}MB)\n`
+    )
 
     // --- Warmup runs (discard) ---
     for (let w = 0; w < benchmarkSettings.numWarmup; w++) {
@@ -383,7 +409,7 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
       // measured per-call wall time and the known audio duration instead, and
       // only prefer the addon value when a future build reports a positive one.
       const statsRtf = jobStats.realTimeFactor || 0
-      const derivedRtf = audioDurationSec > 0 ? (wallMs / 1000) / audioDurationSec : 0
+      const derivedRtf = audioDurationSec > 0 ? wallMs / 1000 / audioDurationSec : 0
       const run = {
         iteration: i + 1,
         wallMs,
@@ -413,15 +439,17 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
 
       allResults.push(run)
 
-      console.log(`  Run ${i + 1}/${benchmarkSettings.numRuns}: ` +
-        `RTF=${run.rtf.toFixed(4)}  ` +
-        `wall=${wallMs.toFixed(0)}ms  ` +
-        `tokens/s=${run.tokensPerSecond.toFixed(1)}  ` +
-        `encoder=${run.encoderMs.toFixed(0)}ms  ` +
-        `decoder=${run.decoderMs.toFixed(0)}ms`)
+      console.log(
+        `  Run ${i + 1}/${benchmarkSettings.numRuns}: ` +
+          `RTF=${run.rtf.toFixed(4)}  ` +
+          `wall=${wallMs.toFixed(0)}ms  ` +
+          `tokens/s=${run.tokensPerSecond.toFixed(1)}  ` +
+          `encoder=${run.encoderMs.toFixed(0)}ms  ` +
+          `decoder=${run.decoderMs.toFixed(0)}ms`
+      )
 
       if (isMobile) {
-        await new Promise(resolve => setTimeout(resolve, 200))
+        await new Promise((resolve) => setTimeout(resolve, 200))
       }
     }
 
@@ -431,11 +459,11 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
       return
     }
 
-    const rtfValues = allResults.map(r => r.rtf)
-    const wallValues = allResults.map(r => r.wallMs)
-    const tpsValues = allResults.map(r => r.tokensPerSecond)
-    const encoderValues = allResults.map(r => r.encoderMs)
-    const decoderValues = allResults.map(r => r.decoderMs)
+    const rtfValues = allResults.map((r) => r.rtf)
+    const wallValues = allResults.map((r) => r.wallMs)
+    const tpsValues = allResults.map((r) => r.tokensPerSecond)
+    const encoderValues = allResults.map((r) => r.encoderMs)
+    const decoderValues = allResults.map((r) => r.decoderMs)
 
     const rtfStats = stats(rtfValues)
     const wallStats = stats(wallValues)
@@ -504,7 +532,11 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
       labels: {
         runner: benchmarkSettings.runnerLabel,
         device: benchmarkSettings.deviceLabel,
-        backend: getRequestedBackendFamily(platformName, benchmarkSettings.useGPU, benchmarkSettings.backendHint),
+        backend: getRequestedBackendFamily(
+          platformName,
+          benchmarkSettings.useGPU,
+          benchmarkSettings.backendHint
+        ),
         activeBackend: observedBackendId !== null ? backendIdToName(observedBackendId) : '',
         gpuModel: _hwGpu() || backendGpuModel,
         requestedBackend: benchmarkSettings.useGPU ? 'gpu' : 'cpu',
@@ -555,7 +587,11 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
       modelType: benchmarkSettings.modelType,
       quant: benchmarkSettings.resolvedQuant,
       useGPU: benchmarkSettings.useGPU,
-      backendHint: getRequestedBackendFamily(platformName, benchmarkSettings.useGPU, benchmarkSettings.backendHint),
+      backendHint: getRequestedBackendFamily(
+        platformName,
+        benchmarkSettings.useGPU,
+        benchmarkSettings.backendHint
+      ),
       activeBackend: observedBackendId !== null ? backendIdToName(observedBackendId) : '',
       deviceLabel: benchmarkSettings.deviceLabel,
       runnerLabel: benchmarkSettings.runnerLabel,
@@ -576,24 +612,39 @@ test('RTF benchmark: collect real-time factor on CI device', { timeout: 600000 }
     }
 
     // --- Assertions ---
-    t.ok(allResults.length === benchmarkSettings.numRuns,
-      `Completed ${benchmarkSettings.numRuns} benchmark runs`)
+    t.ok(
+      allResults.length === benchmarkSettings.numRuns,
+      `Completed ${benchmarkSettings.numRuns} benchmark runs`
+    )
 
     t.ok(rtfStats.mean > 0, 'Mean RTF should be positive')
 
     if (upperBound !== null) {
-      t.ok(rtfStats.mean <= upperBound,
-        `Mean RTF ${rtfStats.mean.toFixed(4)} should be <= ${upperBound}`)
+      t.ok(
+        rtfStats.mean <= upperBound,
+        `Mean RTF ${rtfStats.mean.toFixed(4)} should be <= ${upperBound}`
+      )
     }
 
     t.ok(memorySummary.peakRssMb > 0, 'Peak memory (RSS) should be positive')
     t.ok(memorySummary.avgRssMb > 0, 'Average memory (RSS) should be positive')
-    t.ok(memorySummary.peakRssMb >= memorySummary.avgRssMb, 'Peak memory should be >= average memory')
+    t.ok(
+      memorySummary.peakRssMb >= memorySummary.avgRssMb,
+      'Peak memory should be >= average memory'
+    )
     t.ok(memorySummary.reclaimedMb >= 0, 'Reclaimed memory should be non-negative')
 
     console.log('RTF benchmark completed successfully!\n')
   } finally {
-    try { if (model) await model.unload() } catch (_) { /* ignore */ }
-    try { loggerBinding.releaseLogger() } catch (_) { /* ignore */ }
+    try {
+      if (model) await model.unload()
+    } catch (_) {
+      /* ignore */
+    }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (_) {
+      /* ignore */
+    }
   }
 })

--- a/packages/transcription-parakeet/test/integration/accuracy-multilang.test.js
+++ b/packages/transcription-parakeet/test/integration/accuracy-multilang.test.js
@@ -35,8 +35,9 @@ const LANGUAGE_TESTS = {
     name: 'English',
     code: 'en',
     sampleFile: 'sample.raw',
-    expected: 'Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do. Once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it. And what is the use of a book thought Alice without pictures or conversations',
-    threshold: 0.30 // 30% WER threshold
+    expected:
+      'Alice was beginning to get very tired of sitting by her sister on the bank and of having nothing to do. Once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it. And what is the use of a book thought Alice without pictures or conversations',
+    threshold: 0.3 // 30% WER threshold
   },
   es: {
     name: 'Spanish',
@@ -65,7 +66,7 @@ const LANGUAGE_TESTS = {
 /**
  * Helper function to run transcription for a specific language
  */
-async function runLanguageTest (t, langConfig, loggerBinding, stagedGguf) {
+async function runLanguageTest(t, langConfig, loggerBinding, stagedGguf) {
   const samplePath = path.join(samplesDir, langConfig.sampleFile)
 
   // Check if sample exists
@@ -90,7 +91,9 @@ async function runLanguageTest (t, langConfig, loggerBinding, stagedGguf) {
     const maxSamples = langConfig.maxDurationSeconds * sampleRate
     if (pcmData.length > maxSamples) {
       samplesToUse = maxSamples
-      console.log(`   ⚠️  Truncating from ${(pcmData.length / sampleRate).toFixed(2)}s to ${langConfig.maxDurationSeconds}s for CI`)
+      console.log(
+        `   ⚠️  Truncating from ${(pcmData.length / sampleRate).toFixed(2)}s to ${langConfig.maxDurationSeconds}s for CI`
+      )
     }
   }
 
@@ -113,7 +116,7 @@ async function runLanguageTest (t, langConfig, loggerBinding, stagedGguf) {
 
     const response = await model.run(audioData)
     await response
-      .onUpdate(out => {
+      .onUpdate((out) => {
         const items = Array.isArray(out) ? out : [out]
         for (const seg of items) {
           if (seg && seg.text) transcriptions.push(seg)
@@ -121,7 +124,10 @@ async function runLanguageTest (t, langConfig, loggerBinding, stagedGguf) {
       })
       .await()
 
-    const fullText = transcriptions.map(s => s.text).join(' ').trim()
+    const fullText = transcriptions
+      .map((s) => s.text)
+      .join(' ')
+      .trim()
 
     console.log(`\n📝 ${langConfig.name} transcription (${transcriptions.length} segments):`)
     console.log(`   "${fullText.substring(0, 150)}${fullText.length > 150 ? '...' : ''}"`)
@@ -148,7 +154,9 @@ async function runLanguageTest (t, langConfig, loggerBinding, stagedGguf) {
       // for multilingual GGUFs (TDT v3) and as a "doesn't crash"
       // check for English-only GGUFs (CTC).
       const hasOutput = fullText.length > 0
-      console.log(`\nℹ️ No reference transcript for ${langConfig.name}; checking output non-emptiness`)
+      console.log(
+        `\nℹ️ No reference transcript for ${langConfig.name}; checking output non-emptiness`
+      )
       console.log(`   Output received: ${hasOutput ? 'Yes' : 'No'}`)
       console.log(`   Text length: ${fullText.length} characters`)
 
@@ -164,7 +172,11 @@ async function runLanguageTest (t, langConfig, loggerBinding, stagedGguf) {
     console.log(`❌ Test error: ${error.message}`)
     return { skipped: false, passed: false, error: error.message }
   } finally {
-    try { await model.unload() } catch (e) { /* ignore */ }
+    try {
+      await model.unload()
+    } catch (e) {
+      /* ignore */
+    }
   }
 }
 
@@ -193,11 +205,18 @@ test('Accuracy test - English (primary language)', { timeout: 300000 }, async (t
     } else if (result.error) {
       t.fail(`English accuracy test failed: ${result.error}`)
     } else {
-      t.ok(result.passed, `English WER should be below ${LANGUAGE_TESTS.en.threshold * 100}%, got ${result.werPercent}`)
+      t.ok(
+        result.passed,
+        `English WER should be below ${LANGUAGE_TESTS.en.threshold * 100}%, got ${result.werPercent}`
+      )
       t.ok(result.segmentCount > 0, `Should produce segments (got ${result.segmentCount})`)
     }
   } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })
 
@@ -225,12 +244,22 @@ test('Transcription test - Spanish (non-primary language)', { timeout: 300000 },
       // No reference transcript yet, so we only assert non-empty
       // multi-segment output. TDT v3 should produce real Spanish
       // text here; CTC GGUFs would produce gibberish-but-non-empty.
-      t.ok(result.segmentCount > 0, `Should produce at least one segment for Spanish audio (got ${result.segmentCount})`)
-      t.ok(result.actualText.length > 0, `Should produce non-empty text for Spanish audio (got ${result.actualText.length} chars)`)
+      t.ok(
+        result.segmentCount > 0,
+        `Should produce at least one segment for Spanish audio (got ${result.segmentCount})`
+      )
+      t.ok(
+        result.actualText.length > 0,
+        `Should produce non-empty text for Spanish audio (got ${result.actualText.length} chars)`
+      )
       console.log('\n✅ Spanish audio produced output')
     }
   } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })
 
@@ -255,12 +284,22 @@ test('Transcription test - French (non-primary language)', { timeout: 300000 }, 
     } else if (result.error) {
       t.fail(`French test failed: ${result.error}`)
     } else {
-      t.ok(result.segmentCount > 0, `Should produce at least one segment for French audio (got ${result.segmentCount})`)
-      t.ok(result.actualText.length > 0, `Should produce non-empty text for French audio (got ${result.actualText.length} chars)`)
+      t.ok(
+        result.segmentCount > 0,
+        `Should produce at least one segment for French audio (got ${result.segmentCount})`
+      )
+      t.ok(
+        result.actualText.length > 0,
+        `Should produce non-empty text for French audio (got ${result.actualText.length} chars)`
+      )
       console.log('\n✅ French audio produced output')
     }
   } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })
 
@@ -285,12 +324,22 @@ test('Transcription test - Croatian (non-primary language)', { timeout: 300000 }
     } else if (result.error) {
       t.fail(`Croatian test failed: ${result.error}`)
     } else {
-      t.ok(result.segmentCount > 0, `Should produce at least one segment for Croatian audio (got ${result.segmentCount})`)
-      t.ok(result.actualText.length > 0, `Should produce non-empty text for Croatian audio (got ${result.actualText.length} chars)`)
+      t.ok(
+        result.segmentCount > 0,
+        `Should produce at least one segment for Croatian audio (got ${result.segmentCount})`
+      )
+      t.ok(
+        result.actualText.length > 0,
+        `Should produce non-empty text for Croatian audio (got ${result.actualText.length} chars)`
+      )
       console.log('\n✅ Croatian audio produced output')
     }
   } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })
 
@@ -327,10 +376,17 @@ test('Accuracy test - English (CTC head)', { timeout: 300000 }, async (t) => {
     } else if (result.error) {
       t.fail(`CTC English accuracy test failed: ${result.error}`)
     } else {
-      t.ok(result.passed, `CTC English WER should be below ${LANGUAGE_TESTS.en.threshold * 100}%, got ${result.werPercent}`)
+      t.ok(
+        result.passed,
+        `CTC English WER should be below ${LANGUAGE_TESTS.en.threshold * 100}%, got ${result.werPercent}`
+      )
       t.ok(result.segmentCount > 0, `Should produce segments (got ${result.segmentCount})`)
     }
   } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })

--- a/packages/transcription-parakeet/test/integration/addon-multimodel.test.js
+++ b/packages/transcription-parakeet/test/integration/addon-multimodel.test.js
@@ -13,7 +13,7 @@ const {
 
 const { samplesDir } = getTestPaths()
 
-function loadAudioSample () {
+function loadAudioSample() {
   const samplePath = path.join(samplesDir, 'sample.raw')
   if (!fs.existsSync(samplePath)) return null
   const rawBuffer = fs.readFileSync(samplePath)
@@ -23,11 +23,11 @@ function loadAudioSample () {
   return audio
 }
 
-async function transcribe (model, audio) {
+async function transcribe(model, audio) {
   const segments = []
   const response = await model.run(audio)
   await response
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const seg of items) {
         if (seg && seg.text) segments.push(seg)
@@ -37,7 +37,7 @@ async function transcribe (model, audio) {
   return segments
 }
 
-async function runModelTest (t, modelType, modelPath, audio, expectations) {
+async function runModelTest(t, modelType, modelPath, audio, expectations) {
   const model = new TranscriptionParakeet({
     files: { model: modelPath },
     config: { parakeetConfig: { maxThreads: 4, useGPU: false } }
@@ -46,18 +46,29 @@ async function runModelTest (t, modelType, modelPath, audio, expectations) {
     await model.load()
     const segments = await transcribe(model, audio)
     const joiner = modelType === 'sortformer' ? '\n' : ' '
-    const fullText = segments.map(s => s.text).join(joiner).trim()
-    console.log(`[${modelType}] Result: "${fullText.substring(0, 120)}${fullText.length > 120 ? '...' : ''}"`)
+    const fullText = segments
+      .map((s) => s.text)
+      .join(joiner)
+      .trim()
+    console.log(
+      `[${modelType}] Result: "${fullText.substring(0, 120)}${fullText.length > 120 ? '...' : ''}"`
+    )
 
     t.ok(segments.length > 0, `${modelType} produced ${segments.length} segments`)
     if (expectations.containsSpeaker) {
       t.ok(fullText.includes('Speaker'), `${modelType} output contains speaker labels`)
     } else {
-      t.ok(fullText.length > expectations.minTextLength,
-        `${modelType} produced text (${fullText.length} chars)`)
+      t.ok(
+        fullText.length > expectations.minTextLength,
+        `${modelType} produced text (${fullText.length} chars)`
+      )
     }
   } finally {
-    try { await model.unload() } catch (e) { /* ignore */ }
+    try {
+      await model.unload()
+    } catch (e) {
+      /* ignore */
+    }
   }
 }
 
@@ -67,10 +78,17 @@ test('CTC desktop integration — English transcription', { timeout: 600000 }, a
     const modelPath = await loadGgufOrSkip(t, 'ctc')
     if (!modelPath) return
     const audio = loadAudioSample()
-    if (!audio) { t.pass('sample.raw not found — skipping'); return }
+    if (!audio) {
+      t.pass('sample.raw not found — skipping')
+      return
+    }
     await runModelTest(t, 'ctc', modelPath, audio, { minTextLength: 10 })
   } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })
 
@@ -80,10 +98,17 @@ test('EOU desktop integration — streaming transcription', { timeout: 600000 },
     const modelPath = await loadGgufOrSkip(t, 'eou')
     if (!modelPath) return
     const audio = loadAudioSample()
-    if (!audio) { t.pass('sample.raw not found — skipping'); return }
+    if (!audio) {
+      t.pass('sample.raw not found — skipping')
+      return
+    }
     await runModelTest(t, 'eou', modelPath, audio, { minTextLength: 0 })
   } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })
 
@@ -93,9 +118,16 @@ test('Sortformer desktop integration — speaker diarization', { timeout: 600000
     const modelPath = await loadGgufOrSkip(t, 'sortformer')
     if (!modelPath) return
     const audio = loadAudioSample()
-    if (!audio) { t.pass('sample.raw not found — skipping'); return }
+    if (!audio) {
+      t.pass('sample.raw not found — skipping')
+      return
+    }
     await runModelTest(t, 'sortformer', modelPath, audio, { containsSpeaker: true })
   } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })

--- a/packages/transcription-parakeet/test/integration/cold-start-timing.test.js
+++ b/packages/transcription-parakeet/test/integration/cold-start-timing.test.js
@@ -28,12 +28,12 @@ const {
 const platform = detectPlatform()
 const { modelPath, samplesDir } = getTestPaths()
 
-function getTimeMs () {
+function getTimeMs() {
   const [sec, nsec] = process.hrtime()
   return sec * 1000 + nsec / 1e6
 }
 
-function loadAudio (samplePath) {
+function loadAudio(samplePath) {
   const rawBuffer = fs.readFileSync(samplePath)
   const pcmData = new Int16Array(rawBuffer.buffer, rawBuffer.byteOffset, rawBuffer.length / 2)
   const audioData = new Float32Array(pcmData.length)
@@ -41,11 +41,11 @@ function loadAudio (samplePath) {
   return audioData
 }
 
-async function transcribe (model, audio) {
+async function transcribe(model, audio) {
   const segments = []
   const response = await model.run(audio)
   await response
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const seg of items) {
         if (seg && seg.text) segments.push(seg)
@@ -55,185 +55,223 @@ async function transcribe (model, audio) {
   return segments
 }
 
-test('Cold start timing: first vs subsequent transcription times', { timeout: 600000 }, async (t) => {
-  const NUM_RUNS = 5
-  const ACCEPTABLE_PENALTY_THRESHOLD = 200 // 200%
-  const loggerBinding = setupJsLogger(binding)
+test(
+  'Cold start timing: first vs subsequent transcription times',
+  { timeout: 600000 },
+  async (t) => {
+    const NUM_RUNS = 5
+    const ACCEPTABLE_PENALTY_THRESHOLD = 200 // 200%
+    const loggerBinding = setupJsLogger(binding)
 
-  console.log('\n' + '='.repeat(60))
-  console.log('COLD START TIMING TEST')
-  console.log('='.repeat(60))
-  console.log(` Platform: ${platform}`)
-  console.log(` Model path: ${modelPath}`)
-  console.log(` Mobile: ${isMobile}`)
-  console.log(` Number of runs: ${NUM_RUNS}`)
-  console.log('='.repeat(60) + '\n')
+    console.log('\n' + '='.repeat(60))
+    console.log('COLD START TIMING TEST')
+    console.log('='.repeat(60))
+    console.log(` Platform: ${platform}`)
+    console.log(` Model path: ${modelPath}`)
+    console.log(` Mobile: ${isMobile}`)
+    console.log(` Number of runs: ${NUM_RUNS}`)
+    console.log('='.repeat(60) + '\n')
 
-  const stagedGguf = await loadGgufOrSkip(t)
-  if (!stagedGguf) return
+    const stagedGguf = await loadGgufOrSkip(t)
+    if (!stagedGguf) return
 
-  const samplePath = path.join(samplesDir, 'sample.raw')
-  if (!fs.existsSync(samplePath)) {
-    loggerBinding.releaseLogger()
-    t.pass('Test skipped - sample audio not found')
-    return
-  }
-
-  const audioData = loadAudio(samplePath)
-  console.log(`Audio duration: ${(audioData.length / 16000).toFixed(2)}s\n`)
-
-  const model = new TranscriptionParakeet({
-    files: { model: stagedGguf },
-    config: { parakeetConfig: { maxThreads: 4, useGPU: false } }
-  })
-  const results = []
-
-  try {
-    console.log('📦 Loading + warming model...')
-    const loadStart = getTimeMs()
-    await model.load()
-
-    // Tiny warmup pass so the first measured run isn't dominated by
-    // model init / first-call ggml graph compilation.
-    const silentAudio = new Float32Array(8000).fill(0)
-    await transcribe(model, silentAudio).catch(() => {})
-    const loadEnd = getTimeMs()
-    console.log(`✅ Model loaded and warmed up in ${(loadEnd - loadStart).toFixed(0)}ms\n`)
-
-    console.log(`🎤 Running ${NUM_RUNS} consecutive transcriptions (model fully warmed)...\n`)
-    for (let i = 0; i < NUM_RUNS; i++) {
-      console.log(`--- Run ${i + 1}/${NUM_RUNS} ---`)
-      const runStart = getTimeMs()
-      const segments = await transcribe(model, audioData)
-      const runTime = getTimeMs() - runStart
-      const text = segments.map(s => s.text).join(' ').trim()
-
-      console.log(`  Total time: ${runTime.toFixed(0)}ms`)
-      console.log(`  Segments: ${segments.length}`)
-      console.log(`  Text preview: "${text.substring(0, 50)}${text.length > 50 ? '...' : ''}"\n`)
-
-      results.push({
-        runNumber: i + 1,
-        totalTime: runTime,
-        segmentCount: segments.length,
-        textLength: text.length
-      })
-
-      if (isMobile) await new Promise(resolve => setTimeout(resolve, 200))
+    const samplePath = path.join(samplesDir, 'sample.raw')
+    if (!fs.existsSync(samplePath)) {
+      loggerBinding.releaseLogger()
+      t.pass('Test skipped - sample audio not found')
+      return
     }
 
-    console.log('='.repeat(60))
-    console.log('📊 TIMING SUMMARY')
-    console.log('='.repeat(60))
+    const audioData = loadAudio(samplePath)
+    console.log(`Audio duration: ${(audioData.length / 16000).toFixed(2)}s\n`)
 
-    const times = results.map(r => r.totalTime)
-    const firstRunTime = times[0]
-    const subsequentTimes = times.slice(1)
-    const avgSubsequent = subsequentTimes.reduce((a, b) => a + b, 0) / subsequentTimes.length
-
-    console.log('\n  Run times:')
-    times.forEach((time, i) => {
-      const marker = i === 0 ? ' (FIRST - includes model init)' : ''
-      console.log(`    Run ${i + 1}: ${time.toFixed(0)}ms${marker}`)
-    })
-
-    console.log('\n  Statistics:')
-    console.log(`    First run: ${firstRunTime.toFixed(0)}ms`)
-    console.log(`    Average of runs 2-${NUM_RUNS}: ${avgSubsequent.toFixed(0)}ms`)
-
-    const coldStartPenalty = ((firstRunTime - avgSubsequent) / avgSubsequent) * 100
-    console.log(`    Cold start penalty: ${coldStartPenalty.toFixed(1)}%`)
-    console.log('\n' + '='.repeat(60) + '\n')
-
-    t.ok(results.length === NUM_RUNS, `Completed ${NUM_RUNS} transcription runs`)
-    t.ok(results.every(r => r.segmentCount > 0), 'All runs should produce segments')
-
-    if (coldStartPenalty > 0) {
-      console.log(`ℹ️  Cold start penalty detected: ${coldStartPenalty.toFixed(1)}%`)
-      t.ok(coldStartPenalty <= ACCEPTABLE_PENALTY_THRESHOLD,
-        `Cold start penalty ${coldStartPenalty.toFixed(1)}% should be <= ${ACCEPTABLE_PENALTY_THRESHOLD}%`)
-    } else {
-      console.log('ℹ️  No cold start penalty detected (first run was fast)')
-      t.pass('No cold start penalty - first run was not slower')
-    }
-  } finally {
-    try { await model.unload() } catch (e) { /* ignore */ }
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
-  }
-})
-
-test('Fresh instance timing: new model per transcription (app restart simulation)', { timeout: 600000 }, async (t) => {
-  const NUM_INSTANCES = 1 // single instance to keep CI memory-bounded
-  const loggerBinding = setupJsLogger(binding)
-
-  console.log('\n' + '='.repeat(60))
-  console.log('FRESH INSTANCE TIMING TEST')
-  console.log('This simulates app restarts - each run creates a new model')
-  console.log('='.repeat(60))
-  console.log(` Platform: ${platform}`)
-  console.log(` Instances to create: ${NUM_INSTANCES}`)
-  console.log('='.repeat(60) + '\n')
-
-  const stagedGguf = await loadGgufOrSkip(t)
-  if (!stagedGguf) return
-
-  const samplePath = path.join(samplesDir, 'sample.raw')
-  if (!fs.existsSync(samplePath)) {
-    loggerBinding.releaseLogger()
-    t.pass('Test skipped - sample audio not found')
-    return
-  }
-
-  const audioData = loadAudio(samplePath)
-  const results = []
-
-  for (let instance = 1; instance <= NUM_INSTANCES; instance++) {
-    console.log(`--- Instance ${instance}/${NUM_INSTANCES} ---`)
-    const instanceStart = getTimeMs()
     const model = new TranscriptionParakeet({
       files: { model: stagedGguf },
       config: { parakeetConfig: { maxThreads: 4, useGPU: false } }
     })
+    const results = []
+
     try {
+      console.log('📦 Loading + warming model...')
+      const loadStart = getTimeMs()
       await model.load()
-      const loadTime = getTimeMs() - instanceStart
-      const segments = await transcribe(model, audioData)
-      const totalTime = getTimeMs() - instanceStart
-      const transcriptionTime = totalTime - loadTime
-      const fullText = segments.map(s => s.text).join(' ').trim()
 
-      console.log(`  Load time: ${loadTime.toFixed(0)}ms`)
-      console.log(`  Transcription time: ${transcriptionTime.toFixed(0)}ms`)
-      console.log(`  Total time: ${totalTime.toFixed(0)}ms`)
-      console.log(`  Segments: ${segments.length}\n`)
+      // Tiny warmup pass so the first measured run isn't dominated by
+      // model init / first-call ggml graph compilation.
+      const silentAudio = new Float32Array(8000).fill(0)
+      await transcribe(model, silentAudio).catch(() => {})
+      const loadEnd = getTimeMs()
+      console.log(`✅ Model loaded and warmed up in ${(loadEnd - loadStart).toFixed(0)}ms\n`)
 
-      results.push({
-        loadTime,
-        transcriptionTime,
-        totalTime,
-        segmentCount: segments.length,
-        textLength: fullText.length
+      console.log(`🎤 Running ${NUM_RUNS} consecutive transcriptions (model fully warmed)...\n`)
+      for (let i = 0; i < NUM_RUNS; i++) {
+        console.log(`--- Run ${i + 1}/${NUM_RUNS} ---`)
+        const runStart = getTimeMs()
+        const segments = await transcribe(model, audioData)
+        const runTime = getTimeMs() - runStart
+        const text = segments
+          .map((s) => s.text)
+          .join(' ')
+          .trim()
+
+        console.log(`  Total time: ${runTime.toFixed(0)}ms`)
+        console.log(`  Segments: ${segments.length}`)
+        console.log(`  Text preview: "${text.substring(0, 50)}${text.length > 50 ? '...' : ''}"\n`)
+
+        results.push({
+          runNumber: i + 1,
+          totalTime: runTime,
+          segmentCount: segments.length,
+          textLength: text.length
+        })
+
+        if (isMobile) await new Promise((resolve) => setTimeout(resolve, 200))
+      }
+
+      console.log('='.repeat(60))
+      console.log('📊 TIMING SUMMARY')
+      console.log('='.repeat(60))
+
+      const times = results.map((r) => r.totalTime)
+      const firstRunTime = times[0]
+      const subsequentTimes = times.slice(1)
+      const avgSubsequent = subsequentTimes.reduce((a, b) => a + b, 0) / subsequentTimes.length
+
+      console.log('\n  Run times:')
+      times.forEach((time, i) => {
+        const marker = i === 0 ? ' (FIRST - includes model init)' : ''
+        console.log(`    Run ${i + 1}: ${time.toFixed(0)}ms${marker}`)
       })
+
+      console.log('\n  Statistics:')
+      console.log(`    First run: ${firstRunTime.toFixed(0)}ms`)
+      console.log(`    Average of runs 2-${NUM_RUNS}: ${avgSubsequent.toFixed(0)}ms`)
+
+      const coldStartPenalty = ((firstRunTime - avgSubsequent) / avgSubsequent) * 100
+      console.log(`    Cold start penalty: ${coldStartPenalty.toFixed(1)}%`)
+      console.log('\n' + '='.repeat(60) + '\n')
+
+      t.ok(results.length === NUM_RUNS, `Completed ${NUM_RUNS} transcription runs`)
+      t.ok(
+        results.every((r) => r.segmentCount > 0),
+        'All runs should produce segments'
+      )
+
+      if (coldStartPenalty > 0) {
+        console.log(`ℹ️  Cold start penalty detected: ${coldStartPenalty.toFixed(1)}%`)
+        t.ok(
+          coldStartPenalty <= ACCEPTABLE_PENALTY_THRESHOLD,
+          `Cold start penalty ${coldStartPenalty.toFixed(1)}% should be <= ${ACCEPTABLE_PENALTY_THRESHOLD}%`
+        )
+      } else {
+        console.log('ℹ️  No cold start penalty detected (first run was fast)')
+        t.pass('No cold start penalty - first run was not slower')
+      }
     } finally {
-      try { await model.unload() } catch (e) { /* ignore */ }
+      try {
+        await model.unload()
+      } catch (e) {
+        /* ignore */
+      }
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
     }
-    if (instance < NUM_INSTANCES) await new Promise(resolve => setTimeout(resolve, 500))
   }
+)
 
-  console.log('='.repeat(60))
-  console.log('📊 FRESH INSTANCE SUMMARY')
-  console.log('='.repeat(60))
-  results.forEach((r, i) => {
-    console.log(`  Instance ${i + 1}:`)
-    console.log(`    Load: ${r.loadTime.toFixed(0)}ms`)
-    console.log(`    Transcribe: ${r.transcriptionTime.toFixed(0)}ms`)
-    console.log(`    Total: ${r.totalTime.toFixed(0)}ms`)
-    console.log(`    Segments: ${r.segmentCount}`)
-  })
-  console.log('='.repeat(60) + '\n')
+test(
+  'Fresh instance timing: new model per transcription (app restart simulation)',
+  { timeout: 600000 },
+  async (t) => {
+    const NUM_INSTANCES = 1 // single instance to keep CI memory-bounded
+    const loggerBinding = setupJsLogger(binding)
 
-  t.ok(results.length === NUM_INSTANCES, `Created ${NUM_INSTANCES} fresh model instances`)
-  t.ok(results.every(r => r.segmentCount > 0), 'All instances should produce segments')
+    console.log('\n' + '='.repeat(60))
+    console.log('FRESH INSTANCE TIMING TEST')
+    console.log('This simulates app restarts - each run creates a new model')
+    console.log('='.repeat(60))
+    console.log(` Platform: ${platform}`)
+    console.log(` Instances to create: ${NUM_INSTANCES}`)
+    console.log('='.repeat(60) + '\n')
 
-  try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
-})
+    const stagedGguf = await loadGgufOrSkip(t)
+    if (!stagedGguf) return
+
+    const samplePath = path.join(samplesDir, 'sample.raw')
+    if (!fs.existsSync(samplePath)) {
+      loggerBinding.releaseLogger()
+      t.pass('Test skipped - sample audio not found')
+      return
+    }
+
+    const audioData = loadAudio(samplePath)
+    const results = []
+
+    for (let instance = 1; instance <= NUM_INSTANCES; instance++) {
+      console.log(`--- Instance ${instance}/${NUM_INSTANCES} ---`)
+      const instanceStart = getTimeMs()
+      const model = new TranscriptionParakeet({
+        files: { model: stagedGguf },
+        config: { parakeetConfig: { maxThreads: 4, useGPU: false } }
+      })
+      try {
+        await model.load()
+        const loadTime = getTimeMs() - instanceStart
+        const segments = await transcribe(model, audioData)
+        const totalTime = getTimeMs() - instanceStart
+        const transcriptionTime = totalTime - loadTime
+        const fullText = segments
+          .map((s) => s.text)
+          .join(' ')
+          .trim()
+
+        console.log(`  Load time: ${loadTime.toFixed(0)}ms`)
+        console.log(`  Transcription time: ${transcriptionTime.toFixed(0)}ms`)
+        console.log(`  Total time: ${totalTime.toFixed(0)}ms`)
+        console.log(`  Segments: ${segments.length}\n`)
+
+        results.push({
+          loadTime,
+          transcriptionTime,
+          totalTime,
+          segmentCount: segments.length,
+          textLength: fullText.length
+        })
+      } finally {
+        try {
+          await model.unload()
+        } catch (e) {
+          /* ignore */
+        }
+      }
+      if (instance < NUM_INSTANCES) await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+
+    console.log('='.repeat(60))
+    console.log('📊 FRESH INSTANCE SUMMARY')
+    console.log('='.repeat(60))
+    results.forEach((r, i) => {
+      console.log(`  Instance ${i + 1}:`)
+      console.log(`    Load: ${r.loadTime.toFixed(0)}ms`)
+      console.log(`    Transcribe: ${r.transcriptionTime.toFixed(0)}ms`)
+      console.log(`    Total: ${r.totalTime.toFixed(0)}ms`)
+      console.log(`    Segments: ${r.segmentCount}`)
+    })
+    console.log('='.repeat(60) + '\n')
+
+    t.ok(results.length === NUM_INSTANCES, `Created ${NUM_INSTANCES} fresh model instances`)
+    t.ok(
+      results.every((r) => r.segmentCount > 0),
+      'All instances should produce segments'
+    )
+
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
+  }
+)

--- a/packages/transcription-parakeet/test/integration/corrupted-model.test.js
+++ b/packages/transcription-parakeet/test/integration/corrupted-model.test.js
@@ -4,14 +4,9 @@ const test = require('brittle')
 const path = require('bare-path')
 const fs = require('bare-fs')
 const os = require('bare-os')
-const {
-  binding,
-  TranscriptionParakeet,
-  setupJsLogger,
-  isMobile
-} = require('./helpers.js')
+const { binding, TranscriptionParakeet, setupJsLogger, isMobile } = require('./helpers.js')
 
-function makeTempDir (label) {
+function makeTempDir(label) {
   const root = isMobile
     ? path.join(global.testDir || os.tmpdir(), '.parakeet-test-' + label)
     : path.join(os.tmpdir(), '.parakeet-test-' + label)
@@ -19,20 +14,22 @@ function makeTempDir (label) {
   return root
 }
 
-function cleanupDir (dirPath) {
+function cleanupDir(dirPath) {
   if (!fs.existsSync(dirPath)) return
   try {
     fs.rmSync(dirPath, { recursive: true, force: true })
-  } catch (e) { /* ignore */ }
+  } catch (e) {
+    /* ignore */
+  }
 }
 
-function writeBadGguf (dir, contents) {
+function writeBadGguf(dir, contents) {
   const p = path.join(dir, 'corrupted.gguf')
   fs.writeFileSync(p, contents)
   return p
 }
 
-async function expectLoadError (t, ggufPath) {
+async function expectLoadError(t, ggufPath) {
   const loggerBinding = setupJsLogger(binding)
   let threw = false
   let errorMessage = ''
@@ -46,8 +43,16 @@ async function expectLoadError (t, ggufPath) {
     threw = true
     errorMessage = error?.message || String(error)
   } finally {
-    try { await model.unload() } catch (e) { /* ignore */ }
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      await model.unload()
+    } catch (e) {
+      /* ignore */
+    }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
   t.ok(threw, `load() should reject for corrupted GGUF (got "${errorMessage}")`)
 }
@@ -55,8 +60,10 @@ async function expectLoadError (t, ggufPath) {
 test('Corrupted GGUF (junk bytes) should reject load()', { timeout: 60000 }, async (t) => {
   const dir = makeTempDir('corrupted-models')
   try {
-    const gguf = writeBadGguf(dir,
-      'This is not a valid GGUF file -- the magic number GGUF should be at offset 0')
+    const gguf = writeBadGguf(
+      dir,
+      'This is not a valid GGUF file -- the magic number GGUF should be at offset 0'
+    )
     await expectLoadError(t, gguf)
   } finally {
     cleanupDir(dir)
@@ -73,18 +80,34 @@ test('Empty GGUF should reject load()', { timeout: 60000 }, async (t) => {
   }
 })
 
-test('Truncated GGUF (correct magic, no data) should reject load()', { timeout: 60000 }, async (t) => {
-  const dir = makeTempDir('truncated-models')
-  try {
-    const truncated = Buffer.from([
-      0x47, 0x47, 0x55, 0x46, // "GGUF" magic
-      0x03, 0x00, 0x00, 0x00, // version=3 (little-endian uint32)
-      0xFF, 0xFF, 0xFF, 0xFF, // garbage tensor count
-      0xFF, 0xFF, 0xFF, 0xFF
-    ])
-    const gguf = writeBadGguf(dir, truncated)
-    await expectLoadError(t, gguf)
-  } finally {
-    cleanupDir(dir)
+test(
+  'Truncated GGUF (correct magic, no data) should reject load()',
+  { timeout: 60000 },
+  async (t) => {
+    const dir = makeTempDir('truncated-models')
+    try {
+      const truncated = Buffer.from([
+        0x47,
+        0x47,
+        0x55,
+        0x46, // "GGUF" magic
+        0x03,
+        0x00,
+        0x00,
+        0x00, // version=3 (little-endian uint32)
+        0xff,
+        0xff,
+        0xff,
+        0xff, // garbage tensor count
+        0xff,
+        0xff,
+        0xff,
+        0xff
+      ])
+      const gguf = writeBadGguf(dir, truncated)
+      await expectLoadError(t, gguf)
+    } finally {
+      cleanupDir(dir)
+    }
   }
-})
+)

--- a/packages/transcription-parakeet/test/integration/duplex-streaming-eou.test.js
+++ b/packages/transcription-parakeet/test/integration/duplex-streaming-eou.test.js
@@ -46,7 +46,7 @@ const FEED_CHUNK_MS = 500
 // usual. 3 s gives a comfortable margin over the 2 s lookahead.
 const INTER_UTTERANCE_SILENCE_MS = 3000
 
-function loadAudioSample () {
+function loadAudioSample() {
   const samplePath = path.join(samplesDir, 'sample.raw')
   if (!fs.existsSync(samplePath)) return null
   const rawBuffer = fs.readFileSync(samplePath)
@@ -66,31 +66,44 @@ function loadAudioSample () {
   return audio
 }
 
-function pushableStream () {
+function pushableStream() {
   const queue = []
   let waiter = null
   let ended = false
   return {
-    push (chunk) {
+    push(chunk) {
       if (ended) return
       queue.push(chunk)
-      if (waiter) { const w = waiter; waiter = null; w() }
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w()
+      }
     },
-    end () {
+    end() {
       ended = true
-      if (waiter) { const w = waiter; waiter = null; w() }
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w()
+      }
     },
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       while (true) {
-        if (queue.length > 0) { yield queue.shift(); continue }
+        if (queue.length > 0) {
+          yield queue.shift()
+          continue
+        }
         if (ended) return
-        await new Promise(resolve => { waiter = resolve })
+        await new Promise((resolve) => {
+          waiter = resolve
+        })
       }
     }
   }
 }
 
-async function feedDuplex (model, audio) {
+async function feedDuplex(model, audio) {
   const samplesPerChunk = Math.floor((FEED_CHUNK_MS / 1000) * SAMPLE_RATE)
   const stream = pushableStream()
   const segments = []
@@ -100,7 +113,7 @@ async function feedDuplex (model, audio) {
 
   const response = await model.runStreaming(stream)
   const updateDone = response
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const seg of items) {
         if (!seg) continue
@@ -123,7 +136,7 @@ async function feedDuplex (model, audio) {
     stream.push(chunk)
     lastChunkPushedAt = Date.now()
     if (i + samplesPerChunk < audio.length) {
-      await new Promise(resolve => setTimeout(resolve, FEED_CHUNK_MS))
+      await new Promise((resolve) => setTimeout(resolve, FEED_CHUNK_MS))
     }
   }
   endCalledAt = Date.now()
@@ -133,67 +146,95 @@ async function feedDuplex (model, audio) {
   return { segments, eotBeforeEnd, lastChunkPushedAt, endCalledAt }
 }
 
-test('duplex runStreaming + EOU — emits isEndOfTurn boundaries from <EOU> tokens', { timeout: 600000 }, async (t) => {
-  const loggerBinding = setupJsLogger(binding)
-
-  try {
-    const modelPath = await loadGgufOrSkip(t, 'eou')
-    if (!modelPath) return
-
-    const audio = loadAudioSample()
-    if (!audio) {
-      t.pass('sample.raw not found - skipping')
-      return
-    }
-
-    const model = new TranscriptionParakeet({
-      files: { model: modelPath },
-      config: {
-        parakeetConfig: {
-          streaming: true,
-          streamingChunkMs: STREAM_CHUNK_MS,
-          maxThreads: 4,
-          useGPU: false
-        }
-      }
-    })
+test(
+  'duplex runStreaming + EOU — emits isEndOfTurn boundaries from <EOU> tokens',
+  { timeout: 600000 },
+  async (t) => {
+    const loggerBinding = setupJsLogger(binding)
 
     try {
-      await model.load()
+      const modelPath = await loadGgufOrSkip(t, 'eou')
+      if (!modelPath) return
 
-      console.log(`[duplex-eou] audio duration: ${(audio.length / SAMPLE_RATE).toFixed(2)}s`)
-      console.log(`[duplex-eou] feed chunk: ${FEED_CHUNK_MS}ms; session chunk: ${STREAM_CHUNK_MS}ms`)
+      const audio = loadAudioSample()
+      if (!audio) {
+        t.pass('sample.raw not found - skipping')
+        return
+      }
 
-      const { segments, eotBeforeEnd, lastChunkPushedAt, endCalledAt } =
-        await feedDuplex(model, audio)
+      const model = new TranscriptionParakeet({
+        files: { model: modelPath },
+        config: {
+          parakeetConfig: {
+            streaming: true,
+            streamingChunkMs: STREAM_CHUNK_MS,
+            maxThreads: 4,
+            useGPU: false
+          }
+        }
+      })
 
-      const allEot = segments.filter(s => s.isEndOfTurn === true)
-      const transcript = segments
-        .filter(s => s.text)
-        .map(s => s.text)
-        .join(' ')
-        .trim()
+      try {
+        await model.load()
 
-      console.log(`[duplex-eou] segments=${segments.length} chars=${transcript.length}`)
-      console.log(`[duplex-eou] eot total=${allEot.length} before stream.end()=${eotBeforeEnd.length}`)
-      console.log(`[duplex-eou] last push -> end gap: ${endCalledAt - lastChunkPushedAt}ms`)
-      console.log(`[duplex-eou] transcript: "${transcript.substring(0, 200)}${transcript.length > 200 ? '...' : ''}"`)
+        console.log(`[duplex-eou] audio duration: ${(audio.length / SAMPLE_RATE).toFixed(2)}s`)
+        console.log(
+          `[duplex-eou] feed chunk: ${FEED_CHUNK_MS}ms; session chunk: ${STREAM_CHUNK_MS}ms`
+        )
 
-      t.ok(segments.length > 0,
-        `duplex runStreaming should emit at least one segment (got ${segments.length})`)
-      t.ok(transcript.length > 0,
-        `duplex runStreaming transcript should be non-empty (got ${transcript.length} chars)`)
-      // Primary assertion: the duplex path must surface EOU boundaries.
-      t.ok(allEot.length > 0,
-        `duplex runStreaming should mark at least one end-of-turn boundary on the EOU model (got ${allEot.length})`)
-      // Diagnostic: distinguishes "EOU only at finalize" (the SDK live
-      // mic bug we suspect) from "EOU works mid-stream too".
-      t.ok(eotBeforeEnd.length > 0,
-        `duplex runStreaming should emit at least one EOU before stream.end() so live mic consumers see boundaries mid-stream (got ${eotBeforeEnd.length})`)
+        const { segments, eotBeforeEnd, lastChunkPushedAt, endCalledAt } = await feedDuplex(
+          model,
+          audio
+        )
+
+        const allEot = segments.filter((s) => s.isEndOfTurn === true)
+        const transcript = segments
+          .filter((s) => s.text)
+          .map((s) => s.text)
+          .join(' ')
+          .trim()
+
+        console.log(`[duplex-eou] segments=${segments.length} chars=${transcript.length}`)
+        console.log(
+          `[duplex-eou] eot total=${allEot.length} before stream.end()=${eotBeforeEnd.length}`
+        )
+        console.log(`[duplex-eou] last push -> end gap: ${endCalledAt - lastChunkPushedAt}ms`)
+        console.log(
+          `[duplex-eou] transcript: "${transcript.substring(0, 200)}${transcript.length > 200 ? '...' : ''}"`
+        )
+
+        t.ok(
+          segments.length > 0,
+          `duplex runStreaming should emit at least one segment (got ${segments.length})`
+        )
+        t.ok(
+          transcript.length > 0,
+          `duplex runStreaming transcript should be non-empty (got ${transcript.length} chars)`
+        )
+        // Primary assertion: the duplex path must surface EOU boundaries.
+        t.ok(
+          allEot.length > 0,
+          `duplex runStreaming should mark at least one end-of-turn boundary on the EOU model (got ${allEot.length})`
+        )
+        // Diagnostic: distinguishes "EOU only at finalize" (the SDK live
+        // mic bug we suspect) from "EOU works mid-stream too".
+        t.ok(
+          eotBeforeEnd.length > 0,
+          `duplex runStreaming should emit at least one EOU before stream.end() so live mic consumers see boundaries mid-stream (got ${eotBeforeEnd.length})`
+        )
+      } finally {
+        try {
+          await model.unload()
+        } catch (e) {
+          /* ignore */
+        }
+      }
     } finally {
-      try { await model.unload() } catch (e) { /* ignore */ }
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
     }
-  } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
   }
-})
+)

--- a/packages/transcription-parakeet/test/integration/duplex-streaming.test.js
+++ b/packages/transcription-parakeet/test/integration/duplex-streaming.test.js
@@ -53,7 +53,7 @@ const SAMPLE_RATE = 16000
 const STREAM_CHUNK_MS = 1000
 const FEED_CHUNK_MS = 500
 
-function loadAudioSample () {
+function loadAudioSample() {
   const samplePath = path.join(samplesDir, 'sample.raw')
   if (!fs.existsSync(samplePath)) return null
   const rawBuffer = fs.readFileSync(samplePath)
@@ -63,31 +63,44 @@ function loadAudioSample () {
   return audio
 }
 
-function pushableStream () {
+function pushableStream() {
   const queue = []
   let waiter = null
   let ended = false
   return {
-    push (chunk) {
+    push(chunk) {
       if (ended) return
       queue.push(chunk)
-      if (waiter) { const w = waiter; waiter = null; w() }
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w()
+      }
     },
-    end () {
+    end() {
       ended = true
-      if (waiter) { const w = waiter; waiter = null; w() }
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w()
+      }
     },
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       while (true) {
-        if (queue.length > 0) { yield queue.shift(); continue }
+        if (queue.length > 0) {
+          yield queue.shift()
+          continue
+        }
         if (ended) return
-        await new Promise(resolve => { waiter = resolve })
+        await new Promise((resolve) => {
+          waiter = resolve
+        })
       }
     }
   }
 }
 
-async function feedAndCollect (model, audio) {
+async function feedAndCollect(model, audio) {
   const samplesPerChunk = Math.floor((FEED_CHUNK_MS / 1000) * SAMPLE_RATE)
   const stream = pushableStream()
   const segments = []
@@ -97,7 +110,7 @@ async function feedAndCollect (model, audio) {
 
   const response = await model.runStreaming(stream)
   const updateDone = response
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const seg of items) {
         if (!seg || !seg.text) continue
@@ -115,7 +128,7 @@ async function feedAndCollect (model, audio) {
     stream.push(chunk)
     lastChunkPushedTime = Date.now()
     if (i + samplesPerChunk < audio.length) {
-      await new Promise(resolve => setTimeout(resolve, FEED_CHUNK_MS))
+      await new Promise((resolve) => setTimeout(resolve, FEED_CHUNK_MS))
     }
   }
   stream.end()
@@ -124,75 +137,108 @@ async function feedAndCollect (model, audio) {
   return { segments, firstSegmentTime, lastChunkPushedTime }
 }
 
-test('runStreaming — duplex feed surfaces transcripts incrementally and resolves cleanly', { timeout: 600000 }, async (t) => {
-  const loggerBinding = setupJsLogger(binding)
-
-  try {
-    const modelPath = await loadGgufOrSkip(t, 'tdt')
-    if (!modelPath) return
-
-    const audio = loadAudioSample()
-    if (!audio) {
-      t.pass('sample.raw not found - skipping')
-      return
-    }
-
-    const audioDurationMs = (audio.length / SAMPLE_RATE) * 1000
-    if (audioDurationMs < 4000) {
-      t.pass(`sample.raw is too short (${audioDurationMs.toFixed(0)} ms) for incremental streaming check - skipping`)
-      return
-    }
-
-    const model = new TranscriptionParakeet({
-      files: { model: modelPath },
-      config: {
-        parakeetConfig: {
-          streaming: true,
-          streamingChunkMs: STREAM_CHUNK_MS,
-          maxThreads: 4,
-          useGPU: false
-        }
-      }
-    })
+test(
+  'runStreaming — duplex feed surfaces transcripts incrementally and resolves cleanly',
+  { timeout: 600000 },
+  async (t) => {
+    const loggerBinding = setupJsLogger(binding)
 
     try {
-      await model.load()
+      const modelPath = await loadGgufOrSkip(t, 'tdt')
+      if (!modelPath) return
 
-      console.log(`[duplex/streaming] audio duration: ${(audioDurationMs / 1000).toFixed(2)}s`)
-      console.log(`[duplex/streaming] feed chunk: ${FEED_CHUNK_MS}ms; session chunk: ${STREAM_CHUNK_MS}ms`)
-
-      const startTime = Date.now()
-      const { segments, firstSegmentTime, lastChunkPushedTime } = await feedAndCollect(model, audio)
-      const totalElapsed = Date.now() - startTime
-
-      const transcript = segments.map(s => s.text).join(' ').trim()
-
-      console.log(`[duplex/streaming] segments=${segments.length} chars=${transcript.length}`)
-      console.log(`[duplex/streaming] result: "${transcript.substring(0, 150)}${transcript.length > 150 ? '...' : ''}"`)
-      if (firstSegmentTime !== null && lastChunkPushedTime !== null) {
-        const firstSegmentLeadMs = lastChunkPushedTime - firstSegmentTime
-        console.log(`[duplex/streaming] first segment arrived ${firstSegmentLeadMs}ms before last chunk was pushed (negative = arrived after last push)`)
+      const audio = loadAudioSample()
+      if (!audio) {
+        t.pass('sample.raw not found - skipping')
+        return
       }
-      console.log(`[duplex/streaming] total elapsed=${totalElapsed}ms`)
 
-      t.ok(segments.length > 0,
-        `runStreaming should emit at least one segment (got ${segments.length})`)
-      t.ok(transcript.length > 0,
-        `runStreaming transcript should be non-empty (got ${transcript.length} chars)`)
+      const audioDurationMs = (audio.length / SAMPLE_RATE) * 1000
+      if (audioDurationMs < 4000) {
+        t.pass(
+          `sample.raw is too short (${audioDurationMs.toFixed(0)} ms) for incremental streaming check - skipping`
+        )
+        return
+      }
 
-      // The duplex API guarantees at least one segment arrives before
-      // the *last* chunk is pushed, given an audio clip longer than
-      // (chunkMs + right_lookahead_ms). The offline `run()` path
-      // cannot satisfy this -- it batches everything until
-      // end-of-input -- so this assertion is what differentiates the
-      // two execution paths in the integration suite.
-      t.ok(firstSegmentTime !== null && lastChunkPushedTime !== null &&
-           firstSegmentTime <= lastChunkPushedTime,
-      'first segment should arrive at or before the last chunk is pushed (incremental streaming)')
+      const model = new TranscriptionParakeet({
+        files: { model: modelPath },
+        config: {
+          parakeetConfig: {
+            streaming: true,
+            streamingChunkMs: STREAM_CHUNK_MS,
+            maxThreads: 4,
+            useGPU: false
+          }
+        }
+      })
+
+      try {
+        await model.load()
+
+        console.log(`[duplex/streaming] audio duration: ${(audioDurationMs / 1000).toFixed(2)}s`)
+        console.log(
+          `[duplex/streaming] feed chunk: ${FEED_CHUNK_MS}ms; session chunk: ${STREAM_CHUNK_MS}ms`
+        )
+
+        const startTime = Date.now()
+        const { segments, firstSegmentTime, lastChunkPushedTime } = await feedAndCollect(
+          model,
+          audio
+        )
+        const totalElapsed = Date.now() - startTime
+
+        const transcript = segments
+          .map((s) => s.text)
+          .join(' ')
+          .trim()
+
+        console.log(`[duplex/streaming] segments=${segments.length} chars=${transcript.length}`)
+        console.log(
+          `[duplex/streaming] result: "${transcript.substring(0, 150)}${transcript.length > 150 ? '...' : ''}"`
+        )
+        if (firstSegmentTime !== null && lastChunkPushedTime !== null) {
+          const firstSegmentLeadMs = lastChunkPushedTime - firstSegmentTime
+          console.log(
+            `[duplex/streaming] first segment arrived ${firstSegmentLeadMs}ms before last chunk was pushed (negative = arrived after last push)`
+          )
+        }
+        console.log(`[duplex/streaming] total elapsed=${totalElapsed}ms`)
+
+        t.ok(
+          segments.length > 0,
+          `runStreaming should emit at least one segment (got ${segments.length})`
+        )
+        t.ok(
+          transcript.length > 0,
+          `runStreaming transcript should be non-empty (got ${transcript.length} chars)`
+        )
+
+        // The duplex API guarantees at least one segment arrives before
+        // the *last* chunk is pushed, given an audio clip longer than
+        // (chunkMs + right_lookahead_ms). The offline `run()` path
+        // cannot satisfy this -- it batches everything until
+        // end-of-input -- so this assertion is what differentiates the
+        // two execution paths in the integration suite.
+        t.ok(
+          firstSegmentTime !== null &&
+            lastChunkPushedTime !== null &&
+            firstSegmentTime <= lastChunkPushedTime,
+          'first segment should arrive at or before the last chunk is pushed (incremental streaming)'
+        )
+      } finally {
+        try {
+          await model.unload()
+        } catch (e) {
+          /* ignore */
+        }
+      }
     } finally {
-      try { await model.unload() } catch (e) { /* ignore */ }
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
     }
-  } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
   }
-})
+)

--- a/packages/transcription-parakeet/test/integration/eou-streaming.test.js
+++ b/packages/transcription-parakeet/test/integration/eou-streaming.test.js
@@ -52,7 +52,7 @@ const SAMPLE_RATE = 16000
 const STREAM_CHUNK_MS = 1000
 const FEED_CHUNK_MS = 500
 
-function loadAudioSample () {
+function loadAudioSample() {
   const samplePath = path.join(samplesDir, 'sample.raw')
   if (!fs.existsSync(samplePath)) return null
   const rawBuffer = fs.readFileSync(samplePath)
@@ -62,31 +62,44 @@ function loadAudioSample () {
   return audio
 }
 
-function pushableStream () {
+function pushableStream() {
   const queue = []
   let waiter = null
   let ended = false
   return {
-    push (chunk) {
+    push(chunk) {
       if (ended) return
       queue.push(chunk)
-      if (waiter) { const w = waiter; waiter = null; w() }
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w()
+      }
     },
-    end () {
+    end() {
       ended = true
-      if (waiter) { const w = waiter; waiter = null; w() }
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w()
+      }
     },
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       while (true) {
-        if (queue.length > 0) { yield queue.shift(); continue }
+        if (queue.length > 0) {
+          yield queue.shift()
+          continue
+        }
         if (ended) return
-        await new Promise(resolve => { waiter = resolve })
+        await new Promise((resolve) => {
+          waiter = resolve
+        })
       }
     }
   }
 }
 
-async function streamEou (model, audioData) {
+async function streamEou(model, audioData) {
   const samplesPerChunk = Math.floor((FEED_CHUNK_MS / 1000) * SAMPLE_RATE)
   const stream = pushableStream()
   const segments = []
@@ -94,7 +107,7 @@ async function streamEou (model, audioData) {
   const runPromise = (async () => {
     const response = await model.run(stream)
     await response
-      .onUpdate(out => {
+      .onUpdate((out) => {
         const items = Array.isArray(out) ? out : [out]
         for (const seg of items) {
           if (seg && seg.text) segments.push(seg)
@@ -108,7 +121,7 @@ async function streamEou (model, audioData) {
     const chunk = new Float32Array(audioData.slice(i, endIdx))
     stream.push(chunk)
     if (i + samplesPerChunk < audioData.length) {
-      await new Promise(resolve => setTimeout(resolve, FEED_CHUNK_MS))
+      await new Promise((resolve) => setTimeout(resolve, FEED_CHUNK_MS))
     }
   }
   stream.end()
@@ -117,55 +130,82 @@ async function streamEou (model, audioData) {
   return segments
 }
 
-test('EOU streaming — emits transcript segments and end-of-turn boundaries', { timeout: 600000 }, async (t) => {
-  const loggerBinding = setupJsLogger(binding)
-
-  try {
-    const modelPath = await loadGgufOrSkip(t, 'eou')
-    if (!modelPath) return
-
-    const audio = loadAudioSample()
-    if (!audio) {
-      t.pass('sample.raw not found - skipping')
-      return
-    }
-
-    const model = new TranscriptionParakeet({
-      files: { model: modelPath },
-      config: {
-        parakeetConfig: {
-          streaming: true,
-          streamingChunkMs: STREAM_CHUNK_MS,
-          maxThreads: 4,
-          useGPU: false
-        }
-      }
-    })
+test(
+  'EOU streaming — emits transcript segments and end-of-turn boundaries',
+  { timeout: 600000 },
+  async (t) => {
+    const loggerBinding = setupJsLogger(binding)
 
     try {
-      await model.load()
+      const modelPath = await loadGgufOrSkip(t, 'eou')
+      if (!modelPath) return
 
-      console.log(`[eou/streaming] audio duration: ${(audio.length / SAMPLE_RATE).toFixed(2)}s`)
-      console.log(`[eou/streaming] feed chunk: ${FEED_CHUNK_MS}ms; session chunk: ${STREAM_CHUNK_MS}ms`)
+      const audio = loadAudioSample()
+      if (!audio) {
+        t.pass('sample.raw not found - skipping')
+        return
+      }
 
-      const segments = await streamEou(model, audio)
+      const model = new TranscriptionParakeet({
+        files: { model: modelPath },
+        config: {
+          parakeetConfig: {
+            streaming: true,
+            streamingChunkMs: STREAM_CHUNK_MS,
+            maxThreads: 4,
+            useGPU: false
+          }
+        }
+      })
 
-      const eotSegments = segments.filter(s => s.isEndOfTurn === true)
-      const transcript = segments.map(s => s.text).join(' ').trim()
+      try {
+        await model.load()
 
-      console.log(`[eou/streaming] segments=${segments.length} eotSegments=${eotSegments.length} chars=${transcript.length}`)
-      console.log(`[eou/streaming] result: "${transcript.substring(0, 150)}${transcript.length > 150 ? '...' : ''}"`)
+        console.log(`[eou/streaming] audio duration: ${(audio.length / SAMPLE_RATE).toFixed(2)}s`)
+        console.log(
+          `[eou/streaming] feed chunk: ${FEED_CHUNK_MS}ms; session chunk: ${STREAM_CHUNK_MS}ms`
+        )
 
-      t.ok(segments.length > 0,
-        `EOU streaming should emit at least one segment (got ${segments.length})`)
-      t.ok(transcript.length > 0,
-        `EOU streaming transcript should be non-empty (got ${transcript.length} chars)`)
-      t.ok(eotSegments.length > 0,
-        `EOU streaming should mark at least one end-of-turn boundary on a finalized clip (got ${eotSegments.length})`)
+        const segments = await streamEou(model, audio)
+
+        const eotSegments = segments.filter((s) => s.isEndOfTurn === true)
+        const transcript = segments
+          .map((s) => s.text)
+          .join(' ')
+          .trim()
+
+        console.log(
+          `[eou/streaming] segments=${segments.length} eotSegments=${eotSegments.length} chars=${transcript.length}`
+        )
+        console.log(
+          `[eou/streaming] result: "${transcript.substring(0, 150)}${transcript.length > 150 ? '...' : ''}"`
+        )
+
+        t.ok(
+          segments.length > 0,
+          `EOU streaming should emit at least one segment (got ${segments.length})`
+        )
+        t.ok(
+          transcript.length > 0,
+          `EOU streaming transcript should be non-empty (got ${transcript.length} chars)`
+        )
+        t.ok(
+          eotSegments.length > 0,
+          `EOU streaming should mark at least one end-of-turn boundary on a finalized clip (got ${eotSegments.length})`
+        )
+      } finally {
+        try {
+          await model.unload()
+        } catch (e) {
+          /* ignore */
+        }
+      }
     } finally {
-      try { await model.unload() } catch (e) { /* ignore */ }
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
     }
-  } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
   }
-})
+)

--- a/packages/transcription-parakeet/test/integration/gpu-smoke.test.js
+++ b/packages/transcription-parakeet/test/integration/gpu-smoke.test.js
@@ -66,15 +66,22 @@ const RELAX = process.env && process.env.QVAC_PARAKEET_GPU_SMOKE_RELAX === '1'
 // llm-llamacpp's integration tests.
 const NO_GPU = process.env && process.env.NO_GPU === 'true'
 
-function backendIdToName (id) {
+function backendIdToName(id) {
   switch (id) {
-    case 0: return 'CPU'
-    case 1: return 'Metal'
-    case 2: return 'CUDA'
-    case 3: return 'Vulkan'
-    case 4: return 'OpenCL'
-    case 99: return 'other-GPU'
-    default: return `unknown(${id})`
+    case 0:
+      return 'CPU'
+    case 1:
+      return 'Metal'
+    case 2:
+      return 'CUDA'
+    case 3:
+      return 'Vulkan'
+    case 4:
+      return 'OpenCL'
+    case 99:
+      return 'other-GPU'
+    default:
+      return `unknown(${id})`
   }
 }
 
@@ -83,7 +90,7 @@ function backendIdToName (id) {
 //   - darwin / ios:        metal              (default)
 //   - linux / win32:       vulkan             (default)
 //   - android:             vulkan + opencl    (default; Adreno only)
-function expectsGpu () {
+function expectsGpu() {
   return (
     platform === 'darwin' ||
     platform === 'ios' ||
@@ -93,7 +100,7 @@ function expectsGpu () {
   )
 }
 
-function loadAudioSample () {
+function loadAudioSample() {
   const samplePath = path.join(samplesDir, 'sample.raw')
   if (!fs.existsSync(samplePath)) return null
   const rawBuffer = fs.readFileSync(samplePath)
@@ -103,11 +110,11 @@ function loadAudioSample () {
   return audio
 }
 
-async function transcribe (model, audio) {
+async function transcribe(model, audio) {
   const segments = []
   const response = await model.run(audio)
   await response
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const seg of items) {
         if (seg && seg.text) segments.push(seg)
@@ -117,7 +124,7 @@ async function transcribe (model, audio) {
   return { segments, stats: response.stats || null }
 }
 
-function assertGpuBackend (t, modelType, stats) {
+function assertGpuBackend(t, modelType, stats) {
   if (!stats) {
     t.fail(`${modelType}/GPU: no response.stats returned (cannot verify backend)`)
     return
@@ -133,24 +140,30 @@ function assertGpuBackend (t, modelType, stats) {
   // result, not a GPU regression. (Under parakeet-cpp 2026-06-18 the device-farm
   // vendors Adreno/Mali run on the GPU; this only fires for declined devices.)
   if (platform === 'android' && dev === 0 && stats.gpuUnsupported) {
-    t.pass(`${modelType}/android: GPU present but declined by policy (gpuUnsupported); correctly using CPU`)
+    t.pass(
+      `${modelType}/android: GPU present but declined by policy (gpuUnsupported); correctly using CPU`
+    )
     return
   }
 
   if (!expectsGpu()) {
     // Platforms with no GPU backend wired into the addon today must
     // resolve to CPU. This catches accidental GPU-on-Linux config drift.
-    t.is(dev, 0,
-      `${modelType}/${platform}: backendDevice must be 0 (CPU) on platforms with no GPU wired in`)
+    t.is(
+      dev,
+      0,
+      `${modelType}/${platform}: backendDevice must be 0 (CPU) on platforms with no GPU wired in`
+    )
     return
   }
 
   if (dev !== 1) {
-    const msg = `${modelType}/${platform}: expected GPU backend, got ${name} ` +
-                `(backendDevice=${dev}, backendId=${id}). ` +
-                'useGPU=true was requested but the engine fell back to CPU. ' +
-                'Inspect the addon\'s --native-logs output for the load-time ' +
-                'backend init message.'
+    const msg =
+      `${modelType}/${platform}: expected GPU backend, got ${name} ` +
+      `(backendDevice=${dev}, backendId=${id}). ` +
+      'useGPU=true was requested but the engine fell back to CPU. ' +
+      "Inspect the addon's --native-logs output for the load-time " +
+      'backend init message.'
     if (RELAX) {
       t.comment(`WARNING (relaxed): ${msg}`)
       t.pass(`${modelType}/GPU smoke completed (relaxed)`)
@@ -169,12 +182,14 @@ function assertGpuBackend (t, modelType, stats) {
   } else if (platform === 'linux' || platform === 'win32') {
     t.is(id, 3, `${modelType}/${platform}: expected Vulkan backendId=3, got ${name}`)
   } else if (platform === 'android') {
-    t.ok(id === 3 || id === 4,
-      `${modelType}/${platform}: expected Vulkan(3) or OpenCL(4) backendId, got ${name}`)
+    t.ok(
+      id === 3 || id === 4,
+      `${modelType}/${platform}: expected Vulkan(3) or OpenCL(4) backendId, got ${name}`
+    )
   }
 }
 
-async function runGpuModelTest (t, modelType, modelPath, audio, expectations) {
+async function runGpuModelTest(t, modelType, modelPath, audio, expectations) {
   const model = new TranscriptionParakeet({
     files: { model: modelPath },
     config: { parakeetConfig: { modelType, maxThreads: 4, useGPU: true } }
@@ -183,78 +198,131 @@ async function runGpuModelTest (t, modelType, modelPath, audio, expectations) {
     await model.load()
     const { segments, stats } = await transcribe(model, audio)
     const joiner = modelType === 'sortformer' ? '\n' : ' '
-    const fullText = segments.map(s => s.text).join(joiner).trim()
+    const fullText = segments
+      .map((s) => s.text)
+      .join(joiner)
+      .trim()
     console.log(`[${modelType}/GPU] segments=${segments.length} chars=${fullText.length}`)
-    console.log(`[${modelType}/GPU] result: "${fullText.substring(0, 120)}${fullText.length > 120 ? '...' : ''}"`)
+    console.log(
+      `[${modelType}/GPU] result: "${fullText.substring(0, 120)}${fullText.length > 120 ? '...' : ''}"`
+    )
 
     assertGpuBackend(t, modelType, stats)
 
-    t.ok(segments.length > 0,
-      `${modelType}/GPU produced ${segments.length} segments`)
+    t.ok(segments.length > 0, `${modelType}/GPU produced ${segments.length} segments`)
     if (expectations.containsSpeaker) {
-      t.ok(fullText.includes('Speaker'),
-        `${modelType}/GPU output contains speaker labels`)
+      t.ok(fullText.includes('Speaker'), `${modelType}/GPU output contains speaker labels`)
     } else {
-      t.ok(fullText.length >= expectations.minTextLength,
-        `${modelType}/GPU produced text (${fullText.length} chars)`)
+      t.ok(
+        fullText.length >= expectations.minTextLength,
+        `${modelType}/GPU produced text (${fullText.length} chars)`
+      )
     }
   } finally {
-    try { await model.unload() } catch (e) { /* ignore */ }
+    try {
+      await model.unload()
+    } catch (e) {
+      /* ignore */
+    }
   }
 }
 
-test('CTC GPU smoke — useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  const loggerBinding = setupJsLogger(binding)
-  try {
-    const modelPath = await loadGgufOrSkip(t, 'ctc')
-    if (!modelPath) return
-    const audio = loadAudioSample()
-    if (!audio) { t.pass('sample.raw not found — skipping'); return }
-    await runGpuModelTest(t, 'ctc', modelPath, audio, { minTextLength: 10 })
-  } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+test(
+  'CTC GPU smoke — useGPU=true must engage the GPU backend on GPU-capable platforms',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    const loggerBinding = setupJsLogger(binding)
+    try {
+      const modelPath = await loadGgufOrSkip(t, 'ctc')
+      if (!modelPath) return
+      const audio = loadAudioSample()
+      if (!audio) {
+        t.pass('sample.raw not found — skipping')
+        return
+      }
+      await runGpuModelTest(t, 'ctc', modelPath, audio, { minTextLength: 10 })
+    } finally {
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
+    }
   }
-})
+)
 
-test('TDT GPU smoke — useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  const loggerBinding = setupJsLogger(binding)
-  try {
-    const modelPath = await loadGgufOrSkip(t, 'tdt')
-    if (!modelPath) return
-    const audio = loadAudioSample()
-    if (!audio) { t.pass('sample.raw not found — skipping'); return }
-    await runGpuModelTest(t, 'tdt', modelPath, audio, { minTextLength: 10 })
-  } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+test(
+  'TDT GPU smoke — useGPU=true must engage the GPU backend on GPU-capable platforms',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    const loggerBinding = setupJsLogger(binding)
+    try {
+      const modelPath = await loadGgufOrSkip(t, 'tdt')
+      if (!modelPath) return
+      const audio = loadAudioSample()
+      if (!audio) {
+        t.pass('sample.raw not found — skipping')
+        return
+      }
+      await runGpuModelTest(t, 'tdt', modelPath, audio, { minTextLength: 10 })
+    } finally {
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
+    }
   }
-})
+)
 
 // EOU on offline mode runs the joint-network ASR path; on a clip with
 // real speech that must produce non-empty text. minTextLength=1 catches
 // the zero-token regression triggered by ggml-metal's Q-variant
 // mul_mv + bias/residual fusion on the EOU q8_0 joint network.
-test('EOU GPU smoke — useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  const loggerBinding = setupJsLogger(binding)
-  try {
-    const modelPath = await loadGgufOrSkip(t, 'eou')
-    if (!modelPath) return
-    const audio = loadAudioSample()
-    if (!audio) { t.pass('sample.raw not found — skipping'); return }
-    await runGpuModelTest(t, 'eou', modelPath, audio, { minTextLength: 1 })
-  } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+test(
+  'EOU GPU smoke — useGPU=true must engage the GPU backend on GPU-capable platforms',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    const loggerBinding = setupJsLogger(binding)
+    try {
+      const modelPath = await loadGgufOrSkip(t, 'eou')
+      if (!modelPath) return
+      const audio = loadAudioSample()
+      if (!audio) {
+        t.pass('sample.raw not found — skipping')
+        return
+      }
+      await runGpuModelTest(t, 'eou', modelPath, audio, { minTextLength: 1 })
+    } finally {
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
+    }
   }
-})
+)
 
-test('Sortformer GPU smoke — useGPU=true must engage the GPU backend on GPU-capable platforms', { timeout: 600000, skip: NO_GPU }, async (t) => {
-  const loggerBinding = setupJsLogger(binding)
-  try {
-    const modelPath = await loadGgufOrSkip(t, 'sortformer')
-    if (!modelPath) return
-    const audio = loadAudioSample()
-    if (!audio) { t.pass('sample.raw not found — skipping'); return }
-    await runGpuModelTest(t, 'sortformer', modelPath, audio, { containsSpeaker: true })
-  } finally {
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+test(
+  'Sortformer GPU smoke — useGPU=true must engage the GPU backend on GPU-capable platforms',
+  { timeout: 600000, skip: NO_GPU },
+  async (t) => {
+    const loggerBinding = setupJsLogger(binding)
+    try {
+      const modelPath = await loadGgufOrSkip(t, 'sortformer')
+      if (!modelPath) return
+      const audio = loadAudioSample()
+      if (!audio) {
+        t.pass('sample.raw not found — skipping')
+        return
+      }
+      await runGpuModelTest(t, 'sortformer', modelPath, audio, { containsSpeaker: true })
+    } finally {
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
+    }
   }
-})
+)

--- a/packages/transcription-parakeet/test/integration/helpers.js
+++ b/packages/transcription-parakeet/test/integration/helpers.js
@@ -32,7 +32,9 @@ let _mobileModelManifest = null
 // node_modules walk. Mobile leaves device.gpu null — the probes don't apply
 // there and the Device Farm device name is the proxy.
 let _subprocess = null
-try { _subprocess = require('bare-subprocess') } catch (_) {}
+try {
+  _subprocess = require('bare-subprocess')
+} catch (_) {}
 
 let createPerformanceReporter
 const _scriptBase = path.join('..', '..', '..', '..', 'scripts', 'test-utils')
@@ -55,29 +57,32 @@ try {
     }
 
     return {
-      record (testName, metrics, extra) {
+      record(testName, metrics, extra) {
         const entry = {
           test: testName,
           execution_provider: (extra && extra.execution_provider) || null,
-          metrics: Object.assign({
-            real_time_factor: null,
-            wall_time_ms: null,
-            tps: null,
-            encoder_time_ms: null,
-            decoder_time_ms: null,
-            audio_duration_ms: null,
-            total_time_ms: null,
-            avg_rss_mb: null,
-            peak_rss_mb: null,
-            rss_after_load_mb: null,
-            reclaimed_mb: null
-          }, metrics),
+          metrics: Object.assign(
+            {
+              real_time_factor: null,
+              wall_time_ms: null,
+              tps: null,
+              encoder_time_ms: null,
+              decoder_time_ms: null,
+              audio_duration_ms: null,
+              total_time_ms: null,
+              avg_rss_mb: null,
+              peak_rss_mb: null,
+              rss_after_load_mb: null,
+              reclaimed_mb: null
+            },
+            metrics
+          ),
           input: (extra && extra.input) || null,
           output: (extra && extra.output) || null
         }
         _results.push(entry)
       },
-      toJSON () {
+      toJSON() {
         return {
           schema_version: '1.0',
           addon: _addon,
@@ -87,7 +92,7 @@ try {
           results: _results
         }
       },
-      writeReport () {
+      writeReport() {
         const json = JSON.stringify(this.toJSON())
         const dirs = []
         if (global.testDir) dirs.push(global.testDir)
@@ -99,7 +104,9 @@ try {
         dirs.push('/tmp')
         for (let di = 0; di < dirs.length; di++) {
           try {
-            try { fs.mkdirSync(dirs[di], { recursive: true }) } catch (_) {}
+            try {
+              fs.mkdirSync(dirs[di], { recursive: true })
+            } catch (_) {}
             const p = path.join(dirs[di], 'perf-report.json')
             fs.writeFileSync(p, json)
             console.log('[PERF_REPORT_PATH]' + p)
@@ -108,8 +115,8 @@ try {
           }
         }
       },
-      writeStepSummary () {},
-      writeToConsole () {
+      writeStepSummary() {},
+      writeToConsole() {
         try {
           const json = JSON.stringify(this.toJSON())
           const CHUNK = 800
@@ -119,14 +126,25 @@ try {
             const id = Date.now().toString(36)
             const n = Math.ceil(json.length / CHUNK)
             for (let i = 0; i < n; i++) {
-              console.log('[PERF_CHUNK:' + id + ':' + i + ':' + n + ']' + json.substring(i * CHUNK, (i + 1) * CHUNK))
+              console.log(
+                '[PERF_CHUNK:' +
+                  id +
+                  ':' +
+                  i +
+                  ':' +
+                  n +
+                  ']' +
+                  json.substring(i * CHUNK, (i + 1) * CHUNK)
+              )
             }
           }
         } catch (err) {
           console.log('[perf-reporter] mobile console write failed: ' + err.message)
         }
       },
-      get length () { return _results.length }
+      get length() {
+        return _results.length
+      }
     }
   }
 }
@@ -139,19 +157,23 @@ const _perfReporter = createPerformanceReporter({
 const _reportPath = path.resolve('.', 'test/results/performance-report.json')
 let _reportScheduled = false
 
-function _flushPerfReport () {
+function _flushPerfReport() {
   if (_perfReporter.length === 0) return
-  try { _perfReporter.writeReport(_reportPath) } catch (_) {}
-  try { _perfReporter.writeToConsole() } catch (_) {}
+  try {
+    _perfReporter.writeReport(_reportPath)
+  } catch (_) {}
+  try {
+    _perfReporter.writeToConsole()
+  } catch (_) {}
 }
 
-function _scheduleReportWrite () {
+function _scheduleReportWrite() {
   if (_reportScheduled) return
   _reportScheduled = true
   process.on('exit', _flushPerfReport)
 }
 
-function roundToTwo (value) {
+function roundToTwo(value) {
   return typeof value === 'number' && Number.isFinite(value) ? roundTo(value, 2) : null
 }
 
@@ -171,19 +193,23 @@ function roundToTwo (value) {
  *                            the mobile peak at the post-activation footprint,
  *                            matching the desktop peak floor.
  */
-function recordParakeetStats (label, stats, extra) {
+function recordParakeetStats(label, stats, extra) {
   if (!stats || typeof stats !== 'object') return
   const epOverride = extra && extra.executionProvider
   const ep = epOverride || (/\[gpu\]/i.test(label) ? 'gpu' : /\[cpu\]/i.test(label) ? 'cpu' : null)
 
   const totalTimeSec = typeof stats.totalTime === 'number' ? stats.totalTime : null
   const totalTimeMs = totalTimeSec !== null ? Math.round(totalTimeSec * 1000) : null
-  const wallMs = (extra && typeof extra.wallMs === 'number')
-    ? Math.round(extra.wallMs)
-    : (typeof stats.totalWallMs === 'number' ? Math.round(stats.totalWallMs) : totalTimeMs)
+  const wallMs =
+    extra && typeof extra.wallMs === 'number'
+      ? Math.round(extra.wallMs)
+      : typeof stats.totalWallMs === 'number'
+        ? Math.round(stats.totalWallMs)
+        : totalTimeMs
   const encoderMs = typeof stats.encoderMs === 'number' ? Math.round(stats.encoderMs) : null
   const decoderMs = typeof stats.decoderMs === 'number' ? Math.round(stats.decoderMs) : null
-  const audioMs = typeof stats.audioDurationMs === 'number' ? Math.round(stats.audioDurationMs) : null
+  const audioMs =
+    typeof stats.audioDurationMs === 'number' ? Math.round(stats.audioDurationMs) : null
   const totalTokens = typeof stats.totalTokens === 'number' ? stats.totalTokens : null
 
   // parakeet.cpp (GGML) does not populate realTimeFactor / tokensPerSecond in
@@ -193,38 +219,51 @@ function recordParakeetStats (label, stats, extra) {
   // benchmark (test/benchmark/rtf-benchmark.test.js) does:
   //   RTF = wall time / audio duration (both ms)
   //   TPS = total decoded tokens / total inference time (s)
-  const rtf = (typeof stats.realTimeFactor === 'number' && stats.realTimeFactor > 0)
-    ? stats.realTimeFactor
-    : (Number.isFinite(wallMs) && wallMs > 0 && Number.isFinite(audioMs) && audioMs > 0
+  const rtf =
+    typeof stats.realTimeFactor === 'number' && stats.realTimeFactor > 0
+      ? stats.realTimeFactor
+      : Number.isFinite(wallMs) && wallMs > 0 && Number.isFinite(audioMs) && audioMs > 0
         ? wallMs / audioMs
-        : null)
-  const tps = (typeof stats.tokensPerSecond === 'number' && stats.tokensPerSecond > 0)
-    ? stats.tokensPerSecond
-    : (Number.isFinite(totalTokens) && totalTokens > 0 && Number.isFinite(totalTimeSec) && totalTimeSec > 0
+        : null
+  const tps =
+    typeof stats.tokensPerSecond === 'number' && stats.tokensPerSecond > 0
+      ? stats.tokensPerSecond
+      : Number.isFinite(totalTokens) &&
+          totalTokens > 0 &&
+          Number.isFinite(totalTimeSec) &&
+          totalTimeSec > 0
         ? totalTokens / totalTimeSec
-        : null)
+        : null
 
-  _perfReporter.record(label, {
-    real_time_factor: rtf,
-    wall_time_ms: wallMs,
-    tps,
-    encoder_time_ms: encoderMs,
-    decoder_time_ms: decoderMs,
-    audio_duration_ms: audioMs,
-    total_time_ms: totalTimeMs,
-    avg_rss_mb: roundToTwo(extra && extra.avgRssMb),
-    peak_rss_mb: roundToTwo(extra && extra.peakRssMb),
-    rss_after_load_mb: roundToTwo(extra && extra.rssAfterLoadMb),
-    reclaimed_mb: roundToTwo(extra && extra.reclaimedMb)
-  }, {
-    execution_provider: ep,
-    output: extra && extra.output ? String(extra.output) : null
-  })
+  _perfReporter.record(
+    label,
+    {
+      real_time_factor: rtf,
+      wall_time_ms: wallMs,
+      tps,
+      encoder_time_ms: encoderMs,
+      decoder_time_ms: decoderMs,
+      audio_duration_ms: audioMs,
+      total_time_ms: totalTimeMs,
+      avg_rss_mb: roundToTwo(extra && extra.avgRssMb),
+      peak_rss_mb: roundToTwo(extra && extra.peakRssMb),
+      rss_after_load_mb: roundToTwo(extra && extra.rssAfterLoadMb),
+      reclaimed_mb: roundToTwo(extra && extra.reclaimedMb)
+    },
+    {
+      execution_provider: ep,
+      output: extra && extra.output ? String(extra.output) : null
+    }
+  )
   _scheduleReportWrite()
 
   if (isMobile) {
-    try { _perfReporter.writeReport() } catch (_) {}
-    try { _perfReporter.writeToConsole() } catch (_) {}
+    try {
+      _perfReporter.writeReport()
+    } catch (_) {}
+    try {
+      _perfReporter.writeToConsole()
+    } catch (_) {}
   }
 }
 
@@ -249,7 +288,7 @@ const TranscriptionParakeet = isMobile
  * Detect current platform
  * @returns {string} Platform string (e.g., 'linux-x64', 'darwin-arm64')
  */
-function detectPlatform () {
+function detectPlatform() {
   return `${platform}-${arch}`
 }
 
@@ -266,14 +305,14 @@ function detectPlatform () {
  * @param {number} [maxMs=10000] - Maximum wait time in milliseconds
  * @returns {Promise<boolean>} True if the model left PROCESSING in time
  */
-async function waitUntilIdle (model, maxMs = 10000) {
+async function waitUntilIdle(model, maxMs = 10000) {
   const start = Date.now()
   while (Date.now() - start < maxMs) {
     try {
       const s = await model.status()
       if (s !== 'PROCESSING') return true
     } catch {}
-    await new Promise(resolve => setTimeout(resolve, 100))
+    await new Promise((resolve) => setTimeout(resolve, 100))
   }
   return false
 }
@@ -283,7 +322,7 @@ async function waitUntilIdle (model, maxMs = 10000) {
  * @param {string|Buffer|Uint8Array|Float32Array|Readable} audioInput - Audio input in various formats
  * @returns {Readable} Readable stream
  */
-function createAudioStream (audioInput) {
+function createAudioStream(audioInput) {
   if (typeof audioInput === 'string') {
     const audioBuffer = fs.readFileSync(audioInput)
     // Create stream from Buffer with chunking to simulate streaming behavior
@@ -316,7 +355,7 @@ function createAudioStream (audioInput) {
  * @param {number} sampleRate - Sample rate in Hz (default: 16000)
  * @returns {number} Duration in milliseconds
  */
-function calculateAudioDuration (audioBuffer, audioFormat = 'f32le', sampleRate = 16000) {
+function calculateAudioDuration(audioBuffer, audioFormat = 'f32le', sampleRate = 16000) {
   let bytesPerSample
   if (audioFormat === 's16le') {
     bytesPerSample = 2
@@ -340,14 +379,20 @@ function calculateAudioDuration (audioBuffer, audioFormat = 'f32le', sampleRate 
  * @param {number} [amplitude=0.3] - Amplitude (0-1)
  * @returns {string} The filepath of the generated audio file
  */
-function generateTestAudio (filepath, sampleRate = 16000, duration = 3, frequency = 440, amplitude = 0.3) {
+function generateTestAudio(
+  filepath,
+  sampleRate = 16000,
+  duration = 3,
+  frequency = 440,
+  amplitude = 0.3
+) {
   if (fs.existsSync(filepath)) return filepath
 
   const samples = sampleRate * duration
   const audioData = new Float32Array(samples)
 
   for (let i = 0; i < samples; i++) {
-    audioData[i] = Math.sin(2 * Math.PI * frequency * i / sampleRate) * amplitude
+    audioData[i] = Math.sin((2 * Math.PI * frequency * i) / sampleRate) * amplitude
   }
 
   const buffer = Buffer.from(audioData.buffer)
@@ -361,7 +406,7 @@ function generateTestAudio (filepath, sampleRate = 16000, duration = 3, frequenc
  * @param {number} [amplitude=0.3] - Maximum amplitude of noise
  * @returns {Float32Array} PCM noise data
  */
-function makePcmNoise (numSamples, amplitude = 0.3) {
+function makePcmNoise(numSamples, amplitude = 0.3) {
   const audioData = new Float32Array(numSamples)
   for (let i = 0; i < numSamples; i++) {
     audioData[i] = (Math.random() * 2 - 1) * amplitude
@@ -374,7 +419,7 @@ function makePcmNoise (numSamples, amplitude = 0.3) {
  * @param {Object} [binding] - Optional binding instance (will require if not provided)
  * @returns {Object} The binding instance with logger configured
  */
-function setupJsLogger (overrideBinding = null) {
+function setupJsLogger(overrideBinding = null) {
   const actualBinding = overrideBinding || binding
   // Logger lifecycle in integration can crash or hang when repeatedly toggled.
   // Keep release as a no-op and only enable native logging explicitly when requested.
@@ -383,8 +428,7 @@ function setupJsLogger (overrideBinding = null) {
     actualBinding.__qvacReleaseLoggerPatched = true
   }
 
-  const shouldEnableNativeLogs = process.env &&
-    process.env.QVAC_TEST_NATIVE_LOGS === '1'
+  const shouldEnableNativeLogs = process.env && process.env.QVAC_TEST_NATIVE_LOGS === '1'
 
   if (shouldEnableNativeLogs && !actualBinding.__qvacLoggerSet) {
     const LOG_PRIORITIES = ['ERROR', 'WARNING', 'INFO', 'DEBUG']
@@ -404,17 +448,28 @@ function setupJsLogger (overrideBinding = null) {
  * @param {string} actual - Actual/hypothesis transcription
  * @returns {number} WER as a decimal (0.0 = perfect, 1.0 = 100% error)
  */
-function wordErrorRate (expected, actual) {
-  const normalize = (text) => text.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim()
+function wordErrorRate(expected, actual) {
+  const normalize = (text) =>
+    text
+      .toLowerCase()
+      .replace(/[^\w\s]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
 
-  const r = normalize(expected).split(/\s+/).filter(w => w.length > 0)
-  const h = normalize(actual).split(/\s+/).filter(w => w.length > 0)
+  const r = normalize(expected)
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+  const h = normalize(actual)
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
 
   if (r.length === 0) {
     return h.length === 0 ? 0 : 1
   }
 
-  const d = Array(r.length + 1).fill(null).map(() => Array(h.length + 1).fill(0))
+  const d = Array(r.length + 1)
+    .fill(null)
+    .map(() => Array(h.length + 1).fill(0))
 
   for (let i = 0; i <= r.length; i++) d[i][0] = i
   for (let j = 0; j <= h.length; j++) d[0][j] = j
@@ -422,11 +477,7 @@ function wordErrorRate (expected, actual) {
   for (let i = 1; i <= r.length; i++) {
     for (let j = 1; j <= h.length; j++) {
       const cost = r[i - 1] === h[j - 1] ? 0 : 1
-      d[i][j] = Math.min(
-        d[i - 1][j] + 1,
-        d[i][j - 1] + 1,
-        d[i - 1][j - 1] + cost
-      )
+      d[i][j] = Math.min(d[i - 1][j] + 1, d[i][j - 1] + 1, d[i - 1][j - 1] + cost)
     }
   }
 
@@ -440,7 +491,7 @@ function wordErrorRate (expected, actual) {
  * @param {number} [threshold=0.3] - Maximum acceptable WER (default 30%)
  * @returns {Object} Validation result with wer, passed, and details
  */
-function validateAccuracy (expected, actual, threshold = 0.3) {
+function validateAccuracy(expected, actual, threshold = 0.3) {
   const wer = wordErrorRate(expected, actual)
   const passed = wer <= threshold
 
@@ -460,7 +511,7 @@ function validateAccuracy (expected, actual, threshold = 0.3) {
  * @param {string} [modelsDir] - Optional models directory
  * @returns {Object} Object with modelsDir, samplesDir, modelPath, and audioPath
  */
-function getTestPaths (modelsDir = null) {
+function getTestPaths(modelsDir = null) {
   const writableRoot = global.testDir || (isMobile ? os.tmpdir() : null)
 
   let actualModelsDir, samplesDir
@@ -504,7 +555,7 @@ function getTestPaths (modelsDir = null) {
  * Handles redirects and streams directly to file.
  * Mirrors the pattern used by TTS's downloadModel.js.
  */
-async function downloadWithHttp (url, filepath, maxRedirects = 10) {
+async function downloadWithHttp(url, filepath, maxRedirects = 10) {
   return new Promise((resolve, reject) => {
     const https = require('bare-https')
     const { URL } = require('bare-url')
@@ -565,7 +616,9 @@ async function downloadWithHttp (url, filepath, maxRedirects = 10) {
         downloadedBytes += chunk.length
         if (contentLength > 0 && downloadedBytes % (1024 * 1024) < chunk.length) {
           const percent = ((downloadedBytes / contentLength) * 100).toFixed(1)
-          console.log(` [HTTPS] Progress: ${percent}% (${downloadedBytes} / ${contentLength} bytes)`)
+          console.log(
+            ` [HTTPS] Progress: ${percent}% (${downloadedBytes} / ${contentLength} bytes)`
+          )
         }
       })
 
@@ -597,7 +650,7 @@ async function downloadWithHttp (url, filepath, maxRedirects = 10) {
  * @param {string} destPath - Destination file path
  * @returns {Promise<void>}
  */
-async function downloadFile (url, destPath) {
+async function downloadFile(url, destPath) {
   if (isMobile) {
     return downloadWithHttp(url, destPath)
   }
@@ -612,7 +665,7 @@ async function downloadFile (url, destPath) {
   })
 }
 
-function prestagedModelDir (modelName) {
+function prestagedModelDir(modelName) {
   if (platform !== 'android') return null
   try {
     const p = path.join(PRESTAGED_MODEL_DIR, modelName)
@@ -621,7 +674,7 @@ function prestagedModelDir (modelName) {
   return null
 }
 
-function loadMobileModelManifest () {
+function loadMobileModelManifest() {
   if (_mobileModelManifest !== null) return _mobileModelManifest
   _mobileModelManifest = {}
 
@@ -631,7 +684,9 @@ function loadMobileModelManifest () {
   const candidates = []
   if (samplesDir) candidates.push(path.join(samplesDir, 'model-manifest.json'))
   if (global.assetPaths && global.assetPaths['../../testAssets/model-manifest.json']) {
-    candidates.push(global.assetPaths['../../testAssets/model-manifest.json'].replace('file://', ''))
+    candidates.push(
+      global.assetPaths['../../testAssets/model-manifest.json'].replace('file://', '')
+    )
   }
 
   for (const candidate of candidates) {
@@ -648,7 +703,7 @@ function loadMobileModelManifest () {
   return _mobileModelManifest
 }
 
-function manifestEntryForModel (modelName) {
+function manifestEntryForModel(modelName) {
   const manifest = loadMobileModelManifest()
   for (const entries of Object.values(manifest)) {
     if (!Array.isArray(entries)) continue
@@ -674,7 +729,7 @@ function manifestEntryForModel (modelName) {
  * @param {string} [modelPath] - Optional override for the GGUF path
  * @returns {Promise<string>} Path to the .gguf file
  */
-async function ensureModel (modelPath = null) {
+async function ensureModel(modelPath = null) {
   return ensureGgufForType('tdt', modelPath)
 }
 
@@ -684,7 +739,7 @@ async function ensureModel (modelPath = null) {
  * @param {number} [chunkSize=67108864] - Chunk size in bytes (default 64MB)
  * @returns {Generator<Buffer>} Generator yielding file chunks
  */
-function * readFileChunked (filePath, chunkSize = 64 * 1024 * 1024) {
+function* readFileChunked(filePath, chunkSize = 64 * 1024 * 1024) {
   const stat = fs.statSync(filePath)
   const fileSize = stat.size
   const fd = fs.openSync(filePath, 'r')
@@ -709,7 +764,7 @@ function * readFileChunked (filePath, chunkSize = 64 * 1024 * 1024) {
  * @param {Object} [expectation={}] - Expectations for validation
  * @returns {Promise<Object>} Result object with passed, output, and data
  */
-async function runTranscription (params, expectation = {}) {
+async function runTranscription(params, expectation = {}) {
   if (!params) {
     return {
       output: 'Error: Missing required parameter: params',
@@ -721,9 +776,10 @@ async function runTranscription (params, expectation = {}) {
   const { modelsDir } = getTestPaths()
   const parakeetConfig = params.parakeetConfig || {}
   const modelType = parakeetConfig.modelType || 'tdt'
-  const defaultModelPath =
-      path.join(modelsDir, MODEL_CONFIGS[modelType]?.file ||
-                           MODEL_CONFIGS.tdt.file)
+  const defaultModelPath = path.join(
+    modelsDir,
+    MODEL_CONFIGS[modelType]?.file || MODEL_CONFIGS.tdt.file
+  )
 
   const modelPath = params.modelPath || defaultModelPath
   const files = params.files || getNamedPathsConfig(modelType, modelPath)
@@ -787,8 +843,8 @@ async function runTranscription (params, expectation = {}) {
     }
 
     const fullText = segments
-      .map(s => (s && s.text) ? s.text : '')
-      .filter(t => t.trim().length > 0)
+      .map((s) => (s && s.text ? s.text : ''))
+      .filter((t) => t.trim().length > 0)
       .join(' ')
       .trim()
       .replace(/\s+/g, ' ')
@@ -807,7 +863,10 @@ async function runTranscription (params, expectation = {}) {
     if (expectation.minTextLength !== undefined && textLength < expectation.minTextLength) {
       passed = false
     }
-    if (expectation.expectedText !== undefined && !fullText.toLowerCase().includes(expectation.expectedText.toLowerCase())) {
+    if (
+      expectation.expectedText !== undefined &&
+      !fullText.toLowerCase().includes(expectation.expectedText.toLowerCase())
+    ) {
       passed = false
     }
 
@@ -881,16 +940,16 @@ const REGISTRY_PREFIX_Q4_0 = 'qvac_models_compiled/ggml/parakeet/2026-05-27'
 const REGISTRY_PREFIX_2026_07_01 = 'qvac_models_compiled/ggml/parakeet/2026-07-01'
 const REGISTRY_PREFIX_STREAMING = 'qvac_models_compiled/ggml/parakeet/2026-05-20'
 
-function _registryQ8 (file) {
+function _registryQ8(file) {
   return `${REGISTRY_PREFIX_Q8_0}/${file}`
 }
-function _registryQ4 (file) {
+function _registryQ4(file) {
   return `${REGISTRY_PREFIX_Q4_0}/${file}`
 }
-function _registry20260701 (file) {
+function _registry20260701(file) {
   return `${REGISTRY_PREFIX_2026_07_01}/${file}`
 }
-function _registryStreaming (file) {
+function _registryStreaming(file) {
   return `${REGISTRY_PREFIX_STREAMING}/${file}`
 }
 
@@ -966,11 +1025,11 @@ const MODEL_TYPE_ALIASES = {
 // QVAC_TEST_GGUF_<TYPE> env-key, and the remediation messages — keys off the
 // canonical form so the env var we recommend is always the one the resolver
 // actually reads.
-function canonicalModelType (modelType) {
+function canonicalModelType(modelType) {
   return MODEL_TYPE_ALIASES[modelType] || modelType
 }
 
-function testGgufEnvKey (modelType) {
+function testGgufEnvKey(modelType) {
   return `QVAC_TEST_GGUF_${canonicalModelType(modelType).toUpperCase()}`
 }
 
@@ -982,13 +1041,15 @@ function testGgufEnvKey (modelType) {
 // environments without the devDependency, and return `null` on any
 // failure so `loadGgufOrSkip` can keep its existing
 // fail-hard-via-`t.fail` contract.
-async function downloadFromRegistry (registryPath, registrySource, destPath, minSize) {
+async function downloadFromRegistry(registryPath, registrySource, destPath, minSize) {
   let QVACRegistryClient
   try {
-    ({ QVACRegistryClient } = require('@qvac/registry-client'))
+    ;({ QVACRegistryClient } = require('@qvac/registry-client'))
   } catch (err) {
-    console.log('  Registry client (@qvac/registry-client) not installed; ' +
-      'cannot fetch from QVAC model registry.')
+    console.log(
+      '  Registry client (@qvac/registry-client) not installed; ' +
+        'cannot fetch from QVAC model registry.'
+    )
     return null
   }
 
@@ -1020,18 +1081,24 @@ async function downloadFromRegistry (registryPath, registrySource, destPath, min
     const stats = fs.statSync(result.artifact.path)
     if (stats.size < minSize) {
       console.log(`  Registry download too small: ${stats.size} bytes (expected >=${minSize})`)
-      try { fs.unlinkSync(destPath) } catch (_) {}
+      try {
+        fs.unlinkSync(destPath)
+      } catch (_) {}
       return null
     }
     console.log(`  ✓ Registry download: ${path.basename(destPath)} (${stats.size} bytes)`)
     return destPath
   } catch (err) {
     console.log(`  Registry download failed: ${err && err.message ? err.message : String(err)}`)
-    try { fs.unlinkSync(destPath) } catch (_) {}
+    try {
+      fs.unlinkSync(destPath)
+    } catch (_) {}
     return null
   } finally {
     if (client) {
-      try { await client.close() } catch (_) {}
+      try {
+        await client.close()
+      } catch (_) {}
     }
   }
 }
@@ -1039,7 +1106,7 @@ async function downloadFromRegistry (registryPath, registrySource, destPath, min
 // Resolves the preferred GGUF for `modelType` on the current platform.
 // Mobile prefers q4_0 (smaller payload over Device Farm's network);
 // desktop prefers q8_0 (best WER per byte).
-function _preferredGgufFor (cfg) {
+function _preferredGgufFor(cfg) {
   if (isMobile && cfg.mobileFile && cfg.mobileRegistryPath) {
     return { file: cfg.mobileFile, registryPath: cfg.mobileRegistryPath, quant: 'q4_0' }
   }
@@ -1054,7 +1121,7 @@ function _preferredGgufFor (cfg) {
 // MODEL_CONFIGS stores the q8_0 build under `file`/`registryPath` and the
 // q4_0 build under `mobileFile`/`mobileRegistryPath`; the streaming sortformer
 // additionally publishes full-precision variants under the same prefix.
-function _ggufForQuant (cfg, quant) {
+function _ggufForQuant(cfg, quant) {
   const q = String(quant || '').toLowerCase()
   if (!q) return null
 
@@ -1088,7 +1155,7 @@ function _ggufForQuant (cfg, quant) {
  * @param {string} ggufPathOrName - GGUF file path or basename
  * @returns {string}
  */
-function quantFromGgufName (ggufPathOrName) {
+function quantFromGgufName(ggufPathOrName) {
   const base = path.basename(String(ggufPathOrName || ''))
   const match = base.match(/\.(q8_0|q4_0|f16|f32)\.gguf$/i)
   return match ? match[1].toLowerCase() : ''
@@ -1130,7 +1197,7 @@ function quantFromGgufName (ggufPathOrName) {
  *   (q8_0 on desktop, q4_0 on mobile).
  * @returns {Promise<string|null>} GGUF file path, or null if unavailable
  */
-async function ensureGgufForType (modelType, override = null, options = {}) {
+async function ensureGgufForType(modelType, override = null, options = {}) {
   const canonicalType = canonicalModelType(modelType)
   const cfg = MODEL_CONFIGS[canonicalType]
   if (!cfg) return null
@@ -1151,8 +1218,7 @@ async function ensureGgufForType (modelType, override = null, options = {}) {
   const { modelsDir, samplesDir } = getTestPaths()
   const cachePath = path.join(modelsDir, preferred.file)
 
-  if (fs.existsSync(cachePath) &&
-      fs.statSync(cachePath).size >= (cfg.minSize || 0)) {
+  if (fs.existsSync(cachePath) && fs.statSync(cachePath).size >= (cfg.minSize || 0)) {
     return cachePath
   }
 
@@ -1161,28 +1227,29 @@ async function ensureGgufForType (modelType, override = null, options = {}) {
     fs.mkdirSync(modelsDir, { recursive: true })
     console.log(`  Using pre-staged GGUF ${preferred.file} (copying into writable models dir)`)
     fs.copyFileSync(path.join(staged, preferred.file), cachePath)
-    if (fs.existsSync(cachePath) &&
-        fs.statSync(cachePath).size >= (cfg.minSize || 0)) {
+    if (fs.existsSync(cachePath) && fs.statSync(cachePath).size >= (cfg.minSize || 0)) {
       return cachePath
     }
-    try { fs.unlinkSync(cachePath) } catch (_) {}
+    try {
+      fs.unlinkSync(cachePath)
+    } catch (_) {}
   }
 
   const otherFile = preferred.file === cfg.file ? cfg.mobileFile : cfg.file
   if (allowOtherQuant && otherFile) {
     const otherPath = path.join(modelsDir, otherFile)
-    if (fs.existsSync(otherPath) &&
-        fs.statSync(otherPath).size >= (cfg.minSize || 0)) {
+    if (fs.existsSync(otherPath) && fs.statSync(otherPath).size >= (cfg.minSize || 0)) {
       return otherPath
     }
   }
 
   if (isMobile && samplesDir) {
-    const candidates = (allowOtherQuant ? [cfg.mobileFile, cfg.file] : [preferred.file]).filter(Boolean)
+    const candidates = (allowOtherQuant ? [cfg.mobileFile, cfg.file] : [preferred.file]).filter(
+      Boolean
+    )
     for (const candidate of candidates) {
       const bundledPath = path.join(samplesDir, candidate)
-      if (fs.existsSync(bundledPath) &&
-          fs.statSync(bundledPath).size >= (cfg.minSize || 0)) {
+      if (fs.existsSync(bundledPath) && fs.statSync(bundledPath).size >= (cfg.minSize || 0)) {
         return bundledPath
       }
     }
@@ -1190,11 +1257,12 @@ async function ensureGgufForType (modelType, override = null, options = {}) {
 
   const externalDir = process.env && process.env.QVAC_TEST_GGUF_DIR
   if (externalDir) {
-    const candidates = (allowOtherQuant ? [preferred.file, otherFile] : [preferred.file]).filter(Boolean)
+    const candidates = (allowOtherQuant ? [preferred.file, otherFile] : [preferred.file]).filter(
+      Boolean
+    )
     for (const candidate of candidates) {
       const externalPath = path.join(externalDir, candidate)
-      if (fs.existsSync(externalPath) &&
-          fs.statSync(externalPath).size >= (cfg.minSize || 0)) {
+      if (fs.existsSync(externalPath) && fs.statSync(externalPath).size >= (cfg.minSize || 0)) {
         const stagedPath = path.join(modelsDir, candidate)
         console.log(`  Staging GGUF from ${externalPath} -> ${stagedPath}`)
         fs.copyFileSync(externalPath, stagedPath)
@@ -1209,15 +1277,18 @@ async function ensureGgufForType (modelType, override = null, options = {}) {
       try {
         console.log(`  Downloading ${preferred.file} from mobile model manifest...`)
         await downloadFile(manifestEntry.url, cachePath)
-        if (fs.existsSync(cachePath) &&
-            fs.statSync(cachePath).size >= (cfg.minSize || 0)) {
+        if (fs.existsSync(cachePath) && fs.statSync(cachePath).size >= (cfg.minSize || 0)) {
           return cachePath
         }
         console.log(`  Manifest download too small: ${preferred.file}`)
-        try { fs.unlinkSync(cachePath) } catch (_) {}
+        try {
+          fs.unlinkSync(cachePath)
+        } catch (_) {}
       } catch (err) {
         console.log(`  Manifest download failed for ${preferred.file}: ${err.message}`)
-        try { fs.unlinkSync(cachePath) } catch (_) {}
+        try {
+          fs.unlinkSync(cachePath)
+        } catch (_) {}
       }
     }
   }
@@ -1238,15 +1309,17 @@ async function ensureGgufForType (modelType, override = null, options = {}) {
     return cachePath
   }
 
-  console.log(`  ${canonicalType.toUpperCase()} GGUF not available. Tried ` +
-              `QVAC registry (${preferred.registryPath || 'no path'}). ` +
-              'Run `npm run download-models:registry` or `npm run setup-models`, ' +
-              `or set ${envKey} / QVAC_TEST_GGUF_DIR to a directory of GGUFs.`)
+  console.log(
+    `  ${canonicalType.toUpperCase()} GGUF not available. Tried ` +
+      `QVAC registry (${preferred.registryPath || 'no path'}). ` +
+      'Run `npm run download-models:registry` or `npm run setup-models`, ' +
+      `or set ${envKey} / QVAC_TEST_GGUF_DIR to a directory of GGUFs.`
+  )
   return null
 }
 
 // Back-compat alias so older test files keep working.
-async function ensureModelForType (modelType) {
+async function ensureModelForType(modelType) {
   return ensureGgufForType(modelType)
 }
 
@@ -1271,13 +1344,14 @@ async function ensureModelForType (modelType) {
  *   miss (in which case the function has already recorded
  *   `t.pass` / `t.fail` and the caller should `return` early).
  */
-async function loadGgufOrSkip (t, modelType = 'tdt', options = {}) {
+async function loadGgufOrSkip(t, modelType = 'tdt', options = {}) {
   const ggufPath = await ensureGgufForType(modelType, null, options)
   if (ggufPath && fs.existsSync(ggufPath)) {
     return ggufPath
   }
 
-  const remediation = 'Run `npm run download-models:registry` (fetches ' +
+  const remediation =
+    'Run `npm run download-models:registry` (fetches ' +
     'pre-built GGUFs from the QVAC registry) or `npm run setup-models` ' +
     '(downloads .nemo from HuggingFace and converts locally), or set ' +
     `${testGgufEnvKey(modelType)}=/path/to/model.gguf ` +
@@ -1305,7 +1379,7 @@ async function loadGgufOrSkip (t, modelType = 'tdt', options = {}) {
  * @param {string} ggufPath - absolute path to the .gguf file
  * @returns {Object} { modelPath } config to spread into ParakeetInterface config
  */
-function getNamedPathsConfig (_modelType, ggufPath) {
+function getNamedPathsConfig(_modelType, ggufPath) {
   return { modelPath: ggufPath }
 }
 

--- a/packages/transcription-parakeet/test/integration/live-stream-simulation.test.js
+++ b/packages/transcription-parakeet/test/integration/live-stream-simulation.test.js
@@ -33,7 +33,7 @@ const {
 const platform = detectPlatform()
 const { modelPath, samplesDir } = getTestPaths()
 
-function loadAudio (samplePath) {
+function loadAudio(samplePath) {
   const rawBuffer = fs.readFileSync(samplePath)
   const pcmData = new Int16Array(rawBuffer.buffer, rawBuffer.byteOffset, rawBuffer.length / 2)
   const audioData = new Float32Array(pcmData.length)
@@ -45,27 +45,40 @@ function loadAudio (samplePath) {
  * Pushable async-iterable: producers `push(chunk)` / `end()`,
  * consumers `for await (const c of stream)`.
  */
-function pushableStream () {
+function pushableStream() {
   const queue = []
   let waiter = null
   let ended = false
-  function push (chunk) {
+  function push(chunk) {
     if (ended) return
     queue.push(chunk)
-    if (waiter) { const w = waiter; waiter = null; w() }
+    if (waiter) {
+      const w = waiter
+      waiter = null
+      w()
+    }
   }
-  function end () {
+  function end() {
     ended = true
-    if (waiter) { const w = waiter; waiter = null; w() }
+    if (waiter) {
+      const w = waiter
+      waiter = null
+      w()
+    }
   }
   return {
     push,
     end,
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       while (true) {
-        if (queue.length > 0) { yield queue.shift(); continue }
+        if (queue.length > 0) {
+          yield queue.shift()
+          continue
+        }
         if (ended) return
-        await new Promise(resolve => { waiter = resolve })
+        await new Promise((resolve) => {
+          waiter = resolve
+        })
       }
     }
   }
@@ -77,7 +90,7 @@ function pushableStream () {
  * `{ chunksFed, totalSamplesFed, segments, firstUpdateTime,
  *    feedDurationMs }`.
  */
-async function streamAudio (model, audioData, chunkDurationMs, delayMs) {
+async function streamAudio(model, audioData, chunkDurationMs, delayMs) {
   const sampleRate = 16000
   const samplesPerChunk = Math.floor((chunkDurationMs / 1000) * sampleRate)
   const totalChunks = Math.ceil(audioData.length / samplesPerChunk)
@@ -89,13 +102,15 @@ async function streamAudio (model, audioData, chunkDurationMs, delayMs) {
   const runPromise = (async () => {
     const response = await model.run(stream)
     await response
-      .onUpdate(out => {
+      .onUpdate((out) => {
         if (firstUpdateTime === null) firstUpdateTime = Date.now()
         const items = Array.isArray(out) ? out : [out]
         for (const seg of items) {
           if (seg && seg.text) {
             const txt = seg.text
-            console.log(`[onUpdate] segment: "${txt.substring(0, 60)}${txt.length > 60 ? '...' : ''}"`)
+            console.log(
+              `[onUpdate] segment: "${txt.substring(0, 60)}${txt.length > 60 ? '...' : ''}"`
+            )
             segments.push(seg)
           }
         }
@@ -112,7 +127,7 @@ async function streamAudio (model, audioData, chunkDurationMs, delayMs) {
     chunksFed++
     totalSamplesFed += chunk.length
     if (delayMs > 0 && i + samplesPerChunk < audioData.length) {
-      await new Promise(resolve => setTimeout(resolve, delayMs))
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
     }
   }
   stream.end()
@@ -176,8 +191,13 @@ test('Live stream simulation: chunked audio feeding', { timeout: 300000 }, async
     console.log('\n  Output:')
     console.log(`    Segments received: ${segments.length}`)
     if (segments.length > 0) {
-      const fullText = segments.map(s => s.text).join(' ').trim()
-      console.log(`    Full text: "${fullText.substring(0, 100)}${fullText.length > 100 ? '...' : ''}"`)
+      const fullText = segments
+        .map((s) => s.text)
+        .join(' ')
+        .trim()
+      console.log(
+        `    Full text: "${fullText.substring(0, 100)}${fullText.length > 100 ? '...' : ''}"`
+      )
     }
     console.log('='.repeat(60) + '\n')
 
@@ -185,8 +205,16 @@ test('Live stream simulation: chunked audio feeding', { timeout: 300000 }, async
     t.ok(totalSamplesFed > 0, 'Should have fed samples (totalSamplesFed > 0)')
     t.ok(segments.length > 0, 'Should receive transcription segments')
   } finally {
-    try { await model.unload() } catch (e) { /* ignore */ }
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      await model.unload()
+    } catch (e) {
+      /* ignore */
+    }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })
 
@@ -217,23 +245,37 @@ test('Rapid chunk feeding: stress test with no delay', { timeout: 300000 }, asyn
     await model.load()
 
     console.log('Feeding audio rapidly (100ms chunks, no delay)...')
-    const { chunksFed, totalSamplesFed, segments, feedDurationMs } =
-      await streamAudio(model, audioData, 100, 0)
+    const { chunksFed, totalSamplesFed, segments, feedDurationMs } = await streamAudio(
+      model,
+      audioData,
+      100,
+      0
+    )
 
     console.log('\n' + '='.repeat(60))
     console.log('📊 RAPID FEED RESULTS')
     console.log('='.repeat(60))
     console.log(`  Chunks fed: ${chunksFed}`)
     console.log(`  Feed time: ${feedDurationMs}ms`)
-    console.log(`  Throughput: ${(totalSamplesFed / (feedDurationMs / 1000)).toFixed(0)} samples/sec`)
+    console.log(
+      `  Throughput: ${(totalSamplesFed / (feedDurationMs / 1000)).toFixed(0)} samples/sec`
+    )
     console.log(`  Segments: ${segments.length}`)
     console.log('='.repeat(60) + '\n')
 
     t.ok(chunksFed > 10, 'Should have fed many chunks (rapid feeding)')
     t.ok(segments.length > 0, 'Should produce transcription despite rapid feeding')
   } finally {
-    try { await model.unload() } catch (e) { /* ignore */ }
-    try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+    try {
+      await model.unload()
+    } catch (e) {
+      /* ignore */
+    }
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
+    }
   }
 })
 
@@ -267,9 +309,16 @@ test('Variable chunk sizes: small to large chunks', { timeout: 300000 }, async (
     })
     try {
       await model.load()
-      const { chunksFed, segments, feedDurationMs } =
-        await streamAudio(model, audioData, chunkSizeMs, 0)
-      const fullText = segments.map(s => s.text).join(' ').trim()
+      const { chunksFed, segments, feedDurationMs } = await streamAudio(
+        model,
+        audioData,
+        chunkSizeMs,
+        0
+      )
+      const fullText = segments
+        .map((s) => s.text)
+        .join(' ')
+        .trim()
       results.push({
         chunkSizeMs,
         chunksFed,
@@ -279,7 +328,11 @@ test('Variable chunk sizes: small to large chunks', { timeout: 300000 }, async (
       })
       console.log(`  Chunks: ${chunksFed}, Time: ${feedDurationMs}ms, Segments: ${segments.length}`)
     } finally {
-      try { await model.unload() } catch (e) { /* ignore */ }
+      try {
+        await model.unload()
+      } catch (e) {
+        /* ignore */
+      }
     }
   }
 
@@ -287,12 +340,21 @@ test('Variable chunk sizes: small to large chunks', { timeout: 300000 }, async (
   console.log('📊 VARIABLE CHUNK SIZE SUMMARY')
   console.log('='.repeat(60))
   for (const result of results) {
-    console.log(`  ${result.chunkSizeMs}ms chunks: ${result.chunksFed} chunks, ${result.feedTime}ms, ${result.segments} segments`)
+    console.log(
+      `  ${result.chunkSizeMs}ms chunks: ${result.chunksFed} chunks, ${result.feedTime}ms, ${result.segments} segments`
+    )
   }
   console.log('='.repeat(60) + '\n')
 
   t.ok(results.length === CHUNK_SIZES_MS.length, 'Should test all chunk sizes')
-  t.ok(results.every(r => r.segments > 0), 'All chunk sizes should produce output')
+  t.ok(
+    results.every((r) => r.segments > 0),
+    'All chunk sizes should produce output'
+  )
 
-  try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+  try {
+    loggerBinding.releaseLogger()
+  } catch (e) {
+    /* ignore */
+  }
 })

--- a/packages/transcription-parakeet/test/integration/memory-usage.js
+++ b/packages/transcription-parakeet/test/integration/memory-usage.js
@@ -10,11 +10,11 @@ const DEFAULT_SAMPLE_INTERVAL_MS = 25
 // chance to return freed pages to the OS.
 const RECLAIM_SETTLE_MS = 250
 
-function isPositiveNumber (value) {
+function isPositiveNumber(value) {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
 }
 
-function readRssFromBareOs () {
+function readRssFromBareOs() {
   try {
     const usage = require('bare-os').memoryUsage()
     return usage && isPositiveNumber(usage.rss) ? usage.rss : 0
@@ -23,7 +23,7 @@ function readRssFromBareOs () {
   }
 }
 
-function resolveProcess () {
+function resolveProcess() {
   if (globalThis.process && typeof globalThis.process.memoryUsage === 'function') {
     return globalThis.process
   }
@@ -35,7 +35,7 @@ function resolveProcess () {
   }
 }
 
-function readRssFromProcess () {
+function readRssFromProcess() {
   try {
     const proc = resolveProcess()
     const usage = proc && proc.memoryUsage()
@@ -45,27 +45,27 @@ function readRssFromProcess () {
   }
 }
 
-function readRssBytes () {
+function readRssBytes() {
   return readRssFromBareOs() || readRssFromProcess()
 }
 
-function filterPositive (samples) {
+function filterPositive(samples) {
   return (Array.isArray(samples) ? samples : []).filter(isPositiveNumber)
 }
 
-function sumValues (values) {
+function sumValues(values) {
   return values.reduce((total, value) => total + value, 0)
 }
 
-function maxValue (values) {
+function maxValue(values) {
   return values.reduce((current, value) => (value > current ? value : current), values[0])
 }
 
-function minValue (values) {
+function minValue(values) {
   return values.reduce((current, value) => (value < current ? value : current), values[0])
 }
 
-function summarizeSamples (samples) {
+function summarizeSamples(samples) {
   const values = filterPositive(samples)
   if (values.length === 0) {
     return { count: 0, avgBytes: 0, peakBytes: 0, minBytes: 0 }
@@ -78,18 +78,18 @@ function summarizeSamples (samples) {
   }
 }
 
-function meanOfPositive (values) {
+function meanOfPositive(values) {
   const positives = filterPositive(values)
   if (positives.length === 0) return 0
   return sumValues(positives) / positives.length
 }
 
-function maxWithFloor (values, floor) {
+function maxWithFloor(values, floor) {
   const list = Array.isArray(values) ? values : []
   return list.reduce((current, value) => (value > current ? value : current), floor || 0)
 }
 
-function scheduleSample (state) {
+function scheduleSample(state) {
   state.timer = setTimeout(() => {
     if (!state.running) return
     collectSample(state)
@@ -100,20 +100,20 @@ function scheduleSample (state) {
   }
 }
 
-function collectSample (state) {
+function collectSample(state) {
   const rss = readRssBytes()
   if (rss > 0) state.samples.push(rss)
   return rss
 }
 
-function startSampler (state) {
+function startSampler(state) {
   if (state.running) return
   state.running = true
   collectSample(state)
   scheduleSample(state)
 }
 
-function stopSampler (state) {
+function stopSampler(state) {
   state.running = false
   if (state.timer) {
     clearTimeout(state.timer)
@@ -123,7 +123,7 @@ function stopSampler (state) {
   return summarizeSamples(state.samples)
 }
 
-function createMemorySampler (options) {
+function createMemorySampler(options) {
   const state = {
     intervalMs: (options && options.intervalMs) || DEFAULT_SAMPLE_INTERVAL_MS,
     samples: [],
@@ -134,15 +134,17 @@ function createMemorySampler (options) {
     start: () => startSampler(state),
     stop: () => stopSampler(state),
     sampleOnce: () => collectSample(state),
-    get samples () { return state.samples }
+    get samples() {
+      return state.samples
+    }
   }
 }
 
-function toBytes (value) {
+function toBytes(value) {
   return isPositiveNumber(value) ? value : 0
 }
 
-function computeReclaim (input) {
+function computeReclaim(input) {
   const afterLoad = toBytes(input && input.rssAfterLoadBytes)
   const peak = toBytes(input && input.peakRssBytes)
   const afterUnload = toBytes(input && input.rssAfterUnloadBytes)
@@ -154,18 +156,18 @@ function computeReclaim (input) {
   }
 }
 
-function roundTo (value, digits) {
+function roundTo(value, digits) {
   const factor = 10 ** digits
   return Math.round(value * factor) / factor
 }
 
-function bytesToMb (bytes, digits) {
+function bytesToMb(bytes, digits) {
   if (!isPositiveNumber(bytes)) return 0
   const mb = bytes / BYTES_PER_MB
   return typeof digits === 'number' ? roundTo(mb, digits) : mb
 }
 
-function buildMemorySummary (input) {
+function buildMemorySummary(input) {
   const source = input || {}
   const rssAfterLoadBytes = toBytes(source.rssAfterLoadBytes)
   const peakRssBytes = Math.max(toBytes(source.peakRssBytes), rssAfterLoadBytes)
@@ -183,46 +185,50 @@ function buildMemorySummary (input) {
   }
 }
 
-function toRunResults (runResults) {
+function toRunResults(runResults) {
   return Array.isArray(runResults) ? runResults : []
 }
 
 // Sample-count-weighted mean so runs that contributed more RSS samples carry
 // proportionally more weight; a plain mean-of-means would skew the average when
 // runs have different sample counts.
-function collectWeightedRss (runResults) {
-  return toRunResults(runResults).reduce((acc, result) => {
-    const avg = result && result.avgRssBytes
-    const count = result && result.rssSampleCount
-    if (isPositiveNumber(avg) && isPositiveNumber(count)) {
-      acc.weightedSum += avg * count
-      acc.totalCount += count
-    }
-    return acc
-  }, { weightedSum: 0, totalCount: 0 })
+function collectWeightedRss(runResults) {
+  return toRunResults(runResults).reduce(
+    (acc, result) => {
+      const avg = result && result.avgRssBytes
+      const count = result && result.rssSampleCount
+      if (isPositiveNumber(avg) && isPositiveNumber(count)) {
+        acc.weightedSum += avg * count
+        acc.totalCount += count
+      }
+      return acc
+    },
+    { weightedSum: 0, totalCount: 0 }
+  )
 }
 
-function weightedMeanBytes (runResults) {
+function weightedMeanBytes(runResults) {
   const { weightedSum, totalCount } = collectWeightedRss(runResults)
   return totalCount > 0 ? weightedSum / totalCount : 0
 }
 
-function sumSampleCounts (runResults) {
+function sumSampleCounts(runResults) {
   return toRunResults(runResults).reduce(
-    (total, result) => total + (isPositiveNumber(result && result.rssSampleCount) ? result.rssSampleCount : 0),
+    (total, result) =>
+      total + (isPositiveNumber(result && result.rssSampleCount) ? result.rssSampleCount : 0),
     0
   )
 }
 
-function peakBytesSamples (runResults) {
-  return toRunResults(runResults).map(result => result && result.peakRssBytes)
+function peakBytesSamples(runResults) {
+  return toRunResults(runResults).map((result) => result && result.peakRssBytes)
 }
 
 // Aggregates per-run RSS samplers into a single memory summary. Kept pure (no
 // model/timer access) so the weighting, the after-load fallback and the peak
 // floor are unit-testable; the live gc + settle-then-sample orchestration stays
 // in the benchmark harness.
-function summarizeRunMemory (runResults, context) {
+function summarizeRunMemory(runResults, context) {
   const ctx = context || {}
   const rssAfterLoadBytes = toBytes(ctx.rssAfterLoadBytes)
   return buildMemorySummary({

--- a/packages/transcription-parakeet/test/integration/mobile-perf-runner.js
+++ b/packages/transcription-parakeet/test/integration/mobile-perf-runner.js
@@ -31,15 +31,22 @@ const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 // to a warning instead of failing the run.
 const RELAX = proc.env && proc.env.QVAC_PARAKEET_GPU_SMOKE_RELAX === '1'
 
-function backendIdToName (id) {
+function backendIdToName(id) {
   switch (id) {
-    case 0: return 'CPU'
-    case 1: return 'Metal'
-    case 2: return 'CUDA'
-    case 3: return 'Vulkan'
-    case 4: return 'OpenCL'
-    case 99: return 'other-GPU'
-    default: return `unknown(${id})`
+    case 0:
+      return 'CPU'
+    case 1:
+      return 'Metal'
+    case 2:
+      return 'CUDA'
+    case 3:
+      return 'Vulkan'
+    case 4:
+      return 'OpenCL'
+    case 99:
+      return 'other-GPU'
+    default:
+      return `unknown(${id})`
   }
 }
 
@@ -55,7 +62,7 @@ function backendIdToName (id) {
 // to stop forcing useGPU=false there; until then Android legitimately reports
 // gpuUnsupported and runs on CPU. This assertion makes that state explicit and
 // keeps iOS (Metal) strict.
-function assertPerfBackend (t, label, useGPU, stats) {
+function assertPerfBackend(t, label, useGPU, stats) {
   if (!stats) {
     t.fail(`${label} no JobEnded stats to verify backend`)
     return
@@ -76,8 +83,9 @@ function assertPerfBackend (t, label, useGPU, stats) {
   }
 
   if (dev !== 1) {
-    const msg = `${label} expected GPU backend, got ${name} (backendDevice=${dev}). ` +
-                'useGPU=true was requested but the engine fell back to CPU.'
+    const msg =
+      `${label} expected GPU backend, got ${name} (backendDevice=${dev}). ` +
+      'useGPU=true was requested but the engine fell back to CPU.'
     if (RELAX) {
       t.comment(`WARNING (relaxed): ${msg}`)
       t.pass(`${label} perf backend check completed (relaxed)`)
@@ -94,7 +102,7 @@ function assertPerfBackend (t, label, useGPU, stats) {
   }
 }
 
-function loadSampleAudio () {
+function loadSampleAudio() {
   const samplePath = path.join(samplesDir, 'sample.raw')
   if (!fs.existsSync(samplePath)) return null
 
@@ -107,31 +115,36 @@ function loadSampleAudio () {
   return audioData
 }
 
-async function recordReclaimAfterUnload (teardownLabel, rssAfterLoadBytes, peakRssBytes) {
+async function recordReclaimAfterUnload(teardownLabel, rssAfterLoadBytes, peakRssBytes) {
   if (typeof global.gc === 'function') {
-    try { global.gc() } catch (_) {}
+    try {
+      global.gc()
+    } catch (_) {}
   }
-  await new Promise(resolve => setTimeout(resolve, RECLAIM_SETTLE_MS))
+  await new Promise((resolve) => setTimeout(resolve, RECLAIM_SETTLE_MS))
   const summary = buildMemorySummary({
     rssAfterLoadBytes,
     peakRssBytes,
     rssAfterUnloadBytes: readRssBytes()
   })
-  recordParakeetStats(teardownLabel, {}, {
-    reclaimedMb: summary.reclaimedMb,
-    rssAfterLoadMb: bytesToMb(rssAfterLoadBytes, 2)
-  })
+  recordParakeetStats(
+    teardownLabel,
+    {},
+    {
+      reclaimedMb: summary.reclaimedMb,
+      rssAfterLoadMb: bytesToMb(rssAfterLoadBytes, 2)
+    }
+  )
   console.log('   Reclaimed after unload: ' + summary.reclaimedMb + 'MB')
 }
 
-async function runMobilePerfCase (t, opts) {
+async function runMobilePerfCase(t, opts) {
   if (!opts.quant) {
     // Sweep the requested quants (default: the full q4_0/q8_0/f16 set). Callers
     // can narrow it — e.g. sortformer-streaming (v2.1) only publishes q4_0/q8_0
     // for mobile, so its perf tests pass quants: ['q4_0', 'q8_0'].
-    const quants = Array.isArray(opts.quants) && opts.quants.length > 0
-      ? opts.quants
-      : ['q4_0', 'q8_0', 'f16']
+    const quants =
+      Array.isArray(opts.quants) && opts.quants.length > 0 ? opts.quants : ['q4_0', 'q8_0', 'f16']
     for (const quant of quants) {
       await runMobilePerfCase(t, { ...opts, quant })
     }
@@ -163,7 +176,7 @@ async function runMobilePerfCase (t, opts) {
   const allResults = []
   const receivedStats = []
 
-  function finishCurrentRun () {
+  function finishCurrentRun() {
     if (outputResolve) {
       outputResolve()
       outputResolve = null
@@ -205,7 +218,7 @@ async function runMobilePerfCase (t, opts) {
       ...getNamedPathsConfig(modelType, modelPath)
     }
 
-    function outputCallback (handle, event, id, output, error) {
+    function outputCallback(handle, event, id, output, error) {
       if (event === 'Output' && Array.isArray(output)) {
         for (const segment of output) {
           if (segment && segment.text) {
@@ -231,7 +244,9 @@ async function runMobilePerfCase (t, opts) {
       console.log(`=== Transcription ${run}/${NUM_TRANSCRIPTIONS} ===`)
       const runStartTime = Date.now()
       const startResultCount = allResults.length
-      const outputPromise = new Promise(resolve => { outputResolve = resolve })
+      const outputPromise = new Promise((resolve) => {
+        outputResolve = resolve
+      })
       const memSampler = createMemorySampler()
       memSampler.start()
 
@@ -248,23 +263,33 @@ async function runMobilePerfCase (t, opts) {
       const runTime = Date.now() - runStartTime
       timings.push(runTime)
       const runResults = allResults.slice(startResultCount)
-      const runText = runResults.map(r => r.segment.text).join(' ').trim()
+      const runText = runResults
+        .map((r) => r.segment.text)
+        .join(' ')
+        .trim()
 
       console.log(`   Time: ${runTime}ms`)
       console.log(`   Segments: ${runResults.length}`)
-      console.log(`   Memory: avg ${bytesToMb(runMemory.avgBytes, 1)}MB, peak ${bytesToMb(runMemory.peakBytes, 1)}MB`)
-      console.log(`   Text preview: "${runText.substring(0, 80)}${runText.length > 80 ? '...' : ''}"`)
+      console.log(
+        `   Memory: avg ${bytesToMb(runMemory.avgBytes, 1)}MB, peak ${bytesToMb(runMemory.peakBytes, 1)}MB`
+      )
+      console.log(
+        `   Text preview: "${runText.substring(0, 80)}${runText.length > 80 ? '...' : ''}"`
+      )
 
-      const jobStats = receivedStats.length > 0
-        ? receivedStats[receivedStats.length - 1].stats
-        : null
+      const jobStats =
+        receivedStats.length > 0 ? receivedStats[receivedStats.length - 1].stats : null
       if (jobStats) {
-        recordParakeetStats(`${modelLabel} ${quantLabel} ${epLabel} mobile-perf run ${run}`, jobStats, {
-          wallMs: runTime,
-          output: runText,
-          avgRssMb: bytesToMb(runMemory.avgBytes, 2),
-          peakRssMb: bytesToMb(runMemory.peakBytes, 2)
-        })
+        recordParakeetStats(
+          `${modelLabel} ${quantLabel} ${epLabel} mobile-perf run ${run}`,
+          jobStats,
+          {
+            wallMs: runTime,
+            output: runText,
+            avgRssMb: bytesToMb(runMemory.avgBytes, 2),
+            peakRssMb: bytesToMb(runMemory.peakBytes, 2)
+          }
+        )
         if (typeof jobStats.realTimeFactor === 'number') {
           console.log(`   RTF: ${jobStats.realTimeFactor.toFixed(4)}`)
         }
@@ -272,14 +297,19 @@ async function runMobilePerfCase (t, opts) {
       console.log('')
     }
 
-    t.ok(receivedStats.length >= NUM_TRANSCRIPTIONS, `${modelLabel} ${epLabel} should receive JobEnded stats for every run (got ${receivedStats.length})`)
-    t.ok(timings.length === NUM_TRANSCRIPTIONS, `${modelLabel} ${epLabel} should complete ${NUM_TRANSCRIPTIONS} transcriptions (got ${timings.length})`)
+    t.ok(
+      receivedStats.length >= NUM_TRANSCRIPTIONS,
+      `${modelLabel} ${epLabel} should receive JobEnded stats for every run (got ${receivedStats.length})`
+    )
+    t.ok(
+      timings.length === NUM_TRANSCRIPTIONS,
+      `${modelLabel} ${epLabel} should complete ${NUM_TRANSCRIPTIONS} transcriptions (got ${timings.length})`
+    )
 
     // Verify the engine ran on the backend the case requested, instead of
     // asserting nothing about it (the previous gap called out in the ticket).
-    const lastStats = receivedStats.length > 0
-      ? receivedStats[receivedStats.length - 1].stats
-      : null
+    const lastStats =
+      receivedStats.length > 0 ? receivedStats[receivedStats.length - 1].stats : null
     assertPerfBackend(t, `${modelLabel} ${epLabel}`, useGPU, lastStats)
 
     console.log(`✅ Mobile perf case ${modelLabel} ${epLabel} completed successfully!\n`)
@@ -291,7 +321,11 @@ async function runMobilePerfCase (t, opts) {
         await parakeet.destroyInstance()
         console.log('   Instance destroyed')
         if (peakRssBytes > 0) {
-          await recordReclaimAfterUnload(`${modelLabel} ${quantLabel} ${epLabel} mobile-perf teardown`, rssAfterLoadBytes, peakRssBytes)
+          await recordReclaimAfterUnload(
+            `${modelLabel} ${quantLabel} ${epLabel} mobile-perf teardown`,
+            rssAfterLoadBytes,
+            peakRssBytes
+          )
         }
       } catch (err) {
         console.log('   Instance destroy error:', err.message)

--- a/packages/transcription-parakeet/test/integration/model-file-validation.test.js
+++ b/packages/transcription-parakeet/test/integration/model-file-validation.test.js
@@ -4,14 +4,13 @@ const test = require('brittle')
 const path = require('bare-path')
 const fs = require('bare-fs')
 const os = require('bare-os')
-const {
-  TranscriptionParakeet,
-  loadGgufOrSkip,
-  isMobile
-} = require('./helpers.js')
+const { TranscriptionParakeet, loadGgufOrSkip, isMobile } = require('./helpers.js')
 
 test('Should accept empty files map without throwing', { timeout: 60000 }, async (t) => {
-  if (isMobile) { t.pass('Skipped on mobile'); return }
+  if (isMobile) {
+    t.pass('Skipped on mobile')
+    return
+  }
 
   try {
     const model = new TranscriptionParakeet({ files: {} })
@@ -22,22 +21,32 @@ test('Should accept empty files map without throwing', { timeout: 60000 }, async
   }
 })
 
-test('Non-existent model path produces warning but does not throw', { timeout: 60000 }, async (t) => {
-  if (isMobile) { t.pass('Skipped on mobile'); return }
+test(
+  'Non-existent model path produces warning but does not throw',
+  { timeout: 60000 },
+  async (t) => {
+    if (isMobile) {
+      t.pass('Skipped on mobile')
+      return
+    }
 
-  try {
-    const model = new TranscriptionParakeet({
-      files: { model: '/this/path/definitely/does/not/exist/model.gguf' }
-    })
-    t.ok(model, 'Model instance created despite non-existent path')
-    t.pass('Non-existent path produces warning, not error')
-  } catch (error) {
-    t.fail('Should not throw for non-existent path: ' + error.message)
+    try {
+      const model = new TranscriptionParakeet({
+        files: { model: '/this/path/definitely/does/not/exist/model.gguf' }
+      })
+      t.ok(model, 'Model instance created despite non-existent path')
+      t.pass('Non-existent path produces warning, not error')
+    } catch (error) {
+      t.fail('Should not throw for non-existent path: ' + error.message)
+    }
   }
-})
+)
 
 test('Should accept a valid GGUF path and pass validation', { timeout: 60000 }, async (t) => {
-  if (isMobile) { t.pass('Skipped on mobile'); return }
+  if (isMobile) {
+    t.pass('Skipped on mobile')
+    return
+  }
 
   const ggufPath = await loadGgufOrSkip(t, 'tdt')
   if (!ggufPath) return
@@ -51,16 +60,23 @@ test('Should accept a valid GGUF path and pass validation', { timeout: 60000 }, 
   }
 })
 
-test('Validation runs in the constructor (no async load required)', { timeout: 60000 }, async (t) => {
-  if (isMobile) { t.pass('Skipped on mobile'); return }
+test(
+  'Validation runs in the constructor (no async load required)',
+  { timeout: 60000 },
+  async (t) => {
+    if (isMobile) {
+      t.pass('Skipped on mobile')
+      return
+    }
 
-  try {
-    const model = new TranscriptionParakeet({ files: {} })
-    t.ok(model, 'Constructor completes without throw')
-  } catch (error) {
-    t.fail('Constructor threw unexpectedly: ' + error.message)
+    try {
+      const model = new TranscriptionParakeet({ files: {} })
+      t.ok(model, 'Constructor completes without throw')
+    } catch (error) {
+      t.fail('Constructor threw unexpectedly: ' + error.message)
+    }
   }
-})
+)
 
 test('Provides a tmp scratch dir without polluting cwd', { timeout: 60000 }, async (t) => {
   const tmpDir = path.join(os.tmpdir(), '.parakeet-test-validation-scratch')
@@ -75,5 +91,9 @@ test('Provides a tmp scratch dir without polluting cwd', { timeout: 60000 }, asy
   const model = new TranscriptionParakeet({ files: { model: stub } })
   t.ok(model, 'Wrapper accepts a path-only configuration')
 
-  try { fs.rmSync(tmpDir, { recursive: true, force: true }) } catch (e) { /* ignore */ }
+  try {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  } catch (e) {
+    /* ignore */
+  }
 })

--- a/packages/transcription-parakeet/test/integration/multiple-transcriptions.test.js
+++ b/packages/transcription-parakeet/test/integration/multiple-transcriptions.test.js
@@ -23,7 +23,7 @@ const platform = detectPlatform()
 const { modelPath, samplesDir } = getTestPaths()
 const NO_GPU = proc.env && proc.env.NO_GPU === 'true'
 
-function loadAudio (samplePath) {
+function loadAudio(samplePath) {
   const rawBuffer = fs.readFileSync(samplePath)
   const pcmData = new Int16Array(rawBuffer.buffer, rawBuffer.byteOffset, rawBuffer.length / 2)
   const audioData = new Float32Array(pcmData.length)
@@ -31,11 +31,11 @@ function loadAudio (samplePath) {
   return audioData
 }
 
-async function transcribe (model, audio) {
+async function transcribe(model, audio) {
   const segments = []
   const response = await model.run(audio)
   await response
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const seg of items) {
         if (seg && seg.text) segments.push(seg)
@@ -49,7 +49,7 @@ const ALL_DEVICE_CONFIGS = [
   { id: 'gpu', useGPU: true },
   { id: 'cpu', useGPU: false }
 ]
-const DEVICE_CONFIGS = ALL_DEVICE_CONFIGS.filter(c => {
+const DEVICE_CONFIGS = ALL_DEVICE_CONFIGS.filter((c) => {
   if (NO_GPU && c.useGPU) return false
   if (!isMobile && c.useGPU) return false
   return true
@@ -57,7 +57,7 @@ const DEVICE_CONFIGS = ALL_DEVICE_CONFIGS.filter(c => {
 const MOBILE_PERF_MODEL_TYPES = ['tdt']
 const PERF_MODEL_TYPES = isMobile ? MOBILE_PERF_MODEL_TYPES : ['tdt']
 
-async function resolvePerfModelPath (modelType) {
+async function resolvePerfModelPath(modelType) {
   if (modelType === 'tdt') {
     const resolved = await ensureModel(modelPath)
     if (!resolved) throw new Error(`Unable to resolve model for type: ${modelType}`)
@@ -79,218 +79,244 @@ for (const modelType of PERF_MODEL_TYPES) {
     const testLabel = modelLabel ? `${modelLabel} ${epLabel}` : epLabel
     const perfLabelPrefix = modelLabel ? `${modelLabel} ${epLabel}` : epLabel
 
-    test(`Multiple consecutive transcriptions ${testLabel} should work without errors`, { timeout: 600000 }, async (t) => {
-      const NUM_TRANSCRIPTIONS = 3
-      const loggerBinding = setupJsLogger(binding)
+    test(
+      `Multiple consecutive transcriptions ${testLabel} should work without errors`,
+      { timeout: 600000 },
+      async (t) => {
+        const NUM_TRANSCRIPTIONS = 3
+        const loggerBinding = setupJsLogger(binding)
 
-      console.log('\n' + '='.repeat(60))
-      console.log(`MULTIPLE CONSECUTIVE TRANSCRIPTIONS TEST ${testLabel}`)
-      console.log('='.repeat(60))
-      console.log(` Platform: ${platform}`)
-      if (isMobile) console.log(` Model type: ${modelType}`)
-      console.log(` Number of transcriptions: ${NUM_TRANSCRIPTIONS}`)
-      console.log(` Mobile: ${isMobile}`)
-      console.log(` useGPU: ${deviceConfig.useGPU}`)
-      console.log('='.repeat(60) + '\n')
-
-      const perfModelPath = await resolvePerfModelPath(modelType)
-      console.log(` Model path: ${perfModelPath}`)
-
-      // Check sample audio exists
-      const samplePath = path.join(samplesDir, 'sample.raw')
-      if (!fs.existsSync(samplePath)) {
-        loggerBinding.releaseLogger()
-        t.pass('Test skipped - sample audio not found')
-        return
-      }
-
-      // Configuration
-      const config = {
-        modelPath: perfModelPath,
-        modelType,
-        maxThreads: 4,
-        useGPU: deviceConfig.useGPU,
-        sampleRate: 16000,
-        channels: 1,
-        ...getNamedPathsConfig(modelType, perfModelPath)
-      }
-
-      let parakeet = null
-      const allResults = []
-      // JobEnded payloads carry the C++ runtime stats (RTF, encoder/decoder ms,
-      // tokens/sec, audio duration). We collect them per run so the shared perf
-      // reporter can emit one row per transcription.
-      const receivedStats = []
-      let outputResolve = null
-
-      function finishCurrentRun () {
-        if (outputResolve) {
-          outputResolve()
-          outputResolve = null
-        }
-      }
-
-      try {
-        console.log('=== Creating instance and loading model ===')
-
-        function outputCallback (handle, event, id, output, error) {
-          if (event === 'Output' && Array.isArray(output)) {
-            for (const segment of output) {
-              if (segment && segment.text) {
-                allResults.push({ jobId: id, segment })
-              }
-            }
-          } else if (event === 'JobEnded' && output) {
-            receivedStats.push({ jobId: id, stats: output })
-            finishCurrentRun()
-          } else if (event === 'Error' || error) {
-            finishCurrentRun()
-          }
-        }
-
-        parakeet = new ParakeetInterface(binding, config, outputCallback)
-
-        await parakeet.activate()
-        console.log('   Model activated\n')
-
-        // Load audio once (read into memory)
-        const rawBuffer = fs.readFileSync(samplePath)
-        const pcmData = new Int16Array(rawBuffer.buffer, rawBuffer.byteOffset, rawBuffer.length / 2)
-        const audioData = new Float32Array(pcmData.length)
-        for (let i = 0; i < pcmData.length; i++) {
-          audioData[i] = pcmData[i] / 32768.0
-        }
-        console.log(`   Audio duration: ${(audioData.length / 16000).toFixed(2)}s\n`)
-
-        // Run multiple transcriptions
-        const timings = []
-
-        for (let run = 1; run <= NUM_TRANSCRIPTIONS; run++) {
-          console.log(`=== Transcription ${run}/${NUM_TRANSCRIPTIONS} ===`)
-          const runStartTime = Date.now()
-
-          // Clear results for this run
-          const startResultCount = allResults.length
-
-          // Track when this run completes. Mobile waits for JobEnded so the
-          // perf row has native runtime stats; desktop keeps the previous
-          // output-based behavior.
-          const outputPromise = new Promise(resolve => { outputResolve = resolve })
-          let checkInterval = null
-          if (!isMobile) {
-            checkInterval = setInterval(() => {
-              if (allResults.length > startResultCount) {
-                clearInterval(checkInterval)
-                finishCurrentRun()
-              }
-            }, 100)
-          }
-
-          // Transcribe
-          await parakeet.append({ type: 'audio', data: audioData.buffer })
-          await parakeet.append({ type: 'end of job' })
-
-          const timeout = setTimeout(() => {
-            if (checkInterval) clearInterval(checkInterval)
-            finishCurrentRun()
-          }, 600000)
-
-          await outputPromise
-          if (checkInterval) clearInterval(checkInterval)
-          clearTimeout(timeout)
-
-          const runTime = Date.now() - runStartTime
-          timings.push(runTime)
-
-          // Get results for this run
-          const runResults = allResults.slice(startResultCount)
-          const runText = runResults.map(r => r.segment.text).join(' ').trim()
-
-          console.log(`   Time: ${runTime}ms`)
-          console.log(`   Segments: ${runResults.length}`)
-          console.log(`   Text preview: "${runText.substring(0, 80)}${runText.length > 80 ? '...' : ''}"`)
-
-          // Capture this run's JobEnded stats (most recent one belongs to us
-          // because the output callback observes events in order). Wire into
-          // the shared perf reporter so the CI step summary surfaces RTF,
-          // encoder/decoder timing, tokens-per-second per device.
-          const jobStats = receivedStats.length > 0
-            ? receivedStats[receivedStats.length - 1].stats
-            : null
-          if (jobStats) {
-            try {
-              recordParakeetStats(`${perfLabelPrefix} multi-transcribe run ${run}`, jobStats, {
-                wallMs: runTime,
-                output: runText
-              })
-            } catch (err) {
-              console.log(`   [perf] recordParakeetStats failed: ${err.message}`)
-            }
-            if (typeof jobStats.realTimeFactor === 'number') {
-              console.log(`   RTF: ${jobStats.realTimeFactor.toFixed(4)}`)
-            }
-          }
-          console.log('')
-
-          if (run < NUM_TRANSCRIPTIONS) {
-            await new Promise(resolve => setTimeout(resolve, 200))
-          }
-        }
-
-        // Summary and assertions
+        console.log('\n' + '='.repeat(60))
+        console.log(`MULTIPLE CONSECUTIVE TRANSCRIPTIONS TEST ${testLabel}`)
         console.log('='.repeat(60))
-        console.log(`TEST SUMMARY ${testLabel}`)
-        console.log('='.repeat(60))
-
-        console.log('\n  Timing per run:')
-        timings.forEach((time, i) => {
-          console.log(`    Run ${i + 1}: ${time}ms`)
-        })
-
-        const avgTime = timings.reduce((a, b) => a + b, 0) / timings.length
-        console.log(`\n  Average time: ${avgTime.toFixed(0)}ms`)
-        console.log(`  Total segments: ${allResults.length}`)
+        console.log(` Platform: ${platform}`)
+        if (isMobile) console.log(` Model type: ${modelType}`)
+        console.log(` Number of transcriptions: ${NUM_TRANSCRIPTIONS}`)
+        console.log(` Mobile: ${isMobile}`)
+        console.log(` useGPU: ${deviceConfig.useGPU}`)
         console.log('='.repeat(60) + '\n')
 
-        // Assertions
-        if (isMobile) {
-          t.ok(receivedStats.length >= NUM_TRANSCRIPTIONS, `${testLabel} Should receive JobEnded stats for every run (got ${receivedStats.length})`)
-        }
-        t.ok(timings.length === NUM_TRANSCRIPTIONS, `${testLabel} Should complete ${NUM_TRANSCRIPTIONS} transcriptions (got ${timings.length})`)
+        const perfModelPath = await resolvePerfModelPath(modelType)
+        console.log(` Model path: ${perfModelPath}`)
 
-        // Verify each run produced output when the model emits textual segments.
-        const runsWithOutput = new Set(allResults.map(r => r.jobId)).size
-        if (allResults.length > 0) {
-          if (isMobile) {
-            t.ok(runsWithOutput <= NUM_TRANSCRIPTIONS, `${testLabel} Output job IDs are bounded by run count`)
-          } else {
-            t.ok(runsWithOutput === NUM_TRANSCRIPTIONS, `${epLabel} Multiple runs should produce output for every job (got ${runsWithOutput}/${NUM_TRANSCRIPTIONS} unique job IDs)`)
-          }
-        } else {
-          console.log(`   ${testLabel} produced runtime stats without textual output`)
-        }
-
-        console.log(`✅ Multiple transcriptions test ${testLabel} completed successfully!\n`)
-      } finally {
-        // Cleanup
-        console.log('=== Cleanup ===')
-        finishCurrentRun()
-        if (parakeet) {
-          try {
-            await parakeet.destroyInstance()
-            console.log('   Instance destroyed')
-          } catch (e) {
-            console.log('   Instance destroy error:', e.message)
-          }
-        }
-        try {
+        // Check sample audio exists
+        const samplePath = path.join(samplesDir, 'sample.raw')
+        if (!fs.existsSync(samplePath)) {
           loggerBinding.releaseLogger()
-          console.log('   Logger released')
-        } catch (e) {
-          console.log('   Logger release error:', e.message)
+          t.pass('Test skipped - sample audio not found')
+          return
+        }
+
+        // Configuration
+        const config = {
+          modelPath: perfModelPath,
+          modelType,
+          maxThreads: 4,
+          useGPU: deviceConfig.useGPU,
+          sampleRate: 16000,
+          channels: 1,
+          ...getNamedPathsConfig(modelType, perfModelPath)
+        }
+
+        let parakeet = null
+        const allResults = []
+        // JobEnded payloads carry the C++ runtime stats (RTF, encoder/decoder ms,
+        // tokens/sec, audio duration). We collect them per run so the shared perf
+        // reporter can emit one row per transcription.
+        const receivedStats = []
+        let outputResolve = null
+
+        function finishCurrentRun() {
+          if (outputResolve) {
+            outputResolve()
+            outputResolve = null
+          }
+        }
+
+        try {
+          console.log('=== Creating instance and loading model ===')
+
+          function outputCallback(handle, event, id, output, error) {
+            if (event === 'Output' && Array.isArray(output)) {
+              for (const segment of output) {
+                if (segment && segment.text) {
+                  allResults.push({ jobId: id, segment })
+                }
+              }
+            } else if (event === 'JobEnded' && output) {
+              receivedStats.push({ jobId: id, stats: output })
+              finishCurrentRun()
+            } else if (event === 'Error' || error) {
+              finishCurrentRun()
+            }
+          }
+
+          parakeet = new ParakeetInterface(binding, config, outputCallback)
+
+          await parakeet.activate()
+          console.log('   Model activated\n')
+
+          // Load audio once (read into memory)
+          const rawBuffer = fs.readFileSync(samplePath)
+          const pcmData = new Int16Array(
+            rawBuffer.buffer,
+            rawBuffer.byteOffset,
+            rawBuffer.length / 2
+          )
+          const audioData = new Float32Array(pcmData.length)
+          for (let i = 0; i < pcmData.length; i++) {
+            audioData[i] = pcmData[i] / 32768.0
+          }
+          console.log(`   Audio duration: ${(audioData.length / 16000).toFixed(2)}s\n`)
+
+          // Run multiple transcriptions
+          const timings = []
+
+          for (let run = 1; run <= NUM_TRANSCRIPTIONS; run++) {
+            console.log(`=== Transcription ${run}/${NUM_TRANSCRIPTIONS} ===`)
+            const runStartTime = Date.now()
+
+            // Clear results for this run
+            const startResultCount = allResults.length
+
+            // Track when this run completes. Mobile waits for JobEnded so the
+            // perf row has native runtime stats; desktop keeps the previous
+            // output-based behavior.
+            const outputPromise = new Promise((resolve) => {
+              outputResolve = resolve
+            })
+            let checkInterval = null
+            if (!isMobile) {
+              checkInterval = setInterval(() => {
+                if (allResults.length > startResultCount) {
+                  clearInterval(checkInterval)
+                  finishCurrentRun()
+                }
+              }, 100)
+            }
+
+            // Transcribe
+            await parakeet.append({ type: 'audio', data: audioData.buffer })
+            await parakeet.append({ type: 'end of job' })
+
+            const timeout = setTimeout(() => {
+              if (checkInterval) clearInterval(checkInterval)
+              finishCurrentRun()
+            }, 600000)
+
+            await outputPromise
+            if (checkInterval) clearInterval(checkInterval)
+            clearTimeout(timeout)
+
+            const runTime = Date.now() - runStartTime
+            timings.push(runTime)
+
+            // Get results for this run
+            const runResults = allResults.slice(startResultCount)
+            const runText = runResults
+              .map((r) => r.segment.text)
+              .join(' ')
+              .trim()
+
+            console.log(`   Time: ${runTime}ms`)
+            console.log(`   Segments: ${runResults.length}`)
+            console.log(
+              `   Text preview: "${runText.substring(0, 80)}${runText.length > 80 ? '...' : ''}"`
+            )
+
+            // Capture this run's JobEnded stats (most recent one belongs to us
+            // because the output callback observes events in order). Wire into
+            // the shared perf reporter so the CI step summary surfaces RTF,
+            // encoder/decoder timing, tokens-per-second per device.
+            const jobStats =
+              receivedStats.length > 0 ? receivedStats[receivedStats.length - 1].stats : null
+            if (jobStats) {
+              try {
+                recordParakeetStats(`${perfLabelPrefix} multi-transcribe run ${run}`, jobStats, {
+                  wallMs: runTime,
+                  output: runText
+                })
+              } catch (err) {
+                console.log(`   [perf] recordParakeetStats failed: ${err.message}`)
+              }
+              if (typeof jobStats.realTimeFactor === 'number') {
+                console.log(`   RTF: ${jobStats.realTimeFactor.toFixed(4)}`)
+              }
+            }
+            console.log('')
+
+            if (run < NUM_TRANSCRIPTIONS) {
+              await new Promise((resolve) => setTimeout(resolve, 200))
+            }
+          }
+
+          // Summary and assertions
+          console.log('='.repeat(60))
+          console.log(`TEST SUMMARY ${testLabel}`)
+          console.log('='.repeat(60))
+
+          console.log('\n  Timing per run:')
+          timings.forEach((time, i) => {
+            console.log(`    Run ${i + 1}: ${time}ms`)
+          })
+
+          const avgTime = timings.reduce((a, b) => a + b, 0) / timings.length
+          console.log(`\n  Average time: ${avgTime.toFixed(0)}ms`)
+          console.log(`  Total segments: ${allResults.length}`)
+          console.log('='.repeat(60) + '\n')
+
+          // Assertions
+          if (isMobile) {
+            t.ok(
+              receivedStats.length >= NUM_TRANSCRIPTIONS,
+              `${testLabel} Should receive JobEnded stats for every run (got ${receivedStats.length})`
+            )
+          }
+          t.ok(
+            timings.length === NUM_TRANSCRIPTIONS,
+            `${testLabel} Should complete ${NUM_TRANSCRIPTIONS} transcriptions (got ${timings.length})`
+          )
+
+          // Verify each run produced output when the model emits textual segments.
+          const runsWithOutput = new Set(allResults.map((r) => r.jobId)).size
+          if (allResults.length > 0) {
+            if (isMobile) {
+              t.ok(
+                runsWithOutput <= NUM_TRANSCRIPTIONS,
+                `${testLabel} Output job IDs are bounded by run count`
+              )
+            } else {
+              t.ok(
+                runsWithOutput === NUM_TRANSCRIPTIONS,
+                `${epLabel} Multiple runs should produce output for every job (got ${runsWithOutput}/${NUM_TRANSCRIPTIONS} unique job IDs)`
+              )
+            }
+          } else {
+            console.log(`   ${testLabel} produced runtime stats without textual output`)
+          }
+
+          console.log(`✅ Multiple transcriptions test ${testLabel} completed successfully!\n`)
+        } finally {
+          // Cleanup
+          console.log('=== Cleanup ===')
+          finishCurrentRun()
+          if (parakeet) {
+            try {
+              await parakeet.destroyInstance()
+              console.log('   Instance destroyed')
+            } catch (e) {
+              console.log('   Instance destroy error:', e.message)
+            }
+          }
+          try {
+            loggerBinding.releaseLogger()
+            console.log('   Logger released')
+          } catch (e) {
+            console.log('   Logger release error:', e.message)
+          }
         }
       }
-    })
+    )
   }
 }
 
@@ -298,82 +324,100 @@ for (const modelType of PERF_MODEL_TYPES) {
  * Test that creating fresh model instances for each transcription
  * works correctly. Simulates app-restart scenarios.
  */
-test('Fresh model instance per transcription (app restart simulation)', { timeout: 600000 }, async (t) => {
-  const NUM_INSTANCES = 2
-  const loggerBinding = setupJsLogger(binding)
+test(
+  'Fresh model instance per transcription (app restart simulation)',
+  { timeout: 600000 },
+  async (t) => {
+    const NUM_INSTANCES = 2
+    const loggerBinding = setupJsLogger(binding)
 
-  console.log('\n' + '='.repeat(60))
-  console.log('FRESH INSTANCE PER TRANSCRIPTION TEST')
-  console.log('='.repeat(60))
-  console.log(` Platform: ${platform}`)
-  console.log(` Instances to create: ${NUM_INSTANCES}`)
-  console.log('='.repeat(60) + '\n')
+    console.log('\n' + '='.repeat(60))
+    console.log('FRESH INSTANCE PER TRANSCRIPTION TEST')
+    console.log('='.repeat(60))
+    console.log(` Platform: ${platform}`)
+    console.log(` Instances to create: ${NUM_INSTANCES}`)
+    console.log('='.repeat(60) + '\n')
 
-  const stagedGguf = await loadGgufOrSkip(t)
-  if (!stagedGguf) return
+    const stagedGguf = await loadGgufOrSkip(t)
+    if (!stagedGguf) return
 
-  const samplePath = path.join(samplesDir, 'sample.raw')
-  if (!fs.existsSync(samplePath)) {
-    loggerBinding.releaseLogger()
-    t.pass('Test skipped - sample audio not found')
-    return
-  }
+    const samplePath = path.join(samplesDir, 'sample.raw')
+    if (!fs.existsSync(samplePath)) {
+      loggerBinding.releaseLogger()
+      t.pass('Test skipped - sample audio not found')
+      return
+    }
 
-  const audioData = loadAudio(samplePath)
-  const results = []
+    const audioData = loadAudio(samplePath)
+    const results = []
 
-  for (let instance = 1; instance <= NUM_INSTANCES; instance++) {
-    console.log(`--- Instance ${instance}/${NUM_INSTANCES} ---`)
-    const instanceStartTime = Date.now()
+    for (let instance = 1; instance <= NUM_INSTANCES; instance++) {
+      console.log(`--- Instance ${instance}/${NUM_INSTANCES} ---`)
+      const instanceStartTime = Date.now()
 
-    const model = new TranscriptionParakeet({
-      files: { model: stagedGguf },
-      config: { parakeetConfig: { maxThreads: 4, useGPU: false } }
-    })
-    try {
-      await model.load()
-      const loadTime = Date.now() - instanceStartTime
-
-      const segments = await transcribe(model, audioData)
-      const totalTime = Date.now() - instanceStartTime
-      const transcriptionTime = totalTime - loadTime
-      const fullText = segments.map(s => s.text).join(' ').trim()
-
-      console.log(`   Load time: ${loadTime}ms`)
-      console.log(`   Transcription time: ${transcriptionTime}ms`)
-      console.log(`   Total time: ${totalTime}ms`)
-      console.log(`   Segments: ${segments.length}\n`)
-
-      results.push({
-        loadTime,
-        transcriptionTime,
-        totalTime,
-        segmentCount: segments.length,
-        textLength: fullText.length
+      const model = new TranscriptionParakeet({
+        files: { model: stagedGguf },
+        config: { parakeetConfig: { maxThreads: 4, useGPU: false } }
       })
-    } finally {
-      try { await model.unload() } catch (e) { /* ignore */ }
+      try {
+        await model.load()
+        const loadTime = Date.now() - instanceStartTime
+
+        const segments = await transcribe(model, audioData)
+        const totalTime = Date.now() - instanceStartTime
+        const transcriptionTime = totalTime - loadTime
+        const fullText = segments
+          .map((s) => s.text)
+          .join(' ')
+          .trim()
+
+        console.log(`   Load time: ${loadTime}ms`)
+        console.log(`   Transcription time: ${transcriptionTime}ms`)
+        console.log(`   Total time: ${totalTime}ms`)
+        console.log(`   Segments: ${segments.length}\n`)
+
+        results.push({
+          loadTime,
+          transcriptionTime,
+          totalTime,
+          segmentCount: segments.length,
+          textLength: fullText.length
+        })
+      } finally {
+        try {
+          await model.unload()
+        } catch (e) {
+          /* ignore */
+        }
+      }
+
+      if (instance < NUM_INSTANCES) {
+        await new Promise((resolve) => setTimeout(resolve, 500))
+      }
     }
 
-    if (instance < NUM_INSTANCES) {
-      await new Promise(resolve => setTimeout(resolve, 500))
+    console.log('='.repeat(60))
+    console.log('FRESH INSTANCE SUMMARY')
+    console.log('='.repeat(60))
+    results.forEach((r, i) => {
+      console.log(`  Instance ${i + 1}:`)
+      console.log(`    Load: ${r.loadTime}ms`)
+      console.log(`    Transcribe: ${r.transcriptionTime}ms`)
+      console.log(`    Total: ${r.totalTime}ms`)
+      console.log(`    Segments: ${r.segmentCount}`)
+    })
+    console.log('='.repeat(60) + '\n')
+
+    t.ok(results.length === NUM_INSTANCES, `Created ${NUM_INSTANCES} fresh model instances`)
+    t.ok(
+      results.every((r) => r.segmentCount > 0),
+      'All instances should produce segments'
+    )
+
+    try {
+      loggerBinding.releaseLogger()
+    } catch (e) {
+      /* ignore */
     }
   }
-
-  console.log('='.repeat(60))
-  console.log('FRESH INSTANCE SUMMARY')
-  console.log('='.repeat(60))
-  results.forEach((r, i) => {
-    console.log(`  Instance ${i + 1}:`)
-    console.log(`    Load: ${r.loadTime}ms`)
-    console.log(`    Transcribe: ${r.transcriptionTime}ms`)
-    console.log(`    Total: ${r.totalTime}ms`)
-    console.log(`    Segments: ${r.segmentCount}`)
-  })
-  console.log('='.repeat(60) + '\n')
-
-  t.ok(results.length === NUM_INSTANCES, `Created ${NUM_INSTANCES} fresh model instances`)
-  t.ok(results.every(r => r.segmentCount > 0), 'All instances should produce segments')
-
-  try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
-})
+)

--- a/packages/transcription-parakeet/test/integration/run-with-exit.js
+++ b/packages/transcription-parakeet/test/integration/run-with-exit.js
@@ -19,7 +19,7 @@ require('./all.js')
 
 const RUNNER = Symbol.for('brittle-runner')
 
-function writeExitCode () {
+function writeExitCode() {
   let code = 0
   if (global.Bare && global.Bare.exitCode !== undefined) code = global.Bare.exitCode
   try {
@@ -31,7 +31,10 @@ let lastCount = 0
 let stableTicks = 0
 let done = false
 const stabilityPoll = setInterval(function () {
-  if (done) { clearInterval(stabilityPoll); return }
+  if (done) {
+    clearInterval(stabilityPoll)
+    return
+  }
   const runner = global[RUNNER]
   if (!runner || !runner.started) return
 
@@ -46,6 +49,8 @@ const stabilityPoll = setInterval(function () {
   if (stableTicks >= 3) {
     done = true
     clearInterval(stabilityPoll)
-    try { runner.end() } catch (e) {}
+    try {
+      runner.end()
+    } catch (e) {}
   }
 }, 5000)

--- a/packages/transcription-parakeet/test/integration/sortformer-aosc-streaming.test.js
+++ b/packages/transcription-parakeet/test/integration/sortformer-aosc-streaming.test.js
@@ -46,49 +46,61 @@ const SAMPLE_RATE = 16000
 const STREAM_CHUNK_MS = 2000
 const FEED_CHUNK_MS = 500
 
-function loadAudioSample () {
+function loadAudioSample() {
   const samplePath = path.join(samplesDir, 'sample.raw')
   if (!fs.existsSync(samplePath)) return null
   const rawBuffer = fs.readFileSync(samplePath)
-  const pcm = new Int16Array(
-    rawBuffer.buffer, rawBuffer.byteOffset, rawBuffer.length / 2)
+  const pcm = new Int16Array(rawBuffer.buffer, rawBuffer.byteOffset, rawBuffer.length / 2)
   const audio = new Float32Array(pcm.length)
   for (let i = 0; i < pcm.length; i++) audio[i] = pcm[i] / 32768.0
   return audio
 }
 
-function pushableStream () {
+function pushableStream() {
   const queue = []
   let waiter = null
   let ended = false
   return {
-    push (chunk) {
+    push(chunk) {
       if (ended) return
       queue.push(chunk)
-      if (waiter) { const w = waiter; waiter = null; w() }
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w()
+      }
     },
-    end () {
+    end() {
       ended = true
-      if (waiter) { const w = waiter; waiter = null; w() }
+      if (waiter) {
+        const w = waiter
+        waiter = null
+        w()
+      }
     },
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       while (true) {
-        if (queue.length > 0) { yield queue.shift(); continue }
+        if (queue.length > 0) {
+          yield queue.shift()
+          continue
+        }
         if (ended) return
-        await new Promise(resolve => { waiter = resolve })
+        await new Promise((resolve) => {
+          waiter = resolve
+        })
       }
     }
   }
 }
 
-async function feedAndCollect (model, audio) {
+async function feedAndCollect(model, audio) {
   const samplesPerChunk = Math.floor((FEED_CHUNK_MS / 1000) * SAMPLE_RATE)
   const stream = pushableStream()
   const segments = []
 
   const response = await model.runStreaming(stream)
   const updateDone = response
-    .onUpdate(out => {
+    .onUpdate((out) => {
       const items = Array.isArray(out) ? out : [out]
       for (const seg of items) {
         if (!seg || !seg.text) continue
@@ -102,7 +114,7 @@ async function feedAndCollect (model, audio) {
     const chunk = new Float32Array(audio.slice(i, endIdx))
     stream.push(chunk)
     if (i + samplesPerChunk < audio.length) {
-      await new Promise(resolve => setTimeout(resolve, FEED_CHUNK_MS))
+      await new Promise((resolve) => setTimeout(resolve, FEED_CHUNK_MS))
     }
   }
   stream.end()
@@ -115,13 +127,15 @@ async function feedAndCollect (model, audio) {
 // the text doesn't match (e.g. silence sentinels). Mirrors the parser
 // used by examples/live-mic-diarized.js so the assertion below stays
 // in sync with the actual contract consumers rely on.
-function parseSpeakerId (text) {
+function parseSpeakerId(text) {
   const m = typeof text === 'string' ? text.match(/Speaker\s+(\d+)/) : null
   return m ? parseInt(m[1], 10) : -1
 }
 
-test('Sortformer v2.1 AOSC — default config streams diarization segments',
-  { timeout: 600000 }, async (t) => {
+test(
+  'Sortformer v2.1 AOSC — default config streams diarization segments',
+  { timeout: 600000 },
+  async (t) => {
     const loggerBinding = setupJsLogger(binding)
 
     try {
@@ -129,7 +143,10 @@ test('Sortformer v2.1 AOSC — default config streams diarization segments',
       if (!modelPath) return
 
       const audio = loadAudioSample()
-      if (!audio) { t.pass('sample.raw not found - skipping'); return }
+      if (!audio) {
+        t.pass('sample.raw not found - skipping')
+        return
+      }
 
       const model = new TranscriptionParakeet({
         files: { model: modelPath },
@@ -149,29 +166,40 @@ test('Sortformer v2.1 AOSC — default config streams diarization segments',
         await model.load()
         const segments = await feedAndCollect(model, audio)
 
-        t.ok(segments.length > 0,
-          `AOSC streaming should emit at least one segment (got ${segments.length})`)
+        t.ok(
+          segments.length > 0,
+          `AOSC streaming should emit at least one segment (got ${segments.length})`
+        )
 
-        const speakerIds = segments
-          .map(s => parseSpeakerId(s.text))
-          .filter(id => id >= 0)
-        t.ok(speakerIds.length > 0,
-          'segments should match the "Speaker N: ..." format')
+        const speakerIds = segments.map((s) => parseSpeakerId(s.text)).filter((id) => id >= 0)
+        t.ok(speakerIds.length > 0, 'segments should match the "Speaker N: ..." format')
 
         const distinctIds = new Set(speakerIds)
         console.log(
           `[aosc/default] segments=${segments.length} ` +
-          `speakers=${distinctIds.size} ids=[${[...distinctIds].sort().join(',')}]`)
+            `speakers=${distinctIds.size} ids=[${[...distinctIds].sort().join(',')}]`
+        )
       } finally {
-        try { await model.unload() } catch (e) { /* ignore */ }
+        try {
+          await model.unload()
+        } catch (e) {
+          /* ignore */
+        }
       }
     } finally {
-      try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
     }
-  })
+  }
+)
 
-test('Sortformer v2.1 AOSC — streamingSpkCacheEnable=false falls back to v1 path',
-  { timeout: 600000 }, async (t) => {
+test(
+  'Sortformer v2.1 AOSC — streamingSpkCacheEnable=false falls back to v1 path',
+  { timeout: 600000 },
+  async (t) => {
     const loggerBinding = setupJsLogger(binding)
 
     try {
@@ -179,7 +207,10 @@ test('Sortformer v2.1 AOSC — streamingSpkCacheEnable=false falls back to v1 pa
       if (!modelPath) return
 
       const audio = loadAudioSample()
-      if (!audio) { t.pass('sample.raw not found - skipping'); return }
+      if (!audio) {
+        t.pass('sample.raw not found - skipping')
+        return
+      }
 
       const model = new TranscriptionParakeet({
         files: { model: modelPath },
@@ -202,21 +233,28 @@ test('Sortformer v2.1 AOSC — streamingSpkCacheEnable=false falls back to v1 pa
         await model.load()
         const segments = await feedAndCollect(model, audio)
 
-        t.ok(segments.length > 0,
-          'v1-path streaming should still emit at least one segment ' +
-          `(got ${segments.length})`)
+        t.ok(
+          segments.length > 0,
+          'v1-path streaming should still emit at least one segment ' + `(got ${segments.length})`
+        )
 
-        const speakerIds = segments
-          .map(s => parseSpeakerId(s.text))
-          .filter(id => id >= 0)
-        t.ok(speakerIds.length > 0,
-          'segments should match the "Speaker N: ..." format')
+        const speakerIds = segments.map((s) => parseSpeakerId(s.text)).filter((id) => id >= 0)
+        t.ok(speakerIds.length > 0, 'segments should match the "Speaker N: ..." format')
 
         console.log(`[aosc/disabled] segments=${segments.length}`)
       } finally {
-        try { await model.unload() } catch (e) { /* ignore */ }
+        try {
+          await model.unload()
+        } catch (e) {
+          /* ignore */
+        }
       }
     } finally {
-      try { loggerBinding.releaseLogger() } catch (e) { /* ignore */ }
+      try {
+        loggerBinding.releaseLogger()
+      } catch (e) {
+        /* ignore */
+      }
     }
-  })
+  }
+)

--- a/packages/transcription-parakeet/test/integration/sortformer-streaming-alias.test.js
+++ b/packages/transcription-parakeet/test/integration/sortformer-streaming-alias.test.js
@@ -39,10 +39,16 @@ test('sortformer-streaming alias resolves to the sortformerStreaming config key'
 })
 
 test('sortformer-streaming derives the canonical QVAC_TEST_GGUF env-key', (t) => {
-  t.is(testGgufEnvKey(ALIAS), 'QVAC_TEST_GGUF_SORTFORMERSTREAMING',
-    'env-key uses the canonical key, not the hyphenated alias')
-  t.is(testGgufEnvKey(ALIAS), testGgufEnvKey(CANONICAL),
-    'alias and canonical token derive the same env-key')
+  t.is(
+    testGgufEnvKey(ALIAS),
+    'QVAC_TEST_GGUF_SORTFORMERSTREAMING',
+    'env-key uses the canonical key, not the hyphenated alias'
+  )
+  t.is(
+    testGgufEnvKey(ALIAS),
+    testGgufEnvKey(CANONICAL),
+    'alias and canonical token derive the same env-key'
+  )
 })
 
 test('ensureGgufForType(sortformer-streaming) resolves via the canonical env-key override', async (t) => {
@@ -58,7 +64,9 @@ test('ensureGgufForType(sortformer-streaming) resolves via the canonical env-key
   t.teardown(() => {
     if (previous === undefined) delete process.env[envKey]
     else process.env[envKey] = previous
-    try { fs.unlinkSync(sentinel) } catch (_) {}
+    try {
+      fs.unlinkSync(sentinel)
+    } catch (_) {}
   })
 
   const viaAlias = await ensureGgufForType(ALIAS)

--- a/packages/transcription-parakeet/test/mocks/MockedBinding.js
+++ b/packages/transcription-parakeet/test/mocks/MockedBinding.js
@@ -10,7 +10,7 @@ const state = Object.freeze({
 })
 
 class MockedBinding {
-  constructor () {
+  constructor() {
     this._handle = null
     this._state = state.LOADING
     this._busy = false
@@ -38,7 +38,7 @@ class MockedBinding {
     }
   }
 
-  createInstance (interfaceType, configurationParams, outputCb, transitionCb = null) {
+  createInstance(interfaceType, configurationParams, outputCb, transitionCb = null) {
     console.log('Constructing the parakeet addon (ggml backend)')
     this._interfaceType = interfaceType
     this._config = configurationParams
@@ -48,13 +48,13 @@ class MockedBinding {
     return this._handle
   }
 
-  _callCallbacks (event, output, error = null) {
+  _callCallbacks(event, output, error = null) {
     if (this.outputCb) {
       this.outputCb(this, event, output, error)
     }
   }
 
-  loadWeights (handle, data) {
+  loadWeights(handle, data) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     // Real binding accepts a single GGUF byte stream (`{ filename,
     // chunk, completed }`). The mock just logs the filename to
@@ -63,7 +63,7 @@ class MockedBinding {
     return true
   }
 
-  activate (handle) {
+  activate(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Activated the addon')
     this._state = state.LISTENING
@@ -73,7 +73,7 @@ class MockedBinding {
     }
   }
 
-  pause (handle) {
+  pause(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Paused the processing')
     this._state = state.PAUSED
@@ -82,7 +82,7 @@ class MockedBinding {
     }
   }
 
-  stop (handle) {
+  stop(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Stopped the processing')
     this._state = state.STOPPED
@@ -91,7 +91,7 @@ class MockedBinding {
     }
   }
 
-  cancel (handle) {
+  cancel(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Cancel job')
     this._runToken++
@@ -115,7 +115,7 @@ class MockedBinding {
   // real binding would; endStreaming is intentionally side-effect-free
   // because the JS wrapper synthesises its own JobEnded (see
   // parakeet.js).
-  startStreaming (handle, config = {}) {
+  startStreaming(handle, config = {}) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     if (this._streamingActive) {
       throw new Error('Streaming session already active for this instance')
@@ -128,7 +128,7 @@ class MockedBinding {
     return true
   }
 
-  appendStreamingAudio (handle, data) {
+  appendStreamingAudio(handle, data) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     if (!this._streamingActive) {
       throw new Error('No active streaming session for this instance')
@@ -145,26 +145,34 @@ class MockedBinding {
     const endS = ((chunkIndex + 1) * audioLength) / sampleRate
     process.nextTick(() => {
       if (!this._streamingActive) return
-      this._callCallbacks('Output', [{
-        text: `Mock streaming chunk ${chunkIndex}`,
-        start: startS,
-        end: endS,
-        toAppend: true,
-        isEndOfTurn: false,
-        startsWord: chunkIndex === 0
-      }], null)
+      this._callCallbacks(
+        'Output',
+        [
+          {
+            text: `Mock streaming chunk ${chunkIndex}`,
+            start: startS,
+            end: endS,
+            toAppend: true,
+            isEndOfTurn: false,
+            startsWord: chunkIndex === 0
+          }
+        ],
+        null
+      )
     })
     return true
   }
 
-  endStreaming (handle) {
+  endStreaming(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     if (!this._streamingActive) {
       return { cleaned: false, audioDurationMs: 0, totalSamples: 0 }
     }
-    const samplesFed = this._streamingLog.appended *
-      (this._streamingConfig?.sampleRate || 16000) *
-      (this._streamingConfig?.chunkMs || 1000) / 1000
+    const samplesFed =
+      (this._streamingLog.appended *
+        (this._streamingConfig?.sampleRate || 16000) *
+        (this._streamingConfig?.chunkMs || 1000)) /
+      1000
     this._streamingActive = false
     this._streamingChunkIndex = 0
     this._streamingConfig = null
@@ -176,12 +184,12 @@ class MockedBinding {
     }
   }
 
-  status (handle) {
+  status(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     return this._state
   }
 
-  runJob (handle, data) {
+  runJob(handle, data) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     if (this._busy) {
       return false
@@ -202,9 +210,12 @@ class MockedBinding {
     process.nextTick(() => {
       if (runToken !== this._runToken) return
 
-      const audioLength = data.input.length ?? (data.input.byteLength / 4)
+      const audioLength = data.input.length ?? data.input.byteLength / 4
       const mockTranscription = {
-        text: audioLength > 0 ? `Mock transcription for ${audioLength} samples of audio` : '[No speech detected]',
+        text:
+          audioLength > 0
+            ? `Mock transcription for ${audioLength} samples of audio`
+            : '[No speech detected]',
         start: 0,
         end: audioLength / 16000,
         toAppend: true
@@ -215,22 +226,26 @@ class MockedBinding {
       // emits (see addon/src/model-interface/parakeet/ParakeetModel.cpp)
       // so tests inspecting stats see the GGUF-backend shape.
       const audioDurationMs = Math.floor((audioLength / 16000) * 1000)
-      this._callCallbacks('RuntimeStats', {
-        processCalls: 1,
-        totalSamples: audioLength,
-        totalTokens: 0,
-        totalTranscriptions: 1,
-        totalWallMs: 1,
-        totalTime: 1,
-        modelLoadMs: 0,
-        encoderMs: 1,
-        decoderMs: 0,
-        melSpecMs: 0,
-        totalEncodedFrames: 0,
-        audioDurationMs,
-        backendDevice: 0,
-        backendId: 0
-      }, null)
+      this._callCallbacks(
+        'RuntimeStats',
+        {
+          processCalls: 1,
+          totalSamples: audioLength,
+          totalTokens: 0,
+          totalTranscriptions: 1,
+          totalWallMs: 1,
+          totalTime: 1,
+          modelLoadMs: 0,
+          encoderMs: 1,
+          decoderMs: 0,
+          melSpecMs: 0,
+          totalEncodedFrames: 0,
+          audioDurationMs,
+          backendDevice: 0,
+          backendId: 0
+        },
+        null
+      )
       this._busy = false
       this._state = state.LISTENING
       if (this.transitionCb) this.transitionCb(this, this._state)
@@ -239,7 +254,7 @@ class MockedBinding {
     return true
   }
 
-  load (handle, configurationParams) {
+  load(handle, configurationParams) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Loaded configuration:', configurationParams)
     this._state = state.LOADING
@@ -248,7 +263,7 @@ class MockedBinding {
     }
   }
 
-  reload (handle, configurationParams) {
+  reload(handle, configurationParams) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Reloaded configuration:', configurationParams)
     this._runToken++
@@ -266,7 +281,7 @@ class MockedBinding {
     })
   }
 
-  unload (handle) {
+  unload(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Unloaded the addon')
     this._state = state.IDLE
@@ -275,21 +290,21 @@ class MockedBinding {
     }
   }
 
-  setLogger (callback) {
+  setLogger(callback) {
     console.log('Set logger')
   }
 
-  releaseLogger () {
+  releaseLogger() {
     console.log('Released logger')
   }
 
-  unloadWeights (handle) {
+  unloadWeights(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     console.log('Unloaded weights')
     return true
   }
 
-  destroyInstance (handle) {
+  destroyInstance(handle) {
     if (handle !== this._handle) throw new Error('Invalid handle')
     this._runToken++
     this._busy = false

--- a/packages/transcription-parakeet/test/mocks/utils.js
+++ b/packages/transcription-parakeet/test/mocks/utils.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // A helper function to wait a short time (to allow setImmediate callbacks to fire).
-const wait = (ms = 20) => new Promise(resolve => setTimeout(resolve, ms))
+const wait = (ms = 20) => new Promise((resolve) => setTimeout(resolve, ms))
 
 // Transition callback to log state changes.
 const transitionCb = (instance, newState) => {

--- a/packages/transcription-parakeet/test/unit/addon.test.js
+++ b/packages/transcription-parakeet/test/unit/addon.test.js
@@ -9,7 +9,7 @@ const { ParakeetInterface } = require('../../parakeet')
 const process = require('bare-process')
 global.process = process
 
-function createMockedModel ({ onOutput = () => { }, binding = undefined } = {}) {
+function createMockedModel({ onOutput = () => {}, binding = undefined } = {}) {
   TranscriptionParakeet.prototype.validateModelFiles = () => undefined
 
   const model = new TranscriptionParakeet({
@@ -25,12 +25,17 @@ function createMockedModel ({ onOutput = () => { }, binding = undefined } = {}) 
     }
   })
 
-  model._createAddon = configurationParams => {
+  model._createAddon = (configurationParams) => {
     const _binding = binding || new MockedBinding()
-    const addon = new ParakeetInterface(_binding, configurationParams, (addon, event, jobId, output, error) => {
-      model._outputCallback(addon, event, jobId, output, error)
-      onOutput(addon, event, jobId, output, error)
-    }, transitionCb)
+    const addon = new ParakeetInterface(
+      _binding,
+      configurationParams,
+      (addon, event, jobId, output, error) => {
+        model._outputCallback(addon, event, jobId, output, error)
+        onOutput(addon, event, jobId, output, error)
+      },
+      transitionCb
+    )
 
     return addon
   }
@@ -62,13 +67,13 @@ test('Inference returns correct output for audio input', async (t) => {
   await wait()
 
   // Check that we received an Output event for the audio chunk.
-  const outputEvent = events.find(e => e.event === 'Output' && e.jobId === 1)
+  const outputEvent = events.find((e) => e.event === 'Output' && e.jobId === 1)
   t.ok(outputEvent, 'Should receive an Output event for the audio chunk')
   t.ok(outputEvent.output, 'Output event should have output property')
   t.ok(Array.isArray(outputEvent.output), 'Output should be an array of segments')
 
   // Check that we received a JobEnded event.
-  const jobEndedEvent = events.find(e => e.event === 'JobEnded' && e.jobId === 1)
+  const jobEndedEvent = events.find((e) => e.event === 'JobEnded' && e.jobId === 1)
   t.ok(jobEndedEvent, 'Should receive a JobEnded event for job 1')
 })
 
@@ -84,16 +89,16 @@ test('Model state transitions are handled correctly', async (t) => {
   const response = await model.run(sampleAudio)
   await response._finishPromise
 
-  t.ok(await model.status() === 'listening', 'Status: Model should be listening')
+  t.ok((await model.status()) === 'listening', 'Status: Model should be listening')
 
   await model.pause()
-  t.ok(await model.status() === 'paused', 'Status: Model should be paused')
+  t.ok((await model.status()) === 'paused', 'Status: Model should be paused')
 
   await model.unpause()
-  t.ok(await model.status() === 'listening', 'Status: Model should be listening')
+  t.ok((await model.status()) === 'listening', 'Status: Model should be listening')
 
   await model.addon.activate()
-  t.ok(await model.status() === 'listening', 'Status: Model should be listening')
+  t.ok((await model.status()) === 'listening', 'Status: Model should be listening')
 
   // After destroy, the instance is invalid - we verify via transition callback
   await model.addon.destroyInstance()
@@ -107,14 +112,16 @@ test('Model emits error events when an error occurs during processing', async (t
   // Create a custom binding that throws an error on append
   const binding = {
     createInstance: () => ({ id: 1 }),
-    runJob: () => { throw new Error('Forced error for testing') },
-    loadWeights: () => { },
-    activate: () => { },
-    pause: () => { },
-    stop: () => { },
-    cancel: () => { },
+    runJob: () => {
+      throw new Error('Forced error for testing')
+    },
+    loadWeights: () => {},
+    activate: () => {},
+    pause: () => {},
+    stop: () => {},
+    cancel: () => {},
     status: () => 'idle',
-    destroyInstance: () => { }
+    destroyInstance: () => {}
   }
   const model = createMockedModel({ binding })
 
@@ -126,8 +133,14 @@ test('Model emits error events when an error occurs during processing', async (t
     t.fail('Should have rejected the response')
   } catch (error) {
     // The error should be a QvacErrorAddonParakeet
-    t.ok(error.constructor.name === 'QvacErrorAddonParakeet', 'Error should be a QvacErrorAddonParakeet')
-    t.ok(error.message.includes('Forced error') || typeof error.code === 'number', 'Error should contain forced error message or have error code')
+    t.ok(
+      error.constructor.name === 'QvacErrorAddonParakeet',
+      'Error should be a QvacErrorAddonParakeet'
+    )
+    t.ok(
+      error.message.includes('Forced error') || typeof error.code === 'number',
+      'Error should contain forced error message or have error code'
+    )
   }
 })
 
@@ -141,11 +154,16 @@ test('ParakeetInterface full sequence: status, append, and job boundaries', asyn
   }
 
   const binding = new MockedBinding()
-  const addon = new ParakeetInterface(binding, {
-    modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf',
-    maxThreads: 4,
-    useGPU: false
-  }, onOutput, transitionCb)
+  const addon = new ParakeetInterface(
+    binding,
+    {
+      modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf',
+      maxThreads: 4,
+      useGPU: false
+    },
+    onOutput,
+    transitionCb
+  )
 
   let status = await addon.status()
   t.ok(status === 'loading', 'Initial addon status should be "loading"')
@@ -171,10 +189,10 @@ test('ParakeetInterface full sequence: status, append, and job boundaries', asyn
   t.ok(appendResult2 === 1, 'Job ID should remain 1 for the end-of-job signal')
 
   await wait()
-  const outputEvent = events.find(e => e.event === 'Output' && e.jobId === 1)
+  const outputEvent = events.find((e) => e.event === 'Output' && e.jobId === 1)
   t.ok(outputEvent, 'Output callback should be triggered for audio chunk')
   t.ok(
-    events.find(e => e.event === 'JobEnded' && e.jobId === 1),
+    events.find((e) => e.event === 'JobEnded' && e.jobId === 1),
     'JobEnded callback should be emitted for job 1'
   )
 
@@ -194,7 +212,7 @@ test('ParakeetInterface full sequence: status, append, and job boundaries', asyn
 
   await wait()
   t.ok(
-    events.find(e => e.event === 'JobEnded' && e.jobId === 2),
+    events.find((e) => e.event === 'JobEnded' && e.jobId === 2),
     'JobEnded callback should be emitted for job 2'
   )
 
@@ -203,9 +221,13 @@ test('ParakeetInterface full sequence: status, append, and job boundaries', asyn
 
 test('ParakeetInterface runJob preserves active job when native rejects new job', async (t) => {
   const binding = new MockedBinding()
-  const addon = new ParakeetInterface(binding, {
-    modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
-  }, () => {})
+  const addon = new ParakeetInterface(
+    binding,
+    {
+      modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
+    },
+    () => {}
+  )
 
   addon._activeJobId = 42
   addon._nextJobId = 43
@@ -220,14 +242,22 @@ test('ParakeetInterface runJob preserves active job when native rejects new job'
   t.is(accepted, false, 'runJob should report rejected when native side is busy')
   t.is(addon._activeJobId, 42, 'Current active job ID should remain unchanged')
   t.is(addon._nextJobId, 43, 'Next job counter should not advance on rejection')
-  t.is(await addon.status(), 'processing', 'State should remain unchanged for the current active job')
+  t.is(
+    await addon.status(),
+    'processing',
+    'State should remain unchanged for the current active job'
+  )
 })
 
 test('ParakeetInterface cancel clears active job only after cancel resolves', async (t) => {
   const binding = new MockedBinding()
-  const addon = new ParakeetInterface(binding, {
-    modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
-  }, () => {})
+  const addon = new ParakeetInterface(
+    binding,
+    {
+      modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
+    },
+    () => {}
+  )
 
   addon._activeJobId = 7
   addon._setState('processing')
@@ -250,11 +280,15 @@ test('ParakeetInterface cancel clears active job only after cancel resolves', as
 test('ParakeetInterface cancels buffered job before native run starts', async (t) => {
   const events = []
   const binding = new MockedBinding()
-  const addon = new ParakeetInterface(binding, {
-    modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
-  }, (handle, event, jobId, output, error) => {
-    events.push({ event, jobId, output, error })
-  })
+  const addon = new ParakeetInterface(
+    binding,
+    {
+      modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
+    },
+    (handle, event, jobId, output, error) => {
+      events.push({ event, jobId, output, error })
+    }
+  )
 
   const pendingJobId = await addon.append({
     type: 'audio',
@@ -267,16 +301,22 @@ test('ParakeetInterface cancels buffered job before native run starts', async (t
   t.is(addon._bufferedAudio.length, 0, 'Buffered cancel should clear queued audio')
   t.is(await addon.status(), 'listening', 'Buffered cancel should return to listening state')
   t.ok(
-    events.find(e => e.event === 'Error' && e.jobId === pendingJobId && e.error === 'Job cancelled'),
+    events.find(
+      (e) => e.event === 'Error' && e.jobId === pendingJobId && e.error === 'Job cancelled'
+    ),
     'Buffered cancel should fail the pending JS-owned job'
   )
 })
 
 test('ParakeetInterface ignores stale wrapper job ids when cancelling', async (t) => {
   const binding = new MockedBinding()
-  const addon = new ParakeetInterface(binding, {
-    modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
-  }, () => {})
+  const addon = new ParakeetInterface(
+    binding,
+    {
+      modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
+    },
+    () => {}
+  )
 
   addon._activeJobId = 2
   addon._nextJobId = 3
@@ -295,9 +335,13 @@ test('ParakeetInterface ignores stale wrapper job ids when cancelling', async (t
 })
 
 test('ParakeetInterface unloadWeights throws unsupported operation error', async (t) => {
-  const addon = new ParakeetInterface(new MockedBinding(), {
-    modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
-  }, () => {})
+  const addon = new ParakeetInterface(
+    new MockedBinding(),
+    {
+      modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
+    },
+    () => {}
+  )
 
   let threw = false
   try {
@@ -305,16 +349,23 @@ test('ParakeetInterface unloadWeights throws unsupported operation error', async
   } catch (error) {
     threw = true
     t.is(error.code, 24007, 'unloadWeights should map to FAILED_TO_RESET')
-    t.ok(String(error.message).includes('unloadWeights is not supported'), 'Error should explain supported alternatives')
+    t.ok(
+      String(error.message).includes('unloadWeights is not supported'),
+      'Error should explain supported alternatives'
+    )
   }
   t.ok(threw, 'unloadWeights should throw')
 })
 
 test('ParakeetInterface destroyInstance awaits active cancel before teardown', async (t) => {
   const binding = new MockedBinding()
-  const addon = new ParakeetInterface(binding, {
-    modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
-  }, () => {})
+  const addon = new ParakeetInterface(
+    binding,
+    {
+      modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
+    },
+    () => {}
+  )
 
   addon._activeJobId = 9
   addon._setState('processing')
@@ -343,9 +394,13 @@ test('ParakeetInterface destroyInstance awaits active cancel before teardown', a
 
 test('ParakeetInterface destroyInstance skips cancel with no active job', async (t) => {
   const binding = new MockedBinding()
-  const addon = new ParakeetInterface(binding, {
-    modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
-  }, () => {})
+  const addon = new ParakeetInterface(
+    binding,
+    {
+      modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
+    },
+    () => {}
+  )
 
   let cancelCalls = 0
   binding.cancel = async () => {
@@ -359,9 +414,13 @@ test('ParakeetInterface destroyInstance skips cancel with no active job', async 
 
 test('ParakeetInterface reload preserves wrapper job numbering across native recreation', async (t) => {
   const binding = new MockedBinding()
-  const addon = new ParakeetInterface(binding, {
-    modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
-  }, () => {})
+  const addon = new ParakeetInterface(
+    binding,
+    {
+      modelPath: './models/parakeet-tdt-0.6b-v3.q8_0.gguf'
+    },
+    () => {}
+  )
 
   addon._nextJobId = 7
   addon._activeJobId = 6
@@ -377,5 +436,9 @@ test('ParakeetInterface reload preserves wrapper job numbering across native rec
   t.is(addon._nextJobId, 7, 'reload should preserve JS-owned job numbering')
   t.is(addon._activeJobId, null, 'reload should clear the previous active job')
   t.is(addon._bufferedAudio.length, 0, 'reload should discard buffered audio from the old instance')
-  t.is(await addon.status(), 'loading', 'reload should leave the addon in loading state until activation')
+  t.is(
+    await addon.status(),
+    'loading',
+    'reload should leave the addon in loading state until activation'
+  )
 })

--- a/packages/transcription-parakeet/test/unit/models-manifest.test.js
+++ b/packages/transcription-parakeet/test/unit/models-manifest.test.js
@@ -42,7 +42,7 @@ const EXPECTED_FILES = [
 
 const KNOWN_DATE_PREFIXES = ['2026-07-01', '2026-05-11', '2026-05-27', '2026-05-20']
 
-function loadManifest () {
+function loadManifest() {
   return JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'))
 }
 
@@ -53,7 +53,10 @@ test('manifest: contains only cache-key-bearing fields', (t) => {
     ['cacheEpoch', 'models', 'source'],
     'top level excludes prose and unrelated metadata'
   )
-  t.ok(Number.isInteger(manifest.cacheEpoch) && manifest.cacheEpoch > 0, 'cacheEpoch is a positive integer')
+  t.ok(
+    Number.isInteger(manifest.cacheEpoch) && manifest.cacheEpoch > 0,
+    'cacheEpoch is a positive integer'
+  )
   t.is(manifest.source, 's3', 'source is s3')
 
   for (const [name, entry] of Object.entries(manifest.models)) {
@@ -76,7 +79,9 @@ test('manifest: every entry has a well-formed s3Path + pinned integrity', (t) =>
   const manifest = loadManifest()
   for (const [name, entry] of Object.entries(manifest.models)) {
     t.is(typeof entry.s3Path, 'string', `${name}: s3Path is a string`)
-    const m = entry.s3Path.match(/^qvac_models_compiled\/ggml\/parakeet\/(\d{4}-\d{2}-\d{2})\/(.+)$/)
+    const m = entry.s3Path.match(
+      /^qvac_models_compiled\/ggml\/parakeet\/(\d{4}-\d{2}-\d{2})\/(.+)$/
+    )
     t.ok(m, `${name}: s3Path matches registry layout`)
     if (m) {
       t.ok(KNOWN_DATE_PREFIXES.includes(m[1]), `${name}: date prefix ${m[1]} is known`)
@@ -84,7 +89,10 @@ test('manifest: every entry has a well-formed s3Path + pinned integrity', (t) =>
     }
 
     t.ok(/^[0-9a-f]{64}$/.test(entry.sha256), `${name}: sha256 is pinned as 64-hex`)
-    t.ok(Number.isInteger(entry.bytes) && entry.bytes > 0, `${name}: bytes is pinned as a positive int`)
+    t.ok(
+      Number.isInteger(entry.bytes) && entry.bytes > 0,
+      `${name}: bytes is pinned as a positive int`
+    )
   }
 })
 
@@ -94,6 +102,9 @@ test('manifest: filenames + date prefixes are referenced by helpers.js', (t) => 
   for (const [name, entry] of Object.entries(manifest.models)) {
     t.ok(helpers.includes(name), `${name}: referenced in helpers.js MODEL_CONFIGS`)
     const datePrefix = entry.s3Path.split('/')[3]
-    t.ok(helpers.includes(datePrefix), `${name}: registry date ${datePrefix} referenced in helpers.js`)
+    t.ok(
+      helpers.includes(datePrefix),
+      `${name}: registry date ${datePrefix} referenced in helpers.js`
+    )
   }
 })

--- a/packages/transcription-parakeet/test/unit/streaming-duplex.test.js
+++ b/packages/transcription-parakeet/test/unit/streaming-duplex.test.js
@@ -37,11 +37,7 @@ const { ParakeetInterface } = require('../../parakeet')
 const process = require('bare-process')
 global.process = process
 
-function createMockedModel ({
-  onOutput = () => {},
-  binding = undefined,
-  parakeetConfig = {}
-} = {}) {
+function createMockedModel({ onOutput = () => {}, binding = undefined, parakeetConfig = {} } = {}) {
   TranscriptionParakeet.prototype.validateModelFiles = () => undefined
 
   const model = new TranscriptionParakeet({
@@ -57,7 +53,7 @@ function createMockedModel ({
 
   const _binding = binding || new MockedBinding()
 
-  model._createAddon = configurationParams => {
+  model._createAddon = (configurationParams) => {
     const addon = new ParakeetInterface(
       _binding,
       configurationParams,
@@ -74,12 +70,12 @@ function createMockedModel ({
   return model
 }
 
-function pushable () {
+function pushable() {
   const queue = []
   let waiter = null
   let ended = false
   return {
-    push (chunk) {
+    push(chunk) {
       if (ended) return
       queue.push(chunk)
       if (waiter) {
@@ -88,7 +84,7 @@ function pushable () {
         w()
       }
     },
-    end () {
+    end() {
       ended = true
       if (waiter) {
         const w = waiter
@@ -96,14 +92,16 @@ function pushable () {
         w()
       }
     },
-    async * [Symbol.asyncIterator] () {
+    async *[Symbol.asyncIterator]() {
       while (true) {
         if (queue.length > 0) {
           yield queue.shift()
           continue
         }
         if (ended) return
-        await new Promise(resolve => { waiter = resolve })
+        await new Promise((resolve) => {
+          waiter = resolve
+        })
       }
     }
   }
@@ -127,8 +125,8 @@ test('runStreaming surfaces one Output per pushed chunk and one JobEnded on clos
   // that fired before it landed in the response chain.
   const seenSegments = []
   const updateDone = response
-    .onUpdate(items => {
-      for (const seg of (Array.isArray(items) ? items : [items])) {
+    .onUpdate((items) => {
+      for (const seg of Array.isArray(items) ? items : [items]) {
         seenSegments.push(seg)
       }
     })
@@ -142,20 +140,31 @@ test('runStreaming surfaces one Output per pushed chunk and one JobEnded on clos
   await updateDone
   await wait()
 
-  const outputEvents = events.filter(e => e.event === 'Output')
+  const outputEvents = events.filter((e) => e.event === 'Output')
   t.is(outputEvents.length, 3, 'Three Output events for three pushed chunks')
   t.is(seenSegments.length, 3, 'onUpdate sees exactly three segments')
-  t.is(seenSegments[0].text, 'Mock streaming chunk 0',
-    'First segment text comes from chunk index 0')
-  t.is(seenSegments[1].text, 'Mock streaming chunk 1',
-    'Second segment text comes from chunk index 1')
-  t.is(seenSegments[2].text, 'Mock streaming chunk 2',
-    'Third segment text comes from chunk index 2')
+  t.is(
+    seenSegments[0].text,
+    'Mock streaming chunk 0',
+    'First segment text comes from chunk index 0'
+  )
+  t.is(
+    seenSegments[1].text,
+    'Mock streaming chunk 1',
+    'Second segment text comes from chunk index 1'
+  )
+  t.is(
+    seenSegments[2].text,
+    'Mock streaming chunk 2',
+    'Third segment text comes from chunk index 2'
+  )
 
-  const jobEndedEvents = events.filter(e => e.event === 'JobEnded')
+  const jobEndedEvents = events.filter((e) => e.event === 'JobEnded')
   t.is(jobEndedEvents.length, 1, 'Exactly one synthetic JobEnded')
-  t.ok(jobEndedEvents[0].output && typeof jobEndedEvents[0].output === 'object',
-    'JobEnded payload is the runtime-stats object placeholder')
+  t.ok(
+    jobEndedEvents[0].output && typeof jobEndedEvents[0].output === 'object',
+    'JobEnded payload is the runtime-stats object placeholder'
+  )
 
   const log = model._mockedBinding._streamingLog
   t.is(log.starts, 1, 'startStreaming called once')
@@ -221,8 +230,7 @@ test('cancel after startStreaming tears down the session at the binding layer', 
   await model.addon.appendStreamingAudio(new Float32Array(1024))
   await wait()
 
-  t.ok(model._mockedBinding._streamingActive,
-    'Streaming session active before cancel')
+  t.ok(model._mockedBinding._streamingActive, 'Streaming session active before cancel')
 
   model._mockedBinding.cancel(model.addon._handle)
 
@@ -230,8 +238,10 @@ test('cancel after startStreaming tears down the session at the binding layer', 
   t.is(log.starts, 1, 'startStreaming called once')
   t.is(log.appends, 1, 'appendStreamingAudio called once before cancel')
   t.is(log.cancels, 1, 'cancel invoked the streaming-aware tear-down once')
-  t.absent(model._mockedBinding._streamingActive,
-    'Mock binding flipped streamingActive=false after cancel')
+  t.absent(
+    model._mockedBinding._streamingActive,
+    'Mock binding flipped streamingActive=false after cancel'
+  )
 
   // Bypass `model.unload()` because we cancelled at the binding
   // level (without firing a synthetic terminal event); the wrapper's
@@ -251,10 +261,12 @@ test('endStreaming on a binding with no active session is a no-op', async (t) =>
   // duration captured by ParakeetStreamingProcessor; with no active
   // session, `cleaned` is false and the timing fields are zero.
   const result = model._mockedBinding.endStreaming(model.addon._handle)
-  t.is(typeof result, 'object',
-    'Mock returns the same { cleaned, audioDurationMs, totalSamples } shape as the C++ wrapper')
-  t.is(result.cleaned, false,
-    'cleaned is false when no streaming session was active')
+  t.is(
+    typeof result,
+    'object',
+    'Mock returns the same { cleaned, audioDurationMs, totalSamples } shape as the C++ wrapper'
+  )
+  t.is(result.cleaned, false, 'cleaned is false when no streaming session was active')
   t.is(result.audioDurationMs, 0, 'no session = no audio observed')
   t.is(result.totalSamples, 0, 'no session = no samples observed')
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The JS source in `packages/transcription-parakeet` was not consistently formatted per the package's pinned Prettier config.
- `npm run lint` (which runs `prettier --check`) flagged JS files with code-style issues.

## 📝 How does it solve it?

- Ran `npm run format` (`prettier --write`) across `examples/`, `lib/`, `test/`, and top-level `*.js` to apply the canonical formatting.
- Reformatted 33 files (whitespace/style only — no functional, API, or behavioral changes).

## 🧪 How was it tested?

- Re-ran `prettier --check` → "All matched files use Prettier code style!"


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216426175394532