### PR TITLE
fix[transcription-whispercpp]: prevent malformed audio buffer from poisoning the queue

### DIFF
--- a/packages/transcription-whispercpp/CHANGELOG.md
+++ b/packages/transcription-whispercpp/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A malformed audio buffer whose byte length is not a multiple of 4 (`f32le`) no longer poisons the batch transcription queue. The buffered audio is now drained when a job is finalized, so the bad request fails on its own and later well-formed `transcribe` calls on the same model recover instead of repeatedly failing until the process restarts ([tetherto/qvac#3221](https://github.com/tetherto/qvac/issues/3221)).
+
 ## [0.12.1] - 2026-07-20
 
 ### Removed

--- a/packages/transcription-whispercpp/src/whisper.ts
+++ b/packages/transcription-whispercpp/src/whisper.ts
@@ -379,7 +379,7 @@ export class WhisperInterface {
     try {
       if (data?.type === END_OF_INPUT) {
         const currentJobId = this._nextJobId;
-        const input = this._concatBufferedAudio();
+        const input = this._drainBufferedAudio();
         const previousJobId = this._activeJobId;
         const previousState = this._state;
 
@@ -405,8 +405,6 @@ export class WhisperInterface {
 
         this._activeJobId = currentJobId;
         this._nextJobId = nextSafeId(this._nextJobId);
-        this._bufferedAudio = [];
-        this._bufferedBytes = 0;
         this._setState(state.PROCESSING);
         return currentJobId;
       }
@@ -558,6 +556,13 @@ export class WhisperInterface {
   finishStreaming(): void {
     this._activeJobId = null;
     this._setState(state.LISTENING);
+  }
+
+  _drainBufferedAudio(): Uint8Array {
+    const input = this._concatBufferedAudio();
+    this._bufferedAudio = [];
+    this._bufferedBytes = 0;
+    return input;
   }
 
   _concatBufferedAudio(): Uint8Array {

--- a/packages/transcription-whispercpp/test/unit/addon.inference.test.js
+++ b/packages/transcription-whispercpp/test/unit/addon.inference.test.js
@@ -237,6 +237,28 @@ test('run recovers on the same model after a malformed buffer fails', async (t) 
   t.is(await model.status(), 'listening', 'Model should return to listening after recovery')
 })
 
+test('A rejected end-of-job append drains the buffered audio', async (t) => {
+  const binding = new MockedBinding()
+  binding.runJob = () => false
+
+  const model = createMockedModel({ binding })
+  await model.load()
+
+  await model.addon.append({ type: 'audio', input: new Uint8Array([1, 2, 3, 4]) })
+  try {
+    await model.addon.append({ type: 'end of job' })
+    t.fail('A rejected job should fail the end-of-job append')
+  } catch (error) {
+    t.ok(
+      error.message.includes('a job is already set or being processed'),
+      'A rejected job should surface the busy native error'
+    )
+  }
+
+  t.is(model.addon._bufferedBytes, 0, 'A rejected job should drain the buffered audio')
+  t.is(model.addon._bufferedAudio.length, 0, 'A rejected job should leave no buffered chunks')
+})
+
 test('WhisperInterface runJob preserves active job when native rejects new job', async (t) => {
   const binding = new MockedBinding()
   const addon = new WhisperInterface(

--- a/packages/transcription-whispercpp/test/unit/addon.inference.test.js
+++ b/packages/transcription-whispercpp/test/unit/addon.inference.test.js
@@ -163,6 +163,80 @@ test('Cancel clears in-flight job and allows a new run', async (t) => {
   )
 })
 
+test('A malformed buffer does not poison the queue for later jobs', async (t) => {
+  const events = []
+  const onOutput = (addon, event, jobId, output, error) => {
+    events.push({ event, jobId, output, error })
+  }
+
+  const binding = new MockedBinding()
+  const runValidJob = binding.runJob.bind(binding)
+  binding.runJob = (handle, data) => {
+    if (data.input.byteLength % 4 !== 0) {
+      throw new Error('f32le buffer length must be a multiple of 4')
+    }
+    return runValidJob(handle, data)
+  }
+
+  const model = createMockedModel({ onOutput, binding })
+  await model.load()
+
+  await model.addon.append({ type: 'audio', input: new Uint8Array([1, 2, 3]) })
+  try {
+    await model.addon.append({ type: 'end of job' })
+    t.fail('Malformed buffer should fail the end-of-job append')
+  } catch (error) {
+    t.ok(
+      error.message.includes('f32le buffer length must be a multiple of 4'),
+      'Malformed buffer should surface the native validation error'
+    )
+  }
+
+  t.is(model.addon._bufferedBytes, 0, 'Failed job should drain the buffered audio')
+  t.is(model.addon._bufferedAudio.length, 0, 'Failed job should leave no buffered chunks')
+
+  await model.addon.append({ type: 'audio', input: new Uint8Array([1, 2, 3, 4]) })
+  const recoveredJobId = await model.addon.append({ type: 'end of job' })
+  t.is(recoveredJobId, 1, 'A well-formed job after a failure should start cleanly')
+
+  await wait()
+
+  t.ok(
+    events.find((e) => e.event === 'JobEnded' && e.jobId === recoveredJobId),
+    'A well-formed job should complete after a malformed buffer failed'
+  )
+})
+
+test('run recovers on the same model after a malformed buffer fails', async (t) => {
+  const binding = new MockedBinding()
+  const runValidJob = binding.runJob.bind(binding)
+  binding.runJob = (handle, data) => {
+    if (data.input.byteLength % 4 !== 0) {
+      throw new Error('f32le buffer length must be a multiple of 4')
+    }
+    return runValidJob(handle, data)
+  }
+
+  const model = createMockedModel({ binding })
+  await model.load()
+
+  const malformedResponse = await model.run(new Uint8Array([1, 2, 3]))
+  try {
+    await malformedResponse.await()
+    t.fail('Malformed buffer transcription should reject')
+  } catch (error) {
+    t.ok(
+      error.message.includes('f32le buffer length must be a multiple of 4'),
+      'Malformed buffer transcription should reject with the native validation error'
+    )
+  }
+
+  const recoveredResponse = await model.run(new Uint8Array([1, 2, 3, 4]))
+  const output = await recoveredResponse.await()
+  t.ok(output, 'A well-formed transcription should resolve after a malformed buffer')
+  t.is(await model.status(), 'listening', 'Model should return to listening after recovery')
+})
+
 test('WhisperInterface runJob preserves active job when native rejects new job', async (t) => {
   const binding = new MockedBinding()
   const addon = new WhisperInterface(

--- a/packages/transcription-whispercpp/whisper.d.ts
+++ b/packages/transcription-whispercpp/whisper.d.ts
@@ -76,6 +76,7 @@ export declare class WhisperInterface {
     appendStreamingAudio(data: AudioData): void;
     endStreaming(): void;
     finishStreaming(): void;
+    _drainBufferedAudio(): Uint8Array;
     _concatBufferedAudio(): Uint8Array;
     private _requiredHandle;
 }

--- a/packages/transcription-whispercpp/whisper.js
+++ b/packages/transcription-whispercpp/whisper.js
@@ -248,7 +248,7 @@ class WhisperInterface {
         try {
             if (data?.type === END_OF_INPUT) {
                 const currentJobId = this._nextJobId;
-                const input = this._concatBufferedAudio();
+                const input = this._drainBufferedAudio();
                 const previousJobId = this._activeJobId;
                 const previousState = this._state;
                 let accepted = false;
@@ -271,8 +271,6 @@ class WhisperInterface {
                 }
                 this._activeJobId = currentJobId;
                 this._nextJobId = nextSafeId(this._nextJobId);
-                this._bufferedAudio = [];
-                this._bufferedBytes = 0;
                 this._setState(state.PROCESSING);
                 return currentJobId;
             }
@@ -421,6 +419,12 @@ class WhisperInterface {
     finishStreaming() {
         this._activeJobId = null;
         this._setState(state.LISTENING);
+    }
+    _drainBufferedAudio() {
+        const input = this._concatBufferedAudio();
+        this._bufferedAudio = [];
+        this._bufferedBytes = 0;
+        return input;
     }
     _concatBufferedAudio() {
         if (this._bufferedAudio.length === 0)


### PR DESCRIPTION
## Summary

A malformed `f32le` audio buffer whose byte length is not a multiple of 4 permanently poisoned the batch transcription queue: after the first bad `transcribe` call, every later well-formed call failed until the process was restarted (tetherto/qvac#3221).

The root cause is on the JS side in `WhisperInterface.append`. On an `end of job` append the buffered audio is concatenated and handed to the native `runJob`. The buffer (`_bufferedAudio` / `_bufferedBytes`) was cleared only on the success path, so when native validation rejected the misaligned buffer the stale bytes stayed buffered and were re-sent with every subsequent job, making each later job fail the same native validation.

The fix drains the buffered audio whenever an `end of job` append finalizes a job, regardless of whether `runJob` is accepted or throws, so a bad request fails on its own and later well-formed calls on the same model recover.

## Changes

- `src/whisper.ts`: add `_drainBufferedAudio()` and call it in `append`, so the buffer is always cleared when a job is finalized (removed the success-only clearing).
- `whisper.js` / `whisper.d.ts`: regenerated from the TypeScript source to stay in sync with the `check:generated` gate.
- `test/unit/addon.inference.test.js`: regression tests at the `WhisperInterface` and `model.run()` levels verifying recovery after a malformed buffer.
- `CHANGELOG.md`: add an Unreleased entry.

## Test plan

- [x] `npm run test:unit` (54/54 pass, including the two new regression tests)
- [x] `npm run typecheck`
- [x] `npm run check:generated` (generated artifacts in sync with source)
- [x] `eslint src/whisper.ts` clean; `prettier --check` clean on the test file

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216492154774200