### PR TITLE
QVAC-22472 fix: back-port n_predict-inside-reasoning rollback to llm-llamacpp 0.36.4

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.36.4] - 2026-07-20
+
+Back-port of QVAC-22472 to the 0.36 line (for @qvac/sdk 0.15): hardens reasoning-cache rollback when generation is truncated before a reasoning span closes. It covers both explicit `n_predict` limits and continuous-batching per-sequence slot limits, preserving the last known-good cache state instead of attempting unsafe reasoning compaction.
+
+### Fixed
+
+- Qwen3.5 text and multimodal requests now roll back the current request when `n_predict` is reached inside an open reasoning span, avoiding recurrent compaction failures when no close marker was captured.
+- Continuous batching now propagates scheduler-imposed per-sequence slot truncation as `SequenceLimit`, allowing the driver to use the same rollback path as prediction-limit truncation.
+- Batch stop-reason precedence now preserves `Eos` > `PredictionLimit` > `Antiprompt`, so `n_predict` truncation still triggers rollback when a stop string would also match on the same token.
+- Added focused C++ regression coverage for MTMD `n_predict` rollback, scheduler `LimitReached` propagation, Qwen3.5 continuous-batching sequence-limit rollback, and sibling request survival.
+
+### Pull Requests
+
+- [#3337](https://github.com/tetherto/qvac/pull/3337) - QVAC-22472 fix: back-port n_predict-inside-reasoning rollback to llm-llamacpp 0.36.4
+- [#3318](https://github.com/tetherto/qvac/pull/3318) - QVAC-22472 fix: handle Qwen3.5 n_predict cutoff inside reasoning
+
 ## [0.36.3] - 2026-07-09
 
 This patch release makes continuous-batch runtime stats wait for backend work to complete before reporting throughput. It also hardens cancellation and reset cleanup around asynchronous llama decode work so KV and recurrent state are not mutated while queued GPU work is still in flight.

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.cpp
@@ -111,10 +111,13 @@ bool finalizeTerminalDriver(
   }
   if (prefillOnly) {
     driver.onSequenceEnd(outputCallback);
+    return true;
   } else {
-    driver.onGenerationFinished(outputCallback);
+    const GenerationStopReason terminalReason =
+        reason == StopReason::LimitReached ? GenerationStopReason::SequenceLimit
+                                           : GenerationStopReason::None;
+    return driver.onGenerationFinished(outputCallback, terminalReason);
   }
-  return true;
 }
 
 bool computeSlideCapable(

--- a/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ContinuousBatchScheduler.hpp
@@ -38,10 +38,11 @@ namespace qvac_lib_inference_addon_llama::batching {
 ///
 /// Returns `true` when the terminal hook left the driver in a state safe
 /// to persist via `saveCache`. Cancel/DecodeError paths forward
-/// `onCancel`'s rollback-ok signal; other terminal paths always return
-/// `true`. Callers that persist cache MUST skip `saveCache` when this
-/// returns `false` so a failed recurrent rollback cannot leak the
-/// cancelled request into the on-disk cache.
+/// `onCancel`'s rollback-ok signal; natural generation forwards
+/// `onGenerationFinished` so a prediction-limit rollback can also veto
+/// persistence. Prefill-only paths always return `true`. Callers that
+/// persist cache MUST skip `saveCache` when this returns `false` so a
+/// failed recurrent rollback cannot leak the request into the on-disk cache.
 [[nodiscard]] bool finalizeTerminalDriver(
     SequenceDriver& driver, StopReason reason, bool prefillOnly,
     const std::function<void(const std::string&)>& outputCallback);

--- a/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/LlmContext.hpp
@@ -244,8 +244,9 @@ public:
    * @param outputCallback - the output callback.
    * @return - ok=false for context overflow; cancelled=true when generation
    * was stopped by user cancellation; rollbackOk=false when a cancellation
-   * could not restore the pre-request recurrent state and callers must skip
-   * cache persistence for this request.
+   * or prediction-limit truncation inside reasoning could not restore the
+   * pre-request recurrent state and callers must skip cache persistence for
+   * this request.
    */
   virtual GenerateResponseResult generateResponse(
       const std::function<void(const std::string&)>& outputCallback) = 0;

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.cpp
@@ -719,8 +719,8 @@ void MtmdLlmContext::flushPendingUtf8ToCallback(
 
 bool MtmdLlmContext::cancelGenerationCleanup(
     const std::function<void(const std::string&)>& outputCallback) {
-  // Cancel = "request never happened": roll back to the pre-request
-  // cursor for both prefill- and decode-stage cancels.
+  // Rollback = "request never happened": roll back to the pre-request
+  // cursor for both cancellation and n_predict truncation inside reasoning.
   // `reasoningBoundary` is compaction-only and not used here — restoring
   // it would leak the cancelled prompt / generated-prefix state into
   // the cache.
@@ -769,6 +769,10 @@ bool MtmdLlmContext::cancelGenerationCleanup(
   rollbackState_.clearReasoningBoundary();
   rollbackState_.clearPostReasoning();
   compactor_.clearSpan();
+  generationStopReason_ = GenerationStopReason::None;
+  // The sampled tokens were accepted before rollback; clear sampler history so
+  // the next clean request cannot inherit a request that "never happened".
+  common_sampler_reset(smpl_.get());
   return rollbackOk;
 }
 
@@ -818,6 +822,7 @@ LlmContext::GenerateResponseResult MtmdLlmContext::generateResponse(
   reasoningState_.inside_reasoning = false;
   reasoningState_.recent_output_buffer.clear();
   compactor_.reset();
+  generationStopReason_ = GenerationStopReason::None;
 
   if (thinkingForcedOpen_) {
     if (outputCallback) {
@@ -867,6 +872,7 @@ LlmContext::GenerateResponseResult MtmdLlmContext::generateResponse(
               protectedPrefix_.pos,
               tools_.anchor(),
               tools_.enabled() ? "true" : "false"));
+      generationStopReason_ = GenerationStopReason::ContextOverflow;
       return {.ok = false};
     }
     applyContextDiscard();
@@ -946,6 +952,7 @@ LlmContext::GenerateResponseResult MtmdLlmContext::generateResponse(
         }
       }
       flushPendingUtf8ToCallback(outputCallback);
+      generationStopReason_ = GenerationStopReason::Eos;
       break;
     }
 
@@ -987,11 +994,15 @@ LlmContext::GenerateResponseResult MtmdLlmContext::generateResponse(
       ++current_.cacheTokens;
       capturePendingThinkClose();
       flushPendingUtf8ToCallback(outputCallback);
+      generationStopReason_ = GenerationStopReason::Eos;
       break;
     }
 
-    if (isEos || checkAntiprompt()) {
+    const bool stoppedByAntiprompt = checkAntiprompt();
+    if (isEos || stoppedByAntiprompt) {
       flushPendingUtf8ToCallback(outputCallback);
+      generationStopReason_ =
+          isEos ? GenerationStopReason::Eos : GenerationStopReason::Antiprompt;
       break;
     }
 
@@ -1025,17 +1036,13 @@ LlmContext::GenerateResponseResult MtmdLlmContext::generateResponse(
         .cancelled = true,
         .rollbackOk = cancelGenerationCleanup(outputCallback)};
   }
-  if (nRemain == 0) {
-    flushPendingUtf8ToCallback(outputCallback);
+  if (generationStopReason_ == GenerationStopReason::None &&
+      params_.n_predict > 0 && nRemain == 0) {
+    generationStopReason_ = GenerationStopReason::PredictionLimit;
   }
-  // Drop the reasoning block from the KV cache if the caller opted
-  // in and a `<think>...</think>` (or model-equivalent) was emitted.
-  compactThinkSpan();
-  // Generation completed; cancel cannot fire anymore so the
-  // prefill-entry rollback checkpoint is no longer reachable. Drop
-  // its temp file now instead of waiting for the next inference.
-  rollbackState_.clearPrefillEntry();
-  return {};
+  const bool rollbackOk =
+      onGenerationFinished(outputCallback, generationStopReason_);
+  return {.rollbackOk = rollbackOk};
 }
 
 std::function<void()>
@@ -1774,7 +1781,11 @@ SequenceStepResult MtmdLlmContext::onLogitsReady(
             current_.pos,
             current_.cacheTokens,
             ctxCeiling()));
-    return {.finished = true, .contextOverflow = true};
+    generationStopReason_ = GenerationStopReason::ContextOverflow;
+    return {
+        .finished = true,
+        .contextOverflow = true,
+        .stopReason = GenerationStopReason::ContextOverflow};
   }
   // No applyContextDiscard here: the batcher's per-sequence cap stops a
   // slot before its window fills, and sliding a sequence that holds
@@ -1864,7 +1875,11 @@ SequenceStepResult MtmdLlmContext::onLogitsReady(
       }
     }
     flushPendingUtf8ToCallback(outputCallback);
-    return {.token = tokenId, .finished = true};
+    generationStopReason_ = GenerationStopReason::Eos;
+    return {
+        .token = tokenId,
+        .finished = true,
+        .stopReason = GenerationStopReason::Eos};
   }
 
   // Batch path only: scheduler stops solely on `finished` (see
