### PR TITLE
QVAC-22177 chore: migrate ocr-ggml wrapper to TypeScript

### DIFF
--- a/.github/workflows/on-merge-ocr-ggml.yml
+++ b/.github/workflows/on-merge-ocr-ggml.yml
@@ -146,6 +146,19 @@ jobs:
           name: prebuilds
           path: ${{ env.PKG_DIR }}/prebuilds
 
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: ${{ env.PKG_DIR }}
+        run: npm install --ignore-scripts --package-lock=false
+
+      - name: Build TypeScript wrapper
+        working-directory: ${{ env.PKG_DIR }}
+        run: npm run build:ts
+
       - name: Publish to GitHub Package Registry
         id: publish
         uses: ./.github/actions/publish-library-to-gpr
@@ -197,6 +210,19 @@ jobs:
         with:
           name: prebuilds
           path: ${{ env.PKG_DIR }}/prebuilds
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # 6.3.0
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: ${{ env.PKG_DIR }}
+        run: npm install --ignore-scripts --package-lock=false
+
+      - name: Build TypeScript wrapper
+        working-directory: ${{ env.PKG_DIR }}
+        run: npm run build:ts
 
       - name: Determine dist-tag
         id: dist-tag

--- a/packages/ocr-ggml/.lunteignore
+++ b/packages/ocr-ggml/.lunteignore
@@ -11,3 +11,8 @@ test/results
 examples
 addon
 *.d.ts
+index.js
+ocr-ggml.js
+addonLogging.js
+lib
+src

--- a/packages/ocr-ggml/.prettierignore
+++ b/packages/ocr-ggml/.prettierignore
@@ -10,3 +10,8 @@ test/integration/all.js
 test/results
 examples
 addon
+index.js
+ocr-ggml.js
+addonLogging.js
+lib
+*.d.ts

--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
 project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Migrated the runtime wrapper and type declarations to TypeScript. Sources now live under `src/` and the published root JavaScript entrypoints (`index.js`, `ocr-ggml.js`, `addonLogging.js`, `lib/error.js`) and `.d.ts` declarations are generated from them and committed. Public API, CommonJS export shape, and OCR output are unchanged.
+
 ## [0.11.0] - 2026-07-14
 
 ### Fixed

--- a/packages/ocr-ggml/addonLogging.d.ts
+++ b/packages/ocr-ggml/addonLogging.d.ts
@@ -1,7 +1,7 @@
-export interface AddonLogging {
-  setLogger(callback: (priority: number, message: string) => void): void
-  releaseLogger(): void
+type NativeLoggerCallback = (priority: number, message: string) => void;
+interface AddonLogging {
+    setLogger: (callback: NativeLoggerCallback) => void;
+    releaseLogger: () => void;
 }
-
-declare const addonLogging: AddonLogging
-export default addonLogging
+declare const addonLogging: AddonLogging;
+export = addonLogging;

--- a/packages/ocr-ggml/addonLogging.js
+++ b/packages/ocr-ggml/addonLogging.js
@@ -1,8 +1,12 @@
-module.exports = {
-  get setLogger() {
-    return require('./binding').setLogger
-  },
-  get releaseLogger() {
-    return require('./binding').releaseLogger
-  }
-}
+"use strict";
+const addonLogging = {
+    get setLogger() {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved lazily from package prebuilds.
+        return require("./binding").setLogger;
+    },
+    get releaseLogger() {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved lazily from package prebuilds.
+        return require("./binding").releaseLogger;
+    },
+};
+module.exports = addonLogging;

--- a/packages/ocr-ggml/eslint.config.mjs
+++ b/packages/ocr-ggml/eslint.config.mjs
@@ -1,0 +1,80 @@
+// ESLint flat config (ESM) with strict TypeScript rules and no `any`
+import tseslint from 'typescript-eslint'
+import importPlugin from 'eslint-plugin-import'
+
+export default [
+  // Ignore generated output, native build artifacts, third-party sources, and lockfiles.
+  {
+    ignores: [
+      'index.js',
+      'ocr-ggml.js',
+      'addonLogging.js',
+      'binding.js',
+      'lib/**',
+      'index.d.ts',
+      'ocr-ggml.d.ts',
+      'addonLogging.d.ts',
+      'build/**',
+      'prebuilds/**',
+      'third-party/**',
+      'addon/**',
+      'benchmarks/**',
+      'samples/**',
+      'examples/**',
+      'scripts/**',
+      'test/**',
+      'eslint.config.*',
+      'package-lock.json'
+    ]
+  },
+
+  // Type-aware recommended rules (only for TS files)
+  ...tseslint.configs.recommendedTypeChecked.map((config) => ({
+    ...config,
+    files: ['**/*.ts', '**/*.tsx']
+  })),
+
+  // Project-specific rules, kept aligned with packages/sdk.
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    plugins: {
+      import: importPlugin
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+          alwaysTryTypes: true
+        },
+        node: {
+          extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs']
+        }
+      },
+      'import/extensions': ['.js', '.jsx', '.ts', '.tsx', '.mjs']
+    },
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname
+      }
+    },
+    rules: {
+      'import/no-unresolved': ['error', { ignore: ['^@qvac/ocr-ggml/'] }],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unsafe-assignment': 'error',
+      '@typescript-eslint/no-unsafe-member-access': 'error',
+      '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-return': 'error',
+      '@typescript-eslint/no-unsafe-argument': 'error',
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' }
+      ],
+      '@typescript-eslint/ban-ts-comment': [
+        'error',
+        { 'ts-expect-error': 'allow-with-description' }
+      ],
+      'eol-last': ['error', 'always']
+    }
+  }
+]

--- a/packages/ocr-ggml/index.d.ts
+++ b/packages/ocr-ggml/index.d.ts
@@ -1,5 +1,7 @@
-import type { QvacResponse } from '@qvac/infer-base'
-
+import QvacLogger = require("@qvac/logging");
+import { type QvacResponse } from "@qvac/infer-base";
+import { OcrGgmlInterface, type BackendInfo, type OcrGgmlRunOptions } from "./ocr-ggml";
+import { QvacErrorAddonOcrGgml, ERR_CODES } from "./lib/error";
 /**
  * OCR pipeline backing the addon.
  *   - `easyocr` (default): CRAFT detector + CRNN gen-2 recognizer.
@@ -9,201 +11,187 @@ import type { QvacResponse } from '@qvac/infer-base'
  *     Language-agnostic; EasyOCR-specific knobs (`magRatio`, etc.) are
  *     ignored.
  */
-export type OcrGgmlPipelineType = 'easyocr' | 'doctr'
-
+export type OcrGgmlPipelineType = "easyocr" | "doctr";
 export interface OcrGgmlParams {
-  /**
-   * Path to the detector GGUF file.
-   *   - easyocr: CRAFT model (e.g. `craft_mlt_25k.gguf`)
-   *   - doctr:   DBNet model (e.g. `db_mobilenet_v3_large.gguf`)
-   */
-  pathDetector: string
-  /**
-   * Path to the recognizer GGUF file.
-   *   - easyocr: CRNN gen-2 (e.g. `english_g2.gguf`, `latin_g2.gguf`)
-   *   - doctr:   doctr recognition model (e.g. `crnn_mobilenet_v3_small.gguf`)
-   */
-  pathRecognizer: string
-  /** Languages handled by the recognizer (e.g. `['en']`, `['en', 'fr']`). */
-  langList: string[]
-
-  /** Pipeline backing the addon. Default: `'easyocr'`. */
-  pipelineType?: OcrGgmlPipelineType
-  /** Detection magnification ratio (easyocr only). Default: 1.5. */
-  magRatio?: number
-  /**
-   * EasyOCR `canvas_size`: detection canvas cap (long side, px) applied after
-   * `magRatio` scaling. Bounds CRAFT peak memory on dense/high-resolution
-   * pages; lower it (e.g. 1280) on memory-constrained targets such as mobile.
-   * Default: 2560 (matches `@qvac/ocr-onnx` / EasyOCR). easyocr only.
-   */
-  canvasSize?: number
-  /** Rotation angles tried when the primary pass is low-confidence (easyocr only). Default: [90, 270]. */
-  defaultRotationAngles?: number[]
-  /** Retry low-confidence boxes with contrast adjustment (easyocr only). Default: false. */
-  contrastRetry?: boolean
-  /** Threshold below which contrast-retry kicks in (easyocr only). Default: 0.4. */
-  lowConfidenceThreshold?: number
-  /** Recognizer batch size (easyocr only). Default: 32. */
-  recognizerBatchSize?: number
-  /**
-   * GGML CPU thread count:
-   *   - `0` (default): auto-detect physical cores (hardware_concurrency / 2, floor 1)
-   *   - `> 0`: explicit override
-   *   - `< 0`: leave GGML's CPU backend default unchanged
-   */
-  nThreads?: number
-  /** Directory holding ggml backend shared libraries. Default: `<package>/prebuilds`. */
-  backendsDir?: string
-  /**
-   * Requested ggml backend device. Default: `'cpu'`.
-   *   - `'cpu'`: run inference on the CPU backend (always available).
-   *   - `'vulkan'`: opt in to GPU inference on a Vulkan-capable device
-   *     (Linux/Windows/Android). Requires the `libggml-vulkan` backend shared
-   *     library to be present in `backendsDir`.
-   *   - `'metal'`: opt in to GPU inference on a Metal-capable device (Apple).
-   *     The Metal backend is compiled into the addon, so no extra shared
-   *     library is required.
-   *   - `'opencl'`: opt in to GPU inference on an OpenCL-capable device
-   *     (primarily Android/Adreno, where OpenCL is the sound GPU path).
-   *     Requires the `libggml-opencl` backend shared library to be present in
-   *     `backendsDir`.
-   * When the requested GPU device is not present the pipeline transparently
-   * falls back to CPU and records the reason (see
-   * {@link BackendInfo.fallbackReason}).
-   */
-  backendDevice?: 'cpu' | 'vulkan' | 'metal' | 'opencl'
-  /**
-   * Explicit GPU device selection for `'vulkan'` / `'metal'` / `'opencl'`.
-   * 0-based index
-   * into the GPU/iGPU devices that match the requested backend, in ggml
-   * enumeration order (the resolved index is reported as
-   * {@link BackendInfo.deviceIndex}).
-   *   - When omitted (default), selection prefers a discrete GPU and otherwise
-   *     falls back to an integrated GPU.
-   *   - When out of range, the pipeline falls back to CPU and records the
-   *     reason (see {@link BackendInfo.fallbackReason}).
-   * Ignored for `backendDevice: 'cpu'`. For pinning/reordering Vulkan devices
-   * without code you can also set the `GGML_VK_VISIBLE_DEVICES` env var (see
-   * the README).
-   */
-  gpuDevice?: number
+    /**
+     * Path to the detector GGUF file.
+     *   - easyocr: CRAFT model (e.g. `craft_mlt_25k.gguf`)
+     *   - doctr:   DBNet model (e.g. `db_mobilenet_v3_large.gguf`)
+     */
+    pathDetector: string;
+    /**
+     * Path to the recognizer GGUF file.
+     *   - easyocr: CRNN gen-2 (e.g. `english_g2.gguf`, `latin_g2.gguf`)
+     *   - doctr:   doctr recognition model (e.g. `crnn_mobilenet_v3_small.gguf`)
+     */
+    pathRecognizer: string;
+    /** Languages handled by the recognizer (e.g. `['en']`, `['en', 'fr']`). */
+    langList: string[];
+    /** Pipeline backing the addon. Default: `'easyocr'`. */
+    pipelineType?: OcrGgmlPipelineType;
+    /** Detection magnification ratio (easyocr only). Default: 1.5. */
+    magRatio?: number;
+    /**
+     * EasyOCR `canvas_size`: detection canvas cap (long side, px) applied after
+     * `magRatio` scaling. Bounds CRAFT peak memory on dense/high-resolution
+     * pages; lower it (e.g. 1280) on memory-constrained targets such as mobile.
+     * Default: 2560 (matches `@qvac/ocr-onnx` / EasyOCR). easyocr only.
+     */
+    canvasSize?: number;
+    /** Rotation angles tried when the primary pass is low-confidence (easyocr only). Default: [90, 270]. */
+    defaultRotationAngles?: number[];
+    /** Retry low-confidence boxes with contrast adjustment (easyocr only). Default: false. */
+    contrastRetry?: boolean;
+    /** Threshold below which contrast-retry kicks in (easyocr only). Default: 0.4. */
+    lowConfidenceThreshold?: number;
+    /** Recognizer batch size (easyocr only). Default: 32. */
+    recognizerBatchSize?: number;
+    /**
+     * GGML CPU thread count:
+     *   - `0` (default): auto-detect physical cores (hardware_concurrency / 2, floor 1)
+     *   - `> 0`: explicit override
+     *   - `< 0`: leave GGML's CPU backend default unchanged
+     */
+    nThreads?: number;
+    /** Directory holding ggml backend shared libraries. Default: `<package>/prebuilds`. */
+    backendsDir?: string;
+    /**
+     * Requested ggml backend device. Default: `'cpu'`.
+     *   - `'cpu'`: run inference on the CPU backend (always available).
+     *   - `'vulkan'`: opt in to GPU inference on a Vulkan-capable device
+     *     (Linux/Windows/Android). Requires the `libggml-vulkan` backend shared
+     *     library to be present in `backendsDir`.
+     *   - `'metal'`: opt in to GPU inference on a Metal-capable device (Apple).
+     *     The Metal backend is compiled into the addon, so no extra shared
+     *     library is required.
+     *   - `'opencl'`: opt in to GPU inference on an OpenCL-capable device
+     *     (primarily Android/Adreno, where OpenCL is the sound GPU path).
+     *     Requires the `libggml-opencl` backend shared library to be present in
+     *     `backendsDir`.
+     * When the requested GPU device is not present the pipeline transparently
+     * falls back to CPU and records the reason (see
+     * {@link BackendInfo.fallbackReason}).
+     */
+    backendDevice?: "cpu" | "vulkan" | "metal" | "opencl";
+    /**
+     * Explicit GPU device selection for `'vulkan'` / `'metal'` / `'opencl'`.
+     * 0-based index
+     * into the GPU/iGPU devices that match the requested backend, in ggml
+     * enumeration order (the resolved index is reported as
+     * {@link BackendInfo.deviceIndex}).
+     *   - When omitted (default), selection prefers a discrete GPU and otherwise
+     *     falls back to an integrated GPU.
+     *   - When out of range, the pipeline falls back to CPU and records the
+     *     reason (see {@link BackendInfo.fallbackReason}).
+     * Ignored for `backendDevice: 'cpu'`. For pinning/reordering Vulkan devices
+     * without code you can also set the `GGML_VK_VISIBLE_DEVICES` env var (see
+     * the README).
+     */
+    gpuDevice?: number;
 }
