### PR TITLE
QVAC-22265 test[notask]: DO NOT MERGE - post-merge control routing probe

### DIFF
--- a/vcpkg-overlays/ports/ci-routing-control/CI_ROUTING_TEST.md
+++ b/vcpkg-overlays/ports/ci-routing-control/CI_ROUTING_TEST.md
@@ -1,0 +1,4 @@
+# Post-merge CI routing control
+
+Temporary marker for QVAC-22265. This unrelated overlay port must not trigger
+any addon-specific pull request workflow.


### PR DESCRIPTION
## CI TEST ONLY — DO NOT MERGE

This temporary negative-control PR validates the merged workflow-routing fix from #3267 against the repository default branch.

## Change

Adds one inert Markdown marker under the unrelated path `vcpkg-overlays/ports/ci-routing-control/**`. There are no product or dependency changes.

## Expected result

No addon-specific `On PR Trigger (...)` workflow should start. General repository checks may still run.

If any addon workflow starts, its overlay path filter remains too broad.

## Cleanup

Close without merging and delete this branch after recording the workflow set.

---
Created with Cursor for temporary post-merge CI validation.

Made with [Cursor](https://cursor.com)