### PR TITLE
QVAC-22212 refactor: apply team coding standards to transcription-parakeet

### DIFF
--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -5,24 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-- Applied the team coding standards to the package. Split the oversized C++/JS
-  functions and their inlined loops into smaller named helpers
-  (`ParakeetModel::load`, `openStreamingSession`, `runStreamingProcess`,
-  `JSAdapter::loadFromJSObject`, `startStreaming`, and `parakeet.js`'s
-  `append` / `_addonOutputCallback`), and removed narration comments and
-  decorative section banners.
-- Consolidated the int16-to-float32 PCM conversion (previously duplicated four
-  times) into a single `pcmS16ToFloat32` helper on each side, adding a new
-  `lib/audio.js` module for the JS conversions.
-- Replaced magic numbers with named constants and a backend-id enum, and moved
-  the streaming/AOSC defaults to a single source of truth in `ParakeetConfig`
-  so the JS layer no longer duplicates them. These are internal refactors with
-  no public API change.
-
 ## [0.10.0] - 2026-07-14
 
 ### Fixed

--- a/packages/transcription-parakeet/CHANGELOG.md
+++ b/packages/transcription-parakeet/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Applied the team coding standards to the package. Split the oversized C++/JS
+  functions and their inlined loops into smaller named helpers
+  (`ParakeetModel::load`, `openStreamingSession`, `runStreamingProcess`,
+  `JSAdapter::loadFromJSObject`, `startStreaming`, and `parakeet.js`'s
+  `append` / `_addonOutputCallback`), and removed narration comments and
+  decorative section banners.
+- Consolidated the int16-to-float32 PCM conversion (previously duplicated four
+  times) into a single `pcmS16ToFloat32` helper on each side, adding a new
+  `lib/audio.js` module for the JS conversions.
+- Replaced magic numbers with named constants and a backend-id enum, and moved
+  the streaming/AOSC defaults to a single source of truth in `ParakeetConfig`
+  so the JS layer no longer duplicates them. These are internal refactors with
+  no public API change.
+
 ## [0.10.0] - 2026-07-14
 
 ### Fixed

