### PR TITLE
transcription-parakeet: enable per-arch ggml CPU variants on desktop linux-arm64

### DIFF
--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Desktop linux-arm64 prebuilds now ship per-arch ggml CPU variants (`parakeet-cpp` >= 2026-07-13#1, pulling `ggml-speech` 2026-07-14): the previous armv8-a-baseline build compiled out the ARM dotprod/fp16/i8mm kernels, leaving quantized models slow (tdt q4_0 mean RTF 0.2285 -> 0.0612 on ubuntu-24.04-arm; q4_0 now beats q8_0 like on every other desktop platform).
+
+### Fixed
+
+- `BACKENDS_SUBDIR` is now defined on `parakeet_model_core` (the target that compiles `ParakeetModel.cpp`), so the engine scans `prebuilds/<bare-target>/<module>/` for dynamically-loadable ggml backends instead of the prebuilds root. Latent on all platforms; required for the desktop-Linux per-arch CPU variants.
+
 ## [0.10.0] - 2026-07-14
 
 ### Fixed

--- a/packages/transcription-parakeet/CMakeLists.txt
+++ b/packages/transcription-parakeet/CMakeLists.txt
@@ -186,6 +186,24 @@ target_compile_definitions(${qvac_lib_infer_parakeet} PUBLIC JS_LOGGER)
 # it here lets the addon compute the full backends path from a
 # host-provided prebuilds root without the host needing to know the
 # `<bare-target>/<module-name>` shape itself.
+#
+# The consumer of this define is ParakeetModel.cpp
+# (`#ifdef BACKENDS_SUBDIR` around the eopts.backends_dir join), which
+# is compiled into ${LIB_NAME} (parakeet_model_core) -- NOT into the
+# bare-module target, whose only direct source is binding.cpp. A
+# PRIVATE define on the module target alone never reaches
+# ParakeetModel.cpp's translation unit: the #ifdef silently compiles
+# out, the engine scans `<backendsDir>` (the prebuilds *root*) instead
+# of `<backendsDir>/<bare-target>/<module-name>`, finds no backend
+# .so files there, and falls back to bare-filename dlopen. That
+# fallback masks the bug on Android (per-arch CPU candidate list +
+# APK linker path) and for single-file GPU backends anywhere (the
+# .bare's $ORIGIN RUNPATH resolves them), but the desktop-Linux
+# per-arch CPU MODULE variants (GGML_CPU_ALL_VARIANTS) are reachable
+# only via the directory scan -- without the define the CPU backend
+# never registers ("no CPU device registered").
+target_compile_definitions(${LIB_NAME} PRIVATE
+  BACKENDS_SUBDIR="${BACKENDS_SUBDIR_VALUE}")
 target_compile_definitions(${qvac_lib_infer_parakeet} PRIVATE
   BACKENDS_SUBDIR="${BACKENDS_SUBDIR_VALUE}")
 

--- a/packages/transcription-parakeet/vcpkg.json
+++ b/packages/transcription-parakeet/vcpkg.json
@@ -4,19 +4,19 @@
   "dependencies": [
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-07-07",
+      "version>=": "2026-07-13#1",
       "features": ["metal"],
       "platform": "osx | ios"
     },
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-07-07",
+      "version>=": "2026-07-13#1",
       "features": ["vulkan", "opencl"],
       "platform": "android"
     },
     {
       "name": "parakeet-cpp",
-      "version>=": "2026-07-07",
+      "version>=": "2026-07-13#1",
       "features": ["vulkan"],
       "platform": "!(osx | ios | android)"
     },


### PR DESCRIPTION
## Problem

Desktop linux-arm64 prebuilds compiled ggml at the plain armv8-a baseline (`GGML_NATIVE=OFF`, no `-march`) — the ARM dotprod/fp16/i8mm kernels, including the CPU repack GEMMs, were compiled out. The parakeet CPU-repack change ([whisper.cpp PR #87](https://github.com/tetherto/qvac-ext-lib-whisper.cpp/pull/87)) was therefore flat on linux-arm64 (tdt q4_0 RTF 0.2277 → 0.2285, [run 29058764288](https://github.com/tetherto/qvac/actions/runs/29058764288)) while every other desktop platform sped up.

## Changes

The build-flags change lives in the **ggml-speech vcpkg port** (2026-07-14, [qvac-registry-vcpkg#249](https://github.com/tetherto/qvac-registry-vcpkg/pull/249)) — it applies to every consumer of the port, so per review guidance it is a port change, not a triplet one. The port builds per-arch runtime-scored CPU MODULE variants (SIGILL-safe on any aarch64 host), statically links libc++ into the modules, stages them flat in `lib/`, and excludes the SVE tiers (2–4× slower than NEON on the VL=128 cores in the desktop fleet — A/B in the port PR).

This PR:
1. **Bumps `parakeet-cpp` to `>= 2026-07-13#1`**, whose port now requires `ggml-speech >= 2026-07-14` (per review: consumption flows through the -cpp port constraint, no direct ggml-speech dependency in the package).
2. **Fixes the one addon bug that blocked the dynamically-loaded variants**: `BACKENDS_SUBDIR` is now defined on `parakeet_model_core` — the target that actually compiles `ParakeetModel.cpp` (the `#ifdef BACKENDS_SUBDIR` backends-dir join). Previously it was PRIVATE on the bare-module target only (sole direct source: binding.cpp), so the join silently compiled out on every platform and the engine scanned the prebuilds *root* instead of `prebuilds/<bare-target>/<module>/`. Masked on Android (bare-filename dlopen candidate list + APK linker path) and for single-file GPU backends (the `.bare`'s `$ORIGIN` RUNPATH); the desktop-Linux per-arch CPU variants are only reachable via the directory scan.
3. CHANGELOG entry under `[Unreleased]`.

## Verification (ubuntu-24.04-arm, mean RTF, lower is better)

End-to-end benchmark runs with this exact change set (port content via overlay): [run 29243365879](https://github.com/tetherto/qvac/actions/runs/29243365879) and SVE-policy follow-up [run 29333265683](https://github.com/tetherto/qvac/actions/runs/29333265683) — tdt q4_0 **0.2285 → 0.061–0.063** (~3.6×), q8_0 0.1814 → 0.063, f16 0.137–0.141; q4_0 ≤ q8_0 on all four model types, matching every other desktop platform. All other platforms and Android unchanged/green in the same runs.

**Merge order**: [qvac-registry-vcpkg#249](https://github.com/tetherto/qvac-registry-vcpkg/pull/249) first (this PR's version resolution needs ggml-speech 2026-07-14 in the registry). Composes with #3232/#3233 in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

