### PR TITLE
QVAC-22265 test[notask]: DO NOT MERGE - unrelated overlay routing probe

### DIFF
--- a/vcpkg-overlays/ports/ci-routing-control/CI_ROUTING_TEST.md
+++ b/vcpkg-overlays/ports/ci-routing-control/CI_ROUTING_TEST.md
@@ -1,0 +1,4 @@
+# CI routing control probe
+
+Temporary marker for QVAC-22265. This unrelated overlay port must not trigger
+any addon-specific pull request workflow.


### PR DESCRIPTION
## CI TEST ONLY — DO NOT MERGE

This is the negative-control routing probe for implementation PR #3267. It targets the temporary base branch `tmp-qvac-22265-ci-routing-base`, not `main`.

## What this PR changes

- adds one inert Markdown marker under an unrelated `vcpkg-overlays/ports/ci-routing-control/**` path
- changes no source code, dependency configuration, or production behavior

## Expected result

No addon-specific `On PR Trigger (...)` workflow should start. General repository checks may still run.

If any addon workflow starts, its path filter is still too broad.

## Cleanup

Close this PR without merging and delete its head branch after validation.

---
Created with Cursor for temporary CI validation.

Made with [Cursor](https://cursor.com)