### PR TITLE
QVAC-22035 infra: verify fabric prebuild symbols and run win32 integration on GPU runner

### DIFF
--- a/.github/actions/verify-prebuild-symbols/action.yml
+++ b/.github/actions/verify-prebuild-symbols/action.yml
@@ -40,6 +40,12 @@ runs:
         export NM="${TOOLCHAIN}/bin/llvm-nm"
         EXTRA=""
         if [ "$ENFORCE_EXPORTS" = "true" ]; then EXTRA="--enforce-exports"; fi
+        # Fabric consumers link the shared runtime (DT_NEEDED qvac__fabric@0.bare),
+        # which ships in node_modules -- not beside the addon -- and is pre-loaded
+        # at runtime. Index it as an external provider so its ggml_* exports resolve
+        # the addon's UND engine symbols instead of a false-positive hard-fail.
+        FABRIC_PREBUILDS="node_modules/@qvac/fabric/prebuilds"
+        if [ -d "$FABRIC_PREBUILDS" ]; then EXTRA="$EXTRA --provider-dir $FABRIC_PREBUILDS"; fi
         node "$GITHUB_ACTION_PATH/verify-prebuild-symbols.mjs" --dir prebuilds --platform android $EXTRA
 
     - if: ${{ inputs.platform == 'linux' || inputs.platform == 'darwin' || inputs.platform == 'ios' }}
@@ -53,6 +59,12 @@ runs:
         set -euo pipefail
         EXTRA=""
         if [ "$ENFORCE_EXPORTS" = "true" ]; then EXTRA="--enforce-exports"; fi
+        # Fabric consumers link the shared runtime (DT_NEEDED qvac__fabric@0.bare),
+        # which ships in node_modules -- not beside the addon -- and is pre-loaded
+        # at runtime. Index it as an external provider so its ggml_* exports resolve
+        # the addon's UND engine symbols instead of a false-positive hard-fail.
+        FABRIC_PREBUILDS="node_modules/@qvac/fabric/prebuilds"
+        if [ -d "$FABRIC_PREBUILDS" ]; then EXTRA="$EXTRA --provider-dir $FABRIC_PREBUILDS"; fi
         node "$GITHUB_ACTION_PATH/verify-prebuild-symbols.mjs" --dir prebuilds --platform "$PLATFORM" $EXTRA
 
     - if: ${{ inputs.platform == 'win32' }}

--- a/.github/actions/verify-prebuild-symbols/action.yml
+++ b/.github/actions/verify-prebuild-symbols/action.yml
@@ -40,10 +40,9 @@ runs:
         export NM="${TOOLCHAIN}/bin/llvm-nm"
         EXTRA=""
         if [ "$ENFORCE_EXPORTS" = "true" ]; then EXTRA="--enforce-exports"; fi
-        # Fabric consumers link the shared runtime (DT_NEEDED qvac__fabric@0.bare),
-        # which ships in node_modules -- not beside the addon -- and is pre-loaded
-        # at runtime. Index it as an external provider so its ggml_* exports resolve
-        # the addon's UND engine symbols instead of a false-positive hard-fail.
+        # When @qvac/fabric is installed, index its prebuilds as an external provider.
+        # The script matches provider exports to each binary's DT_NEEDED by soname, so
+        # mere presence of the package in node_modules cannot mask a genuine UND.
         FABRIC_PREBUILDS="node_modules/@qvac/fabric/prebuilds"
         if [ -d "$FABRIC_PREBUILDS" ]; then EXTRA="$EXTRA --provider-dir $FABRIC_PREBUILDS"; fi
         node "$GITHUB_ACTION_PATH/verify-prebuild-symbols.mjs" --dir prebuilds --platform android $EXTRA
@@ -59,10 +58,9 @@ runs:
         set -euo pipefail
         EXTRA=""
         if [ "$ENFORCE_EXPORTS" = "true" ]; then EXTRA="--enforce-exports"; fi
