### PR TITLE
[DO NOT MERGE] probe: whisper linux-arm64 source-build baseline

### DIFF
--- a/packages/transcription-whispercpp/README.md
+++ b/packages/transcription-whispercpp/README.md
@@ -573,3 +573,5 @@ This project is licensed under the Apache-2.0 License – see the LICENSE file f
 
 For questions or issues, please open an issue on the GitHub repository.
 
+
+<!-- CI source-build baseline probe (no functional change) -->


### PR DESCRIPTION
No-op change to trigger the transcription-whispercpp source pipeline on unmodified main.

Purpose: [qvac#3310](https://github.com/tetherto/qvac/pull/3310)'s source-built whisper addon hits `GGML_ASSERT(device)` (no CPU backend modules load; `ggml_vulkan: No devices found`) on `ubuntu-24.04-arm` integration ([failing job](https://github.com/tetherto/qvac/actions/runs/29576938557/job/87875044687)), while main's **published** `@qvac/transcription-whispercpp@0.12.0` prebuilds pass the same job ([baseline run](https://github.com/tetherto/qvac/actions/runs/29597605969)). This PR discriminates: source build from unmodified main (pre-reorg registry whisper-cpp port, current ggml-speech + addon code) —
- fails the same way → regression is in current source inputs on main (ggml-speech pin / addon glue), predates the repo reorg
- passes → the reorg overlay is implicated and we debug it before merging the reorg stack

Closes after one CI cycle either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)