### PR TITLE
QVAC-22265 test[notask]: DO NOT MERGE - post-merge fabric routing probe

### DIFF
--- a/vcpkg-overlays/ports/qvac-fabric/CI_ROUTING_TEST.md
+++ b/vcpkg-overlays/ports/qvac-fabric/CI_ROUTING_TEST.md
@@ -1,0 +1,4 @@
+# Post-merge CI routing probe
+
+Temporary marker for QVAC-22265. This file verifies that qvac-fabric path
+changes trigger only the seven addon workflows that consume qvac-fabric.


### PR DESCRIPTION
## CI TEST ONLY — DO NOT MERGE

This temporary PR validates the merged workflow-routing fix from #3267 against the repository default branch.

## Change

Adds one inert Markdown marker under `vcpkg-overlays/ports/qvac-fabric/**`. There are no product or dependency changes.

## Expected addon workflows

Exactly these seven should start:

- LLM
- Embed
- VLA
- Classification-ggml
- OCR-GGML
- NMTCPP
- Fabric

These unrelated addon workflows must not start:

- TTS-GGML
- Stable Diffusion
- Whispercpp
- Parakeet
- BCI Whispercpp
- OCR-ONNX
- ONNX

General repository checks may still run.

## Cleanup

Close without merging and delete this branch after recording the workflow set and concurrency result.

---
Created with Cursor for temporary post-merge CI validation.

Made with [Cursor](https://cursor.com)