-        # Fabric consumers link the shared runtime (DT_NEEDED qvac__fabric@0.bare),
-        # which ships in node_modules -- not beside the addon -- and is pre-loaded
-        # at runtime. Index it as an external provider so its ggml_* exports resolve
-        # the addon's UND engine symbols instead of a false-positive hard-fail.
+        # When @qvac/fabric is installed, index its prebuilds as an external provider.
+        # The script matches provider exports to each binary's DT_NEEDED by soname, so
+        # mere presence of the package in node_modules cannot mask a genuine UND.
         FABRIC_PREBUILDS="node_modules/@qvac/fabric/prebuilds"
         if [ -d "$FABRIC_PREBUILDS" ]; then EXTRA="$EXTRA --provider-dir $FABRIC_PREBUILDS"; fi
         node "$GITHUB_ACTION_PATH/verify-prebuild-symbols.mjs" --dir prebuilds --platform "$PLATFORM" $EXTRA

--- a/.github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs
+++ b/.github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs
@@ -27,12 +27,28 @@
 //      Pass `--enforce-exports` to turn leaked engine exports into a hard fail
 //      (see packages/transcription-parakeet/symbols.map for the fix template).
 //
+// A DT_NEEDED provider does not have to sit in the scanned prebuilds/ tree. The
+// shared @qvac/fabric runtime (`qvac__fabric@0.bare`) ships in node_modules, not
+// beside the addon, and is pre-loaded (`require('@qvac/fabric')` in binding.js)
+// before the addon is dlopen'd -- so its `ggml_*` exports resolve the addon's UND
+// engine symbols at runtime. Point the check at it with
+// `--provider-dir node_modules/@qvac/fabric/prebuilds` so those symbols count as
+// provided instead of reading as a false-positive UND hard-fail. A provider dir's
+// exports form a GLOBAL satisfied pool (they are NOT matched to a DT_NEEDED soname:
+// the addon needs the ABI-versioned `qvac__fabric@0.bare` while the file on disk is
+// the unversioned `qvac__fabric.bare`). The pool only ever satisfies symbols the
+// runtime truly exports, so a symbol nobody provides still fails. Provider dirs are
+// never themselves checked.
+//
 // Usage:
 //   node verify-prebuild-symbols.mjs --dir <prebuilds-dir> [options]
 //   node verify-prebuild-symbols.mjs <prebuilds-dir>
 //
 // Options:
 //   --dir <path>            Directory to scan recursively (repeatable). Default: ./prebuilds
+//   --provider-dir <path>   Extra directory (repeatable) whose binaries contribute
+//                           DT_NEEDED-provider exports but are NOT checked. Use for
+//                           the shared @qvac/fabric runtime in node_modules.
 //   --platform <p>          linux|android|darwin|ios|win32 (informational; affects messaging)
 //   --engine-prefixes <csv> Symbol roots treated as engine-internal.
 //                           Default: ggml,gguf,llama,whisper,clip,mtmd,sd,stable_diffusion
