### PR TITLE
QVAC-22330 chore: bump @qvac/transcription-parakeet to ^0.10.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -214,7 +214,7 @@
     "@qvac/ocr-ggml": "^0.10.2",
     "@qvac/rag": "^0.6.4",
     "@qvac/registry-client": "^0.6.1",
-    "@qvac/transcription-parakeet": "^0.9.1",
+    "@qvac/transcription-parakeet": "^0.10.0",
     "@qvac/transcription-whispercpp": "^0.11.1",
     "@qvac/translation-nmtcpp": "^7.2.2",
     "@qvac/tts-ggml": "^0.4.2",


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- The SDK pinned `@qvac/transcription-parakeet` at `^0.9.1`, so it did not pick up the `0.10.0` release.
- `0.10.0` bumps the `qvac-lib-inference-addon-cpp` vcpkg dependency to `1.2.4`, which hardens `JsLogger` concurrent-env ownership (QVAC-21544 follow-up).

## 📝 How does it solve it?

- Bump the `@qvac/transcription-parakeet` dependency range in `packages/sdk/package.json` from `^0.9.1` to `^0.10.0`.

## 📦 Changes introduced in `@qvac/transcription-parakeet` 0.10.0

The `^0.9.1` → `^0.10.0` bump pulls in the following release (per the package `CHANGELOG.md`):

### 0.10.0 — 2026-07-14

**Fixed**

- Bumped the `qvac-lib-inference-addon-cpp` vcpkg dependency to `1.2.4` (JsLogger concurrent-env ownership hardening fix, QVAC-21544 follow-up).

No API or behavioral changes to the parakeet transcription surface itself — the release is a native-dependency hardening bump.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216570537947482