### PR TITLE
QVAC-22213 refactor: apply team coding standards to tts-ggml

### DIFF
--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -35,21 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Applied the team coding standards to the package. Split the oversized C++/JS
-  functions and their inlined loops into smaller named helpers
-  (`ChatterboxModel::synthesize` and its streaming/batch/enhancer/denoiser
-  stages, `OutputResampler::resample`, `StreamingEnhancer::process`,
-  `WsolaTimeStretch`, and `index.js`'s `TTSGgml` constructor and
-  `_addonOutputCallback`), and removed narration comments while keeping the
-  non-obvious "why" rationale.
-- Consolidated the float32-to-int16 PCM conversion (previously duplicated
-  across both engines) into a single shared `pcmFloatToInt16` helper in
-  `PcmConversion.hpp`.
-- Replaced magic numbers with named constants: the output sample-rate bounds
-  and the flush/chunk defaults on the JS side, and a shared GPU "offload all
-  layers" constant, the Chatterbox native sample rate, and the int16 PCM
-  full-scale constant on the C++ side. These are internal refactors with no
-  public API change.
+- Internal refactor to apply the team coding standards; no public API or behavior change.
 
 ## [0.5.0] - 2026-07-14
 

--- a/packages/tts-ggml/CHANGELOG.md
+++ b/packages/tts-ggml/CHANGELOG.md
@@ -33,6 +33,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opt-in `vulkanCacheDir` (Supertonic + `useGPU: true`): persists the Vulkan pipeline cache (`GGML_VK_PIPELINE_CACHE_DIR`) and pre-warms it at `load()` so the first-dispatch shader-compile cost is paid once per install, not on the first `run()`. Fully opt-in/non-breaking; Vulkan analogue of `openclCacheDir` (QVAC-21910, tetherto/qvac#3120).
 - **Per-call cancellation via `AbortSignal` on `run()`.** `model.run({ input, signal })` now accepts an optional `AbortSignal`; when it aborts, `response.await()` rejects with the abort reason. An already-aborted signal rejects deterministically without dispatching the engine (no native interrupt) — the race-free way to cancel on fast hardware. Additive/non-breaking. Non-streaming `run()` only: **ignored when `streamOutput: true`** (and on `runStream` / `runStreaming`). (QVAC-22247, tetherto/qvac#3260)
 
+### Changed
+
+- Applied the team coding standards to the package. Split the oversized C++/JS
+  functions and their inlined loops into smaller named helpers
+  (`ChatterboxModel::synthesize` and its streaming/batch/enhancer/denoiser
+  stages, `OutputResampler::resample`, `StreamingEnhancer::process`,
+  `WsolaTimeStretch`, and `index.js`'s `TTSGgml` constructor and
+  `_addonOutputCallback`), and removed narration comments while keeping the
+  non-obvious "why" rationale.
+- Consolidated the float32-to-int16 PCM conversion (previously duplicated
+  across both engines) into a single shared `pcmFloatToInt16` helper in
+  `PcmConversion.hpp`.
+- Replaced magic numbers with named constants: the output sample-rate bounds
+  and the flush/chunk defaults on the JS side, and a shared GPU "offload all
+  layers" constant, the Chatterbox native sample rate, and the int16 PCM
+  full-scale constant on the C++ side. These are internal refactors with no
+  public API change.
+
 ## [0.5.0] - 2026-07-14
 
 ### Fixed

--- a/packages/tts-ggml/CMakeLists.txt
+++ b/packages/tts-ggml/CMakeLists.txt
@@ -318,6 +318,8 @@ if(BUILD_TESTING)
       addon/tests/test_supertonic_config.cpp
       addon/tests/test_time_stretch.cpp
       addon/tests/test_streaming_enhancer.cpp
+      addon/tests/test_output_resampler.cpp
+      addon/tests/test_pcm_conversion.cpp
       addon/tests/AddonCppTest.cpp
       addon/src/model-interface/chatterbox/ChatterboxModel.cpp
       addon/src/model-interface/supertonic/SupertonicModel.cpp

--- a/packages/tts-ggml/addon/src/addon/AddonJs.hpp
+++ b/packages/tts-ggml/addon/src/addon/AddonJs.hpp
@@ -89,7 +89,7 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
   const EngineType engineType = adapter.readEngineType(configurationParams, env);
 
   unique_ptr<model::IModel> model;
-  int sampleRate = 24000;
+  int sampleRate = chatterbox::kChatterboxNativeSampleRate;
 
   // The output sample rate is baked into the JS output handlers at instance
   // creation. Final-rate precedence:
@@ -113,7 +113,10 @@ inline js_value_t* createInstance(js_env_t* env, js_callback_info_t* info) try {
     const bool enhanced = !cfg.enhancerGgufPath.empty();
     const int outSr = cfg.outputSampleRate.value_or(0);
     sampleRate =
-        outSr > 0 ? outSr : (enhanced ? kLavasrEnhancedSampleRate : 24000);
+        outSr > 0
+            ? outSr
+            : (enhanced ? kLavasrEnhancedSampleRate
+                        : chatterbox::kChatterboxNativeSampleRate);
     model = make_unique<ChatterboxModel>(std::move(cfg));
   }
 

--- a/packages/tts-ggml/addon/src/model-interface/BackendUtils.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/BackendUtils.hpp
@@ -20,6 +20,13 @@ inline constexpr int kBackendDeviceGpu = 1;
 // loaded".
 inline constexpr int kBackendIdNone = -1;
 
+// n_gpu_layers value meaning "offload every layer to the GPU", forwarded to
+// tts-cpp when a caller expresses GPU intent via the boolean useGpu switch
+// without an explicit layer count (llama.cpp's large-number convention;
+// tts-cpp clamps it to the model's real layer count). Shared by both engines
+// so the useGpu->layers mapping can't drift between them.
+inline constexpr int kOffloadAllGpuLayers = 99;
+
 inline int backendIdFromName(const std::string& name) {
   if (name == "CPU") return 0;
   if (name.rfind("Metal",  0) == 0 || name.rfind("MTL", 0) == 0) return 1;

--- a/packages/tts-ggml/addon/src/model-interface/OutputResampler.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/OutputResampler.hpp
@@ -26,38 +26,51 @@ struct OutputResampler {
     if (sr_in == sr_out || input.empty()) {
       return input;
     }
-    constexpr int kLanczosA = 5;
-    constexpr double kPi = 3.14159265358979323846;
-
     const double ratio = static_cast<double>(sr_out) / sr_in;
     const auto out_len = static_cast<size_t>(std::round(input.size() * ratio));
-    std::vector<float> output(out_len, 0.0f);
     const double scale = std::min(1.0, ratio);
 
+    std::vector<float> output(out_len, 0.0f);
     for (size_t i = 0; i < out_len; i++) {
-      const double center = i / ratio;
-      const int left = static_cast<int>(
-          std::max(0.0, std::floor(center - kLanczosA / scale)));
-      const int right = static_cast<int>(std::min(
-          static_cast<double>(input.size()) - 1,
-          std::floor(center + kLanczosA / scale)));
-
-      float sum = 0.0f;
-      float weight_sum = 0.0f;
-      for (int j = left; j <= right; j++) {
-        const double x = (center - j) * scale;
-        double weight = 1.0;
-        if (x != 0.0) {
-          const double pi_x = kPi * x;
-          weight = std::sin(pi_x) * std::sin(pi_x / kLanczosA) /
-                   (pi_x * pi_x / kLanczosA);
-        }
-        sum += input[j] * static_cast<float>(weight);
-        weight_sum += static_cast<float>(weight);
-      }
-      output[i] = (weight_sum > 0.0f) ? sum / weight_sum : 0.0f;
+      output[i] = resampleOne(input, i / ratio, scale);
     }
     return output;
+  }
+
+private:
+  static constexpr int kLanczosA = 5;
+  static constexpr double kPi = 3.14159265358979323846;
+
+  // Normalized-sinc Lanczos (a=5) tap weight for a source offset `x` (already
+  // scaled for the downsampling case). x == 0 is the window peak.
+  static double lanczosWeight(double x) {
+    if (x == 0.0) {
+      return 1.0;
+    }
+    const double pi_x = kPi * x;
+    return std::sin(pi_x) * std::sin(pi_x / kLanczosA) /
+           (pi_x * pi_x / kLanczosA);
+  }
+
+  // One output sample: the weighted sum of the input taps whose Lanczos window
+  // covers `center` (in input-sample units), normalized by the weight sum.
+  static float resampleOne(const std::vector<float>& input, double center,
+                           double scale) {
+    const int left = static_cast<int>(
+        std::max(0.0, std::floor(center - kLanczosA / scale)));
+    const int right = static_cast<int>(
+        std::min(static_cast<double>(input.size()) - 1,
+                 std::floor(center + kLanczosA / scale)));
+
+    float sum = 0.0f;
+    float weight_sum = 0.0f;
+    for (int j = left; j <= right; j++) {
+      const auto weight =
+          static_cast<float>(lanczosWeight((center - j) * scale));
+      sum += input[j] * weight;
+      weight_sum += weight;
+    }
+    return (weight_sum > 0.0f) ? sum / weight_sum : 0.0f;
   }
 };
 

--- a/packages/tts-ggml/addon/src/model-interface/PcmConversion.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/PcmConversion.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace qvac::ttsggml {
+
+// Full-scale magnitude for signed 16-bit PCM. Float samples in [-1, 1] map onto
+// [-32767, 32767]; -32768 is left unused so the mapping stays symmetric. Shared
+// by both engines so the float->int16 conversion can't drift between them.
+inline constexpr float kInt16PcmScale = 32767.0f;
+
+inline std::vector<int16_t> pcmFloatToInt16(const float* pcm, std::size_t samples) {
+  std::vector<int16_t> out(samples);
+  for (std::size_t i = 0; i < samples; ++i) {
+    const float clamped = std::clamp(pcm[i], -1.0f, 1.0f);
+    out[i] = static_cast<int16_t>(std::lround(clamped * kInt16PcmScale));
+  }
+  return out;
+}
+
+inline std::vector<int16_t> pcmFloatToInt16(const std::vector<float>& pcm) {
+  return pcmFloatToInt16(pcm.data(), pcm.size());
+}
+
+} // namespace qvac::ttsggml

--- a/packages/tts-ggml/addon/src/model-interface/StreamingEnhancer.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/StreamingEnhancer.hpp
@@ -135,6 +135,29 @@ private:
     return std::clamp(v, 0L, static_cast<long>(len));
   }
 
+  // Append the contiguous output span out[from, to) to result.
+  static void emitRange(std::vector<float>& result,
+                        const std::vector<float>& out, long from, long to) {
+    for (long j = from; j < to; ++j) {
+      result.push_back(out[static_cast<std::size_t>(j)]);
+    }
+  }
+
+  // Append a linear crossfade of the `xl` held samples into the new window's
+  // output (starting at oSent): weight w ramps 1/(xl+1) .. xl/(xl+1), so the
+  // previous window fades out as the new one fades in across the shared region.
+  static void emitCrossfade(std::vector<float>& result,
+                            const std::vector<float>& held,
+                            const std::vector<float>& out, long oSent,
+                            std::size_t xl) {
+    for (std::size_t k = 0; k < xl; ++k) {
+      const double w =
+          static_cast<double>(k + 1) / static_cast<double>(xl + 1);
+      result.push_back(static_cast<float>(
+          (1.0 - w) * held[k] + w * out[static_cast<std::size_t>(oSent) + k]));
+    }
+  }
+
   std::vector<float> process(bool finalPass) {
     const int64_t availEnd = inTotal_;
     // How far we can finalize: keep `marginIn_` of look-ahead on non-final
@@ -171,18 +194,10 @@ private:
     const long span = std::max(0L, oHeldEnd - oSent);
     const std::size_t xl =
         std::min(held_.size(), static_cast<std::size_t>(span));
-    for (std::size_t k = 0; k < xl; ++k) {
-      const double w = static_cast<double>(k + 1) / static_cast<double>(xl + 1);
-      result.push_back(
-          static_cast<float>(
-              (1.0 - w) * held_[k] +
-              w * out[static_cast<std::size_t>(oSent) + k]));
-    }
+    emitCrossfade(result, held_, out, oSent, xl);
     // Cover any rounding drift between the two windows' lengths with the new
     // window's samples (keeps the emitted stream input-contiguous).
-    for (long j = oSent + static_cast<long>(xl); j < oHeldEnd; ++j) {
-      result.push_back(out[static_cast<std::size_t>(j)]);
-    }
+    emitRange(result, out, oSent + static_cast<long>(xl), oHeldEnd);
 
     // --- Region B: fresh contiguous output (heldEndIn_, newSentEnd). ---
     // Hold back `crossfadeIn_` of just-committed audio (grid-snapped) so the
@@ -191,9 +206,7 @@ private:
         finalPass ? commitEnd
                   : std::max(heldEndIn_, alignDown(commitEnd - crossfadeIn_));
     const long oNewSent = outIndex(newSentEnd, winStart, L);
-    for (long j = oHeldEnd; j < oNewSent; ++j) {
-      result.push_back(out[static_cast<std::size_t>(j)]);
-    }
+    emitRange(result, out, oHeldEnd, oNewSent);
     sentIn_ = newSentEnd;
 
     // --- Reserve the new held (crossfade) span [newSentEnd, commitEnd). ---

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxConfig.hpp
@@ -5,6 +5,12 @@
 
 namespace qvac::ttsggml::chatterbox {
 
+// Native output sample rate (Hz) of Chatterbox's S3Gen/HiFT vocoder. The engine
+// emits at this rate; the addon tags un-enhanced output with it and feeds the
+// streaming enhancer at it. Shared so the model and AddonJs can't disagree on
+// the un-enhanced native rate.
+inline constexpr int kChatterboxNativeSampleRate = 24000;
+
 /**
  * Configuration for the Chatterbox engine wrapping tts-cpp::tts-cpp.
  *

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -20,6 +21,7 @@
 #include "model-interface/BackendUtils.hpp"
 #include "model-interface/EnhancerLoader.hpp"
 #include "model-interface/OutputResampler.hpp"
+#include "model-interface/PcmConversion.hpp"
 #include "model-interface/StreamingEnhancer.hpp"
 #include "model-interface/chatterbox/TimeStretch.hpp"
 
@@ -82,7 +84,7 @@ tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) 
     // Explicit useGpu must produce an explicit n_gpu_layers so we don't
     // depend on the tts-cpp library default flipping out from under us
     // (see also: gpu-smoke.test.js asserts backendDevice from this).
-    opts.n_gpu_layers = *cfg.useGpu ? 99 : 0;
+    opts.n_gpu_layers = *cfg.useGpu ? kOffloadAllGpuLayers : 0;
   }
   if (cfg.streamChunkTokens.has_value())      opts.stream_chunk_tokens       = *cfg.streamChunkTokens;
   if (cfg.streamFirstChunkTokens.has_value()) opts.stream_first_chunk_tokens = *cfg.streamFirstChunkTokens;
@@ -141,20 +143,6 @@ tts_cpp::chatterbox::EngineOptions toEngineOptions(const ChatterboxConfig& cfg) 
   return opts;
 }
 
-std::vector<int16_t> pcmFloatToInt16(const float* pcm, size_t samples) {
-  std::vector<int16_t> out;
-  out.resize(samples);
-  for (size_t i = 0; i < samples; ++i) {
-    float s = std::clamp(pcm[i], -1.0f, 1.0f);
-    out[i] = static_cast<int16_t>(std::lround(s * 32767.0f));
-  }
-  return out;
-}
-
-std::vector<int16_t> pcmFloatToInt16(const std::vector<float>& pcm) {
-  return pcmFloatToInt16(pcm.data(), pcm.size());
-}
-
 // A speed of 1.0 (or close enough that the WSOLA hop rounds to identity) is
 // a no-op — skip the time-stretch entirely so the default path is untouched.
 bool speedActive(float speed) {
@@ -164,12 +152,157 @@ bool speedActive(float speed) {
 constexpr float MIN_SPEED = 0.25f;
 constexpr float MAX_SPEED = 4.0f;
 
-// Chatterbox's S3Gen/HiFT vocoder emits 24 kHz. When the LavaSR enhancer is
-// active the engine is configured to emit this native rate (output_sample_rate
-// = 0 in toEngineOptions) and the addon enhances/resamples afterwards, so the
-// streaming enhancer feeds the enhancer at this rate. Matches the literal
-// AddonJs uses to tag the un-enhanced native rate.
-constexpr int CHATTERBOX_NATIVE_RATE = 24000;
+// Sample rates involved once the LavaSR enhancer is active: the engine emits
+// its native rate, the enhancer upsamples to `workRate` (48 kHz), and the
+// streaming path finally emits at `streamFinalRate` (a caller-requested rate,
+// else the work rate). All zero when no enhancer is loaded.
+struct EnhancerRates {
+  int workRate = 0;
+  int streamFinalRate = 0;
+};
+
+EnhancerRates resolveEnhancerRates(
+    const std::shared_ptr<tts_cpp::lavasr::Enhancer>& enhancer,
+    const std::optional<int>& outputSampleRate) {
+  if (!enhancer) return {};
+  const int workRate = enhancer->output_sample_rate();
+  const bool hasRequestedRate =
+      outputSampleRate.has_value() && *outputSampleRate > 0;
+  return {workRate, hasRequestedRate ? *outputSampleRate : workRate};
+}
+
+// Wraps the one-shot enhancer as a streaming stage: enhance at the engine's
+// native rate, then resample to the streaming final rate when they differ.
+std::shared_ptr<StreamingEnhancer> makeStreamingEnhancer(
+    const std::shared_ptr<tts_cpp::lavasr::Enhancer>& enhancer,
+    const EnhancerRates& rates) {
+  if (!enhancer) return nullptr;
+  const int workRate = rates.workRate;
+  const int finalRate = rates.streamFinalRate;
+  return std::make_shared<StreamingEnhancer>(
+      [enhancer, workRate, finalRate](const std::vector<float>& raw) {
+        std::vector<float> enhanced =
+            enhancer->enhance(raw, kChatterboxNativeSampleRate);
+        if (finalRate != workRate) {
+          enhanced = OutputResampler::resample(enhanced, workRate, finalRate);
+        }
+        return enhanced;
+      },
+      kChatterboxNativeSampleRate, finalRate);
+}
+
+// Per-chunk post-processing for the native streaming path: an optional
+// seam-free LavaSR enhancement stage followed by an optional pitch-preserving
+// WSOLA stretch stage, emitting int16 PCM through the caller's callback. Kept
+// as a functor so the engine can call it per chunk while each DSP stage stays
+// individually readable and testable.
+struct StreamChunkPostProcessor {
+  const ChatterboxModel::ChunkCallback& emit;
+  std::shared_ptr<StreamingEnhancer> streamEnhancer;
+  std::shared_ptr<WsolaTimeStretch> stretcher;
+  std::size_t& emittedSamples;
+
+  bool isPassthrough() const { return !streamEnhancer && !stretcher; }
+
+  std::vector<float> enhanceStage(const float* pcm, std::size_t samples,
+                                  bool isLast) const {
+    if (!streamEnhancer) return std::vector<float>(pcm, pcm + samples);
+    std::vector<float> audio = streamEnhancer->feed(pcm, samples);
+    if (isLast) {
+      const std::vector<float> tail = streamEnhancer->flush();
+      audio.insert(audio.end(), tail.begin(), tail.end());
+    }
+    return audio;
+  }
+
+  std::vector<float> stretchStage(std::vector<float> audio, bool isLast) const {
+    if (!stretcher) return audio;
+    std::vector<float> stretched = stretcher->feed(audio.data(), audio.size());
+    if (isLast) {
+      const std::vector<float> tail = stretcher->flush();
+      stretched.insert(stretched.end(), tail.begin(), tail.end());
+    }
+    return stretched;
+  }
+
+  void operator()(const float* pcm, std::size_t samples, int chunkIndex,
+                  bool isLast) {
+    if (isPassthrough()) {
+      emittedSamples += samples;
+      emit(pcmFloatToInt16(pcm, samples), chunkIndex, isLast);
+      return;
+    }
+    std::vector<float> audio =
+        stretchStage(enhanceStage(pcm, samples, isLast), isLast);
+    emittedSamples += audio.size();
+    emit(pcmFloatToInt16(audio), chunkIndex, isLast);
+  }
+};
+
+tts_cpp::chatterbox::SynthesisResult runStreamingSynthesis(
+    tts_cpp::chatterbox::Engine& engine, const std::string& text,
+    const ChatterboxModel::ChunkCallback& chunkCallback,
+    const std::shared_ptr<tts_cpp::lavasr::Enhancer>& enhancer, float speed,
+    const EnhancerRates& rates, std::size_t& emittedSamples) {
+  try {
+    auto stretcher = speedActive(speed)
+                         ? std::make_shared<WsolaTimeStretch>(speed)
+                         : nullptr;
+    StreamChunkPostProcessor postProcessor{chunkCallback,
+                                           makeStreamingEnhancer(enhancer, rates),
+                                           stretcher, emittedSamples};
+    return engine.synthesize(text, std::move(postProcessor));
+  } catch (const std::exception& e) {
+    throw createTTSError(TTSErrorCode::SynthesisFailed,
+                         std::string("engine.synthesize: ") + e.what());
+  }
+}
+
+tts_cpp::chatterbox::SynthesisResult runBatchSynthesis(
+    tts_cpp::chatterbox::Engine& engine, const std::string& text) {
+  try {
+    return engine.synthesize(text);
+  } catch (const std::exception& e) {
+    throw createTTSError(TTSErrorCode::SynthesisFailed,
+                         std::string("engine.synthesize: ") + e.what());
+  }
+}
+
+// LavaSR neural denoiser (batch path). Runs BEFORE the enhancer and preserves
+// the sample rate. Streaming + denoiser is rejected in validateConfig (a
+// stateful streaming denoiser is the follow-up), so this only applies here.
+void applyBatchDenoiser(tts_cpp::chatterbox::SynthesisResult& result,
+                        tts_cpp::lavasr::Denoiser& denoiser) {
+  try {
+    result.pcm = denoiser.denoise(result.pcm, result.sample_rate);
+  } catch (const std::exception& e) {
+    throw createTTSError(
+        TTSErrorCode::SynthesisFailed,
+        std::string("chatterbox.lavasr-denoiser: ") + e.what());
+  }
+}
+
+// LavaSR neural bandwidth extension (batch path). Enhances the whole utterance
+// at once (the streaming path enhances per chunk instead), updating
+// result.sample_rate to the enhancer's 48 kHz output, then honours a requested
+// outputSampleRate that the engine bypassed while enhancing.
+void applyBatchEnhancer(tts_cpp::chatterbox::SynthesisResult& result,
+                        tts_cpp::lavasr::Enhancer& enhancer,
+                        const std::optional<int>& outputSampleRate) {
+  try {
+    result.pcm = enhancer.enhance(result.pcm, result.sample_rate);
+    result.sample_rate = enhancer.output_sample_rate();
+  } catch (const std::exception& e) {
+    throw createTTSError(TTSErrorCode::SynthesisFailed,
+                         std::string("chatterbox.lavasr: ") + e.what());
+  }
+  if (outputSampleRate.has_value() && *outputSampleRate > 0 &&
+      *outputSampleRate != result.sample_rate) {
+    result.pcm = OutputResampler::resample(result.pcm, result.sample_rate,
+                                           *outputSampleRate);
+    result.sample_rate = *outputSampleRate;
+  }
+}
 
 } // namespace
 
@@ -413,10 +546,9 @@ void ChatterboxModel::cancel() const {
 
 ChatterboxModel::SynthesizeResult ChatterboxModel::synthesize(
     const std::string& text, const ChunkCallback& chunkCallback) {
-  // Capture the engine under the lock; keep it alive for the duration
-  // of synthesize() via the local `engine` shared_ptr even if reload()
-  // concurrently swaps a new one in.  Reload's new engine takes effect
-  // on the NEXT synthesize call.
+  // Capture the engine (and enhancer/denoiser) under the lock and keep them
+  // alive via these locals for the whole call, even if reload() swaps new ones
+  // in concurrently -- the replacements take effect on the NEXT synthesize.
   std::shared_ptr<tts_cpp::chatterbox::Engine> engine;
   std::shared_ptr<tts_cpp::lavasr::Enhancer> enhancer;
   std::shared_ptr<tts_cpp::lavasr::Denoiser> denoiser;
@@ -435,165 +567,39 @@ ChatterboxModel::SynthesizeResult ChatterboxModel::synthesize(
                          "synthesis cancelled before it started");
   }
 
-  // Snapshot the streaming decision against the engine we're actually
-  // about to call, BEFORE process() needs it.  Reading engine_ /
-  // engine->options() outside the lock from process() would race with
-  // reload() swapping a new engine in; pinning the decision here keeps
-  // the read tied to the local `engine` shared_ptr for the call's
-  // lifetime.
+  // Pin the streaming decision to the engine we actually call; reading
+  // engine->options() later (e.g. from process()) would race with reload()
+  // swapping a new engine in behind our back.
   const bool wasStreaming =
       static_cast<bool>(chunkCallback) &&
       engine->options().stream_chunk_tokens > 0;
 
-  // Speaking-rate control.  Chatterbox's engine has no native rate knob, so
-  // we post-process the 24 kHz PCM with a pitch-preserving WSOLA stretch
-  // (see TimeStretch.hpp / ChatterboxConfig::speed).  In streaming mode a
-  // single stretcher instance threads the overlap-add state across chunks so
-  // the concatenated output has no per-chunk seams.
-  // Unset -> 1.0 (no rate change), preserving the raw model output for
-  // backward compatibility; callers opt in by passing an explicit speed.
+  // Speaking-rate control is a post-synthesis pitch-preserving WSOLA stretch
+  // (Chatterbox has no native rate knob; see TimeStretch.hpp). Unset -> 1.0
+  // leaves the raw model output untouched for backward compatibility.
   const float speed = cfg_.speed.value_or(1.0f);
   const bool stretch = speedActive(speed);
+  const EnhancerRates rates =
+      resolveEnhancerRates(enhancer, cfg_.outputSampleRate);
 
   const auto tStart = std::chrono::steady_clock::now();
 
-  // Streaming publishes its (already-stretched) audio per chunk via
-  // chunkCallback; sum the emitted samples here so the stats below use the
-  // real output length without re-stretching result.pcm.  The callback runs
-  // synchronously on this thread, so a plain counter is safe.
+  // The streaming callback runs synchronously on this thread, so this plain
+  // counter safely tallies the emitted sample count for the stats below.
   std::size_t streamedSamples = 0;
+  tts_cpp::chatterbox::SynthesisResult result =
+      wasStreaming ? runStreamingSynthesis(*engine, text, chunkCallback,
+                                           enhancer, speed, rates,
+                                           streamedSamples)
+                   : runBatchSynthesis(*engine, text);
 
-  // LavaSR enhancer rates. When enhancing, the engine emits its native rate and
-  // the enhancer upsamples to its work rate (48 kHz); we then resample to any
-  // caller-requested outputSampleRate. `streamFinalRate` is what the streaming
-  // callback ultimately emits at (and what the duration stat must use, since
-  // result.sample_rate stays at the engine's native rate on the streaming
-  // path).
-  const int enhancerWorkRate =
-      enhancer ? enhancer->output_sample_rate() : 0; // 48 kHz
-  const int requestedRate =
-      (cfg_.outputSampleRate.has_value() && *cfg_.outputSampleRate > 0)
-          ? *cfg_.outputSampleRate
-          : 0;
-  const int streamFinalRate =
-      enhancer ? (requestedRate > 0 ? requestedRate : enhancerWorkRate) : 0;
-
-  tts_cpp::chatterbox::SynthesisResult result;
-  try {
-    if (wasStreaming) {
-      auto stretcher =
-          stretch ? std::make_shared<WsolaTimeStretch>(speed) : nullptr;
-      // Streaming bandwidth extension: re-runs the one-shot enhancer over a
-      // sliding window with look-ahead + crossfade so each emitted chunk is
-      // enhanced (and resampled to streamFinalRate) seam-free. Adds ~0.34 s of
-      // algorithmic latency (the enhancer's receptive field). The final engine
-      // chunk drains the held look-ahead via flush().
-      std::shared_ptr<StreamingEnhancer> senh;
-      if (enhancer) {
-        senh = std::make_shared<StreamingEnhancer>(
-            [enhancer, enhancerWorkRate, streamFinalRate](
-                const std::vector<float>& raw) {
-              std::vector<float> e =
-                  enhancer->enhance(raw, CHATTERBOX_NATIVE_RATE);
-              if (streamFinalRate != enhancerWorkRate) {
-                e = OutputResampler::resample(
-                    e, enhancerWorkRate, streamFinalRate);
-              }
-              return e;
-            },
-            CHATTERBOX_NATIVE_RATE,
-            streamFinalRate);
-      }
-      result = engine->synthesize(
-          text,
-          [&chunkCallback, senh, stretcher, &streamedSamples](
-              const float* pcm,
-              std::size_t samples,
-              int chunkIndex,
-              bool isLast) {
-            // Fast path: no post-processing -> forward the raw chunk untouched.
-            if (!senh && !stretcher) {
-              streamedSamples += samples;
-              chunkCallback(pcmFloatToInt16(pcm, samples), chunkIndex, isLast);
-              return;
-            }
-            // Stage 1: streaming LavaSR enhancement (seam-free; may emit fewer
-            // samples than it consumed on early chunks while the look-ahead
-            // fills, and the bulk of the tail on the final chunk).
-            std::vector<float> audio;
-            if (senh) {
-              audio = senh->feed(pcm, samples);
-              if (isLast) {
-                std::vector<float> tail = senh->flush();
-                audio.insert(audio.end(), tail.begin(), tail.end());
-              }
-            } else {
-              audio.assign(pcm, pcm + samples);
-            }
-            // Stage 2: WSOLA speed stretch (rate-agnostic, seam-free).
-            if (stretcher) {
-              std::vector<float> s =
-                  stretcher->feed(audio.data(), audio.size());
-              if (isLast) {
-                std::vector<float> tail = stretcher->flush();
-                s.insert(s.end(), tail.begin(), tail.end());
-              }
-              audio = std::move(s);
-            }
-            streamedSamples += audio.size();
-            chunkCallback(pcmFloatToInt16(audio), chunkIndex, isLast);
-          });
-    } else {
-      result = engine->synthesize(text);
-    }
-  } catch (const std::exception& e) {
-    throw createTTSError(TTSErrorCode::SynthesisFailed,
-                         std::string("engine.synthesize: ") + e.what());
-  }
-
-  // LavaSR neural denoiser (batch path). Runs BEFORE the enhancer and preserves
-  // the sample rate. Streaming + denoiser is rejected in validateConfig (a
-  // stateful streaming denoiser is the follow-up), so this only applies on the
-  // batch path. The UL-UNAS forward is implemented in qvac-ext-lib-whisper.cpp
-  // PR #78; this runs whenever a denoiser was loaded.
-  if (!wasStreaming && denoiser) {
-    try {
-      result.pcm = denoiser->denoise(result.pcm, result.sample_rate);
-    } catch (const std::exception& e) {
-      throw createTTSError(
-          TTSErrorCode::SynthesisFailed,
-          std::string("chatterbox.lavasr-denoiser: ") + e.what());
-    }
-  }
-
-  // LavaSR neural bandwidth extension (batch path). The streaming path enhances
-  // per chunk inside the callback above (StreamingEnhancer); here we enhance
-  // the whole utterance at once. Applied before the WSOLA speed stretch so rate
-  // control operates on the 48 kHz enhanced signal; result.sample_rate is
-  // updated so the stats below are correct and the JS callback reports 48000.
+  if (!wasStreaming && denoiser) applyBatchDenoiser(result, *denoiser);
   if (!wasStreaming && enhancer) {
-    try {
-      result.pcm = enhancer->enhance(result.pcm, result.sample_rate);
-      result.sample_rate = enhancer->output_sample_rate();
-    } catch (const std::exception& e) {
-      throw createTTSError(
-          TTSErrorCode::SynthesisFailed,
-          std::string("chatterbox.lavasr: ") + e.what());
-    }
-    // Honor outputSampleRate after enhancement (the enhancer emits 48 kHz; the
-    // engine's output_sample_rate was bypassed while enhancing).
-    if (cfg_.outputSampleRate.has_value() && *cfg_.outputSampleRate > 0 &&
-        *cfg_.outputSampleRate != result.sample_rate) {
-      result.pcm = OutputResampler::resample(
-          result.pcm, result.sample_rate, *cfg_.outputSampleRate);
-      result.sample_rate = *cfg_.outputSampleRate;
-    }
+    applyBatchEnhancer(result, *enhancer, cfg_.outputSampleRate);
   }
 
-  // Batch: build the PCM we return (stretched in-place if a speed is active).
-  // Streaming: the chunks were already published, so there is nothing to
-  // return — take the sample count straight from what the callback emitted
-  // rather than re-running a full-utterance WSOLA over result.pcm.
+  // Streaming already published (and counted) its chunks; batch converts the
+  // whole utterance here, stretching it in place first when a speed is active.
   std::vector<int16_t> pcm;
   std::size_t outSamples;
   if (wasStreaming) {
@@ -607,14 +613,19 @@ ChatterboxModel::SynthesizeResult ChatterboxModel::synthesize(
   const auto tEnd = std::chrono::steady_clock::now();
   const double elapsedSec =
       std::chrono::duration<double>(tEnd - tStart).count();
-
-  // Rate the output was actually emitted at. On the streaming+enhancer path the
-  // chunks are emitted at streamFinalRate while result.sample_rate stays at the
-  // engine's native rate (the engine emitted native; the addon enhanced after),
-  // so use streamFinalRate there; otherwise result.sample_rate is already the
-  // emitted rate (batch enhance/resample updates it in place).
+  // On the streaming+enhancer path chunks are emitted at streamFinalRate while
+  // result.sample_rate stays native; elsewhere result.sample_rate is already
+  // the emitted rate (batch enhance/resample updates it in place).
   const int emittedRate =
-      (wasStreaming && enhancer) ? streamFinalRate : result.sample_rate;
+      (wasStreaming && enhancer) ? rates.streamFinalRate : result.sample_rate;
+  recordSynthesisStats(outSamples, elapsedSec, emittedRate, text.size());
+
+  return {std::move(pcm), wasStreaming};
+}
+
+void ChatterboxModel::recordSynthesisStats(std::size_t outSamples,
+                                           double elapsedSec, int emittedRate,
+                                           std::size_t textLength) {
   totalTime_ = elapsedSec;
   totalSamples_ = static_cast<int64_t>(outSamples);
   audioDurationMs_ = emittedRate > 0
@@ -623,11 +634,9 @@ ChatterboxModel::SynthesizeResult ChatterboxModel::synthesize(
                          : 0.0;
   realTimeFactor_ =
       audioDurationMs_ > 0 ? (elapsedSec * 1000.0) / audioDurationMs_ : 0.0;
-  textLength_ = text.size();
+  textLength_ = textLength;
   tokensPerSecond_ =
-      elapsedSec > 0 ? static_cast<double>(textLength_) / elapsedSec : 0.0;
-
-  return {std::move(pcm), wasStreaming};
+      elapsedSec > 0 ? static_cast<double>(textLength) / elapsedSec : 0.0;
 }
 
 std::any ChatterboxModel::process(const std::any& input) {

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/ChatterboxModel.hpp
@@ -2,6 +2,7 @@
 
 #include <any>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -125,6 +126,8 @@ private:
   };
   SynthesizeResult synthesize(const std::string& text,
                               const ChunkCallback& chunkCallback);
+  void recordSynthesisStats(std::size_t outSamples, double elapsedSec,
+                            int emittedRate, std::size_t textLength);
   static void validateConfig(const ChatterboxConfig& cfg);
 
   // Called under `engineMu_`.

--- a/packages/tts-ggml/addon/src/model-interface/chatterbox/TimeStretch.hpp
+++ b/packages/tts-ggml/addon/src/model-interface/chatterbox/TimeStretch.hpp
@@ -119,6 +119,23 @@ private:
     }
   }
 
+  // Normalized cross-correlation of the candidate frame at input offset `inOff`
+  // (relative to inBase_) against the running similarity target_. Dividing out
+  // the candidate's energy favors the most similar waveform SHAPE over the
+  // loudest offset (classic WSOLA normalization); raw correlation would bias
+  // toward high-energy frames and smear transients. The target energy is
+  // constant across candidates, so it doesn't affect the argmax and is omitted.
+  float matchScore(std::size_t inOff) const {
+    float dot = 0.0f;
+    float energy = 0.0f;
+    for (int k = 0; k < N_; ++k) {
+      const float s = inBuf_[inOff + static_cast<std::size_t>(k)];
+      dot += s * target_[static_cast<std::size_t>(k)];
+      energy += s * s;
+    }
+    return dot / std::sqrt(energy + 1e-9f);
+  }
+
   // Find the frame start near `ideal` whose overlap region best matches the
   // running `target_` (the natural waveform continuation predicted from the
   // previously emitted frame).  Plain cross-correlation, classic WSOLA.
@@ -133,21 +150,7 @@ private:
     long best = lo;
     float bestScore = -std::numeric_limits<float>::infinity();
     for (long a = lo; a <= hi; ++a) {
-      const std::size_t inOff = static_cast<std::size_t>(a) - inBase_;
-      float dot = 0.0f;
-      float energy = 0.0f;
-      for (int k = 0; k < N_; ++k) {
-        const float s = inBuf_[inOff + static_cast<std::size_t>(k)];
-        dot += s * target_[static_cast<std::size_t>(k)];
-        energy += s * s;
-      }
-      // Normalized cross-correlation: divide out the candidate frame's energy
-      // so the match favors the most similar waveform SHAPE, not merely the
-      // loudest offset. Raw correlation biases toward high-energy frames and
-      // smears amplitude transients (classic WSOLA normalizes). The target
-      // energy is constant across candidates, so it doesn't affect the argmax
-      // and is omitted.
-      const float score = dot / std::sqrt(energy + 1e-9f);
+      const float score = matchScore(static_cast<std::size_t>(a) - inBase_);
       if (score > bestScore) {
         bestScore = score;
         best = a;

--- a/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
+++ b/packages/tts-ggml/addon/src/model-interface/supertonic/SupertonicModel.cpp
@@ -20,6 +20,7 @@
 #include "model-interface/BackendUtils.hpp"
 #include "model-interface/EnhancerLoader.hpp"
 #include "model-interface/OutputResampler.hpp"
+#include "model-interface/PcmConversion.hpp"
 #include "model-interface/supertonic/SupertonicEngineOptions.hpp"
 
 namespace qvac::ttsggml::supertonic {
@@ -54,7 +55,7 @@ tts_cpp::supertonic::EngineOptions toEngineOptions(const SupertonicConfig& cfg) 
   if (cfg.nGpuLayers.has_value()) {
     opts.n_gpu_layers = *cfg.nGpuLayers;
   } else if (cfg.useGpu.has_value()) {
-    opts.n_gpu_layers = *cfg.useGpu ? 99 : 0;
+    opts.n_gpu_layers = *cfg.useGpu ? kOffloadAllGpuLayers : 0;
   }
   opts.noise_npy_path = cfg.noiseNpyPath;
 
@@ -88,16 +89,6 @@ tts_cpp::supertonic::EngineOptions toEngineOptions(const SupertonicConfig& cfg) 
 
   detail::applyVulkanPipelineCache(opts, cfg);
   return opts;
-}
-
-std::vector<int16_t> pcmFloatToInt16(const float* pcm, size_t samples) {
-  std::vector<int16_t> out;
-  out.resize(samples);
-  for (size_t i = 0; i < samples; ++i) {
-    float s = std::clamp(pcm[i], -1.0f, 1.0f);
-    out[i] = static_cast<int16_t>(std::lround(s * 32767.0f));
-  }
-  return out;
 }
 
 }
@@ -146,12 +137,12 @@ void SupertonicModel::validateConfig(const SupertonicConfig& cfg) {
         TTSErrorCode::ModelFileNotFound,
         "lavasr denoiser GGUF not found: " + cfg.denoiserGgufPath);
   }
-  // Defense-in-depth: the JS layer (index.js::_validateConfig) runs the
-  // same conflict check before this method is reached, so direct C++
-  // callers are the only ones who can actually trip this branch.
-  // Mirror the Chatterbox suffix verbatim so users see an identical
-  // hint regardless of which engine they instantiated.  `layers != 0`
-  // matches llama.cpp's "-1 = offload all" sentinel convention.
+  // Defense-in-depth: the JS binding runs the same useGPU/nGpuLayers conflict
+  // check before this method is reached, so direct C++ callers are the only
+  // ones who can actually trip this branch. Mirror the Chatterbox suffix
+  // verbatim so users see an identical hint regardless of which engine they
+  // instantiated. `layers != 0` matches llama.cpp's "-1 = offload all"
+  // sentinel convention.
   if (cfg.useGpu.has_value() && cfg.nGpuLayers.has_value()) {
     const bool wantsGpuFlag   = *cfg.useGpu;
     const int  layers         = *cfg.nGpuLayers;

--- a/packages/tts-ggml/addon/tests/test_output_resampler.cpp
+++ b/packages/tts-ggml/addon/tests/test_output_resampler.cpp
@@ -1,0 +1,91 @@
+// Unit tests for OutputResampler, the windowed-sinc (Lanczos a=5) resampler the
+// addon applies on the LavaSR enhancer path (the enhancer always emits 48 kHz,
+// so a caller-requested output rate is honored here). Exercised in isolation —
+// no engine / GGUF — so these always run. Also guards the loop extraction
+// (lanczosWeight / resampleOne) done for the coding-standards refactor.
+
+#include <cmath>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/OutputResampler.hpp"
+
+using qvac::ttsggml::OutputResampler;
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+std::vector<float> sine(double freqHz, double seconds, int sr) {
+  const auto n = static_cast<std::size_t>(seconds * sr);
+  std::vector<float> out(n);
+  const double w = 2.0 * kPi * freqHz / static_cast<double>(sr);
+  for (std::size_t i = 0; i < n; ++i)
+    out[i] = static_cast<float>(std::sin(w * static_cast<double>(i)));
+  return out;
+}
+
+// Dominant period (in samples) via autocorrelation peak over a lag range.
+int dominantPeriod(const std::vector<float>& x, int minLag, int maxLag) {
+  int bestLag = minLag;
+  double best = -1e30;
+  for (int lag = minLag; lag <= maxLag; ++lag) {
+    double acc = 0.0;
+    for (std::size_t i = 0; i + static_cast<std::size_t>(lag) < x.size(); ++i)
+      acc += static_cast<double>(x[i]) * static_cast<double>(x[i + lag]);
+    if (acc > best) {
+      best = acc;
+      bestLag = lag;
+    }
+  }
+  return bestLag;
+}
+
+} // namespace
+
+TEST(OutputResampler, IdentityRateReturnsInputUnchanged) {
+  const auto in = sine(300.0, 0.05, 24000);
+  const auto out = OutputResampler::resample(in, 24000, 24000);
+  ASSERT_EQ(out.size(), in.size());
+  for (std::size_t i = 0; i < in.size(); ++i)
+    EXPECT_FLOAT_EQ(out[i], in[i]);
+}
+
+TEST(OutputResampler, EmptyInputReturnsEmpty) {
+  const std::vector<float> in;
+  EXPECT_TRUE(OutputResampler::resample(in, 24000, 48000).empty());
+}
+
+TEST(OutputResampler, UpsampleDoublesLength) {
+  const auto in = sine(300.0, 0.1, 24000);
+  const auto out = OutputResampler::resample(in, 24000, 48000);
+  EXPECT_EQ(out.size(), in.size() * 2);
+}
+
+TEST(OutputResampler, DownsampleHalvesLength) {
+  const auto in = sine(300.0, 0.1, 48000);
+  const auto out = OutputResampler::resample(in, 48000, 24000);
+  EXPECT_EQ(out.size(), in.size() / 2);
+}
+
+TEST(OutputResampler, PreservesConstantSignal) {
+  // Normalized Lanczos weights sum to 1, so a DC input must come back as the
+  // same constant — exactly what the weight-sum division in resampleOne
+  // guarantees. A direct check on the extracted kernel.
+  const std::vector<float> in(4096, 0.5f);
+  const auto up = OutputResampler::resample(in, 24000, 48000);
+  ASSERT_FALSE(up.empty());
+  for (std::size_t i = 64; i + 64 < up.size(); ++i)
+    EXPECT_NEAR(up[i], 0.5f, 1e-4f);
+}
+
+TEST(OutputResampler, PreservesToneFrequencyOnUpsample) {
+  // A 300 Hz tone has period 80 samples at 24 kHz and 160 at 48 kHz; correct
+  // interpolation keeps the frequency (the period scales with the rate ratio).
+  const auto in = sine(300.0, 0.2, 24000);
+  const auto out = OutputResampler::resample(in, 24000, 48000);
+  for (const float s : out)
+    ASSERT_TRUE(std::isfinite(s));
+  EXPECT_NEAR(dominantPeriod(out, 160 - 20, 160 + 20), 160, 4);
+}

--- a/packages/tts-ggml/addon/tests/test_pcm_conversion.cpp
+++ b/packages/tts-ggml/addon/tests/test_pcm_conversion.cpp
@@ -1,0 +1,50 @@
+// Unit tests for the shared float->int16 PCM conversion (PcmConversion.hpp),
+// centralized from the two engines during the coding-standards refactor.
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "model-interface/PcmConversion.hpp"
+
+using qvac::ttsggml::kInt16PcmScale;
+using qvac::ttsggml::pcmFloatToInt16;
+
+TEST(PcmConversion, ScaleIsSymmetricFullScale) {
+  EXPECT_FLOAT_EQ(kInt16PcmScale, 32767.0f);
+}
+
+TEST(PcmConversion, MapsEndpointsToSymmetricFullScale) {
+  const std::vector<float> in{0.0f, 1.0f, -1.0f};
+  const auto out = pcmFloatToInt16(in);
+  ASSERT_EQ(out.size(), 3u);
+  EXPECT_EQ(out[0], 0);
+  EXPECT_EQ(out[1], static_cast<int16_t>(32767));
+  EXPECT_EQ(out[2], static_cast<int16_t>(-32767));
+}
+
+TEST(PcmConversion, ClampsOutOfRangeInput) {
+  const std::vector<float> in{2.0f, -2.0f, 1.5f, -3.3f};
+  const auto out = pcmFloatToInt16(in);
+  EXPECT_EQ(out[0], static_cast<int16_t>(32767));
+  EXPECT_EQ(out[1], static_cast<int16_t>(-32767));
+  EXPECT_EQ(out[2], static_cast<int16_t>(32767));
+  EXPECT_EQ(out[3], static_cast<int16_t>(-32767));
+}
+
+TEST(PcmConversion, RoundsHalfAwayFromZero) {
+  // 0.5 * 32767 = 16383.5 -> std::lround rounds half away from zero.
+  const std::vector<float> in{0.5f, -0.5f};
+  const auto out = pcmFloatToInt16(in);
+  EXPECT_EQ(out[0], static_cast<int16_t>(16384));
+  EXPECT_EQ(out[1], static_cast<int16_t>(-16384));
+}
+
+TEST(PcmConversion, PointerAndVectorOverloadsAgree) {
+  const std::vector<float> in{0.1f, -0.2f, 0.9f, -0.9f, 0.0f};
+  const auto viaVector = pcmFloatToInt16(in);
+  const auto viaPointer = pcmFloatToInt16(in.data(), in.size());
+  EXPECT_EQ(viaVector, viaPointer);
+}

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -12,10 +12,15 @@ const {
 const { TTSInterface } = require('./tts')
 const { QvacErrorAddonTTSGgml, ERR_CODES } = require('./lib/error')
 const { splitTtsText } = require('./lib/textChunker')
-const { accumulateTextStream } = require('./lib/textStreamAccumulator')
+const { accumulateTextStream, DEFAULT_FLUSH_AFTER_MS } = require('./lib/textStreamAccumulator')
 
 const ENGINE_CHATTERBOX = 'chatterbox'
 const ENGINE_SUPERTONIC = 'supertonic'
+
+// Accepted output sample-rate window (Hz): below 8 kHz speech is unintelligible;
+// above 192 kHz is past any audio DAC and only wastes memory/CPU on resampling.
+const MIN_OUTPUT_SAMPLE_RATE = 8000
+const MAX_OUTPUT_SAMPLE_RATE = 192000
 
 const CHATTERBOX_T3_TURBO = 'chatterbox-t3-turbo.gguf'
 const CHATTERBOX_T3_MTL = 'chatterbox-t3-mtl.gguf'
@@ -234,6 +239,86 @@ function ttsOutputDebugString(data) {
   return JSON.stringify(summary)
 }
 
+function resolveDefaultLazySessionLoading(lazySessionLoading) {
+  if (lazySessionLoading != null) return lazySessionLoading
+  return platform() === 'ios' || platform() === 'android'
+}
+
+function validateOutputSampleRate(outputSampleRate) {
+  if (outputSampleRate == null) return null
+  if (outputSampleRate < MIN_OUTPUT_SAMPLE_RATE || outputSampleRate > MAX_OUTPUT_SAMPLE_RATE) {
+    throw new Error(
+      'outputSampleRate must be between ' +
+        MIN_OUTPUT_SAMPLE_RATE +
+        ' and ' +
+        MAX_OUTPUT_SAMPLE_RATE +
+        ', got ' +
+        outputSampleRate
+    )
+  }
+  return outputSampleRate
+}
+
+// LavaSR enhancer (opt-in): enhancement is ON iff a GGUF path is provided (via
+// files.lavasrEnhancer or enhancer.enhancerPath), so there is no separate
+// on/off flag to keep in sync. A provided `enhancer` block must use the
+// supported type so a typo can't silently disable it.
+function resolveEnhancerGgufPath(normalizedFiles, enhancer) {
+  if (enhancer != null && enhancer.type !== 'lavasr') {
+    throw new Error(`tts-ggml: unknown enhancer.type '${enhancer.type}', expected 'lavasr'.`)
+  }
+  return firstNonEmpty(normalizedFiles.lavasrEnhancer, enhancer ? enhancer.enhancerPath : undefined)
+}
+
+// LavaSR denoiser (opt-in, mirrors the enhancer): runs BEFORE the enhancer and
+// is rate-preserving, enabled purely by supplying a GGUF path. A provided
+// `denoiser` block must use the supported type so a typo can't silently disable
+// it.
+function resolveDenoiserGgufPath(normalizedFiles, denoiser) {
+  if (denoiser != null && denoiser.type !== 'lavasr') {
+    throw new Error(`tts-ggml: unknown denoiser.type '${denoiser.type}', expected 'lavasr'.`)
+  }
+  return firstNonEmpty(normalizedFiles.lavasrDenoiser, denoiser ? denoiser.denoiserPath : undefined)
+}
+
+// `layers != 0` (not > 0) so a future llama.cpp-style nGpuLayers:-1 ("offload
+// all layers") reads as "wants GPU" rather than falsely passing as "wants CPU".
+function assertGpuIntentConsistent(useGPU, nGpuLayers) {
+  if (typeof useGPU !== 'boolean' || nGpuLayers == null) return
+  const layersWantGpu = nGpuLayers !== 0
+  if (useGPU === layersWantGpu) return
+  throw new Error(
+    'tts-ggml: useGPU=' +
+      useGPU +
+      ' conflicts with nGpuLayers=' +
+      nGpuLayers +
+      '. ' +
+      'Either drop one of the two, or make them agree ' +
+      '(useGPU:true + nGpuLayers!=0, or useGPU:false + nGpuLayers=0).'
+  )
+}
+
+function isAudioOutputEvent(data) {
+  return data != null && typeof data === 'object' && !!data.outputArray
+}
+
+function isStatsEvent(data) {
+  return (
+    data != null &&
+    typeof data === 'object' &&
+    ('totalTime' in data || 'audioDurationMs' in data || 'totalSamples' in data)
+  )
+}
+
+function computeSentenceStreamStats(chunks, acc) {
+  const totalChars = chunks.join('').length
+  return {
+    ...acc,
+    tokensPerSecond: acc.totalTime > 0 ? totalChars / acc.totalTime : 0,
+    realTimeFactor: acc.audioDurationMs > 0 ? (acc.totalTime * 1000.0) / acc.audioDurationMs : 0
+  }
+}
+
 /**
  * GGML-backed Chatterbox TTS (via the `tts-cpp` / qvac-tts.cpp library).
  *
@@ -247,44 +332,32 @@ function ttsOutputDebugString(data) {
  */
 class TTSGgml {
   constructor(options = {}) {
-    const {
-      files: filesInput = {},
-      config = {},
-      logger,
-      lazySessionLoading,
-      engine,
-      referenceAudio,
-      voiceDir,
-      seed,
-      nGpuLayers,
-      nCtx,
-      kvCacheType,
-      threads,
-      streamChunkTokens,
-      streamFirstChunkTokens,
-      cfmSteps,
-      cfgRate,
-      voice,
-      voiceName,
-      steps,
-      numInferenceSteps,
-      speed,
-      noiseNpyPath,
-      enhancer,
-      denoiser,
-      backendsDir,
-      openclCacheDir,
-      vulkanCacheDir,
-      mecabDictDir,
-      mecabDictPath,
-      cangjieTsvPath,
-      opts,
-      exclusiveRun
-    } = options
+    this._initInferenceState(options)
 
-    this.opts = opts || {}
-    this.exclusiveRun = !!exclusiveRun
-    this.logger = new QvacLogger(logger)
+    const normalizedFiles = normalizeGgmlFiles(options.files || {})
+    this._config = { ...(options.config || {}) }
+    this._lazySessionLoading = resolveDefaultLazySessionLoading(options.lazySessionLoading)
+    this._outputSampleRate = validateOutputSampleRate(this._config.outputSampleRate)
+
+    this._resolveEngineAndModelPaths(options.engine, normalizedFiles)
+    this._resolveDictionaryPaths(options, normalizedFiles)
+    this._assignSynthesisOptions(options)
+    this._enhancerGgufPath = resolveEnhancerGgufPath(normalizedFiles, options.enhancer)
+    this._denoiserGgufPath = resolveDenoiserGgufPath(normalizedFiles, options.denoiser)
+    this._resolveBackendPaths(options)
+
+    // Run the conflict check before any engine-specific GPU policy so a caller
+    // passing { useGPU:false, nGpuLayers:99 } gets the precise conflict message
+    // instead of, e.g., the Supertonic branch firing first and confusing them.
+    assertGpuIntentConsistent(this._config.useGPU, this._nGpuLayers)
+    this._assertEngineStreamingSupport()
+    this._applyDefaultGpuIntent()
+  }
+
+  _initInferenceState(options) {
+    this.opts = options.opts || {}
+    this.exclusiveRun = !!options.exclusiveRun
+    this.logger = new QvacLogger(options.logger)
     this.state = {
       configLoaded: false,
       weightsLoaded: false,
@@ -292,7 +365,8 @@ class TTSGgml {
     }
     this.addon = null
     this._sentenceStreamCtx = null
-    /** Serializes `run({ streamOutput: true })`, `runStream`, and `runStreaming` until each response settles (Whisper-style). */
+    // Serializes run({ streamOutput: true }), runStream, and runStreaming until
+    // each response settles (Whisper-style).
     this._ttsInferenceQueueWaiter = Promise.resolve()
     this._job = createJobHandler({
       cancel: () => {
@@ -305,24 +379,11 @@ class TTSGgml {
       : async function runNow(fn) {
           return fn()
         }
+  }
 
-    const normalizedFiles = normalizeGgmlFiles(filesInput)
-    this._config = { ...config }
-
-    this._lazySessionLoading =
-      lazySessionLoading != null
-        ? lazySessionLoading
-        : platform() === 'ios' || platform() === 'android'
-
-    const outputSampleRate = this._config.outputSampleRate
-    if (outputSampleRate != null && (outputSampleRate < 8000 || outputSampleRate > 192000)) {
-      throw new Error('outputSampleRate must be between 8000 and 192000, got ' + outputSampleRate)
-    }
-    this._outputSampleRate = outputSampleRate || null
-
+  _resolveEngineAndModelPaths(engine, normalizedFiles) {
     this._engineType = detectEngineType(engine, normalizedFiles)
     this._voicesDir = normalizedFiles.voicesDir
-
     if (this._engineType === ENGINE_SUPERTONIC) {
       const root = normalizedFiles.modelDir
       this._supertonicModelPath = firstNonEmpty(
@@ -331,135 +392,81 @@ class TTSGgml {
       )
       this._t3ModelPath = undefined
       this._s3genModelPath = undefined
+      return
+    }
+    const root = normalizedFiles.modelDir
+    if (root) {
+      const resolved = resolveChatterboxModelDirPaths(root)
+      this._t3ModelPath = firstNonEmpty(normalizedFiles.t3Model, resolved.t3)
+      this._s3genModelPath = firstNonEmpty(normalizedFiles.s3genModel, resolved.s3)
     } else {
-      const root = normalizedFiles.modelDir
-      if (root) {
-        const resolved = resolveChatterboxModelDirPaths(root)
-        this._t3ModelPath = firstNonEmpty(normalizedFiles.t3Model, resolved.t3)
-        this._s3genModelPath = firstNonEmpty(normalizedFiles.s3genModel, resolved.s3)
-      } else {
-        this._t3ModelPath = normalizedFiles.t3Model
-        this._s3genModelPath = normalizedFiles.s3genModel
-      }
-      this._supertonicModelPath = undefined
+      this._t3ModelPath = normalizedFiles.t3Model
+      this._s3genModelPath = normalizedFiles.s3genModel
     }
+    this._supertonicModelPath = undefined
+  }
 
-    // Multilingual preprocessing dictionaries (Chatterbox MTL only).
-    // Accept either a top-level option or a `files.*` entry; the host
-    // resolves/stages them (e.g. from the QVAC model registry) and the
-    // addon forwards the local paths to tts-cpp.
-    this._mecabDictPath = firstNonEmpty(mecabDictPath, mecabDictDir, normalizedFiles.mecabDictDir)
-    this._cangjieTsvPath = firstNonEmpty(cangjieTsvPath, normalizedFiles.cangjieTsvPath)
-
-    this._referenceAudio = referenceAudio
-    this._voiceDir = voiceDir
-    this._seed = seed
-    this._nGpuLayers = nGpuLayers
-    this._nCtx = nCtx
-    this._kvCacheType = kvCacheType
-    this._threads = threads
-    this._streamChunkTokens = streamChunkTokens
-    this._streamFirstChunkTokens = streamFirstChunkTokens
-    this._cfmSteps = cfmSteps
-    this._cfgRate = cfgRate
-    this._voice = firstNonEmpty(voice, voiceName)
-    this._steps = firstNonEmpty(steps, numInferenceSteps)
-    this._speed = speed
-    this._noiseNpyPath = noiseNpyPath
-
-    // LavaSR enhancer (opt-in). Enhancement is ON iff a GGUF path is provided
-    // — via files.lavasrEnhancer or enhancer.enhancerPath — so there is no
-    // separate on/off flag to keep in sync (a future SDK layer can gate at
-    // runtime by choosing whether to pass the path). A provided `enhancer`
-    // block must use the supported type so a typo can't silently disable it.
-    if (enhancer != null && enhancer.type !== 'lavasr') {
-      throw new Error(`tts-ggml: unknown enhancer.type '${enhancer.type}', expected 'lavasr'.`)
-    }
-    this._enhancerGgufPath = firstNonEmpty(
-      normalizedFiles.lavasrEnhancer,
-      enhancer ? enhancer.enhancerPath : undefined
+  // Multilingual preprocessing dictionaries (Chatterbox MTL only): accept a
+  // top-level option or a files.* entry; the host resolves/stages them and the
+  // addon forwards the local paths to tts-cpp.
+  _resolveDictionaryPaths(options, normalizedFiles) {
+    this._mecabDictPath = firstNonEmpty(
+      options.mecabDictPath,
+      options.mecabDictDir,
+      normalizedFiles.mecabDictDir
     )
+    this._cangjieTsvPath = firstNonEmpty(options.cangjieTsvPath, normalizedFiles.cangjieTsvPath)
+  }
 
-    // LavaSR denoiser (opt-in, mirrors the enhancer). The denoiser runs BEFORE
-    // the enhancer and is rate-preserving; it is enabled purely by supplying a
-    // GGUF path — via files.lavasrDenoiser or denoiser.denoiserPath — so there
-    // is no separate on/off flag. A provided `denoiser` block must use the
-    // supported type so a typo can't silently disable it.
-    // The tts-cpp UL-UNAS denoiser forward is implemented in
-    // qvac-ext-lib-whisper.cpp PR #78 (scalar CPU port, validated bit-close to
-    // the ONNX reference); a supplied denoiser path activates at runtime once
-    // the pinned tts-cpp version includes #78.
-    if (denoiser != null && denoiser.type !== 'lavasr') {
-      throw new Error(`tts-ggml: unknown denoiser.type '${denoiser.type}', expected 'lavasr'.`)
-    }
-    this._denoiserGgufPath = firstNonEmpty(
-      normalizedFiles.lavasrDenoiser,
-      denoiser ? denoiser.denoiserPath : undefined
-    )
+  _assignSynthesisOptions(options) {
+    this._referenceAudio = options.referenceAudio
+    this._voiceDir = options.voiceDir
+    this._seed = options.seed
+    this._nGpuLayers = options.nGpuLayers
+    this._nCtx = options.nCtx
+    this._kvCacheType = options.kvCacheType
+    this._threads = options.threads
+    this._streamChunkTokens = options.streamChunkTokens
+    this._streamFirstChunkTokens = options.streamFirstChunkTokens
+    this._cfmSteps = options.cfmSteps
+    this._cfgRate = options.cfgRate
+    this._voice = firstNonEmpty(options.voice, options.voiceName)
+    this._steps = firstNonEmpty(options.steps, options.numInferenceSteps)
+    this._speed = options.speed
+    this._noiseNpyPath = options.noiseNpyPath
+  }
 
-    // Per-platform fallback for `backendsDir` when the host didn't
-    // pass one. Mirrors the qvac/packages/llm-llamacpp +
-    // transcription-parakeet resolution shape
+  // Per-platform fallback for backendsDir when the host didn't pass one; mirrors
+  // the llm-llamacpp + transcription-parakeet resolution shape. The Vulkan cache
+  // dir is forwarded so the backend's first-dispatch pipeline-compile cost is
+  // paid once per install instead of once per process (empty -> no cache).
+  _resolveBackendPaths(options) {
     this._backendsDir = firstNonEmpty(
-      backendsDir,
+      options.backendsDir,
       this._config?.backendsDir,
       path.join(__dirname, 'prebuilds')
     )
-    this._openclCacheDir = firstNonEmpty(openclCacheDir, this._config?.openclCacheDir)
-    // Persistent Vulkan pipeline cache dir. Forwarded to the addon, which
-    // sets GGML_VK_PIPELINE_CACHE_DIR so the Vulkan backend's first-dispatch
-    // pipeline-compile cost is paid once per install instead of once per
-    // process. Host-provided (must be app-writable); empty -> no cache.
-    this._vulkanCacheDir = firstNonEmpty(vulkanCacheDir, this._config?.vulkanCacheDir)
+    this._openclCacheDir = firstNonEmpty(options.openclCacheDir, this._config?.openclCacheDir)
+    this._vulkanCacheDir = firstNonEmpty(options.vulkanCacheDir, this._config?.vulkanCacheDir)
+  }
 
-    // Run the conflict check before any engine-specific GPU policy so a
-    // caller passing { useGPU:false, nGpuLayers:99 } gets the precise
-    // conflict message instead of, e.g., the Supertonic "GPU not
-    // supported" branch firing on `nGpuLayers > 0` and confusing them.
-    // `layers != 0` (rather than `layers > 0`) so a future llama.cpp-
-    // style `nGpuLayers: -1` ("offload all layers") doesn't falsely
-    // pass through as "wants CPU" against an explicit useGPU:true.
-    if (typeof this._config.useGPU === 'boolean' && this._nGpuLayers != null) {
-      const layersWantGpu = this._nGpuLayers !== 0
-      if (this._config.useGPU !== layersWantGpu) {
-        throw new Error(
-          'tts-ggml: useGPU=' +
-            this._config.useGPU +
-            ' conflicts with nGpuLayers=' +
-            this._nGpuLayers +
-            '. ' +
-            'Either drop one of the two, or make them agree ' +
-            '(useGPU:true + nGpuLayers!=0, or useGPU:false + nGpuLayers=0).'
-        )
-      }
+  _assertEngineStreamingSupport() {
+    if (
+      this._engineType === ENGINE_SUPERTONIC &&
+      (this._streamChunkTokens != null || this._streamFirstChunkTokens != null)
+    ) {
+      throw new Error(
+        'tts-ggml: streamChunkTokens / streamFirstChunkTokens are Chatterbox-only ' +
+          'options (sub-sentence native streaming via the chatterbox::Engine ' +
+          'streaming chunked S3Gen+HiFT loop). Supertonic does not support sub-' +
+          'sentence native streaming; use sentence-level streaming via the engine-' +
+          'agnostic runStream() / runStreaming() / run({ streamOutput: true }) APIs.'
+      )
     }
-
-    if (this._engineType === ENGINE_SUPERTONIC) {
-      if (this._streamChunkTokens != null || this._streamFirstChunkTokens != null) {
-        throw new Error(
-          'tts-ggml: streamChunkTokens / streamFirstChunkTokens are Chatterbox-only ' +
-            'options (sub-sentence native streaming via the chatterbox::Engine ' +
-            'streaming chunked S3Gen+HiFT loop). Supertonic does not support sub-' +
-            'sentence native streaming; use sentence-level streaming via the engine-' +
-            'agnostic runStream() / runStreaming() / run({ streamOutput: true }) APIs.'
-        )
-      }
-    }
-
-    // LavaSR enhancement + Chatterbox native chunk streaming is supported: the
-    // addon runs the enhancer over a sliding window with look-ahead + crossfade
-    // so each emitted chunk is bandwidth-extended seam-free (the StreamingEnhancer
-    // in ChatterboxModel). This adds ~0.34 s of look-ahead latency — inherent to
-    // the enhancer's receptive field — so the first audio arrives a little later
-    // than un-enhanced streaming.
-
-    // LavaSR denoise + native chunk streaming is NOT supported yet. The UL-UNAS
-    // denoiser is causal (streaming-friendly in principle), but tts-cpp only
-    // exposes a one-shot denoise() today — a stateful streaming denoiser (GRU
-    // hidden-state carry across chunks, à la StreamingEnhancer) is the
-    // follow-up. Reject the combo up front so it can't silently drop denoising
-    // on the streaming path; batch synthesis (run/runStream/runStreaming without
-    // streamChunkTokens) applies the denoiser normally.
+    // LavaSR denoise + native chunk streaming is NOT supported yet: tts-cpp only
+    // exposes a one-shot denoise() today, so reject the combo up front rather
+    // than silently dropping denoising on the streaming path. Batch synthesis
+    // applies the denoiser normally.
     if (
       this._denoiserGgufPath &&
       (this._streamChunkTokens != null || this._streamFirstChunkTokens != null)
@@ -471,12 +478,12 @@ class TTSGgml {
           'denoise is a planned follow-up (needs a stateful streaming denoiser).'
       )
     }
+  }
 
-    // Default GPU off only when neither knob is set, for every engine. A
-    // caller passing nGpuLayers alone keeps it (no silent conflict with the
-    // JS-side default). Supertonic GPU intent now flows through to tts-cpp on
-    // GPU-capable hosts (Metal / Vulkan / CUDA), including Android, where
-    // tts-cpp picks the GPU backend per its per-vendor allowlist.
+  // Default GPU off only when neither knob is set (every engine). A caller
+  // passing nGpuLayers alone keeps it; Supertonic GPU intent flows through to
+  // tts-cpp on GPU-capable hosts (Metal / Vulkan / CUDA, including Android).
+  _applyDefaultGpuIntent() {
     if (this._config.useGPU === undefined && this._nGpuLayers == null) {
       this._config.useGPU = false
     }
@@ -713,11 +720,7 @@ class TTSGgml {
     }
 
     this._sentenceStreamTextIterableDrive().catch((err) => {
-      if (this._sentenceStreamCtx && this._sentenceStreamCtx.chunkResolver) {
-        const rej = this._sentenceStreamCtx.chunkResolver.reject
-        this._sentenceStreamCtx.chunkResolver = null
-        rej(err)
-      }
+      this._rejectActiveChunk(err)
       this._sentenceStreamCtx = null
       this._job.fail(err)
     })
@@ -744,11 +747,7 @@ class TTSGgml {
         await donePromise
       }
     } catch (err) {
-      if (this._sentenceStreamCtx && this._sentenceStreamCtx.chunkResolver) {
-        const rej = this._sentenceStreamCtx.chunkResolver.reject
-        this._sentenceStreamCtx.chunkResolver = null
-        rej(err)
-      }
+      this._rejectActiveChunk(err)
       this._sentenceStreamCtx = null
       this._job.fail(err)
       return
@@ -761,30 +760,17 @@ class TTSGgml {
     this._sentenceStreamCtx = null
 
     if (chunks.length === 0) {
-      if (this.opts?.stats) {
-        this._job.end({
-          totalTime: 0,
-          tokensPerSecond: 0,
-          realTimeFactor: 0,
-          audioDurationMs: 0,
-          totalSamples: 0
-        })
-      } else {
-        this._job.end()
-      }
+      this._endJobWithStats({
+        totalTime: 0,
+        tokensPerSecond: 0,
+        realTimeFactor: 0,
+        audioDurationMs: 0,
+        totalSamples: 0
+      })
       return
     }
 
-    const totalChars = chunks.join('').length
-    const merged = { ...acc }
-    merged.tokensPerSecond = acc.totalTime > 0 ? totalChars / acc.totalTime : 0
-    merged.realTimeFactor =
-      acc.audioDurationMs > 0 ? (acc.totalTime * 1000.0) / acc.audioDurationMs : 0
-    if (this.opts?.stats) {
-      this._job.end(merged)
-    } else {
-      this._job.end()
-    }
+    this._endJobWithStats(computeSentenceStreamStats(chunks, acc))
   }
 
   _runStreamOrchestrator(text, options) {
@@ -813,11 +799,7 @@ class TTSGgml {
     }
 
     this._sentenceStreamDriveBody().catch((err) => {
-      if (this._sentenceStreamCtx && this._sentenceStreamCtx.chunkResolver) {
-        const rej = this._sentenceStreamCtx.chunkResolver.reject
-        this._sentenceStreamCtx.chunkResolver = null
-        rej(err)
-      }
+      this._rejectActiveChunk(err)
       this._sentenceStreamCtx = null
       this._job.fail(err)
     })
@@ -1015,88 +997,101 @@ class TTSGgml {
     acc.totalSamples += s
   }
 
+  _rejectActiveChunk(error) {
+    const ctx = this._sentenceStreamCtx
+    if (!ctx || !ctx.chunkResolver) return
+    const reject = ctx.chunkResolver.reject
+    ctx.chunkResolver = null
+    reject(error)
+  }
+
+  _endJobWithStats(stats) {
+    if (this.opts?.stats) {
+      this._job.end(stats)
+    } else {
+      this._job.end()
+    }
+  }
+
   _addonOutputCallback(addon, event, data, error) {
     if (typeof error === 'string' && error.length > 0) {
-      this.logger.error(`TTS job failed with error: ${error}`)
-      if (this._sentenceStreamCtx && this._sentenceStreamCtx.chunkResolver) {
-        const rej = this._sentenceStreamCtx.chunkResolver.reject
-        this._sentenceStreamCtx.chunkResolver = null
-        rej(new Error(error))
-      }
-      this._job.fail(error)
+      this._handleAddonError(error)
       return
     }
-
-    if (data && typeof data === 'object' && data.outputArray) {
-      try {
-        this.logger.debug(`TTS job produced output: ${ttsOutputDebugString(data)}`)
-      } catch (err) {
-        if (err instanceof RangeError) {
-          this.logger.debug('TTS job produced output: [data too large]')
-        } else {
-          throw err
-        }
-      }
-      if (this._sentenceStreamCtx) {
-        const ctx = this._sentenceStreamCtx
-        const idx = ctx.chunkIdx
-        const sentenceChunk = ctx.chunks[idx] || ''
-        const enriched = {
-          outputArray: data.outputArray,
-          chunkIndex: idx,
-          sentenceChunk
-        }
-        if (data.sampleRate != null) enriched.sampleRate = data.sampleRate
-        if (!ctx.textStreamMode) {
-          enriched.isLast = idx >= ctx.chunks.length - 1
-        }
-        this._job.output(enriched)
-      } else {
-        this._job.output(data)
-      }
+    if (isAudioOutputEvent(data)) {
+      this._handleAddonOutput(data)
       return
     }
-
-    if (
-      data &&
-      typeof data === 'object' &&
-      ('totalTime' in data || 'audioDurationMs' in data || 'totalSamples' in data)
-    ) {
-      this.logger.info(`TTS job completed. Stats: ${JSON.stringify(data)}`)
-      if (this._sentenceStreamCtx) {
-        const ctx = this._sentenceStreamCtx
-        this._mergeSentenceStreamStats(ctx.acc, data)
-        if (ctx.chunkResolver) {
-          ctx.chunkResolver.resolve()
-          ctx.chunkResolver = null
-        }
-        if (ctx.textStreamMode) {
-          return
-        }
-        const isLast = ctx.chunkIdx >= ctx.chunks.length - 1
-        if (isLast) {
-          const totalChars = ctx.chunks.join('').length
-          const merged = { ...ctx.acc }
-          merged.tokensPerSecond = ctx.acc.totalTime > 0 ? totalChars / ctx.acc.totalTime : 0
-          merged.realTimeFactor =
-            ctx.acc.audioDurationMs > 0 ? (ctx.acc.totalTime * 1000.0) / ctx.acc.audioDurationMs : 0
-          if (this.opts?.stats) {
-            this._job.end(merged)
-          } else {
-            this._job.end()
-          }
-        }
-        return
-      }
-      if (this.opts?.stats) {
-        this._job.end(data)
-      } else {
-        this._job.end()
-      }
+    if (isStatsEvent(data)) {
+      this._handleAddonStats(data)
       return
     }
-
     this.logger.debug(`Received TTS event: ${event}`)
+  }
+
+  _handleAddonError(error) {
+    this.logger.error(`TTS job failed with error: ${error}`)
+    this._rejectActiveChunk(new Error(error))
+    this._job.fail(error)
+  }
+
+  _handleAddonOutput(data) {
+    this._logOutputSafely(data)
+    if (this._sentenceStreamCtx) {
+      this._job.output(this._enrichStreamChunk(data))
+    } else {
+      this._job.output(data)
+    }
+  }
+
+  _logOutputSafely(data) {
+    try {
+      this.logger.debug(`TTS job produced output: ${ttsOutputDebugString(data)}`)
+    } catch (err) {
+      if (err instanceof RangeError) {
+        this.logger.debug('TTS job produced output: [data too large]')
+      } else {
+        throw err
+      }
+    }
+  }
+
+  _enrichStreamChunk(data) {
+    const ctx = this._sentenceStreamCtx
+    const idx = ctx.chunkIdx
+    const enriched = {
+      outputArray: data.outputArray,
+      chunkIndex: idx,
+      sentenceChunk: ctx.chunks[idx] || ''
+    }
+    if (data.sampleRate != null) enriched.sampleRate = data.sampleRate
+    if (!ctx.textStreamMode) {
+      enriched.isLast = idx >= ctx.chunks.length - 1
+    }
+    return enriched
+  }
+
+  _handleAddonStats(data) {
+    this.logger.info(`TTS job completed. Stats: ${JSON.stringify(data)}`)
+    if (this._sentenceStreamCtx) {
+      this._finalizeSentenceStreamChunkStats(data)
+    } else {
+      this._endJobWithStats(data)
+    }
+  }
+
+  _finalizeSentenceStreamChunkStats(data) {
+    const ctx = this._sentenceStreamCtx
+    this._mergeSentenceStreamStats(ctx.acc, data)
+    if (ctx.chunkResolver) {
+      ctx.chunkResolver.resolve()
+      ctx.chunkResolver = null
+    }
+    if (ctx.textStreamMode) return
+    const isLast = ctx.chunkIdx >= ctx.chunks.length - 1
+    if (isLast) {
+      this._endJobWithStats(computeSentenceStreamStats(ctx.chunks, ctx.acc))
+    }
   }
 
   async cancel() {
@@ -1106,12 +1101,7 @@ class TTSGgml {
   }
 
   _failAndClearActiveResponse(reason) {
-    if (this._sentenceStreamCtx && this._sentenceStreamCtx.chunkResolver) {
-      this._sentenceStreamCtx.chunkResolver.reject(
-        reason instanceof Error ? reason : new Error(String(reason))
-      )
-      this._sentenceStreamCtx.chunkResolver = null
-    }
+    this._rejectActiveChunk(reason instanceof Error ? reason : new Error(String(reason)))
     this._sentenceStreamCtx = null
     this._job.fail(reason)
   }

--- a/packages/tts-ggml/index.js
+++ b/packages/tts-ggml/index.js
@@ -654,7 +654,7 @@ class TTSGgml {
         ? rawPreset
         : 'multilingual'
     const maxBufferScalars = o.maxBufferScalars
-    const flushAfterMs = o.flushAfterMs != null ? o.flushAfterMs : 500
+    const flushAfterMs = o.flushAfterMs != null ? o.flushAfterMs : DEFAULT_FLUSH_AFTER_MS
     const sentenceDelimiter =
       o.sentenceDelimiter instanceof RegExp ? o.sentenceDelimiter : undefined
     return {

--- a/packages/tts-ggml/lib/textChunker.js
+++ b/packages/tts-ggml/lib/textChunker.js
@@ -112,13 +112,15 @@ function countScalars(s) {
   return [...s].length
 }
 
+const MIN_HARD_SPLIT_SCALARS = 10
+
 /**
  * @param {string} text
  * @param {number} maxScalars
  * @returns {string[]}
  */
 function hardSplitByMaxScalars(text, maxScalars) {
-  if (maxScalars < 10) maxScalars = 10
+  if (maxScalars < MIN_HARD_SPLIT_SCALARS) maxScalars = MIN_HARD_SPLIT_SCALARS
   const g = [...text]
   if (g.length <= maxScalars) return [text]
   const out = []
@@ -160,6 +162,20 @@ function mergeUpToMaxScalars(pieces, maxScalars) {
   return out.filter((s) => s.trim().length > 0)
 }
 
+// Default per-chunk grapheme caps, shared with textStreamAccumulator's buffer
+// sizing. Korean packs more meaning per grapheme, so it flushes shorter chunks.
+const KOREAN_MAX_CHUNK_SCALARS = 120
+const DEFAULT_MAX_CHUNK_SCALARS = 300
+
+/**
+ * @param {string} [language]
+ * @returns {number}
+ */
+function defaultMaxChunkScalars(language) {
+  const lang = (language || 'en').toLowerCase()
+  return lang === 'ko' ? KOREAN_MAX_CHUNK_SCALARS : DEFAULT_MAX_CHUNK_SCALARS
+}
+
 /**
  * Split long text into synthesis-sized chunks for sentence streaming.
  *
@@ -175,7 +191,8 @@ function mergeUpToMaxScalars(pieces, maxScalars) {
 function splitTtsText(text, options = {}) {
   const mergeToMaxScalars = options.mergeToMaxScalars !== false
   const language = (options.language || 'en').toLowerCase()
-  const maxScalars = options.maxScalars != null ? options.maxScalars : language === 'ko' ? 120 : 300
+  const maxScalars =
+    options.maxScalars != null ? options.maxScalars : defaultMaxChunkScalars(language)
 
   const raw = text.trim()
   if (!raw) return []
@@ -215,5 +232,8 @@ module.exports = {
   intlSentenceSegmentationAvailable,
   splitByIntlSentences,
   splitByAsciiAndCjkPunctuation,
-  countScalars
+  countScalars,
+  defaultMaxChunkScalars,
+  KOREAN_MAX_CHUNK_SCALARS,
+  DEFAULT_MAX_CHUNK_SCALARS
 }

--- a/packages/tts-ggml/lib/textStreamAccumulator.js
+++ b/packages/tts-ggml/lib/textStreamAccumulator.js
@@ -1,6 +1,11 @@
 'use strict'
 
-const { countScalars } = require('./textChunker')
+const { countScalars, defaultMaxChunkScalars } = require('./textChunker')
+
+// Idle flush delay: emit the buffered fragment when no new fragment arrives
+// within this window (timer reset on each fragment). Shared with the
+// runStreaming default in index.js so the two never drift.
+const DEFAULT_FLUSH_AFTER_MS = 500
 
 /**
  * @param {string} s
@@ -47,8 +52,7 @@ function buildSentenceEndTester(opts) {
  * @param {string} [language]
  */
 function defaultMaxBufferScalars(language) {
-  const lang = (language || 'en').toLowerCase()
-  return lang === 'ko' ? 120 : 300
+  return defaultMaxChunkScalars(language)
 }
 
 /**
@@ -66,7 +70,7 @@ function defaultMaxBufferScalars(language) {
  * @returns {AsyncGenerator<string, void, void>}
  */
 async function* accumulateTextStream(source, opts) {
-  const flushAfterMs = opts.flushAfterMs != null ? opts.flushAfterMs : 500
+  const flushAfterMs = opts.flushAfterMs != null ? opts.flushAfterMs : DEFAULT_FLUSH_AFTER_MS
   const defaultMax = defaultMaxBufferScalars(opts.language)
   let maxScalars
   if (opts.maxBufferScalars == null) {
@@ -169,5 +173,6 @@ module.exports = {
   accumulateTextStream,
   defaultMaxBufferScalars,
   buildSentenceEndTester,
-  splitGraphemeHead
+  splitGraphemeHead,
+  DEFAULT_FLUSH_AFTER_MS
 }

--- a/packages/tts-ggml/test/unit/textChunker.test.js
+++ b/packages/tts-ggml/test/unit/textChunker.test.js
@@ -4,7 +4,10 @@ const test = require('brittle')
 const {
   splitTtsText,
   intlSentenceSegmentationAvailable,
-  splitByAsciiAndCjkPunctuation
+  splitByAsciiAndCjkPunctuation,
+  defaultMaxChunkScalars,
+  KOREAN_MAX_CHUNK_SCALARS,
+  DEFAULT_MAX_CHUNK_SCALARS
 } = require('../../lib/textChunker.js')
 
 test('splitByAsciiAndCjkPunctuation splits on CJK full stops', (t) => {
@@ -38,4 +41,19 @@ test('splitTtsText mergeToMaxScalars:false does not merge sentences by max lengt
   const sentenceLevel = splitTtsText(text, { language: 'en', mergeToMaxScalars: false })
   const merged = splitTtsText(text, { language: 'en', mergeToMaxScalars: true, maxScalars: 100 })
   t.ok(sentenceLevel.length >= merged.length)
+})
+
+test('defaultMaxChunkScalars returns the Korean cap for ko regardless of case', (t) => {
+  t.is(defaultMaxChunkScalars('ko'), KOREAN_MAX_CHUNK_SCALARS)
+  t.is(defaultMaxChunkScalars('KO'), KOREAN_MAX_CHUNK_SCALARS)
+})
+
+test('defaultMaxChunkScalars falls back to the default cap for other languages', (t) => {
+  t.is(defaultMaxChunkScalars('en'), DEFAULT_MAX_CHUNK_SCALARS)
+  t.is(defaultMaxChunkScalars('ja'), DEFAULT_MAX_CHUNK_SCALARS)
+  t.is(defaultMaxChunkScalars(undefined), DEFAULT_MAX_CHUNK_SCALARS)
+})
+
+test('default per-language caps keep Korean shorter than the default', (t) => {
+  t.ok(KOREAN_MAX_CHUNK_SCALARS < DEFAULT_MAX_CHUNK_SCALARS)
 })

--- a/packages/tts-ggml/test/utils/runChatterboxTTS.js
+++ b/packages/tts-ggml/test/utils/runChatterboxTTS.js
@@ -50,12 +50,11 @@ async function loadChatterboxTTS(params = {}) {
     config.useGPU = params.useGPU
   } else if (proc.env && proc.env.NO_GPU === 'true') {
     // Honour the workflow matrix's `no_gpu: 'true'` flag (which sets the
-    // NO_GPU env var on the job).  Defensive override -- as of tts-ggml
-    // 0.1.2 the addon's `index.js::_validateConfig` defaults Chatterbox
-    // to `useGPU = false`, so an unset value already lands on CPU, but
-    // pinning it here makes the no-GPU matrix entries' contract
-    // explicit at the test layer and survives any future flip back to
-    // an opt-out GPU default.
+    // NO_GPU env var on the job).  Defensive override -- the addon already
+    // defaults Chatterbox to `useGPU = false` when unset, so an unset value
+    // lands on CPU, but pinning it here makes the no-GPU matrix entries'
+    // contract explicit at the test layer and survives any future flip back
+    // to an opt-out GPU default.
     config.useGPU = false
   }
 


### PR DESCRIPTION
## Summary

Applies the team coding standards to the `tts-ggml` package. Internal refactor only, with no public API or behavior change.

- Split oversized C++/JS functions and their inline loops into named helpers: `ChatterboxModel::synthesize` and its streaming/batch/enhancer/denoiser stages, `OutputResampler::resample` (`lanczosWeight` / `resampleOne`), `StreamingEnhancer::process` (`emitRange` / `emitCrossfade`), `WsolaTimeStretch::bestMatch` (`matchScore`), and `index.js`'s `TTSGgml` constructor / `_addonOutputCallback`.
- Consolidate the float32-to-int16 PCM conversion (previously duplicated across both engines) into a single shared `pcmFloatToInt16` helper in the new `PcmConversion.hpp`.
- Replace magic numbers with named constants: the output sample-rate bounds and the flush/chunk defaults on the JS side; a shared GPU "offload all layers" constant, the Chatterbox native sample rate, and the int16 PCM full-scale constant on the C++ side.
- Remove narration comments and refresh the stale `_validateConfig` references, keeping the non-obvious "why" rationale.
- Add unit tests for the extracted `OutputResampler` / PCM-conversion helpers and the `textChunker` scalar helpers.

## Test plan

- [x] `npm run test:unit`: 94/94 pass (265/265 asserts)
- [x] `npm run test:dts`: clean; `node --check` clean on all changed JS
- [x] clang `-fsyntax-only` (from `compile_commands.json`): `SupertonicModel.cpp` clean; `ChatterboxModel.cpp` clean apart from a local stale-header `s3gen_cfg_rate` (the tts-cpp floor bump from #3251 is not reflected in the local overlay; builds in CI against the pinned tts-cpp)
- [x] DSP loop extractions (`OutputResampler`, `StreamingEnhancer`, `WsolaTimeStretch`) verified bit-exact vs the pre-refactor code via a standalone harness (streaming-vs-batch parity within 4 ULP; matching FNV fingerprints)
- [x] Rebased onto current `main`, reconciling with #3251 (S3Gen `cfgRate`) and #3260 (`run()` abort-signal); both features preserved and re-wired
- [ ] `tts_ggml_tests` gtest run not executed locally (pre-existing cross-repo tts-cpp/ggml-speech build break, independent of this change)