### PR TITLE
QVAC-22265 fix: scope qvac-fabric CI to consumer addons

### DIFF
--- a/.github/workflows/on-pr-bci-whispercpp.yml
+++ b/.github/workflows/on-pr-bci-whispercpp.yml
@@ -8,7 +8,8 @@ on:
       - "packages/bci-whispercpp/**"
       - ".github/workflows/*bci-whispercpp*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/on-pr-classification-ggml.yml
+++ b/.github/workflows/on-pr-classification-ggml.yml
@@ -16,7 +16,9 @@ on:
       - "packages/classification-ggml/**"
       - ".github/workflows/*classification-ggml*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
+      - "vcpkg-overlays/ports/qvac-fabric/**"
   workflow_dispatch:
 
   workflow_call:

--- a/.github/workflows/on-pr-diffusion-cpp.yml
+++ b/.github/workflows/on-pr-diffusion-cpp.yml
@@ -16,7 +16,8 @@ on:
       - "packages/diffusion-cpp/**"
       - ".github/workflows/*diffusion*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
   workflow_dispatch:
 
   workflow_call:

--- a/.github/workflows/on-pr-embed-llamacpp.yml
+++ b/.github/workflows/on-pr-embed-llamacpp.yml
@@ -16,7 +16,9 @@ on:
       - "packages/embed-llamacpp/**"
       - ".github/workflows/*embed*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
+      - "vcpkg-overlays/ports/qvac-fabric/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/on-pr-fabric.yml
+++ b/.github/workflows/on-pr-fabric.yml
@@ -15,7 +15,9 @@ on:
     paths:
       - "packages/fabric/**"
       - ".github/workflows/*fabric*.yml"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
+      - "vcpkg-overlays/ports/qvac-fabric/**"
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/on-pr-llm-llamacpp.yml
+++ b/.github/workflows/on-pr-llm-llamacpp.yml
@@ -16,7 +16,9 @@ on:
       - "packages/llm-llamacpp/**"
       - ".github/workflows/*llm-llamacpp*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
+      - "vcpkg-overlays/ports/qvac-fabric/**"
 
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/on-pr-ocr-ggml.yml
+++ b/.github/workflows/on-pr-ocr-ggml.yml
@@ -15,7 +15,9 @@ on:
     paths:
       - "packages/ocr-ggml/**"
       - ".github/workflows/*ocr-ggml*.yml"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
+      - "vcpkg-overlays/ports/qvac-fabric/**"
   workflow_dispatch:
     inputs:
       base_sha:
@@ -39,6 +41,10 @@ permissions:
 
 env:
   PKG_DIR: packages/ocr-ggml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   label-gate:

--- a/.github/workflows/on-pr-ocr-onnx.yml
+++ b/.github/workflows/on-pr-ocr-onnx.yml
@@ -16,7 +16,8 @@ on:
       - "packages/ocr-onnx/**"
       - ".github/workflows/*ocr-onnx*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/on-pr-onnx.yml
+++ b/.github/workflows/on-pr-onnx.yml
@@ -15,7 +15,8 @@ on:
     paths:
       - "packages/onnx/**"
       - ".github/workflows/*onnx*.yml"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/on-pr-transcription-parakeet.yml
+++ b/.github/workflows/on-pr-transcription-parakeet.yml
@@ -8,7 +8,8 @@ on:
       - "packages/transcription-parakeet/**"
       - ".github/workflows/*parakeet*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/on-pr-transcription-whispercpp.yml
+++ b/.github/workflows/on-pr-transcription-whispercpp.yml
@@ -8,7 +8,8 @@ on:
       - "packages/transcription-whispercpp/**"
       - ".github/workflows/*whispercpp*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/on-pr-translation-nmtcpp.yml
+++ b/.github/workflows/on-pr-translation-nmtcpp.yml
@@ -16,7 +16,9 @@ on:
       - "packages/translation-nmtcpp/**"
       - ".github/workflows/*nmtcpp*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
+      - "vcpkg-overlays/ports/qvac-fabric/**"
   workflow_dispatch:
 
 permissions:
@@ -109,7 +111,9 @@ jobs:
               - "packages/translation-nmtcpp/**"
               - ".github/workflows/*nmtcpp*.yml"
               - ".github/actions/cache-models/**"
-              - "vcpkg-overlays/**"
+              - "vcpkg-overlays/triplets/**"
+              - "vcpkg-overlays/toolchains/**"
+              - "vcpkg-overlays/ports/qvac-fabric/**"
   verify-fabric-lockstep:
     needs: [authorize, changes]
     if: always() && !cancelled() && needs.authorize.outputs.allowed == 'true' && (needs.changes.outputs.pkg == 'true' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/on-pr-tts-ggml.yml
+++ b/.github/workflows/on-pr-tts-ggml.yml
@@ -8,7 +8,8 @@ on:
       - "packages/tts-ggml/**"
       - ".github/workflows/*tts-ggml*.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/on-pr-vla.yml
+++ b/.github/workflows/on-pr-vla.yml
@@ -16,7 +16,9 @@ on:
       - "packages/vla-ggml/**"
       - ".github/workflows/*-vla.yml"
       - ".github/actions/cache-models/**"
-      - "vcpkg-overlays/**"
+      - "vcpkg-overlays/triplets/**"
+      - "vcpkg-overlays/toolchains/**"
+      - "vcpkg-overlays/ports/qvac-fabric/**"
   workflow_dispatch:
 
   workflow_call:


### PR DESCRIPTION
## Purpose

This is the implementation PR for QVAC-22265. It scopes addon workflow routing without changing CI trust gates or stage selection.

## Summary

- scope `qvac-fabric` overlay changes to the seven addons that consume it
- preserve shared triplet and toolchain triggers independently
- add the missing OCR-GGML concurrency guard so label bursts cancel superseded runs
- keep NMT's internal path filter aligned with its workflow trigger

## Test plan

- [x] Verify workflow syntax with `actionlint`
- [x] Verify workflow routing matches package `vcpkg.json` dependencies
- [x] Run label-gate tests (58 passing)
- [x] Create isolated fabric and unrelated-port probe PRs (#3268 and #3269)
- [ ] Confirm server-side path routing after this workflow change exists on `main`

## Pre-merge CI probe result

PR #3268 changed only `vcpkg-overlays/ports/qvac-fabric/CI_ROUTING_TEST.md`. PR #3269 changed only `vcpkg-overlays/ports/ci-routing-control/CI_ROUTING_TEST.md`. Both targeted a temporary `tmp-*` base containing this fix and were clearly marked `DO NOT MERGE`.

GitHub still evaluated `pull_request_target` path routing using workflow definitions from the repository default branch (`main`), where the old broad `vcpkg-overlays/**` filters remain. Consequently both probes started all addon workflows. The probes were closed without merging and all temporary branches were deleted.

This means exact server-side path-filter behavior cannot be validated safely in this repository before the workflow definitions reach `main`. After this PR merges, the same two marker probes can be repeated against `main`, or the next qvac-fabric PR can confirm that only the seven consumer workflows start.

## Related

- Asana: https://app.asana.com/1/45238840754660/project/1214153063536860/task/1216570695830444
- Incident PR: https://github.com/tetherto/qvac/pull/3036
- Closed fabric probe: https://github.com/tetherto/qvac/pull/3268
- Closed negative-control probe: https://github.com/tetherto/qvac/pull/3269

---
Created with Cursor.