@@ -70,6 +86,7 @@ function fail (msg) {
 function parseArgs (argv) {
   const opts = {
     dirs: [],
+    providerDirs: [],
     platform: process.env.PREBUILD_PLATFORM || '',
     enginePrefixes: ['ggml', 'gguf', 'llama', 'whisper', 'clip', 'mtmd', 'sd', 'stable_diffusion'],
     enforceExports: false,
@@ -83,6 +100,7 @@ function parseArgs (argv) {
     const a = argv[i]
     switch (a) {
       case '--dir': opts.dirs.push(argv[++i]); break
+      case '--provider-dir': opts.providerDirs.push(argv[++i]); break
       case '--platform': opts.platform = argv[++i]; break
       case '--engine-prefixes': opts.enginePrefixes = argv[++i].split(',').map(s => s.trim()).filter(Boolean); break
       case '--enforce-exports': opts.enforceExports = true; break
@@ -103,7 +121,7 @@ function parseArgs (argv) {
 
 function printHelp () {
   const text = process.argv[1] ? `node ${basename(process.argv[1])}` : 'verify-prebuild-symbols'
-  console.log(`Usage: ${text} --dir <prebuilds-dir> [--platform p] [--enforce-exports] [--engine-prefixes csv] [--json]`)
+  console.log(`Usage: ${text} --dir <prebuilds-dir> [--provider-dir path] [--platform p] [--enforce-exports] [--engine-prefixes csv] [--json]`)
 }
 
 // ---------------------------------------------------------------------------
@@ -264,16 +282,54 @@ function main () {
     process.exit(0)
   }
 
-  // Pre-index exported symbols of every binary by soname so DT_NEEDED lookups
-  // can resolve against co-located libraries.
+  // Pre-index exported symbols by soname (on-disk basename) so DT_NEEDED lookups
+  // resolve against co-located libraries. External --provider-dir trees (e.g. the
+  // shared @qvac/fabric runtime, which lives in node_modules rather than beside
+  // the addon) contribute their exports to the SAME index but are never checked.
   const exportsBySoname = new Map()
   const fmtByPath = new Map()
-  for (const p of binaries) {
+
+  function indexExports (p) {
     const fmt = detectFormat(p)
-    fmtByPath.set(p, fmt)
+    if (fmt === 'unknown') return fmt
+    const { exported } = symbolsOf(tools, p, fmt)
+    const key = basename(p)
+    const prev = exportsBySoname.get(key)
+    // Union across hosts/dirs: the same soname (qvac__fabric@0.bare) appears once
+    // per platform subdir; each exports the same C ABI, so merging is correct.
+    if (prev) for (const s of exported) prev.add(s)
+    else exportsBySoname.set(key, new Set(exported))
+    return fmt
+  }
+
+  for (const p of binaries) {
+    fmtByPath.set(p, indexExports(p))
+  }
+
+  // Provider binaries (--provider-dir) contribute their exports to a GLOBAL pool
+  // that satisfies any addon's UND engine imports -- NOT keyed by DT_NEEDED soname.
+  // Passing a provider dir is an explicit assertion that those libs are supplied at
+  // runtime (e.g. @qvac/fabric, preloaded via require('@qvac/fabric') before the
+  // addon is dlopen'd). Soname-matching them is wrong here: the addon's DT_NEEDED is
+  // the ABI-versioned soname `qvac__fabric@0.bare`, but the file staged on disk is
+  // the unversioned `qvac__fabric.bare` (bare maps the soname to the loaded module
+  // by name at runtime), so a basename lookup would always miss. The pool can only
+  // satisfy symbols the runtime actually exports, so a genuinely-unprovided symbol
+  // (nobody exports it) still fails. Provider binaries are never themselves checked
+  // (the fabric runtime legitimately carries its own UND backend symbols + ggml_*
+  // exports, which would false-positive under the UND / export-hygiene checks).
+  const providerExports = new Set()
+  const providerBinaries = []
+  for (const d of opts.providerDirs) walk(resolve(d), providerBinaries)
+  for (const p of providerBinaries) {
+    const fmt = detectFormat(p)
     if (fmt === 'unknown') continue
     const { exported } = symbolsOf(tools, p, fmt)
-    exportsBySoname.set(basename(p), exported)
+    for (const s of exported) providerExports.add(s)
+  }
+
+  if (opts.providerDirs.length > 0 && !opts.quiet) {
+    console.log(`verify-prebuild-symbols: pooled ${providerExports.size} exported symbol(s) from ${providerBinaries.length} external provider binary(ies) in ${opts.providerDirs.join(', ')}.`)
   }
 
   // DT_NEEDED provider resolution (ELF) requires readelf; without it every
@@ -314,6 +370,7 @@ function main () {
     for (const s of undefined_) {
       if (!isEngineSymbol(s, opts.enginePrefixes)) continue
       if (provided.has(s)) continue
+      if (providerExports.has(s)) continue // supplied by a --provider-dir runtime
       unresolvedEngine.push(s)
     }
 

--- a/.github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs
+++ b/.github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs
@@ -27,18 +27,23 @@
 //      Pass `--enforce-exports` to turn leaked engine exports into a hard fail
 //      (see packages/transcription-parakeet/symbols.map for the fix template).
 //
-// A DT_NEEDED provider does not have to sit in the scanned prebuilds/ tree. The
-// shared @qvac/fabric runtime (`qvac__fabric@0.bare`) ships in node_modules, not
-// beside the addon, and is pre-loaded (`require('@qvac/fabric')` in binding.js)
-// before the addon is dlopen'd -- so its `ggml_*` exports resolve the addon's UND
-// engine symbols at runtime. Point the check at it with
-// `--provider-dir node_modules/@qvac/fabric/prebuilds` so those symbols count as
-// provided instead of reading as a false-positive UND hard-fail. A provider dir's
-// exports form a GLOBAL satisfied pool (they are NOT matched to a DT_NEEDED soname:
-// the addon needs the ABI-versioned `qvac__fabric@0.bare` while the file on disk is
-// the unversioned `qvac__fabric.bare`). The pool only ever satisfies symbols the
-// runtime truly exports, so a symbol nobody provides still fails. Provider dirs are
-// never themselves checked.
+// A DT_NEEDED provider does not have to sit in the scanned prebuilds/ tree. A shared
+// runtime like @qvac/fabric (`qvac__fabric@0.bare`) ships in node_modules, not beside
+// the addon, and is pre-loaded (`require('@qvac/fabric')` in binding.js) before the
+// addon is dlopen'd -- so its `ggml_*` exports resolve the addon's UND engine symbols
+// at runtime. Point the check at it with `--provider-dir <path>` (repeatable) and its
+// binaries join DT_NEEDED resolution exactly like co-located libs, with two twists:
+//   * they are indexed by their real DT_SONAME (read from the binary), not their
+//     on-disk basename -- the addon's DT_NEEDED is the ABI-versioned soname
+//     `qvac__fabric@0.bare` while the staged file is the unversioned `qvac__fabric.bare`,
+//     so a basename key would never match.
+//   * they are never themselves checked (a runtime legitimately carries its own UND
+//     backend symbols + engine exports that would false-positive the UND / export checks).
+// Because resolution is still keyed on each binary's own DT_NEEDED, a provider only
+// satisfies symbols for addons that actually link it: a package that merely has the
+// provider in node_modules without a matching DT_NEEDED is NOT masked, and a symbol
+// nobody exports still fails. The mechanism is generic -- pass any provider tree; there
+// is no runtime-specific special-casing.
 //
 // Usage:
 //   node verify-prebuild-symbols.mjs --dir <prebuilds-dir> [options]
@@ -46,9 +51,10 @@
 //
 // Options:
 //   --dir <path>            Directory to scan recursively (repeatable). Default: ./prebuilds
-//   --provider-dir <path>   Extra directory (repeatable) whose binaries contribute
-//                           DT_NEEDED-provider exports but are NOT checked. Use for
-//                           the shared @qvac/fabric runtime in node_modules.
+//   --provider-dir <path>   Extra directory (repeatable) whose binaries are indexed by
+//                           their DT_SONAME to satisfy DT_NEEDED imports but are NOT
+//                           themselves checked. Use for a shared runtime that ships
+//                           outside the addon tree (e.g. @qvac/fabric in node_modules).
 //   --platform <p>          linux|android|darwin|ios|win32 (informational; affects messaging)
 //   --engine-prefixes <csv> Symbol roots treated as engine-internal.
 //                           Default: ggml,gguf,llama,whisper,clip,mtmd,sd,stable_diffusion
@@ -254,6 +260,22 @@ function neededOf (tools, path, format) {
   return needed
 }
 
+// The DT_SONAME a binary advertises -- this is what a consumer's DT_NEEDED holds,
+// and it can diverge from the on-disk filename (e.g. `qvac__fabric@0.bare` soname
+// staged as `qvac__fabric.bare`). ELF-only; '' when absent or readelf unavailable.
+function sonameOf (tools, path, format) {
+  if (format !== 'elf' || !tools.readelf) return ''
+  let out = ''
+  try {
+    out = execFileSync(tools.readelf, ['-d', '--wide', path], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+  } catch (e) { out = e.stdout ? e.stdout.toString() : '' }
+  for (const line of out.split('\n')) {
+    const m = line.match(/\(SONAME\)\s+Library soname:\s+\[([^\]]+)\]/)
+    if (m) return m[1]
+  }
+  return ''
+}
+
 // ---------------------------------------------------------------------------
 // Core check
 // ---------------------------------------------------------------------------
@@ -282,54 +304,43 @@ function main () {
     process.exit(0)
   }
 
-  // Pre-index exported symbols by soname (on-disk basename) so DT_NEEDED lookups
-  // resolve against co-located libraries. External --provider-dir trees (e.g. the
-  // shared @qvac/fabric runtime, which lives in node_modules rather than beside
-  // the addon) contribute their exports to the SAME index but are never checked.
+  // Index exported symbols by DT_NEEDED key so per-binary lookups resolve against
+  // their declared dependencies. Co-located libs are keyed by on-disk basename
+  // (filename == soname for qvac's backend libs today). External --provider-dir
+  // trees are keyed by their real DT_SONAME instead, since a shared runtime's soname
+  // diverges from its staged filename (`qvac__fabric@0.bare` vs `qvac__fabric.bare`);
+  // provider exports are never themselves checked.
   const exportsBySoname = new Map()
   const fmtByPath = new Map()
 
-  function indexExports (p) {
-    const fmt = detectFormat(p)
-    if (fmt === 'unknown') return fmt
-    const { exported } = symbolsOf(tools, p, fmt)
-    const key = basename(p)
+  function addExports (key, exported) {
     const prev = exportsBySoname.get(key)
-    // Union across hosts/dirs: the same soname (qvac__fabric@0.bare) appears once
+    // Union across hosts/dirs: the same key (e.g. qvac__fabric@0.bare) appears once
     // per platform subdir; each exports the same C ABI, so merging is correct.
     if (prev) for (const s of exported) prev.add(s)
     else exportsBySoname.set(key, new Set(exported))
-    return fmt
   }
 
   for (const p of binaries) {
-    fmtByPath.set(p, indexExports(p))
+    const fmt = detectFormat(p)
+    fmtByPath.set(p, fmt)
+    if (fmt === 'unknown') continue
+    addExports(basename(p), symbolsOf(tools, p, fmt).exported)
   }
 
-  // Provider binaries (--provider-dir) contribute their exports to a GLOBAL pool
-  // that satisfies any addon's UND engine imports -- NOT keyed by DT_NEEDED soname.
-  // Passing a provider dir is an explicit assertion that those libs are supplied at
-  // runtime (e.g. @qvac/fabric, preloaded via require('@qvac/fabric') before the
-  // addon is dlopen'd). Soname-matching them is wrong here: the addon's DT_NEEDED is
-  // the ABI-versioned soname `qvac__fabric@0.bare`, but the file staged on disk is
-  // the unversioned `qvac__fabric.bare` (bare maps the soname to the loaded module
-  // by name at runtime), so a basename lookup would always miss. The pool can only
-  // satisfy symbols the runtime actually exports, so a genuinely-unprovided symbol
-  // (nobody exports it) still fails. Provider binaries are never themselves checked
-  // (the fabric runtime legitimately carries its own UND backend symbols + ggml_*
-  // exports, which would false-positive under the UND / export-hygiene checks).
-  const providerExports = new Set()
   const providerBinaries = []
   for (const d of opts.providerDirs) walk(resolve(d), providerBinaries)
   for (const p of providerBinaries) {
     const fmt = detectFormat(p)
     if (fmt === 'unknown') continue
-    const { exported } = symbolsOf(tools, p, fmt)
-    for (const s of exported) providerExports.add(s)
+    // Key on the advertised soname (fallback to basename) so it matches consumers'
+    // DT_NEEDED entries, not the on-disk filename.
+    const key = sonameOf(tools, p, fmt) || basename(p)
+    addExports(key, symbolsOf(tools, p, fmt).exported)
   }
 
   if (opts.providerDirs.length > 0 && !opts.quiet) {
-    console.log(`verify-prebuild-symbols: pooled ${providerExports.size} exported symbol(s) from ${providerBinaries.length} external provider binary(ies) in ${opts.providerDirs.join(', ')}.`)
+    console.log(`verify-prebuild-symbols: indexed ${providerBinaries.length} external provider binary(ies) by soname from ${opts.providerDirs.join(', ')}.`)
   }
 
   // DT_NEEDED provider resolution (ELF) requires readelf; without it every
@@ -351,14 +362,15 @@ function main () {
 
     const { undefined_, exported } = symbolsOf(tools, p, fmt)
 
-    // Provider set = exported symbols of co-located DT_NEEDED libs.
-    // NOTE: exportsBySoname is keyed by on-disk basename, while DT_NEEDED holds
-    // sonames. They coincide for qvac's backend libs today (filename == soname),
-    // but if a soname (libfoo.so.1) ever diverged from the filename
-    // (libfoo.so.1.2.3 + a symlink) and the symlink weren't staged in prebuilds/,
-    // this lookup would miss and a genuinely-resolved symbol would read as
-    // unresolved. Latent fragility -- revisit if a backend lib grows a versioned
-    // soname.
+    // Provider set = exported symbols of this binary's DT_NEEDED libs, resolved
+    // against the shared index. That index keys co-located libs by on-disk basename
+    // (filename == soname for qvac's backend libs today) and --provider-dir libs by
+    // their real DT_SONAME, so a shared runtime whose soname diverges from its staged
+    // filename (`qvac__fabric@0.bare` vs `qvac__fabric.bare`) still resolves. A binary
+    // that does not DT_NEEDED a provider gets nothing from it -- so the pool cannot
+    // mask a genuine UND on an addon that merely has the provider in node_modules.
+    // (Latent fragility: a co-located backend lib whose soname diverged from its
+    // filename -- libfoo.so.1 vs libfoo.so.1.2.3 -- would miss the basename key.)
     const needed = neededOf(tools, p, fmt)
     const provided = new Set()
     for (const soname of needed) {
@@ -370,7 +382,6 @@ function main () {
     for (const s of undefined_) {
       if (!isEngineSymbol(s, opts.enginePrefixes)) continue
       if (provided.has(s)) continue
-      if (providerExports.has(s)) continue // supplied by a --provider-dir runtime
       unresolvedEngine.push(s)
     }
 

--- a/.github/workflows/gate-selftest.yml
+++ b/.github/workflows/gate-selftest.yml
@@ -64,8 +64,8 @@ jobs:
           # pre-loaded at runtime, not co-located beside the addon). Critically, the
           # provider FILE on disk is the unversioned `qvac__fabric.bare` while the
           # addon's DT_NEEDED is the ABI-versioned SONAME `qvac__fabric@0.bare` -- the
-          # real fabric layout. A basename-keyed lookup misses this divergence, so the
-          # provider exports must be pooled globally (this is what regressed once).
+          # real fabric layout. The gate must index the provider by its DT_SONAME (not
+          # its basename) to match the DT_NEEDED across this divergence.
           rm -rf /tmp/prov
           mkdir -p /tmp/prov/prebuilds/linux-x64 /tmp/prov/providers/linux-x64
           printf 'int ggml_test_symbol(void){return 42;}\n' > /tmp/prov/provider.c
@@ -82,6 +82,26 @@ jobs:
           # With --provider-dir the fabric exports resolve the UND import -> MUST pass.
           node .github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs --dir /tmp/prov/prebuilds --provider-dir /tmp/prov/providers --platform linux
           echo "OK: gate passed once the shared-runtime provider was indexed via --provider-dir."
+
+      - name: Gate MUST NOT mask UND symbols when --provider-dir is present but the addon does not DT_NEEDED it
+        shell: bash
+        run: |
+          set -euo pipefail
+          # An addon with a genuine UND ggml_* and NO DT_NEEDED on the provider soname
+          # must still hard-fail even when a --provider-dir is indexed (e.g. @qvac/fabric
+          # happens to be in node_modules but this binary does not dynamically link it).
+          # Proves resolution is keyed on each binary's own DT_NEEDED, not a global pool.
+          rm -rf /tmp/mask
+          mkdir -p /tmp/mask/prebuilds/linux-x64 /tmp/mask/providers/linux-x64
+          printf 'int ggml_test_symbol(void){return 42;}\n' > /tmp/mask/provider.c
+          printf 'extern int ggml_test_symbol(void);\nint addon_entry(void){return ggml_test_symbol();}\n' > /tmp/mask/addon.c
+          cc -shared -fPIC -Wl,-soname,qvac__fabric@0.bare -o /tmp/mask/providers/linux-x64/qvac__fabric.bare /tmp/mask/provider.c
+          cc -shared -fPIC -o /tmp/mask/prebuilds/linux-x64/qvac__static.bare /tmp/mask/addon.c
+          if node .github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs --dir /tmp/mask/prebuilds --provider-dir /tmp/mask/providers --platform linux; then
+            echo "::error::Gate PASSED on an addon without a matching DT_NEEDED -- the provider index would mask a genuine dlopen-crash UND."
+            exit 1
+          fi
+          echo "OK: gate hard-failed when the provider was indexed but the addon did not DT_NEEDED its soname."
 
   fleet-dryrun:
     # De-risks the fleet-wide activation flagged in review: the gate runs inside

--- a/.github/workflows/gate-selftest.yml
+++ b/.github/workflows/gate-selftest.yml
@@ -54,6 +54,35 @@ jobs:
           node .github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs --dir /tmp/good/package/prebuilds/android-arm64 --platform android
           echo "OK: gate correctly passed on 0.2.0."
 
+      - name: Gate MUST resolve engine symbols against an external --provider-dir
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Reproduce the shared-runtime (@qvac/fabric) case: an addon .bare with an
+          # UND ggml_* symbol + DT_NEEDED on qvac__fabric@0.bare, whose provider lives
+          # OUTSIDE the scanned prebuilds/ tree (it ships in node_modules and is
+          # pre-loaded at runtime, not co-located beside the addon). Critically, the
+          # provider FILE on disk is the unversioned `qvac__fabric.bare` while the
+          # addon's DT_NEEDED is the ABI-versioned SONAME `qvac__fabric@0.bare` -- the
+          # real fabric layout. A basename-keyed lookup misses this divergence, so the
+          # provider exports must be pooled globally (this is what regressed once).
+          rm -rf /tmp/prov
+          mkdir -p /tmp/prov/prebuilds/linux-x64 /tmp/prov/providers/linux-x64
+          printf 'int ggml_test_symbol(void){return 42;}\n' > /tmp/prov/provider.c
+          printf 'extern int ggml_test_symbol(void);\nint addon_entry(void){return ggml_test_symbol();}\n' > /tmp/prov/addon.c
+          cc -shared -fPIC -Wl,-soname,qvac__fabric@0.bare -o /tmp/prov/providers/linux-x64/qvac__fabric.bare /tmp/prov/provider.c
+          cc -shared -fPIC -o /tmp/prov/prebuilds/linux-x64/qvac__addon.bare /tmp/prov/addon.c -L/tmp/prov/providers/linux-x64 -l:qvac__fabric.bare -Wl,--no-as-needed
+          # Without the provider dir the engine symbol is unresolved -> MUST hard-fail
+          # (proves --provider-dir did not neuter the real UND check).
+          if node .github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs --dir /tmp/prov/prebuilds --platform linux; then
+            echo "::error::Gate PASSED with the shared-runtime provider absent -- it would miss a genuinely-unresolved engine symbol."
+            exit 1
+          fi
+          echo "OK: gate hard-failed when the shared-runtime provider was not indexed."
+          # With --provider-dir the fabric exports resolve the UND import -> MUST pass.
+          node .github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs --dir /tmp/prov/prebuilds --provider-dir /tmp/prov/providers --platform linux
+          echo "OK: gate passed once the shared-runtime provider was indexed via --provider-dir."
+
   fleet-dryrun:
     # De-risks the fleet-wide activation flagged in review: the gate runs inside
     # reusable-prebuilds.yml, which all 14 prebuild-*.yml callers reference by

--- a/.github/workflows/integration-test-classification-ggml.yml
+++ b/.github/workflows/integration-test-classification-ggml.yml
@@ -57,9 +57,13 @@ jobs:
             platform: darwin
             arch: arm64
             runner: qvac-macos26-arm64-gpu
-          - os: windows-2022
+          # @qvac/fabric hard-imports vulkan-1.dll on Windows; the self-hosted
+          # qvac-win25-x64-gpu runner has the Vulkan loader installed (same env
+          # as llm-llamacpp and other fabric consumers being migrated).
+          - os: windows-2025
             platform: win32
             arch: x64
+            runner: qvac-win25-x64-gpu
 
     steps:
       - name: Manual Workspace Cleanup

--- a/.github/workflows/integration-test-classification-ggml.yml
+++ b/.github/workflows/integration-test-classification-ggml.yml
@@ -57,11 +57,10 @@ jobs:
             platform: darwin
             arch: arm64
             runner: qvac-macos26-arm64-gpu
-          # @qvac/fabric hard-imports vulkan-1.dll on Windows; the self-hosted
-          # qvac-win25-x64-gpu runner has the Vulkan loader installed (same env
-          # as llm-llamacpp and other fabric consumers being migrated).
-          - os: windows-2025
-            platform: win32
+          # @qvac/fabric hard-imports vulkan-1.dll on Windows; qvac-win25-x64-gpu has
+          # the Vulkan loader installed (same env as llm-llamacpp and other fabric
+          # consumers being migrated).
+          - platform: win32
             arch: x64
             runner: qvac-win25-x64-gpu
 


### PR DESCRIPTION
## 🎯 What problem does this PR solve?

- `verify-prebuild-symbols` false-fails fabric consumers: thin addons with `DT_NEEDED qvac__fabric@0.bare` and UND `ggml_*` imports look unresolved because `@qvac/fabric` ships in `node_modules`, not beside the addon prebuild
- Soname mismatch makes basename lookup wrong: DT_NEEDED is `qvac__fabric@0.bare` but the on-disk file is `qvac__fabric.bare`
- Classification win32 integration fails on GitHub-hosted `windows-2022`: `@qvac/fabric` hard-imports `vulkan-1.dll`, which is not available there

## 📝 How does it solve it?

- Add `--provider-dir` to `verify-prebuild-symbols.mjs`: pool exports from external provider trees (e.g. `node_modules/@qvac/fabric/prebuilds`) into a global satisfied set without checking the provider binaries themselves
- Auto-wire `--provider-dir` in the composite action when `@qvac/fabric` prebuilds are present after `npm install`
- Add a `gate-selftest.yml` regression that proves unresolved symbols still hard-fail without the provider dir, and pass with it
- Move classification win32 integration from `windows-2022` to self-hosted `qvac-win25-x64-gpu` (same env as `llm-llamacpp` and other fabric consumers)

**Files changed (4):**

| File | Change |
|------|--------|
| `.github/actions/verify-prebuild-symbols/verify-prebuild-symbols.mjs` | `--provider-dir` + global export pool |
| `.github/actions/verify-prebuild-symbols/action.yml` | Auto-detect fabric prebuilds |
| `.github/workflows/gate-selftest.yml` | Regression test for provider-dir |
| `.github/workflows/integration-test-classification-ggml.yml` | Win32 → `qvac-win25-x64-gpu` |

**Merge note:** `reusable-prebuilds.yml` pins `verify-prebuild-symbols`. After this PR merges, update that pin to this PR’s merge commit.

## 🧪 How was it tested?

- `gate-selftest` regression added for `--provider-dir` behavior
- Classification integration verified on `QVAC-22035` branch with full clean pass after switching win32 to `qvac-win25-x64-gpu` (including fabric load on Windows)

### Semantic note (exportsBySoname indexing)

The `indexExports` refactor changes same-basename indexing from last-write-wins to **union** when the same soname appears in multiple subdirs (e.g. per-platform trees under a multi-dir scan). This is intentional: fabric consumers share one C ABI across arches, and prebuild scans are single-platform in practice — so merging export sets is correct and avoids missing symbols when the same backend lib basename appears more than once.