-
-/**
- * Backend device the C++ pipeline resolved for inference, as reported by
- * {@link OcrGgml.getBackendInfo}.
- */
-export interface BackendInfo {
-  /** Requested device (`'cpu'` | `'vulkan'` | `'metal'` | `'opencl'`). */
-  requested: string
-  /** Resolved device type (`'CPU'` | `'GPU'` | `'IGPU'` | `'ACCEL'`). */
-  backendDevice: string
-  /** ggml backend/device name of the resolved device (e.g. `'Vulkan0'`, `'CPU'`). */
-  backendName: string
-  /**
-   * ggml device index of the selected device (the index into the loaded ggml
-   * devices), or `-1` when the CPU backend was selected (including fallback).
-   */
-  deviceIndex: number
-  /** Human-readable device description (e.g. `'NVIDIA GeForce RTX 4090'`, `'Apple M3'`); empty when ggml provides none. */
-  backendDescription: string
-  /** Empty when the requested device was used; otherwise why it fell back to CPU. */
-  fallbackReason: string
-}
-
+export type { BackendInfo, OcrGgmlRunOptions };
 export interface OcrGgmlArgs {
-  params: OcrGgmlParams
-  opts?: { stats?: boolean }
-  logger?: any
+    params: OcrGgmlParams;
+    opts?: {
+        stats?: boolean;
+    };
+    logger?: QvacLogger.LoggerInterface | null;
 }
-
-export interface OcrGgmlRunOptions {
-  /** Merge nearby boxes into paragraph-style regions. Default: false. */
-  paragraph?: boolean
-  /** Extra padding around detected boxes, as a fraction of box size. Default: 0.1. */
-  boxMarginMultiplier?: number
-  /** Override `defaultRotationAngles` for this single call. */
-  rotationAngles?: number[]
-}
-
 export interface OcrGgmlRunInput {
-  /** Path to a JPEG, PNG, or BMP file. */
-  path: string
-  options?: OcrGgmlRunOptions
+    /** Path to a JPEG, PNG, or BMP file. */
+    path: string;
+    options?: OcrGgmlRunOptions;
 }
-
 /**
  * One detected text region. Shape matches `@qvac/ocr-onnx` so downstream
  * consumers can swap backends without changing data handling code.
  */
 export type InferredText = [
-  /** Bounding box: [[x,y], [x,y], [x,y], [x,y]]. */
-  [[number, number], [number, number], [number, number], [number, number]],
-  /** Recognized text. */
-  string,
-  /** Confidence in [0, 1]. */
-  number
-]
-
+    /** Bounding box: [[x,y], [x,y], [x,y], [x,y]]. */
+    [
+        [number, number],
+        [number, number],
+        [number, number],
+        [number, number]
+    ],
+    /** Recognized text. */
+    string,
+    /** Confidence in [0, 1]. */
+    number
+];
 export interface InferenceClientState {
-  configLoaded: boolean
-  weightsLoaded: boolean
-  destroyed: boolean
+    configLoaded: boolean;
+    weightsLoaded: boolean;
+    destroyed: boolean;
 }
-
 export interface RuntimeStats {
-  /** Total wall-clock time for the run (seconds). */
-  totalTime: number
-  /** Detection step duration (seconds). */
-  detectionTime: number
-  /** Recognition step duration (seconds). */
-  recognitionTime: number
-  /** Number of detected boxes (aligned + unaligned). */
-  numBoxes: number
-  /**
-   * Whether inference ran on a GPU (Vulkan) device (`1`) or the CPU (`0`).
-   * `RuntimeStats` values are numeric only, so this flag is the in-stats signal
-   * for the selected backend; richer string detail (name, fallback reason) is
-   * available via {@link OcrGgml.getBackendInfo}.
-   */
-  backendIsGpu: number
+    /** Total wall-clock time for the run (seconds). */
+    totalTime: number;
+    /** Detection step duration (seconds). */
+    detectionTime: number;
+    /** Recognition step duration (seconds). */
+    recognitionTime: number;
+    /** Number of detected boxes (aligned + unaligned). */
+    numBoxes: number;
+    /**
+     * Whether inference ran on a GPU (Vulkan) device (`1`) or the CPU (`0`).
+     * `RuntimeStats` values are numeric only, so this flag is the in-stats signal
+     * for the selected backend; richer string detail (name, fallback reason) is
+     * available via {@link OcrGgml.getBackendInfo}.
+     */
+    backendIsGpu: number;
 }
-
-export class OcrGgml {
-  constructor(args: OcrGgmlArgs)
-  getState(): InferenceClientState
-  load(): Promise<void>
-  run(input: OcrGgmlRunInput): Promise<QvacResponse<InferredText[]>>
-  unload(): Promise<void>
-  destroy(): Promise<void>
-  /** Backend device resolved for inference; `null` before `load()` / after `unload()`. */
-  getBackendInfo(): BackendInfo | null
-
-  static readonly inferenceManagerConfig: { noAdditionalDownload: boolean }
-  static getModelKey(): string
+/**
+ * GGML-backed OCR implementation.
+ *
+ * Public surface matches `@qvac/ocr-onnx` so a downstream caller can switch
+ * inference engines by swapping the import.
+ */
+export declare class OcrGgml {
+    opts: {
+        stats?: boolean;
+    };
+    logger: QvacLogger;
+    addon: OcrGgmlInterface | null;
+    params: OcrGgmlParams;
+    state: InferenceClientState;
+    private _packageName;
+    private _packageVersion;
+    private _job;
+    private _run;
+    private _backendInfo;
+    constructor({ params, opts, logger }: OcrGgmlArgs);
+    getState(): InferenceClientState;
+    load(): Promise<void>;
+    run(input: OcrGgmlRunInput): Promise<QvacResponse<InferredText[]>>;
+    /**
+     * Backend device the C++ pipeline resolved for inference. Available after
+     * `load()`; `null` before load or after unload.
+     */
+    getBackendInfo(): BackendInfo | null;
+    unload(): Promise<void>;
+    destroy(): Promise<void>;
+    private _load;
+    private _createAddon;
+    private _runInternal;
+    /**
+     * Read an image file from disk and prepare it for the addon. Mirrors the
+     * ocr-onnx convention: JPEG / PNG are passed encoded to the addon (decoded
+     * by OpenCV in C++); BMP is decoded in JS to raw RGB.
+     */
+    private _readImage;
+    private _decodeBmp;
+    private _addonOutputCallback;
+    /** Inference Manager diagnostics hook (parity with ocr-onnx). */
+    _getDiagnosticsJSON(): string;
+    /** Inference Manager hooks (parity with ocr-onnx) */
+    static inferenceManagerConfig: {
+        noAdditionalDownload: boolean;
+    };
+    static getModelKey(): string;
 }
-
-export const modelClass: typeof OcrGgml
-export const modelFile: unknown
-
-export const ERR_CODES: {
-  readonly FAILED_TO_LOAD_WEIGHTS: number
-  readonly FAILED_TO_CANCEL: number
-  readonly FAILED_TO_RUN_JOB: number
-  readonly FAILED_TO_GET_STATUS: number
-  readonly FAILED_TO_DESTROY: number
-  readonly FAILED_TO_ACTIVATE: number
-  readonly MISSING_REQUIRED_PARAMETER: number
-  readonly UNSUPPORTED_LANGUAGE: number
-  readonly INVALID_IMAGE_OR_INSUFFICIENT_DATA: number
-  readonly UNSUPPORTED_IMAGE_FORMAT: number
-  readonly NOT_LOADED: number
-}
-
-export class QvacErrorAddonOcrGgml extends Error {
-  code: number
-}
-
-export const binding: unknown
-export const addonLogging: unknown
+export { QvacErrorAddonOcrGgml, ERR_CODES };
+export declare const modelClass: typeof OcrGgml;
+export declare const modelFile: unknown;
+export declare const binding: unknown;
+export declare const addonLogging: unknown;

--- a/packages/ocr-ggml/index.js
+++ b/packages/ocr-ggml/index.js
@@ -1,12 +1,16 @@
-'use strict'
-
-const path = require('bare-path')
-const fs = require('bare-fs')
-const QvacLogger = require('@qvac/logging')
-const { createJobHandler, exclusiveRunQueue } = require('@qvac/infer-base')
-
-const { QvacErrorAddonOcrGgml, ERR_CODES } = require('./lib/error')
-
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ERR_CODES = exports.QvacErrorAddonOcrGgml = exports.OcrGgml = void 0;
+/* eslint-disable @typescript-eslint/no-require-imports -- Bare modules and @qvac/logging expose CommonJS export shapes. */
+const path = require("bare-path");
+const fs = require("bare-fs");
+const QvacLogger = require("@qvac/logging");
+/* eslint-enable @typescript-eslint/no-require-imports */
+const infer_base_1 = require("@qvac/infer-base");
+const ocr_ggml_1 = require("./ocr-ggml");
+const error_1 = require("./lib/error");
+Object.defineProperty(exports, "QvacErrorAddonOcrGgml", { enumerable: true, get: function () { return error_1.QvacErrorAddonOcrGgml; } });
+Object.defineProperty(exports, "ERR_CODES", { enumerable: true, get: function () { return error_1.ERR_CODES; } });
 /**
  * GGML-backed OCR implementation.
  *
@@ -14,413 +18,351 @@ const { QvacErrorAddonOcrGgml, ERR_CODES } = require('./lib/error')
  * inference engines by swapping the import.
  */
 class OcrGgml {
-  /**
-   * @param {Object} args
-   * @param {Object} args.params
-   * @param {string} args.params.pathDetector - path to the CRAFT .gguf
-   * @param {string} args.params.pathRecognizer - path to the recognizer .gguf
-   * @param {string[]} args.params.langList - e.g. `['en']`
-   * @param {number} [args.params.magRatio=1.5]
-   * @param {number} [args.params.canvasSize=2560] - EasyOCR `canvas_size`: detection canvas cap (long side, px). Lower it (e.g. 1280) on memory-constrained targets to bound CRAFT peak memory. EasyOCR only.
-   * @param {number[]} [args.params.defaultRotationAngles]
-   * @param {boolean} [args.params.contrastRetry]
-   * @param {number} [args.params.lowConfidenceThreshold]
-   * @param {number} [args.params.recognizerBatchSize]
-   * @param {number} [args.params.nThreads] - 0=auto (physical cores), >0=explicit, <0=leave default
-   * @param {string} [args.params.backendsDir] - override directory for ggml backend shared libs
-   * @param {'cpu'|'vulkan'|'metal'|'opencl'} [args.params.backendDevice='cpu'] - requested ggml backend device. `'vulkan'` (Linux/Windows/Android), `'metal'` (Apple) and `'opencl'` (Android/Adreno) opt in to GPU inference with transparent CPU fallback when no matching device is present.
-   * @param {number} [args.params.gpuDevice] - explicit 0-based index into the matching GPU/iGPU devices for `'vulkan'`/`'metal'`/`'opencl'`. Omit to prefer a discrete GPU (then integrated); out-of-range falls back to CPU. Ignored for `'cpu'`.
-   * @param {Object} [args.opts]
-   * @param {boolean} [args.opts.stats] - emit timing stats on finish
-   * @param {Object} [args.logger]
-   */
-  constructor({ params, opts = {}, logger = null }) {
-    this.opts = opts
-    this.logger = new QvacLogger(logger)
-    this.addon = null
-    this.params = params
-    this._packageName = '@qvac/ocr-ggml'
-    this._packageVersion = require('./package.json').version
-    this._job = createJobHandler({ cancel: () => this.addon && this.addon.cancel() })
-    this._run = exclusiveRunQueue()
-    this._backendInfo = null
-
-    this.state = {
-      configLoaded: false,
-      weightsLoaded: false,
-      destroyed: false
+    opts;
+    logger;
+    addon;
+    params;
+    state;
+    _packageName;
+    _packageVersion;
+    _job;
+    _run;
+    _backendInfo;
+    constructor({ params, opts = {}, logger = null }) {
+        this.opts = opts;
+        this.logger = new QvacLogger(logger);
+        this.addon = null;
+        this.params = params;
+        this._packageName = "@qvac/ocr-ggml";
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- package metadata is read from the package root at runtime.
+        this._packageVersion = require("./package.json").version;
+        this._job = (0, infer_base_1.createJobHandler)({ cancel: () => this.addon?.cancel() });
+        this._run = (0, infer_base_1.exclusiveRunQueue)();
+        this._backendInfo = null;
+        this.state = {
+            configLoaded: false,
+            weightsLoaded: false,
+            destroyed: false,
+        };
     }
-  }
-
-  /**
-   * @returns {{configLoaded: boolean, weightsLoaded: boolean, destroyed: boolean}}
-   */
-  getState() {
-    return this.state
-  }
-
-  async load() {
-    if (this.state.configLoaded || this.state.weightsLoaded) {
-      this.logger.info('Reload requested - unloading existing model first')
-      await this.unload()
+    getState() {
+        return this.state;
     }
-    await this._load()
-  }
-
-  /**
-   * @param {{ path: string, options?: Object }} input
-   * @returns {Promise<import('@qvac/infer-base').QvacResponse>}
-   */
-  async run(input) {
-    return this._run(() => this._runInternal(input))
-  }
-
-  /**
-   * Backend device the C++ pipeline resolved for inference. Available after
-   * `load()`; `null` before load or after unload.
-   * @returns {{ requested: string, backendDevice: string, backendName: string, deviceIndex: number, backendDescription: string, fallbackReason: string }|null}
-   */
-  getBackendInfo() {
-    return this._backendInfo
-  }
-
-  async unload() {
-    if (this.addon) {
-      await this.addon.destroy()
-      this.addon = null
+    async load() {
+        if (this.state.configLoaded || this.state.weightsLoaded) {
+            this.logger.info("Reload requested - unloading existing model first");
+            await this.unload();
+        }
+        await this._load();
     }
-    this._backendInfo = null
-    this.state.configLoaded = false
-    this.state.weightsLoaded = false
-  }
-
-  async destroy() {
-    await this.unload()
-    this.state.destroyed = true
-  }
-
-  async _load() {
-    if (!this.params || typeof this.params !== 'object') {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.MISSING_REQUIRED_PARAMETER,
-        adds: 'params object is required'
-      })
+    async run(input) {
+        return this._run(() => this._runInternal(input));
     }
-
-    if (!this.params.pathDetector) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.MISSING_REQUIRED_PARAMETER,
-        adds: 'pathDetector'
-      })
+    /**
+     * Backend device the C++ pipeline resolved for inference. Available after
+     * `load()`; `null` before load or after unload.
+     */
+    getBackendInfo() {
+        return this._backendInfo;
     }
-    if (!this.params.pathRecognizer) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.MISSING_REQUIRED_PARAMETER,
-        adds: 'pathRecognizer'
-      })
+    async unload() {
+        if (this.addon) {
+            await this.addon.destroy();
+            this.addon = null;
+        }
+        this._backendInfo = null;
+        this.state.configLoaded = false;
+        this.state.weightsLoaded = false;
     }
-    if (!Array.isArray(this.params.langList) || this.params.langList.length === 0) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.MISSING_REQUIRED_PARAMETER,
-        adds: 'langList (non-empty array)'
-      })
+    async destroy() {
+        await this.unload();
+        this.state.destroyed = true;
     }
