### PR TITLE
QVAC-22256 fix[mod]: pin f16 Gemma4 mmproj in models.manifest.json

### DIFF
--- a/packages/llm-llamacpp/test/integration/models.manifest.json
+++ b/packages/llm-llamacpp/test/integration/models.manifest.json
@@ -163,12 +163,12 @@
       "sha256": "b5310340b3a23d31655d7119d100d5df1b2d8ee17b3ca8b0a23ad7e9eb5fa705",
       "bytes": 3462678272
     },
-    "mmproj-google_gemma-4-E2B-it-bf16.gguf": {
+    "mmproj-google_gemma-4-E2B-it-f16.gguf": {
       "urls": [
-        "https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/b5e99bd964eaacc27ba484bb2eb3e9f6160b9143/mmproj-google_gemma-4-E2B-it-bf16.gguf"
+        "https://huggingface.co/bartowski/google_gemma-4-E2B-it-GGUF/resolve/b5e99bd964eaacc27ba484bb2eb3e9f6160b9143/mmproj-google_gemma-4-E2B-it-f16.gguf"
       ],
-      "sha256": "d460bb51ce5115232a723a7366694c8ee70d8aa8f60159d182a1da0777d10db3",
-      "bytes": 986833408
+      "sha256": "3397f2e15859d268dc91782e92e70c485c7780448d57d622d145374390168f71",
+      "bytes": 985653760
     },
     "SmolVLM2-500M-Video-Instruct-Q8_0.gguf": {
       "urls": [


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

#3255 switched `gemma4.test.js`, `_vlm-image-perf.js`, and `test/mobile/model-manifest.json` to `mmproj-google_gemma-4-E2B-it-f16.gguf`, but the pinned integrity manifest `test/integration/models.manifest.json` was never updated — it still only pins the bf16 mmproj. `resolveModelEntry` hard-fails on unpinned models, so:

- The **Android** weekend leg dies before reaching any device, at "Generate model pre-stage commands": `[prestage] mmproj-google_gemma-4-E2B-it-f16.gguf has no usable pinned manifest URL`.
- The **iOS** weekend leg reaches Device Farm but the `vlmPerfGemma4` group fails on every device with `Model "mmproj-google_gemma-4-E2B-it-f16.gguf" is missing from required models.manifest.json` (all other groups pass).

Seen on the manual weekend run against main: https://github.com/tetherto/qvac/actions/runs/29553957401. Net effect: the f16 fix from #3255 has never actually executed on hardware — every Gemma4 test dies before the model loads. It slipped through because #3255 ran without the `verify` label, so the gated heavy tests never ran pre-merge.

## 📝 How does it solve it?

Replaces the now-orphaned bf16 entry (nothing references it since #3255) with the f16 pin, at the same HF revision `b5e99bd` the bf16 entry used:

- `sha256: 3397f2e15859d268dc91782e92e70c485c7780448d57d622d145374390168f71`
- `bytes: 985653760`

Values come from HuggingFace's LFS metadata API; the method was sanity-checked by confirming it reproduces the existing bf16 entry's sha256/bytes exactly. Dropping bf16 rather than keeping both avoids holding an unused ~1 GB model in the CI model cache (the manifest is also the cache key).

## 🧪 How was it tested?

- `jq` validates the manifest and the new entry resolves.
- The real proof is a weekend-workflow dispatch against main after merge (`vlmPerfGemma4` on both Device Farm pools) — will trigger it post-merge.