--- a/packages/transcription-parakeet/CMakeLists.txt
+++ b/packages/transcription-parakeet/CMakeLists.txt
@@ -409,6 +409,7 @@ if(BUILD_TESTING)
     add_executable(
         parakeet_tests
         addon/tests/test_core.cpp
+        addon/tests/test_config_and_audio.cpp
         addon/tests/AddonCppTest.cpp
         addon/src/model-interface/parakeet/ParakeetModel.cpp
         addon/src/model-interface/parakeet/ParakeetConfig.cpp

--- a/packages/transcription-parakeet/addon/src/addon/AddonJs.hpp
+++ b/packages/transcription-parakeet/addon/src/addon/AddonJs.hpp
@@ -42,6 +42,28 @@ inline ParakeetConfig createParakeetConfig(
   return adapter.loadFromJSObject(configurationParams, env);
 }
 
+inline js::Object transcriptToJsObject(js_env_t* env, const Transcript& t) {
+  auto obj = js::Object::create(env);
+  obj.setProperty(env, "text", js::String::create(env, t.text));
+  obj.setProperty(env, "toAppend", js::Boolean::create(env, t.toAppend));
+  obj.setProperty(env, "start", js::Number::create(env, t.start));
+  obj.setProperty(env, "end", js::Number::create(env, t.end));
+  obj.setProperty(
+      env, "id", js::Number::create(env, static_cast<uint64_t>(t.id)));
+  obj.setProperty(env, "isEndOfTurn", js::Boolean::create(env, t.isEndOfTurn));
+  obj.setProperty(env, "startsWord", js::Boolean::create(env, t.startsWord));
+  return obj;
+}
+
+inline js_value_t*
+transcriptsToJsArray(js_env_t* env, const std::vector<Transcript>& output) {
+  auto jsOutput = js::Array::create(env);
+  for (size_t i = 0; i < output.size(); ++i) {
+    jsOutput.set(env, i, transcriptToJsObject(env, output[i]));
+  }
+  return jsOutput;
+}
+
 struct JsParakeetOutputHandler
     : qvac_lib_inference_addon_cpp::out_handl::JsBaseOutputHandler<
           std::vector<Transcript>> {
@@ -49,41 +71,7 @@ struct JsParakeetOutputHandler
       : qvac_lib_inference_addon_cpp::out_handl::JsBaseOutputHandler<
             std::vector<Transcript>>(
             [this](const std::vector<Transcript>& output) -> js_value_t* {
-              auto jsOutput = js::Array::create(this->env_);
-              for (size_t i = 0; i < output.size(); ++i) {
-                auto jsTranscript = js::Object::create(this->env_);
-                jsTranscript.setProperty(
-                    this->env_,
-                    "text",
-                    js::String::create(this->env_, output[i].text));
-                jsTranscript.setProperty(
-                    this->env_,
-                    "toAppend",
-                    js::Boolean::create(this->env_, output[i].toAppend));
-                jsTranscript.setProperty(
-                    this->env_,
-                    "start",
-                    js::Number::create(this->env_, output[i].start));
-                jsTranscript.setProperty(
-                    this->env_,
-                    "end",
-                    js::Number::create(this->env_, output[i].end));
-                jsTranscript.setProperty(
-                    this->env_,
-                    "id",
-                    js::Number::create(
-                        this->env_, static_cast<uint64_t>(output[i].id)));
-                jsTranscript.setProperty(
-                    this->env_,
-                    "isEndOfTurn",
-                    js::Boolean::create(this->env_, output[i].isEndOfTurn));
-                jsTranscript.setProperty(
-                    this->env_,
-                    "startsWord",
-                    js::Boolean::create(this->env_, output[i].startsWord));
-                jsOutput.set(this->env_, i, jsTranscript);
-              }
-              return jsOutput;
+              return transcriptsToJsArray(this->env_, output);
             }) {}
 };
 
@@ -165,15 +153,78 @@ inline js_value_t* getBackendInfo(js_env_t* env, js_callback_info_t* info) try {
 }
 JSCATCH
 
-// ─── Duplex streaming entry points ────────────────────────────────────────
-// Mirrors transcription-whispercpp's StreamingProcessor wiring. Each
-// addon instance can host at most one active streaming session at a
-// time. Audio appended via appendStreamingAudio() bypasses the
-// framework's append() -> runJob() -> process() lifecycle entirely;
-// per-segment Transcripts are queued straight into addonCpp->outputQueue,
-// so the existing JS `onUpdate` channel surfaces them as soon as the
-// engine emits each chunk. Tear down via endStreaming() (graceful) or
-// cancelWithStreaming() (forceful).
+// Duplex streaming entry points. One session per addon instance; audio from
+// appendStreamingAudio() bypasses the append()/runJob()/process() lifecycle
+// and queues per-segment Transcripts straight into addonCpp->outputQueue.
+
+inline ParakeetStreamingProcessor::Config
+streamingConfigFromModel(ParakeetModel& model) {
+  ParakeetStreamingProcessor::Config config;
+  config.sampleRate = model.getSampleRate();
+  config.chunkMs = model.getStreamingChunkMs();
+  config.historyMs = model.getStreamingHistoryMs();
+  config.emitPartials = model.getStreamingEmitPartials();
+  config.emitEnergyVad = model.getStreamingEnergyVad();
+  config.diarOnsetThreshold = model.getDiarOnsetThreshold();
+  config.diarMinSegmentMs =
+      static_cast<int>(model.getDiarMinDurationOn() * 1000.0F);
+  config.leftContextMs = model.getStreamingLeftContextMs();
+  config.rightLookaheadMs = model.getStreamingRightLookaheadMs();
+  config.spkCacheEnable = model.getStreamingSpkCacheEnable();
+  config.spkCacheLen = model.getStreamingSpkCacheLen();
+  config.fifoLen = model.getStreamingFifoLen();
+  config.chunkLeftContextMs = model.getStreamingChunkLeftContextMs();
+  config.chunkRightContextMs = model.getStreamingChunkRightContextMs();
+  config.spkCacheUpdatePeriod = model.getStreamingSpkCacheUpdatePeriod();
+  return config;
+}
+
+inline void overrideIfPositive(
+    js_env_t* env, js::Object& obj, const char* name, int& target) {
+  if (auto value = obj.getOptionalPropertyAs<js::Number, double>(env, name)) {
+    const int intValue = static_cast<int>(*value);
+    if (intValue > 0)
+      target = intValue;
+  }
+}
+
+inline void overrideIfNonNegative(
+    js_env_t* env, js::Object& obj, const char* name, int& target) {
+  if (auto value = obj.getOptionalPropertyAs<js::Number, double>(env, name)) {
+    const int intValue = static_cast<int>(*value);
+    if (intValue >= 0)
+      target = intValue;
+  }
+}
+
+inline void
+overrideBool(js_env_t* env, js::Object& obj, const char* name, bool& target) {
+  if (auto value = obj.getOptionalPropertyAs<js::Boolean, bool>(env, name)) {
+    target = *value;
+  }
+}
+
+inline void applyStreamingOverrides(
+    js_env_t* env, js::Object& configObj,
+    ParakeetStreamingProcessor::Config& config) {
+  overrideIfPositive(env, configObj, "chunkMs", config.chunkMs);
+  overrideIfPositive(env, configObj, "historyMs", config.historyMs);
+  overrideIfPositive(env, configObj, "leftContextMs", config.leftContextMs);
+  overrideIfNonNegative(
+      env, configObj, "rightLookaheadMs", config.rightLookaheadMs);
+  overrideBool(env, configObj, "emitPartials", config.emitPartials);
+  overrideBool(env, configObj, "emitEnergyVad", config.emitEnergyVad);
+  // AOSC per-call overrides (v2.1+ Sortformer only).
+  overrideBool(env, configObj, "spkCacheEnable", config.spkCacheEnable);
+  overrideIfPositive(env, configObj, "spkCacheLen", config.spkCacheLen);
+  overrideIfPositive(env, configObj, "fifoLen", config.fifoLen);
+  overrideIfNonNegative(
+      env, configObj, "chunkLeftContextMs", config.chunkLeftContextMs);
+  overrideIfNonNegative(
+      env, configObj, "chunkRightContextMs", config.chunkRightContextMs);
+  overrideIfPositive(
+      env, configObj, "spkCacheUpdatePeriod", config.spkCacheUpdatePeriod);
+}
 
 inline js_value_t*
 startStreaming(js_env_t* env, js_callback_info_t* info) try {
@@ -186,102 +237,9 @@ startStreaming(js_env_t* env, js_callback_info_t* info) try {
   auto& parakeetModel =
       dynamic_cast<ParakeetModel&>(instance.addonCpp->model.get());
 
-  ParakeetStreamingProcessor::Config config;
-  config.sampleRate         = parakeetModel.getSampleRate();
-  config.chunkMs            = parakeetModel.getStreamingChunkMs();
-  config.historyMs          = parakeetModel.getStreamingHistoryMs();
-  config.emitPartials       = parakeetModel.getStreamingEmitPartials();
-  config.emitEnergyVad      = parakeetModel.getStreamingEnergyVad();
-  config.diarOnsetThreshold = parakeetModel.getDiarOnsetThreshold();
-  config.diarMinSegmentMs   = static_cast<int>(
-      parakeetModel.getDiarMinDurationOn() * 1000.0F);
-  config.leftContextMs      = parakeetModel.getStreamingLeftContextMs();
-  config.rightLookaheadMs   = parakeetModel.getStreamingRightLookaheadMs();
-  // AOSC defaults sourced from the model's load-time ParakeetConfig.
-  config.spkCacheEnable = parakeetModel.getStreamingSpkCacheEnable();
-  config.spkCacheLen = parakeetModel.getStreamingSpkCacheLen();
-  config.fifoLen = parakeetModel.getStreamingFifoLen();
-  config.chunkLeftContextMs = parakeetModel.getStreamingChunkLeftContextMs();
-  config.chunkRightContextMs = parakeetModel.getStreamingChunkRightContextMs();
-  config.spkCacheUpdatePeriod =
-      parakeetModel.getStreamingSpkCacheUpdatePeriod();
-
-  if (auto chunkMs =
-          configObj.getOptionalProperty<js::Number>(env, "chunkMs");
-      chunkMs.has_value()) {
-    const auto v = static_cast<int>(chunkMs.value().as<double>(env));
-    if (v > 0) config.chunkMs = v;
-  }
-  if (auto historyMs =
-          configObj.getOptionalProperty<js::Number>(env, "historyMs");
-      historyMs.has_value()) {
-    const auto v = static_cast<int>(historyMs.value().as<double>(env));
-    if (v > 0) config.historyMs = v;
-  }
-  if (auto leftContextMs =
-          configObj.getOptionalProperty<js::Number>(env, "leftContextMs");
-      leftContextMs.has_value()) {
-    const auto v = static_cast<int>(leftContextMs.value().as<double>(env));
-    if (v > 0) config.leftContextMs = v;
-  }
-  if (auto rightLookaheadMs =
-          configObj.getOptionalProperty<js::Number>(env, "rightLookaheadMs");
-      rightLookaheadMs.has_value()) {
-    const auto v = static_cast<int>(rightLookaheadMs.value().as<double>(env));
-    if (v >= 0) config.rightLookaheadMs = v;
-  }
-  if (auto emitPartials =
-          configObj.getOptionalProperty<js::Boolean>(env, "emitPartials");
-      emitPartials.has_value()) {
-    config.emitPartials = emitPartials.value().as<bool>(env);
-  }
-  if (auto emitEnergyVad =
-          configObj.getOptionalProperty<js::Boolean>(env, "emitEnergyVad");
-      emitEnergyVad.has_value()) {
-    config.emitEnergyVad = emitEnergyVad.value().as<bool>(env);
-  }
-  // AOSC per-call overrides (v2.1+ Sortformer only).
-  if (auto spkCacheEnable =
-          configObj.getOptionalProperty<js::Boolean>(env, "spkCacheEnable");
-      spkCacheEnable.has_value()) {
-    config.spkCacheEnable = spkCacheEnable.value().as<bool>(env);
-  }
-  if (auto spkCacheLen =
-          configObj.getOptionalProperty<js::Number>(env, "spkCacheLen");
-      spkCacheLen.has_value()) {
-    const auto v = static_cast<int>(spkCacheLen.value().as<double>(env));
-    if (v > 0)
-      config.spkCacheLen = v;
-  }
-  if (auto fifoLen = configObj.getOptionalProperty<js::Number>(env, "fifoLen");
-      fifoLen.has_value()) {
-    const auto v = static_cast<int>(fifoLen.value().as<double>(env));
-    if (v > 0)
-      config.fifoLen = v;
-  }
-  if (auto chunkLeftContextMs =
-          configObj.getOptionalProperty<js::Number>(env, "chunkLeftContextMs");
-      chunkLeftContextMs.has_value()) {
-    const auto v = static_cast<int>(chunkLeftContextMs.value().as<double>(env));
-    if (v >= 0)
-      config.chunkLeftContextMs = v;
-  }
-  if (auto chunkRightContextMs =
-          configObj.getOptionalProperty<js::Number>(env, "chunkRightContextMs");
-      chunkRightContextMs.has_value()) {
-    const auto v =
-        static_cast<int>(chunkRightContextMs.value().as<double>(env));
-    if (v >= 0)
-      config.chunkRightContextMs = v;
-  }
-  if (auto spkCacheUpdatePeriod = configObj.getOptionalProperty<js::Number>(
-          env, "spkCacheUpdatePeriod");
-      spkCacheUpdatePeriod.has_value()) {
-    const auto v =
-        static_cast<int>(spkCacheUpdatePeriod.value().as<double>(env));
-    if (v > 0)
-      config.spkCacheUpdatePeriod = v;
-  }
+  ParakeetStreamingProcessor::Config config =
+      streamingConfigFromModel(parakeetModel);
+  applyStreamingOverrides(env, configObj, config);
 
   {
     std::lock_guard<std::mutex> lock(g_streamingMtx);
@@ -294,11 +252,7 @@ startStreaming(js_env_t* env, js_callback_info_t* info) try {
             parakeetModel, instance.addonCpp->outputQueue, config);
   }
 
-  // The return value is informational only -- ParakeetInterface's
-  // startStreaming() in parakeet.js synthesises its own currentJobId and
-  // discards this value. Kept as Boolean(true) instead of switching to
-  // a void / undefined return so existing JS callers (and the
-  // MockedBinding parity tests) keep working unchanged.
+  // Informational only; parakeet.js synthesises its own jobId.
   return js::Boolean::create(env, true);
 }
 JSCATCH

--- a/packages/transcription-parakeet/addon/src/js-interface/JSAdapter.cpp
+++ b/packages/transcription-parakeet/addon/src/js-interface/JSAdapter.cpp
@@ -1,5 +1,8 @@
 #include "JSAdapter.hpp"
 
+#include <optional>
+#include <string>
+
 #include "inference-addon-cpp/JsUtils.hpp"
 #include "inference-addon-cpp/Logger.hpp"
 
@@ -7,172 +10,83 @@ namespace qvac_lib_infer_parakeet {
 
 using namespace qvac_lib_inference_addon_cpp;
 
+namespace {
+
+void readInt(js::Object& obj, js_env_t* env, const char* name, int& target) {
+  if (auto value = obj.getOptionalPropertyAs<js::Number, int32_t>(env, name)) {
+    target = *value;
+  }
+}
+
+void readBool(js::Object& obj, js_env_t* env, const char* name, bool& target) {
+  if (auto value = obj.getOptionalPropertyAs<js::Boolean, bool>(env, name)) {
+    target = *value;
+  }
+}
+
+void readString(
+    js::Object& obj, js_env_t* env, const char* name, std::string& target) {
+  if (auto value =
+          obj.getOptionalPropertyAs<js::String, std::string>(env, name)) {
+    target = *value;
+  }
+}
+
+} // namespace
+
 auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
     -> ParakeetConfig {
   ParakeetConfig config;
 
-  auto modelPathOpt =
-      jsObject.getOptionalProperty<js::String>(env, "modelPath");
-  if (modelPathOpt.has_value()) {
-    config.modelPath = modelPathOpt.value().as<std::string>(env);
-  }
+  readString(jsObject, env, "modelPath", config.modelPath);
+  readString(jsObject, env, "path", config.modelPath);
+  readInt(jsObject, env, "maxThreads", config.maxThreads);
+  readBool(jsObject, env, "useGPU", config.useGPU);
+  readInt(jsObject, env, "sampleRate", config.sampleRate);
+  readInt(jsObject, env, "channels", config.channels);
+  readBool(jsObject, env, "captionEnabled", config.captionEnabled);
+  readBool(jsObject, env, "timestampsEnabled", config.timestampsEnabled);
+  readInt(jsObject, env, "seed", config.seed);
 
-  auto pathOpt = jsObject.getOptionalProperty<js::String>(env, "path");
-  if (pathOpt.has_value()) {
-    config.modelPath = pathOpt.value().as<std::string>(env);
-  }
+  // Streaming mode; unspecified fields keep ParakeetConfig's defaults.
+  readBool(jsObject, env, "streaming", config.streaming);
+  readInt(jsObject, env, "streamingChunkMs", config.streamingChunkMs);
+  readInt(jsObject, env, "streamingHistoryMs", config.streamingHistoryMs);
+  readBool(
+      jsObject, env, "streamingEmitPartials", config.streamingEmitPartials);
+  readBool(jsObject, env, "streamingEnergyVad", config.streamingEnergyVad);
+  readInt(
+      jsObject, env, "streamingLeftContextMs", config.streamingLeftContextMs);
+  readInt(
+      jsObject,
+      env,
+      "streamingRightLookaheadMs",
+      config.streamingRightLookaheadMs);
 
-  auto threadsOpt = jsObject.getOptionalProperty<js::Number>(env, "maxThreads");
-  if (threadsOpt.has_value()) {
-    config.maxThreads = threadsOpt.value().as<int32_t>(env);
-  }
+  // AOSC (v2.1+ Sortformer only); ignored for v1/v2/non-Sortformer engines.
+  readBool(
+      jsObject, env, "streamingSpkCacheEnable", config.streamingSpkCacheEnable);
+  readInt(jsObject, env, "streamingSpkCacheLen", config.streamingSpkCacheLen);
+  readInt(jsObject, env, "streamingFifoLen", config.streamingFifoLen);
+  readInt(
+      jsObject,
+      env,
+      "streamingChunkLeftContextMs",
+      config.streamingChunkLeftContextMs);
+  readInt(
+      jsObject,
+      env,
+      "streamingChunkRightContextMs",
+      config.streamingChunkRightContextMs);
+  readInt(
+      jsObject,
+      env,
+      "streamingSpkCacheUpdatePeriod",
+      config.streamingSpkCacheUpdatePeriod);
 
-  auto gpuOpt = jsObject.getOptionalProperty<js::Boolean>(env, "useGPU");
-  if (gpuOpt.has_value()) {
-    config.useGPU = gpuOpt.value().as<bool>(env);
-  }
-
-  auto sampleRateOpt =
-      jsObject.getOptionalProperty<js::Number>(env, "sampleRate");
-  if (sampleRateOpt.has_value()) {
-    config.sampleRate = sampleRateOpt.value().as<int32_t>(env);
-  }
-
-  auto channelsOpt = jsObject.getOptionalProperty<js::Number>(env, "channels");
-  if (channelsOpt.has_value()) {
-    config.channels = channelsOpt.value().as<int32_t>(env);
-  }
-
-  auto captionOpt =
-      jsObject.getOptionalProperty<js::Boolean>(env, "captionEnabled");
-  if (captionOpt.has_value()) {
-    config.captionEnabled = captionOpt.value().as<bool>(env);
-  }
-
-  auto timestampsOpt =
-      jsObject.getOptionalProperty<js::Boolean>(env, "timestampsEnabled");
-  if (timestampsOpt.has_value()) {
-    config.timestampsEnabled = timestampsOpt.value().as<bool>(env);
-  }
-
-  auto seedOpt = jsObject.getOptionalProperty<js::Number>(env, "seed");
-  if (seedOpt.has_value()) {
-    config.seed = seedOpt.value().as<int32_t>(env);
-  }
-
-  // Streaming mode (see ParakeetConfig comments). All fields optional;
-  // unspecified values keep ParakeetConfig's defaults.
-  auto streamingOpt =
-      jsObject.getOptionalProperty<js::Boolean>(env, "streaming");
-  if (streamingOpt.has_value()) {
-    config.streaming = streamingOpt.value().as<bool>(env);
-  }
-
-  auto streamingChunkMsOpt =
-      jsObject.getOptionalProperty<js::Number>(env, "streamingChunkMs");
-  if (streamingChunkMsOpt.has_value()) {
-    config.streamingChunkMs = streamingChunkMsOpt.value().as<int32_t>(env);
-  }
-
-  auto streamingHistoryMsOpt =
-      jsObject.getOptionalProperty<js::Number>(env, "streamingHistoryMs");
-  if (streamingHistoryMsOpt.has_value()) {
-    config.streamingHistoryMs = streamingHistoryMsOpt.value().as<int32_t>(env);
-  }
-
-  auto streamingEmitPartialsOpt =
-      jsObject.getOptionalProperty<js::Boolean>(env, "streamingEmitPartials");
-  if (streamingEmitPartialsOpt.has_value()) {
-    config.streamingEmitPartials = streamingEmitPartialsOpt.value().as<bool>(env);
-  }
-
-  auto streamingEnergyVadOpt =
-      jsObject.getOptionalProperty<js::Boolean>(env, "streamingEnergyVad");
-  if (streamingEnergyVadOpt.has_value()) {
-    config.streamingEnergyVad = streamingEnergyVadOpt.value().as<bool>(env);
-  }
-
-  auto streamingLeftContextMsOpt =
-      jsObject.getOptionalProperty<js::Number>(env, "streamingLeftContextMs");
-  if (streamingLeftContextMsOpt.has_value()) {
-    config.streamingLeftContextMs =
-        streamingLeftContextMsOpt.value().as<int32_t>(env);
-  }
-
-  auto streamingRightLookaheadMsOpt =
-      jsObject.getOptionalProperty<js::Number>(
-          env, "streamingRightLookaheadMs");
-  if (streamingRightLookaheadMsOpt.has_value()) {
-    config.streamingRightLookaheadMs =
-        streamingRightLookaheadMsOpt.value().as<int32_t>(env);
-  }
-
-  // AOSC (v2.1+ Sortformer only). All optional; unspecified values keep
-  // ParakeetConfig's defaults. Forwarded into
-  // parakeet::SortformerStreamingOptions by ParakeetModel /
-  // ParakeetStreamingProcessor; ignored for v1/v2/non-Sortformer.
-  auto streamingSpkCacheEnableOpt =
-      jsObject.getOptionalProperty<js::Boolean>(env, "streamingSpkCacheEnable");
-  if (streamingSpkCacheEnableOpt.has_value()) {
-    config.streamingSpkCacheEnable =
-        streamingSpkCacheEnableOpt.value().as<bool>(env);
-  }
-
-  auto streamingSpkCacheLenOpt =
-      jsObject.getOptionalProperty<js::Number>(env, "streamingSpkCacheLen");
-  if (streamingSpkCacheLenOpt.has_value()) {
-    config.streamingSpkCacheLen =
-        streamingSpkCacheLenOpt.value().as<int32_t>(env);
-  }
-
-  auto streamingFifoLenOpt =
-      jsObject.getOptionalProperty<js::Number>(env, "streamingFifoLen");
-  if (streamingFifoLenOpt.has_value()) {
-    config.streamingFifoLen = streamingFifoLenOpt.value().as<int32_t>(env);
-  }
-
-  auto streamingChunkLeftContextMsOpt =
-      jsObject.getOptionalProperty<js::Number>(
-          env, "streamingChunkLeftContextMs");
-  if (streamingChunkLeftContextMsOpt.has_value()) {
-    config.streamingChunkLeftContextMs =
-        streamingChunkLeftContextMsOpt.value().as<int32_t>(env);
-  }
-
-  auto streamingChunkRightContextMsOpt =
-      jsObject.getOptionalProperty<js::Number>(
-          env, "streamingChunkRightContextMs");
-  if (streamingChunkRightContextMsOpt.has_value()) {
-    config.streamingChunkRightContextMs =
-        streamingChunkRightContextMsOpt.value().as<int32_t>(env);
-  }
-
-  auto streamingSpkCacheUpdatePeriodOpt =
-      jsObject.getOptionalProperty<js::Number>(
-          env, "streamingSpkCacheUpdatePeriod");
-  if (streamingSpkCacheUpdatePeriodOpt.has_value()) {
-    config.streamingSpkCacheUpdatePeriod =
-        streamingSpkCacheUpdatePeriodOpt.value().as<int32_t>(env);
-  }
-
-  // Dynamic-backend loading knobs. Both forwarded to
-  // parakeet::EngineOptions and consumed once per-process on the
-  // first Engine construction (the ggml-backend registry + the
-  // ggml-opencl program-binary cache are both process singletons --
-  // see parakeet::set_backends_directory / set_opencl_cache_dir for
-  // the detailed lifetime contract). Empty -> leave the existing
-  // setting alone.
-  auto backendsDirOpt =
-      jsObject.getOptionalProperty<js::String>(env, "backendsDir");
-  if (backendsDirOpt.has_value()) {
-    config.backendsDir = backendsDirOpt.value().as<std::string>(env);
-  }
-
-  auto openclCacheDirOpt =
-      jsObject.getOptionalProperty<js::String>(env, "openclCacheDir");
-  if (openclCacheDirOpt.has_value()) {
-    config.openclCacheDir = openclCacheDirOpt.value().as<std::string>(env);
-  }
+  // Dynamic-backend loading; empty -> leave the existing setting alone.
+  readString(jsObject, env, "backendsDir", config.backendsDir);
+  readString(jsObject, env, "openclCacheDir", config.openclCacheDir);
 
   auto innerConfigOpt = jsObject.getOptionalProperty<js::Object>(env, "config");
   if (innerConfigOpt.has_value()) {
@@ -182,38 +96,19 @@ auto JSAdapter::loadFromJSObject(js::Object jsObject, js_env_t* env)
   return config;
 }
 
-auto JSAdapter::loadModelParams(js::Object modelParamsObj, js_env_t *env,
-                                ParakeetConfig &parakeetConfig)
+auto JSAdapter::loadModelParams(
+    js::Object modelParamsObj, js_env_t* env, ParakeetConfig& parakeetConfig)
     -> ParakeetConfig {
-  auto threadsOpt =
-      modelParamsObj.getOptionalProperty<js::Number>(env, "maxThreads");
-  if (threadsOpt.has_value()) {
-    parakeetConfig.maxThreads = threadsOpt.value().as<int32_t>(env);
-  }
-
-  auto gpuOpt = modelParamsObj.getOptionalProperty<js::Boolean>(env, "useGPU");
-  if (gpuOpt.has_value()) {
-    parakeetConfig.useGPU = gpuOpt.value().as<bool>(env);
-  }
-
+  readInt(modelParamsObj, env, "maxThreads", parakeetConfig.maxThreads);
+  readBool(modelParamsObj, env, "useGPU", parakeetConfig.useGPU);
   return parakeetConfig;
 }
 
-auto JSAdapter::loadAudioParams(js::Object audioParamsObj, js_env_t *env,
-                                ParakeetConfig &parakeetConfig)
+auto JSAdapter::loadAudioParams(
+    js::Object audioParamsObj, js_env_t* env, ParakeetConfig& parakeetConfig)
     -> ParakeetConfig {
-  auto sampleRateOpt =
-      audioParamsObj.getOptionalProperty<js::Number>(env, "sampleRate");
-  if (sampleRateOpt.has_value()) {
-    parakeetConfig.sampleRate = sampleRateOpt.value().as<int32_t>(env);
-  }
-
-  auto channelsOpt =
-      audioParamsObj.getOptionalProperty<js::Number>(env, "channels");
-  if (channelsOpt.has_value()) {
-    parakeetConfig.channels = channelsOpt.value().as<int32_t>(env);
-  }
-
+  readInt(audioParamsObj, env, "sampleRate", parakeetConfig.sampleRate);
+  readInt(audioParamsObj, env, "channels", parakeetConfig.channels);
   return parakeetConfig;
 }
 

--- a/packages/transcription-parakeet/addon/src/model-interface/ParakeetStreamingProcessor.cpp
+++ b/packages/transcription-parakeet/addon/src/model-interface/ParakeetStreamingProcessor.cpp
@@ -110,13 +110,8 @@ void ParakeetStreamingProcessor::end() {
   }
   if (shouldSignal)
     cv_.notify_all();
-  // join() runs at most once across end() / cancel() / dtor's cancel(),
-  // even when they race on different threads. Without this guard the
-  // loser observed thread_.joinable() == true and called join() on an
-  // already-joined thread, raising std::system_error.
-  std::call_once(teardown_once_, [this] {
-    if (thread_.joinable()) thread_.join();
-  });
+  // call_once joins the worker exactly once even if end()/cancel()/dtor race.
+  joinWorkerOnce();
 }
 
 void ParakeetStreamingProcessor::cancel() {
@@ -136,6 +131,10 @@ void ParakeetStreamingProcessor::cancel() {
     }
     cv_.notify_all();
   }
+  joinWorkerOnce();
+}
+
+void ParakeetStreamingProcessor::joinWorkerOnce() {
   std::call_once(teardown_once_, [this] {
     if (thread_.joinable()) thread_.join();
   });

--- a/packages/transcription-parakeet/addon/src/model-interface/ParakeetStreamingProcessor.hpp
+++ b/packages/transcription-parakeet/addon/src/model-interface/ParakeetStreamingProcessor.hpp
@@ -12,8 +12,8 @@
 #include <parakeet/streaming.h>
 
 #include "inference-addon-cpp/queue/OutputQueue.hpp"
-
 #include "model-interface/ParakeetTypes.hpp"
+#include "model-interface/parakeet/ParakeetConfig.hpp"
 
 namespace qvac_lib_infer_parakeet {
 
@@ -43,29 +43,27 @@ class ParakeetModel;
 class ParakeetStreamingProcessor {
 public:
   struct Config {
-    int sampleRate          = 16000;
-    int chunkMs             = 1000;
-    int historyMs           = 30000;
-    bool emitPartials       = true;
-    bool emitEnergyVad      = false;
+    int sampleRate = 16000;
+    int chunkMs = ParakeetConfig::DEFAULT_STREAMING_CHUNK_MS;
+    int historyMs = ParakeetConfig::DEFAULT_STREAMING_HISTORY_MS;
+    bool emitPartials = true;
+    bool emitEnergyVad = false;
     float diarOnsetThreshold = 0.5F;
-    int  diarMinSegmentMs   = 200;
+    int diarMinSegmentMs = 200;
     // ASR-only knobs (Sortformer ignores them). <0 means "leave the
     // parakeet engine default in place" (10000 / 2000 ms respectively).
-    int  leftContextMs      = -1;
-    int  rightLookaheadMs   = -1;
-    // === AOSC (v2.1+ Sortformer only) ====================================
-    // Forwarded into parakeet::SortformerStreamingOptions when the loaded
-    // model is a v2.1 Sortformer GGUF (auto-detected from the GGUF's
-    // `parakeet.model_variant` metadata tag). parakeet-cpp ignores these
-    // fields on v1/v2 GGUFs and on non-Sortformer engines, so they are
-    // always safe to forward.
+    int leftContextMs = -1;
+    int rightLookaheadMs = -1;
+    // AOSC (v2.1+ Sortformer only); ignored on v1/v2 and non-Sortformer.
     bool spkCacheEnable = true;
-    int spkCacheLen = 188;
-    int fifoLen = 188;
-    int chunkLeftContextMs = 80;
-    int chunkRightContextMs = 560;
-    int spkCacheUpdatePeriod = 144;
+    int spkCacheLen = ParakeetConfig::DEFAULT_STREAMING_SPK_CACHE_LEN;
+    int fifoLen = ParakeetConfig::DEFAULT_STREAMING_FIFO_LEN;
+    int chunkLeftContextMs =
+        ParakeetConfig::DEFAULT_STREAMING_CHUNK_LEFT_CONTEXT_MS;
+    int chunkRightContextMs =
+        ParakeetConfig::DEFAULT_STREAMING_CHUNK_RIGHT_CONTEXT_MS;
+    int spkCacheUpdatePeriod =
+        ParakeetConfig::DEFAULT_STREAMING_SPK_CACHE_UPDATE_PERIOD;
   };
 
   ParakeetStreamingProcessor(
@@ -107,6 +105,7 @@ private:
   void onAsrSegment(const parakeet::StreamingSegment& seg);
   void onDiarSegment(const parakeet::StreamingDiarizationSegment& seg);
   void emitPending();
+  void joinWorkerOnce();
 
   ParakeetModel& model_;
   std::shared_ptr<qvac_lib_inference_addon_cpp::OutputQueue> output_queue_;
@@ -130,12 +129,7 @@ private:
   std::atomic_bool worker_done_{false};
   std::thread thread_;
 
-  // Serialises end() / cancel() / dtor so the worker thread is joined
-  // exactly once even when end() races with cancel(), or two cancel()
-  // calls race, or the dtor's fallback cancel() races with an explicit
-  // end()/cancel() from the binding. Without this, the loser of the race
-  // observed thread_.joinable() == true and called join() on an already
-  // joined thread, which raises std::system_error.
+  // Joins the worker exactly once across racing end()/cancel()/dtor calls.
   std::once_flag teardown_once_;
 
   // Wall-clock seconds of audio fed so far; mirrors what the legacy

--- a/packages/transcription-parakeet/addon/src/model-interface/ParakeetStreamingProcessor.hpp
+++ b/packages/transcription-parakeet/addon/src/model-interface/ParakeetStreamingProcessor.hpp
@@ -44,7 +44,7 @@ class ParakeetStreamingProcessor {
 public:
   struct Config {
     int sampleRate = 16000;
-    int chunkMs = ParakeetConfig::DEFAULT_STREAMING_CHUNK_MS;
+    int chunkMs = 1000;
     int historyMs = ParakeetConfig::DEFAULT_STREAMING_HISTORY_MS;
     bool emitPartials = true;
     bool emitEnergyVad = false;

--- a/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetConfig.hpp
+++ b/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetConfig.hpp
@@ -7,6 +7,14 @@
 namespace qvac_lib_infer_parakeet {
 
 struct ParakeetConfig {
+  static constexpr int DEFAULT_STREAMING_CHUNK_MS = 2000;
+  static constexpr int DEFAULT_STREAMING_HISTORY_MS = 30000;
+  static constexpr int DEFAULT_STREAMING_SPK_CACHE_LEN = 188;
+  static constexpr int DEFAULT_STREAMING_FIFO_LEN = 188;
+  static constexpr int DEFAULT_STREAMING_CHUNK_LEFT_CONTEXT_MS = 80;
+  static constexpr int DEFAULT_STREAMING_CHUNK_RIGHT_CONTEXT_MS = 560;
+  static constexpr int DEFAULT_STREAMING_SPK_CACHE_UPDATE_PERIOD = 144;
+
   std::string modelPath;
 
   // ModelType is auto-detected by ParakeetModel::load() from the
@@ -14,13 +22,13 @@ struct ParakeetConfig {
   // is just a placeholder until that override fires.
   ModelType modelType = ModelType::TDT;
 
-  int  maxThreads        = 4;
-  bool useGPU            = false;
-  int  sampleRate        = 16000;
-  int  channels          = 1;
-  bool captionEnabled    = false;
+  int maxThreads = 4;
+  bool useGPU = false;
+  int sampleRate = 16000;
+  int channels = 1;
+  bool captionEnabled = false;
   bool timestampsEnabled = true;
-  int  seed              = -1;
+  int seed = -1;
 
   // ── Streaming mode ──────────────────────────────────────────────────────
   // When true, the model opens a long-lived qvac_parakeet streaming session
@@ -41,11 +49,12 @@ struct ParakeetConfig {
   // a single long-lived session for the lifetime of one runStreaming() call
   // regardless of how many append-style chunks it ingests.
   // Off by default for batch-style transcription.
-  bool streaming             = false;
-  int  streamingChunkMs      = 2000;
-  int  streamingHistoryMs    = 30000;   // Sortformer rolling window only
+  bool streaming = false;
+  int streamingChunkMs = DEFAULT_STREAMING_CHUNK_MS;
+  int streamingHistoryMs =
+      DEFAULT_STREAMING_HISTORY_MS; // Sortformer rolling window only
   bool streamingEmitPartials = true;
-  bool streamingEnergyVad    = false;   // CTC/TDT only; ignored elsewhere
+  bool streamingEnergyVad = false; // CTC/TDT only; ignored elsewhere
   // Forwarded to parakeet::StreamingOptions.left_context_ms /
   // right_lookahead_ms. ASR sessions only (Sortformer ignores both --
   // it has its own SortformerStreamingOptions::history_ms knob).
@@ -54,8 +63,8 @@ struct ParakeetConfig {
   // bounds the rolling encoder context retained upstream of each chunk.
   // -1 keeps parakeet's own defaults (10000 / 2000) so callers that don't
   // set the field behave like before.
-  int  streamingLeftContextMs    = -1;
-  int  streamingRightLookaheadMs = -1;
+  int streamingLeftContextMs = -1;
+  int streamingRightLookaheadMs = -1;
 
   // === AOSC (Audio-Online Speaker Cache; v2.1+ Sortformer only) ───────────
   // Forwarded to parakeet::SortformerStreamingOptions.spkcache_* /
@@ -72,11 +81,11 @@ struct ParakeetConfig {
   // Setting streamingSpkCacheEnable = false on a v2.1 model forces the
   // v1 sliding-window code path (useful for regression comparison).
   bool streamingSpkCacheEnable = true;
-  int streamingSpkCacheLen = 188;          // long-term speaker rows (~15s)
-  int streamingFifoLen = 188;              // FIFO warmup buffer rows
-  int streamingChunkLeftContextMs = 80;    // encoder left context  (~1 frame)
-  int streamingChunkRightContextMs = 560;  // encoder right context (~7 frames)
-  int streamingSpkCacheUpdatePeriod = 144; // FIFO-overflow pop-out count
+  int streamingSpkCacheLen = DEFAULT_STREAMING_SPK_CACHE_LEN;
+  int streamingFifoLen = DEFAULT_STREAMING_FIFO_LEN;
+  int streamingChunkLeftContextMs = DEFAULT_STREAMING_CHUNK_LEFT_CONTEXT_MS;
+  int streamingChunkRightContextMs = DEFAULT_STREAMING_CHUNK_RIGHT_CONTEXT_MS;
+  int streamingSpkCacheUpdatePeriod = DEFAULT_STREAMING_SPK_CACHE_UPDATE_PERIOD;
 
   // ── Dynamic-backend loading ────────────────────────────────────────────
   // Forwarded to parakeet::EngineOptions::backends_dir /

--- a/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
+++ b/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetModel.cpp
@@ -29,95 +29,107 @@ using namespace qvac_lib_inference_addon_cpp;
 
 namespace {
 
-// Stable numeric mapping from parakeet::Engine::backend_name()
-// to the integer code surfaced on JS as `RuntimeStats.backendId`.
-// Match by prefix because ggml_backend_name() returns indexed strings
-// like "CUDA0" / "Vulkan0" / "MTL0" when multiple GPUs of the same
-// family are present. Keep in sync with index.d.ts BackendId comment.
-//
-// Metal note: ggml-metal at the qvac-parakeet pin (upstream 58c38058)
-// reports the device as `"MTL0"` from `ggml_backend_name()` despite
-// parakeet's own header advertising the name as `"Metal"`. Treat both
-// forms (and any future indexed `MetalN` variant) as the Metal family.
+// backendId family codes surfaced on JS as `RuntimeStats.backendId`; kept
+// in sync with index.d.ts. Device classes for backend_device_ / getBackend
+// DeviceClass().
+enum BackendId {
+  BackendCpu = 0,
+  BackendMetal = 1,
+  BackendCuda = 2,
+  BackendVulkan = 3,
+  BackendOpenCl = 4,
+  BackendOther = 99
+};
+enum BackendDeviceClass { DeviceCpu = 0, DeviceGpu = 1 };
+
+// n_gpu_layers value that offloads every layer to the GPU backend.
+constexpr int OFFLOAD_ALL_LAYERS_TO_GPU = 999;
+
+// Match by prefix: ggml_backend_name() returns indexed strings like "CUDA0"
+// / "Vulkan0" / "MTL0" on multi-GPU hosts. Metal reports as "MTL0" from
+// ggml despite parakeet advertising "Metal", so accept both forms.
 int backendIdFromName(const std::string& name) {
-  if (name == "CPU") return 0;
-  if (name.rfind("Metal",  0) == 0 || name.rfind("MTL", 0) == 0) return 1;
-  if (name.rfind("CUDA",   0) == 0) return 2;
-  if (name.rfind("Vulkan", 0) == 0) return 3;
-  if (name.rfind("OpenCL", 0) == 0) return 4;
-  return 99;
+  if (name == "CPU")
+    return BackendCpu;
+  if (name.rfind("Metal", 0) == 0 || name.rfind("MTL", 0) == 0)
+    return BackendMetal;
+  if (name.rfind("CUDA", 0) == 0)
+    return BackendCuda;
+  if (name.rfind("Vulkan", 0) == 0)
+    return BackendVulkan;
+  if (name.rfind("OpenCL", 0) == 0)
+    return BackendOpenCl;
+  return BackendOther;
 }
 
-// Maps a ggml backend *registry* name (e.g. "CUDA", "Vulkan", "Metal",
-// "OpenCL") to the same numeric family code as backendIdFromName, so the
-// device the engine selected can be matched against the ggml device registry
-// to recover its human-readable description.
+// Maps a ggml backend *registry* name to the same family code so the engine's
+// device can be matched against the ggml device registry for its description.
 int backendIdFromRegName(std::string regName) {
   std::transform(
       regName.begin(), regName.end(), regName.begin(), [](unsigned char c) {
         return std::tolower(c);
       });
   if (regName.rfind("metal", 0) == 0)
-    return 1;
+    return BackendMetal;
   if (regName.rfind("cuda", 0) == 0)
-    return 2;
+    return BackendCuda;
   if (regName.rfind("vulkan", 0) == 0)
-    return 3;
+    return BackendVulkan;
   if (regName.rfind("opencl", 0) == 0)
-    return 4;
-  return 99;
+    return BackendOpenCl;
+  return BackendOther;
 }
 
-// Human-readable description of the active GPU device (e.g.
-// "NVIDIA GeForce RTX 3090", "Apple M2 Pro"), recovered from the ggml device
-// registry after the engine has registered its backends. This is the fallback
-// the perf reporter uses on CI runners where nvidia-smi / procfs are
-// unavailable but the ggml backend (CUDA / Vulkan / Metal) still knows the
-// device name via cudaGetDeviceProperties / VkPhysicalDeviceProperties /
-// MTLDevice.name. Returns "" when the active backend is CPU or no GPU device
-// is registered. Best-effort on a multi-GPU host: prefers the first device
-// whose backend family matches what the engine reported, else the first
-// GPU/IGPU device.
-std::string captureBackendDescription(int backendId, int backendDevice) {
-  if (backendDevice != 1) {
-    return ""; // CPU backend: no GPU hardware name to report.
-  }
+bool isGpuDevice(ggml_backend_dev_t dev) {
+  const enum ggml_backend_dev_type type = ggml_backend_dev_type(dev);
+  return type == GGML_BACKEND_DEVICE_TYPE_GPU ||
+         type == GGML_BACKEND_DEVICE_TYPE_IGPU;
+}
 
-  ggml_backend_dev_t firstGpu = nullptr;
+std::string deviceDescriptionOrName(ggml_backend_dev_t dev) {
+  const char* desc = ggml_backend_dev_description(dev);
+  if (desc != nullptr && desc[0] != '\0')
+    return desc;
+  const char* name = ggml_backend_dev_name(dev);
+  return (name != nullptr) ? name : "";
+}
+
+int backendIdOfDevice(ggml_backend_dev_t dev) {
+  ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+  const char* regName = (reg != nullptr) ? ggml_backend_reg_name(reg) : "";
+  return backendIdFromRegName(regName != nullptr ? regName : "");
+}
+
+// Finds the ggml GPU device whose backend family matches backendId, setting
+// firstGpuOut to the first GPU device seen as a fallback.
+ggml_backend_dev_t
+findGpuDeviceForBackend(int backendId, ggml_backend_dev_t& firstGpuOut) {
+  firstGpuOut = nullptr;
   const size_t devCount = ggml_backend_dev_count();
   for (size_t i = 0; i < devCount; ++i) {
     ggml_backend_dev_t dev = ggml_backend_dev_get(i);
-    if (dev == nullptr) {
+    if (dev == nullptr || !isGpuDevice(dev))
       continue;
-    }
-    const enum ggml_backend_dev_type type = ggml_backend_dev_type(dev);
-    if (type != GGML_BACKEND_DEVICE_TYPE_GPU &&
-        type != GGML_BACKEND_DEVICE_TYPE_IGPU) {
-      continue;
-    }
-    if (firstGpu == nullptr) {
-      firstGpu = dev;
-    }
-    ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
-    const char* regName = (reg != nullptr) ? ggml_backend_reg_name(reg) : "";
-    if (backendIdFromRegName(regName != nullptr ? regName : "") == backendId) {
-      const char* desc = ggml_backend_dev_description(dev);
-      if (desc != nullptr && desc[0] != '\0') {
-        return desc;
-      }
-      const char* devName = ggml_backend_dev_name(dev);
-      return (devName != nullptr) ? devName : "";
-    }
+    if (firstGpuOut == nullptr)
+      firstGpuOut = dev;
+    if (backendIdOfDevice(dev) == backendId)
+      return dev;
   }
+  return nullptr;
+}
 
-  if (firstGpu != nullptr) {
-    const char* desc = ggml_backend_dev_description(firstGpu);
-    if (desc != nullptr && desc[0] != '\0') {
-      return desc;
-    }
-    const char* devName = ggml_backend_dev_name(firstGpu);
-    return (devName != nullptr) ? devName : "";
-  }
+// Human-readable GPU device name recovered from the ggml device registry;
+// "" on CPU or when no GPU is registered. Prefers the device whose backend
+// family matches the engine, else the first GPU/IGPU device.
+std::string captureBackendDescription(int backendId, int backendDevice) {
+  if (backendDevice != DeviceGpu)
+    return "";
+  ggml_backend_dev_t firstGpu = nullptr;
+  ggml_backend_dev_t matched = findGpuDeviceForBackend(backendId, firstGpu);
+  if (matched != nullptr)
+    return deviceDescriptionOrName(matched);
+  if (firstGpu != nullptr)
+    return deviceDescriptionOrName(firstGpu);
   return "";
 }
 
@@ -143,23 +155,9 @@ int64_t measureMs(Fn&& fn) {
   return std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-//  ggml -> qvac-logging bridge
-// ─────────────────────────────────────────────────────────────────────────
-// ggml's metal / vulkan / opencl backends log via fprintf-to-stderr by
-// default, which bypasses the binding's QLOG() pipe and bleeds into
-// example output (`ggml_metal_library_compile_pipeline: ...` lines on
-// every kernel JIT). We install a process-wide ggml log callback that
-// rewrites each line as a QLOG() call so:
-//   - by default (no `setLogger()` from JS), QLOG is a no-op and ggml
-//     stays silent;
-//   - with `--native-logs` (a.k.a. `binding.setLogger(...)`), ggml info
-//     / warning / error lines flow through the same JS logger as the
-//     binding's own messages, prefixed by `[C++ INFO]` etc.
-//
-// Multi-part lines (GGML_LOG_LEVEL_CONT, used e.g. when a metal
-// pipeline compile splits into two prints) are buffered and flushed
-// together so QLOG sees one logical line per ggml line.
+// Routes ggml's stderr logging through the binding's QLOG() pipe so it obeys
+// --native-logs (or stays silent by default). Multi-part CONT lines are
+// buffered and flushed together so QLOG sees one logical line per ggml line.
 
 std::mutex& ggmlLogBufMutex() {
   static std::mutex m;
@@ -185,14 +183,7 @@ logger::Priority ggmlLevelToPriority(ggml_log_level level) {
   }
 }
 
-void ggmlLogTrampoline(ggml_log_level level, const char * text, void * /*user_data*/) {
-  if (!text) return;
-  std::lock_guard<std::mutex> lk(ggmlLogBufMutex());
-  if (level != GGML_LOG_LEVEL_CONT)
-    ggmlLogBufLevel() = level;
-  ggmlLogBuf().append(text);
-  // Flush whole lines as they arrive; ggml emits both `\n`-terminated
-  // strings and bare fragments, so we drain every newline we see.
+void flushCompleteLogLines() {
   for (size_t nl = ggmlLogBuf().find('\n'); nl != std::string::npos;
        nl = ggmlLogBuf().find('\n')) {
     std::string line = ggmlLogBuf().substr(0, nl);
@@ -202,6 +193,17 @@ void ggmlLogTrampoline(ggml_log_level level, const char * text, void * /*user_da
   }
 }
 
+void ggmlLogTrampoline(
+    ggml_log_level level, const char* text, void* /*user_data*/) {
+  if (!text)
+    return;
+  std::lock_guard<std::mutex> lk(ggmlLogBufMutex());
+  if (level != GGML_LOG_LEVEL_CONT)
+    ggmlLogBufLevel() = level;
+  ggmlLogBuf().append(text);
+  flushCompleteLogLines();
+}
+
 void installGgmlLogTrampolineOnce() {
   static std::once_flag once;
   std::call_once(once, [] {
@@ -209,11 +211,147 @@ void installGgmlLogTrampolineOnce() {
   });
 }
 
-} // namespace
+constexpr float PCM_S16_SCALE = 1.0F / 32768.0F;
 
-// ─────────────────────────────────────────────────────────────────────────
-//  Constructor / destructor
-// ─────────────────────────────────────────────────────────────────────────
+float pcmS16ToFloat32(int16_t sample) {
+  return static_cast<float>(sample) * PCM_S16_SCALE;
+}
+
+int16_t readLittleEndianS16(uint8_t lo, uint8_t hi) {
+  return static_cast<int16_t>(lo | (hi << 8));
+}
+
+std::vector<float> decodeS16lePcm(const std::vector<uint8_t>& bytes) {
+  const size_t nSamples = bytes.size() / 2;
+  std::vector<float> out(nSamples);
+  for (size_t i = 0; i < nSamples; ++i) {
+    out[i] =
+        pcmS16ToFloat32(readLittleEndianS16(bytes[i * 2], bytes[i * 2 + 1]));
+  }
+  return out;
+}
+
+std::string formatSpeakerSegment(int speakerId, double startS, double endS) {
+  std::ostringstream os;
+  os << "Speaker " << speakerId << ": "
+     << formatSeconds(static_cast<float>(startS)) << " - "
+     << formatSeconds(static_cast<float>(endS));
+  return os.str();
+}
+
+template <typename Segments>
+std::string formatDiarizationSegments(const Segments& segments) {
+  std::ostringstream os;
+  bool first = true;
+  for (const auto& s : segments) {
+    if (!first)
+      os << "\n";
+    first = false;
+    os << formatSpeakerSegment(s.speaker_id, s.start_s, s.end_s);
+  }
+  return os.str();
+}
+
+Transcript
+makeDiarizationTranscript(const parakeet::StreamingDiarizationSegment& seg) {
+  Transcript t;
+  t.text = formatSpeakerSegment(seg.speaker_id, seg.start_s, seg.end_s);
+  t.start = static_cast<float>(seg.start_s);
+  t.end = static_cast<float>(seg.end_s);
+  t.toAppend = true;
+  return t;
+}
+
+Transcript makeAsrTranscript(const parakeet::StreamingSegment& seg) {
+  Transcript t;
+  t.text = seg.text;
+  t.start = static_cast<float>(seg.start_s);
+  t.end = static_cast<float>(seg.end_s);
+  t.toAppend = true;
+  t.isEndOfTurn = seg.is_eou_boundary;
+  t.startsWord = seg.starts_word;
+  return t;
+}
+
+std::string joinTranscriptText(
+    const std::vector<Transcript>& segments, const char* separator) {
+  std::ostringstream os;
+  for (size_t i = 0; i < segments.size(); ++i) {
+    if (i > 0)
+      os << separator;
+    os << segments[i].text;
+  }
+  return os.str();
+}
+
+parakeet::EngineOptions
+buildEngineOptions(const ParakeetConfig& cfg, const fs::path& ggufPath) {
+  parakeet::EngineOptions eopts;
+  eopts.model_gguf_path = ggufPath.string();
+  // n_threads = 0 lets ggml pick hardware_concurrency; maxThreads is honoured
+  // only when explicitly set non-zero.
+  eopts.n_threads = cfg.maxThreads > 0 ? cfg.maxThreads : 0;
+  eopts.n_gpu_layers = cfg.useGPU ? OFFLOAD_ALL_LAYERS_TO_GPU : 0;
+  eopts.verbose = false;
+  // Compose the backends-scan dir from the host prebuilds root plus the
+  // cmake-bare per-target subdir (BACKENDS_SUBDIR). Empty -> ggml's default
+  // compile-time search path.
+  if (!cfg.backendsDir.empty()) {
+    fs::path backendsDirPath(cfg.backendsDir);
+#ifdef BACKENDS_SUBDIR
+    backendsDirPath =
+        (backendsDirPath / fs::path(BACKENDS_SUBDIR)).lexically_normal();
+#endif
+    eopts.backends_dir = backendsDirPath.string();
+  }
+  // Empty -> leave $GGML_OPENCL_CACHE_DIR alone (Android-only, read once).
+  eopts.opencl_cache_dir = cfg.openclCacheDir;
+  return eopts;
+}
+
+parakeet::SortformerStreamingOptions buildSortformerStreamingOptions(
+    const ParakeetConfig& cfg, int sampleRate, float onset,
+    float minDurationOn) {
+  parakeet::SortformerStreamingOptions opts;
+  opts.sample_rate = sampleRate;
+  opts.chunk_ms = cfg.streamingChunkMs > 0
+                      ? cfg.streamingChunkMs
+                      : ParakeetConfig::DEFAULT_STREAMING_CHUNK_MS;
+  opts.history_ms = cfg.streamingHistoryMs > 0
+                        ? cfg.streamingHistoryMs
+                        : ParakeetConfig::DEFAULT_STREAMING_HISTORY_MS;
+  opts.threshold = onset;
+  opts.min_segment_ms = static_cast<int>(minDurationOn * 1000.0F);
+  opts.emit_partials = cfg.streamingEmitPartials;
+  // AOSC (v2.1+ Sortformer only); parakeet-cpp ignores it on v1/v2 GGUFs.
+  opts.spkcache_enable = cfg.streamingSpkCacheEnable;
+  opts.spkcache_len = cfg.streamingSpkCacheLen;
+  opts.fifo_len = cfg.streamingFifoLen;
+  opts.chunk_left_context_ms = cfg.streamingChunkLeftContextMs;
+  opts.chunk_right_context_ms = cfg.streamingChunkRightContextMs;
+  opts.spkcache_update_period = cfg.streamingSpkCacheUpdatePeriod;
+  return opts;
+}
+
+parakeet::StreamingOptions
+buildAsrStreamingOptions(const ParakeetConfig& cfg, int sampleRate) {
+  parakeet::StreamingOptions opts;
+  opts.sample_rate = sampleRate;
+  opts.chunk_ms = cfg.streamingChunkMs > 0
+                      ? cfg.streamingChunkMs
+                      : ParakeetConfig::DEFAULT_STREAMING_CHUNK_MS;
+  if (cfg.streamingLeftContextMs > 0) {
+    opts.left_context_ms = cfg.streamingLeftContextMs;
+  }
+  if (cfg.streamingRightLookaheadMs >= 0) {
+    opts.right_lookahead_ms = cfg.streamingRightLookaheadMs;
+  }
+  opts.emit_partials = cfg.streamingEmitPartials;
+  opts.enable_energy_vad = cfg.streamingEnergyVad;
+  return opts;
+}
+
+} // namespace
 
 ParakeetModel::ParakeetModel(const ParakeetConfig& config) : cfg_(config) {
   if (cfg_.sampleRate != 0) {
@@ -225,20 +363,12 @@ ParakeetModel::~ParakeetModel() {
   try {
     unload();
   } catch (...) {
-    // destructors must not throw
   }
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-//  Lifecycle
-// ─────────────────────────────────────────────────────────────────────────
-
 void ParakeetModel::initializeBackend() {
-  // Backend init for ggml is handled inside Engine's constructor (which
-  // picks Metal / Vulkan / OpenCL / CPU based on which ggml backends are
-  // compiled in). All we need to do here is route ggml's own log lines
-  // through the binding's QLOG() pipe so they obey --native-logs (or
-  // stay silent by default) instead of bleeding to stderr.
+  // Engine's constructor selects the ggml backend; here we only route ggml's
+  // own log lines through QLOG() so they obey --native-logs.
   installGgmlLogTrampolineOnce();
 }
 
@@ -249,10 +379,8 @@ std::filesystem::path ParakeetModel::writeBufferToTempFile() {
         "ParakeetModel::load: no GGUF bytes received before load()");
   }
 
-  // Generate a per-process unique temp filename. We avoid std::tmpnam
-  // because it's racy + deprecated, and we want a deterministic-ish
-  // suffix so multiple ParakeetModel instances in the same process
-  // don't collide.
+  // Per-process unique temp filename (std::tmpnam is racy/deprecated) so
+  // multiple ParakeetModel instances in one process don't collide.
   const auto pid = static_cast<unsigned long>(std::random_device{}());
   const auto when = std::chrono::steady_clock::now().time_since_epoch().count();
   std::ostringstream name;
@@ -293,6 +421,94 @@ void ParakeetModel::cleanupTempFile() {
   }
 }
 
+std::filesystem::path ParakeetModel::resolveGgufPath() {
+  // Prefer an existing cfg_.modelPath (skips the temp-file copy); otherwise
+  // materialise streamed setWeightsForFile() bytes into a temp file.
+  if (!cfg_.modelPath.empty() && fs::exists(cfg_.modelPath)) {
+    return cfg_.modelPath;
+  }
+  if (gguf_completed_ && !gguf_buffer_.empty()) {
+    gguf_temp_path_ = writeBufferToTempFile();
+    return gguf_temp_path_;
+  }
+  throw qvac_errors::StatusError(
+      qvac_errors::general_error::InvalidArgument,
+      "ParakeetModel::load: no GGUF available "
+      "(no setWeightsForFile() bytes and modelPath is missing or empty)");
+}
+
+void ParakeetModel::detectModelType() {
+  if (!engine_)
+    return;
+  // The engine reports `parakeet.model.type` from GGUF metadata, so callers
+  // don't pass modelType; keep cfg_.modelType only if it's unrecognised.
+  const std::string detected = engine_->model_type();
+  if (detected == "ctc")
+    cfg_.modelType = ModelType::CTC;
+  else if (detected == "tdt")
+    cfg_.modelType = ModelType::TDT;
+  else if (detected == "eou")
+    cfg_.modelType = ModelType::EOU;
+  else if (detected == "sortformer")
+    cfg_.modelType = ModelType::SORTFORMER;
+}
+
+void ParakeetModel::captureBackend() {
+  if (!engine_)
+    return;
+  backend_device_ = engine_->backend_device() == parakeet::BackendDevice::GPU
+                        ? DeviceGpu
+                        : DeviceCpu;
+  backend_name_ = engine_->backend_name();
+  backend_id_ = backendIdFromName(backend_name_);
+  backend_gpu_unsupported_ = engine_->gpu_unsupported() ? 1 : 0;
+  backend_description_ =
+      captureBackendDescription(backend_id_, backend_device_);
+
+  QLOG(
+      logger::Priority::INFO,
+      std::string("Parakeet engine loaded; model_type=") +
+          engine_->model_type() + " backend=" + backend_name_ +
+          " (device=" + (backend_device_ == DeviceGpu ? "GPU" : "CPU") +
+          ", id=" + std::to_string(backend_id_) + ", gpu='" +
+          backend_description_ + "')");
+}
+
+void ParakeetModel::warnOnGpuFallback() const {
+  if (cfg_.useGPU && backend_device_ != DeviceGpu &&
+      !backend_gpu_unsupported_) {
+    QLOG(
+        logger::Priority::WARNING,
+        "Parakeet: useGPU=true was requested but the active backend is CPU. "
+        "The platform's GPU backend either isn't compiled in or refused to "
+        "initialise (e.g. missing OpenCL ICD, Adreno-tier policy, simulator "
+        "without Metal). Falling back to CPU.");
+  }
+}
+
+void ParakeetModel::openStreamingSessionOrThrow() {
+  try {
+    openStreamingSession();
+  } catch (const std::exception& e) {
+    QLOG(
+        logger::Priority::ERROR,
+        std::string("Failed to open streaming session: ") + e.what());
+    throw;
+  }
+}
+
+void ParakeetModel::warnOnSampleRateMismatch() const {
+  // The engine's mel preprocessor is hardcoded to 16 kHz, so warn if the
+  // caller asked for anything else.
+  if (sample_rate_ != static_cast<int>(SAMPLE_RATE)) {
+    QLOG(
+        logger::Priority::WARNING,
+        "Parakeet engine assumes 16 kHz audio; cfg.sampleRate=" +
+            std::to_string(sample_rate_) +
+            " will be ignored at the engine boundary");
+  }
+}
+
 void ParakeetModel::load() {
   if (is_loaded_) return;
 
@@ -301,135 +517,24 @@ void ParakeetModel::load() {
            std::to_string(static_cast<int>(cfg_.modelType)) + ")");
 
   modelLoadMs_ = measureMs([&] {
-    fs::path ggufPath;
-
-    // Two ways to source the GGUF:
-    //   1. Caller streamed bytes via setWeightsForFile() -- we materialise
-    //      them to a temp file. This is the path the addon framework
-    //      uses by default.
-    //   2. Caller pre-set `cfg_.modelPath` to an existing GGUF on disk.
-    //      We skip the temp-file dance and load from the path directly.
-    // Prefer cfg_.modelPath when it points at an existing file -- avoids
-    // the temp-file copy entirely. setWeightsForFile() bytes are the
-    // fallback for callers that don't have direct filesystem access.
-    if (!cfg_.modelPath.empty() && fs::exists(cfg_.modelPath)) {
-      ggufPath = cfg_.modelPath;
-    } else if (gguf_completed_ && !gguf_buffer_.empty()) {
-      gguf_temp_path_ = writeBufferToTempFile();
-      ggufPath = gguf_temp_path_;
-    } else {
-      throw qvac_errors::StatusError(
-          qvac_errors::general_error::InvalidArgument,
-          "ParakeetModel::load: no GGUF available "
-          "(no setWeightsForFile() bytes and modelPath is missing or empty)");
-    }
-
+    const fs::path ggufPath = resolveGgufPath();
     installGgmlLogTrampolineOnce();
-    parakeet::EngineOptions eopts;
-    eopts.model_gguf_path = ggufPath.string();
-    // n_threads = 0 lets ggml pick hardware_concurrency, matching the
-    // standalone CLI's default. cfg_.maxThreads is honoured only when
-    // explicitly set non-zero.
-    eopts.n_threads       = cfg_.maxThreads > 0 ? cfg_.maxThreads : 0;
-    // Engine picks the GPU backend based on ggml's compile-time backends
-    // when n_gpu_layers > 0; we leave it at 0 for back-compat with the
-    // legacy CPU-only path and bump only when cfg_.useGPU is true.
-    eopts.n_gpu_layers    = cfg_.useGPU ? 999 : 0;
-    eopts.verbose         = false;
-    // Compose the actual backends-scan directory from the host-
-    // provided prebuilds root plus the cmake-bare per-target subdir
-    // (BACKENDS_SUBDIR, e.g. `android-arm64/qvac__transcription-parakeet`).
-    // Mirrors the exact shape qvac/packages/llm-llamacpp uses in
-    // addon/src/model-interface/LlamaLazyInitializeBackend.cpp so a
-    // host that already passes `path.join(__dirname, 'prebuilds')`
-    // gets the same resolution semantics across both addons. Empty
-    // backendsDir -> leave eopts.backends_dir empty so parakeet-cpp
-    // falls back to ggml's compile-time default search path
-    // (`ggml_backend_load_all()` rather than `..._from_path()`).
-    if (!cfg_.backendsDir.empty()) {
-      fs::path backendsDirPath(cfg_.backendsDir);
-#ifdef BACKENDS_SUBDIR
-      backendsDirPath =
-          (backendsDirPath / fs::path(BACKENDS_SUBDIR)).lexically_normal();
-#endif
-      eopts.backends_dir = backendsDirPath.string();
-    }
-    // Forwarded as-is. Empty string -> leave $GGML_OPENCL_CACHE_DIR
-    // alone (the env-set-by-host path still wins). Only consumed on
-    // Android by parakeet::set_opencl_cache_dir(); other platforms
-    // ignore it. Process-singleton scoped: a second Engine ctor with
-    // a different value is silently ignored on the parakeet-cpp side
-    // because ggml-opencl only reads the env var once at first init.
-    eopts.opencl_cache_dir = cfg_.openclCacheDir;
-
-    {
-      std::lock_guard<std::mutex> lk(engine_mutex_);
-      engine_ = std::make_unique<parakeet::Engine>(eopts);
-    }
+    const parakeet::EngineOptions eopts = buildEngineOptions(cfg_, ggufPath);
+    std::lock_guard<std::mutex> lk(engine_mutex_);
+    engine_ = std::make_unique<parakeet::Engine>(eopts);
   });
 
   is_loaded_ = true;
-
-  // Auto-detect modelType from the loaded GGUF's metadata. The engine
-  // returns "ctc" / "tdt" / "eou" / "sortformer" reflecting the
-  // `parakeet.model.type` GGUF metadata field, so JS callers don't
-  // need to pass `modelType` themselves -- the binding picks the
-  // right dispatch (ASR vs Sortformer) automatically. We only fall
-  // back to whatever cfg_.modelType the caller passed if the engine
-  // reports something unrecognised.
-  if (engine_) {
-    const std::string detected = engine_->model_type();
-    if (detected == "ctc")        cfg_.modelType = ModelType::CTC;
-    else if (detected == "tdt")   cfg_.modelType = ModelType::TDT;
-    else if (detected == "eou")   cfg_.modelType = ModelType::EOU;
-    else if (detected == "sortformer") cfg_.modelType = ModelType::SORTFORMER;
-
-    backend_device_ =
-        engine_->backend_device() == parakeet::BackendDevice::GPU ? 1 : 0;
-    backend_name_   = engine_->backend_name();
-    backend_id_     = backendIdFromName(backend_name_);
-    backend_gpu_unsupported_ = engine_->gpu_unsupported() ? 1 : 0;
-    backend_description_ =
-        captureBackendDescription(backend_id_, backend_device_);
-
-    QLOG(
-        logger::Priority::INFO,
-        std::string("Parakeet engine loaded; model_type=") + detected +
-            " backend=" + backend_name_ +
-            " (device=" + (backend_device_ == 1 ? "GPU" : "CPU") +
-            ", id=" + std::to_string(backend_id_) + ", gpu='" +
-            backend_description_ + "')");
-    if (cfg_.useGPU && backend_device_ != 1 && !backend_gpu_unsupported_) {
-      QLOG(logger::Priority::WARNING,
-           "Parakeet: useGPU=true was requested but the active backend is CPU. "
-           "The platform's GPU backend either isn't compiled in or refused to "
-           "initialise (e.g. missing OpenCL ICD, Adreno-tier policy, simulator "
-           "without Metal). Falling back to CPU.");
-    }
-  }
+  detectModelType();
+  captureBackend();
+  warnOnGpuFallback();
 
   if (cfg_.streaming) {
-    try {
-      openStreamingSession();
-    } catch (const std::exception& e) {
-      QLOG(logger::Priority::ERROR,
-           std::string("Failed to open streaming session: ") + e.what());
-      throw;
-    }
+    openStreamingSessionOrThrow();
   }
 
-  // Best-effort sample-rate sanity check. The engine itself doesn't expose
-  // its mel preprocessor's expected sample rate today (it's hardcoded to
-  // 16 kHz inside qvac-parakeet.cpp), so we just warn if the caller asked
-  // for something else.
-  if (sample_rate_ != static_cast<int>(SAMPLE_RATE)) {
-    QLOG(logger::Priority::WARNING,
-         "Parakeet engine assumes 16 kHz audio; cfg.sampleRate=" +
-             std::to_string(sample_rate_) +
-             " will be ignored at the engine boundary");
-  }
+  warnOnSampleRateMismatch();
 
-  // Free the staging buffer; we kept it only to feed the engine.
   gguf_buffer_.clear();
   gguf_buffer_.shrink_to_fit();
 
@@ -449,12 +554,8 @@ void ParakeetModel::unload() {
 }
 
 void ParakeetModel::reload() {
-  // reload() requires a persistent cfg_.modelPath. unload() clears
-  // gguf_buffer_, so a model originally loaded from a streamed byte
-  // buffer (loadWeights()) without a backing file on disk would fail to
-  // re-open here. The JS layer always writes the bytes to a temp file
-  // before calling load(), so cfg_.modelPath is set in practice; surface
-  // a clear error if a future caller skips that step.
+  // Requires a persistent modelPath: unload() drops the in-memory GGUF
+  // buffer, so a stream-only load has nothing to re-open.
   if (cfg_.modelPath.empty()) {
     throw qvac_errors::StatusError(
         qvac_errors::general_error::InternalError,
@@ -484,19 +585,9 @@ void ParakeetModel::endOfStream() {
   }
   streaming_finalized_ = true;
 
-  // Drain any segments emitted by finalize() into output_ + on_segment_
-  // so the trailing partial chunk surfaces in the next runtimeStats()
-  // tick / next process() return.
-  std::vector<Transcript> drained;
-  {
-    std::lock_guard<std::mutex> lk(streaming_mutex_);
-    drained.swap(pending_streaming_segments_);
-  }
-  for (auto& seg : drained) {
-    output_.push_back(seg);
-    if (on_segment_) on_segment_(seg);
-    ++totalTranscriptions_;
-  }
+  // Surface segments emitted by finalize() so the trailing partial chunk
+  // reaches the next process() return.
+  emitStreamingSegments(takePendingStreamingSegments());
 }
 
 void ParakeetModel::reset() {
@@ -513,24 +604,17 @@ void ParakeetModel::warmup() {
   try {
     runAsrProcess(silence);
   } catch (...) {
-    // warmup failures are non-fatal
   }
   output_.clear();
   is_warmed_up_ = true;
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-//  Cancellation
-// ─────────────────────────────────────────────────────────────────────────
-
 void ParakeetModel::throwIfCancelled() const {
   const auto active = activeGeneration_.load(std::memory_order_relaxed);
   const auto cancel = cancelGeneration_.load(std::memory_order_relaxed);
   if (active != 0 && cancel >= active) {
-    // The framework's GeneralErrorCode set doesn't include
-    // OperationCanceled; we raise InternalError with the recognised
-    // ERR_JOB_CANCELLED text so isCancellationError() can detect it
-    // upstream.
+    // The framework has no OperationCanceled code, so raise InternalError
+    // with ERR_JOB_CANCELLED text that isCancellationError() recognises.
     throw qvac_errors::StatusError(
         qvac_errors::general_error::InternalError, ERR_JOB_CANCELLED);
   }
@@ -544,17 +628,9 @@ bool ParakeetModel::isCancellationError(const std::exception& e) {
 void ParakeetModel::cancel() const {
   const auto active = activeGeneration_.load(std::memory_order_relaxed);
   cancelGeneration_.store(active, std::memory_order_relaxed);
-  // Streaming sessions own their own cancel() that interrupts any
-  // in-flight feed_pcm_f32. Best-effort -- the JobRunner's framework
-  // also waits for processingSync.
-  //
-  // cancel() is documented as concurrent with process()/unload()/reload(),
-  // and openStreamingSession() / closeStreamingSession() / endOfStream() /
-  // ~ParakeetModel all .reset() the unique_ptrs from another thread.
-  // Snapshot raw pointers under session_mutex_ so we don't race against a
-  // concurrent .reset(); the engine's session-internal cancel() is itself
-  // thread-safe with concurrent feed/finalize, so we can release the lock
-  // before invoking it.
+  // cancel() may race with the open/close/unload lifecycle, so snapshot the
+  // session pointers under session_mutex_ and invoke the engine's own
+  // (thread-safe) cancel() outside the lock.
   parakeet::StreamSession*           asr  = nullptr;
   parakeet::SortformerStreamSession* diar = nullptr;
   {
@@ -566,16 +642,10 @@ void ParakeetModel::cancel() const {
   if (diar) { try { diar->cancel(); } catch (...) {} }
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-//  Weight loading
-// ─────────────────────────────────────────────────────────────────────────
-
 void ParakeetModel::set_weights_for_file(const std::string& filename,
                                          std::span<const uint8_t> contents,
                                          bool completed) {
-  // We expect a single GGUF; any other extension is rejected with the
-  // same error code the legacy binding used so JS callers see no shape
-  // change.
+  // Only a single GGUF is accepted; other extensions are rejected.
   const std::string lower = [&] {
     std::string s = filename;
     std::transform(s.begin(), s.end(), s.begin(), ::tolower);
@@ -604,11 +674,7 @@ void ParakeetModel::set_weights_for_file(
     const std::string& filename,
     std::unique_ptr<std::basic_streambuf<char>> streambuf) {
   if (!streambuf) return;
-  // Drain the streambuf without relying on seekg/tellg (which not all
-  // streambuf implementations support; bare's stream wrappers and
-  // simple test fakes both lack seekoff overrides). We read in 64 KiB
-  // chunks until sgetn returns less than the requested size, which
-  // signals EOF.
+  // Drain via sgetn in fixed chunks (not all streambufs support seekg/tellg).
   std::vector<uint8_t> buf;
   std::array<char, 64 * 1024> tmp{};
   while (true) {
@@ -631,10 +697,6 @@ void ParakeetModel::setWeightsForFile(
   set_weights_for_file(filename, std::move(streambuf));
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-//  Static helpers
-// ─────────────────────────────────────────────────────────────────────────
-
 std::vector<float>
 ParakeetModel::preprocessAudioData(const std::vector<uint8_t>& audioData,
                                    const std::string& audioFormat) {
@@ -643,20 +705,8 @@ ParakeetModel::preprocessAudioData(const std::vector<uint8_t>& audioData,
         qvac_errors::general_error::InvalidArgument,
         "ParakeetModel::preprocessAudioData: only s16le PCM is supported");
   }
-  const size_t nSamples = audioData.size() / 2;
-  std::vector<float> out(nSamples);
-  constexpr float inv = 1.0f / 32768.0f;
-  for (size_t i = 0; i < nSamples; ++i) {
-    const int16_t s = static_cast<int16_t>(
-        audioData[i * 2] | (audioData[i * 2 + 1] << 8));
-    out[i] = static_cast<float>(s) * inv;
-  }
-  return out;
+  return decodeS16lePcm(audioData);
 }
-
-// ─────────────────────────────────────────────────────────────────────────
-//  Engine dispatch
-// ─────────────────────────────────────────────────────────────────────────
 
 std::string ParakeetModel::runAsrProcess(const Input& input) {
   if (input.empty()) return ERR_AUDIO_SHORT;
@@ -672,13 +722,8 @@ std::string ParakeetModel::runAsrProcess(const Input& input) {
       engine->transcribe_samples(input.data(),
                                  static_cast<int>(input.size()),
                                  sample_rate_);
-  // Record per-stage timings verbatim from the engine. The earlier
-  // fallback (substitute the entire transcribe_samples wall-clock when
-  // encoder_ms == 0) silently mis-attributed mel + decoder time as
-  // encoder time, inflating the encoder bucket roughly 3-5x on the
-  // first call. Engines that don't report encoder_ms record 0; callers
-  // that need the full-pipeline wall clock can derive it from
-  // melSpecMs_ + encoderMs_ + decoderMs_.
+  // Record per-stage timings verbatim; engines that don't report a stage
+  // record 0 rather than mis-attributing wall-clock across buckets.
   encoderMs_         += static_cast<int64_t>(result.encoder_ms);
   decoderMs_         += static_cast<int64_t>(result.decode_ms);
   melSpecMs_         += static_cast<int64_t>(result.preprocess_ms);
@@ -712,20 +757,8 @@ std::string ParakeetModel::runSortformerProcess(const Input& input) {
 
   if (diar.segments.empty()) return ERR_NO_SPEAKERS;
 
-  std::ostringstream os;
-  for (size_t i = 0; i < diar.segments.size(); ++i) {
-    const auto& s = diar.segments[i];
-    if (i > 0) os << "\n";
-    os << "Speaker " << s.speaker_id << ": "
-       << formatSeconds(static_cast<float>(s.start_s)) << " - "
-       << formatSeconds(static_cast<float>(s.end_s));
-  }
-  return os.str();
+  return formatDiarizationSegments(diar.segments);
 }
-
-// ─────────────────────────────────────────────────────────────────────────
-//  Streaming session lifecycle
-// ─────────────────────────────────────────────────────────────────────────
 
 std::unique_ptr<parakeet::StreamSession> ParakeetModel::createDuplexAsrSession(
     const parakeet::StreamingOptions& opts,
@@ -780,95 +813,71 @@ void ParakeetModel::openStreamingSession() {
   }
 
   if (cfg_.modelType == ModelType::SORTFORMER) {
-    parakeet::SortformerStreamingOptions opts;
-    opts.sample_rate    = sample_rate_;
-    opts.chunk_ms       = cfg_.streamingChunkMs > 0 ? cfg_.streamingChunkMs : 2000;
-    opts.history_ms     = cfg_.streamingHistoryMs > 0 ? cfg_.streamingHistoryMs : 30000;
-    opts.threshold      = diarConfig_.onset;
-    opts.min_segment_ms = static_cast<int>(diarConfig_.minDurationOn * 1000.0f);
-    opts.emit_partials  = cfg_.streamingEmitPartials;
-    // AOSC (v2.1+ Sortformer only; ignored for v1/v2 GGUFs). The engine
-    // detects v2.1 via the GGUF metadata tag `parakeet.model_variant` and
-    // only consults these fields then -- safe to forward unconditionally.
-    opts.spkcache_enable = cfg_.streamingSpkCacheEnable;
-    opts.spkcache_len = cfg_.streamingSpkCacheLen;
-    opts.fifo_len = cfg_.streamingFifoLen;
-    opts.chunk_left_context_ms = cfg_.streamingChunkLeftContextMs;
-    opts.chunk_right_context_ms = cfg_.streamingChunkRightContextMs;
-    opts.spkcache_update_period = cfg_.streamingSpkCacheUpdatePeriod;
-
-    auto session = engine->diarize_start(
-        opts, [this](const parakeet::StreamingDiarizationSegment& seg) {
-          // Synthetic terminator (fired on finalize when audio ended on a
-          // chunk boundary): nothing to emit.
-          if (seg.speaker_id < 0)
-            return;
-          Transcript t;
-          std::ostringstream os;
-          os << "Speaker " << seg.speaker_id << ": "
-             << formatSeconds(static_cast<float>(seg.start_s)) << " - "
-             << formatSeconds(static_cast<float>(seg.end_s));
-          t.text     = os.str();
-          t.start    = static_cast<float>(seg.start_s);
-          t.end      = static_cast<float>(seg.end_s);
-          t.toAppend = true;
-          {
-            std::lock_guard<std::mutex> lk(streaming_mutex_);
-            pending_streaming_segments_.push_back(std::move(t));
-          }
-        });
-    {
-      std::lock_guard<std::mutex> lk(session_mutex_);
-      diar_session_ = std::move(session);
-    }
+    openSortformerStreamingSession(*engine);
   } else {
-    if (cfg_.streamingHistoryMs > 0) {
-      QLOG(logger::Priority::WARNING,
-           "streamingHistoryMs is Sortformer-only and is ignored for ASR streaming sessions");
-    }
-    parakeet::StreamingOptions opts;
-    opts.sample_rate    = sample_rate_;
-    // Match the documented default (2000 ms) when the caller leaves
-    // streamingChunkMs at its zero sentinel; the previous 1000 ms fallback
-    // diverged from README / index.d.ts / ParakeetConfig advertisements.
-    opts.chunk_ms       = cfg_.streamingChunkMs > 0 ? cfg_.streamingChunkMs : 2000;
-    if (cfg_.streamingLeftContextMs > 0) {
-      opts.left_context_ms = cfg_.streamingLeftContextMs;
-    }
-    if (cfg_.streamingRightLookaheadMs >= 0) {
-      opts.right_lookahead_ms = cfg_.streamingRightLookaheadMs;
-    }
-    opts.emit_partials  = cfg_.streamingEmitPartials;
-    opts.enable_energy_vad = cfg_.streamingEnergyVad;
+    openAsrStreamingSession(*engine);
+  }
+}
 
-    auto session = engine->stream_start(
-        opts, [this](const parakeet::StreamingSegment& seg) {
-          if (seg.text.empty() && !seg.is_eou_boundary)
-            return;
-          Transcript t;
-          t.text        = seg.text;
-          t.start       = static_cast<float>(seg.start_s);
-          t.end         = static_cast<float>(seg.end_s);
-          t.toAppend    = true;
-          t.isEndOfTurn = seg.is_eou_boundary;
-          t.startsWord  = seg.starts_word;
-          {
-            std::lock_guard<std::mutex> lk(streaming_mutex_);
-            pending_streaming_segments_.push_back(std::move(t));
-          }
-        });
-    {
-      std::lock_guard<std::mutex> lk(session_mutex_);
-      asr_session_ = std::move(session);
-    }
+void ParakeetModel::openSortformerStreamingSession(parakeet::Engine& engine) {
+  const parakeet::SortformerStreamingOptions opts =
+      buildSortformerStreamingOptions(
+          cfg_, sample_rate_, diarConfig_.onset, diarConfig_.minDurationOn);
+  auto session = engine.diarize_start(
+      opts, [this](const parakeet::StreamingDiarizationSegment& seg) {
+        // Negative speaker_id is the synthetic finalize terminator.
+        if (seg.speaker_id < 0)
+          return;
+        pushPendingSegment(makeDiarizationTranscript(seg));
+      });
+  std::lock_guard<std::mutex> lk(session_mutex_);
+  diar_session_ = std::move(session);
+}
+
+void ParakeetModel::openAsrStreamingSession(parakeet::Engine& engine) {
+  if (cfg_.streamingHistoryMs > 0) {
+    QLOG(
+        logger::Priority::WARNING,
+        "streamingHistoryMs is Sortformer-only and is ignored for ASR "
+        "streaming sessions");
+  }
+  const parakeet::StreamingOptions opts =
+      buildAsrStreamingOptions(cfg_, sample_rate_);
+  auto session =
+      engine.stream_start(opts, [this](const parakeet::StreamingSegment& seg) {
+        if (seg.text.empty() && !seg.is_eou_boundary)
+          return;
+        pushPendingSegment(makeAsrTranscript(seg));
+      });
+  std::lock_guard<std::mutex> lk(session_mutex_);
+  asr_session_ = std::move(session);
+}
+
+void ParakeetModel::pushPendingSegment(Transcript segment) {
+  std::lock_guard<std::mutex> lk(streaming_mutex_);
+  pending_streaming_segments_.push_back(std::move(segment));
+}
+
+std::vector<Transcript> ParakeetModel::takePendingStreamingSegments() {
+  std::vector<Transcript> drained;
+  std::lock_guard<std::mutex> lk(streaming_mutex_);
+  drained.swap(pending_streaming_segments_);
+  return drained;
+}
+
+void ParakeetModel::emitStreamingSegments(
+    const std::vector<Transcript>& segments) {
+  for (const auto& seg : segments) {
+    output_.push_back(seg);
+    if (on_segment_)
+      on_segment_(seg);
+    ++totalTranscriptions_;
   }
 }
 
 void ParakeetModel::closeStreamingSession() {
-  // Snapshot-and-release pattern: take ownership of the unique_ptrs under
-  // session_mutex_ so a concurrent cancel() can't observe a half-destroyed
-  // session, then run the (potentially blocking) session->cancel() and
-  // ~Session calls outside the lock.
+  // Take ownership of the sessions under session_mutex_ so a concurrent
+  // cancel() can't see a half-destroyed session, then destroy outside it.
   std::unique_ptr<parakeet::StreamSession> asrToDestroy;
   std::unique_ptr<parakeet::SortformerStreamSession> diarToDestroy;
   {
@@ -898,91 +907,38 @@ void ParakeetModel::closeStreamingSession() {
   streaming_finalized_     = false;
 }
 
-std::string ParakeetModel::runStreamingProcess(const Input& input) {
-  if (input.empty()) return ERR_AUDIO_SHORT;
-  if (streaming_finalized_) {
-    QLOG(logger::Priority::WARNING,
-         "process() called after streaming session was finalized; ignoring");
-    return std::string();
-  }
-
-  // The JS append() layer batches every chunk for a job in JS memory and
-  // forwards the concatenated buffer in a single 'end of job' runJob call
-  // (see parakeet.js); the framework's IModel interface has no separate
-  // end-of-stream hook, so process() is invoked exactly once per JS run().
-  // Feed the batch, then immediately finalize the session so
-  // flush_remainder() processes the trailing right_lookahead window. Without
-  // the finalize, ~chunk_ms + right_lookahead_ms of audio (3 s on default
-  // settings) sit in StreamSession::pending and the terminal <EOU> never
-  // reaches eou_decode_window.
-  const int64_t t = measureMs([&] {
+int64_t ParakeetModel::feedStreamingChunk(const Input& input) {
+  // Feed the batch then finalize so flush_remainder() drains the trailing
+  // right_lookahead window (otherwise the terminal <EOU> never surfaces).
+  return measureMs([&] {
     if (cfg_.modelType == ModelType::SORTFORMER) {
       if (diar_session_) {
         diar_session_->feed_pcm_f32(input.data(),
                                     static_cast<int>(input.size()));
-        try { diar_session_->finalize(); } catch (...) {}
+        try {
+          diar_session_->finalize();
+        } catch (...) {
+        }
       }
     } else {
       if (asr_session_) {
         asr_session_->feed_pcm_f32(input.data(),
                                    static_cast<int>(input.size()));
-        try { asr_session_->finalize(); } catch (...) {}
+        try {
+          asr_session_->finalize();
+        } catch (...) {
+        }
       }
     }
   });
-  encoderMs_ += t;
-  streaming_audio_seconds_ +=
-      static_cast<double>(input.size()) / static_cast<double>(sample_rate_);
+}
 
-  // Drain segments collected via the streaming callback during the feed
-  // (and during the finalize() flush above).
-  std::vector<Transcript> drained;
-  {
-    std::lock_guard<std::mutex> lk(streaming_mutex_);
-    drained.swap(pending_streaming_segments_);
-  }
-
-  if (drained.empty()) {
-    return cfg_.modelType == ModelType::SORTFORMER ? ERR_NO_SPEAKERS
-                                                   : ERR_NO_SPEECH;
-  }
-
-  for (auto& seg : drained) {
-    output_.push_back(seg);
-    if (on_segment_) on_segment_(seg);
-    ++totalTranscriptions_;
-  }
-
-  // Concatenate text from drained segments for back-compat with callers
-  // that read process()'s return string directly. Sortformer segments
-  // are already pre-formatted ("Speaker N: ..."); join with newlines so
-  // the JS-side parser keeps working unchanged.
-  std::ostringstream os;
-  const char* sep = (cfg_.modelType == ModelType::SORTFORMER) ? "\n" : " ";
-  for (size_t i = 0; i < drained.size(); ++i) {
-    if (i > 0) os << sep;
-    os << drained[i].text;
-  }
-
-  // The session was finalized above, so feed_pcm_f32 would throw on the
-  // next process() call. Reopen a fresh session for the next job; each JS
-  // run() on this framework path is treated as an independent utterance.
-  //
-  // IMPORTANT (cross-call streaming state): the close+reopen below WIPES
-  // engine-side streaming state that consumers may believe survives across
-  // process() calls -- specifically:
-  //   * Sortformer cross-chunk speaker history (the engine starts over)
-  //   * EOU rolling window / partial decode state for ASR
-  //   * the streaming session's internal sample-position clock
-  // i.e. README / index.d.ts / ParakeetConfig::streaming language about
-  // "preserves speaker IDs across appends" applies to a SINGLE run() call
-  // (which the JS append() layer batches into one process() invocation),
-  // NOT across multiple run() calls on the same model instance. Use the
-  // duplex `runStreaming()` API (ParakeetStreamingProcessor) when you
-  // need a single long-lived session that survives across many append()
-  // batches without resetting -- the duplex path owns its own
-  // parakeet::StreamSession that is never closed mid-flight by the
-  // framework.
+void ParakeetModel::reopenStreamingSession() {
+  // Each framework-path run() is an independent utterance, so the finalized
+  // session is closed and reopened. This WIPES engine-side cross-chunk state
+  // (Sortformer speaker history, EOU window); "preserves state across
+  // appends" holds only within a single run(). Use runStreaming() for a
+  // long-lived session.
   closeStreamingSession();
   try {
     openStreamingSession();
@@ -990,13 +946,37 @@ std::string ParakeetModel::runStreamingProcess(const Input& input) {
     QLOG(logger::Priority::WARNING,
          std::string("Failed to reopen streaming session: ") + e.what());
   }
-
-  return os.str();
 }
 
-// ─────────────────────────────────────────────────────────────────────────
-//  IModel API
-// ─────────────────────────────────────────────────────────────────────────
+std::string ParakeetModel::runStreamingProcess(const Input& input) {
+  if (input.empty())
+    return ERR_AUDIO_SHORT;
+  if (streaming_finalized_) {
+    QLOG(
+        logger::Priority::WARNING,
+        "process() called after streaming session was finalized; ignoring");
+    return std::string();
+  }
+
+  encoderMs_ += feedStreamingChunk(input);
+  streaming_audio_seconds_ +=
+      static_cast<double>(input.size()) / static_cast<double>(sample_rate_);
+
+  std::vector<Transcript> drained = takePendingStreamingSegments();
+  if (drained.empty()) {
+    return cfg_.modelType == ModelType::SORTFORMER ? ERR_NO_SPEAKERS
+                                                   : ERR_NO_SPEECH;
+  }
+
+  emitStreamingSegments(drained);
+  // Sortformer segments are pre-formatted ("Speaker N: ..."); join with
+  // newlines so the JS parser keeps working. ASR joins with spaces.
+  const char* separator = isSortformer() ? "\n" : " ";
+  std::string joined = joinTranscriptText(drained, separator);
+
+  reopenStreamingSession();
+  return joined;
+}
 
 void ParakeetModel::process(const Input& input) {
   throwIfCancelled();
@@ -1026,9 +1006,8 @@ void ParakeetModel::process(const Input& input) {
           (cfg_.modelType == ModelType::SORTFORMER ? diar_session_ != nullptr
                                                    : asr_session_ != nullptr);
       if (cfg_.streaming && hasSession) {
-        // runStreamingProcess drains the per-segment callback queue
-        // straight into output_ + on_segment_, so we must skip the
-        // legacy single-Transcript push below.
+        // runStreamingProcess already pushes per-segment Transcripts, so
+        // skip the single-Transcript push below.
         text = runStreamingProcess(input);
         streamed = true;
       } else if (cfg_.modelType == ModelType::SORTFORMER) {
@@ -1048,11 +1027,8 @@ void ParakeetModel::process(const Input& input) {
   processed_time_ += duration;
 
   if (streamed) {
-    // Streaming path already pushed per-segment Transcripts during
-    // runStreamingProcess's drain. If the engine emitted nothing at
-    // all for this chunk (silence sentinel), emit a single placeholder
-    // so the JS side still gets one Output per process() with an
-    // unambiguous "no speech" signal -- matches legacy behaviour.
+    // On a silence sentinel the streaming drain emitted nothing, so push a
+    // single "no speech" placeholder to keep one Output per process().
     if (text.empty() || isSentinel(text)) {
       Transcript transcript;
       transcript.text     = text.empty() ? ERR_NO_SPEECH : text;
@@ -1122,16 +1098,13 @@ std::string ParakeetModel::getName() const {
 }
 
 RuntimeStats ParakeetModel::runtimeStats() const {
-  // RuntimeStats is a `vector<pair<string, variant<double, int64_t>>>` --
-  // a flat key/value list.
   RuntimeStats stats;
   stats.emplace_back("processCalls",        static_cast<int64_t>(processCalls_));
   stats.emplace_back("totalSamples",        static_cast<int64_t>(totalSamples_));
   stats.emplace_back("totalTokens",         static_cast<int64_t>(totalTokens_));
   stats.emplace_back("totalTranscriptions", static_cast<int64_t>(totalTranscriptions_));
   stats.emplace_back("totalWallMs",         static_cast<int64_t>(totalWallMs_));
-  // Legacy alias of totalWallMs; the addon-cpp output handlers and
-  // AddonCppTest expect this key by name.
+  // Legacy alias of totalWallMs; addon-cpp output handlers expect this key.
   stats.emplace_back("totalTime",           static_cast<int64_t>(totalWallMs_));
   stats.emplace_back("modelLoadMs",         static_cast<int64_t>(modelLoadMs_));
   stats.emplace_back("encoderMs",           static_cast<int64_t>(encoderMs_));
@@ -1139,12 +1112,8 @@ RuntimeStats ParakeetModel::runtimeStats() const {
   stats.emplace_back("melSpecMs",           static_cast<int64_t>(melSpecMs_));
   stats.emplace_back("totalEncodedFrames",  static_cast<int64_t>(totalEncodedFrames_));
 
-  // Active backend, captured once at load() and stable for the
-  // lifetime of the model. `backendDevice` is the post-fallback
-  // device class (0 = CPU, 1 = GPU); `backendId` identifies which
-  // GPU backend is engaged (see backendIdFromName above for the
-  // mapping). Both are int64 to fit RuntimeStats's variant; the JS
-  // side reads them from runtimeStats() (a.k.a. response.stats).
+  // Active backend captured at load(): backendDevice is the device class
+  // (0 = CPU, 1 = GPU); backendId identifies the GPU backend family.
   stats.emplace_back("backendDevice",       static_cast<int64_t>(backend_device_));
   stats.emplace_back("backendId",           static_cast<int64_t>(backend_id_));
   stats.emplace_back(

--- a/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetModel.hpp
+++ b/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetModel.hpp
@@ -128,9 +128,7 @@ public:
     return backend_description_;
   }
   int                 getStreamingChunkMs() const {
-    return cfg_.streamingChunkMs > 0
-               ? cfg_.streamingChunkMs
-               : ParakeetConfig::DEFAULT_STREAMING_CHUNK_MS;
+    return cfg_.streamingChunkMs > 0 ? cfg_.streamingChunkMs : 1000;
   }
   int                 getStreamingHistoryMs() const {
     return cfg_.streamingHistoryMs > 0

--- a/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetModel.hpp
+++ b/packages/transcription-parakeet/addon/src/model-interface/parakeet/ParakeetModel.hpp
@@ -128,15 +128,17 @@ public:
     return backend_description_;
   }
   int                 getStreamingChunkMs() const {
-    return cfg_.streamingChunkMs > 0 ? cfg_.streamingChunkMs : 1000;
+    return cfg_.streamingChunkMs > 0
+               ? cfg_.streamingChunkMs
+               : ParakeetConfig::DEFAULT_STREAMING_CHUNK_MS;
   }
   int                 getStreamingHistoryMs() const {
-    return cfg_.streamingHistoryMs > 0 ? cfg_.streamingHistoryMs : 30000;
+    return cfg_.streamingHistoryMs > 0
+               ? cfg_.streamingHistoryMs
+               : ParakeetConfig::DEFAULT_STREAMING_HISTORY_MS;
   }
-  // <0 sentinel = "not set; let parakeet use its own defaults"
-  // (10000 / 2000). Returned verbatim so callers can treat the negative
-  // value as "skip the override" rather than baking a duplicate of
-  // parakeet's defaults into our wrapper.
+  // <0 = "not set; keep parakeet's own defaults". Returned verbatim so
+  // callers treat the negative value as "skip the override".
   int                 getStreamingLeftContextMs() const {
     return cfg_.streamingLeftContextMs;
   }
@@ -236,6 +238,14 @@ private:
   void throwIfCancelled() const;
   static bool isCancellationError(const std::exception& e);
 
+  // load() decomposition.
+  std::filesystem::path resolveGgufPath();
+  void detectModelType();
+  void captureBackend();
+  void warnOnGpuFallback() const;
+  void warnOnSampleRateMismatch() const;
+  void openStreamingSessionOrThrow();
+
   // ── GGUF buffer staging ────────────────────────────────────────────────
   // The addon framework streams the GGUF bytes via setWeightsForFile().
   // We accumulate them into `gguf_buffer_` keyed by the (single) GGUF
@@ -263,20 +273,9 @@ private:
   std::unique_ptr<parakeet::Engine> engine_;
   mutable std::mutex                     engine_mutex_;
 
-  // Streaming sessions (only one of the two is open at a time, depending on
-  // model_type). Lifetime: opened in load() when cfg_.streaming == true,
-  // finalize()d on endOfStream(), reset on unload(). Each process() call
-  // routes through feed_pcm_f32() instead of the offline *_samples paths.
-  //
-  // session_mutex_ guards the unique_ptrs against the data race between
-  // cancel() (framework-callable from any thread, concurrent with
-  // process()/unload()/reload()) and the lifecycle paths
-  // openStreamingSession() / closeStreamingSession() / endOfStream() /
-  // ~ParakeetModel that .reset() them. cancel() copies the raw pointer
-  // under the lock and invokes the engine's session-internal cancel()
-  // (itself thread-safe with concurrent feed/finalize) without holding
-  // the lock further; closeStreamingSession() moves ownership out under
-  // the lock and runs the destructor outside.
+  // Only one session is open at a time (model_type decides which).
+  // session_mutex_ guards the unique_ptrs against the race between cancel()
+  // (callable from any thread) and the open/close/unload lifecycle.
   mutable std::mutex                                 session_mutex_;
   std::unique_ptr<parakeet::StreamSession>           asr_session_;
   std::unique_ptr<parakeet::SortformerStreamSession> diar_session_;
@@ -293,26 +292,17 @@ private:
   // other than 16 000 throws on load.
   int                                  sample_rate_ = 16000;
 
-  // Active backend, captured once at load() from
-  // parakeet::Engine::backend_device() / ::backend_name(). The
-  // *_device_ field is the post-fallback truth: a load-time GPU init
-  // failure (e.g. Adreno-tier rejection, missing OpenCL ICD subgroup
-  // extensions, simulator without Metal) leaves it at 0 / "CPU" even
-  // when cfg_.useGPU was true. Surfaced through runtimeStats() as
-  // numeric fields (the addon-cpp RuntimeStats variant only carries
-  // double / int64); the GPU smoke tests gate on
-  // `backendDevice == 1` and friends.
-  //
-  // backend_id_ codes (kept stable; mirrored on the JS side):
-  //   0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL, 99 = other
+  // Active backend, captured once at load(). backend_device_ is the
+  // post-fallback truth (0 = CPU, 1 = GPU): a GPU init failure leaves it at
+  // CPU even when cfg_.useGPU was true. backend_id_ codes are mirrored on
+  // the JS side: 0 = CPU, 1 = Metal, 2 = CUDA, 3 = Vulkan, 4 = OpenCL,
+  // 99 = other.
   int                                  backend_device_ = 0;
   int                                  backend_id_     = 0;
   int backend_gpu_unsupported_ = 0;
   std::string                          backend_name_   = "CPU";
-  // Human-readable GPU device name (e.g. "NVIDIA GeForce RTX 3090", "Apple
-  // M2 Pro") recovered from the ggml device registry at load(); empty on CPU
-  // or when ggml provides no description. Surfaced to JS via getBackendInfo()
-  // as the nvidia-smi-independent GPU-name fallback for the perf reporter.
+  // Human-readable GPU device name recovered from the ggml device registry
+  // at load(); empty on CPU. Surfaced to JS via getBackendInfo().
   std::string backend_description_;
 
   // ── Token / sentinel constants ─────────────────────────────────────────
@@ -349,33 +339,29 @@ private:
   std::string runAsrProcess(const Input& input);
 
   // ── Streaming session helpers ──────────────────────────────────────────
-  // Opens an ASR or Sortformer streaming session against the loaded engine
-  // for the LEGACY framework path: called from load() when cfg_.streaming
-  // is true, then runStreamingProcess() drives it via the framework's
-  // process() callback. The on_segment callback pushes a Transcript onto
-  // pending_streaming_segments_ for the next process() call to drain into
-  // output_ + on_segment_.
-  //
-  // For the duplex path consumed by `runStreaming(...)` see
-  // `createDuplexAsrSession()` / `createDuplexDiarizationSession()` (above)
-  // and `ParakeetStreamingProcessor` (../ParakeetStreamingProcessor.hpp);
-  // those own a separate session per addon instance and queue segments
-  // directly into addonCpp->outputQueue without going through process().
+  // LEGACY framework path (cfg_.streaming): opened in load(), driven by
+  // runStreamingProcess() via process(). The duplex `runStreaming(...)`
+  // path uses createDuplexAsrSession() / createDuplexDiarizationSession()
+  // and ParakeetStreamingProcessor instead.
   void openStreamingSession();
+  void openSortformerStreamingSession(parakeet::Engine& engine);
+  void openAsrStreamingSession(parakeet::Engine& engine);
   void closeStreamingSession();
+  void pushPendingSegment(Transcript segment);
+  std::vector<Transcript> takePendingStreamingSegments();
+  void emitStreamingSegments(const std::vector<Transcript>& segments);
+  int64_t feedStreamingChunk(const Input& input);
+  void reopenStreamingSession();
 
-  // process() drainage: streaming-session callbacks fire mid-feed (and
-  // potentially from a different thread on finalize()), so we stash the
-  // per-segment Transcripts here under streaming_mutex_ and flush them
-  // into output_ at the end of each process() call.
+  // Streaming-session callbacks fire mid-feed (and from a different thread
+  // on finalize()), so segments are stashed here under streaming_mutex_ and
+  // flushed into output_ at the end of each process() call.
   std::mutex                          streaming_mutex_;
   std::vector<Transcript>             pending_streaming_segments_;
 
-  // Runs cfg_.streaming feed for a chunk and returns the concatenated
-  // text of the segments fired during the call (joined with single
-  // spaces). Sentinel-string fallbacks ([No speech detected] etc.) are
-  // applied when the session emitted nothing for the chunk so the
-  // existing Transcript-shaped JS contract stays intact.
+  // Feeds a cfg_.streaming chunk and returns the concatenated text of the
+  // segments fired during the call. Sentinel strings are applied when the
+  // session emitted nothing so the Transcript-shaped JS contract holds.
   std::string runStreamingProcess(const Input& input);
 
   // ── Runtime stats (subset of legacy fields; we now derive most numbers

--- a/packages/transcription-parakeet/addon/tests/test_config_and_audio.cpp
+++ b/packages/transcription-parakeet/addon/tests/test_config_and_audio.cpp
@@ -1,0 +1,71 @@
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/ParakeetTypes.hpp"
+#include "model-interface/parakeet/ParakeetConfig.hpp"
+#include "model-interface/parakeet/ParakeetModel.hpp"
+
+using namespace qvac_lib_infer_parakeet;
+
+namespace {
+
+ParakeetConfig makeCpuTestConfig() {
+  ParakeetConfig cfg;
+  cfg.modelType = ModelType::TDT;
+  cfg.maxThreads = 2;
+  cfg.useGPU = false;
+  cfg.sampleRate = 16000;
+  cfg.channels = 1;
+  return cfg;
+}
+
+} // namespace
+
+TEST(ParakeetStreamingConfig, DefaultsUseNamedConstants) {
+  ParakeetConfig c;
+  EXPECT_EQ(c.streamingChunkMs, ParakeetConfig::DEFAULT_STREAMING_CHUNK_MS);
+  EXPECT_EQ(c.streamingHistoryMs, ParakeetConfig::DEFAULT_STREAMING_HISTORY_MS);
+  EXPECT_EQ(
+      c.streamingSpkCacheLen, ParakeetConfig::DEFAULT_STREAMING_SPK_CACHE_LEN);
+  EXPECT_EQ(c.streamingFifoLen, ParakeetConfig::DEFAULT_STREAMING_FIFO_LEN);
+  EXPECT_EQ(
+      c.streamingChunkLeftContextMs,
+      ParakeetConfig::DEFAULT_STREAMING_CHUNK_LEFT_CONTEXT_MS);
+  EXPECT_EQ(
+      c.streamingChunkRightContextMs,
+      ParakeetConfig::DEFAULT_STREAMING_CHUNK_RIGHT_CONTEXT_MS);
+  EXPECT_EQ(
+      c.streamingSpkCacheUpdatePeriod,
+      ParakeetConfig::DEFAULT_STREAMING_SPK_CACHE_UPDATE_PERIOD);
+}
+
+TEST(ParakeetStreamingGetters, FallBackToConfigDefaultsOnNonPositiveValues) {
+  ParakeetConfig c = makeCpuTestConfig();
+  c.streamingChunkMs = 0;
+  c.streamingHistoryMs = -1;
+  ParakeetModel m(c);
+  EXPECT_EQ(
+      m.getStreamingChunkMs(), ParakeetConfig::DEFAULT_STREAMING_CHUNK_MS);
+  EXPECT_EQ(
+      m.getStreamingHistoryMs(), ParakeetConfig::DEFAULT_STREAMING_HISTORY_MS);
+}
+
+TEST(ParakeetStreamingGetters, HonourPositiveOverrides) {
+  ParakeetConfig c = makeCpuTestConfig();
+  c.streamingChunkMs = 1234;
+  c.streamingHistoryMs = 5678;
+  ParakeetModel m(c);
+  EXPECT_EQ(m.getStreamingChunkMs(), 1234);
+  EXPECT_EQ(m.getStreamingHistoryMs(), 5678);
+}
+
+TEST(ParakeetPreprocessAudio, S16LeHandlesRangeExtremes) {
+  std::vector<uint8_t> raw = {0x00, 0x00, 0x00, 0x80, 0xFF, 0x7F};
+  auto out = ParakeetModel::preprocessAudioData(raw, "s16le");
+  ASSERT_EQ(out.size(), 3U);
+  EXPECT_NEAR(out[0], 0.0F, 1e-6F);
+  EXPECT_NEAR(out[1], -1.0F, 1e-6F);
+  EXPECT_NEAR(out[2], 32767.0F / 32768.0F, 1e-6F);
+}

--- a/packages/transcription-parakeet/addon/tests/test_config_and_audio.cpp
+++ b/packages/transcription-parakeet/addon/tests/test_config_and_audio.cpp
@@ -41,13 +41,12 @@ TEST(ParakeetStreamingConfig, DefaultsUseNamedConstants) {
       ParakeetConfig::DEFAULT_STREAMING_SPK_CACHE_UPDATE_PERIOD);
 }
 
-TEST(ParakeetStreamingGetters, FallBackToConfigDefaultsOnNonPositiveValues) {
+TEST(ParakeetStreamingGetters, FallBackToBuiltInDefaultsOnNonPositiveValues) {
   ParakeetConfig c = makeCpuTestConfig();
   c.streamingChunkMs = 0;
   c.streamingHistoryMs = -1;
   ParakeetModel m(c);
-  EXPECT_EQ(
-      m.getStreamingChunkMs(), ParakeetConfig::DEFAULT_STREAMING_CHUNK_MS);
+  EXPECT_EQ(m.getStreamingChunkMs(), 1000);
   EXPECT_EQ(
       m.getStreamingHistoryMs(), ParakeetConfig::DEFAULT_STREAMING_HISTORY_MS);
 }

--- a/packages/transcription-parakeet/index.js
+++ b/packages/transcription-parakeet/index.js
@@ -6,6 +6,7 @@ const { createJobHandler } = require('@qvac/infer-base')
 
 const { ParakeetInterface } = require('./parakeet')
 const { END_OF_INPUT, ERR_CODES, QvacErrorAddonParakeet } = require('./lib/error')
+const { toFloat32Chunk } = require('./lib/audio')
 
 /**
  * High-level Parakeet speech-to-text client backed by the ggml engine
@@ -126,24 +127,17 @@ class TranscriptionParakeet {
       streamingEnergyVad: this.params.streamingEnergyVad === true,
       streamingLeftContextMs: this.params.streamingLeftContextMs ?? -1,
       streamingRightLookaheadMs: this.params.streamingRightLookaheadMs ?? -1,
-      // AOSC (v2.1+ Sortformer only). parakeet-cpp ignores these on
-      // non-Sortformer engines and on v1/v2 GGUFs. Defaults mirror the
-      // C++ ParakeetConfig defaults; passing the field explicitly (vs
-      // letting C++ pick its own default) ensures user overrides at
-      // the JS layer reach the native engine instead of being silently
-      // discarded by _buildConfigurationParams.
+      // AOSC (v2.1+ Sortformer only). Numeric fields are forwarded as-is;
+      // an unset field stays undefined so the native ParakeetConfig
+      // applies its own default rather than duplicating the value here.
       streamingSpkCacheEnable: this.params.streamingSpkCacheEnable !== false,
-      streamingSpkCacheLen: this.params.streamingSpkCacheLen ?? 188,
-      streamingFifoLen: this.params.streamingFifoLen ?? 188,
-      streamingChunkLeftContextMs: this.params.streamingChunkLeftContextMs ?? 80,
-      streamingChunkRightContextMs: this.params.streamingChunkRightContextMs ?? 560,
-      streamingSpkCacheUpdatePeriod: this.params.streamingSpkCacheUpdatePeriod ?? 144,
-      // Forwarded as-is; ParakeetInterface fills in a per-package
-      // default for `backendsDir` (`path.join(__dirname, 'prebuilds')`)
-      // when the host doesn't pass one, so explicit `undefined`
-      // values here are intentional (they keep the default-resolution
-      // path on the JS side). `openclCacheDir` has no JS-side default;
-      // the addon is a no-op when it's empty.
+      streamingSpkCacheLen: this.params.streamingSpkCacheLen,
+      streamingFifoLen: this.params.streamingFifoLen,
+      streamingChunkLeftContextMs: this.params.streamingChunkLeftContextMs,
+      streamingChunkRightContextMs: this.params.streamingChunkRightContextMs,
+      streamingSpkCacheUpdatePeriod: this.params.streamingSpkCacheUpdatePeriod,
+      // ParakeetInterface fills in a per-package `backendsDir` default
+      // when the host omits one, so a passthrough undefined is intended.
       backendsDir: this.params.backendsDir,
       openclCacheDir: this.params.openclCacheDir
     }
@@ -280,16 +274,7 @@ class TranscriptionParakeet {
   async _pumpStreamingAudio(audioStream) {
     this.logger.debug('Start pumping audio into duplex streaming session')
     for await (const chunk of audioStream) {
-      let audioData
-      if (chunk instanceof Float32Array) {
-        audioData = chunk
-      } else {
-        const int16Data = new Int16Array(chunk.buffer, chunk.byteOffset, chunk.byteLength / 2)
-        audioData = new Float32Array(int16Data.length)
-        for (let i = 0; i < int16Data.length; i++) {
-          audioData[i] = int16Data[i] / 32768.0
-        }
-      }
+      const audioData = toFloat32Chunk(chunk)
       if (audioData.length === 0) continue
       await this.addon.appendStreamingAudio(audioData)
     }
@@ -306,20 +291,7 @@ class TranscriptionParakeet {
     this.logger.debug('Start handling audio stream')
     for await (const chunk of audioStream) {
       this.logger.debug('Appending audio chunk', { chunkLength: chunk.length })
-
-      // Convert chunk to Float32Array if needed
-      let audioData
-      if (chunk instanceof Float32Array) {
-        audioData = chunk
-      } else {
-        // Assume s16le format, convert to float32
-        const int16Data = new Int16Array(chunk.buffer, chunk.byteOffset, chunk.byteLength / 2)
-        audioData = new Float32Array(int16Data.length)
-        for (let i = 0; i < int16Data.length; i++) {
-          audioData[i] = int16Data[i] / 32768.0
-        }
-      }
-
+      const audioData = toFloat32Chunk(chunk)
       await this.addon.append({
         type: 'audio',
         data: audioData.buffer

--- a/packages/transcription-parakeet/lib/audio.js
+++ b/packages/transcription-parakeet/lib/audio.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const PCM_S16_SCALE = 32768
+
+function pcmS16ToFloat32(int16Samples) {
+  const audio = new Float32Array(int16Samples.length)
+  for (let i = 0; i < int16Samples.length; i++) {
+    audio[i] = int16Samples[i] / PCM_S16_SCALE
+  }
+  return audio
+}
+
+function toFloat32Chunk(chunk) {
+  if (chunk instanceof Float32Array) {
+    return chunk
+  }
+  const int16Samples = new Int16Array(chunk.buffer, chunk.byteOffset, chunk.byteLength / 2)
+  return pcmS16ToFloat32(int16Samples)
+}
+
+function sumChunkLengths(chunks) {
+  return chunks.reduce((total, chunk) => total + chunk.length, 0)
+}
+
+function mergeFloat32Chunks(chunks) {
+  const merged = new Float32Array(sumChunkLengths(chunks))
+  let offset = 0
+  for (const chunk of chunks) {
+    merged.set(chunk, offset)
+    offset += chunk.length
+  }
+  return merged
+}
+
+module.exports = {
+  PCM_S16_SCALE,
+  pcmS16ToFloat32,
+  toFloat32Chunk,
+  mergeFloat32Chunks
+}

--- a/packages/transcription-parakeet/parakeet.js
+++ b/packages/transcription-parakeet/parakeet.js
@@ -3,6 +3,7 @@
 const path = require('bare-path')
 
 const { QvacErrorAddonParakeet, ERR_CODES, END_OF_INPUT } = require('./lib/error')
+const { pcmS16ToFloat32, mergeFloat32Chunks } = require('./lib/audio')
 
 const state = Object.freeze({
   LOADING: 'loading',
@@ -106,17 +107,8 @@ class ParakeetInterface {
   }
 
   /**
-   * Per-platform fallback for `backendsDir` when the host didn't pass
-   * one. Mirrors the qvac/packages/llm-llamacpp resolution shape
-   * (`path.join(__dirname, 'prebuilds')`) so a host that already
-   * threads `prebuilds/` through that addon doesn't need to special-
-   * case parakeet. The native addon expects the directory that
-   * directly contains the `lib<prefix>ggml-*.so` files; cmake-bare
-   * installs them under `prebuilds/<bare-target>/<module-name>/`,
-   * but the addon-side `BACKENDS_SUBDIR` compile define joins the
-   * `<bare-target>/<module-name>` shape on its own. Keep this in
-   * sync with the `BACKENDS_SUBDIR_VALUE` derivation in
-   * CMakeLists.txt.
+   * Fall back to `<package_dir>/prebuilds` for `backendsDir` when the
+   * host didn't pass one (see the constructor's `backendsDir` doc).
    * @private
    */
   _applyDefaults(configurationParams) {
@@ -136,8 +128,6 @@ class ParakeetInterface {
 
   _createNativeInstance(configurationParams) {
     this._config = configurationParams
-    // Wrapper job ids are owned in JS, so recreating the native instance only
-    // clears native state and buffered audio.
     this._activeJobId = null
     this._onCancelComplete = null
     this._bufferedAudio = []
@@ -150,46 +140,51 @@ class ParakeetInterface {
     )
   }
 
+  _looksLikeStats(data) {
+    return (
+      !!data &&
+      typeof data === 'object' &&
+      ('totalTime' in data || 'audioDurationMs' in data || 'totalSamples' in data)
+    )
+  }
+
+  _looksLikeTranscript(data) {
+    return (
+      Array.isArray(data) || (!!data && typeof data === 'object' && typeof data.text === 'string')
+    )
+  }
+
+  _mapAddonEvent(event, data, isError) {
+    const eventStr = typeof event === 'string' ? event : String(event)
+    if (eventStr === 'Error' || eventStr === 'JobEnded' || eventStr === 'Output') return eventStr
+    if (isError || eventStr.includes('Error')) return 'Error'
+    if (eventStr.includes('RuntimeStats')) return 'JobEnded'
+    if (eventStr.includes('Output')) return 'Output'
+    if (this._looksLikeStats(data)) return 'JobEnded'
+    if (this._looksLikeTranscript(data)) return 'Output'
+    return event
+  }
+
+  _resolvePendingCancel() {
+    if (!this._onCancelComplete) return false
+    const resolve = this._onCancelComplete
+    this._onCancelComplete = null
+    resolve()
+    return true
+  }
+
   _addonOutputCallback(addon, event, data, error) {
     const isError = typeof error === 'string' && error.length > 0
-    const eventStr = typeof event === 'string' ? event : String(event)
-
-    let mappedEvent = event
-    if (eventStr === 'Error' || eventStr === 'JobEnded' || eventStr === 'Output') {
-      mappedEvent = eventStr
-    } else if (isError || eventStr.includes('Error')) {
-      mappedEvent = 'Error'
-    } else if (eventStr.includes('RuntimeStats')) {
-      mappedEvent = 'JobEnded'
-    } else if (eventStr.includes('Output')) {
-      mappedEvent = 'Output'
-    } else {
-      const isStats =
-        data &&
-        typeof data === 'object' &&
-        ('totalTime' in data || 'audioDurationMs' in data || 'totalSamples' in data)
-      const isTranscriptOutput =
-        Array.isArray(data) || (data && typeof data === 'object' && typeof data.text === 'string')
-      if (isStats) mappedEvent = 'JobEnded'
-      else if (isTranscriptOutput) mappedEvent = 'Output'
-    }
-
+    const mappedEvent = this._mapAddonEvent(event, data, isError)
     const isTerminal = mappedEvent === 'Error' || mappedEvent === 'JobEnded'
 
     const jobId = this._activeJobId
     if (jobId === null) {
-      if (isTerminal && this._onCancelComplete) {
-        const resolve = this._onCancelComplete
-        this._onCancelComplete = null
-        resolve()
-      }
+      if (isTerminal) this._resolvePendingCancel()
       return
     }
 
-    if (isTerminal && this._onCancelComplete) {
-      const resolve = this._onCancelComplete
-      this._onCancelComplete = null
-      resolve()
+    if (isTerminal && this._resolvePendingCancel()) {
       return
     }
 
@@ -201,7 +196,7 @@ class ParakeetInterface {
       this._outputCallback(addon, mappedEvent, jobId, data, isError ? error : null)
     }
 
-    if (mappedEvent === 'Error' || mappedEvent === 'JobEnded') {
+    if (isTerminal) {
       this._activeJobId = null
       this._setState(state.LISTENING)
     }
@@ -268,57 +263,56 @@ class ParakeetInterface {
   async append(data) {
     try {
       if (data?.type === END_OF_INPUT) {
-        const currentJobId = this._nextJobId
-        const input = this._concatBufferedAudio()
-        const previousState = this._state
-        let accepted = false
-        try {
-          accepted = this._binding.runJob(this._handle, {
-            type: 'audio',
-            input
-          })
-        } catch (error) {
-          this._setState(previousState)
-          throw error
-        }
-        if (!accepted) {
-          this._setState(previousState)
-          throw new Error('Cannot set new job: a job is already set or being processed')
-        }
-
-        this._activeJobId = currentJobId
-        this._nextJobId = nextSafeId(this._nextJobId)
-        this._bufferedAudio = []
-        this._bufferedBytes = 0
-        this._setState(state.PROCESSING)
-        return currentJobId
+        return this._submitBufferedJob()
       }
-
       if (data?.type === 'audio') {
-        const normalized = this._normalizeAudioInput(data.data)
-        if (this._bufferedBytes + normalized.byteLength > MAX_BUFFERED_BYTES) {
-          throw createParakeetError(ERR_CODES.BUFFER_LIMIT_EXCEEDED, MAX_BUFFERED_BYTES + ' bytes')
-        }
-        this._bufferedAudio.push(normalized)
-        this._bufferedBytes += normalized.byteLength
-        return this._nextJobId
+        return this._bufferAudioChunk(data.data)
       }
-
       throw new Error(`Unknown append input type: ${data?.type}`)
     } catch (error) {
       throw createParakeetError(ERR_CODES.FAILED_TO_APPEND, error.message, error)
     }
   }
 
+  _submitBufferedJob() {
+    const currentJobId = this._nextJobId
+    const input = this._concatBufferedAudio()
+    const previousState = this._state
+    let accepted = false
+    try {
+      accepted = this._binding.runJob(this._handle, { type: 'audio', input })
+    } catch (error) {
+      this._setState(previousState)
+      throw error
+    }
+    if (!accepted) {
+      this._setState(previousState)
+      throw new Error('Cannot set new job: a job is already set or being processed')
+    }
+
+    this._activeJobId = currentJobId
+    this._nextJobId = nextSafeId(this._nextJobId)
+    this._bufferedAudio = []
+    this._bufferedBytes = 0
+    this._setState(state.PROCESSING)
+    return currentJobId
+  }
+
+  _bufferAudioChunk(rawData) {
+    const normalized = this._normalizeAudioInput(rawData)
+    if (this._bufferedBytes + normalized.byteLength > MAX_BUFFERED_BYTES) {
+      throw createParakeetError(ERR_CODES.BUFFER_LIMIT_EXCEEDED, MAX_BUFFERED_BYTES + ' bytes')
+    }
+    this._bufferedAudio.push(normalized)
+    this._bufferedBytes += normalized.byteLength
+    return this._nextJobId
+  }
+
   /**
    * Get current model status (JS-side state-machine value).
    *
-   * NOTE: returns the JavaScript-tracked state of this addon wrapper, not
-   * a native query into inference-addon-cpp -- the framework does
-   * not surface a `status` RPC and `binding.cpp` does not export
-   * `JsInterface::status`. Values reflect transitions driven by this
-   * wrapper itself (`listening` / `processing` / `idle` / `paused` /
-   * `stopped` / `loading`).
+   * NOTE: returns the JS wrapper state, not a native query -- there is no
+   * `status` RPC in inference-addon-cpp.
    * @returns {Promise<string>} - 'loading', 'listening', 'processing', 'idle', 'paused', 'stopped'
    */
   async status() {
@@ -332,10 +326,8 @@ class ParakeetInterface {
   /**
    * Pause processing.
    *
-   * NOTE: JS-side bookkeeping only. Flips the wrapper's state machine to
-   * `'paused'` but does NOT signal the native engine -- there is no
-   * `JsInterface::pause` export. Use `cancel()` (or `stop()`) if you need
-   * the active inference call to actually abort.
+   * NOTE: JS-side bookkeeping only; does not signal the native engine.
+   * Use `cancel()` or `stop()` to actually abort inference.
    * @returns {Promise<void>}
    */
   async pause() {
@@ -574,20 +566,9 @@ class ParakeetInterface {
     try {
       if (this._activeJobId === null) return
       const jobId = this._activeJobId
-      // The native cleanupStreamingSession returns
-      // { cleaned, audioDurationMs, totalSamples } captured right before
-      // the worker thread joined, so the synthetic JobEnded below carries
-      // the actual audio duration / sample count instead of zeros. The
-      // C++ binding reads them off ParakeetStreamingProcessor::audioSeconds
-      // (joined-worker, race-free at this point).
+      // Native teardown returns stats captured before the worker joined.
       const teardown = this._binding.endStreaming(this._handle) || {}
-      // The native StreamingProcessor doesn't emit a synthetic JobEnded
-      // (the addon framework's runtimeStats path is bypassed entirely),
-      // so the JS-side state machine has to mark the job as finished
-      // manually. We pretend a regular JobEnded landed: clear the
-      // active job, push a JobEnded event with the stats we just
-      // recovered so the public TranscriptionParakeet response resolves
-      // with a non-zero `audioDurationMs` / `totalSamples` payload.
+      // Streaming bypasses the runtimeStats path, so emit JobEnded manually.
       this._activeJobId = null
       this._setState(state.LISTENING)
       if (this._outputCallback) {
@@ -629,11 +610,7 @@ class ParakeetInterface {
     }
     if (ArrayBuffer.isView(data)) {
       if (data instanceof Int16Array) {
-        const audio = new Float32Array(data.length)
-        for (let i = 0; i < data.length; i++) {
-          audio[i] = data[i] / 32768.0
-        }
-        return audio
+        return pcmS16ToFloat32(data)
       }
       return new Float32Array(data.buffer, data.byteOffset, Math.floor(data.byteLength / 4))
     }
@@ -650,14 +627,7 @@ class ParakeetInterface {
     if (this._bufferedAudio.length === 1) {
       return this._bufferedAudio[0]
     }
-    const totalLength = this._bufferedAudio.reduce((sum, chunk) => sum + chunk.length, 0)
-    const merged = new Float32Array(totalLength)
-    let offset = 0
-    for (const chunk of this._bufferedAudio) {
-      merged.set(chunk, offset)
-      offset += chunk.length
-    }
-    return merged
+    return mergeFloat32Chunks(this._bufferedAudio)
   }
 }
 

--- a/packages/transcription-parakeet/test/unit/audio.test.js
+++ b/packages/transcription-parakeet/test/unit/audio.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const test = require('brittle')
+const {
+  PCM_S16_SCALE,
+  pcmS16ToFloat32,
+  toFloat32Chunk,
+  mergeFloat32Chunks
+} = require('../../lib/audio')
+
+test('PCM_S16_SCALE is 2^15', (t) => {
+  t.is(PCM_S16_SCALE, 32768)
+})
+
+test('pcmS16ToFloat32 scales int16 samples into [-1, 1]', (t) => {
+  const input = new Int16Array([0, 16384, -16384, -32768])
+  const out = pcmS16ToFloat32(input)
+
+  t.ok(out instanceof Float32Array, 'returns a Float32Array')
+  t.is(out.length, input.length, 'length is preserved')
+  t.is(out[0], 0)
+  t.is(out[1], 0.5)
+  t.is(out[2], -0.5)
+  t.is(out[3], -1)
+})
+
+test('toFloat32Chunk returns Float32Array input unchanged', (t) => {
+  const chunk = new Float32Array([0.1, -0.2, 0.3])
+  t.is(toFloat32Chunk(chunk), chunk, 'same reference is returned')
+})
+
+test('toFloat32Chunk converts s16le byte chunks to float32', (t) => {
+  // 16384 -> 0x4000, -16384 -> 0xC000 (little-endian bytes).
+  const bytes = new Uint8Array([0x00, 0x40, 0x00, 0xc0])
+  const out = toFloat32Chunk(bytes)
+
+  t.ok(out instanceof Float32Array, 'returns a Float32Array')
+  t.is(out.length, 2, 'two int16 samples decoded from four bytes')
+  t.is(out[0], 0.5)
+  t.is(out[1], -0.5)
+})
+
+test('mergeFloat32Chunks concatenates chunks in order', (t) => {
+  const merged = mergeFloat32Chunks([
+    new Float32Array([1, 2]),
+    new Float32Array([]),
+    new Float32Array([3, 4, 5])
+  ])
+
+  t.ok(merged instanceof Float32Array)
+  t.alike(Array.from(merged), [1, 2, 3, 4, 5])
+})
+
+test('mergeFloat32Chunks returns an empty array for empty input', (t) => {
+  t.is(mergeFloat32Chunks([]).length, 0)
+})

--- a/packages/transcription-parakeet/test/unit/config-defaults.test.js
+++ b/packages/transcription-parakeet/test/unit/config-defaults.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const test = require('brittle')
+const TranscriptionParakeet = require('../../index.js')
+
+TranscriptionParakeet.prototype.validateModelFiles = () => undefined
+
+function buildParams(parakeetConfig = {}) {
+  const model = new TranscriptionParakeet({
+    files: { model: './models/parakeet-tdt-0.6b-v3.q8_0.gguf' },
+    config: { parakeetConfig }
+  })
+  return model._buildConfigurationParams()
+}
+
+test('AOSC numeric fields stay undefined so the native config owns the defaults', (t) => {
+  const params = buildParams()
+
+  t.is(params.streamingSpkCacheLen, undefined, 'spkCacheLen is not hardcoded on the JS side')
+  t.is(params.streamingFifoLen, undefined, 'fifoLen is not hardcoded on the JS side')
+  t.is(params.streamingChunkLeftContextMs, undefined)
+  t.is(params.streamingChunkRightContextMs, undefined)
+  t.is(params.streamingSpkCacheUpdatePeriod, undefined)
+})
+
+test('AOSC numeric fields are forwarded verbatim when the caller sets them', (t) => {
+  const params = buildParams({
+    streamingSpkCacheLen: 200,
+    streamingFifoLen: 100,
+    streamingChunkLeftContextMs: 40,
+    streamingChunkRightContextMs: 320,
+    streamingSpkCacheUpdatePeriod: 72
+  })
+
+  t.is(params.streamingSpkCacheLen, 200)
+  t.is(params.streamingFifoLen, 100)
+  t.is(params.streamingChunkLeftContextMs, 40)
+  t.is(params.streamingChunkRightContextMs, 320)
+  t.is(params.streamingSpkCacheUpdatePeriod, 72)
+})
+
+test('streamingSpkCacheEnable defaults to true and coerces to a boolean', (t) => {
+  t.is(buildParams().streamingSpkCacheEnable, true, 'enabled by default')
+  t.is(
+    buildParams({ streamingSpkCacheEnable: false }).streamingSpkCacheEnable,
+    false,
+    'explicit false is honoured'
+  )
+})


### PR DESCRIPTION
## Summary

Applies the team coding standards to the `transcription-parakeet` package. Internal refactor only, with no public API or behavior change.

- Split oversized C++/JS functions and their inline loops into named helpers (`ParakeetModel::load`, `openStreamingSession`, `runStreamingProcess`, `JSAdapter::loadFromJSObject`, `startStreaming`, and `parakeet.js`'s `append` / `_addonOutputCallback`).
- Consolidate the int16-to-float32 PCM conversion (previously duplicated four times) into a single helper per side: a new `lib/audio.js` module on the JS side and `decodeS16lePcm` / `pcmS16ToFloat32` in C++.
- Replace magic numbers with named constants and a `BackendId` enum, and move the streaming/AOSC defaults to a single source of truth in `ParakeetConfig` so the JS layer no longer duplicates them.
- Remove narration comments and decorative section banners; trim verbose concurrency notes to intent-only.

## Test plan

- [x] `git-clang-format --diff` clean on changed files
- [x] `clang-tidy` (`readability-identifier-naming`, `--warnings-as-errors='*'`) clean on all changed TUs
- [x] `parakeet_tests` build + run: 36 pass, 2 GGUF-guarded skips; full `.bare` addon builds and links
- [x] `npm run test:unit`: 46/46 pass
- [x] `npm run lint`: prettier clean, no new lunte warnings vs base

Made with [Cursor](https://cursor.com)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216532422132659