-
-    const SUPPORTED_LANGUAGES = new Set(['en'])
-    const hasSupported = this.params.langList.some((l) => SUPPORTED_LANGUAGES.has(l))
-    if (!hasSupported) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.UNSUPPORTED_LANGUAGE,
-        adds: `none of the requested languages are supported: ${this.params.langList.join(', ')}`
-      })
+    async _load() {
+        if (!this.params || typeof this.params !== "object") {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.MISSING_REQUIRED_PARAMETER,
+                adds: "params object is required",
+            });
+        }
+        if (!this.params.pathDetector) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.MISSING_REQUIRED_PARAMETER,
+                adds: "pathDetector",
+            });
+        }
+        if (!this.params.pathRecognizer) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.MISSING_REQUIRED_PARAMETER,
+                adds: "pathRecognizer",
+            });
+        }
+        if (!Array.isArray(this.params.langList) || this.params.langList.length === 0) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.MISSING_REQUIRED_PARAMETER,
+                adds: "langList (non-empty array)",
+            });
+        }
+        const SUPPORTED_LANGUAGES = new Set(["en"]);
+        const hasSupported = this.params.langList.some((l) => SUPPORTED_LANGUAGES.has(l));
+        if (!hasSupported) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.UNSUPPORTED_LANGUAGE,
+                adds: `none of the requested languages are supported: ${this.params.langList.join(", ")}`,
+            });
+        }
+        const configurationParams = {
+            pathDetector: this.params.pathDetector,
+            pathRecognizer: this.params.pathRecognizer,
+            langList: this.params.langList,
+        };
+        // Forward optional config knobs only when explicitly set so the C++
+        // defaults (in OcrConfig) win otherwise.
+        const optionalFields = [
+            "magRatio",
+            "canvasSize",
+            "defaultRotationAngles",
+            "contrastRetry",
+            "lowConfidenceThreshold",
+            "recognizerBatchSize",
+            "nThreads",
+            "pipelineType",
+            "backendDevice",
+            "gpuDevice",
+        ];
+        for (const field of optionalFields) {
+            if (this.params[field] !== undefined) {
+                configurationParams[field] = this.params[field];
+            }
+        }
+        configurationParams.backendsDir =
+            this.params.backendsDir !== undefined
+                ? this.params.backendsDir
+                : path.join(__dirname, "prebuilds");
+        this.logger.info("Creating ocr-ggml addon");
+        this.addon = this._createAddon(configurationParams);
+        await this.addon.activate();
+        this.state.configLoaded = true;
+        this.state.weightsLoaded = true;
+        // Capture the backend device the C++ pipeline actually resolved (Vulkan vs
+        // CPU fallback). RuntimeStats can only carry numbers, so backend identity
+        // strings are surfaced here and via _getDiagnosticsJSON().
+        try {
+            this._backendInfo = this.addon.getBackendInfo();
+            if (this._backendInfo) {
+                this.logger.info("ocr-ggml backend: " + JSON.stringify(this._backendInfo));
+            }
+        }
+        catch (err) {
+            this.logger.warn("ocr-ggml: failed to read backend info: " + (0, error_1.errorMessage)(err));
+            this._backendInfo = null;
+        }
+        this.logger.info("ocr-ggml model loaded");
     }
-
-    const configurationParams = {
-      pathDetector: this.params.pathDetector,
-      pathRecognizer: this.params.pathRecognizer,
-      langList: this.params.langList
+    _createAddon(configurationParams) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved lazily from package prebuilds.
+        const binding = require("./binding");
+        return new ocr_ggml_1.OcrGgmlInterface(binding, configurationParams, this._addonOutputCallback.bind(this), this.logger);
     }
-
-    // Forward optional config knobs only when explicitly set so the C++
-    // defaults (in OcrConfig) win otherwise.
-    const optionalFields = [
-      'magRatio',
-      'canvasSize',
-      'defaultRotationAngles',
-      'contrastRetry',
-      'lowConfidenceThreshold',
-      'recognizerBatchSize',
-      'nThreads',
-      'pipelineType',
-      'backendDevice',
-      'gpuDevice'
-    ]
-    for (const field of optionalFields) {
-      if (this.params[field] !== undefined) {
-        configurationParams[field] = this.params[field]
-      }
+    async _runInternal(input) {
+        this.logger.info("Starting OCR inference");
+        if (!this.addon) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.NOT_LOADED,
+                adds: "call load() before run()",
+            });
+        }
+        const response = this._job.start();
+        try {
+            const imageInput = this._readImage(input.path);
+            await this.addon.runJob({
+                type: "image",
+                input: imageInput,
+                options: input.options,
+            });
+        }
+        catch (err) {
+            this._job.fail(err);
+            throw err;
+        }
+        return response;
     }
-
-    configurationParams.backendsDir =
-      this.params.backendsDir !== undefined
-        ? this.params.backendsDir
-        : path.join(__dirname, 'prebuilds')
-
-    this.logger.info('Creating ocr-ggml addon')
-    this.addon = this._createAddon(configurationParams)
-    await this.addon.activate()
-    this.state.configLoaded = true
-    this.state.weightsLoaded = true
-
-    // Capture the backend device the C++ pipeline actually resolved (Vulkan vs
-    // CPU fallback). RuntimeStats can only carry numbers, so backend identity
-    // strings are surfaced here and via _getDiagnosticsJSON().
-    try {
-      this._backendInfo = this.addon.getBackendInfo()
-      if (this._backendInfo) {
-        this.logger.info('ocr-ggml backend: ' + JSON.stringify(this._backendInfo))
-      }
-    } catch (err) {
-      this.logger.warn('ocr-ggml: failed to read backend info: ' + err.message)
-      this._backendInfo = null
+    /**
+     * Read an image file from disk and prepare it for the addon. Mirrors the
+     * ocr-onnx convention: JPEG / PNG are passed encoded to the addon (decoded
+     * by OpenCV in C++); BMP is decoded in JS to raw RGB.
+     */
+    _readImage(imagePath) {
+        this.logger.debug("Reading image from path:", imagePath);
+        const contents = fs.readFileSync(imagePath);
+        if (!contents || contents.length < 4) {
+            this.logger.error("Invalid image file or insufficient data");
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+                adds: imagePath,
+            });
+        }
+        // JPEG: starts with 0xFF 0xD8
+        if (contents[0] === 0xff && contents[1] === 0xd8) {
+            return { data: contents, isEncoded: true };
+        }
+        // PNG: 0x89 P N G
+        if (contents[0] === 0x89 &&
+            contents[1] === 0x50 &&
+            contents[2] === 0x4e &&
+            contents[3] === 0x47) {
+            return { data: contents, isEncoded: true };
+        }
+        // BMP: 'BM'
+        if (contents[0] === 0x42 && contents[1] === 0x4d) {
+            return this._decodeBmp(contents, imagePath);
+        }
+        this.logger.error("Unsupported image format");
+        throw new error_1.QvacErrorAddonOcrGgml({
+            code: error_1.ERR_CODES.UNSUPPORTED_IMAGE_FORMAT,
+            adds: imagePath,
+        });
     }
-
-    this.logger.info('ocr-ggml model loaded')
-  }
-
-  _createAddon(configurationParams) {
-    const binding = require('./binding')
-    const { OcrGgmlInterface } = require('./ocr-ggml')
-    return new OcrGgmlInterface(
-      binding,
-      configurationParams,
-      this._addonOutputCallback.bind(this),
-      this.logger
-    )
-  }
-
-  async _runInternal(input) {
-    this.logger.info('Starting OCR inference')
-
-    if (!this.addon) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.NOT_LOADED,
-        adds: 'call load() before run()'
-      })
+    _decodeBmp(contents, imagePath) {
+        if (contents.length < 14 + 4) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+                adds: imagePath,
+            });
+        }
+        const infoHeaderSize = contents.readUInt32LE(14);
+        if (contents.length < 14 + infoHeaderSize) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+                adds: imagePath,
+            });
+        }
+        let width, height, bitsPerPixel;
+        if (infoHeaderSize >= 40) {
+            width = contents.readInt32LE(18);
+            height = contents.readInt32LE(22);
+            bitsPerPixel = contents.readUInt16LE(28);
+        }
+        else if (infoHeaderSize >= 12) {
+            width = contents.readUInt16LE(18);
+            height = contents.readInt16LE(20);
+            bitsPerPixel = 24;
+        }
+        else {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.UNSUPPORTED_IMAGE_FORMAT,
+                adds: `BMP header size ${infoHeaderSize}`,
+            });
+        }
+        if (width <= 0 || height === 0) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+                adds: `${imagePath} (invalid BMP dimensions ${width}x${height})`,
+            });
+        }
+        const SUPPORTED_BITS = new Set([8, 24, 32]);
+        if (!SUPPORTED_BITS.has(bitsPerPixel)) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.UNSUPPORTED_IMAGE_FORMAT,
+                adds: `BMP bitsPerPixel ${bitsPerPixel} (supported: 8, 24, 32)`,
+            });
+        }
+        const pixelDataOffset = contents.readUInt32LE(10);
+        if (pixelDataOffset >= contents.length) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+                adds: `${imagePath} (BMP pixelDataOffset ${pixelDataOffset} out of range)`,
+            });
+        }
+        const pixelDataBuffer = contents.slice(pixelDataOffset);
+        const bytesPerPixel = bitsPerPixel / 8;
+        const unpaddedRowSize = width * bytesPerPixel;
+        const paddedRowSize = Math.ceil(unpaddedRowSize / 4) * 4;
+        const rows = Math.abs(height);
+        if (pixelDataBuffer.length < rows * paddedRowSize) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+                adds: imagePath,
+            });
+        }
+        const unpaddedData = Buffer.alloc(rows * unpaddedRowSize);
+        for (let row = 0; row < rows; row++) {
+            const srcStart = row * paddedRowSize;
+            const srcEnd = srcStart + unpaddedRowSize;
+            let destRow = row;
+            if (height > 0)
+                destRow = rows - row - 1;
+            const destStart = destRow * unpaddedRowSize;
+            pixelDataBuffer.copy(unpaddedData, destStart, srcStart, srcEnd);
+        }
+        return { width, height: rows, data: unpaddedData, bitsPerPixel };
     }
