### PR TITLE
infra[notask]: move embed & vla arm64 macOS integration tests to self-hosted macos26

### DIFF
--- a/.github/workflows/integration-test-embed-llamacpp.yml
+++ b/.github/workflows/integration-test-embed-llamacpp.yml
@@ -56,6 +56,7 @@ jobs:
           - os: macos-15-xlarge
             platform: darwin
             arch: arm64
+            runner: qvac-macos26-arm64-gpu
           - os: macos-15-large
             platform: darwin
             arch: x64

--- a/.github/workflows/integration-test-vla.yml
+++ b/.github/workflows/integration-test-vla.yml
@@ -64,7 +64,7 @@ jobs:
           - os: macos-15-xlarge
             platform: darwin
             arch: arm64
-            runner: macos-15-xlarge
+            runner: qvac-macos26-arm64-gpu
           - os: macos-15-large
             platform: darwin
             arch: x64


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The Apple-Silicon macOS legs of the EMBED and VLA integration-test workflows run on GitHub-hosted `macos-15-xlarge` runners, which are billed (SKU `actions_macos_xl`, ~$0.10/min) and make up a meaningful share of the repo's GitHub Actions spend.

- We now have self-hosted Apple-Silicon Mac Studios registered as `qvac-macos26-arm64-gpu` that are free to run on and were provisioned for exactly this workload.

## 📝 How does it solve it?

- Points the `arch: arm64` macOS matrix leg (`os: macos-15-xlarge`) in `integration-test-embed-llamacpp.yml` and `integration-test-vla.yml` at the self-hosted `qvac-macos26-arm64-gpu` runner via the matrix `runner` field — the same pattern already used by `integration-test-llm-llamacpp.yml`.

- The Intel `macos-15-large` (`arch: x64`) leg is intentionally left on the GitHub-hosted runner to preserve x86_64 macOS coverage (the Mac Studios are arm64-only).

- Job names derive from `${{ matrix.platform }}-${{ matrix.arch }}`, so required status-check names are unchanged — no branch-protection impact.

## 🧪 How was it tested?

- `actionlint` on both files: no new errors. Remaining output is pre-existing shellcheck style notes plus the expected "unknown label" warning that also applies to the repo's existing `qvac-*` self-hosted labels.

- `yaml.safe_load` parse check passes on both files.

- `git diff` verified: only the arm64 leg's `runner` changed; the Intel `macos-15-large` leg is untouched.

- Post-merge: confirm the `darwin-arm64-integration-tests` leg of each workflow schedules on a `qvac-macos26-arm64-gpu` runner and passes.