### PR TITLE
QVAC-22268 chore: format check generated changelog markdown in qv-sdk-changelog skill

### DIFF
--- a/.cursor/skills/qv-sdk-changelog/SKILL.md
+++ b/.cursor/skills/qv-sdk-changelog/SKILL.md
@@ -117,6 +117,21 @@ After writing the file, re-run the raw generator (or rebuild the root aggregate)
 `packages/<package>/CHANGELOG.md` picks up the new `CHANGELOG_LLM.md` (the aggregator
 prefers it over `CHANGELOG.md`). Easiest way: re-run the script from Step 3 — it's idempotent.
 
+**Format the generated markdown (mandatory).** `CHANGELOG_LLM.md` is authored by
+hand here, so it is the file most likely to carry markdown formatting issues that a
+committed-file format check would later reject. Every SDK pod package uses prettier
+(`format` = `prettier --check .`, `format:fix` = `prettier --write .`). Run the check
+scoped to the changelog output so any issue surfaces now:
+
+```bash
+cd packages/<package>
+bunx prettier --check "changelog/**/*.md" "CHANGELOG.md"
+```
+
+If it reports problems, fix them — `bunx prettier --write` on the same paths, or hand-edit —
+and re-run the check until it passes clean. Do this before moving on so the release commit
+carries only prettier-clean markdown.
+
 **Downstream rendering note:** the docs site reads `CHANGELOG_LLM.md`
 **verbatim** and inlines it under a `### @qvac/<pkg>` subsection of the
 minor series page (one permanent `v<X.Y>.x.mdx` per minor line — see
@@ -325,6 +340,7 @@ Before completing:
 - [ ] PRs scoped to package path only
 - [ ] Changelog files written to correct version directory
 - [ ] CHANGELOG_LLM.md generated (mandatory) and follows format guide
+- [ ] Generated markdown is prettier-clean (`prettier --check` on the changelog output passes)
 - [ ] announcement-post.txt generated (mandatory, gitignored)
 - [ ] NOTICE file updated for the target package
 - [ ] When `--package=sdk`: `qv-sdk-bare-sdk-sync` run, `check:deps-vs-sdk` passing, bare-sdk NOTICE regenerated


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The `qv-sdk-changelog` skill never runs a format check on the markdown it produces. `CHANGELOG_LLM.md` is authored by hand during the workflow, so it can carry prettier violations that only surface later as a committed-file format failure.
- The skill invokes the `generate-changelog-sdk-pod.cjs` generator directly, bypassing the `sdk` package's `changelog:generate` npm script (which does end in `prettier --write changelog`), so nothing formats the output on the skill path.

## 📝 How does it solve it?

- Adds a mandatory format step at the end of Step 4, after `CHANGELOG_LLM.md` is written and the raw generator re-runs, so all committable changelog markdown is covered by a single check.
- The step runs the SDK-pod prettier check scoped to the changelog output (`bunx prettier --check "changelog/**/*.md" "CHANGELOG.md"`); on failure, fix with `--write` or by hand and re-check until clean.
- Adds a matching Quality Checklist item ("Generated markdown is prettier-clean").
- Scope is the SDK pod only (the one `qv-sdk-changelog` skill, parameterized per package); addon-pod skills are untouched.