-
-    const response = this._job.start()
-    try {
-      const imageInput = this._readImage(input.path)
-      await this.addon.runJob({
-        type: 'image',
-        input: imageInput,
-        options: input.options
-      })
-    } catch (err) {
-      this._job.fail(err)
-      throw err
+    _addonOutputCallback(_addon, event, data, error) {
+        if (typeof event === "string" && event.includes("Error")) {
+            return this._job.fail(error);
+        }
+        // JobEnded may arrive with stats payload, with null (stats disabled), or
+        // not at all on some platforms - handle the event name explicitly so
+        // await() doesn't hang when data is null.
+        if (event === "JobEnded") {
+            const isStatsObject = typeof data === "object" &&
+                data !== null &&
+                !Array.isArray(data) &&
+                ("totalTime" in data || "detectionTime" in data);
+            if (isStatsObject) {
+                this.logger.info("OCR inference completed. Stats:", JSON.stringify(data));
+            }
+            return this._job.end(this.opts?.stats && isStatsObject ? data : null);
+        }
+        // Some addon paths surface stats without a 'JobEnded' event name; keep
+        // the legacy heuristic as a fallback so we still close the job.
+        const isStatsObject = typeof data === "object" &&
+            data !== null &&
+            !Array.isArray(data) &&
+            ("totalTime" in data || "detectionTime" in data);
+        if (isStatsObject) {
+            this.logger.info("OCR inference completed. Stats:", JSON.stringify(data));
+            return this._job.end(this.opts?.stats ? data : null);
+        }
+        if (Array.isArray(data)) {
+            return this._job.output(data);
+        }
     }
-    return response
-  }
-
-  /**
-   * Read an image file from disk and prepare it for the addon. Mirrors the
-   * ocr-onnx convention: JPEG / PNG are passed encoded to the addon (decoded
-   * by OpenCV in C++); BMP is decoded in JS to raw RGB.
-   *
-   * @param {string} imagePath
-   * @returns {{ data: Buffer, isEncoded?: boolean, width?: number, height?: number, bitsPerPixel?: number }}
-   */
-  _readImage(imagePath) {
-    this.logger.debug('Reading image from path:', imagePath)
-    const contents = fs.readFileSync(imagePath)
-    if (!contents || contents.length < 4) {
-      this.logger.error('Invalid image file or insufficient data')
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
-        adds: imagePath
-      })
+    /** Inference Manager diagnostics hook (parity with ocr-onnx). */
+    _getDiagnosticsJSON() {
+        return JSON.stringify({
+            status: this.state.destroyed
+                ? "destroyed"
+                : this.state.configLoaded
+                    ? "loaded"
+                    : "not_loaded",
+            params: this.params,
+            backend: this._backendInfo,
+        });
     }
-
-    // JPEG: starts with 0xFF 0xD8
-    if (contents[0] === 0xff && contents[1] === 0xd8) {
-      return { data: contents, isEncoded: true }
+    /** Inference Manager hooks (parity with ocr-onnx) */
+    static inferenceManagerConfig = {
+        noAdditionalDownload: true,
+    };
+    static getModelKey() {
+        return "ocr-ggml";
     }
-    // PNG: 0x89 P N G
-    if (
-      contents[0] === 0x89 &&
-      contents[1] === 0x50 &&
-      contents[2] === 0x4e &&
-      contents[3] === 0x47
-    ) {
-      return { data: contents, isEncoded: true }
-    }
-    // BMP: 'BM'
-    if (contents[0] === 0x42 && contents[1] === 0x4d) {
-      return this._decodeBmp(contents, imagePath)
-    }
-
-    this.logger.error('Unsupported image format')
-    throw new QvacErrorAddonOcrGgml({
-      code: ERR_CODES.UNSUPPORTED_IMAGE_FORMAT,
-      adds: imagePath
-    })
-  }
-
-  _decodeBmp(contents, imagePath) {
-    if (contents.length < 14 + 4) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
-        adds: imagePath
-      })
-    }
-
-    const infoHeaderSize = contents.readUInt32LE(14)
-    if (contents.length < 14 + infoHeaderSize) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
-        adds: imagePath
-      })
-    }
-
-    let width, height, bitsPerPixel
-    if (infoHeaderSize >= 40) {
-      width = contents.readInt32LE(18)
-      height = contents.readInt32LE(22)
-      bitsPerPixel = contents.readUInt16LE(28)
-    } else if (infoHeaderSize >= 12) {
-      width = contents.readUInt16LE(18)
-      height = contents.readInt16LE(20)
-      bitsPerPixel = 24
-    } else {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.UNSUPPORTED_IMAGE_FORMAT,
-        adds: `BMP header size ${infoHeaderSize}`
-      })
-    }
-
-    if (width <= 0 || height === 0) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
-        adds: `${imagePath} (invalid BMP dimensions ${width}x${height})`
-      })
-    }
-
-    const SUPPORTED_BITS = new Set([8, 24, 32])
-    if (!SUPPORTED_BITS.has(bitsPerPixel)) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.UNSUPPORTED_IMAGE_FORMAT,
-        adds: `BMP bitsPerPixel ${bitsPerPixel} (supported: 8, 24, 32)`
-      })
-    }
-
-    const pixelDataOffset = contents.readUInt32LE(10)
-    if (pixelDataOffset >= contents.length) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
-        adds: `${imagePath} (BMP pixelDataOffset ${pixelDataOffset} out of range)`
-      })
-    }
-    const pixelDataBuffer = contents.slice(pixelDataOffset)
-
-    const bytesPerPixel = bitsPerPixel / 8
-    const unpaddedRowSize = width * bytesPerPixel
-    const paddedRowSize = Math.ceil(unpaddedRowSize / 4) * 4
-    const rows = Math.abs(height)
-
-    if (pixelDataBuffer.length < rows * paddedRowSize) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
-        adds: imagePath
-      })
-    }
-
-    const unpaddedData = Buffer.alloc(rows * unpaddedRowSize)
-    for (let row = 0; row < rows; row++) {
-      const srcStart = row * paddedRowSize
-      const srcEnd = srcStart + unpaddedRowSize
-      let destRow = row
-      if (height > 0) destRow = rows - row - 1
-      const destStart = destRow * unpaddedRowSize
-      pixelDataBuffer.copy(unpaddedData, destStart, srcStart, srcEnd)
-    }
-
-    return { width, height: rows, data: unpaddedData, bitsPerPixel }
-  }
-
-  _addonOutputCallback(addon, event, data, error) {
-    if (event && event.includes('Error')) {
-      return this._job.fail(error)
-    }
-
-    // JobEnded may arrive with stats payload, with null (stats disabled), or
-    // not at all on some platforms - handle the event name explicitly so
-    // await() doesn't hang when data is null.
-    if (event === 'JobEnded') {
-      const isStatsObject =
-        typeof data === 'object' &&
-        data !== null &&
-        !Array.isArray(data) &&
-        ('totalTime' in data || 'detectionTime' in data)
-      if (isStatsObject) {
-        this.logger.info('OCR inference completed. Stats:', JSON.stringify(data))
-      }
-      return this._job.end(this.opts?.stats && isStatsObject ? data : null)
-    }
-
-    // Some addon paths surface stats without a 'JobEnded' event name; keep
-    // the legacy heuristic as a fallback so we still close the job.
-    const isStatsObject =
-      typeof data === 'object' &&
-      data !== null &&
-      !Array.isArray(data) &&
-      ('totalTime' in data || 'detectionTime' in data)
-    if (isStatsObject) {
-      this.logger.info('OCR inference completed. Stats:', JSON.stringify(data))
-      return this._job.end(this.opts?.stats ? data : null)
-    }
-
-    if (Array.isArray(data)) {
-      return this._job.output(data)
-    }
-  }
-
-  /** Inference Manager diagnostics hook (parity with ocr-onnx). */
-  _getDiagnosticsJSON() {
-    return JSON.stringify({
-      status: this.state.destroyed
-        ? 'destroyed'
-        : this.state.configLoaded
-          ? 'loaded'
-          : 'not_loaded',
-      params: this.params,
-      backend: this._backendInfo
-    })
-  }
-
-  /** Inference Manager hooks (parity with ocr-onnx) */
-  static inferenceManagerConfig = {
-    noAdditionalDownload: true
-  }
-
-  static getModelKey() {
-    return 'ocr-ggml'
-  }
 }
-
+exports.OcrGgml = OcrGgml;
 module.exports = {
-  OcrGgml,
-  modelClass: OcrGgml,
-  get modelFile() {
-    return require.addon.resolve('.')
-  },
-  QvacErrorAddonOcrGgml,
-  ERR_CODES,
-  get binding() {
-    return require('./binding')
-  },
-  get addonLogging() {
-    return require('./addonLogging')
-  }
-}
+    OcrGgml,
+    modelClass: OcrGgml,
+    get modelFile() {
+        return require.addon.resolve(".");
+    },
+    QvacErrorAddonOcrGgml: error_1.QvacErrorAddonOcrGgml,
+    ERR_CODES: error_1.ERR_CODES,
+    get binding() {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved lazily from package prebuilds.
+        return require("./binding");
+    },
+    get addonLogging() {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- resolved lazily to defer native binding load.
+        return require("./addonLogging");
+    },
+};

--- a/packages/ocr-ggml/lib/error.d.ts
+++ b/packages/ocr-ggml/lib/error.d.ts
@@ -1,0 +1,20 @@
+import QvacError = require("@qvac/error");
+declare const QvacErrorBase: typeof QvacError.QvacErrorBase;
+export declare class QvacErrorAddonOcrGgml extends QvacErrorBase {
+}
+/** Extract a human-readable message from an unknown thrown value. */
+export declare function errorMessage(err: unknown): string;
+export declare const ERR_CODES: Readonly<{
+    FAILED_TO_LOAD_WEIGHTS: 8101;
+    FAILED_TO_CANCEL: 8102;
+    FAILED_TO_RUN_JOB: 8103;
+    FAILED_TO_GET_STATUS: 8104;
+    FAILED_TO_DESTROY: 8105;
+    FAILED_TO_ACTIVATE: 8106;
+    MISSING_REQUIRED_PARAMETER: 8107;
+    UNSUPPORTED_LANGUAGE: 8108;
+    INVALID_IMAGE_OR_INSUFFICIENT_DATA: 8109;
+    UNSUPPORTED_IMAGE_FORMAT: 8110;
+    NOT_LOADED: 8111;
+}>;
+export {};

--- a/packages/ocr-ggml/lib/error.js
+++ b/packages/ocr-ggml/lib/error.js
@@ -1,80 +1,88 @@
-'use strict'
-
-const { QvacErrorBase, addCodes } = require('@qvac/error')
-const { name, version } = require('../package.json')
-
-class QvacErrorAddonOcrGgml extends QvacErrorBase {}
-
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ERR_CODES = exports.QvacErrorAddonOcrGgml = void 0;
+exports.errorMessage = errorMessage;
+/* eslint-disable @typescript-eslint/no-require-imports -- @qvac/error exposes a CommonJS export shape. */
+const QvacError = require("@qvac/error");
+/* eslint-enable @typescript-eslint/no-require-imports */
+const { QvacErrorBase, addCodes } = QvacError;
+class QvacErrorAddonOcrGgml extends QvacErrorBase {
+}
+exports.QvacErrorAddonOcrGgml = QvacErrorAddonOcrGgml;
+/** Extract a human-readable message from an unknown thrown value. */
+function errorMessage(err) {
+    if (err instanceof Error)
+        return err.message;
+    if (err && typeof err === "object" && "message" in err) {
+        const message = err.message;
+        if (typeof message === "string" && message)
+            return message;
+    }
+    return typeof err === "string" ? err : "unknown error";
+}
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- package metadata is read from the package root at runtime.
+const { name, version } = require("../package.json");
 // Allocated error code range: 8101..8200
 // (translation-nmtcpp uses 8001..9000 broadly; ocr-onnx claims its own block.)
