### PR TITLE
QVAC-22561: Follow up: Update pin for verify-prebuild-symbols

### DIFF
--- a/.github/workflows/reusable-prebuilds.yml
+++ b/.github/workflows/reusable-prebuilds.yml
@@ -399,7 +399,7 @@ jobs:
       # Export-leak findings stay warnings during rollout (enforce-exports
       # defaults to false) until every ggml addon ships a symbols.map.
       - name: Verify prebuild symbols
-        uses: tetherto/qvac/.github/actions/verify-prebuild-symbols@f8e9a76e3c4336c044775857f1eca8ca2f663741
+        uses: tetherto/qvac/.github/actions/verify-prebuild-symbols@980912224ed17173caead9904e4fd02c939727a9
         with:
           platform: ${{ matrix.platform }}
           workdir: ${{ env.WORKDIR }}


### PR DESCRIPTION
Follow-up to #3333 

Update the pin in reusable-prebuilds to enable the new version of the action.