### PR TITLE
test: [DO NOT MERGE] macos26 self-hosted runner smoke test (embed + vla)

### DIFF
--- a/packages/embed-llamacpp/README.md
+++ b/packages/embed-llamacpp/README.md
@@ -284,3 +284,6 @@ C++ unit tests live under [`addon/test/`](./addon/test/) and exercise the native
 This project is licensed under the Apache-2.0 [License](./LICENSE) – see the LICENSE file for details.
 
 _For questions or issues, please open an issue on the GitHub repository._
+
+<!-- ci: throwaway smoke test for macos26 self-hosted runner migration (#3276) — do not merge -->
+

--- a/packages/vla-ggml/README.md
+++ b/packages/vla-ggml/README.md
@@ -173,3 +173,6 @@ see [`sim/README.md`](./sim/README.md).
 
 @qvac/vla-ggml itself is Apache-2.0. Bundled third-party components are governed
 by their respective licenses; see [`NOTICE`](./NOTICE).
+
+<!-- ci: throwaway smoke test for macos26 self-hosted runner migration (#3276) — do not merge -->
+


### PR DESCRIPTION
## 🎯 Purpose (throwaway — do not merge)

Validates PR #3276 after merge: confirms the **darwin-arm64** desktop integration
legs of `embed-llamacpp` and `vla-ggml` run green on the self-hosted
`qvac-macos26-arm64-gpu` Mac Studios (not GitHub-hosted `macos-15-xlarge`).

Changes are no-op README touches purely to trip the `packages/embed-llamacpp/**`
and `packages/vla-ggml/**` path filters.

## How to drive it
- Labels required: `verified` (trust) + `run-desktop-addon-tests` (routes desktop stage).
- Watch the `darwin-arm64-integration-tests` jobs — they should schedule on a
  `qvac-macos26-arm64-gpu-*` runner. The Intel `darwin-x64` legs stay on hosted `macos-15-large`.

Close without merging once green.