### PR TITLE
QVAC-22536: Update qvac-fabric to 9840.0.0

### DIFF
--- a/packages/fabric/CMakeLists.txt
+++ b/packages/fabric/CMakeLists.txt
@@ -95,16 +95,20 @@ target_link_libraries(
   ${qvac-fabric}
   PRIVATE
     "$<LINK_LIBRARY:WHOLE_ARCHIVE,llama::llama>"
-    "$<LINK_LIBRARY:WHOLE_ARCHIVE,llama::common>"
+    "$<LINK_LIBRARY:WHOLE_ARCHIVE,llama::llama-common>"
     "$<LINK_LIBRARY:WHOLE_ARCHIVE,llama::mtmd>"
 )
 
-# build_info is a small separate static library defining the LLAMA_BUILD_NUMBER
-# / LLAMA_COMMIT globals that libcommon references; whole-archive it so those
-# symbols are present and can be exported.
-if(TARGET llama::build_info)
+# llama-common-base (formerly build_info) is a small separate static library
+# defining the LLAMA_BUILD_NUMBER / LLAMA_COMMIT globals that llama-common
+# references; whole-archive it so those symbols are present and can be exported.
+# Upstream #21936 renamed the OBJECT `build_info` target to the STATIC
+# `llama-common-base` target (a PUBLIC dep of llama-common), so it is no longer
+# transitively pulled in by whole-archiving llama-common and must be listed
+# explicitly here.
+if(TARGET llama::llama-common-base)
   target_link_libraries(${qvac-fabric}
-    PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,llama::build_info>")
+    PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,llama::llama-common-base>")
 endif()
 
 # Force-include the full ggml core (ggml + ggml-base) object code on every Unix
@@ -174,22 +178,23 @@ elseif(WIN32)
 
   set(_fabric_export_libs
     "$<TARGET_FILE:llama::llama>"
-    "$<TARGET_FILE:llama::common>"
+    "$<TARGET_FILE:llama::llama-common>"
     "$<TARGET_FILE:llama::mtmd>"
     "$<TARGET_FILE:ggml::ggml>"
     "$<TARGET_FILE:ggml::ggml-base>")
-  # build_info carries the LLAMA_BUILD_NUMBER / LLAMA_COMMIT data globals. Scan
-  # it only when it is a real archive; the vcpkg export ships it as an INTERFACE
-  # (or OBJECT) target with no TARGET_FILE, in which case those objects are
-  # merged into common.lib and the symbols are picked up from there. These data
-  # globals are not exported from the runtime at all: bare delay-loads sibling
-  # .bare modules on Windows and delay-loading cannot resolve data imports, so
-  # consumers define module-local copies instead (see windows_fabric_data.cpp).
-  if(TARGET llama::build_info)
-    get_target_property(_fabric_build_info_type llama::build_info TYPE)
+  # llama-common-base (formerly build_info) carries the LLAMA_BUILD_NUMBER /
+  # LLAMA_COMMIT data globals. Scan it only when it is a real archive; if the
+  # vcpkg export ships it as an INTERFACE (or OBJECT) target with no TARGET_FILE,
+  # those objects are merged into llama-common.lib and the symbols are picked up
+  # from there. These data globals are not exported from the runtime at all: bare
+  # delay-loads sibling .bare modules on Windows and delay-loading cannot resolve
+  # data imports, so consumers define module-local copies instead (see
+  # windows_fabric_data.cpp).
+  if(TARGET llama::llama-common-base)
+    get_target_property(_fabric_build_info_type llama::llama-common-base TYPE)
     if(NOT _fabric_build_info_type STREQUAL "OBJECT_LIBRARY"
        AND NOT _fabric_build_info_type STREQUAL "INTERFACE_LIBRARY")
-      list(APPEND _fabric_export_libs "$<TARGET_FILE:llama::build_info>")
+      list(APPEND _fabric_export_libs "$<TARGET_FILE:llama::llama-common-base>")
     endif()
   endif()
 

--- a/packages/fabric/package.json
+++ b/packages/fabric/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qvac/fabric",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shared bare addon hosting the qvac-fabric (forked llama.cpp + ggml) runtime for QVAC inference addons",
   "addon": true,
   "engines": {

--- a/packages/fabric/symbols.map
+++ b/packages/fabric/symbols.map
@@ -10,8 +10,9 @@
     llava_*;
     mtmd_*;
 
-    # llama.cpp build-info globals (from llama::build_info), e.g.
-    # LLAMA_BUILD_NUMBER / LLAMA_COMMIT, referenced by libcommon.
+    # llama.cpp build-info globals (from llama::llama-common-base, formerly
+    # llama::build_info), e.g. LLAMA_BUILD_NUMBER / LLAMA_COMMIT, referenced by
+    # llama-common.
     LLAMA_*;
 
     # ggml public C API (also consumed by the dlopen'd backend .so files at

--- a/packages/fabric/vcpkg.json
+++ b/packages/fabric/vcpkg.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "qvac-fabric",
-      "version>=": "9341.1.5"
+      "version>=": "9840.0.0"
     },
     {
       "name": "qvac-lint-cpp",


### PR DESCRIPTION
## What problem does this PR solve?

The fabric package is outdated after QVAC Fabric has been synced with upstream, build version 9840.

## How does it solve it?

Updates the qvac-fabric version in vcpkg to the latest published one.

## Breaking changes

None.