-const ERR_CODES = Object.freeze({
-  FAILED_TO_LOAD_WEIGHTS: 8101,
-  FAILED_TO_CANCEL: 8102,
-  FAILED_TO_RUN_JOB: 8103,
-  FAILED_TO_GET_STATUS: 8104,
-  FAILED_TO_DESTROY: 8105,
-  FAILED_TO_ACTIVATE: 8106,
-  MISSING_REQUIRED_PARAMETER: 8107,
-  UNSUPPORTED_LANGUAGE: 8108,
-  INVALID_IMAGE_OR_INSUFFICIENT_DATA: 8109,
-  UNSUPPORTED_IMAGE_FORMAT: 8110,
-  NOT_LOADED: 8111
-})
-
-addCodes(
-  {
-    [ERR_CODES.FAILED_TO_LOAD_WEIGHTS]: {
-      name: 'FAILED_TO_LOAD_WEIGHTS',
-      message: (message) => `Failed to load weights, error: ${message}`
+exports.ERR_CODES = Object.freeze({
+    FAILED_TO_LOAD_WEIGHTS: 8101,
+    FAILED_TO_CANCEL: 8102,
+    FAILED_TO_RUN_JOB: 8103,
+    FAILED_TO_GET_STATUS: 8104,
+    FAILED_TO_DESTROY: 8105,
+    FAILED_TO_ACTIVATE: 8106,
+    MISSING_REQUIRED_PARAMETER: 8107,
+    UNSUPPORTED_LANGUAGE: 8108,
+    INVALID_IMAGE_OR_INSUFFICIENT_DATA: 8109,
+    UNSUPPORTED_IMAGE_FORMAT: 8110,
+    NOT_LOADED: 8111,
+});
+addCodes({
+    [exports.ERR_CODES.FAILED_TO_LOAD_WEIGHTS]: {
+        name: "FAILED_TO_LOAD_WEIGHTS",
+        message: (message) => `Failed to load weights, error: ${message}`,
     },
-    [ERR_CODES.FAILED_TO_CANCEL]: {
-      name: 'FAILED_TO_CANCEL',
-      message: (message) => `Failed to cancel inference, error: ${message}`
+    [exports.ERR_CODES.FAILED_TO_CANCEL]: {
+        name: "FAILED_TO_CANCEL",
+        message: (message) => `Failed to cancel inference, error: ${message}`,
     },
-    [ERR_CODES.FAILED_TO_RUN_JOB]: {
-      name: 'FAILED_TO_RUN_JOB',
-      message: (message) => `Failed to run OCR job, error: ${message}`
+    [exports.ERR_CODES.FAILED_TO_RUN_JOB]: {
+        name: "FAILED_TO_RUN_JOB",
+        message: (message) => `Failed to run OCR job, error: ${message}`,
     },
-    [ERR_CODES.FAILED_TO_GET_STATUS]: {
-      name: 'FAILED_TO_GET_STATUS',
-      message: (message) => `Failed to get addon status, error: ${message}`
+    [exports.ERR_CODES.FAILED_TO_GET_STATUS]: {
+        name: "FAILED_TO_GET_STATUS",
+        message: (message) => `Failed to get addon status, error: ${message}`,
     },
-    [ERR_CODES.FAILED_TO_DESTROY]: {
-      name: 'FAILED_TO_DESTROY',
-      message: (message) => `Failed to destroy instance, error: ${message}`
+    [exports.ERR_CODES.FAILED_TO_DESTROY]: {
+        name: "FAILED_TO_DESTROY",
+        message: (message) => `Failed to destroy instance, error: ${message}`,
     },
-    [ERR_CODES.FAILED_TO_ACTIVATE]: {
-      name: 'FAILED_TO_ACTIVATE',
-      message: (message) => `Failed to activate model, error: ${message}`
+    [exports.ERR_CODES.FAILED_TO_ACTIVATE]: {
+        name: "FAILED_TO_ACTIVATE",
+        message: (message) => `Failed to activate model, error: ${message}`,
     },
-    [ERR_CODES.MISSING_REQUIRED_PARAMETER]: {
-      name: 'MISSING_REQUIRED_PARAMETER',
-      message: (message) => `Missing required parameter: ${message}`
+    [exports.ERR_CODES.MISSING_REQUIRED_PARAMETER]: {
+        name: "MISSING_REQUIRED_PARAMETER",
+        message: (message) => `Missing required parameter: ${message}`,
     },
-    [ERR_CODES.UNSUPPORTED_LANGUAGE]: {
-      name: 'UNSUPPORTED_LANGUAGE',
-      message: (message) => `Unsupported language(s): ${message}`
+    [exports.ERR_CODES.UNSUPPORTED_LANGUAGE]: {
+        name: "UNSUPPORTED_LANGUAGE",
+        message: (message) => `Unsupported language(s): ${message}`,
     },
-    [ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA]: {
-      name: 'INVALID_IMAGE_OR_INSUFFICIENT_DATA',
-      message: (message) => `Invalid image file or insufficient data: ${message}`
+    [exports.ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA]: {
+        name: "INVALID_IMAGE_OR_INSUFFICIENT_DATA",
+        message: (message) => `Invalid image file or insufficient data: ${message}`,
     },
-    [ERR_CODES.UNSUPPORTED_IMAGE_FORMAT]: {
-      name: 'UNSUPPORTED_IMAGE_FORMAT',
-      message: (message) => `Unsupported image format: ${message}`
+    [exports.ERR_CODES.UNSUPPORTED_IMAGE_FORMAT]: {
+        name: "UNSUPPORTED_IMAGE_FORMAT",
+        message: (message) => `Unsupported image format: ${message}`,
     },
-    [ERR_CODES.NOT_LOADED]: {
-      name: 'NOT_LOADED',
-      message: (message) => `OCR model is not loaded: ${message}`
-    }
-  },
-  {
+    [exports.ERR_CODES.NOT_LOADED]: {
+        name: "NOT_LOADED",
+        message: (message) => `OCR model is not loaded: ${message}`,
+    },
+}, {
     name,
-    version
-  }
-)
-
-module.exports = {
-  ERR_CODES,
-  QvacErrorAddonOcrGgml
-}
+    version,
+});

--- a/packages/ocr-ggml/ocr-ggml.d.ts
+++ b/packages/ocr-ggml/ocr-ggml.d.ts
@@ -1,0 +1,108 @@
+type NativeLoggerCallback = (priority: number, message: string) => void;
+/**
+ * Logger object forwarded to the native `setLogger` bridge. Any subset of the
+ * four level methods may be provided; each receives a formatted C++ log line.
+ */
+export interface TransitionLogger {
+    error?: (message: string) => void;
+    warn?: (message: string) => void;
+    info?: (message: string) => void;
+    debug?: (message: string) => void;
+}
+/**
+ * Backend device the C++ pipeline resolved for inference, as reported by the
+ * native `getBackendInfo` binding.
+ */
+export interface BackendInfo {
+    /** Requested device (`'cpu'` | `'vulkan'` | `'metal'` | `'opencl'`). */
+    requested: string;
+    /** Resolved device type (`'CPU'` | `'GPU'` | `'IGPU'` | `'ACCEL'`). */
+    backendDevice: string;
+    /** ggml backend/device name of the resolved device (e.g. `'Vulkan0'`, `'CPU'`). */
+    backendName: string;
+    /**
+     * ggml device index of the selected device (the index into the loaded ggml
+     * devices), or `-1` when the CPU backend was selected (including fallback).
+     */
+    deviceIndex: number;
+    /** Human-readable device description (e.g. `'NVIDIA GeForce RTX 4090'`, `'Apple M3'`); empty when ggml provides none. */
+    backendDescription: string;
+    /** Empty when the requested device was used; otherwise why it fell back to CPU. */
+    fallbackReason: string;
+}
+/** Configuration object passed through to the native OCR addon. */
+export interface OcrGgmlConfigurationParams {
+    pathDetector: string;
+    pathRecognizer: string;
+    langList: string[];
+    backendsDir?: string;
+    [key: string]: unknown;
+}
+/** Options accepted by a single OCR run. */
+export interface OcrGgmlRunOptions {
+    paragraph?: boolean;
+    boxMarginMultiplier?: number;
+    rotationAngles?: number[];
+}
+/** OCR inference job payload handed to the native runner. */
+export interface OcrGgmlJob {
+    type: "image";
+    input: {
+        data: Buffer;
+        isEncoded?: boolean;
+        width?: number;
+        height?: number;
+        bitsPerPixel?: number;
+    };
+    options?: OcrGgmlRunOptions;
+}
+/** Raw callback the native addon invokes with inference events. */
+export type OcrGgmlOutputCallback = (addon: unknown, event: unknown, data: unknown, error: unknown) => void;
+/** Native binding surface used by {@link OcrGgmlInterface}. */
+export interface OcrGgmlBinding {
+    createInstance(owner: OcrGgmlInterface, configurationParams: OcrGgmlConfigurationParams, outputCb: OcrGgmlOutputCallback): object;
+    setLogger(callback: NativeLoggerCallback): void;
+    releaseLogger(): void;
+    activate(handle: unknown): void;
+    cancel(handle: unknown): Promise<void>;
+    runJob(handle: unknown, data: OcrGgmlJob): Promise<boolean>;
+    getBackendInfo(handle: unknown): BackendInfo;
+    destroyInstance(handle: unknown): void;
+}
+/**
+ * Thin wrapper around the C++ bare addon. Mirrors the surface of
+ * `translation-nmtcpp`'s `marian.js` / `ocr-onnx`'s `ocr-fasttext.js`.
+ */
+export declare class OcrGgmlInterface {
+    private _binding;
+    private _handle;
+    private _loggerInitialized;
+    /**
+     * @param configurationParams - configuration for inference setup
+     * @param outputCb - invoked on inference events (output, error, stats)
+     * @param transitionCb - optional logger object with `info`/`warn`/`error`/`debug`
+     *   methods. When provided, C++ log lines are forwarded via `binding.setLogger`.
+     */
+    constructor(binding: OcrGgmlBinding, configurationParams: OcrGgmlConfigurationParams, outputCb: OcrGgmlOutputCallback, transitionCb?: TransitionLogger | null);
+    destroyInstance(): Promise<void>;
+    unload(): Promise<void>;
+    /**
+     * Moves the addon to LISTENING after construction-time work is finished.
+     */
+    activate(): Promise<void>;
+    cancel(): Promise<void>;
+    /**
+     * Submit an OCR inference job.
+     * @param data.type - `'image'`
+     * @param data.input - either `{ data, isEncoded: true }` for a raw JPEG/PNG
+     *   buffer, or `{ data, width, height }` for raw RGB pixels.
+     * @param data.options - optional per-run overrides.
+     */
+    runJob(data: OcrGgmlJob): Promise<boolean>;
+    /**
+     * Returns the backend device the C++ pipeline resolved for inference.
+     */
+    getBackendInfo(): BackendInfo | null;
+    destroy(): Promise<void>;
+}
+export {};

--- a/packages/ocr-ggml/ocr-ggml.js
+++ b/packages/ocr-ggml/ocr-ggml.js
@@ -1,128 +1,122 @@
-'use strict'
-
-const { QvacErrorAddonOcrGgml, ERR_CODES } = require('./lib/error')
-
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.OcrGgmlInterface = void 0;
+const error_1 = require("./lib/error");
 /**
  * Thin wrapper around the C++ bare addon. Mirrors the surface of
  * `translation-nmtcpp`'s `marian.js` / `ocr-onnx`'s `ocr-fasttext.js`.
  */
 class OcrGgmlInterface {
-  /**
-   * @param {Object} configurationParams - configuration for inference setup
-   * @param {Function} outputCb - invoked on inference events (output, error, stats)
-   * @param {Object|null} [transitionCb=null] - optional logger object with
-   *   `info`/`warn`/`error`/`debug` methods. When provided, C++ log lines are
-   *   forwarded via `binding.setLogger`.
-   */
-  constructor(binding, configurationParams, outputCb, transitionCb = null) {
-    this._binding = binding
-    this._handle = this._binding.createInstance(this, configurationParams, outputCb)
-
-    this._loggerInitialized = false
-    if (transitionCb && typeof transitionCb === 'object') {
-      this._binding.setLogger((priority, message) => {
-        const levels = ['error', 'warn', 'info', 'debug']
-        const level = levels[priority] || 'info'
-        if (typeof transitionCb[level] === 'function') {
-          transitionCb[level](message)
+    _binding;
+    _handle;
+    _loggerInitialized;
+    /**
+     * @param configurationParams - configuration for inference setup
+     * @param outputCb - invoked on inference events (output, error, stats)
+     * @param transitionCb - optional logger object with `info`/`warn`/`error`/`debug`
+     *   methods. When provided, C++ log lines are forwarded via `binding.setLogger`.
+     */
+    constructor(binding, configurationParams, outputCb, transitionCb = null) {
+        this._binding = binding;
+        this._handle = this._binding.createInstance(this, configurationParams, outputCb);
+        this._loggerInitialized = false;
+        if (transitionCb && typeof transitionCb === "object") {
+            this._binding.setLogger((priority, message) => {
+                const levels = ["error", "warn", "info", "debug"];
+                const level = levels[priority] || "info";
+                const write = transitionCb[level];
+                if (typeof write === "function") {
+                    write(message);
+                }
+            });
+            this._loggerInitialized = true;
         }
-      })
-      this._loggerInitialized = true
     }
-  }
-
-  async destroyInstance() {
-    await this.destroy()
-  }
-
-  async unload() {
-    await this.destroy()
-  }
-
-  /**
-   * Moves the addon to LISTENING after construction-time work is finished.
-   */
-  async activate() {
-    try {
-      this._binding.activate(this._handle)
-    } catch (err) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.FAILED_TO_ACTIVATE,
-        adds: err.message,
-        cause: err
-      })
+    async destroyInstance() {
+        await this.destroy();
     }
-  }
-
-  async cancel() {
-    try {
-      await this._binding.cancel(this._handle)
-    } catch (err) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.FAILED_TO_CANCEL,
-        adds: err.message,
-        cause: err
-      })
+    async unload() {
+        await this.destroy();
     }
-  }
-
-  /**
-   * Submit an OCR inference job.
-   * @param {Object} data
-   * @param {'image'} data.type
-   * @param {Object} data.input - either `{ data, isEncoded: true }` for a
-   *   raw JPEG/PNG buffer, or `{ data, width, height }` for raw RGB pixels.
-   * @param {Object} [data.options]
-   * @param {boolean} [data.options.paragraph]
-   * @param {number} [data.options.boxMarginMultiplier]
-   * @param {number[]} [data.options.rotationAngles]
-   */
-  async runJob(data) {
-    try {
-      return this._binding.runJob(this._handle, data)
-    } catch (err) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.FAILED_TO_RUN_JOB,
-        adds: err.message,
-        cause: err
-      })
+    /**
+     * Moves the addon to LISTENING after construction-time work is finished.
+     */
+    // eslint-disable-next-line @typescript-eslint/require-await -- kept async so synchronous throws surface as promise rejections (preserves the original wrapper behavior).
+    async activate() {
+        try {
+            this._binding.activate(this._handle);
+        }
+        catch (err) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.FAILED_TO_ACTIVATE,
+                adds: (0, error_1.errorMessage)(err),
+                cause: err,
+            });
+        }
     }
-  }
-
-  /**
-   * Returns the backend device the C++ pipeline resolved for inference.
-   * @returns {{ requested: string, backendDevice: string, backendName: string, deviceIndex: number, backendDescription: string, fallbackReason: string }}
-   */
-  getBackendInfo() {
-    if (this._handle === null) {
-      return null
+    async cancel() {
+        try {
+            await this._binding.cancel(this._handle);
+        }
+        catch (err) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.FAILED_TO_CANCEL,
+                adds: (0, error_1.errorMessage)(err),
+                cause: err,
+            });
+        }
     }
-    return this._binding.getBackendInfo(this._handle)
-  }
-
-  async destroy() {
-    if (this._handle === null) {
-      return
+    /**
+     * Submit an OCR inference job.
+     * @param data.type - `'image'`
+     * @param data.input - either `{ data, isEncoded: true }` for a raw JPEG/PNG
+     *   buffer, or `{ data, width, height }` for raw RGB pixels.
+     * @param data.options - optional per-run overrides.
+     */
+    async runJob(data) {
+        try {
+            // Return the native promise directly (no await): mirrors the original
+            // wrapper, where only synchronous throws from invoking runJob are
+            // wrapped and async rejections propagate unchanged.
+            return this._binding.runJob(this._handle, data);
+        }
+        catch (err) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.FAILED_TO_RUN_JOB,
+                adds: (0, error_1.errorMessage)(err),
+                cause: err,
+            });
+        }
     }
-
-    try {
-      if (this._loggerInitialized) {
-        this._binding.releaseLogger()
-        this._loggerInitialized = false
-      }
-
-      this._binding.destroyInstance(this._handle)
-      this._handle = null
-    } catch (err) {
-      throw new QvacErrorAddonOcrGgml({
-        code: ERR_CODES.FAILED_TO_DESTROY,
-        adds: err.message,
-        cause: err
-      })
+    /**
+     * Returns the backend device the C++ pipeline resolved for inference.
+     */
+    getBackendInfo() {
+        if (this._handle === null) {
+            return null;
+        }
+        return this._binding.getBackendInfo(this._handle);
     }
-  }
+    // eslint-disable-next-line @typescript-eslint/require-await -- kept async so synchronous throws surface as promise rejections (preserves the original wrapper behavior).
+    async destroy() {
+        if (this._handle === null) {
+            return;
+        }
+        try {
+            if (this._loggerInitialized) {
+                this._binding.releaseLogger();
+                this._loggerInitialized = false;
+            }
+            this._binding.destroyInstance(this._handle);
+            this._handle = null;
+        }
+        catch (err) {
+            throw new error_1.QvacErrorAddonOcrGgml({
+                code: error_1.ERR_CODES.FAILED_TO_DESTROY,
+                adds: (0, error_1.errorMessage)(err),
+                cause: err,
+            });
+        }
+    }
 }