@@ -1872,11 +1887,20 @@ SequenceStepResult MtmdLlmContext::onLogitsReady(
   const bool reachedBudget =
       inlineDecodeBatch == nullptr && params_.n_predict > 0 &&
       generatedAfterAccept >= static_cast<unsigned>(params_.n_predict);
-  const bool finished = isEos || reachedBudget || checkAntiprompt();
+  GenerationStopReason stopReason = GenerationStopReason::None;
+  if (isEos) {
+    stopReason = GenerationStopReason::Eos;
+  } else if (reachedBudget) {
+    stopReason = GenerationStopReason::PredictionLimit;
+  } else if (checkAntiprompt()) {
+    stopReason = GenerationStopReason::Antiprompt;
+  }
+  const bool finished = stopReason != GenerationStopReason::None;
   if (finished) {
+    generationStopReason_ = stopReason;
     flushPendingUtf8ToCallback(outputCallback);
   }
-  return {.token = tokenId, .finished = finished};
+  return {.token = tokenId, .finished = finished, .stopReason = stopReason};
 }
 
 void MtmdLlmContext::onSequenceEnd(
@@ -1884,12 +1908,31 @@ void MtmdLlmContext::onSequenceEnd(
   flushPendingUtf8ToCallback(outputCallback);
 }
 
-void MtmdLlmContext::onGenerationFinished(
-    const std::function<void(const std::string&)>& outputCallback) {
+bool MtmdLlmContext::onGenerationFinished(
+    const std::function<void(const std::string&)>& outputCallback,
+    GenerationStopReason terminalReason) {
+  if (terminalReason != GenerationStopReason::None) {
+    generationStopReason_ = terminalReason;
+  }
   capturePendingThinkClose();
   onSequenceEnd(outputCallback);
+  if (shouldRollbackKnownReasoningCutoff()) {
+    return cancelGenerationCleanup(outputCallback);
+  }
   compactThinkSpan();
   rollbackState_.clearPrefillEntry();
+  generationStopReason_ = GenerationStopReason::None;
+  return true;
+}
+
+bool MtmdLlmContext::shouldRollbackKnownReasoningCutoff() const {
+  const bool knownTruncation =
+      generationStopReason_ == GenerationStopReason::PredictionLimit ||
+      generationStopReason_ == GenerationStopReason::SequenceLimit;
+  return knownTruncation && needsRecurrentSnapshot_ &&
+         removeThinkingFromContext_ && reasoningEnabled_ &&
+         reasoningState_.inside_reasoning && compactor_.hasOpenSpan() &&
+         !compactor_.hasCapturedCloseSpan();
 }
 
 bool MtmdLlmContext::onCancel(

--- a/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/MtmdLlmContext.hpp
@@ -256,8 +256,10 @@ public:
   void onSequenceEnd(
       const std::function<void(const std::string&)>& outputCallback) override;
 
-  void onGenerationFinished(
-      const std::function<void(const std::string&)>& outputCallback) override;
+  [[nodiscard]] bool onGenerationFinished(
+      const std::function<void(const std::string&)>& outputCallback,
+      GenerationStopReason terminalReason =
+          GenerationStopReason::None) override;
 
   [[nodiscard]] bool onCancel(
       const std::function<void(const std::string&)>& outputCallback) override;
@@ -324,6 +326,7 @@ private:
   void setOpenThinkSpan(llama_pos start);
   void capturePendingThinkClose();
   void compactThinkSpan();
+  [[nodiscard]] bool shouldRollbackKnownReasoningCutoff() const;
   void configureReasoningTags(
       const std::string& thinkingStartTag, const std::string& thinkingEndTag,
       const std::string& forcedOpenText);
@@ -384,6 +387,7 @@ private:
   double visionEncodeMs_ = 0.0;
   int32_t visionEncodeTiles_ = 0;
   bool pendingBatchFirstMsg_ = false;
+  GenerationStopReason generationStopReason_ = GenerationStopReason::None;
   // Snapshot of `current_` / `protectedPrefix_` at `evalMessageWithTools`
   // entry. Restored by `cancelGenerationCleanup` to roll back to the
   // pre-request cursor.

--- a/packages/llm-llamacpp/addon/src/model-interface/ReasoningBlockCompactor.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/ReasoningBlockCompactor.hpp
@@ -81,13 +81,15 @@ public:
   [[nodiscard]] bool hasOpenSpan() const noexcept {
     return thinkSpan_.has_value();
   }
+  [[nodiscard]] bool hasCapturedCloseSpan() const noexcept {
+    return thinkSpan_.has_value() && thinkSpan_->second >= 0;
+  }
   // Test accessor: true when a span has been opened AND its close
   // position has been committed (i.e. the `requestCloseCapture()` →
-  // `onCloseCommitted()` handshake completed). Unit-test seam for the
-  // close-capture contract; production callers should not key off the
-  // close-position directly — `compact()` is the only consumer.
+  // `onCloseCommitted()` handshake completed). Kept for compatibility
+  // with unit tests; production code should use `hasCapturedCloseSpan()`.
   [[nodiscard]] bool hasCapturedCloseSpanForTesting() const noexcept {
-    return thinkSpan_.has_value() && thinkSpan_->second >= 0;
+    return hasCapturedCloseSpan();
   }
   void clearSpan() noexcept {
     thinkSpan_.reset();

--- a/packages/llm-llamacpp/addon/src/model-interface/SequenceDriver.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/SequenceDriver.hpp
@@ -17,6 +17,15 @@
 class LlamaBatch;
 struct PromptLayout;
 
+enum class GenerationStopReason : uint8_t {
+  None,
+  Eos,
+  Antiprompt,
+  PredictionLimit,
+  SequenceLimit,
+  ContextOverflow,
+};
+
 /// Per-sequence step outcome reported by `SequenceDriver::onLogitsReady`.
 /// `decodedInline` lets a driver piggy-back a fresh `llama_decode` (for
 /// example to flush a forced follow-up token) without bouncing through
@@ -26,6 +35,7 @@ struct SequenceStepResult {
   bool finished = false;
   bool decodedInline = false;
   bool contextOverflow = false;
+  GenerationStopReason stopReason = GenerationStopReason::None;
   /// Tokens dropped from this sequence's KV-cache by an in-step context
   /// slide. The scheduler must subtract it from the request's position
   /// before feeding the next token.
@@ -211,9 +221,16 @@ public:
   virtual void onSequenceEnd(
       const std::function<void(const std::string&)>& outputCallback) = 0;
 
-  /// Fired when generation reaches a natural EOG / stop token.
-  virtual void onGenerationFinished(
-      const std::function<void(const std::string&)>& outputCallback) = 0;
+  /// Fired when generation reaches a natural EOG / stop token, generation
+  /// budget limit, or scheduler-imposed sequence limit. `terminalReason`
+  /// carries reasons known only at finalization time (e.g. the scheduler's
+  /// per-sequence slot cap). Returns `false` when finalisation had to roll
+  /// back the request but could not prove live recurrent state matches
+  /// metadata, in which case callers MUST skip cache persistence for this
+  /// request.
+  [[nodiscard]] virtual bool onGenerationFinished(
+      const std::function<void(const std::string&)>& outputCallback,
+      GenerationStopReason terminalReason = GenerationStopReason::None) = 0;
 
   /// Fired when the sequence is cancelled (user-requested or fatal error).
   /// Returns `true` when internal rollback (metadata + live KV / recurrent

--- a/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.cpp
@@ -783,6 +783,7 @@ LlmContext::GenerateResponseResult TextLlmContext::generateResponse(
   forcedTokens_.clear();
   assistantOutput_.clear();
   generationStarted_ = false;
+  generationStopReason_ = GenerationStopReason::None;
 
   // The chat template force-opened the reasoning channel in the prompt (e.g.
   // Qwen3 / DeepSeek-R1 templates end with "<think>\n"). Emit the matching
@@ -814,12 +815,14 @@ LlmContext::GenerateResponseResult TextLlmContext::generateResponse(
     const SequenceStepResult step =
         onLogitsReady(-1, generatedAfterAccept, outputCallback, &batch);
     if (step.contextOverflow) {
+      generationStopReason_ = GenerationStopReason::ContextOverflow;
       return {.ok = false};
     }
     if (step.decodedInline) {
       continue;
     }
     if (step.finished) {
+      generationStopReason_ = step.stopReason;
       break;
     }
 
@@ -847,8 +850,14 @@ LlmContext::GenerateResponseResult TextLlmContext::generateResponse(
     return {
         .ok = true, .cancelled = true, .rollbackOk = onCancel(outputCallback)};
   }
-  onGenerationFinished(outputCallback);
-  return {};
+  if (generationStopReason_ == GenerationStopReason::None &&
+      params_.n_predict > 0 &&
+      generatedAfterAccept >= static_cast<unsigned>(params_.n_predict)) {
+    generationStopReason_ = GenerationStopReason::PredictionLimit;
+  }
+  const bool rollbackOk =
+      onGenerationFinished(outputCallback, generationStopReason_);
+  return {.rollbackOk = rollbackOk};
 }
 
 SequenceStepResult TextLlmContext::onLogitsReady(
@@ -878,7 +887,10 @@ SequenceStepResult TextLlmContext::onLogitsReady(
             firstMsgTokens_,
             tools_.anchor(),
             tools_.enabled() ? "true" : "false"));
-    return {.finished = true, .contextOverflow = true};
+    return {
+        .finished = true,
+        .contextOverflow = true,
+        .stopReason = GenerationStopReason::ContextOverflow};
   }
   const llama_pos discarded = applyContextDiscard();
   // Batch path only: the scheduler cannot retry a full window, so a slot
@@ -886,7 +898,11 @@ SequenceStepResult TextLlmContext::onLogitsReady(
   // Single-prompt keeps its legacy behavior (warn inside the slider and
   // continue).
   if (inlineDecodeBatch == nullptr && nPast_ + 1 > ctxCeiling()) {
-    return {.finished = true, .contextOverflow = true, .discarded = discarded};
+    return {
+        .finished = true,
+        .contextOverflow = true,
+        .stopReason = GenerationStopReason::ContextOverflow,
+        .discarded = discarded};
   }
 
   bool sampledToken = forcedTokens_.empty();
@@ -1018,14 +1034,32 @@ SequenceStepResult TextLlmContext::onLogitsReady(
         common_token_to_piece(modelCtx_.lctx, tokenId, true);
     emitOutputPiece(outputCallback, callMarker);
     flushPendingUtf8ToCallback(outputCallback);
-    return {.token = tokenId, .finished = true, .discarded = discarded};
+    generationStopReason_ = GenerationStopReason::Eos;
+    return {
+        .token = tokenId,
+        .finished = true,
+        .stopReason = GenerationStopReason::Eos,
+        .discarded = discarded};
   }
-  const bool finished = isEos || reachedBudget || checkAntiprompt();
+  GenerationStopReason stopReason = GenerationStopReason::None;
+  if (isEos) {
+    stopReason = GenerationStopReason::Eos;
+  } else if (reachedBudget) {
+    stopReason = GenerationStopReason::PredictionLimit;
+  } else if (checkAntiprompt()) {
+    stopReason = GenerationStopReason::Antiprompt;
+  }
+  const bool finished = stopReason != GenerationStopReason::None;
   if (finished) {
+    generationStopReason_ = stopReason;
     flushPendingUtf8ToCallback(outputCallback);
   }
 
-  return {.token = tokenId, .finished = finished, .discarded = discarded};
+  return {
+      .token = tokenId,
+      .finished = finished,
+      .stopReason = stopReason,
+      .discarded = discarded};
 }
 
 void TextLlmContext::onSequenceEnd(
@@ -1033,10 +1067,17 @@ void TextLlmContext::onSequenceEnd(
   flushPendingUtf8ToCallback(outputCallback);
 }
 
-void TextLlmContext::onGenerationFinished(
-    const std::function<void(const std::string&)>& outputCallback) {
+bool TextLlmContext::onGenerationFinished(
+    const std::function<void(const std::string&)>& outputCallback,
+    GenerationStopReason terminalReason) {
+  if (terminalReason != GenerationStopReason::None) {
+    generationStopReason_ = terminalReason;
+  }
   capturePendingThinkClose();
   onSequenceEnd(outputCallback);
+  if (shouldRollbackKnownReasoningCutoff()) {
+    return rollbackCurrentRequest(outputCallback);
+  }
   if (generationStarted_) {
     onGenerationCompletePolicy(assistantOutput_);
     assistantOutput_.clear();
@@ -1050,12 +1091,29 @@ void TextLlmContext::onGenerationFinished(
   // prefill-entry rollback checkpoint is no longer reachable. Drop
   // its temp file now instead of waiting for the next inference.
   rollbackState_.clearPrefillEntry();
+  generationStopReason_ = GenerationStopReason::None;
+  return true;
 }
 
 bool TextLlmContext::onCancel(
     const std::function<void(const std::string&)>& outputCallback) {
-  // Cancel = "request never happened": roll back to the pre-request
-  // cursor for both prefill- and decode-stage cancels.
+  return rollbackCurrentRequest(outputCallback);
+}
+
+bool TextLlmContext::shouldRollbackKnownReasoningCutoff() const {
+  const bool knownTruncation =
+      generationStopReason_ == GenerationStopReason::PredictionLimit ||
+      generationStopReason_ == GenerationStopReason::SequenceLimit;
+  return knownTruncation && needsRecurrentSnapshot_ &&
+         removeThinkingFromContext_ && reasoningEnabled_ &&
+         reasoningState_.inside_reasoning && compactor_.hasOpenSpan() &&
+         !compactor_.hasCapturedCloseSpan();
+}
+
+bool TextLlmContext::rollbackCurrentRequest(
+    const std::function<void(const std::string&)>& outputCallback) {
+  // Rollback = "request never happened": roll back to the pre-request
+  // cursor for both cancellation and n_predict truncation inside reasoning.
   // `reasoningBoundary` is compaction-only and not used here — restoring
   // it would leak the cancelled prompt / generated-prefix state into
   // the cache.
@@ -1091,6 +1149,10 @@ bool TextLlmContext::onCancel(
   compactor_.clearSpan();
   assistantOutput_.clear();
   generationStarted_ = false;
+  generationStopReason_ = GenerationStopReason::None;
+  // The sampled tokens were accepted before rollback; clear sampler history so
+  // the next clean request cannot inherit a request that "never happened".
+  common_sampler_reset(smpl_.get());
   return rollbackOk;
 }
 

--- a/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.hpp
+++ b/packages/llm-llamacpp/addon/src/model-interface/TextLlmContext.hpp
@@ -197,8 +197,10 @@ public:
   void onSequenceEnd(
       const std::function<void(const std::string&)>& outputCallback) override;
 
-  void onGenerationFinished(
-      const std::function<void(const std::string&)>& outputCallback) override;
+  [[nodiscard]] bool onGenerationFinished(
+      const std::function<void(const std::string&)>& outputCallback,
+      GenerationStopReason terminalReason =
+          GenerationStopReason::None) override;
 
   [[nodiscard]] bool onCancel(
       const std::function<void(const std::string&)>& outputCallback) override;
@@ -284,6 +286,9 @@ private:
   void setOpenThinkSpan(llama_pos start);
   void capturePendingThinkClose();
   void compactThinkSpan();
+  [[nodiscard]] bool shouldRollbackKnownReasoningCutoff() const;
+  [[nodiscard]] bool rollbackCurrentRequest(
+      const std::function<void(const std::string&)>& outputCallback);
   void configureReasoningTags(
       const std::string& thinkingStartTag, const std::string& thinkingEndTag,
       const std::string& forcedOpenText);
@@ -339,6 +344,7 @@ private:
   llama_pos preRequestFirstMsgTokens_ = 0;
   bool pendingBatchFirstMsg_ = false;
   bool generationStarted_ = false;
+  GenerationStopReason generationStopReason_ = GenerationStopReason::None;
   std::string assistantOutput_;
   ThreadPoolPtr threadpool_;
   ThreadPoolPtr threadpoolBatch_;

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {

--- a/packages/llm-llamacpp/test/integration/qwen3-5.test.js
+++ b/packages/llm-llamacpp/test/integration/qwen3-5.test.js
@@ -382,6 +382,128 @@ test('Qwen3.5-0.8B reasoning-budget=0 disables thinking', {
     `disabled (${disabled.length}) should be substantially shorter than baseline (${baseline.length})`)
 })
 
+test(
+  'Qwen3.5-0.8B n_predict exhaustion mid-reasoning does not abort',
+  {
+    timeout: 600_000
+  },
+  async (t) => {
+    const [modelName, dirPath] = await ensureModel({
+      modelName: QWEN3_5_MODEL.name,
+      downloadUrl: QWEN3_5_MODEL.url
+    })
+    const modelPath = path.join(dirPath, modelName)
+
+    const addon = new LlmLlamacpp({
+      files: { model: [modelPath] },
+      config: {
+        device: useCpu ? 'cpu' : 'gpu',
+        gpu_layers: '999',
+        ctx_size: '2048',
+        n_predict: '64',
+        temp: '0',
+        seed: '42',
+        verbosity: '2'
+      },
+      logger: createLogger(),
+      opts: { stats: true }
+    })
+
+    try {
+      await addon.load()
+
+      const sessionName = path.join(dirPath, 'qwen3-5-npredict-mid-reasoning-cache.bin')
+      cleanupIntegrationCacheFiles(sessionName)
+      const systemMsg = {
+        role: 'system',
+        content: 'You are a helpful assistant. Answer concisely with just the city name.'
+      }
+      const userTurn1 = {
+        role: 'user',
+        content: 'What is the capital of France?'
+      }
+      const noReasoning = {
+        generationParams: { reasoning_budget: 0 }
+      }
+      const primerResponse = await addon.run([systemMsg, userTurn1], {
+        cacheKey: sessionName,
+        ...noReasoning
+      })
+      const primerOutput = await collectResponse(primerResponse)
+      t.ok(/paris/i.test(primerOutput), `primer mentions Paris: "${primerOutput.slice(0, 100)}"`)
+      t.ok(
+        primerResponse.stats?.CacheTokens > 0,
+        `primer populated cache (CacheTokens=${primerResponse.stats?.CacheTokens})`
+      )
+
+      const response = await addon.run(
+        [
+          systemMsg,
+          userTurn1,
+          { role: 'assistant', content: primerOutput },
+          {
+            role: 'user',
+            content:
+              'Before answering, reason in detail for at least 20 sentences, then answer: What is the capital of France?'
+          }
+        ],
+        {
+          cacheKey: sessionName,
+          generationParams: {
+            remove_thinking_from_context: true
+          }
+        }
+      )
+      const output = await collectResponse(response)
+
+      t.comment(`small-budget output (${output.length} chars): "${output.slice(0, 300)}"`)
+      t.comment(`small-budget stats: ${JSON.stringify(response.stats || {})}`)
+      t.ok(output.length > 0, `small-budget run produced output (${output.length} chars)`)
+      t.ok(
+        output.includes('<think>'),
+        `small-budget run should enter reasoning before n_predict cutoff: "${output.slice(0, 120)}"`
+      )
+      t.absent(
+        /<\/think>/.test(output),
+        `small-budget run should be cut off before closing reasoning: "${output.slice(-120)}"`
+      )
+      t.ok(
+        response.stats?.generatedTokens >= 64,
+        `small-budget run should reach n_predict (generatedTokens=${response.stats?.generatedTokens})`
+      )
+      t.is(
+        response.stats?.CacheTokens,
+        primerResponse.stats?.CacheTokens,
+        `small-budget run should roll cache back to primer state (${primerResponse.stats?.CacheTokens})`
+      )
+
+      const followUpResponse = await addon.run(
+        [
+          systemMsg,
+          userTurn1,
+          { role: 'assistant', content: primerOutput },
+          { role: 'user', content: 'And what about Germany?' }
+        ],
+        {
+          cacheKey: sessionName,
+          ...noReasoning
+        }
+      )
+      const followUpOutput = await collectResponse(followUpResponse)
+      t.ok(
+        /berlin/i.test(followUpOutput),
+        `follow-up after rollback should still answer from clean cache: "${followUpOutput.slice(0, 100)}"`
+      )
+      t.ok(
+        followUpResponse.stats?.CacheTokens > primerResponse.stats?.CacheTokens,
+        `follow-up should extend primer cache (${primerResponse.stats?.CacheTokens} -> ${followUpResponse.stats?.CacheTokens})`
+      )
+    } finally {
+      await addon.unload().catch(() => {})
+    }
+  }
+)
+
 test('Qwen3.5-0.8B per-request generationParams.reasoning_budget overrides load-time default', {
   timeout: 600_000
 }, async t => {

--- a/packages/llm-llamacpp/test/unit/test_continuous_batch_finalize.cpp
+++ b/packages/llm-llamacpp/test/unit/test_continuous_batch_finalize.cpp
@@ -24,6 +24,7 @@ using qvac_lib_inference_addon_llama::batching::StopReason;
 class RecordingDriver : public SequenceDriver {
 public:
   std::vector<std::string> calls;
+  GenerationStopReason terminalReason = GenerationStopReason::None;
 
   [[nodiscard]] llama_pos getNPast() const override { return 0; }
   [[nodiscard]] int32_t getNSlides() const override { return 0; }
@@ -48,9 +49,12 @@ public:
   void onSequenceEnd(const std::function<void(const std::string&)>&) override {
     calls.emplace_back("onSequenceEnd");
   }
-  void onGenerationFinished(
-      const std::function<void(const std::string&)>&) override {
+  [[nodiscard]] bool onGenerationFinished(
+      const std::function<void(const std::string&)>&,
+      GenerationStopReason reason = GenerationStopReason::None) override {
     calls.emplace_back("onGenerationFinished");
+    terminalReason = reason;
+    return rollbackOk;
   }
   [[nodiscard]] bool
   onCancel(const std::function<void(const std::string&)>&) override {
@@ -105,6 +109,20 @@ TEST(ContinuousBatchFinalize, NaturalFinishRunsGenerationFinishedHook) {
       driver, StopReason::Finished, /*prefillOnly=*/false, kNoCallback);
 
   EXPECT_TRUE(driver.fired("onGenerationFinished"));
+  EXPECT_EQ(driver.terminalReason, GenerationStopReason::None);
+}
+
+/// Scheduler-imposed per-sequence cap is a known truncation reason. Preserve it
+/// at the finalization boundary so recurrent drivers can roll back open
+/// reasoning spans instead of treating the slot as a normal completion and
+/// attempting strict compaction.
+TEST(ContinuousBatchFinalize, LimitReachedPropagatesSequenceLimit) {
+  RecordingDriver driver;
+  (void)finalizeTerminalDriver(
+      driver, StopReason::LimitReached, /*prefillOnly=*/false, kNoCallback);
+
+  EXPECT_TRUE(driver.fired("onGenerationFinished"));
+  EXPECT_EQ(driver.terminalReason, GenerationStopReason::SequenceLimit);
 }
 
 /// A prefill-only slot never generated, so it only flushes via onSequenceEnd
@@ -119,10 +137,11 @@ TEST(ContinuousBatchFinalize, PrefillOnlyOnlyFlushes) {
   EXPECT_FALSE(driver.fired("onCancel"));
 }
 
-/// `finalizeTerminalDriver` must forward the driver's rollback-ok signal
-/// from `onCancel` on Cancelled / DecodeError paths so the scheduler can
-/// skip `saveCache` when a recurrent full-state restore was refused.
-/// Non-cancel paths always report OK because no rollback runs.
+/// `finalizeTerminalDriver` must forward the driver's rollback-ok signal so
+/// the scheduler can skip `saveCache` when a recurrent full-state restore was
+/// refused. Cancelled / DecodeError paths report through `onCancel`; natural
+/// generation finalization can also report a rollback failure when generation
+/// was truncated mid-reasoning.
 TEST(ContinuousBatchFinalize, CancelForwardsRollbackFailure) {
   RecordingDriver driver;
   driver.rollbackOk = false;
@@ -137,9 +156,9 @@ TEST(ContinuousBatchFinalize, CancelForwardsRollbackSuccess) {
       driver, StopReason::Cancelled, /*prefillOnly=*/false, kNoCallback));
 }
 
-TEST(ContinuousBatchFinalize, NaturalFinishAlwaysReportsRollbackOk) {
+TEST(ContinuousBatchFinalize, NaturalFinishForwardsRollbackFailure) {
   RecordingDriver driver;
-  driver.rollbackOk = false; // Should be ignored on non-cancel paths.
-  EXPECT_TRUE(finalizeTerminalDriver(
+  driver.rollbackOk = false;
+  EXPECT_FALSE(finalizeTerminalDriver(
       driver, StopReason::Finished, /*prefillOnly=*/false, kNoCallback));
 }

--- a/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
+++ b/packages/llm-llamacpp/test/unit/test_continuous_batching_integration.cpp
@@ -837,6 +837,90 @@ TEST_F(
   // replay path succeeded on both slots.
 }
 
+TEST_F(
+    ContinuousBatchingIntegrationTest,
+    Qwen35HybridSequenceLimitMidReasoningRollsBackAndKeepsSibling) {
+  REQUIRE_MODEL(qwen35HybridModel_);
+  config_["ctx_size"] = "512";
+  config_["parallel"] = "2";
+  config_["n_predict"] = "-1";
+  config_["n_discarded"] = "0";
+  config_["temp"] = "0";
+  auto model = loadModel(qwen35HybridModel_);
+
+  const fs::path cachePath =
+      fs::temp_directory_path() /
+      ("batch-qwen35-seqlimit-rollback-" + uniqueTestId() + ".bin");
+
+  const char* systemMsg =
+      R"({"role":"system","content":"You are a helpful assistant. Answer concisely with just the city name."})";
+  const char* userTurn1 =
+      R"({"role":"user","content":"What is the capital of France?"})";
+
+  LlamaModel::Prompt primer;
+  primer.input = std::string("[") + systemMsg + "," + userTurn1 + "]";
+  primer.cacheKey = cachePath.string();
+  primer.saveCacheToDisk = true;
+  primer.generationParams.reasoning_budget = 0;
+  primer.generationParams.n_predict = 16;
+  auto primerOutputs =
+      model->processPromptBatch(std::vector<LlamaModel::Prompt>{primer});
+  ASSERT_EQ(primerOutputs.size(), 1u);
+  ASSERT_TRUE(containsCaseInsensitive(primerOutputs[0], "Paris"))
+      << "primer should answer from the clean cache seed: " << primerOutputs[0];
+  ASSERT_TRUE(fs::exists(cachePath));
+  const double primeCacheTokens =
+      test_common::getStatValue(model->runtimeStats(), "CacheTokens");
+  ASSERT_GT(primeCacheTokens, 0.0) << "primer did not populate CacheTokens";
+
+  auto makeLimitPrompt = [systemMsg, userTurn1] {
+    LlamaModel::Prompt p;
+    p.input =
+        std::string("[") + systemMsg + "," + userTurn1 +
+        R"(,{"role":"assistant","content":"Paris"},{"role":"user","content":"Before answering, reason in detail for at least 80 sentences, then answer: What is the capital of France?"}])";
+    p.generationParams.remove_thinking_from_context = true;
+    return p;
+  };
+
+  auto limit = makeLimitPrompt();
+  limit.cacheKey = cachePath.string();
+  limit.saveCacheToDisk = true;
+  auto limitOutputs =
+      model->processPromptBatch(std::vector<LlamaModel::Prompt>{limit});
+  ASSERT_EQ(limitOutputs.size(), 1u);
+  EXPECT_FALSE(limitOutputs[0].empty());
+  const double limitGeneratedTokens =
+      test_common::getStatValue(model->runtimeStats(), "generatedTokens");
+  const double limitCacheTokens =
+      test_common::getStatValue(model->runtimeStats(), "CacheTokens");
+  SCOPED_TRACE(
+      "limitGeneratedTokens=" + std::to_string(limitGeneratedTokens) +
+      ", primeCacheTokens=" + std::to_string(primeCacheTokens) +
+      ", limitCacheTokens=" + std::to_string(limitCacheTokens) +
+      ", limit output (first 240 chars): " + limitOutputs[0].substr(0, 240));
+  EXPECT_GE(limitGeneratedTokens, 64.0)
+      << "n_predict is unbounded, so a long generation here means the "
+         "scheduler slot cap, not n_predict, truncated the request";
+  EXPECT_LE(std::abs(limitCacheTokens - primeCacheTokens), 1.0)
+      << "sequence-limit truncation must roll back to the warm cache baseline";
+
+  auto sibling = makePrompt("What is 2+2? Answer with just the number.");
+  sibling.generationParams.reasoning_budget = 0;
+  sibling.generationParams.n_predict = 16;
+  std::vector<LlamaModel::Prompt> prompts{
+      makeLimitPrompt(), std::move(sibling)};
+  auto outputs = model->processPromptBatch(prompts);
+
+  ASSERT_EQ(outputs.size(), 2u);
+  EXPECT_FALSE(outputs[0].empty())
+      << "sequence-limit truncated prompt should still return partial output";
+  EXPECT_FALSE(outputs[1].empty())
+      << "healthy sibling request must complete instead of being failed by "
+         "the truncated recurrent reasoning request";
+
+  fs::remove(cachePath);
+}
+
 TEST_F(ContinuousBatchingIntegrationTest, TwoPromptBatchHarmonyToolCalls) {
   REQUIRE_MODEL(harmonyModel_);
   config_["ctx_size"] = "4096";

--- a/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
+++ b/packages/llm-llamacpp/test/unit/test_mtmd_llm_context.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -44,6 +46,23 @@ fs::path multimodalTestImagePath() {
 #endif
 
   return "packages/llm-llamacpp/media/fruitPlate.png";
+}
+
+bool containsCaseInsensitive(
+    const std::string& haystack, const std::string& needle) {
+  auto toLower = [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  };
+  std::string haystackLower = haystack;
+  std::string needleLower = needle;
+  std::transform(
+      haystackLower.begin(),
+      haystackLower.end(),
+      haystackLower.begin(),
+      toLower);
+  std::transform(
+      needleLower.begin(), needleLower.end(), needleLower.begin(), toLower);
+  return haystackLower.find(needleLower) != std::string::npos;
 }
 } // namespace
 
@@ -447,6 +466,100 @@ TEST_F(
   const auto stats = model->runtimeStats();
   EXPECT_EQ(
       getStatValue(stats, "CacheTokens"), static_cast<double>(sequenceCells));
+
+  fs::remove(cachePath);
+}
+
+TEST_F(MtmdLlmContextTest, Qwen35MtmdNPredictCutoffMidReasoningRollsBackCache) {
+  if (!hasValidQwen35Model()) {
+    GTEST_SKIP() << "Qwen3.5 multimodal model or projection file not found";
+  }
+
+  config_files["n_predict"] = "64";
+  config_files["temp"] = "0";
+
+  auto model = createQwen35Model();
+  ASSERT_NE(model, nullptr) << "Qwen3.5 multimodal model failed to load";
+  auto* base = LlamaModelTestPeer::llmContext(*model);
+  ASSERT_NE(base, nullptr);
+  auto* ctx = dynamic_cast<MtmdLlmContext*>(base);
+  ASSERT_NE(ctx, nullptr) << "Qwen3.5 VLM must use the MTMD context";
+
+  const fs::path cachePath =
+      fs::temp_directory_path() / "qvac-qwen35-mtmd-npredict-rollback.bin";
+  fs::remove(cachePath);
+
+  const char* systemMsg =
+      R"({"role":"system","content":"You are a helpful assistant. Answer concisely with just the city name."})";
+  const char* userTurn1 =
+      R"({"role":"user","content":"What is the capital of France?"})";
+
+  LlamaModel::Prompt primer;
+  primer.input = std::string("[") + systemMsg + "," + userTurn1 + "]";
+  primer.cacheKey = cachePath.string();
+  primer.generationParams.reasoning_budget = 0;
+
+  const std::string primerOutput = model->processPrompt(primer);
+  ASSERT_TRUE(containsCaseInsensitive(primerOutput, "Paris"))
+      << "primer should answer from the clean cache seed: " << primerOutput;
+
+  auto* mem = llama_get_memory(model->getContext());
+  ASSERT_NE(mem, nullptr);
+  const llama_seq_id seqId = ctx->getSeqId();
+  const llama_pos primerCacheTokens = ctx->getCacheTokens();
+  const llama_pos primerSequenceCells =
+      static_cast<llama_pos>(llama_memory_seq_token_count(mem, seqId));
+  ASSERT_GT(primerCacheTokens, 0)
+      << "primer must populate the MTMD cache before rollback test";
+  ASSERT_EQ(primerCacheTokens, primerSequenceCells)
+      << "test setup expects MTMD bookkeeping to match live memory";
+
+  LlamaModel::Prompt cutoff;
+  cutoff.input =
+      R"([{"role":"user","content":"Before answering, reason in detail for at least 20 sentences, then answer: What is the capital of France?"}])";
+  cutoff.cacheKey = cachePath.string();
+  cutoff.generationParams.remove_thinking_from_context = true;
+
+  const std::string cutoffOutput = model->processPrompt(cutoff);
+  const auto cutoffStats = model->runtimeStats();
+  const double generatedTokens = getStatValue(cutoffStats, "generatedTokens");
+  const double reportedCacheTokens = getStatValue(cutoffStats, "CacheTokens");
+  const llama_pos postCutoffSequenceCells =
+      static_cast<llama_pos>(llama_memory_seq_token_count(mem, seqId));
+
+  SCOPED_TRACE(
+      "generatedTokens=" + std::to_string(generatedTokens) +
+      ", reportedCacheTokens=" + std::to_string(reportedCacheTokens) +
+      ", primerCacheTokens=" + std::to_string(primerCacheTokens) +
+      ", ctxCacheTokens=" + std::to_string(ctx->getCacheTokens()) +
+      ", sequenceCells=" + std::to_string(postCutoffSequenceCells) +
+      ", cutoff output (first 200 chars): " + cutoffOutput.substr(0, 200));
+
+  EXPECT_NE(cutoffOutput.find("<think>"), std::string::npos)
+      << "small-budget MTMD run must enter reasoning before n_predict cutoff";
+  EXPECT_EQ(cutoffOutput.find("</think>"), std::string::npos)
+      << "test must stop inside reasoning to exercise rollback, not compaction";
+  EXPECT_GE(generatedTokens, 64.0)
+      << "small-budget MTMD run should reach n_predict";
+  EXPECT_EQ(ctx->getCacheTokens(), primerCacheTokens)
+      << "MTMD rollback must restore cache-token bookkeeping to primer state";
+  EXPECT_EQ(postCutoffSequenceCells, primerSequenceCells)
+      << "MTMD rollback must restore live llama memory to primer state";
+  EXPECT_EQ(reportedCacheTokens, static_cast<double>(primerCacheTokens))
+      << "runtime stats must report the rolled-back cache size";
+
+  LlamaModel::Prompt followUp;
+  followUp.input =
+      R"([{"role":"user","content":"And what about Germany? Answer with just the city name."}])";
+  followUp.cacheKey = cachePath.string();
+  followUp.generationParams.reasoning_budget = 0;
+
+  const std::string followUpOutput = model->processPrompt(followUp);
+  EXPECT_TRUE(containsCaseInsensitive(followUpOutput, "Berlin"))
+      << "follow-up after rollback should answer from clean cache: "
+      << followUpOutput;
+  EXPECT_GT(ctx->getCacheTokens(), primerCacheTokens)
+      << "follow-up should extend the rolled-back primer cache";
 
   fs::remove(cachePath);
 }

--- a/packages/llm-llamacpp/test/unit/test_slide_capable_capability.cpp
+++ b/packages/llm-llamacpp/test/unit/test_slide_capable_capability.cpp
@@ -44,8 +44,11 @@ public:
     return {};
   }
   void onSequenceEnd(const std::function<void(const std::string&)>&) override {}
-  void onGenerationFinished(
-      const std::function<void(const std::string&)>&) override {}
+  [[nodiscard]] bool onGenerationFinished(
+      const std::function<void(const std::string&)>&,
+      GenerationStopReason = GenerationStopReason::None) override {
+    return true;
+  }
   [[nodiscard]] bool
   onCancel(const std::function<void(const std::string&)>&) override {
     return true;


### PR DESCRIPTION
## 🎯 Problem

`@qvac/sdk` **0.15** pins `@qvac/llm-llamacpp ^0.36.3`, so it does not receive the QVAC-22472 fix (handle Qwen3.5 `n_predict` cutoff inside an open reasoning span), which shipped only on the 0.37.x line ([#3318](https://github.com/tetherto/qvac/pull/3318) + version bump [#3327](https://github.com/tetherto/qvac/pull/3327)). SDK 0.15 needs the fix back-ported to the 0.36 line.

## 📝 How

Cherry-pick of #3318 (`0d782b12c`) onto the 0.36 release line (`release-llm-0.36.3`). The C++ fix, unit tests, and the new `qwen3-5.test.js` regression case apply cleanly (all touched C++/unit files are identical between 0.36.3 and #3318's base); the only manual resolution was grafting the new `Qwen3.5-0.8B n_predict exhaustion mid-reasoning does not abort` integration test into 0.36.3's `qwen3-5.test.js`.

This PR contains the **fix only** — the `0.36.4` version bump + CHANGELOG will follow once CI is green (kept at 0.36.3 for now so nothing publishes prematurely).

## 🧪 Tested

Full CI matrix (labels `verified` + `run-cpp/desktop/mobile-addon-tests` + `prebuilds`) — [On PR Trigger (LLM) run 29739082927](https://github.com/tetherto/qvac/actions/runs/29739082927), **conclusion: success**:

| Job | Result |
|-----|--------|
| cpp-tests (linux-x64, windows-x64, darwin-arm64) | ✅ QVAC-22472 unit tests pass |
| integration test-linux-x64, test-win32-x64, test-linux-arm64, test-darwin-arm64 | ✅ |
| mobile Android + iOS (E2E) | ✅ |
| integration test-darwin-x64 | ❌ pre-existing (see note) |

The new `Qwen3.5-0.8B n_predict exhaustion mid-reasoning does not abort` regression test **passes on every platform incl. darwin-x64** (`ok … 7503ms`), directly exercising the fix.

> **Note — `test-darwin-x64` failure is pre-existing and non-gating.** It fails in `reasoning.test.js`'s `Qwen3 sliding context hard-fails stale reasoning compaction` test (macOS x64 VM, exit 134) — a known environment-specific failure. `reasoning.test.js` is **byte-identical between 0.36.3 and this branch** and #3318 never touched it, so this failure is independent of the back-port and does not fail the run.

### Back-port completeness validation

Verified the cherry-pick captured all of #3318 with nothing missed:

- **File set + line counts** match #3318 exactly (14 files, +541/−61).
- **13 cleanly-applied files** (all `addon/src/model-interface/*` + `test/unit/*.cpp`): the resulting blobs are **byte-identical** to #3318's post-merge blobs (verified via `git rev-parse <commit>:<file>` object-hash comparison) — same resulting code, not just same line counts.
- **`test/integration/qwen3-5.test.js`** (the only manually-resolved file, since it had diverged on the 0.36 line): the grafted block's added lines are **identical** to #3318's added lines (122 vs 122, `diff` empty), and #3318 made **0 deletions** to this file — so nothing was dropped.

**#3327** (version/changelog only: `0.37.0→0.37.1` + a `[0.37.1]` CHANGELOG entry) is intentionally **not** applied verbatim — its version is wrong for the 0.36 line. Its substance is re-targeted to the `0.36.4` bump + `## [0.36.4]` CHANGELOG entry done after CI green (see below).

## ⚠️ Breaking

None. Bugfix back-port; no API changes.

---
Targets SDK-0.15's 0.36 line. Next: version bump to `0.36.4` + CHANGELOG after CI green, then release.

