### PR TITLE
QVAC-22385 chore: bump consumer package versions for qvac-fabric 9840.0.0

### DIFF
--- a/packages/classification-ggml/CHANGELOG.md
+++ b/packages/classification-ggml/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-07-20
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.1.6` → `9840.0.0` (llama.cpp b9840 rebase; no API change for this package).
+
+### Pull Requests
+
+- [#3036](https://github.com/tetherto/qvac/pull/3036) - QVAC-22385 rebase qvac-fabric to b9840 (9840.0.0)
+
 ## [0.12.0] - 2026-07-16
 
 ### Changed

--- a/packages/classification-ggml/package.json
+++ b/packages/classification-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/classification-ggml",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "GGML image classification addon for QVAC (MobileNetV3-Small CPU inference)",
   "addon": true,
   "scripts": {

--- a/packages/embed-llamacpp/CHANGELOG.md
+++ b/packages/embed-llamacpp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.28.0] - 2026-07-20
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.1.6` → `9840.0.0` (llama.cpp b9840 rebase; no API change for this package).
+
+### Pull Requests
+
+- [#3036](https://github.com/tetherto/qvac/pull/3036) - QVAC-22385 rebase qvac-fabric to b9840 (9840.0.0)
+
 ## [0.27.0] - 2026-07-14
 
 ### Fixed

--- a/packages/embed-llamacpp/package.json
+++ b/packages/embed-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/embed-llamacpp",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "bert addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.38.0] - 2026-07-20
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.1.6` → `9840.0.0` (llama.cpp b9840 rebase; no API change for this package).
+
+### Pull Requests
+
+- [#3036](https://github.com/tetherto/qvac/pull/3036) - QVAC-22385 rebase qvac-fabric to b9840 (9840.0.0)
+
 ## [0.37.1] - 2026-07-18
 
 This patch release hardens reasoning-cache rollback when generation is truncated before a reasoning span closes. It covers both explicit `n_predict` limits and continuous-batching per-sequence slot limits, preserving the last known-good cache state instead of attempting unsafe reasoning compaction.

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/ocr-ggml/CHANGELOG.md
+++ b/packages/ocr-ggml/CHANGELOG.md
@@ -10,6 +10,16 @@ project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Migrated the runtime wrapper and type declarations to TypeScript. Sources now live under `src/` and the published root JavaScript entrypoints (`index.js`, `ocr-ggml.js`, `addonLogging.js`, `lib/error.js`) and `.d.ts` declarations are generated from them and committed. Public API, CommonJS export shape, and OCR output are unchanged.
 
+## [0.12.0] - 2026-07-20
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.1.6` → `9840.0.0` (llama.cpp b9840 rebase; no API change for this package).
+
+### Pull Requests
+
+- [#3036](https://github.com/tetherto/qvac/pull/3036) - QVAC-22385 rebase qvac-fabric to b9840 (9840.0.0)
+
 ## [0.11.0] - 2026-07-14
 
 ### Fixed

--- a/packages/ocr-ggml/package.json
+++ b/packages/ocr-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/ocr-ggml",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "GGML-backed OCR addon for qvac (EasyOCR pipeline on GGUF weights)",
   "addon": true,
   "engines": {

--- a/packages/translation-nmtcpp/CHANGELOG.md
+++ b/packages/translation-nmtcpp/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.0] - 2026-07-20
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.1.6` → `9840.0.0` (llama.cpp b9840 rebase; no API change for this package).
+
+### Pull Requests
+
+- [#3036](https://github.com/tetherto/qvac/pull/3036) - QVAC-22385 rebase qvac-fabric to b9840 (9840.0.0)
+
 ## [8.0.0] - 2026-07-14
 
 ### Fixed

--- a/packages/translation-nmtcpp/package.json
+++ b/packages/translation-nmtcpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/translation-nmtcpp",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "translation addon for qvac",
   "addon": true,
   "engines": {

--- a/packages/vla-ggml/CHANGELOG.md
+++ b/packages/vla-ggml/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.13.0] - 2026-07-20
+
+### Changed
+
+- `qvac-fabric` dependency bumped `9341.1.6` → `9840.0.0` (llama.cpp b9840 rebase; no API change for this package).
+
+### Pull Requests
+
+- [#3036](https://github.com/tetherto/qvac/pull/3036) - QVAC-22385 rebase qvac-fabric to b9840 (9840.0.0)
+
 ## [0.12.0] - 2026-07-14
 
 ### Fixed

--- a/packages/vla-ggml/package.json
+++ b/packages/vla-ggml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/vla-ggml",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "VLA vision-language-action inference addon for QVAC (ggml backend)",
   "addon": true,
   "engines": {


### PR DESCRIPTION
## 🎯 Problem

The 6 `qvac-fabric` consumers were switched to depend on `qvac-fabric 9840.0.0` (llama.cpp b9840) in [#3036](https://github.com/tetherto/qvac/pull/3036), but that PR was scoped to the vcpkg `version>=` bump only — no package version bumps or CHANGELOG entries. Their published versions therefore don't yet reflect the new fabric base.

## 📝 How

Minor version bump + a CHANGELOG entry for each consumer, documenting the `qvac-fabric 9341.1.6 → 9840.0.0` dependency bump:

| Package | version |
|---|---|
| classification-ggml | 0.12.0 → 0.13.0 |
| embed-llamacpp | 0.27.0 → 0.28.0 |
| llm-llamacpp | 0.37.1 → 0.38.0 |
| ocr-ggml | 0.11.0 → 0.12.0 |
| translation-nmtcpp | 8.0.0 → 8.1.0 |
| vla-ggml | 0.12.0 → 0.13.0 |

`ocr-ggml` keeps its existing `## [Unreleased]` section on top, with the new `## [0.12.0]` entry inserted below it.

Rollout chain: fabric [PR #176](https://github.com/tetherto/qvac-fabric-llm.cpp/pull/176) (b9840) → registry [PR #252](https://github.com/tetherto/qvac-registry-vcpkg/pull/252) (`qvac-fabric 9840.0.0`, merged) → consumer dependency switch [#3036](https://github.com/tetherto/qvac/pull/3036) (merged) → **this PR** (versions + changelogs).

## 🧪 Tested

Version/CHANGELOG-only change — no source or native changes. The b9840 consumer builds and integration tests were validated on #3036.

## ⚠️ Breaking

None. No API changes for any package.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216605680938561