-
-module.exports = {
-  OcrGgmlInterface
-}
+exports.OcrGgmlInterface = OcrGgmlInterface;

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -7,11 +7,18 @@
     "bare": ">=1.19.0"
   },
   "scripts": {
-    "build": "bare-make generate && bare-make build && bare-make install",
-    "build:pack": "mkdir -p dist && npm pack --pack-destination dist",
+    "build": "npm run build:ts && npm run build:native",
+    "build:native": "bare-make generate && bare-make build && bare-make install",
+    "build:ts": "tsc -p tsconfig.build.json",
+    "build:pack": "npm run build:ts && mkdir -p dist && npm pack --pack-destination dist",
+    "check:generated": "npm run build:ts && git diff --exit-code -- index.js ocr-ggml.js addonLogging.js lib/error.js index.d.ts ocr-ggml.d.ts addonLogging.d.ts lib/error.d.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "mobile:copy-prebuilds": "node ./scripts/copy-mobile-test-assets.js",
     "mobile:generate-urls": "bash ./scripts/generate-ocr-ggml-presigned-urls.sh",
-    "lint": "prettier --check \"**/*.{js,cjs,mjs}\" && lunte",
+    "lint": "npm run lint:js && npm run lint:ts",
+    "lint:js": "prettier --check \"**/*.{js,cjs,mjs}\" && lunte",
+    "lint:ts": "eslint \"src/**/*.ts\" --max-warnings=0",
+    "lint:ts:fix": "eslint \"src/**/*.ts\" --fix",
     "format": "prettier --write \"**/*.{js,cjs,mjs}\"",
     "lint-cpp": "clang-tidy -p build $(find addon/src -name '*.cpp')",
     "test:unit:generate": "brittle -r test/unit/all.js test/unit/*.test.js",
@@ -20,8 +27,9 @@
     "test:integration": "npm run test:integration:generate && bash test/integration/run-tests.sh",
     "test:mobile:generate": "bare ./scripts/generate-mobile-integration-tests.js",
     "test:mobile:validate": "node scripts/validate-mobile-tests.js",
-    "test": "npm run lint && npm run test:unit && npm run test:integration",
-    "test:dts": "tsc -p tsconfig.dts.json",
+    "test": "npm run lint && npm run test:types && npm run test:unit && npm run test:integration",
+    "test:types": "npm run typecheck && npm run check:generated",
+    "test:dts": "npm run test:types",
     "test:cpp:build": "bare-make generate -D BUILD_TESTING=ON && bare-make build --target addon-test",
     "test:cpp:run": "cd build/addon/tests/ && ./addon-test --gtest_output=xml:cpp-test-results.xml",
     "test:cpp": "npm run test:cpp:build && npm run test:cpp:run",
@@ -35,6 +43,7 @@
     "binding.js",
     "index.js",
     "ocr-ggml.js",
+    "ocr-ggml.d.ts",
     "prebuilds",
     "lib",
     "index.d.ts",
@@ -73,10 +82,14 @@
     "brittle": "^3.4.0",
     "cmake-bare": "^1.7.5",
     "cmake-vcpkg": "^1.1.0",
+    "eslint": "^9.39.4",
+    "eslint-import-resolver-typescript": "^4.4.5",
+    "eslint-plugin-import": "^2.32.0",
     "lunte": "^1.8.0",
     "prettier": "^3.6.2",
     "prettier-config-holepunch": "^2.0.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "typescript-eslint": "^8.63.0"
   },
   "dependencies": {
     "@qvac/error": "^0.1.0",
@@ -85,7 +98,10 @@
   },
   "exports": {
     "./package": "./package.json",
-    ".": "./index.js",
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
     "./addonLogging": {
       "types": "./addonLogging.d.ts",
       "default": "./addonLogging.js"

--- a/packages/ocr-ggml/src/addonLogging.ts
+++ b/packages/ocr-ggml/src/addonLogging.ts
@@ -1,0 +1,24 @@
+type NativeLoggerCallback = (priority: number, message: string) => void;
+
+interface AddonLogging {
+  setLogger: (callback: NativeLoggerCallback) => void;
+  releaseLogger: () => void;
+}
+
+interface AddonLoggingBinding {
+  setLogger: (callback: NativeLoggerCallback) => void;
+  releaseLogger: () => void;
+}
+
+const addonLogging: AddonLogging = {
+  get setLogger() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved lazily from package prebuilds.
+    return (require("./binding") as AddonLoggingBinding).setLogger;
+  },
+  get releaseLogger() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved lazily from package prebuilds.
+    return (require("./binding") as AddonLoggingBinding).releaseLogger;
+  },
+};
+
+export = addonLogging;

--- a/packages/ocr-ggml/src/bare-modules.d.ts
+++ b/packages/ocr-ggml/src/bare-modules.d.ts
@@ -1,0 +1,7 @@
+declare module "bare-fs" {
+  export function readFileSync(path: string): Buffer;
+}
+
+declare module "bare-path" {
+  export function join(...paths: string[]): string;
+}

