### PR TITLE
QVAC-22472 chore: bump llm-llamacpp to 0.36.4

### DIFF
--- a/packages/llm-llamacpp/CHANGELOG.md
+++ b/packages/llm-llamacpp/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.36.4] - 2026-07-20
+
+Back-port of QVAC-22472 to the 0.36 line (for @qvac/sdk 0.15): hardens reasoning-cache rollback when generation is truncated before a reasoning span closes. It covers both explicit `n_predict` limits and continuous-batching per-sequence slot limits, preserving the last known-good cache state instead of attempting unsafe reasoning compaction.
+
+### Fixed
+
+- Qwen3.5 text and multimodal requests now roll back the current request when `n_predict` is reached inside an open reasoning span, avoiding recurrent compaction failures when no close marker was captured.
+- Continuous batching now propagates scheduler-imposed per-sequence slot truncation as `SequenceLimit`, allowing the driver to use the same rollback path as prediction-limit truncation.
+- Batch stop-reason precedence now preserves `Eos` > `PredictionLimit` > `Antiprompt`, so `n_predict` truncation still triggers rollback when a stop string would also match on the same token.
+- Added focused C++ regression coverage for MTMD `n_predict` rollback, scheduler `LimitReached` propagation, Qwen3.5 continuous-batching sequence-limit rollback, and sibling request survival.
+
+### Pull Requests
+
+- [#3337](https://github.com/tetherto/qvac/pull/3337) - QVAC-22472 fix: back-port n_predict-inside-reasoning rollback to llm-llamacpp 0.36.4
+- [#3318](https://github.com/tetherto/qvac/pull/3318) - QVAC-22472 fix: handle Qwen3.5 n_predict cutoff inside reasoning
+
 ## [0.36.3] - 2026-07-09
 
 This patch release makes continuous-batch runtime stats wait for backend work to complete before reporting throughput. It also hardens cancellation and reset cleanup around asynchronous llama decode work so KV and recurrent state are not mutated while queued GPU work is still in flight.

--- a/packages/llm-llamacpp/package.json
+++ b/packages/llm-llamacpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/llm-llamacpp",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "description": "llama addon for qvac",
   "addon": true,
   "scripts": {


### PR DESCRIPTION
## 🎯 Problem

The QVAC-22472 back-port fix landed on `release-llm-0.36.4` via #3337, but the `release-*` ruleset forbids direct pushes — the version bump + CHANGELOG must come through a PR.

## 📝 How

Helper PR into `release-llm-0.36.4`: bumps `@qvac/llm-llamacpp` `0.36.3` → `0.36.4` and adds the `## [0.36.4]` CHANGELOG entry (reasoning-cache rollback hardening; reuses #3327's wording; credits #3318 + #3337). Single commit; no code changes.

## 🧪 Tested

Version-only change. The fix itself was validated on #3337 (cpp-tests + qwen3-5 integration green across platforms).

## ⚠️ Breaking

None.

---
Merge target: `release-llm-0.36.4` (the 0.36.4 back-port branch, PR #3337). After this merges, `release-llm-0.36.4` carries fix + 0.36.4 bump, ready for release.
