### PR TITLE
fix[notask|api]: accept non-string JSON Schema enum values in tool schemas

### DIFF
--- a/packages/sdk/contract/schema.json
+++ b/packages/sdk/contract/schema.json
@@ -466,7 +466,20 @@
                               "enum": {
                                 "type": "array",
                                 "items": {
-                                  "type": "string"
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
                                 }
                               }
                             },
@@ -1415,7 +1428,20 @@
                         "enum": {
                           "type": "array",
                           "items": {
-                            "type": "string"
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           }
                         }
                       },

--- a/packages/sdk/schemas/tools.ts
+++ b/packages/sdk/schemas/tools.ts
@@ -18,6 +18,8 @@ export const TOOLS_MODE = {
 
 export type ToolsMode = (typeof TOOLS_MODE)[keyof typeof TOOLS_MODE]
 
+const jsonSchemaEnumValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()])
+
 export const toolSchema = z.object({
   type: z.literal('function'),
   name: z.string(),
@@ -29,7 +31,7 @@ export const toolSchema = z.object({
       z.object({
         type: z.enum(['string', 'number', 'integer', 'boolean', 'object', 'array']),
         description: z.string().optional(),
-        enum: z.array(z.string()).optional()
+        enum: z.array(jsonSchemaEnumValueSchema).optional()
       })
     ),
     required: z.array(z.string()).optional()

--- a/packages/sdk/test/unit/completion-stream-schemas.test.ts
+++ b/packages/sdk/test/unit/completion-stream-schemas.test.ts
@@ -5,6 +5,7 @@ import {
   generationParamsSchema,
   toolDialectSchema
 } from '@/schemas/completion-stream'
+import { toolSchema } from '@/schemas/tools'
 import { REASONING_BUDGET_MAX } from '@/schemas/llamacpp-config'
 import { contractValidate } from './utils/contract-validator'
 
@@ -63,6 +64,31 @@ test('toolDialectSchema: accepts qwen35 and gemma4', (t) => {
 
 test('toolDialectSchema: rejects unknown dialects', (t) => {
   t.is(toolDialectSchema.safeParse('unknown').success, false)
+})
+
+test('toolSchema: accepts non-string JSON Schema enum values', (t) => {
+  const result = toolSchema.safeParse({
+    type: 'function',
+    name: 'get_sensor_readings_history_by_interval',
+    description: 'Retrieve historical sensor readings.',
+    parameters: {
+      type: 'object',
+      properties: {
+        interval: {
+          type: 'integer',
+          description: 'The time interval in seconds for the data returned.',
+          enum: [15, 120, 300, 900, 3600, 14400, 86400, 604800]
+        },
+        includeMeta: {
+          type: 'boolean',
+          enum: [true, false]
+        }
+      },
+      required: ['interval']
+    }
+  })
+
+  t.is(result.success, true)
 })
 
 test('completionStreamResponseSchema: round-trips backendDevice through completionStats event', (t) => {

--- a/packages/sdk/utils/mcp-adapter.ts
+++ b/packages/sdk/utils/mcp-adapter.ts
@@ -16,8 +16,9 @@ export type McpToolsResult = {
 const VALID_TYPES = ['string', 'number', 'integer', 'boolean', 'object', 'array'] as const
 
 type ValidType = (typeof VALID_TYPES)[number]
-type PropEntry = { type: ValidType; description?: string; enum?: string[] }
-type PropInput = { type?: unknown; description?: string; enum?: string[] }
+type JsonSchemaEnumValue = string | number | boolean | null
+type PropEntry = { type: ValidType; description?: string; enum?: JsonSchemaEnumValue[] }
+type PropInput = { type?: unknown; description?: string; enum?: JsonSchemaEnumValue[] }
 
 function isValidType(value: unknown): value is ValidType {
   return typeof value === 'string' && VALID_TYPES.includes(value as ValidType)

--- a/packages/sdk/utils/tool-helpers.ts
+++ b/packages/sdk/utils/tool-helpers.ts
@@ -3,6 +3,7 @@ import { toolSchema, type Tool, type ToolCall, type ToolCallWithCall } from '@/s
 import { InvalidToolsArrayError, InvalidToolSchemaError } from '@/utils/errors-client'
 
 type ZodObjectType = z.ZodObject<z.ZodRawShape>
+type JsonSchemaEnumValue = string | number | boolean | null
 
 export type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>
 
@@ -48,7 +49,7 @@ export function convertToolInput(input: ToolInput): Tool {
     {
       type: 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'
       description?: string
-      enum?: string[]
+      enum?: JsonSchemaEnumValue[]
     }
   > = {}
   const required: string[] = []


### PR DESCRIPTION
## What problem does this PR solve?

The SDK tool schema (`toolSchema`) only accepted `string[]` for a parameter's `enum`, so any tool whose parameters used integer, boolean, or null enums was rejected at validation. This surfaced running benchmarks through `qvac sdk serve` against real MCP tools (e.g. an `interval` param with `enum: [15, 120, 300, 900, ...]`), where a valid JSON Schema tool was refused.

## How does it solve it?

`enum` now accepts any JSON Schema primitive (`string | number | boolean | null`) instead of only strings, matching the JSON Schema spec. The change is applied at the schema boundary (`schemas/tools.ts`) and mirrored in the supporting type annotations in `mcp-adapter.ts` and `tool-helpers.ts`. Since `completion-stream` and `batch-completion-stream` reuse `toolSchema`, the cross-language `contract/schema.json` was regenerated (`bun run contract:export`) so the enum items are emitted as an `anyOf` of the four primitives.

```ts
// Now valid: non-string enum values in tool parameters
const tool = {
  type: 'function',
  name: 'get_sensor_readings_history_by_interval',
  description: 'Retrieve historical sensor readings.',
  parameters: {
    type: 'object',
    properties: {
      interval: { type: 'integer', enum: [15, 120, 300, 900, 3600] },
      includeMeta: { type: 'boolean', enum: [true, false] }
    },
    required: ['interval']
  }
}
```

## Breaking changes

None. This widens accepted input (previously-valid string enums still pass); the generated contract adds primitives to the enum item type.

## How was it tested?

- Added a unit regression test asserting integer and boolean enums parse.
- `bun run lint`, `bun run typecheck`, and `bun run test:unit` all pass.