--- a/packages/ocr-ggml/src/index.ts
+++ b/packages/ocr-ggml/src/index.ts
@@ -1,0 +1,585 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- Bare modules and @qvac/logging expose CommonJS export shapes. */
+import path = require("bare-path");
+import fs = require("bare-fs");
+import QvacLogger = require("@qvac/logging");
+/* eslint-enable @typescript-eslint/no-require-imports */
+import {
+  createJobHandler,
+  exclusiveRunQueue,
+  type JobHandler,
+  type QvacResponse,
+} from "@qvac/infer-base";
+
+import {
+  OcrGgmlInterface,
+  type BackendInfo,
+  type OcrGgmlBinding,
+  type OcrGgmlConfigurationParams,
+  type OcrGgmlRunOptions,
+} from "./ocr-ggml";
+import { QvacErrorAddonOcrGgml, ERR_CODES, errorMessage } from "./lib/error";
+
+/**
+ * OCR pipeline backing the addon.
+ *   - `easyocr` (default): CRAFT detector + CRNN gen-2 recognizer.
+ *     Uses `langList`, `magRatio`, `defaultRotationAngles`, `contrastRetry`,
+ *     `lowConfidenceThreshold`, `recognizerBatchSize`.
+ *   - `doctr`: DBNet detector + doctr recognizer.
+ *     Language-agnostic; EasyOCR-specific knobs (`magRatio`, etc.) are
+ *     ignored.
+ */
+export type OcrGgmlPipelineType = "easyocr" | "doctr";
+
+export interface OcrGgmlParams {
+  /**
+   * Path to the detector GGUF file.
+   *   - easyocr: CRAFT model (e.g. `craft_mlt_25k.gguf`)
+   *   - doctr:   DBNet model (e.g. `db_mobilenet_v3_large.gguf`)
+   */
+  pathDetector: string;
+  /**
+   * Path to the recognizer GGUF file.
+   *   - easyocr: CRNN gen-2 (e.g. `english_g2.gguf`, `latin_g2.gguf`)
+   *   - doctr:   doctr recognition model (e.g. `crnn_mobilenet_v3_small.gguf`)
+   */
+  pathRecognizer: string;
+  /** Languages handled by the recognizer (e.g. `['en']`, `['en', 'fr']`). */
+  langList: string[];
+
+  /** Pipeline backing the addon. Default: `'easyocr'`. */
+  pipelineType?: OcrGgmlPipelineType;
+  /** Detection magnification ratio (easyocr only). Default: 1.5. */
+  magRatio?: number;
+  /**
+   * EasyOCR `canvas_size`: detection canvas cap (long side, px) applied after
+   * `magRatio` scaling. Bounds CRAFT peak memory on dense/high-resolution
+   * pages; lower it (e.g. 1280) on memory-constrained targets such as mobile.
+   * Default: 2560 (matches `@qvac/ocr-onnx` / EasyOCR). easyocr only.
+   */
+  canvasSize?: number;
+  /** Rotation angles tried when the primary pass is low-confidence (easyocr only). Default: [90, 270]. */
+  defaultRotationAngles?: number[];
+  /** Retry low-confidence boxes with contrast adjustment (easyocr only). Default: false. */
+  contrastRetry?: boolean;
+  /** Threshold below which contrast-retry kicks in (easyocr only). Default: 0.4. */
+  lowConfidenceThreshold?: number;
+  /** Recognizer batch size (easyocr only). Default: 32. */
+  recognizerBatchSize?: number;
+  /**
+   * GGML CPU thread count:
+   *   - `0` (default): auto-detect physical cores (hardware_concurrency / 2, floor 1)
+   *   - `> 0`: explicit override
+   *   - `< 0`: leave GGML's CPU backend default unchanged
+   */
+  nThreads?: number;
+  /** Directory holding ggml backend shared libraries. Default: `<package>/prebuilds`. */
+  backendsDir?: string;
+  /**
+   * Requested ggml backend device. Default: `'cpu'`.
+   *   - `'cpu'`: run inference on the CPU backend (always available).
+   *   - `'vulkan'`: opt in to GPU inference on a Vulkan-capable device
+   *     (Linux/Windows/Android). Requires the `libggml-vulkan` backend shared
+   *     library to be present in `backendsDir`.
+   *   - `'metal'`: opt in to GPU inference on a Metal-capable device (Apple).
+   *     The Metal backend is compiled into the addon, so no extra shared
+   *     library is required.
+   *   - `'opencl'`: opt in to GPU inference on an OpenCL-capable device
+   *     (primarily Android/Adreno, where OpenCL is the sound GPU path).
+   *     Requires the `libggml-opencl` backend shared library to be present in
+   *     `backendsDir`.
+   * When the requested GPU device is not present the pipeline transparently
+   * falls back to CPU and records the reason (see
+   * {@link BackendInfo.fallbackReason}).
+   */
+  backendDevice?: "cpu" | "vulkan" | "metal" | "opencl";
+  /**
+   * Explicit GPU device selection for `'vulkan'` / `'metal'` / `'opencl'`.
+   * 0-based index
+   * into the GPU/iGPU devices that match the requested backend, in ggml
+   * enumeration order (the resolved index is reported as
+   * {@link BackendInfo.deviceIndex}).
+   *   - When omitted (default), selection prefers a discrete GPU and otherwise
+   *     falls back to an integrated GPU.
+   *   - When out of range, the pipeline falls back to CPU and records the
+   *     reason (see {@link BackendInfo.fallbackReason}).
+   * Ignored for `backendDevice: 'cpu'`. For pinning/reordering Vulkan devices
+   * without code you can also set the `GGML_VK_VISIBLE_DEVICES` env var (see
+   * the README).
+   */
+  gpuDevice?: number;
+}
+
+export type { BackendInfo, OcrGgmlRunOptions };
+
+export interface OcrGgmlArgs {
+  params: OcrGgmlParams;
+  opts?: { stats?: boolean };
+  logger?: QvacLogger.LoggerInterface | null;
+}
+
+export interface OcrGgmlRunInput {
+  /** Path to a JPEG, PNG, or BMP file. */
+  path: string;
+  options?: OcrGgmlRunOptions;
+}
+
+/**
+ * One detected text region. Shape matches `@qvac/ocr-onnx` so downstream
+ * consumers can swap backends without changing data handling code.
+ */
+export type InferredText = [
+  /** Bounding box: [[x,y], [x,y], [x,y], [x,y]]. */
+  [[number, number], [number, number], [number, number], [number, number]],
+  /** Recognized text. */
+  string,
+  /** Confidence in [0, 1]. */
+  number,
+];
+
+export interface InferenceClientState {
+  configLoaded: boolean;
+  weightsLoaded: boolean;
+  destroyed: boolean;
+}
+
+export interface RuntimeStats {
+  /** Total wall-clock time for the run (seconds). */
+  totalTime: number;
+  /** Detection step duration (seconds). */
+  detectionTime: number;
+  /** Recognition step duration (seconds). */
+  recognitionTime: number;
+  /** Number of detected boxes (aligned + unaligned). */
+  numBoxes: number;
+  /**
+   * Whether inference ran on a GPU (Vulkan) device (`1`) or the CPU (`0`).
+   * `RuntimeStats` values are numeric only, so this flag is the in-stats signal
+   * for the selected backend; richer string detail (name, fallback reason) is
+   * available via {@link OcrGgml.getBackendInfo}.
+   */
+  backendIsGpu: number;
+}
+
+interface ReadImageResult {
+  data: Buffer;
+  isEncoded?: boolean;
+  width?: number;
+  height?: number;
+  bitsPerPixel?: number;
+}
+
+type RunExclusive = <T>(fn: () => Promise<T>) => Promise<T>;
+
+/**
+ * GGML-backed OCR implementation.
+ *
+ * Public surface matches `@qvac/ocr-onnx` so a downstream caller can switch
+ * inference engines by swapping the import.
+ */
+export class OcrGgml {
+  opts: { stats?: boolean };
+  logger: QvacLogger;
+  addon: OcrGgmlInterface | null;
+  params: OcrGgmlParams;
+  state: InferenceClientState;
+
+  private _packageName: string;
+  private _packageVersion: string;
+  private _job: JobHandler;
+  private _run: RunExclusive;
+  private _backendInfo: BackendInfo | null;
+
+  constructor({ params, opts = {}, logger = null }: OcrGgmlArgs) {
+    this.opts = opts;
+    this.logger = new QvacLogger(logger as QvacLogger.LoggerInterface);
+    this.addon = null;
+    this.params = params;
+    this._packageName = "@qvac/ocr-ggml";
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- package metadata is read from the package root at runtime.
+    this._packageVersion = (require("./package.json") as { version: string }).version;
+    this._job = createJobHandler({ cancel: () => this.addon?.cancel() });
+    this._run = exclusiveRunQueue() as RunExclusive;
+    this._backendInfo = null;
+
+    this.state = {
+      configLoaded: false,
+      weightsLoaded: false,
+      destroyed: false,
+    };
+  }
+
+  getState(): InferenceClientState {
+    return this.state;
+  }
+
+  async load(): Promise<void> {
+    if (this.state.configLoaded || this.state.weightsLoaded) {
+      this.logger.info("Reload requested - unloading existing model first");
+      await this.unload();
+    }
+    await this._load();
+  }
+
+  async run(input: OcrGgmlRunInput): Promise<QvacResponse<InferredText[]>> {
+    return this._run(() => this._runInternal(input));
+  }
+
+  /**
+   * Backend device the C++ pipeline resolved for inference. Available after
+   * `load()`; `null` before load or after unload.
+   */
+  getBackendInfo(): BackendInfo | null {
+    return this._backendInfo;
+  }
+
+  async unload(): Promise<void> {
+    if (this.addon) {
+      await this.addon.destroy();
+      this.addon = null;
+    }
+    this._backendInfo = null;
+    this.state.configLoaded = false;
+    this.state.weightsLoaded = false;
+  }
+
+  async destroy(): Promise<void> {
+    await this.unload();
+    this.state.destroyed = true;
+  }
+
+  private async _load(): Promise<void> {
+    if (!this.params || typeof this.params !== "object") {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.MISSING_REQUIRED_PARAMETER,
+        adds: "params object is required",
+      });
+    }
+
+    if (!this.params.pathDetector) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.MISSING_REQUIRED_PARAMETER,
+        adds: "pathDetector",
+      });
+    }
+    if (!this.params.pathRecognizer) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.MISSING_REQUIRED_PARAMETER,
+        adds: "pathRecognizer",
+      });
+    }
+    if (!Array.isArray(this.params.langList) || this.params.langList.length === 0) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.MISSING_REQUIRED_PARAMETER,
+        adds: "langList (non-empty array)",
+      });
+    }
+
+    const SUPPORTED_LANGUAGES = new Set(["en"]);
+    const hasSupported = this.params.langList.some((l) => SUPPORTED_LANGUAGES.has(l));
+    if (!hasSupported) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.UNSUPPORTED_LANGUAGE,
+        adds: `none of the requested languages are supported: ${this.params.langList.join(", ")}`,
+      });
+    }
+
+    const configurationParams: OcrGgmlConfigurationParams = {
+      pathDetector: this.params.pathDetector,
+      pathRecognizer: this.params.pathRecognizer,
+      langList: this.params.langList,
+    };
+
+    // Forward optional config knobs only when explicitly set so the C++
+    // defaults (in OcrConfig) win otherwise.
+    const optionalFields: (keyof OcrGgmlParams)[] = [
+      "magRatio",
+      "canvasSize",
+      "defaultRotationAngles",
+      "contrastRetry",
+      "lowConfidenceThreshold",
+      "recognizerBatchSize",
+      "nThreads",
+      "pipelineType",
+      "backendDevice",
+      "gpuDevice",
+    ];
+    for (const field of optionalFields) {
+      if (this.params[field] !== undefined) {
+        (configurationParams as Record<string, unknown>)[field] = this.params[field];
+      }
+    }
+
+    configurationParams.backendsDir =
+      this.params.backendsDir !== undefined
+        ? this.params.backendsDir
+        : path.join(__dirname, "prebuilds");
+
+    this.logger.info("Creating ocr-ggml addon");
+    this.addon = this._createAddon(configurationParams);
+    await this.addon.activate();
+    this.state.configLoaded = true;
+    this.state.weightsLoaded = true;
+
+    // Capture the backend device the C++ pipeline actually resolved (Vulkan vs
+    // CPU fallback). RuntimeStats can only carry numbers, so backend identity
+    // strings are surfaced here and via _getDiagnosticsJSON().
+    try {
+      this._backendInfo = this.addon.getBackendInfo();
+      if (this._backendInfo) {
+        this.logger.info("ocr-ggml backend: " + JSON.stringify(this._backendInfo));
+      }
+    } catch (err) {
+      this.logger.warn("ocr-ggml: failed to read backend info: " + errorMessage(err));
+      this._backendInfo = null;
+    }
+
+    this.logger.info("ocr-ggml model loaded");
+  }
+
+  private _createAddon(configurationParams: OcrGgmlConfigurationParams): OcrGgmlInterface {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved lazily from package prebuilds.
+    const binding = require("./binding") as OcrGgmlBinding;
+    return new OcrGgmlInterface(
+      binding,
+      configurationParams,
+      this._addonOutputCallback.bind(this),
+      this.logger,
+    );
+  }
+
+  private async _runInternal(input: OcrGgmlRunInput): Promise<QvacResponse<InferredText[]>> {
+    this.logger.info("Starting OCR inference");
+
+    if (!this.addon) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.NOT_LOADED,
+        adds: "call load() before run()",
+      });
+    }
+
+    const response = this._job.start() as QvacResponse<InferredText[]>;
+    try {
+      const imageInput = this._readImage(input.path);
+      await this.addon.runJob({
+        type: "image",
+        input: imageInput,
+        options: input.options,
+      });
+    } catch (err) {
+      this._job.fail(err as Error);
+      throw err;
+    }
+    return response;
+  }
+
+  /**
+   * Read an image file from disk and prepare it for the addon. Mirrors the
+   * ocr-onnx convention: JPEG / PNG are passed encoded to the addon (decoded
+   * by OpenCV in C++); BMP is decoded in JS to raw RGB.
+   */
+  private _readImage(imagePath: string): ReadImageResult {
+    this.logger.debug("Reading image from path:", imagePath);
+    const contents = fs.readFileSync(imagePath);
+    if (!contents || contents.length < 4) {
+      this.logger.error("Invalid image file or insufficient data");
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+        adds: imagePath,
+      });
+    }
+
+    // JPEG: starts with 0xFF 0xD8
+    if (contents[0] === 0xff && contents[1] === 0xd8) {
+      return { data: contents, isEncoded: true };
+    }
+    // PNG: 0x89 P N G
+    if (
+      contents[0] === 0x89 &&
+      contents[1] === 0x50 &&
+      contents[2] === 0x4e &&
+      contents[3] === 0x47
+    ) {
+      return { data: contents, isEncoded: true };
+    }
+    // BMP: 'BM'
+    if (contents[0] === 0x42 && contents[1] === 0x4d) {
+      return this._decodeBmp(contents, imagePath);
+    }
+
+    this.logger.error("Unsupported image format");
+    throw new QvacErrorAddonOcrGgml({
+      code: ERR_CODES.UNSUPPORTED_IMAGE_FORMAT,
+      adds: imagePath,
+    });
+  }
+
+  private _decodeBmp(contents: Buffer, imagePath: string): ReadImageResult {
+    if (contents.length < 14 + 4) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+        adds: imagePath,
+      });
+    }
+
+    const infoHeaderSize = contents.readUInt32LE(14);
+    if (contents.length < 14 + infoHeaderSize) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+        adds: imagePath,
+      });
+    }
+
+    let width: number, height: number, bitsPerPixel: number;
+    if (infoHeaderSize >= 40) {
+      width = contents.readInt32LE(18);
+      height = contents.readInt32LE(22);
+      bitsPerPixel = contents.readUInt16LE(28);
+    } else if (infoHeaderSize >= 12) {
+      width = contents.readUInt16LE(18);
+      height = contents.readInt16LE(20);
+      bitsPerPixel = 24;
+    } else {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.UNSUPPORTED_IMAGE_FORMAT,
+        adds: `BMP header size ${infoHeaderSize}`,
+      });
+    }
+
+    if (width <= 0 || height === 0) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+        adds: `${imagePath} (invalid BMP dimensions ${width}x${height})`,
+      });
+    }
+
+    const SUPPORTED_BITS = new Set([8, 24, 32]);
+    if (!SUPPORTED_BITS.has(bitsPerPixel)) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.UNSUPPORTED_IMAGE_FORMAT,
+        adds: `BMP bitsPerPixel ${bitsPerPixel} (supported: 8, 24, 32)`,
+      });
+    }
+
+    const pixelDataOffset = contents.readUInt32LE(10);
+    if (pixelDataOffset >= contents.length) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+        adds: `${imagePath} (BMP pixelDataOffset ${pixelDataOffset} out of range)`,
+      });
+    }
+    const pixelDataBuffer = contents.slice(pixelDataOffset);
+
+    const bytesPerPixel = bitsPerPixel / 8;
+    const unpaddedRowSize = width * bytesPerPixel;
+    const paddedRowSize = Math.ceil(unpaddedRowSize / 4) * 4;
+    const rows = Math.abs(height);
+
+    if (pixelDataBuffer.length < rows * paddedRowSize) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA,
+        adds: imagePath,
+      });
+    }
+
+    const unpaddedData = Buffer.alloc(rows * unpaddedRowSize);
+    for (let row = 0; row < rows; row++) {
+      const srcStart = row * paddedRowSize;
+      const srcEnd = srcStart + unpaddedRowSize;
+      let destRow = row;
+      if (height > 0) destRow = rows - row - 1;
+      const destStart = destRow * unpaddedRowSize;
+      pixelDataBuffer.copy(unpaddedData, destStart, srcStart, srcEnd);
+    }
+
+    return { width, height: rows, data: unpaddedData, bitsPerPixel };
+  }
+
+  private _addonOutputCallback(
+    _addon: unknown,
+    event: unknown,
+    data: unknown,
+    error: unknown,
+  ): void {
+    if (typeof event === "string" && event.includes("Error")) {
+      return this._job.fail(error as Error);
+    }
+
+    // JobEnded may arrive with stats payload, with null (stats disabled), or
+    // not at all on some platforms - handle the event name explicitly so
+    // await() doesn't hang when data is null.
+    if (event === "JobEnded") {
+      const isStatsObject =
+        typeof data === "object" &&
+        data !== null &&
+        !Array.isArray(data) &&
+        ("totalTime" in data || "detectionTime" in data);
+      if (isStatsObject) {
+        this.logger.info("OCR inference completed. Stats:", JSON.stringify(data));
+      }
+      return this._job.end(this.opts?.stats && isStatsObject ? data : null);
+    }
+
+    // Some addon paths surface stats without a 'JobEnded' event name; keep
+    // the legacy heuristic as a fallback so we still close the job.
+    const isStatsObject =
+      typeof data === "object" &&
+      data !== null &&
+      !Array.isArray(data) &&
+      ("totalTime" in data || "detectionTime" in data);
+    if (isStatsObject) {
+      this.logger.info("OCR inference completed. Stats:", JSON.stringify(data));
+      return this._job.end(this.opts?.stats ? data : null);
+    }
+
+    if (Array.isArray(data)) {
+      return this._job.output(data);
+    }
+  }
+
+  /** Inference Manager diagnostics hook (parity with ocr-onnx). */
+  _getDiagnosticsJSON(): string {
+    return JSON.stringify({
+      status: this.state.destroyed
+        ? "destroyed"
+        : this.state.configLoaded
+          ? "loaded"
+          : "not_loaded",
+      params: this.params,
+      backend: this._backendInfo,
+    });
+  }
+
+  /** Inference Manager hooks (parity with ocr-onnx) */
+  static inferenceManagerConfig = {
+    noAdditionalDownload: true,
+  };
+
+  static getModelKey(): string {
+    return "ocr-ggml";
+  }
+}
+
+export { QvacErrorAddonOcrGgml, ERR_CODES };
+
+export declare const modelClass: typeof OcrGgml;
+export declare const modelFile: unknown;
+export declare const binding: unknown;
+export declare const addonLogging: unknown;
+
+module.exports = {
+  OcrGgml,
+  modelClass: OcrGgml,
+  get modelFile() {
+    return (require as unknown as { addon: { resolve(id: string): unknown } }).addon.resolve(".");
+  },
+  QvacErrorAddonOcrGgml,
+  ERR_CODES,
+  get binding() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- native binding is resolved lazily from package prebuilds.
+    return require("./binding") as unknown;
+  },
+  get addonLogging() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- resolved lazily to defer native binding load.
+    return require("./addonLogging") as unknown;
+  },
+};

--- a/packages/ocr-ggml/src/lib/error.ts
+++ b/packages/ocr-ggml/src/lib/error.ts
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- @qvac/error exposes a CommonJS export shape. */
+import QvacError = require("@qvac/error");
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const { QvacErrorBase, addCodes } = QvacError;
+
+export class QvacErrorAddonOcrGgml extends QvacErrorBase {}
+
+/** Extract a human-readable message from an unknown thrown value. */
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object" && "message" in err) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string" && message) return message;
+  }
+  return typeof err === "string" ? err : "unknown error";
+}
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- package metadata is read from the package root at runtime.
+const { name, version } = require("../package.json") as {
+  name: string;
+  version: string;
+};
+
+// Allocated error code range: 8101..8200
+// (translation-nmtcpp uses 8001..9000 broadly; ocr-onnx claims its own block.)
+export const ERR_CODES = Object.freeze({
+  FAILED_TO_LOAD_WEIGHTS: 8101,
+  FAILED_TO_CANCEL: 8102,
+  FAILED_TO_RUN_JOB: 8103,
+  FAILED_TO_GET_STATUS: 8104,
+  FAILED_TO_DESTROY: 8105,
+  FAILED_TO_ACTIVATE: 8106,
+  MISSING_REQUIRED_PARAMETER: 8107,
+  UNSUPPORTED_LANGUAGE: 8108,
+  INVALID_IMAGE_OR_INSUFFICIENT_DATA: 8109,
+  UNSUPPORTED_IMAGE_FORMAT: 8110,
+  NOT_LOADED: 8111,
+});
+
+addCodes(
+  {
+    [ERR_CODES.FAILED_TO_LOAD_WEIGHTS]: {
+      name: "FAILED_TO_LOAD_WEIGHTS",
+      message: (message: string) => `Failed to load weights, error: ${message}`,
+    },
+    [ERR_CODES.FAILED_TO_CANCEL]: {
+      name: "FAILED_TO_CANCEL",
+      message: (message: string) =>
+        `Failed to cancel inference, error: ${message}`,
+    },
+    [ERR_CODES.FAILED_TO_RUN_JOB]: {
+      name: "FAILED_TO_RUN_JOB",
+      message: (message: string) => `Failed to run OCR job, error: ${message}`,
+    },
+    [ERR_CODES.FAILED_TO_GET_STATUS]: {
+      name: "FAILED_TO_GET_STATUS",
+      message: (message: string) =>
+        `Failed to get addon status, error: ${message}`,
+    },
+    [ERR_CODES.FAILED_TO_DESTROY]: {
+      name: "FAILED_TO_DESTROY",
+      message: (message: string) =>
+        `Failed to destroy instance, error: ${message}`,
+    },
+    [ERR_CODES.FAILED_TO_ACTIVATE]: {
+      name: "FAILED_TO_ACTIVATE",
+      message: (message: string) =>
+        `Failed to activate model, error: ${message}`,
+    },
+    [ERR_CODES.MISSING_REQUIRED_PARAMETER]: {
+      name: "MISSING_REQUIRED_PARAMETER",
+      message: (message: string) => `Missing required parameter: ${message}`,
+    },
+    [ERR_CODES.UNSUPPORTED_LANGUAGE]: {
+      name: "UNSUPPORTED_LANGUAGE",
+      message: (message: string) => `Unsupported language(s): ${message}`,
+    },
+    [ERR_CODES.INVALID_IMAGE_OR_INSUFFICIENT_DATA]: {
+      name: "INVALID_IMAGE_OR_INSUFFICIENT_DATA",
+      message: (message: string) =>
+        `Invalid image file or insufficient data: ${message}`,
+    },
+    [ERR_CODES.UNSUPPORTED_IMAGE_FORMAT]: {
+      name: "UNSUPPORTED_IMAGE_FORMAT",
+      message: (message: string) => `Unsupported image format: ${message}`,
+    },
+    [ERR_CODES.NOT_LOADED]: {
+      name: "NOT_LOADED",
+      message: (message: string) => `OCR model is not loaded: ${message}`,
+    },
+  },
+  {
+    name,
+    version,
+  },
+);

--- a/packages/ocr-ggml/src/ocr-ggml.ts
+++ b/packages/ocr-ggml/src/ocr-ggml.ts
@@ -1,0 +1,225 @@
+import { QvacErrorAddonOcrGgml, ERR_CODES, errorMessage } from "./lib/error";
+
+type NativeLoggerCallback = (priority: number, message: string) => void;
+
+type LogLevel = "error" | "warn" | "info" | "debug";
+
+/**
+ * Logger object forwarded to the native `setLogger` bridge. Any subset of the
+ * four level methods may be provided; each receives a formatted C++ log line.
+ */
+export interface TransitionLogger {
+  error?: (message: string) => void;
+  warn?: (message: string) => void;
+  info?: (message: string) => void;
+  debug?: (message: string) => void;
+}
+
+/**
+ * Backend device the C++ pipeline resolved for inference, as reported by the
+ * native `getBackendInfo` binding.
+ */
+export interface BackendInfo {
+  /** Requested device (`'cpu'` | `'vulkan'` | `'metal'` | `'opencl'`). */
+  requested: string;
+  /** Resolved device type (`'CPU'` | `'GPU'` | `'IGPU'` | `'ACCEL'`). */
+  backendDevice: string;
+  /** ggml backend/device name of the resolved device (e.g. `'Vulkan0'`, `'CPU'`). */
+  backendName: string;
+  /**
+   * ggml device index of the selected device (the index into the loaded ggml
+   * devices), or `-1` when the CPU backend was selected (including fallback).
+   */
+  deviceIndex: number;
+  /** Human-readable device description (e.g. `'NVIDIA GeForce RTX 4090'`, `'Apple M3'`); empty when ggml provides none. */
+  backendDescription: string;
+  /** Empty when the requested device was used; otherwise why it fell back to CPU. */
+  fallbackReason: string;
+}
+
+/** Configuration object passed through to the native OCR addon. */
+export interface OcrGgmlConfigurationParams {
+  pathDetector: string;
+  pathRecognizer: string;
+  langList: string[];
+  backendsDir?: string;
+  [key: string]: unknown;
+}
+
+/** Options accepted by a single OCR run. */
+export interface OcrGgmlRunOptions {
+  paragraph?: boolean;
+  boxMarginMultiplier?: number;
+  rotationAngles?: number[];
+}
+
+/** OCR inference job payload handed to the native runner. */
+export interface OcrGgmlJob {
+  type: "image";
+  input: {
+    data: Buffer;
+    isEncoded?: boolean;
+    width?: number;
+    height?: number;
+    bitsPerPixel?: number;
+  };
+  options?: OcrGgmlRunOptions;
+}
+
+/** Raw callback the native addon invokes with inference events. */
+export type OcrGgmlOutputCallback = (
+  addon: unknown,
+  event: unknown,
+  data: unknown,
+  error: unknown,
+) => void;
+
+/** Native binding surface used by {@link OcrGgmlInterface}. */
+export interface OcrGgmlBinding {
+  createInstance(
+    owner: OcrGgmlInterface,
+    configurationParams: OcrGgmlConfigurationParams,
+    outputCb: OcrGgmlOutputCallback,
+  ): object;
+  setLogger(callback: NativeLoggerCallback): void;
+  releaseLogger(): void;
+  activate(handle: unknown): void;
+  cancel(handle: unknown): Promise<void>;
+  runJob(handle: unknown, data: OcrGgmlJob): Promise<boolean>;
+  getBackendInfo(handle: unknown): BackendInfo;
+  destroyInstance(handle: unknown): void;
+}
+
+/**
+ * Thin wrapper around the C++ bare addon. Mirrors the surface of
+ * `translation-nmtcpp`'s `marian.js` / `ocr-onnx`'s `ocr-fasttext.js`.
+ */
+export class OcrGgmlInterface {
+  private _binding: OcrGgmlBinding;
+  private _handle: object | null;
+  private _loggerInitialized: boolean;
+
+  /**
+   * @param configurationParams - configuration for inference setup
+   * @param outputCb - invoked on inference events (output, error, stats)
+   * @param transitionCb - optional logger object with `info`/`warn`/`error`/`debug`
+   *   methods. When provided, C++ log lines are forwarded via `binding.setLogger`.
+   */
+  constructor(
+    binding: OcrGgmlBinding,
+    configurationParams: OcrGgmlConfigurationParams,
+    outputCb: OcrGgmlOutputCallback,
+    transitionCb: TransitionLogger | null = null,
+  ) {
+    this._binding = binding;
+    this._handle = this._binding.createInstance(
+      this,
+      configurationParams,
+      outputCb,
+    );
+
+    this._loggerInitialized = false;
+    if (transitionCb && typeof transitionCb === "object") {
+      this._binding.setLogger((priority: number, message: string) => {
+        const levels: LogLevel[] = ["error", "warn", "info", "debug"];
+        const level = levels[priority] || "info";
+        const write = transitionCb[level];
+        if (typeof write === "function") {
+          write(message);
+        }
+      });
+      this._loggerInitialized = true;
+    }
+  }
+
+  async destroyInstance(): Promise<void> {
+    await this.destroy();
+  }
+
+  async unload(): Promise<void> {
+    await this.destroy();
+  }
+
+  /**
+   * Moves the addon to LISTENING after construction-time work is finished.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await -- kept async so synchronous throws surface as promise rejections (preserves the original wrapper behavior).
+  async activate(): Promise<void> {
+    try {
+      this._binding.activate(this._handle);
+    } catch (err) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.FAILED_TO_ACTIVATE,
+        adds: errorMessage(err),
+        cause: err as Error,
+      });
+    }
+  }
+
+  async cancel(): Promise<void> {
+    try {
+      await this._binding.cancel(this._handle);
+    } catch (err) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.FAILED_TO_CANCEL,
+        adds: errorMessage(err),
+        cause: err as Error,
+      });
+    }
+  }
+
+  /**
+   * Submit an OCR inference job.
+   * @param data.type - `'image'`
+   * @param data.input - either `{ data, isEncoded: true }` for a raw JPEG/PNG
+   *   buffer, or `{ data, width, height }` for raw RGB pixels.
+   * @param data.options - optional per-run overrides.
+   */
+  async runJob(data: OcrGgmlJob): Promise<boolean> {
+    try {
+      // Return the native promise directly (no await): mirrors the original
+      // wrapper, where only synchronous throws from invoking runJob are
+      // wrapped and async rejections propagate unchanged.
+      return this._binding.runJob(this._handle, data);
+    } catch (err) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.FAILED_TO_RUN_JOB,
+        adds: errorMessage(err),
+        cause: err as Error,
+      });
+    }
+  }
+
+  /**
+   * Returns the backend device the C++ pipeline resolved for inference.
+   */
+  getBackendInfo(): BackendInfo | null {
+    if (this._handle === null) {
+      return null;
+    }
+    return this._binding.getBackendInfo(this._handle);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await -- kept async so synchronous throws surface as promise rejections (preserves the original wrapper behavior).
+  async destroy(): Promise<void> {
+    if (this._handle === null) {
+      return;
+    }
+
+    try {
+      if (this._loggerInitialized) {
+        this._binding.releaseLogger();
+        this._loggerInitialized = false;
+      }
+
+      this._binding.destroyInstance(this._handle);
+      this._handle = null;
+    } catch (err) {
+      throw new QvacErrorAddonOcrGgml({
+        code: ERR_CODES.FAILED_TO_DESTROY,
+        adds: errorMessage(err),
+        cause: err as Error,
+      });
+    }
+  }
+}

--- a/packages/ocr-ggml/tsconfig.build.json
+++ b/packages/ocr-ggml/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": false,
+    "noEmit": false,
+    "outDir": ".",
+    "rootDir": "src",
+    "sourceMap": false
+  },
+  "exclude": []
+}

--- a/packages/ocr-ggml/tsconfig.dts.json
+++ b/packages/ocr-ggml/tsconfig.dts.json
@@ -1,17 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022"],
-    "types": ["node"],
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "verbatimModuleSyntax": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noEmit": true
-  },
-  "include": ["index.d.ts", "addonLogging.d.ts"]
+  "extends": "./tsconfig.json"
 }

--- a/packages/ocr-ggml/tsconfig.json
+++ b/packages/ocr-ggml/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `@qvac/ocr-ggml` keeps its runtime wrapper and TypeScript declarations as separate hand-maintained files, which drift as the addon API changes.
- Aligns the package with the addon TypeScript-migration pattern established for `@qvac/classification-ggml` (ref #3192): author sources in TypeScript while still publishing JavaScript entrypoints for SDK and Bare consumers.

## 📝 How does it solve it?

- Adds TypeScript-authored wrapper sources under `src/` (`index.ts`, `ocr-ggml.ts`, `addonLogging.ts`, `lib/error.ts`, plus `bare-modules.d.ts` ambient declarations for `bare-fs`/`bare-path`).
- Generates and commits the root JavaScript entrypoints and `.d.ts` declarations from the TS sources (`index.js`, `index.d.ts`, `ocr-ggml.js`, new `ocr-ggml.d.ts`, `addonLogging.js`, `addonLogging.d.ts`, `lib/error.js`, new `lib/error.d.ts`), preserving the existing CommonJS export shapes — including the lazy `modelFile`/`binding`/`addonLogging` getters on the root export.
- Adds `tsconfig.json` (typecheck) and `tsconfig.build.json` (emit JS + declarations to package root), and simplifies `tsconfig.dts.json`.
- Adds SDK-aligned strict TypeScript ESLint config (`eslint.config.mjs`); updates `.prettierignore` / `.lunteignore` so generated output is excluded and TS sources stay in ESLint's domain.
- Updates `package.json`: `build:ts`, `build:native`, `typecheck`, `check:generated` (generated-output freshness gate), `lint:js` / `lint:ts`, `test:types`; ships `ocr-ggml.d.ts` in `files`; upgrades the `.` export to `types` + `default` conditions (classification-style).
- Updates the publish workflow (`on-merge-ocr-ggml.yml`) to rebuild the TypeScript wrapper before publishing to GPR and npm.

## 🧪 How was it tested?

- `npm run build:ts` — success; committed output matches (`check:generated` clean)
- `npm run typecheck` (`tsc --noEmit`) — clean
- `npm run lint` — JS (prettier + lunte) and TS (eslint, `--max-warnings=0`) both pass
- `npm run test:unit` — 5/5 tests, 11/11 asserts pass under Bare
- `npm pack --dry-run` — all entrypoints + declarations packed (48 files), `src/` excluded
- Export-shape parity verified against the previous JS: root export keeps the exact 7-key object with lazy getters (`modelFile` → `require.addon.resolve(".")`, `binding`, `addonLogging`); `addonLogging.js` still defers the native binding load
- Integration/mobile/C++ tests require native prebuilds and were not run locally (same limitation as the reference PRs); CI covers them
